### PR TITLE
[GCS]GCS client support multi-thread subscribe&resubscribe&unsubscribe

### DIFF
--- a/src/ray/core_worker/actor_manager.cc
+++ b/src/ray/core_worker/actor_manager.cc
@@ -89,11 +89,8 @@ bool ActorManager::AddActorHandle(std::unique_ptr<ActorHandle> actor_handle,
     auto actor_notification_callback =
         std::bind(&ActorManager::HandleActorStateNotification, this,
                   std::placeholders::_1, std::placeholders::_2);
-    {
-      absl::MutexLock lock(&gcs_client_mutex_);
-      RAY_CHECK_OK(gcs_client_->Actors().AsyncSubscribe(
-          actor_id, actor_notification_callback, nullptr));
-    }
+    RAY_CHECK_OK(gcs_client_->Actors().AsyncSubscribe(
+        actor_id, actor_notification_callback, nullptr));
 
     if (!RayConfig::instance().gcs_actor_service_enabled()) {
       RAY_CHECK(reference_counter_->SetDeleteCallback(

--- a/src/ray/core_worker/actor_manager.h
+++ b/src/ray/core_worker/actor_manager.h
@@ -132,11 +132,8 @@ class ActorManager {
   void HandleActorStateNotification(const ActorID &actor_id,
                                     const gcs::ActorTableData &actor_data);
 
-  /// Mutex to protect the gcs_client_ field.
-  /// NOTE: Now gcs client is not thread safe, so we add lock protection.
-  mutable absl::Mutex gcs_client_mutex_;
   /// GCS client.
-  std::shared_ptr<gcs::GcsClient> gcs_client_ GUARDED_BY(gcs_client_mutex_);
+  std::shared_ptr<gcs::GcsClient> gcs_client_;
 
   /// Interface to submit tasks directly to other actors.
   std::shared_ptr<CoreWorkerDirectActorTaskSubmitterInterface> direct_actor_submitter_;

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -310,8 +310,11 @@ Status ServiceBasedActorInfoAccessor::AsyncSubscribe(
                                                   on_subscribe, subscribe_done);
   };
 
-  subscribe_operations_[actor_id] = subscribe_operation;
-  fetch_data_operations_[actor_id] = fetch_data_operation;
+  {
+    absl::MutexLock lock(&mutex_);
+    subscribe_operations_[actor_id] = subscribe_operation;
+    fetch_data_operations_[actor_id] = fetch_data_operation;
+  }
   return subscribe_operation(
       [fetch_data_operation, done](const Status &status) { fetch_data_operation(done); });
 }
@@ -319,6 +322,7 @@ Status ServiceBasedActorInfoAccessor::AsyncSubscribe(
 Status ServiceBasedActorInfoAccessor::AsyncUnsubscribe(const ActorID &actor_id) {
   RAY_LOG(DEBUG) << "Cancelling subscription to an actor, actor id = " << actor_id;
   auto status = client_impl_->GetGcsPubSub().Unsubscribe(ACTOR_CHANNEL, actor_id.Hex());
+  absl::MutexLock lock(&mutex_);
   subscribe_operations_.erase(actor_id);
   fetch_data_operations_.erase(actor_id);
   RAY_LOG(DEBUG) << "Finished cancelling subscription to an actor, actor id = "
@@ -402,6 +406,7 @@ void ServiceBasedActorInfoAccessor::AsyncResubscribe(bool is_pubsub_server_resta
   // If only the GCS sever has restarted, we only need to fetch data from the GCS server.
   // If the pub-sub server has also restarted, we need to resubscribe to the pub-sub
   // server first, then fetch data from the GCS server.
+  absl::MutexLock lock(&mutex_);
   if (is_pubsub_server_restarted) {
     if (subscribe_all_operation_ != nullptr) {
       RAY_CHECK_OK(subscribe_all_operation_(
@@ -410,7 +415,11 @@ void ServiceBasedActorInfoAccessor::AsyncResubscribe(bool is_pubsub_server_resta
     for (auto &item : subscribe_operations_) {
       auto &actor_id = item.first;
       RAY_CHECK_OK(item.second([this, actor_id](const Status &status) {
-        fetch_data_operations_[actor_id](nullptr);
+        absl::MutexLock lock(&mutex_);
+        auto fetch_data_operation = fetch_data_operations_[actor_id];
+        if (fetch_data_operation != nullptr) {
+          fetch_data_operation(nullptr);
+        }
       }));
     }
   } else {
@@ -1202,8 +1211,11 @@ Status ServiceBasedObjectInfoAccessor::AsyncSubscribeToLocations(
                                                   on_subscribe, subscribe_done);
   };
 
-  subscribe_object_operations_[object_id] = subscribe_operation;
-  fetch_object_data_operations_[object_id] = fetch_data_operation;
+  {
+    absl::MutexLock lock(&mutex_);
+    subscribe_object_operations_[object_id] = subscribe_operation;
+    fetch_object_data_operations_[object_id] = fetch_data_operation;
+  }
   return subscribe_operation(
       [fetch_data_operation, done](const Status &status) { fetch_data_operation(done); });
 }
@@ -1213,10 +1225,15 @@ void ServiceBasedObjectInfoAccessor::AsyncResubscribe(bool is_pubsub_server_rest
   // If only the GCS sever has restarted, we only need to fetch data from the GCS server.
   // If the pub-sub server has also restarted, we need to resubscribe to the pub-sub
   // server first, then fetch data from the GCS server.
+  absl::MutexLock lock(&mutex_);
   if (is_pubsub_server_restarted) {
     for (auto &item : subscribe_object_operations_) {
       RAY_CHECK_OK(item.second([this, item](const Status &status) {
-        fetch_object_data_operations_[item.first](nullptr);
+        absl::MutexLock lock(&mutex_);
+        auto fetch_object_data_operation = fetch_object_data_operations_[item.first];
+        if (fetch_object_data_operation != nullptr) {
+          fetch_object_data_operation(nullptr);
+        }
       }));
     }
   } else {
@@ -1230,6 +1247,7 @@ Status ServiceBasedObjectInfoAccessor::AsyncUnsubscribeToLocations(
     const ObjectID &object_id) {
   RAY_LOG(DEBUG) << "Unsubscribing object location, object id = " << object_id;
   auto status = client_impl_->GetGcsPubSub().Unsubscribe(OBJECT_CHANNEL, object_id.Hex());
+  absl::MutexLock lock(&mutex_);
   subscribe_object_operations_.erase(object_id);
   fetch_object_data_operations_.erase(object_id);
   RAY_LOG(DEBUG) << "Finished unsubscribing object location, object id = " << object_id;

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -417,6 +417,9 @@ void ServiceBasedActorInfoAccessor::AsyncResubscribe(bool is_pubsub_server_resta
       RAY_CHECK_OK(item.second([this, actor_id](const Status &status) {
         absl::MutexLock lock(&mutex_);
         auto fetch_data_operation = fetch_data_operations_[actor_id];
+        // `fetch_data_operation` is called in the callback function of subscribe.
+        // Before that, if the user calls `AsyncUnsubscribe` function, the corresponding
+        // fetch function will be deleted, so we need to check if it's null.
         if (fetch_data_operation != nullptr) {
           fetch_data_operation(nullptr);
         }
@@ -1231,6 +1234,9 @@ void ServiceBasedObjectInfoAccessor::AsyncResubscribe(bool is_pubsub_server_rest
       RAY_CHECK_OK(item.second([this, item](const Status &status) {
         absl::MutexLock lock(&mutex_);
         auto fetch_object_data_operation = fetch_object_data_operations_[item.first];
+        // `fetch_object_data_operation` is called in the callback function of subscribe.
+        // Before that, if the user calls `AsyncUnsubscribeToLocations` function, the
+        // corresponding fetch function will be deleted, so we need to check if it's null.
         if (fetch_object_data_operation != nullptr) {
           fetch_object_data_operation(nullptr);
         }

--- a/src/ray/gcs/gcs_client/service_based_accessor.h
+++ b/src/ray/gcs/gcs_client/service_based_accessor.h
@@ -123,11 +123,16 @@ class ServiceBasedActorInfoAccessor : public ActorInfoAccessor {
   /// server restarts from a failure.
   FetchDataOperation fetch_all_data_operation_;
 
+  // Mutex to protect the subscribe_operations_ field and fetch_data_operations_ field.
+  absl::Mutex mutex_;
+
   /// Save the subscribe operation of actors.
-  std::unordered_map<ActorID, SubscribeOperation> subscribe_operations_;
+  std::unordered_map<ActorID, SubscribeOperation> subscribe_operations_
+      GUARDED_BY(mutex_);
 
   /// Save the fetch data operation of actors.
-  std::unordered_map<ActorID, FetchDataOperation> fetch_data_operations_;
+  std::unordered_map<ActorID, FetchDataOperation> fetch_data_operations_
+      GUARDED_BY(mutex_);
 
   ServiceBasedGcsClient *client_impl_;
 
@@ -327,13 +332,19 @@ class ServiceBasedObjectInfoAccessor : public ObjectInfoAccessor {
   void AsyncResubscribe(bool is_pubsub_server_restarted) override;
 
  private:
+  // Mutex to protect the subscribe_object_operations_ field and
+  // fetch_object_data_operations_ field.
+  absl::Mutex mutex_;
+
   /// Save the subscribe operations, so we can call them again when PubSub
   /// server restarts from a failure.
-  std::unordered_map<ObjectID, SubscribeOperation> subscribe_object_operations_;
+  std::unordered_map<ObjectID, SubscribeOperation> subscribe_object_operations_
+      GUARDED_BY(mutex_);
 
   /// Save the fetch data operation in this function, so we can call it again when GCS
   /// server restarts from a failure.
-  std::unordered_map<ObjectID, FetchDataOperation> fetch_object_data_operations_;
+  std::unordered_map<ObjectID, FetchDataOperation> fetch_object_data_operations_
+      GUARDED_BY(mutex_);
 
   ServiceBasedGcsClient *client_impl_;
 

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -1143,6 +1143,45 @@ TEST_F(ServiceBasedGcsClientTest, TestGcsRedisFailureDetector) {
   RAY_CHECK(gcs_server_->IsStopped());
 }
 
+TEST_F(ServiceBasedGcsClientTest, TestMultiThreadSubAndUnsub) {
+  auto sub_finished_count = std::make_shared<std::atomic<int>>(0);
+  int size = 5;
+  std::vector<std::unique_ptr<std::thread>> threads;
+  threads.resize(size);
+
+  // Multithreading subscribe/resubscribe/unsubscribe actors.
+  auto job_id = JobID::FromInt(1);
+  for (int index = 0; index < size; ++index) {
+    threads[index].reset(new std::thread([this, job_id] {
+      auto actor_id = ActorID::Of(job_id, RandomTaskId(), 0);
+      ASSERT_TRUE(SubscribeActor(
+          actor_id, [](const ActorID &id, const rpc::ActorTableData &result) {}));
+      gcs_client_->Actors().AsyncResubscribe(false);
+      UnsubscribeActor(actor_id);
+    }));
+  }
+  for (auto &thread : threads) {
+    thread->join();
+    thread.reset();
+  }
+
+  // Multithreading subscribe/resubscribe/unsubscribe objects.
+  for (int index = 0; index < size; ++index) {
+    threads[index].reset(new std::thread([this] {
+      auto object_id = ObjectID::FromRandom();
+      ASSERT_TRUE(SubscribeToLocations(
+          object_id,
+          [](const ObjectID &id, const gcs::ObjectChangeNotification &result) {}));
+      gcs_client_->Objects().AsyncResubscribe(false);
+      UnsubscribeToLocations(object_id);
+    }));
+  }
+  for (auto &thread : threads) {
+    thread->join();
+    thread.reset();
+  }
+}
+
 }  // namespace ray
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Currently GCS client Actors() & Objects() is not thread safe, because it caches subscribe and fetch functions.
When multi-threaded calls, there will be a crash problem. In this PR, I added a testcase to verify this problem.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
