### PR TITLE
Keep build-autoscaler-images.sh alive in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -394,7 +394,7 @@ deploy:
 
   - provider: script
     edge: true # This supposedly opts in to deploy v2.
-    script: bash $TRAVIS_BUILD_DIR/ci/travis/build-autoscaler-images.sh || true
+    script: ./ci/keep_alive bash $TRAVIS_BUILD_DIR/ci/travis/build-autoscaler-images.sh || true
     skip_cleanup: true
     on:
       repo: ray-project/ray


### PR DESCRIPTION
We don't have Linux wheels for most of the recent commits because the Linux wheel Travis job times out because of the `build-autoscaler-images.sh` script. This attempts to keep the script alive (though I don't think the CI will properly test this PR because as of https://github.com/ray-project/ray/pull/6518, the `build-autoscaler-images.sh` script only runs in the CI on the master branch, so it doesn't appear to get tested). We should probably change that.