### PR TITLE
[Stats] fix stats shutdown crash if opencensus exporter not initialized

### DIFF
--- a/src/ray/stats/stats.h
+++ b/src/ray/stats/stats.h
@@ -103,7 +103,10 @@ static inline void Init(const TagsType &global_tags, const int metrics_agent_por
 static inline void Shutdown() {
   // TODO(sang): Harvest thread is not currently cleaned up.
   absl::MutexLock lock(&stats_mutex);
-  metrics_io_service_pool->Stop();
+  if (!StatsConfig::instance().IsInitialized()) {
+    // Return if stats had never been initialized.
+    return;
+  }
   opencensus::stats::StatsExporter::Shutdown();
   metrics_io_service_pool = nullptr;
   exporter = nullptr;

--- a/src/ray/stats/stats.h
+++ b/src/ray/stats/stats.h
@@ -107,6 +107,7 @@ static inline void Shutdown() {
     // Return if stats had never been initialized.
     return;
   }
+  metrics_io_service_pool->Stop();
   opencensus::stats::StatsExporter::Shutdown();
   metrics_io_service_pool = nullptr;
   exporter = nullptr;


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
