### PR TITLE
Only build docker wheels in LINUX_WHEELS env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -436,4 +436,4 @@ deploy:
     on:
       repo: ray-project/ray
       all_branches: true
-      condition: $LINUX_WHEELS = 1 || $MAC_WHEELS = 1
+      condition: $LINUX_WHEELS = 1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

The current condition for docker images builds are `$LINUX_WHEELS = 1 || $MAC_WHEELS = 1`. This makes no sense because we can't build and push the same set of docker images in two places. In addition, wheels built for mac will not be compatible with ones used in docker VMs. 

Fortunately the MacOS docker builds has been consistently failing due to `docker` doesn't exist on travis MacOS environment. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
