### PR TITLE
Fix broken actor failure tests.

### DIFF
--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -955,7 +955,7 @@ def test_actor_owner_worker_dies_before_dependency_ready(ray_start_cluster):
     # Wait for the `Owner` to exit.
     wait_for_pid_to_exit(owner_pid)
     # It will hang here if location is not properly resolved.
-    assert (wait_for_condition(lambda: ray.get(caller.hang.remote())))
+    wait_for_condition(lambda: ray.get(caller.hang.remote()))
 
 
 @pytest.mark.parametrize(
@@ -1025,7 +1025,7 @@ def test_actor_owner_node_dies_before_dependency_ready(ray_start_cluster):
     wait_for_pid_to_exit(owner_pid)
 
     # It will hang here if location is not properly resolved.
-    assert (wait_for_condition(lambda: ray.get(caller.hang.remote())))
+    wait_for_condition(lambda: ray.get(caller.hang.remote()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

`wait for condition` now returns None

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
