### PR TITLE
[dist] swap mac/linux wheel build order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,26 +99,11 @@ matrix:
       script:
         - true  # we still need this block to exist, otherwise it will fall back to the global one
 
-    # Build Linux wheels and multi-platform jars.
-    - os: linux
-      env:
-        - LINUX_WHEELS=1 LINUX_JARS=1
-        - PYTHONWARNINGS=ignore
-        - RAY_INSTALL_JAVA=1
-      install:
-        - . ./ci/travis/ci.sh init RAY_CI_LINUX_WHEELS_AFFECTED,RAY_CI_JAVA_AFFECTED,RAY_CI_STREAMING_JAVA_AFFECTED
-      before_script:
-        - . ./ci/travis/ci.sh build
-      script:
-        - . ./ci/travis/ci.sh test_wheels
-        - bash ./java/build-jar-multiplatform.sh linux
-      cache: false
-
     # Build MacOS wheels and MacOS jars
     - os: osx
       osx_image: xcode7
       env:
-        - MAC_WHEELS=1 MULTIPLATFORM_JARS=1
+        - MAC_WHEELS=1 MAC_JARS=1
         - PYTHONWARNINGS=ignore
         - RAY_INSTALL_JAVA=1
       install:
@@ -128,8 +113,23 @@ matrix:
       script:
         - . ./ci/travis/ci.sh test_wheels
         - bash ./java/build-jar-multiplatform.sh darwin
+
+    # Build Linux wheels and multi-platform jars.
+    - os: linux
+      env:
+        - LINUX_WHEELS=1 MULTIPLATFORM_JARS=1
+        - PYTHONWARNINGS=ignore
+        - RAY_INSTALL_JAVA=1
+      install:
+        - . ./ci/travis/ci.sh init RAY_CI_LINUX_WHEELS_AFFECTED,RAY_CI_JAVA_AFFECTED,RAY_CI_STREAMING_JAVA_AFFECTED
+      before_script:
+        - . ./ci/travis/ci.sh build
+      script:
+        - . ./ci/travis/ci.sh test_wheels
+        - bash ./java/build-jar-multiplatform.sh linux
         - bash ./java/build-jar-multiplatform.sh multiplatform
         #- bash ./java/build-jar-multiplatform.sh deploy
+      cache: false
 
     # RLlib: Learning tests (from rllib/tuned_examples/*.yaml).
     - os: linux
@@ -411,7 +411,7 @@ deploy:
     on:
       repo: ray-project/ray
       all_branches: true
-      condition: $MULTIPLATFORM_JARS = 1 || $LINUX_JARS=1
+      condition: $MULTIPLATFORM_JARS = 1 || $MAC_JARS=1
 
   - provider: s3
     edge: true # This supposedly opts in to deploy v2.
@@ -427,7 +427,7 @@ deploy:
     on:
       repo: ray-project/ray
       branch: master
-      condition: $MULTIPLATFORM_JARS = 1 || $LINUX_JARS=1
+      condition: $MULTIPLATFORM_JARS = 1 || $MAC_JARS=1
 
   - provider: script
     edge: true # This supposedly opts in to deploy v2.

--- a/java/build-jar-multiplatform.sh
+++ b/java/build-jar-multiplatform.sh
@@ -78,14 +78,14 @@ build_jars_multiplatform() {
   build_jars multiplatform false
 }
 
-# Download linux/windows ray-related jar from s3
-# This function assumes darwin jars exist already.
+# Download darwin/windows ray-related jar from s3
+# This function assumes linux jars exist already.
 download_jars() {
   local wait_time=0
   local sleep_time_units=60
 
   for f in "$@"; do
-    for os in 'linux' 'windows'; do
+    for os in 'darwin' 'windows'; do
       if [[ "$os" == "windows" ]]; then
         break
       fi


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Since `linux_wheels` job is significantly slower than `mac_wheels` job, and `mac_wheels` job dependends on `linux_wheels` job, we swap those two jobs build order to avoid unnecessary waitting time.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
