### PR TITLE
[Core] Worker stderr logging hotfix

### DIFF
--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -29,6 +29,7 @@ class LogFileInfo:
                  size_when_last_opened=None,
                  file_position=None,
                  file_handle=None,
+                 is_err_file=False,
                  job_id=None):
         assert (filename is not None and size_when_last_opened is not None
                 and file_position is not None)
@@ -36,6 +37,7 @@ class LogFileInfo:
         self.size_when_last_opened = size_when_last_opened
         self.file_position = file_position
         self.file_handle = file_handle
+        self.is_err_file = is_err_file
         self.job_id = job_id
         self.worker_pid = None
 
@@ -128,6 +130,8 @@ class LogMonitor:
                 else:
                     job_id = None
 
+                is_err_file = file_path.endswith("err")
+
                 self.log_filenames.add(file_path)
                 self.closed_file_infos.append(
                     LogFileInfo(
@@ -135,6 +139,7 @@ class LogMonitor:
                         size_when_last_opened=0,
                         file_position=0,
                         file_handle=None,
+                        is_err_file=is_err_file,
                         job_id=job_id))
                 log_filename = os.path.basename(file_path)
                 logger.info("Beginning to track file {}".format(log_filename))
@@ -245,6 +250,7 @@ class LogMonitor:
                         "ip": self.ip,
                         "pid": file_info.worker_pid,
                         "job": file_info.job_id,
+                        "is_err": file_info.is_err_file,
                         "lines": lines_to_publish
                     }))
                 anything_published = True

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1009,6 +1009,8 @@ def print_logs(redis_client, threads_stopped, job_id):
                     job_id.binary()) != data["job"]:
                 continue
 
+            print_file = sys.stderr if data["is_err"] else sys.stdout
+
             def color_for(data):
                 if data["pid"] == "raylet":
                     return colorama.Fore.YELLOW
@@ -1017,14 +1019,18 @@ def print_logs(redis_client, threads_stopped, job_id):
 
             if data["ip"] == localhost:
                 for line in data["lines"]:
-                    print("{}{}(pid={}){} {}".format(
-                        colorama.Style.DIM, color_for(data), data["pid"],
-                        colorama.Style.RESET_ALL, line))
+                    print(
+                        "{}{}(pid={}){} {}".format(
+                            colorama.Style.DIM, color_for(data), data["pid"],
+                            colorama.Style.RESET_ALL, line),
+                        file=print_file)
             else:
                 for line in data["lines"]:
-                    print("{}{}(pid={}, ip={}){} {}".format(
-                        colorama.Style.DIM, color_for(data), data["pid"],
-                        data["ip"], colorama.Style.RESET_ALL, line))
+                    print(
+                        "{}{}(pid={}, ip={}){} {}".format(
+                            colorama.Style.DIM, color_for(data), data["pid"],
+                            data["ip"], colorama.Style.RESET_ALL, line),
+                        file=print_file)
 
     except (OSError, redis.exceptions.ConnectionError) as e:
         logger.error("print_logs: {}".format(e))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This makes worker stderr logs print on the driver's stderr instead of the driver's stdout. 

## Related issue number

#9654

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
