### PR TITLE
Pin pytest version to 5.4.3 

### DIFF
--- a/ci/asan_tests/ray-project/requirements.txt
+++ b/ci/asan_tests/ray-project/requirements.txt
@@ -19,7 +19,7 @@ Pillow
 prometheus_client
 py-spy
 pygments
-pytest
+pytest==5.4.3
 pytest-asyncio
 pytest-rerunfailures
 pytest-sugar

--- a/ci/asan_tests/run_asan_tests.sh
+++ b/ci/asan_tests/run_asan_tests.sh
@@ -11,7 +11,7 @@ asan_install() {
 asan_setup() {
   echo "Setting up the environment"
   pip install -r ray-project/requirements.txt
-  pip install -U pytest
+  pip install -U pytest==5.4.3
 
   echo "Installing cython example"
   (cd "${ROOT_DIR}"/../doc/examples/cython && python setup.py install --user)

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -237,7 +237,7 @@ install_dependencies() {
     esac
     pip_packages+=(scipy tensorflow=="${tf_version}" cython==0.29.0 gym \
       opencv-python-headless pyyaml pandas==1.0.5 requests feather-format lxml openpyxl xlrd \
-      py-spy pytest pytest-timeout networkx tabulate aiohttp uvicorn dataclasses pygments werkzeug \
+      py-spy pytest==5.4.3 pytest-timeout networkx tabulate aiohttp uvicorn dataclasses pygments werkzeug \
       kubernetes flask grpcio pytest-sugar pytest-rerunfailures pytest-asyncio scikit-learn==0.22.2 numba \
       Pillow prometheus_client boto3 pettingzoo mypy)
     if [ "${OSTYPE}" != msys ]; then

--- a/ci/travis/test-wheels.sh
+++ b/ci/travis/test-wheels.sh
@@ -71,7 +71,7 @@ if [[ "$platform" == "linux" ]]; then
     "$PYTHON_EXE" -u -c "import ray; print(ray.__commit__)" | grep "$TRAVIS_COMMIT" || (echo "ray.__commit__ not set properly!" && exit 1)
 
     # Install the dependencies to run the tests.
-    "$PIP_CMD" install -q aiohttp google grpcio pytest requests
+    "$PIP_CMD" install -q aiohttp google grpcio pytest==5.4.3 requests
 
     # Run a simple test script to make sure that the wheel works.
     for SCRIPT in "${TEST_SCRIPTS[@]}"; do
@@ -112,7 +112,7 @@ elif [[ "$platform" == "macosx" ]]; then
     "$PIP_CMD" install -q "$PYTHON_WHEEL"
 
     # Install the dependencies to run the tests.
-    "$PIP_CMD" install -q aiohttp google grpcio pytest requests
+    "$PIP_CMD" install -q aiohttp google grpcio pytest==5.4.3 requests
 
     # Run a simple test script to make sure that the wheel works.
     for SCRIPT in "${TEST_SCRIPTS[@]}"; do


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
New Pytest 6.0 is giving a bunch of breakage. https://travis-ci.com/github/ray-project/ray/builds/177518820

Before we figure out how to migrate, we should pin the version.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
