### PR TITLE
Fix GCS related tests

### DIFF
--- a/src/ray/common/test_util.cc
+++ b/src/ray/common/test_util.cc
@@ -41,6 +41,10 @@ void TestSetupUtil::StartUpRedisServers(const std::vector<int> &redis_server_por
 int TestSetupUtil::StartUpRedisServer(const int &port) {
   int actual_port = port;
   if (port == 0) {
+    static std::atomic<bool> srand_called(false);
+    if (!srand_called.exchange(true)) {
+      srand(current_time_ms() % RAND_MAX);
+    }
     // Use random port (in range [2000, 7000) to avoid port conflicts between UTs.
     actual_port = rand() % 5000 + 2000;
   }

--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -68,8 +68,8 @@ class GlobalStateAccessorTest : public ::testing::Test {
   void TearDown() override {
     gcs_server_->Stop();
     io_service_->stop();
-    gcs_server_.reset();
     thread_io_service_->join();
+    gcs_server_.reset();
 
     gcs_client_->Disconnect();
     global_state_->Disconnect();
@@ -272,6 +272,10 @@ TEST_F(GlobalStateAccessorTest, TestWorkerTable) {
 }  // namespace ray
 
 int main(int argc, char **argv) {
+  InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
+                                         ray::RayLog::ShutDownRayLog, argv[0],
+                                         ray::RayLogLevel::INFO,
+                                         /*log_dir=*/"");
   ::testing::InitGoogleTest(&argc, argv);
   RAY_CHECK(argc == 4);
   ray::TEST_REDIS_SERVER_EXEC_PATH = argv[1];

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -71,8 +71,8 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
 
     gcs_server_->Stop();
     server_io_service_->stop();
-    gcs_server_.reset();
     server_io_service_thread_->join();
+    gcs_server_.reset();
     TestSetupUtil::FlushAllRedisServers();
     client_io_service_thread_->join();
   }
@@ -81,8 +81,8 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     RAY_LOG(INFO) << "Stopping GCS service, port = " << gcs_server_->GetPort();
     gcs_server_->Stop();
     server_io_service_->stop();
-    gcs_server_.reset();
     server_io_service_thread_->join();
+    gcs_server_.reset();
     RAY_LOG(INFO) << "Finished stopping GCS service.";
 
     server_io_service_.reset(new boost::asio::io_service());
@@ -1182,6 +1182,10 @@ TEST_F(ServiceBasedGcsClientTest, TestMultiThreadSubAndUnsub) {
 }  // namespace ray
 
 int main(int argc, char **argv) {
+  InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
+                                         ray::RayLog::ShutDownRayLog, argv[0],
+                                         ray::RayLogLevel::INFO,
+                                         /*log_dir=*/"");
   ::testing::InitGoogleTest(&argc, argv);
   RAY_CHECK(argc == 4);
   ray::TEST_REDIS_SERVER_EXEC_PATH = argv[1];

--- a/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
@@ -57,8 +57,8 @@ class GcsServerTest : public ::testing::Test {
   void TearDown() override {
     gcs_server_->Stop();
     io_service_.stop();
-    gcs_server_.reset();
     thread_io_service_->join();
+    gcs_server_.reset();
   }
 
   bool AddJob(const rpc::AddJobRequest &request) {

--- a/src/ray/gcs/store_client/test/redis_store_client_test.cc
+++ b/src/ray/gcs/store_client/test/redis_store_client_test.cc
@@ -60,6 +60,10 @@ TEST_F(RedisStoreClientTest, AsyncGetAllAndBatchDeleteTest) {
 }  // namespace ray
 
 int main(int argc, char **argv) {
+  InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
+                                         ray::RayLog::ShutDownRayLog, argv[0],
+                                         ray::RayLogLevel::INFO,
+                                         /*log_dir=*/"");
   ::testing::InitGoogleTest(&argc, argv);
   RAY_CHECK(argc == 4);
   ray::TEST_REDIS_SERVER_EXEC_PATH = argv[1];

--- a/src/ray/gcs/test/asio_test.cc
+++ b/src/ray/gcs/test/asio_test.cc
@@ -74,6 +74,10 @@ TEST_F(RedisAsioTest, TestRedisCommands) {
 }  // namespace ray
 
 int main(int argc, char **argv) {
+  InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
+                                         ray::RayLog::ShutDownRayLog, argv[0],
+                                         ray::RayLogLevel::INFO,
+                                         /*log_dir=*/"");
   ::testing::InitGoogleTest(&argc, argv);
   RAY_CHECK(argc == 4);
   ray::TEST_REDIS_SERVER_EXEC_PATH = argv[1];

--- a/src/ray/gcs/test/redis_gcs_client_test.cc
+++ b/src/ray/gcs/test/redis_gcs_client_test.cc
@@ -1492,6 +1492,10 @@ TEST_F(TestGcsWithAsio, TestHashTable) {
 }  // namespace ray
 
 int main(int argc, char **argv) {
+  InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
+                                         ray::RayLog::ShutDownRayLog, argv[0],
+                                         ray::RayLogLevel::INFO,
+                                         /*log_dir=*/"");
   ::testing::InitGoogleTest(&argc, argv);
   RAY_CHECK(argc == 4);
   ray::TEST_REDIS_SERVER_EXEC_PATH = argv[1];

--- a/src/ray/gcs/test/redis_object_info_accessor_test.cc
+++ b/src/ray/gcs/test/redis_object_info_accessor_test.cc
@@ -144,6 +144,10 @@ TEST_F(RedisObjectInfoAccessorTest, TestGetAddRemove) {
 }  // namespace ray
 
 int main(int argc, char **argv) {
+  InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
+                                         ray::RayLog::ShutDownRayLog, argv[0],
+                                         ray::RayLogLevel::INFO,
+                                         /*log_dir=*/"");
   ::testing::InitGoogleTest(&argc, argv);
   RAY_CHECK(argc == 4);
   ray::TEST_REDIS_SERVER_EXEC_PATH = argv[1];


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Bugs:
* Forget to call `srand()` before calling `rand()`.
* `GcsServer` is destroyed before the IO thread is fully stopped. Try to access invalid memory from the IO thread.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
