### PR TITLE
Fix compile error

### DIFF
--- a/src/ray/core_worker/common.h
+++ b/src/ray/core_worker/common.h
@@ -119,7 +119,6 @@ struct ActorCreationOptions {
 using PlacementStrategy = rpc::PlacementStrategy;
 
 struct PlacementGroupCreationOptions {
-  PlacementGroupCreationOptions() = default;
   PlacementGroupCreationOptions(
       std::string name, PlacementStrategy strategy,
       std::vector<std::unordered_map<std::string, double>> bundles)


### PR DESCRIPTION
## Why are these changes needed?

Default constructor is implicitly deleted due to `const` members, which triggers a warning as an error.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
