### PR TITLE
[cpp worker] support Ray::Get() static method

### DIFF
--- a/cpp/include/ray/api.h
+++ b/cpp/include/ray/api.h
@@ -40,9 +40,9 @@ class Ray {
   static ObjectRef<T> Put(const T &obj);
 
   /// Get a single object from the object store.
-  /// This method will be blocked until all the objects are ready.
+  /// This method will be blocked until the object is ready.
   ///
-  /// \param[in] object The object reference which should be got.
+  /// \param[in] object The object reference which should be returned.
   /// \return shared pointer of the result.
   template <typename T>
   static std::shared_ptr<T> Get(const ObjectRef<T> &object);

--- a/cpp/include/ray/api.h
+++ b/cpp/include/ray/api.h
@@ -39,6 +39,14 @@ class Ray {
   template <typename T>
   static ObjectRef<T> Put(const T &obj);
 
+  /// Get a single object from the object store.
+  /// This method will be blocked until all the objects are ready.
+  ///
+  /// \param[in] object The object reference which should be got.
+  /// \return shared pointer of the result.
+  template <typename T>
+  static std::shared_ptr<T> Get(const ObjectRef<T> &object);
+
   /// Get a list of objects from the object store.
   /// This method will be blocked until all the objects are ready.
   ///
@@ -76,10 +84,6 @@ class Ray {
   static RayRuntime *runtime_;
 
   static std::once_flag is_inited_;
-
-  /// Used by ObjectRef to implement .Get()
-  template <typename T>
-  static std::shared_ptr<T> Get(const ObjectRef<T> &object);
 
   template <typename ReturnType, typename FuncType, typename ExecFuncType,
             typename... ArgTypes>

--- a/cpp/src/ray/test/api_test.cc
+++ b/cpp/src/ray/test/api_test.cc
@@ -44,10 +44,15 @@ TEST(RayApiTest, PutTest) {
 
 TEST(RayApiTest, StaticGetTest) {
   Ray::Init();
+  /// `Get` member function
+  auto obj_ref1 = Ray::Put(100);
+  auto res1 = obj_ref1.Get();
+  EXPECT_EQ(100, *res1);
 
-  auto obj_ref = Ray::Put(100);
-  auto res = Ray::Get(obj_ref);
-  EXPECT_EQ(100, *res);
+  /// `Get` static function
+  auto obj_ref2 = Ray::Put(200);
+  auto res2 = Ray::Get(obj_ref2);
+  EXPECT_EQ(200, *res2);
 }
 
 TEST(RayApiTest, WaitTest) {

--- a/cpp/src/ray/test/api_test.cc
+++ b/cpp/src/ray/test/api_test.cc
@@ -42,6 +42,14 @@ TEST(RayApiTest, PutTest) {
   EXPECT_EQ(1, *i1);
 }
 
+TEST(RayApiTest, StaticGetTest) {
+  Ray::Init();
+
+  auto obj_ref = Ray::Put(100);
+  auto res = Ray::Get(obj_ref);
+  EXPECT_EQ(100, *res);
+}
+
 TEST(RayApiTest, WaitTest) {
   Ray::Init();
   auto r0 = Ray::Task(Return1).Remote();


### PR DESCRIPTION
## Why are these changes needed?
- Problem
    We just support `Get` to be a member function of object_ref now. The demo like this:
```
  auto obj_ref1 = Ray::Put(100);
  auto res1 = obj_ref1.Get();
  EXPECT_EQ(100, *res1);
```
    And maybe users need a static function(same as python api), like this:
```
  auto obj_ref2 = Ray::Put(200);
  auto res2 = Ray::Get(obj_ref2);
  EXPECT_EQ(200, *res2);
```
- solution
  * Make `Get` method of `Ray` class to be public 

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
