### PR TITLE
Fix macOS incompatibility in format.sh

### DIFF
--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -199,12 +199,12 @@ format_changed() {
             shellcheck_bazel
         fi
 
-        local shell_files
-        # shellcheck disable=SC2207
-        shell_files=($(
-          git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- '*.sh' &&
-          git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- ':(exclude)*.*' | xargs -r git --no-pager grep -l '^#!\(/usr\)\?/bin/\(env \+\)\?\(ba\)\?sh'
-        ))
+        local shell_files non_shell_files
+        non_shell_files=($(git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- ':(exclude)*.sh'))
+        shell_files=($(git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- '*.sh'))
+        if [ 0 -lt "${#non_shell_files[@]}" ]; then
+            shell_files+=($(git --no-pager grep -l -- '^#!\(/usr\)\?/bin/\(env \+\)\?\(ba\)\?sh' "${non_shell_files[@]}"))
+        fi
         if [ 0 -lt "${#shell_files[@]}" ]; then
             shellcheck_scripts "${shell_files[@]}"
         fi


### PR DESCRIPTION
## Why are these changes needed?

`xargs -r` is not available on macOS's `xargs`.

## Related issue number

#8574

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
