### PR TITLE
[tune] Fix restoration for function API PBT

### DIFF
--- a/python/ray/tune/function_runner.py
+++ b/python/ray/tune/function_runner.py
@@ -170,7 +170,7 @@ class StatusReporter:
         # resume training.
         self._continue_semaphore.acquire()
 
-    def make_checkpoint_dir(self, step=None):
+    def make_checkpoint_dir(self, step):
         checkpoint_dir = TrainableUtil.make_checkpoint_dir(
             self.logdir, index=step)
         logger.debug("Making checkpoint dir at %s", checkpoint_dir)
@@ -386,8 +386,8 @@ class FunctionRunner(Trainable):
         if not checkpoint:
             state.update(iteration=0, timesteps_total=0, episodes_total=0)
             # We drop a marker here to indicate that the checkpoint is empty
-            FuncCheckpointUtil.mk_null_checkpoint_dir(parent_dir)
-            checkpoint = parent_dir
+            checkpoint = FuncCheckpointUtil.mk_null_checkpoint_dir(self.logdir)
+            parent_dir = checkpoint
         elif isinstance(checkpoint, dict):
             parent_dir = TrainableUtil.make_checkpoint_dir(
                 self.logdir, index=self.training_iteration)

--- a/python/ray/tune/function_runner.py
+++ b/python/ray/tune/function_runner.py
@@ -66,7 +66,7 @@ class FuncCheckpointUtil:
     def mk_null_checkpoint_dir(logdir):
         """Indicate that the given checkpoint doesn't have state."""
         checkpoint_dir = TrainableUtil.make_checkpoint_dir(
-            logdir, index=0, override=True)
+            logdir, index=-1, override=True)
         open(os.path.join(checkpoint_dir, NULL_MARKER), "a").close()
         return checkpoint_dir
 

--- a/python/ray/tune/function_runner.py
+++ b/python/ray/tune/function_runner.py
@@ -319,7 +319,7 @@ class FunctionRunner(Trainable):
         self._status_reporter.save_checkpoint(checkpoint)
 
     def restore_from_object(self, obj):
-        if self.default_checkpoint_dir is not None and os.exists(
+        if self.default_checkpoint_dir is not None and os.path.exists(
                 self.default_checkpoint_dir):
             shutil.rmtree(self.default_checkpoint_dir)
             logger.debug("Clearing default checkpoint: %s",
@@ -340,7 +340,7 @@ class FunctionRunner(Trainable):
         self._report_thread_runner_error()
         session.shutdown()
 
-        if self.default_checkpoint_dir is not None and os.exists(
+        if self.default_checkpoint_dir is not None and os.path.exists(
                 self.default_checkpoint_dir):
             shutil.rmtree(self.default_checkpoint_dir)
             logger.debug("Clearing default checkpoint: %s",

--- a/python/ray/tune/function_runner.py
+++ b/python/ray/tune/function_runner.py
@@ -23,7 +23,7 @@ RESULT_FETCH_TIMEOUT = 0.2
 ERROR_REPORT_TIMEOUT = 10
 ERROR_FETCH_TIMEOUT = 1
 
-NULL_MARKER = ".null_ckpt"
+NULL_MARKER = ".null_marker"
 TEMP_MARKER = ".temp_marker"
 
 
@@ -55,7 +55,7 @@ class FuncCheckpointUtil:
 
     If "save" is called on a trial whose most recent checkpoint
     is temporary, "create_perm_checkpoint" will be called. This
-    migrates the temporary checkpoint to a permanent checkpoint.
+    copies the temporary checkpoint to a permanent checkpoint directory.
     """
 
     @staticmethod
@@ -86,6 +86,7 @@ class FuncCheckpointUtil:
 
     @staticmethod
     def create_perm_checkpoint(checkpoint_dir, logdir, step):
+        """Copies temporary checkpoint to a permanent checkpoint directory."""
         checkpoint_dir = os.path.abspath(checkpoint_dir)
         temporary_marker = os.path.join(checkpoint_dir, TEMP_MARKER)
         assert os.path.exists(temporary_marker), (

--- a/python/ray/tune/function_runner.py
+++ b/python/ray/tune/function_runner.py
@@ -189,7 +189,8 @@ class FunctionRunner(Trainable):
         session.init(self._status_reporter)
         self._runner = None
         self._restore_tmpdir = None
-        self.default_checkpoint_dir = None
+        self.default_checkpoint_dir = TrainableUtil.make_checkpoint_dir(
+            self.logdir, index="default", dryrun=True)
 
     def _trainable_func(self):
         """Subclasses can override this to set the trainable func."""
@@ -283,8 +284,10 @@ class FunctionRunner(Trainable):
         return fn(self)
 
     def create_default_checkpoint_dir(self):
-        self.default_checkpoint_dir = TrainableUtil.make_checkpoint_dir(
+        checkpoint_dir = TrainableUtil.make_checkpoint_dir(
             self.logdir, index="default")
+        assert checkpoint_dir == self.default_checkpoint_dir, (
+            "Checkpoint directory validation failed!")
         return self.default_checkpoint_dir
 
     def save(self, checkpoint_path=None):
@@ -319,8 +322,7 @@ class FunctionRunner(Trainable):
         self._status_reporter.save_checkpoint(checkpoint)
 
     def restore_from_object(self, obj):
-        if self.default_checkpoint_dir is not None and os.exists(
-                self.default_checkpoint_dir):
+        if os.exists(self.default_checkpoint_dir):
             shutil.rmtree(self.default_checkpoint_dir)
             logger.debug("Clearing default checkpoint: %s",
                          self.default_checkpoint_dir)

--- a/python/ray/tune/function_runner.py
+++ b/python/ray/tune/function_runner.py
@@ -53,10 +53,6 @@ class FuncCheckpointUtil:
     will be removed. We cannot remove them any earlier because
     the loading of checkpoints is non-deterministic.
 
-    Temporary checkpoints are also not treated like regular
-    checkpoints because Tune assumes that in-memory checkpoints
-    are removed.
-
     If "save" is called on a trial whose most recent checkpoint
     is temporary, "create_perm_checkpoint" will be called. This
     migrates the temporary checkpoint to a permanent checkpoint.

--- a/python/ray/tune/session.py
+++ b/python/ray/tune/session.py
@@ -98,11 +98,15 @@ def save_checkpoint(checkpoint):
 
 
 @contextmanager
-def checkpoint_dir(step=None):
+def checkpoint_dir(step):
     """Returns a checkpoint dir inside a context.
 
     Store any files related to restoring state within the
     provided checkpoint dir.
+
+    Args:
+        step (int): Index for the checkpoint. Expected to be a
+            monotonically increasing quantity.
 
     .. code-block:: python
 
@@ -135,6 +139,9 @@ def checkpoint_dir(step=None):
     .. versionadded:: 0.8.7
     """
     _session = get_session()
+
+    if step is None:
+        raise ValueError("checkpoint_dir(step) must be provided - got None.")
 
     if _session:
         _checkpoint_dir = _session.make_checkpoint_dir(step=step)

--- a/python/ray/tune/session.py
+++ b/python/ray/tune/session.py
@@ -144,7 +144,7 @@ def checkpoint_dir(step=None):
     yield _checkpoint_dir
 
     if _session:
-        _session.save_checkpoint(_checkpoint_dir)
+        _session.set_checkpoint(_checkpoint_dir)
 
 
 def get_trial_dir():

--- a/python/ray/tune/tests/test_function_api.py
+++ b/python/ray/tune/tests/test_function_api.py
@@ -20,8 +20,8 @@ class FunctionApiTest(unittest.TestCase):
 
     def testFunctionNoCheckpointing(self):
         def train(config, checkpoint_dir=None):
-            for i in range(10):
-                tune.report(test=i)
+            for step in range(10):
+                tune.report(test=step)
 
         wrapped = wrap_function(train)
 
@@ -56,6 +56,7 @@ class FunctionApiTest(unittest.TestCase):
         checkpoint_obj = new_trainable.save_to_object()
         new_trainable.restore_from_object(checkpoint_obj)
         checkpoint = new_trainable.save()
+
         new_trainable.stop()
 
         new_trainable2 = wrapped()

--- a/python/ray/tune/tests/test_function_api.py
+++ b/python/ray/tune/tests/test_function_api.py
@@ -149,8 +149,6 @@ class FunctionCheckpointingTest(unittest.TestCase):
         self.assertTrue(result[TRAINING_ITERATION] == 3)
 
     def testReuseNullCheckpoint(self):
-        """pass"""
-
         def train(config, checkpoint_dir=None):
             assert not checkpoint_dir
             for step in range(10):
@@ -179,8 +177,6 @@ class FunctionCheckpointingTest(unittest.TestCase):
         self.assertTrue(result[TRAINING_ITERATION] == 1)
 
     def testMultipleNullCheckpoints(self):
-        """pass"""
-
         def train(config, checkpoint_dir=None):
             assert not checkpoint_dir
             for step in range(10):
@@ -198,8 +194,6 @@ class FunctionCheckpointingTest(unittest.TestCase):
         self.assertTrue(result[TRAINING_ITERATION] == 1)
 
     def testMultipleNullMemoryCheckpoints(self):
-        """pass"""
-
         def train(config, checkpoint_dir=None):
             assert not checkpoint_dir
             for step in range(10):

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -109,23 +109,18 @@ class TrainableUtil:
         return checkpoint_dir
 
     @staticmethod
-    def make_checkpoint_dir(checkpoint_dir, index, dryrun=False):
+    def make_checkpoint_dir(checkpoint_dir, index):
         """Creates a checkpoint directory within the provided path.
 
         Args:
             checkpoint_dir (str): Path to checkpoint directory.
             index (str): A subdirectory will be created
                 at the checkpoint directory named 'checkpoint_{index}'.
-            dryrun (bool): Generates and returns the path but does not
-                create an actual folder on file system.
         """
         suffix = "checkpoint"
         if index is not None:
             suffix += "_{}".format(index)
         checkpoint_dir = os.path.join(checkpoint_dir, suffix)
-
-        if dryrun:
-            return checkpoint_dir
 
         os.makedirs(checkpoint_dir, exist_ok=True)
         # Drop marker in directory to identify it as a checkpoint dir.

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -109,18 +109,23 @@ class TrainableUtil:
         return checkpoint_dir
 
     @staticmethod
-    def make_checkpoint_dir(checkpoint_dir, index):
+    def make_checkpoint_dir(checkpoint_dir, index, dryrun=False):
         """Creates a checkpoint directory within the provided path.
 
         Args:
             checkpoint_dir (str): Path to checkpoint directory.
             index (str): A subdirectory will be created
                 at the checkpoint directory named 'checkpoint_{index}'.
+            dryrun (bool): Generates and returns the path but does not
+                create an actual folder on file system.
         """
         suffix = "checkpoint"
         if index is not None:
             suffix += "_{}".format(index)
         checkpoint_dir = os.path.join(checkpoint_dir, suffix)
+
+        if dryrun:
+            return checkpoint_dir
 
         os.makedirs(checkpoint_dir, exist_ok=True)
         # Drop marker in directory to identify it as a checkpoint dir.

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -109,7 +109,7 @@ class TrainableUtil:
         return checkpoint_dir
 
     @staticmethod
-    def make_checkpoint_dir(checkpoint_dir, index):
+    def make_checkpoint_dir(checkpoint_dir, index, override=False):
         """Creates a checkpoint directory within the provided path.
 
         Args:
@@ -122,6 +122,8 @@ class TrainableUtil:
             suffix += "_{}".format(index)
         checkpoint_dir = os.path.join(checkpoint_dir, suffix)
 
+        if override and os.path.exists(checkpoint_dir):
+            shutil.rmtree(checkpoint_dir)
         os.makedirs(checkpoint_dir, exist_ok=True)
         # Drop marker in directory to identify it as a checkpoint dir.
         open(os.path.join(checkpoint_dir, ".is_checkpoint"), "a").close()

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -116,6 +116,8 @@ class TrainableUtil:
             checkpoint_dir (str): Path to checkpoint directory.
             index (str): A subdirectory will be created
                 at the checkpoint directory named 'checkpoint_{index}'.
+            override (bool): Deletes checkpoint_dir before creating
+                a new one.
         """
         suffix = "checkpoint"
         if index is not None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Unlike the "Class API", we cannot actually alter the control flow of the function API. 

The class API lets us "save" or "restore" during training. The function API relies on the user to have saved before hand so that we can fetch the checkpoint. As a result, there are some odd behaviors/edge cases we need to address.

There are two cases that we address in this PR: "null" and "temporary" checkpoints.

#### Null Checkpoints

Null checkpoints are generated when a trial is being saved
but a checkpoint has not been created. In this case,
a marker is set, indicating that the checkpoint is null.

When restoring from an null checkpoint, the FunctionRunner
will detect this and *not* restore from any checkpoint at all.

#### Temporary Checkpoints

Temporary checkpoints are generated when a trial is being
restored from a prior in-memory checkpoint. The in-memory checkpoint
is materialized on the hard-disk when being restored from. However,
since the checkpoint is "ephemeral" (since in-memory), it should be
considered as temporary. A marker will be set indicating that a checkpoint is temporary.

[In the Trainable Class, the disk checkpoint is immediately deleted]. However,
in the Function API, temporary checkpoints will be removed
only upon termination of the trial. We cannot remove them any earlier because
the loading of checkpoints is non-deterministic.

If "save" is called on a trial whose most recent checkpoint
is temporary, "create_perm_checkpoint" will be called. This
copies the temporary checkpoint to a permanent checkpoint directory. However,
the temporary checkpoint will still exist and will be removed later.
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)