### PR TITLE
Implement closing stdin for graceful process termination

### DIFF
--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -215,7 +215,7 @@ class Node:
             self.kill_all_processes(check_alive=False, allow_graceful=True)
             sys.exit(1)
 
-        ray.utils.set_sigterm_handler(sigterm_handler)
+        ray.utils.set_sigterm_handler(sigterm_handler, False)
 
     def _init_temp(self, redis_client):
         # Create an dictionary to store temp file index.
@@ -797,7 +797,11 @@ class Node:
                    exit code.
         """
         process_infos = self.all_processes[process_type]
-        if process_type != ray_constants.PROCESS_TYPE_REDIS_SERVER:
+        if process_type == ray_constants.PROCESS_TYPE_REDIS_SERVER:
+            # TODO(mehrdadn): Do this on all platforms, not just Windows.
+            if sys.platform == "win32":
+                self.create_redis_client().shutdown()
+        else:
             assert len(process_infos) == 1
         for process_info in process_infos:
             process = process_info.process

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -22,6 +22,7 @@
 #include "ray/gcs/gcs_client/service_based_gcs_client.h"
 #include "ray/raylet/raylet.h"
 #include "ray/stats/stats.h"
+#include "ray/util/util.h"
 
 DEFINE_string(raylet_socket_name, "", "The socket name of raylet.");
 DEFINE_string(store_socket_name, "", "The socket name of object store.");
@@ -245,7 +246,8 @@ int main(int argc, char *argv[]) {
   };
   boost::asio::signal_set signals(main_service);
 #ifdef _WIN32
-  signals.add(SIGBREAK);
+  // TODO(mehrdadn): Do this on all platforms, not just Windows.
+  AwaitPipeClose(main_service, 0, handler, 1000 / 60);
 #else
   signals.add(SIGTERM);
 #endif

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -324,7 +324,8 @@ ray::Status NodeManager::RegisterGcs() {
 
 void NodeManager::KillWorker(std::shared_ptr<WorkerInterface> worker) {
 #ifdef _WIN32
-  // TODO(mehrdadn): implement graceful process termination mechanism
+  // TODO(mehrdadn): Do this on all platforms, not just Windows.
+  RAY_CHECK(worker->GetProcess().CloseStdIn());
 #else
   // If we're just cleaning up a single worker, allow it some time to clean
   // up its state before force killing. The client socket will be closed

--- a/src/ray/util/process.h
+++ b/src/ray/util/process.h
@@ -63,9 +63,13 @@ class Process {
                    bool decouple = false);
   /// Convenience function to run the given command line and wait for it to finish.
   static std::error_code Call(const std::vector<std::string> &args);
+  /// Closes the standard input pipe (if any) for the process.
+  /// \return True if the pipe was previously open, or false otherwise.
+  bool CloseStdIn();
   static Process CreateNewDummy();
   static Process FromPid(pid_t pid);
   pid_t GetId() const;
+  int GetStdIn() const;
   /// Returns an opaque pointer or handle to the underlying process object.
   /// Implementation detail, used only for identity testing. Do not dereference.
   const void *Get() const;

--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -14,7 +14,25 @@
 
 #pragma once
 
+namespace boost {
+
+namespace asio {
+
+class io_context;
+typedef io_context io_service;
+
+}  // namespace asio
+
+namespace system {
+
+class error_code;
+
+}  // namespace system
+
+}  // namespace boost
+
 #include <chrono>
+#include <functional>
 #include <iterator>
 #include <mutex>
 #include <random>
@@ -165,3 +183,14 @@ void FillRandom(T *data) {
     (*data)[i] = static_cast<uint8_t>(dist(generator));
   }
 }
+
+/// Waits for the read end of the given pipe to close.
+/// Intended for use on stdin, but only when stdin is a pipe (not a physical file).
+/// Note that the file descriptor may be swapped (e.g. via dup2()) during the wait.
+/// This is to ensure that data can continue to be piped to any existing readers.
+/// \param rfd The file descriptor for the read end of the pipe.
+/// \param poll_msec The polling period for platforms that cannot wait for closure.
+void AwaitPipeClose(boost::asio::io_service &io_service, int rfd,
+                    std::function<void(const boost::system::error_code &, int)> callback,
+                    long poll_msec);
+


### PR DESCRIPTION
## Why are these changes needed?

Uses stdin closure to signal process termination to children.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
