### PR TITLE
Ignore grep exit code for shellcheck in format.sh

### DIFF
--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -203,7 +203,7 @@ format_changed() {
         non_shell_files=($(git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- ':(exclude)*.sh'))
         shell_files=($(git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- '*.sh'))
         if [ 0 -lt "${#non_shell_files[@]}" ]; then
-            shell_files+=($(git --no-pager grep -l -- '^#!\(/usr\)\?/bin/\(env \+\)\?\(ba\)\?sh' "${non_shell_files[@]}"))
+            shell_files+=($(git --no-pager grep -l -- '^#!\(/usr\)\?/bin/\(env \+\)\?\(ba\)\?sh' "${non_shell_files[@]}" || true))
         fi
         if [ 0 -lt "${#shell_files[@]}" ]; then
             shellcheck_scripts "${shell_files[@]}"
@@ -221,7 +221,7 @@ format_all() {
     # shellcheck disable=SC2207
     shell_files=($(
       git -C "${ROOT}" ls-files --exclude-standard HEAD -- "*.sh" &&
-      git -C "${ROOT}" --no-pager grep -l '^#!\(/usr\)\?/bin/\(env \+\)\?\(ba\)\?sh' ":(exclude)*.sh"
+      { git -C "${ROOT}" --no-pager grep -l '^#!\(/usr\)\?/bin/\(env \+\)\?\(ba\)\?sh' ":(exclude)*.sh" || true; }
     ))
     if [ 0 -lt "${#shell_files[@]}" ]; then
       shellcheck_scripts "${shell_files[@]}"


### PR DESCRIPTION
## Why are these changes needed?

We attempt to detect shell scripts without file extensions in `format.sh`, but a failure to find any is not an actual failure in the code.

## Related issue number

#8574 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
