### PR TITLE
support of lack of private ssh keys

### DIFF
--- a/python/ray/autoscaler/command_runner.py
+++ b/python/ray/autoscaler/command_runner.py
@@ -441,6 +441,7 @@ class SSHCommandRunner(CommandRunnerInterface):
             return "ssh -o IdentitiesOnly=yes {}@{}\n".format(
                 self.ssh_user, self.ssh_ip)
 
+
 class DockerCommandRunner(SSHCommandRunner):
     def __init__(self, docker_config, **common_args):
         self.ssh_command_runner = SSHCommandRunner(**common_args)

--- a/python/ray/autoscaler/command_runner.py
+++ b/python/ray/autoscaler/command_runner.py
@@ -239,7 +239,8 @@ class SSHOptions:
 
     def to_ssh_options_list(self, *, timeout=60):
         self.arg_dict["ConnectTimeout"] = "{}s".format(timeout)
-        return ["-i", self.ssh_key] + [
+        ssh_key_option = ["-i", self.ssh_key] if self.ssh_key else []
+        return ssh_key_option + [
             x for y in (["-o", "{}={}".format(k, v)]
                         for k, v in self.arg_dict.items()
                         if v is not None) for x in y
@@ -261,7 +262,7 @@ class SSHCommandRunner(CommandRunnerInterface):
         self.node_id = node_id
         self.use_internal_ip = use_internal_ip
         self.provider = provider
-        self.ssh_private_key = auth_config["ssh_private_key"]
+        self.ssh_private_key = auth_config.get("ssh_private_key")
         self.ssh_user = auth_config["ssh_user"]
         self.ssh_control_path = ssh_control_path
         self.ssh_ip = None
@@ -433,9 +434,12 @@ class SSHCommandRunner(CommandRunnerInterface):
         self.process_runner.check_call(command)
 
     def remote_shell_command_str(self):
-        return "ssh -o IdentitiesOnly=yes -i {} {}@{}\n".format(
-            self.ssh_private_key, self.ssh_user, self.ssh_ip)
-
+        if self.ssh_private_key:
+            return "ssh -o IdentitiesOnly=yes -i {} {}@{}\n".format(
+                self.ssh_private_key, self.ssh_user, self.ssh_ip)
+        else:
+            return "ssh -o IdentitiesOnly=yes {}@{}\n".format(
+                self.ssh_user, self.ssh_ip)
 
 class DockerCommandRunner(SSHCommandRunner):
     def __init__(self, docker_config, **common_args):

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -558,7 +558,7 @@ def get_or_create_head_node(config, config_file, no_restart, restart_only, yes,
             # head node won't be able to connect to workers
             remote_config["auth"].pop("ssh_proxy_command", None)
 
-            if config["provider"]["type"] != "kubernetes":
+            if "ssh_private_key" in config["auth"]:
                 remote_key_path = "~/ray_bootstrap_key.pem"
                 remote_config["auth"]["ssh_private_key"] = remote_key_path
 
@@ -578,7 +578,7 @@ def get_or_create_head_node(config, config_file, no_restart, restart_only, yes,
                 "~/ray_bootstrap_config.yaml": remote_config_file.name
             })
 
-            if config["provider"]["type"] != "kubernetes":
+            if "ssh_private_key" in config["auth"]:
                 config["file_mounts"].update({
                     remote_key_path: config["auth"]["ssh_private_key"],
                 })

--- a/python/ray/autoscaler/local/example-full.yaml
+++ b/python/ray/autoscaler/local/example-full.yaml
@@ -42,7 +42,8 @@ provider:
 # How Ray will authenticate with newly launched nodes.
 auth:
     ssh_user: YOUR_USERNAME
-    ssh_private_key: ~/.ssh/id_rsa
+    # Optional if an ssh private key is necessary to ssh to the cluster.
+    # ssh_private_key: ~/.ssh/id_rsa
 
 # Leave this empty.
 head_node: {}


### PR DESCRIPTION
This PR removes the dependency on private ssh keys in the yaml.
If the node provider requires a private ssh key, the bootstrap config should make sure to add it. If it does not require a private ssh key then the bootstrap config does not add it and the autoscaler should be able to absorb that.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
