### PR TITLE
Create ~/.ssh if it doesn't already exist

### DIFF
--- a/python/ray/autoscaler/aws/config.py
+++ b/python/ray/autoscaler/aws/config.py
@@ -289,6 +289,11 @@ def _configure_key_pair(config):
 
     ec2 = _resource("ec2", config)
 
+    # Writing the new ssh key to the filesystem fails if the ~/.ssh
+    # directory doesn't already exist.
+    if not os.path.exists(os.path.expanduser("~/.ssh")):
+        os.makedirs(os.path.expanduser("~/.ssh"))
+
     # Try a few times to get or create a good key pair.
     MAX_NUM_KEYS = 30
     for i in range(MAX_NUM_KEYS):

--- a/python/ray/autoscaler/aws/config.py
+++ b/python/ray/autoscaler/aws/config.py
@@ -291,8 +291,7 @@ def _configure_key_pair(config):
 
     # Writing the new ssh key to the filesystem fails if the ~/.ssh
     # directory doesn't already exist.
-    if not os.path.exists(os.path.expanduser("~/.ssh")):
-        os.makedirs(os.path.expanduser("~/.ssh"))
+    os.makedirs(os.path.expanduser("~/.ssh"), exist_ok=True)
 
     # Try a few times to get or create a good key pair.
     MAX_NUM_KEYS = 30

--- a/python/ray/autoscaler/gcp/config.py
+++ b/python/ray/autoscaler/gcp/config.py
@@ -291,6 +291,11 @@ def _configure_key_pair(config, compute):
                 key_found = True
                 break
 
+        # Writing the new ssh key to the filesystem fails if the ~/.ssh
+        # directory doesn't already exist.
+        if not os.path.exists(os.path.expanduser("~/.ssh")):
+            os.makedirs(os.path.expanduser("~/.ssh"))
+
         # Create a key since it doesn't exist locally or in GCP
         if not key_found and not os.path.exists(private_key_path):
             logger.info("_configure_key_pair: "

--- a/python/ray/autoscaler/gcp/config.py
+++ b/python/ray/autoscaler/gcp/config.py
@@ -293,8 +293,7 @@ def _configure_key_pair(config, compute):
 
         # Writing the new ssh key to the filesystem fails if the ~/.ssh
         # directory doesn't already exist.
-        if not os.path.exists(os.path.expanduser("~/.ssh")):
-            os.makedirs(os.path.expanduser("~/.ssh"))
+        os.makedirs(os.path.expanduser("~/.ssh"), exist_ok=True)
 
         # Create a key since it doesn't exist locally or in GCP
         if not key_found and not os.path.exists(private_key_path):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

If the ~/.ssh folder doesn't already exist, then creating a new ssh key when starting up a gcp/aws cluster fails. We need to create it if it doesn't already exist.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
