### PR TITLE
Fix LINT for build-docker-images.sh

### DIFF
--- a/ci/travis/build-docker-images.sh
+++ b/ci/travis/build-docker-images.sh
@@ -11,7 +11,7 @@ DOCKER_USERNAME="raytravisbot"
 
 docker_push() {
     if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-        docker push $@
+        docker push "$@"
     else
         echo "Skipping docker push because it's in PR environment."
     fi
@@ -32,8 +32,8 @@ if [[ "$TRAVIS" == "true" ]]; then
     wheel="$(basename "$ROOT_DIR"/.whl/*cp37m-manylinux*)"
     commit_sha=$(echo "$TRAVIS_COMMIT" | head -c 6)
     cp -r "$ROOT_DIR"/.whl "$ROOT_DIR"/docker/ray/.whl
-    cp $ROOT_DIR/python/requirements.txt $ROOT_DIR/docker/autoscaler/requirements.txt
-    cp $ROOT_DIR/python/requirements_autoscaler.txt $ROOT_DIR/docker/autoscaler/requirements_autoscaler.txt
+    cp "$ROOT_DIR"/python/requirements.txt "$ROOT_DIR"/docker/autoscaler/requirements.txt
+    cp "$ROOT_DIR"/python/requirements_autoscaler.txt "$ROOT_DIR"/docker/autoscaler/requirements_autoscaler.txt
 
     docker build -t rayproject/base-deps docker/base-deps
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Lint is currently broken
```
$ shellcheck ./scripts/build-docker-images.sh

In ./scripts/build-docker-images.sh line 14:
        docker push $@
                    ^-- SC2068: Double quote array expansions to avoid re-splitting elements.


In ./scripts/build-docker-images.sh line 35:
    cp $ROOT_DIR/python/requirements.txt $ROOT_DIR/docker/autoscaler/requirements.txt
       ^-------^ SC2086: Double quote to prevent globbing and word splitting.
                                         ^-------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
    cp "$ROOT_DIR"/python/requirements.txt "$ROOT_DIR"/docker/autoscaler/requirements.txt


In ./scripts/build-docker-images.sh line 36:
    cp $ROOT_DIR/python/requirements_autoscaler.txt $ROOT_DIR/docker/autoscaler/requirements_autoscaler.txt
       ^-------^ SC2086: Double quote to prevent globbing and word splitting.
                                                    ^-------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
    cp "$ROOT_DIR"/python/requirements_autoscaler.txt "$ROOT_DIR"/docker/autoscaler/requirements_autoscaler.txt

For more information:
  https://www.shellcheck.net/wiki/SC2068 -- Double quote array expansions to ...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
<!-- Please give a short summary of the change and the problem this solves. -->
```
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
