### PR TITLE
c++ style: change sigils to the left instead of the right (automatically, via clang-format)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,4 +2,4 @@ BasedOnStyle: Google
 ColumnLimit: 90
 DerivePointerAlignment: false
 IndentCaseLabels: false
-PointerAlignment: Right
+PointerAlignment: Left

--- a/cpp/include/ray/api.h
+++ b/cpp/include/ray/api.h
@@ -1,13 +1,14 @@
 
 #pragma once
 
-#include <memory>
-
 #include <ray/api/generated/actor_funcs.generated.h>
 #include <ray/api/generated/create_funcs.generated.h>
 #include <ray/api/generated/funcs.generated.h>
 #include <ray/api/ray_runtime.h>
+
+#include <memory>
 #include <msgpack.hpp>
+
 #include "ray/core.h"
 namespace ray {
 namespace api {
@@ -228,13 +229,10 @@ inline ActorTaskCaller<ReturnType> Ray::CallActorInternal(FuncType &actor_func,
   return ActorTaskCaller<ReturnType>(runtime_, actor.ID(), ptr, buffer);
 }
 
-#include <ray/api/generated/exec_funcs.generated.h>
-
-#include <ray/api/generated/call_funcs_impl.generated.h>
-
-#include <ray/api/generated/create_actors_impl.generated.h>
-
 #include <ray/api/generated/call_actors_impl.generated.h>
+#include <ray/api/generated/call_funcs_impl.generated.h>
+#include <ray/api/generated/create_actors_impl.generated.h>
+#include <ray/api/generated/exec_funcs.generated.h>
 
 }  // namespace api
 }  // namespace ray

--- a/cpp/include/ray/api.h
+++ b/cpp/include/ray/api.h
@@ -38,7 +38,7 @@ class Ray {
   /// \param[in] obj The object which should be stored.
   /// \return ObjectRef A reference to the object in the object store.
   template <typename T>
-  static ObjectRef<T> Put(const T &obj);
+  static ObjectRef<T> Put(const T& obj);
 
   /// Get a list of objects from the object store.
   /// This method will be blocked until all the objects are ready.
@@ -46,7 +46,7 @@ class Ray {
   /// \param[in] ids The object id array which should be got.
   /// \return shared pointer array of the result.
   template <typename T>
-  static std::vector<std::shared_ptr<T>> Get(const std::vector<ObjectID> &ids);
+  static std::vector<std::shared_ptr<T>> Get(const std::vector<ObjectID>& ids);
 
   /// Get a list of objects from the object store.
   /// This method will be blocked until all the objects are ready.
@@ -54,7 +54,7 @@ class Ray {
   /// \param[in] objects The object array which should be got.
   /// \return shared pointer array of the result.
   template <typename T>
-  static std::vector<std::shared_ptr<T>> Get(const std::vector<ObjectRef<T>> &ids);
+  static std::vector<std::shared_ptr<T>> Get(const std::vector<ObjectRef<T>>& ids);
 
   /// Wait for a list of objects to be locally available,
   /// until specified number of objects are ready, or specified timeout has passed.
@@ -64,7 +64,7 @@ class Ray {
   /// \param[in] timeout_ms The maximum wait time in milliseconds.
   /// \return Two arrays, one containing locally available objects, one containing the
   /// rest.
-  static WaitResult Wait(const std::vector<ObjectID> &ids, int num_objects,
+  static WaitResult Wait(const std::vector<ObjectID>& ids, int num_objects,
                          int timeout_ms);
 
 /// Include the `Call` methods for calling remote functions.
@@ -74,31 +74,31 @@ class Ray {
 #include "api/generated/create_actors.generated.h"
 
  private:
-  static RayRuntime *runtime_;
+  static RayRuntime* runtime_;
 
   static std::once_flag is_inited_;
 
   /// Used by ObjectRef to implement .Get()
   template <typename T>
-  static std::shared_ptr<T> Get(const ObjectRef<T> &object);
+  static std::shared_ptr<T> Get(const ObjectRef<T>& object);
 
   template <typename ReturnType, typename FuncType, typename ExecFuncType,
             typename... ArgTypes>
-  static TaskCaller<ReturnType> TaskInternal(FuncType &func, ExecFuncType &exec_func,
-                                             ArgTypes &... args);
+  static TaskCaller<ReturnType> TaskInternal(FuncType& func, ExecFuncType& exec_func,
+                                             ArgTypes&... args);
 
   template <typename ActorType, typename FuncType, typename ExecFuncType,
             typename... ArgTypes>
-  static ActorCreator<ActorType> CreateActorInternal(FuncType &func,
-                                                     ExecFuncType &exec_func,
-                                                     ArgTypes &... args);
+  static ActorCreator<ActorType> CreateActorInternal(FuncType& func,
+                                                     ExecFuncType& exec_func,
+                                                     ArgTypes&... args);
 
   template <typename ReturnType, typename ActorType, typename FuncType,
             typename ExecFuncType, typename... ArgTypes>
-  static ActorTaskCaller<ReturnType> CallActorInternal(FuncType &actor_func,
-                                                       ExecFuncType &exec_func,
-                                                       ActorHandle<ActorType> &actor,
-                                                       ArgTypes &... args);
+  static ActorTaskCaller<ReturnType> CallActorInternal(FuncType& actor_func,
+                                                       ExecFuncType& exec_func,
+                                                       ActorHandle<ActorType>& actor,
+                                                       ArgTypes&... args);
 
 /// Include the `Call` methods for calling actor methods.
 /// Used by ActorHandle to implement .Call()
@@ -129,7 +129,7 @@ namespace api {
 
 template <typename T>
 inline static std::vector<ObjectID> ObjectRefsToObjectIDs(
-    const std::vector<ObjectRef<T>> &object_refs) {
+    const std::vector<ObjectRef<T>>& object_refs) {
   std::vector<ObjectID> object_ids;
   for (auto it = object_refs.begin(); it != object_refs.end(); it++) {
     object_ids.push_back(it->ID());
@@ -138,7 +138,7 @@ inline static std::vector<ObjectID> ObjectRefsToObjectIDs(
 }
 
 template <typename T>
-inline ObjectRef<T> Ray::Put(const T &obj) {
+inline ObjectRef<T> Ray::Put(const T& obj) {
   std::shared_ptr<msgpack::sbuffer> buffer(new msgpack::sbuffer());
   msgpack::packer<msgpack::sbuffer> packer(buffer.get());
   Serializer::Serialize(packer, obj);
@@ -147,7 +147,7 @@ inline ObjectRef<T> Ray::Put(const T &obj) {
 }
 
 template <typename T>
-inline std::shared_ptr<T> Ray::Get(const ObjectRef<T> &object) {
+inline std::shared_ptr<T> Ray::Get(const ObjectRef<T>& object) {
   auto packed_object = runtime_->Get(object.ID());
   msgpack::unpacker unpacker;
   unpacker.reserve_buffer(packed_object->size());
@@ -159,7 +159,7 @@ inline std::shared_ptr<T> Ray::Get(const ObjectRef<T> &object) {
 }
 
 template <typename T>
-inline std::vector<std::shared_ptr<T>> Ray::Get(const std::vector<ObjectID> &ids) {
+inline std::vector<std::shared_ptr<T>> Ray::Get(const std::vector<ObjectID>& ids) {
   auto result = runtime_->Get(ids);
   std::vector<std::shared_ptr<T>> return_objects;
   return_objects.reserve(result.size());
@@ -176,20 +176,20 @@ inline std::vector<std::shared_ptr<T>> Ray::Get(const std::vector<ObjectID> &ids
 }
 
 template <typename T>
-inline std::vector<std::shared_ptr<T>> Ray::Get(const std::vector<ObjectRef<T>> &ids) {
+inline std::vector<std::shared_ptr<T>> Ray::Get(const std::vector<ObjectRef<T>>& ids) {
   auto object_ids = ObjectRefsToObjectIDs<T>(ids);
   return Get<T>(object_ids);
 }
 
-inline WaitResult Ray::Wait(const std::vector<ObjectID> &ids, int num_objects,
+inline WaitResult Ray::Wait(const std::vector<ObjectID>& ids, int num_objects,
                             int timeout_ms) {
   return runtime_->Wait(ids, num_objects, timeout_ms);
 }
 
 template <typename ReturnType, typename FuncType, typename ExecFuncType,
           typename... ArgTypes>
-inline TaskCaller<ReturnType> Ray::TaskInternal(FuncType &func, ExecFuncType &exec_func,
-                                                ArgTypes &... args) {
+inline TaskCaller<ReturnType> Ray::TaskInternal(FuncType& func, ExecFuncType& exec_func,
+                                                ArgTypes&... args) {
   std::shared_ptr<msgpack::sbuffer> buffer(new msgpack::sbuffer());
   msgpack::packer<msgpack::sbuffer> packer(buffer.get());
   Arguments::WrapArgs(packer, args...);
@@ -201,9 +201,9 @@ inline TaskCaller<ReturnType> Ray::TaskInternal(FuncType &func, ExecFuncType &ex
 
 template <typename ActorType, typename FuncType, typename ExecFuncType,
           typename... ArgTypes>
-inline ActorCreator<ActorType> Ray::CreateActorInternal(FuncType &create_func,
-                                                        ExecFuncType &exec_func,
-                                                        ArgTypes &... args) {
+inline ActorCreator<ActorType> Ray::CreateActorInternal(FuncType& create_func,
+                                                        ExecFuncType& exec_func,
+                                                        ArgTypes&... args) {
   std::shared_ptr<msgpack::sbuffer> buffer(new msgpack::sbuffer());
   msgpack::packer<msgpack::sbuffer> packer(buffer.get());
   Arguments::WrapArgs(packer, args...);
@@ -215,15 +215,15 @@ inline ActorCreator<ActorType> Ray::CreateActorInternal(FuncType &create_func,
 
 template <typename ReturnType, typename ActorType, typename FuncType,
           typename ExecFuncType, typename... ArgTypes>
-inline ActorTaskCaller<ReturnType> Ray::CallActorInternal(FuncType &actor_func,
-                                                          ExecFuncType &exec_func,
-                                                          ActorHandle<ActorType> &actor,
-                                                          ArgTypes &... args) {
+inline ActorTaskCaller<ReturnType> Ray::CallActorInternal(FuncType& actor_func,
+                                                          ExecFuncType& exec_func,
+                                                          ActorHandle<ActorType>& actor,
+                                                          ArgTypes&... args) {
   std::shared_ptr<msgpack::sbuffer> buffer(new msgpack::sbuffer());
   msgpack::packer<msgpack::sbuffer> packer(buffer.get());
   Arguments::WrapArgs(packer, args...);
   RemoteFunctionPtrHolder ptr;
-  MemberFunctionPtrHolder holder = *(MemberFunctionPtrHolder *)(&actor_func);
+  MemberFunctionPtrHolder holder = *(MemberFunctionPtrHolder*)(&actor_func);
   ptr.function_pointer = reinterpret_cast<uintptr_t>(holder.value[0]);
   ptr.exec_function_pointer = reinterpret_cast<uintptr_t>(exec_func);
   return ActorTaskCaller<ReturnType>(runtime_, actor.ID(), ptr, buffer);

--- a/cpp/include/ray/api/actor_creator.h
+++ b/cpp/include/ray/api/actor_creator.h
@@ -11,13 +11,13 @@ class ActorCreator {
  public:
   ActorCreator();
 
-  ActorCreator(RayRuntime *runtime, RemoteFunctionPtrHolder ptr,
+  ActorCreator(RayRuntime* runtime, RemoteFunctionPtrHolder ptr,
                std::shared_ptr<msgpack::sbuffer> args);
 
   ActorHandle<ActorType> Remote();
 
  private:
-  RayRuntime *runtime_;
+  RayRuntime* runtime_;
   RemoteFunctionPtrHolder ptr_;
   std::shared_ptr<msgpack::sbuffer> args_;
 };
@@ -28,7 +28,7 @@ template <typename ActorType>
 ActorCreator<ActorType>::ActorCreator() {}
 
 template <typename ActorType>
-ActorCreator<ActorType>::ActorCreator(RayRuntime *runtime, RemoteFunctionPtrHolder ptr,
+ActorCreator<ActorType>::ActorCreator(RayRuntime* runtime, RemoteFunctionPtrHolder ptr,
                                       std::shared_ptr<msgpack::sbuffer> args)
     : runtime_(runtime), ptr_(ptr), args_(args) {}
 

--- a/cpp/include/ray/api/actor_handle.h
+++ b/cpp/include/ray/api/actor_handle.h
@@ -17,10 +17,10 @@ class ActorHandle {
  public:
   ActorHandle();
 
-  ActorHandle(const ActorID &id);
+  ActorHandle(const ActorID& id);
 
   /// Get a untyped ID of the actor
-  const ActorID &ID() const;
+  const ActorID& ID() const;
 
   /// Include the `Call` methods for calling remote functions.
 #include <ray/api/generated/actor_call.generated.h>
@@ -38,12 +38,12 @@ template <typename ActorType>
 ActorHandle<ActorType>::ActorHandle() {}
 
 template <typename ActorType>
-ActorHandle<ActorType>::ActorHandle(const ActorID &id) {
+ActorHandle<ActorType>::ActorHandle(const ActorID& id) {
   id_ = id;
 }
 
 template <typename ActorType>
-const ActorID &ActorHandle<ActorType>::ID() const {
+const ActorID& ActorHandle<ActorType>::ID() const {
   return id_;
 }
 

--- a/cpp/include/ray/api/actor_task_caller.h
+++ b/cpp/include/ray/api/actor_task_caller.h
@@ -11,13 +11,13 @@ class ActorTaskCaller {
  public:
   ActorTaskCaller();
 
-  ActorTaskCaller(RayRuntime *runtime, ActorID id, RemoteFunctionPtrHolder ptr,
+  ActorTaskCaller(RayRuntime* runtime, ActorID id, RemoteFunctionPtrHolder ptr,
                   std::shared_ptr<msgpack::sbuffer> args);
 
   ObjectRef<ReturnType> Remote();
 
  private:
-  RayRuntime *runtime_;
+  RayRuntime* runtime_;
   ActorID id_;
   RemoteFunctionPtrHolder ptr_;
   std::shared_ptr<msgpack::sbuffer> args_;
@@ -29,7 +29,7 @@ template <typename ReturnType>
 ActorTaskCaller<ReturnType>::ActorTaskCaller() {}
 
 template <typename ReturnType>
-ActorTaskCaller<ReturnType>::ActorTaskCaller(RayRuntime *runtime, ActorID id,
+ActorTaskCaller<ReturnType>::ActorTaskCaller(RayRuntime* runtime, ActorID id,
                                              RemoteFunctionPtrHolder ptr,
                                              std::shared_ptr<msgpack::sbuffer> args)
     : runtime_(runtime), id_(id), ptr_(ptr), args_(args) {}

--- a/cpp/include/ray/api/arguments.h
+++ b/cpp/include/ray/api/arguments.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <ray/api/serializer.h>
+
 #include <msgpack.hpp>
 
 namespace ray {

--- a/cpp/include/ray/api/arguments.h
+++ b/cpp/include/ray/api/arguments.h
@@ -10,33 +10,33 @@ namespace api {
 
 class Arguments {
  public:
-  static void WrapArgs(msgpack::packer<msgpack::sbuffer> &packer);
+  static void WrapArgs(msgpack::packer<msgpack::sbuffer>& packer);
 
   template <typename Arg1Type>
-  static void WrapArgs(msgpack::packer<msgpack::sbuffer> &packer, Arg1Type &arg1);
+  static void WrapArgs(msgpack::packer<msgpack::sbuffer>& packer, Arg1Type& arg1);
 
   template <typename Arg1Type, typename... OtherArgTypes>
-  static void WrapArgs(msgpack::packer<msgpack::sbuffer> &packer, Arg1Type &arg1,
-                       OtherArgTypes &... args);
+  static void WrapArgs(msgpack::packer<msgpack::sbuffer>& packer, Arg1Type& arg1,
+                       OtherArgTypes&... args);
 
-  static void UnwrapArgs(msgpack::unpacker &unpacker);
+  static void UnwrapArgs(msgpack::unpacker& unpacker);
 
   template <typename Arg1Type>
-  static void UnwrapArgs(msgpack::unpacker &unpacker, std::shared_ptr<Arg1Type> *arg1);
+  static void UnwrapArgs(msgpack::unpacker& unpacker, std::shared_ptr<Arg1Type>* arg1);
 
   template <typename Arg1Type, typename... OtherArgTypes>
-  static void UnwrapArgs(msgpack::unpacker &unpacker, std::shared_ptr<Arg1Type> *arg1,
-                         std::shared_ptr<OtherArgTypes> *... args);
+  static void UnwrapArgs(msgpack::unpacker& unpacker, std::shared_ptr<Arg1Type>* arg1,
+                         std::shared_ptr<OtherArgTypes>*... args);
 };
 
 // --------- inline implementation ------------
 #include <typeinfo>
 
-inline void Arguments::WrapArgs(msgpack::packer<msgpack::sbuffer> &packer) {}
+inline void Arguments::WrapArgs(msgpack::packer<msgpack::sbuffer>& packer) {}
 
 template <typename Arg1Type>
-inline void Arguments::WrapArgs(msgpack::packer<msgpack::sbuffer> &packer,
-                                Arg1Type &arg1) {
+inline void Arguments::WrapArgs(msgpack::packer<msgpack::sbuffer>& packer,
+                                Arg1Type& arg1) {
   /// Notice ObjectRefClassPrefix should be modified by ObjectRef class name or namespace.
   static const std::string ObjectRefClassPrefix = "N3ray3api9ObjectRef";
   std::string type_name = typeid(arg1).name();
@@ -51,17 +51,17 @@ inline void Arguments::WrapArgs(msgpack::packer<msgpack::sbuffer> &packer,
 }
 
 template <typename Arg1Type, typename... OtherArgTypes>
-inline void Arguments::WrapArgs(msgpack::packer<msgpack::sbuffer> &packer, Arg1Type &arg1,
-                                OtherArgTypes &... args) {
+inline void Arguments::WrapArgs(msgpack::packer<msgpack::sbuffer>& packer, Arg1Type& arg1,
+                                OtherArgTypes&... args) {
   WrapArgs(packer, arg1);
   WrapArgs(packer, args...);
 }
 
-inline void Arguments::UnwrapArgs(msgpack::unpacker &unpacker) {}
+inline void Arguments::UnwrapArgs(msgpack::unpacker& unpacker) {}
 
 template <typename Arg1Type>
-inline void Arguments::UnwrapArgs(msgpack::unpacker &unpacker,
-                                  std::shared_ptr<Arg1Type> *arg1) {
+inline void Arguments::UnwrapArgs(msgpack::unpacker& unpacker,
+                                  std::shared_ptr<Arg1Type>* arg1) {
   bool is_object_ref;
   Serializer::Deserialize(unpacker, &is_object_ref);
   if (is_object_ref) {
@@ -74,9 +74,9 @@ inline void Arguments::UnwrapArgs(msgpack::unpacker &unpacker,
 }
 
 template <typename Arg1Type, typename... OtherArgTypes>
-inline void Arguments::UnwrapArgs(msgpack::unpacker &unpacker,
-                                  std::shared_ptr<Arg1Type> *arg1,
-                                  std::shared_ptr<OtherArgTypes> *... args) {
+inline void Arguments::UnwrapArgs(msgpack::unpacker& unpacker,
+                                  std::shared_ptr<Arg1Type>* arg1,
+                                  std::shared_ptr<OtherArgTypes>*... args) {
   UnwrapArgs(unpacker, arg1);
   UnwrapArgs(unpacker, args...);
 }

--- a/cpp/include/ray/api/generated/actor_call.generated.h
+++ b/cpp/include/ray/api/generated/actor_call.generated.h
@@ -17,7 +17,7 @@ ActorTaskCaller<ReturnType> Task(ActorFunc1<ActorType, ReturnType, Arg1Type> act
 
 template <typename ReturnType, typename Arg1Type>
 ActorTaskCaller<ReturnType> Task(ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func,
-                                 ObjectRef<Arg1Type> &arg1);
+                                 ObjectRef<Arg1Type>& arg1);
 
 // 2 args
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
@@ -28,14 +28,14 @@ ActorTaskCaller<ReturnType> Task(
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
 ActorTaskCaller<ReturnType> Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    ObjectRef<Arg1Type> &arg1, Arg2Type arg2);
+    ObjectRef<Arg1Type>& arg1, Arg2Type arg2);
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
 ActorTaskCaller<ReturnType> Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func, Arg1Type arg1,
-    ObjectRef<Arg2Type> &arg2);
+    ObjectRef<Arg2Type>& arg2);
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
 ActorTaskCaller<ReturnType> Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    ObjectRef<Arg1Type> &arg1, ObjectRef<Arg2Type> &arg2);
+    ObjectRef<Arg1Type>& arg1, ObjectRef<Arg2Type>& arg2);

--- a/cpp/include/ray/api/generated/actor_call_impl.generated.h
+++ b/cpp/include/ray/api/generated/actor_call_impl.generated.h
@@ -19,7 +19,7 @@ ActorTaskCaller<ReturnType> ActorHandle<ActorType>::Task(
 template <typename ActorType>
 template <typename ReturnType, typename Arg1Type>
 ActorTaskCaller<ReturnType> ActorHandle<ActorType>::Task(
-    ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func, ObjectRef<Arg1Type> &arg1) {
+    ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func, ObjectRef<Arg1Type>& arg1) {
   return Ray::Task(actor_func, *this, arg1);
 }
 
@@ -36,7 +36,7 @@ template <typename ActorType>
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
 ActorTaskCaller<ReturnType> ActorHandle<ActorType>::Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    ObjectRef<Arg1Type> &arg1, Arg2Type arg2) {
+    ObjectRef<Arg1Type>& arg1, Arg2Type arg2) {
   return Ray::Task(actor_func, *this, arg1, arg2);
 }
 
@@ -44,7 +44,7 @@ template <typename ActorType>
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
 ActorTaskCaller<ReturnType> ActorHandle<ActorType>::Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func, Arg1Type arg1,
-    ObjectRef<Arg2Type> &arg2) {
+    ObjectRef<Arg2Type>& arg2) {
   return Ray::Task(actor_func, *this, arg1, arg2);
 }
 
@@ -52,6 +52,6 @@ template <typename ActorType>
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
 ActorTaskCaller<ReturnType> ActorHandle<ActorType>::Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    ObjectRef<Arg1Type> &arg1, ObjectRef<Arg2Type> &arg2) {
+    ObjectRef<Arg1Type>& arg1, ObjectRef<Arg2Type>& arg2) {
   return Ray::Task(actor_func, *this, arg1, arg2);
 }

--- a/cpp/include/ray/api/generated/call_actors.generated.h
+++ b/cpp/include/ray/api/generated/call_actors.generated.h
@@ -5,36 +5,36 @@
 // 0 args
 template <typename ReturnType, typename ActorType>
 static ActorTaskCaller<ReturnType> Task(ActorFunc0<ActorType, ReturnType> actor_func,
-                                        ActorHandle<ActorType> &actor);
+                                        ActorHandle<ActorType>& actor);
 
 // 1 arg
 template <typename ReturnType, typename ActorType, typename Arg1Type>
 static ActorTaskCaller<ReturnType> Task(
-    ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func, ActorHandle<ActorType> &actor,
+    ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func, ActorHandle<ActorType>& actor,
     Arg1Type arg1);
 
 template <typename ReturnType, typename ActorType, typename Arg1Type>
 static ActorTaskCaller<ReturnType> Task(
-    ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func, ActorHandle<ActorType> &actor,
-    ObjectRef<Arg1Type> &arg1);
+    ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func, ActorHandle<ActorType>& actor,
+    ObjectRef<Arg1Type>& arg1);
 
 // 2 args
 template <typename ReturnType, typename ActorType, typename Arg1Type, typename Arg2Type>
 static ActorTaskCaller<ReturnType> Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    ActorHandle<ActorType> &actor, Arg1Type arg1, Arg2Type arg2);
+    ActorHandle<ActorType>& actor, Arg1Type arg1, Arg2Type arg2);
 
 template <typename ReturnType, typename ActorType, typename Arg1Type, typename Arg2Type>
 static ActorTaskCaller<ReturnType> Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    ActorHandle<ActorType> &actor, ObjectRef<Arg1Type> &arg1, Arg2Type arg2);
+    ActorHandle<ActorType>& actor, ObjectRef<Arg1Type>& arg1, Arg2Type arg2);
 
 template <typename ReturnType, typename ActorType, typename Arg1Type, typename Arg2Type>
 static ActorTaskCaller<ReturnType> Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    ActorHandle<ActorType> &actor, Arg1Type arg1, ObjectRef<Arg2Type> &arg2);
+    ActorHandle<ActorType>& actor, Arg1Type arg1, ObjectRef<Arg2Type>& arg2);
 
 template <typename ReturnType, typename ActorType, typename Arg1Type, typename Arg2Type>
 static ActorTaskCaller<ReturnType> Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    ActorHandle<ActorType> &actor, ObjectRef<Arg1Type> &arg1, ObjectRef<Arg2Type> &arg2);
+    ActorHandle<ActorType>& actor, ObjectRef<Arg1Type>& arg1, ObjectRef<Arg2Type>& arg2);

--- a/cpp/include/ray/api/generated/call_actors_impl.generated.h
+++ b/cpp/include/ray/api/generated/call_actors_impl.generated.h
@@ -2,7 +2,7 @@
 // 0 args
 template <typename ReturnType, typename ActorType>
 ActorTaskCaller<ReturnType> Ray::Task(ActorFunc0<ActorType, ReturnType> actor_func,
-                                      ActorHandle<ActorType> &actor) {
+                                      ActorHandle<ActorType>& actor) {
   return CallActorInternal<ReturnType, ActorType>(
       actor_func, ActorExecFunction<ReturnType, ActorType>, actor);
 }
@@ -10,7 +10,7 @@ ActorTaskCaller<ReturnType> Ray::Task(ActorFunc0<ActorType, ReturnType> actor_fu
 // 1 arg
 template <typename ReturnType, typename ActorType, typename Arg1Type>
 ActorTaskCaller<ReturnType> Ray::Task(
-    ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func, ActorHandle<ActorType> &actor,
+    ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func, ActorHandle<ActorType>& actor,
     Arg1Type arg1) {
   return CallActorInternal<ReturnType, ActorType>(
       actor_func, ActorExecFunction<ReturnType, ActorType, Arg1Type>, actor, arg1);
@@ -18,8 +18,8 @@ ActorTaskCaller<ReturnType> Ray::Task(
 
 template <typename ReturnType, typename ActorType, typename Arg1Type>
 ActorTaskCaller<ReturnType> Ray::Task(
-    ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func, ActorHandle<ActorType> &actor,
-    ObjectRef<Arg1Type> &arg1) {
+    ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func, ActorHandle<ActorType>& actor,
+    ObjectRef<Arg1Type>& arg1) {
   return CallActorInternal<ReturnType, ActorType>(
       actor_func, ActorExecFunction<ReturnType, ActorType, Arg1Type>, actor, arg1);
 }
@@ -28,7 +28,7 @@ ActorTaskCaller<ReturnType> Ray::Task(
 template <typename ReturnType, typename ActorType, typename Arg1Type, typename Arg2Type>
 ActorTaskCaller<ReturnType> Ray::Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    ActorHandle<ActorType> &actor, Arg1Type arg1, Arg2Type arg2) {
+    ActorHandle<ActorType>& actor, Arg1Type arg1, Arg2Type arg2) {
   return CallActorInternal<ReturnType, ActorType>(
       actor_func, ActorExecFunction<ReturnType, ActorType, Arg1Type, Arg2Type>, actor,
       arg1, arg2);
@@ -37,7 +37,7 @@ ActorTaskCaller<ReturnType> Ray::Task(
 template <typename ReturnType, typename ActorType, typename Arg1Type, typename Arg2Type>
 ActorTaskCaller<ReturnType> Ray::Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    ActorHandle<ActorType> &actor, ObjectRef<Arg1Type> &arg1, Arg2Type arg2) {
+    ActorHandle<ActorType>& actor, ObjectRef<Arg1Type>& arg1, Arg2Type arg2) {
   return CallActorInternal<ReturnType, ActorType>(
       actor_func, ActorExecFunction<ReturnType, ActorType, Arg1Type, Arg2Type>, actor,
       arg1, arg2);
@@ -46,7 +46,7 @@ ActorTaskCaller<ReturnType> Ray::Task(
 template <typename ReturnType, typename ActorType, typename Arg1Type, typename Arg2Type>
 ActorTaskCaller<ReturnType> Ray::Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    ActorHandle<ActorType> &actor, Arg1Type arg1, ObjectRef<Arg2Type> &arg2) {
+    ActorHandle<ActorType>& actor, Arg1Type arg1, ObjectRef<Arg2Type>& arg2) {
   return CallActorInternal<ReturnType, ActorType>(
       actor_func, ActorExecFunction<ReturnType, ActorType, Arg1Type, Arg2Type>, actor,
       arg1, arg2);
@@ -55,7 +55,7 @@ ActorTaskCaller<ReturnType> Ray::Task(
 template <typename ReturnType, typename ActorType, typename Arg1Type, typename Arg2Type>
 ActorTaskCaller<ReturnType> Ray::Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    ActorHandle<ActorType> &actor, ObjectRef<Arg1Type> &arg1, ObjectRef<Arg2Type> &arg2) {
+    ActorHandle<ActorType>& actor, ObjectRef<Arg1Type>& arg1, ObjectRef<Arg2Type>& arg2) {
   return CallActorInternal<ReturnType, ActorType>(
       actor_func, ActorExecFunction<ReturnType, ActorType, Arg1Type, Arg2Type>, actor,
       arg1, arg2);

--- a/cpp/include/ray/api/generated/call_funcs.generated.h
+++ b/cpp/include/ray/api/generated/call_funcs.generated.h
@@ -17,7 +17,7 @@ static TaskCaller<ReturnType> Task(Func1<ReturnType, Arg1Type> func, Arg1Type ar
 
 template <typename ReturnType, typename Arg1Type>
 static TaskCaller<ReturnType> Task(Func1<ReturnType, Arg1Type> func,
-                                   ObjectRef<Arg1Type> &arg1);
+                                   ObjectRef<Arg1Type>& arg1);
 
 // 2 args
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
@@ -26,12 +26,12 @@ static TaskCaller<ReturnType> Task(Func2<ReturnType, Arg1Type, Arg2Type> func,
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
 static TaskCaller<ReturnType> Task(Func2<ReturnType, Arg1Type, Arg2Type> func,
-                                   ObjectRef<Arg1Type> &arg1, Arg2Type arg2);
+                                   ObjectRef<Arg1Type>& arg1, Arg2Type arg2);
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
 static TaskCaller<ReturnType> Task(Func2<ReturnType, Arg1Type, Arg2Type> func,
-                                   Arg1Type arg1, ObjectRef<Arg2Type> &arg2);
+                                   Arg1Type arg1, ObjectRef<Arg2Type>& arg2);
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
 static TaskCaller<ReturnType> Task(Func2<ReturnType, Arg1Type, Arg2Type> func,
-                                   ObjectRef<Arg1Type> &arg1, ObjectRef<Arg2Type> &arg2);
+                                   ObjectRef<Arg1Type>& arg1, ObjectRef<Arg2Type>& arg2);

--- a/cpp/include/ray/api/generated/call_funcs_impl.generated.h
+++ b/cpp/include/ray/api/generated/call_funcs_impl.generated.h
@@ -14,7 +14,7 @@ TaskCaller<ReturnType> Ray::Task(Func1<ReturnType, Arg1Type> func, Arg1Type arg1
 
 template <typename ReturnType, typename Arg1Type>
 TaskCaller<ReturnType> Ray::Task(Func1<ReturnType, Arg1Type> func,
-                                 ObjectRef<Arg1Type> &arg1) {
+                                 ObjectRef<Arg1Type>& arg1) {
   return TaskInternal<ReturnType>(func, NormalExecFunction<ReturnType, Arg1Type>, arg1);
 }
 
@@ -28,21 +28,21 @@ TaskCaller<ReturnType> Ray::Task(Func2<ReturnType, Arg1Type, Arg2Type> func,
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
 TaskCaller<ReturnType> Ray::Task(Func2<ReturnType, Arg1Type, Arg2Type> func,
-                                 ObjectRef<Arg1Type> &arg1, Arg2Type arg2) {
+                                 ObjectRef<Arg1Type>& arg1, Arg2Type arg2) {
   return TaskInternal<ReturnType>(
       func, NormalExecFunction<ReturnType, Arg1Type, Arg2Type>, arg1, arg2);
 }
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
 TaskCaller<ReturnType> Ray::Task(Func2<ReturnType, Arg1Type, Arg2Type> func,
-                                 Arg1Type arg1, ObjectRef<Arg2Type> &arg2) {
+                                 Arg1Type arg1, ObjectRef<Arg2Type>& arg2) {
   return TaskInternal<ReturnType>(
       func, NormalExecFunction<ReturnType, Arg1Type, Arg2Type>, arg1, arg2);
 }
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
 TaskCaller<ReturnType> Ray::Task(Func2<ReturnType, Arg1Type, Arg2Type> func,
-                                 ObjectRef<Arg1Type> &arg1, ObjectRef<Arg2Type> &arg2) {
+                                 ObjectRef<Arg1Type>& arg1, ObjectRef<Arg2Type>& arg2) {
   return TaskInternal<ReturnType>(
       func, NormalExecFunction<ReturnType, Arg1Type, Arg2Type>, arg1, arg2);
 }

--- a/cpp/include/ray/api/generated/create_actors.generated.h
+++ b/cpp/include/ray/api/generated/create_actors.generated.h
@@ -18,7 +18,7 @@ static ActorCreator<ActorType> Actor(CreateActorFunc1<ActorType, Arg1Type> creat
 
 template <typename ActorType, typename Arg1Type>
 static ActorCreator<ActorType> Actor(CreateActorFunc1<ActorType, Arg1Type> create_func,
-                                     ObjectRef<Arg1Type> &arg1);
+                                     ObjectRef<Arg1Type>& arg1);
 
 // 2 args
 template <typename ActorType, typename Arg1Type, typename Arg2Type>
@@ -29,14 +29,14 @@ static ActorCreator<ActorType> Actor(
 template <typename ActorType, typename Arg1Type, typename Arg2Type>
 static ActorCreator<ActorType> Actor(
     CreateActorFunc2<ActorType, Arg1Type, Arg2Type> create_func,
-    ObjectRef<Arg1Type> &arg1, Arg2Type arg2);
+    ObjectRef<Arg1Type>& arg1, Arg2Type arg2);
 
 template <typename ActorType, typename Arg1Type, typename Arg2Type>
 static ActorCreator<ActorType> Actor(
     CreateActorFunc2<ActorType, Arg1Type, Arg2Type> create_func, Arg1Type arg1,
-    ObjectRef<Arg2Type> &arg2);
+    ObjectRef<Arg2Type>& arg2);
 
 template <typename ActorType, typename Arg1Type, typename Arg2Type>
 static ActorCreator<ActorType> Actor(
     CreateActorFunc2<ActorType, Arg1Type, Arg2Type> create_func,
-    ObjectRef<Arg1Type> &arg1, ObjectRef<Arg2Type> &arg2);
+    ObjectRef<Arg1Type>& arg1, ObjectRef<Arg2Type>& arg2);

--- a/cpp/include/ray/api/generated/create_actors_impl.generated.h
+++ b/cpp/include/ray/api/generated/create_actors_impl.generated.h
@@ -3,8 +3,7 @@
 // 0 args
 template <typename ActorType>
 ActorCreator<ActorType> Ray::Actor(CreateActorFunc0<ActorType> create_func) {
-  return CreateActorInternal<ActorType>(create_func,
-                                        CreateActorExecFunction<ActorType *>);
+  return CreateActorInternal<ActorType>(create_func, CreateActorExecFunction<ActorType*>);
 }
 
 // 1 arg
@@ -12,14 +11,14 @@ template <typename ActorType, typename Arg1Type>
 ActorCreator<ActorType> Ray::Actor(CreateActorFunc1<ActorType, Arg1Type> create_func,
                                    Arg1Type arg1) {
   return CreateActorInternal<ActorType>(
-      create_func, CreateActorExecFunction<ActorType *, Arg1Type>, arg1);
+      create_func, CreateActorExecFunction<ActorType*, Arg1Type>, arg1);
 }
 
 template <typename ActorType, typename Arg1Type>
 ActorCreator<ActorType> Ray::Actor(CreateActorFunc1<ActorType, Arg1Type> create_func,
-                                   ObjectRef<Arg1Type> &arg1) {
+                                   ObjectRef<Arg1Type>& arg1) {
   return CreateActorInternal<ActorType>(
-      create_func, CreateActorExecFunction<ActorType *, Arg1Type>, arg1);
+      create_func, CreateActorExecFunction<ActorType*, Arg1Type>, arg1);
 }
 
 // 2 args
@@ -28,29 +27,29 @@ ActorCreator<ActorType> Ray::Actor(
     CreateActorFunc2<ActorType, Arg1Type, Arg2Type> create_func, Arg1Type arg1,
     Arg2Type arg2) {
   return CreateActorInternal<ActorType>(
-      create_func, CreateActorExecFunction<ActorType *, Arg1Type, Arg2Type>, arg1, arg2);
+      create_func, CreateActorExecFunction<ActorType*, Arg1Type, Arg2Type>, arg1, arg2);
 }
 
 template <typename ActorType, typename Arg1Type, typename Arg2Type>
 ActorCreator<ActorType> Ray::Actor(
     CreateActorFunc2<ActorType, Arg1Type, Arg2Type> create_func,
-    ObjectRef<Arg1Type> &arg1, Arg2Type arg2) {
+    ObjectRef<Arg1Type>& arg1, Arg2Type arg2) {
   return CreateActorInternal<ActorType>(
-      create_func, CreateActorExecFunction<ActorType *, Arg1Type, Arg2Type>, arg1, arg2);
+      create_func, CreateActorExecFunction<ActorType*, Arg1Type, Arg2Type>, arg1, arg2);
 }
 
 template <typename ActorType, typename Arg1Type, typename Arg2Type>
 ActorCreator<ActorType> Ray::Actor(
     CreateActorFunc2<ActorType, Arg1Type, Arg2Type> create_func, Arg1Type arg1,
-    ObjectRef<Arg2Type> &arg2) {
+    ObjectRef<Arg2Type>& arg2) {
   return CreateActorInternal<ActorType>(
-      create_func, CreateActorExecFunction<ActorType *, Arg1Type, Arg2Type>, arg1, arg2);
+      create_func, CreateActorExecFunction<ActorType*, Arg1Type, Arg2Type>, arg1, arg2);
 }
 
 template <typename ActorType, typename Arg1Type, typename Arg2Type>
 ActorCreator<ActorType> Ray::Actor(
     CreateActorFunc2<ActorType, Arg1Type, Arg2Type> create_func,
-    ObjectRef<Arg1Type> &arg1, ObjectRef<Arg2Type> &arg2) {
+    ObjectRef<Arg1Type>& arg1, ObjectRef<Arg2Type>& arg2) {
   return CreateActorInternal<ActorType>(
-      create_func, CreateActorExecFunction<ActorType *, Arg1Type, Arg2Type>, arg1, arg2);
+      create_func, CreateActorExecFunction<ActorType*, Arg1Type, Arg2Type>, arg1, arg2);
 }

--- a/cpp/include/ray/api/generated/create_funcs.generated.h
+++ b/cpp/include/ray/api/generated/create_funcs.generated.h
@@ -3,12 +3,12 @@
 
 // 0 args
 template <typename ReturnType>
-using CreateActorFunc0 = ReturnType *(*)();
+using CreateActorFunc0 = ReturnType* (*)();
 
 // 1 arg
 template <typename ReturnType, typename Arg1Type>
-using CreateActorFunc1 = ReturnType *(*)(Arg1Type);
+using CreateActorFunc1 = ReturnType* (*)(Arg1Type);
 
 // 2 args
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-using CreateActorFunc2 = ReturnType *(*)(Arg1Type, Arg2Type);
+using CreateActorFunc2 = ReturnType* (*)(Arg1Type, Arg2Type);

--- a/cpp/include/ray/api/generated/exec_funcs.generated.h
+++ b/cpp/include/ray/api/generated/exec_funcs.generated.h
@@ -10,8 +10,8 @@
 template <typename ReturnType, typename CastReturnType, typename... OtherArgTypes>
 std::shared_ptr<msgpack::sbuffer> ExecuteNormalFunction(
     uintptr_t base_addr, size_t func_offset,
-    std::shared_ptr<msgpack::sbuffer> &args_buffer, TaskType task_type,
-    std::shared_ptr<OtherArgTypes> &... args) {
+    std::shared_ptr<msgpack::sbuffer>& args_buffer, TaskType task_type,
+    std::shared_ptr<OtherArgTypes>&... args) {
   msgpack::unpacker unpacker;
   unpacker.reserve_buffer(args_buffer->size());
   memcpy(unpacker.buffer(), args_buffer->data(), args_buffer->size());
@@ -33,16 +33,16 @@ std::shared_ptr<msgpack::sbuffer> ExecuteNormalFunction(
 template <typename ReturnType, typename ActorType, typename... OtherArgTypes>
 std::shared_ptr<msgpack::sbuffer> ExecuteActorFunction(
     uintptr_t base_addr, size_t func_offset,
-    std::shared_ptr<msgpack::sbuffer> &args_buffer,
-    std::shared_ptr<msgpack::sbuffer> &actor_buffer,
-    std::shared_ptr<OtherArgTypes> &... args) {
+    std::shared_ptr<msgpack::sbuffer>& args_buffer,
+    std::shared_ptr<msgpack::sbuffer>& actor_buffer,
+    std::shared_ptr<OtherArgTypes>&... args) {
   msgpack::unpacker actor_unpacker;
   actor_unpacker.reserve_buffer(actor_buffer->size());
   memcpy(actor_unpacker.buffer(), actor_buffer->data(), actor_buffer->size());
   actor_unpacker.buffer_consumed(actor_buffer->size());
   uintptr_t actor_ptr;
   Serializer::Deserialize(actor_unpacker, &actor_ptr);
-  ActorType *actor_object = (ActorType *)actor_ptr;
+  ActorType* actor_object = (ActorType*)actor_ptr;
 
   msgpack::unpacker unpacker;
   unpacker.reserve_buffer(args_buffer->size());
@@ -55,7 +55,7 @@ std::shared_ptr<msgpack::sbuffer> ExecuteActorFunction(
   MemberFunctionPtrHolder holder;
   holder.value[0] = base_addr + func_offset;
   holder.value[1] = 0;
-  Func func = *((Func *)&holder);
+  Func func = *((Func*)&holder);
   return_value = (actor_object->*func)(*args...);
 
   std::shared_ptr<msgpack::sbuffer> returnBuffer(new msgpack::sbuffer());
@@ -68,7 +68,7 @@ std::shared_ptr<msgpack::sbuffer> ExecuteActorFunction(
 template <typename ReturnType>
 std::shared_ptr<msgpack::sbuffer> NormalExecFunction(
     uintptr_t base_addr, size_t func_offset,
-    std::shared_ptr<msgpack::sbuffer> &args_buffer) {
+    std::shared_ptr<msgpack::sbuffer>& args_buffer) {
   return ExecuteNormalFunction<ReturnType, ReturnType>(
       base_addr, func_offset, args_buffer, TaskType::NORMAL_TASK);
 }
@@ -77,7 +77,7 @@ std::shared_ptr<msgpack::sbuffer> NormalExecFunction(
 template <typename ReturnType, typename Arg1Type>
 std::shared_ptr<msgpack::sbuffer> NormalExecFunction(
     uintptr_t base_addr, size_t func_offset,
-    std::shared_ptr<msgpack::sbuffer> &args_buffer) {
+    std::shared_ptr<msgpack::sbuffer>& args_buffer) {
   std::shared_ptr<Arg1Type> arg1_ptr;
   return ExecuteNormalFunction<ReturnType, ReturnType>(
       base_addr, func_offset, args_buffer, TaskType::NORMAL_TASK, arg1_ptr);
@@ -87,7 +87,7 @@ std::shared_ptr<msgpack::sbuffer> NormalExecFunction(
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
 std::shared_ptr<msgpack::sbuffer> NormalExecFunction(
     uintptr_t base_addr, size_t func_offset,
-    std::shared_ptr<msgpack::sbuffer> &args_buffer) {
+    std::shared_ptr<msgpack::sbuffer>& args_buffer) {
   std::shared_ptr<Arg1Type> arg1_ptr;
   std::shared_ptr<Arg2Type> arg2_ptr;
   return ExecuteNormalFunction<ReturnType, ReturnType>(
@@ -98,7 +98,7 @@ std::shared_ptr<msgpack::sbuffer> NormalExecFunction(
 template <typename ReturnType>
 std::shared_ptr<msgpack::sbuffer> CreateActorExecFunction(
     uintptr_t base_addr, size_t func_offset,
-    std::shared_ptr<msgpack::sbuffer> &args_buffer) {
+    std::shared_ptr<msgpack::sbuffer>& args_buffer) {
   return ExecuteNormalFunction<ReturnType, uintptr_t>(base_addr, func_offset, args_buffer,
                                                       TaskType::ACTOR_CREATION_TASK);
 }
@@ -107,7 +107,7 @@ std::shared_ptr<msgpack::sbuffer> CreateActorExecFunction(
 template <typename ReturnType, typename Arg1Type>
 std::shared_ptr<msgpack::sbuffer> CreateActorExecFunction(
     uintptr_t base_addr, size_t func_offset,
-    std::shared_ptr<msgpack::sbuffer> &args_buffer) {
+    std::shared_ptr<msgpack::sbuffer>& args_buffer) {
   std::shared_ptr<Arg1Type> arg1_ptr;
   return ExecuteNormalFunction<ReturnType, uintptr_t>(
       base_addr, func_offset, args_buffer, TaskType::ACTOR_CREATION_TASK, arg1_ptr);
@@ -117,7 +117,7 @@ std::shared_ptr<msgpack::sbuffer> CreateActorExecFunction(
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
 std::shared_ptr<msgpack::sbuffer> CreateActorExecFunction(
     uintptr_t base_addr, size_t func_offset,
-    std::shared_ptr<msgpack::sbuffer> &args_buffer) {
+    std::shared_ptr<msgpack::sbuffer>& args_buffer) {
   std::shared_ptr<Arg1Type> arg1_ptr;
   std::shared_ptr<Arg2Type> arg2_ptr;
   return ExecuteNormalFunction<ReturnType, uintptr_t>(base_addr, func_offset, args_buffer,
@@ -129,8 +129,8 @@ std::shared_ptr<msgpack::sbuffer> CreateActorExecFunction(
 template <typename ReturnType, typename ActorType>
 std::shared_ptr<msgpack::sbuffer> ActorExecFunction(
     uintptr_t base_addr, size_t func_offset,
-    std::shared_ptr<msgpack::sbuffer> &args_buffer,
-    std::shared_ptr<msgpack::sbuffer> &actor_buffer) {
+    std::shared_ptr<msgpack::sbuffer>& args_buffer,
+    std::shared_ptr<msgpack::sbuffer>& actor_buffer) {
   return ExecuteActorFunction<ReturnType, ActorType>(base_addr, func_offset, args_buffer,
                                                      actor_buffer);
 }
@@ -139,8 +139,8 @@ std::shared_ptr<msgpack::sbuffer> ActorExecFunction(
 template <typename ReturnType, typename ActorType, typename Arg1Type>
 std::shared_ptr<msgpack::sbuffer> ActorExecFunction(
     uintptr_t base_addr, size_t func_offset,
-    std::shared_ptr<msgpack::sbuffer> &args_buffer,
-    std::shared_ptr<msgpack::sbuffer> &actor_buffer) {
+    std::shared_ptr<msgpack::sbuffer>& args_buffer,
+    std::shared_ptr<msgpack::sbuffer>& actor_buffer) {
   std::shared_ptr<Arg1Type> arg1_ptr;
   return ExecuteActorFunction<ReturnType, ActorType>(base_addr, func_offset, args_buffer,
                                                      actor_buffer, arg1_ptr);
@@ -150,8 +150,8 @@ std::shared_ptr<msgpack::sbuffer> ActorExecFunction(
 template <typename ReturnType, typename ActorType, typename Arg1Type, typename Arg2Type>
 std::shared_ptr<msgpack::sbuffer> ActorExecFunction(
     uintptr_t base_addr, size_t func_offset,
-    std::shared_ptr<msgpack::sbuffer> &args_buffer,
-    std::shared_ptr<msgpack::sbuffer> &actor_buffer) {
+    std::shared_ptr<msgpack::sbuffer>& args_buffer,
+    std::shared_ptr<msgpack::sbuffer>& actor_buffer) {
   std::shared_ptr<Arg1Type> arg1_ptr;
   std::shared_ptr<Arg2Type> arg2_ptr;
   return ExecuteActorFunction<ReturnType, ActorType>(base_addr, func_offset, args_buffer,

--- a/cpp/include/ray/api/object_ref.h
+++ b/cpp/include/ray/api/object_ref.h
@@ -2,9 +2,8 @@
 #pragma once
 
 #include <memory>
-#include <utility>
-
 #include <msgpack.hpp>
+#include <utility>
 
 #include "ray/core.h"
 

--- a/cpp/include/ray/api/object_ref.h
+++ b/cpp/include/ray/api/object_ref.h
@@ -17,12 +17,12 @@ class ObjectRef {
  public:
   ObjectRef();
 
-  ObjectRef(const ObjectID &id);
+  ObjectRef(const ObjectID& id);
 
-  bool operator==(const ObjectRef<T> &object) const;
+  bool operator==(const ObjectRef<T>& object) const;
 
   /// Get a untyped ID of the object
-  const ObjectID &ID() const;
+  const ObjectID& ID() const;
 
   /// Get the object from the object store.
   /// This method will be blocked until the object is ready.
@@ -44,17 +44,17 @@ template <typename T>
 ObjectRef<T>::ObjectRef() {}
 
 template <typename T>
-ObjectRef<T>::ObjectRef(const ObjectID &id) {
+ObjectRef<T>::ObjectRef(const ObjectID& id) {
   id_ = id;
 }
 
 template <typename T>
-inline bool ObjectRef<T>::operator==(const ObjectRef<T> &object) const {
+inline bool ObjectRef<T>::operator==(const ObjectRef<T>& object) const {
   return id_ == object.id_;
 }
 
 template <typename T>
-const ObjectID &ObjectRef<T>::ID() const {
+const ObjectID& ObjectRef<T>::ID() const {
   return id_;
 }
 

--- a/cpp/include/ray/api/ray_exception.h
+++ b/cpp/include/ray/api/ray_exception.h
@@ -8,9 +8,9 @@ namespace api {
 
 class RayException : public std::exception {
  public:
-  RayException(const std::string &msg) : msg_(msg){};
+  RayException(const std::string& msg) : msg_(msg){};
 
-  const char *what() const noexcept override { return msg_.c_str(); };
+  const char* what() const noexcept override { return msg_.c_str(); };
 
   std::string msg_;
 };

--- a/cpp/include/ray/api/ray_runtime.h
+++ b/cpp/include/ray/api/ray_runtime.h
@@ -1,13 +1,14 @@
 
 #pragma once
 
+#include <ray/api/wait_result.h>
+
 #include <cstdint>
 #include <memory>
 #include <msgpack.hpp>
 #include <typeinfo>
 #include <vector>
 
-#include <ray/api/wait_result.h>
 #include "ray/core.h"
 
 namespace ray {

--- a/cpp/include/ray/api/ray_runtime.h
+++ b/cpp/include/ray/api/ray_runtime.h
@@ -28,19 +28,19 @@ struct RemoteFunctionPtrHolder {
 class RayRuntime {
  public:
   virtual ObjectID Put(std::shared_ptr<msgpack::sbuffer> data) = 0;
-  virtual std::shared_ptr<msgpack::sbuffer> Get(const ObjectID &id) = 0;
+  virtual std::shared_ptr<msgpack::sbuffer> Get(const ObjectID& id) = 0;
 
   virtual std::vector<std::shared_ptr<msgpack::sbuffer>> Get(
-      const std::vector<ObjectID> &ids) = 0;
+      const std::vector<ObjectID>& ids) = 0;
 
-  virtual WaitResult Wait(const std::vector<ObjectID> &ids, int num_objects,
+  virtual WaitResult Wait(const std::vector<ObjectID>& ids, int num_objects,
                           int timeout_ms) = 0;
 
-  virtual ObjectID Call(RemoteFunctionPtrHolder &fptr,
+  virtual ObjectID Call(RemoteFunctionPtrHolder& fptr,
                         std::shared_ptr<msgpack::sbuffer> args) = 0;
-  virtual ActorID CreateActor(RemoteFunctionPtrHolder &fptr,
+  virtual ActorID CreateActor(RemoteFunctionPtrHolder& fptr,
                               std::shared_ptr<msgpack::sbuffer> args) = 0;
-  virtual ObjectID CallActor(const RemoteFunctionPtrHolder &fptr, const ActorID &actor,
+  virtual ObjectID CallActor(const RemoteFunctionPtrHolder& fptr, const ActorID& actor,
                              std::shared_ptr<msgpack::sbuffer> args) = 0;
 };
 }  // namespace api

--- a/cpp/include/ray/api/serializer.h
+++ b/cpp/include/ray/api/serializer.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <ray/api/ray_exception.h>
+
 #include <msgpack.hpp>
 
 namespace ray {

--- a/cpp/include/ray/api/serializer.h
+++ b/cpp/include/ray/api/serializer.h
@@ -11,23 +11,23 @@ namespace api {
 class Serializer {
  public:
   template <typename T>
-  static void Serialize(msgpack::packer<msgpack::sbuffer> &packer, const T &val);
+  static void Serialize(msgpack::packer<msgpack::sbuffer>& packer, const T& val);
 
   template <typename T>
-  static void Deserialize(msgpack::unpacker &unpacker, T *val);
+  static void Deserialize(msgpack::unpacker& unpacker, T* val);
 };
 
 // ---------- implementation ----------
 
 template <typename T>
-inline void Serializer::Serialize(msgpack::packer<msgpack::sbuffer> &packer,
-                                  const T &val) {
+inline void Serializer::Serialize(msgpack::packer<msgpack::sbuffer>& packer,
+                                  const T& val) {
   packer.pack(val);
   return;
 }
 
 template <typename T>
-inline void Serializer::Deserialize(msgpack::unpacker &unpacker, T *val) {
+inline void Serializer::Deserialize(msgpack::unpacker& unpacker, T* val) {
   msgpack::object_handle oh;
   bool result = unpacker.next(oh);
   if (result == false) {

--- a/cpp/include/ray/api/task_caller.h
+++ b/cpp/include/ray/api/task_caller.h
@@ -11,13 +11,13 @@ class TaskCaller {
  public:
   TaskCaller();
 
-  TaskCaller(RayRuntime *runtime, RemoteFunctionPtrHolder ptr,
+  TaskCaller(RayRuntime* runtime, RemoteFunctionPtrHolder ptr,
              std::shared_ptr<msgpack::sbuffer> args);
 
   ObjectRef<ReturnType> Remote();
 
  private:
-  RayRuntime *runtime_;
+  RayRuntime* runtime_;
   RemoteFunctionPtrHolder ptr_;
   std::shared_ptr<msgpack::sbuffer> args_;
 };
@@ -28,7 +28,7 @@ template <typename ReturnType>
 TaskCaller<ReturnType>::TaskCaller() {}
 
 template <typename ReturnType>
-TaskCaller<ReturnType>::TaskCaller(RayRuntime *runtime, RemoteFunctionPtrHolder ptr,
+TaskCaller<ReturnType>::TaskCaller(RayRuntime* runtime, RemoteFunctionPtrHolder ptr,
                                    std::shared_ptr<msgpack::sbuffer> args)
     : runtime_(runtime), ptr_(ptr), args_(args) {}
 

--- a/cpp/include/ray/api/wait_result.h
+++ b/cpp/include/ray/api/wait_result.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <vector>
+
 #include "ray/core.h"
 
 namespace ray {

--- a/cpp/include/ray/api/wait_result.h
+++ b/cpp/include/ray/api/wait_result.h
@@ -15,8 +15,8 @@ class WaitResult {
   /// The object id array of unready objects
   std::vector<ObjectID> unready;
   WaitResult(){};
-  WaitResult(std::vector<ObjectID> &&ready_objects,
-             std::vector<ObjectID> &&unready_objects)
+  WaitResult(std::vector<ObjectID>&& ready_objects,
+             std::vector<ObjectID>&& unready_objects)
       : ready(std::move(ready_objects)), unready(std::move(unready_objects)){};
 };
 }  // namespace api

--- a/cpp/src/example/example.cc
+++ b/cpp/src/example/example.cc
@@ -19,7 +19,7 @@ class Counter {
 
   Counter() { count = 0; }
 
-  static Counter *FactoryCreate() { return new Counter(); }
+  static Counter* FactoryCreate() { return new Counter(); }
   /// non static function
   int Add(int x) {
     count += x;

--- a/cpp/src/ray/api.cc
+++ b/cpp/src/ray/api.cc
@@ -1,7 +1,7 @@
 
 #include <ray/api.h>
-
 #include <ray/api/ray_config.h>
+
 #include "runtime/abstract_ray_runtime.h"
 
 namespace ray {

--- a/cpp/src/ray/api.cc
+++ b/cpp/src/ray/api.cc
@@ -7,7 +7,7 @@
 namespace ray {
 namespace api {
 
-RayRuntime *Ray::runtime_ = nullptr;
+RayRuntime* Ray::runtime_ = nullptr;
 
 std::once_flag Ray::is_inited_;
 void Ray::Init() {

--- a/cpp/src/ray/runtime/abstract_ray_runtime.cc
+++ b/cpp/src/ray/runtime/abstract_ray_runtime.cc
@@ -1,11 +1,12 @@
 
 #include "abstract_ray_runtime.h"
 
-#include <cassert>
-
 #include <ray/api.h>
 #include <ray/api/ray_config.h>
 #include <ray/api/ray_exception.h>
+
+#include <cassert>
+
 #include "../util/address_helper.h"
 #include "../util/process_helper.h"
 #include "local_mode_ray_runtime.h"

--- a/cpp/src/ray/runtime/abstract_ray_runtime.cc
+++ b/cpp/src/ray/runtime/abstract_ray_runtime.cc
@@ -14,8 +14,8 @@
 
 namespace ray {
 namespace api {
-AbstractRayRuntime *AbstractRayRuntime::DoInit(std::shared_ptr<RayConfig> config) {
-  AbstractRayRuntime *runtime;
+AbstractRayRuntime* AbstractRayRuntime::DoInit(std::shared_ptr<RayConfig> config) {
+  AbstractRayRuntime* runtime;
   if (config->run_mode == RunMode::SINGLE_PROCESS) {
     GenerateBaseAddressOfCurrentLibrary();
     runtime = new LocalModeRayRuntime(config);
@@ -28,7 +28,7 @@ AbstractRayRuntime *AbstractRayRuntime::DoInit(std::shared_ptr<RayConfig> config
 }
 
 void AbstractRayRuntime::Put(std::shared_ptr<msgpack::sbuffer> data,
-                             const ObjectID &object_id) {
+                             const ObjectID& object_id) {
   object_store_->Put(object_id, data);
 }
 
@@ -39,21 +39,21 @@ ObjectID AbstractRayRuntime::Put(std::shared_ptr<msgpack::sbuffer> data) {
   return object_id;
 }
 
-std::shared_ptr<msgpack::sbuffer> AbstractRayRuntime::Get(const ObjectID &object_id) {
+std::shared_ptr<msgpack::sbuffer> AbstractRayRuntime::Get(const ObjectID& object_id) {
   return object_store_->Get(object_id, -1);
 }
 
 std::vector<std::shared_ptr<msgpack::sbuffer>> AbstractRayRuntime::Get(
-    const std::vector<ObjectID> &ids) {
+    const std::vector<ObjectID>& ids) {
   return object_store_->Get(ids, -1);
 }
 
-WaitResult AbstractRayRuntime::Wait(const std::vector<ObjectID> &ids, int num_objects,
+WaitResult AbstractRayRuntime::Wait(const std::vector<ObjectID>& ids, int num_objects,
                                     int timeout_ms) {
   return object_store_->Wait(ids, num_objects, timeout_ms);
 }
 
-ObjectID AbstractRayRuntime::Call(RemoteFunctionPtrHolder &fptr,
+ObjectID AbstractRayRuntime::Call(RemoteFunctionPtrHolder& fptr,
                                   std::shared_ptr<msgpack::sbuffer> args) {
   InvocationSpec invocationSpec;
   invocationSpec.task_id =
@@ -67,13 +67,13 @@ ObjectID AbstractRayRuntime::Call(RemoteFunctionPtrHolder &fptr,
   return task_submitter_->SubmitTask(invocationSpec);
 }
 
-ActorID AbstractRayRuntime::CreateActor(RemoteFunctionPtrHolder &fptr,
+ActorID AbstractRayRuntime::CreateActor(RemoteFunctionPtrHolder& fptr,
                                         std::shared_ptr<msgpack::sbuffer> args) {
   return task_submitter_->CreateActor(fptr, args);
 }
 
-ObjectID AbstractRayRuntime::CallActor(const RemoteFunctionPtrHolder &fptr,
-                                       const ActorID &actor,
+ObjectID AbstractRayRuntime::CallActor(const RemoteFunctionPtrHolder& fptr,
+                                       const ActorID& actor,
                                        std::shared_ptr<msgpack::sbuffer> args) {
   InvocationSpec invocationSpec;
   invocationSpec.task_id =
@@ -87,11 +87,11 @@ ObjectID AbstractRayRuntime::CallActor(const RemoteFunctionPtrHolder &fptr,
   return task_submitter_->SubmitActorTask(invocationSpec);
 }
 
-const TaskID &AbstractRayRuntime::GetCurrentTaskId() {
+const TaskID& AbstractRayRuntime::GetCurrentTaskId() {
   return worker_->GetCurrentTaskID();
 }
 
-const JobID &AbstractRayRuntime::GetCurrentJobID() { return worker_->GetCurrentJobID(); }
+const JobID& AbstractRayRuntime::GetCurrentJobID() { return worker_->GetCurrentJobID(); }
 
 ActorID AbstractRayRuntime::GetNextActorID() {
   const int next_task_index = worker_->GetNextTaskIndex();
@@ -100,7 +100,7 @@ ActorID AbstractRayRuntime::GetNextActorID() {
   return actor_id;
 }
 
-const std::unique_ptr<WorkerContext> &AbstractRayRuntime::GetWorkerContext() {
+const std::unique_ptr<WorkerContext>& AbstractRayRuntime::GetWorkerContext() {
   return worker_;
 }
 

--- a/cpp/src/ray/runtime/abstract_ray_runtime.h
+++ b/cpp/src/ray/runtime/abstract_ray_runtime.h
@@ -1,11 +1,12 @@
 
 #pragma once
 
-#include <mutex>
-
 #include <ray/api/ray_config.h>
 #include <ray/api/ray_runtime.h>
+
 #include <msgpack.hpp>
+#include <mutex>
+
 #include "./object/object_store.h"
 #include "./task/task_executor.h"
 #include "./task/task_submitter.h"

--- a/cpp/src/ray/runtime/abstract_ray_runtime.h
+++ b/cpp/src/ray/runtime/abstract_ray_runtime.h
@@ -19,31 +19,31 @@ class AbstractRayRuntime : public RayRuntime {
  public:
   virtual ~AbstractRayRuntime(){};
 
-  void Put(std::shared_ptr<msgpack::sbuffer> data, const ObjectID &object_id);
+  void Put(std::shared_ptr<msgpack::sbuffer> data, const ObjectID& object_id);
 
   ObjectID Put(std::shared_ptr<msgpack::sbuffer> data);
 
-  std::shared_ptr<msgpack::sbuffer> Get(const ObjectID &id);
+  std::shared_ptr<msgpack::sbuffer> Get(const ObjectID& id);
 
-  std::vector<std::shared_ptr<msgpack::sbuffer>> Get(const std::vector<ObjectID> &ids);
+  std::vector<std::shared_ptr<msgpack::sbuffer>> Get(const std::vector<ObjectID>& ids);
 
-  WaitResult Wait(const std::vector<ObjectID> &ids, int num_objects, int timeout_ms);
+  WaitResult Wait(const std::vector<ObjectID>& ids, int num_objects, int timeout_ms);
 
-  ObjectID Call(RemoteFunctionPtrHolder &fptr, std::shared_ptr<msgpack::sbuffer> args);
+  ObjectID Call(RemoteFunctionPtrHolder& fptr, std::shared_ptr<msgpack::sbuffer> args);
 
-  ActorID CreateActor(RemoteFunctionPtrHolder &fptr,
+  ActorID CreateActor(RemoteFunctionPtrHolder& fptr,
                       std::shared_ptr<msgpack::sbuffer> args);
 
-  ObjectID CallActor(const RemoteFunctionPtrHolder &fptr, const ActorID &actor,
+  ObjectID CallActor(const RemoteFunctionPtrHolder& fptr, const ActorID& actor,
                      std::shared_ptr<msgpack::sbuffer> args);
 
   ActorID GetNextActorID();
 
-  const TaskID &GetCurrentTaskId();
+  const TaskID& GetCurrentTaskId();
 
-  const JobID &GetCurrentJobID();
+  const JobID& GetCurrentJobID();
 
-  const std::unique_ptr<WorkerContext> &GetWorkerContext();
+  const std::unique_ptr<WorkerContext>& GetWorkerContext();
 
  protected:
   std::shared_ptr<RayConfig> config_;
@@ -53,9 +53,9 @@ class AbstractRayRuntime : public RayRuntime {
   std::unique_ptr<ObjectStore> object_store_;
 
  private:
-  static AbstractRayRuntime *DoInit(std::shared_ptr<RayConfig> config);
+  static AbstractRayRuntime* DoInit(std::shared_ptr<RayConfig> config);
 
-  void Execute(const TaskSpecification &task_spec);
+  void Execute(const TaskSpecification& task_spec);
 
   friend class Ray;
 };

--- a/cpp/src/ray/runtime/local_mode_ray_runtime.cc
+++ b/cpp/src/ray/runtime/local_mode_ray_runtime.cc
@@ -2,6 +2,7 @@
 #include "local_mode_ray_runtime.h"
 
 #include <ray/api.h>
+
 #include "../util/address_helper.h"
 #include "./object/local_mode_object_store.h"
 #include "./object/object_store.h"

--- a/cpp/src/ray/runtime/local_mode_ray_runtime.h
+++ b/cpp/src/ray/runtime/local_mode_ray_runtime.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <unordered_map>
+
 #include "abstract_ray_runtime.h"
 #include "ray/core.h"
 

--- a/cpp/src/ray/runtime/native_ray_runtime.cc
+++ b/cpp/src/ray/runtime/native_ray_runtime.cc
@@ -2,6 +2,7 @@
 #include "native_ray_runtime.h"
 
 #include <ray/api.h>
+
 #include "../util/address_helper.h"
 #include "./object/native_object_store.h"
 #include "./object/object_store.h"

--- a/cpp/src/ray/runtime/native_ray_runtime.h
+++ b/cpp/src/ray/runtime/native_ray_runtime.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <unordered_map>
+
 #include "abstract_ray_runtime.h"
 #include "ray/core.h"
 

--- a/cpp/src/ray/runtime/object/local_mode_object_store.cc
+++ b/cpp/src/ray/runtime/object/local_mode_object_store.cc
@@ -1,12 +1,14 @@
 
+#include "local_mode_object_store.h"
+
+#include <ray/api/ray_exception.h>
+
 #include <algorithm>
 #include <chrono>
 #include <list>
 #include <thread>
 
-#include <ray/api/ray_exception.h>
 #include "../abstract_ray_runtime.h"
-#include "local_mode_object_store.h"
 
 namespace ray {
 namespace api {

--- a/cpp/src/ray/runtime/object/local_mode_object_store.cc
+++ b/cpp/src/ray/runtime/object/local_mode_object_store.cc
@@ -12,16 +12,16 @@
 
 namespace ray {
 namespace api {
-LocalModeObjectStore::LocalModeObjectStore(LocalModeRayRuntime &local_mode_ray_tuntime)
+LocalModeObjectStore::LocalModeObjectStore(LocalModeRayRuntime& local_mode_ray_tuntime)
     : local_mode_ray_tuntime_(local_mode_ray_tuntime) {
   memory_store_ =
       std::unique_ptr<::ray::CoreWorkerMemoryStore>(new ::ray::CoreWorkerMemoryStore());
 }
 
-void LocalModeObjectStore::PutRaw(const ObjectID &object_id,
+void LocalModeObjectStore::PutRaw(const ObjectID& object_id,
                                   std::shared_ptr<msgpack::sbuffer> data) {
   auto buffer = std::make_shared<::ray::LocalMemoryBuffer>(
-      reinterpret_cast<uint8_t *>(data->data()), data->size(), true);
+      reinterpret_cast<uint8_t*>(data->data()), data->size(), true);
   auto status = memory_store_->Put(
       ::ray::RayObject(buffer, nullptr, std::vector<ObjectID>()), object_id);
   if (!status) {
@@ -29,7 +29,7 @@ void LocalModeObjectStore::PutRaw(const ObjectID &object_id,
   }
 }
 
-std::shared_ptr<msgpack::sbuffer> LocalModeObjectStore::GetRaw(const ObjectID &object_id,
+std::shared_ptr<msgpack::sbuffer> LocalModeObjectStore::GetRaw(const ObjectID& object_id,
                                                                int timeout_ms) {
   std::vector<ObjectID> object_ids;
   object_ids.push_back(object_id);
@@ -39,7 +39,7 @@ std::shared_ptr<msgpack::sbuffer> LocalModeObjectStore::GetRaw(const ObjectID &o
 }
 
 std::vector<std::shared_ptr<msgpack::sbuffer>> LocalModeObjectStore::GetRaw(
-    const std::vector<ObjectID> &ids, int timeout_ms) {
+    const std::vector<ObjectID>& ids, int timeout_ms) {
   std::vector<std::shared_ptr<::ray::RayObject>> results;
   ::ray::Status status =
       memory_store_->Get(ids, (int)ids.size(), timeout_ms,
@@ -53,17 +53,17 @@ std::vector<std::shared_ptr<msgpack::sbuffer>> LocalModeObjectStore::GetRaw(
   for (size_t i = 0; i < results.size(); i++) {
     auto data_buffer = results[i]->GetData();
     auto sbuffer = std::make_shared<msgpack::sbuffer>(data_buffer->Size());
-    sbuffer->write(reinterpret_cast<const char *>(data_buffer->Data()),
+    sbuffer->write(reinterpret_cast<const char*>(data_buffer->Data()),
                    data_buffer->Size());
     result_sbuffers.push_back(sbuffer);
   }
   return result_sbuffers;
 }
 
-WaitResult LocalModeObjectStore::Wait(const std::vector<ObjectID> &ids, int num_objects,
+WaitResult LocalModeObjectStore::Wait(const std::vector<ObjectID>& ids, int num_objects,
                                       int timeout_ms) {
   absl::flat_hash_set<ObjectID> memory_object_ids;
-  for (const auto &object_id : ids) {
+  for (const auto& object_id : ids) {
     memory_object_ids.insert(object_id);
   }
   absl::flat_hash_set<ObjectID> ready;

--- a/cpp/src/ray/runtime/object/local_mode_object_store.h
+++ b/cpp/src/ray/runtime/object/local_mode_object_store.h
@@ -2,10 +2,10 @@
 #pragma once
 
 #include <unordered_map>
-#include "ray/core.h"
 
 #include "../local_mode_ray_runtime.h"
 #include "object_store.h"
+#include "ray/core.h"
 
 namespace ray {
 namespace api {

--- a/cpp/src/ray/runtime/object/local_mode_object_store.h
+++ b/cpp/src/ray/runtime/object/local_mode_object_store.h
@@ -12,21 +12,21 @@ namespace api {
 
 class LocalModeObjectStore : public ObjectStore {
  public:
-  LocalModeObjectStore(LocalModeRayRuntime &local_mode_ray_tuntime);
+  LocalModeObjectStore(LocalModeRayRuntime& local_mode_ray_tuntime);
 
-  WaitResult Wait(const std::vector<ObjectID> &ids, int num_objects, int timeout_ms);
+  WaitResult Wait(const std::vector<ObjectID>& ids, int num_objects, int timeout_ms);
 
  private:
-  void PutRaw(const ObjectID &object_id, std::shared_ptr<msgpack::sbuffer> data);
+  void PutRaw(const ObjectID& object_id, std::shared_ptr<msgpack::sbuffer> data);
 
-  std::shared_ptr<msgpack::sbuffer> GetRaw(const ObjectID &object_id, int timeout_ms);
+  std::shared_ptr<msgpack::sbuffer> GetRaw(const ObjectID& object_id, int timeout_ms);
 
-  std::vector<std::shared_ptr<msgpack::sbuffer>> GetRaw(const std::vector<ObjectID> &ids,
+  std::vector<std::shared_ptr<msgpack::sbuffer>> GetRaw(const std::vector<ObjectID>& ids,
                                                         int timeout_ms);
 
   std::unique_ptr<::ray::CoreWorkerMemoryStore> memory_store_;
 
-  LocalModeRayRuntime &local_mode_ray_tuntime_;
+  LocalModeRayRuntime& local_mode_ray_tuntime_;
 };
 
 }  // namespace api

--- a/cpp/src/ray/runtime/object/native_object_store.cc
+++ b/cpp/src/ray/runtime/object/native_object_store.cc
@@ -1,12 +1,14 @@
 
+#include "native_object_store.h"
+
+#include <ray/api/ray_exception.h>
+
 #include <algorithm>
 #include <chrono>
 #include <list>
 #include <thread>
 
-#include <ray/api/ray_exception.h>
 #include "../abstract_ray_runtime.h"
-#include "native_object_store.h"
 
 namespace ray {
 namespace api {

--- a/cpp/src/ray/runtime/object/native_object_store.cc
+++ b/cpp/src/ray/runtime/object/native_object_store.cc
@@ -12,23 +12,23 @@
 
 namespace ray {
 namespace api {
-NativeObjectStore::NativeObjectStore(NativeRayRuntime &native_ray_tuntime)
+NativeObjectStore::NativeObjectStore(NativeRayRuntime& native_ray_tuntime)
     : native_ray_tuntime_(native_ray_tuntime) {}
 
-void NativeObjectStore::PutRaw(const ObjectID &object_id,
+void NativeObjectStore::PutRaw(const ObjectID& object_id,
                                std::shared_ptr<msgpack::sbuffer> data) {}
 
-std::shared_ptr<msgpack::sbuffer> NativeObjectStore::GetRaw(const ObjectID &object_id,
+std::shared_ptr<msgpack::sbuffer> NativeObjectStore::GetRaw(const ObjectID& object_id,
                                                             int timeout_ms) {
   return nullptr;
 }
 
 std::vector<std::shared_ptr<msgpack::sbuffer>> NativeObjectStore::GetRaw(
-    const std::vector<ObjectID> &ids, int timeout_ms) {
+    const std::vector<ObjectID>& ids, int timeout_ms) {
   return std::vector<std::shared_ptr<msgpack::sbuffer>>();
 }
 
-WaitResult NativeObjectStore::Wait(const std::vector<ObjectID> &ids, int num_objects,
+WaitResult NativeObjectStore::Wait(const std::vector<ObjectID>& ids, int num_objects,
                                    int timeout_ms) {
   native_ray_tuntime_.GetWorkerContext();
   return WaitResult();

--- a/cpp/src/ray/runtime/object/native_object_store.h
+++ b/cpp/src/ray/runtime/object/native_object_store.h
@@ -2,10 +2,10 @@
 #pragma once
 
 #include <unordered_map>
-#include "ray/core.h"
 
 #include "../native_ray_runtime.h"
 #include "object_store.h"
+#include "ray/core.h"
 
 namespace ray {
 namespace api {

--- a/cpp/src/ray/runtime/object/native_object_store.h
+++ b/cpp/src/ray/runtime/object/native_object_store.h
@@ -12,19 +12,19 @@ namespace api {
 
 class NativeObjectStore : public ObjectStore {
  public:
-  NativeObjectStore(NativeRayRuntime &native_ray_tuntime);
+  NativeObjectStore(NativeRayRuntime& native_ray_tuntime);
 
-  WaitResult Wait(const std::vector<ObjectID> &ids, int num_objects, int timeout_ms);
+  WaitResult Wait(const std::vector<ObjectID>& ids, int num_objects, int timeout_ms);
 
  private:
-  void PutRaw(const ObjectID &object_id, std::shared_ptr<msgpack::sbuffer> data);
+  void PutRaw(const ObjectID& object_id, std::shared_ptr<msgpack::sbuffer> data);
 
-  std::shared_ptr<msgpack::sbuffer> GetRaw(const ObjectID &object_id, int timeout_ms);
+  std::shared_ptr<msgpack::sbuffer> GetRaw(const ObjectID& object_id, int timeout_ms);
 
-  std::vector<std::shared_ptr<msgpack::sbuffer>> GetRaw(const std::vector<ObjectID> &ids,
+  std::vector<std::shared_ptr<msgpack::sbuffer>> GetRaw(const std::vector<ObjectID>& ids,
                                                         int timeout_ms);
 
-  NativeRayRuntime &native_ray_tuntime_;
+  NativeRayRuntime& native_ray_tuntime_;
 };
 
 }  // namespace api

--- a/cpp/src/ray/runtime/object/object_store.cc
+++ b/cpp/src/ray/runtime/object/object_store.cc
@@ -7,17 +7,17 @@
 namespace ray {
 namespace api {
 
-void ObjectStore::Put(const ObjectID &object_id, std::shared_ptr<msgpack::sbuffer> data) {
+void ObjectStore::Put(const ObjectID& object_id, std::shared_ptr<msgpack::sbuffer> data) {
   PutRaw(object_id, data);
 }
 
-std::shared_ptr<msgpack::sbuffer> ObjectStore::Get(const ObjectID &object_id,
+std::shared_ptr<msgpack::sbuffer> ObjectStore::Get(const ObjectID& object_id,
                                                    int timeout_ms) {
   return GetRaw(object_id, timeout_ms);
 }
 
 std::vector<std::shared_ptr<msgpack::sbuffer>> ObjectStore::Get(
-    const std::vector<ObjectID> &ids, int timeout_ms) {
+    const std::vector<ObjectID>& ids, int timeout_ms) {
   return GetRaw(ids, timeout_ms);
 }
 }  // namespace api

--- a/cpp/src/ray/runtime/object/object_store.h
+++ b/cpp/src/ray/runtime/object/object_store.h
@@ -1,9 +1,9 @@
 
 #pragma once
 
-#include <memory>
-
 #include <ray/api/wait_result.h>
+
+#include <memory>
 #include <msgpack.hpp>
 
 namespace ray {

--- a/cpp/src/ray/runtime/object/object_store.h
+++ b/cpp/src/ray/runtime/object/object_store.h
@@ -20,7 +20,7 @@ class ObjectStore {
   ///
   /// \param[in] object_id The object which should be stored.
   /// \param[in] data The Serialized object buffer which should be stored.
-  void Put(const ObjectID &object_id, std::shared_ptr<msgpack::sbuffer> data);
+  void Put(const ObjectID& object_id, std::shared_ptr<msgpack::sbuffer> data);
 
   /// Get a single object from the object store.
   /// This method will be blocked until the object are ready or wait for timeout.
@@ -28,7 +28,7 @@ class ObjectStore {
   /// \param[in] object_id The object id which should be got.
   /// \param[in] timeout_ms The maximum wait time in milliseconds.
   /// \return shared pointer of the result buffer.
-  std::shared_ptr<msgpack::sbuffer> Get(const ObjectID &object_id,
+  std::shared_ptr<msgpack::sbuffer> Get(const ObjectID& object_id,
                                         int timeout_ms = default_get_timeout_ms);
 
   /// Get a list of objects from the object store.
@@ -38,7 +38,7 @@ class ObjectStore {
   /// \param[in] timeout_ms The maximum wait time in milliseconds.
   /// \return shared pointer array of the result buffer.
   std::vector<std::shared_ptr<msgpack::sbuffer>> Get(
-      const std::vector<ObjectID> &ids, int timeout_ms = default_get_timeout_ms);
+      const std::vector<ObjectID>& ids, int timeout_ms = default_get_timeout_ms);
 
   /// Wait for a list of ObjectRefs to be locally available,
   /// until specified number of objects are ready, or specified timeout has passed.
@@ -48,18 +48,18 @@ class ObjectStore {
   /// \param[in] timeout_ms The maximum wait time in milliseconds.
   /// \return WaitResult Two arrays, one containing locally available objects, one
   /// containing the rest.
-  virtual WaitResult Wait(const std::vector<ObjectID> &ids, int num_objects,
+  virtual WaitResult Wait(const std::vector<ObjectID>& ids, int num_objects,
                           int timeout_ms) = 0;
 
  private:
-  virtual void PutRaw(const ObjectID &object_id,
+  virtual void PutRaw(const ObjectID& object_id,
                       std::shared_ptr<msgpack::sbuffer> data) = 0;
 
-  virtual std::shared_ptr<msgpack::sbuffer> GetRaw(const ObjectID &object_id,
+  virtual std::shared_ptr<msgpack::sbuffer> GetRaw(const ObjectID& object_id,
                                                    int timeout_ms) = 0;
 
   virtual std::vector<std::shared_ptr<msgpack::sbuffer>> GetRaw(
-      const std::vector<ObjectID> &ids, int timeout_ms) = 0;
+      const std::vector<ObjectID>& ids, int timeout_ms) = 0;
 };
 }  // namespace api
 }  // namespace ray

--- a/cpp/src/ray/runtime/task/invocation_spec.h
+++ b/cpp/src/ray/runtime/task/invocation_spec.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <msgpack.hpp>
+
 #include "ray/core.h"
 
 namespace ray {

--- a/cpp/src/ray/runtime/task/local_mode_task_submitter.cc
+++ b/cpp/src/ray/runtime/task/local_mode_task_submitter.cc
@@ -1,11 +1,13 @@
 
+#include "local_mode_task_submitter.h"
+
+#include <ray/api/ray_exception.h>
+
 #include <boost/asio/post.hpp>
 #include <memory>
 
-#include <ray/api/ray_exception.h>
 #include "../../util/address_helper.h"
 #include "../abstract_ray_runtime.h"
-#include "local_mode_task_submitter.h"
 
 namespace ray {
 namespace api {

--- a/cpp/src/ray/runtime/task/local_mode_task_submitter.cc
+++ b/cpp/src/ray/runtime/task/local_mode_task_submitter.cc
@@ -13,12 +13,12 @@ namespace ray {
 namespace api {
 
 LocalModeTaskSubmitter::LocalModeTaskSubmitter(
-    LocalModeRayRuntime &local_mode_ray_tuntime)
+    LocalModeRayRuntime& local_mode_ray_tuntime)
     : local_mode_ray_tuntime_(local_mode_ray_tuntime) {
   thread_pool_.reset(new boost::asio::thread_pool(10));
 }
 
-ObjectID LocalModeTaskSubmitter::Submit(const InvocationSpec &invocation, TaskType type) {
+ObjectID LocalModeTaskSubmitter::Submit(const InvocationSpec& invocation, TaskType type) {
   /// TODO(Guyang Song): Make the infomation of TaskSpecification more reasonable
   /// We just reuse the TaskSpecification class and make the single process mode work.
   /// Maybe some infomation of TaskSpecification are not reasonable or invalid.
@@ -49,8 +49,7 @@ ObjectID LocalModeTaskSubmitter::Submit(const InvocationSpec &invocation, TaskTy
     throw RayException("unknown task type");
   }
   auto buffer = std::make_shared<::ray::LocalMemoryBuffer>(
-      reinterpret_cast<uint8_t *>(invocation.args->data()), invocation.args->size(),
-      true);
+      reinterpret_cast<uint8_t*>(invocation.args->data()), invocation.args->size(), true);
   /// TODO(Guyang Song): Use both 'AddByRefArg' and 'AddByValueArg' to distinguish
   auto arg = TaskArgByValue(
       std::make_shared<::ray::RayObject>(buffer, nullptr, std::vector<ObjectID>()));
@@ -65,7 +64,7 @@ ObjectID LocalModeTaskSubmitter::Submit(const InvocationSpec &invocation, TaskTy
     actor = actor_contexts_.at(invocation.actor_id).get()->current_actor;
     mutex = actor_contexts_.at(invocation.actor_id).get()->actor_mutex;
   }
-  AbstractRayRuntime *runtime = &local_mode_ray_tuntime_;
+  AbstractRayRuntime* runtime = &local_mode_ray_tuntime_;
   if (type == TaskType::ACTOR_CREATION_TASK || type == TaskType::ACTOR_TASK) {
     /// TODO(Guyang Song): Handle task dependencies.
     /// Execute actor task directly in the main thread because we must guarantee the actor
@@ -74,7 +73,7 @@ ObjectID LocalModeTaskSubmitter::Submit(const InvocationSpec &invocation, TaskTy
   } else {
     boost::asio::post(*thread_pool_.get(),
                       std::bind(
-                          [actor, mutex, runtime](TaskSpecification &ts) {
+                          [actor, mutex, runtime](TaskSpecification& ts) {
                             if (mutex) {
                               absl::MutexLock lock(mutex.get());
                             }
@@ -85,11 +84,11 @@ ObjectID LocalModeTaskSubmitter::Submit(const InvocationSpec &invocation, TaskTy
   return return_object_id;
 }
 
-ObjectID LocalModeTaskSubmitter::SubmitTask(const InvocationSpec &invocation) {
+ObjectID LocalModeTaskSubmitter::SubmitTask(const InvocationSpec& invocation) {
   return Submit(invocation, TaskType::NORMAL_TASK);
 }
 
-ActorID LocalModeTaskSubmitter::CreateActor(RemoteFunctionPtrHolder &fptr,
+ActorID LocalModeTaskSubmitter::CreateActor(RemoteFunctionPtrHolder& fptr,
                                             std::shared_ptr<msgpack::sbuffer> args) {
   ActorID id = local_mode_ray_tuntime_.GetNextActorID();
   typedef std::shared_ptr<msgpack::sbuffer> (*ExecFunction)(
@@ -105,7 +104,7 @@ ActorID LocalModeTaskSubmitter::CreateActor(RemoteFunctionPtrHolder &fptr,
   return id;
 }
 
-ObjectID LocalModeTaskSubmitter::SubmitActorTask(const InvocationSpec &invocation) {
+ObjectID LocalModeTaskSubmitter::SubmitActorTask(const InvocationSpec& invocation) {
   return Submit(invocation, TaskType::ACTOR_TASK);
 }
 

--- a/cpp/src/ray/runtime/task/local_mode_task_submitter.h
+++ b/cpp/src/ray/runtime/task/local_mode_task_submitter.h
@@ -3,6 +3,7 @@
 #include <boost/asio/thread_pool.hpp>
 #include <memory>
 #include <queue>
+
 #include "../local_mode_ray_runtime.h"
 #include "absl/synchronization/mutex.h"
 #include "invocation_spec.h"

--- a/cpp/src/ray/runtime/task/local_mode_task_submitter.h
+++ b/cpp/src/ray/runtime/task/local_mode_task_submitter.h
@@ -16,14 +16,14 @@ namespace api {
 
 class LocalModeTaskSubmitter : public TaskSubmitter {
  public:
-  LocalModeTaskSubmitter(LocalModeRayRuntime &local_mode_ray_tuntime);
+  LocalModeTaskSubmitter(LocalModeRayRuntime& local_mode_ray_tuntime);
 
-  ObjectID SubmitTask(const InvocationSpec &invocation);
+  ObjectID SubmitTask(const InvocationSpec& invocation);
 
-  ActorID CreateActor(RemoteFunctionPtrHolder &fptr,
+  ActorID CreateActor(RemoteFunctionPtrHolder& fptr,
                       std::shared_ptr<msgpack::sbuffer> args);
 
-  ObjectID SubmitActorTask(const InvocationSpec &invocation);
+  ObjectID SubmitActorTask(const InvocationSpec& invocation);
 
  private:
   std::unordered_map<ActorID, std::unique_ptr<ActorContext>> actor_contexts_;
@@ -32,9 +32,9 @@ class LocalModeTaskSubmitter : public TaskSubmitter {
 
   std::unique_ptr<boost::asio::thread_pool> thread_pool_;
 
-  LocalModeRayRuntime &local_mode_ray_tuntime_;
+  LocalModeRayRuntime& local_mode_ray_tuntime_;
 
-  ObjectID Submit(const InvocationSpec &invocation, TaskType type);
+  ObjectID Submit(const InvocationSpec& invocation, TaskType type);
 };
 }  // namespace api
 }  // namespace ray

--- a/cpp/src/ray/runtime/task/native_task_submitter.cc
+++ b/cpp/src/ray/runtime/task/native_task_submitter.cc
@@ -1,5 +1,7 @@
 #include "native_task_submitter.h"
+
 #include <ray/api/ray_exception.h>
+
 #include "../../util/address_helper.h"
 #include "../abstract_ray_runtime.h"
 

--- a/cpp/src/ray/runtime/task/native_task_submitter.cc
+++ b/cpp/src/ray/runtime/task/native_task_submitter.cc
@@ -8,23 +8,23 @@
 namespace ray {
 namespace api {
 
-NativeTaskSubmitter::NativeTaskSubmitter(NativeRayRuntime &native_ray_tuntime_)
+NativeTaskSubmitter::NativeTaskSubmitter(NativeRayRuntime& native_ray_tuntime_)
     : native_ray_tuntime_(native_ray_tuntime_) {}
 
-ObjectID NativeTaskSubmitter::Submit(const InvocationSpec &invocation, TaskType type) {
+ObjectID NativeTaskSubmitter::Submit(const InvocationSpec& invocation, TaskType type) {
   return ObjectID();
 }
 
-ObjectID NativeTaskSubmitter::SubmitTask(const InvocationSpec &invocation) {
+ObjectID NativeTaskSubmitter::SubmitTask(const InvocationSpec& invocation) {
   return Submit(invocation, TaskType::NORMAL_TASK);
 }
 
-ActorID NativeTaskSubmitter::CreateActor(RemoteFunctionPtrHolder &fptr,
+ActorID NativeTaskSubmitter::CreateActor(RemoteFunctionPtrHolder& fptr,
                                          std::shared_ptr<msgpack::sbuffer> args) {
   return native_ray_tuntime_.GetNextActorID();
 }
 
-ObjectID NativeTaskSubmitter::SubmitActorTask(const InvocationSpec &invocation) {
+ObjectID NativeTaskSubmitter::SubmitActorTask(const InvocationSpec& invocation) {
   return Submit(invocation, TaskType::ACTOR_TASK);
 }
 

--- a/cpp/src/ray/runtime/task/native_task_submitter.h
+++ b/cpp/src/ray/runtime/task/native_task_submitter.h
@@ -3,6 +3,7 @@
 #include <boost/asio/thread_pool.hpp>
 #include <memory>
 #include <queue>
+
 #include "../native_ray_runtime.h"
 #include "invocation_spec.h"
 #include "ray/core.h"

--- a/cpp/src/ray/runtime/task/native_task_submitter.h
+++ b/cpp/src/ray/runtime/task/native_task_submitter.h
@@ -14,19 +14,19 @@ namespace api {
 
 class NativeTaskSubmitter : public TaskSubmitter {
  public:
-  NativeTaskSubmitter(NativeRayRuntime &native_ray_tuntime);
+  NativeTaskSubmitter(NativeRayRuntime& native_ray_tuntime);
 
-  ObjectID SubmitTask(const InvocationSpec &invocation);
+  ObjectID SubmitTask(const InvocationSpec& invocation);
 
-  ActorID CreateActor(RemoteFunctionPtrHolder &fptr,
+  ActorID CreateActor(RemoteFunctionPtrHolder& fptr,
                       std::shared_ptr<msgpack::sbuffer> args);
 
-  ObjectID SubmitActorTask(const InvocationSpec &invocation);
+  ObjectID SubmitActorTask(const InvocationSpec& invocation);
 
  private:
-  NativeRayRuntime &native_ray_tuntime_;
+  NativeRayRuntime& native_ray_tuntime_;
 
-  ObjectID Submit(const InvocationSpec &invocation, TaskType type);
+  ObjectID Submit(const InvocationSpec& invocation, TaskType type);
 };
 }  // namespace api
 }  // namespace ray

--- a/cpp/src/ray/runtime/task/task_executor.cc
+++ b/cpp/src/ray/runtime/task/task_executor.cc
@@ -1,9 +1,10 @@
 
+#include "task_executor.h"
+
 #include <memory>
 
 #include "../../util/address_helper.h"
 #include "../abstract_ray_runtime.h"
-#include "task_executor.h"
 
 namespace ray {
 namespace api {

--- a/cpp/src/ray/runtime/task/task_executor.cc
+++ b/cpp/src/ray/runtime/task/task_executor.cc
@@ -9,22 +9,22 @@
 namespace ray {
 namespace api {
 
-TaskExecutor::TaskExecutor(AbstractRayRuntime &abstract_ray_tuntime_)
+TaskExecutor::TaskExecutor(AbstractRayRuntime& abstract_ray_tuntime_)
     : abstract_ray_tuntime_(abstract_ray_tuntime_) {}
 
 // TODO(Guyang Song): Make a common task execution function used for both local mode and
 // cluster mode.
-std::unique_ptr<ObjectID> TaskExecutor::Execute(const InvocationSpec &invocation) {
+std::unique_ptr<ObjectID> TaskExecutor::Execute(const InvocationSpec& invocation) {
   abstract_ray_tuntime_.GetWorkerContext();
   return std::unique_ptr<ObjectID>(new ObjectID());
 };
 
-void TaskExecutor::Invoke(const TaskSpecification &task_spec,
+void TaskExecutor::Invoke(const TaskSpecification& task_spec,
                           std::shared_ptr<msgpack::sbuffer> actor,
-                          AbstractRayRuntime *runtime) {
+                          AbstractRayRuntime* runtime) {
   auto args = std::make_shared<msgpack::sbuffer>(task_spec.ArgDataSize(0));
   /// TODO(Guyang Song): Avoid the memory copy.
-  args->write(reinterpret_cast<const char *>(task_spec.ArgData(0)),
+  args->write(reinterpret_cast<const char*>(task_spec.ArgData(0)),
               task_spec.ArgDataSize(0));
   auto function_descriptor = task_spec.FunctionDescriptor();
   auto typed_descriptor = function_descriptor->As<ray::CppFunctionDescriptor>();

--- a/cpp/src/ray/runtime/task/task_executor.h
+++ b/cpp/src/ray/runtime/task/task_executor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+
 #include "absl/synchronization/mutex.h"
 #include "invocation_spec.h"
 #include "ray/core.h"

--- a/cpp/src/ray/runtime/task/task_executor.h
+++ b/cpp/src/ray/runtime/task/task_executor.h
@@ -22,19 +22,19 @@ class ActorContext {
 
 class TaskExecutor {
  public:
-  TaskExecutor(AbstractRayRuntime &abstract_ray_tuntime_);
+  TaskExecutor(AbstractRayRuntime& abstract_ray_tuntime_);
 
   /// TODO(Guyang Song): support multiple tasks execution
-  std::unique_ptr<ObjectID> Execute(const InvocationSpec &invocation);
+  std::unique_ptr<ObjectID> Execute(const InvocationSpec& invocation);
 
-  static void Invoke(const TaskSpecification &task_spec,
+  static void Invoke(const TaskSpecification& task_spec,
                      std::shared_ptr<msgpack::sbuffer> actor,
-                     AbstractRayRuntime *runtime);
+                     AbstractRayRuntime* runtime);
 
   virtual ~TaskExecutor(){};
 
  private:
-  AbstractRayRuntime &abstract_ray_tuntime_;
+  AbstractRayRuntime& abstract_ray_tuntime_;
 };
 }  // namespace api
 }  // namespace ray

--- a/cpp/src/ray/runtime/task/task_submitter.h
+++ b/cpp/src/ray/runtime/task/task_submitter.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <ray/api/ray_runtime.h>
+
 #include <memory>
 
-#include <ray/api/ray_runtime.h>
 #include "invocation_spec.h"
 
 namespace ray {

--- a/cpp/src/ray/runtime/task/task_submitter.h
+++ b/cpp/src/ray/runtime/task/task_submitter.h
@@ -15,12 +15,12 @@ class TaskSubmitter {
 
   virtual ~TaskSubmitter(){};
 
-  virtual ObjectID SubmitTask(const InvocationSpec &invocation) = 0;
+  virtual ObjectID SubmitTask(const InvocationSpec& invocation) = 0;
 
-  virtual ActorID CreateActor(RemoteFunctionPtrHolder &fptr,
+  virtual ActorID CreateActor(RemoteFunctionPtrHolder& fptr,
                               std::shared_ptr<msgpack::sbuffer> args) = 0;
 
-  virtual ObjectID SubmitActorTask(const InvocationSpec &invocation) = 0;
+  virtual ObjectID SubmitActorTask(const InvocationSpec& invocation) = 0;
 };
 }  // namespace api
 }  // namespace ray

--- a/cpp/src/ray/test/api_test.cc
+++ b/cpp/src/ray/test/api_test.cc
@@ -1,6 +1,7 @@
 
 #include <gtest/gtest.h>
 #include <ray/api.h>
+
 #include <future>
 #include <thread>
 

--- a/cpp/src/ray/test/api_test.cc
+++ b/cpp/src/ray/test/api_test.cc
@@ -20,8 +20,8 @@ class Counter {
 
   Counter() { count = 0; }
 
-  static Counter *FactoryCreate() {
-    Counter *counter = new Counter();
+  static Counter* FactoryCreate() {
+    Counter* counter = new Counter();
     return counter;
   }
 

--- a/cpp/src/ray/test/slow_function_test.cc
+++ b/cpp/src/ray/test/slow_function_test.cc
@@ -1,6 +1,7 @@
 
 #include <gtest/gtest.h>
 #include <ray/api.h>
+
 #include <chrono>
 #include <thread>
 

--- a/cpp/src/ray/util/address_helper.cc
+++ b/cpp/src/ray/util/address_helper.cc
@@ -8,7 +8,7 @@ uintptr_t dynamic_library_base_addr;
 
 extern "C" void GenerateBaseAddressOfCurrentLibrary() {
   Dl_info info;
-  dladdr((void *)GenerateBaseAddressOfCurrentLibrary, &info);
+  dladdr((void*)GenerateBaseAddressOfCurrentLibrary, &info);
   dynamic_library_base_addr = (uintptr_t)info.dli_fbase;
   return;
 }

--- a/src/ray/common/buffer.h
+++ b/src/ray/common/buffer.h
@@ -26,7 +26,7 @@ namespace ray {
 class Buffer {
  public:
   /// Pointer to the data.
-  virtual uint8_t *Data() const = 0;
+  virtual uint8_t* Data() const = 0;
 
   /// Size of this buffer.
   virtual size_t Size() const = 0;
@@ -38,7 +38,7 @@ class Buffer {
 
   virtual ~Buffer(){};
 
-  bool operator==(const Buffer &rhs) const {
+  bool operator==(const Buffer& rhs) const {
     if (this->Size() != rhs.Size()) {
       return false;
     }
@@ -61,7 +61,7 @@ class LocalMemoryBuffer : public Buffer {
   /// \param size The size of the passed in buffer.
   /// \param copy_data If true, data will be copied and owned by this buffer,
   ///                  otherwise the buffer only points to the given address.
-  LocalMemoryBuffer(uint8_t *data, size_t size, bool copy_data = false)
+  LocalMemoryBuffer(uint8_t* data, size_t size, bool copy_data = false)
       : has_data_copy_(copy_data) {
     if (copy_data) {
       RAY_CHECK(data != nullptr);
@@ -82,7 +82,7 @@ class LocalMemoryBuffer : public Buffer {
     size_ = buffer_.size();
   }
 
-  uint8_t *Data() const override { return data_; }
+  uint8_t* Data() const override { return data_; }
 
   size_t Size() const override { return size_; }
 
@@ -95,11 +95,11 @@ class LocalMemoryBuffer : public Buffer {
  private:
   /// Disable copy constructor and assignment, as default copy will
   /// cause invalid data_.
-  LocalMemoryBuffer &operator=(const LocalMemoryBuffer &) = delete;
-  LocalMemoryBuffer(const LocalMemoryBuffer &) = delete;
+  LocalMemoryBuffer& operator=(const LocalMemoryBuffer&) = delete;
+  LocalMemoryBuffer(const LocalMemoryBuffer&) = delete;
 
   /// Pointer to the data.
-  uint8_t *data_;
+  uint8_t* data_;
   /// Size of the buffer.
   size_t size_;
   /// Whether this buffer holds a copy of data.
@@ -113,10 +113,10 @@ class LocalMemoryBuffer : public Buffer {
 class PlasmaBuffer : public Buffer {
  public:
   PlasmaBuffer(std::shared_ptr<arrow::Buffer> buffer,
-               std::function<void(PlasmaBuffer *)> on_delete = nullptr)
+               std::function<void(PlasmaBuffer*)> on_delete = nullptr)
       : buffer_(buffer), on_delete_(on_delete) {}
 
-  uint8_t *Data() const override { return const_cast<uint8_t *>(buffer_->data()); }
+  uint8_t* Data() const override { return const_cast<uint8_t*>(buffer_->data()); }
 
   size_t Size() const override { return buffer_->size(); }
 
@@ -135,7 +135,7 @@ class PlasmaBuffer : public Buffer {
   /// for the object (when it's a plasma::PlasmaBuffer).
   std::shared_ptr<arrow::Buffer> buffer_;
   /// Callback to run on destruction.
-  std::function<void(PlasmaBuffer *)> on_delete_;
+  std::function<void(PlasmaBuffer*)> on_delete_;
 };
 
 }  // namespace ray

--- a/src/ray/common/bundle_spec.cc
+++ b/src/ray/common/bundle_spec.cc
@@ -27,7 +27,7 @@ void BundleSpecification::ComputeResources() {
   }
 }
 
-const ResourceSet &BundleSpecification::GetRequiredResources() const {
+const ResourceSet& BundleSpecification::GetRequiredResources() const {
   return *unit_resource_;
 }
 
@@ -51,7 +51,7 @@ int64_t BundleSpecification::Index() const {
   return message_->bundle_id().bundle_index();
 }
 
-std::string FormatPlacementGroupResource(const std::string &original_resource_name,
+std::string FormatPlacementGroupResource(const std::string& original_resource_name,
                                          PlacementGroupID group_id,
                                          int64_t bundle_index) {
   auto str = original_resource_name + "_group_" + group_id.Hex() + "_" +
@@ -60,13 +60,13 @@ std::string FormatPlacementGroupResource(const std::string &original_resource_na
   return str;
 }
 
-std::string FormatPlacementGroupResource(const std::string &original_resource_name,
-                                         const BundleSpecification &bundle_spec) {
+std::string FormatPlacementGroupResource(const std::string& original_resource_name,
+                                         const BundleSpecification& bundle_spec) {
   return FormatPlacementGroupResource(
       original_resource_name, bundle_spec.PlacementGroupId(), bundle_spec.Index());
 }
 
-std::string GetOriginalResourceName(const std::string &resource) {
+std::string GetOriginalResourceName(const std::string& resource) {
   auto idx = resource.find("_group_");
   RAY_CHECK(idx >= 0) << "This isn't a placement group resource " << resource;
   return resource.substr(0, idx);

--- a/src/ray/common/bundle_spec.h
+++ b/src/ray/common/bundle_spec.h
@@ -27,7 +27,7 @@
 
 namespace ray {
 
-typedef std::function<void(const ResourceIdSet &)> ScheduleBundleCallback;
+typedef std::function<void(const ResourceIdSet&)> ScheduleBundleCallback;
 /// Arguments are the raylet ID to spill back to, the raylet's
 /// address and the raylet's port.
 typedef std::function<void()> SpillbackBundleCallback;
@@ -60,23 +60,23 @@ class BundleSpecification : public MessageWrapper<rpc::Bundle> {
   /// Return the resources that are to be acquired by this bundle.
   ///
   /// \return The resources that will be acquired by this bundle.
-  const ResourceSet &GetRequiredResources() const;
+  const ResourceSet& GetRequiredResources() const;
 
   /// Override dispatch behaviour.
-  void OnScheduleInstead(const ScheduleBundleCallback &callback) {
+  void OnScheduleInstead(const ScheduleBundleCallback& callback) {
     on_schedule_ = callback;
   }
 
   /// Override spillback behaviour.
-  void OnSpillbackInstead(const SpillbackBundleCallback &callback) {
+  void OnSpillbackInstead(const SpillbackBundleCallback& callback) {
     on_spillback_ = callback;
   }
 
   /// Returns the schedule bundle callback, or nullptr.
-  const ScheduleBundleCallback &OnSchedule() const { return on_schedule_; }
+  const ScheduleBundleCallback& OnSchedule() const { return on_schedule_; }
 
   /// Returns the spillback bundle callback, or nullptr.
-  const SpillbackBundleCallback &OnSpillback() const { return on_spillback_; }
+  const SpillbackBundleCallback& OnSpillback() const { return on_spillback_; }
 
  private:
   void ComputeResources();
@@ -92,14 +92,14 @@ class BundleSpecification : public MessageWrapper<rpc::Bundle> {
 };
 
 /// Format a placement group resource, e.g., CPU -> CPU_group_YYY_i
-std::string FormatPlacementGroupResource(const std::string &original_resource_name,
+std::string FormatPlacementGroupResource(const std::string& original_resource_name,
                                          PlacementGroupID group_id, int64_t bundle_index);
 
 /// Format a placement group resource, e.g., CPU -> CPU_group_YYY_i
-std::string FormatPlacementGroupResource(const std::string &original_resource_name,
-                                         const BundleSpecification &bundle_spec);
+std::string FormatPlacementGroupResource(const std::string& original_resource_name,
+                                         const BundleSpecification& bundle_spec);
 
 /// Return the original resource name of the placement group resource.
-std::string GetOriginalResourceName(const std::string &resource);
+std::string GetOriginalResourceName(const std::string& resource);
 
 }  // namespace ray

--- a/src/ray/common/client_connection.h
+++ b/src/ray/common/client_connection.h
@@ -30,7 +30,7 @@ typedef boost::asio::generic::stream_protocol local_stream_protocol;
 typedef boost::asio::basic_stream_socket<local_stream_protocol> local_stream_socket;
 
 /// Connect to a socket with retry times.
-Status ConnectSocketRetry(local_stream_socket &socket, const std::string &endpoint,
+Status ConnectSocketRetry(local_stream_socket& socket, const std::string& endpoint,
                           int num_retries = -1, int64_t timeout_in_ms = -1);
 
 /// \typename ServerConnection
@@ -46,7 +46,7 @@ class ServerConnection : public std::enable_shared_from_this<ServerConnection> {
   ///
   /// \param socket A reference to the server socket.
   /// \return std::shared_ptr<ServerConnection>.
-  static std::shared_ptr<ServerConnection> Create(local_stream_socket &&socket);
+  static std::shared_ptr<ServerConnection> Create(local_stream_socket&& socket);
 
   /// Write a message to the client.
   ///
@@ -54,7 +54,7 @@ class ServerConnection : public std::enable_shared_from_this<ServerConnection> {
   /// \param length The size in bytes of the message.
   /// \param message A pointer to the message buffer.
   /// \return Status.
-  ray::Status WriteMessage(int64_t type, int64_t length, const uint8_t *message);
+  ray::Status WriteMessage(int64_t type, int64_t length, const uint8_t* message);
 
   /// Write a message to the client asynchronously.
   ///
@@ -62,43 +62,43 @@ class ServerConnection : public std::enable_shared_from_this<ServerConnection> {
   /// \param length The size in bytes of the message.
   /// \param message A pointer to the message buffer.
   /// \param handler A callback to run on write completion.
-  void WriteMessageAsync(int64_t type, int64_t length, const uint8_t *message,
-                         const std::function<void(const ray::Status &)> &handler);
+  void WriteMessageAsync(int64_t type, int64_t length, const uint8_t* message,
+                         const std::function<void(const ray::Status&)>& handler);
 
   /// Read a message from the client.
   ///
   /// \param type The message type (e.g., a flatbuffer enum).
   /// \param message A pointer to the message buffer.
   /// \return Status.
-  Status ReadMessage(int64_t type, std::vector<uint8_t> *message);
+  Status ReadMessage(int64_t type, std::vector<uint8_t>* message);
 
   /// Write a buffer to this connection.
   ///
   /// \param buffer The buffer.
   /// \return Status.
-  Status WriteBuffer(const std::vector<boost::asio::const_buffer> &buffer);
+  Status WriteBuffer(const std::vector<boost::asio::const_buffer>& buffer);
 
   /// Write a buffer to this connection asynchronously.
   ///
   /// \param buffer The buffer.
   /// \param handler A callback to run on write completion.
   /// \return Status.
-  void WriteBufferAsync(const std::vector<boost::asio::const_buffer> &buffer,
-                        const std::function<void(const ray::Status &)> &handler);
+  void WriteBufferAsync(const std::vector<boost::asio::const_buffer>& buffer,
+                        const std::function<void(const ray::Status&)>& handler);
 
   /// Read a buffer from this connection.
   ///
   /// \param buffer The buffer.
   /// \return Status.
-  Status ReadBuffer(const std::vector<boost::asio::mutable_buffer> &buffer);
+  Status ReadBuffer(const std::vector<boost::asio::mutable_buffer>& buffer);
 
   /// Read a buffer from this connection asynchronously.
   ///
   /// \param buffer The buffer.
   /// \param handler A callback to run on read completion.
   /// \return Status.
-  void ReadBufferAsync(const std::vector<boost::asio::mutable_buffer> &buffer,
-                       const std::function<void(const ray::Status &)> &handler);
+  void ReadBufferAsync(const std::vector<boost::asio::mutable_buffer>& buffer,
+                       const std::function<void(const ray::Status&)>& handler);
 
   /// Shuts down socket for this connection.
   void Close() {
@@ -120,7 +120,7 @@ class ServerConnection : public std::enable_shared_from_this<ServerConnection> {
 
  protected:
   /// A private constructor for a server connection.
-  ServerConnection(local_stream_socket &&socket);
+  ServerConnection(local_stream_socket&& socket);
 
   /// A message that is queued for writing asynchronously.
   struct AsyncWriteBuffer {
@@ -128,7 +128,7 @@ class ServerConnection : public std::enable_shared_from_this<ServerConnection> {
     int64_t write_type;
     uint64_t write_length;
     std::vector<uint8_t> write_message;
-    std::function<void(const ray::Status &)> handler;
+    std::function<void(const ray::Status&)> handler;
   };
 
   /// The socket connection to the server.
@@ -167,9 +167,9 @@ class ServerConnection : public std::enable_shared_from_this<ServerConnection> {
 
 class ClientConnection;
 
-using ClientHandler = std::function<void(ClientConnection &)>;
+using ClientHandler = std::function<void(ClientConnection&)>;
 using MessageHandler = std::function<void(std::shared_ptr<ClientConnection>, int64_t,
-                                          const std::vector<uint8_t> &)>;
+                                          const std::vector<uint8_t>&)>;
 
 /// \typename ClientConnection
 ///
@@ -191,9 +191,9 @@ class ClientConnection : public ServerConnection {
   /// message types received from this client, used for debug messages.
   /// \return std::shared_ptr<ClientConnection>.
   static std::shared_ptr<ClientConnection> Create(
-      ClientHandler &new_client_handler, MessageHandler &message_handler,
-      local_stream_socket &&socket, const std::string &debug_label,
-      const std::vector<std::string> &message_type_enum_names,
+      ClientHandler& new_client_handler, MessageHandler& message_handler,
+      local_stream_socket&& socket, const std::string& debug_label,
+      const std::vector<std::string>& message_type_enum_names,
       int64_t error_message_type);
 
   std::shared_ptr<ClientConnection> shared_ClientConnection_from_this() {
@@ -210,16 +210,16 @@ class ClientConnection : public ServerConnection {
 
  protected:
   /// A protected constructor for a node client connection.
-  ClientConnection(MessageHandler &message_handler, local_stream_socket &&socket,
-                   const std::string &debug_label,
-                   const std::vector<std::string> &message_type_enum_names,
+  ClientConnection(MessageHandler& message_handler, local_stream_socket&& socket,
+                   const std::string& debug_label,
+                   const std::vector<std::string>& message_type_enum_names,
                    int64_t error_message_type);
   /// Process an error from the last operation, then process the  message
   /// header from the client.
-  void ProcessMessageHeader(const boost::system::error_code &error);
+  void ProcessMessageHeader(const boost::system::error_code& error);
   /// Process an error from reading the message header, then process the
   /// message from the client.
-  void ProcessMessage(const boost::system::error_code &error);
+  void ProcessMessage(const boost::system::error_code& error);
   /// Check if the ray cookie in a received message is correct. Note, if the cookie
   /// is wrong and the remote endpoint is known, raylet process will crash. If the remote
   /// endpoint is unknown, this method will only print a warning.

--- a/src/ray/common/common_protocol.cc
+++ b/src/ray/common/common_protocol.cc
@@ -16,12 +16,12 @@
 
 #include "ray/util/logging.h"
 
-std::string string_from_flatbuf(const flatbuffers::String &string) {
+std::string string_from_flatbuf(const flatbuffers::String& string) {
   return std::string(string.data(), string.size());
 }
 
 std::vector<std::string> string_vec_from_flatbuf(
-    const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> &flatbuf_vec) {
+    const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>& flatbuf_vec) {
   std::vector<std::string> string_vector;
   string_vector.reserve(flatbuf_vec.size());
   for (int64_t i = 0; i < flatbuf_vec.size(); i++) {
@@ -32,11 +32,11 @@ std::vector<std::string> string_vec_from_flatbuf(
 }
 
 flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>>
-string_vec_to_flatbuf(flatbuffers::FlatBufferBuilder &fbb,
-                      const std::vector<std::string> &string_vector) {
+string_vec_to_flatbuf(flatbuffers::FlatBufferBuilder& fbb,
+                      const std::vector<std::string>& string_vector) {
   std::vector<flatbuffers::Offset<flatbuffers::String>> flatbuf_str_vec;
   flatbuf_str_vec.reserve(flatbuf_str_vec.size());
-  for (auto const &str : string_vector) {
+  for (auto const& str : string_vector) {
     flatbuf_str_vec.push_back(fbb.CreateString(str));
   }
   return fbb.CreateVector(flatbuf_str_vec);

--- a/src/ray/common/common_protocol.h
+++ b/src/ray/common/common_protocol.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <flatbuffers/flatbuffers.h>
+
 #include <unordered_set>
 
 #include "ray/common/id.h"

--- a/src/ray/common/common_protocol.h
+++ b/src/ray/common/common_protocol.h
@@ -27,7 +27,7 @@
 /// @param id The ID to be converted.
 /// @return The flatbuffer string containing the ID.
 template <typename ID>
-flatbuffers::Offset<flatbuffers::String> to_flatbuf(flatbuffers::FlatBufferBuilder &fbb,
+flatbuffers::Offset<flatbuffers::String> to_flatbuf(flatbuffers::FlatBufferBuilder& fbb,
                                                     ID id);
 
 /// Convert a flatbuffer string to an unique ID.
@@ -35,7 +35,7 @@ flatbuffers::Offset<flatbuffers::String> to_flatbuf(flatbuffers::FlatBufferBuild
 /// @param string The flatbuffer string.
 /// @return The ID.
 template <typename ID>
-ID from_flatbuf(const flatbuffers::String &string);
+ID from_flatbuf(const flatbuffers::String& string);
 
 /// Convert a flatbuffer vector of strings to a vector of unique IDs.
 ///
@@ -43,7 +43,7 @@ ID from_flatbuf(const flatbuffers::String &string);
 /// @return The vector of IDs.
 template <typename ID>
 const std::vector<ID> from_flatbuf(
-    const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> &vector);
+    const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>& vector);
 
 /// Convert a flatbuffer vector of strings to an unordered_set of unique IDs.
 ///
@@ -51,7 +51,7 @@ const std::vector<ID> from_flatbuf(
 /// @return The unordered set of IDs.
 template <typename ID>
 const std::unordered_set<ID> unordered_set_from_flatbuf(
-    const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> &vector);
+    const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>& vector);
 
 /// Convert a flatbuffer of string that concatenated
 /// unique IDs to a vector of unique IDs.
@@ -59,7 +59,7 @@ const std::unordered_set<ID> unordered_set_from_flatbuf(
 /// @param vector The flatbuffer vector.
 /// @return The vector of IDs.
 template <typename ID>
-const std::vector<ID> ids_from_flatbuf(const flatbuffers::String &string);
+const std::vector<ID> ids_from_flatbuf(const flatbuffers::String& string);
 
 /// Convert a vector of unique IDs to a flatbuffer string.
 /// The IDs are concatenated to a string with binary.
@@ -69,7 +69,7 @@ const std::vector<ID> ids_from_flatbuf(const flatbuffers::String &string);
 /// @return Flatbuffer string of concatenated IDs.
 template <typename ID>
 flatbuffers::Offset<flatbuffers::String> ids_to_flatbuf(
-    flatbuffers::FlatBufferBuilder &fbb, const std::vector<ID> &ids);
+    flatbuffers::FlatBufferBuilder& fbb, const std::vector<ID>& ids);
 
 /// Convert an array of unique IDs to a flatbuffer vector of strings.
 ///
@@ -79,7 +79,7 @@ flatbuffers::Offset<flatbuffers::String> ids_to_flatbuf(
 /// @return Flatbuffer vector of strings.
 template <typename ID>
 flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>>
-to_flatbuf(flatbuffers::FlatBufferBuilder &fbb, ID ids[], int64_t num_ids);
+to_flatbuf(flatbuffers::FlatBufferBuilder& fbb, ID ids[], int64_t num_ids);
 
 /// Convert a vector of unique IDs to a flatbuffer vector of strings.
 ///
@@ -88,7 +88,7 @@ to_flatbuf(flatbuffers::FlatBufferBuilder &fbb, ID ids[], int64_t num_ids);
 /// @return Flatbuffer vector of strings.
 template <typename ID>
 flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>>
-to_flatbuf(flatbuffers::FlatBufferBuilder &fbb, const std::vector<ID> &ids);
+to_flatbuf(flatbuffers::FlatBufferBuilder& fbb, const std::vector<ID>& ids);
 
 /// Convert an unordered_set of unique IDs to a flatbuffer vector of strings.
 ///
@@ -97,36 +97,36 @@ to_flatbuf(flatbuffers::FlatBufferBuilder &fbb, const std::vector<ID> &ids);
 /// @return Flatbuffer vector of strings.
 template <typename ID>
 flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>>
-to_flatbuf(flatbuffers::FlatBufferBuilder &fbb, const std::unordered_set<ID> &ids);
+to_flatbuf(flatbuffers::FlatBufferBuilder& fbb, const std::unordered_set<ID>& ids);
 
 /// Convert a flatbuffer string to a std::string.
 ///
 /// @param fbb Reference to the flatbuffer builder.
 /// @param string A flatbuffers string.
 /// @return The std::string version of the flatbuffer string.
-std::string string_from_flatbuf(const flatbuffers::String &string);
+std::string string_from_flatbuf(const flatbuffers::String& string);
 
 std::vector<std::string> string_vec_from_flatbuf(
-    const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> &flatbuf_vec);
+    const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>& flatbuf_vec);
 
 flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>>
-string_vec_to_flatbuf(flatbuffers::FlatBufferBuilder &fbb,
-                      const std::vector<std::string> &string_vector);
+string_vec_to_flatbuf(flatbuffers::FlatBufferBuilder& fbb,
+                      const std::vector<std::string>& string_vector);
 
 template <typename ID>
-flatbuffers::Offset<flatbuffers::String> to_flatbuf(flatbuffers::FlatBufferBuilder &fbb,
+flatbuffers::Offset<flatbuffers::String> to_flatbuf(flatbuffers::FlatBufferBuilder& fbb,
                                                     ID id) {
-  return fbb.CreateString(reinterpret_cast<const char *>(id.Data()), id.Size());
+  return fbb.CreateString(reinterpret_cast<const char*>(id.Data()), id.Size());
 }
 
 template <typename ID>
-ID from_flatbuf(const flatbuffers::String &string) {
+ID from_flatbuf(const flatbuffers::String& string) {
   return ID::FromBinary(string.str());
 }
 
 template <typename ID>
 const std::vector<ID> from_flatbuf(
-    const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> &vector) {
+    const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>& vector) {
   std::vector<ID> ids;
   for (int64_t i = 0; i < vector.Length(); i++) {
     ids.push_back(from_flatbuf<ID>(*vector.Get(i)));
@@ -136,7 +136,7 @@ const std::vector<ID> from_flatbuf(
 
 template <typename ID>
 const std::unordered_set<ID> unordered_set_from_flatbuf(
-    const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> &vector) {
+    const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>& vector) {
   std::unordered_set<ID> ids;
   for (int64_t i = 0; i < vector.Length(); i++) {
     ids.insert(from_flatbuf<ID>(*vector.Get(i)));
@@ -145,8 +145,8 @@ const std::unordered_set<ID> unordered_set_from_flatbuf(
 }
 
 template <typename ID>
-const std::vector<ID> ids_from_flatbuf(const flatbuffers::String &string) {
-  const auto &ids = string_from_flatbuf(string);
+const std::vector<ID> ids_from_flatbuf(const flatbuffers::String& string) {
+  const auto& ids = string_from_flatbuf(string);
   std::vector<ID> ret;
   size_t id_size = ID::Size();
   RAY_CHECK(ids.size() % id_size == 0);
@@ -154,7 +154,7 @@ const std::vector<ID> ids_from_flatbuf(const flatbuffers::String &string) {
 
   for (size_t i = 0; i < count; ++i) {
     auto pos = static_cast<size_t>(id_size * i);
-    const auto &id = ids.substr(pos, id_size);
+    const auto& id = ids.substr(pos, id_size);
     ret.push_back(ID::FromBinary(id));
   }
 
@@ -163,9 +163,9 @@ const std::vector<ID> ids_from_flatbuf(const flatbuffers::String &string) {
 
 template <typename ID>
 flatbuffers::Offset<flatbuffers::String> ids_to_flatbuf(
-    flatbuffers::FlatBufferBuilder &fbb, const std::vector<ID> &ids) {
+    flatbuffers::FlatBufferBuilder& fbb, const std::vector<ID>& ids) {
   std::string result;
-  for (const auto &id : ids) {
+  for (const auto& id : ids) {
     result += id.Binary();
   }
 
@@ -174,7 +174,7 @@ flatbuffers::Offset<flatbuffers::String> ids_to_flatbuf(
 
 template <typename ID>
 flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>>
-to_flatbuf(flatbuffers::FlatBufferBuilder &fbb, ID ids[], int64_t num_ids) {
+to_flatbuf(flatbuffers::FlatBufferBuilder& fbb, ID ids[], int64_t num_ids) {
   std::vector<flatbuffers::Offset<flatbuffers::String>> results;
   for (int64_t i = 0; i < num_ids; i++) {
     results.push_back(to_flatbuf(fbb, ids[i]));
@@ -184,7 +184,7 @@ to_flatbuf(flatbuffers::FlatBufferBuilder &fbb, ID ids[], int64_t num_ids) {
 
 template <typename ID>
 flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>>
-to_flatbuf(flatbuffers::FlatBufferBuilder &fbb, const std::vector<ID> &ids) {
+to_flatbuf(flatbuffers::FlatBufferBuilder& fbb, const std::vector<ID>& ids) {
   std::vector<flatbuffers::Offset<flatbuffers::String>> results;
   for (auto id : ids) {
     results.push_back(to_flatbuf(fbb, id));
@@ -194,7 +194,7 @@ to_flatbuf(flatbuffers::FlatBufferBuilder &fbb, const std::vector<ID> &ids) {
 
 template <typename ID>
 flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>>
-to_flatbuf(flatbuffers::FlatBufferBuilder &fbb, const std::unordered_set<ID> &ids) {
+to_flatbuf(flatbuffers::FlatBufferBuilder& fbb, const std::unordered_set<ID>& ids) {
   std::vector<flatbuffers::Offset<flatbuffers::String>> results;
   for (auto id : ids) {
     results.push_back(to_flatbuf(fbb, id));

--- a/src/ray/common/function_descriptor.cc
+++ b/src/ray/common/function_descriptor.cc
@@ -21,9 +21,9 @@ FunctionDescriptor FunctionDescriptorBuilder::Empty() {
   return empty;
 }
 
-FunctionDescriptor FunctionDescriptorBuilder::BuildJava(const std::string &class_name,
-                                                        const std::string &function_name,
-                                                        const std::string &signature) {
+FunctionDescriptor FunctionDescriptorBuilder::BuildJava(const std::string& class_name,
+                                                        const std::string& function_name,
+                                                        const std::string& signature) {
   rpc::FunctionDescriptor descriptor;
   auto typed_descriptor = descriptor.mutable_java_function_descriptor();
   typed_descriptor->set_class_name(class_name);
@@ -33,8 +33,8 @@ FunctionDescriptor FunctionDescriptorBuilder::BuildJava(const std::string &class
 }
 
 FunctionDescriptor FunctionDescriptorBuilder::BuildPython(
-    const std::string &module_name, const std::string &class_name,
-    const std::string &function_name, const std::string &function_hash) {
+    const std::string& module_name, const std::string& class_name,
+    const std::string& function_name, const std::string& function_hash) {
   rpc::FunctionDescriptor descriptor;
   auto typed_descriptor = descriptor.mutable_python_function_descriptor();
   typed_descriptor->set_module_name(module_name);
@@ -45,8 +45,8 @@ FunctionDescriptor FunctionDescriptorBuilder::BuildPython(
 }
 
 FunctionDescriptor FunctionDescriptorBuilder::BuildCpp(
-    const std::string &lib_name, const std::string &function_offset,
-    const std::string &exec_function_offset) {
+    const std::string& lib_name, const std::string& function_offset,
+    const std::string& exec_function_offset) {
   rpc::FunctionDescriptor descriptor;
   auto typed_descriptor = descriptor.mutable_cpp_function_descriptor();
   typed_descriptor->set_lib_name(lib_name);
@@ -72,7 +72,7 @@ FunctionDescriptor FunctionDescriptorBuilder::FromProto(rpc::FunctionDescriptor 
 }
 
 FunctionDescriptor FunctionDescriptorBuilder::FromVector(
-    rpc::Language language, const std::vector<std::string> &function_descriptor_list) {
+    rpc::Language language, const std::vector<std::string>& function_descriptor_list) {
   if (language == rpc::Language::JAVA) {
     RAY_CHECK(function_descriptor_list.size() == 3);
     return FunctionDescriptorBuilder::BuildJava(
@@ -102,7 +102,7 @@ FunctionDescriptor FunctionDescriptorBuilder::FromVector(
 }
 
 FunctionDescriptor FunctionDescriptorBuilder::Deserialize(
-    const std::string &serialized_binary) {
+    const std::string& serialized_binary) {
   rpc::FunctionDescriptor descriptor;
   descriptor.ParseFromString(serialized_binary);
   return FunctionDescriptorBuilder::FromProto(std::move(descriptor));

--- a/src/ray/common/function_descriptor.h
+++ b/src/ray/common/function_descriptor.h
@@ -54,8 +54,8 @@ class FunctionDescriptorInterface : public MessageWrapper<rpc::FunctionDescripto
   virtual std::string CallSiteString() const { return ToString(); }
 
   template <typename Subtype>
-  Subtype *As() {
-    return reinterpret_cast<Subtype *>(this);
+  Subtype* As() {
+    return reinterpret_cast<Subtype*>(this);
   }
 };
 
@@ -74,9 +74,9 @@ class EmptyFunctionDescriptor : public FunctionDescriptorInterface {
     return std::hash<int>()(ray::FunctionDescriptorType::FUNCTION_DESCRIPTOR_NOT_SET);
   }
 
-  inline bool operator==(const EmptyFunctionDescriptor &other) const { return true; }
+  inline bool operator==(const EmptyFunctionDescriptor& other) const { return true; }
 
-  inline bool operator!=(const EmptyFunctionDescriptor &other) const { return false; }
+  inline bool operator!=(const EmptyFunctionDescriptor& other) const { return false; }
 
   virtual std::string ToString() const { return "{type=EmptyFunctionDescriptor}"; }
 };
@@ -101,7 +101,7 @@ class JavaFunctionDescriptor : public FunctionDescriptorInterface {
            std::hash<std::string>()(typed_message_->signature());
   }
 
-  inline bool operator==(const JavaFunctionDescriptor &other) const {
+  inline bool operator==(const JavaFunctionDescriptor& other) const {
     if (this == &other) {
       return true;
     }
@@ -110,7 +110,7 @@ class JavaFunctionDescriptor : public FunctionDescriptorInterface {
            this->Signature() == other.Signature();
   }
 
-  inline bool operator!=(const JavaFunctionDescriptor &other) const {
+  inline bool operator!=(const JavaFunctionDescriptor& other) const {
     return !(*this == other);
   }
 
@@ -120,14 +120,14 @@ class JavaFunctionDescriptor : public FunctionDescriptorInterface {
            ", signature=" + typed_message_->signature() + "}";
   }
 
-  const std::string &ClassName() const { return typed_message_->class_name(); }
+  const std::string& ClassName() const { return typed_message_->class_name(); }
 
-  const std::string &FunctionName() const { return typed_message_->function_name(); }
+  const std::string& FunctionName() const { return typed_message_->function_name(); }
 
-  const std::string &Signature() const { return typed_message_->signature(); }
+  const std::string& Signature() const { return typed_message_->signature(); }
 
  private:
-  const rpc::JavaFunctionDescriptor *typed_message_;
+  const rpc::JavaFunctionDescriptor* typed_message_;
 };
 
 class PythonFunctionDescriptor : public FunctionDescriptorInterface {
@@ -151,7 +151,7 @@ class PythonFunctionDescriptor : public FunctionDescriptorInterface {
            std::hash<std::string>()(typed_message_->function_hash());
   }
 
-  inline bool operator==(const PythonFunctionDescriptor &other) const {
+  inline bool operator==(const PythonFunctionDescriptor& other) const {
     if (this == &other) {
       return true;
     }
@@ -161,7 +161,7 @@ class PythonFunctionDescriptor : public FunctionDescriptorInterface {
            this->FunctionHash() == other.FunctionHash();
   }
 
-  inline bool operator!=(const PythonFunctionDescriptor &other) const {
+  inline bool operator!=(const PythonFunctionDescriptor& other) const {
     return !(*this == other);
   }
 
@@ -178,16 +178,16 @@ class PythonFunctionDescriptor : public FunctionDescriptorInterface {
            typed_message_->function_name();
   }
 
-  const std::string &ModuleName() const { return typed_message_->module_name(); }
+  const std::string& ModuleName() const { return typed_message_->module_name(); }
 
-  const std::string &ClassName() const { return typed_message_->class_name(); }
+  const std::string& ClassName() const { return typed_message_->class_name(); }
 
-  const std::string &FunctionName() const { return typed_message_->function_name(); }
+  const std::string& FunctionName() const { return typed_message_->function_name(); }
 
-  const std::string &FunctionHash() const { return typed_message_->function_hash(); }
+  const std::string& FunctionHash() const { return typed_message_->function_hash(); }
 
  private:
-  const rpc::PythonFunctionDescriptor *typed_message_;
+  const rpc::PythonFunctionDescriptor* typed_message_;
 };
 
 class CppFunctionDescriptor : public FunctionDescriptorInterface {
@@ -210,7 +210,7 @@ class CppFunctionDescriptor : public FunctionDescriptorInterface {
            std::hash<std::string>()(typed_message_->exec_function_offset());
   }
 
-  inline bool operator==(const CppFunctionDescriptor &other) const {
+  inline bool operator==(const CppFunctionDescriptor& other) const {
     if (this == &other) {
       return true;
     }
@@ -219,7 +219,7 @@ class CppFunctionDescriptor : public FunctionDescriptorInterface {
            this->ExecFunctionOffset() == other.ExecFunctionOffset();
   }
 
-  inline bool operator!=(const CppFunctionDescriptor &other) const {
+  inline bool operator!=(const CppFunctionDescriptor& other) const {
     return !(*this == other);
   }
 
@@ -229,21 +229,21 @@ class CppFunctionDescriptor : public FunctionDescriptorInterface {
            ", exec_function_offset=" + typed_message_->exec_function_offset() + "}";
   }
 
-  const std::string &LibName() const { return typed_message_->lib_name(); }
+  const std::string& LibName() const { return typed_message_->lib_name(); }
 
-  const std::string &FunctionOffset() const { return typed_message_->function_offset(); }
+  const std::string& FunctionOffset() const { return typed_message_->function_offset(); }
 
-  const std::string &ExecFunctionOffset() const {
+  const std::string& ExecFunctionOffset() const {
     return typed_message_->exec_function_offset();
   }
 
  private:
-  const rpc::CppFunctionDescriptor *typed_message_;
+  const rpc::CppFunctionDescriptor* typed_message_;
 };
 
 typedef std::shared_ptr<FunctionDescriptorInterface> FunctionDescriptor;
 
-inline bool operator==(const FunctionDescriptor &left, const FunctionDescriptor &right) {
+inline bool operator==(const FunctionDescriptor& left, const FunctionDescriptor& right) {
   if (left.get() == right.get()) {
     return true;
   }
@@ -255,24 +255,24 @@ inline bool operator==(const FunctionDescriptor &left, const FunctionDescriptor 
   }
   switch (left->Type()) {
   case ray::FunctionDescriptorType::FUNCTION_DESCRIPTOR_NOT_SET:
-    return static_cast<const EmptyFunctionDescriptor &>(*left) ==
-           static_cast<const EmptyFunctionDescriptor &>(*right);
+    return static_cast<const EmptyFunctionDescriptor&>(*left) ==
+           static_cast<const EmptyFunctionDescriptor&>(*right);
   case ray::FunctionDescriptorType::kJavaFunctionDescriptor:
-    return static_cast<const JavaFunctionDescriptor &>(*left) ==
-           static_cast<const JavaFunctionDescriptor &>(*right);
+    return static_cast<const JavaFunctionDescriptor&>(*left) ==
+           static_cast<const JavaFunctionDescriptor&>(*right);
   case ray::FunctionDescriptorType::kPythonFunctionDescriptor:
-    return static_cast<const PythonFunctionDescriptor &>(*left) ==
-           static_cast<const PythonFunctionDescriptor &>(*right);
+    return static_cast<const PythonFunctionDescriptor&>(*left) ==
+           static_cast<const PythonFunctionDescriptor&>(*right);
   case ray::FunctionDescriptorType::kCppFunctionDescriptor:
-    return static_cast<const CppFunctionDescriptor &>(*left) ==
-           static_cast<const CppFunctionDescriptor &>(*right);
+    return static_cast<const CppFunctionDescriptor&>(*left) ==
+           static_cast<const CppFunctionDescriptor&>(*right);
   default:
     RAY_LOG(FATAL) << "Unknown function descriptor type: " << left->Type();
     return false;
   }
 }
 
-inline bool operator!=(const FunctionDescriptor &left, const FunctionDescriptor &right) {
+inline bool operator!=(const FunctionDescriptor& left, const FunctionDescriptor& right) {
   return !(left == right);
 }
 
@@ -287,24 +287,24 @@ class FunctionDescriptorBuilder {
   /// Build a JavaFunctionDescriptor.
   ///
   /// \return a ray::JavaFunctionDescriptor
-  static FunctionDescriptor BuildJava(const std::string &class_name,
-                                      const std::string &function_name,
-                                      const std::string &signature);
+  static FunctionDescriptor BuildJava(const std::string& class_name,
+                                      const std::string& function_name,
+                                      const std::string& signature);
 
   /// Build a PythonFunctionDescriptor.
   ///
   /// \return a ray::PythonFunctionDescriptor
-  static FunctionDescriptor BuildPython(const std::string &module_name,
-                                        const std::string &class_name,
-                                        const std::string &function_name,
-                                        const std::string &function_hash);
+  static FunctionDescriptor BuildPython(const std::string& module_name,
+                                        const std::string& class_name,
+                                        const std::string& function_name,
+                                        const std::string& function_hash);
 
   /// Build a CppFunctionDescriptor.
   ///
   /// \return a ray::CppFunctionDescriptor
-  static FunctionDescriptor BuildCpp(const std::string &lib_name,
-                                     const std::string &function_offset,
-                                     const std::string &exec_function_offset);
+  static FunctionDescriptor BuildCpp(const std::string& lib_name,
+                                     const std::string& function_offset,
+                                     const std::string& exec_function_offset);
 
   /// Build a ray::FunctionDescriptor according to input message.
   ///
@@ -315,11 +315,11 @@ class FunctionDescriptorBuilder {
   ///
   /// \return new ray::FunctionDescriptor
   static FunctionDescriptor FromVector(
-      rpc::Language language, const std::vector<std::string> &function_descriptor_list);
+      rpc::Language language, const std::vector<std::string>& function_descriptor_list);
 
   /// Build a ray::FunctionDescriptor from serialized binary.
   ///
   /// \return new ray::FunctionDescriptor
-  static FunctionDescriptor Deserialize(const std::string &serialized_binary);
+  static FunctionDescriptor Deserialize(const std::string& serialized_binary);
 };
 }  // namespace ray

--- a/src/ray/common/grpc_util.h
+++ b/src/ray/common/grpc_util.h
@@ -46,16 +46,16 @@ class MessageWrapper {
   /// Construct from protobuf-serialized binary.
   ///
   /// \param serialized_binary Protobuf-serialized binary.
-  explicit MessageWrapper(const std::string &serialized_binary)
+  explicit MessageWrapper(const std::string& serialized_binary)
       : message_(std::make_shared<Message>()) {
     message_->ParseFromString(serialized_binary);
   }
 
   /// Get const reference of the protobuf message.
-  const Message &GetMessage() const { return *message_; }
+  const Message& GetMessage() const { return *message_; }
 
   /// Get reference of the protobuf message.
-  Message &GetMutableMessage() { return *message_; }
+  Message& GetMutableMessage() { return *message_; }
 
   /// Serialize the message to a string.
   const std::string Serialize() const { return message_->SerializeAsString(); }
@@ -66,7 +66,7 @@ class MessageWrapper {
 };
 
 /// Helper function that converts a ray status to gRPC status.
-inline grpc::Status RayStatusToGrpcStatus(const Status &ray_status) {
+inline grpc::Status RayStatusToGrpcStatus(const Status& ray_status) {
   if (ray_status.ok()) {
     return grpc::Status::OK;
   } else {
@@ -76,7 +76,7 @@ inline grpc::Status RayStatusToGrpcStatus(const Status &ray_status) {
 }
 
 /// Helper function that converts a gRPC status to ray status.
-inline Status GrpcStatusToRayStatus(const grpc::Status &grpc_status) {
+inline Status GrpcStatusToRayStatus(const grpc::Status& grpc_status) {
   if (grpc_status.ok()) {
     return Status::OK();
   } else {
@@ -91,21 +91,21 @@ inline Status GrpcStatusToRayStatus(const grpc::Status &grpc_status) {
 /// Converts a Protobuf `RepeatedPtrField` to a vector.
 template <class T>
 inline std::vector<T> VectorFromProtobuf(
-    const ::google::protobuf::RepeatedPtrField<T> &pb_repeated) {
+    const ::google::protobuf::RepeatedPtrField<T>& pb_repeated) {
   return std::vector<T>(pb_repeated.begin(), pb_repeated.end());
 }
 
 /// Converts a Protobuf `RepeatedField` to a vector.
 template <class T>
 inline std::vector<T> VectorFromProtobuf(
-    const ::google::protobuf::RepeatedField<T> &pb_repeated) {
+    const ::google::protobuf::RepeatedField<T>& pb_repeated) {
   return std::vector<T>(pb_repeated.begin(), pb_repeated.end());
 }
 
 /// Converts a Protobuf `RepeatedField` to a vector of IDs.
 template <class ID>
 inline std::vector<ID> IdVectorFromProtobuf(
-    const ::google::protobuf::RepeatedPtrField<::std::string> &pb_repeated) {
+    const ::google::protobuf::RepeatedPtrField<::std::string>& pb_repeated) {
   auto str_vec = VectorFromProtobuf(pb_repeated);
   std::vector<ID> ret;
   std::transform(str_vec.begin(), str_vec.end(), std::back_inserter(ret),

--- a/src/ray/common/id.h
+++ b/src/ray/common/id.h
@@ -40,7 +40,7 @@ class JobID;
 /// once we separated the `WorkerID` from `UniqueID`.
 ///
 /// A helper function that get the `DriverID` of the given job.
-WorkerID ComputeDriverIdFromJob(const JobID &job_id);
+WorkerID ComputeDriverIdFromJob(const JobID& job_id);
 
 /// The type of this object. `PUT_OBJECT` indicates this object
 /// is generated through `ray.put` during the task's execution.
@@ -54,7 +54,7 @@ enum class ObjectType : uint8_t {
 using ObjectIDFlagsType = uint16_t;
 using ObjectIDIndexType = uint32_t;
 // Declaration.
-uint64_t MurmurHash64A(const void *key, int len, unsigned int seed);
+uint64_t MurmurHash64A(const void* key, int len, unsigned int seed);
 
 // Change the compiler alignment to 1 byte (default is 8).
 #pragma pack(push, 1)
@@ -70,27 +70,27 @@ class BaseID {
   BaseID();
   // Warning: this can duplicate IDs after a fork() call. We assume this never happens.
   static T FromRandom();
-  static T FromBinary(const std::string &binary);
-  static const T &Nil();
+  static T FromBinary(const std::string& binary);
+  static const T& Nil();
   static size_t Size() { return T::Size(); }
 
   size_t Hash() const;
   bool IsNil() const;
-  bool operator==(const BaseID &rhs) const;
-  bool operator!=(const BaseID &rhs) const;
-  const uint8_t *Data() const;
+  bool operator==(const BaseID& rhs) const;
+  bool operator!=(const BaseID& rhs) const;
+  const uint8_t* Data() const;
   std::string Binary() const;
   std::string Hex() const;
 
  protected:
-  BaseID(const std::string &binary) {
+  BaseID(const std::string& binary) {
     RAY_CHECK(binary.size() == Size() || binary.size() == 0)
         << "expected size is " << Size() << ", but got " << binary.size();
-    std::memcpy(const_cast<uint8_t *>(this->Data()), binary.data(), binary.size());
+    std::memcpy(const_cast<uint8_t*>(this->Data()), binary.data(), binary.size());
   }
   // All IDs are immutable for hash evaluations. MutableData is only allow to use
   // in construction time, so this function is protected.
-  uint8_t *MutableData();
+  uint8_t* MutableData();
   // For lazy evaluation, be careful to have one Id contained in another.
   // This hash code will be duplicated.
   mutable size_t hash_ = 0;
@@ -105,7 +105,7 @@ class UniqueID : public BaseID<UniqueID> {
   MSGPACK_DEFINE(id_);
 
  protected:
-  UniqueID(const std::string &binary);
+  UniqueID(const std::string& binary);
 
  protected:
   uint8_t id_[kUniqueIDSize];
@@ -150,7 +150,7 @@ class ActorID : public BaseID<ActorID> {
   /// \param parent_task_counter The counter of the parent task.
   ///
   /// \return The random `ActorID`.
-  static ActorID Of(const JobID &job_id, const TaskID &parent_task_id,
+  static ActorID Of(const JobID& job_id, const TaskID& parent_task_id,
                     const size_t parent_task_counter);
 
   /// Creates a nil ActorID with the given job.
@@ -158,7 +158,7 @@ class ActorID : public BaseID<ActorID> {
   /// \param job_id The job id to which this actor belongs.
   ///
   /// \return The `ActorID` with unique bytes being nil.
-  static ActorID NilFromJob(const JobID &job_id);
+  static ActorID NilFromJob(const JobID& job_id);
 
   // Warning: this can duplicate IDs after a fork() call. We assume this never happens.
   static ActorID FromRandom() = delete;
@@ -188,13 +188,13 @@ class TaskID : public BaseID<TaskID> {
 
   static size_t Size() { return kLength; }
 
-  static TaskID ComputeDriverTaskId(const WorkerID &driver_id);
+  static TaskID ComputeDriverTaskId(const WorkerID& driver_id);
 
   // Warning: this can duplicate IDs after a fork() call. We assume this never happens.
   static TaskID FromRandom() = delete;
 
   /// The ID generated for driver task.
-  static TaskID ForDriverTask(const JobID &job_id);
+  static TaskID ForDriverTask(const JobID& job_id);
 
   /// Generate driver task id for the given job.
   static TaskID ForFakeTask();
@@ -205,7 +205,7 @@ class TaskID : public BaseID<TaskID> {
   ///        by this actor creation task.
   ///
   /// \return The ID of the actor creation task.
-  static TaskID ForActorCreationTask(const ActorID &actor_id);
+  static TaskID ForActorCreationTask(const ActorID& actor_id);
 
   /// Creates a TaskID for actor task.
   ///
@@ -216,8 +216,8 @@ class TaskID : public BaseID<TaskID> {
   /// \param actor_id The ID of the actor to which this task belongs.
   ///
   /// \return The ID of the actor task.
-  static TaskID ForActorTask(const JobID &job_id, const TaskID &parent_task_id,
-                             size_t parent_task_counter, const ActorID &actor_id);
+  static TaskID ForActorTask(const JobID& job_id, const TaskID& parent_task_id,
+                             size_t parent_task_counter, const ActorID& actor_id);
 
   /// Creates a TaskID for normal task.
   ///
@@ -227,7 +227,7 @@ class TaskID : public BaseID<TaskID> {
   ///        parent task before this one.
   ///
   /// \return The ID of the normal task.
-  static TaskID ForNormalTask(const JobID &job_id, const TaskID &parent_task_id,
+  static TaskID ForNormalTask(const JobID& job_id, const TaskID& parent_task_id,
                               size_t parent_task_counter);
 
   /// Get the id of the actor to which this task belongs.
@@ -303,7 +303,7 @@ class ObjectID : public BaseID<ObjectID> {
   /// \param index What index of the object put in the task.
   ///
   /// \return The computed object ID.
-  static ObjectID ForPut(const TaskID &task_id, ObjectIDIndexType put_index);
+  static ObjectID ForPut(const TaskID& task_id, ObjectIDIndexType put_index);
 
   /// Compute the object ID of an object returned by the task.
   ///
@@ -311,7 +311,7 @@ class ObjectID : public BaseID<ObjectID> {
   /// \param return_index What index of the object returned by in the task.
   ///
   /// \return The computed object ID.
-  static ObjectID ForTaskReturn(const TaskID &task_id, ObjectIDIndexType return_index);
+  static ObjectID ForTaskReturn(const TaskID& task_id, ObjectIDIndexType return_index);
 
   /// Create an object id randomly.
   ///
@@ -327,13 +327,13 @@ class ObjectID : public BaseID<ObjectID> {
   ///
   /// \param actor_id The ID of the actor to track.
   /// \return The computed object ID.
-  static ObjectID ForActorHandle(const ActorID &actor_id);
+  static ObjectID ForActorHandle(const ActorID& actor_id);
 
   MSGPACK_DEFINE(id_);
 
  private:
   /// A helper method to generate an ObjectID.
-  static ObjectID GenerateObjectId(const std::string &task_id_binary,
+  static ObjectID GenerateObjectId(const std::string& task_id_binary,
                                    ObjectIDFlagsType flags,
                                    ObjectIDIndexType object_index = 0);
 
@@ -373,27 +373,27 @@ static_assert(sizeof(ObjectID) == ObjectID::kLength + sizeof(size_t),
 static_assert(sizeof(PlacementGroupID) == PlacementGroupID::kLength + sizeof(size_t),
               "PlacementGroupID size is not as expected");
 
-std::ostream &operator<<(std::ostream &os, const UniqueID &id);
-std::ostream &operator<<(std::ostream &os, const JobID &id);
-std::ostream &operator<<(std::ostream &os, const ActorID &id);
-std::ostream &operator<<(std::ostream &os, const TaskID &id);
-std::ostream &operator<<(std::ostream &os, const ObjectID &id);
-std::ostream &operator<<(std::ostream &os, const PlacementGroupID &id);
+std::ostream& operator<<(std::ostream& os, const UniqueID& id);
+std::ostream& operator<<(std::ostream& os, const JobID& id);
+std::ostream& operator<<(std::ostream& os, const ActorID& id);
+std::ostream& operator<<(std::ostream& os, const TaskID& id);
+std::ostream& operator<<(std::ostream& os, const ObjectID& id);
+std::ostream& operator<<(std::ostream& os, const PlacementGroupID& id);
 
 #define DEFINE_UNIQUE_ID(type)                                                 \
   class RAY_EXPORT type : public UniqueID {                                    \
    public:                                                                     \
-    explicit type(const UniqueID &from) {                                      \
+    explicit type(const UniqueID& from) {                                      \
       std::memcpy(&id_, from.Data(), kUniqueIDSize);                           \
     }                                                                          \
     type() : UniqueID() {}                                                     \
     static type FromRandom() { return type(UniqueID::FromRandom()); }          \
-    static type FromBinary(const std::string &binary) { return type(binary); } \
+    static type FromBinary(const std::string& binary) { return type(binary); } \
     static type Nil() { return type(UniqueID::Nil()); }                        \
     static size_t Size() { return kUniqueIDSize; }                             \
                                                                                \
    private:                                                                    \
-    explicit type(const std::string &binary) {                                 \
+    explicit type(const std::string& binary) {                                 \
       RAY_CHECK(binary.size() == Size() || binary.size() == 0)                 \
           << "expected size is " << Size() << ", but got " << binary.size();   \
       std::memcpy(&id_, binary.data(), binary.size());                         \
@@ -422,7 +422,7 @@ T BaseID<T>::FromRandom() {
 }
 
 template <typename T>
-T BaseID<T>::FromBinary(const std::string &binary) {
+T BaseID<T>::FromBinary(const std::string& binary) {
   RAY_CHECK(binary.size() == T::Size() || binary.size() == 0)
       << "expected size is " << T::Size() << ", but got " << binary.size();
   T t;
@@ -431,7 +431,7 @@ T BaseID<T>::FromBinary(const std::string &binary) {
 }
 
 template <typename T>
-const T &BaseID<T>::Nil() {
+const T& BaseID<T>::Nil() {
   static const T nil_id;
   return nil_id;
 }
@@ -453,34 +453,34 @@ size_t BaseID<T>::Hash() const {
 }
 
 template <typename T>
-bool BaseID<T>::operator==(const BaseID &rhs) const {
+bool BaseID<T>::operator==(const BaseID& rhs) const {
   return std::memcmp(Data(), rhs.Data(), T::Size()) == 0;
 }
 
 template <typename T>
-bool BaseID<T>::operator!=(const BaseID &rhs) const {
+bool BaseID<T>::operator!=(const BaseID& rhs) const {
   return !(*this == rhs);
 }
 
 template <typename T>
-uint8_t *BaseID<T>::MutableData() {
-  return reinterpret_cast<uint8_t *>(this) + sizeof(hash_);
+uint8_t* BaseID<T>::MutableData() {
+  return reinterpret_cast<uint8_t*>(this) + sizeof(hash_);
 }
 
 template <typename T>
-const uint8_t *BaseID<T>::Data() const {
-  return reinterpret_cast<const uint8_t *>(this) + sizeof(hash_);
+const uint8_t* BaseID<T>::Data() const {
+  return reinterpret_cast<const uint8_t*>(this) + sizeof(hash_);
 }
 
 template <typename T>
 std::string BaseID<T>::Binary() const {
-  return std::string(reinterpret_cast<const char *>(Data()), T::Size());
+  return std::string(reinterpret_cast<const char*>(Data()), T::Size());
 }
 
 template <typename T>
 std::string BaseID<T>::Hex() const {
   constexpr char hex[] = "0123456789abcdef";
-  const uint8_t *id = Data();
+  const uint8_t* id = Data();
   std::string result;
   for (size_t i = 0; i < T::Size(); i++) {
     unsigned int val = id[i];
@@ -497,11 +497,11 @@ namespace std {
 #define DEFINE_UNIQUE_ID(type)                                           \
   template <>                                                            \
   struct hash<::ray::type> {                                             \
-    size_t operator()(const ::ray::type &id) const { return id.Hash(); } \
+    size_t operator()(const ::ray::type& id) const { return id.Hash(); } \
   };                                                                     \
   template <>                                                            \
   struct hash<const ::ray::type> {                                       \
-    size_t operator()(const ::ray::type &id) const { return id.Hash(); } \
+    size_t operator()(const ::ray::type& id) const { return id.Hash(); } \
   };
 
 DEFINE_UNIQUE_ID(UniqueID);

--- a/src/ray/common/id_test.cc
+++ b/src/ray/common/id_test.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "gtest/gtest.h"
-
 #include "ray/common/common_protocol.h"
 #include "ray/common/task/task_spec.h"
 

--- a/src/ray/common/id_test.cc
+++ b/src/ray/common/id_test.cc
@@ -18,7 +18,7 @@
 
 namespace ray {
 
-void TestReturnObjectId(const TaskID &task_id, int64_t return_index) {
+void TestReturnObjectId(const TaskID& task_id, int64_t return_index) {
   // Round trip test for computing the object ID for a task's return value,
   // then computing the task ID that created the object.
   ObjectID return_id = ObjectID::ForTaskReturn(task_id, return_index);
@@ -29,7 +29,7 @@ void TestReturnObjectId(const TaskID &task_id, int64_t return_index) {
   ASSERT_EQ(return_id.ObjectIndex(), return_index);
 }
 
-void TestPutObjectId(const TaskID &task_id, int64_t put_index) {
+void TestPutObjectId(const TaskID& task_id, int64_t put_index) {
   // Round trip test for computing the object ID for a task's put value, then
   // computing the task ID that created the object.
   ObjectID put_id = ObjectID::ForPut(task_id, put_index);
@@ -121,7 +121,7 @@ TEST(HashTest, TestNilHash) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/common/network_util.cc
+++ b/src/ray/common/network_util.cc
@@ -67,7 +67,7 @@ std::string GetValidLocalIp(int port, int64_t timeout_ms) {
   return address;
 }
 
-bool Ping(const std::string &ip, int port, int64_t timeout_ms) {
+bool Ping(const std::string& ip, int port, int64_t timeout_ms) {
   AsyncClient client;
   bool is_timeout;
   return client.Connect(ip, port, timeout_ms, &is_timeout);

--- a/src/ray/common/network_util.h
+++ b/src/ray/common/network_util.h
@@ -47,8 +47,8 @@ class AsyncClient {
   /// \param is_timeout Whether connection timeout.
   /// \param error_code Set to indicate what error occurred, if any.
   /// \return Whether the connection is successful.
-  bool Connect(const std::string &ip, int port, int64_t timeout_ms, bool *is_timeout,
-               boost::system::error_code *error_code = nullptr) {
+  bool Connect(const std::string& ip, int port, int64_t timeout_ms, bool* is_timeout,
+               boost::system::error_code* error_code = nullptr) {
     try {
       auto endpoint =
           boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(ip), port);
@@ -86,14 +86,14 @@ class AsyncClient {
   }
 
  private:
-  void ConnectHandle(boost::system::error_code error_code, bool &is_connected) {
+  void ConnectHandle(boost::system::error_code error_code, bool& is_connected) {
     error_code_ = error_code;
     if (!error_code) {
       is_connected = true;
     }
   }
 
-  void TimerHandle(bool *is_timeout) {
+  void TimerHandle(bool* is_timeout) {
     socket_.close();
     *is_timeout = true;
   }
@@ -121,6 +121,6 @@ std::string GetValidLocalIp(int port, int64_t timeout_ms);
 /// \param port The port that the target rpc server is listening on.
 /// \param timeout_ms The maximum wait time in milliseconds.
 /// \return Whether target rpc server is valid.
-bool Ping(const std::string &ip, int port, int64_t timeout_ms);
+bool Ping(const std::string& ip, int port, int64_t timeout_ms);
 
 bool CheckFree(int port);

--- a/src/ray/common/placement_group.h
+++ b/src/ray/common/placement_group.h
@@ -64,9 +64,9 @@ class PlacementGroupSpecBuilder {
   /// See `common.proto` for meaning of the arguments.
   ///
   /// \return Reference to the builder object itself.
-  PlacementGroupSpecBuilder &SetPlacementGroupSpec(
-      const PlacementGroupID &placement_group_id, std::string name,
-      const std::vector<std::unordered_map<std::string, double>> &bundles,
+  PlacementGroupSpecBuilder& SetPlacementGroupSpec(
+      const PlacementGroupID& placement_group_id, std::string name,
+      const std::vector<std::unordered_map<std::string, double>>& bundles,
       const rpc::PlacementStrategy strategy) {
     message_->set_placement_group_id(placement_group_id.Binary());
     message_->set_name(name);

--- a/src/ray/common/ray_config.h
+++ b/src/ray/common/ray_config.h
@@ -42,7 +42,7 @@ class RayConfig {
 #undef RAY_CONFIG
 
  public:
-  static RayConfig &instance() {
+  static RayConfig& instance() {
     static RayConfig config;
     return config;
   }

--- a/src/ray/common/ray_object.cc
+++ b/src/ray/common/ray_object.cc
@@ -18,7 +18,7 @@ namespace ray {
 
 std::shared_ptr<LocalMemoryBuffer> MakeErrorMetadataBuffer(rpc::ErrorType error_type) {
   std::string meta = std::to_string(static_cast<int>(error_type));
-  auto metadata = const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(meta.data()));
+  auto metadata = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(meta.data()));
   auto meta_buffer =
       std::make_shared<LocalMemoryBuffer>(metadata, meta.size(), /*copy_data=*/true);
   return meta_buffer;
@@ -27,12 +27,12 @@ std::shared_ptr<LocalMemoryBuffer> MakeErrorMetadataBuffer(rpc::ErrorType error_
 RayObject::RayObject(rpc::ErrorType error_type)
     : RayObject(nullptr, MakeErrorMetadataBuffer(error_type), {}) {}
 
-bool RayObject::IsException(rpc::ErrorType *error_type) const {
+bool RayObject::IsException(rpc::ErrorType* error_type) const {
   if (metadata_ == nullptr) {
     return false;
   }
   // TODO (kfstorm): metadata should be structured.
-  const std::string metadata(reinterpret_cast<const char *>(metadata_->Data()),
+  const std::string metadata(reinterpret_cast<const char*>(metadata_->Data()),
                              metadata_->Size());
   const auto error_type_descriptor = ray::rpc::ErrorType_descriptor();
   for (int i = 0; i < error_type_descriptor->value_count(); i++) {
@@ -51,7 +51,7 @@ bool RayObject::IsInPlasmaError() const {
   if (metadata_ == nullptr) {
     return false;
   }
-  const std::string metadata(reinterpret_cast<const char *>(metadata_->Data()),
+  const std::string metadata(reinterpret_cast<const char*>(metadata_->Data()),
                              metadata_->Size());
   return metadata == std::to_string(ray::rpc::ErrorType::OBJECT_IN_PLASMA);
 }

--- a/src/ray/common/ray_object.h
+++ b/src/ray/common/ray_object.h
@@ -38,8 +38,8 @@ class RayObject {
   /// \param[in] metadata Metadata of the ray object.
   /// \param[in] nested_ids ObjectIDs that were serialized in data.
   /// \param[in] copy_data Whether this class should hold a copy of data.
-  RayObject(const std::shared_ptr<Buffer> &data, const std::shared_ptr<Buffer> &metadata,
-            const std::vector<ObjectID> &nested_ids, bool copy_data = false)
+  RayObject(const std::shared_ptr<Buffer>& data, const std::shared_ptr<Buffer>& metadata,
+            const std::vector<ObjectID>& nested_ids, bool copy_data = false)
       : data_(data),
         metadata_(metadata),
         nested_ids_(nested_ids),
@@ -64,13 +64,13 @@ class RayObject {
   RayObject(rpc::ErrorType error_type);
 
   /// Return the data of the ray object.
-  const std::shared_ptr<Buffer> &GetData() const { return data_; }
+  const std::shared_ptr<Buffer>& GetData() const { return data_; }
 
   /// Return the metadata of the ray object.
-  const std::shared_ptr<Buffer> &GetMetadata() const { return metadata_; }
+  const std::shared_ptr<Buffer>& GetMetadata() const { return metadata_; }
 
   /// Return the object IDs that were serialized in data.
-  const std::vector<ObjectID> &GetNestedIds() const { return nested_ids_; }
+  const std::vector<ObjectID>& GetNestedIds() const { return nested_ids_; }
 
   uint64_t GetSize() const {
     uint64_t size = 0;
@@ -86,7 +86,7 @@ class RayObject {
   bool HasMetadata() const { return metadata_ != nullptr; }
 
   /// Whether the object represents an exception.
-  bool IsException(rpc::ErrorType *error_type = nullptr) const;
+  bool IsException(rpc::ErrorType* error_type = nullptr) const;
 
   /// Whether the object has been promoted to plasma (i.e., since it was too
   /// large to return directly as part of a gRPC response).

--- a/src/ray/common/status.cc
+++ b/src/ray/common/status.cc
@@ -57,14 +57,14 @@ namespace ray {
 #define STATUS_CODE_OBJECT_STORE_ALREADY_SEALED "ObjectAlreadySealed"
 #define STATUS_CODE_OBJECT_STORE_FULL "ObjectStoreFull"
 
-Status::Status(StatusCode code, const std::string &msg) {
+Status::Status(StatusCode code, const std::string& msg) {
   assert(code != StatusCode::OK);
   state_ = new State;
   state_->code = code;
   state_->msg = msg;
 }
 
-void Status::CopyFrom(const State *state) {
+void Status::CopyFrom(const State* state) {
   delete state_;
   if (state == nullptr) {
     state_ = nullptr;
@@ -116,7 +116,7 @@ std::string Status::ToString() const {
   return result;
 }
 
-Status boost_to_ray_status(const boost::system::error_code &error) {
+Status boost_to_ray_status(const boost::system::error_code& error) {
   switch (error.value()) {
   case boost::system::errc::success:
     return Status::OK();

--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -112,53 +112,53 @@ class RAY_EXPORT Status {
   Status() : state_(NULL) {}
   ~Status() { delete state_; }
 
-  Status(StatusCode code, const std::string &msg);
+  Status(StatusCode code, const std::string& msg);
 
   // Copy the specified status.
-  Status(const Status &s);
-  void operator=(const Status &s);
+  Status(const Status& s);
+  void operator=(const Status& s);
 
   // Return a success status.
   static Status OK() { return Status(); }
 
   // Return error status of an appropriate type.
-  static Status OutOfMemory(const std::string &msg) {
+  static Status OutOfMemory(const std::string& msg) {
     return Status(StatusCode::OutOfMemory, msg);
   }
 
-  static Status KeyError(const std::string &msg) {
+  static Status KeyError(const std::string& msg) {
     return Status(StatusCode::KeyError, msg);
   }
 
-  static Status TypeError(const std::string &msg) {
+  static Status TypeError(const std::string& msg) {
     return Status(StatusCode::TypeError, msg);
   }
 
-  static Status UnknownError(const std::string &msg) {
+  static Status UnknownError(const std::string& msg) {
     return Status(StatusCode::UnknownError, msg);
   }
 
-  static Status NotImplemented(const std::string &msg) {
+  static Status NotImplemented(const std::string& msg) {
     return Status(StatusCode::NotImplemented, msg);
   }
 
-  static Status Invalid(const std::string &msg) {
+  static Status Invalid(const std::string& msg) {
     return Status(StatusCode::Invalid, msg);
   }
 
-  static Status IOError(const std::string &msg) {
+  static Status IOError(const std::string& msg) {
     return Status(StatusCode::IOError, msg);
   }
 
-  static Status RedisError(const std::string &msg) {
+  static Status RedisError(const std::string& msg) {
     return Status(StatusCode::RedisError, msg);
   }
 
-  static Status TimedOut(const std::string &msg) {
+  static Status TimedOut(const std::string& msg) {
     return Status(StatusCode::TimedOut, msg);
   }
 
-  static Status Interrupted(const std::string &msg) {
+  static Status Interrupted(const std::string& msg) {
     return Status(StatusCode::Interrupted, msg);
   }
 
@@ -170,27 +170,27 @@ class RAY_EXPORT Status {
     return Status(StatusCode::UnexpectedSystemExit, "user code caused exit");
   }
 
-  static Status NotFound(const std::string &msg) {
+  static Status NotFound(const std::string& msg) {
     return Status(StatusCode::NotFound, msg);
   }
 
-  static Status Disconnected(const std::string &msg) {
+  static Status Disconnected(const std::string& msg) {
     return Status(StatusCode::Disconnected, msg);
   }
 
-  static Status ObjectExists(const std::string &msg) {
+  static Status ObjectExists(const std::string& msg) {
     return Status(StatusCode::ObjectExists, msg);
   }
 
-  static Status ObjectNotFound(const std::string &msg) {
+  static Status ObjectNotFound(const std::string& msg) {
     return Status(StatusCode::ObjectNotFound, msg);
   }
 
-  static Status ObjectAlreadySealed(const std::string &msg) {
+  static Status ObjectAlreadySealed(const std::string& msg) {
     return Status(StatusCode::ObjectAlreadySealed, msg);
   }
 
-  static Status ObjectStoreFull(const std::string &msg) {
+  static Status ObjectStoreFull(const std::string& msg) {
     return Status(StatusCode::ObjectStoreFull, msg);
   }
 
@@ -240,20 +240,20 @@ class RAY_EXPORT Status {
   };
   // OK status has a `NULL` state_.  Otherwise, `state_` points to
   // a `State` structure containing the error code and message(s)
-  State *state_;
+  State* state_;
 
-  void CopyFrom(const State *s);
+  void CopyFrom(const State* s);
 };
 
-static inline std::ostream &operator<<(std::ostream &os, const Status &x) {
+static inline std::ostream& operator<<(std::ostream& os, const Status& x) {
   os << x.ToString();
   return os;
 }
 
-inline Status::Status(const Status &s)
+inline Status::Status(const Status& s)
     : state_((s.state_ == NULL) ? NULL : new State(*s.state_)) {}
 
-inline void Status::operator=(const Status &s) {
+inline void Status::operator=(const Status& s) {
   // The following condition catches both aliasing (when this == &s),
   // and the common case where both s and *this are ok.
   if (state_ != s.state_) {
@@ -261,6 +261,6 @@ inline void Status::operator=(const Status &s) {
   }
 }
 
-Status boost_to_ray_status(const boost::system::error_code &error);
+Status boost_to_ray_status(const boost::system::error_code& error);
 
 }  // namespace ray

--- a/src/ray/common/task/scheduling_resources.cc
+++ b/src/ray/common/task/scheduling_resources.cc
@@ -22,48 +22,48 @@ FractionalResourceQuantity::FractionalResourceQuantity(double resource_quantity)
 }
 
 const FractionalResourceQuantity FractionalResourceQuantity::operator+(
-    const FractionalResourceQuantity &rhs) const {
+    const FractionalResourceQuantity& rhs) const {
   FractionalResourceQuantity result = *this;
   result += rhs;
   return result;
 }
 
 const FractionalResourceQuantity FractionalResourceQuantity::operator-(
-    const FractionalResourceQuantity &rhs) const {
+    const FractionalResourceQuantity& rhs) const {
   FractionalResourceQuantity result = *this;
   result -= rhs;
   return result;
 }
 
-void FractionalResourceQuantity::operator+=(const FractionalResourceQuantity &rhs) {
+void FractionalResourceQuantity::operator+=(const FractionalResourceQuantity& rhs) {
   resource_quantity_ += rhs.resource_quantity_;
 }
 
-void FractionalResourceQuantity::operator-=(const FractionalResourceQuantity &rhs) {
+void FractionalResourceQuantity::operator-=(const FractionalResourceQuantity& rhs) {
   resource_quantity_ -= rhs.resource_quantity_;
 }
 
-bool FractionalResourceQuantity::operator==(const FractionalResourceQuantity &rhs) const {
+bool FractionalResourceQuantity::operator==(const FractionalResourceQuantity& rhs) const {
   return resource_quantity_ == rhs.resource_quantity_;
 }
 
-bool FractionalResourceQuantity::operator!=(const FractionalResourceQuantity &rhs) const {
+bool FractionalResourceQuantity::operator!=(const FractionalResourceQuantity& rhs) const {
   return !(*this == rhs);
 }
 
-bool FractionalResourceQuantity::operator<(const FractionalResourceQuantity &rhs) const {
+bool FractionalResourceQuantity::operator<(const FractionalResourceQuantity& rhs) const {
   return resource_quantity_ < rhs.resource_quantity_;
 }
 
-bool FractionalResourceQuantity::operator>(const FractionalResourceQuantity &rhs) const {
+bool FractionalResourceQuantity::operator>(const FractionalResourceQuantity& rhs) const {
   return rhs < *this;
 }
 
-bool FractionalResourceQuantity::operator<=(const FractionalResourceQuantity &rhs) const {
+bool FractionalResourceQuantity::operator<=(const FractionalResourceQuantity& rhs) const {
   return !(*this > rhs);
 }
 
-bool FractionalResourceQuantity::operator>=(const FractionalResourceQuantity &rhs) const {
+bool FractionalResourceQuantity::operator>=(const FractionalResourceQuantity& rhs) const {
   bool result = !(*this < rhs);
   return result;
 }
@@ -75,22 +75,22 @@ double FractionalResourceQuantity::ToDouble() const {
 ResourceSet::ResourceSet() {}
 
 ResourceSet::ResourceSet(
-    const std::unordered_map<std::string, FractionalResourceQuantity> &resource_map)
+    const std::unordered_map<std::string, FractionalResourceQuantity>& resource_map)
     : resource_capacity_(resource_map) {
-  for (auto const &resource_pair : resource_map) {
+  for (auto const& resource_pair : resource_map) {
     RAY_CHECK(resource_pair.second > 0);
   }
 }
 
-ResourceSet::ResourceSet(const std::unordered_map<std::string, double> &resource_map) {
-  for (auto const &resource_pair : resource_map) {
+ResourceSet::ResourceSet(const std::unordered_map<std::string, double>& resource_map) {
+  for (auto const& resource_pair : resource_map) {
     RAY_CHECK(resource_pair.second > 0);
     resource_capacity_[resource_pair.first] =
         FractionalResourceQuantity(resource_pair.second);
   }
 }
 
-ResourceSet::ResourceSet(const std::vector<std::string> &resource_labels,
+ResourceSet::ResourceSet(const std::vector<std::string>& resource_labels,
                          const std::vector<double> resource_capacity) {
   RAY_CHECK(resource_labels.size() == resource_capacity.size());
   for (size_t i = 0; i < resource_labels.size(); i++) {
@@ -102,7 +102,7 @@ ResourceSet::ResourceSet(const std::vector<std::string> &resource_labels,
 
 ResourceSet::~ResourceSet() {}
 
-bool ResourceSet::operator==(const ResourceSet &rhs) const {
+bool ResourceSet::operator==(const ResourceSet& rhs) const {
   return (this->IsSubset(rhs) && rhs.IsSubset(*this));
 }
 
@@ -111,12 +111,12 @@ bool ResourceSet::IsEmpty() const {
   return resource_capacity_.empty();
 }
 
-bool ResourceSet::IsSubset(const ResourceSet &other) const {
+bool ResourceSet::IsSubset(const ResourceSet& other) const {
   // Check to make sure all keys of this are in other.
-  for (const auto &resource_pair : resource_capacity_) {
-    const auto &resource_name = resource_pair.first;
-    const FractionalResourceQuantity &lhs_quantity = resource_pair.second;
-    const FractionalResourceQuantity &rhs_quantity = other.GetResource(resource_name);
+  for (const auto& resource_pair : resource_capacity_) {
+    const auto& resource_name = resource_pair.first;
+    const FractionalResourceQuantity& lhs_quantity = resource_pair.second;
+    const FractionalResourceQuantity& rhs_quantity = other.GetResource(resource_name);
     if (lhs_quantity > rhs_quantity) {
       // Resource found in rhs, but lhs capacity exceeds rhs capacity.
       return false;
@@ -126,23 +126,23 @@ bool ResourceSet::IsSubset(const ResourceSet &other) const {
 }
 
 /// Test whether this ResourceSet is a superset of the other ResourceSet
-bool ResourceSet::IsSuperset(const ResourceSet &other) const {
+bool ResourceSet::IsSuperset(const ResourceSet& other) const {
   return other.IsSubset(*this);
 }
 
 /// Test whether this ResourceSet is precisely equal to the other ResourceSet.
-bool ResourceSet::IsEqual(const ResourceSet &rhs) const {
+bool ResourceSet::IsEqual(const ResourceSet& rhs) const {
   return (this->IsSubset(rhs) && rhs.IsSubset(*this));
 }
 
-void ResourceSet::AddOrUpdateResource(const std::string &resource_name,
-                                      const FractionalResourceQuantity &capacity) {
+void ResourceSet::AddOrUpdateResource(const std::string& resource_name,
+                                      const FractionalResourceQuantity& capacity) {
   if (capacity > 0) {
     resource_capacity_[resource_name] = capacity;
   }
 }
 
-bool ResourceSet::DeleteResource(const std::string &resource_name) {
+bool ResourceSet::DeleteResource(const std::string& resource_name) {
   if (resource_capacity_.count(resource_name) == 1) {
     resource_capacity_.erase(resource_name);
     return true;
@@ -151,12 +151,12 @@ bool ResourceSet::DeleteResource(const std::string &resource_name) {
   }
 }
 
-void ResourceSet::SubtractResources(const ResourceSet &other) {
+void ResourceSet::SubtractResources(const ResourceSet& other) {
   // Subtract the resources, make sure none goes below zero and delete any if new capacity
   // is zero.
-  for (const auto &resource_pair : other.GetResourceAmountMap()) {
-    const std::string &resource_label = resource_pair.first;
-    const FractionalResourceQuantity &resource_capacity = resource_pair.second;
+  for (const auto& resource_pair : other.GetResourceAmountMap()) {
+    const std::string& resource_label = resource_pair.first;
+    const FractionalResourceQuantity& resource_capacity = resource_pair.second;
     if (resource_capacity_.count(resource_label) == 1) {
       resource_capacity_[resource_label] -= resource_capacity;
     }
@@ -166,12 +166,12 @@ void ResourceSet::SubtractResources(const ResourceSet &other) {
   }
 }
 
-void ResourceSet::SubtractResourcesStrict(const ResourceSet &other) {
+void ResourceSet::SubtractResourcesStrict(const ResourceSet& other) {
   // Subtract the resources, make sure none goes below zero and delete any if new capacity
   // is zero.
-  for (const auto &resource_pair : other.GetResourceAmountMap()) {
-    const std::string &resource_label = resource_pair.first;
-    const FractionalResourceQuantity &resource_capacity = resource_pair.second;
+  for (const auto& resource_pair : other.GetResourceAmountMap()) {
+    const std::string& resource_label = resource_pair.first;
+    const FractionalResourceQuantity& resource_capacity = resource_pair.second;
     RAY_CHECK(resource_capacity_.count(resource_label) == 1)
         << "Attempt to acquire unknown resource: " << resource_label << " capacity "
         << resource_capacity.ToDouble();
@@ -191,18 +191,18 @@ void ResourceSet::SubtractResourcesStrict(const ResourceSet &other) {
 
 // Add a set of resources to the current set of resources subject to upper limits on
 // capacity from the total_resource set
-void ResourceSet::AddResourcesCapacityConstrained(const ResourceSet &other,
-                                                  const ResourceSet &total_resources) {
-  const std::unordered_map<std::string, FractionalResourceQuantity> &total_resource_map =
+void ResourceSet::AddResourcesCapacityConstrained(const ResourceSet& other,
+                                                  const ResourceSet& total_resources) {
+  const std::unordered_map<std::string, FractionalResourceQuantity>& total_resource_map =
       total_resources.GetResourceAmountMap();
-  for (const auto &resource_pair : other.GetResourceAmountMap()) {
-    const std::string &to_add_resource_label = resource_pair.first;
-    const FractionalResourceQuantity &to_add_resource_capacity = resource_pair.second;
+  for (const auto& resource_pair : other.GetResourceAmountMap()) {
+    const std::string& to_add_resource_label = resource_pair.first;
+    const FractionalResourceQuantity& to_add_resource_capacity = resource_pair.second;
     if (total_resource_map.count(to_add_resource_label) != 0) {
       // If resource exists in total map, add to the local capacity map.
       // If the new capacity will be greater the total capacity, set the new capacity to
       // total capacity (capping to the total)
-      const FractionalResourceQuantity &total_capacity =
+      const FractionalResourceQuantity& total_capacity =
           total_resource_map.at(to_add_resource_label);
       resource_capacity_[to_add_resource_label] =
           std::min(resource_capacity_[to_add_resource_label] + to_add_resource_capacity,
@@ -219,31 +219,31 @@ void ResourceSet::AddResourcesCapacityConstrained(const ResourceSet &other,
 }
 
 // Perform an outer join.
-void ResourceSet::AddResources(const ResourceSet &other) {
-  for (const auto &resource_pair : other.GetResourceAmountMap()) {
-    const std::string &resource_label = resource_pair.first;
-    const FractionalResourceQuantity &resource_capacity = resource_pair.second;
+void ResourceSet::AddResources(const ResourceSet& other) {
+  for (const auto& resource_pair : other.GetResourceAmountMap()) {
+    const std::string& resource_label = resource_pair.first;
+    const FractionalResourceQuantity& resource_capacity = resource_pair.second;
     resource_capacity_[resource_label] += resource_capacity;
   }
 }
 
-void ResourceSet::AddBundleResources(const PlacementGroupID &bundle_id,
-                                     const int bundle_index, const ResourceSet &other) {
-  for (const auto &resource_pair : other.GetResourceAmountMap()) {
-    const std::string &resource_label =
+void ResourceSet::AddBundleResources(const PlacementGroupID& bundle_id,
+                                     const int bundle_index, const ResourceSet& other) {
+  for (const auto& resource_pair : other.GetResourceAmountMap()) {
+    const std::string& resource_label =
         FormatPlacementGroupResource(resource_pair.first, bundle_id, bundle_index);
-    const FractionalResourceQuantity &resource_capacity = resource_pair.second;
+    const FractionalResourceQuantity& resource_capacity = resource_pair.second;
     resource_capacity_[resource_label] += resource_capacity;
   }
 }
 
-void ResourceSet::ReturnBundleResources(const PlacementGroupID &bundle_id,
+void ResourceSet::ReturnBundleResources(const PlacementGroupID& bundle_id,
                                         const int bundle_index) {
   for (auto iter = resource_capacity_.begin(); iter != resource_capacity_.end();) {
-    const std::string &bundle_resource_label = iter->first;
+    const std::string& bundle_resource_label = iter->first;
     if (bundle_resource_label.find(bundle_id.Hex()) != std::string::npos) {
-      const std::string &resource_label = GetOriginalResourceName(bundle_resource_label);
-      const FractionalResourceQuantity &resource_capacity = iter->second;
+      const std::string& resource_label = GetOriginalResourceName(bundle_resource_label);
+      const FractionalResourceQuantity& resource_capacity = iter->second;
       resource_capacity_[resource_label] += resource_capacity;
       iter = resource_capacity_.erase(iter);
     } else {
@@ -253,11 +253,11 @@ void ResourceSet::ReturnBundleResources(const PlacementGroupID &bundle_id,
 }
 
 FractionalResourceQuantity ResourceSet::GetResource(
-    const std::string &resource_name) const {
+    const std::string& resource_name) const {
   if (resource_capacity_.count(resource_name) == 0) {
     return 0;
   }
-  const FractionalResourceQuantity &capacity = resource_capacity_.at(resource_name);
+  const FractionalResourceQuantity& capacity = resource_capacity_.at(resource_name);
   return capacity;
 }
 
@@ -307,14 +307,14 @@ const std::string ResourceSet::ToString() const {
 
 const std::unordered_map<std::string, double> ResourceSet::GetResourceMap() const {
   std::unordered_map<std::string, double> result;
-  for (const auto &resource_pair : resource_capacity_) {
+  for (const auto& resource_pair : resource_capacity_) {
     result[resource_pair.first] = resource_pair.second.ToDouble();
   }
   return result;
 };
 
-const std::unordered_map<std::string, FractionalResourceQuantity>
-    &ResourceSet::GetResourceAmountMap() const {
+const std::unordered_map<std::string, FractionalResourceQuantity>&
+ResourceSet::GetResourceAmountMap() const {
   return resource_capacity_;
 };
 
@@ -333,24 +333,24 @@ ResourceIds::ResourceIds(double resource_quantity) {
   decrement_backlog_ = 0;
 }
 
-ResourceIds::ResourceIds(const std::vector<int64_t> &whole_ids)
+ResourceIds::ResourceIds(const std::vector<int64_t>& whole_ids)
     : whole_ids_(whole_ids), total_capacity_(whole_ids.size()), decrement_backlog_(0) {}
 
 ResourceIds::ResourceIds(
-    const std::vector<std::pair<int64_t, FractionalResourceQuantity>> &fractional_ids)
+    const std::vector<std::pair<int64_t, FractionalResourceQuantity>>& fractional_ids)
     : fractional_ids_(fractional_ids),
       total_capacity_(TotalQuantity()),
       decrement_backlog_(0) {}
 
 ResourceIds::ResourceIds(
-    const std::vector<int64_t> &whole_ids,
-    const std::vector<std::pair<int64_t, FractionalResourceQuantity>> &fractional_ids)
+    const std::vector<int64_t>& whole_ids,
+    const std::vector<std::pair<int64_t, FractionalResourceQuantity>>& fractional_ids)
     : whole_ids_(whole_ids),
       fractional_ids_(fractional_ids),
       total_capacity_(TotalQuantity()),
       decrement_backlog_(0) {}
 
-bool ResourceIds::Contains(const FractionalResourceQuantity &resource_quantity) const {
+bool ResourceIds::Contains(const FractionalResourceQuantity& resource_quantity) const {
   if (resource_quantity >= 1) {
     double whole_quantity = resource_quantity.ToDouble();
     RAY_CHECK(IsWhole(whole_quantity));
@@ -359,7 +359,7 @@ bool ResourceIds::Contains(const FractionalResourceQuantity &resource_quantity) 
     if (whole_ids_.size() > 0) {
       return true;
     } else {
-      for (auto const &fractional_pair : fractional_ids_) {
+      for (auto const& fractional_pair : fractional_ids_) {
         if (fractional_pair.second >= resource_quantity) {
           return true;
         }
@@ -369,7 +369,7 @@ bool ResourceIds::Contains(const FractionalResourceQuantity &resource_quantity) 
   }
 }
 
-ResourceIds ResourceIds::Acquire(const FractionalResourceQuantity &resource_quantity) {
+ResourceIds ResourceIds::Acquire(const FractionalResourceQuantity& resource_quantity) {
   if (resource_quantity >= 1) {
     // Handle the whole case.
     double whole_quantity = resource_quantity.ToDouble();
@@ -387,7 +387,7 @@ ResourceIds ResourceIds::Acquire(const FractionalResourceQuantity &resource_quan
 
   } else {
     // Handle the fractional case.
-    for (auto &fractional_pair : fractional_ids_) {
+    for (auto& fractional_pair : fractional_ids_) {
       if (fractional_pair.second >= resource_quantity) {
         auto return_pair = std::make_pair(fractional_pair.first, resource_quantity);
         fractional_pair.second -= resource_quantity;
@@ -417,8 +417,8 @@ ResourceIds ResourceIds::Acquire(const FractionalResourceQuantity &resource_quan
   }
 }
 
-void ResourceIds::Release(const ResourceIds &resource_ids) {
-  auto const &whole_ids_to_return = resource_ids.WholeIds();
+void ResourceIds::Release(const ResourceIds& resource_ids) {
+  auto const& whole_ids_to_return = resource_ids.WholeIds();
 
   int64_t return_resource_count = whole_ids_to_return.size();
   if (return_resource_count > decrement_backlog_) {
@@ -434,12 +434,12 @@ void ResourceIds::Release(const ResourceIds &resource_ids) {
   }
 
   // Return the fractional IDs.
-  auto const &fractional_ids_to_return = resource_ids.FractionalIds();
-  for (auto const &fractional_pair_to_return : fractional_ids_to_return) {
+  auto const& fractional_ids_to_return = resource_ids.FractionalIds();
+  for (auto const& fractional_pair_to_return : fractional_ids_to_return) {
     int64_t resource_id = fractional_pair_to_return.first;
-    auto const &fractional_pair_it = std::find_if(
+    auto const& fractional_pair_it = std::find_if(
         fractional_ids_.begin(), fractional_ids_.end(),
-        [resource_id](std::pair<int64_t, FractionalResourceQuantity> &fractional_pair) {
+        [resource_id](std::pair<int64_t, FractionalResourceQuantity>& fractional_pair) {
           return fractional_pair.first == resource_id;
         });
     if (fractional_pair_it == fractional_ids_.end()) {
@@ -463,16 +463,16 @@ void ResourceIds::Release(const ResourceIds &resource_ids) {
   }
 }
 
-ResourceIds ResourceIds::Plus(const ResourceIds &resource_ids) const {
+ResourceIds ResourceIds::Plus(const ResourceIds& resource_ids) const {
   ResourceIds resource_ids_to_return(whole_ids_, fractional_ids_);
   resource_ids_to_return.Release(resource_ids);
   return resource_ids_to_return;
 }
 
-const std::vector<int64_t> &ResourceIds::WholeIds() const { return whole_ids_; }
+const std::vector<int64_t>& ResourceIds::WholeIds() const { return whole_ids_; }
 
-const std::vector<std::pair<int64_t, FractionalResourceQuantity>>
-    &ResourceIds::FractionalIds() const {
+const std::vector<std::pair<int64_t, FractionalResourceQuantity>>&
+ResourceIds::FractionalIds() const {
   return fractional_ids_;
 }
 
@@ -483,7 +483,7 @@ bool ResourceIds::TotalQuantityIsZero() const {
 FractionalResourceQuantity ResourceIds::TotalQuantity() const {
   FractionalResourceQuantity total_quantity =
       FractionalResourceQuantity(whole_ids_.size());
-  for (auto const &fractional_pair : fractional_ids_) {
+  for (auto const& fractional_pair : fractional_ids_) {
     total_quantity += fractional_pair.second;
   }
   return total_quantity;
@@ -491,11 +491,11 @@ FractionalResourceQuantity ResourceIds::TotalQuantity() const {
 
 std::string ResourceIds::ToString() const {
   std::string return_string = "Whole IDs: [";
-  for (auto const &whole_id : whole_ids_) {
+  for (auto const& whole_id : whole_ids_) {
     return_string += std::to_string(whole_id) + ", ";
   }
   return_string += "], Fractional IDs: ";
-  for (auto const &fractional_pair : fractional_ids_) {
+  for (auto const& fractional_pair : fractional_ids_) {
     double fractional_amount = fractional_pair.second.ToDouble();
     return_string += "(" + std::to_string(fractional_pair.first) + ", " +
                      std::to_string(fractional_amount) + "), ";
@@ -564,22 +564,22 @@ bool ResourceIds::IsWhole(double resource_quantity) const {
 
 ResourceIdSet::ResourceIdSet() {}
 
-ResourceIdSet::ResourceIdSet(const ResourceSet &resource_set) {
-  for (auto const &resource_pair : resource_set.GetResourceMap()) {
-    auto const &resource_name = resource_pair.first;
+ResourceIdSet::ResourceIdSet(const ResourceSet& resource_set) {
+  for (auto const& resource_pair : resource_set.GetResourceMap()) {
+    auto const& resource_name = resource_pair.first;
     double resource_quantity = resource_pair.second;
     available_resources_[resource_name] = ResourceIds(resource_quantity);
   }
 }
 
 ResourceIdSet::ResourceIdSet(
-    const std::unordered_map<std::string, ResourceIds> &available_resources)
+    const std::unordered_map<std::string, ResourceIds>& available_resources)
     : available_resources_(available_resources) {}
 
-bool ResourceIdSet::Contains(const ResourceSet &resource_set) const {
-  for (auto const &resource_pair : resource_set.GetResourceAmountMap()) {
-    auto const &resource_name = resource_pair.first;
-    const FractionalResourceQuantity &resource_quantity = resource_pair.second;
+bool ResourceIdSet::Contains(const ResourceSet& resource_set) const {
+  for (auto const& resource_pair : resource_set.GetResourceAmountMap()) {
+    auto const& resource_name = resource_pair.first;
+    const FractionalResourceQuantity& resource_quantity = resource_pair.second;
 
     auto it = available_resources_.find(resource_name);
     if (it == available_resources_.end()) {
@@ -593,12 +593,12 @@ bool ResourceIdSet::Contains(const ResourceSet &resource_set) const {
   return true;
 }
 
-ResourceIdSet ResourceIdSet::Acquire(const ResourceSet &resource_set) {
+ResourceIdSet ResourceIdSet::Acquire(const ResourceSet& resource_set) {
   std::unordered_map<std::string, ResourceIds> acquired_resources;
 
-  for (auto const &resource_pair : resource_set.GetResourceAmountMap()) {
-    auto const &resource_name = resource_pair.first;
-    const FractionalResourceQuantity &resource_quantity = resource_pair.second;
+  for (auto const& resource_pair : resource_set.GetResourceAmountMap()) {
+    auto const& resource_name = resource_pair.first;
+    const FractionalResourceQuantity& resource_quantity = resource_pair.second;
 
     auto it = available_resources_.find(resource_name);
     RAY_CHECK(it != available_resources_.end());
@@ -610,10 +610,10 @@ ResourceIdSet ResourceIdSet::Acquire(const ResourceSet &resource_set) {
   return ResourceIdSet(acquired_resources);
 }
 
-void ResourceIdSet::Release(const ResourceIdSet &resource_id_set) {
-  for (auto const &resource_pair : resource_id_set.AvailableResources()) {
-    auto const &resource_name = resource_pair.first;
-    auto const &resource_ids = resource_pair.second;
+void ResourceIdSet::Release(const ResourceIdSet& resource_id_set) {
+  for (auto const& resource_pair : resource_id_set.AvailableResources()) {
+    auto const& resource_name = resource_pair.first;
+    auto const& resource_ids = resource_pair.second;
     RAY_CHECK(!resource_ids.TotalQuantityIsZero());
 
     auto it = available_resources_.find(resource_name);
@@ -625,13 +625,13 @@ void ResourceIdSet::Release(const ResourceIdSet &resource_id_set) {
   }
 }
 
-void ResourceIdSet::ReleaseConstrained(const ResourceIdSet &resource_id_set,
-                                       const ResourceSet &resources_total) {
-  for (auto const &resource_pair : resource_id_set.AvailableResources()) {
-    auto const &resource_name = resource_pair.first;
+void ResourceIdSet::ReleaseConstrained(const ResourceIdSet& resource_id_set,
+                                       const ResourceSet& resources_total) {
+  for (auto const& resource_pair : resource_id_set.AvailableResources()) {
+    auto const& resource_name = resource_pair.first;
     // Release only if the resource exists in resources_total
     if (resources_total.GetResource(resource_name) != 0) {
-      auto const &resource_ids = resource_pair.second;
+      auto const& resource_ids = resource_pair.second;
       RAY_CHECK(!resource_ids.TotalQuantityIsZero());
 
       auto it = available_resources_.find(resource_name);
@@ -646,18 +646,18 @@ void ResourceIdSet::ReleaseConstrained(const ResourceIdSet &resource_id_set,
 
 void ResourceIdSet::Clear() { available_resources_.clear(); }
 
-ResourceIdSet ResourceIdSet::Plus(const ResourceIdSet &resource_id_set) const {
+ResourceIdSet ResourceIdSet::Plus(const ResourceIdSet& resource_id_set) const {
   ResourceIdSet resource_id_set_to_return(available_resources_);
   resource_id_set_to_return.Release(resource_id_set);
   return resource_id_set_to_return;
 }
 
-void ResourceIdSet::AddOrUpdateResource(const std::string &resource_name,
+void ResourceIdSet::AddOrUpdateResource(const std::string& resource_name,
                                         int64_t capacity) {
   auto it = available_resources_.find(resource_name);
   if (it != available_resources_.end()) {
     // If resource exists, update capacity
-    ResourceIds &resid = (it->second);
+    ResourceIds& resid = (it->second);
     resid.UpdateCapacity(capacity);
   } else {
     // If resource does not exist, create
@@ -665,12 +665,12 @@ void ResourceIdSet::AddOrUpdateResource(const std::string &resource_name,
   }
 }
 
-void ResourceIdSet::AddBundleResource(const std::string &resource_name,
-                                      ResourceIds &resource_ids) {
+void ResourceIdSet::AddBundleResource(const std::string& resource_name,
+                                      ResourceIds& resource_ids) {
   available_resources_[resource_name] = resource_ids;
 }
 
-void ResourceIdSet::CancelResourceReserve(const std::string &resource_name) {
+void ResourceIdSet::CancelResourceReserve(const std::string& resource_name) {
   std::string origin_resource_name = GetOriginalResourceName(resource_name);
   auto iter_orig = available_resources_.find(origin_resource_name);
   auto iter_bundle = available_resources_.find(resource_name);
@@ -685,11 +685,11 @@ void ResourceIdSet::CancelResourceReserve(const std::string &resource_name) {
     available_resources_.erase(iter_bundle);
   }
 }
-void ResourceIdSet::DeleteResource(const std::string &resource_name) {
+void ResourceIdSet::DeleteResource(const std::string& resource_name) {
   available_resources_.erase(resource_name);
 }
 
-const std::unordered_map<std::string, ResourceIds> &ResourceIdSet::AvailableResources()
+const std::unordered_map<std::string, ResourceIds>& ResourceIdSet::AvailableResources()
     const {
   return available_resources_;
 }
@@ -706,7 +706,7 @@ ResourceIdSet ResourceIdSet::GetCpuResources() const {
 
 ResourceSet ResourceIdSet::ToResourceSet() const {
   std::unordered_map<std::string, FractionalResourceQuantity> resource_set;
-  for (auto const &resource_pair : available_resources_) {
+  for (auto const& resource_pair : available_resources_) {
     resource_set[resource_pair.first] = resource_pair.second.TotalQuantity();
   }
   return ResourceSet(resource_set);
@@ -732,9 +732,9 @@ std::string ResourceIdSet::ToString() const {
 }
 
 std::vector<flatbuffers::Offset<protocol::ResourceIdSetInfo>> ResourceIdSet::ToFlatbuf(
-    flatbuffers::FlatBufferBuilder &fbb) const {
+    flatbuffers::FlatBufferBuilder& fbb) const {
   std::vector<flatbuffers::Offset<protocol::ResourceIdSetInfo>> return_message;
-  for (auto const &resource_pair : available_resources_) {
+  for (auto const& resource_pair : available_resources_) {
     std::vector<int64_t> resource_ids;
     std::vector<double> resource_fractions;
     for (auto whole_id : resource_pair.second.WholeIds()) {
@@ -742,7 +742,7 @@ std::vector<flatbuffers::Offset<protocol::ResourceIdSetInfo>> ResourceIdSet::ToF
       resource_fractions.push_back(1);
     }
 
-    for (auto const &fractional_pair : resource_pair.second.FractionalIds()) {
+    for (auto const& fractional_pair : resource_pair.second.FractionalIds()) {
       resource_ids.push_back(fractional_pair.first);
       resource_fractions.push_back(fractional_pair.second.ToDouble());
     }
@@ -770,58 +770,58 @@ SchedulingResources::SchedulingResources()
       resources_available_(ResourceSet()),
       resources_load_(ResourceSet()) {}
 
-SchedulingResources::SchedulingResources(const ResourceSet &total)
+SchedulingResources::SchedulingResources(const ResourceSet& total)
     : resources_total_(total),
       resources_available_(total),
       resources_load_(ResourceSet()) {}
 
 SchedulingResources::~SchedulingResources() {}
 
-const ResourceSet &SchedulingResources::GetAvailableResources() const {
+const ResourceSet& SchedulingResources::GetAvailableResources() const {
   return resources_available_;
 }
 
-void SchedulingResources::SetAvailableResources(ResourceSet &&newset) {
+void SchedulingResources::SetAvailableResources(ResourceSet&& newset) {
   resources_available_ = newset;
 }
 
-const ResourceSet &SchedulingResources::GetTotalResources() const {
+const ResourceSet& SchedulingResources::GetTotalResources() const {
   return resources_total_;
 }
 
-void SchedulingResources::SetTotalResources(ResourceSet &&newset) {
+void SchedulingResources::SetTotalResources(ResourceSet&& newset) {
   resources_total_ = newset;
 }
 
-const ResourceSet &SchedulingResources::GetLoadResources() const {
+const ResourceSet& SchedulingResources::GetLoadResources() const {
   return resources_load_;
 }
 
-void SchedulingResources::SetLoadResources(ResourceSet &&newset) {
+void SchedulingResources::SetLoadResources(ResourceSet&& newset) {
   resources_load_ = newset;
 }
 
 // Return specified resources back to SchedulingResources.
-void SchedulingResources::Release(const ResourceSet &resources) {
+void SchedulingResources::Release(const ResourceSet& resources) {
   return resources_available_.AddResourcesCapacityConstrained(resources,
                                                               resources_total_);
 }
 
 // Take specified resources from SchedulingResources.
-void SchedulingResources::Acquire(const ResourceSet &resources) {
+void SchedulingResources::Acquire(const ResourceSet& resources) {
   resources_available_.SubtractResourcesStrict(resources);
 }
 
-void SchedulingResources::UpdateResourceCapacity(const std::string &resource_name,
+void SchedulingResources::UpdateResourceCapacity(const std::string& resource_name,
                                                  int64_t capacity) {
   const FractionalResourceQuantity new_capacity = FractionalResourceQuantity(capacity);
-  const FractionalResourceQuantity &current_capacity =
+  const FractionalResourceQuantity& current_capacity =
       resources_total_.GetResource(resource_name);
   if (current_capacity > 0) {
     // If the resource exists, add to total and available resources
     const FractionalResourceQuantity capacity_difference =
         new_capacity - current_capacity;
-    const FractionalResourceQuantity &current_available_capacity =
+    const FractionalResourceQuantity& current_available_capacity =
         resources_available_.GetResource(resource_name);
     FractionalResourceQuantity new_available_capacity =
         current_available_capacity + capacity_difference;
@@ -837,22 +837,22 @@ void SchedulingResources::UpdateResourceCapacity(const std::string &resource_nam
   }
 }
 
-void SchedulingResources::UpdateBundleResource(const PlacementGroupID &group,
+void SchedulingResources::UpdateBundleResource(const PlacementGroupID& group,
                                                const int bundle_index,
-                                               const ResourceSet &resource_set) {
+                                               const ResourceSet& resource_set) {
   resources_available_.SubtractResourcesStrict(resource_set);
   resources_available_.AddBundleResources(group, bundle_index, resource_set);
   resources_total_.SubtractResourcesStrict(resource_set);
   resources_total_.AddBundleResources(group, bundle_index, resource_set);
 }
 
-void SchedulingResources::ReturnBundleResource(const PlacementGroupID &group,
+void SchedulingResources::ReturnBundleResource(const PlacementGroupID& group,
                                                const int bundle_index) {
   resources_available_.ReturnBundleResources(group, bundle_index);
   resources_total_.ReturnBundleResources(group, bundle_index);
 }
 
-void SchedulingResources::DeleteResource(const std::string &resource_name) {
+void SchedulingResources::DeleteResource(const std::string& resource_name) {
   resources_total_.DeleteResource(resource_name);
   resources_available_.DeleteResource(resource_name);
   resources_load_.DeleteResource(resource_name);

--- a/src/ray/common/task/scheduling_resources.h
+++ b/src/ray/common/task/scheduling_resources.h
@@ -35,23 +35,23 @@ class FractionalResourceQuantity {
   FractionalResourceQuantity(double resource_quantity);
 
   /// \brief Addition of FractionalResourceQuantity.
-  const FractionalResourceQuantity operator+(const FractionalResourceQuantity &rhs) const;
+  const FractionalResourceQuantity operator+(const FractionalResourceQuantity& rhs) const;
 
   /// \brief Subtraction of FractionalResourceQuantity.
-  const FractionalResourceQuantity operator-(const FractionalResourceQuantity &rhs) const;
+  const FractionalResourceQuantity operator-(const FractionalResourceQuantity& rhs) const;
 
   /// \brief Addition and assignment of FractionalResourceQuantity.
-  void operator+=(const FractionalResourceQuantity &rhs);
+  void operator+=(const FractionalResourceQuantity& rhs);
 
   /// \brief Subtraction and assignment of FractionalResourceQuantity.
-  void operator-=(const FractionalResourceQuantity &rhs);
+  void operator-=(const FractionalResourceQuantity& rhs);
 
-  bool operator==(const FractionalResourceQuantity &rhs) const;
-  bool operator!=(const FractionalResourceQuantity &rhs) const;
-  bool operator<(const FractionalResourceQuantity &rhs) const;
-  bool operator>(const FractionalResourceQuantity &rhs) const;
-  bool operator<=(const FractionalResourceQuantity &rhs) const;
-  bool operator>=(const FractionalResourceQuantity &rhs) const;
+  bool operator==(const FractionalResourceQuantity& rhs) const;
+  bool operator!=(const FractionalResourceQuantity& rhs) const;
+  bool operator<(const FractionalResourceQuantity& rhs) const;
+  bool operator>(const FractionalResourceQuantity& rhs) const;
+  bool operator<=(const FractionalResourceQuantity& rhs) const;
+  bool operator>=(const FractionalResourceQuantity& rhs) const;
 
   /// \brief Return actual resource amount as a double.
   double ToDouble() const;
@@ -77,14 +77,14 @@ class ResourceSet {
 
   /// \brief Constructs ResourceSet from the specified resource map.
   ResourceSet(
-      const std::unordered_map<std::string, FractionalResourceQuantity> &resource_map);
+      const std::unordered_map<std::string, FractionalResourceQuantity>& resource_map);
 
   /// \brief Constructs ResourceSet from the specified resource map.
-  ResourceSet(const std::unordered_map<std::string, double> &resource_map);
+  ResourceSet(const std::unordered_map<std::string, double>& resource_map);
 
   /// \brief Constructs ResourceSet from two equal-length vectors with label and capacity
   /// specification.
-  ResourceSet(const std::vector<std::string> &resource_labels,
+  ResourceSet(const std::vector<std::string>& resource_labels,
               const std::vector<double> resource_capacity);
 
   /// \brief Empty ResourceSet destructor.
@@ -94,42 +94,42 @@ class ResourceSet {
   ///
   /// \param rhs: Right-hand side object for equality comparison.
   /// \return True if objects are equal, False otherwise.
-  bool operator==(const ResourceSet &rhs) const;
+  bool operator==(const ResourceSet& rhs) const;
 
   /// \brief Test equality with the other specified ResourceSet object.
   ///
   /// \param other: Right-hand side object for equality comparison.
   /// \return True if objects are equal, False otherwise.
-  bool IsEqual(const ResourceSet &other) const;
+  bool IsEqual(const ResourceSet& other) const;
 
   /// \brief Test whether this ResourceSet is a subset of the other ResourceSet.
   ///
   /// \param other: The resource set we check being a subset of.
   /// \return True if the current resource set is the subset of other. False
   /// otherwise.
-  bool IsSubset(const ResourceSet &other) const;
+  bool IsSubset(const ResourceSet& other) const;
 
   /// \brief Test if this ResourceSet is a superset of the other ResourceSet.
   ///
   /// \param other: The resource set we check being a superset of.
   /// \return True if the current resource set is the superset of other.
   /// False otherwise.
-  bool IsSuperset(const ResourceSet &other) const;
+  bool IsSuperset(const ResourceSet& other) const;
 
   /// \brief Add or update a new resource to the resource set.
   ///
   /// \param resource_name: name/label of the resource to add.
   /// \param capacity: numeric capacity value for the resource to add.
   /// \return True, if the resource was successfully added. False otherwise.
-  void AddOrUpdateResource(const std::string &resource_name,
-                           const FractionalResourceQuantity &capacity);
+  void AddOrUpdateResource(const std::string& resource_name,
+                           const FractionalResourceQuantity& capacity);
 
   /// \brief Delete a resource from the resource set.
   ///
   /// \param resource_name: name/label of the resource to delete.
   /// \return True if the resource was found while deleting, false if the resource did not
   /// exist in the set.
-  bool DeleteResource(const std::string &resource_name);
+  bool DeleteResource(const std::string& resource_name);
 
   /// \brief Add a set of resources to the current set of resources subject to upper
   /// limits on capacity from the total_resource set.
@@ -138,15 +138,15 @@ class ResourceSet {
   /// \param total_resources: Total resource set which sets upper limits on capacity for
   /// each label. \return True if the resource set was added successfully. False
   /// otherwise.
-  void AddResourcesCapacityConstrained(const ResourceSet &other,
-                                       const ResourceSet &total_resources);
+  void AddResourcesCapacityConstrained(const ResourceSet& other,
+                                       const ResourceSet& total_resources);
 
   /// \brief Aggregate resources from the other set into this set, adding any missing
   /// resource labels to this set.
   ///
   /// \param other: The other resource set to add.
   /// \return Void.
-  void AddResources(const ResourceSet &other);
+  void AddResources(const ResourceSet& other);
 
   /// \brief Aggregate resources from the other set into this set, adding any missing
   /// resource labels to this set.
@@ -155,8 +155,8 @@ class ResourceSet {
   /// \param bundle_index: The index of the bundle.
   /// \param other: The other resource set to add.
   /// \return Void.
-  void AddBundleResources(const PlacementGroupID &bundle_id, const int bundle_index,
-                          const ResourceSet &other);
+  void AddBundleResources(const PlacementGroupID& bundle_id, const int bundle_index,
+                          const ResourceSet& other);
 
   /// \brief Return back all the bundle resource. Changing the resource name and adding
   /// any missing resource labels to this set.
@@ -164,7 +164,7 @@ class ResourceSet {
   /// \param bundle_id: The placement group id.
   /// \param bundle_index: The index of the bundle.
   /// \return Void.
-  void ReturnBundleResources(const PlacementGroupID &bundle_id, const int bundle_index);
+  void ReturnBundleResources(const PlacementGroupID& bundle_id, const int bundle_index);
 
   /// \brief Subtract a set of resources from the current set of resources and
   /// check that the post-subtraction result nonnegative. Assumes other
@@ -173,21 +173,21 @@ class ResourceSet {
   ///
   /// \param other: The resource set to subtract from the current resource set.
   /// \return Void.
-  void SubtractResources(const ResourceSet &other);
+  void SubtractResources(const ResourceSet& other);
 
   /// \brief Same as SubtractResources but throws an error if the resource value
   /// goes below zero.
   ///
   /// \param other: The resource set to subtract from the current resource set.
   /// \return Void.
-  void SubtractResourcesStrict(const ResourceSet &other);
+  void SubtractResourcesStrict(const ResourceSet& other);
 
   /// Return the capacity value associated with the specified resource.
   ///
   /// \param resource_name: Resource name for which capacity is requested.
   /// \return The capacity value associated with the specified resource, zero if resource
   /// does not exist.
-  FractionalResourceQuantity GetResource(const std::string &resource_name) const;
+  FractionalResourceQuantity GetResource(const std::string& resource_name) const;
 
   /// Return the number of CPUs.
   ///
@@ -212,8 +212,8 @@ class ResourceSet {
   /// size is in kResourceConversionFactor of a unit.
   ///
   /// \return map of resource in string to size in FractionalResourceQuantity.
-  const std::unordered_map<std::string, FractionalResourceQuantity>
-      &GetResourceAmountMap() const;
+  const std::unordered_map<std::string, FractionalResourceQuantity>&
+  GetResourceAmountMap() const;
 
   const std::string ToString() const;
 
@@ -242,21 +242,21 @@ class ResourceIds {
   /// \brief Constructs ResourceIds with a given set of whole IDs.
   ///
   /// \param whole_ids: A vector of the resource IDs that are completely available.
-  explicit ResourceIds(const std::vector<int64_t> &whole_ids);
+  explicit ResourceIds(const std::vector<int64_t>& whole_ids);
 
   /// \brief Constructs ResourceIds with a given set of fractional IDs.
   ///
   /// \param fractional_ids: A vector of the resource IDs that are partially available.
   explicit ResourceIds(
-      const std::vector<std::pair<int64_t, FractionalResourceQuantity>> &fractional_ids);
+      const std::vector<std::pair<int64_t, FractionalResourceQuantity>>& fractional_ids);
 
   /// \brief Constructs ResourceIds with a given set of whole IDs and fractional IDs.
   ///
   /// \param whole_ids: A vector of the resource IDs that are completely available.
   /// \param fractional_ids: A vector of the resource IDs that are partially available.
   ResourceIds(
-      const std::vector<int64_t> &whole_ids,
-      const std::vector<std::pair<int64_t, FractionalResourceQuantity>> &fractional_ids);
+      const std::vector<int64_t>& whole_ids,
+      const std::vector<std::pair<int64_t, FractionalResourceQuantity>>& fractional_ids);
 
   /// \brief Check if we have at least the requested amount.
   ///
@@ -268,36 +268,36 @@ class ResourceIds {
   ///
   /// \param resource_quantity Either a whole number or a fraction less than 1.
   /// \return True if there we have enough of the resource.
-  bool Contains(const FractionalResourceQuantity &resource_quantity) const;
+  bool Contains(const FractionalResourceQuantity& resource_quantity) const;
 
   /// \brief Acquire the requested amount of the resource.
   ///
   /// \param resource_quantity The amount to acquire. Either a whole number or a
   /// fraction less than 1.
   /// \return A ResourceIds representing the specific acquired IDs.
-  ResourceIds Acquire(const FractionalResourceQuantity &resource_quantity);
+  ResourceIds Acquire(const FractionalResourceQuantity& resource_quantity);
 
   /// \brief Return some resource IDs.
   ///
   /// \param resource_ids The specific resource IDs to return.
   /// \return Void.
-  void Release(const ResourceIds &resource_ids);
+  void Release(const ResourceIds& resource_ids);
 
   /// \brief Combine these IDs with some other IDs and return the result.
   ///
   /// \param resource_ids The IDs to add to these ones.
   /// \return The combination of the IDs.
-  ResourceIds Plus(const ResourceIds &resource_ids) const;
+  ResourceIds Plus(const ResourceIds& resource_ids) const;
 
   /// \brief Return just the whole IDs.
   ///
   /// \return The whole IDs.
-  const std::vector<int64_t> &WholeIds() const;
+  const std::vector<int64_t>& WholeIds() const;
 
   /// \brief Return just the fractional IDs.
   ///
   /// \return The fractional IDs.
-  const std::vector<std::pair<int64_t, FractionalResourceQuantity>> &FractionalIds()
+  const std::vector<std::pair<int64_t, FractionalResourceQuantity>>& FractionalIds()
       const;
 
   /// \brief Check if ResourceIds has any resources.
@@ -366,32 +366,32 @@ class ResourceIdSet {
   /// \brief Construct a ResourceIdSet from a ResourceSet.
   ///
   /// \param resource_set A mapping from resource name to quantity.
-  ResourceIdSet(const ResourceSet &resource_set);
+  ResourceIdSet(const ResourceSet& resource_set);
 
   /// \brief Construct a ResourceIdSet from a mapping from resource names to ResourceIds.
   ///
   /// \param resource_set A mapping from resource name to IDs.
-  ResourceIdSet(const std::unordered_map<std::string, ResourceIds> &available_resources);
+  ResourceIdSet(const std::unordered_map<std::string, ResourceIds>& available_resources);
 
   /// \brief See if a requested collection of resources is contained.
   ///
   /// \param resource_set A mapping from resource name to quantity.
   /// \return True if each resource in resource_set is contained in the corresponding
   /// ResourceIds in this ResourceIdSet.
-  bool Contains(const ResourceSet &resource_set) const;
+  bool Contains(const ResourceSet& resource_set) const;
 
   /// \brief Acquire a set of resources and return the specific acquired IDs.
   ///
   /// \param resource_set A mapping from resource name to quantity. This specifies
   /// the amount of each resource to acquire.
   /// \return A ResourceIdSet with the requested quantities, but with specific IDs.
-  ResourceIdSet Acquire(const ResourceSet &resource_set);
+  ResourceIdSet Acquire(const ResourceSet& resource_set);
 
   /// \brief Return a set of resource IDs.
   ///
   /// \param resource_id_set The resource IDs to return.
   /// \return Void.
-  void Release(const ResourceIdSet &resource_id_set);
+  void Release(const ResourceIdSet& resource_id_set);
 
   /// \brief Return a set of resource IDs subject to their existence in the
   /// resources_total set.
@@ -400,8 +400,8 @@ class ResourceIdSet {
   /// \param resources_total Constraint set to restrict the release to. If a resource
   /// exists in resource_id_set but not in resources_total, it is not added to this
   /// ResourceIdSet. \return Void.
-  void ReleaseConstrained(const ResourceIdSet &resource_id_set,
-                          const ResourceSet &resources_total);
+  void ReleaseConstrained(const ResourceIdSet& resource_id_set,
+                          const ResourceSet& resources_total);
 
   /// \brief Clear out all of the resource IDs.
   ///
@@ -412,7 +412,7 @@ class ResourceIdSet {
   ///
   /// \param resource_id_set The other set of resource IDs to combine with this one.
   /// \return The combination of the two sets of resource IDs.
-  ResourceIdSet Plus(const ResourceIdSet &resource_id_set) const;
+  ResourceIdSet Plus(const ResourceIdSet& resource_id_set) const;
 
   /// \brief Creates or updates a resource in the ResourceIdSet if it already exists.
   /// Raises an exception if the new capacity (when less than old capacity) cannot be set
@@ -420,29 +420,29 @@ class ResourceIdSet {
   ///
   /// \param resource_name the name of the resource to create/update
   /// \param capacity capacity of the resource being added
-  void AddOrUpdateResource(const std::string &resource_name, int64_t capacity);
+  void AddOrUpdateResource(const std::string& resource_name, int64_t capacity);
 
   /// \brief  Add a Bundle resource in the ResourceIdSet.
   ///
   /// \param resource_name the name of the resource to create/update
   /// \param resource_ids resource_ids of the resource being added
-  void AddBundleResource(const std::string &resource_name, ResourceIds &resource_ids);
+  void AddBundleResource(const std::string& resource_name, ResourceIds& resource_ids);
 
   /// \brief  remove a Bundle resource in the ResourceIdSet.
   ///
   /// \param resource_name the name of the resource to remove.
 
-  void CancelResourceReserve(const std::string &resource_name);
+  void CancelResourceReserve(const std::string& resource_name);
   /// \brief Deletes a resource in the ResourceIdSet. This does not raise an exception,
   /// just deletes the resource. Tasks with acquired resources keep running.
   ///
   /// \param resource_name the name of the resource to delete
-  void DeleteResource(const std::string &resource_name);
+  void DeleteResource(const std::string& resource_name);
 
   /// \brief Get the underlying mapping from resource name to resource IDs.
   ///
   /// \return The resource name to resource IDs mapping.
-  const std::unordered_map<std::string, ResourceIds> &AvailableResources() const;
+  const std::unordered_map<std::string, ResourceIds>& AvailableResources() const;
 
   /// Return the CPU resources.
   ///
@@ -464,7 +464,7 @@ class ResourceIdSet {
   /// \param fbb A flatbuffer builder object.
   /// \return A flatbuffer serialized version of this object.
   std::vector<flatbuffers::Offset<ray::protocol::ResourceIdSetInfo>> ToFlatbuf(
-      flatbuffers::FlatBufferBuilder &fbb) const;
+      flatbuffers::FlatBufferBuilder& fbb) const;
 
   /// \brief Serialize this object as a string.
   ///
@@ -491,7 +491,7 @@ class SchedulingResources {
   /// to the resource set specified.
   ///
   /// \param total: The amount of total configured capacity.
-  SchedulingResources(const ResourceSet &total);
+  SchedulingResources(const ResourceSet& total);
 
   /// \brief SchedulingResources destructor.
   ~SchedulingResources();
@@ -499,47 +499,47 @@ class SchedulingResources {
   /// \brief Request the set and capacity of resources currently available.
   ///
   /// \return Immutable set of resources with currently available capacity.
-  const ResourceSet &GetAvailableResources() const;
+  const ResourceSet& GetAvailableResources() const;
 
   /// \brief Overwrite available resource capacity with the specified resource set.
   ///
   /// \param newset: The set of resources that replaces available resource capacity.
   /// \return Void.
-  void SetAvailableResources(ResourceSet &&newset);
+  void SetAvailableResources(ResourceSet&& newset);
 
   /// \brief Request the total resources capacity.
   ///
   /// \return Immutable set of resources with currently total capacity.
-  const ResourceSet &GetTotalResources() const;
+  const ResourceSet& GetTotalResources() const;
 
   /// \brief Overwrite total resource capacity with the specified resource set.
   ///
   /// \param newset: The set of resources that replaces total resource capacity.
   /// \return Void.
-  void SetTotalResources(ResourceSet &&newset);
+  void SetTotalResources(ResourceSet&& newset);
 
   /// \brief Request the resource load information.
   ///
   /// \return Immutable set of resources describing the load information.
-  const ResourceSet &GetLoadResources() const;
+  const ResourceSet& GetLoadResources() const;
 
   /// \brief Overwrite information about resource load with new resource load set.
   ///
   /// \param newset: The set of resources that replaces resource load information.
   /// \return Void.
-  void SetLoadResources(ResourceSet &&newset);
+  void SetLoadResources(ResourceSet&& newset);
 
   /// \brief Release the amount of resources specified.
   ///
   /// \param resources: the amount of resources to be released.
   /// \return Void.
-  void Release(const ResourceSet &resources);
+  void Release(const ResourceSet& resources);
 
   /// \brief Acquire the amount of resources specified.
   ///
   /// \param resources: the amount of resources to be acquired.
   /// \return Void.
-  void Acquire(const ResourceSet &resources);
+  void Acquire(const ResourceSet& resources);
 
   /// Returns debug string for class.
   ///
@@ -552,25 +552,25 @@ class SchedulingResources {
   /// \param resource_name: Name of the resource to be modified
   /// \param capacity: New capacity of the resource.
   /// \return Void.
-  void UpdateResourceCapacity(const std::string &resource_name, int64_t capacity);
+  void UpdateResourceCapacity(const std::string& resource_name, int64_t capacity);
 
   /// \brief Update total, available and load resources with the ResourceIds.
   /// Create if not exists.
   /// \param resource_name: Name of the resource to be modified
   /// \param resource_set: New resource_set of the resource.
-  void UpdateBundleResource(const PlacementGroupID &group, const int bundle_index,
-                            const ResourceSet &resource_set);
+  void UpdateBundleResource(const PlacementGroupID& group, const int bundle_index,
+                            const ResourceSet& resource_set);
 
   /// \brief delete total, available and load resources with the ResourceIds.
   /// Create if not exists.
   /// \param resource_name: Name of the resource to be deleted
-  void ReturnBundleResource(const PlacementGroupID &group, const int bundle_index);
+  void ReturnBundleResource(const PlacementGroupID& group, const int bundle_index);
 
   /// \brief Delete resource from total, available and load resources.
   ///
   /// \param resource_name: Name of the resource to be deleted.
   /// \return Void.
-  void DeleteResource(const std::string &resource_name);
+  void DeleteResource(const std::string& resource_name);
 
  private:
   /// Static resource configuration (e.g., static_resources).
@@ -586,9 +586,9 @@ class SchedulingResources {
 namespace std {
 template <>
 struct hash<ray::ResourceSet> {
-  size_t operator()(ray::ResourceSet const &k) const {
+  size_t operator()(ray::ResourceSet const& k) const {
     size_t seed = k.GetResourceMap().size();
-    for (auto &elem : k.GetResourceMap()) {
+    for (auto& elem : k.GetResourceMap()) {
       seed ^= std::hash<std::string>()(elem.first);
       seed ^= std::hash<double>()(elem.second);
     }

--- a/src/ray/common/task/task.cc
+++ b/src/ray/common/task/task.cc
@@ -4,21 +4,21 @@
 
 namespace ray {
 
-const TaskExecutionSpecification &Task::GetTaskExecutionSpec() const {
+const TaskExecutionSpecification& Task::GetTaskExecutionSpec() const {
   return task_execution_spec_;
 }
 
-const TaskSpecification &Task::GetTaskSpecification() const { return task_spec_; }
+const TaskSpecification& Task::GetTaskSpecification() const { return task_spec_; }
 
 void Task::IncrementNumForwards() { task_execution_spec_.IncrementNumForwards(); }
 
-const std::vector<rpc::ObjectReference> &Task::GetDependencies() const {
+const std::vector<rpc::ObjectReference>& Task::GetDependencies() const {
   return dependencies_;
 }
 
 void Task::ComputeDependencies() { dependencies_ = task_spec_.GetDependencies(); }
 
-void Task::CopyTaskExecutionSpec(const Task &task) {
+void Task::CopyTaskExecutionSpec(const Task& task) {
   task_execution_spec_ = task.task_execution_spec_;
 }
 

--- a/src/ray/common/task/task.h
+++ b/src/ray/common/task/task.h
@@ -8,12 +8,12 @@
 
 namespace ray {
 
-typedef std::function<void(const std::shared_ptr<void>, const std::string &, int,
-                           const WorkerID &, const ResourceIdSet &)>
+typedef std::function<void(const std::shared_ptr<void>, const std::string&, int,
+                           const WorkerID&, const ResourceIdSet&)>
     DispatchTaskCallback;
 /// Arguments are the raylet ID to spill back to, the raylet's
 /// address and the raylet's port.
-typedef std::function<void(const ClientID &, const std::string &, int)>
+typedef std::function<void(const ClientID&, const std::string&, int)>
     SpillbackTaskCallback;
 
 typedef std::function<void()> CancelTaskCallback;
@@ -33,7 +33,7 @@ class Task {
   /// Construct a `Task` object from a protobuf message.
   ///
   /// \param message The protobuf message.
-  explicit Task(const rpc::Task &message)
+  explicit Task(const rpc::Task& message)
       : task_spec_(message.task_spec()),
         task_execution_spec_(message.task_execution_spec()) {
     ComputeDependencies();
@@ -48,17 +48,17 @@ class Task {
   }
 
   /// Override dispatch behaviour.
-  void OnDispatchInstead(const DispatchTaskCallback &callback) {
+  void OnDispatchInstead(const DispatchTaskCallback& callback) {
     on_dispatch_ = callback;
   }
 
   /// Override spillback behaviour.
-  void OnSpillbackInstead(const SpillbackTaskCallback &callback) {
+  void OnSpillbackInstead(const SpillbackTaskCallback& callback) {
     on_spillback_ = callback;
   }
 
   /// Override cancellation behaviour.
-  void OnCancellationInstead(const CancelTaskCallback &callback) {
+  void OnCancellationInstead(const CancelTaskCallback& callback) {
     on_cancellation_ = callback;
   }
 
@@ -66,12 +66,12 @@ class Task {
   /// updated at runtime.
   ///
   /// \return The mutable specification for the task.
-  const TaskExecutionSpecification &GetTaskExecutionSpec() const;
+  const TaskExecutionSpecification& GetTaskExecutionSpec() const;
 
   /// Get the immutable specification for the task.
   ///
   /// \return The immutable specification for the task.
-  const TaskSpecification &GetTaskSpecification() const;
+  const TaskSpecification& GetTaskSpecification() const;
 
   /// Increment the number of times this task has been forwarded.
   void IncrementNumForwards();
@@ -80,20 +80,20 @@ class Task {
   /// arguments and the mutable execution dependencies.
   ///
   /// \return The object dependencies.
-  const std::vector<rpc::ObjectReference> &GetDependencies() const;
+  const std::vector<rpc::ObjectReference>& GetDependencies() const;
 
   /// Update the dynamic/mutable information for this task.
   /// \param task Task structure with updated dynamic information.
-  void CopyTaskExecutionSpec(const Task &task);
+  void CopyTaskExecutionSpec(const Task& task);
 
   /// Returns the override dispatch task callback, or nullptr.
-  const DispatchTaskCallback &OnDispatch() const { return on_dispatch_; }
+  const DispatchTaskCallback& OnDispatch() const { return on_dispatch_; }
 
   /// Returns the override spillback task callback, or nullptr.
-  const SpillbackTaskCallback &OnSpillback() const { return on_spillback_; }
+  const SpillbackTaskCallback& OnSpillback() const { return on_spillback_; }
 
   /// Returns the cancellation task callback, or nullptr.
-  const CancelTaskCallback &OnCancellation() const { return on_cancellation_; }
+  const CancelTaskCallback& OnCancellation() const { return on_cancellation_; }
 
   std::string DebugString() const;
 

--- a/src/ray/common/task/task_execution_spec.cc
+++ b/src/ray/common/task/task_execution_spec.cc
@@ -1,6 +1,6 @@
-#include <sstream>
-
 #include "ray/common/task/task_execution_spec.h"
+
+#include <sstream>
 
 namespace ray {
 

--- a/src/ray/common/task/task_execution_spec.h
+++ b/src/ray/common/task/task_execution_spec.h
@@ -25,7 +25,7 @@ class TaskExecutionSpecification : public MessageWrapper<rpc::TaskExecutionSpec>
   /// Construct from protobuf-serialized binary.
   ///
   /// \param serialized_binary Protobuf-serialized binary.
-  explicit TaskExecutionSpecification(const std::string &serialized_binary)
+  explicit TaskExecutionSpecification(const std::string& serialized_binary)
       : MessageWrapper(serialized_binary) {}
 
   /// Get the number of times this task has been forwarded.

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -13,7 +13,7 @@ std::unordered_map<SchedulingClass, SchedulingClassDescriptor>
     TaskSpecification::sched_id_to_cls_;
 int TaskSpecification::next_sched_id_;
 
-SchedulingClassDescriptor &TaskSpecification::GetSchedulingClassDescriptor(
+SchedulingClassDescriptor& TaskSpecification::GetSchedulingClassDescriptor(
     SchedulingClass id) {
   absl::MutexLock lock(&mutex_);
   auto it = sched_id_to_cls_.find(id);
@@ -21,7 +21,7 @@ SchedulingClassDescriptor &TaskSpecification::GetSchedulingClassDescriptor(
   return it->second;
 }
 
-SchedulingClass TaskSpecification::GetSchedulingClass(const ResourceSet &sched_cls) {
+SchedulingClass TaskSpecification::GetSchedulingClass(const ResourceSet& sched_cls) {
   SchedulingClass sched_cls_id;
   absl::MutexLock lock(&mutex_);
   auto it = sched_cls_to_id_.find(sched_cls);
@@ -128,16 +128,16 @@ rpc::ObjectReference TaskSpecification::ArgRef(size_t arg_index) const {
   return message_->args(arg_index).object_ref();
 }
 
-const uint8_t *TaskSpecification::ArgData(size_t arg_index) const {
-  return reinterpret_cast<const uint8_t *>(message_->args(arg_index).data().data());
+const uint8_t* TaskSpecification::ArgData(size_t arg_index) const {
+  return reinterpret_cast<const uint8_t*>(message_->args(arg_index).data().data());
 }
 
 size_t TaskSpecification::ArgDataSize(size_t arg_index) const {
   return message_->args(arg_index).data().size();
 }
 
-const uint8_t *TaskSpecification::ArgMetadata(size_t arg_index) const {
-  return reinterpret_cast<const uint8_t *>(message_->args(arg_index).metadata().data());
+const uint8_t* TaskSpecification::ArgMetadata(size_t arg_index) const {
+  return reinterpret_cast<const uint8_t*>(message_->args(arg_index).metadata().data());
 }
 
 size_t TaskSpecification::ArgMetadataSize(size_t arg_index) const {
@@ -148,7 +148,7 @@ const std::vector<ObjectID> TaskSpecification::ArgInlinedIds(size_t arg_index) c
   return IdVectorFromProtobuf<ObjectID>(message_->args(arg_index).nested_inlined_ids());
 }
 
-const ResourceSet &TaskSpecification::GetRequiredResources() const {
+const ResourceSet& TaskSpecification::GetRequiredResources() const {
   return *required_resources_;
 }
 
@@ -173,14 +173,14 @@ std::vector<rpc::ObjectReference> TaskSpecification::GetDependencies() const {
     }
   }
   if (IsActorTask()) {
-    const auto &dummy_ref =
+    const auto& dummy_ref =
         GetReferenceForActorDummyObject(PreviousActorTaskDummyObjectId());
     dependencies.push_back(dummy_ref);
   }
   return dependencies;
 }
 
-const ResourceSet &TaskSpecification::GetRequiredPlacementResources() const {
+const ResourceSet& TaskSpecification::GetRequiredPlacementResources() const {
   return *required_placement_resources_;
 }
 
@@ -224,7 +224,7 @@ TaskID TaskSpecification::CallerId() const {
   return TaskID::FromBinary(message_->caller_id());
 }
 
-const rpc::Address &TaskSpecification::CallerAddress() const {
+const rpc::Address& TaskSpecification::CallerAddress() const {
   return message_->caller_address();
 }
 

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -21,7 +21,7 @@ typedef ResourceSet SchedulingClassDescriptor;
 typedef int SchedulingClass;
 
 static inline rpc::ObjectReference GetReferenceForActorDummyObject(
-    const ObjectID &object_id) {
+    const ObjectID& object_id) {
   rpc::ObjectReference ref;
   ref.set_object_id(object_id.Binary());
   return ref;
@@ -54,7 +54,7 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   /// Construct from protobuf-serialized binary.
   ///
   /// \param serialized_binary Protobuf-serialized binary.
-  explicit TaskSpecification(const std::string &serialized_binary)
+  explicit TaskSpecification(const std::string& serialized_binary)
       : MessageWrapper(serialized_binary) {
     ComputeResources();
   }
@@ -82,11 +82,11 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
 
   ObjectID ReturnId(size_t return_index) const;
 
-  const uint8_t *ArgData(size_t arg_index) const;
+  const uint8_t* ArgData(size_t arg_index) const;
 
   size_t ArgDataSize(size_t arg_index) const;
 
-  const uint8_t *ArgMetadata(size_t arg_index) const;
+  const uint8_t* ArgMetadata(size_t arg_index) const;
 
   size_t ArgMetadataSize(size_t arg_index) const;
 
@@ -105,7 +105,7 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   ///
   /// \return The resources that will be acquired during the execution of this
   /// task.
-  const ResourceSet &GetRequiredResources() const;
+  const ResourceSet& GetRequiredResources() const;
 
   /// Return the resources that are required for a task to be placed on a node.
   /// This will typically be the same as the resources acquired during execution
@@ -116,7 +116,7 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   /// so the placement of the actor should take this into account.
   ///
   /// \return The resources that are required to place a task on a node.
-  const ResourceSet &GetRequiredPlacementResources() const;
+  const ResourceSet& GetRequiredPlacementResources() const;
 
   /// Return the ObjectIDs of any dependencies passed by reference to this
   /// task. This is recomputed each time, so it can be used if the task spec is
@@ -158,7 +158,7 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
 
   TaskID CallerId() const;
 
-  const rpc::Address &CallerAddress() const;
+  const rpc::Address& CallerAddress() const;
 
   WorkerID CallerWorkerId() const;
 
@@ -184,10 +184,10 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   std::string CallSiteString() const;
 
   // Lookup the resource shape that corresponds to the static key.
-  static SchedulingClassDescriptor &GetSchedulingClassDescriptor(SchedulingClass id);
+  static SchedulingClassDescriptor& GetSchedulingClassDescriptor(SchedulingClass id);
 
   // Compute a static key that represents the given resource shape.
-  static SchedulingClass GetSchedulingClass(const ResourceSet &sched_cls);
+  static SchedulingClass GetSchedulingClass(const ResourceSet& sched_cls);
 
  private:
   void ComputeResources();

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -10,7 +10,7 @@ namespace ray {
 /// Argument of a task.
 class TaskArg {
  public:
-  virtual void ToProto(rpc::TaskArg *arg_proto) const = 0;
+  virtual void ToProto(rpc::TaskArg* arg_proto) const = 0;
   virtual ~TaskArg(){};
 };
 
@@ -20,10 +20,10 @@ class TaskArgByReference : public TaskArg {
   ///
   /// \param[in] object_id Id of the argument.
   /// \return The task argument.
-  TaskArgByReference(const ObjectID &object_id, const rpc::Address &owner_address)
+  TaskArgByReference(const ObjectID& object_id, const rpc::Address& owner_address)
       : id_(object_id), owner_address_(owner_address) {}
 
-  void ToProto(rpc::TaskArg *arg_proto) const {
+  void ToProto(rpc::TaskArg* arg_proto) const {
     auto ref = arg_proto->mutable_object_ref();
     ref->set_object_id(id_.Binary());
     ref->mutable_owner_address()->CopyFrom(owner_address_);
@@ -41,20 +41,20 @@ class TaskArgByValue : public TaskArg {
   ///
   /// \param[in] value Value of the argument.
   /// \return The task argument.
-  TaskArgByValue(const std::shared_ptr<RayObject> &value) : value_(value) {
+  TaskArgByValue(const std::shared_ptr<RayObject>& value) : value_(value) {
     RAY_CHECK(value) << "Value can't be null.";
   }
 
-  void ToProto(rpc::TaskArg *arg_proto) const {
+  void ToProto(rpc::TaskArg* arg_proto) const {
     if (value_->HasData()) {
-      const auto &data = value_->GetData();
+      const auto& data = value_->GetData();
       arg_proto->set_data(data->Data(), data->Size());
     }
     if (value_->HasMetadata()) {
-      const auto &metadata = value_->GetMetadata();
+      const auto& metadata = value_->GetMetadata();
       arg_proto->set_metadata(metadata->Data(), metadata->Size());
     }
-    for (const auto &nested_id : value_->GetNestedIds()) {
+    for (const auto& nested_id : value_->GetNestedIds()) {
       arg_proto->add_nested_inlined_ids(nested_id.Binary());
     }
   }
@@ -73,19 +73,19 @@ class TaskSpecBuilder {
   TaskSpecification Build() { return TaskSpecification(message_); }
 
   /// Get a reference to the internal protobuf message object.
-  const rpc::TaskSpec &GetMessage() const { return *message_; }
+  const rpc::TaskSpec& GetMessage() const { return *message_; }
 
   /// Set the common attributes of the task spec.
   /// See `common.proto` for meaning of the arguments.
   ///
   /// \return Reference to the builder object itself.
-  TaskSpecBuilder &SetCommonTaskSpec(
-      const TaskID &task_id, const Language &language,
-      const ray::FunctionDescriptor &function_descriptor, const JobID &job_id,
-      const TaskID &parent_task_id, uint64_t parent_counter, const TaskID &caller_id,
-      const rpc::Address &caller_address, uint64_t num_returns,
-      const std::unordered_map<std::string, double> &required_resources,
-      const std::unordered_map<std::string, double> &required_placement_resources) {
+  TaskSpecBuilder& SetCommonTaskSpec(
+      const TaskID& task_id, const Language& language,
+      const ray::FunctionDescriptor& function_descriptor, const JobID& job_id,
+      const TaskID& parent_task_id, uint64_t parent_counter, const TaskID& caller_id,
+      const rpc::Address& caller_address, uint64_t num_returns,
+      const std::unordered_map<std::string, double>& required_resources,
+      const std::unordered_map<std::string, double>& required_placement_resources) {
     message_->set_type(TaskType::NORMAL_TASK);
     message_->set_language(language);
     *message_->mutable_function_descriptor() = function_descriptor->GetMessage();
@@ -107,10 +107,10 @@ class TaskSpecBuilder {
   /// See `common.proto` for meaning of the arguments.
   ///
   /// \return Reference to the builder object itself.
-  TaskSpecBuilder &SetDriverTaskSpec(const TaskID &task_id, const Language &language,
-                                     const JobID &job_id, const TaskID &parent_task_id,
-                                     const TaskID &caller_id,
-                                     const rpc::Address &caller_address) {
+  TaskSpecBuilder& SetDriverTaskSpec(const TaskID& task_id, const Language& language,
+                                     const JobID& job_id, const TaskID& parent_task_id,
+                                     const TaskID& caller_id,
+                                     const rpc::Address& caller_address) {
     message_->set_type(TaskType::DRIVER_TASK);
     message_->set_language(language);
     message_->set_job_id(job_id.Binary());
@@ -124,7 +124,7 @@ class TaskSpecBuilder {
   }
 
   /// Add an argument to the task.
-  TaskSpecBuilder &AddArg(const TaskArg &arg) {
+  TaskSpecBuilder& AddArg(const TaskArg& arg) {
     auto ref = message_->add_args();
     arg.ToProto(ref);
     return *this;
@@ -134,16 +134,16 @@ class TaskSpecBuilder {
   /// See `common.proto` for meaning of the arguments.
   ///
   /// \return Reference to the builder object itself.
-  TaskSpecBuilder &SetActorCreationTaskSpec(
-      const ActorID &actor_id, int64_t max_restarts = 0,
-      const std::vector<std::string> &dynamic_worker_options = {},
+  TaskSpecBuilder& SetActorCreationTaskSpec(
+      const ActorID& actor_id, int64_t max_restarts = 0,
+      const std::vector<std::string>& dynamic_worker_options = {},
       int max_concurrency = 1, bool is_detached = false, std::string name = "",
-      bool is_asyncio = false, const std::string &extension_data = "") {
+      bool is_asyncio = false, const std::string& extension_data = "") {
     message_->set_type(TaskType::ACTOR_CREATION_TASK);
     auto actor_creation_spec = message_->mutable_actor_creation_task_spec();
     actor_creation_spec->set_actor_id(actor_id.Binary());
     actor_creation_spec->set_max_actor_restarts(max_restarts);
-    for (const auto &option : dynamic_worker_options) {
+    for (const auto& option : dynamic_worker_options) {
       actor_creation_spec->add_dynamic_worker_options(option);
     }
     actor_creation_spec->set_max_concurrency(max_concurrency);
@@ -158,9 +158,9 @@ class TaskSpecBuilder {
   /// See `common.proto` for meaning of the arguments.
   ///
   /// \return Reference to the builder object itself.
-  TaskSpecBuilder &SetActorTaskSpec(const ActorID &actor_id,
-                                    const ObjectID &actor_creation_dummy_object_id,
-                                    const ObjectID &previous_actor_task_dummy_object_id,
+  TaskSpecBuilder& SetActorTaskSpec(const ActorID& actor_id,
+                                    const ObjectID& actor_creation_dummy_object_id,
+                                    const ObjectID& previous_actor_task_dummy_object_id,
                                     uint64_t actor_counter) {
     message_->set_type(TaskType::ACTOR_TASK);
     auto actor_spec = message_->mutable_actor_task_spec();

--- a/src/ray/common/test/client_connection_test.cc
+++ b/src/ray/common/test/client_connection_test.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "ray/common/client_connection.h"
+
 #include <boost/asio.hpp>
 #include <boost/asio/error.hpp>
 #include <list>
@@ -19,8 +21,6 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-
-#include "ray/common/client_connection.h"
 
 namespace ray {
 namespace raylet {

--- a/src/ray/common/test/client_connection_test.cc
+++ b/src/ray/common/test/client_connection_test.cc
@@ -45,7 +45,7 @@ class ClientConnectionTest : public ::testing::Test {
   }
 
   ray::Status WriteBadMessage(std::shared_ptr<ray::ClientConnection> conn, int64_t type,
-                              int64_t length, const uint8_t *message) {
+                              int64_t length, const uint8_t* message) {
     std::vector<boost::asio::const_buffer> message_buffers;
     auto write_cookie = 123456;  // incorrect version.
     message_buffers.push_back(boost::asio::buffer(&write_cookie, sizeof(write_cookie)));
@@ -66,11 +66,11 @@ TEST_F(ClientConnectionTest, SimpleSyncWrite) {
   const uint8_t arr[5] = {1, 2, 3, 4, 5};
   int num_messages = 0;
 
-  ClientHandler client_handler = [](ClientConnection &client) {};
+  ClientHandler client_handler = [](ClientConnection& client) {};
 
   MessageHandler message_handler =
       [&arr, &num_messages](std::shared_ptr<ClientConnection> client,
-                            int64_t message_type, const std::vector<uint8_t> &message) {
+                            int64_t message_type, const std::vector<uint8_t>& message) {
         ASSERT_TRUE(!std::memcmp(arr, message.data(), 5));
         num_messages += 1;
       };
@@ -95,18 +95,18 @@ TEST_F(ClientConnectionTest, SimpleAsyncWrite) {
   const uint8_t msg3[5] = {8, 8, 8, 8, 8};
   int num_messages = 0;
 
-  ClientHandler client_handler = [](ClientConnection &client) {};
+  ClientHandler client_handler = [](ClientConnection& client) {};
 
   MessageHandler noop_handler = [](std::shared_ptr<ClientConnection> client,
                                    int64_t message_type,
-                                   const std::vector<uint8_t> &message) {};
+                                   const std::vector<uint8_t>& message) {};
 
   std::shared_ptr<ClientConnection> reader = NULL;
 
   MessageHandler message_handler = [&msg1, &msg2, &msg3, &num_messages, &reader](
                                        std::shared_ptr<ClientConnection> client,
                                        int64_t message_type,
-                                       const std::vector<uint8_t> &message) {
+                                       const std::vector<uint8_t>& message) {
     if (num_messages == 0) {
       ASSERT_TRUE(!std::memcmp(msg1, message.data(), 5));
     } else if (num_messages == 1) {
@@ -126,7 +126,7 @@ TEST_F(ClientConnectionTest, SimpleAsyncWrite) {
   reader = ClientConnection::Create(client_handler, message_handler, std::move(out_),
                                     "reader", {}, error_message_type_);
 
-  std::function<void(const ray::Status &)> callback = [](const ray::Status &status) {
+  std::function<void(const ray::Status&)> callback = [](const ray::Status& status) {
     RAY_CHECK_OK(status);
   };
 
@@ -158,10 +158,10 @@ TEST_F(ClientConnectionTest, SimpleAsyncReadWriteBuffers) {
   std::vector<uint8_t> read_buffer = {0, 0, 0, 0, 0};
 
   writer->WriteBufferAsync({boost::asio::buffer(write_buffer)},
-                           [](const ray::Status &status) { RAY_CHECK_OK(status); });
+                           [](const ray::Status& status) { RAY_CHECK_OK(status); });
 
   reader->ReadBufferAsync({boost::asio::buffer(read_buffer)},
-                          [&write_buffer, &read_buffer](const ray::Status &status) {
+                          [&write_buffer, &read_buffer](const ray::Status& status) {
                             RAY_CHECK_OK(status);
                             RAY_CHECK(write_buffer == read_buffer);
                           });
@@ -171,16 +171,16 @@ TEST_F(ClientConnectionTest, SimpleAsyncReadWriteBuffers) {
 TEST_F(ClientConnectionTest, SimpleAsyncError) {
   const uint8_t msg1[5] = {1, 2, 3, 4, 5};
 
-  ClientHandler client_handler = [](ClientConnection &client) {};
+  ClientHandler client_handler = [](ClientConnection& client) {};
 
   MessageHandler noop_handler = [](std::shared_ptr<ClientConnection> client,
                                    int64_t message_type,
-                                   const std::vector<uint8_t> &message) {};
+                                   const std::vector<uint8_t>& message) {};
 
   auto writer = ClientConnection::Create(client_handler, noop_handler, std::move(in_),
                                          "writer", {}, error_message_type_);
 
-  std::function<void(const ray::Status &)> callback = [](const ray::Status &status) {
+  std::function<void(const ray::Status&)> callback = [](const ray::Status& status) {
     ASSERT_TRUE(!status.ok());
   };
 
@@ -192,20 +192,19 @@ TEST_F(ClientConnectionTest, SimpleAsyncError) {
 TEST_F(ClientConnectionTest, CallbackWithSharedRefDoesNotLeakConnection) {
   const uint8_t msg1[5] = {1, 2, 3, 4, 5};
 
-  ClientHandler client_handler = [](ClientConnection &client) {};
+  ClientHandler client_handler = [](ClientConnection& client) {};
 
   MessageHandler noop_handler = [](std::shared_ptr<ClientConnection> client,
                                    int64_t message_type,
-                                   const std::vector<uint8_t> &message) {};
+                                   const std::vector<uint8_t>& message) {};
 
   auto writer = ClientConnection::Create(client_handler, noop_handler, std::move(in_),
                                          "writer", {}, error_message_type_);
 
-  std::function<void(const ray::Status &)> callback =
-      [writer](const ray::Status &status) {
-        static_cast<void>(writer);
-        ASSERT_TRUE(status.ok());
-      };
+  std::function<void(const ray::Status&)> callback = [writer](const ray::Status& status) {
+    static_cast<void>(writer);
+    ASSERT_TRUE(status.ok());
+  };
   writer->WriteMessageAsync(0, 5, msg1, callback);
   io_service_.run();
 }
@@ -214,11 +213,11 @@ TEST_F(ClientConnectionTest, ProcessBadMessage) {
   const uint8_t arr[5] = {1, 2, 3, 4, 5};
   int num_messages = 0;
 
-  ClientHandler client_handler = [](ClientConnection &client) {};
+  ClientHandler client_handler = [](ClientConnection& client) {};
 
   MessageHandler message_handler =
       [&arr, &num_messages](std::shared_ptr<ClientConnection> client,
-                            int64_t message_type, const std::vector<uint8_t> &message) {
+                            int64_t message_type, const std::vector<uint8_t>& message) {
         ASSERT_TRUE(!std::memcmp(arr, message.data(), 5));
         num_messages += 1;
       };
@@ -244,7 +243,7 @@ TEST_F(ClientConnectionTest, ProcessBadMessage) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/common/test_util.cc
+++ b/src/ray/common/test_util.cc
@@ -27,18 +27,18 @@
 
 namespace ray {
 
-void TestSetupUtil::StartUpRedisServers(const std::vector<int> &redis_server_ports) {
+void TestSetupUtil::StartUpRedisServers(const std::vector<int>& redis_server_ports) {
   if (redis_server_ports.empty()) {
     TEST_REDIS_SERVER_PORTS.push_back(StartUpRedisServer(0));
   } else {
-    for (const auto &port : redis_server_ports) {
+    for (const auto& port : redis_server_ports) {
       TEST_REDIS_SERVER_PORTS.push_back(StartUpRedisServer(port));
     }
   }
 }
 
 // start a redis server with specified port, use random one when 0 given
-int TestSetupUtil::StartUpRedisServer(const int &port) {
+int TestSetupUtil::StartUpRedisServer(const int& port) {
   int actual_port = port;
   if (port == 0) {
     static std::atomic<bool> srand_called(false);
@@ -62,13 +62,13 @@ int TestSetupUtil::StartUpRedisServer(const int &port) {
 }
 
 void TestSetupUtil::ShutDownRedisServers() {
-  for (const auto &port : TEST_REDIS_SERVER_PORTS) {
+  for (const auto& port : TEST_REDIS_SERVER_PORTS) {
     ShutDownRedisServer(port);
   }
   TEST_REDIS_SERVER_PORTS = std::vector<int>();
 }
 
-void TestSetupUtil::ShutDownRedisServer(const int &port) {
+void TestSetupUtil::ShutDownRedisServer(const int& port) {
   std::vector<std::string> cmdargs(
       {TEST_REDIS_CLIENT_EXEC_PATH, "-p", std::to_string(port), "shutdown"});
   RAY_LOG(INFO) << "Stop redis command is: " << CreateCommandLine(cmdargs);
@@ -79,12 +79,12 @@ void TestSetupUtil::ShutDownRedisServer(const int &port) {
 }
 
 void TestSetupUtil::FlushAllRedisServers() {
-  for (const auto &port : TEST_REDIS_SERVER_PORTS) {
+  for (const auto& port : TEST_REDIS_SERVER_PORTS) {
     FlushRedisServer(port);
   }
 }
 
-void TestSetupUtil::FlushRedisServer(const int &port) {
+void TestSetupUtil::FlushRedisServer(const int& port) {
   std::vector<std::string> cmdargs(
       {TEST_REDIS_CLIENT_EXEC_PATH, "-p", std::to_string(port), "flushall"});
   RAY_LOG(INFO) << "Cleaning up redis with command: " << CreateCommandLine(cmdargs);
@@ -95,7 +95,7 @@ void TestSetupUtil::FlushRedisServer(const int &port) {
 }
 
 std::string TestSetupUtil::StartObjectStore(
-    const boost::optional<std::string> &socket_name) {
+    const boost::optional<std::string>& socket_name) {
   std::string socket_suffix;
   if (socket_name) {
     socket_suffix = *socket_name;
@@ -112,11 +112,11 @@ std::string TestSetupUtil::StartObjectStore(
   return store_socket_name;
 }
 
-void TestSetupUtil::StopObjectStore(const std::string &store_socket_name) {
+void TestSetupUtil::StopObjectStore(const std::string& store_socket_name) {
   KillProcessBySocketName(store_socket_name);
 }
 
-std::string TestSetupUtil::StartGcsServer(const std::string &redis_address) {
+std::string TestSetupUtil::StartGcsServer(const std::string& redis_address) {
   std::string gcs_server_socket_name =
       ray::JoinPaths(ray::GetUserTempDir(), "gcs_server" + ObjectID::FromRandom().Hex());
   std::vector<std::string> cmdargs(
@@ -129,14 +129,14 @@ std::string TestSetupUtil::StartGcsServer(const std::string &redis_address) {
   return gcs_server_socket_name;
 }
 
-void TestSetupUtil::StopGcsServer(const std::string &gcs_server_socket_name) {
+void TestSetupUtil::StopGcsServer(const std::string& gcs_server_socket_name) {
   KillProcessBySocketName(gcs_server_socket_name);
 }
 
-std::string TestSetupUtil::StartRaylet(const std::string &store_socket_name,
-                                       const std::string &node_ip_address,
-                                       const int &port, const std::string &redis_address,
-                                       const std::string &resource) {
+std::string TestSetupUtil::StartRaylet(const std::string& store_socket_name,
+                                       const std::string& node_ip_address,
+                                       const int& port, const std::string& redis_address,
+                                       const std::string& resource) {
   std::string raylet_socket_name =
       ray::JoinPaths(ray::GetUserTempDir(), "raylet" + ObjectID::FromRandom().Hex());
   std::vector<std::string> cmdargs(
@@ -157,7 +157,7 @@ std::string TestSetupUtil::StartRaylet(const std::string &store_socket_name,
   return raylet_socket_name;
 }
 
-void TestSetupUtil::StopRaylet(const std::string &raylet_socket_name) {
+void TestSetupUtil::StopRaylet(const std::string& raylet_socket_name) {
   KillProcessBySocketName(raylet_socket_name);
 }
 
@@ -192,7 +192,7 @@ void KillProcessBySocketName(std::string socket_name) {
   ASSERT_EQ(unlink(pidfile_path.c_str()), 0);
 }
 
-int KillAllExecutable(const std::string &executable) {
+int KillAllExecutable(const std::string& executable) {
   std::vector<std::string> cmdargs;
 #ifdef _WIN32
   cmdargs.insert(cmdargs.end(), {"taskkill", "/IM", executable});
@@ -225,7 +225,7 @@ std::shared_ptr<Buffer> GenerateRandomBuffer() {
 }
 
 std::shared_ptr<RayObject> GenerateRandomObject(
-    const std::vector<ObjectID> &inlined_ids) {
+    const std::vector<ObjectID>& inlined_ids) {
   return std::shared_ptr<RayObject>(
       new RayObject(GenerateRandomBuffer(), nullptr, inlined_ids));
 }

--- a/src/ray/common/test_util.h
+++ b/src/ray/common/test_util.h
@@ -28,7 +28,7 @@ namespace ray {
 static inline std::vector<rpc::ObjectReference> ObjectIdsToRefs(
     std::vector<ObjectID> object_ids) {
   std::vector<rpc::ObjectReference> refs;
-  for (const auto &object_id : object_ids) {
+  for (const auto& object_id : object_ids) {
     rpc::ObjectReference ref;
     ref.set_object_id(object_id.Binary());
     refs.push_back(ref);
@@ -55,7 +55,7 @@ void KillProcessBySocketName(std::string socket_name);
 /// Kills all processes with the given executable name (similar to killall).
 /// Note: On Windows, this should include the file extension (e.g. ".exe"), if any.
 /// This cannot be done automatically as doing so may be incorrect in some cases.
-int KillAllExecutable(const std::string &executable_with_suffix);
+int KillAllExecutable(const std::string& executable_with_suffix);
 
 // A helper function to return a random task id.
 TaskID RandomTaskId();
@@ -66,7 +66,7 @@ JobID RandomJobId();
 std::shared_ptr<Buffer> GenerateRandomBuffer();
 
 std::shared_ptr<RayObject> GenerateRandomObject(
-    const std::vector<ObjectID> &inlined_ids = {});
+    const std::vector<ObjectID>& inlined_ids = {});
 
 /// Path to redis server executable binary.
 extern std::string TEST_REDIS_SERVER_EXEC_PATH;
@@ -99,27 +99,27 @@ extern std::string TEST_MOCK_WORKER_EXEC_PATH;
 /// 5. start/stop raylet monitor
 class TestSetupUtil {
  public:
-  static void StartUpRedisServers(const std::vector<int> &redis_server_ports);
+  static void StartUpRedisServers(const std::vector<int>& redis_server_ports);
   static void ShutDownRedisServers();
   static void FlushAllRedisServers();
 
   static std::string StartObjectStore(
-      const boost::optional<std::string> &socket_name = boost::none);
-  static void StopObjectStore(const std::string &store_socket_name);
+      const boost::optional<std::string>& socket_name = boost::none);
+  static void StopObjectStore(const std::string& store_socket_name);
 
-  static std::string StartGcsServer(const std::string &redis_address);
-  static void StopGcsServer(const std::string &gcs_server_socket_name);
+  static std::string StartGcsServer(const std::string& redis_address);
+  static void StopGcsServer(const std::string& gcs_server_socket_name);
 
-  static std::string StartRaylet(const std::string &store_socket_name,
-                                 const std::string &node_ip_address, const int &port,
-                                 const std::string &redis_address,
-                                 const std::string &resource);
-  static void StopRaylet(const std::string &raylet_socket_name);
+  static std::string StartRaylet(const std::string& store_socket_name,
+                                 const std::string& node_ip_address, const int& port,
+                                 const std::string& redis_address,
+                                 const std::string& resource);
+  static void StopRaylet(const std::string& raylet_socket_name);
 
  private:
-  static int StartUpRedisServer(const int &port);
-  static void ShutDownRedisServer(const int &port);
-  static void FlushRedisServer(const int &port);
+  static int StartUpRedisServer(const int& port);
+  static void ShutDownRedisServer(const int& port);
+  static void FlushRedisServer(const int& port);
 };
 
 }  // namespace ray

--- a/src/ray/core_worker/actor_handle.cc
+++ b/src/ray/core_worker/actor_handle.cc
@@ -19,11 +19,11 @@
 namespace {
 
 ray::rpc::ActorHandle CreateInnerActorHandle(
-    const class ActorID &actor_id, const TaskID &owner_id,
-    const ray::rpc::Address &owner_address, const class JobID &job_id,
-    const ObjectID &initial_cursor, const Language actor_language,
-    const ray::FunctionDescriptor &actor_creation_task_function_descriptor,
-    const std::string &extension_data, int64_t max_task_retries) {
+    const class ActorID& actor_id, const TaskID& owner_id,
+    const ray::rpc::Address& owner_address, const class JobID& job_id,
+    const ObjectID& initial_cursor, const Language actor_language,
+    const ray::FunctionDescriptor& actor_creation_task_function_descriptor,
+    const std::string& extension_data, int64_t max_task_retries) {
   ray::rpc::ActorHandle inner;
   inner.set_actor_id(actor_id.Data(), actor_id.Size());
   inner.set_owner_id(owner_id.Binary());
@@ -38,14 +38,14 @@ ray::rpc::ActorHandle CreateInnerActorHandle(
   return inner;
 }
 
-ray::rpc::ActorHandle CreateInnerActorHandleFromString(const std::string &serialized) {
+ray::rpc::ActorHandle CreateInnerActorHandleFromString(const std::string& serialized) {
   ray::rpc::ActorHandle inner;
   inner.ParseFromString(serialized);
   return inner;
 }
 
 ray::rpc::ActorHandle CreateInnerActorHandleFromActorTableData(
-    const ray::gcs::ActorTableData &actor_table_data) {
+    const ray::gcs::ActorTableData& actor_table_data) {
   ray::rpc::ActorHandle inner;
   inner.set_actor_id(actor_table_data.actor_id());
   inner.set_owner_id(actor_table_data.parent_id());
@@ -66,22 +66,22 @@ ray::rpc::ActorHandle CreateInnerActorHandleFromActorTableData(
 namespace ray {
 
 ActorHandle::ActorHandle(
-    const class ActorID &actor_id, const TaskID &owner_id,
-    const rpc::Address &owner_address, const class JobID &job_id,
-    const ObjectID &initial_cursor, const Language actor_language,
-    const ray::FunctionDescriptor &actor_creation_task_function_descriptor,
-    const std::string &extension_data, int64_t max_task_retries)
+    const class ActorID& actor_id, const TaskID& owner_id,
+    const rpc::Address& owner_address, const class JobID& job_id,
+    const ObjectID& initial_cursor, const Language actor_language,
+    const ray::FunctionDescriptor& actor_creation_task_function_descriptor,
+    const std::string& extension_data, int64_t max_task_retries)
     : ActorHandle(CreateInnerActorHandle(
           actor_id, owner_id, owner_address, job_id, initial_cursor, actor_language,
           actor_creation_task_function_descriptor, extension_data, max_task_retries)) {}
 
-ActorHandle::ActorHandle(const std::string &serialized)
+ActorHandle::ActorHandle(const std::string& serialized)
     : ActorHandle(CreateInnerActorHandleFromString(serialized)) {}
 
-ActorHandle::ActorHandle(const gcs::ActorTableData &actor_table_data)
+ActorHandle::ActorHandle(const gcs::ActorTableData& actor_table_data)
     : ActorHandle(CreateInnerActorHandleFromActorTableData(actor_table_data)) {}
 
-void ActorHandle::SetActorTaskSpec(TaskSpecBuilder &builder, const ObjectID new_cursor) {
+void ActorHandle::SetActorTaskSpec(TaskSpecBuilder& builder, const ObjectID new_cursor) {
   absl::MutexLock guard(&mutex_);
   // Build actor task spec.
   const TaskID actor_creation_task_id = TaskID::ForActorCreationTask(GetActorID());
@@ -93,7 +93,7 @@ void ActorHandle::SetActorTaskSpec(TaskSpecBuilder &builder, const ObjectID new_
   actor_cursor_ = new_cursor;
 }
 
-void ActorHandle::SetResubmittedActorTaskSpec(TaskSpecification &spec,
+void ActorHandle::SetResubmittedActorTaskSpec(TaskSpecification& spec,
                                               const ObjectID new_cursor) {
   absl::MutexLock guard(&mutex_);
   auto mutable_spec = spec.GetMutableMessage().mutable_actor_task_spec();
@@ -102,6 +102,6 @@ void ActorHandle::SetResubmittedActorTaskSpec(TaskSpecification &spec,
   actor_cursor_ = new_cursor;
 }
 
-void ActorHandle::Serialize(std::string *output) { inner_.SerializeToString(output); }
+void ActorHandle::Serialize(std::string* output) { inner_.SerializeToString(output); }
 
 }  // namespace ray

--- a/src/ray/core_worker/actor_handle.h
+++ b/src/ray/core_worker/actor_handle.h
@@ -32,17 +32,17 @@ class ActorHandle {
       : inner_(inner), actor_cursor_(ObjectID::FromBinary(inner_.actor_cursor())) {}
 
   // Constructs a new ActorHandle as part of the actor creation process.
-  ActorHandle(const ActorID &actor_id, const TaskID &owner_id,
-              const rpc::Address &owner_address, const JobID &job_id,
-              const ObjectID &initial_cursor, const Language actor_language,
-              const ray::FunctionDescriptor &actor_creation_task_function_descriptor,
-              const std::string &extension_data, int64_t max_task_retries);
+  ActorHandle(const ActorID& actor_id, const TaskID& owner_id,
+              const rpc::Address& owner_address, const JobID& job_id,
+              const ObjectID& initial_cursor, const Language actor_language,
+              const ray::FunctionDescriptor& actor_creation_task_function_descriptor,
+              const std::string& extension_data, int64_t max_task_retries);
 
   /// Constructs an ActorHandle from a serialized string.
-  ActorHandle(const std::string &serialized);
+  ActorHandle(const std::string& serialized);
 
   /// Constructs an ActorHandle from a gcs::ActorTableData message.
-  ActorHandle(const gcs::ActorTableData &actor_table_data);
+  ActorHandle(const gcs::ActorTableData& actor_table_data);
 
   ActorID GetActorID() const { return ActorID::FromBinary(inner_.actor_id()); };
 
@@ -68,7 +68,7 @@ class ActorHandle {
   /// \param[in] builder Task spec builder.
   /// \param[in] new_cursor Actor dummy object. This is legacy code needed for
   /// raylet-based actor restart.
-  void SetActorTaskSpec(TaskSpecBuilder &builder, const ObjectID new_cursor);
+  void SetActorTaskSpec(TaskSpecBuilder& builder, const ObjectID new_cursor);
 
   /// Reset the actor task spec fields of an existing task so that the task can
   /// be re-executed.
@@ -77,9 +77,9 @@ class ActorHandle {
   /// before.
   /// \param[in] new_cursor Actor dummy object. This is legacy code needed for
   /// raylet-based actor restart.
-  void SetResubmittedActorTaskSpec(TaskSpecification &spec, const ObjectID new_cursor);
+  void SetResubmittedActorTaskSpec(TaskSpecification& spec, const ObjectID new_cursor);
 
-  void Serialize(std::string *output);
+  void Serialize(std::string* output);
 
   int64_t MaxTaskRetries() const { return inner_.max_task_retries(); }
 

--- a/src/ray/core_worker/actor_manager.cc
+++ b/src/ray/core_worker/actor_manager.cc
@@ -20,10 +20,10 @@
 namespace ray {
 
 ActorID ActorManager::RegisterActorHandle(std::unique_ptr<ActorHandle> actor_handle,
-                                          const ObjectID &outer_object_id,
-                                          const TaskID &caller_id,
-                                          const std::string &call_site,
-                                          const rpc::Address &caller_address) {
+                                          const ObjectID& outer_object_id,
+                                          const TaskID& caller_id,
+                                          const std::string& call_site,
+                                          const rpc::Address& caller_address) {
   const ActorID actor_id = actor_handle->GetActorID();
   const rpc::Address owner_address = actor_handle->GetOwnerAddress();
   const auto actor_creation_return_id = ObjectID::ForActorHandle(actor_id);
@@ -36,8 +36,8 @@ ActorID ActorManager::RegisterActorHandle(std::unique_ptr<ActorHandle> actor_han
   return actor_id;
 }
 
-const std::unique_ptr<ActorHandle> &ActorManager::GetActorHandle(
-    const ActorID &actor_id) {
+const std::unique_ptr<ActorHandle>& ActorManager::GetActorHandle(
+    const ActorID& actor_id) {
   absl::MutexLock lock(&mutex_);
   auto it = actor_handles_.find(actor_id);
   RAY_CHECK(it != actor_handles_.end())
@@ -46,17 +46,17 @@ const std::unique_ptr<ActorHandle> &ActorManager::GetActorHandle(
   return it->second;
 }
 
-bool ActorManager::CheckActorHandleExists(const ActorID &actor_id) {
+bool ActorManager::CheckActorHandleExists(const ActorID& actor_id) {
   absl::MutexLock lock(&mutex_);
   return actor_handles_.find(actor_id) != actor_handles_.end();
 }
 
 bool ActorManager::AddNewActorHandle(std::unique_ptr<ActorHandle> actor_handle,
-                                     const TaskID &caller_id,
-                                     const std::string &call_site,
-                                     const rpc::Address &caller_address,
+                                     const TaskID& caller_id,
+                                     const std::string& call_site,
+                                     const rpc::Address& caller_address,
                                      bool is_detached) {
-  const auto &actor_id = actor_handle->GetActorID();
+  const auto& actor_id = actor_handle->GetActorID();
   const auto actor_creation_return_id = ObjectID::ForActorHandle(actor_id);
   // Detached actor doesn't need ref counting.
   if (!is_detached) {
@@ -72,11 +72,11 @@ bool ActorManager::AddNewActorHandle(std::unique_ptr<ActorHandle> actor_handle,
 }
 
 bool ActorManager::AddActorHandle(std::unique_ptr<ActorHandle> actor_handle,
-                                  bool is_owner_handle, const TaskID &caller_id,
-                                  const std::string &call_site,
-                                  const rpc::Address &caller_address,
-                                  const ActorID &actor_id,
-                                  const ObjectID &actor_creation_return_id) {
+                                  bool is_owner_handle, const TaskID& caller_id,
+                                  const std::string& call_site,
+                                  const rpc::Address& caller_address,
+                                  const ActorID& actor_id,
+                                  const ObjectID& actor_creation_return_id) {
   reference_counter_->AddLocalReference(actor_creation_return_id, call_site);
   direct_actor_submitter_->AddActorQueueIfNotExists(actor_id);
   bool inserted;
@@ -95,7 +95,7 @@ bool ActorManager::AddActorHandle(std::unique_ptr<ActorHandle> actor_handle,
     if (!RayConfig::instance().gcs_actor_service_enabled()) {
       RAY_CHECK(reference_counter_->SetDeleteCallback(
           actor_creation_return_id,
-          [this, actor_id, is_owner_handle](const ObjectID &object_id) {
+          [this, actor_id, is_owner_handle](const ObjectID& object_id) {
             if (is_owner_handle) {
               // If we own the actor and the actor handle is no longer in scope,
               // terminate the actor. We do not do this if the GCS service is
@@ -126,8 +126,8 @@ bool ActorManager::AddActorHandle(std::unique_ptr<ActorHandle> actor_handle,
 }
 
 void ActorManager::WaitForActorOutOfScope(
-    const ActorID &actor_id,
-    std::function<void(const ActorID &)> actor_out_of_scope_callback) {
+    const ActorID& actor_id,
+    std::function<void(const ActorID&)> actor_out_of_scope_callback) {
   absl::MutexLock lock(&mutex_);
   auto it = actor_handles_.find(actor_id);
   if (it == actor_handles_.end()) {
@@ -135,7 +135,7 @@ void ActorManager::WaitForActorOutOfScope(
   } else {
     // GCS actor manager will wait until the actor has been created before polling the
     // owner. This should avoid any asynchronous problems.
-    auto callback = [actor_id, actor_out_of_scope_callback](const ObjectID &object_id) {
+    auto callback = [actor_id, actor_out_of_scope_callback](const ObjectID& object_id) {
       actor_out_of_scope_callback(actor_id);
     };
 
@@ -150,9 +150,9 @@ void ActorManager::WaitForActorOutOfScope(
   }
 }
 
-void ActorManager::HandleActorStateNotification(const ActorID &actor_id,
-                                                const gcs::ActorTableData &actor_data) {
-  const auto &actor_state = gcs::ActorTableData::ActorState_Name(actor_data.state());
+void ActorManager::HandleActorStateNotification(const ActorID& actor_id,
+                                                const gcs::ActorTableData& actor_data) {
+  const auto& actor_state = gcs::ActorTableData::ActorState_Name(actor_data.state());
   RAY_LOG(INFO) << "received notification on actor, state: " << actor_state
                 << ", actor_id: " << actor_id
                 << ", ip address: " << actor_data.address().ip_address()
@@ -179,7 +179,7 @@ void ActorManager::HandleActorStateNotification(const ActorID &actor_id,
 std::vector<ObjectID> ActorManager::GetActorHandleIDsFromHandles() {
   absl::MutexLock lock(&mutex_);
   std::vector<ObjectID> actor_handle_ids;
-  for (const auto &handle : actor_handles_) {
+  for (const auto& handle : actor_handles_) {
     auto actor_id = handle.first;
     auto actor_handle_id = ObjectID::ForActorHandle(actor_id);
     actor_handle_ids.push_back(actor_handle_id);

--- a/src/ray/core_worker/actor_manager.h
+++ b/src/ray/core_worker/actor_manager.h
@@ -29,15 +29,15 @@ class ActorCreatorInterface {
   ///
   /// \param task_spec The specification for the actor creation task.
   /// \return Status
-  virtual Status RegisterActor(const TaskSpecification &task_spec) = 0;
+  virtual Status RegisterActor(const TaskSpecification& task_spec) = 0;
 
   /// Asynchronously request GCS to create the actor.
   ///
   /// \param task_spec The specification for the actor creation task.
   /// \param callback Callback that will be called after the actor info is written to GCS.
   /// \return Status
-  virtual Status AsyncCreateActor(const TaskSpecification &task_spec,
-                                  const gcs::StatusCallback &callback) = 0;
+  virtual Status AsyncCreateActor(const TaskSpecification& task_spec,
+                                  const gcs::StatusCallback& callback) = 0;
 };
 
 class DefaultActorCreator : public ActorCreatorInterface {
@@ -45,18 +45,18 @@ class DefaultActorCreator : public ActorCreatorInterface {
   explicit DefaultActorCreator(std::shared_ptr<gcs::GcsClient> gcs_client)
       : gcs_client_(std::move(gcs_client)) {}
 
-  Status RegisterActor(const TaskSpecification &task_spec) override {
+  Status RegisterActor(const TaskSpecification& task_spec) override {
     auto promise = std::make_shared<std::promise<void>>();
     auto status = gcs_client_->Actors().AsyncRegisterActor(
-        task_spec, [promise](const Status &status) { promise->set_value(); });
+        task_spec, [promise](const Status& status) { promise->set_value(); });
     if (status.ok()) {
       promise->get_future().wait();
     }
     return status;
   }
 
-  Status AsyncCreateActor(const TaskSpecification &task_spec,
-                          const gcs::StatusCallback &callback) override {
+  Status AsyncCreateActor(const TaskSpecification& task_spec,
+                          const gcs::StatusCallback& callback) override {
     return gcs_client_->Actors().AsyncCreateActor(task_spec, callback);
   }
 
@@ -95,21 +95,21 @@ class ActorManager {
   /// \param[in] call_site The caller's site.
   /// \return The ActorID of the deserialized handle.
   ActorID RegisterActorHandle(std::unique_ptr<ActorHandle> actor_handle,
-                              const ObjectID &outer_object_id, const TaskID &caller_id,
-                              const std::string &call_site,
-                              const rpc::Address &caller_address);
+                              const ObjectID& outer_object_id, const TaskID& caller_id,
+                              const std::string& call_site,
+                              const rpc::Address& caller_address);
 
   /// Get a handle to an actor.
   ///
   /// \param[in] actor_id The actor handle to get.
   /// \return reference to the actor_handle's pointer.
   /// NOTE: Returned actorHandle should not be stored anywhere.
-  const std::unique_ptr<ActorHandle> &GetActorHandle(const ActorID &actor_id);
+  const std::unique_ptr<ActorHandle>& GetActorHandle(const ActorID& actor_id);
 
   /// Check if an actor handle that corresponds to an actor_id exists.
   /// \param[in] actor_id The actor id of a handle.
   /// \return True if the actor_handle for an actor_id exists. False otherwise.
-  bool CheckActorHandleExists(const ActorID &actor_id);
+  bool CheckActorHandleExists(const ActorID& actor_id);
 
   /// Give this worker a new handle to an actor.
   ///
@@ -128,8 +128,8 @@ class ActorManager {
   /// actor. \return True if the handle was added and False if we already had a handle to
   /// the same actor.
   bool AddNewActorHandle(std::unique_ptr<ActorHandle> actor_handle,
-                         const TaskID &caller_id, const std::string &call_site,
-                         const rpc::Address &caller_address, bool is_detached);
+                         const TaskID& caller_id, const std::string& call_site,
+                         const rpc::Address& caller_address, bool is_detached);
 
   /// Wait for actor out of scope.
   ///
@@ -137,8 +137,8 @@ class ActorManager {
   /// \param actor_out_of_scope_callback The callback function that will be called when
   /// an actor_id goes out of scope.
   void WaitForActorOutOfScope(
-      const ActorID &actor_id,
-      std::function<void(const ActorID &)> actor_out_of_scope_callback);
+      const ActorID& actor_id,
+      std::function<void(const ActorID&)> actor_out_of_scope_callback);
 
   /// Get a list of actor_ids from existing actor handles.
   /// This is used for debugging purpose.
@@ -163,16 +163,16 @@ class ActorManager {
   /// \return True if the handle was added and False if we already had a handle
   /// to the same actor.
   bool AddActorHandle(std::unique_ptr<ActorHandle> actor_handle, bool is_owner_handle,
-                      const TaskID &caller_id, const std::string &call_site,
-                      const rpc::Address &caller_address, const ActorID &actor_id,
-                      const ObjectID &actor_creation_return_id);
+                      const TaskID& caller_id, const std::string& call_site,
+                      const rpc::Address& caller_address, const ActorID& actor_id,
+                      const ObjectID& actor_creation_return_id);
 
   /// Handle actor state notification published from GCS.
   ///
   /// \param[in] actor_id The actor id of this notification.
   /// \param[in] actor_data The GCS actor data.
-  void HandleActorStateNotification(const ActorID &actor_id,
-                                    const gcs::ActorTableData &actor_data);
+  void HandleActorStateNotification(const ActorID& actor_id,
+                                    const gcs::ActorTableData& actor_data);
 
   /// GCS client.
   std::shared_ptr<gcs::GcsClient> gcs_client_;

--- a/src/ray/core_worker/actor_reporter.cc
+++ b/src/ray/core_worker/actor_reporter.cc
@@ -19,7 +19,7 @@
 
 namespace ray {
 
-void ActorReporter::PublishTerminatedActor(const TaskSpecification &actor_creation_task) {
+void ActorReporter::PublishTerminatedActor(const TaskSpecification& actor_creation_task) {
   auto actor_id = actor_creation_task.ActorCreationId();
   auto data = gcs::CreateActorTableData(actor_creation_task, rpc::Address(),
                                         rpc::ActorTableData::DEAD, 0);

--- a/src/ray/core_worker/actor_reporter.h
+++ b/src/ray/core_worker/actor_reporter.h
@@ -22,7 +22,7 @@ namespace ray {
 // Interface for testing.
 class ActorReporterInterface {
  public:
-  virtual void PublishTerminatedActor(const TaskSpecification &actor_creation_task) = 0;
+  virtual void PublishTerminatedActor(const TaskSpecification& actor_creation_task) = 0;
 
   virtual ~ActorReporterInterface() {}
 };
@@ -34,7 +34,7 @@ class ActorReporter : public ActorReporterInterface {
   ~ActorReporter() {}
 
   /// Called when an actor that we own can no longer be restarted.
-  void PublishTerminatedActor(const TaskSpecification &actor_creation_task) override;
+  void PublishTerminatedActor(const TaskSpecification& actor_creation_task) override;
 
  private:
   /// GCS client

--- a/src/ray/core_worker/common.h
+++ b/src/ray/core_worker/common.h
@@ -37,12 +37,12 @@ std::string LanguageString(Language language);
 class RayFunction {
  public:
   RayFunction() {}
-  RayFunction(Language language, const ray::FunctionDescriptor &function_descriptor)
+  RayFunction(Language language, const ray::FunctionDescriptor& function_descriptor)
       : language_(language), function_descriptor_(function_descriptor) {}
 
   Language GetLanguage() const { return language_; }
 
-  const ray::FunctionDescriptor &GetFunctionDescriptor() const {
+  const ray::FunctionDescriptor& GetFunctionDescriptor() const {
     return function_descriptor_;
   }
 
@@ -54,7 +54,7 @@ class RayFunction {
 /// Options for all tasks (actor and non-actor) except for actor creation.
 struct TaskOptions {
   TaskOptions() {}
-  TaskOptions(int num_returns, std::unordered_map<std::string, double> &resources)
+  TaskOptions(int num_returns, std::unordered_map<std::string, double>& resources)
       : num_returns(num_returns), resources(resources) {}
 
   /// Number of returns of this task.
@@ -68,10 +68,10 @@ struct ActorCreationOptions {
   ActorCreationOptions() {}
   ActorCreationOptions(
       int64_t max_restarts, int64_t max_task_retries, int max_concurrency,
-      const std::unordered_map<std::string, double> &resources,
-      const std::unordered_map<std::string, double> &placement_resources,
-      const std::vector<std::string> &dynamic_worker_options, bool is_detached,
-      std::string &name, bool is_asyncio,
+      const std::unordered_map<std::string, double>& resources,
+      const std::unordered_map<std::string, double>& placement_resources,
+      const std::vector<std::string>& dynamic_worker_options, bool is_detached,
+      std::string& name, bool is_asyncio,
       PlacementOptions placement_options = std::make_pair(PlacementGroupID::Nil(), -1))
       : max_restarts(max_restarts),
         max_task_retries(max_task_retries),

--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -25,22 +25,22 @@ struct WorkerThreadContext {
 
   int GetNextPutIndex() { return ++put_index_; }
 
-  const TaskID &GetCurrentTaskID() const { return current_task_id_; }
+  const TaskID& GetCurrentTaskID() const { return current_task_id_; }
 
   std::shared_ptr<const TaskSpecification> GetCurrentTask() const {
     return current_task_;
   }
 
-  void SetCurrentTaskId(const TaskID &task_id) { current_task_id_ = task_id; }
+  void SetCurrentTaskId(const TaskID& task_id) { current_task_id_ = task_id; }
 
-  void SetCurrentTask(const TaskSpecification &task_spec) {
+  void SetCurrentTask(const TaskSpecification& task_spec) {
     RAY_CHECK(task_index_ == 0);
     RAY_CHECK(put_index_ == 0);
     SetCurrentTaskId(task_spec.TaskId());
     current_task_ = std::make_shared<const TaskSpecification>(task_spec);
   }
 
-  void ResetCurrentTask(const TaskSpecification &task_spec) {
+  void ResetCurrentTask(const TaskSpecification& task_spec) {
     SetCurrentTaskId(TaskID::Nil());
     task_index_ = 0;
     put_index_ = 0;
@@ -63,8 +63,8 @@ struct WorkerThreadContext {
 thread_local std::unique_ptr<WorkerThreadContext> WorkerContext::thread_context_ =
     nullptr;
 
-WorkerContext::WorkerContext(WorkerType worker_type, const WorkerID &worker_id,
-                             const JobID &job_id)
+WorkerContext::WorkerContext(WorkerType worker_type, const WorkerID& worker_id,
+                             const JobID& job_id)
     : worker_type_(worker_type),
       worker_id_(worker_id),
       current_job_id_(worker_type_ == WorkerType::DRIVER ? job_id : JobID::Nil()),
@@ -80,25 +80,25 @@ WorkerContext::WorkerContext(WorkerType worker_type, const WorkerID &worker_id,
 
 const WorkerType WorkerContext::GetWorkerType() const { return worker_type_; }
 
-const WorkerID &WorkerContext::GetWorkerID() const { return worker_id_; }
+const WorkerID& WorkerContext::GetWorkerID() const { return worker_id_; }
 
 int WorkerContext::GetNextTaskIndex() { return GetThreadContext().GetNextTaskIndex(); }
 
 int WorkerContext::GetNextPutIndex() { return GetThreadContext().GetNextPutIndex(); }
 
-const JobID &WorkerContext::GetCurrentJobID() const { return current_job_id_; }
+const JobID& WorkerContext::GetCurrentJobID() const { return current_job_id_; }
 
-const TaskID &WorkerContext::GetCurrentTaskID() const {
+const TaskID& WorkerContext::GetCurrentTaskID() const {
   return GetThreadContext().GetCurrentTaskID();
 }
 
-void WorkerContext::SetCurrentJobId(const JobID &job_id) { current_job_id_ = job_id; }
+void WorkerContext::SetCurrentJobId(const JobID& job_id) { current_job_id_ = job_id; }
 
-void WorkerContext::SetCurrentTaskId(const TaskID &task_id) {
+void WorkerContext::SetCurrentTaskId(const TaskID& task_id) {
   GetThreadContext().SetCurrentTaskId(task_id);
 }
 
-void WorkerContext::SetCurrentTask(const TaskSpecification &task_spec) {
+void WorkerContext::SetCurrentTask(const TaskSpecification& task_spec) {
   GetThreadContext().SetCurrentTask(task_spec);
   if (task_spec.IsNormalTask()) {
     RAY_CHECK(current_job_id_.IsNil());
@@ -120,7 +120,7 @@ void WorkerContext::SetCurrentTask(const TaskSpecification &task_spec) {
   }
 }
 
-void WorkerContext::ResetCurrentTask(const TaskSpecification &task_spec) {
+void WorkerContext::ResetCurrentTask(const TaskSpecification& task_spec) {
   GetThreadContext().ResetCurrentTask(task_spec);
   if (task_spec.IsNormalTask()) {
     SetCurrentJobId(JobID::Nil());
@@ -131,7 +131,7 @@ std::shared_ptr<const TaskSpecification> WorkerContext::GetCurrentTask() const {
   return GetThreadContext().GetCurrentTask();
 }
 
-const ActorID &WorkerContext::GetCurrentActorID() const { return current_actor_id_; }
+const ActorID& WorkerContext::GetCurrentActorID() const { return current_actor_id_; }
 
 bool WorkerContext::CurrentThreadIsMain() const {
   return boost::this_thread::get_id() == main_thread_id_;
@@ -162,7 +162,7 @@ int WorkerContext::CurrentActorMaxConcurrency() const {
 
 bool WorkerContext::CurrentActorIsAsync() const { return current_actor_is_asyncio_; }
 
-WorkerThreadContext &WorkerContext::GetThreadContext() {
+WorkerThreadContext& WorkerContext::GetThreadContext() {
   if (thread_context_ == nullptr) {
     thread_context_ = std::unique_ptr<WorkerThreadContext>(new WorkerThreadContext());
   }

--- a/src/ray/core_worker/context.h
+++ b/src/ray/core_worker/context.h
@@ -25,29 +25,29 @@ struct WorkerThreadContext;
 
 class WorkerContext {
  public:
-  WorkerContext(WorkerType worker_type, const WorkerID &worker_id, const JobID &job_id);
+  WorkerContext(WorkerType worker_type, const WorkerID& worker_id, const JobID& job_id);
 
   const WorkerType GetWorkerType() const;
 
-  const WorkerID &GetWorkerID() const;
+  const WorkerID& GetWorkerID() const;
 
-  const JobID &GetCurrentJobID() const;
+  const JobID& GetCurrentJobID() const;
 
-  const TaskID &GetCurrentTaskID() const;
-
-  // TODO(edoakes): remove this once Python core worker uses the task interfaces.
-  void SetCurrentJobId(const JobID &job_id);
+  const TaskID& GetCurrentTaskID() const;
 
   // TODO(edoakes): remove this once Python core worker uses the task interfaces.
-  void SetCurrentTaskId(const TaskID &task_id);
+  void SetCurrentJobId(const JobID& job_id);
 
-  void SetCurrentTask(const TaskSpecification &task_spec);
+  // TODO(edoakes): remove this once Python core worker uses the task interfaces.
+  void SetCurrentTaskId(const TaskID& task_id);
 
-  void ResetCurrentTask(const TaskSpecification &task_spec);
+  void SetCurrentTask(const TaskSpecification& task_spec);
+
+  void ResetCurrentTask(const TaskSpecification& task_spec);
 
   std::shared_ptr<const TaskSpecification> GetCurrentTask() const;
 
-  const ActorID &GetCurrentActorID() const;
+  const ActorID& GetCurrentActorID() const;
 
   /// Returns whether the current thread is the main worker thread.
   bool CurrentThreadIsMain() const;
@@ -88,7 +88,7 @@ class WorkerContext {
   boost::thread::id main_thread_id_;
 
  private:
-  static WorkerThreadContext &GetThreadContext();
+  static WorkerThreadContext& GetThreadContext();
 
   /// Per-thread worker context.
   static thread_local std::unique_ptr<WorkerThreadContext> thread_context_;

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -57,12 +57,12 @@ struct CoreWorkerOptions {
   // Callback that must be implemented and provided by the language-specific worker
   // frontend to execute tasks and return their results.
   using TaskExecutionCallback = std::function<Status(
-      TaskType task_type, const RayFunction &ray_function,
-      const std::unordered_map<std::string, double> &required_resources,
-      const std::vector<std::shared_ptr<RayObject>> &args,
-      const std::vector<ObjectID> &arg_reference_ids,
-      const std::vector<ObjectID> &return_ids,
-      std::vector<std::shared_ptr<RayObject>> *results)>;
+      TaskType task_type, const RayFunction& ray_function,
+      const std::unordered_map<std::string, double>& required_resources,
+      const std::vector<std::shared_ptr<RayObject>>& args,
+      const std::vector<ObjectID>& arg_reference_ids,
+      const std::vector<ObjectID>& return_ids,
+      std::vector<std::shared_ptr<RayObject>>* results)>;
 
   /// Type of this worker (i.e., DRIVER or WORKER).
   WorkerType worker_type;
@@ -108,7 +108,7 @@ struct CoreWorkerOptions {
   /// be held up in garbage objects.
   std::function<void()> gc_collect;
   /// Language worker callback to get the current call stack.
-  std::function<void(std::string *)> get_lang_stack;
+  std::function<void(std::string*)> get_lang_stack;
   // Function that tries to interrupt the currently running Python thread.
   std::function<bool()> kill_main;
   /// Whether to enable object ref counting.
@@ -171,25 +171,25 @@ class CoreWorkerProcess {
   /// Initialize core workers at the process level.
   ///
   /// \param[in] options The various initialization options.
-  static void Initialize(const CoreWorkerOptions &options);
+  static void Initialize(const CoreWorkerOptions& options);
 
   /// Get the core worker associated with the current thread.
   /// NOTE (kfstorm): Here we return a reference instead of a `shared_ptr` to make sure
   /// `CoreWorkerProcess` has full control of the destruction timing of `CoreWorker`.
-  static CoreWorker &GetCoreWorker();
+  static CoreWorker& GetCoreWorker();
 
   /// Try to get the `CoreWorker` instance by worker ID.
   /// If the current thread is not associated with a core worker, returns a null pointer.
   ///
   /// \param[in] workerId The worker ID.
   /// \return The `CoreWorker` instance.
-  static std::shared_ptr<CoreWorker> TryGetWorker(const WorkerID &worker_id);
+  static std::shared_ptr<CoreWorker> TryGetWorker(const WorkerID& worker_id);
 
   /// Set the core worker associated with the current thread by worker ID.
   /// Currently used by Java worker only.
   ///
   /// \param worker_id The worker ID of the core worker instance.
-  static void SetCurrentThreadWorkerId(const WorkerID &worker_id);
+  static void SetCurrentThreadWorkerId(const WorkerID& worker_id);
 
   /// Whether the current process has been initialized for core worker.
   static bool IsInitialized();
@@ -216,7 +216,7 @@ class CoreWorkerProcess {
   /// Create an `CoreWorkerProcess` with proper options.
   ///
   /// \param[in] options The various initialization options.
-  CoreWorkerProcess(const CoreWorkerOptions &options);
+  CoreWorkerProcess(const CoreWorkerOptions& options);
 
   /// Check that the core worker environment is initialized for this process.
   ///
@@ -227,7 +227,7 @@ class CoreWorkerProcess {
   ///
   /// \param[in] workerId The worker ID.
   /// \return The `CoreWorker` instance.
-  std::shared_ptr<CoreWorker> GetWorker(const WorkerID &worker_id) const
+  std::shared_ptr<CoreWorker> GetWorker(const WorkerID& worker_id) const
       LOCKS_EXCLUDED(worker_map_mutex_);
 
   /// Create a new `CoreWorker` instance.
@@ -274,11 +274,11 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   ///
   /// \param[in] options The various initialization options.
   /// \param[in] worker_id ID of this worker.
-  CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_id);
+  CoreWorker(const CoreWorkerOptions& options, const WorkerID& worker_id);
 
-  CoreWorker(CoreWorker const &) = delete;
+  CoreWorker(CoreWorker const&) = delete;
 
-  void operator=(CoreWorker const &other) = delete;
+  void operator=(CoreWorker const& other) = delete;
 
   ///
   /// Public methods used by `CoreWorkerProcess` and `CoreWorker` itself.
@@ -303,21 +303,21 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \return void.
   void RunTaskExecutionLoop();
 
-  const WorkerID &GetWorkerID() const;
+  const WorkerID& GetWorkerID() const;
 
   WorkerType GetWorkerType() const { return options_.worker_type; }
 
   Language GetLanguage() const { return options_.language; }
 
-  WorkerContext &GetWorkerContext() { return worker_context_; }
+  WorkerContext& GetWorkerContext() { return worker_context_; }
 
-  const TaskID &GetCurrentTaskId() const { return worker_context_.GetCurrentTaskID(); }
+  const TaskID& GetCurrentTaskId() const { return worker_context_.GetCurrentTaskID(); }
 
-  const JobID &GetCurrentJobId() const { return worker_context_.GetCurrentJobID(); }
+  const JobID& GetCurrentJobId() const { return worker_context_.GetCurrentJobID(); }
 
-  void SetWebuiDisplay(const std::string &key, const std::string &message);
+  void SetWebuiDisplay(const std::string& key, const std::string& message);
 
-  void SetActorTitle(const std::string &title);
+  void SetActorTitle(const std::string& title);
 
   void SetCallerCreationTimestamp();
 
@@ -326,7 +326,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// by the language frontend when a new reference is created.
   ///
   /// \param[in] object_id The object ID to increase the reference count for.
-  void AddLocalReference(const ObjectID &object_id) {
+  void AddLocalReference(const ObjectID& object_id) {
     AddLocalReference(object_id, CurrentCallSite());
   }
 
@@ -334,7 +334,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// by the language frontend when a reference is destroyed.
   ///
   /// \param[in] object_id The object ID to decrease the reference count for.
-  void RemoveLocalReference(const ObjectID &object_id) {
+  void RemoveLocalReference(const ObjectID& object_id) {
     std::vector<ObjectID> deleted;
     reference_counter_->RemoveLocalReference(object_id, &deleted);
     // TOOD(ilr): better way of keeping an object from being deleted
@@ -353,7 +353,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] The ray object.
   /// \param[in] object_id The object ID to serialize.
   /// appended to the serialized object ID.
-  void PutObjectIntoPlasma(const RayObject &object, const ObjectID &object_id);
+  void PutObjectIntoPlasma(const RayObject& object, const ObjectID& object_id);
 
   /// Promote an object to plasma. If the
   /// object already exists locally, it will be put into the plasma store. If
@@ -361,12 +361,12 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   ///
   /// \param[in] object_id The object ID to serialize.
   /// appended to the serialized object ID.
-  void PromoteObjectToPlasma(const ObjectID &object_id);
+  void PromoteObjectToPlasma(const ObjectID& object_id);
 
   /// Get the RPC address of this worker.
   ///
   /// \param[out] The RPC address of this worker.
-  const rpc::Address &GetRpcAddress() const;
+  const rpc::Address& GetRpcAddress() const;
 
   /// Get the RPC address of the worker that owns the given object.
   ///
@@ -374,7 +374,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// us, or the caller previously added the ownership information (via
   /// RegisterOwnershipInfoAndResolveFuture).
   /// \param[out] The RPC address of the worker that owns this object.
-  rpc::Address GetOwnerAddress(const ObjectID &object_id) const;
+  rpc::Address GetOwnerAddress(const ObjectID& object_id) const;
 
   /// Get the owner information of an object. This should be
   /// called when serializing an object ID, and the returned information should
@@ -391,7 +391,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// appended to the serialized object ID.
   /// \param[out] owner_address The address of the object's owner. This should
   /// be appended to the serialized object ID.
-  void GetOwnershipInfo(const ObjectID &object_id, rpc::Address *owner_address);
+  void GetOwnershipInfo(const ObjectID& object_id, rpc::Address* owner_address);
 
   /// Add a reference to an ObjectID that was deserialized by the language
   /// frontend. This will also start the process to resolve the future.
@@ -406,9 +406,9 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// or if it was passed out-of-band by the application (deserialized from a
   /// byte string).
   /// \param[out] owner_address The address of the object's owner.
-  void RegisterOwnershipInfoAndResolveFuture(const ObjectID &object_id,
-                                             const ObjectID &outer_object_id,
-                                             const rpc::Address &owner_address);
+  void RegisterOwnershipInfoAndResolveFuture(const ObjectID& object_id,
+                                             const ObjectID& outer_object_id,
+                                             const rpc::Address& owner_address);
 
   ///
   /// Public methods related to storing and retrieving objects.
@@ -427,8 +427,8 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] contained_object_ids The IDs serialized in this object.
   /// \param[out] object_id Generated ID of the object.
   /// \return Status.
-  Status Put(const RayObject &object, const std::vector<ObjectID> &contained_object_ids,
-             ObjectID *object_id);
+  Status Put(const RayObject& object, const std::vector<ObjectID>& contained_object_ids,
+             ObjectID* object_id);
 
   /// Put an object with specified ID into object store.
   ///
@@ -437,8 +437,8 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] object_id Object ID specified by the user.
   /// \param[in] pin_object Whether or not to tell the raylet to pin this object.
   /// \return Status.
-  Status Put(const RayObject &object, const std::vector<ObjectID> &contained_object_ids,
-             const ObjectID &object_id, bool pin_object = false);
+  Status Put(const RayObject& object, const std::vector<ObjectID>& contained_object_ids,
+             const ObjectID& object_id, bool pin_object = false);
 
   /// Create and return a buffer in the object store that can be directly written
   /// into. After writing to the buffer, the caller must call `Seal()` to finalize
@@ -451,9 +451,9 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[out] object_id Object ID generated for the put.
   /// \param[out] data Buffer for the user to write the object into.
   /// \return Status.
-  Status Create(const std::shared_ptr<Buffer> &metadata, const size_t data_size,
-                const std::vector<ObjectID> &contained_object_ids, ObjectID *object_id,
-                std::shared_ptr<Buffer> *data);
+  Status Create(const std::shared_ptr<Buffer>& metadata, const size_t data_size,
+                const std::vector<ObjectID>& contained_object_ids, ObjectID* object_id,
+                std::shared_ptr<Buffer>* data);
 
   /// Create and return a buffer in the object store that can be directly written
   /// into. After writing to the buffer, the caller must call `Seal()` to finalize
@@ -465,8 +465,8 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] object_id Object ID specified by the user.
   /// \param[out] data Buffer for the user to write the object into.
   /// \return Status.
-  Status Create(const std::shared_ptr<Buffer> &metadata, const size_t data_size,
-                const ObjectID &object_id, std::shared_ptr<Buffer> *data);
+  Status Create(const std::shared_ptr<Buffer>& metadata, const size_t data_size,
+                const ObjectID& object_id, std::shared_ptr<Buffer>* data);
 
   /// Finalize placing an object into the object store. This should be called after
   /// a corresponding `Create()` call and then writing into the returned buffer.
@@ -476,8 +476,8 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] owner_address Address of the owner of the object who will be contacted by
   /// the raylet if the object is pinned. If not provided, defaults to this worker.
   /// \return Status.
-  Status Seal(const ObjectID &object_id, bool pin_object,
-              const absl::optional<rpc::Address> &owner_address = absl::nullopt);
+  Status Seal(const ObjectID& object_id, bool pin_object,
+              const absl::optional<rpc::Address>& owner_address = absl::nullopt);
 
   /// Get a list of objects from the object store. Objects that failed to be retrieved
   /// will be returned as nullptrs.
@@ -486,15 +486,15 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] timeout_ms Timeout in milliseconds, wait infinitely if it's negative.
   /// \param[out] results Result list of objects data.
   /// \return Status.
-  Status Get(const std::vector<ObjectID> &ids, const int64_t timeout_ms,
-             std::vector<std::shared_ptr<RayObject>> *results);
+  Status Get(const std::vector<ObjectID>& ids, const int64_t timeout_ms,
+             std::vector<std::shared_ptr<RayObject>>* results);
 
   /// Return whether or not the object store contains the given object.
   ///
   /// \param[in] object_id ID of the objects to check for.
   /// \param[out] has_object Whether or not the object is present.
   /// \return Status.
-  Status Contains(const ObjectID &object_id, bool *has_object);
+  Status Contains(const ObjectID& object_id, bool* has_object);
 
   /// Wait for a list of objects to appear in the object store.
   /// Duplicate object ids are supported, and `num_objects` includes duplicate ids in this
@@ -507,8 +507,8 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] timeout_ms Timeout in milliseconds, wait infinitely if it's negative.
   /// \param[out] results A bitset that indicates each object has appeared or not.
   /// \return Status.
-  Status Wait(const std::vector<ObjectID> &object_ids, const int num_objects,
-              const int64_t timeout_ms, std::vector<bool> *results);
+  Status Wait(const std::vector<ObjectID>& object_ids, const int num_objects,
+              const int64_t timeout_ms, std::vector<bool>* results);
 
   /// Delete a list of objects from the plasma object store.
   ///
@@ -518,7 +518,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] delete_creating_tasks Whether also delete the tasks that
   /// created these objects.
   /// \return Status.
-  Status Delete(const std::vector<ObjectID> &object_ids, bool local_only,
+  Status Delete(const std::vector<ObjectID>& object_ids, bool local_only,
                 bool delete_creating_tasks);
 
   /// Trigger garbage collection on each worker in the cluster.
@@ -548,32 +548,32 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] The error message.
   /// \param[in] The timestamp of the error.
   /// \return Status.
-  Status PushError(const JobID &job_id, const std::string &type,
-                   const std::string &error_message, double timestamp);
+  Status PushError(const JobID& job_id, const std::string& type,
+                   const std::string& error_message, double timestamp);
 
   /// Request raylet backend to prepare a checkpoint for an actor.
   ///
   /// \param[in] actor_id ID of the actor.
   /// \param[out] checkpoint_id ID of the new checkpoint (output parameter).
   /// \return Status.
-  Status PrepareActorCheckpoint(const ActorID &actor_id,
-                                ActorCheckpointID *checkpoint_id);
+  Status PrepareActorCheckpoint(const ActorID& actor_id,
+                                ActorCheckpointID* checkpoint_id);
 
   /// Notify raylet backend that an actor was resumed from a checkpoint.
   ///
   /// \param[in] actor_id ID of the actor.
   /// \param[in] checkpoint_id ID of the checkpoint from which the actor was resumed.
   /// \return Status.
-  Status NotifyActorResumedFromCheckpoint(const ActorID &actor_id,
-                                          const ActorCheckpointID &checkpoint_id);
+  Status NotifyActorResumedFromCheckpoint(const ActorID& actor_id,
+                                          const ActorCheckpointID& checkpoint_id);
 
   /// Sets a resource with the specified capacity and client id
   /// \param[in] resource_name Name of the resource to be set.
   /// \param[in] capacity Capacity of the resource.
   /// \param[in] client_Id ClientID where the resource is to be set.
   /// \return Status
-  Status SetResource(const std::string &resource_name, const double capacity,
-                     const ClientID &client_id);
+  Status SetResource(const std::string& resource_name, const double capacity,
+                     const ClientID& client_id);
 
   /// Submit a normal task.
   ///
@@ -581,9 +581,9 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] args Arguments of this task.
   /// \param[in] task_options Options for this task.
   /// \param[out] return_ids Ids of the return objects.
-  void SubmitTask(const RayFunction &function,
-                  const std::vector<std::unique_ptr<TaskArg>> &args,
-                  const TaskOptions &task_options, std::vector<ObjectID> *return_ids,
+  void SubmitTask(const RayFunction& function,
+                  const std::vector<std::unique_ptr<TaskArg>>& args,
+                  const TaskOptions& task_options, std::vector<ObjectID>* return_ids,
                   int max_retries, PlacementOptions placement_options);
 
   /// Create an actor.
@@ -597,10 +597,10 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[out] actor_id ID of the created actor. This can be used to submit
   /// tasks on the actor.
   /// \return Status error if actor creation fails, likely due to raylet failure.
-  Status CreateActor(const RayFunction &function,
-                     const std::vector<std::unique_ptr<TaskArg>> &args,
-                     const ActorCreationOptions &actor_creation_options,
-                     const std::string &extension_data, ActorID *actor_id);
+  Status CreateActor(const RayFunction& function,
+                     const std::vector<std::unique_ptr<TaskArg>>& args,
+                     const ActorCreationOptions& actor_creation_options,
+                     const std::string& extension_data, ActorID* actor_id);
 
   /// Create a placement group.
   ///
@@ -610,8 +610,8 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// This can be used to shedule actor in node \return Status error if placement group
   /// creation fails, likely due to raylet failure.
   Status CreatePlacementGroup(
-      const PlacementGroupCreationOptions &placement_group_creation_options,
-      PlacementGroupID *placement_group_id);
+      const PlacementGroupCreationOptions& placement_group_creation_options,
+      PlacementGroupID* placement_group_id);
 
   /// Submit an actor task.
   ///
@@ -624,10 +624,10 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \return Status error if the task is invalid or if the task submission
   /// failed. Tasks can be invalid for direct actor calls because not all tasks
   /// are currently supported.
-  void SubmitActorTask(const ActorID &actor_id, const RayFunction &function,
-                       const std::vector<std::unique_ptr<TaskArg>> &args,
-                       const TaskOptions &task_options,
-                       std::vector<ObjectID> *return_ids);
+  void SubmitActorTask(const ActorID& actor_id, const RayFunction& function,
+                       const std::vector<std::unique_ptr<TaskArg>>& args,
+                       const TaskOptions& task_options,
+                       std::vector<ObjectID>* return_ids);
 
   /// Tell an actor to exit immediately, without completing outstanding work.
   ///
@@ -635,19 +635,19 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] no_restart If set to true, the killed actor will not be
   /// restarted anymore.
   /// \param[out] Status
-  Status KillActor(const ActorID &actor_id, bool force_kill, bool no_restart);
+  Status KillActor(const ActorID& actor_id, bool force_kill, bool no_restart);
 
   /// Stops the task associated with the given Object ID.
   ///
   /// \param[in] object_id of the task to kill (must be a Non-Actor task)
   /// \param[in] force_kill Whether to force kill a task by killing the worker.
   /// \param[out] Status
-  Status CancelTask(const ObjectID &object_id, bool force_kill);
+  Status CancelTask(const ObjectID& object_id, bool force_kill);
   /// Decrease the reference count for this actor. Should be called by the
   /// language frontend when a reference to the ActorHandle destroyed.
   ///
   /// \param[in] actor_id The actor ID to decrease the reference count for.
-  void RemoveActorHandleReference(const ActorID &actor_id);
+  void RemoveActorHandleReference(const ActorID& actor_id);
 
   /// Add an actor handle from a serialized string.
   ///
@@ -659,8 +659,8 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] outer_object_id The object ID that contained the serialized
   /// actor handle, if any.
   /// \return The ActorID of the deserialized handle.
-  ActorID DeserializeAndRegisterActorHandle(const std::string &serialized,
-                                            const ObjectID &outer_object_id);
+  ActorID DeserializeAndRegisterActorHandle(const std::string& serialized,
+                                            const ObjectID& outer_object_id);
 
   /// Serialize an actor handle.
   ///
@@ -673,20 +673,20 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// serialized actor handle in the language frontend is stored inside an
   /// object, then this must be recorded in the worker's ReferenceCounter.
   /// \return Status::Invalid if we don't have the specified handle.
-  Status SerializeActorHandle(const ActorID &actor_id, std::string *output,
-                              ObjectID *actor_handle_id) const;
+  Status SerializeActorHandle(const ActorID& actor_id, std::string* output,
+                              ObjectID* actor_handle_id) const;
 
   ///
   /// Public methods related to task execution. Should not be used by driver processes.
   ///
 
-  const ActorID &GetActorId() const { return actor_id_; }
+  const ActorID& GetActorId() const { return actor_id_; }
 
   // Get the resource IDs available to this worker (as assigned by the raylet).
   const ResourceMappingType GetResourceIDs() const;
 
   /// Create a profile event with a reference to the core worker's profiler.
-  std::unique_ptr<worker::ProfileEvent> CreateProfileEvent(const std::string &event_type);
+  std::unique_ptr<worker::ProfileEvent> CreateProfileEvent(const std::string& event_type);
 
  public:
   /// Allocate the return objects for an executing task. The caller should write into the
@@ -699,10 +699,10 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[out] return_objects RayObjects containing buffers to write results into.
   /// \return Status.
   Status AllocateReturnObjects(
-      const std::vector<ObjectID> &object_ids, const std::vector<size_t> &data_sizes,
-      const std::vector<std::shared_ptr<Buffer>> &metadatas,
-      const std::vector<std::vector<ObjectID>> &contained_object_ids,
-      std::vector<std::shared_ptr<RayObject>> *return_objects);
+      const std::vector<ObjectID>& object_ids, const std::vector<size_t>& data_sizes,
+      const std::vector<std::shared_ptr<Buffer>>& metadatas,
+      const std::vector<std::vector<ObjectID>>& contained_object_ids,
+      std::vector<std::shared_ptr<RayObject>>* return_objects);
 
   /// Get a handle to an actor.
   ///
@@ -712,7 +712,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   ///
   /// \param[in] actor_id The actor handle to get.
   /// \return Status::Invalid if we don't have this actor handle.
-  const ActorHandle *GetActorHandle(const ActorID &actor_id) const;
+  const ActorHandle* GetActorHandle(const ActorID& actor_id) const;
 
   /// Get a handle to a named actor.
   ///
@@ -722,7 +722,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[out] actor_handle A handle to the requested actor.
   /// \return The raw pointer to the actor handle if found, nullptr otherwise.
   /// The second pair contains the status of getting a named actor handle.
-  std::pair<const ActorHandle *, Status> GetNamedActorHandle(const std::string &name);
+  std::pair<const ActorHandle*, Status> GetNamedActorHandle(const std::string& name);
 
   ///
   /// The following methods are handlers for the core worker's gRPC server, which follow
@@ -731,66 +731,66 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   ///
 
   /// Implements gRPC server handler.
-  void HandleAssignTask(const rpc::AssignTaskRequest &request,
-                        rpc::AssignTaskReply *reply,
+  void HandleAssignTask(const rpc::AssignTaskRequest& request,
+                        rpc::AssignTaskReply* reply,
                         rpc::SendReplyCallback send_reply_callback) override;
 
   /// Implements gRPC server handler.
-  void HandlePushTask(const rpc::PushTaskRequest &request, rpc::PushTaskReply *reply,
+  void HandlePushTask(const rpc::PushTaskRequest& request, rpc::PushTaskReply* reply,
                       rpc::SendReplyCallback send_reply_callback) override;
 
   /// Implements gRPC server handler.
   void HandleDirectActorCallArgWaitComplete(
-      const rpc::DirectActorCallArgWaitCompleteRequest &request,
-      rpc::DirectActorCallArgWaitCompleteReply *reply,
+      const rpc::DirectActorCallArgWaitCompleteRequest& request,
+      rpc::DirectActorCallArgWaitCompleteReply* reply,
       rpc::SendReplyCallback send_reply_callback) override;
 
   /// Implements gRPC server handler.
-  void HandleGetObjectStatus(const rpc::GetObjectStatusRequest &request,
-                             rpc::GetObjectStatusReply *reply,
+  void HandleGetObjectStatus(const rpc::GetObjectStatusRequest& request,
+                             rpc::GetObjectStatusReply* reply,
                              rpc::SendReplyCallback send_reply_callback) override;
 
   /// Implements gRPC server handler.
-  void HandleWaitForActorOutOfScope(const rpc::WaitForActorOutOfScopeRequest &request,
-                                    rpc::WaitForActorOutOfScopeReply *reply,
+  void HandleWaitForActorOutOfScope(const rpc::WaitForActorOutOfScopeRequest& request,
+                                    rpc::WaitForActorOutOfScopeReply* reply,
                                     rpc::SendReplyCallback send_reply_callback) override;
 
   /// Implements gRPC server handler.
-  void HandleWaitForObjectEviction(const rpc::WaitForObjectEvictionRequest &request,
-                                   rpc::WaitForObjectEvictionReply *reply,
+  void HandleWaitForObjectEviction(const rpc::WaitForObjectEvictionRequest& request,
+                                   rpc::WaitForObjectEvictionReply* reply,
                                    rpc::SendReplyCallback send_reply_callback) override;
 
   /// Implements gRPC server handler.
-  void HandleWaitForRefRemoved(const rpc::WaitForRefRemovedRequest &request,
-                               rpc::WaitForRefRemovedReply *reply,
+  void HandleWaitForRefRemoved(const rpc::WaitForRefRemovedRequest& request,
+                               rpc::WaitForRefRemovedReply* reply,
                                rpc::SendReplyCallback send_reply_callback) override;
 
   /// Implements gRPC server handler.
-  void HandleKillActor(const rpc::KillActorRequest &request, rpc::KillActorReply *reply,
+  void HandleKillActor(const rpc::KillActorRequest& request, rpc::KillActorReply* reply,
                        rpc::SendReplyCallback send_reply_callback) override;
 
   /// Implements gRPC server handler.
-  void HandleCancelTask(const rpc::CancelTaskRequest &request,
-                        rpc::CancelTaskReply *reply,
+  void HandleCancelTask(const rpc::CancelTaskRequest& request,
+                        rpc::CancelTaskReply* reply,
                         rpc::SendReplyCallback send_reply_callback) override;
 
   /// Implements gRPC server handler.
-  void HandleRemoteCancelTask(const rpc::RemoteCancelTaskRequest &request,
-                              rpc::RemoteCancelTaskReply *reply,
+  void HandleRemoteCancelTask(const rpc::RemoteCancelTaskRequest& request,
+                              rpc::RemoteCancelTaskReply* reply,
                               rpc::SendReplyCallback send_reply_callback) override;
 
   /// Implements gRPC server handler.
-  void HandlePlasmaObjectReady(const rpc::PlasmaObjectReadyRequest &request,
-                               rpc::PlasmaObjectReadyReply *reply,
+  void HandlePlasmaObjectReady(const rpc::PlasmaObjectReadyRequest& request,
+                               rpc::PlasmaObjectReadyReply* reply,
                                rpc::SendReplyCallback send_reply_callback) override;
 
   /// Get statistics from core worker.
-  void HandleGetCoreWorkerStats(const rpc::GetCoreWorkerStatsRequest &request,
-                                rpc::GetCoreWorkerStatsReply *reply,
+  void HandleGetCoreWorkerStats(const rpc::GetCoreWorkerStatsRequest& request,
+                                rpc::GetCoreWorkerStatsReply* reply,
                                 rpc::SendReplyCallback send_reply_callback) override;
 
   /// Trigger local GC on this worker.
-  void HandleLocalGC(const rpc::LocalGCRequest &request, rpc::LocalGCReply *reply,
+  void HandleLocalGC(const rpc::LocalGCRequest& request, rpc::LocalGCReply* reply,
                      rpc::SendReplyCallback send_reply_callback) override;
 
   ///
@@ -799,11 +799,11 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   ///
 
   /// Block current fiber until event is triggered.
-  void YieldCurrentFiber(FiberEvent &event);
+  void YieldCurrentFiber(FiberEvent& event);
 
   /// The callback expected to be implemented by the client.
   using SetResultCallback =
-      std::function<void(std::shared_ptr<RayObject>, ObjectID object_id, void *)>;
+      std::function<void(std::shared_ptr<RayObject>, ObjectID object_id, void*)>;
 
   /// Perform async get from in-memory store.
   ///
@@ -811,19 +811,19 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] success_callback The callback to use the result object.
   /// \param[in] python_future the void* object to be passed to SetResultCallback
   /// \return void
-  void GetAsync(const ObjectID &object_id, SetResultCallback success_callback,
-                void *python_future);
+  void GetAsync(const ObjectID& object_id, SetResultCallback success_callback,
+                void* python_future);
 
   /// Subscribe to receive notification of an object entering the plasma store.
   ///
   /// \param[in] object_id The object to wait for.
   /// \return void
-  void SubscribeToPlasmaAdd(const ObjectID &object_id);
+  void SubscribeToPlasmaAdd(const ObjectID& object_id);
 
  private:
-  void SetCurrentTaskId(const TaskID &task_id);
+  void SetCurrentTaskId(const TaskID& task_id);
 
-  void SetActorId(const ActorID &actor_id);
+  void SetActorId(const ActorID& actor_id);
 
   /// Run the io_service_ event loop. This should be called in a background thread.
   void RunIOService();
@@ -836,10 +836,10 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   void RegisterToGcs();
 
   /// Check if the raylet has failed. If so, shutdown.
-  void CheckForRayletFailure(const boost::system::error_code &error);
+  void CheckForRayletFailure(const boost::system::error_code& error);
 
   /// Heartbeat for internal bookkeeping.
-  void InternalHeartbeat(const boost::system::error_code &error);
+  void InternalHeartbeat(const boost::system::error_code& error);
 
   ///
   /// Private methods related to task submission.
@@ -850,7 +850,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   ///
   /// \param[in] object_id The object ID to increase the reference count for.
   /// \param[in] call_site The call site from the language frontend.
-  void AddLocalReference(const ObjectID &object_id, std::string call_site) {
+  void AddLocalReference(const ObjectID& object_id, std::string call_site) {
     reference_counter_->AddLocalReference(object_id, call_site);
   }
 
@@ -872,16 +872,16 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   ///                     arguments and recursively, any object IDs that were
   ///                     contained in those objects.
   /// \return Status.
-  Status ExecuteTask(const TaskSpecification &task_spec,
-                     const std::shared_ptr<ResourceMappingType> &resource_ids,
-                     std::vector<std::shared_ptr<RayObject>> *return_objects,
-                     ReferenceCounter::ReferenceTableProto *borrowed_refs);
+  Status ExecuteTask(const TaskSpecification& task_spec,
+                     const std::shared_ptr<ResourceMappingType>& resource_ids,
+                     std::vector<std::shared_ptr<RayObject>>* return_objects,
+                     ReferenceCounter::ReferenceTableProto* borrowed_refs);
 
   /// Execute a local mode task (runs normal ExecuteTask)
   ///
   /// \param spec[in] task_spec Task specification.
-  void ExecuteTaskLocalMode(const TaskSpecification &task_spec,
-                            const ActorID &actor_id = ActorID::Nil());
+  void ExecuteTaskLocalMode(const TaskSpecification& task_spec,
+                            const ActorID& actor_id = ActorID::Nil());
 
   /// Get the values of the task arguments for the executor. Values are
   /// retrieved from the local plasma store or, if the value is inlined, from
@@ -910,16 +910,16 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   ///                  any ObjectIDs that were included in the task spec's
   ///                  inlined arguments.
   /// \return Error if the values could not be retrieved.
-  Status GetAndPinArgsForExecutor(const TaskSpecification &task,
-                                  std::vector<std::shared_ptr<RayObject>> *args,
-                                  std::vector<ObjectID> *arg_reference_ids,
-                                  std::vector<ObjectID> *pinned_ids);
+  Status GetAndPinArgsForExecutor(const TaskSpecification& task,
+                                  std::vector<std::shared_ptr<RayObject>>* args,
+                                  std::vector<ObjectID>* arg_reference_ids,
+                                  std::vector<ObjectID>* pinned_ids);
 
   /// Returns whether the message was sent to the wrong worker. The right error reply
   /// is sent automatically. Messages end up on the wrong worker when a worker dies
   /// and a new one takes its place with the same place. In this situation, we want
   /// the new worker to reject messages meant for the old one.
-  bool HandleWrongRecipient(const WorkerID &intended_worker_id,
+  bool HandleWrongRecipient(const WorkerID& intended_worker_id,
                             rpc::SendReplyCallback send_reply_callback) {
     if (intended_worker_id != worker_context_.GetWorkerID()) {
       std::ostringstream stream;
@@ -936,12 +936,12 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   }
 
   /// Handler if a raylet node is removed from the cluster.
-  void OnNodeRemoved(const rpc::GcsNodeInfo &node_info);
+  void OnNodeRemoved(const rpc::GcsNodeInfo& node_info);
 
   const CoreWorkerOptions options_;
 
   /// Callback to get the current language (e.g., Python) call site.
-  std::function<void(std::string *)> get_call_site_;
+  std::function<void(std::string*)> get_call_site_;
 
   // Convenience method to get the current language call site.
   std::string CurrentCallSite() {
@@ -1108,7 +1108,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
 
   // Fallback for when GetAsync cannot directly get the requested object.
   void PlasmaCallback(SetResultCallback success, std::shared_ptr<RayObject> ray_object,
-                      ObjectID object_id, void *py_future);
+                      ObjectID object_id, void* py_future);
 
   /// Whether we are shutting down and not running further tasks.
   bool exiting_ = false;

--- a/src/ray/core_worker/fiber.h
+++ b/src/ray/core_worker/fiber.h
@@ -110,7 +110,7 @@ class FiberState {
             });
   }
 
-  void EnqueueFiber(std::function<void()> &&callback) {
+  void EnqueueFiber(std::function<void()>&& callback) {
     auto op_status = channel_.push([this, callback]() {
       rate_limiter_.Acquire();
       callback();

--- a/src/ray/core_worker/future_resolver.cc
+++ b/src/ray/core_worker/future_resolver.cc
@@ -16,8 +16,8 @@
 
 namespace ray {
 
-void FutureResolver::ResolveFutureAsync(const ObjectID &object_id,
-                                        const rpc::Address &owner_address) {
+void FutureResolver::ResolveFutureAsync(const ObjectID& object_id,
+                                        const rpc::Address& owner_address) {
   absl::MutexLock lock(&mu_);
   const auto owner_worker_id = WorkerID::FromBinary(owner_address.worker_id());
   if (rpc_address_.worker_id() == owner_address.worker_id()) {
@@ -37,7 +37,7 @@ void FutureResolver::ResolveFutureAsync(const ObjectID &object_id,
   request.set_owner_worker_id(owner_worker_id.Binary());
   it->second->GetObjectStatus(
       request,
-      [this, object_id](const Status &status, const rpc::GetObjectStatusReply &reply) {
+      [this, object_id](const Status& status, const rpc::GetObjectStatusReply& reply) {
         if (!status.ok()) {
           RAY_LOG(WARNING) << "Error retrieving the value of object ID " << object_id
                            << " that was deserialized: " << status.ToString();

--- a/src/ray/core_worker/future_resolver.h
+++ b/src/ray/core_worker/future_resolver.h
@@ -28,7 +28,7 @@ namespace ray {
 class FutureResolver {
  public:
   FutureResolver(std::shared_ptr<CoreWorkerMemoryStore> store,
-                 rpc::ClientFactoryFn client_factory, const rpc::Address &rpc_address)
+                 rpc::ClientFactoryFn client_factory, const rpc::Address& rpc_address)
       : in_memory_store_(store),
         client_factory_(client_factory),
         rpc_address_(rpc_address) {}
@@ -41,7 +41,7 @@ class FutureResolver {
   /// \param[in] object_id The ID of the future to resolve.
   /// \param[in] owner_address The address of the task or actor that owns the
   /// future.
-  void ResolveFutureAsync(const ObjectID &object_id, const rpc::Address &owner_address);
+  void ResolveFutureAsync(const ObjectID& object_id, const rpc::Address& owner_address);
 
  private:
   /// Used to store values of resolved futures.

--- a/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
@@ -198,7 +198,7 @@ JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeInitialize(
       RAY_LOG(INFO) << "Calling System.gc() ...";
       env->CallStaticObjectMethod(java_system_class, java_system_gc);
       last_gc_time_ms = current_time_ms();
-      RAY_LOG(INFO) << "GC finished in " << (double) (last_gc_time_ms - start) / 1000
+      RAY_LOG(INFO) << "GC finished in " << (double)(last_gc_time_ms - start) / 1000
                     << " seconds.";
     }
   };

--- a/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
@@ -23,7 +23,7 @@
 #include "ray/core_worker/actor_handle.h"
 #include "ray/core_worker/core_worker.h"
 
-thread_local JNIEnv *local_env = nullptr;
+thread_local JNIEnv* local_env = nullptr;
 jobject java_task_executor = nullptr;
 
 /// Store Java instances of function descriptor in the cache to avoid unnessesary JNI
@@ -32,7 +32,7 @@ thread_local std::unordered_map<size_t,
                                 std::vector<std::pair<ray::FunctionDescriptor, jobject>>>
     executor_function_descriptor_cache;
 
-inline ray::gcs::GcsClientOptions ToGcsClientOptions(JNIEnv *env,
+inline ray::gcs::GcsClientOptions ToGcsClientOptions(JNIEnv* env,
                                                      jobject gcs_client_options) {
   std::string ip = JavaStringToNativeString(
       env, (jstring)env->GetObjectField(gcs_client_options, java_gcs_client_options_ip));
@@ -43,19 +43,19 @@ inline ray::gcs::GcsClientOptions ToGcsClientOptions(JNIEnv *env,
   return ray::gcs::GcsClientOptions(ip, port, password, /*is_test_client=*/false);
 }
 
-jobject ToJavaArgs(JNIEnv *env, jbooleanArray java_check_results,
-                   const std::vector<std::shared_ptr<ray::RayObject>> &args) {
+jobject ToJavaArgs(JNIEnv* env, jbooleanArray java_check_results,
+                   const std::vector<std::shared_ptr<ray::RayObject>>& args) {
   if (java_check_results == nullptr) {
     // If `java_check_results` is null, it means that `checkByteBufferArguments`
     // failed. In this case, just return null here. The args won't be used anyway.
     return nullptr;
   } else {
-    jboolean *check_results = env->GetBooleanArrayElements(java_check_results, nullptr);
+    jboolean* check_results = env->GetBooleanArrayElements(java_check_results, nullptr);
     size_t i = 0;
     jobject args_array_list = NativeVectorToJavaList<std::shared_ptr<ray::RayObject>>(
         env, args,
-        [check_results, &i](JNIEnv *env,
-                            const std::shared_ptr<ray::RayObject> &native_object) {
+        [check_results, &i](JNIEnv* env,
+                            const std::shared_ptr<ray::RayObject>& native_object) {
           if (*(check_results + (i++))) {
             // If the type of this argument is ByteBuffer, we create a
             // DirectByteBuffer here To avoid data copy.
@@ -72,12 +72,12 @@ jobject ToJavaArgs(JNIEnv *env, jbooleanArray java_check_results,
   }
 }
 
-JNIEnv *GetJNIEnv() {
-  JNIEnv *env = local_env;
+JNIEnv* GetJNIEnv() {
+  JNIEnv* env = local_env;
   if (!env) {
     // Attach the native thread to JVM.
     auto status =
-        jvm->AttachCurrentThreadAsDaemon(reinterpret_cast<void **>(&env), nullptr);
+        jvm->AttachCurrentThreadAsDaemon(reinterpret_cast<void**>(&env), nullptr);
     RAY_CHECK(status == JNI_OK) << "Failed to get JNIEnv. Return code: " << status;
     local_env = env;
   }
@@ -90,36 +90,36 @@ extern "C" {
 #endif
 
 JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeInitialize(
-    JNIEnv *env, jclass, jint workerMode, jstring nodeIpAddress, jint nodeManagerPort,
+    JNIEnv* env, jclass, jint workerMode, jstring nodeIpAddress, jint nodeManagerPort,
     jstring driverName, jstring storeSocket, jstring rayletSocket, jbyteArray jobId,
     jobject gcsClientOptions, jint numWorkersPerProcess, jstring logDir,
     jobject rayletConfigParameters) {
   auto raylet_config = JavaMapToNativeMap<std::string, std::string>(
       env, rayletConfigParameters,
-      [](JNIEnv *env, jobject java_key) {
+      [](JNIEnv* env, jobject java_key) {
         return JavaStringToNativeString(env, (jstring)java_key);
       },
-      [](JNIEnv *env, jobject java_value) {
+      [](JNIEnv* env, jobject java_value) {
         return JavaStringToNativeString(env, (jstring)java_value);
       });
   RayConfig::instance().initialize(raylet_config);
 
   auto task_execution_callback =
-      [](ray::TaskType task_type, const ray::RayFunction &ray_function,
-         const std::unordered_map<std::string, double> &required_resources,
-         const std::vector<std::shared_ptr<ray::RayObject>> &args,
-         const std::vector<ObjectID> &arg_reference_ids,
-         const std::vector<ObjectID> &return_ids,
-         std::vector<std::shared_ptr<ray::RayObject>> *results) {
-        JNIEnv *env = GetJNIEnv();
+      [](ray::TaskType task_type, const ray::RayFunction& ray_function,
+         const std::unordered_map<std::string, double>& required_resources,
+         const std::vector<std::shared_ptr<ray::RayObject>>& args,
+         const std::vector<ObjectID>& arg_reference_ids,
+         const std::vector<ObjectID>& return_ids,
+         std::vector<std::shared_ptr<ray::RayObject>>* results) {
+        JNIEnv* env = GetJNIEnv();
         RAY_CHECK(java_task_executor);
 
         // convert RayFunction
         auto function_descriptor = ray_function.GetFunctionDescriptor();
         size_t fd_hash = function_descriptor->Hash();
-        auto &fd_vector = executor_function_descriptor_cache[fd_hash];
+        auto& fd_vector = executor_function_descriptor_cache[fd_hash];
         jobject ray_function_array_list = nullptr;
-        for (auto &pair : fd_vector) {
+        for (auto& pair : fd_vector) {
           if (pair.first == function_descriptor) {
             ray_function_array_list = pair.second;
             break;
@@ -151,7 +151,7 @@ JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeInitialize(
           std::vector<std::shared_ptr<ray::RayObject>> return_objects;
           JavaListToNativeVector<std::shared_ptr<ray::RayObject>>(
               env, java_return_objects, &return_objects,
-              [](JNIEnv *env, jobject java_native_ray_object) {
+              [](JNIEnv* env, jobject java_native_ray_object) {
                 return JavaNativeRayObjectToNativeRayObject(env, java_native_ray_object);
               });
           std::vector<size_t> data_sizes;
@@ -194,7 +194,7 @@ JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeInitialize(
     absl::MutexLock lock(&mutex);
     int64_t start = current_time_ms();
     if (last_gc_time_ms + 1000 < start) {
-      JNIEnv *env = GetJNIEnv();
+      JNIEnv* env = GetJNIEnv();
       RAY_LOG(INFO) << "Calling System.gc() ...";
       env->CallStaticObjectMethod(java_system_class, java_system_gc);
       last_gc_time_ms = current_time_ms();
@@ -234,21 +234,21 @@ JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeInitialize(
 }
 
 JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeRunTaskExecutor(
-    JNIEnv *env, jclass o, jobject javaTaskExecutor) {
+    JNIEnv* env, jclass o, jobject javaTaskExecutor) {
   java_task_executor = javaTaskExecutor;
   ray::CoreWorkerProcess::RunTaskExecutionLoop();
   java_task_executor = nullptr;
 }
 
-JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeShutdown(JNIEnv *env,
+JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeShutdown(JNIEnv* env,
                                                                            jclass o) {
   ray::CoreWorkerProcess::Shutdown();
 }
 
 JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeSetResource(
-    JNIEnv *env, jclass, jstring resourceName, jdouble capacity, jbyteArray nodeId) {
+    JNIEnv* env, jclass, jstring resourceName, jdouble capacity, jbyteArray nodeId) {
   const auto node_id = JavaByteArrayToId<ClientID>(env, nodeId);
-  const char *native_resource_name = env->GetStringUTFChars(resourceName, JNI_FALSE);
+  const char* native_resource_name = env->GetStringUTFChars(resourceName, JNI_FALSE);
 
   auto status = ray::CoreWorkerProcess::GetCoreWorker().SetResource(
       native_resource_name, static_cast<double>(capacity), node_id);
@@ -257,13 +257,13 @@ JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeSetResource(
 }
 
 JNIEXPORT jbyteArray JNICALL
-Java_io_ray_runtime_RayNativeRuntime_nativeGetActorIdOfNamedActor(JNIEnv *env, jclass,
+Java_io_ray_runtime_RayNativeRuntime_nativeGetActorIdOfNamedActor(JNIEnv* env, jclass,
                                                                   jstring actor_name,
                                                                   jboolean global) {
-  const char *native_actor_name = env->GetStringUTFChars(actor_name, JNI_FALSE);
+  const char* native_actor_name = env->GetStringUTFChars(actor_name, JNI_FALSE);
   auto full_name = GetActorFullName(global, native_actor_name);
 
-  const auto *actor_handle =
+  const auto* actor_handle =
       ray::CoreWorkerProcess::GetCoreWorker().GetNamedActorHandle(full_name).first;
   ray::ActorID actor_id;
   if (actor_handle) {
@@ -273,12 +273,12 @@ Java_io_ray_runtime_RayNativeRuntime_nativeGetActorIdOfNamedActor(JNIEnv *env, j
   }
   jbyteArray bytes = env->NewByteArray(actor_id.Size());
   env->SetByteArrayRegion(bytes, 0, actor_id.Size(),
-                          reinterpret_cast<const jbyte *>(actor_id.Data()));
+                          reinterpret_cast<const jbyte*>(actor_id.Data()));
   return bytes;
 }
 
 JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeKillActor(
-    JNIEnv *env, jclass, jbyteArray actorId, jboolean noRestart) {
+    JNIEnv* env, jclass, jbyteArray actorId, jboolean noRestart) {
   auto status = ray::CoreWorkerProcess::GetCoreWorker().KillActor(
       JavaByteArrayToId<ActorID>(env, actorId),
       /*force_kill=*/true, noRestart);
@@ -286,7 +286,7 @@ JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeKillActor(
 }
 
 JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeSetCoreWorker(
-    JNIEnv *env, jclass, jbyteArray workerId) {
+    JNIEnv* env, jclass, jbyteArray workerId) {
   const auto worker_id = JavaByteArrayToId<ray::WorkerID>(env, workerId);
   ray::CoreWorkerProcess::SetCurrentThreadWorkerId(worker_id);
 }

--- a/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.h
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.h
@@ -28,7 +28,7 @@ extern "C" {
  * (ILjava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;[BLio/ray/runtime/gcs/GcsClientOptions;ILjava/lang/String;Ljava/util/Map;)V
  */
 JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeInitialize(
-    JNIEnv *, jclass, jint, jstring, jint, jstring, jstring, jstring, jbyteArray, jobject,
+    JNIEnv*, jclass, jint, jstring, jint, jstring, jstring, jstring, jbyteArray, jobject,
     jint, jstring, jobject);
 
 /*
@@ -37,14 +37,14 @@ JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeInitialize(
  * Signature: (Lio/ray/runtime/task/TaskExecutor;)V
  */
 JNIEXPORT void JNICALL
-Java_io_ray_runtime_RayNativeRuntime_nativeRunTaskExecutor(JNIEnv *, jclass, jobject);
+Java_io_ray_runtime_RayNativeRuntime_nativeRunTaskExecutor(JNIEnv*, jclass, jobject);
 
 /*
  * Class:     io_ray_runtime_RayNativeRuntime
  * Method:    nativeShutdown
  * Signature: ()V
  */
-JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeShutdown(JNIEnv *,
+JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeShutdown(JNIEnv*,
                                                                            jclass);
 
 /*
@@ -53,14 +53,14 @@ JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeShutdown(JNIEn
  * Signature: (Ljava/lang/String;D[B)V
  */
 JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeSetResource(
-    JNIEnv *, jclass, jstring, jdouble, jbyteArray);
+    JNIEnv*, jclass, jstring, jdouble, jbyteArray);
 
 /*
  * Class:     io_ray_runtime_RayNativeRuntime
  * Method:    nativeKillActor
  * Signature: ([BZ)V
  */
-JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeKillActor(JNIEnv *,
+JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeKillActor(JNIEnv*,
                                                                             jclass,
                                                                             jbyteArray,
                                                                             jboolean);
@@ -71,7 +71,7 @@ JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeKillActor(JNIE
  * Signature: (Ljava/lang/String;Z)[B
  */
 JNIEXPORT jbyteArray JNICALL
-Java_io_ray_runtime_RayNativeRuntime_nativeGetActorIdOfNamedActor(JNIEnv *, jclass,
+Java_io_ray_runtime_RayNativeRuntime_nativeGetActorIdOfNamedActor(JNIEnv*, jclass,
                                                                   jstring, jboolean);
 
 /*
@@ -80,7 +80,7 @@ Java_io_ray_runtime_RayNativeRuntime_nativeGetActorIdOfNamedActor(JNIEnv *, jcla
  * Signature: ([B)V
  */
 JNIEXPORT void JNICALL
-Java_io_ray_runtime_RayNativeRuntime_nativeSetCoreWorker(JNIEnv *, jclass, jbyteArray);
+Java_io_ray_runtime_RayNativeRuntime_nativeSetCoreWorker(JNIEnv*, jclass, jbyteArray);
 
 #ifdef __cplusplus
 }

--- a/src/ray/core_worker/lib/java/io_ray_runtime_actor_NativeActorHandle.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_actor_NativeActorHandle.cc
@@ -16,11 +16,11 @@
 
 #include <jni.h>
 
+#include "jni_utils.h"
 #include "ray/common/id.h"
 #include "ray/core_worker/actor_handle.h"
 #include "ray/core_worker/common.h"
 #include "ray/core_worker/core_worker.h"
-#include "jni_utils.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/ray/core_worker/lib/java/io_ray_runtime_actor_NativeActorHandle.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_actor_NativeActorHandle.cc
@@ -27,25 +27,25 @@ extern "C" {
 #endif
 
 JNIEXPORT jint JNICALL Java_io_ray_runtime_actor_NativeActorHandle_nativeGetLanguage(
-    JNIEnv *env, jclass o, jbyteArray actorId) {
+    JNIEnv* env, jclass o, jbyteArray actorId) {
   auto actor_id = JavaByteArrayToId<ray::ActorID>(env, actorId);
-  const ray::ActorHandle *native_actor_handle =
+  const ray::ActorHandle* native_actor_handle =
       ray::CoreWorkerProcess::GetCoreWorker().GetActorHandle(actor_id);
   return native_actor_handle->ActorLanguage();
 }
 
 JNIEXPORT jobject JNICALL
 Java_io_ray_runtime_actor_NativeActorHandle_nativeGetActorCreationTaskFunctionDescriptor(
-    JNIEnv *env, jclass o, jbyteArray actorId) {
+    JNIEnv* env, jclass o, jbyteArray actorId) {
   auto actor_id = JavaByteArrayToId<ray::ActorID>(env, actorId);
-  const ray::ActorHandle *native_actor_handle =
+  const ray::ActorHandle* native_actor_handle =
       ray::CoreWorkerProcess::GetCoreWorker().GetActorHandle(actor_id);
   auto function_descriptor = native_actor_handle->ActorCreationTaskFunctionDescriptor();
   return NativeRayFunctionDescriptorToJavaStringList(env, function_descriptor);
 }
 
 JNIEXPORT jbyteArray JNICALL Java_io_ray_runtime_actor_NativeActorHandle_nativeSerialize(
-    JNIEnv *env, jclass o, jbyteArray actorId) {
+    JNIEnv* env, jclass o, jbyteArray actorId) {
   auto actor_id = JavaByteArrayToId<ray::ActorID>(env, actorId);
   std::string output;
   ObjectID actor_handle_id;
@@ -53,16 +53,16 @@ JNIEXPORT jbyteArray JNICALL Java_io_ray_runtime_actor_NativeActorHandle_nativeS
       actor_id, &output, &actor_handle_id);
   jbyteArray bytes = env->NewByteArray(output.size());
   env->SetByteArrayRegion(bytes, 0, output.size(),
-                          reinterpret_cast<const jbyte *>(output.c_str()));
+                          reinterpret_cast<const jbyte*>(output.c_str()));
   return bytes;
 }
 
 JNIEXPORT jbyteArray JNICALL
-Java_io_ray_runtime_actor_NativeActorHandle_nativeDeserialize(JNIEnv *env, jclass o,
+Java_io_ray_runtime_actor_NativeActorHandle_nativeDeserialize(JNIEnv* env, jclass o,
                                                               jbyteArray data) {
   auto buffer = JavaByteArrayToNativeBuffer(env, data);
   RAY_CHECK(buffer->Size() > 0);
-  auto binary = std::string(reinterpret_cast<char *>(buffer->Data()), buffer->Size());
+  auto binary = std::string(reinterpret_cast<char*>(buffer->Data()), buffer->Size());
   auto actor_id =
       ray::CoreWorkerProcess::GetCoreWorker().DeserializeAndRegisterActorHandle(
           binary, /*outer_object_id=*/ObjectID::Nil());

--- a/src/ray/core_worker/lib/java/io_ray_runtime_actor_NativeActorHandle.h
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_actor_NativeActorHandle.h
@@ -27,7 +27,7 @@ extern "C" {
  * Signature: ([B)I
  */
 JNIEXPORT jint JNICALL Java_io_ray_runtime_actor_NativeActorHandle_nativeGetLanguage(
-    JNIEnv *, jclass, jbyteArray);
+    JNIEnv*, jclass, jbyteArray);
 
 /*
  * Class:     io_ray_runtime_actor_NativeActorHandle
@@ -36,7 +36,7 @@ JNIEXPORT jint JNICALL Java_io_ray_runtime_actor_NativeActorHandle_nativeGetLang
  */
 JNIEXPORT jobject JNICALL
 Java_io_ray_runtime_actor_NativeActorHandle_nativeGetActorCreationTaskFunctionDescriptor(
-    JNIEnv *, jclass, jbyteArray);
+    JNIEnv*, jclass, jbyteArray);
 
 /*
  * Class:     io_ray_runtime_actor_NativeActorHandle
@@ -44,7 +44,7 @@ Java_io_ray_runtime_actor_NativeActorHandle_nativeGetActorCreationTaskFunctionDe
  * Signature: ([B)[B
  */
 JNIEXPORT jbyteArray JNICALL
-Java_io_ray_runtime_actor_NativeActorHandle_nativeSerialize(JNIEnv *, jclass, jbyteArray);
+Java_io_ray_runtime_actor_NativeActorHandle_nativeSerialize(JNIEnv*, jclass, jbyteArray);
 
 /*
  * Class:     io_ray_runtime_actor_NativeActorHandle
@@ -52,7 +52,7 @@ Java_io_ray_runtime_actor_NativeActorHandle_nativeSerialize(JNIEnv *, jclass, jb
  * Signature: ([B)[B
  */
 JNIEXPORT jbyteArray JNICALL
-Java_io_ray_runtime_actor_NativeActorHandle_nativeDeserialize(JNIEnv *, jclass,
+Java_io_ray_runtime_actor_NativeActorHandle_nativeDeserialize(JNIEnv*, jclass,
                                                               jbyteArray);
 
 #ifdef __cplusplus

--- a/src/ray/core_worker/lib/java/io_ray_runtime_context_NativeWorkerContext.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_context_NativeWorkerContext.cc
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 #include "io_ray_runtime_context_NativeWorkerContext.h"
+
 #include <jni.h>
+
+#include "jni_utils.h"
 #include "ray/common/id.h"
 #include "ray/core_worker/context.h"
 #include "ray/core_worker/core_worker.h"
-#include "jni_utils.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/ray/core_worker/lib/java/io_ray_runtime_context_NativeWorkerContext.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_context_NativeWorkerContext.cc
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 JNIEXPORT jint JNICALL
-Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentTaskType(JNIEnv *env,
+Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentTaskType(JNIEnv* env,
                                                                          jclass) {
   auto task_spec =
       ray::CoreWorkerProcess::GetCoreWorker().GetWorkerContext().GetCurrentTask();
@@ -35,33 +35,33 @@ Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentTaskType(JNIEnv 
 }
 
 JNIEXPORT jobject JNICALL
-Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentTaskId(JNIEnv *env,
+Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentTaskId(JNIEnv* env,
                                                                        jclass) {
-  const ray::TaskID &task_id =
+  const ray::TaskID& task_id =
       ray::CoreWorkerProcess::GetCoreWorker().GetWorkerContext().GetCurrentTaskID();
   return IdToJavaByteBuffer<ray::TaskID>(env, task_id);
 }
 
 JNIEXPORT jobject JNICALL
-Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentJobId(JNIEnv *env,
+Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentJobId(JNIEnv* env,
                                                                       jclass) {
-  const auto &job_id =
+  const auto& job_id =
       ray::CoreWorkerProcess::GetCoreWorker().GetWorkerContext().GetCurrentJobID();
   return IdToJavaByteBuffer<ray::JobID>(env, job_id);
 }
 
 JNIEXPORT jobject JNICALL
-Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentWorkerId(JNIEnv *env,
+Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentWorkerId(JNIEnv* env,
                                                                          jclass) {
-  const auto &worker_id =
+  const auto& worker_id =
       ray::CoreWorkerProcess::GetCoreWorker().GetWorkerContext().GetWorkerID();
   return IdToJavaByteBuffer<ray::WorkerID>(env, worker_id);
 }
 
 JNIEXPORT jobject JNICALL
-Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentActorId(JNIEnv *env,
+Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentActorId(JNIEnv* env,
                                                                         jclass) {
-  const auto &actor_id =
+  const auto& actor_id =
       ray::CoreWorkerProcess::GetCoreWorker().GetWorkerContext().GetCurrentActorID();
   return IdToJavaByteBuffer<ray::ActorID>(env, actor_id);
 }

--- a/src/ray/core_worker/lib/java/io_ray_runtime_context_NativeWorkerContext.h
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_context_NativeWorkerContext.h
@@ -27,8 +27,7 @@ extern "C" {
  * Signature: ()I
  */
 JNIEXPORT jint JNICALL
-Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentTaskType(JNIEnv *,
-                                                                         jclass);
+Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentTaskType(JNIEnv*, jclass);
 
 /*
  * Class:     io_ray_runtime_context_NativeWorkerContext
@@ -36,7 +35,7 @@ Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentTaskType(JNIEnv 
  * Signature: ()Ljava/nio/ByteBuffer;
  */
 JNIEXPORT jobject JNICALL
-Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentTaskId(JNIEnv *, jclass);
+Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentTaskId(JNIEnv*, jclass);
 
 /*
  * Class:     io_ray_runtime_context_NativeWorkerContext
@@ -44,7 +43,7 @@ Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentTaskId(JNIEnv *,
  * Signature: ()Ljava/nio/ByteBuffer;
  */
 JNIEXPORT jobject JNICALL
-Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentJobId(JNIEnv *, jclass);
+Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentJobId(JNIEnv*, jclass);
 
 /*
  * Class:     io_ray_runtime_context_NativeWorkerContext
@@ -52,8 +51,7 @@ Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentJobId(JNIEnv *, 
  * Signature: ()Ljava/nio/ByteBuffer;
  */
 JNIEXPORT jobject JNICALL
-Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentWorkerId(JNIEnv *,
-                                                                         jclass);
+Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentWorkerId(JNIEnv*, jclass);
 
 /*
  * Class:     io_ray_runtime_context_NativeWorkerContext
@@ -61,7 +59,7 @@ Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentWorkerId(JNIEnv 
  * Signature: ()Ljava/nio/ByteBuffer;
  */
 JNIEXPORT jobject JNICALL
-Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentActorId(JNIEnv *, jclass);
+Java_io_ray_runtime_context_NativeWorkerContext_nativeGetCurrentActorId(JNIEnv*, jclass);
 
 #ifdef __cplusplus
 }

--- a/src/ray/core_worker/lib/java/io_ray_runtime_gcs_GlobalStateAccessor.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_gcs_GlobalStateAccessor.cc
@@ -16,8 +16,8 @@
 
 #include <jni.h>
 
-#include "ray/core_worker/common.h"
 #include "jni_utils.h"
+#include "ray/core_worker/common.h"
 #include "ray/gcs/gcs_client/global_state_accessor.h"
 
 #ifdef __cplusplus

--- a/src/ray/core_worker/lib/java/io_ray_runtime_gcs_GlobalStateAccessor.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_gcs_GlobalStateAccessor.cc
@@ -25,57 +25,52 @@ extern "C" {
 #endif
 JNIEXPORT jlong JNICALL
 Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeCreateGlobalStateAccessor(
-    JNIEnv *env, jobject o, jstring j_redis_address, jstring j_redis_passowrd) {
+    JNIEnv* env, jobject o, jstring j_redis_address, jstring j_redis_passowrd) {
   std::string redis_address = JavaStringToNativeString(env, j_redis_address);
   std::string redis_password = JavaStringToNativeString(env, j_redis_passowrd);
-  ray::gcs::GlobalStateAccessor *gcs_accessor =
+  ray::gcs::GlobalStateAccessor* gcs_accessor =
       new ray::gcs::GlobalStateAccessor(redis_address, redis_password);
   return reinterpret_cast<jlong>(gcs_accessor);
 }
 
 JNIEXPORT void JNICALL
 Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeDestroyGlobalStateAccessor(
-    JNIEnv *env, jobject o, jlong gcs_accessor_ptr) {
-  auto *gcs_accessor =
-      reinterpret_cast<ray::gcs::GlobalStateAccessor *>(gcs_accessor_ptr);
+    JNIEnv* env, jobject o, jlong gcs_accessor_ptr) {
+  auto* gcs_accessor = reinterpret_cast<ray::gcs::GlobalStateAccessor*>(gcs_accessor_ptr);
   delete gcs_accessor;
 }
 
 JNIEXPORT jboolean JNICALL Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeConnect(
-    JNIEnv *env, jobject o, jlong gcs_accessor_ptr) {
-  auto *gcs_accessor =
-      reinterpret_cast<ray::gcs::GlobalStateAccessor *>(gcs_accessor_ptr);
+    JNIEnv* env, jobject o, jlong gcs_accessor_ptr) {
+  auto* gcs_accessor = reinterpret_cast<ray::gcs::GlobalStateAccessor*>(gcs_accessor_ptr);
   return gcs_accessor->Connect();
 }
 
 JNIEXPORT jobject JNICALL Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetAllJobInfo(
-    JNIEnv *env, jobject o, jlong gcs_accessor_ptr) {
-  auto *gcs_accessor =
-      reinterpret_cast<ray::gcs::GlobalStateAccessor *>(gcs_accessor_ptr);
+    JNIEnv* env, jobject o, jlong gcs_accessor_ptr) {
+  auto* gcs_accessor = reinterpret_cast<ray::gcs::GlobalStateAccessor*>(gcs_accessor_ptr);
   auto job_info_list = gcs_accessor->GetAllJobInfo();
   return NativeVectorToJavaList<std::string>(
-      env, job_info_list, [](JNIEnv *env, const std::string &str) {
+      env, job_info_list, [](JNIEnv* env, const std::string& str) {
         return NativeStringToJavaByteArray(env, str);
       });
 }
 
 JNIEXPORT jobject JNICALL
-Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetAllNodeInfo(JNIEnv *env, jobject o,
+Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetAllNodeInfo(JNIEnv* env, jobject o,
                                                                  jlong gcs_accessor_ptr) {
-  auto *gcs_accessor =
-      reinterpret_cast<ray::gcs::GlobalStateAccessor *>(gcs_accessor_ptr);
+  auto* gcs_accessor = reinterpret_cast<ray::gcs::GlobalStateAccessor*>(gcs_accessor_ptr);
   auto node_info_list = gcs_accessor->GetAllNodeInfo();
   return NativeVectorToJavaList<std::string>(
-      env, node_info_list, [](JNIEnv *env, const std::string &str) {
+      env, node_info_list, [](JNIEnv* env, const std::string& str) {
         return NativeStringToJavaByteArray(env, str);
       });
 }
 
 JNIEXPORT jbyteArray JNICALL
 Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetNodeResourceInfo(
-    JNIEnv *env, jobject o, jlong gcs_accessor_ptr, jbyteArray node_id_bytes) {
-  auto *gcs_accessor =
-      reinterpret_cast<ray::gcs::GlobalStateAccessor *>(gcs_accessor_ptr);
+    JNIEnv* env, jobject o, jlong gcs_accessor_ptr, jbyteArray node_id_bytes) {
+  auto* gcs_accessor = reinterpret_cast<ray::gcs::GlobalStateAccessor*>(gcs_accessor_ptr);
   auto node_id = JavaByteArrayToId<ray::ClientID>(env, node_id_bytes);
   auto node_resource_info = gcs_accessor->GetNodeResourceInfo(node_id);
   return static_cast<jbyteArray>(NativeStringToJavaByteArray(env, node_resource_info));
@@ -83,9 +78,8 @@ Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetNodeResourceInfo(
 
 JNIEXPORT jbyteArray JNICALL
 Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetInternalConfig(
-    JNIEnv *env, jobject o, jlong gcs_accessor_ptr) {
-  auto *gcs_accessor =
-      reinterpret_cast<ray::gcs::GlobalStateAccessor *>(gcs_accessor_ptr);
+    JNIEnv* env, jobject o, jlong gcs_accessor_ptr) {
+  auto* gcs_accessor = reinterpret_cast<ray::gcs::GlobalStateAccessor*>(gcs_accessor_ptr);
   auto internal_config_string = gcs_accessor->GetInternalConfig();
   return static_cast<jbyteArray>(
       NativeStringToJavaByteArray(env, internal_config_string));
@@ -93,23 +87,21 @@ Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetInternalConfig(
 
 JNIEXPORT jobject JNICALL
 Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetAllActorInfo(
-    JNIEnv *env, jobject o, jlong gcs_accessor_ptr) {
-  auto *gcs_accessor =
-      reinterpret_cast<ray::gcs::GlobalStateAccessor *>(gcs_accessor_ptr);
+    JNIEnv* env, jobject o, jlong gcs_accessor_ptr) {
+  auto* gcs_accessor = reinterpret_cast<ray::gcs::GlobalStateAccessor*>(gcs_accessor_ptr);
   auto actor_info_list = gcs_accessor->GetAllActorInfo();
   return NativeVectorToJavaList<std::string>(
-      env, actor_info_list, [](JNIEnv *env, const std::string &str) {
+      env, actor_info_list, [](JNIEnv* env, const std::string& str) {
         return NativeStringToJavaByteArray(env, str);
       });
 }
 
 JNIEXPORT jbyteArray JNICALL
-Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetActorInfo(JNIEnv *env, jobject o,
+Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetActorInfo(JNIEnv* env, jobject o,
                                                                jlong gcs_accessor_ptr,
                                                                jbyteArray actorId) {
   const auto actor_id = JavaByteArrayToId<ActorID>(env, actorId);
-  auto *gcs_accessor =
-      reinterpret_cast<ray::gcs::GlobalStateAccessor *>(gcs_accessor_ptr);
+  auto* gcs_accessor = reinterpret_cast<ray::gcs::GlobalStateAccessor*>(gcs_accessor_ptr);
   auto actor_info = gcs_accessor->GetActorInfo(actor_id);
   if (actor_info) {
     return NativeStringToJavaByteArray(env, *actor_info);
@@ -119,10 +111,9 @@ Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetActorInfo(JNIEnv *env, jobj
 
 JNIEXPORT jbyteArray JNICALL
 Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetActorCheckpointId(
-    JNIEnv *env, jobject o, jlong gcs_accessor_ptr, jbyteArray actorId) {
+    JNIEnv* env, jobject o, jlong gcs_accessor_ptr, jbyteArray actorId) {
   const auto actor_id = JavaByteArrayToId<ActorID>(env, actorId);
-  auto *gcs_accessor =
-      reinterpret_cast<ray::gcs::GlobalStateAccessor *>(gcs_accessor_ptr);
+  auto* gcs_accessor = reinterpret_cast<ray::gcs::GlobalStateAccessor*>(gcs_accessor_ptr);
   auto actor_checkpoint_id = gcs_accessor->GetActorCheckpointId(actor_id);
   if (actor_checkpoint_id) {
     return NativeStringToJavaByteArray(env, *actor_checkpoint_id);

--- a/src/ray/core_worker/lib/java/io_ray_runtime_gcs_GlobalStateAccessor.h
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_gcs_GlobalStateAccessor.h
@@ -27,7 +27,7 @@ extern "C" {
  * Signature: (Ljava/lang/String;Ljava/lang/String;)J
  */
 JNIEXPORT jlong JNICALL
-Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeCreateGlobalStateAccessor(JNIEnv *,
+Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeCreateGlobalStateAccessor(JNIEnv*,
                                                                             jobject,
                                                                             jstring,
                                                                             jstring);
@@ -38,7 +38,7 @@ Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeCreateGlobalStateAccessor(JNIE
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL
-Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeDestroyGlobalStateAccessor(JNIEnv *,
+Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeDestroyGlobalStateAccessor(JNIEnv*,
                                                                              jobject,
                                                                              jlong);
 
@@ -48,7 +48,7 @@ Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeDestroyGlobalStateAccessor(JNI
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL
-Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeConnect(JNIEnv *, jobject, jlong);
+Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeConnect(JNIEnv*, jobject, jlong);
 
 /*
  * Class:     io_ray_runtime_gcs_GlobalStateAccessor
@@ -56,7 +56,7 @@ Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeConnect(JNIEnv *, jobject, jlo
  * Signature: (J)Ljava/util/List;
  */
 JNIEXPORT jobject JNICALL
-Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetAllJobInfo(JNIEnv *, jobject, jlong);
+Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetAllJobInfo(JNIEnv*, jobject, jlong);
 
 /*
  * Class:     io_ray_runtime_gcs_GlobalStateAccessor
@@ -64,8 +64,7 @@ Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetAllJobInfo(JNIEnv *, jobjec
  * Signature: (J)Ljava/util/List;
  */
 JNIEXPORT jobject JNICALL
-Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetAllNodeInfo(JNIEnv *, jobject,
-                                                                 jlong);
+Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetAllNodeInfo(JNIEnv*, jobject, jlong);
 
 /*
  * Class:     io_ray_runtime_gcs_GlobalStateAccessor
@@ -73,7 +72,7 @@ Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetAllNodeInfo(JNIEnv *, jobje
  * Signature: (J[B)[B
  */
 JNIEXPORT jbyteArray JNICALL
-Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetNodeResourceInfo(JNIEnv *, jobject,
+Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetNodeResourceInfo(JNIEnv*, jobject,
                                                                       jlong, jbyteArray);
 
 /*
@@ -82,7 +81,7 @@ Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetNodeResourceInfo(JNIEnv *, 
  * Signature: (J)[B
  */
 JNIEXPORT jbyteArray JNICALL
-Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetInternalConfig(JNIEnv *, jobject,
+Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetInternalConfig(JNIEnv*, jobject,
                                                                     jlong);
 
 /*
@@ -91,7 +90,7 @@ Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetInternalConfig(JNIEnv *, jo
  * Signature: (J)Ljava/util/List;
  */
 JNIEXPORT jobject JNICALL
-Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetAllActorInfo(JNIEnv *, jobject,
+Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetAllActorInfo(JNIEnv*, jobject,
                                                                   jlong);
 
 /*
@@ -100,7 +99,7 @@ Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetAllActorInfo(JNIEnv *, jobj
  * Signature: (J[B)[B
  */
 JNIEXPORT jbyteArray JNICALL
-Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetActorInfo(JNIEnv *, jobject, jlong,
+Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetActorInfo(JNIEnv*, jobject, jlong,
                                                                jbyteArray);
 
 /*
@@ -109,7 +108,7 @@ Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetActorInfo(JNIEnv *, jobject
  * Signature: (J[B)[B
  */
 JNIEXPORT jbyteArray JNICALL
-Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetActorCheckpointId(JNIEnv *, jobject,
+Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetActorCheckpointId(JNIEnv*, jobject,
                                                                        jlong, jbyteArray);
 
 #ifdef __cplusplus

--- a/src/ray/core_worker/lib/java/io_ray_runtime_metric_NativeMetric.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_metric_NativeMetric.cc
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 #include "io_ray_runtime_metric_NativeMetric.h"
-#include "jni_utils.h"
-#include "ray/stats/metric.h"
 
 #include <jni.h>
 
 #include <algorithm>
+
+#include "jni_utils.h"
 #include "opencensus/tags/tag_key.h"
+#include "ray/stats/metric.h"
 
 using TagKeyType = opencensus::tags::TagKey;
 using TagsType = std::vector<std::pair<opencensus::tags::TagKey, std::string>>;

--- a/src/ray/core_worker/lib/java/io_ray_runtime_metric_NativeMetric.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_metric_NativeMetric.cc
@@ -34,10 +34,10 @@ using TagsType = std::vector<std::pair<opencensus::tags::TagKey, std::string>>;
 /// \param[out] description metric description in native string.
 /// \param[out] unit metric measurement unit in native string.
 /// \param[out] tag_keys metric tag key vector unit in native vector.
-inline void MetricTransform(JNIEnv *env, jstring j_name, jstring j_description,
+inline void MetricTransform(JNIEnv* env, jstring j_name, jstring j_description,
                             jstring j_unit, jobject tag_key_list,
-                            std::string *metric_name, std::string *description,
-                            std::string *unit, std::vector<TagKeyType> &tag_keys) {
+                            std::string* metric_name, std::string* description,
+                            std::string* unit, std::vector<TagKeyType>& tag_keys) {
   *metric_name = JavaStringToNativeString(env, static_cast<jstring>(j_name));
   *description = JavaStringToNativeString(env, static_cast<jstring>(j_description));
   *unit = JavaStringToNativeString(env, static_cast<jstring>(j_unit));
@@ -48,7 +48,7 @@ inline void MetricTransform(JNIEnv *env, jstring j_name, jstring j_description,
   // item when it already exists.
   std::transform(tag_key_str_list.begin(), tag_key_str_list.end(),
                  std::back_inserter(tag_keys),
-                 [](std::string &tag_key) { return TagKeyType::Register(tag_key); });
+                 [](std::string& tag_key) { return TagKeyType::Register(tag_key); });
 }
 
 #ifdef __cplusplus
@@ -56,13 +56,13 @@ extern "C" {
 #endif
 
 JNIEXPORT void JNICALL Java_io_ray_runtime_metric_NativeMetric_registerTagkeyNative(
-    JNIEnv *env, jclass obj, jstring str) {
+    JNIEnv* env, jclass obj, jstring str) {
   std::string tag_key_name = JavaStringToNativeString(env, static_cast<jstring>(str));
   RAY_IGNORE_EXPR(TagKeyType::Register(tag_key_name));
 }
 
 JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerGaugeNative(
-    JNIEnv *env, jclass obj, jstring j_name, jstring j_description, jstring j_unit,
+    JNIEnv* env, jclass obj, jstring j_name, jstring j_description, jstring j_unit,
     jobject tag_key_list) {
   std::string metric_name;
   std::string description;
@@ -70,12 +70,12 @@ JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerGaugeNat
   std::vector<TagKeyType> tag_keys;
   MetricTransform(env, j_name, j_description, j_unit, tag_key_list, &metric_name,
                   &description, &unit, tag_keys);
-  auto *gauge = new ray::stats::Gauge(metric_name, description, unit, tag_keys);
+  auto* gauge = new ray::stats::Gauge(metric_name, description, unit, tag_keys);
   return reinterpret_cast<jlong>(gauge);
 }
 
 JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerCountNative(
-    JNIEnv *env, jclass obj, jstring j_name, jstring j_description, jstring j_unit,
+    JNIEnv* env, jclass obj, jstring j_name, jstring j_description, jstring j_unit,
     jobject tag_key_list) {
   std::string metric_name;
   std::string description;
@@ -83,12 +83,12 @@ JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerCountNat
   std::vector<TagKeyType> tag_keys;
   MetricTransform(env, j_name, j_description, j_unit, tag_key_list, &metric_name,
                   &description, &unit, tag_keys);
-  auto *count = new ray::stats::Count(metric_name, description, unit, tag_keys);
+  auto* count = new ray::stats::Count(metric_name, description, unit, tag_keys);
   return reinterpret_cast<jlong>(count);
 }
 
 JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerSumNative(
-    JNIEnv *env, jclass obj, jstring j_name, jstring j_description, jstring j_unit,
+    JNIEnv* env, jclass obj, jstring j_name, jstring j_description, jstring j_unit,
     jobject tag_key_list) {
   std::string metric_name;
   std::string description;
@@ -96,12 +96,12 @@ JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerSumNativ
   std::vector<TagKeyType> tag_keys;
   MetricTransform(env, j_name, j_description, j_unit, tag_key_list, &metric_name,
                   &description, &unit, tag_keys);
-  auto *sum = new ray::stats::Sum(metric_name, description, unit, tag_keys);
+  auto* sum = new ray::stats::Sum(metric_name, description, unit, tag_keys);
   return reinterpret_cast<jlong>(sum);
 }
 
 JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerHistogramNative(
-    JNIEnv *env, jclass obj, jstring j_name, jstring j_description, jstring j_unit,
+    JNIEnv* env, jclass obj, jstring j_name, jstring j_description, jstring j_unit,
     jdoubleArray j_boundaries, jobject tag_key_list) {
   std::string metric_name;
   std::string description;
@@ -113,23 +113,23 @@ JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerHistogra
 
   JavaDoubleArrayToNativeDoubleVector(env, j_boundaries, &boundaries);
 
-  auto *histogram =
+  auto* histogram =
       new ray::stats::Histogram(metric_name, description, unit, boundaries, tag_keys);
   return reinterpret_cast<jlong>(histogram);
 }
 
 JNIEXPORT void JNICALL Java_io_ray_runtime_metric_NativeMetric_unregisterMetricNative(
-    JNIEnv *env, jclass obj, jlong metric_native_pointer) {
-  ray::stats::Metric *metric =
-      reinterpret_cast<ray::stats::Metric *>(metric_native_pointer);
+    JNIEnv* env, jclass obj, jlong metric_native_pointer) {
+  ray::stats::Metric* metric =
+      reinterpret_cast<ray::stats::Metric*>(metric_native_pointer);
   delete metric;
 }
 
 JNIEXPORT void JNICALL Java_io_ray_runtime_metric_NativeMetric_recordNative(
-    JNIEnv *env, jclass obj, jlong metric_native_pointer, jdouble value,
+    JNIEnv* env, jclass obj, jlong metric_native_pointer, jdouble value,
     jobject tag_key_list, jobject tag_value_list) {
-  ray::stats::Metric *metric =
-      reinterpret_cast<ray::stats::Metric *>(metric_native_pointer);
+  ray::stats::Metric* metric =
+      reinterpret_cast<ray::stats::Metric*>(metric_native_pointer);
   std::vector<std::string> tag_key_str_list;
   std::vector<std::string> tag_value_str_list;
   JavaStringListToNativeStringVector(env, tag_key_list, &tag_key_str_list);

--- a/src/ray/core_worker/lib/java/io_ray_runtime_metric_NativeMetric.h
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_metric_NativeMetric.h
@@ -13,7 +13,7 @@ extern "C" {
  * Signature: (Ljava/lang/String;)V
  */
 JNIEXPORT void JNICALL
-Java_io_ray_runtime_metric_NativeMetric_registerTagkeyNative(JNIEnv *, jclass, jstring);
+Java_io_ray_runtime_metric_NativeMetric_registerTagkeyNative(JNIEnv*, jclass, jstring);
 
 /*
  * Class:     io_ray_runtime_metric_NativeMetric
@@ -21,7 +21,7 @@ Java_io_ray_runtime_metric_NativeMetric_registerTagkeyNative(JNIEnv *, jclass, j
  * Signature: (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)J
  */
 JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerCountNative(
-    JNIEnv *, jclass, jstring, jstring, jstring, jobject);
+    JNIEnv*, jclass, jstring, jstring, jstring, jobject);
 
 /*
  * Class:     io_ray_runtime_metric_NativeMetric
@@ -29,7 +29,7 @@ JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerCountNat
  * Signature: (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)J
  */
 JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerGaugeNative(
-    JNIEnv *, jclass, jstring, jstring, jstring, jobject);
+    JNIEnv*, jclass, jstring, jstring, jstring, jobject);
 
 /*
  * Class:     io_ray_runtime_metric_NativeMetric
@@ -37,7 +37,7 @@ JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerGaugeNat
  * Signature: (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[DLjava/util/List;)J
  */
 JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerHistogramNative(
-    JNIEnv *, jclass, jstring, jstring, jstring, jdoubleArray, jobject);
+    JNIEnv*, jclass, jstring, jstring, jstring, jdoubleArray, jobject);
 
 /*
  * Class:     io_ray_runtime_metric_NativeMetric
@@ -45,7 +45,7 @@ JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerHistogra
  * Signature: (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)J
  */
 JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerSumNative(
-    JNIEnv *, jclass, jstring, jstring, jstring, jobject);
+    JNIEnv*, jclass, jstring, jstring, jstring, jobject);
 
 /*
  * Class:     io_ray_runtime_metric_NativeMetric
@@ -53,7 +53,7 @@ JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerSumNativ
  * Signature: (JDLjava/util/List;Ljava/util/List;)V
  */
 JNIEXPORT void JNICALL Java_io_ray_runtime_metric_NativeMetric_recordNative(
-    JNIEnv *, jclass, jlong, jdouble, jobject, jobject);
+    JNIEnv*, jclass, jlong, jdouble, jobject, jobject);
 
 /*
  * Class:     io_ray_runtime_metric_NativeMetric
@@ -61,7 +61,7 @@ JNIEXPORT void JNICALL Java_io_ray_runtime_metric_NativeMetric_recordNative(
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL
-Java_io_ray_runtime_metric_NativeMetric_unregisterMetricNative(JNIEnv *, jclass, jlong);
+Java_io_ray_runtime_metric_NativeMetric_unregisterMetricNative(JNIEnv*, jclass, jlong);
 
 #ifdef __cplusplus
 }

--- a/src/ray/core_worker/lib/java/io_ray_runtime_object_NativeObjectStore.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_object_NativeObjectStore.cc
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #include "io_ray_runtime_object_NativeObjectStore.h"
+
 #include <jni.h>
+
 #include "jni_utils.h"
 #include "ray/common/id.h"
 #include "ray/core_worker/common.h"

--- a/src/ray/core_worker/lib/java/io_ray_runtime_object_NativeObjectStore.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_object_NativeObjectStore.cc
@@ -21,8 +21,8 @@
 #include "ray/core_worker/common.h"
 #include "ray/core_worker/core_worker.h"
 
-ray::Status PutSerializedObject(JNIEnv *env, jobject obj, ray::ObjectID object_id,
-                                ray::ObjectID *out_object_id, bool pin_object = true) {
+ray::Status PutSerializedObject(JNIEnv* env, jobject obj, ray::ObjectID object_id,
+                                ray::ObjectID* out_object_id, bool pin_object = true) {
   auto native_ray_object = JavaNativeRayObjectToNativeRayObject(env, obj);
   RAY_CHECK(native_ray_object != nullptr);
 
@@ -64,7 +64,7 @@ extern "C" {
 
 JNIEXPORT jbyteArray JNICALL
 Java_io_ray_runtime_object_NativeObjectStore_nativePut__Lio_ray_runtime_object_NativeRayObject_2(
-    JNIEnv *env, jclass, jobject obj) {
+    JNIEnv* env, jclass, jobject obj) {
   ray::ObjectID object_id;
   auto status = PutSerializedObject(env, obj, /*object_id=*/ray::ObjectID::Nil(),
                                     /*out_object_id=*/&object_id, /*pin_object=*/true);
@@ -74,7 +74,7 @@ Java_io_ray_runtime_object_NativeObjectStore_nativePut__Lio_ray_runtime_object_N
 
 JNIEXPORT void JNICALL
 Java_io_ray_runtime_object_NativeObjectStore_nativePut___3BLio_ray_runtime_object_NativeRayObject_2(
-    JNIEnv *env, jclass, jbyteArray objectId, jobject obj) {
+    JNIEnv* env, jclass, jbyteArray objectId, jobject obj) {
   auto object_id = JavaByteArrayToId<ray::ObjectID>(env, objectId);
   ray::ObjectID dummy_object_id;
   auto status =
@@ -84,10 +84,10 @@ Java_io_ray_runtime_object_NativeObjectStore_nativePut___3BLio_ray_runtime_objec
 }
 
 JNIEXPORT jobject JNICALL Java_io_ray_runtime_object_NativeObjectStore_nativeGet(
-    JNIEnv *env, jclass, jobject ids, jlong timeoutMs) {
+    JNIEnv* env, jclass, jobject ids, jlong timeoutMs) {
   std::vector<ray::ObjectID> object_ids;
   JavaListToNativeVector<ray::ObjectID>(
-      env, ids, &object_ids, [](JNIEnv *env, jobject id) {
+      env, ids, &object_ids, [](JNIEnv* env, jobject id) {
         return JavaByteArrayToId<ray::ObjectID>(env, static_cast<jbyteArray>(id));
       });
   std::vector<std::shared_ptr<ray::RayObject>> results;
@@ -99,17 +99,17 @@ JNIEXPORT jobject JNICALL Java_io_ray_runtime_object_NativeObjectStore_nativeGet
 }
 
 JNIEXPORT jobject JNICALL Java_io_ray_runtime_object_NativeObjectStore_nativeWait(
-    JNIEnv *env, jclass, jobject objectIds, jint numObjects, jlong timeoutMs) {
+    JNIEnv* env, jclass, jobject objectIds, jint numObjects, jlong timeoutMs) {
   std::vector<ray::ObjectID> object_ids;
   JavaListToNativeVector<ray::ObjectID>(
-      env, objectIds, &object_ids, [](JNIEnv *env, jobject id) {
+      env, objectIds, &object_ids, [](JNIEnv* env, jobject id) {
         return JavaByteArrayToId<ray::ObjectID>(env, static_cast<jbyteArray>(id));
       });
   std::vector<bool> results;
   auto status = ray::CoreWorkerProcess::GetCoreWorker().Wait(
       object_ids, (int)numObjects, (int64_t)timeoutMs, &results);
   THROW_EXCEPTION_AND_RETURN_IF_NOT_OK(env, status, nullptr);
-  return NativeVectorToJavaList<bool>(env, results, [](JNIEnv *env, const bool &item) {
+  return NativeVectorToJavaList<bool>(env, results, [](JNIEnv* env, const bool& item) {
     jobject java_item =
         env->NewObject(java_boolean_class, java_boolean_init, (jboolean)item);
     RAY_CHECK_JAVA_EXCEPTION(env);
@@ -118,11 +118,11 @@ JNIEXPORT jobject JNICALL Java_io_ray_runtime_object_NativeObjectStore_nativeWai
 }
 
 JNIEXPORT void JNICALL Java_io_ray_runtime_object_NativeObjectStore_nativeDelete(
-    JNIEnv *env, jclass, jobject objectIds, jboolean localOnly,
+    JNIEnv* env, jclass, jobject objectIds, jboolean localOnly,
     jboolean deleteCreatingTasks) {
   std::vector<ray::ObjectID> object_ids;
   JavaListToNativeVector<ray::ObjectID>(
-      env, objectIds, &object_ids, [](JNIEnv *env, jobject id) {
+      env, objectIds, &object_ids, [](JNIEnv* env, jobject id) {
         return JavaByteArrayToId<ray::ObjectID>(env, static_cast<jbyteArray>(id));
       });
   auto status = ray::CoreWorkerProcess::GetCoreWorker().Delete(
@@ -132,7 +132,7 @@ JNIEXPORT void JNICALL Java_io_ray_runtime_object_NativeObjectStore_nativeDelete
 
 JNIEXPORT void JNICALL
 Java_io_ray_runtime_object_NativeObjectStore_nativeAddLocalReference(
-    JNIEnv *env, jclass, jbyteArray workerId, jbyteArray objectId) {
+    JNIEnv* env, jclass, jbyteArray workerId, jbyteArray objectId) {
   auto worker_id = JavaByteArrayToId<ray::WorkerID>(env, workerId);
   auto object_id = JavaByteArrayToId<ray::ObjectID>(env, objectId);
   auto core_worker = ray::CoreWorkerProcess::TryGetWorker(worker_id);
@@ -142,7 +142,7 @@ Java_io_ray_runtime_object_NativeObjectStore_nativeAddLocalReference(
 
 JNIEXPORT void JNICALL
 Java_io_ray_runtime_object_NativeObjectStore_nativeRemoveLocalReference(
-    JNIEnv *env, jclass, jbyteArray workerId, jbyteArray objectId) {
+    JNIEnv* env, jclass, jbyteArray workerId, jbyteArray objectId) {
   auto worker_id = JavaByteArrayToId<ray::WorkerID>(env, workerId);
   auto object_id = JavaByteArrayToId<ray::ObjectID>(env, objectId);
   // We can't control the timing of Java GC, so it's normal that this method is called but
@@ -155,17 +155,17 @@ Java_io_ray_runtime_object_NativeObjectStore_nativeRemoveLocalReference(
 }
 
 JNIEXPORT jobject JNICALL
-Java_io_ray_runtime_object_NativeObjectStore_nativeGetAllReferenceCounts(JNIEnv *env,
+Java_io_ray_runtime_object_NativeObjectStore_nativeGetAllReferenceCounts(JNIEnv* env,
                                                                          jclass) {
   auto reference_counts = ray::CoreWorkerProcess::GetCoreWorker().GetAllReferenceCounts();
   return NativeMapToJavaMap<ray::ObjectID, std::pair<size_t, size_t>>(
       env, reference_counts,
-      [](JNIEnv *env, const ray::ObjectID &key) {
+      [](JNIEnv* env, const ray::ObjectID& key) {
         return IdToJavaByteArray<ObjectID>(env, key);
       },
-      [](JNIEnv *env, const std::pair<size_t, size_t> &value) {
+      [](JNIEnv* env, const std::pair<size_t, size_t>& value) {
         jlongArray array = env->NewLongArray(2);
-        jlong *elements = env->GetLongArrayElements(array, nullptr);
+        jlong* elements = env->GetLongArrayElements(array, nullptr);
         elements[0] = static_cast<jlong>(value.first);
         elements[1] = static_cast<jlong>(value.second);
         env->ReleaseLongArrayElements(array, elements, 0);

--- a/src/ray/core_worker/lib/java/io_ray_runtime_object_NativeObjectStore.h
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_object_NativeObjectStore.h
@@ -28,7 +28,7 @@ extern "C" {
  */
 JNIEXPORT jbyteArray JNICALL
 Java_io_ray_runtime_object_NativeObjectStore_nativePut__Lio_ray_runtime_object_NativeRayObject_2(
-    JNIEnv *, jclass, jobject);
+    JNIEnv*, jclass, jobject);
 
 /*
  * Class:     io_ray_runtime_object_NativeObjectStore
@@ -37,14 +37,14 @@ Java_io_ray_runtime_object_NativeObjectStore_nativePut__Lio_ray_runtime_object_N
  */
 JNIEXPORT void JNICALL
 Java_io_ray_runtime_object_NativeObjectStore_nativePut___3BLio_ray_runtime_object_NativeRayObject_2(
-    JNIEnv *, jclass, jbyteArray, jobject);
+    JNIEnv*, jclass, jbyteArray, jobject);
 
 /*
  * Class:     io_ray_runtime_object_NativeObjectStore
  * Method:    nativeGet
  * Signature: (Ljava/util/List;J)Ljava/util/List;
  */
-JNIEXPORT jobject JNICALL Java_io_ray_runtime_object_NativeObjectStore_nativeGet(JNIEnv *,
+JNIEXPORT jobject JNICALL Java_io_ray_runtime_object_NativeObjectStore_nativeGet(JNIEnv*,
                                                                                  jclass,
                                                                                  jobject,
                                                                                  jlong);
@@ -55,7 +55,7 @@ JNIEXPORT jobject JNICALL Java_io_ray_runtime_object_NativeObjectStore_nativeGet
  * Signature: (Ljava/util/List;IJ)Ljava/util/List;
  */
 JNIEXPORT jobject JNICALL Java_io_ray_runtime_object_NativeObjectStore_nativeWait(
-    JNIEnv *, jclass, jobject, jint, jlong);
+    JNIEnv*, jclass, jobject, jint, jlong);
 
 /*
  * Class:     io_ray_runtime_object_NativeObjectStore
@@ -63,7 +63,7 @@ JNIEXPORT jobject JNICALL Java_io_ray_runtime_object_NativeObjectStore_nativeWai
  * Signature: (Ljava/util/List;ZZ)V
  */
 JNIEXPORT void JNICALL Java_io_ray_runtime_object_NativeObjectStore_nativeDelete(
-    JNIEnv *, jclass, jobject, jboolean, jboolean);
+    JNIEnv*, jclass, jobject, jboolean, jboolean);
 
 /*
  * Class:     io_ray_runtime_object_NativeObjectStore
@@ -71,7 +71,7 @@ JNIEXPORT void JNICALL Java_io_ray_runtime_object_NativeObjectStore_nativeDelete
  * Signature: ([B)V
  */
 JNIEXPORT void JNICALL
-Java_io_ray_runtime_object_NativeObjectStore_nativeAddLocalReference(JNIEnv *, jclass,
+Java_io_ray_runtime_object_NativeObjectStore_nativeAddLocalReference(JNIEnv*, jclass,
                                                                      jbyteArray,
                                                                      jbyteArray);
 
@@ -81,7 +81,7 @@ Java_io_ray_runtime_object_NativeObjectStore_nativeAddLocalReference(JNIEnv *, j
  * Signature: ([B)V
  */
 JNIEXPORT void JNICALL
-Java_io_ray_runtime_object_NativeObjectStore_nativeRemoveLocalReference(JNIEnv *, jclass,
+Java_io_ray_runtime_object_NativeObjectStore_nativeRemoveLocalReference(JNIEnv*, jclass,
                                                                         jbyteArray,
                                                                         jbyteArray);
 
@@ -91,8 +91,7 @@ Java_io_ray_runtime_object_NativeObjectStore_nativeRemoveLocalReference(JNIEnv *
  * Signature: ()Ljava/util/Map;
  */
 JNIEXPORT jobject JNICALL
-Java_io_ray_runtime_object_NativeObjectStore_nativeGetAllReferenceCounts(JNIEnv *,
-                                                                         jclass);
+Java_io_ray_runtime_object_NativeObjectStore_nativeGetAllReferenceCounts(JNIEnv*, jclass);
 
 #ifdef __cplusplus
 }

--- a/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskExecutor.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskExecutor.cc
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 #include "io_ray_runtime_task_NativeTaskExecutor.h"
+
 #include <jni.h>
+
+#include "jni_utils.h"
 #include "ray/common/id.h"
 #include "ray/core_worker/common.h"
 #include "ray/core_worker/core_worker.h"
-#include "jni_utils.h"
 #include "ray/raylet_client/raylet_client.h"
 
 #ifdef __cplusplus

--- a/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskExecutor.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskExecutor.cc
@@ -29,24 +29,24 @@ extern "C" {
 using ray::ClientID;
 
 JNIEXPORT jbyteArray JNICALL
-Java_io_ray_runtime_task_NativeTaskExecutor_nativePrepareCheckpoint(JNIEnv *env, jclass) {
-  auto &core_worker = ray::CoreWorkerProcess::GetCoreWorker();
-  const auto &actor_id = core_worker.GetWorkerContext().GetCurrentActorID();
-  const auto &task_spec = core_worker.GetWorkerContext().GetCurrentTask();
+Java_io_ray_runtime_task_NativeTaskExecutor_nativePrepareCheckpoint(JNIEnv* env, jclass) {
+  auto& core_worker = ray::CoreWorkerProcess::GetCoreWorker();
+  const auto& actor_id = core_worker.GetWorkerContext().GetCurrentActorID();
+  const auto& task_spec = core_worker.GetWorkerContext().GetCurrentTask();
   RAY_CHECK(task_spec->IsActorTask());
   ActorCheckpointID checkpoint_id;
   auto status = core_worker.PrepareActorCheckpoint(actor_id, &checkpoint_id);
   THROW_EXCEPTION_AND_RETURN_IF_NOT_OK(env, status, nullptr);
   jbyteArray result = env->NewByteArray(checkpoint_id.Size());
   env->SetByteArrayRegion(result, 0, checkpoint_id.Size(),
-                          reinterpret_cast<const jbyte *>(checkpoint_id.Data()));
+                          reinterpret_cast<const jbyte*>(checkpoint_id.Data()));
   return result;
 }
 
 JNIEXPORT void JNICALL
 Java_io_ray_runtime_task_NativeTaskExecutor_nativeNotifyActorResumedFromCheckpoint(
-    JNIEnv *env, jclass, jbyteArray checkpointId) {
-  const auto &actor_id =
+    JNIEnv* env, jclass, jbyteArray checkpointId) {
+  const auto& actor_id =
       ray::CoreWorkerProcess::GetCoreWorker().GetWorkerContext().GetCurrentActorID();
   const auto checkpoint_id = JavaByteArrayToId<ActorCheckpointID>(env, checkpointId);
   auto status = ray::CoreWorkerProcess::GetCoreWorker().NotifyActorResumedFromCheckpoint(

--- a/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskExecutor.h
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskExecutor.h
@@ -29,7 +29,7 @@ extern "C" {
  * Signature: ()[B
  */
 JNIEXPORT jbyteArray JNICALL
-Java_io_ray_runtime_task_NativeTaskExecutor_nativePrepareCheckpoint(JNIEnv *, jclass);
+Java_io_ray_runtime_task_NativeTaskExecutor_nativePrepareCheckpoint(JNIEnv*, jclass);
 
 /*
  * Class:     io_ray_runtime_task_NativeTaskExecutor
@@ -38,7 +38,7 @@ Java_io_ray_runtime_task_NativeTaskExecutor_nativePrepareCheckpoint(JNIEnv *, jc
  */
 JNIEXPORT void JNICALL
 Java_io_ray_runtime_task_NativeTaskExecutor_nativeNotifyActorResumedFromCheckpoint(
-    JNIEnv *, jclass, jbyteArray);
+    JNIEnv*, jclass, jbyteArray);
 
 #ifdef __cplusplus
 }

--- a/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskSubmitter.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskSubmitter.cc
@@ -25,10 +25,10 @@
 thread_local std::unordered_map<jint, std::vector<std::pair<jobject, ray::RayFunction>>>
     submitter_function_descriptor_cache;
 
-inline const ray::RayFunction &ToRayFunction(JNIEnv *env, jobject functionDescriptor,
+inline const ray::RayFunction& ToRayFunction(JNIEnv* env, jobject functionDescriptor,
                                              jint hash) {
-  auto &fd_vector = submitter_function_descriptor_cache[hash];
-  for (auto &pair : fd_vector) {
+  auto& fd_vector = submitter_function_descriptor_cache[hash];
+  for (auto& pair : fd_vector) {
     if (env->CallBooleanMethod(pair.first, java_object_equals, functionDescriptor)) {
       return pair.second;
     }
@@ -52,10 +52,10 @@ inline const ray::RayFunction &ToRayFunction(JNIEnv *env, jobject functionDescri
   return fd_vector.back().second;
 }
 
-inline std::vector<std::unique_ptr<ray::TaskArg>> ToTaskArgs(JNIEnv *env, jobject args) {
+inline std::vector<std::unique_ptr<ray::TaskArg>> ToTaskArgs(JNIEnv* env, jobject args) {
   std::vector<std::unique_ptr<ray::TaskArg>> task_args;
   JavaListToNativeVector<std::unique_ptr<ray::TaskArg>>(
-      env, args, &task_args, [](JNIEnv *env, jobject arg) {
+      env, args, &task_args, [](JNIEnv* env, jobject arg) {
         auto java_id = env->GetObjectField(arg, java_function_arg_id);
         if (java_id) {
           auto java_id_bytes = static_cast<jbyteArray>(
@@ -74,21 +74,21 @@ inline std::vector<std::unique_ptr<ray::TaskArg>> ToTaskArgs(JNIEnv *env, jobjec
   return task_args;
 }
 
-inline std::unordered_map<std::string, double> ToResources(JNIEnv *env,
+inline std::unordered_map<std::string, double> ToResources(JNIEnv* env,
                                                            jobject java_resources) {
   return JavaMapToNativeMap<std::string, double>(
       env, java_resources,
-      [](JNIEnv *env, jobject java_key) {
+      [](JNIEnv* env, jobject java_key) {
         return JavaStringToNativeString(env, (jstring)java_key);
       },
-      [](JNIEnv *env, jobject java_value) {
+      [](JNIEnv* env, jobject java_value) {
         double value = env->CallDoubleMethod(java_value, java_double_double_value);
         RAY_CHECK_JAVA_EXCEPTION(env);
         return value;
       });
 }
 
-inline ray::TaskOptions ToTaskOptions(JNIEnv *env, jint numReturns, jobject callOptions) {
+inline ray::TaskOptions ToTaskOptions(JNIEnv* env, jint numReturns, jobject callOptions) {
   std::unordered_map<std::string, double> resources;
   if (callOptions) {
     jobject java_resources =
@@ -100,7 +100,7 @@ inline ray::TaskOptions ToTaskOptions(JNIEnv *env, jint numReturns, jobject call
   return task_options;
 }
 
-inline ray::ActorCreationOptions ToActorCreationOptions(JNIEnv *env,
+inline ray::ActorCreationOptions ToActorCreationOptions(JNIEnv* env,
                                                         jobject actorCreationOptions) {
   bool global = false;
   std::string name = "";
@@ -165,16 +165,16 @@ inline ray::PlacementStrategy ConvertStrategy(jint java_strategy) {
 }
 
 inline ray::PlacementGroupCreationOptions ToPlacementGroupCreationOptions(
-    JNIEnv *env, jobject java_bundles, jint java_strategy) {
+    JNIEnv* env, jobject java_bundles, jint java_strategy) {
   std::vector<std::unordered_map<std::string, double>> bundles;
   JavaListToNativeVector<std::unordered_map<std::string, double>>(
-      env, java_bundles, &bundles, [](JNIEnv *env, jobject java_bundle) {
+      env, java_bundles, &bundles, [](JNIEnv* env, jobject java_bundle) {
         return JavaMapToNativeMap<std::string, double>(
             env, java_bundle,
-            [](JNIEnv *env, jobject java_key) {
+            [](JNIEnv* env, jobject java_key) {
               return JavaStringToNativeString(env, (jstring)java_key);
             },
-            [](JNIEnv *env, jobject java_value) {
+            [](JNIEnv* env, jobject java_value) {
               double value = env->CallDoubleMethod(java_value, java_double_double_value);
               RAY_CHECK_JAVA_EXCEPTION(env);
               return value;
@@ -188,9 +188,9 @@ extern "C" {
 #endif
 
 JNIEXPORT jobject JNICALL Java_io_ray_runtime_task_NativeTaskSubmitter_nativeSubmitTask(
-    JNIEnv *env, jclass p, jobject functionDescriptor, jint functionDescriptorHash,
+    JNIEnv* env, jclass p, jobject functionDescriptor, jint functionDescriptorHash,
     jobject args, jint numReturns, jobject callOptions) {
-  const auto &ray_function =
+  const auto& ray_function =
       ToRayFunction(env, functionDescriptor, functionDescriptorHash);
   auto task_args = ToTaskArgs(env, args);
   auto task_options = ToTaskOptions(env, numReturns, callOptions);
@@ -211,9 +211,9 @@ JNIEXPORT jobject JNICALL Java_io_ray_runtime_task_NativeTaskSubmitter_nativeSub
 
 JNIEXPORT jbyteArray JNICALL
 Java_io_ray_runtime_task_NativeTaskSubmitter_nativeCreateActor(
-    JNIEnv *env, jclass p, jobject functionDescriptor, jint functionDescriptorHash,
+    JNIEnv* env, jclass p, jobject functionDescriptor, jint functionDescriptorHash,
     jobject args, jobject actorCreationOptions) {
-  const auto &ray_function =
+  const auto& ray_function =
       ToRayFunction(env, functionDescriptor, functionDescriptorHash);
   auto task_args = ToTaskArgs(env, args);
   auto actor_creation_options = ToActorCreationOptions(env, actorCreationOptions);
@@ -229,10 +229,10 @@ Java_io_ray_runtime_task_NativeTaskSubmitter_nativeCreateActor(
 
 JNIEXPORT jobject JNICALL
 Java_io_ray_runtime_task_NativeTaskSubmitter_nativeSubmitActorTask(
-    JNIEnv *env, jclass p, jbyteArray actorId, jobject functionDescriptor,
+    JNIEnv* env, jclass p, jbyteArray actorId, jobject functionDescriptor,
     jint functionDescriptorHash, jobject args, jint numReturns, jobject callOptions) {
   auto actor_id = JavaByteArrayToId<ray::ActorID>(env, actorId);
-  const auto &ray_function =
+  const auto& ray_function =
       ToRayFunction(env, functionDescriptor, functionDescriptorHash);
   auto task_args = ToTaskArgs(env, args);
   auto task_options = ToTaskOptions(env, numReturns, callOptions);
@@ -250,7 +250,7 @@ Java_io_ray_runtime_task_NativeTaskSubmitter_nativeSubmitActorTask(
 }
 
 JNIEXPORT jbyteArray JNICALL
-Java_io_ray_runtime_task_NativeTaskSubmitter_nativeCreatePlacementGroup(JNIEnv *env,
+Java_io_ray_runtime_task_NativeTaskSubmitter_nativeCreatePlacementGroup(JNIEnv* env,
                                                                         jclass,
                                                                         jobject bundles,
                                                                         jint strategy) {

--- a/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskSubmitter.h
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskSubmitter.h
@@ -28,7 +28,7 @@ extern "C" {
  * (Lio/ray/runtime/functionmanager/FunctionDescriptor;ILjava/util/List;ILio/ray/api/options/CallOptions;)Ljava/util/List;
  */
 JNIEXPORT jobject JNICALL Java_io_ray_runtime_task_NativeTaskSubmitter_nativeSubmitTask(
-    JNIEnv *, jclass, jobject, jint, jobject, jint, jobject);
+    JNIEnv*, jclass, jobject, jint, jobject, jint, jobject);
 
 /*
  * Class:     io_ray_runtime_task_NativeTaskSubmitter
@@ -37,7 +37,7 @@ JNIEXPORT jobject JNICALL Java_io_ray_runtime_task_NativeTaskSubmitter_nativeSub
  * (Lio/ray/runtime/functionmanager/FunctionDescriptor;ILjava/util/List;Lio/ray/api/options/ActorCreationOptions;)[B
  */
 JNIEXPORT jbyteArray JNICALL
-Java_io_ray_runtime_task_NativeTaskSubmitter_nativeCreateActor(JNIEnv *, jclass, jobject,
+Java_io_ray_runtime_task_NativeTaskSubmitter_nativeCreateActor(JNIEnv*, jclass, jobject,
                                                                jint, jobject, jobject);
 
 /*
@@ -47,7 +47,7 @@ Java_io_ray_runtime_task_NativeTaskSubmitter_nativeCreateActor(JNIEnv *, jclass,
  * ([BLio/ray/runtime/functionmanager/FunctionDescriptor;ILjava/util/List;ILio/ray/api/options/CallOptions;)Ljava/util/List;
  */
 JNIEXPORT jobject JNICALL
-Java_io_ray_runtime_task_NativeTaskSubmitter_nativeSubmitActorTask(JNIEnv *, jclass,
+Java_io_ray_runtime_task_NativeTaskSubmitter_nativeSubmitActorTask(JNIEnv*, jclass,
                                                                    jbyteArray, jobject,
                                                                    jint, jobject, jint,
                                                                    jobject);
@@ -58,7 +58,7 @@ Java_io_ray_runtime_task_NativeTaskSubmitter_nativeSubmitActorTask(JNIEnv *, jcl
  * Signature: (Ljava/util/List;I)[B
  */
 JNIEXPORT jbyteArray JNICALL
-Java_io_ray_runtime_task_NativeTaskSubmitter_nativeCreatePlacementGroup(JNIEnv *, jclass,
+Java_io_ray_runtime_task_NativeTaskSubmitter_nativeCreatePlacementGroup(JNIEnv*, jclass,
                                                                         jobject, jint);
 
 #ifdef __cplusplus

--- a/src/ray/core_worker/lib/java/jni_init.cc
+++ b/src/ray/core_worker/lib/java/jni_init.cc
@@ -102,9 +102,9 @@ jmethodID java_task_executor_execute;
 jclass java_placement_group_class;
 jfieldID java_placement_group_id;
 
-JavaVM *jvm;
+JavaVM* jvm;
 
-inline jclass LoadClass(JNIEnv *env, const char *class_name) {
+inline jclass LoadClass(JNIEnv* env, const char* class_name) {
   jclass tempLocalClassRef = env->FindClass(class_name);
   jclass ret = (jclass)env->NewGlobalRef(tempLocalClassRef);
   RAY_CHECK(ret) << "Can't load Java class " << class_name;
@@ -113,9 +113,9 @@ inline jclass LoadClass(JNIEnv *env, const char *class_name) {
 }
 
 /// Load and cache frequently-used Java classes and methods
-jint JNI_OnLoad(JavaVM *vm, void *reserved) {
-  JNIEnv *env;
-  if (vm->GetEnv(reinterpret_cast<void **>(&env), CURRENT_JNI_VERSION) != JNI_OK) {
+jint JNI_OnLoad(JavaVM* vm, void* reserved) {
+  JNIEnv* env;
+  if (vm->GetEnv(reinterpret_cast<void**>(&env), CURRENT_JNI_VERSION) != JNI_OK) {
     return JNI_ERR;
   }
 
@@ -249,9 +249,9 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved) {
 }
 
 /// Unload java classes
-void JNI_OnUnload(JavaVM *vm, void *reserved) {
-  JNIEnv *env;
-  vm->GetEnv(reinterpret_cast<void **>(&env), CURRENT_JNI_VERSION);
+void JNI_OnUnload(JavaVM* vm, void* reserved) {
+  JNIEnv* env;
+  vm->GetEnv(reinterpret_cast<void**>(&env), CURRENT_JNI_VERSION);
 
   env->DeleteGlobalRef(java_boolean_class);
   env->DeleteGlobalRef(java_double_class);

--- a/src/ray/core_worker/lib/java/jni_utils.h
+++ b/src/ray/core_worker/lib/java/jni_utils.h
@@ -179,7 +179,7 @@ extern jfieldID java_placement_group_id;
 
 #define CURRENT_JNI_VERSION JNI_VERSION_1_8
 
-extern JavaVM *jvm;
+extern JavaVM* jvm;
 
 /// Throws a Java RayException if the status is not OK.
 #define THROW_EXCEPTION_AND_RETURN_IF_NOT_OK(env, status, ret)               \
@@ -218,12 +218,12 @@ extern JavaVM *jvm;
 /// NOTE: Instances of this class cannot be used across threads.
 class JavaByteArrayBuffer : public ray::Buffer {
  public:
-  JavaByteArrayBuffer(JNIEnv *env, jbyteArray java_byte_array)
+  JavaByteArrayBuffer(JNIEnv* env, jbyteArray java_byte_array)
       : env_(env), java_byte_array_(java_byte_array) {
     native_bytes_ = env_->GetByteArrayElements(java_byte_array_, nullptr);
   }
 
-  uint8_t *Data() const override { return reinterpret_cast<uint8_t *>(native_bytes_); }
+  uint8_t* Data() const override { return reinterpret_cast<uint8_t*>(native_bytes_); }
 
   size_t Size() const override { return env_->GetArrayLength(java_byte_array_); }
 
@@ -237,47 +237,47 @@ class JavaByteArrayBuffer : public ray::Buffer {
   }
 
  private:
-  JNIEnv *env_;
+  JNIEnv* env_;
   jbyteArray java_byte_array_;
-  jbyte *native_bytes_;
+  jbyte* native_bytes_;
 };
 
 /// Convert a Java byte array to a C++ UniqueID.
 template <typename ID>
-inline ID JavaByteArrayToId(JNIEnv *env, const jbyteArray &bytes) {
+inline ID JavaByteArrayToId(JNIEnv* env, const jbyteArray& bytes) {
   std::string id_str(ID::Size(), 0);
   env->GetByteArrayRegion(bytes, 0, ID::Size(),
-                          reinterpret_cast<jbyte *>(&id_str.front()));
+                          reinterpret_cast<jbyte*>(&id_str.front()));
   return ID::FromBinary(id_str);
 }
 
 /// Convert C++ UniqueID to a Java byte array.
 template <typename ID>
-inline jbyteArray IdToJavaByteArray(JNIEnv *env, const ID &id) {
+inline jbyteArray IdToJavaByteArray(JNIEnv* env, const ID& id) {
   jbyteArray array = env->NewByteArray(ID::Size());
   env->SetByteArrayRegion(array, 0, ID::Size(),
-                          reinterpret_cast<const jbyte *>(id.Data()));
+                          reinterpret_cast<const jbyte*>(id.Data()));
   return array;
 }
 
 /// Convert C++ UniqueID to a Java ByteBuffer.
 template <typename ID>
-inline jobject IdToJavaByteBuffer(JNIEnv *env, const ID &id) {
+inline jobject IdToJavaByteBuffer(JNIEnv* env, const ID& id) {
   return env->NewDirectByteBuffer(
-      reinterpret_cast<void *>(const_cast<uint8_t *>(id.Data())), id.Size());
+      reinterpret_cast<void*>(const_cast<uint8_t*>(id.Data())), id.Size());
 }
 
 /// Convert C++ String to a Java ByteArray.
-inline jbyteArray NativeStringToJavaByteArray(JNIEnv *env, const std::string &str) {
+inline jbyteArray NativeStringToJavaByteArray(JNIEnv* env, const std::string& str) {
   jbyteArray array = env->NewByteArray(str.size());
   env->SetByteArrayRegion(array, 0, str.size(),
-                          reinterpret_cast<const jbyte *>(str.c_str()));
+                          reinterpret_cast<const jbyte*>(str.c_str()));
   return array;
 }
 
 /// Convert a Java String to C++ std::string.
-inline std::string JavaStringToNativeString(JNIEnv *env, jstring jstr) {
-  const char *c_str = env->GetStringUTFChars(jstr, nullptr);
+inline std::string JavaStringToNativeString(JNIEnv* env, jstring jstr) {
+  const char* c_str = env->GetStringUTFChars(jstr, nullptr);
   std::string result(c_str);
   env->ReleaseStringUTFChars(static_cast<jstring>(jstr), c_str);
   return result;
@@ -286,8 +286,8 @@ inline std::string JavaStringToNativeString(JNIEnv *env, jstring jstr) {
 /// Convert a Java List to C++ std::vector.
 template <typename NativeT>
 inline void JavaListToNativeVector(
-    JNIEnv *env, jobject java_list, std::vector<NativeT> *native_vector,
-    std::function<NativeT(JNIEnv *, jobject)> element_converter) {
+    JNIEnv* env, jobject java_list, std::vector<NativeT>* native_vector,
+    std::function<NativeT(JNIEnv*, jobject)> element_converter) {
   int size = env->CallIntMethod(java_list, java_list_size);
   RAY_CHECK_JAVA_EXCEPTION(env);
   native_vector->clear();
@@ -300,18 +300,18 @@ inline void JavaListToNativeVector(
 }
 
 /// Convert a Java List<String> to C++ std::vector<std::string>.
-inline void JavaStringListToNativeStringVector(JNIEnv *env, jobject java_list,
-                                               std::vector<std::string> *native_vector) {
+inline void JavaStringListToNativeStringVector(JNIEnv* env, jobject java_list,
+                                               std::vector<std::string>* native_vector) {
   JavaListToNativeVector<std::string>(
-      env, java_list, native_vector, [](JNIEnv *env, jobject jstr) {
+      env, java_list, native_vector, [](JNIEnv* env, jobject jstr) {
         return JavaStringToNativeString(env, static_cast<jstring>(jstr));
       });
 }
 
 /// Convert a Java long array to C++ std::vector<long>.
-inline void JavaLongArrayToNativeLongVector(JNIEnv *env, jlongArray long_array,
-                                            std::vector<long> *native_vector) {
-  jlong *long_array_ptr = env->GetLongArrayElements(long_array, nullptr);
+inline void JavaLongArrayToNativeLongVector(JNIEnv* env, jlongArray long_array,
+                                            std::vector<long>* native_vector) {
+  jlong* long_array_ptr = env->GetLongArrayElements(long_array, nullptr);
   jsize vec_size = env->GetArrayLength(long_array);
   for (int i = 0; i < vec_size; ++i) {
     native_vector->push_back(static_cast<long>(long_array_ptr[i]));
@@ -320,9 +320,9 @@ inline void JavaLongArrayToNativeLongVector(JNIEnv *env, jlongArray long_array,
 }
 
 /// Convert a Java double array to C++ std::vector<double>.
-inline void JavaDoubleArrayToNativeDoubleVector(JNIEnv *env, jdoubleArray double_array,
-                                                std::vector<double> *native_vector) {
-  jdouble *double_array_ptr = env->GetDoubleArrayElements(double_array, nullptr);
+inline void JavaDoubleArrayToNativeDoubleVector(JNIEnv* env, jdoubleArray double_array,
+                                                std::vector<double>* native_vector) {
+  jdouble* double_array_ptr = env->GetDoubleArrayElements(double_array, nullptr);
   jsize vec_size = env->GetArrayLength(double_array);
   for (int i = 0; i < vec_size; ++i) {
     native_vector->push_back(static_cast<double>(double_array_ptr[i]));
@@ -333,13 +333,13 @@ inline void JavaDoubleArrayToNativeDoubleVector(JNIEnv *env, jdoubleArray double
 /// Convert a C++ std::vector to a Java List.
 template <typename NativeT>
 inline jobject NativeVectorToJavaList(
-    JNIEnv *env, const std::vector<NativeT> &native_vector,
-    std::function<jobject(JNIEnv *, const NativeT &)> element_converter) {
+    JNIEnv* env, const std::vector<NativeT>& native_vector,
+    std::function<jobject(JNIEnv*, const NativeT&)> element_converter) {
   jobject java_list =
       env->NewObject(java_array_list_class, java_array_list_init_with_capacity,
                      (jint)native_vector.size());
   RAY_CHECK_JAVA_EXCEPTION(env);
-  for (const auto &item : native_vector) {
+  for (const auto& item : native_vector) {
     auto element = element_converter(env, item);
     env->CallVoidMethod(java_list, java_list_add, element);
     RAY_CHECK_JAVA_EXCEPTION(env);
@@ -350,16 +350,16 @@ inline jobject NativeVectorToJavaList(
 
 /// Convert a C++ std::vector<std::string> to a Java List<String>
 inline jobject NativeStringVectorToJavaStringList(
-    JNIEnv *env, const std::vector<std::string> &native_vector) {
+    JNIEnv* env, const std::vector<std::string>& native_vector) {
   return NativeVectorToJavaList<std::string>(
       env, native_vector,
-      [](JNIEnv *env, const std::string &str) { return env->NewStringUTF(str.c_str()); });
+      [](JNIEnv* env, const std::string& str) { return env->NewStringUTF(str.c_str()); });
 }
 
 template <typename ID>
-inline jobject NativeIdVectorToJavaByteArrayList(JNIEnv *env,
-                                                 const std::vector<ID> &native_vector) {
-  return NativeVectorToJavaList<ID>(env, native_vector, [](JNIEnv *env, const ID &id) {
+inline jobject NativeIdVectorToJavaByteArrayList(JNIEnv* env,
+                                                 const std::vector<ID>& native_vector) {
+  return NativeVectorToJavaList<ID>(env, native_vector, [](JNIEnv* env, const ID& id) {
     return IdToJavaByteArray<ID>(env, id);
   });
 }
@@ -367,9 +367,9 @@ inline jobject NativeIdVectorToJavaByteArrayList(JNIEnv *env,
 /// Convert a Java Map<?, ?> to a C++ std::unordered_map<?, ?>
 template <typename key_type, typename value_type>
 inline std::unordered_map<key_type, value_type> JavaMapToNativeMap(
-    JNIEnv *env, jobject java_map,
-    const std::function<key_type(JNIEnv *, jobject)> &key_converter,
-    const std::function<value_type(JNIEnv *, jobject)> &value_converter) {
+    JNIEnv* env, jobject java_map,
+    const std::function<key_type(JNIEnv*, jobject)>& key_converter,
+    const std::function<value_type(JNIEnv*, jobject)>& value_converter) {
   std::unordered_map<key_type, value_type> native_map;
   if (java_map) {
     jobject entry_set = env->CallObjectMethod(java_map, java_map_entry_set);
@@ -401,12 +401,12 @@ inline std::unordered_map<key_type, value_type> JavaMapToNativeMap(
 /// Convert a C++ std::unordered_map<?, ?> to a Java Map<?, ?>
 template <typename key_type, typename value_type>
 inline jobject NativeMapToJavaMap(
-    JNIEnv *env, const std::unordered_map<key_type, value_type> &native_map,
-    const std::function<jobject(JNIEnv *, const key_type &)> &key_converter,
-    const std::function<jobject(JNIEnv *, const value_type &)> &value_converter) {
+    JNIEnv* env, const std::unordered_map<key_type, value_type>& native_map,
+    const std::function<jobject(JNIEnv*, const key_type&)>& key_converter,
+    const std::function<jobject(JNIEnv*, const value_type&)>& value_converter) {
   jobject java_map = env->NewObject(java_hash_map_class, java_hash_map_init);
   RAY_CHECK_JAVA_EXCEPTION(env);
-  for (const auto &entry : native_map) {
+  for (const auto& entry : native_map) {
     jobject java_key = key_converter(env, entry.first);
     jobject java_value = value_converter(env, entry.second);
     env->CallObjectMethod(java_map, java_map_put, java_key, java_value);
@@ -418,7 +418,7 @@ inline jobject NativeMapToJavaMap(
 }
 
 /// Convert a C++ ray::Buffer to a Java byte array.
-inline jbyteArray NativeBufferToJavaByteArray(JNIEnv *env,
+inline jbyteArray NativeBufferToJavaByteArray(JNIEnv* env,
                                               const std::shared_ptr<ray::Buffer> buffer) {
   if (!buffer) {
     return nullptr;
@@ -426,14 +426,14 @@ inline jbyteArray NativeBufferToJavaByteArray(JNIEnv *env,
   jbyteArray java_byte_array = env->NewByteArray(buffer->Size());
   if (buffer->Size() > 0) {
     env->SetByteArrayRegion(java_byte_array, 0, buffer->Size(),
-                            reinterpret_cast<const jbyte *>(buffer->Data()));
+                            reinterpret_cast<const jbyte*>(buffer->Data()));
   }
   return java_byte_array;
 }
 
 /// Convert a Java byte[] as a C++ std::shared_ptr<JavaByteArrayBuffer>.
 inline std::shared_ptr<JavaByteArrayBuffer> JavaByteArrayToNativeBuffer(
-    JNIEnv *env, const jbyteArray &javaByteArray) {
+    JNIEnv* env, const jbyteArray& javaByteArray) {
   if (!javaByteArray) {
     return nullptr;
   }
@@ -443,7 +443,7 @@ inline std::shared_ptr<JavaByteArrayBuffer> JavaByteArrayToNativeBuffer(
 /// Convert a Java NativeRayObject to a C++ ray::RayObject.
 /// NOTE: the returned ray::RayObject cannot be used across threads.
 inline std::shared_ptr<ray::RayObject> JavaNativeRayObjectToNativeRayObject(
-    JNIEnv *env, const jobject &java_obj) {
+    JNIEnv* env, const jobject& java_obj) {
   if (!java_obj) {
     return nullptr;
   }
@@ -464,7 +464,7 @@ inline std::shared_ptr<ray::RayObject> JavaNativeRayObjectToNativeRayObject(
       env->GetObjectField(java_obj, java_native_ray_object_contained_object_ids);
   std::vector<ray::ObjectID> contained_object_ids;
   JavaListToNativeVector<ray::ObjectID>(
-      env, java_contained_ids, &contained_object_ids, [](JNIEnv *env, jobject id) {
+      env, java_contained_ids, &contained_object_ids, [](JNIEnv* env, jobject id) {
         return JavaByteArrayToId<ray::ObjectID>(env, static_cast<jbyteArray>(id));
       });
   return std::make_shared<ray::RayObject>(data_buffer, metadata_buffer,
@@ -473,7 +473,7 @@ inline std::shared_ptr<ray::RayObject> JavaNativeRayObjectToNativeRayObject(
 
 /// Convert a C++ ray::RayObject to a Java NativeRayObject.
 inline jobject NativeRayObjectToJavaNativeRayObject(
-    JNIEnv *env, const std::shared_ptr<ray::RayObject> &rayObject) {
+    JNIEnv* env, const std::shared_ptr<ray::RayObject>& rayObject) {
   if (!rayObject) {
     return nullptr;
   }
@@ -489,7 +489,7 @@ inline jobject NativeRayObjectToJavaNativeRayObject(
 
 // TODO(po): Convert C++ ray::FunctionDescriptor to Java FunctionDescriptor
 inline jobject NativeRayFunctionDescriptorToJavaStringList(
-    JNIEnv *env, const ray::FunctionDescriptor &function_descriptor) {
+    JNIEnv* env, const ray::FunctionDescriptor& function_descriptor) {
   if (function_descriptor->Type() ==
       ray::FunctionDescriptorType::kJavaFunctionDescriptor) {
     auto typed_descriptor = function_descriptor->As<ray::JavaFunctionDescriptor>();

--- a/src/ray/core_worker/lib/java/jni_utils.h
+++ b/src/ray/core_worker/lib/java/jni_utils.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <jni.h>
+
 #include <algorithm>
 
 #include "ray/common/buffer.h"

--- a/src/ray/core_worker/object_recovery_manager.cc
+++ b/src/ray/core_worker/object_recovery_manager.cc
@@ -18,7 +18,7 @@
 
 namespace ray {
 
-Status ObjectRecoveryManager::RecoverObject(const ObjectID &object_id) {
+Status ObjectRecoveryManager::RecoverObject(const ObjectID& object_id) {
   // Check the ReferenceCounter to see if there is a location for the object.
   bool pinned = false;
   bool owned_by_us = reference_counter_->IsPlasmaObjectPinned(object_id, &pinned);
@@ -49,7 +49,7 @@ Status ObjectRecoveryManager::RecoverObject(const ObjectID &object_id) {
     // Lookup the object in the GCS to find another copy.
     RAY_RETURN_NOT_OK(object_lookup_(
         object_id,
-        [this](const ObjectID &object_id, const std::vector<rpc::Address> &locations) {
+        [this](const ObjectID& object_id, const std::vector<rpc::Address>& locations) {
           PinOrReconstructObject(object_id, locations);
         }));
   } else {
@@ -59,7 +59,7 @@ Status ObjectRecoveryManager::RecoverObject(const ObjectID &object_id) {
 }
 
 void ObjectRecoveryManager::PinOrReconstructObject(
-    const ObjectID &object_id, const std::vector<rpc::Address> &locations) {
+    const ObjectID& object_id, const std::vector<rpc::Address>& locations) {
   RAY_LOG(INFO) << "Lost object " << object_id << " has " << locations.size()
                 << " locations";
   if (!locations.empty()) {
@@ -76,8 +76,8 @@ void ObjectRecoveryManager::PinOrReconstructObject(
 }
 
 void ObjectRecoveryManager::PinExistingObjectCopy(
-    const ObjectID &object_id, const rpc::Address &raylet_address,
-    const std::vector<rpc::Address> &other_locations) {
+    const ObjectID& object_id, const rpc::Address& raylet_address,
+    const std::vector<rpc::Address>& other_locations) {
   // If a copy still exists, pin the object by sending a
   // PinObjectIDs RPC.
   const auto node_id = ClientID::FromBinary(raylet_address.raylet_id());
@@ -102,7 +102,7 @@ void ObjectRecoveryManager::PinExistingObjectCopy(
 
   client->PinObjectIDs(rpc_address_, {object_id},
                        [this, object_id, other_locations, node_id](
-                           const Status &status, const rpc::PinObjectIDsReply &reply) {
+                           const Status& status, const rpc::PinObjectIDsReply& reply) {
                          if (status.ok()) {
                            // TODO(swang): Make sure that the node is still alive when
                            // marking the object as pinned.
@@ -118,7 +118,7 @@ void ObjectRecoveryManager::PinExistingObjectCopy(
                        });
 }
 
-void ObjectRecoveryManager::ReconstructObject(const ObjectID &object_id) {
+void ObjectRecoveryManager::ReconstructObject(const ObjectID& object_id) {
   // Notify the task manager that we are retrying the task that created this
   // object.
   const auto task_id = object_id.TaskId();
@@ -127,7 +127,7 @@ void ObjectRecoveryManager::ReconstructObject(const ObjectID &object_id) {
 
   if (status.ok()) {
     // Try to recover the task's dependencies.
-    for (const auto &dep : task_deps) {
+    for (const auto& dep : task_deps) {
       auto status = RecoverObject(dep);
       if (!status.ok()) {
         RAY_LOG(INFO) << "Failed to reconstruct object " << dep << ": "

--- a/src/ray/core_worker/object_recovery_manager.h
+++ b/src/ray/core_worker/object_recovery_manager.h
@@ -24,26 +24,26 @@
 
 namespace ray {
 
-typedef std::function<std::shared_ptr<PinObjectsInterface>(const std::string &ip_address,
+typedef std::function<std::shared_ptr<PinObjectsInterface>(const std::string& ip_address,
                                                            int port)>
     ObjectPinningClientFactoryFn;
 
-typedef std::function<void(const ObjectID &object_id,
-                           const std::vector<rpc::Address> &raylet_locations)>
+typedef std::function<void(const ObjectID& object_id,
+                           const std::vector<rpc::Address>& raylet_locations)>
     ObjectLookupCallback;
 
 class ObjectRecoveryManager {
  public:
-  ObjectRecoveryManager(const rpc::Address &rpc_address,
+  ObjectRecoveryManager(const rpc::Address& rpc_address,
                         ObjectPinningClientFactoryFn client_factory,
                         std::shared_ptr<PinObjectsInterface> local_object_pinning_client,
-                        std::function<Status(const ObjectID &object_id,
-                                             const ObjectLookupCallback &callback)>
+                        std::function<Status(const ObjectID& object_id,
+                                             const ObjectLookupCallback& callback)>
                             object_lookup,
                         std::shared_ptr<TaskResubmissionInterface> task_resubmitter,
                         std::shared_ptr<ReferenceCounter> reference_counter,
                         std::shared_ptr<CoreWorkerMemoryStore> in_memory_store,
-                        std::function<void(const ObjectID &object_id, bool pin_object)>
+                        std::function<void(const ObjectID& object_id, bool pin_object)>
                             reconstruction_failure_callback,
                         bool lineage_reconstruction_enabled)
       : task_resubmitter_(task_resubmitter),
@@ -83,23 +83,23 @@ class ObjectRecoveryManager {
   /// if the object is not recoverable because we do not own it. Note that the
   /// Status::OK value only indicates that the recovery operation has started,
   /// but does not guarantee that the recovery operation is successful.
-  Status RecoverObject(const ObjectID &object_id);
+  Status RecoverObject(const ObjectID& object_id);
 
  private:
   /// Pin a new copy for a lost object from the given locations or, if that
   /// fails, attempt to reconstruct it by resubmitting the task that created
   /// the object.
-  void PinOrReconstructObject(const ObjectID &object_id,
-                              const std::vector<rpc::Address> &locations);
+  void PinOrReconstructObject(const ObjectID& object_id,
+                              const std::vector<rpc::Address>& locations);
 
   /// Pin a new copy for the object at the given location. If that fails, then
   /// try one of the other locations.
-  void PinExistingObjectCopy(const ObjectID &object_id,
-                             const rpc::Address &raylet_address,
-                             const std::vector<rpc::Address> &other_locations);
+  void PinExistingObjectCopy(const ObjectID& object_id,
+                             const rpc::Address& raylet_address,
+                             const std::vector<rpc::Address>& other_locations);
 
   /// Reconstruct an object by resubmitting the task that created it.
-  void ReconstructObject(const ObjectID &object_id);
+  void ReconstructObject(const ObjectID& object_id);
 
   /// Used to resubmit tasks.
   std::shared_ptr<TaskResubmissionInterface> task_resubmitter_;
@@ -117,15 +117,15 @@ class ObjectRecoveryManager {
   std::shared_ptr<PinObjectsInterface> local_object_pinning_client_;
 
   /// Function to lookup an object's locations from the global database.
-  const std::function<Status(const ObjectID &object_id,
-                             const ObjectLookupCallback &callback)>
+  const std::function<Status(const ObjectID& object_id,
+                             const ObjectLookupCallback& callback)>
       object_lookup_;
 
   /// Used to store object values (InPlasmaError) if recovery succeeds.
   std::shared_ptr<CoreWorkerMemoryStore> in_memory_store_;
 
   /// Callback to call if recovery fails.
-  const std::function<void(const ObjectID &object_id, bool pin_object)>
+  const std::function<void(const ObjectID& object_id, bool pin_object)>
       reconstruction_failure_callback_;
 
   /// Whether lineage reconstruction is enabled. If disabled, then we will try

--- a/src/ray/core_worker/profiling.cc
+++ b/src/ray/core_worker/profiling.cc
@@ -20,16 +20,16 @@ namespace ray {
 
 namespace worker {
 
-ProfileEvent::ProfileEvent(const std::shared_ptr<Profiler> &profiler,
-                           const std::string &event_type)
+ProfileEvent::ProfileEvent(const std::shared_ptr<Profiler>& profiler,
+                           const std::string& event_type)
     : profiler_(profiler) {
   rpc_event_.set_event_type(event_type);
   rpc_event_.set_start_time(absl::GetCurrentTimeNanos() / 1e9);
 }
 
-Profiler::Profiler(WorkerContext &worker_context, const std::string &node_ip_address,
-                   boost::asio::io_service &io_service,
-                   const std::shared_ptr<gcs::GcsClient> &gcs_client)
+Profiler::Profiler(WorkerContext& worker_context, const std::string& node_ip_address,
+                   boost::asio::io_service& io_service,
+                   const std::shared_ptr<gcs::GcsClient>& gcs_client)
     : io_service_(io_service),
       timer_(io_service_, boost::asio::chrono::seconds(1)),
       rpc_profile_data_(new rpc::ProfileTableData()),
@@ -40,7 +40,7 @@ Profiler::Profiler(WorkerContext &worker_context, const std::string &node_ip_add
   timer_.async_wait(boost::bind(&Profiler::FlushEvents, this));
 }
 
-void Profiler::AddEvent(const rpc::ProfileTableData::ProfileEvent &event) {
+void Profiler::AddEvent(const rpc::ProfileTableData::ProfileEvent& event) {
   absl::MutexLock lock(&mutex_);
   rpc_profile_data_->add_profile_events()->CopyFrom(event);
 }

--- a/src/ray/core_worker/profiling.h
+++ b/src/ray/core_worker/profiling.h
@@ -26,12 +26,12 @@ namespace worker {
 
 class Profiler {
  public:
-  Profiler(WorkerContext &worker_context, const std::string &node_ip_address,
-           boost::asio::io_service &io_service,
-           const std::shared_ptr<gcs::GcsClient> &gcs_client);
+  Profiler(WorkerContext& worker_context, const std::string& node_ip_address,
+           boost::asio::io_service& io_service,
+           const std::shared_ptr<gcs::GcsClient>& gcs_client);
 
   // Add an event to the queue to be flushed periodically.
-  void AddEvent(const rpc::ProfileTableData::ProfileEvent &event) LOCKS_EXCLUDED(mutex_);
+  void AddEvent(const rpc::ProfileTableData::ProfileEvent& event) LOCKS_EXCLUDED(mutex_);
 
  private:
   // Flush all of the events that have been added since last flush to the GCS.
@@ -41,7 +41,7 @@ class Profiler {
   absl::Mutex mutex_;
 
   // ASIO IO service event loop. Must be started by the caller.
-  boost::asio::io_service &io_service_;
+  boost::asio::io_service& io_service_;
 
   // Timer used to periodically flush events to the GCS.
   boost::asio::steady_timer timer_;
@@ -56,7 +56,7 @@ class Profiler {
 
 class ProfileEvent {
  public:
-  ProfileEvent(const std::shared_ptr<Profiler> &profiler, const std::string &event_type);
+  ProfileEvent(const std::shared_ptr<Profiler>& profiler, const std::string& event_type);
 
   // Set the end time for the event and add it to the profiler.
   ~ProfileEvent() {
@@ -65,7 +65,7 @@ class ProfileEvent {
   }
 
   // Set extra metadata for the event, which could change during the event.
-  void SetExtraData(const std::string &extra_data) {
+  void SetExtraData(const std::string& extra_data) {
     rpc_event_.set_extra_data(extra_data);
   }
 

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -31,20 +31,19 @@ namespace ray {
 // Interface for mocking.
 class ReferenceCounterInterface {
  public:
-  virtual void AddLocalReference(const ObjectID &object_id,
-                                 const std::string &call_site) = 0;
-  virtual bool AddBorrowedObject(const ObjectID &object_id, const ObjectID &outer_id,
-                                 const rpc::Address &owner_address) = 0;
-  virtual void AddOwnedObject(const ObjectID &object_id,
-                              const std::vector<ObjectID> &contained_ids,
-                              const rpc::Address &owner_address,
-                              const std::string &call_site, const int64_t object_size,
+  virtual void AddLocalReference(const ObjectID& object_id,
+                                 const std::string& call_site) = 0;
+  virtual bool AddBorrowedObject(const ObjectID& object_id, const ObjectID& outer_id,
+                                 const rpc::Address& owner_address) = 0;
+  virtual void AddOwnedObject(const ObjectID& object_id,
+                              const std::vector<ObjectID>& contained_ids,
+                              const rpc::Address& owner_address,
+                              const std::string& call_site, const int64_t object_size,
                               bool is_reconstructable,
-                              const absl::optional<ClientID> &pinned_at_raylet_id =
+                              const absl::optional<ClientID>& pinned_at_raylet_id =
                                   absl::optional<ClientID>()) = 0;
-  virtual bool SetDeleteCallback(
-      const ObjectID &object_id,
-      const std::function<void(const ObjectID &)> callback) = 0;
+  virtual bool SetDeleteCallback(const ObjectID& object_id,
+                                 const std::function<void(const ObjectID&)> callback) = 0;
 
   virtual ~ReferenceCounterInterface() {}
 };
@@ -55,11 +54,11 @@ class ReferenceCounter : public ReferenceCounterInterface {
  public:
   using ReferenceTableProto =
       ::google::protobuf::RepeatedPtrField<rpc::ObjectReferenceCount>;
-  using ReferenceRemovedCallback = std::function<void(const ObjectID &)>;
+  using ReferenceRemovedCallback = std::function<void(const ObjectID&)>;
   using LineageReleasedCallback =
-      std::function<void(const ObjectID &, std::vector<ObjectID> *)>;
+      std::function<void(const ObjectID&, std::vector<ObjectID>*)>;
 
-  ReferenceCounter(const rpc::WorkerAddress &rpc_address,
+  ReferenceCounter(const rpc::WorkerAddress& rpc_address,
                    bool distributed_ref_counting_enabled = true,
                    bool lineage_pinning_enabled = false,
                    rpc::ClientFactoryFn client_factory = nullptr)
@@ -80,14 +79,14 @@ class ReferenceCounter : public ReferenceCounterInterface {
   /// any owner information, since we don't know how it was created.
   ///
   /// \param[in] object_id The object to to increment the count for.
-  void AddLocalReference(const ObjectID &object_id, const std::string &call_site)
+  void AddLocalReference(const ObjectID& object_id, const std::string& call_site)
       LOCKS_EXCLUDED(mutex_);
 
   /// Decrease the local reference count for the ObjectID by one.
   ///
   /// \param[in] object_id The object to decrement the count for.
   /// \param[out] deleted List to store objects that hit zero ref count.
-  void RemoveLocalReference(const ObjectID &object_id, std::vector<ObjectID> *deleted)
+  void RemoveLocalReference(const ObjectID& object_id, std::vector<ObjectID>* deleted)
       LOCKS_EXCLUDED(mutex_);
 
   /// Add references for the provided object IDs that correspond to them being
@@ -102,16 +101,16 @@ class ReferenceCounter : public ReferenceCounterInterface {
   /// \param[out] deleted Any objects that are newly out of scope after this
   /// function call.
   void UpdateSubmittedTaskReferences(
-      const std::vector<ObjectID> &argument_ids_to_add,
-      const std::vector<ObjectID> &argument_ids_to_remove = std::vector<ObjectID>(),
-      std::vector<ObjectID> *deleted = nullptr) LOCKS_EXCLUDED(mutex_);
+      const std::vector<ObjectID>& argument_ids_to_add,
+      const std::vector<ObjectID>& argument_ids_to_remove = std::vector<ObjectID>(),
+      std::vector<ObjectID>* deleted = nullptr) LOCKS_EXCLUDED(mutex_);
 
   /// Add references for the object dependencies of a resubmitted task. This
   /// does not increment the arguments' lineage ref counts because we should
   /// have already incremented them when the task was first submitted.
   ///
   /// \param[in] argument_ids The arguments of the task to add references for.
-  void UpdateResubmittedTaskReferences(const std::vector<ObjectID> &argument_ids)
+  void UpdateResubmittedTaskReferences(const std::vector<ObjectID>& argument_ids)
       LOCKS_EXCLUDED(mutex_);
 
   /// Update object references that were given to a submitted task. The task
@@ -129,10 +128,10 @@ class ReferenceCounter : public ReferenceCounterInterface {
   /// arguments. Some references in this table may still be borrowed by the
   /// worker and/or a task that the worker submitted.
   /// \param[out] deleted The object IDs whos reference counts reached zero.
-  void UpdateFinishedTaskReferences(const std::vector<ObjectID> &argument_ids,
-                                    bool release_lineage, const rpc::Address &worker_addr,
-                                    const ReferenceTableProto &borrowed_refs,
-                                    std::vector<ObjectID> *deleted)
+  void UpdateFinishedTaskReferences(const std::vector<ObjectID>& argument_ids,
+                                    bool release_lineage, const rpc::Address& worker_addr,
+                                    const ReferenceTableProto& borrowed_refs,
+                                    std::vector<ObjectID>* deleted)
       LOCKS_EXCLUDED(mutex_);
 
   /// Release the lineage ref count for this list of object IDs. An object's
@@ -143,7 +142,7 @@ class ReferenceCounter : public ReferenceCounterInterface {
   ///
   /// \param[in] argument_ids The list of objects whose lineage ref counts we
   /// should decrement.
-  void ReleaseLineageReferences(const std::vector<ObjectID> &argument_ids)
+  void ReleaseLineageReferences(const std::vector<ObjectID>& argument_ids)
       LOCKS_EXCLUDED(mutex_);
 
   /// Add an object that we own. The object may depend on other objects.
@@ -165,17 +164,17 @@ class ReferenceCounter : public ReferenceCounterInterface {
   /// \param[in] is_reconstructable Whether the object can be reconstructed
   /// through lineage re-execution.
   void AddOwnedObject(
-      const ObjectID &object_id, const std::vector<ObjectID> &contained_ids,
-      const rpc::Address &owner_address, const std::string &call_site,
+      const ObjectID& object_id, const std::vector<ObjectID>& contained_ids,
+      const rpc::Address& owner_address, const std::string& call_site,
       const int64_t object_size, bool is_reconstructable,
-      const absl::optional<ClientID> &pinned_at_raylet_id = absl::optional<ClientID>())
+      const absl::optional<ClientID>& pinned_at_raylet_id = absl::optional<ClientID>())
       LOCKS_EXCLUDED(mutex_);
 
   /// Update the size of the object.
   ///
   /// \param[in] object_id The ID of the object.
   /// \param[in] size The known size of the object.
-  void UpdateObjectSize(const ObjectID &object_id, int64_t object_size)
+  void UpdateObjectSize(const ObjectID& object_id, int64_t object_size)
       LOCKS_EXCLUDED(mutex_);
 
   /// Add an object that we are borrowing.
@@ -187,8 +186,8 @@ class ReferenceCounter : public ReferenceCounterInterface {
   /// out-of-band.
   /// task ID (for non-actors) or the actor ID of the owner.
   /// \param[in] owner_address The owner's address.
-  bool AddBorrowedObject(const ObjectID &object_id, const ObjectID &outer_id,
-                         const rpc::Address &owner_address) LOCKS_EXCLUDED(mutex_);
+  bool AddBorrowedObject(const ObjectID& object_id, const ObjectID& outer_id,
+                         const rpc::Address& owner_address) LOCKS_EXCLUDED(mutex_);
 
   /// Get the owner address of the given object.
   ///
@@ -197,7 +196,7 @@ class ReferenceCounter : public ReferenceCounterInterface {
   /// \return false if the object is out of scope or we do not yet have
   /// ownership information. The latter can happen when object IDs are pasesd
   /// out of band.
-  bool GetOwner(const ObjectID &object_id, rpc::Address *owner_address = nullptr) const
+  bool GetOwner(const ObjectID& object_id, rpc::Address* owner_address = nullptr) const
       LOCKS_EXCLUDED(mutex_);
 
   /// Get the owner addresses of the given objects. The owner address
@@ -212,20 +211,20 @@ class ReferenceCounter : public ReferenceCounterInterface {
   ///
   /// \param[in] object_id The object to check.
   /// \return Whether the object value has been freed.
-  bool IsPlasmaObjectFreed(const ObjectID &object_id) const;
+  bool IsPlasmaObjectFreed(const ObjectID& object_id) const;
 
   /// Release the underlying value from plasma (if any) for these objects.
   ///
   /// \param[in] object_ids The IDs whose values to free.
-  void FreePlasmaObjects(const std::vector<ObjectID> &object_ids) LOCKS_EXCLUDED(mutex_);
+  void FreePlasmaObjects(const std::vector<ObjectID>& object_ids) LOCKS_EXCLUDED(mutex_);
 
   /// Sets the callback that will be run when the object goes out of scope.
   /// Returns true if the object was in scope and the callback was added, else false.
-  bool SetDeleteCallback(const ObjectID &object_id,
-                         const std::function<void(const ObjectID &)> callback)
+  bool SetDeleteCallback(const ObjectID& object_id,
+                         const std::function<void(const ObjectID&)> callback)
       LOCKS_EXCLUDED(mutex_);
 
-  void ResetDeleteCallbacks(const std::vector<ObjectID> &object_ids)
+  void ResetDeleteCallbacks(const std::vector<ObjectID>& object_ids)
       LOCKS_EXCLUDED(mutex_);
 
   /// Set a callback for when we are no longer borrowing this object (when our
@@ -239,9 +238,9 @@ class ReferenceCounter : public ReferenceCounterInterface {
   /// \param[in] owner_address The owner of object_id's address.
   /// \param[in] ref_removed_callback The callback to call when we are no
   /// longer borrowing the object.
-  void SetRefRemovedCallback(const ObjectID &object_id, const ObjectID &contained_in_id,
-                             const rpc::Address &owner_address,
-                             const ReferenceRemovedCallback &ref_removed_callback)
+  void SetRefRemovedCallback(const ObjectID& object_id, const ObjectID& contained_in_id,
+                             const rpc::Address& owner_address,
+                             const ReferenceRemovedCallback& ref_removed_callback)
       LOCKS_EXCLUDED(mutex_);
 
   /// Set a callback to call whenever a Reference that we own is deleted. A
@@ -251,7 +250,7 @@ class ReferenceCounter : public ReferenceCounterInterface {
   /// the future.
   ///
   /// \param[in] callback The callback to call.
-  void SetReleaseLineageCallback(const LineageReleasedCallback &callback);
+  void SetReleaseLineageCallback(const LineageReleasedCallback& callback);
 
   /// Respond to the object's owner once we are no longer borrowing it.  The
   /// sender is the owner of the object ID. We will send the reply when our
@@ -263,7 +262,7 @@ class ReferenceCounter : public ReferenceCounterInterface {
   /// any object IDs that were nested inside the object that we or others are
   /// now borrowing.
   /// \param[in] send_reply_callback The callback to send the reply.
-  void HandleRefRemoved(const ObjectID &object_id, rpc::WaitForRefRemovedReply *reply,
+  void HandleRefRemoved(const ObjectID& object_id, rpc::WaitForRefRemovedReply* reply,
                         rpc::SendReplyCallback send_reply_callback)
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
@@ -293,8 +292,8 @@ class ReferenceCounter : public ReferenceCounterInterface {
   /// arguments.
   /// \param[out] proto The protobuf table to populate with the borrowed
   /// references.
-  void GetAndClearLocalBorrowers(const std::vector<ObjectID> &borrowed_ids,
-                                 ReferenceTableProto *proto) LOCKS_EXCLUDED(mutex_);
+  void GetAndClearLocalBorrowers(const std::vector<ObjectID>& borrowed_ids,
+                                 ReferenceTableProto* proto) LOCKS_EXCLUDED(mutex_);
 
   /// Mark that this ObjectID contains another ObjectID(s). This should be
   /// called in two cases:
@@ -312,15 +311,15 @@ class ReferenceCounter : public ReferenceCounterInterface {
   /// outer object ID is not owned by us, then this is used to contact the
   /// outer object's owner, since it is considered a borrower for the inner
   /// IDs.
-  void AddNestedObjectIds(const ObjectID &object_id,
-                          const std::vector<ObjectID> &inner_ids,
-                          const rpc::WorkerAddress &owner_address) LOCKS_EXCLUDED(mutex_);
+  void AddNestedObjectIds(const ObjectID& object_id,
+                          const std::vector<ObjectID>& inner_ids,
+                          const rpc::WorkerAddress& owner_address) LOCKS_EXCLUDED(mutex_);
 
   /// Update the pinned location of an object stored in plasma.
   ///
   /// \param[in] object_id The object to update.
   /// \param[in] raylet_id The raylet that is now pinning the object ID.
-  void UpdateObjectPinnedAtRaylet(const ObjectID &object_id, const ClientID &raylet_id)
+  void UpdateObjectPinnedAtRaylet(const ObjectID& object_id, const ClientID& raylet_id)
       LOCKS_EXCLUDED(mutex_);
 
   /// Check whether the object is pinned at a remote plasma store node.
@@ -331,7 +330,7 @@ class ReferenceCounter : public ReferenceCounterInterface {
   /// \return True if the object exists and is owned by us, false otherwise. We
   /// return false here because a borrower should not know the pinned location
   /// for an object.
-  bool IsPlasmaObjectPinned(const ObjectID &object_id, bool *pinned) const
+  bool IsPlasmaObjectPinned(const ObjectID& object_id, bool* pinned) const
       LOCKS_EXCLUDED(mutex_);
 
   /// Get and reset the objects that were pinned on the given node.  This
@@ -341,20 +340,20 @@ class ReferenceCounter : public ReferenceCounterInterface {
   ///
   /// \param[in] node_id The node whose object store has been removed.
   /// \return The set of objects that were pinned on the given node.
-  std::vector<ObjectID> ResetObjectsOnRemovedNode(const ClientID &raylet_id);
+  std::vector<ObjectID> ResetObjectsOnRemovedNode(const ClientID& raylet_id);
 
   /// Whether we have a reference to a particular ObjectID.
   ///
   /// \param[in] object_id The object ID to check for.
   /// \return Whether we have a reference to the object ID.
-  bool HasReference(const ObjectID &object_id) const LOCKS_EXCLUDED(mutex_);
+  bool HasReference(const ObjectID& object_id) const LOCKS_EXCLUDED(mutex_);
 
   /// Write the current reference table to the given proto.
   ///
   /// \param[out] stats The proto to write references to.
   void AddObjectRefStats(
       const absl::flat_hash_map<ObjectID, std::pair<int64_t, std::string>> pinned_objects,
-      rpc::CoreWorkerStats *stats) const LOCKS_EXCLUDED(mutex_);
+      rpc::CoreWorkerStats* stats) const LOCKS_EXCLUDED(mutex_);
 
  private:
   struct Reference {
@@ -363,9 +362,9 @@ class ReferenceCounter : public ReferenceCounterInterface {
     Reference(std::string call_site, const int64_t object_size)
         : call_site(call_site), object_size(object_size) {}
     /// Constructor for a reference that we created.
-    Reference(const rpc::Address &owner_address, std::string call_site,
+    Reference(const rpc::Address& owner_address, std::string call_site,
               const int64_t object_size, bool is_reconstructable,
-              const absl::optional<ClientID> &pinned_at_raylet_id)
+              const absl::optional<ClientID>& pinned_at_raylet_id)
         : call_site(call_site),
           object_size(object_size),
           owned_by_us(true),
@@ -375,9 +374,9 @@ class ReferenceCounter : public ReferenceCounterInterface {
 
     /// Constructor from a protobuf. This is assumed to be a message from
     /// another process, so the object defaults to not being owned by us.
-    static Reference FromProto(const rpc::ObjectReferenceCount &ref_count);
+    static Reference FromProto(const rpc::ObjectReferenceCount& ref_count);
     /// Serialize to a protobuf.
-    void ToProto(rpc::ObjectReferenceCount *ref) const;
+    void ToProto(rpc::ObjectReferenceCount* ref) const;
 
     /// The reference count. This number includes:
     /// - Python references to the ObjectID.
@@ -507,16 +506,16 @@ class ReferenceCounter : public ReferenceCounterInterface {
 
     /// Callback that will be called when this ObjectID no longer has
     /// references.
-    std::function<void(const ObjectID &)> on_delete;
+    std::function<void(const ObjectID&)> on_delete;
     /// Callback that is called when this process is no longer a borrower
     /// (RefCount() == 0).
-    std::function<void(const ObjectID &)> on_ref_removed;
+    std::function<void(const ObjectID&)> on_ref_removed;
   };
 
   using ReferenceTable = absl::flat_hash_map<ObjectID, Reference>;
 
-  bool GetOwnerInternal(const ObjectID &object_id,
-                        rpc::Address *owner_address = nullptr) const
+  bool GetOwnerInternal(const ObjectID& object_id,
+                        rpc::Address* owner_address = nullptr) const
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Release the pinned plasma object, if any. Also unsets the raylet address
@@ -528,18 +527,18 @@ class ReferenceCounter : public ReferenceCounterInterface {
   void ShutdownIfNeeded() EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Deserialize a ReferenceTable.
-  static ReferenceTable ReferenceTableFromProto(const ReferenceTableProto &proto);
+  static ReferenceTable ReferenceTableFromProto(const ReferenceTableProto& proto);
 
   /// Serialize a ReferenceTable.
-  static void ReferenceTableToProto(const ReferenceTable &table,
-                                    ReferenceTableProto *proto);
+  static void ReferenceTableToProto(const ReferenceTable& table,
+                                    ReferenceTableProto* proto);
 
   /// Remove references for the provided object IDs that correspond to them
   /// being dependencies to a submitted task. This should be called when
   /// inlined dependencies are inlined or when the task finishes for plasma
   /// dependencies.
-  void RemoveSubmittedTaskReferences(const std::vector<ObjectID> &argument_ids,
-                                     bool release_lineage, std::vector<ObjectID> *deleted)
+  void RemoveSubmittedTaskReferences(const std::vector<ObjectID>& argument_ids,
+                                     bool release_lineage, std::vector<ObjectID>* deleted)
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Helper method to mark that this ObjectID contains another ObjectID(s).
@@ -551,9 +550,9 @@ class ReferenceCounter : public ReferenceCounterInterface {
   /// outer object ID is not owned by us, then this is used to contact the
   /// outer object's owner, since it is considered a borrower for the inner
   /// IDs.
-  void AddNestedObjectIdsInternal(const ObjectID &object_id,
-                                  const std::vector<ObjectID> &inner_ids,
-                                  const rpc::WorkerAddress &owner_address)
+  void AddNestedObjectIdsInternal(const ObjectID& object_id,
+                                  const std::vector<ObjectID>& inner_ids,
+                                  const rpc::WorkerAddress& owner_address)
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Populates the table with the ObjectID that we were or are still
@@ -575,8 +574,8 @@ class ReferenceCounter : public ReferenceCounterInterface {
   ///   that contained it. We don't need this anymore because we already marked
   ///   that the borrowed ID contained another ID in the returned
   ///   borrowed_refs.
-  bool GetAndClearLocalBorrowersInternal(const ObjectID &object_id,
-                                         ReferenceTable *borrowed_refs)
+  bool GetAndClearLocalBorrowersInternal(const ObjectID& object_id,
+                                         ReferenceTable* borrowed_refs)
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Merge remote borrowers into our local ref count. This will add any
@@ -592,9 +591,9 @@ class ReferenceCounter : public ReferenceCounterInterface {
   ///   owner.
   /// - If we are the owner of the ID, then also contact any new borrowers and
   ///   wait for them to stop using the reference.
-  void MergeRemoteBorrowers(const ObjectID &object_id,
-                            const rpc::WorkerAddress &worker_addr,
-                            const ReferenceTable &borrowed_refs)
+  void MergeRemoteBorrowers(const ObjectID& object_id,
+                            const rpc::WorkerAddress& worker_addr,
+                            const ReferenceTable& borrowed_refs)
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Wait for a borrower to stop using its reference. This should only be
@@ -605,27 +604,27 @@ class ReferenceCounter : public ReferenceCounterInterface {
   /// ID. This is used in cases where we return an object ID that we own inside
   /// an object that we do not own. Then, we must notify the owner of the outer
   /// object that they are borrowing the inner.
-  void WaitForRefRemoved(const ReferenceTable::iterator &reference_it,
-                         const rpc::WorkerAddress &addr,
-                         const ObjectID &contained_in_id = ObjectID::Nil())
+  void WaitForRefRemoved(const ReferenceTable::iterator& reference_it,
+                         const rpc::WorkerAddress& addr,
+                         const ObjectID& contained_in_id = ObjectID::Nil())
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Helper method to add an object that we are borrowing. This is used when
   /// deserializing IDs from a task's arguments, or when deserializing an ID
   /// during ray.get().
-  bool AddBorrowedObjectInternal(const ObjectID &object_id, const ObjectID &outer_id,
-                                 const rpc::Address &owner_address)
+  bool AddBorrowedObjectInternal(const ObjectID& object_id, const ObjectID& outer_id,
+                                 const rpc::Address& owner_address)
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Helper method to delete an entry from the reference map and run any necessary
   /// callbacks. Assumes that the entry is in object_id_refs_ and invalidates the
   /// iterator.
   void DeleteReferenceInternal(ReferenceTable::iterator entry,
-                               std::vector<ObjectID> *deleted)
+                               std::vector<ObjectID>* deleted)
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Helper method to decrement the lineage ref count for a list of objects.
-  void ReleaseLineageReferencesInternal(const std::vector<ObjectID> &argument_ids)
+  void ReleaseLineageReferencesInternal(const std::vector<ObjectID>& argument_ids)
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Address of our RPC server. This is used to determine whether we own a

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.h
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.h
@@ -32,7 +32,7 @@ class CoreWorkerMemoryStore {
   ///            and the `remove_after_get` flag for Get() will be ignored.
   /// \param[in] raylet_client If not null, used to notify tasks blocked / unblocked.
   CoreWorkerMemoryStore(
-      std::function<void(const RayObject &, const ObjectID &)> store_in_plasma = nullptr,
+      std::function<void(const RayObject&, const ObjectID&)> store_in_plasma = nullptr,
       std::shared_ptr<ReferenceCounter> counter = nullptr,
       std::shared_ptr<raylet::RayletClient> raylet_client = nullptr,
       std::function<Status()> check_signals = nullptr);
@@ -44,7 +44,7 @@ class CoreWorkerMemoryStore {
   /// \param[in] object_id Object ID specified by user.
   /// \return Whether the object was put into the memory store. If false, then
   /// this is because the object was promoted to and stored in plasma instead.
-  bool Put(const RayObject &object, const ObjectID &object_id);
+  bool Put(const RayObject& object, const ObjectID& object_id);
 
   /// Get a list of objects from the object store.
   ///
@@ -56,20 +56,20 @@ class CoreWorkerMemoryStore {
   /// finishes. This has no effect if ref counting is enabled.
   /// \param[out] results Result list of objects data.
   /// \return Status.
-  Status Get(const std::vector<ObjectID> &object_ids, int num_objects, int64_t timeout_ms,
-             const WorkerContext &ctx, bool remove_after_get,
-             std::vector<std::shared_ptr<RayObject>> *results);
+  Status Get(const std::vector<ObjectID>& object_ids, int num_objects, int64_t timeout_ms,
+             const WorkerContext& ctx, bool remove_after_get,
+             std::vector<std::shared_ptr<RayObject>>* results);
 
   /// Convenience wrapper around Get() that stores results in a given result map.
-  Status Get(const absl::flat_hash_set<ObjectID> &object_ids, int64_t timeout_ms,
-             const WorkerContext &ctx,
-             absl::flat_hash_map<ObjectID, std::shared_ptr<RayObject>> *results,
-             bool *got_exception);
+  Status Get(const absl::flat_hash_set<ObjectID>& object_ids, int64_t timeout_ms,
+             const WorkerContext& ctx,
+             absl::flat_hash_map<ObjectID, std::shared_ptr<RayObject>>* results,
+             bool* got_exception);
 
   /// Convenience wrapper around Get() that stores ready objects in a given result set.
-  Status Wait(const absl::flat_hash_set<ObjectID> &object_ids, int num_objects,
-              int64_t timeout_ms, const WorkerContext &ctx,
-              absl::flat_hash_set<ObjectID> *ready);
+  Status Wait(const absl::flat_hash_set<ObjectID>& object_ids, int num_objects,
+              int64_t timeout_ms, const WorkerContext& ctx,
+              absl::flat_hash_set<ObjectID>* ready);
 
   /// Asynchronously get an object from the object store. The object will not be removed
   /// from storage after GetAsync (TODO(ekl): integrate this with object GC).
@@ -77,7 +77,7 @@ class CoreWorkerMemoryStore {
   /// \param[in] object_id The object id to get.
   /// \param[in] callback The callback to run with the reference to the retrieved
   ///            object value once available.
-  void GetAsync(const ObjectID &object_id,
+  void GetAsync(const ObjectID& object_id,
                 std::function<void(std::shared_ptr<RayObject>)> callback);
 
   /// Get a single object if available. If the object is not local yet, or if the object
@@ -86,7 +86,7 @@ class CoreWorkerMemoryStore {
   ///
   /// \param[in] object_id The object id to get.
   /// \return pointer to the local object, or nullptr if promoted to plasma.
-  std::shared_ptr<RayObject> GetOrPromoteToPlasma(const ObjectID &object_id);
+  std::shared_ptr<RayObject> GetOrPromoteToPlasma(const ObjectID& object_id);
 
   /// Delete a list of objects from the object store.
   /// NOTE(swang): Objects that contain IsInPlasmaError will not be
@@ -99,14 +99,14 @@ class CoreWorkerMemoryStore {
   /// include the IDs of the plasma objects to delete, based on the
   /// in-memory objects that contained InPlasmaError.
   /// \return Void.
-  void Delete(const absl::flat_hash_set<ObjectID> &object_ids,
-              absl::flat_hash_set<ObjectID> *plasma_ids_to_delete);
+  void Delete(const absl::flat_hash_set<ObjectID>& object_ids,
+              absl::flat_hash_set<ObjectID>* plasma_ids_to_delete);
 
   /// Delete a list of objects from the object store.
   ///
   /// \param[in] object_ids IDs of the objects to delete.
   /// \return Void.
-  void Delete(const std::vector<ObjectID> &object_ids);
+  void Delete(const std::vector<ObjectID>& object_ids);
 
   /// Check whether this store contains the object.
   ///
@@ -114,7 +114,7 @@ class CoreWorkerMemoryStore {
   /// \param[out] in_plasma Set to true if the object was spilled to plasma.
   /// Will only be true if the store contains the object.
   /// \return Whether the store has the object.
-  bool Contains(const ObjectID &object_id, bool *in_plasma);
+  bool Contains(const ObjectID& object_id, bool* in_plasma);
 
   /// Returns the number of objects in this store.
   ///
@@ -138,13 +138,13 @@ class CoreWorkerMemoryStore {
   /// See the public version of `Get` for meaning of the other arguments.
   /// \param[in] abort_if_any_object_is_exception Whether we should abort if any object
   /// is an exception.
-  Status GetImpl(const std::vector<ObjectID> &object_ids, int num_objects,
-                 int64_t timeout_ms, const WorkerContext &ctx, bool remove_after_get,
-                 std::vector<std::shared_ptr<RayObject>> *results,
+  Status GetImpl(const std::vector<ObjectID>& object_ids, int num_objects,
+                 int64_t timeout_ms, const WorkerContext& ctx, bool remove_after_get,
+                 std::vector<std::shared_ptr<RayObject>>* results,
                  bool abort_if_any_object_is_exception);
 
   /// Optional callback for putting objects into the plasma store.
-  std::function<void(const RayObject &, const ObjectID &)> store_in_plasma_;
+  std::function<void(const RayObject&, const ObjectID&)> store_in_plasma_;
 
   /// If enabled, holds a reference to local worker ref counter. TODO(ekl) make this
   /// mandatory once Java is supported.

--- a/src/ray/core_worker/store_provider/plasma_store_provider.h
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.h
@@ -34,7 +34,7 @@ namespace ray {
 class CoreWorkerPlasmaStoreProvider {
  public:
   CoreWorkerPlasmaStoreProvider(
-      const std::string &store_socket,
+      const std::string& store_socket,
       const std::shared_ptr<raylet::RayletClient> raylet_client,
       const std::shared_ptr<ReferenceCounter> reference_counter,
       std::function<Status()> check_signals, bool evict_if_full,
@@ -55,7 +55,7 @@ class CoreWorkerPlasmaStoreProvider {
   /// \param[out] object_exists Optional. Returns whether an object with the
   /// same ID already exists. If this is true, then the Put does not write any
   /// object data.
-  Status Put(const RayObject &object, const ObjectID &object_id, bool *object_exists);
+  Status Put(const RayObject& object, const ObjectID& object_id, bool* object_exists);
 
   /// Create an object in plasma and return a mutable buffer to it. The buffer should be
   /// subsequently written to and then sealed using Seal().
@@ -64,8 +64,8 @@ class CoreWorkerPlasmaStoreProvider {
   /// \param[in] data_size The size of the object.
   /// \param[in] object_id The ID of the object.
   /// \param[out] data The mutable object buffer in plasma that can be written to.
-  Status Create(const std::shared_ptr<Buffer> &metadata, const size_t data_size,
-                const ObjectID &object_id, std::shared_ptr<Buffer> *data);
+  Status Create(const std::shared_ptr<Buffer>& metadata, const size_t data_size,
+                const ObjectID& object_id, std::shared_ptr<Buffer>* data);
 
   /// Seal an object buffer created with Create().
   ///
@@ -74,7 +74,7 @@ class CoreWorkerPlasmaStoreProvider {
   ///
   /// \param[in] object_id The ID of the object. This can be used as an
   /// argument to Get to retrieve the object data.
-  Status Seal(const ObjectID &object_id);
+  Status Seal(const ObjectID& object_id);
 
   /// Release the first reference to the object created by Put() or Create(). This should
   /// be called exactly once per object and until it is called, the object is pinned and
@@ -82,20 +82,20 @@ class CoreWorkerPlasmaStoreProvider {
   ///
   /// \param[in] object_id The ID of the object. This can be used as an
   /// argument to Get to retrieve the object data.
-  Status Release(const ObjectID &object_id);
+  Status Release(const ObjectID& object_id);
 
-  Status Get(const absl::flat_hash_set<ObjectID> &object_ids, int64_t timeout_ms,
-             const WorkerContext &ctx,
-             absl::flat_hash_map<ObjectID, std::shared_ptr<RayObject>> *results,
-             bool *got_exception);
+  Status Get(const absl::flat_hash_set<ObjectID>& object_ids, int64_t timeout_ms,
+             const WorkerContext& ctx,
+             absl::flat_hash_map<ObjectID, std::shared_ptr<RayObject>>* results,
+             bool* got_exception);
 
-  Status Contains(const ObjectID &object_id, bool *has_object);
+  Status Contains(const ObjectID& object_id, bool* has_object);
 
-  Status Wait(const absl::flat_hash_set<ObjectID> &object_ids, int num_objects,
-              int64_t timeout_ms, const WorkerContext &ctx,
-              absl::flat_hash_set<ObjectID> *ready);
+  Status Wait(const absl::flat_hash_set<ObjectID>& object_ids, int num_objects,
+              int64_t timeout_ms, const WorkerContext& ctx,
+              absl::flat_hash_set<ObjectID>* ready);
 
-  Status Delete(const absl::flat_hash_set<ObjectID> &object_ids, bool local_only,
+  Status Delete(const absl::flat_hash_set<ObjectID>& object_ids, bool local_only,
                 bool delete_creating_tasks);
 
   /// Lists objects in used (pinned) by the current client.
@@ -124,11 +124,11 @@ class CoreWorkerPlasmaStoreProvider {
   /// exception.
   /// \return Status.
   Status FetchAndGetFromPlasmaStore(
-      absl::flat_hash_set<ObjectID> &remaining, const std::vector<ObjectID> &batch_ids,
+      absl::flat_hash_set<ObjectID>& remaining, const std::vector<ObjectID>& batch_ids,
       int64_t timeout_ms, bool fetch_only, bool in_direct_call_task,
-      const TaskID &task_id,
-      absl::flat_hash_map<ObjectID, std::shared_ptr<RayObject>> *results,
-      bool *got_exception);
+      const TaskID& task_id,
+      absl::flat_hash_map<ObjectID, std::shared_ptr<RayObject>>* results,
+      bool* got_exception);
 
   /// Print a warning if we've attempted too many times, but some objects are still
   /// unavailable. Only the keys in the 'remaining' map are used.
@@ -136,7 +136,7 @@ class CoreWorkerPlasmaStoreProvider {
   /// \param[in] num_attemps The number of attempted times.
   /// \param[in] remaining The remaining objects.
   static void WarnIfAttemptedTooManyTimes(int num_attempts,
-                                          const absl::flat_hash_set<ObjectID> &remaining);
+                                          const absl::flat_hash_set<ObjectID>& remaining);
 
   /// Put something in the plasma store so that subsequent plasma store accesses
   /// will be faster. Currently the first access is always slow, and we don't
@@ -164,7 +164,7 @@ class CoreWorkerPlasmaStoreProvider {
     // automatically removed from this list via destructor callback. The map key uniquely
     // identifies a buffer. It should not be a shared ptr since that would keep the Buffer
     // alive forever (i.e., this is a weak ref map).
-    absl::flat_hash_map<std::pair<ObjectID, PlasmaBuffer *>, std::string> active_buffers_
+    absl::flat_hash_map<std::pair<ObjectID, PlasmaBuffer*>, std::string> active_buffers_
         GUARDED_BY(active_buffers_mutex_);
   };
 

--- a/src/ray/core_worker/test/actor_manager_test.cc
+++ b/src/ray/core_worker/test/actor_manager_test.cc
@@ -30,22 +30,22 @@ using ::testing::_;
 
 class MockActorInfoAccessor : public gcs::RedisActorInfoAccessor {
  public:
-  MockActorInfoAccessor(gcs::RedisGcsClient *client)
+  MockActorInfoAccessor(gcs::RedisGcsClient* client)
       : gcs::RedisActorInfoAccessor(client) {}
 
   ~MockActorInfoAccessor() {}
 
   ray::Status AsyncSubscribe(
-      const ActorID &actor_id,
-      const gcs::SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
-      const gcs::StatusCallback &done) {
+      const ActorID& actor_id,
+      const gcs::SubscribeCallback<ActorID, rpc::ActorTableData>& subscribe,
+      const gcs::StatusCallback& done) {
     auto callback_entry = std::make_pair(actor_id, subscribe);
     callback_map_.emplace(actor_id, subscribe);
     return Status::OK();
   }
 
-  bool ActorStateNotificationPublished(const ActorID &actor_id,
-                                       const gcs::ActorTableData &actor_data) {
+  bool ActorStateNotificationPublished(const ActorID& actor_id,
+                                       const gcs::ActorTableData& actor_data) {
     auto it = callback_map_.find(actor_id);
     if (it == callback_map_.end()) return false;
     auto actor_state_notification_callback = it->second;
@@ -53,7 +53,7 @@ class MockActorInfoAccessor : public gcs::RedisActorInfoAccessor {
     return true;
   }
 
-  bool CheckSubscriptionRequested(const ActorID &actor_id) {
+  bool CheckSubscriptionRequested(const ActorID& actor_id) {
     return callback_map_.find(actor_id) != callback_map_.end();
   }
 
@@ -63,9 +63,9 @@ class MockActorInfoAccessor : public gcs::RedisActorInfoAccessor {
 
 class MockGcsClient : public gcs::RedisGcsClient {
  public:
-  MockGcsClient(const gcs::GcsClientOptions &options) : gcs::RedisGcsClient(options) {}
+  MockGcsClient(const gcs::GcsClientOptions& options) : gcs::RedisGcsClient(options) {}
 
-  void Init(MockActorInfoAccessor *actor_accesor_mock) {
+  void Init(MockActorInfoAccessor* actor_accesor_mock) {
     actor_accessor_.reset(actor_accesor_mock);
   }
 
@@ -76,13 +76,13 @@ class MockDirectActorSubmitter : public CoreWorkerDirectActorTaskSubmitterInterf
  public:
   MockDirectActorSubmitter() : CoreWorkerDirectActorTaskSubmitterInterface() {}
 
-  MOCK_METHOD1(AddActorQueueIfNotExists, void(const ActorID &actor_id));
-  MOCK_METHOD3(ConnectActor, void(const ActorID &actor_id, const rpc::Address &address,
+  MOCK_METHOD1(AddActorQueueIfNotExists, void(const ActorID& actor_id));
+  MOCK_METHOD3(ConnectActor, void(const ActorID& actor_id, const rpc::Address& address,
                                   int64_t num_restarts));
   MOCK_METHOD3(DisconnectActor,
-               void(const ActorID &actor_id, int64_t num_restarts, bool dead));
+               void(const ActorID& actor_id, int64_t num_restarts, bool dead));
   MOCK_METHOD3(KillActor,
-               void(const ActorID &actor_id, bool force_kill, bool no_restart));
+               void(const ActorID& actor_id, bool force_kill, bool no_restart));
 
   virtual ~MockDirectActorSubmitter() {}
 };
@@ -92,21 +92,21 @@ class MockReferenceCounter : public ReferenceCounterInterface {
   MockReferenceCounter() : ReferenceCounterInterface() {}
 
   MOCK_METHOD2(AddLocalReference,
-               void(const ObjectID &object_id, const std::string &call_sit));
+               void(const ObjectID& object_id, const std::string& call_sit));
 
   MOCK_METHOD3(AddBorrowedObject,
-               bool(const ObjectID &object_id, const ObjectID &outer_id,
-                    const rpc::Address &owner_address));
+               bool(const ObjectID& object_id, const ObjectID& outer_id,
+                    const rpc::Address& owner_address));
 
   MOCK_METHOD7(AddOwnedObject,
-               void(const ObjectID &object_id, const std::vector<ObjectID> &contained_ids,
-                    const rpc::Address &owner_address, const std::string &call_site,
+               void(const ObjectID& object_id, const std::vector<ObjectID>& contained_ids,
+                    const rpc::Address& owner_address, const std::string& call_site,
                     const int64_t object_size, bool is_reconstructable,
-                    const absl::optional<ClientID> &pinned_at_raylet_id));
+                    const absl::optional<ClientID>& pinned_at_raylet_id));
 
   MOCK_METHOD2(SetDeleteCallback,
-               bool(const ObjectID &object_id,
-                    const std::function<void(const ObjectID &)> callback));
+               bool(const ObjectID& object_id,
+                    const std::function<void(const ObjectID&)> callback));
 
   virtual ~MockReferenceCounter() {}
 };
@@ -152,7 +152,7 @@ class ActorManagerTest : public ::testing::Test {
 
   gcs::GcsClientOptions options_;
   std::shared_ptr<MockGcsClient> gcs_client_mock_;
-  MockActorInfoAccessor *actor_info_accessor_;
+  MockActorInfoAccessor* actor_info_accessor_;
   std::shared_ptr<MockDirectActorSubmitter> direct_actor_submitter_;
   std::shared_ptr<MockReferenceCounter> reference_counter_;
   std::shared_ptr<ActorManager> actor_manager_;
@@ -186,7 +186,7 @@ TEST_F(ActorManagerTest, TestAddAndGetActorHandleEndToEnd) {
   ASSERT_FALSE(actor_manager_->AddNewActorHandle(move(actor_handle2), task_id, call_site,
                                                  caller_address, false));
   // Make sure we can get an actor handle correctly.
-  const std::unique_ptr<ActorHandle> &actor_handle_to_get =
+  const std::unique_ptr<ActorHandle>& actor_handle_to_get =
       actor_manager_->GetActorHandle(actor_id);
   ASSERT_TRUE(actor_handle_to_get->GetActorID() == actor_id);
 
@@ -233,7 +233,7 @@ TEST_F(ActorManagerTest, RegisterActorHandles) {
       std::move(actor_handle), outer_object_id, task_id, call_site, caller_address);
   ASSERT_TRUE(returned_actor_id == actor_id);
   // Let's try to get the handle and make sure it works.
-  const std::unique_ptr<ActorHandle> &actor_handle_to_get =
+  const std::unique_ptr<ActorHandle>& actor_handle_to_get =
       actor_manager_->GetActorHandle(actor_id);
   ASSERT_TRUE(actor_handle_to_get->GetActorID() == actor_id);
   ASSERT_TRUE(actor_handle_to_get->CreationJobID() == job_id);
@@ -289,7 +289,7 @@ TEST_F(ActorManagerTest, TestActorStateNotificationAlive) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -45,14 +45,14 @@ int node_manager_port = 0;
 namespace ray {
 
 static void flushall_redis(void) {
-  redisContext *context = redisConnect("127.0.0.1", 6379);
+  redisContext* context = redisConnect("127.0.0.1", 6379);
   freeReplyObject(redisCommand(context, "FLUSHALL"));
   freeReplyObject(redisCommand(context, "SET NumRedisShards 1"));
   freeReplyObject(redisCommand(context, "LPUSH RedisShards 127.0.0.1:6380"));
   redisFree(context);
 }
 
-ActorID CreateActorHelper(std::unordered_map<std::string, double> &resources,
+ActorID CreateActorHelper(std::unordered_map<std::string, double>& resources,
                           int64_t max_restarts) {
   std::unique_ptr<ActorHandle> actor_handle;
 
@@ -81,7 +81,7 @@ ActorID CreateActorHelper(std::unordered_map<std::string, double> &resources,
 
 std::string MetadataToString(std::shared_ptr<RayObject> obj) {
   auto metadata = obj->GetMetadata();
-  return std::string(reinterpret_cast<const char *>(metadata->Data()), metadata->Size());
+  return std::string(reinterpret_cast<const char*>(metadata->Data()), metadata->Size());
 }
 
 class CoreWorkerTest : public ::testing::Test {
@@ -100,7 +100,7 @@ class CoreWorkerTest : public ::testing::Test {
     }
 
     // start plasma store.
-    for (auto &store_socket : raylet_store_socket_names_) {
+    for (auto& store_socket : raylet_store_socket_names_) {
       store_socket = TestSetupUtil::StartObjectStore();
     }
 
@@ -117,11 +117,11 @@ class CoreWorkerTest : public ::testing::Test {
   }
 
   ~CoreWorkerTest() {
-    for (const auto &raylet_socket_name : raylet_socket_names_) {
+    for (const auto& raylet_socket_name : raylet_socket_names_) {
       TestSetupUtil::StopRaylet(raylet_socket_name);
     }
 
-    for (const auto &store_socket_name : raylet_store_socket_names_) {
+    for (const auto& store_socket_name : raylet_store_socket_names_) {
       TestSetupUtil::StopObjectStore(store_socket_name);
     }
 
@@ -175,28 +175,28 @@ class CoreWorkerTest : public ::testing::Test {
   }
 
   // Test normal tasks.
-  void TestNormalTask(std::unordered_map<std::string, double> &resources);
+  void TestNormalTask(std::unordered_map<std::string, double>& resources);
 
   // Test actor tasks.
-  void TestActorTask(std::unordered_map<std::string, double> &resources);
+  void TestActorTask(std::unordered_map<std::string, double>& resources);
 
   // Test actor failure case, verify that the tasks would either succeed or
   // fail with exceptions, in that case the return objects fetched from `Get`
   // contain errors.
-  void TestActorFailure(std::unordered_map<std::string, double> &resources);
+  void TestActorFailure(std::unordered_map<std::string, double>& resources);
 
   // Test actor failover case. Verify that actor can be reconstructed successfully,
   // and as long as we wait for actor reconstruction before submitting new tasks,
   // it is guaranteed that all tasks are successfully completed.
-  void TestActorRestart(std::unordered_map<std::string, double> &resources);
+  void TestActorRestart(std::unordered_map<std::string, double>& resources);
 
  protected:
-  bool WaitForDirectCallActorState(const ActorID &actor_id, bool wait_alive,
+  bool WaitForDirectCallActorState(const ActorID& actor_id, bool wait_alive,
                                    int timeout_ms);
 
   // Get the pid for the worker process that runs the actor.
-  int GetActorPid(const ActorID &actor_id,
-                  std::unordered_map<std::string, double> &resources);
+  int GetActorPid(const ActorID& actor_id,
+                  std::unordered_map<std::string, double>& resources);
 
   int num_nodes_;
   std::vector<std::string> raylet_socket_names_;
@@ -205,7 +205,7 @@ class CoreWorkerTest : public ::testing::Test {
   std::string gcs_server_socket_name_;
 };
 
-bool CoreWorkerTest::WaitForDirectCallActorState(const ActorID &actor_id, bool wait_alive,
+bool CoreWorkerTest::WaitForDirectCallActorState(const ActorID& actor_id, bool wait_alive,
                                                  int timeout_ms) {
   auto condition_func = [actor_id, wait_alive]() -> bool {
     bool actor_alive =
@@ -217,8 +217,8 @@ bool CoreWorkerTest::WaitForDirectCallActorState(const ActorID &actor_id, bool w
   return WaitForCondition(condition_func, timeout_ms);
 }
 
-int CoreWorkerTest::GetActorPid(const ActorID &actor_id,
-                                std::unordered_map<std::string, double> &resources) {
+int CoreWorkerTest::GetActorPid(const ActorID& actor_id,
+                                std::unordered_map<std::string, double>& resources) {
   std::vector<std::unique_ptr<TaskArg>> args;
   TaskOptions options{1, resources};
   std::vector<ObjectID> return_ids;
@@ -236,13 +236,13 @@ int CoreWorkerTest::GetActorPid(const ActorID &actor_id,
     return -1;
   }
 
-  auto data = reinterpret_cast<char *>(results[0]->GetData()->Data());
+  auto data = reinterpret_cast<char*>(results[0]->GetData()->Data());
   std::string pid_string(data, results[0]->GetData()->Size());
   return std::stoi(pid_string);
 }
 
-void CoreWorkerTest::TestNormalTask(std::unordered_map<std::string, double> &resources) {
-  auto &driver = CoreWorkerProcess::GetCoreWorker();
+void CoreWorkerTest::TestNormalTask(std::unordered_map<std::string, double>& resources) {
+  auto& driver = CoreWorkerProcess::GetCoreWorker();
 
   // Test for tasks with by-value and by-ref args.
   {
@@ -283,8 +283,8 @@ void CoreWorkerTest::TestNormalTask(std::unordered_map<std::string, double> &res
   }
 }
 
-void CoreWorkerTest::TestActorTask(std::unordered_map<std::string, double> &resources) {
-  auto &driver = CoreWorkerProcess::GetCoreWorker();
+void CoreWorkerTest::TestActorTask(std::unordered_map<std::string, double>& resources) {
+  auto& driver = CoreWorkerProcess::GetCoreWorker();
 
   auto actor_id = CreateActorHelper(resources, 1000);
 
@@ -366,8 +366,8 @@ void CoreWorkerTest::TestActorTask(std::unordered_map<std::string, double> &reso
 }
 
 void CoreWorkerTest::TestActorRestart(
-    std::unordered_map<std::string, double> &resources) {
-  auto &driver = CoreWorkerProcess::GetCoreWorker();
+    std::unordered_map<std::string, double>& resources) {
+  auto& driver = CoreWorkerProcess::GetCoreWorker();
 
   // creating actor.
   auto actor_id = CreateActorHelper(resources, 1000);
@@ -425,8 +425,8 @@ void CoreWorkerTest::TestActorRestart(
 }
 
 void CoreWorkerTest::TestActorFailure(
-    std::unordered_map<std::string, double> &resources) {
-  auto &driver = CoreWorkerProcess::GetCoreWorker();
+    std::unordered_map<std::string, double>& resources) {
+  auto& driver = CoreWorkerProcess::GetCoreWorker();
 
   // creating actor.
   auto actor_id = CreateActorHelper(resources, 0 /* not reconstructable */);
@@ -462,7 +462,7 @@ void CoreWorkerTest::TestActorFailure(
     }
 
     for (int i = 0; i < num_tasks; i++) {
-      const auto &entry = all_results[i];
+      const auto& entry = all_results[i];
       std::vector<ObjectID> return_ids;
       return_ids.push_back(entry.first);
       std::vector<std::shared_ptr<RayObject>> results;
@@ -543,7 +543,7 @@ TEST_F(ZeroNodeTest, TestTaskSpecPerf) {
                               function.GetFunctionDescriptor(), job_id, RandomTaskId(), 0,
                               RandomTaskId(), address, num_returns, resources, resources);
     // Set task arguments.
-    for (const auto &arg : args) {
+    for (const auto& arg : args) {
       builder.AddArg(*arg);
     }
 
@@ -560,7 +560,7 @@ TEST_F(ZeroNodeTest, TestTaskSpecPerf) {
 }
 
 TEST_F(SingleNodeTest, TestDirectActorTaskSubmissionPerf) {
-  auto &driver = CoreWorkerProcess::GetCoreWorker();
+  auto& driver = CoreWorkerProcess::GetCoreWorker();
   std::vector<ObjectID> object_ids;
   // Create an actor.
   std::unordered_map<std::string, double> resources;
@@ -576,7 +576,7 @@ TEST_F(SingleNodeTest, TestDirectActorTaskSubmissionPerf) {
     // Create arguments with PassByValue.
     std::vector<std::unique_ptr<TaskArg>> args;
     int64_t array[] = {SHOULD_CHECK_MESSAGE_ORDER, i};
-    auto buffer = std::make_shared<LocalMemoryBuffer>(reinterpret_cast<uint8_t *>(array),
+    auto buffer = std::make_shared<LocalMemoryBuffer>(reinterpret_cast<uint8_t*>(array),
                                                       sizeof(array));
     args.emplace_back(new TaskArgByValue(
         std::make_shared<RayObject>(buffer, nullptr, std::vector<ObjectID>())));
@@ -593,7 +593,7 @@ TEST_F(SingleNodeTest, TestDirectActorTaskSubmissionPerf) {
   RAY_LOG(INFO) << "finish submitting " << num_tasks << " tasks"
                 << ", which takes " << current_time_ms() - start_ms << " ms";
 
-  for (const auto &object_id : object_ids) {
+  for (const auto& object_id : object_ids) {
     std::vector<std::shared_ptr<RayObject>> results;
     RAY_CHECK_OK(driver.Get({object_id}, -1, &results));
     ASSERT_EQ(results.size(), 1);
@@ -648,7 +648,7 @@ TEST_F(SingleNodeTest, TestMemoryStoreProvider) {
   std::shared_ptr<CoreWorkerMemoryStore> provider_ptr =
       std::make_shared<CoreWorkerMemoryStore>();
 
-  auto &provider = *provider_ptr;
+  auto& provider = *provider_ptr;
 
   uint8_t array1[] = {1, 2, 3, 4, 5, 6, 7, 8};
   uint8_t array2[] = {10, 11, 12, 13, 14, 15};
@@ -692,7 +692,7 @@ TEST_F(SingleNodeTest, TestMemoryStoreProvider) {
   ASSERT_TRUE(!got_exception);
   ASSERT_EQ(results.size(), ids.size());
   for (size_t i = 0; i < ids.size(); i++) {
-    const auto &expected = buffers[i];
+    const auto& expected = buffers[i];
     ASSERT_EQ(results[ids[i]]->GetData()->Size(), expected.GetData()->Size());
     ASSERT_EQ(memcmp(results[ids[i]]->GetData()->Data(), expected.GetData()->Data(),
                      expected.GetData()->Size()),
@@ -743,10 +743,10 @@ TEST_F(SingleNodeTest, TestMemoryStoreProvider) {
   // Check that only the ready ids are returned when timeout ends before thread runs.
   RAY_CHECK_OK(provider.Wait(wait_ids, ready_ids.size() + 1, 100, ctx, &wait_results));
   ASSERT_EQ(ready_ids.size(), wait_results.size());
-  for (const auto &ready_id : ready_ids) {
+  for (const auto& ready_id : ready_ids) {
     ASSERT_TRUE(wait_results.find(ready_id) != wait_results.end());
   }
-  for (const auto &unready_id : unready_ids) {
+  for (const auto& unready_id : unready_ids) {
     ASSERT_TRUE(wait_results.find(unready_id) == wait_results.end());
   }
 
@@ -754,7 +754,7 @@ TEST_F(SingleNodeTest, TestMemoryStoreProvider) {
   // Check that enough objects are returned after the thread inserts at least one object.
   RAY_CHECK_OK(provider.Wait(wait_ids, ready_ids.size() + 1, 5000, ctx, &wait_results));
   ASSERT_TRUE(wait_results.size() >= ready_ids.size() + 1);
-  for (const auto &ready_id : ready_ids) {
+  for (const auto& ready_id : ready_ids) {
     ASSERT_TRUE(wait_results.find(ready_id) != wait_results.end());
   }
 
@@ -763,20 +763,20 @@ TEST_F(SingleNodeTest, TestMemoryStoreProvider) {
   async_thread.join();
   RAY_CHECK_OK(provider.Wait(wait_ids, wait_ids.size(), -1, ctx, &wait_results));
   ASSERT_EQ(wait_results.size(), ready_ids.size() + unready_ids.size());
-  for (const auto &ready_id : ready_ids) {
+  for (const auto& ready_id : ready_ids) {
     ASSERT_TRUE(wait_results.find(ready_id) != wait_results.end());
   }
-  for (const auto &unready_id : unready_ids) {
+  for (const auto& unready_id : unready_ids) {
     ASSERT_TRUE(wait_results.find(unready_id) != wait_results.end());
   }
 }
 
 TEST_F(SingleNodeTest, TestObjectInterface) {
-  auto &core_worker = CoreWorkerProcess::GetCoreWorker();
+  auto& core_worker = CoreWorkerProcess::GetCoreWorker();
 
   uint8_t array1[] = {1, 2, 3, 4, 5, 6, 7, 8};
   const size_t array2_size = 200 * 1024;
-  uint8_t *array2 = new uint8_t[array2_size];
+  uint8_t* array2 = new uint8_t[array2_size];
 
   std::vector<RayObject> buffers;
   buffers.emplace_back(std::make_shared<LocalMemoryBuffer>(array1, sizeof(array1)),
@@ -877,7 +877,7 @@ TEST_F(TwoNodeTest, TestActorTaskCrossNodesFailure) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   RAY_CHECK(argc == 8);
   ray::TEST_STORE_EXEC_PATH = std::string(argv[1]);

--- a/src/ray/core_worker/test/direct_actor_transport_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_test.cc
@@ -57,10 +57,10 @@ rpc::PushTaskRequest CreatePushTaskRequestHelper(ActorID actor_id, int64_t count
 
 class MockWorkerClient : public rpc::CoreWorkerClientInterface {
  public:
-  const rpc::Address &Addr() const override { return addr; }
+  const rpc::Address& Addr() const override { return addr; }
 
   void PushActorTask(std::unique_ptr<rpc::PushTaskRequest> request, bool skip_queue,
-                     const rpc::ClientCallback<rpc::PushTaskReply> &callback) override {
+                     const rpc::ClientCallback<rpc::PushTaskReply>& callback) override {
     received_seq_nos.push_back(request->sequence_number());
     callbacks.push_back(callback);
   }
@@ -84,15 +84,15 @@ class MockTaskFinisher : public TaskFinisherInterface {
  public:
   MockTaskFinisher() {}
 
-  MOCK_METHOD3(CompletePendingTask, void(const TaskID &, const rpc::PushTaskReply &,
-                                         const rpc::Address &addr));
+  MOCK_METHOD3(CompletePendingTask,
+               void(const TaskID&, const rpc::PushTaskReply&, const rpc::Address& addr));
   MOCK_METHOD3(PendingTaskFailed,
-               bool(const TaskID &task_id, rpc::ErrorType error_type, Status *status));
+               bool(const TaskID& task_id, rpc::ErrorType error_type, Status* status));
 
   MOCK_METHOD2(OnTaskDependenciesInlined,
-               void(const std::vector<ObjectID> &, const std::vector<ObjectID> &));
+               void(const std::vector<ObjectID>&, const std::vector<ObjectID>&));
 
-  MOCK_METHOD1(MarkTaskCanceled, bool(const TaskID &task_id));
+  MOCK_METHOD1(MarkTaskCanceled, bool(const TaskID& task_id));
 };
 
 class DirectActorSubmitterTest : public ::testing::Test {
@@ -102,7 +102,7 @@ class DirectActorSubmitterTest : public ::testing::Test {
         store_(std::shared_ptr<CoreWorkerMemoryStore>(new CoreWorkerMemoryStore())),
         task_finisher_(std::make_shared<MockTaskFinisher>()),
         submitter_(
-            [&](const rpc::Address &addr) {
+            [&](const rpc::Address& addr) {
               num_clients_connected_++;
               return worker_client_;
             },
@@ -402,7 +402,7 @@ TEST_F(DirectActorSubmitterTest, TestActorRestartOutOfOrderGcs) {
 
 class MockDependencyWaiter : public DependencyWaiter {
  public:
-  MOCK_METHOD2(Wait, void(const std::vector<rpc::ObjectReference> &dependencies,
+  MOCK_METHOD2(Wait, void(const std::vector<rpc::ObjectReference>& dependencies,
                           std::function<void()> on_dependencies_available));
 
   virtual ~MockDependencyWaiter() {}
@@ -410,7 +410,7 @@ class MockDependencyWaiter : public DependencyWaiter {
 
 class MockWorkerContext : public WorkerContext {
  public:
-  MockWorkerContext(WorkerType worker_type, const JobID &job_id)
+  MockWorkerContext(WorkerType worker_type, const JobID& job_id)
       : WorkerContext(worker_type, WorkerID::FromRandom(), job_id) {
     current_actor_is_direct_call_ = true;
   }
@@ -428,14 +428,14 @@ class DirectActorReceiverTest : public ::testing::Test {
     receiver_ = std::unique_ptr<CoreWorkerDirectTaskReceiver>(
         new CoreWorkerDirectTaskReceiver(worker_context_, main_io_service_, execute_task,
                                          [] { return Status::OK(); }));
-    receiver_->Init([&](const rpc::Address &addr) { return worker_client_; },
+    receiver_->Init([&](const rpc::Address& addr) { return worker_client_; },
                     rpc_address_, dependency_waiter_);
   }
 
-  Status MockExecuteTask(const TaskSpecification &task_spec,
-                         const std::shared_ptr<ResourceMappingType> &resource_ids,
-                         std::vector<std::shared_ptr<RayObject>> *return_objects,
-                         ReferenceCounter::ReferenceTableProto *borrowed_refs) {
+  Status MockExecuteTask(const TaskSpecification& task_spec,
+                         const std::shared_ptr<ResourceMappingType>& resource_ids,
+                         std::vector<std::shared_ptr<RayObject>>* return_objects,
+                         ReferenceCounter::ReferenceTableProto* borrowed_refs) {
     return Status::OK();
   }
 
@@ -544,7 +544,7 @@ TEST_F(DirectActorReceiverTest, TestNewTaskFromDifferentWorker) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
 
   InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,

--- a/src/ray/core_worker/test/mock_worker.cc
+++ b/src/ray/core_worker/test/mock_worker.cc
@@ -32,8 +32,8 @@ namespace ray {
 /// for more details on how this class is used.
 class MockWorker {
  public:
-  MockWorker(const std::string &store_socket, const std::string &raylet_socket,
-             int node_manager_port, const gcs::GcsClientOptions &gcs_options) {
+  MockWorker(const std::string& store_socket, const std::string& raylet_socket,
+             int node_manager_port, const gcs::GcsClientOptions& gcs_options) {
     CoreWorkerOptions options = {
         WorkerType::WORKER,  // worker_type
         Language::PYTHON,    // langauge
@@ -66,12 +66,12 @@ class MockWorker {
   void RunTaskExecutionLoop() { CoreWorkerProcess::RunTaskExecutionLoop(); }
 
  private:
-  Status ExecuteTask(TaskType task_type, const RayFunction &ray_function,
-                     const std::unordered_map<std::string, double> &required_resources,
-                     const std::vector<std::shared_ptr<RayObject>> &args,
-                     const std::vector<ObjectID> &arg_reference_ids,
-                     const std::vector<ObjectID> &return_ids,
-                     std::vector<std::shared_ptr<RayObject>> *results) {
+  Status ExecuteTask(TaskType task_type, const RayFunction& ray_function,
+                     const std::unordered_map<std::string, double>& required_resources,
+                     const std::vector<std::shared_ptr<RayObject>>& args,
+                     const std::vector<ObjectID>& arg_reference_ids,
+                     const std::vector<ObjectID>& return_ids,
+                     std::vector<std::shared_ptr<RayObject>>* results) {
     // Note that this doesn't include dummy object id.
     const ray::FunctionDescriptor function_descriptor =
         ray_function.GetFunctionDescriptor();
@@ -93,11 +93,10 @@ class MockWorker {
     }
   }
 
-  Status GetWorkerPid(std::vector<std::shared_ptr<RayObject>> *results) {
+  Status GetWorkerPid(std::vector<std::shared_ptr<RayObject>>* results) {
     // Save the pid of current process to the return object.
     std::string pid_string = std::to_string(static_cast<int>(getpid()));
-    auto data =
-        const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(pid_string.data()));
+    auto data = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(pid_string.data()));
     auto memory_buffer =
         std::make_shared<LocalMemoryBuffer>(data, pid_string.size(), true);
     results->push_back(
@@ -105,17 +104,17 @@ class MockWorker {
     return Status::OK();
   }
 
-  Status MergeInputArgsAsOutput(const std::vector<std::shared_ptr<RayObject>> &args,
-                                const std::vector<ObjectID> &return_ids,
-                                std::vector<std::shared_ptr<RayObject>> *results) {
+  Status MergeInputArgsAsOutput(const std::vector<std::shared_ptr<RayObject>>& args,
+                                const std::vector<ObjectID>& return_ids,
+                                std::vector<std::shared_ptr<RayObject>>* results) {
     // Merge all the content from input args.
     std::vector<uint8_t> buffer;
-    for (const auto &arg : args) {
-      auto &data = arg->GetData();
+    for (const auto& arg : args) {
+      auto& data = arg->GetData();
       buffer.insert(buffer.end(), data->Data(), data->Data() + data->Size());
     }
     if (buffer.size() >= 8) {
-      auto int_arr = reinterpret_cast<int64_t *>(buffer.data());
+      auto int_arr = reinterpret_cast<int64_t*>(buffer.data());
       if (int_arr[0] == SHOULD_CHECK_MESSAGE_ORDER) {
         auto seq_no = int_arr[1];
         if (seq_no > 0) {
@@ -141,7 +140,7 @@ class MockWorker {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   RAY_CHECK(argc == 4);
   auto store_socket = std::string(argv[1]);
   auto raylet_socket = std::string(argv[2]);

--- a/src/ray/core_worker/test/object_recovery_manager_test.cc
+++ b/src/ray/core_worker/test/object_recovery_manager_test.cc
@@ -112,30 +112,31 @@ class ObjectRecoveryManagerTest : public ::testing::Test {
         ref_counter_(std::make_shared<ReferenceCounter>(
             rpc::Address(), /*distributed_ref_counting_enabled=*/true,
             /*lineage_pinning_enabled=*/true)),
-        manager_(rpc::Address(),
-                 [&](const std::string &ip, int port) { return raylet_client_; },
-                 raylet_client_,
-                 [&](const ObjectID &object_id, const ObjectLookupCallback &callback) {
-                   object_directory_->AsyncGetLocations(object_id, callback);
-                   return Status::OK();
-                 },
-                 task_resubmitter_, ref_counter_, memory_store_,
-                 [&](const ObjectID &object_id, bool pin_object) {
-                   RAY_CHECK(failed_reconstructions_.count(object_id) == 0);
-                   failed_reconstructions_[object_id] = pin_object;
+        manager_(
+            rpc::Address(),
+            [&](const std::string &ip, int port) { return raylet_client_; },
+            raylet_client_,
+            [&](const ObjectID &object_id, const ObjectLookupCallback &callback) {
+              object_directory_->AsyncGetLocations(object_id, callback);
+              return Status::OK();
+            },
+            task_resubmitter_, ref_counter_, memory_store_,
+            [&](const ObjectID &object_id, bool pin_object) {
+              RAY_CHECK(failed_reconstructions_.count(object_id) == 0);
+              failed_reconstructions_[object_id] = pin_object;
 
-                   std::string meta =
-                       std::to_string(static_cast<int>(rpc::ErrorType::OBJECT_IN_PLASMA));
-                   auto metadata = const_cast<uint8_t *>(
-                       reinterpret_cast<const uint8_t *>(meta.data()));
-                   auto meta_buffer =
-                       std::make_shared<LocalMemoryBuffer>(metadata, meta.size());
-                   auto data = RayObject(nullptr, meta_buffer, std::vector<ObjectID>());
-                   RAY_CHECK(memory_store_->Put(data, object_id));
+              std::string meta =
+                  std::to_string(static_cast<int>(rpc::ErrorType::OBJECT_IN_PLASMA));
+              auto metadata =
+                  const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(meta.data()));
+              auto meta_buffer =
+                  std::make_shared<LocalMemoryBuffer>(metadata, meta.size());
+              auto data = RayObject(nullptr, meta_buffer, std::vector<ObjectID>());
+              RAY_CHECK(memory_store_->Put(data, object_id));
 
-                   ref_counter_->UpdateObjectPinnedAtRaylet(object_id, local_raylet_id_);
-                 },
-                 /*lineage_reconstruction_enabled=*/true) {}
+              ref_counter_->UpdateObjectPinnedAtRaylet(object_id, local_raylet_id_);
+            },
+            /*lineage_reconstruction_enabled=*/true) {}
 
   ClientID local_raylet_id_;
   std::unordered_map<ObjectID, bool> failed_reconstructions_;

--- a/src/ray/core_worker/test/object_recovery_manager_test.cc
+++ b/src/ray/core_worker/test/object_recovery_manager_test.cc
@@ -33,16 +33,16 @@ class MockTaskResubmitter : public TaskResubmissionInterface {
  public:
   MockTaskResubmitter() {}
 
-  void AddTask(const TaskID &task_id, std::vector<ObjectID> task_deps) {
+  void AddTask(const TaskID& task_id, std::vector<ObjectID> task_deps) {
     task_specs[task_id] = task_deps;
   }
 
-  Status ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *task_deps) {
+  Status ResubmitTask(const TaskID& task_id, std::vector<ObjectID>* task_deps) {
     if (task_specs.find(task_id) == task_specs.end()) {
       return Status::Invalid("");
     }
 
-    for (const auto &dep : task_specs[task_id]) {
+    for (const auto& dep : task_specs[task_id]) {
       task_deps->push_back(dep);
     }
     num_tasks_resubmitted++;
@@ -56,15 +56,15 @@ class MockTaskResubmitter : public TaskResubmissionInterface {
 class MockRayletClient : public PinObjectsInterface {
  public:
   void PinObjectIDs(
-      const rpc::Address &caller_address, const std::vector<ObjectID> &object_ids,
-      const ray::rpc::ClientCallback<ray::rpc::PinObjectIDsReply> &callback) override {
+      const rpc::Address& caller_address, const std::vector<ObjectID>& object_ids,
+      const ray::rpc::ClientCallback<ray::rpc::PinObjectIDsReply>& callback) override {
     RAY_LOG(INFO) << "PinObjectIDs " << object_ids.size();
     callbacks.push_back(callback);
   }
 
   size_t Flush() {
     size_t flushed = callbacks.size();
-    for (const auto &callback : callbacks) {
+    for (const auto& callback : callbacks) {
       callback(Status::OK(), rpc::PinObjectIDsReply());
     }
     callbacks.clear();
@@ -76,19 +76,19 @@ class MockRayletClient : public PinObjectsInterface {
 
 class MockObjectDirectory {
  public:
-  void AsyncGetLocations(const ObjectID &object_id,
-                         const ObjectLookupCallback &callback) {
+  void AsyncGetLocations(const ObjectID& object_id,
+                         const ObjectLookupCallback& callback) {
     callbacks.push_back({object_id, callback});
   }
 
-  void SetLocations(const ObjectID &object_id,
-                    const std::vector<rpc::Address> &addresses) {
+  void SetLocations(const ObjectID& object_id,
+                    const std::vector<rpc::Address>& addresses) {
     locations[object_id] = addresses;
   }
 
   size_t Flush() {
     size_t flushed = callbacks.size();
-    for (const auto &pair : callbacks) {
+    for (const auto& pair : callbacks) {
       pair.second(pair.first, locations[pair.first]);
     }
     for (size_t i = 0; i < flushed; i++) {
@@ -114,21 +114,21 @@ class ObjectRecoveryManagerTest : public ::testing::Test {
             /*lineage_pinning_enabled=*/true)),
         manager_(
             rpc::Address(),
-            [&](const std::string &ip, int port) { return raylet_client_; },
+            [&](const std::string& ip, int port) { return raylet_client_; },
             raylet_client_,
-            [&](const ObjectID &object_id, const ObjectLookupCallback &callback) {
+            [&](const ObjectID& object_id, const ObjectLookupCallback& callback) {
               object_directory_->AsyncGetLocations(object_id, callback);
               return Status::OK();
             },
             task_resubmitter_, ref_counter_, memory_store_,
-            [&](const ObjectID &object_id, bool pin_object) {
+            [&](const ObjectID& object_id, bool pin_object) {
               RAY_CHECK(failed_reconstructions_.count(object_id) == 0);
               failed_reconstructions_[object_id] = pin_object;
 
               std::string meta =
                   std::to_string(static_cast<int>(rpc::ErrorType::OBJECT_IN_PLASMA));
               auto metadata =
-                  const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(meta.data()));
+                  const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(meta.data()));
               auto meta_buffer =
                   std::make_shared<LocalMemoryBuffer>(metadata, meta.size());
               auto data = RayObject(nullptr, meta_buffer, std::vector<ObjectID>());
@@ -232,7 +232,7 @@ TEST_F(ObjectRecoveryManagerTest, TestReconstructionChain) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/core_worker/test/scheduling_queue_test.cc
+++ b/src/ray/core_worker/test/scheduling_queue_test.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include <thread>
-#include "gtest/gtest.h"
 
+#include "gtest/gtest.h"
 #include "ray/common/test_util.h"
 #include "ray/core_worker/transport/direct_actor_transport.h"
 

--- a/src/ray/core_worker/test/scheduling_queue_test.cc
+++ b/src/ray/core_worker/test/scheduling_queue_test.cc
@@ -24,7 +24,7 @@ class MockWaiter : public DependencyWaiter {
  public:
   MockWaiter() {}
 
-  void Wait(const std::vector<rpc::ObjectReference> &dependencies,
+  void Wait(const std::vector<rpc::ObjectReference>& dependencies,
             std::function<void()> on_dependencies_available) override {
     callbacks_.push_back([on_dependencies_available]() { on_dependencies_available(); });
   }
@@ -160,7 +160,7 @@ TEST(SchedulingQueueTest, TestSkipAlreadyProcessedByClient) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/core_worker/test/task_manager_test.cc
+++ b/src/ray/core_worker/test/task_manager_test.cc
@@ -51,15 +51,16 @@ class TaskManagerTest : public ::testing::Test {
             rpc::Address(),
             /*distributed_ref_counting_enabled=*/true, lineage_pinning_enabled))),
         actor_reporter_(std::shared_ptr<ActorReporterInterface>(new MockActorManager())),
-        manager_(store_, reference_counter_, actor_reporter_,
-                 [this](TaskSpecification &spec, bool delay) {
-                   num_retries_++;
-                   return Status::OK();
-                 },
-                 [this](const ClientID &node_id) { return all_nodes_alive_; },
-                 [this](const ObjectID &object_id) {
-                   objects_to_recover_.push_back(object_id);
-                 }) {}
+        manager_(
+            store_, reference_counter_, actor_reporter_,
+            [this](TaskSpecification &spec, bool delay) {
+              num_retries_++;
+              return Status::OK();
+            },
+            [this](const ClientID &node_id) { return all_nodes_alive_; },
+            [this](const ObjectID &object_id) {
+              objects_to_recover_.push_back(object_id);
+            }) {}
 
   std::shared_ptr<CoreWorkerMemoryStore> store_;
   std::shared_ptr<ReferenceCounter> reference_counter_;

--- a/src/ray/core_worker/test/task_manager_test.cc
+++ b/src/ray/core_worker/test/task_manager_test.cc
@@ -28,7 +28,7 @@ TaskSpecification CreateTaskHelper(uint64_t num_returns,
   TaskSpecification task;
   task.GetMutableMessage().set_task_id(TaskID::ForFakeTask().Binary());
   task.GetMutableMessage().set_num_returns(num_returns);
-  for (const ObjectID &dep : dependencies) {
+  for (const ObjectID& dep : dependencies) {
     task.GetMutableMessage().add_args()->mutable_object_ref()->set_object_id(
         dep.Binary());
   }
@@ -36,7 +36,7 @@ TaskSpecification CreateTaskHelper(uint64_t num_returns,
 }
 
 class MockActorManager : public ActorReporterInterface {
-  void PublishTerminatedActor(const TaskSpecification &actor_creation_task) override {
+  void PublishTerminatedActor(const TaskSpecification& actor_creation_task) override {
     num_terminations += 1;
   }
 
@@ -53,12 +53,12 @@ class TaskManagerTest : public ::testing::Test {
         actor_reporter_(std::shared_ptr<ActorReporterInterface>(new MockActorManager())),
         manager_(
             store_, reference_counter_, actor_reporter_,
-            [this](TaskSpecification &spec, bool delay) {
+            [this](TaskSpecification& spec, bool delay) {
               num_retries_++;
               return Status::OK();
             },
-            [this](const ClientID &node_id) { return all_nodes_alive_; },
-            [this](const ObjectID &object_id) {
+            [this](const ClientID& node_id) { return all_nodes_alive_; },
+            [this](const ObjectID& object_id) {
               objects_to_recover_.push_back(object_id);
             }) {}
 
@@ -530,7 +530,7 @@ TEST_F(TaskManagerLineageTest, TestResubmitTask) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/core_worker/transport/dependency_resolver.h
+++ b/src/ray/core_worker/transport/dependency_resolver.h
@@ -38,7 +38,7 @@ class LocalDependencyResolver {
   ///
   /// Postcondition: all direct call id arguments that haven't been spilled to plasma
   /// are converted to values and all remaining arguments are arguments in the task spec.
-  void ResolveDependencies(TaskSpecification &task, std::function<void()> on_complete);
+  void ResolveDependencies(TaskSpecification& task, std::function<void()> on_complete);
 
   /// Return the number of tasks pending dependency resolution.
   /// TODO(ekl) this should be exposed in worker stats.

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -49,12 +49,12 @@ const int kMaxReorderWaitSeconds = 30;
 // Interface for testing.
 class CoreWorkerDirectActorTaskSubmitterInterface {
  public:
-  virtual void AddActorQueueIfNotExists(const ActorID &actor_id) = 0;
-  virtual void ConnectActor(const ActorID &actor_id, const rpc::Address &address,
+  virtual void AddActorQueueIfNotExists(const ActorID& actor_id) = 0;
+  virtual void ConnectActor(const ActorID& actor_id, const rpc::Address& address,
                             int64_t num_restarts) = 0;
-  virtual void DisconnectActor(const ActorID &actor_id, int64_t num_restarts,
+  virtual void DisconnectActor(const ActorID& actor_id, int64_t num_restarts,
                                bool dead = false) = 0;
-  virtual void KillActor(const ActorID &actor_id, bool force_kill, bool no_restart) = 0;
+  virtual void KillActor(const ActorID& actor_id, bool force_kill, bool no_restart) = 0;
 
   virtual ~CoreWorkerDirectActorTaskSubmitterInterface() {}
 };
@@ -76,7 +76,7 @@ class CoreWorkerDirectActorTaskSubmitter
   /// not receive another reference to the same actor.
   ///
   /// \param[in] actor_id The actor for whom to add a queue.
-  void AddActorQueueIfNotExists(const ActorID &actor_id);
+  void AddActorQueueIfNotExists(const ActorID& actor_id);
 
   /// Submit a task to an actor for execution.
   ///
@@ -91,7 +91,7 @@ class CoreWorkerDirectActorTaskSubmitter
   /// try a clean exit.
   /// \param[in] no_restart If set to true, the killed actor will not be
   /// restarted anymore.
-  void KillActor(const ActorID &actor_id, bool force_kill, bool no_restart);
+  void KillActor(const ActorID& actor_id, bool force_kill, bool no_restart);
 
   /// Create connection to actor and send all pending tasks.
   ///
@@ -100,7 +100,7 @@ class CoreWorkerDirectActorTaskSubmitter
   /// \param[in] num_restarts How many times this actor has been restarted
   /// before. If we've already seen a later incarnation of the actor, we will
   /// ignore the command to connect.
-  void ConnectActor(const ActorID &actor_id, const rpc::Address &address,
+  void ConnectActor(const ActorID& actor_id, const rpc::Address& address,
                     int64_t num_restarts);
 
   /// Disconnect from a failed actor.
@@ -111,7 +111,7 @@ class CoreWorkerDirectActorTaskSubmitter
   /// ignore the command to connect.
   /// \param[in] dead Whether the actor is permanently dead. In this case, all
   /// pending tasks for the actor should be failed.
-  void DisconnectActor(const ActorID &actor_id, int64_t num_restarts, bool dead = false);
+  void DisconnectActor(const ActorID& actor_id, int64_t num_restarts, bool dead = false);
 
   /// Set the timerstamp for the caller.
   void SetCallerCreationTimestamp(int64_t timestamp);
@@ -197,7 +197,7 @@ class CoreWorkerDirectActorTaskSubmitter
   /// \param[in] skip_queue Whether to skip the task queue. This will send the
   /// task for execution immediately.
   /// \return Void.
-  void PushActorTask(const ClientQueue &queue, const TaskSpecification &task_spec,
+  void PushActorTask(const ClientQueue& queue, const TaskSpecification& task_spec,
                      bool skip_queue) EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   /// Send all pending tasks for an actor.
@@ -206,16 +206,16 @@ class CoreWorkerDirectActorTaskSubmitter
   ///
   /// \param[in] actor_id Actor ID.
   /// \return Void.
-  void SendPendingTasks(const ActorID &actor_id) EXCLUSIVE_LOCKS_REQUIRED(mu_);
+  void SendPendingTasks(const ActorID& actor_id) EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   /// Disconnect the RPC client for an actor.
-  void DisconnectRpcClient(ClientQueue &queue) EXCLUSIVE_LOCKS_REQUIRED(mu_);
+  void DisconnectRpcClient(ClientQueue& queue) EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   /// Whether the specified actor is alive.
   ///
   /// \param[in] actor_id The actor ID.
   /// \return Whether this actor is alive.
-  bool IsActorAlive(const ActorID &actor_id) const;
+  bool IsActorAlive(const ActorID& actor_id) const;
 
   /// Factory for producing new core worker clients.
   rpc::ClientFactoryFn client_factory_;
@@ -259,7 +259,7 @@ class InboundRequest {
 class DependencyWaiter {
  public:
   /// Calls `callback` once the specified objects become available.
-  virtual void Wait(const std::vector<rpc::ObjectReference> &dependencies,
+  virtual void Wait(const std::vector<rpc::ObjectReference>& dependencies,
                     std::function<void()> on_dependencies_available) = 0;
 
   virtual ~DependencyWaiter(){};
@@ -267,10 +267,10 @@ class DependencyWaiter {
 
 class DependencyWaiterImpl : public DependencyWaiter {
  public:
-  DependencyWaiterImpl(DependencyWaiterInterface &dependency_client)
+  DependencyWaiterImpl(DependencyWaiterInterface& dependency_client)
       : dependency_client_(dependency_client) {}
 
-  void Wait(const std::vector<rpc::ObjectReference> &dependencies,
+  void Wait(const std::vector<rpc::ObjectReference>& dependencies,
             std::function<void()> on_dependencies_available) override {
     auto tag = next_request_id_++;
     requests_[tag] = on_dependencies_available;
@@ -288,7 +288,7 @@ class DependencyWaiterImpl : public DependencyWaiter {
  private:
   int64_t next_request_id_ = 0;
   std::unordered_map<int64_t, std::function<void()>> requests_;
-  DependencyWaiterInterface &dependency_client_;
+  DependencyWaiterInterface& dependency_client_;
 };
 
 /// Wraps a thread-pool to block posts until the pool has free slots. This is used
@@ -329,8 +329,8 @@ class BoundedExecutor {
 /// See direct_actor.proto for a description of the ordering protocol.
 class SchedulingQueue {
  public:
-  SchedulingQueue(boost::asio::io_service &main_io_service, DependencyWaiter &waiter,
-                  WorkerContext &worker_context,
+  SchedulingQueue(boost::asio::io_service& main_io_service, DependencyWaiter& waiter,
+                  WorkerContext& worker_context,
                   int64_t reorder_wait_seconds = kMaxReorderWaitSeconds)
       : worker_context_(worker_context),
         reorder_wait_seconds_(reorder_wait_seconds),
@@ -340,7 +340,7 @@ class SchedulingQueue {
 
   void Add(int64_t seq_no, int64_t client_processed_up_to,
            std::function<void()> accept_request, std::function<void()> reject_request,
-           const std::vector<rpc::ObjectReference> &dependencies = {}) {
+           const std::vector<rpc::ObjectReference>& dependencies = {}) {
     if (seq_no == -1) {
       accept_request();  // A seq_no of -1 means no ordering constraint.
       return;
@@ -425,7 +425,7 @@ class SchedulingQueue {
       wait_timer_.expires_from_now(boost::posix_time::seconds(reorder_wait_seconds_));
       RAY_LOG(DEBUG) << "waiting for " << next_seq_no_ << " queue size "
                      << pending_tasks_.size();
-      wait_timer_.async_wait([this](const boost::system::error_code &error) {
+      wait_timer_.async_wait([this](const boost::system::error_code& error) {
         if (error == boost::asio::error::operation_aborted) {
           return;  // time deadline was adjusted
         }
@@ -448,7 +448,7 @@ class SchedulingQueue {
   }
 
   // Worker context.
-  WorkerContext &worker_context_;
+  WorkerContext& worker_context_;
   /// Max time in seconds to wait for dependencies to show up.
   const int64_t reorder_wait_seconds_ = 0;
   /// Sorted map of (accept, rej) task callbacks keyed by their sequence number.
@@ -461,7 +461,7 @@ class SchedulingQueue {
   /// The id of the thread that constructed this scheduling queue.
   boost::thread::id main_thread_id_;
   /// Reference to the waiter owned by the task receiver.
-  DependencyWaiter &waiter_;
+  DependencyWaiter& waiter_;
   /// If concurrent calls are allowed, holds the pool for executing these tasks.
   std::unique_ptr<BoundedExecutor> pool_;
   /// Whether we should enqueue requests into asyncio pool. Setting this to true
@@ -476,17 +476,17 @@ class SchedulingQueue {
 class CoreWorkerDirectTaskReceiver {
  public:
   using TaskHandler =
-      std::function<Status(const TaskSpecification &task_spec,
+      std::function<Status(const TaskSpecification& task_spec,
                            const std::shared_ptr<ResourceMappingType> resource_ids,
-                           std::vector<std::shared_ptr<RayObject>> *return_objects,
-                           ReferenceCounter::ReferenceTableProto *borrower_refs)>;
+                           std::vector<std::shared_ptr<RayObject>>* return_objects,
+                           ReferenceCounter::ReferenceTableProto* borrower_refs)>;
 
   using OnTaskDone = std::function<ray::Status()>;
 
-  CoreWorkerDirectTaskReceiver(WorkerContext &worker_context,
-                               boost::asio::io_service &main_io_service,
-                               const TaskHandler &task_handler,
-                               const OnTaskDone &task_done)
+  CoreWorkerDirectTaskReceiver(WorkerContext& worker_context,
+                               boost::asio::io_service& main_io_service,
+                               const TaskHandler& task_handler,
+                               const OnTaskDone& task_done)
       : worker_context_(worker_context),
         task_handler_(task_handler),
         task_main_io_service_(main_io_service),
@@ -501,16 +501,16 @@ class CoreWorkerDirectTaskReceiver {
   /// \param[in] request The request message.
   /// \param[out] reply The reply message.
   /// \param[in] send_reply_callback The callback to be called when the request is done.
-  void HandlePushTask(const rpc::PushTaskRequest &request, rpc::PushTaskReply *reply,
+  void HandlePushTask(const rpc::PushTaskRequest& request, rpc::PushTaskReply* reply,
                       rpc::SendReplyCallback send_reply_callback);
 
  private:
   // Worker context.
-  WorkerContext &worker_context_;
+  WorkerContext& worker_context_;
   /// The callback function to process a task.
   TaskHandler task_handler_;
   /// The IO event loop for running tasks on.
-  boost::asio::io_service &task_main_io_service_;
+  boost::asio::io_service& task_main_io_service_;
   /// The callback function to be invoked when finishing a task.
   OnTaskDone task_done_;
   /// Factory for producing new core worker clients.

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -31,7 +31,7 @@
 
 namespace ray {
 
-typedef std::function<std::shared_ptr<WorkerLeaseInterface>(const std::string &ip_address,
+typedef std::function<std::shared_ptr<WorkerLeaseInterface>(const std::string& ip_address,
                                                             int port)>
     LeaseClientFactoryFn;
 
@@ -82,7 +82,7 @@ class CoreWorkerDirectTaskSubmitter {
   /// \param[in] force_kill Whether to kill the worker executing the task.
   Status CancelTask(TaskSpecification task_spec, bool force_kill);
 
-  Status CancelRemoteTask(const ObjectID &object_id, const rpc::Address &worker_addr,
+  Status CancelRemoteTask(const ObjectID& object_id, const rpc::Address& worker_addr,
                           bool force_kill);
 
  private:
@@ -95,43 +95,43 @@ class CoreWorkerDirectTaskSubmitter {
   /// \param[in] was_error Whether the task failed to be submitted.
   /// \param[in] assigned_resources Resource ids previously assigned to the worker.
   void OnWorkerIdle(
-      const rpc::WorkerAddress &addr, const SchedulingKey &task_queue_key, bool was_error,
-      const google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry> &assigned_resources)
+      const rpc::WorkerAddress& addr, const SchedulingKey& task_queue_key, bool was_error,
+      const google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry>& assigned_resources)
       EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   /// Get an existing lease client or connect a new one. If a raylet_address is
   /// provided, this connects to a remote raylet. Else, this connects to the
   /// local raylet.
   std::shared_ptr<WorkerLeaseInterface> GetOrConnectLeaseClient(
-      const rpc::Address *raylet_address) EXCLUSIVE_LOCKS_REQUIRED(mu_);
+      const rpc::Address* raylet_address) EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   /// Request a new worker from the raylet if no such requests are currently in
   /// flight and there are tasks queued. If a raylet address is provided, then
   /// the worker should be requested from the raylet at that address. Else, the
   /// worker should be requested from the local raylet.
-  void RequestNewWorkerIfNeeded(const SchedulingKey &task_queue_key,
-                                const rpc::Address *raylet_address = nullptr)
+  void RequestNewWorkerIfNeeded(const SchedulingKey& task_queue_key,
+                                const rpc::Address* raylet_address = nullptr)
       EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   /// Cancel a pending worker lease and retry until the cancellation succeeds
   /// (i.e., the raylet drops the request). This should be called when there
   /// are no more tasks queued with the given scheduling key and there is an
   /// in-flight lease request for that key.
-  void CancelWorkerLeaseIfNeeded(const SchedulingKey &scheduling_key)
+  void CancelWorkerLeaseIfNeeded(const SchedulingKey& scheduling_key)
       EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   /// Set up client state for newly granted worker lease.
-  void AddWorkerLeaseClient(const rpc::WorkerAddress &addr,
+  void AddWorkerLeaseClient(const rpc::WorkerAddress& addr,
                             std::shared_ptr<WorkerLeaseInterface> lease_client)
       EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   /// Push a task to a specific worker.
-  void PushNormalTask(const rpc::WorkerAddress &addr,
-                      rpc::CoreWorkerClientInterface &client,
-                      const SchedulingKey &task_queue_key,
-                      const TaskSpecification &task_spec,
-                      const google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry>
-                          &assigned_resources);
+  void PushNormalTask(const rpc::WorkerAddress& addr,
+                      rpc::CoreWorkerClientInterface& client,
+                      const SchedulingKey& task_queue_key,
+                      const TaskSpecification& task_spec,
+                      const google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry>&
+                          assigned_resources);
 
   /// Address of our RPC server.
   rpc::Address rpc_address_;

--- a/src/ray/core_worker/transport/raylet_transport.cc
+++ b/src/ray/core_worker/transport/raylet_transport.cc
@@ -20,15 +20,15 @@
 namespace ray {
 
 CoreWorkerRayletTaskReceiver::CoreWorkerRayletTaskReceiver(
-    const WorkerID &worker_id, std::shared_ptr<raylet::RayletClient> &raylet_client,
-    const TaskHandler &task_handler)
+    const WorkerID& worker_id, std::shared_ptr<raylet::RayletClient>& raylet_client,
+    const TaskHandler& task_handler)
     : worker_id_(worker_id), raylet_client_(raylet_client), task_handler_(task_handler) {}
 
 void CoreWorkerRayletTaskReceiver::HandleAssignTask(
-    const rpc::AssignTaskRequest &request, rpc::AssignTaskReply *reply,
+    const rpc::AssignTaskRequest& request, rpc::AssignTaskReply* reply,
     rpc::SendReplyCallback send_reply_callback) {
   const Task task(request.task());
-  const auto &task_spec = task.GetTaskSpecification();
+  const auto& task_spec = task.GetTaskSpecification();
   RAY_LOG(DEBUG) << "Received task " << task_spec.TaskId() << " is create "
                  << task_spec.IsActorCreationTask();
 
@@ -39,8 +39,8 @@ void CoreWorkerRayletTaskReceiver::HandleAssignTask(
       flatbuffers::GetRoot<protocol::ResourceIdSetInfos>(request.resource_ids().data())
           ->resource_infos();
   for (size_t i = 0; i < resource_infos->size(); ++i) {
-    auto const &fractional_resource_ids = resource_infos->Get(i);
-    auto &acquired_resources =
+    auto const& fractional_resource_ids = resource_infos->Get(i);
+    auto& acquired_resources =
         (*resource_ids)[string_from_flatbuf(*fractional_resource_ids->resource_name())];
 
     size_t num_resource_ids = fractional_resource_ids->resource_ids()->size();

--- a/src/ray/core_worker/transport/raylet_transport.cc
+++ b/src/ray/core_worker/transport/raylet_transport.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "ray/core_worker/transport/raylet_transport.h"
+
 #include "ray/common/common_protocol.h"
 #include "ray/common/task/task.h"
 

--- a/src/ray/core_worker/transport/raylet_transport.h
+++ b/src/ray/core_worker/transport/raylet_transport.h
@@ -26,14 +26,14 @@ namespace ray {
 class CoreWorkerRayletTaskReceiver {
  public:
   using TaskHandler =
-      std::function<Status(const TaskSpecification &task_spec,
-                           const std::shared_ptr<ResourceMappingType> &resource_ids,
-                           std::vector<std::shared_ptr<RayObject>> *return_objects,
-                           ReferenceCounter::ReferenceTableProto *borrower_refs)>;
+      std::function<Status(const TaskSpecification& task_spec,
+                           const std::shared_ptr<ResourceMappingType>& resource_ids,
+                           std::vector<std::shared_ptr<RayObject>>* return_objects,
+                           ReferenceCounter::ReferenceTableProto* borrower_refs)>;
 
-  CoreWorkerRayletTaskReceiver(const WorkerID &worker_id,
-                               std::shared_ptr<raylet::RayletClient> &raylet_client,
-                               const TaskHandler &task_handler);
+  CoreWorkerRayletTaskReceiver(const WorkerID& worker_id,
+                               std::shared_ptr<raylet::RayletClient>& raylet_client,
+                               const TaskHandler& task_handler);
 
   /// Handle a `AssignTask` request.
   /// The implementation can handle this request asynchronously. When handling is done,
@@ -42,8 +42,8 @@ class CoreWorkerRayletTaskReceiver {
   /// \param[in] request The request message.
   /// \param[out] reply The reply message.
   /// \param[in] send_reply_callback The callback to be called when the request is done.
-  void HandleAssignTask(const rpc::AssignTaskRequest &request,
-                        rpc::AssignTaskReply *reply,
+  void HandleAssignTask(const rpc::AssignTaskRequest& request,
+                        rpc::AssignTaskReply* reply,
                         rpc::SendReplyCallback send_reply_callback);
 
  private:
@@ -51,7 +51,7 @@ class CoreWorkerRayletTaskReceiver {
   WorkerID worker_id_;
   /// Reference to the core worker's raylet client. This is a pointer ref so that it
   /// can be initialized by core worker after this class is constructed.
-  std::shared_ptr<raylet::RayletClient> &raylet_client_;
+  std::shared_ptr<raylet::RayletClient>& raylet_client_;
   /// The callback function to process a task.
   TaskHandler task_handler_;
   /// The callback to process arg wait complete.

--- a/src/ray/gcs/accessor.h
+++ b/src/ray/gcs/accessor.h
@@ -37,21 +37,21 @@ class ActorInfoAccessor {
   ///
   /// \param actor_table_data_list The container to hold the actor specification.
   /// \return Status
-  virtual Status GetAll(std::vector<rpc::ActorTableData> *actor_table_data_list) = 0;
+  virtual Status GetAll(std::vector<rpc::ActorTableData>* actor_table_data_list) = 0;
 
   /// Get actor specification from GCS asynchronously.
   ///
   /// \param actor_id The ID of actor to look up in the GCS.
   /// \param callback Callback that will be called after lookup finishes.
   /// \return Status
-  virtual Status AsyncGet(const ActorID &actor_id,
-                          const OptionalItemCallback<rpc::ActorTableData> &callback) = 0;
+  virtual Status AsyncGet(const ActorID& actor_id,
+                          const OptionalItemCallback<rpc::ActorTableData>& callback) = 0;
 
   /// Get all actor specification from GCS asynchronously.
   ///
   /// \param callback Callback that will be called after lookup finishes.
   /// \return Status
-  virtual Status AsyncGetAll(const MultiItemCallback<rpc::ActorTableData> &callback) = 0;
+  virtual Status AsyncGetAll(const MultiItemCallback<rpc::ActorTableData>& callback) = 0;
 
   /// Get actor specification for a named actor from GCS asynchronously.
   ///
@@ -59,16 +59,16 @@ class ActorInfoAccessor {
   /// \param callback Callback that will be called after lookup finishes.
   /// \return Status
   virtual Status AsyncGetByName(
-      const std::string &name,
-      const OptionalItemCallback<rpc::ActorTableData> &callback) = 0;
+      const std::string& name,
+      const OptionalItemCallback<rpc::ActorTableData>& callback) = 0;
 
   /// Register actor to GCS asynchronously.
   ///
   /// \param task_spec The specification for the actor creation task.
   /// \param callback Callback that will be called after the actor info is written to GCS.
   /// \return Status
-  virtual Status AsyncRegisterActor(const TaskSpecification &task_spec,
-                                    const StatusCallback &callback) = 0;
+  virtual Status AsyncRegisterActor(const TaskSpecification& task_spec,
+                                    const StatusCallback& callback) = 0;
 
   /// Asynchronously request GCS to create the actor.
   ///
@@ -80,8 +80,8 @@ class ActorInfoAccessor {
   /// \param task_spec The specification for the actor creation task.
   /// \param callback Callback that will be called after the actor info is written to GCS.
   /// \return Status
-  virtual Status AsyncCreateActor(const TaskSpecification &task_spec,
-                                  const StatusCallback &callback) = 0;
+  virtual Status AsyncCreateActor(const TaskSpecification& task_spec,
+                                  const StatusCallback& callback) = 0;
 
   /// Register an actor to GCS asynchronously.
   ///
@@ -89,8 +89,8 @@ class ActorInfoAccessor {
   /// \param callback Callback that will be called after actor has been registered
   /// to the GCS.
   /// \return Status
-  virtual Status AsyncRegister(const std::shared_ptr<rpc::ActorTableData> &data_ptr,
-                               const StatusCallback &callback) = 0;
+  virtual Status AsyncRegister(const std::shared_ptr<rpc::ActorTableData>& data_ptr,
+                               const StatusCallback& callback) = 0;
 
   /// Update dynamic states of actor in GCS asynchronously.
   ///
@@ -100,9 +100,9 @@ class ActorInfoAccessor {
   /// \return Status
   /// TODO(micafan) Don't expose the whole `ActorTableData` and only allow
   /// updating dynamic states.
-  virtual Status AsyncUpdate(const ActorID &actor_id,
-                             const std::shared_ptr<rpc::ActorTableData> &data_ptr,
-                             const StatusCallback &callback) = 0;
+  virtual Status AsyncUpdate(const ActorID& actor_id,
+                             const std::shared_ptr<rpc::ActorTableData>& data_ptr,
+                             const StatusCallback& callback) = 0;
 
   /// Subscribe to any register or update operations of actors.
   ///
@@ -112,8 +112,8 @@ class ActorInfoAccessor {
   /// are ready to receive notification.
   /// \return Status
   virtual Status AsyncSubscribeAll(
-      const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
-      const StatusCallback &done) = 0;
+      const SubscribeCallback<ActorID, rpc::ActorTableData>& subscribe,
+      const StatusCallback& done) = 0;
 
   /// Subscribe to any update operations of an actor.
   ///
@@ -122,15 +122,15 @@ class ActorInfoAccessor {
   /// \param done Callback that will be called when subscription is complete.
   /// \return Status
   virtual Status AsyncSubscribe(
-      const ActorID &actor_id,
-      const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
-      const StatusCallback &done) = 0;
+      const ActorID& actor_id,
+      const SubscribeCallback<ActorID, rpc::ActorTableData>& subscribe,
+      const StatusCallback& done) = 0;
 
   /// Cancel subscription to an actor.
   ///
   /// \param actor_id The ID of the actor to be unsubscribed to.
   /// \return Status
-  virtual Status AsyncUnsubscribe(const ActorID &actor_id) = 0;
+  virtual Status AsyncUnsubscribe(const ActorID& actor_id) = 0;
 
   /// Add actor checkpoint data to GCS asynchronously.
   ///
@@ -142,8 +142,8 @@ class ActorInfoAccessor {
   /// otherwise the checkpoint may be overwritten. This issue will be resolved if
   /// necessary.
   virtual Status AsyncAddCheckpoint(
-      const std::shared_ptr<rpc::ActorCheckpointData> &data_ptr,
-      const StatusCallback &callback) = 0;
+      const std::shared_ptr<rpc::ActorCheckpointData>& data_ptr,
+      const StatusCallback& callback) = 0;
 
   /// Get actor checkpoint data from GCS asynchronously.
   ///
@@ -152,8 +152,8 @@ class ActorInfoAccessor {
   /// \param callback The callback that will be called after lookup finishes.
   /// \return Status
   virtual Status AsyncGetCheckpoint(
-      const ActorCheckpointID &checkpoint_id, const ActorID &actor_id,
-      const OptionalItemCallback<rpc::ActorCheckpointData> &callback) = 0;
+      const ActorCheckpointID& checkpoint_id, const ActorID& actor_id,
+      const OptionalItemCallback<rpc::ActorCheckpointData>& callback) = 0;
 
   /// Get actor checkpoint id data from GCS asynchronously.
   ///
@@ -161,8 +161,8 @@ class ActorInfoAccessor {
   /// \param callback The callback that will be called after lookup finishes.
   /// \return Status
   virtual Status AsyncGetCheckpointID(
-      const ActorID &actor_id,
-      const OptionalItemCallback<rpc::ActorCheckpointIdData> &callback) = 0;
+      const ActorID& actor_id,
+      const OptionalItemCallback<rpc::ActorCheckpointIdData>& callback) = 0;
 
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
@@ -191,16 +191,16 @@ class JobInfoAccessor {
   /// \param callback Callback that will be called after job has been added
   /// to GCS.
   /// \return Status
-  virtual Status AsyncAdd(const std::shared_ptr<rpc::JobTableData> &data_ptr,
-                          const StatusCallback &callback) = 0;
+  virtual Status AsyncAdd(const std::shared_ptr<rpc::JobTableData>& data_ptr,
+                          const StatusCallback& callback) = 0;
 
   /// Mark job as finished in GCS asynchronously.
   ///
   /// \param job_id ID of the job that will be make finished to GCS.
   /// \param callback Callback that will be called after update finished.
   /// \return Status
-  virtual Status AsyncMarkFinished(const JobID &job_id,
-                                   const StatusCallback &callback) = 0;
+  virtual Status AsyncMarkFinished(const JobID& job_id,
+                                   const StatusCallback& callback) = 0;
 
   /// Subscribe to job updates.
   ///
@@ -208,14 +208,14 @@ class JobInfoAccessor {
   /// \param done Callback that will be called when subscription is complete.
   /// \return Status
   virtual Status AsyncSubscribeAll(
-      const SubscribeCallback<JobID, rpc::JobTableData> &subscribe,
-      const StatusCallback &done) = 0;
+      const SubscribeCallback<JobID, rpc::JobTableData>& subscribe,
+      const StatusCallback& done) = 0;
 
   /// Get all job info from GCS asynchronously.
   ///
   /// \param callback Callback that will be called after lookup finished.
   /// \return Status
-  virtual Status AsyncGetAll(const MultiItemCallback<rpc::JobTableData> &callback) = 0;
+  virtual Status AsyncGetAll(const MultiItemCallback<rpc::JobTableData>& callback) = 0;
 
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
@@ -244,16 +244,16 @@ class TaskInfoAccessor {
   /// \param callback Callback that will be called after task has been added
   /// to GCS.
   /// \return Status
-  virtual Status AsyncAdd(const std::shared_ptr<rpc::TaskTableData> &data_ptr,
-                          const StatusCallback &callback) = 0;
+  virtual Status AsyncAdd(const std::shared_ptr<rpc::TaskTableData>& data_ptr,
+                          const StatusCallback& callback) = 0;
 
   /// Get task information from GCS asynchronously.
   ///
   /// \param task_id The ID of the task to look up in GCS.
   /// \param callback Callback that is called after lookup finished.
   /// \return Status
-  virtual Status AsyncGet(const TaskID &task_id,
-                          const OptionalItemCallback<rpc::TaskTableData> &callback) = 0;
+  virtual Status AsyncGet(const TaskID& task_id,
+                          const OptionalItemCallback<rpc::TaskTableData>& callback) = 0;
 
   /// Delete tasks from GCS asynchronously.
   ///
@@ -262,8 +262,8 @@ class TaskInfoAccessor {
   /// \return Status
   // TODO(micafan) Will support callback of batch deletion in the future.
   // Currently this callback will never be called.
-  virtual Status AsyncDelete(const std::vector<TaskID> &task_ids,
-                             const StatusCallback &callback) = 0;
+  virtual Status AsyncDelete(const std::vector<TaskID>& task_ids,
+                             const StatusCallback& callback) = 0;
 
   /// Subscribe asynchronously to the event that the given task is added in GCS.
   ///
@@ -272,15 +272,15 @@ class TaskInfoAccessor {
   /// \param done Callback that will be called when subscription is complete.
   /// \return Status
   virtual Status AsyncSubscribe(
-      const TaskID &task_id,
-      const SubscribeCallback<TaskID, rpc::TaskTableData> &subscribe,
-      const StatusCallback &done) = 0;
+      const TaskID& task_id,
+      const SubscribeCallback<TaskID, rpc::TaskTableData>& subscribe,
+      const StatusCallback& done) = 0;
 
   /// Cancel subscription to a task asynchronously.
   ///
   /// \param task_id The ID of the task to be unsubscribed to.
   /// \return Status
-  virtual Status AsyncUnsubscribe(const TaskID &task_id) = 0;
+  virtual Status AsyncUnsubscribe(const TaskID& task_id) = 0;
 
   /// Add a task lease to GCS asynchronously.
   ///
@@ -288,8 +288,8 @@ class TaskInfoAccessor {
   /// \param callback Callback that will be called after task lease has been added
   /// to GCS.
   /// \return Status
-  virtual Status AsyncAddTaskLease(const std::shared_ptr<rpc::TaskLeaseData> &data_ptr,
-                                   const StatusCallback &callback) = 0;
+  virtual Status AsyncAddTaskLease(const std::shared_ptr<rpc::TaskLeaseData>& data_ptr,
+                                   const StatusCallback& callback) = 0;
 
   /// Get task lease information from GCS asynchronously.
   ///
@@ -297,8 +297,8 @@ class TaskInfoAccessor {
   /// \param callback Callback that is called after lookup finished.
   /// \return Status
   virtual Status AsyncGetTaskLease(
-      const TaskID &task_id,
-      const OptionalItemCallback<rpc::TaskLeaseData> &callback) = 0;
+      const TaskID& task_id,
+      const OptionalItemCallback<rpc::TaskLeaseData>& callback) = 0;
 
   /// Subscribe asynchronously to the event that the given task lease is added in GCS.
   ///
@@ -308,15 +308,15 @@ class TaskInfoAccessor {
   /// \param done Callback that will be called when subscription is complete.
   /// \return Status
   virtual Status AsyncSubscribeTaskLease(
-      const TaskID &task_id,
-      const SubscribeCallback<TaskID, boost::optional<rpc::TaskLeaseData>> &subscribe,
-      const StatusCallback &done) = 0;
+      const TaskID& task_id,
+      const SubscribeCallback<TaskID, boost::optional<rpc::TaskLeaseData>>& subscribe,
+      const StatusCallback& done) = 0;
 
   /// Cancel subscription to a task lease asynchronously.
   ///
   /// \param task_id The ID of the task to be unsubscribed to.
   /// \return Status
-  virtual Status AsyncUnsubscribeTaskLease(const TaskID &task_id) = 0;
+  virtual Status AsyncUnsubscribeTaskLease(const TaskID& task_id) = 0;
 
   /// Attempt task reconstruction to GCS asynchronously.
   ///
@@ -325,8 +325,8 @@ class TaskInfoAccessor {
   /// has been added to GCS.
   /// \return Status
   virtual Status AttemptTaskReconstruction(
-      const std::shared_ptr<rpc::TaskReconstructionData> &data_ptr,
-      const StatusCallback &callback) = 0;
+      const std::shared_ptr<rpc::TaskReconstructionData>& data_ptr,
+      const StatusCallback& callback) = 0;
 
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
@@ -354,15 +354,15 @@ class ObjectInfoAccessor {
   /// \param callback Callback that will be called after lookup finishes.
   /// \return Status
   virtual Status AsyncGetLocations(
-      const ObjectID &object_id,
-      const MultiItemCallback<rpc::ObjectTableData> &callback) = 0;
+      const ObjectID& object_id,
+      const MultiItemCallback<rpc::ObjectTableData>& callback) = 0;
 
   /// Get all object's locations from GCS asynchronously.
   ///
   /// \param callback Callback that will be called after lookup finished.
   /// \return Status
   virtual Status AsyncGetAll(
-      const MultiItemCallback<rpc::ObjectLocationInfo> &callback) = 0;
+      const MultiItemCallback<rpc::ObjectLocationInfo>& callback) = 0;
 
   /// Add location of object to GCS asynchronously.
   ///
@@ -370,8 +370,8 @@ class ObjectInfoAccessor {
   /// \param node_id The location that will be added to GCS.
   /// \param callback Callback that will be called after object has been added to GCS.
   /// \return Status
-  virtual Status AsyncAddLocation(const ObjectID &object_id, const ClientID &node_id,
-                                  const StatusCallback &callback) = 0;
+  virtual Status AsyncAddLocation(const ObjectID& object_id, const ClientID& node_id,
+                                  const StatusCallback& callback) = 0;
 
   /// Remove location of object from GCS asynchronously.
   ///
@@ -379,8 +379,8 @@ class ObjectInfoAccessor {
   /// \param node_id The location that will be removed from GCS.
   /// \param callback Callback that will be called after the delete finished.
   /// \return Status
-  virtual Status AsyncRemoveLocation(const ObjectID &object_id, const ClientID &node_id,
-                                     const StatusCallback &callback) = 0;
+  virtual Status AsyncRemoveLocation(const ObjectID& object_id, const ClientID& node_id,
+                                     const StatusCallback& callback) = 0;
 
   /// Subscribe to any update of an object's location.
   ///
@@ -390,15 +390,15 @@ class ObjectInfoAccessor {
   /// \param done Callback that will be called when subscription is complete.
   /// \return Status
   virtual Status AsyncSubscribeToLocations(
-      const ObjectID &object_id,
-      const SubscribeCallback<ObjectID, ObjectChangeNotification> &subscribe,
-      const StatusCallback &done) = 0;
+      const ObjectID& object_id,
+      const SubscribeCallback<ObjectID, ObjectChangeNotification>& subscribe,
+      const StatusCallback& done) = 0;
 
   /// Cancel subscription to any update of an object's location.
   ///
   /// \param object_id The ID of the object to be unsubscribed to.
   /// \return Status
-  virtual Status AsyncUnsubscribeToLocations(const ObjectID &object_id) = 0;
+  virtual Status AsyncUnsubscribeToLocations(const ObjectID& object_id) = 0;
 
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
@@ -425,7 +425,7 @@ class NodeInfoAccessor {
   ///
   /// \param node_info The information of node to register to GCS.
   /// \return Status
-  virtual Status RegisterSelf(const rpc::GcsNodeInfo &local_node_info) = 0;
+  virtual Status RegisterSelf(const rpc::GcsNodeInfo& local_node_info) = 0;
 
   /// Cancel registration of local node to GCS synchronously.
   ///
@@ -435,34 +435,34 @@ class NodeInfoAccessor {
   /// Get id of local node which was registered by 'RegisterSelf'.
   ///
   /// \return ClientID
-  virtual const ClientID &GetSelfId() const = 0;
+  virtual const ClientID& GetSelfId() const = 0;
 
   /// Get information of local node which was registered by 'RegisterSelf'.
   ///
   /// \return GcsNodeInfo
-  virtual const rpc::GcsNodeInfo &GetSelfInfo() const = 0;
+  virtual const rpc::GcsNodeInfo& GetSelfInfo() const = 0;
 
   /// Register a node to GCS asynchronously.
   ///
   /// \param node_info The information of node to register to GCS.
   /// \param callback Callback that will be called when registration is complete.
   /// \return Status
-  virtual Status AsyncRegister(const rpc::GcsNodeInfo &node_info,
-                               const StatusCallback &callback) = 0;
+  virtual Status AsyncRegister(const rpc::GcsNodeInfo& node_info,
+                               const StatusCallback& callback) = 0;
 
   /// Cancel registration of a node to GCS asynchronously.
   ///
   /// \param node_id The ID of node that to be unregistered.
   /// \param callback Callback that will be called when unregistration is complete.
   /// \return Status
-  virtual Status AsyncUnregister(const ClientID &node_id,
-                                 const StatusCallback &callback) = 0;
+  virtual Status AsyncUnregister(const ClientID& node_id,
+                                 const StatusCallback& callback) = 0;
 
   /// Get information of all nodes from GCS asynchronously.
   ///
   /// \param callback Callback that will be called after lookup finishes.
   /// \return Status
-  virtual Status AsyncGetAll(const MultiItemCallback<rpc::GcsNodeInfo> &callback) = 0;
+  virtual Status AsyncGetAll(const MultiItemCallback<rpc::GcsNodeInfo>& callback) = 0;
 
   /// Subscribe to node addition and removal events from GCS and cache those information.
   ///
@@ -472,8 +472,8 @@ class NodeInfoAccessor {
   /// \param done Callback that will be called when subscription is complete.
   /// \return Status
   virtual Status AsyncSubscribeToNodeChange(
-      const SubscribeCallback<ClientID, rpc::GcsNodeInfo> &subscribe,
-      const StatusCallback &done) = 0;
+      const SubscribeCallback<ClientID, rpc::GcsNodeInfo>& subscribe,
+      const StatusCallback& done) = 0;
 
   /// Get node information from local cache.
   /// Non-thread safe.
@@ -483,7 +483,7 @@ class NodeInfoAccessor {
   /// \param node_id The ID of node to look up in local cache.
   /// \return The item returned by GCS. If the item to read doesn't exist,
   /// this optional object is empty.
-  virtual boost::optional<rpc::GcsNodeInfo> Get(const ClientID &node_id) const = 0;
+  virtual boost::optional<rpc::GcsNodeInfo> Get(const ClientID& node_id) const = 0;
 
   /// Get information of all nodes from local cache.
   /// Non-thread safe.
@@ -491,7 +491,7 @@ class NodeInfoAccessor {
   /// is called before.
   ///
   /// \return All nodes in cache.
-  virtual const std::unordered_map<ClientID, rpc::GcsNodeInfo> &GetAll() const = 0;
+  virtual const std::unordered_map<ClientID, rpc::GcsNodeInfo>& GetAll() const = 0;
 
   /// Search the local cache to find out if the given node is removed.
   /// Non-thread safe.
@@ -500,7 +500,7 @@ class NodeInfoAccessor {
   ///
   /// \param node_id The id of the node to check.
   /// \return Whether the node is removed.
-  virtual bool IsRemoved(const ClientID &node_id) const = 0;
+  virtual bool IsRemoved(const ClientID& node_id) const = 0;
 
   // TODO(micafan) Define ResourceMap in GCS proto.
   typedef std::unordered_map<std::string, std::shared_ptr<rpc::ResourceTableData>>
@@ -511,26 +511,26 @@ class NodeInfoAccessor {
   /// \param node_id The ID of node to lookup dynamic resources.
   /// \param callback Callback that will be called after lookup finishes.
   /// \return Status
-  virtual Status AsyncGetResources(const ClientID &node_id,
-                                   const OptionalItemCallback<ResourceMap> &callback) = 0;
+  virtual Status AsyncGetResources(const ClientID& node_id,
+                                   const OptionalItemCallback<ResourceMap>& callback) = 0;
 
   /// Update resources of node in GCS asynchronously.
   ///
   /// \param node_id The ID of node to update dynamic resources.
   /// \param resources The dynamic resources of node to be updated.
   /// \param callback Callback that will be called after update finishes.
-  virtual Status AsyncUpdateResources(const ClientID &node_id,
-                                      const ResourceMap &resources,
-                                      const StatusCallback &callback) = 0;
+  virtual Status AsyncUpdateResources(const ClientID& node_id,
+                                      const ResourceMap& resources,
+                                      const StatusCallback& callback) = 0;
 
   /// Delete resources of a node from GCS asynchronously.
   ///
   /// \param node_id The ID of node to delete resources from GCS.
   /// \param resource_names The names of resource to be deleted.
   /// \param callback Callback that will be called after delete finishes.
-  virtual Status AsyncDeleteResources(const ClientID &node_id,
-                                      const std::vector<std::string> &resource_names,
-                                      const StatusCallback &callback) = 0;
+  virtual Status AsyncDeleteResources(const ClientID& node_id,
+                                      const std::vector<std::string>& resource_names,
+                                      const StatusCallback& callback) = 0;
 
   /// Subscribe to node resource changes.
   ///
@@ -538,8 +538,8 @@ class NodeInfoAccessor {
   /// \param done Callback that will be called when subscription is complete.
   /// \return Status
   virtual Status AsyncSubscribeToResources(
-      const ItemCallback<rpc::NodeResourceChange> &subscribe,
-      const StatusCallback &done) = 0;
+      const ItemCallback<rpc::NodeResourceChange>& subscribe,
+      const StatusCallback& done) = 0;
 
   /// Report heartbeat of a node to GCS asynchronously.
   ///
@@ -548,8 +548,8 @@ class NodeInfoAccessor {
   /// \return Status
   // TODO(micafan) NodeStateAccessor will call this method to report heartbeat.
   virtual Status AsyncReportHeartbeat(
-      const std::shared_ptr<rpc::HeartbeatTableData> &data_ptr,
-      const StatusCallback &callback) = 0;
+      const std::shared_ptr<rpc::HeartbeatTableData>& data_ptr,
+      const StatusCallback& callback) = 0;
 
   /// Subscribe to the heartbeat of each node from GCS.
   ///
@@ -557,8 +557,8 @@ class NodeInfoAccessor {
   /// \param done Callback that will be called when subscription is complete.
   /// \return Status
   virtual Status AsyncSubscribeHeartbeat(
-      const SubscribeCallback<ClientID, rpc::HeartbeatTableData> &subscribe,
-      const StatusCallback &done) = 0;
+      const SubscribeCallback<ClientID, rpc::HeartbeatTableData>& subscribe,
+      const StatusCallback& done) = 0;
 
   /// Report state of all nodes to GCS asynchronously.
   ///
@@ -566,8 +566,8 @@ class NodeInfoAccessor {
   /// \param callback Callback that will be called after report finishes.
   /// \return Status
   virtual Status AsyncReportBatchHeartbeat(
-      const std::shared_ptr<rpc::HeartbeatBatchTableData> &data_ptr,
-      const StatusCallback &callback) = 0;
+      const std::shared_ptr<rpc::HeartbeatBatchTableData>& data_ptr,
+      const StatusCallback& callback) = 0;
 
   /// Subscribe batched state of all nodes from GCS.
   ///
@@ -576,8 +576,8 @@ class NodeInfoAccessor {
   /// \param done Callback that will be called when subscription is complete.
   /// \return Status
   virtual Status AsyncSubscribeBatchHeartbeat(
-      const ItemCallback<rpc::HeartbeatBatchTableData> &subscribe,
-      const StatusCallback &done) = 0;
+      const ItemCallback<rpc::HeartbeatBatchTableData>& subscribe,
+      const StatusCallback& done) = 0;
 
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
@@ -594,15 +594,15 @@ class NodeInfoAccessor {
   /// \param config Map of config options
   /// \return Status
   virtual Status AsyncSetInternalConfig(
-      std::unordered_map<std::string, std::string> &config) = 0;
+      std::unordered_map<std::string, std::string>& config) = 0;
 
   /// Get the internal config string from GCS.
   ///
   /// \param callback Processes a map of config options
   /// \return Status
   virtual Status AsyncGetInternalConfig(
-      const OptionalItemCallback<std::unordered_map<std::string, std::string>>
-          &callback) = 0;
+      const OptionalItemCallback<std::unordered_map<std::string, std::string>>&
+          callback) = 0;
 
  protected:
   NodeInfoAccessor() = default;
@@ -627,8 +627,8 @@ class ErrorInfoAccessor {
   /// \param data_ptr The error message that will be reported to GCS.
   /// \param callback Callback that will be called when report is complete.
   /// \return Status
-  virtual Status AsyncReportJobError(const std::shared_ptr<rpc::ErrorTableData> &data_ptr,
-                                     const StatusCallback &callback) = 0;
+  virtual Status AsyncReportJobError(const std::shared_ptr<rpc::ErrorTableData>& data_ptr,
+                                     const StatusCallback& callback) = 0;
 
  protected:
   ErrorInfoAccessor() = default;
@@ -648,15 +648,15 @@ class StatsInfoAccessor {
   /// \param callback Callback that will be called when add is complete.
   /// \return Status
   virtual Status AsyncAddProfileData(
-      const std::shared_ptr<rpc::ProfileTableData> &data_ptr,
-      const StatusCallback &callback) = 0;
+      const std::shared_ptr<rpc::ProfileTableData>& data_ptr,
+      const StatusCallback& callback) = 0;
 
   /// Get all profile info from GCS asynchronously.
   ///
   /// \param callback Callback that will be called after lookup finished.
   /// \return Status
   virtual Status AsyncGetAll(
-      const MultiItemCallback<rpc::ProfileTableData> &callback) = 0;
+      const MultiItemCallback<rpc::ProfileTableData>& callback) = 0;
 
  protected:
   StatsInfoAccessor() = default;
@@ -677,8 +677,8 @@ class WorkerInfoAccessor {
   /// \param done Callback that will be called when subscription is complete.
   /// \return Status
   virtual Status AsyncSubscribeToWorkerFailures(
-      const SubscribeCallback<WorkerID, rpc::WorkerTableData> &subscribe,
-      const StatusCallback &done) = 0;
+      const SubscribeCallback<WorkerID, rpc::WorkerTableData>& subscribe,
+      const StatusCallback& done) = 0;
 
   /// Report a worker failure to GCS asynchronously.
   ///
@@ -686,22 +686,22 @@ class WorkerInfoAccessor {
   /// \param callback Callback that will be called when report is complate.
   /// \param Status
   virtual Status AsyncReportWorkerFailure(
-      const std::shared_ptr<rpc::WorkerTableData> &data_ptr,
-      const StatusCallback &callback) = 0;
+      const std::shared_ptr<rpc::WorkerTableData>& data_ptr,
+      const StatusCallback& callback) = 0;
 
   /// Get worker specification from GCS asynchronously.
   ///
   /// \param worker_id The ID of worker to look up in the GCS.
   /// \param callback Callback that will be called after lookup finishes.
   /// \return Status
-  virtual Status AsyncGet(const WorkerID &worker_id,
-                          const OptionalItemCallback<rpc::WorkerTableData> &callback) = 0;
+  virtual Status AsyncGet(const WorkerID& worker_id,
+                          const OptionalItemCallback<rpc::WorkerTableData>& callback) = 0;
 
   /// Get all worker info from GCS asynchronously.
   ///
   /// \param callback Callback that will be called after lookup finished.
   /// \return Status
-  virtual Status AsyncGetAll(const MultiItemCallback<rpc::WorkerTableData> &callback) = 0;
+  virtual Status AsyncGetAll(const MultiItemCallback<rpc::WorkerTableData>& callback) = 0;
 
   /// Add worker information to GCS asynchronously.
   ///
@@ -709,8 +709,8 @@ class WorkerInfoAccessor {
   /// \param callback Callback that will be called after worker information has been added
   /// to GCS.
   /// \return Status
-  virtual Status AsyncAdd(const std::shared_ptr<rpc::WorkerTableData> &data_ptr,
-                          const StatusCallback &callback) = 0;
+  virtual Status AsyncAdd(const std::shared_ptr<rpc::WorkerTableData>& data_ptr,
+                          const StatusCallback& callback) = 0;
 
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
@@ -736,7 +736,7 @@ class PlacementGroupInfoAccessor {
   /// \param callback Callback that will be called after the placement group info is
   /// written to GCS. \return Status
   virtual Status AsyncCreatePlacementGroup(
-      const PlacementGroupSpecification &placement_group_spec) = 0;
+      const PlacementGroupSpecification& placement_group_spec) = 0;
 
  protected:
   PlacementGroupInfoAccessor() = default;

--- a/src/ray/gcs/asio.cc
+++ b/src/ray/gcs/asio.cc
@@ -20,8 +20,8 @@ extern "C" {
 #include "hiredis/async.h"
 }
 
-RedisAsioClient::RedisAsioClient(boost::asio::io_service &io_service,
-                                 ray::gcs::RedisAsyncContext &redis_async_context)
+RedisAsioClient::RedisAsioClient(boost::asio::io_service& io_service,
+                                 ray::gcs::RedisAsyncContext& redis_async_context)
     : redis_async_context_(redis_async_context),
       io_service_(io_service),
       socket_(io_service),
@@ -29,10 +29,10 @@ RedisAsioClient::RedisAsioClient(boost::asio::io_service &io_service,
       write_requested_(false),
       read_in_progress_(false),
       write_in_progress_(false) {
-  redisAsyncContext *async_context = redis_async_context_.GetRawRedisAsyncContext();
+  redisAsyncContext* async_context = redis_async_context_.GetRawRedisAsyncContext();
 
   // gives access to c->fd
-  redisContext *c = &(async_context->c);
+  redisContext* c = &(async_context->c);
 
 #ifdef _WIN32
   SOCKET sock = SOCKET_ERROR;
@@ -110,27 +110,27 @@ void RedisAsioClient::del_io(bool write) {
 
 void RedisAsioClient::cleanup() {}
 
-static inline RedisAsioClient *cast_to_client(void *private_data) {
+static inline RedisAsioClient* cast_to_client(void* private_data) {
   RAY_CHECK(private_data != nullptr);
-  return static_cast<RedisAsioClient *>(private_data);
+  return static_cast<RedisAsioClient*>(private_data);
 }
 
-extern "C" void call_C_addRead(void *private_data) {
+extern "C" void call_C_addRead(void* private_data) {
   cast_to_client(private_data)->add_io(false);
 }
 
-extern "C" void call_C_delRead(void *private_data) {
+extern "C" void call_C_delRead(void* private_data) {
   cast_to_client(private_data)->del_io(false);
 }
 
-extern "C" void call_C_addWrite(void *private_data) {
+extern "C" void call_C_addWrite(void* private_data) {
   cast_to_client(private_data)->add_io(true);
 }
 
-extern "C" void call_C_delWrite(void *private_data) {
+extern "C" void call_C_delWrite(void* private_data) {
   cast_to_client(private_data)->del_io(true);
 }
 
-extern "C" void call_C_cleanup(void *private_data) {
+extern "C" void call_C_cleanup(void* private_data) {
   cast_to_client(private_data)->cleanup();
 }

--- a/src/ray/gcs/asio.h
+++ b/src/ray/gcs/asio.h
@@ -35,12 +35,12 @@
 #pragma once
 
 #include <stdio.h>
-#include <iostream>
-#include <string>
 
 #include <boost/asio.hpp>
 #include <boost/asio/error.hpp>
 #include <boost/bind.hpp>
+#include <iostream>
+#include <string>
 
 #include "ray/gcs/redis_async_context.h"
 

--- a/src/ray/gcs/asio.h
+++ b/src/ray/gcs/asio.h
@@ -53,8 +53,8 @@ class RedisAsioClient {
   /// \param io_service The single-threaded event loop for this client.
   /// \param redis_async_context The redis async context used to execute redis commands
   /// for this client.
-  RedisAsioClient(boost::asio::io_service &io_service,
-                  ray::gcs::RedisAsyncContext &redis_async_context);
+  RedisAsioClient(boost::asio::io_service& io_service,
+                  ray::gcs::RedisAsyncContext& redis_async_context);
 
   void operate();
 
@@ -64,9 +64,9 @@ class RedisAsioClient {
   void cleanup();
 
  private:
-  ray::gcs::RedisAsyncContext &redis_async_context_;
+  ray::gcs::RedisAsyncContext& redis_async_context_;
 
-  boost::asio::io_service &io_service_;
+  boost::asio::io_service& io_service_;
   boost::asio::ip::tcp::socket socket_;
   // Hiredis wanted to add a read operation to the event loop
   // but the read might not have happened yet
@@ -81,8 +81,8 @@ class RedisAsioClient {
 };
 
 // C wrappers for class member functions
-extern "C" void call_C_addRead(void *private_data);
-extern "C" void call_C_delRead(void *private_data);
-extern "C" void call_C_addWrite(void *private_data);
-extern "C" void call_C_delWrite(void *private_data);
-extern "C" void call_C_cleanup(void *private_data);
+extern "C" void call_C_addRead(void* private_data);
+extern "C" void call_C_delRead(void* private_data);
+extern "C" void call_C_addWrite(void* private_data);
+extern "C" void call_C_delWrite(void* private_data);
+extern "C" void call_C_cleanup(void* private_data);

--- a/src/ray/gcs/callback.h
+++ b/src/ray/gcs/callback.h
@@ -37,30 +37,30 @@ using StatusCallback = std::function<void(Status status)>;
 /// this optional object is empty.
 template <typename Data>
 using OptionalItemCallback =
-    std::function<void(Status status, const boost::optional<Data> &result)>;
+    std::function<void(Status status, const boost::optional<Data>& result)>;
 
 /// This callback is used to receive multiple items from GCS when a read completes.
 /// \param status Status indicates whether the read was successful.
 /// \param result The items returned by GCS.
 template <typename Data>
 using MultiItemCallback =
-    std::function<void(Status status, const std::vector<Data> &result)>;
+    std::function<void(Status status, const std::vector<Data>& result)>;
 
 /// This callback is used to receive notifications of the subscribed items in the GCS.
 /// \param id The id of the item.
 /// \param result The notification message.
 template <typename ID, typename Data>
-using SubscribeCallback = std::function<void(const ID &id, const Data &result)>;
+using SubscribeCallback = std::function<void(const ID& id, const Data& result)>;
 
 /// This callback is used to receive a single item from GCS.
 /// \param result The item returned by GCS.
 template <typename Data>
-using ItemCallback = std::function<void(const Data &result)>;
+using ItemCallback = std::function<void(const Data& result)>;
 
 /// This callback is used to receive multiple key-value items from GCS.
 /// \param result The key-value items returned by GCS.
 template <typename Key, typename Value>
-using MapCallback = std::function<void(const std::unordered_map<Key, Value> &result)>;
+using MapCallback = std::function<void(const std::unordered_map<Key, Value>& result)>;
 
 }  // namespace gcs
 

--- a/src/ray/gcs/entry_change_notification.h
+++ b/src/ray/gcs/entry_change_notification.h
@@ -31,12 +31,12 @@ class EntryChangeNotification {
   EntryChangeNotification(rpc::GcsChangeMode change_mode, Data data)
       : change_mode_(change_mode), data_(std::move(data)) {}
 
-  EntryChangeNotification(EntryChangeNotification &&other) {
+  EntryChangeNotification(EntryChangeNotification&& other) {
     change_mode_ = other.change_mode_;
     data_ = std::move(other.data_);
   }
 
-  EntryChangeNotification &operator=(EntryChangeNotification &&other) {
+  EntryChangeNotification& operator=(EntryChangeNotification&& other) {
     change_mode_ = other.change_mode_;
     data_ = std::move(other.data_);
   }
@@ -55,7 +55,7 @@ class EntryChangeNotification {
   /// Get data of this notification.
   ///
   /// \return Data
-  const Data &GetData() const { return data_; }
+  const Data& GetData() const { return data_; }
 
  private:
   rpc::GcsChangeMode change_mode_;

--- a/src/ray/gcs/gcs_client.h
+++ b/src/ray/gcs/gcs_client.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+
 #include "ray/common/status.h"
 #include "ray/gcs/accessor.h"
 #include "ray/util/logging.h"

--- a/src/ray/gcs/gcs_client.h
+++ b/src/ray/gcs/gcs_client.h
@@ -38,7 +38,7 @@ class GcsClientOptions {
   /// \param port GCS service port.
   /// \param password GCS service password.
   /// \param is_test_client Whether this client is used for tests.
-  GcsClientOptions(const std::string &ip, int port, const std::string &password,
+  GcsClientOptions(const std::string& ip, int port, const std::string& password,
                    bool is_test_client = false)
       : server_ip_(ip),
         server_port_(port),
@@ -71,7 +71,7 @@ class GcsClient : public std::enable_shared_from_this<GcsClient> {
   /// This function must be called before calling other functions.
   ///
   /// \return Status
-  virtual Status Connect(boost::asio::io_service &io_service) = 0;
+  virtual Status Connect(boost::asio::io_service& io_service) = 0;
 
   /// Disconnect with GCS Service. Non-thread safe.
   virtual void Disconnect() = 0;
@@ -81,63 +81,63 @@ class GcsClient : public std::enable_shared_from_this<GcsClient> {
 
   /// Get the sub-interface for accessing actor information in GCS.
   /// This function is thread safe.
-  ActorInfoAccessor &Actors() {
+  ActorInfoAccessor& Actors() {
     RAY_CHECK(actor_accessor_ != nullptr);
     return *actor_accessor_;
   }
 
   /// Get the sub-interface for accessing job information in GCS.
   /// This function is thread safe.
-  JobInfoAccessor &Jobs() {
+  JobInfoAccessor& Jobs() {
     RAY_CHECK(job_accessor_ != nullptr);
     return *job_accessor_;
   }
 
   /// Get the sub-interface for accessing object information in GCS.
   /// This function is thread safe.
-  ObjectInfoAccessor &Objects() {
+  ObjectInfoAccessor& Objects() {
     RAY_CHECK(object_accessor_ != nullptr);
     return *object_accessor_;
   }
 
   /// Get the sub-interface for accessing node information in GCS.
   /// This function is thread safe.
-  NodeInfoAccessor &Nodes() {
+  NodeInfoAccessor& Nodes() {
     RAY_CHECK(node_accessor_ != nullptr);
     return *node_accessor_;
   }
 
   /// Get the sub-interface for accessing task information in GCS.
   /// This function is thread safe.
-  TaskInfoAccessor &Tasks() {
+  TaskInfoAccessor& Tasks() {
     RAY_CHECK(task_accessor_ != nullptr);
     return *task_accessor_;
   }
 
   /// Get the sub-interface for accessing error information in GCS.
   /// This function is thread safe.
-  ErrorInfoAccessor &Errors() {
+  ErrorInfoAccessor& Errors() {
     RAY_CHECK(error_accessor_ != nullptr);
     return *error_accessor_;
   }
 
   /// Get the sub-interface for accessing stats information in GCS.
   /// This function is thread safe.
-  StatsInfoAccessor &Stats() {
+  StatsInfoAccessor& Stats() {
     RAY_CHECK(stats_accessor_ != nullptr);
     return *stats_accessor_;
   }
 
   /// Get the sub-interface for accessing worker information in GCS.
   /// This function is thread safe.
-  WorkerInfoAccessor &Workers() {
+  WorkerInfoAccessor& Workers() {
     RAY_CHECK(worker_accessor_ != nullptr);
     return *worker_accessor_;
   }
 
   /// Get the sub-interface for accessing worker information in GCS.
   /// This function is thread safe.
-  PlacementGroupInfoAccessor &PlacementGroups() {
+  PlacementGroupInfoAccessor& PlacementGroups() {
     RAY_CHECK(placement_group_accessor_ != nullptr);
     return *placement_group_accessor_;
   }
@@ -146,7 +146,7 @@ class GcsClient : public std::enable_shared_from_this<GcsClient> {
   /// Constructor of GcsClient.
   ///
   /// \param options Options for client.
-  GcsClient(const GcsClientOptions &options) : options_(options) {}
+  GcsClient(const GcsClientOptions& options) : options_(options) {}
 
   GcsClientOptions options_;
 

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -19,8 +19,8 @@
 namespace ray {
 namespace gcs {
 
-GlobalStateAccessor::GlobalStateAccessor(const std::string &redis_address,
-                                         const std::string &redis_password,
+GlobalStateAccessor::GlobalStateAccessor(const std::string& redis_address,
+                                         const std::string& redis_password,
                                          bool is_test) {
   RAY_LOG(INFO) << "Redis server address = " << redis_address
                 << ", is test flag = " << is_test;
@@ -105,17 +105,17 @@ std::vector<std::string> GlobalStateAccessor::GetAllObjectInfo() {
 }
 
 std::unique_ptr<std::string> GlobalStateAccessor::GetObjectInfo(
-    const ObjectID &object_id) {
+    const ObjectID& object_id) {
   std::unique_ptr<std::string> object_info;
   std::promise<bool> promise;
   auto on_done = [object_id, &object_info, &promise](
-                     const Status &status,
-                     const std::vector<rpc::ObjectTableData> &result) {
+                     const Status& status,
+                     const std::vector<rpc::ObjectTableData>& result) {
     RAY_CHECK_OK(status);
     if (!result.empty()) {
       rpc::ObjectLocationInfo object_location_info;
       object_location_info.set_object_id(object_id.Binary());
-      for (auto &data : result) {
+      for (auto& data : result) {
         object_location_info.add_locations()->CopyFrom(data);
       }
       object_info.reset(new std::string(object_location_info.SerializeAsString()));
@@ -127,17 +127,17 @@ std::unique_ptr<std::string> GlobalStateAccessor::GetObjectInfo(
   return object_info;
 }
 
-std::string GlobalStateAccessor::GetNodeResourceInfo(const ClientID &node_id) {
+std::string GlobalStateAccessor::GetNodeResourceInfo(const ClientID& node_id) {
   rpc::ResourceMap node_resource_map;
   std::promise<void> promise;
   auto on_done =
       [&node_resource_map, &promise](
-          const Status &status,
-          const boost::optional<ray::gcs::NodeInfoAccessor::ResourceMap> &result) {
+          const Status& status,
+          const boost::optional<ray::gcs::NodeInfoAccessor::ResourceMap>& result) {
         RAY_CHECK_OK(status);
         if (result) {
           auto result_value = result.get();
-          for (auto &data : result_value) {
+          for (auto& data : result_value) {
             (*node_resource_map.mutable_items())[data.first] = *data.second;
           }
         }
@@ -178,7 +178,7 @@ std::vector<std::string> GlobalStateAccessor::GetAllActorInfo() {
   return actor_table_data;
 }
 
-std::unique_ptr<std::string> GlobalStateAccessor::GetActorInfo(const ActorID &actor_id) {
+std::unique_ptr<std::string> GlobalStateAccessor::GetActorInfo(const ActorID& actor_id) {
   std::unique_ptr<std::string> actor_table_data;
   std::promise<bool> promise;
   RAY_CHECK_OK(gcs_client_->Actors().AsyncGet(
@@ -189,7 +189,7 @@ std::unique_ptr<std::string> GlobalStateAccessor::GetActorInfo(const ActorID &ac
 }
 
 std::unique_ptr<std::string> GlobalStateAccessor::GetActorCheckpointId(
-    const ActorID &actor_id) {
+    const ActorID& actor_id) {
   std::unique_ptr<std::string> actor_checkpoint_id_data;
   std::promise<bool> promise;
   RAY_CHECK_OK(gcs_client_->Actors().AsyncGetCheckpointID(
@@ -200,7 +200,7 @@ std::unique_ptr<std::string> GlobalStateAccessor::GetActorCheckpointId(
 }
 
 std::unique_ptr<std::string> GlobalStateAccessor::GetWorkerInfo(
-    const WorkerID &worker_id) {
+    const WorkerID& worker_id) {
   std::unique_ptr<std::string> worker_table_data;
   std::promise<bool> promise;
   RAY_CHECK_OK(gcs_client_->Workers().AsyncGet(
@@ -219,12 +219,12 @@ std::vector<std::string> GlobalStateAccessor::GetAllWorkerInfo() {
   return worker_table_data;
 }
 
-bool GlobalStateAccessor::AddWorkerInfo(const std::string &serialized_string) {
+bool GlobalStateAccessor::AddWorkerInfo(const std::string& serialized_string) {
   auto data_ptr = std::make_shared<WorkerTableData>();
   data_ptr->ParseFromString(serialized_string);
   std::promise<bool> promise;
   RAY_CHECK_OK(
-      gcs_client_->Workers().AsyncAdd(data_ptr, [&promise](const Status &status) {
+      gcs_client_->Workers().AsyncAdd(data_ptr, [&promise](const Status& status) {
         RAY_CHECK_OK(status);
         promise.set_value(true);
       }));

--- a/src/ray/gcs/gcs_client/global_state_accessor.h
+++ b/src/ray/gcs/gcs_client/global_state_accessor.h
@@ -31,8 +31,8 @@ class GlobalStateAccessor {
   /// \param redis_address The address of GCS Redis.
   /// \param redis_password The password of GCS Redis.
   /// \param is_test Whether this accessor is used for tests.
-  explicit GlobalStateAccessor(const std::string &redis_address,
-                               const std::string &redis_password, bool is_test = false);
+  explicit GlobalStateAccessor(const std::string& redis_address,
+                               const std::string& redis_password, bool is_test = false);
 
   ~GlobalStateAccessor();
 
@@ -76,7 +76,7 @@ class GlobalStateAccessor {
   /// \return Object info. To support multi-language, we serialize each ObjectTableData
   /// and return the serialized string. Where used, it needs to be deserialized with
   /// protobuf function.
-  std::unique_ptr<std::string> GetObjectInfo(const ObjectID &object_id);
+  std::unique_ptr<std::string> GetObjectInfo(const ObjectID& object_id);
 
   /// Get information of a node resource from GCS Service.
   ///
@@ -84,7 +84,7 @@ class GlobalStateAccessor {
   /// \return node resource map info. To support multi-language, we serialize each
   /// ResourceTableData and return the serialized string. Where used, it needs to be
   /// deserialized with protobuf function.
-  std::string GetNodeResourceInfo(const ClientID &node_id);
+  std::string GetNodeResourceInfo(const ClientID& node_id);
 
   /// Get internal config from GCS Service.
   ///
@@ -105,7 +105,7 @@ class GlobalStateAccessor {
   /// \return Actor info. To support multi-language, we serialize each ActorTableData and
   /// return the serialized string. Where used, it needs to be deserialized with
   /// protobuf function.
-  std::unique_ptr<std::string> GetActorInfo(const ActorID &actor_id);
+  std::unique_ptr<std::string> GetActorInfo(const ActorID& actor_id);
 
   /// Get checkpoint id of an actor from GCS Service.
   ///
@@ -113,7 +113,7 @@ class GlobalStateAccessor {
   /// \return Actor checkpoint id. To support multi-language, we serialize each
   /// ActorCheckpointIdData and return the serialized string. Where used, it needs to be
   /// deserialized with protobuf function.
-  std::unique_ptr<std::string> GetActorCheckpointId(const ActorID &actor_id);
+  std::unique_ptr<std::string> GetActorCheckpointId(const ActorID& actor_id);
 
   /// Get information of a worker from GCS Service.
   ///
@@ -121,7 +121,7 @@ class GlobalStateAccessor {
   /// \return Worker info. To support multi-language, we serialize each WorkerTableData
   /// and return the serialized string. Where used, it needs to be deserialized with
   /// protobuf function.
-  std::unique_ptr<std::string> GetWorkerInfo(const WorkerID &worker_id);
+  std::unique_ptr<std::string> GetWorkerInfo(const WorkerID& worker_id);
 
   /// Get information of all workers from GCS Service.
   ///
@@ -135,7 +135,7 @@ class GlobalStateAccessor {
   /// \param serialized_string The serialized data of worker to be added in the GCS
   /// Service, use string is convenient for python to use.
   /// \return Is operation success.
-  bool AddWorkerInfo(const std::string &serialized_string);
+  bool AddWorkerInfo(const std::string& serialized_string);
 
  private:
   /// MultiItem transformation helper in template style.
@@ -143,11 +143,11 @@ class GlobalStateAccessor {
   /// \return MultiItemCallback within in rpc type DATA.
   template <class DATA>
   MultiItemCallback<DATA> TransformForMultiItemCallback(
-      std::vector<std::string> &data_vec, std::promise<bool> &promise) {
-    return [&data_vec, &promise](const Status &status, const std::vector<DATA> &result) {
+      std::vector<std::string>& data_vec, std::promise<bool>& promise) {
+    return [&data_vec, &promise](const Status& status, const std::vector<DATA>& result) {
       RAY_CHECK_OK(status);
       std::transform(result.begin(), result.end(), std::back_inserter(data_vec),
-                     [](const DATA &data) { return data.SerializeAsString(); });
+                     [](const DATA& data) { return data.SerializeAsString(); });
       promise.set_value(true);
     };
   }
@@ -157,8 +157,8 @@ class GlobalStateAccessor {
   /// \return OptionalItemCallback within in rpc type DATA.
   template <class DATA>
   OptionalItemCallback<DATA> TransformForOptionalItemCallback(
-      std::unique_ptr<std::string> &data, std::promise<bool> &promise) {
-    return [&data, &promise](const Status &status, const boost::optional<DATA> &result) {
+      std::unique_ptr<std::string>& data, std::promise<bool>& promise) {
+    return [&data, &promise](const Status& status, const boost::optional<DATA>& result) {
       RAY_CHECK_OK(status);
       if (result) {
         data.reset(new std::string(result->SerializeAsString()));

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -20,11 +20,11 @@ namespace ray {
 namespace gcs {
 
 ServiceBasedJobInfoAccessor::ServiceBasedJobInfoAccessor(
-    ServiceBasedGcsClient *client_impl)
+    ServiceBasedGcsClient* client_impl)
     : client_impl_(client_impl) {}
 
 Status ServiceBasedJobInfoAccessor::AsyncAdd(
-    const std::shared_ptr<JobTableData> &data_ptr, const StatusCallback &callback) {
+    const std::shared_ptr<JobTableData>& data_ptr, const StatusCallback& callback) {
   JobID job_id = JobID::FromBinary(data_ptr->job_id());
   RAY_LOG(DEBUG) << "Adding job, job id = " << job_id
                  << ", driver pid = " << data_ptr->driver_pid();
@@ -32,7 +32,7 @@ Status ServiceBasedJobInfoAccessor::AsyncAdd(
   request.mutable_data()->CopyFrom(*data_ptr);
   client_impl_->GetGcsRpcClient().AddJob(
       request,
-      [job_id, data_ptr, callback](const Status &status, const rpc::AddJobReply &reply) {
+      [job_id, data_ptr, callback](const Status& status, const rpc::AddJobReply& reply) {
         if (callback) {
           callback(status);
         }
@@ -43,14 +43,14 @@ Status ServiceBasedJobInfoAccessor::AsyncAdd(
   return Status::OK();
 }
 
-Status ServiceBasedJobInfoAccessor::AsyncMarkFinished(const JobID &job_id,
-                                                      const StatusCallback &callback) {
+Status ServiceBasedJobInfoAccessor::AsyncMarkFinished(const JobID& job_id,
+                                                      const StatusCallback& callback) {
   RAY_LOG(DEBUG) << "Marking job state, job id = " << job_id;
   rpc::MarkJobFinishedRequest request;
   request.set_job_id(job_id.Binary());
   client_impl_->GetGcsRpcClient().MarkJobFinished(
       request,
-      [job_id, callback](const Status &status, const rpc::MarkJobFinishedReply &reply) {
+      [job_id, callback](const Status& status, const rpc::MarkJobFinishedReply& reply) {
         if (callback) {
           callback(status);
         }
@@ -61,13 +61,13 @@ Status ServiceBasedJobInfoAccessor::AsyncMarkFinished(const JobID &job_id,
 }
 
 Status ServiceBasedJobInfoAccessor::AsyncSubscribeAll(
-    const SubscribeCallback<JobID, JobTableData> &subscribe, const StatusCallback &done) {
+    const SubscribeCallback<JobID, JobTableData>& subscribe, const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr);
-  fetch_all_data_operation_ = [this, subscribe](const StatusCallback &done) {
+  fetch_all_data_operation_ = [this, subscribe](const StatusCallback& done) {
     auto callback = [subscribe, done](
-                        const Status &status,
-                        const std::vector<rpc::JobTableData> &job_info_list) {
-      for (auto &job_info : job_info_list) {
+                        const Status& status,
+                        const std::vector<rpc::JobTableData>& job_info_list) {
+      for (auto& job_info : job_info_list) {
         subscribe(JobID::FromBinary(job_info.job_id()), job_info);
       }
       if (done) {
@@ -76,8 +76,8 @@ Status ServiceBasedJobInfoAccessor::AsyncSubscribeAll(
     };
     RAY_CHECK_OK(AsyncGetAll(callback));
   };
-  subscribe_operation_ = [this, subscribe](const StatusCallback &done) {
-    auto on_subscribe = [subscribe](const std::string &id, const std::string &data) {
+  subscribe_operation_ = [this, subscribe](const StatusCallback& done) {
+    auto on_subscribe = [subscribe](const std::string& id, const std::string& data) {
       JobTableData job_data;
       job_data.ParseFromString(data);
       subscribe(JobID::FromBinary(id), job_data);
@@ -85,7 +85,7 @@ Status ServiceBasedJobInfoAccessor::AsyncSubscribeAll(
     return client_impl_->GetGcsPubSub().SubscribeAll(JOB_CHANNEL, on_subscribe, done);
   };
   return subscribe_operation_(
-      [this, done](const Status &status) { fetch_all_data_operation_(done); });
+      [this, done](const Status& status) { fetch_all_data_operation_(done); });
 }
 
 void ServiceBasedJobInfoAccessor::AsyncResubscribe(bool is_pubsub_server_restarted) {
@@ -96,7 +96,7 @@ void ServiceBasedJobInfoAccessor::AsyncResubscribe(bool is_pubsub_server_restart
   if (is_pubsub_server_restarted) {
     if (subscribe_operation_ != nullptr) {
       RAY_CHECK_OK(subscribe_operation_(
-          [this](const Status &status) { fetch_all_data_operation_(nullptr); }));
+          [this](const Status& status) { fetch_all_data_operation_(nullptr); }));
     }
   } else {
     if (fetch_all_data_operation_ != nullptr) {
@@ -106,12 +106,12 @@ void ServiceBasedJobInfoAccessor::AsyncResubscribe(bool is_pubsub_server_restart
 }
 
 Status ServiceBasedJobInfoAccessor::AsyncGetAll(
-    const MultiItemCallback<rpc::JobTableData> &callback) {
+    const MultiItemCallback<rpc::JobTableData>& callback) {
   RAY_LOG(DEBUG) << "Getting all job info.";
   RAY_CHECK(callback);
   rpc::GetAllJobInfoRequest request;
   client_impl_->GetGcsRpcClient().GetAllJobInfo(
-      request, [callback](const Status &status, const rpc::GetAllJobInfoReply &reply) {
+      request, [callback](const Status& status, const rpc::GetAllJobInfoReply& reply) {
         auto result = VectorFromProtobuf(reply.job_info_list());
         callback(status, result);
         RAY_LOG(DEBUG) << "Finished getting all job info.";
@@ -120,22 +120,22 @@ Status ServiceBasedJobInfoAccessor::AsyncGetAll(
 }
 
 ServiceBasedActorInfoAccessor::ServiceBasedActorInfoAccessor(
-    ServiceBasedGcsClient *client_impl)
+    ServiceBasedGcsClient* client_impl)
     : client_impl_(client_impl) {}
 
 Status ServiceBasedActorInfoAccessor::GetAll(
-    std::vector<ActorTableData> *actor_table_data_list) {
+    std::vector<ActorTableData>* actor_table_data_list) {
   return Status::Invalid("Not implemented");
 }
 
 Status ServiceBasedActorInfoAccessor::AsyncGet(
-    const ActorID &actor_id, const OptionalItemCallback<rpc::ActorTableData> &callback) {
+    const ActorID& actor_id, const OptionalItemCallback<rpc::ActorTableData>& callback) {
   RAY_LOG(DEBUG) << "Getting actor info, actor id = " << actor_id;
   rpc::GetActorInfoRequest request;
   request.set_actor_id(actor_id.Binary());
   client_impl_->GetGcsRpcClient().GetActorInfo(
       request,
-      [actor_id, callback](const Status &status, const rpc::GetActorInfoReply &reply) {
+      [actor_id, callback](const Status& status, const rpc::GetActorInfoReply& reply) {
         if (reply.has_actor_table_data()) {
           callback(status, reply.actor_table_data());
         } else {
@@ -148,11 +148,11 @@ Status ServiceBasedActorInfoAccessor::AsyncGet(
 }
 
 Status ServiceBasedActorInfoAccessor::AsyncGetAll(
-    const MultiItemCallback<rpc::ActorTableData> &callback) {
+    const MultiItemCallback<rpc::ActorTableData>& callback) {
   RAY_LOG(DEBUG) << "Getting all actor info.";
   rpc::GetAllActorInfoRequest request;
   client_impl_->GetGcsRpcClient().GetAllActorInfo(
-      request, [callback](const Status &status, const rpc::GetAllActorInfoReply &reply) {
+      request, [callback](const Status& status, const rpc::GetAllActorInfoReply& reply) {
         auto result = VectorFromProtobuf(reply.actor_table_data());
         callback(status, result);
         RAY_LOG(DEBUG) << "Finished getting all actor info, status = " << status;
@@ -161,13 +161,13 @@ Status ServiceBasedActorInfoAccessor::AsyncGetAll(
 }
 
 Status ServiceBasedActorInfoAccessor::AsyncGetByName(
-    const std::string &name, const OptionalItemCallback<rpc::ActorTableData> &callback) {
+    const std::string& name, const OptionalItemCallback<rpc::ActorTableData>& callback) {
   RAY_LOG(DEBUG) << "Getting actor info, name = " << name;
   rpc::GetNamedActorInfoRequest request;
   request.set_name(name);
   client_impl_->GetGcsRpcClient().GetNamedActorInfo(
       request,
-      [name, callback](const Status &status, const rpc::GetNamedActorInfoReply &reply) {
+      [name, callback](const Status& status, const rpc::GetNamedActorInfoReply& reply) {
         if (reply.has_actor_table_data()) {
           callback(status, reply.actor_table_data());
         } else {
@@ -180,12 +180,12 @@ Status ServiceBasedActorInfoAccessor::AsyncGetByName(
 }
 
 Status ServiceBasedActorInfoAccessor::AsyncRegisterActor(
-    const ray::TaskSpecification &task_spec, const ray::gcs::StatusCallback &callback) {
+    const ray::TaskSpecification& task_spec, const ray::gcs::StatusCallback& callback) {
   RAY_CHECK(task_spec.IsActorCreationTask() && callback);
   rpc::RegisterActorRequest request;
   request.mutable_task_spec()->CopyFrom(task_spec.GetMessage());
   client_impl_->GetGcsRpcClient().RegisterActor(
-      request, [callback](const Status &, const rpc::RegisterActorReply &reply) {
+      request, [callback](const Status&, const rpc::RegisterActorReply& reply) {
         auto status =
             reply.status().code() == (int)StatusCode::OK
                 ? Status()
@@ -196,12 +196,12 @@ Status ServiceBasedActorInfoAccessor::AsyncRegisterActor(
 }
 
 Status ServiceBasedActorInfoAccessor::AsyncCreateActor(
-    const ray::TaskSpecification &task_spec, const ray::gcs::StatusCallback &callback) {
+    const ray::TaskSpecification& task_spec, const ray::gcs::StatusCallback& callback) {
   RAY_CHECK(task_spec.IsActorCreationTask() && callback);
   rpc::CreateActorRequest request;
   request.mutable_task_spec()->CopyFrom(task_spec.GetMessage());
   client_impl_->GetGcsRpcClient().CreateActor(
-      request, [callback](const Status &, const rpc::CreateActorReply &reply) {
+      request, [callback](const Status&, const rpc::CreateActorReply& reply) {
         auto status =
             reply.status().code() == (int)StatusCode::OK
                 ? Status()
@@ -212,18 +212,18 @@ Status ServiceBasedActorInfoAccessor::AsyncCreateActor(
 }
 
 Status ServiceBasedActorInfoAccessor::AsyncRegister(
-    const std::shared_ptr<rpc::ActorTableData> &data_ptr,
-    const StatusCallback &callback) {
+    const std::shared_ptr<rpc::ActorTableData>& data_ptr,
+    const StatusCallback& callback) {
   ActorID actor_id = ActorID::FromBinary(data_ptr->actor_id());
   RAY_LOG(DEBUG) << "Registering actor info, actor id = " << actor_id;
   rpc::RegisterActorInfoRequest request;
   request.mutable_actor_table_data()->CopyFrom(*data_ptr);
 
   auto operation = [this, request, actor_id,
-                    callback](const SequencerDoneCallback &done_callback) {
+                    callback](const SequencerDoneCallback& done_callback) {
     client_impl_->GetGcsRpcClient().RegisterActorInfo(
         request, [actor_id, callback, done_callback](
-                     const Status &status, const rpc::RegisterActorInfoReply &reply) {
+                     const Status& status, const rpc::RegisterActorInfoReply& reply) {
           if (callback) {
             callback(status);
           }
@@ -238,18 +238,18 @@ Status ServiceBasedActorInfoAccessor::AsyncRegister(
 }
 
 Status ServiceBasedActorInfoAccessor::AsyncUpdate(
-    const ActorID &actor_id, const std::shared_ptr<rpc::ActorTableData> &data_ptr,
-    const StatusCallback &callback) {
+    const ActorID& actor_id, const std::shared_ptr<rpc::ActorTableData>& data_ptr,
+    const StatusCallback& callback) {
   RAY_LOG(DEBUG) << "Updating actor info, actor id = " << actor_id;
   rpc::UpdateActorInfoRequest request;
   request.set_actor_id(actor_id.Binary());
   request.mutable_actor_table_data()->CopyFrom(*data_ptr);
 
   auto operation = [this, request, actor_id,
-                    callback](const SequencerDoneCallback &done_callback) {
+                    callback](const SequencerDoneCallback& done_callback) {
     client_impl_->GetGcsRpcClient().UpdateActorInfo(
         request, [actor_id, callback, done_callback](
-                     const Status &status, const rpc::UpdateActorInfoReply &reply) {
+                     const Status& status, const rpc::UpdateActorInfoReply& reply) {
           if (callback) {
             callback(status);
           }
@@ -264,14 +264,14 @@ Status ServiceBasedActorInfoAccessor::AsyncUpdate(
 }
 
 Status ServiceBasedActorInfoAccessor::AsyncSubscribeAll(
-    const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
-    const StatusCallback &done) {
+    const SubscribeCallback<ActorID, rpc::ActorTableData>& subscribe,
+    const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr);
-  fetch_all_data_operation_ = [this, subscribe](const StatusCallback &done) {
+  fetch_all_data_operation_ = [this, subscribe](const StatusCallback& done) {
     auto callback = [subscribe, done](
-                        const Status &status,
-                        const std::vector<rpc::ActorTableData> &actor_info_list) {
-      for (auto &actor_info : actor_info_list) {
+                        const Status& status,
+                        const std::vector<rpc::ActorTableData>& actor_info_list) {
+      for (auto& actor_info : actor_info_list) {
         subscribe(ActorID::FromBinary(actor_info.actor_id()), actor_info);
       }
       if (done) {
@@ -281,8 +281,8 @@ Status ServiceBasedActorInfoAccessor::AsyncSubscribeAll(
     RAY_CHECK_OK(AsyncGetAll(callback));
   };
 
-  subscribe_all_operation_ = [this, subscribe](const StatusCallback &done) {
-    auto on_subscribe = [subscribe](const std::string &id, const std::string &data) {
+  subscribe_all_operation_ = [this, subscribe](const StatusCallback& done) {
+    auto on_subscribe = [subscribe](const std::string& id, const std::string& data) {
       ActorTableData actor_data;
       actor_data.ParseFromString(data);
       subscribe(ActorID::FromBinary(actor_data.actor_id()), actor_data);
@@ -291,21 +291,21 @@ Status ServiceBasedActorInfoAccessor::AsyncSubscribeAll(
   };
 
   return subscribe_all_operation_(
-      [this, done](const Status &status) { fetch_all_data_operation_(done); });
+      [this, done](const Status& status) { fetch_all_data_operation_(done); });
 }
 
 Status ServiceBasedActorInfoAccessor::AsyncSubscribe(
-    const ActorID &actor_id,
-    const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
-    const StatusCallback &done) {
+    const ActorID& actor_id,
+    const SubscribeCallback<ActorID, rpc::ActorTableData>& subscribe,
+    const StatusCallback& done) {
   RAY_LOG(DEBUG) << "Subscribing update operations of actor, actor id = " << actor_id;
   RAY_CHECK(subscribe != nullptr) << "Failed to subscribe actor, actor id = " << actor_id;
 
   auto fetch_data_operation = [this, actor_id,
-                               subscribe](const StatusCallback &fetch_done) {
+                               subscribe](const StatusCallback& fetch_done) {
     auto callback = [actor_id, subscribe, fetch_done](
-                        const Status &status,
-                        const boost::optional<rpc::ActorTableData> &result) {
+                        const Status& status,
+                        const boost::optional<rpc::ActorTableData>& result) {
       if (result) {
         subscribe(actor_id, *result);
       }
@@ -317,8 +317,8 @@ Status ServiceBasedActorInfoAccessor::AsyncSubscribe(
   };
 
   auto subscribe_operation = [this, actor_id,
-                              subscribe](const StatusCallback &subscribe_done) {
-    auto on_subscribe = [subscribe](const std::string &id, const std::string &data) {
+                              subscribe](const StatusCallback& subscribe_done) {
+    auto on_subscribe = [subscribe](const std::string& id, const std::string& data) {
       ActorTableData actor_data;
       actor_data.ParseFromString(data);
       subscribe(ActorID::FromBinary(actor_data.actor_id()), actor_data);
@@ -333,10 +333,10 @@ Status ServiceBasedActorInfoAccessor::AsyncSubscribe(
     fetch_data_operations_[actor_id] = fetch_data_operation;
   }
   return subscribe_operation(
-      [fetch_data_operation, done](const Status &status) { fetch_data_operation(done); });
+      [fetch_data_operation, done](const Status& status) { fetch_data_operation(done); });
 }
 
-Status ServiceBasedActorInfoAccessor::AsyncUnsubscribe(const ActorID &actor_id) {
+Status ServiceBasedActorInfoAccessor::AsyncUnsubscribe(const ActorID& actor_id) {
   RAY_LOG(DEBUG) << "Cancelling subscription to an actor, actor id = " << actor_id;
   auto status = client_impl_->GetGcsPubSub().Unsubscribe(ACTOR_CHANNEL, actor_id.Hex());
   absl::MutexLock lock(&mutex_);
@@ -348,8 +348,8 @@ Status ServiceBasedActorInfoAccessor::AsyncUnsubscribe(const ActorID &actor_id) 
 }
 
 Status ServiceBasedActorInfoAccessor::AsyncAddCheckpoint(
-    const std::shared_ptr<rpc::ActorCheckpointData> &data_ptr,
-    const StatusCallback &callback) {
+    const std::shared_ptr<rpc::ActorCheckpointData>& data_ptr,
+    const StatusCallback& callback) {
   ActorID actor_id = ActorID::FromBinary(data_ptr->actor_id());
   ActorCheckpointID checkpoint_id =
       ActorCheckpointID::FromBinary(data_ptr->checkpoint_id());
@@ -359,10 +359,10 @@ Status ServiceBasedActorInfoAccessor::AsyncAddCheckpoint(
   request.mutable_checkpoint_data()->CopyFrom(*data_ptr);
 
   auto operation = [this, request, actor_id, checkpoint_id,
-                    callback](const SequencerDoneCallback &done_callback) {
+                    callback](const SequencerDoneCallback& done_callback) {
     client_impl_->GetGcsRpcClient().AddActorCheckpoint(
         request, [actor_id, checkpoint_id, callback, done_callback](
-                     const Status &status, const rpc::AddActorCheckpointReply &reply) {
+                     const Status& status, const rpc::AddActorCheckpointReply& reply) {
           if (callback) {
             callback(status);
           }
@@ -378,15 +378,15 @@ Status ServiceBasedActorInfoAccessor::AsyncAddCheckpoint(
 }
 
 Status ServiceBasedActorInfoAccessor::AsyncGetCheckpoint(
-    const ActorCheckpointID &checkpoint_id, const ActorID &actor_id,
-    const OptionalItemCallback<rpc::ActorCheckpointData> &callback) {
+    const ActorCheckpointID& checkpoint_id, const ActorID& actor_id,
+    const OptionalItemCallback<rpc::ActorCheckpointData>& callback) {
   RAY_LOG(DEBUG) << "Getting actor checkpoint, checkpoint id = " << checkpoint_id;
   rpc::GetActorCheckpointRequest request;
   request.set_actor_id(actor_id.Binary());
   request.set_checkpoint_id(checkpoint_id.Binary());
   client_impl_->GetGcsRpcClient().GetActorCheckpoint(
-      request, [checkpoint_id, callback](const Status &status,
-                                         const rpc::GetActorCheckpointReply &reply) {
+      request, [checkpoint_id, callback](const Status& status,
+                                         const rpc::GetActorCheckpointReply& reply) {
         if (reply.has_checkpoint_data()) {
           callback(status, reply.checkpoint_data());
         } else {
@@ -399,14 +399,14 @@ Status ServiceBasedActorInfoAccessor::AsyncGetCheckpoint(
 }
 
 Status ServiceBasedActorInfoAccessor::AsyncGetCheckpointID(
-    const ActorID &actor_id,
-    const OptionalItemCallback<rpc::ActorCheckpointIdData> &callback) {
+    const ActorID& actor_id,
+    const OptionalItemCallback<rpc::ActorCheckpointIdData>& callback) {
   RAY_LOG(DEBUG) << "Getting actor checkpoint id, actor id = " << actor_id;
   rpc::GetActorCheckpointIDRequest request;
   request.set_actor_id(actor_id.Binary());
   client_impl_->GetGcsRpcClient().GetActorCheckpointID(
-      request, [actor_id, callback](const Status &status,
-                                    const rpc::GetActorCheckpointIDReply &reply) {
+      request, [actor_id, callback](const Status& status,
+                                    const rpc::GetActorCheckpointIDReply& reply) {
         if (reply.has_checkpoint_id_data()) {
           callback(status, reply.checkpoint_id_data());
         } else {
@@ -427,11 +427,11 @@ void ServiceBasedActorInfoAccessor::AsyncResubscribe(bool is_pubsub_server_resta
   if (is_pubsub_server_restarted) {
     if (subscribe_all_operation_ != nullptr) {
       RAY_CHECK_OK(subscribe_all_operation_(
-          [this](const Status &status) { fetch_all_data_operation_(nullptr); }));
+          [this](const Status& status) { fetch_all_data_operation_(nullptr); }));
     }
-    for (auto &item : subscribe_operations_) {
-      auto &actor_id = item.first;
-      RAY_CHECK_OK(item.second([this, actor_id](const Status &status) {
+    for (auto& item : subscribe_operations_) {
+      auto& actor_id = item.first;
+      RAY_CHECK_OK(item.second([this, actor_id](const Status& status) {
         absl::MutexLock lock(&mutex_);
         auto fetch_data_operation = fetch_data_operations_[actor_id];
         // `fetch_data_operation` is called in the callback function of subscribe.
@@ -446,17 +446,17 @@ void ServiceBasedActorInfoAccessor::AsyncResubscribe(bool is_pubsub_server_resta
     if (fetch_all_data_operation_ != nullptr) {
       fetch_all_data_operation_(nullptr);
     }
-    for (auto &item : fetch_data_operations_) {
+    for (auto& item : fetch_data_operations_) {
       item.second(nullptr);
     }
   }
 }
 
 ServiceBasedNodeInfoAccessor::ServiceBasedNodeInfoAccessor(
-    ServiceBasedGcsClient *client_impl)
+    ServiceBasedGcsClient* client_impl)
     : client_impl_(client_impl) {}
 
-Status ServiceBasedNodeInfoAccessor::RegisterSelf(const GcsNodeInfo &local_node_info) {
+Status ServiceBasedNodeInfoAccessor::RegisterSelf(const GcsNodeInfo& local_node_info) {
   auto node_id = ClientID::FromBinary(local_node_info.node_id());
   RAY_LOG(DEBUG) << "Registering node info, node id = " << node_id
                  << ", address is = " << local_node_info.node_manager_address();
@@ -466,10 +466,10 @@ Status ServiceBasedNodeInfoAccessor::RegisterSelf(const GcsNodeInfo &local_node_
   request.mutable_node_info()->CopyFrom(local_node_info);
 
   auto operation = [this, request, local_node_info,
-                    node_id](const SequencerDoneCallback &done_callback) {
+                    node_id](const SequencerDoneCallback& done_callback) {
     client_impl_->GetGcsRpcClient().RegisterNode(
         request, [this, node_id, local_node_info, done_callback](
-                     const Status &status, const rpc::RegisterNodeReply &reply) {
+                     const Status& status, const rpc::RegisterNodeReply& reply) {
           if (status.ok()) {
             local_node_info_.CopyFrom(local_node_info);
             local_node_id_ = ClientID::FromBinary(local_node_info.node_id());
@@ -492,7 +492,7 @@ Status ServiceBasedNodeInfoAccessor::UnregisterSelf() {
   request.set_node_id(local_node_info_.node_id());
   client_impl_->GetGcsRpcClient().UnregisterNode(
       request,
-      [this, node_id](const Status &status, const rpc::UnregisterNodeReply &reply) {
+      [this, node_id](const Status& status, const rpc::UnregisterNodeReply& reply) {
         if (status.ok()) {
           local_node_info_.set_state(GcsNodeInfo::DEAD);
           local_node_id_ = ClientID::Nil();
@@ -503,21 +503,21 @@ Status ServiceBasedNodeInfoAccessor::UnregisterSelf() {
   return Status::OK();
 }
 
-const ClientID &ServiceBasedNodeInfoAccessor::GetSelfId() const { return local_node_id_; }
+const ClientID& ServiceBasedNodeInfoAccessor::GetSelfId() const { return local_node_id_; }
 
-const GcsNodeInfo &ServiceBasedNodeInfoAccessor::GetSelfInfo() const {
+const GcsNodeInfo& ServiceBasedNodeInfoAccessor::GetSelfInfo() const {
   return local_node_info_;
 }
 
-Status ServiceBasedNodeInfoAccessor::AsyncRegister(const rpc::GcsNodeInfo &node_info,
-                                                   const StatusCallback &callback) {
+Status ServiceBasedNodeInfoAccessor::AsyncRegister(const rpc::GcsNodeInfo& node_info,
+                                                   const StatusCallback& callback) {
   ClientID node_id = ClientID::FromBinary(node_info.node_id());
   RAY_LOG(DEBUG) << "Registering node info, node id = " << node_id;
   rpc::RegisterNodeRequest request;
   request.mutable_node_info()->CopyFrom(node_info);
   client_impl_->GetGcsRpcClient().RegisterNode(
       request,
-      [node_id, callback](const Status &status, const rpc::RegisterNodeReply &reply) {
+      [node_id, callback](const Status& status, const rpc::RegisterNodeReply& reply) {
         if (callback) {
           callback(status);
         }
@@ -527,14 +527,14 @@ Status ServiceBasedNodeInfoAccessor::AsyncRegister(const rpc::GcsNodeInfo &node_
   return Status::OK();
 }
 
-Status ServiceBasedNodeInfoAccessor::AsyncUnregister(const ClientID &node_id,
-                                                     const StatusCallback &callback) {
+Status ServiceBasedNodeInfoAccessor::AsyncUnregister(const ClientID& node_id,
+                                                     const StatusCallback& callback) {
   RAY_LOG(DEBUG) << "Unregistering node info, node id = " << node_id;
   rpc::UnregisterNodeRequest request;
   request.set_node_id(node_id.Binary());
   client_impl_->GetGcsRpcClient().UnregisterNode(
       request,
-      [node_id, callback](const Status &status, const rpc::UnregisterNodeReply &reply) {
+      [node_id, callback](const Status& status, const rpc::UnregisterNodeReply& reply) {
         if (callback) {
           callback(status);
         }
@@ -545,11 +545,11 @@ Status ServiceBasedNodeInfoAccessor::AsyncUnregister(const ClientID &node_id,
 }
 
 Status ServiceBasedNodeInfoAccessor::AsyncGetAll(
-    const MultiItemCallback<GcsNodeInfo> &callback) {
+    const MultiItemCallback<GcsNodeInfo>& callback) {
   RAY_LOG(DEBUG) << "Getting information of all nodes.";
   rpc::GetAllNodeInfoRequest request;
   client_impl_->GetGcsRpcClient().GetAllNodeInfo(
-      request, [callback](const Status &status, const rpc::GetAllNodeInfoReply &reply) {
+      request, [callback](const Status& status, const rpc::GetAllNodeInfoReply& reply) {
         std::vector<GcsNodeInfo> result;
         result.reserve((reply.node_info_list_size()));
         for (int index = 0; index < reply.node_info_list_size(); ++index) {
@@ -563,16 +563,16 @@ Status ServiceBasedNodeInfoAccessor::AsyncGetAll(
 }
 
 Status ServiceBasedNodeInfoAccessor::AsyncSubscribeToNodeChange(
-    const SubscribeCallback<ClientID, GcsNodeInfo> &subscribe,
-    const StatusCallback &done) {
+    const SubscribeCallback<ClientID, GcsNodeInfo>& subscribe,
+    const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr);
   RAY_CHECK(node_change_callback_ == nullptr);
   node_change_callback_ = subscribe;
 
-  fetch_node_data_operation_ = [this](const StatusCallback &done) {
-    auto callback = [this, done](const Status &status,
-                                 const std::vector<GcsNodeInfo> &node_info_list) {
-      for (auto &node_info : node_info_list) {
+  fetch_node_data_operation_ = [this](const StatusCallback& done) {
+    auto callback = [this, done](const Status& status,
+                                 const std::vector<GcsNodeInfo>& node_info_list) {
+      for (auto& node_info : node_info_list) {
         HandleNotification(node_info);
       }
       if (done) {
@@ -582,8 +582,8 @@ Status ServiceBasedNodeInfoAccessor::AsyncSubscribeToNodeChange(
     RAY_CHECK_OK(AsyncGetAll(callback));
   };
 
-  subscribe_node_operation_ = [this](const StatusCallback &done) {
-    auto on_subscribe = [this](const std::string &id, const std::string &data) {
+  subscribe_node_operation_ = [this](const StatusCallback& done) {
+    auto on_subscribe = [this](const std::string& id, const std::string& data) {
       GcsNodeInfo node_info;
       node_info.ParseFromString(data);
       HandleNotification(node_info);
@@ -591,13 +591,13 @@ Status ServiceBasedNodeInfoAccessor::AsyncSubscribeToNodeChange(
     return client_impl_->GetGcsPubSub().SubscribeAll(NODE_CHANNEL, on_subscribe, done);
   };
 
-  return subscribe_node_operation_([this, subscribe, done](const Status &status) {
+  return subscribe_node_operation_([this, subscribe, done](const Status& status) {
     fetch_node_data_operation_(done);
   });
 }
 
 boost::optional<GcsNodeInfo> ServiceBasedNodeInfoAccessor::Get(
-    const ClientID &node_id) const {
+    const ClientID& node_id) const {
   RAY_CHECK(!node_id.IsNil());
   auto entry = node_cache_.find(node_id);
   if (entry != node_cache_.end()) {
@@ -606,23 +606,23 @@ boost::optional<GcsNodeInfo> ServiceBasedNodeInfoAccessor::Get(
   return boost::none;
 }
 
-const std::unordered_map<ClientID, GcsNodeInfo> &ServiceBasedNodeInfoAccessor::GetAll()
+const std::unordered_map<ClientID, GcsNodeInfo>& ServiceBasedNodeInfoAccessor::GetAll()
     const {
   return node_cache_;
 }
 
-bool ServiceBasedNodeInfoAccessor::IsRemoved(const ClientID &node_id) const {
+bool ServiceBasedNodeInfoAccessor::IsRemoved(const ClientID& node_id) const {
   return removed_nodes_.count(node_id) == 1;
 }
 
 Status ServiceBasedNodeInfoAccessor::AsyncGetResources(
-    const ClientID &node_id, const OptionalItemCallback<ResourceMap> &callback) {
+    const ClientID& node_id, const OptionalItemCallback<ResourceMap>& callback) {
   RAY_LOG(DEBUG) << "Getting node resources, node id = " << node_id;
   rpc::GetResourcesRequest request;
   request.set_node_id(node_id.Binary());
   client_impl_->GetGcsRpcClient().GetResources(
       request,
-      [node_id, callback](const Status &status, const rpc::GetResourcesReply &reply) {
+      [node_id, callback](const Status& status, const rpc::GetResourcesReply& reply) {
         ResourceMap resource_map;
         for (auto resource : reply.resources()) {
           resource_map[resource.first] =
@@ -636,20 +636,20 @@ Status ServiceBasedNodeInfoAccessor::AsyncGetResources(
 }
 
 Status ServiceBasedNodeInfoAccessor::AsyncUpdateResources(
-    const ClientID &node_id, const ResourceMap &resources,
-    const StatusCallback &callback) {
+    const ClientID& node_id, const ResourceMap& resources,
+    const StatusCallback& callback) {
   RAY_LOG(DEBUG) << "Updating node resources, node id = " << node_id;
   rpc::UpdateResourcesRequest request;
   request.set_node_id(node_id.Binary());
-  for (auto &resource : resources) {
+  for (auto& resource : resources) {
     (*request.mutable_resources())[resource.first] = *resource.second;
   }
 
   auto operation = [this, request, node_id,
-                    callback](const SequencerDoneCallback &done_callback) {
+                    callback](const SequencerDoneCallback& done_callback) {
     client_impl_->GetGcsRpcClient().UpdateResources(
         request, [node_id, callback, done_callback](
-                     const Status &status, const rpc::UpdateResourcesReply &reply) {
+                     const Status& status, const rpc::UpdateResourcesReply& reply) {
           if (callback) {
             callback(status);
           }
@@ -664,20 +664,20 @@ Status ServiceBasedNodeInfoAccessor::AsyncUpdateResources(
 }
 
 Status ServiceBasedNodeInfoAccessor::AsyncDeleteResources(
-    const ClientID &node_id, const std::vector<std::string> &resource_names,
-    const StatusCallback &callback) {
+    const ClientID& node_id, const std::vector<std::string>& resource_names,
+    const StatusCallback& callback) {
   RAY_LOG(DEBUG) << "Deleting node resources, node id = " << node_id;
   rpc::DeleteResourcesRequest request;
   request.set_node_id(node_id.Binary());
-  for (auto &resource_name : resource_names) {
+  for (auto& resource_name : resource_names) {
     request.add_resource_name_list(resource_name);
   }
 
   auto operation = [this, request, node_id,
-                    callback](const SequencerDoneCallback &done_callback) {
+                    callback](const SequencerDoneCallback& done_callback) {
     client_impl_->GetGcsRpcClient().DeleteResources(
         request, [node_id, callback, done_callback](
-                     const Status &status, const rpc::DeleteResourcesReply &reply) {
+                     const Status& status, const rpc::DeleteResourcesReply& reply) {
           if (callback) {
             callback(status);
           }
@@ -692,10 +692,10 @@ Status ServiceBasedNodeInfoAccessor::AsyncDeleteResources(
 }
 
 Status ServiceBasedNodeInfoAccessor::AsyncSubscribeToResources(
-    const ItemCallback<rpc::NodeResourceChange> &subscribe, const StatusCallback &done) {
+    const ItemCallback<rpc::NodeResourceChange>& subscribe, const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr);
-  subscribe_resource_operation_ = [this, subscribe](const StatusCallback &done) {
-    auto on_subscribe = [subscribe](const std::string &id, const std::string &data) {
+  subscribe_resource_operation_ = [this, subscribe](const StatusCallback& done) {
+    auto on_subscribe = [subscribe](const std::string& id, const std::string& data) {
       rpc::NodeResourceChange node_resource_change;
       node_resource_change.ParseFromString(data);
       subscribe(node_resource_change);
@@ -707,12 +707,12 @@ Status ServiceBasedNodeInfoAccessor::AsyncSubscribeToResources(
 }
 
 Status ServiceBasedNodeInfoAccessor::AsyncReportHeartbeat(
-    const std::shared_ptr<rpc::HeartbeatTableData> &data_ptr,
-    const StatusCallback &callback) {
+    const std::shared_ptr<rpc::HeartbeatTableData>& data_ptr,
+    const StatusCallback& callback) {
   rpc::ReportHeartbeatRequest request;
   request.mutable_heartbeat()->CopyFrom(*data_ptr);
   client_impl_->GetGcsRpcClient().ReportHeartbeat(
-      request, [callback](const Status &status, const rpc::ReportHeartbeatReply &reply) {
+      request, [callback](const Status& status, const rpc::ReportHeartbeatReply& reply) {
         if (callback) {
           callback(status);
         }
@@ -721,8 +721,8 @@ Status ServiceBasedNodeInfoAccessor::AsyncReportHeartbeat(
 }
 
 Status ServiceBasedNodeInfoAccessor::AsyncSubscribeHeartbeat(
-    const SubscribeCallback<ClientID, rpc::HeartbeatTableData> &subscribe,
-    const StatusCallback &done) {
+    const SubscribeCallback<ClientID, rpc::HeartbeatTableData>& subscribe,
+    const StatusCallback& done) {
   const std::string error_msg =
       "Unsupported method of AsyncSubscribeHeartbeat in ServiceBasedNodeInfoAccessor.";
   RAY_LOG(FATAL) << error_msg;
@@ -730,8 +730,8 @@ Status ServiceBasedNodeInfoAccessor::AsyncSubscribeHeartbeat(
 }
 
 Status ServiceBasedNodeInfoAccessor::AsyncReportBatchHeartbeat(
-    const std::shared_ptr<rpc::HeartbeatBatchTableData> &data_ptr,
-    const StatusCallback &callback) {
+    const std::shared_ptr<rpc::HeartbeatBatchTableData>& data_ptr,
+    const StatusCallback& callback) {
   const std::string error_msg =
       "Unsupported method of AsyncReportBatchHeartbeat in ServiceBasedNodeInfoAccessor.";
   RAY_LOG(FATAL) << error_msg;
@@ -739,11 +739,11 @@ Status ServiceBasedNodeInfoAccessor::AsyncReportBatchHeartbeat(
 }
 
 Status ServiceBasedNodeInfoAccessor::AsyncSubscribeBatchHeartbeat(
-    const ItemCallback<rpc::HeartbeatBatchTableData> &subscribe,
-    const StatusCallback &done) {
+    const ItemCallback<rpc::HeartbeatBatchTableData>& subscribe,
+    const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr);
-  subscribe_batch_heartbeat_operation_ = [this, subscribe](const StatusCallback &done) {
-    auto on_subscribe = [subscribe](const std::string &id, const std::string &data) {
+  subscribe_batch_heartbeat_operation_ = [this, subscribe](const StatusCallback& done) {
+    auto on_subscribe = [subscribe](const std::string& id, const std::string& data) {
       rpc::HeartbeatBatchTableData heartbeat_batch_table_data;
       heartbeat_batch_table_data.ParseFromString(data);
       subscribe(heartbeat_batch_table_data);
@@ -754,7 +754,7 @@ Status ServiceBasedNodeInfoAccessor::AsyncSubscribeBatchHeartbeat(
   return subscribe_batch_heartbeat_operation_(done);
 }
 
-void ServiceBasedNodeInfoAccessor::HandleNotification(const GcsNodeInfo &node_info) {
+void ServiceBasedNodeInfoAccessor::HandleNotification(const GcsNodeInfo& node_info) {
   ClientID node_id = ClientID::FromBinary(node_info.node_id());
   bool is_alive = (node_info.state() == GcsNodeInfo::ALIVE);
   auto entry = node_cache_.find(node_id);
@@ -788,7 +788,7 @@ void ServiceBasedNodeInfoAccessor::HandleNotification(const GcsNodeInfo &node_in
     } else {
       removed_nodes_.insert(node_id);
     }
-    GcsNodeInfo &cache_data = node_cache_[node_id];
+    GcsNodeInfo& cache_data = node_cache_[node_id];
     node_change_callback_(node_id, cache_data);
   }
 }
@@ -801,7 +801,7 @@ void ServiceBasedNodeInfoAccessor::AsyncResubscribe(bool is_pubsub_server_restar
   if (is_pubsub_server_restarted) {
     if (subscribe_node_operation_ != nullptr) {
       RAY_CHECK_OK(subscribe_node_operation_(
-          [this](const Status &status) { fetch_node_data_operation_(nullptr); }));
+          [this](const Status& status) { fetch_node_data_operation_(nullptr); }));
     }
     if (subscribe_resource_operation_ != nullptr) {
       RAY_CHECK_OK(subscribe_resource_operation_(nullptr));
@@ -817,12 +817,12 @@ void ServiceBasedNodeInfoAccessor::AsyncResubscribe(bool is_pubsub_server_restar
 }
 
 Status ServiceBasedNodeInfoAccessor::AsyncSetInternalConfig(
-    std::unordered_map<std::string, std::string> &config) {
+    std::unordered_map<std::string, std::string>& config) {
   rpc::SetInternalConfigRequest request;
   request.mutable_config()->mutable_config()->insert(config.begin(), config.end());
 
   client_impl_->GetGcsRpcClient().SetInternalConfig(
-      request, [](const Status &status, const rpc::SetInternalConfigReply &reply) {
+      request, [](const Status& status, const rpc::SetInternalConfigReply& reply) {
         if (!status.ok()) {
           RAY_LOG(ERROR) << "Failed to set internal config: " << status.message();
         }
@@ -831,11 +831,11 @@ Status ServiceBasedNodeInfoAccessor::AsyncSetInternalConfig(
 }
 
 Status ServiceBasedNodeInfoAccessor::AsyncGetInternalConfig(
-    const OptionalItemCallback<std::unordered_map<std::string, std::string>> &callback) {
+    const OptionalItemCallback<std::unordered_map<std::string, std::string>>& callback) {
   rpc::GetInternalConfigRequest request;
   client_impl_->GetGcsRpcClient().GetInternalConfig(
       request,
-      [callback](const Status &status, const rpc::GetInternalConfigReply &reply) {
+      [callback](const Status& status, const rpc::GetInternalConfigReply& reply) {
         boost::optional<std::unordered_map<std::string, std::string>> config;
         if (status.ok()) {
           if (reply.has_config()) {
@@ -854,11 +854,11 @@ Status ServiceBasedNodeInfoAccessor::AsyncGetInternalConfig(
 }
 
 ServiceBasedTaskInfoAccessor::ServiceBasedTaskInfoAccessor(
-    ServiceBasedGcsClient *client_impl)
+    ServiceBasedGcsClient* client_impl)
     : client_impl_(client_impl) {}
 
 Status ServiceBasedTaskInfoAccessor::AsyncAdd(
-    const std::shared_ptr<rpc::TaskTableData> &data_ptr, const StatusCallback &callback) {
+    const std::shared_ptr<rpc::TaskTableData>& data_ptr, const StatusCallback& callback) {
   TaskID task_id = TaskID::FromBinary(data_ptr->task().task_spec().task_id());
   JobID job_id = JobID::FromBinary(data_ptr->task().task_spec().job_id());
   RAY_LOG(DEBUG) << "Adding task, task id = " << task_id << ", job id = " << job_id;
@@ -866,7 +866,7 @@ Status ServiceBasedTaskInfoAccessor::AsyncAdd(
   request.mutable_task_data()->CopyFrom(*data_ptr);
   client_impl_->GetGcsRpcClient().AddTask(
       request,
-      [task_id, job_id, callback](const Status &status, const rpc::AddTaskReply &reply) {
+      [task_id, job_id, callback](const Status& status, const rpc::AddTaskReply& reply) {
         if (callback) {
           callback(status);
         }
@@ -877,12 +877,12 @@ Status ServiceBasedTaskInfoAccessor::AsyncAdd(
 }
 
 Status ServiceBasedTaskInfoAccessor::AsyncGet(
-    const TaskID &task_id, const OptionalItemCallback<rpc::TaskTableData> &callback) {
+    const TaskID& task_id, const OptionalItemCallback<rpc::TaskTableData>& callback) {
   RAY_LOG(DEBUG) << "Getting task, task id = " << task_id;
   rpc::GetTaskRequest request;
   request.set_task_id(task_id.Binary());
   client_impl_->GetGcsRpcClient().GetTask(
-      request, [task_id, callback](const Status &status, const rpc::GetTaskReply &reply) {
+      request, [task_id, callback](const Status& status, const rpc::GetTaskReply& reply) {
         if (reply.has_task_data()) {
           callback(status, reply.task_data());
         } else {
@@ -894,16 +894,16 @@ Status ServiceBasedTaskInfoAccessor::AsyncGet(
   return Status::OK();
 }
 
-Status ServiceBasedTaskInfoAccessor::AsyncDelete(const std::vector<TaskID> &task_ids,
-                                                 const StatusCallback &callback) {
+Status ServiceBasedTaskInfoAccessor::AsyncDelete(const std::vector<TaskID>& task_ids,
+                                                 const StatusCallback& callback) {
   RAY_LOG(DEBUG) << "Deleting tasks, task id list size = " << task_ids.size();
   rpc::DeleteTasksRequest request;
-  for (auto &task_id : task_ids) {
+  for (auto& task_id : task_ids) {
     request.add_task_id_list(task_id.Binary());
   }
   client_impl_->GetGcsRpcClient().DeleteTasks(
       request,
-      [task_ids, callback](const Status &status, const rpc::DeleteTasksReply &reply) {
+      [task_ids, callback](const Status& status, const rpc::DeleteTasksReply& reply) {
         if (callback) {
           callback(status);
         }
@@ -914,15 +914,15 @@ Status ServiceBasedTaskInfoAccessor::AsyncDelete(const std::vector<TaskID> &task
 }
 
 Status ServiceBasedTaskInfoAccessor::AsyncSubscribe(
-    const TaskID &task_id, const SubscribeCallback<TaskID, rpc::TaskTableData> &subscribe,
-    const StatusCallback &done) {
+    const TaskID& task_id, const SubscribeCallback<TaskID, rpc::TaskTableData>& subscribe,
+    const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr) << "Failed to subscribe task, task id = " << task_id;
 
   auto fetch_data_operation = [this, task_id,
-                               subscribe](const StatusCallback &fetch_done) {
+                               subscribe](const StatusCallback& fetch_done) {
     auto callback = [task_id, subscribe, fetch_done](
-                        const Status &status,
-                        const boost::optional<rpc::TaskTableData> &result) {
+                        const Status& status,
+                        const boost::optional<rpc::TaskTableData>& result) {
       if (result) {
         subscribe(task_id, *result);
       }
@@ -934,9 +934,9 @@ Status ServiceBasedTaskInfoAccessor::AsyncSubscribe(
   };
 
   auto subscribe_operation = [this, task_id,
-                              subscribe](const StatusCallback &subscribe_done) {
-    auto on_subscribe = [task_id, subscribe](const std::string &id,
-                                             const std::string &data) {
+                              subscribe](const StatusCallback& subscribe_done) {
+    auto on_subscribe = [task_id, subscribe](const std::string& id,
+                                             const std::string& data) {
       TaskTableData task_data;
       task_data.ParseFromString(data);
       subscribe(task_id, task_data);
@@ -948,10 +948,10 @@ Status ServiceBasedTaskInfoAccessor::AsyncSubscribe(
   subscribe_task_operations_[task_id] = subscribe_operation;
   fetch_task_data_operations_[task_id] = fetch_data_operation;
   return subscribe_operation(
-      [fetch_data_operation, done](const Status &status) { fetch_data_operation(done); });
+      [fetch_data_operation, done](const Status& status) { fetch_data_operation(done); });
 }
 
-Status ServiceBasedTaskInfoAccessor::AsyncUnsubscribe(const TaskID &task_id) {
+Status ServiceBasedTaskInfoAccessor::AsyncUnsubscribe(const TaskID& task_id) {
   RAY_LOG(DEBUG) << "Unsubscribing task, task id = " << task_id;
   auto status = client_impl_->GetGcsPubSub().Unsubscribe(TASK_CHANNEL, task_id.Hex());
   subscribe_task_operations_.erase(task_id);
@@ -961,7 +961,7 @@ Status ServiceBasedTaskInfoAccessor::AsyncUnsubscribe(const TaskID &task_id) {
 }
 
 Status ServiceBasedTaskInfoAccessor::AsyncAddTaskLease(
-    const std::shared_ptr<rpc::TaskLeaseData> &data_ptr, const StatusCallback &callback) {
+    const std::shared_ptr<rpc::TaskLeaseData>& data_ptr, const StatusCallback& callback) {
   TaskID task_id = TaskID::FromBinary(data_ptr->task_id());
   ClientID node_id = ClientID::FromBinary(data_ptr->node_manager_id());
   RAY_LOG(DEBUG) << "Adding task lease, task id = " << task_id
@@ -969,8 +969,8 @@ Status ServiceBasedTaskInfoAccessor::AsyncAddTaskLease(
   rpc::AddTaskLeaseRequest request;
   request.mutable_task_lease_data()->CopyFrom(*data_ptr);
   client_impl_->GetGcsRpcClient().AddTaskLease(
-      request, [task_id, node_id, callback](const Status &status,
-                                            const rpc::AddTaskLeaseReply &reply) {
+      request, [task_id, node_id, callback](const Status& status,
+                                            const rpc::AddTaskLeaseReply& reply) {
         if (callback) {
           callback(status);
         }
@@ -981,13 +981,13 @@ Status ServiceBasedTaskInfoAccessor::AsyncAddTaskLease(
 }
 
 Status ServiceBasedTaskInfoAccessor::AsyncGetTaskLease(
-    const TaskID &task_id, const OptionalItemCallback<rpc::TaskLeaseData> &callback) {
+    const TaskID& task_id, const OptionalItemCallback<rpc::TaskLeaseData>& callback) {
   RAY_LOG(DEBUG) << "Getting task lease, task id = " << task_id;
   rpc::GetTaskLeaseRequest request;
   request.set_task_id(task_id.Binary());
   client_impl_->GetGcsRpcClient().GetTaskLease(
       request,
-      [task_id, callback](const Status &status, const rpc::GetTaskLeaseReply &reply) {
+      [task_id, callback](const Status& status, const rpc::GetTaskLeaseReply& reply) {
         if (reply.has_task_lease_data()) {
           callback(status, reply.task_lease_data());
         } else {
@@ -1000,17 +1000,17 @@ Status ServiceBasedTaskInfoAccessor::AsyncGetTaskLease(
 }
 
 Status ServiceBasedTaskInfoAccessor::AsyncSubscribeTaskLease(
-    const TaskID &task_id,
-    const SubscribeCallback<TaskID, boost::optional<rpc::TaskLeaseData>> &subscribe,
-    const StatusCallback &done) {
+    const TaskID& task_id,
+    const SubscribeCallback<TaskID, boost::optional<rpc::TaskLeaseData>>& subscribe,
+    const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr)
       << "Failed to subscribe task lease, task id = " << task_id;
 
   auto fetch_data_operation = [this, task_id,
-                               subscribe](const StatusCallback &fetch_done) {
+                               subscribe](const StatusCallback& fetch_done) {
     auto callback = [task_id, subscribe, fetch_done](
-                        const Status &status,
-                        const boost::optional<rpc::TaskLeaseData> &result) {
+                        const Status& status,
+                        const boost::optional<rpc::TaskLeaseData>& result) {
       subscribe(task_id, result);
       if (fetch_done) {
         fetch_done(status);
@@ -1020,9 +1020,9 @@ Status ServiceBasedTaskInfoAccessor::AsyncSubscribeTaskLease(
   };
 
   auto subscribe_operation = [this, task_id,
-                              subscribe](const StatusCallback &subscribe_done) {
-    auto on_subscribe = [task_id, subscribe](const std::string &id,
-                                             const std::string &data) {
+                              subscribe](const StatusCallback& subscribe_done) {
+    auto on_subscribe = [task_id, subscribe](const std::string& id,
+                                             const std::string& data) {
       TaskLeaseData task_lease_data;
       task_lease_data.ParseFromString(data);
       subscribe(task_id, task_lease_data);
@@ -1034,10 +1034,10 @@ Status ServiceBasedTaskInfoAccessor::AsyncSubscribeTaskLease(
   subscribe_task_lease_operations_[task_id] = subscribe_operation;
   fetch_task_lease_data_operations_[task_id] = fetch_data_operation;
   return subscribe_operation(
-      [fetch_data_operation, done](const Status &status) { fetch_data_operation(done); });
+      [fetch_data_operation, done](const Status& status) { fetch_data_operation(done); });
 }
 
-Status ServiceBasedTaskInfoAccessor::AsyncUnsubscribeTaskLease(const TaskID &task_id) {
+Status ServiceBasedTaskInfoAccessor::AsyncUnsubscribeTaskLease(const TaskID& task_id) {
   RAY_LOG(DEBUG) << "Unsubscribing task lease, task id = " << task_id;
   auto status =
       client_impl_->GetGcsPubSub().Unsubscribe(TASK_LEASE_CHANNEL, task_id.Hex());
@@ -1048,8 +1048,8 @@ Status ServiceBasedTaskInfoAccessor::AsyncUnsubscribeTaskLease(const TaskID &tas
 }
 
 Status ServiceBasedTaskInfoAccessor::AttemptTaskReconstruction(
-    const std::shared_ptr<rpc::TaskReconstructionData> &data_ptr,
-    const StatusCallback &callback) {
+    const std::shared_ptr<rpc::TaskReconstructionData>& data_ptr,
+    const StatusCallback& callback) {
   ClientID node_id = ClientID::FromBinary(data_ptr->node_manager_id());
   RAY_LOG(DEBUG) << "Reconstructing task, reconstructions num = "
                  << data_ptr->num_reconstructions() << ", node id = " << node_id;
@@ -1057,8 +1057,8 @@ Status ServiceBasedTaskInfoAccessor::AttemptTaskReconstruction(
   request.mutable_task_reconstruction()->CopyFrom(*data_ptr);
   client_impl_->GetGcsRpcClient().AttemptTaskReconstruction(
       request,
-      [data_ptr, node_id, callback](const Status &status,
-                                    const rpc::AttemptTaskReconstructionReply &reply) {
+      [data_ptr, node_id, callback](const Status& status,
+                                    const rpc::AttemptTaskReconstructionReply& reply) {
         if (callback) {
           callback(status);
         }
@@ -1075,40 +1075,40 @@ void ServiceBasedTaskInfoAccessor::AsyncResubscribe(bool is_pubsub_server_restar
   // If the pub-sub server has also restarted, we need to resubscribe to the pub-sub
   // server first, then fetch data from the GCS server.
   if (is_pubsub_server_restarted) {
-    for (auto &item : subscribe_task_operations_) {
-      auto &task_id = item.first;
-      RAY_CHECK_OK(item.second([this, task_id](const Status &status) {
+    for (auto& item : subscribe_task_operations_) {
+      auto& task_id = item.first;
+      RAY_CHECK_OK(item.second([this, task_id](const Status& status) {
         fetch_task_data_operations_[task_id](nullptr);
       }));
     }
-    for (auto &item : subscribe_task_lease_operations_) {
-      auto &task_id = item.first;
-      RAY_CHECK_OK(item.second([this, task_id](const Status &status) {
+    for (auto& item : subscribe_task_lease_operations_) {
+      auto& task_id = item.first;
+      RAY_CHECK_OK(item.second([this, task_id](const Status& status) {
         fetch_task_lease_data_operations_[task_id](nullptr);
       }));
     }
   } else {
-    for (auto &item : fetch_task_data_operations_) {
+    for (auto& item : fetch_task_data_operations_) {
       item.second(nullptr);
     }
-    for (auto &item : fetch_task_lease_data_operations_) {
+    for (auto& item : fetch_task_lease_data_operations_) {
       item.second(nullptr);
     }
   }
 }
 
 ServiceBasedObjectInfoAccessor::ServiceBasedObjectInfoAccessor(
-    ServiceBasedGcsClient *client_impl)
+    ServiceBasedGcsClient* client_impl)
     : client_impl_(client_impl) {}
 
 Status ServiceBasedObjectInfoAccessor::AsyncGetLocations(
-    const ObjectID &object_id, const MultiItemCallback<rpc::ObjectTableData> &callback) {
+    const ObjectID& object_id, const MultiItemCallback<rpc::ObjectTableData>& callback) {
   RAY_LOG(DEBUG) << "Getting object locations, object id = " << object_id;
   rpc::GetObjectLocationsRequest request;
   request.set_object_id(object_id.Binary());
   client_impl_->GetGcsRpcClient().GetObjectLocations(
-      request, [object_id, callback](const Status &status,
-                                     const rpc::GetObjectLocationsReply &reply) {
+      request, [object_id, callback](const Status& status,
+                                     const rpc::GetObjectLocationsReply& reply) {
         std::vector<ObjectTableData> result;
         result.reserve((reply.object_table_data_list_size()));
         for (int index = 0; index < reply.object_table_data_list_size(); ++index) {
@@ -1122,12 +1122,12 @@ Status ServiceBasedObjectInfoAccessor::AsyncGetLocations(
 }
 
 Status ServiceBasedObjectInfoAccessor::AsyncGetAll(
-    const MultiItemCallback<rpc::ObjectLocationInfo> &callback) {
+    const MultiItemCallback<rpc::ObjectLocationInfo>& callback) {
   RAY_LOG(DEBUG) << "Getting all object locations.";
   rpc::GetAllObjectLocationsRequest request;
   client_impl_->GetGcsRpcClient().GetAllObjectLocations(
       request,
-      [callback](const Status &status, const rpc::GetAllObjectLocationsReply &reply) {
+      [callback](const Status& status, const rpc::GetAllObjectLocationsReply& reply) {
         std::vector<rpc::ObjectLocationInfo> result;
         result.reserve((reply.object_location_info_list_size()));
         for (int index = 0; index < reply.object_location_info_list_size(); ++index) {
@@ -1139,9 +1139,9 @@ Status ServiceBasedObjectInfoAccessor::AsyncGetAll(
   return Status::OK();
 }
 
-Status ServiceBasedObjectInfoAccessor::AsyncAddLocation(const ObjectID &object_id,
-                                                        const ClientID &node_id,
-                                                        const StatusCallback &callback) {
+Status ServiceBasedObjectInfoAccessor::AsyncAddLocation(const ObjectID& object_id,
+                                                        const ClientID& node_id,
+                                                        const StatusCallback& callback) {
   RAY_LOG(DEBUG) << "Adding object location, object id = " << object_id
                  << ", node id = " << node_id;
   rpc::AddObjectLocationRequest request;
@@ -1149,10 +1149,10 @@ Status ServiceBasedObjectInfoAccessor::AsyncAddLocation(const ObjectID &object_i
   request.set_node_id(node_id.Binary());
 
   auto operation = [this, request, object_id, node_id,
-                    callback](const SequencerDoneCallback &done_callback) {
+                    callback](const SequencerDoneCallback& done_callback) {
     client_impl_->GetGcsRpcClient().AddObjectLocation(
         request, [object_id, node_id, callback, done_callback](
-                     const Status &status, const rpc::AddObjectLocationReply &reply) {
+                     const Status& status, const rpc::AddObjectLocationReply& reply) {
           if (callback) {
             callback(status);
           }
@@ -1168,7 +1168,7 @@ Status ServiceBasedObjectInfoAccessor::AsyncAddLocation(const ObjectID &object_i
 }
 
 Status ServiceBasedObjectInfoAccessor::AsyncRemoveLocation(
-    const ObjectID &object_id, const ClientID &node_id, const StatusCallback &callback) {
+    const ObjectID& object_id, const ClientID& node_id, const StatusCallback& callback) {
   RAY_LOG(DEBUG) << "Removing object location, object id = " << object_id
                  << ", node id = " << node_id;
   rpc::RemoveObjectLocationRequest request;
@@ -1176,10 +1176,10 @@ Status ServiceBasedObjectInfoAccessor::AsyncRemoveLocation(
   request.set_node_id(node_id.Binary());
 
   auto operation = [this, request, object_id, node_id,
-                    callback](const SequencerDoneCallback &done_callback) {
+                    callback](const SequencerDoneCallback& done_callback) {
     client_impl_->GetGcsRpcClient().RemoveObjectLocation(
         request, [object_id, node_id, callback, done_callback](
-                     const Status &status, const rpc::RemoveObjectLocationReply &reply) {
+                     const Status& status, const rpc::RemoveObjectLocationReply& reply) {
           if (callback) {
             callback(status);
           }
@@ -1194,17 +1194,17 @@ Status ServiceBasedObjectInfoAccessor::AsyncRemoveLocation(
 }
 
 Status ServiceBasedObjectInfoAccessor::AsyncSubscribeToLocations(
-    const ObjectID &object_id,
-    const SubscribeCallback<ObjectID, ObjectChangeNotification> &subscribe,
-    const StatusCallback &done) {
+    const ObjectID& object_id,
+    const SubscribeCallback<ObjectID, ObjectChangeNotification>& subscribe,
+    const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr)
       << "Failed to subscribe object location, object id = " << object_id;
 
   auto fetch_data_operation = [this, object_id,
-                               subscribe](const StatusCallback &fetch_done) {
+                               subscribe](const StatusCallback& fetch_done) {
     auto callback = [object_id, subscribe, fetch_done](
-                        const Status &status,
-                        const std::vector<rpc::ObjectTableData> &result) {
+                        const Status& status,
+                        const std::vector<rpc::ObjectTableData>& result) {
       if (status.ok()) {
         gcs::ObjectChangeNotification notification(rpc::GcsChangeMode::APPEND_OR_ADD,
                                                    result);
@@ -1218,9 +1218,9 @@ Status ServiceBasedObjectInfoAccessor::AsyncSubscribeToLocations(
   };
 
   auto subscribe_operation = [this, object_id,
-                              subscribe](const StatusCallback &subscribe_done) {
-    auto on_subscribe = [object_id, subscribe](const std::string &id,
-                                               const std::string &data) {
+                              subscribe](const StatusCallback& subscribe_done) {
+    auto on_subscribe = [object_id, subscribe](const std::string& id,
+                                               const std::string& data) {
       rpc::ObjectLocationChange object_location_change;
       object_location_change.ParseFromString(data);
       std::vector<rpc::ObjectTableData> object_data_vector;
@@ -1241,7 +1241,7 @@ Status ServiceBasedObjectInfoAccessor::AsyncSubscribeToLocations(
     fetch_object_data_operations_[object_id] = fetch_data_operation;
   }
   return subscribe_operation(
-      [fetch_data_operation, done](const Status &status) { fetch_data_operation(done); });
+      [fetch_data_operation, done](const Status& status) { fetch_data_operation(done); });
 }
 
 void ServiceBasedObjectInfoAccessor::AsyncResubscribe(bool is_pubsub_server_restarted) {
@@ -1251,8 +1251,8 @@ void ServiceBasedObjectInfoAccessor::AsyncResubscribe(bool is_pubsub_server_rest
   // server first, then fetch data from the GCS server.
   absl::MutexLock lock(&mutex_);
   if (is_pubsub_server_restarted) {
-    for (auto &item : subscribe_object_operations_) {
-      RAY_CHECK_OK(item.second([this, item](const Status &status) {
+    for (auto& item : subscribe_object_operations_) {
+      RAY_CHECK_OK(item.second([this, item](const Status& status) {
         absl::MutexLock lock(&mutex_);
         auto fetch_object_data_operation = fetch_object_data_operations_[item.first];
         // `fetch_object_data_operation` is called in the callback function of subscribe.
@@ -1264,14 +1264,14 @@ void ServiceBasedObjectInfoAccessor::AsyncResubscribe(bool is_pubsub_server_rest
       }));
     }
   } else {
-    for (auto &item : fetch_object_data_operations_) {
+    for (auto& item : fetch_object_data_operations_) {
       item.second(nullptr);
     }
   }
 }
 
 Status ServiceBasedObjectInfoAccessor::AsyncUnsubscribeToLocations(
-    const ObjectID &object_id) {
+    const ObjectID& object_id) {
   RAY_LOG(DEBUG) << "Unsubscribing object location, object id = " << object_id;
   auto status = client_impl_->GetGcsPubSub().Unsubscribe(OBJECT_CHANNEL, object_id.Hex());
   absl::MutexLock lock(&mutex_);
@@ -1282,20 +1282,20 @@ Status ServiceBasedObjectInfoAccessor::AsyncUnsubscribeToLocations(
 }
 
 ServiceBasedStatsInfoAccessor::ServiceBasedStatsInfoAccessor(
-    ServiceBasedGcsClient *client_impl)
+    ServiceBasedGcsClient* client_impl)
     : client_impl_(client_impl) {}
 
 Status ServiceBasedStatsInfoAccessor::AsyncAddProfileData(
-    const std::shared_ptr<rpc::ProfileTableData> &data_ptr,
-    const StatusCallback &callback) {
+    const std::shared_ptr<rpc::ProfileTableData>& data_ptr,
+    const StatusCallback& callback) {
   ClientID node_id = ClientID::FromBinary(data_ptr->component_id());
   RAY_LOG(DEBUG) << "Adding profile data, component type = " << data_ptr->component_type()
                  << ", node id = " << node_id;
   rpc::AddProfileDataRequest request;
   request.mutable_profile_data()->CopyFrom(*data_ptr);
   client_impl_->GetGcsRpcClient().AddProfileData(
-      request, [data_ptr, node_id, callback](const Status &status,
-                                             const rpc::AddProfileDataReply &reply) {
+      request, [data_ptr, node_id, callback](const Status& status,
+                                             const rpc::AddProfileDataReply& reply) {
         if (callback) {
           callback(status);
         }
@@ -1307,13 +1307,13 @@ Status ServiceBasedStatsInfoAccessor::AsyncAddProfileData(
 }
 
 Status ServiceBasedStatsInfoAccessor::AsyncGetAll(
-    const MultiItemCallback<rpc::ProfileTableData> &callback) {
+    const MultiItemCallback<rpc::ProfileTableData>& callback) {
   RAY_LOG(DEBUG) << "Getting all profile info.";
   RAY_CHECK(callback);
   rpc::GetAllProfileInfoRequest request;
   client_impl_->GetGcsRpcClient().GetAllProfileInfo(
       request,
-      [callback](const Status &status, const rpc::GetAllProfileInfoReply &reply) {
+      [callback](const Status& status, const rpc::GetAllProfileInfoReply& reply) {
         auto result = VectorFromProtobuf(reply.profile_info_list());
         callback(status, result);
         RAY_LOG(DEBUG) << "Finished getting all job info.";
@@ -1322,20 +1322,20 @@ Status ServiceBasedStatsInfoAccessor::AsyncGetAll(
 }
 
 ServiceBasedErrorInfoAccessor::ServiceBasedErrorInfoAccessor(
-    ServiceBasedGcsClient *client_impl)
+    ServiceBasedGcsClient* client_impl)
     : client_impl_(client_impl) {}
 
 Status ServiceBasedErrorInfoAccessor::AsyncReportJobError(
-    const std::shared_ptr<rpc::ErrorTableData> &data_ptr,
-    const StatusCallback &callback) {
+    const std::shared_ptr<rpc::ErrorTableData>& data_ptr,
+    const StatusCallback& callback) {
   JobID job_id = JobID::FromBinary(data_ptr->job_id());
   std::string type = data_ptr->type();
   RAY_LOG(DEBUG) << "Reporting job error, job id = " << job_id << ", type = " << type;
   rpc::ReportJobErrorRequest request;
   request.mutable_error_data()->CopyFrom(*data_ptr);
   client_impl_->GetGcsRpcClient().ReportJobError(
-      request, [job_id, type, callback](const Status &status,
-                                        const rpc::ReportJobErrorReply &reply) {
+      request, [job_id, type, callback](const Status& status,
+                                        const rpc::ReportJobErrorReply& reply) {
         if (callback) {
           callback(status);
         }
@@ -1346,15 +1346,15 @@ Status ServiceBasedErrorInfoAccessor::AsyncReportJobError(
 }
 
 ServiceBasedWorkerInfoAccessor::ServiceBasedWorkerInfoAccessor(
-    ServiceBasedGcsClient *client_impl)
+    ServiceBasedGcsClient* client_impl)
     : client_impl_(client_impl) {}
 
 Status ServiceBasedWorkerInfoAccessor::AsyncSubscribeToWorkerFailures(
-    const SubscribeCallback<WorkerID, rpc::WorkerTableData> &subscribe,
-    const StatusCallback &done) {
+    const SubscribeCallback<WorkerID, rpc::WorkerTableData>& subscribe,
+    const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr);
-  subscribe_operation_ = [this, subscribe](const StatusCallback &done) {
-    auto on_subscribe = [subscribe](const std::string &id, const std::string &data) {
+  subscribe_operation_ = [this, subscribe](const StatusCallback& done) {
+    auto on_subscribe = [subscribe](const std::string& id, const std::string& data) {
       rpc::WorkerTableData worker_failure_data;
       worker_failure_data.ParseFromString(data);
       subscribe(WorkerID::FromBinary(id), worker_failure_data);
@@ -1373,15 +1373,15 @@ void ServiceBasedWorkerInfoAccessor::AsyncResubscribe(bool is_pubsub_server_rest
 }
 
 Status ServiceBasedWorkerInfoAccessor::AsyncReportWorkerFailure(
-    const std::shared_ptr<rpc::WorkerTableData> &data_ptr,
-    const StatusCallback &callback) {
+    const std::shared_ptr<rpc::WorkerTableData>& data_ptr,
+    const StatusCallback& callback) {
   rpc::Address worker_address = data_ptr->worker_address();
   RAY_LOG(DEBUG) << "Reporting worker failure, " << worker_address.DebugString();
   rpc::ReportWorkerFailureRequest request;
   request.mutable_worker_failure()->CopyFrom(*data_ptr);
   client_impl_->GetGcsRpcClient().ReportWorkerFailure(
-      request, [worker_address, callback](const Status &status,
-                                          const rpc::ReportWorkerFailureReply &reply) {
+      request, [worker_address, callback](const Status& status,
+                                          const rpc::ReportWorkerFailureReply& reply) {
         if (callback) {
           callback(status);
         }
@@ -1392,14 +1392,14 @@ Status ServiceBasedWorkerInfoAccessor::AsyncReportWorkerFailure(
 }
 
 Status ServiceBasedWorkerInfoAccessor::AsyncGet(
-    const WorkerID &worker_id,
-    const OptionalItemCallback<rpc::WorkerTableData> &callback) {
+    const WorkerID& worker_id,
+    const OptionalItemCallback<rpc::WorkerTableData>& callback) {
   RAY_LOG(DEBUG) << "Getting worker info, worker id = " << worker_id;
   rpc::GetWorkerInfoRequest request;
   request.set_worker_id(worker_id.Binary());
   client_impl_->GetGcsRpcClient().GetWorkerInfo(
       request,
-      [worker_id, callback](const Status &status, const rpc::GetWorkerInfoReply &reply) {
+      [worker_id, callback](const Status& status, const rpc::GetWorkerInfoReply& reply) {
         if (reply.has_worker_table_data()) {
           callback(status, reply.worker_table_data());
         } else {
@@ -1411,11 +1411,11 @@ Status ServiceBasedWorkerInfoAccessor::AsyncGet(
 }
 
 Status ServiceBasedWorkerInfoAccessor::AsyncGetAll(
-    const MultiItemCallback<rpc::WorkerTableData> &callback) {
+    const MultiItemCallback<rpc::WorkerTableData>& callback) {
   RAY_LOG(DEBUG) << "Getting all worker info.";
   rpc::GetAllWorkerInfoRequest request;
   client_impl_->GetGcsRpcClient().GetAllWorkerInfo(
-      request, [callback](const Status &status, const rpc::GetAllWorkerInfoReply &reply) {
+      request, [callback](const Status& status, const rpc::GetAllWorkerInfoReply& reply) {
         auto result = VectorFromProtobuf(reply.worker_table_data());
         callback(status, result);
         RAY_LOG(DEBUG) << "Finished getting all worker info, status = " << status;
@@ -1424,12 +1424,12 @@ Status ServiceBasedWorkerInfoAccessor::AsyncGetAll(
 }
 
 Status ServiceBasedWorkerInfoAccessor::AsyncAdd(
-    const std::shared_ptr<rpc::WorkerTableData> &data_ptr,
-    const StatusCallback &callback) {
+    const std::shared_ptr<rpc::WorkerTableData>& data_ptr,
+    const StatusCallback& callback) {
   rpc::AddWorkerInfoRequest request;
   request.mutable_worker_data()->CopyFrom(*data_ptr);
   client_impl_->GetGcsRpcClient().AddWorkerInfo(
-      request, [callback](const Status &status, const rpc::AddWorkerInfoReply &reply) {
+      request, [callback](const Status& status, const rpc::AddWorkerInfoReply& reply) {
         if (callback) {
           callback(status);
         }
@@ -1438,16 +1438,16 @@ Status ServiceBasedWorkerInfoAccessor::AsyncAdd(
 }
 
 ServiceBasedPlacementGroupInfoAccessor::ServiceBasedPlacementGroupInfoAccessor(
-    ServiceBasedGcsClient *client_impl)
+    ServiceBasedGcsClient* client_impl)
     : client_impl_(client_impl) {}
 
 Status ServiceBasedPlacementGroupInfoAccessor::AsyncCreatePlacementGroup(
-    const ray::PlacementGroupSpecification &placement_group_spec) {
+    const ray::PlacementGroupSpecification& placement_group_spec) {
   rpc::CreatePlacementGroupRequest request;
   request.mutable_placement_group_spec()->CopyFrom(placement_group_spec.GetMessage());
   client_impl_->GetGcsRpcClient().CreatePlacementGroup(
-      request, [placement_group_spec](const Status &,
-                                      const rpc::CreatePlacementGroupReply &reply) {
+      request,
+      [placement_group_spec](const Status&, const rpc::CreatePlacementGroupReply& reply) {
         auto status =
             reply.status().code() == (int)StatusCode::OK
                 ? Status()

--- a/src/ray/gcs/gcs_client/service_based_accessor.h
+++ b/src/ray/gcs/gcs_client/service_based_accessor.h
@@ -22,9 +22,9 @@
 namespace ray {
 namespace gcs {
 
-using SubscribeOperation = std::function<Status(const StatusCallback &done)>;
+using SubscribeOperation = std::function<Status(const StatusCallback& done)>;
 
-using FetchDataOperation = std::function<void(const StatusCallback &done)>;
+using FetchDataOperation = std::function<void(const StatusCallback& done)>;
 
 class ServiceBasedGcsClient;
 
@@ -33,19 +33,19 @@ class ServiceBasedGcsClient;
 /// that uses GCS Service as the backend.
 class ServiceBasedJobInfoAccessor : public JobInfoAccessor {
  public:
-  explicit ServiceBasedJobInfoAccessor(ServiceBasedGcsClient *client_impl);
+  explicit ServiceBasedJobInfoAccessor(ServiceBasedGcsClient* client_impl);
 
   virtual ~ServiceBasedJobInfoAccessor() = default;
 
-  Status AsyncAdd(const std::shared_ptr<JobTableData> &data_ptr,
-                  const StatusCallback &callback) override;
+  Status AsyncAdd(const std::shared_ptr<JobTableData>& data_ptr,
+                  const StatusCallback& callback) override;
 
-  Status AsyncMarkFinished(const JobID &job_id, const StatusCallback &callback) override;
+  Status AsyncMarkFinished(const JobID& job_id, const StatusCallback& callback) override;
 
-  Status AsyncSubscribeAll(const SubscribeCallback<JobID, JobTableData> &subscribe,
-                           const StatusCallback &done) override;
+  Status AsyncSubscribeAll(const SubscribeCallback<JobID, JobTableData>& subscribe,
+                           const StatusCallback& done) override;
 
-  Status AsyncGetAll(const MultiItemCallback<rpc::JobTableData> &callback) override;
+  Status AsyncGetAll(const MultiItemCallback<rpc::JobTableData>& callback) override;
 
   void AsyncResubscribe(bool is_pubsub_server_restarted) override;
 
@@ -58,7 +58,7 @@ class ServiceBasedJobInfoAccessor : public JobInfoAccessor {
   /// server restarts from a failure.
   SubscribeOperation subscribe_operation_;
 
-  ServiceBasedGcsClient *client_impl_;
+  ServiceBasedGcsClient* client_impl_;
 };
 
 /// \class ServiceBasedActorInfoAccessor
@@ -66,54 +66,54 @@ class ServiceBasedJobInfoAccessor : public JobInfoAccessor {
 /// that uses GCS Service as the backend.
 class ServiceBasedActorInfoAccessor : public ActorInfoAccessor {
  public:
-  explicit ServiceBasedActorInfoAccessor(ServiceBasedGcsClient *client_impl);
+  explicit ServiceBasedActorInfoAccessor(ServiceBasedGcsClient* client_impl);
 
   virtual ~ServiceBasedActorInfoAccessor() = default;
 
-  Status GetAll(std::vector<ActorTableData> *actor_table_data_list) override;
+  Status GetAll(std::vector<ActorTableData>* actor_table_data_list) override;
 
-  Status AsyncGet(const ActorID &actor_id,
-                  const OptionalItemCallback<rpc::ActorTableData> &callback) override;
+  Status AsyncGet(const ActorID& actor_id,
+                  const OptionalItemCallback<rpc::ActorTableData>& callback) override;
 
-  Status AsyncGetAll(const MultiItemCallback<rpc::ActorTableData> &callback) override;
+  Status AsyncGetAll(const MultiItemCallback<rpc::ActorTableData>& callback) override;
 
   Status AsyncGetByName(
-      const std::string &name,
-      const OptionalItemCallback<rpc::ActorTableData> &callback) override;
+      const std::string& name,
+      const OptionalItemCallback<rpc::ActorTableData>& callback) override;
 
-  Status AsyncRegisterActor(const TaskSpecification &task_spec,
-                            const StatusCallback &callback) override;
+  Status AsyncRegisterActor(const TaskSpecification& task_spec,
+                            const StatusCallback& callback) override;
 
-  Status AsyncCreateActor(const TaskSpecification &task_spec,
-                          const StatusCallback &callback) override;
+  Status AsyncCreateActor(const TaskSpecification& task_spec,
+                          const StatusCallback& callback) override;
 
-  Status AsyncRegister(const std::shared_ptr<rpc::ActorTableData> &data_ptr,
-                       const StatusCallback &callback) override;
+  Status AsyncRegister(const std::shared_ptr<rpc::ActorTableData>& data_ptr,
+                       const StatusCallback& callback) override;
 
-  Status AsyncUpdate(const ActorID &actor_id,
-                     const std::shared_ptr<rpc::ActorTableData> &data_ptr,
-                     const StatusCallback &callback) override;
+  Status AsyncUpdate(const ActorID& actor_id,
+                     const std::shared_ptr<rpc::ActorTableData>& data_ptr,
+                     const StatusCallback& callback) override;
 
   Status AsyncSubscribeAll(
-      const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
-      const StatusCallback &done) override;
+      const SubscribeCallback<ActorID, rpc::ActorTableData>& subscribe,
+      const StatusCallback& done) override;
 
-  Status AsyncSubscribe(const ActorID &actor_id,
-                        const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
-                        const StatusCallback &done) override;
+  Status AsyncSubscribe(const ActorID& actor_id,
+                        const SubscribeCallback<ActorID, rpc::ActorTableData>& subscribe,
+                        const StatusCallback& done) override;
 
-  Status AsyncUnsubscribe(const ActorID &actor_id) override;
+  Status AsyncUnsubscribe(const ActorID& actor_id) override;
 
-  Status AsyncAddCheckpoint(const std::shared_ptr<rpc::ActorCheckpointData> &data_ptr,
-                            const StatusCallback &callback) override;
+  Status AsyncAddCheckpoint(const std::shared_ptr<rpc::ActorCheckpointData>& data_ptr,
+                            const StatusCallback& callback) override;
 
   Status AsyncGetCheckpoint(
-      const ActorCheckpointID &checkpoint_id, const ActorID &actor_id,
-      const OptionalItemCallback<rpc::ActorCheckpointData> &callback) override;
+      const ActorCheckpointID& checkpoint_id, const ActorID& actor_id,
+      const OptionalItemCallback<rpc::ActorCheckpointData>& callback) override;
 
   Status AsyncGetCheckpointID(
-      const ActorID &actor_id,
-      const OptionalItemCallback<rpc::ActorCheckpointIdData> &callback) override;
+      const ActorID& actor_id,
+      const OptionalItemCallback<rpc::ActorCheckpointIdData>& callback) override;
 
   void AsyncResubscribe(bool is_pubsub_server_restarted) override;
 
@@ -137,7 +137,7 @@ class ServiceBasedActorInfoAccessor : public ActorInfoAccessor {
   std::unordered_map<ActorID, FetchDataOperation> fetch_data_operations_
       GUARDED_BY(mutex_);
 
-  ServiceBasedGcsClient *client_impl_;
+  ServiceBasedGcsClient* client_impl_;
 
   Sequencer<ActorID> sequencer_;
 };
@@ -147,71 +147,71 @@ class ServiceBasedActorInfoAccessor : public ActorInfoAccessor {
 /// that uses GCS Service as the backend.
 class ServiceBasedNodeInfoAccessor : public NodeInfoAccessor {
  public:
-  explicit ServiceBasedNodeInfoAccessor(ServiceBasedGcsClient *client_impl);
+  explicit ServiceBasedNodeInfoAccessor(ServiceBasedGcsClient* client_impl);
 
   virtual ~ServiceBasedNodeInfoAccessor() = default;
 
-  Status RegisterSelf(const GcsNodeInfo &local_node_info) override;
+  Status RegisterSelf(const GcsNodeInfo& local_node_info) override;
 
   Status UnregisterSelf() override;
 
-  const ClientID &GetSelfId() const override;
+  const ClientID& GetSelfId() const override;
 
-  const GcsNodeInfo &GetSelfInfo() const override;
+  const GcsNodeInfo& GetSelfInfo() const override;
 
-  Status AsyncRegister(const rpc::GcsNodeInfo &node_info,
-                       const StatusCallback &callback) override;
+  Status AsyncRegister(const rpc::GcsNodeInfo& node_info,
+                       const StatusCallback& callback) override;
 
-  Status AsyncUnregister(const ClientID &node_id,
-                         const StatusCallback &callback) override;
+  Status AsyncUnregister(const ClientID& node_id,
+                         const StatusCallback& callback) override;
 
-  Status AsyncGetAll(const MultiItemCallback<GcsNodeInfo> &callback) override;
+  Status AsyncGetAll(const MultiItemCallback<GcsNodeInfo>& callback) override;
 
   Status AsyncSubscribeToNodeChange(
-      const SubscribeCallback<ClientID, GcsNodeInfo> &subscribe,
-      const StatusCallback &done) override;
+      const SubscribeCallback<ClientID, GcsNodeInfo>& subscribe,
+      const StatusCallback& done) override;
 
-  boost::optional<GcsNodeInfo> Get(const ClientID &node_id) const override;
+  boost::optional<GcsNodeInfo> Get(const ClientID& node_id) const override;
 
-  const std::unordered_map<ClientID, GcsNodeInfo> &GetAll() const override;
+  const std::unordered_map<ClientID, GcsNodeInfo>& GetAll() const override;
 
-  bool IsRemoved(const ClientID &node_id) const override;
+  bool IsRemoved(const ClientID& node_id) const override;
 
-  Status AsyncGetResources(const ClientID &node_id,
-                           const OptionalItemCallback<ResourceMap> &callback) override;
+  Status AsyncGetResources(const ClientID& node_id,
+                           const OptionalItemCallback<ResourceMap>& callback) override;
 
-  Status AsyncUpdateResources(const ClientID &node_id, const ResourceMap &resources,
-                              const StatusCallback &callback) override;
+  Status AsyncUpdateResources(const ClientID& node_id, const ResourceMap& resources,
+                              const StatusCallback& callback) override;
 
-  Status AsyncDeleteResources(const ClientID &node_id,
-                              const std::vector<std::string> &resource_names,
-                              const StatusCallback &callback) override;
+  Status AsyncDeleteResources(const ClientID& node_id,
+                              const std::vector<std::string>& resource_names,
+                              const StatusCallback& callback) override;
 
-  Status AsyncSubscribeToResources(const ItemCallback<rpc::NodeResourceChange> &subscribe,
-                                   const StatusCallback &done) override;
+  Status AsyncSubscribeToResources(const ItemCallback<rpc::NodeResourceChange>& subscribe,
+                                   const StatusCallback& done) override;
 
-  Status AsyncReportHeartbeat(const std::shared_ptr<rpc::HeartbeatTableData> &data_ptr,
-                              const StatusCallback &callback) override;
+  Status AsyncReportHeartbeat(const std::shared_ptr<rpc::HeartbeatTableData>& data_ptr,
+                              const StatusCallback& callback) override;
 
   Status AsyncSubscribeHeartbeat(
-      const SubscribeCallback<ClientID, rpc::HeartbeatTableData> &subscribe,
-      const StatusCallback &done) override;
+      const SubscribeCallback<ClientID, rpc::HeartbeatTableData>& subscribe,
+      const StatusCallback& done) override;
 
   Status AsyncReportBatchHeartbeat(
-      const std::shared_ptr<rpc::HeartbeatBatchTableData> &data_ptr,
-      const StatusCallback &callback) override;
+      const std::shared_ptr<rpc::HeartbeatBatchTableData>& data_ptr,
+      const StatusCallback& callback) override;
 
   Status AsyncSubscribeBatchHeartbeat(
-      const ItemCallback<rpc::HeartbeatBatchTableData> &subscribe,
-      const StatusCallback &done) override;
+      const ItemCallback<rpc::HeartbeatBatchTableData>& subscribe,
+      const StatusCallback& done) override;
 
   void AsyncResubscribe(bool is_pubsub_server_restarted) override;
 
   Status AsyncSetInternalConfig(
-      std::unordered_map<std::string, std::string> &config) override;
+      std::unordered_map<std::string, std::string>& config) override;
 
   Status AsyncGetInternalConfig(
-      const OptionalItemCallback<std::unordered_map<std::string, std::string>> &callback)
+      const OptionalItemCallback<std::unordered_map<std::string, std::string>>& callback)
       override;
 
  private:
@@ -225,12 +225,12 @@ class ServiceBasedNodeInfoAccessor : public NodeInfoAccessor {
   /// server restarts from a failure.
   FetchDataOperation fetch_node_data_operation_;
 
-  void HandleNotification(const GcsNodeInfo &node_info);
+  void HandleNotification(const GcsNodeInfo& node_info);
 
-  ServiceBasedGcsClient *client_impl_;
+  ServiceBasedGcsClient* client_impl_;
 
   using NodeChangeCallback =
-      std::function<void(const ClientID &id, const GcsNodeInfo &node_info)>;
+      std::function<void(const ClientID& id, const GcsNodeInfo& node_info)>;
 
   GcsNodeInfo local_node_info_;
   ClientID local_node_id_;
@@ -251,42 +251,42 @@ class ServiceBasedNodeInfoAccessor : public NodeInfoAccessor {
 /// that uses GCS service as the backend.
 class ServiceBasedTaskInfoAccessor : public TaskInfoAccessor {
  public:
-  explicit ServiceBasedTaskInfoAccessor(ServiceBasedGcsClient *client_impl);
+  explicit ServiceBasedTaskInfoAccessor(ServiceBasedGcsClient* client_impl);
 
   virtual ~ServiceBasedTaskInfoAccessor() = default;
 
-  Status AsyncAdd(const std::shared_ptr<rpc::TaskTableData> &data_ptr,
-                  const StatusCallback &callback) override;
+  Status AsyncAdd(const std::shared_ptr<rpc::TaskTableData>& data_ptr,
+                  const StatusCallback& callback) override;
 
-  Status AsyncGet(const TaskID &task_id,
-                  const OptionalItemCallback<rpc::TaskTableData> &callback) override;
+  Status AsyncGet(const TaskID& task_id,
+                  const OptionalItemCallback<rpc::TaskTableData>& callback) override;
 
-  Status AsyncDelete(const std::vector<TaskID> &task_ids,
-                     const StatusCallback &callback) override;
+  Status AsyncDelete(const std::vector<TaskID>& task_ids,
+                     const StatusCallback& callback) override;
 
-  Status AsyncSubscribe(const TaskID &task_id,
-                        const SubscribeCallback<TaskID, rpc::TaskTableData> &subscribe,
-                        const StatusCallback &done) override;
+  Status AsyncSubscribe(const TaskID& task_id,
+                        const SubscribeCallback<TaskID, rpc::TaskTableData>& subscribe,
+                        const StatusCallback& done) override;
 
-  Status AsyncUnsubscribe(const TaskID &task_id) override;
+  Status AsyncUnsubscribe(const TaskID& task_id) override;
 
-  Status AsyncAddTaskLease(const std::shared_ptr<rpc::TaskLeaseData> &data_ptr,
-                           const StatusCallback &callback) override;
+  Status AsyncAddTaskLease(const std::shared_ptr<rpc::TaskLeaseData>& data_ptr,
+                           const StatusCallback& callback) override;
 
   Status AsyncGetTaskLease(
-      const TaskID &task_id,
-      const OptionalItemCallback<rpc::TaskLeaseData> &callback) override;
+      const TaskID& task_id,
+      const OptionalItemCallback<rpc::TaskLeaseData>& callback) override;
 
   Status AsyncSubscribeTaskLease(
-      const TaskID &task_id,
-      const SubscribeCallback<TaskID, boost::optional<rpc::TaskLeaseData>> &subscribe,
-      const StatusCallback &done) override;
+      const TaskID& task_id,
+      const SubscribeCallback<TaskID, boost::optional<rpc::TaskLeaseData>>& subscribe,
+      const StatusCallback& done) override;
 
-  Status AsyncUnsubscribeTaskLease(const TaskID &task_id) override;
+  Status AsyncUnsubscribeTaskLease(const TaskID& task_id) override;
 
   Status AttemptTaskReconstruction(
-      const std::shared_ptr<rpc::TaskReconstructionData> &data_ptr,
-      const StatusCallback &callback) override;
+      const std::shared_ptr<rpc::TaskReconstructionData>& data_ptr,
+      const StatusCallback& callback) override;
 
   void AsyncResubscribe(bool is_pubsub_server_restarted) override;
 
@@ -301,7 +301,7 @@ class ServiceBasedTaskInfoAccessor : public TaskInfoAccessor {
   std::unordered_map<TaskID, FetchDataOperation> fetch_task_data_operations_;
   std::unordered_map<TaskID, FetchDataOperation> fetch_task_lease_data_operations_;
 
-  ServiceBasedGcsClient *client_impl_;
+  ServiceBasedGcsClient* client_impl_;
 };
 
 /// \class ServiceBasedObjectInfoAccessor
@@ -309,28 +309,28 @@ class ServiceBasedTaskInfoAccessor : public TaskInfoAccessor {
 /// that uses GCS service as the backend.
 class ServiceBasedObjectInfoAccessor : public ObjectInfoAccessor {
  public:
-  explicit ServiceBasedObjectInfoAccessor(ServiceBasedGcsClient *client_impl);
+  explicit ServiceBasedObjectInfoAccessor(ServiceBasedGcsClient* client_impl);
 
   virtual ~ServiceBasedObjectInfoAccessor() = default;
 
   Status AsyncGetLocations(
-      const ObjectID &object_id,
-      const MultiItemCallback<rpc::ObjectTableData> &callback) override;
+      const ObjectID& object_id,
+      const MultiItemCallback<rpc::ObjectTableData>& callback) override;
 
-  Status AsyncGetAll(const MultiItemCallback<rpc::ObjectLocationInfo> &callback) override;
+  Status AsyncGetAll(const MultiItemCallback<rpc::ObjectLocationInfo>& callback) override;
 
-  Status AsyncAddLocation(const ObjectID &object_id, const ClientID &node_id,
-                          const StatusCallback &callback) override;
+  Status AsyncAddLocation(const ObjectID& object_id, const ClientID& node_id,
+                          const StatusCallback& callback) override;
 
-  Status AsyncRemoveLocation(const ObjectID &object_id, const ClientID &node_id,
-                             const StatusCallback &callback) override;
+  Status AsyncRemoveLocation(const ObjectID& object_id, const ClientID& node_id,
+                             const StatusCallback& callback) override;
 
   Status AsyncSubscribeToLocations(
-      const ObjectID &object_id,
-      const SubscribeCallback<ObjectID, ObjectChangeNotification> &subscribe,
-      const StatusCallback &done) override;
+      const ObjectID& object_id,
+      const SubscribeCallback<ObjectID, ObjectChangeNotification>& subscribe,
+      const StatusCallback& done) override;
 
-  Status AsyncUnsubscribeToLocations(const ObjectID &object_id) override;
+  Status AsyncUnsubscribeToLocations(const ObjectID& object_id) override;
 
   void AsyncResubscribe(bool is_pubsub_server_restarted) override;
 
@@ -349,7 +349,7 @@ class ServiceBasedObjectInfoAccessor : public ObjectInfoAccessor {
   std::unordered_map<ObjectID, FetchDataOperation> fetch_object_data_operations_
       GUARDED_BY(mutex_);
 
-  ServiceBasedGcsClient *client_impl_;
+  ServiceBasedGcsClient* client_impl_;
 
   Sequencer<ObjectID> sequencer_;
 };
@@ -359,17 +359,17 @@ class ServiceBasedObjectInfoAccessor : public ObjectInfoAccessor {
 /// that uses GCS Service as the backend.
 class ServiceBasedStatsInfoAccessor : public StatsInfoAccessor {
  public:
-  explicit ServiceBasedStatsInfoAccessor(ServiceBasedGcsClient *client_impl);
+  explicit ServiceBasedStatsInfoAccessor(ServiceBasedGcsClient* client_impl);
 
   virtual ~ServiceBasedStatsInfoAccessor() = default;
 
-  Status AsyncAddProfileData(const std::shared_ptr<rpc::ProfileTableData> &data_ptr,
-                             const StatusCallback &callback) override;
+  Status AsyncAddProfileData(const std::shared_ptr<rpc::ProfileTableData>& data_ptr,
+                             const StatusCallback& callback) override;
 
-  Status AsyncGetAll(const MultiItemCallback<rpc::ProfileTableData> &callback) override;
+  Status AsyncGetAll(const MultiItemCallback<rpc::ProfileTableData>& callback) override;
 
  private:
-  ServiceBasedGcsClient *client_impl_;
+  ServiceBasedGcsClient* client_impl_;
 };
 
 /// \class ServiceBasedErrorInfoAccessor
@@ -377,15 +377,15 @@ class ServiceBasedStatsInfoAccessor : public StatsInfoAccessor {
 /// that uses GCS Service as the backend.
 class ServiceBasedErrorInfoAccessor : public ErrorInfoAccessor {
  public:
-  explicit ServiceBasedErrorInfoAccessor(ServiceBasedGcsClient *client_impl);
+  explicit ServiceBasedErrorInfoAccessor(ServiceBasedGcsClient* client_impl);
 
   virtual ~ServiceBasedErrorInfoAccessor() = default;
 
-  Status AsyncReportJobError(const std::shared_ptr<rpc::ErrorTableData> &data_ptr,
-                             const StatusCallback &callback) override;
+  Status AsyncReportJobError(const std::shared_ptr<rpc::ErrorTableData>& data_ptr,
+                             const StatusCallback& callback) override;
 
  private:
-  ServiceBasedGcsClient *client_impl_;
+  ServiceBasedGcsClient* client_impl_;
 };
 
 /// \class ServiceBasedWorkerInfoAccessor
@@ -393,24 +393,24 @@ class ServiceBasedErrorInfoAccessor : public ErrorInfoAccessor {
 /// that uses GCS Service as the backend.
 class ServiceBasedWorkerInfoAccessor : public WorkerInfoAccessor {
  public:
-  explicit ServiceBasedWorkerInfoAccessor(ServiceBasedGcsClient *client_impl);
+  explicit ServiceBasedWorkerInfoAccessor(ServiceBasedGcsClient* client_impl);
 
   virtual ~ServiceBasedWorkerInfoAccessor() = default;
 
   Status AsyncSubscribeToWorkerFailures(
-      const SubscribeCallback<WorkerID, rpc::WorkerTableData> &subscribe,
-      const StatusCallback &done) override;
+      const SubscribeCallback<WorkerID, rpc::WorkerTableData>& subscribe,
+      const StatusCallback& done) override;
 
-  Status AsyncReportWorkerFailure(const std::shared_ptr<rpc::WorkerTableData> &data_ptr,
-                                  const StatusCallback &callback) override;
+  Status AsyncReportWorkerFailure(const std::shared_ptr<rpc::WorkerTableData>& data_ptr,
+                                  const StatusCallback& callback) override;
 
-  Status AsyncGet(const WorkerID &worker_id,
-                  const OptionalItemCallback<rpc::WorkerTableData> &callback) override;
+  Status AsyncGet(const WorkerID& worker_id,
+                  const OptionalItemCallback<rpc::WorkerTableData>& callback) override;
 
-  Status AsyncGetAll(const MultiItemCallback<rpc::WorkerTableData> &callback) override;
+  Status AsyncGetAll(const MultiItemCallback<rpc::WorkerTableData>& callback) override;
 
-  Status AsyncAdd(const std::shared_ptr<rpc::WorkerTableData> &data_ptr,
-                  const StatusCallback &callback) override;
+  Status AsyncAdd(const std::shared_ptr<rpc::WorkerTableData>& data_ptr,
+                  const StatusCallback& callback) override;
 
   void AsyncResubscribe(bool is_pubsub_server_restarted) override;
 
@@ -419,7 +419,7 @@ class ServiceBasedWorkerInfoAccessor : public WorkerInfoAccessor {
   /// restarts from a failure.
   SubscribeOperation subscribe_operation_;
 
-  ServiceBasedGcsClient *client_impl_;
+  ServiceBasedGcsClient* client_impl_;
 };
 
 /// \class ServiceBasedPlacementGroupInfoAccessor
@@ -429,15 +429,15 @@ class ServiceBasedWorkerInfoAccessor : public WorkerInfoAccessor {
 class ServiceBasedPlacementGroupInfoAccessor : public PlacementGroupInfoAccessor {
   // TODO(AlisaWu):fill the ServiceAccessor.
  public:
-  explicit ServiceBasedPlacementGroupInfoAccessor(ServiceBasedGcsClient *client_impl);
+  explicit ServiceBasedPlacementGroupInfoAccessor(ServiceBasedGcsClient* client_impl);
 
   virtual ~ServiceBasedPlacementGroupInfoAccessor() = default;
 
   Status AsyncCreatePlacementGroup(
-      const PlacementGroupSpecification &placement_group_spec) override;
+      const PlacementGroupSpecification& placement_group_spec) override;
 
  private:
-  ServiceBasedGcsClient *client_impl_;
+  ServiceBasedGcsClient* client_impl_;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_client/service_based_gcs_client.cc
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.cc
@@ -24,10 +24,10 @@ extern "C" {
 namespace ray {
 namespace gcs {
 
-ServiceBasedGcsClient::ServiceBasedGcsClient(const GcsClientOptions &options)
+ServiceBasedGcsClient::ServiceBasedGcsClient(const GcsClientOptions& options)
     : GcsClient(options) {}
 
-Status ServiceBasedGcsClient::Connect(boost::asio::io_service &io_service) {
+Status ServiceBasedGcsClient::Connect(boost::asio::io_service& io_service) {
   RAY_CHECK(!is_connected_);
 
   if (options_.server_ip_.empty()) {
@@ -43,7 +43,7 @@ Status ServiceBasedGcsClient::Connect(boost::asio::io_service &io_service) {
   gcs_pub_sub_.reset(new GcsPubSub(redis_gcs_client_->GetRedisClient()));
 
   // Get gcs service address.
-  get_server_address_func_ = [this](std::pair<std::string, int> *address) {
+  get_server_address_func_ = [this](std::pair<std::string, int>* address) {
     return GetGcsServerAddressFromRedis(
         redis_gcs_client_->primary_context()->sync_context(), address);
   };
@@ -98,12 +98,12 @@ void ServiceBasedGcsClient::Disconnect() {
 }
 
 bool ServiceBasedGcsClient::GetGcsServerAddressFromRedis(
-    redisContext *context, std::pair<std::string, int> *address, int max_attempts) {
+    redisContext* context, std::pair<std::string, int>* address, int max_attempts) {
   // Get gcs server address.
   int num_attempts = 0;
-  redisReply *reply = nullptr;
+  redisReply* reply = nullptr;
   while (num_attempts < max_attempts) {
-    reply = reinterpret_cast<redisReply *>(redisCommand(context, "GET GcsServerAddress"));
+    reply = reinterpret_cast<redisReply*>(redisCommand(context, "GET GcsServerAddress"));
     if (reply && reply->type != REDIS_REPLY_NIL) {
       break;
     }
@@ -150,7 +150,7 @@ void ServiceBasedGcsClient::PeriodicallyCheckGcsServerAddress() {
   auto check_period = boost::posix_time::milliseconds(
       RayConfig::instance().gcs_service_address_check_interval_milliseconds());
   detect_timer_->expires_from_now(check_period);
-  detect_timer_->async_wait([this](const boost::system::error_code &error) {
+  detect_timer_->async_wait([this](const boost::system::error_code& error) {
     if (error == boost::asio::error::operation_aborted) {
       // `operation_aborted` is set when `detect_timer_` is canceled or destroyed.
       return;

--- a/src/ray/gcs/gcs_client/service_based_gcs_client.h
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.h
@@ -23,17 +23,17 @@ namespace gcs {
 
 class RAY_EXPORT ServiceBasedGcsClient : public GcsClient {
  public:
-  explicit ServiceBasedGcsClient(const GcsClientOptions &options);
+  explicit ServiceBasedGcsClient(const GcsClientOptions& options);
 
-  Status Connect(boost::asio::io_service &io_service) override;
+  Status Connect(boost::asio::io_service& io_service) override;
 
   void Disconnect() override;
 
-  GcsPubSub &GetGcsPubSub() { return *gcs_pub_sub_; }
+  GcsPubSub& GetGcsPubSub() { return *gcs_pub_sub_; }
 
-  RedisGcsClient &GetRedisGcsClient() { return *redis_gcs_client_; }
+  RedisGcsClient& GetRedisGcsClient() { return *redis_gcs_client_; }
 
-  rpc::GcsRpcClient &GetGcsRpcClient() { return *gcs_rpc_client_; }
+  rpc::GcsRpcClient& GetGcsRpcClient() { return *gcs_rpc_client_; }
 
  private:
   /// Get gcs server address from redis.
@@ -43,8 +43,8 @@ class RAY_EXPORT ServiceBasedGcsClient : public GcsClient {
   /// \param address The address of gcs server.
   /// \param max_attempts The maximum number of times to get gcs server rpc address.
   /// \return Returns true if gcs server address is obtained, False otherwise.
-  bool GetGcsServerAddressFromRedis(redisContext *context,
-                                    std::pair<std::string, int> *address,
+  bool GetGcsServerAddressFromRedis(redisContext* context,
+                                    std::pair<std::string, int>* address,
                                     int max_attempts = 1);
 
   /// Fire a periodic timer to check if GCS sever address has changed.
@@ -69,7 +69,7 @@ class RAY_EXPORT ServiceBasedGcsClient : public GcsClient {
 
   // A timer used to check if gcs server address changed.
   std::unique_ptr<boost::asio::deadline_timer> detect_timer_;
-  std::function<bool(std::pair<std::string, int> *)> get_server_address_func_;
+  std::function<bool(std::pair<std::string, int>*)> get_server_address_func_;
   std::function<void(bool)> resubscribe_func_;
   std::pair<std::string, int> current_gcs_server_address_;
 };

--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -77,7 +77,7 @@ class GlobalStateAccessorTest : public ::testing::Test {
     TestSetupUtil::FlushAllRedisServers();
   }
 
-  bool WaitReady(std::future<bool> future, const std::chrono::milliseconds &timeout_ms) {
+  bool WaitReady(std::future<bool> future, const std::chrono::milliseconds& timeout_ms) {
     auto status = future.wait_for(timeout_ms);
     return status == std::future_status::ready && future.get();
   }
@@ -223,7 +223,7 @@ TEST_F(GlobalStateAccessorTest, TestObjectTable) {
   }
   ASSERT_EQ(global_state_->GetAllObjectInfo().size(), object_count);
 
-  for (auto &object_id : object_ids) {
+  for (auto& object_id : object_ids) {
     ASSERT_TRUE(global_state_->GetObjectInfo(object_id));
   }
 }
@@ -244,7 +244,7 @@ TEST_F(GlobalStateAccessorTest, TestActorTable) {
   }
   ASSERT_EQ(global_state_->GetAllActorInfo().size(), actor_count);
 
-  for (auto &actor_id : actor_ids) {
+  for (auto& actor_id : actor_ids) {
     ASSERT_TRUE(global_state_->GetActorInfo(actor_id));
   }
 }
@@ -271,7 +271,7 @@ TEST_F(GlobalStateAccessorTest, TestWorkerTable) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
                                          ray::RayLog::ShutDownRayLog, argv[0],
                                          ray::RayLogLevel::INFO,

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "ray/gcs/gcs_client/service_based_gcs_client.h"
+
 #include "gtest/gtest.h"
 #include "ray/common/test_util.h"
 #include "ray/gcs/gcs_client/service_based_accessor.h"

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -103,21 +103,21 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
   }
 
   bool SubscribeToAllJobs(
-      const gcs::SubscribeCallback<JobID, rpc::JobTableData> &subscribe) {
+      const gcs::SubscribeCallback<JobID, rpc::JobTableData>& subscribe) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Jobs().AsyncSubscribeAll(
         subscribe, [&promise](Status status) { promise.set_value(status.ok()); }));
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool AddJob(const std::shared_ptr<rpc::JobTableData> &job_table_data) {
+  bool AddJob(const std::shared_ptr<rpc::JobTableData>& job_table_data) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Jobs().AsyncAdd(
         job_table_data, [&promise](Status status) { promise.set_value(status.ok()); }));
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool MarkJobFinished(const JobID &job_id) {
+  bool MarkJobFinished(const JobID& job_id) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Jobs().AsyncMarkFinished(
         job_id, [&promise](Status status) { promise.set_value(status.ok()); }));
@@ -125,8 +125,8 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
   }
 
   bool SubscribeActor(
-      const ActorID &actor_id,
-      const gcs::SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe) {
+      const ActorID& actor_id,
+      const gcs::SubscribeCallback<ActorID, rpc::ActorTableData>& subscribe) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Actors().AsyncSubscribe(
         actor_id, subscribe,
@@ -134,27 +134,27 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  void UnsubscribeActor(const ActorID &actor_id) {
+  void UnsubscribeActor(const ActorID& actor_id) {
     RAY_CHECK_OK(gcs_client_->Actors().AsyncUnsubscribe(actor_id));
   }
 
   bool SubscribeAllActors(
-      const gcs::SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe) {
+      const gcs::SubscribeCallback<ActorID, rpc::ActorTableData>& subscribe) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Actors().AsyncSubscribeAll(
         subscribe, [&promise](Status status) { promise.set_value(status.ok()); }));
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool RegisterActor(const std::shared_ptr<rpc::ActorTableData> &actor_table_data) {
+  bool RegisterActor(const std::shared_ptr<rpc::ActorTableData>& actor_table_data) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Actors().AsyncRegister(
         actor_table_data, [&promise](Status status) { promise.set_value(status.ok()); }));
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool UpdateActor(const ActorID &actor_id,
-                   const std::shared_ptr<rpc::ActorTableData> &actor_table_data) {
+  bool UpdateActor(const ActorID& actor_id,
+                   const std::shared_ptr<rpc::ActorTableData>& actor_table_data) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Actors().AsyncUpdate(
         actor_id, actor_table_data,
@@ -162,12 +162,12 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  rpc::ActorTableData GetActor(const ActorID &actor_id) {
+  rpc::ActorTableData GetActor(const ActorID& actor_id) {
     std::promise<bool> promise;
     rpc::ActorTableData actor_table_data;
     RAY_CHECK_OK(gcs_client_->Actors().AsyncGet(
         actor_id, [&actor_table_data, &promise](
-                      Status status, const boost::optional<rpc::ActorTableData> &result) {
+                      Status status, const boost::optional<rpc::ActorTableData>& result) {
           assert(result);
           actor_table_data.CopyFrom(*result);
           promise.set_value(true);
@@ -177,7 +177,7 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
   }
 
   bool AddCheckpoint(
-      const std::shared_ptr<rpc::ActorCheckpointData> &actor_checkpoint_data) {
+      const std::shared_ptr<rpc::ActorCheckpointData>& actor_checkpoint_data) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Actors().AsyncAddCheckpoint(
         actor_checkpoint_data,
@@ -185,14 +185,14 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  rpc::ActorCheckpointData GetCheckpoint(const ActorID &actor_id,
-                                         const ActorCheckpointID &checkpoint_id) {
+  rpc::ActorCheckpointData GetCheckpoint(const ActorID& actor_id,
+                                         const ActorCheckpointID& checkpoint_id) {
     std::promise<bool> promise;
     rpc::ActorCheckpointData actor_checkpoint_data;
     RAY_CHECK_OK(gcs_client_->Actors().AsyncGetCheckpoint(
         checkpoint_id, actor_id,
         [&actor_checkpoint_data, &promise](
-            Status status, const boost::optional<rpc::ActorCheckpointData> &result) {
+            Status status, const boost::optional<rpc::ActorCheckpointData>& result) {
           assert(result);
           actor_checkpoint_data.CopyFrom(*result);
           promise.set_value(true);
@@ -201,13 +201,13 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return actor_checkpoint_data;
   }
 
-  rpc::ActorCheckpointIdData GetCheckpointID(const ActorID &actor_id) {
+  rpc::ActorCheckpointIdData GetCheckpointID(const ActorID& actor_id) {
     std::promise<bool> promise;
     rpc::ActorCheckpointIdData actor_checkpoint_id_data;
     RAY_CHECK_OK(gcs_client_->Actors().AsyncGetCheckpointID(
         actor_id,
         [&actor_checkpoint_id_data, &promise](
-            Status status, const boost::optional<rpc::ActorCheckpointIdData> &result) {
+            Status status, const boost::optional<rpc::ActorCheckpointIdData>& result) {
           assert(result);
           actor_checkpoint_id_data.CopyFrom(*result);
           promise.set_value(true);
@@ -217,14 +217,14 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
   }
 
   bool SubscribeToNodeChange(
-      const gcs::SubscribeCallback<ClientID, rpc::GcsNodeInfo> &subscribe) {
+      const gcs::SubscribeCallback<ClientID, rpc::GcsNodeInfo>& subscribe) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Nodes().AsyncSubscribeToNodeChange(
         subscribe, [&promise](Status status) { promise.set_value(status.ok()); }));
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool RegisterSelf(const rpc::GcsNodeInfo &local_node_info) {
+  bool RegisterSelf(const rpc::GcsNodeInfo& local_node_info) {
     Status status = gcs_client_->Nodes().RegisterSelf(local_node_info);
     return status.ok();
   }
@@ -234,7 +234,7 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return status.ok();
   }
 
-  bool RegisterNode(const rpc::GcsNodeInfo &node_info) {
+  bool RegisterNode(const rpc::GcsNodeInfo& node_info) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Nodes().AsyncRegister(
         node_info, [&promise](Status status) { promise.set_value(status.ok()); }));
@@ -245,7 +245,7 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     std::promise<bool> promise;
     std::vector<rpc::GcsNodeInfo> nodes;
     RAY_CHECK_OK(gcs_client_->Nodes().AsyncGetAll(
-        [&nodes, &promise](Status status, const std::vector<rpc::GcsNodeInfo> &result) {
+        [&nodes, &promise](Status status, const std::vector<rpc::GcsNodeInfo>& result) {
           assert(!result.empty());
           nodes.assign(result.begin(), result.end());
           promise.set_value(status.ok());
@@ -254,27 +254,27 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return nodes;
   }
 
-  bool UnregisterNode(const ClientID &node_id) {
+  bool UnregisterNode(const ClientID& node_id) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Nodes().AsyncUnregister(
         node_id, [&promise](Status status) { promise.set_value(status.ok()); }));
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool SubscribeToResources(const gcs::ItemCallback<rpc::NodeResourceChange> &subscribe) {
+  bool SubscribeToResources(const gcs::ItemCallback<rpc::NodeResourceChange>& subscribe) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Nodes().AsyncSubscribeToResources(
         subscribe, [&promise](Status status) { promise.set_value(status.ok()); }));
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  gcs::NodeInfoAccessor::ResourceMap GetResources(const ClientID &node_id) {
+  gcs::NodeInfoAccessor::ResourceMap GetResources(const ClientID& node_id) {
     gcs::NodeInfoAccessor::ResourceMap resource_map;
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Nodes().AsyncGetResources(
         node_id, [&resource_map, &promise](
                      Status status,
-                     const boost::optional<gcs::NodeInfoAccessor::ResourceMap> &result) {
+                     const boost::optional<gcs::NodeInfoAccessor::ResourceMap>& result) {
           if (result) {
             resource_map.insert(result->begin(), result->end());
           }
@@ -284,7 +284,7 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return resource_map;
   }
 
-  bool UpdateResources(const ClientID &node_id, const std::string &key) {
+  bool UpdateResources(const ClientID& node_id, const std::string& key) {
     std::promise<bool> promise;
     gcs::NodeInfoAccessor::ResourceMap resource_map;
     auto resource = std::make_shared<rpc::ResourceTableData>();
@@ -296,8 +296,8 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool DeleteResources(const ClientID &node_id,
-                       const std::vector<std::string> &resource_names) {
+  bool DeleteResources(const ClientID& node_id,
+                       const std::vector<std::string>& resource_names) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Nodes().AsyncDeleteResources(
         node_id, resource_names,
@@ -306,7 +306,7 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
   }
 
   bool SubscribeBatchHeartbeat(
-      const gcs::ItemCallback<rpc::HeartbeatBatchTableData> &subscribe) {
+      const gcs::ItemCallback<rpc::HeartbeatBatchTableData>& subscribe) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Nodes().AsyncSubscribeBatchHeartbeat(
         subscribe, [&promise](Status status) { promise.set_value(status.ok()); }));
@@ -321,8 +321,8 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
   }
 
   bool SubscribeTask(
-      const TaskID &task_id,
-      const gcs::SubscribeCallback<TaskID, rpc::TaskTableData> &subscribe) {
+      const TaskID& task_id,
+      const gcs::SubscribeCallback<TaskID, rpc::TaskTableData>& subscribe) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Tasks().AsyncSubscribe(
         task_id, subscribe,
@@ -330,7 +330,7 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  void UnsubscribeTask(const TaskID &task_id) {
+  void UnsubscribeTask(const TaskID& task_id) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Tasks().AsyncUnsubscribe(task_id));
   }
@@ -342,12 +342,12 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  rpc::TaskTableData GetTask(const TaskID &task_id) {
+  rpc::TaskTableData GetTask(const TaskID& task_id) {
     std::promise<bool> promise;
     rpc::TaskTableData task_table_data;
     RAY_CHECK_OK(gcs_client_->Tasks().AsyncGet(
         task_id, [&task_table_data, &promise](
-                     Status status, const boost::optional<rpc::TaskTableData> &result) {
+                     Status status, const boost::optional<rpc::TaskTableData>& result) {
           if (result) {
             task_table_data.CopyFrom(*result);
           }
@@ -357,7 +357,7 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return task_table_data;
   }
 
-  bool DeleteTask(const std::vector<TaskID> &task_ids) {
+  bool DeleteTask(const std::vector<TaskID>& task_ids) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Tasks().AsyncDelete(
         task_ids, [&promise](Status status) { promise.set_value(status.ok()); }));
@@ -365,9 +365,9 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
   }
 
   bool SubscribeTaskLease(
-      const TaskID &task_id,
-      const gcs::SubscribeCallback<TaskID, boost::optional<rpc::TaskLeaseData>>
-          &subscribe) {
+      const TaskID& task_id,
+      const gcs::SubscribeCallback<TaskID, boost::optional<rpc::TaskLeaseData>>&
+          subscribe) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Tasks().AsyncSubscribeTaskLease(
         task_id, subscribe,
@@ -375,7 +375,7 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  void UnsubscribeTaskLease(const TaskID &task_id) {
+  void UnsubscribeTaskLease(const TaskID& task_id) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Tasks().AsyncUnsubscribeTaskLease(task_id));
   }
@@ -397,8 +397,8 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
   }
 
   bool SubscribeToLocations(
-      const ObjectID &object_id,
-      const gcs::SubscribeCallback<ObjectID, gcs::ObjectChangeNotification> &subscribe) {
+      const ObjectID& object_id,
+      const gcs::SubscribeCallback<ObjectID, gcs::ObjectChangeNotification>& subscribe) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Objects().AsyncSubscribeToLocations(
         object_id, subscribe,
@@ -406,12 +406,12 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  void UnsubscribeToLocations(const ObjectID &object_id) {
+  void UnsubscribeToLocations(const ObjectID& object_id) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Objects().AsyncUnsubscribeToLocations(object_id));
   }
 
-  bool AddLocation(const ObjectID &object_id, const ClientID &node_id) {
+  bool AddLocation(const ObjectID& object_id, const ClientID& node_id) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Objects().AsyncAddLocation(
         object_id, node_id,
@@ -419,7 +419,7 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool RemoveLocation(const ObjectID &object_id, const ClientID &node_id) {
+  bool RemoveLocation(const ObjectID& object_id, const ClientID& node_id) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Objects().AsyncRemoveLocation(
         object_id, node_id,
@@ -427,12 +427,12 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  std::vector<rpc::ObjectTableData> GetLocations(const ObjectID &object_id) {
+  std::vector<rpc::ObjectTableData> GetLocations(const ObjectID& object_id) {
     std::promise<bool> promise;
     std::vector<rpc::ObjectTableData> locations;
     RAY_CHECK_OK(gcs_client_->Objects().AsyncGetLocations(
         object_id, [&locations, &promise](
-                       Status status, const std::vector<rpc::ObjectTableData> &result) {
+                       Status status, const std::vector<rpc::ObjectTableData>& result) {
           locations = result;
           promise.set_value(status.ok());
         }));
@@ -440,7 +440,7 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return locations;
   }
 
-  bool AddProfileData(const std::shared_ptr<rpc::ProfileTableData> &profile_table_data) {
+  bool AddProfileData(const std::shared_ptr<rpc::ProfileTableData>& profile_table_data) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Stats().AsyncAddProfileData(
         profile_table_data,
@@ -448,7 +448,7 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool ReportJobError(const std::shared_ptr<rpc::ErrorTableData> &error_table_data) {
+  bool ReportJobError(const std::shared_ptr<rpc::ErrorTableData>& error_table_data) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Errors().AsyncReportJobError(
         error_table_data, [&promise](Status status) { promise.set_value(status.ok()); }));
@@ -456,7 +456,7 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
   }
 
   bool SubscribeToWorkerFailures(
-      const gcs::SubscribeCallback<WorkerID, rpc::WorkerTableData> &subscribe) {
+      const gcs::SubscribeCallback<WorkerID, rpc::WorkerTableData>& subscribe) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Workers().AsyncSubscribeToWorkerFailures(
         subscribe, [&promise](Status status) { promise.set_value(status.ok()); }));
@@ -464,7 +464,7 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
   }
 
   bool ReportWorkerFailure(
-      const std::shared_ptr<rpc::WorkerTableData> &worker_failure_data) {
+      const std::shared_ptr<rpc::WorkerTableData>& worker_failure_data) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Workers().AsyncReportWorkerFailure(
         worker_failure_data,
@@ -472,26 +472,26 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool AddWorker(const std::shared_ptr<rpc::WorkerTableData> &worker_data) {
+  bool AddWorker(const std::shared_ptr<rpc::WorkerTableData>& worker_data) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Workers().AsyncAdd(
         worker_data, [&promise](Status status) { promise.set_value(status.ok()); }));
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool WaitReady(std::future<bool> future, const std::chrono::milliseconds &timeout_ms) {
+  bool WaitReady(std::future<bool> future, const std::chrono::milliseconds& timeout_ms) {
     auto status = future.wait_for(timeout_ms);
     return status == std::future_status::ready && future.get();
   }
 
-  void WaitPendingDone(std::atomic<int> &current_count, int expected_count) {
+  void WaitPendingDone(std::atomic<int>& current_count, int expected_count) {
     auto condition = [&current_count, expected_count]() {
       return current_count == expected_count;
     };
     EXPECT_TRUE(WaitForCondition(condition, timeout_ms_.count()));
   }
 
-  void CheckActorData(const gcs::ActorTableData &actor,
+  void CheckActorData(const gcs::ActorTableData& actor,
                       rpc::ActorTableData_ActorState expected_state) {
     ASSERT_TRUE(actor.state() == expected_state);
   }
@@ -518,7 +518,7 @@ TEST_F(ServiceBasedGcsClientTest, TestJobInfo) {
 
   // Subscribe to all jobs.
   std::atomic<int> job_updates(0);
-  auto on_subscribe = [&job_updates](const JobID &job_id, const gcs::JobTableData &data) {
+  auto on_subscribe = [&job_updates](const JobID& job_id, const gcs::JobTableData& data) {
     job_updates++;
   };
   ASSERT_TRUE(SubscribeToAllJobs(on_subscribe));
@@ -536,8 +536,8 @@ TEST_F(ServiceBasedGcsClientTest, TestActorInfo) {
 
   // Subscribe to any update operations of an actor.
   std::atomic<int> actor_update_count(0);
-  auto on_subscribe = [&actor_update_count](const ActorID &actor_id,
-                                            const gcs::ActorTableData &data) {
+  auto on_subscribe = [&actor_update_count](const ActorID& actor_id,
+                                            const gcs::ActorTableData& data) {
     ++actor_update_count;
   };
   ASSERT_TRUE(SubscribeActor(actor_id, on_subscribe));
@@ -589,8 +589,8 @@ TEST_F(ServiceBasedGcsClientTest, TestActorSubscribeAll) {
 
   // Subscribe to any register or update operations of actors.
   std::atomic<int> actor_update_count(0);
-  auto on_subscribe = [&actor_update_count](const ActorID &actor_id,
-                                            const gcs::ActorTableData &data) {
+  auto on_subscribe = [&actor_update_count](const ActorID& actor_id,
+                                            const gcs::ActorTableData& data) {
     ++actor_update_count;
   };
   ASSERT_TRUE(SubscribeAllActors(on_subscribe));
@@ -609,8 +609,8 @@ TEST_F(ServiceBasedGcsClientTest, TestNodeInfo) {
   // Subscribe to node addition and removal events from GCS.
   std::atomic<int> register_count(0);
   std::atomic<int> unregister_count(0);
-  auto on_subscribe = [&register_count, &unregister_count](const ClientID &node_id,
-                                                           const rpc::GcsNodeInfo &data) {
+  auto on_subscribe = [&register_count, &unregister_count](const ClientID& node_id,
+                                                           const rpc::GcsNodeInfo& data) {
     if (data.state() == rpc::GcsNodeInfo::ALIVE) {
       ++register_count;
     } else if (data.state() == rpc::GcsNodeInfo::DEAD) {
@@ -660,7 +660,7 @@ TEST_F(ServiceBasedGcsClientTest, TestNodeResources) {
   std::atomic<int> add_count(0);
   std::atomic<int> remove_count(0);
   auto on_subscribe = [&add_count,
-                       &remove_count](const rpc::NodeResourceChange &notification) {
+                       &remove_count](const rpc::NodeResourceChange& notification) {
     if (0 == notification.deleted_resources_size()) {
       ++add_count;
     } else {
@@ -690,7 +690,7 @@ TEST_F(ServiceBasedGcsClientTest, TestNodeHeartbeat) {
   // Subscribe batched state of all nodes from GCS.
   std::atomic<int> heartbeat_batch_count(0);
   auto on_subscribe =
-      [&heartbeat_batch_count](const gcs::HeartbeatBatchTableData &result) {
+      [&heartbeat_batch_count](const gcs::HeartbeatBatchTableData& result) {
         ++heartbeat_batch_count;
       };
   ASSERT_TRUE(SubscribeBatchHeartbeat(on_subscribe));
@@ -716,8 +716,8 @@ TEST_F(ServiceBasedGcsClientTest, TestTaskInfo) {
 
   // Subscribe to the event that the given task is added in GCS.
   std::atomic<int> task_count(0);
-  auto task_subscribe = [&task_count](const TaskID &id,
-                                      const rpc::TaskTableData &result) { ++task_count; };
+  auto task_subscribe = [&task_count](const TaskID& id,
+                                      const rpc::TaskTableData& result) { ++task_count; };
   ASSERT_TRUE(SubscribeTask(task_id, task_subscribe));
 
   // Add a task to GCS.
@@ -743,8 +743,8 @@ TEST_F(ServiceBasedGcsClientTest, TestTaskInfo) {
   // Subscribe to the event that the given task lease is added in GCS.
   std::atomic<int> task_lease_count(0);
   auto task_lease_subscribe = [&task_lease_count](
-                                  const TaskID &id,
-                                  const boost::optional<rpc::TaskLeaseData> &result) {
+                                  const TaskID& id,
+                                  const boost::optional<rpc::TaskLeaseData>& result) {
     ++task_lease_count;
   };
   ASSERT_TRUE(SubscribeTaskLease(task_id, task_lease_subscribe));
@@ -780,8 +780,8 @@ TEST_F(ServiceBasedGcsClientTest, TestObjectInfo) {
   std::atomic<int> object_add_count(0);
   std::atomic<int> object_remove_count(0);
   auto on_subscribe = [&object_add_count, &object_remove_count](
-                          const ObjectID &object_id,
-                          const gcs::ObjectChangeNotification &result) {
+                          const ObjectID& object_id,
+                          const gcs::ObjectChangeNotification& result) {
     if (!result.GetData().empty()) {
       if (result.IsAdded()) {
         ++object_add_count;
@@ -827,8 +827,8 @@ TEST_F(ServiceBasedGcsClientTest, TestStats) {
 TEST_F(ServiceBasedGcsClientTest, TestWorkerInfo) {
   // Subscribe to all unexpected failure of workers from GCS.
   std::atomic<int> worker_failure_count(0);
-  auto on_subscribe = [&worker_failure_count](const WorkerID &worker_id,
-                                              const rpc::WorkerTableData &result) {
+  auto on_subscribe = [&worker_failure_count](const WorkerID& worker_id,
+                                              const rpc::WorkerTableData& result) {
     ++worker_failure_count;
   };
   ASSERT_TRUE(SubscribeToWorkerFailures(on_subscribe));
@@ -861,7 +861,7 @@ TEST_F(ServiceBasedGcsClientTest, TestJobTableResubscribe) {
 
   // Subscribe to all jobs.
   std::atomic<int> job_update_count(0);
-  auto subscribe = [&job_update_count](const JobID &id, const rpc::JobTableData &result) {
+  auto subscribe = [&job_update_count](const JobID& id, const rpc::JobTableData& result) {
     ++job_update_count;
   };
   ASSERT_TRUE(SubscribeToAllJobs(subscribe));
@@ -889,7 +889,7 @@ TEST_F(ServiceBasedGcsClientTest, TestActorTableResubscribe) {
   // All the notifications for the following `SubscribeAllActors` operation.
   std::vector<gcs::ActorTableData> subscribe_all_notifications;
   auto subscribe_all = [&num_subscribe_all_notifications, &subscribe_all_notifications](
-                           const ActorID &id, const rpc::ActorTableData &data) {
+                           const ActorID& id, const rpc::ActorTableData& data) {
     subscribe_all_notifications.emplace_back(data);
     ++num_subscribe_all_notifications;
   };
@@ -901,7 +901,7 @@ TEST_F(ServiceBasedGcsClientTest, TestActorTableResubscribe) {
   // All the notifications for the following `SubscribeActor` operation.
   std::vector<gcs::ActorTableData> subscribe_one_notifications;
   auto actor_subscribe = [&num_subscribe_one_notifications, &subscribe_one_notifications](
-                             const ActorID &actor_id, const gcs::ActorTableData &data) {
+                             const ActorID& actor_id, const gcs::ActorTableData& data) {
     subscribe_one_notifications.emplace_back(data);
     ++num_subscribe_one_notifications;
   };
@@ -947,15 +947,15 @@ TEST_F(ServiceBasedGcsClientTest, TestObjectTableResubscribe) {
   std::atomic<int> object1_change_count(0);
   std::atomic<int> object2_change_count(0);
   ASSERT_TRUE(SubscribeToLocations(
-      object1_id, [&object1_change_count](const ObjectID &object_id,
-                                          const gcs::ObjectChangeNotification &result) {
+      object1_id, [&object1_change_count](const ObjectID& object_id,
+                                          const gcs::ObjectChangeNotification& result) {
         if (!result.GetData().empty()) {
           ++object1_change_count;
         }
       }));
   ASSERT_TRUE(SubscribeToLocations(
-      object2_id, [&object2_change_count](const ObjectID &object_id,
-                                          const gcs::ObjectChangeNotification &result) {
+      object2_id, [&object2_change_count](const ObjectID& object_id,
+                                          const gcs::ObjectChangeNotification& result) {
         if (!result.GetData().empty()) {
           ++object2_change_count;
         }
@@ -988,8 +988,8 @@ TEST_F(ServiceBasedGcsClientTest, TestNodeTableResubscribe) {
   // Test that subscription of the node table can still work when GCS server restarts.
   // Subscribe to node addition and removal events from GCS and cache those information.
   std::atomic<int> node_change_count(0);
-  auto node_subscribe = [&node_change_count](const ClientID &id,
-                                             const rpc::GcsNodeInfo &result) {
+  auto node_subscribe = [&node_change_count](const ClientID& id,
+                                             const rpc::GcsNodeInfo& result) {
     ++node_change_count;
   };
   ASSERT_TRUE(SubscribeToNodeChange(node_subscribe));
@@ -997,7 +997,7 @@ TEST_F(ServiceBasedGcsClientTest, TestNodeTableResubscribe) {
   // Subscribe to node resource changes.
   std::atomic<int> resource_change_count(0);
   auto resource_subscribe =
-      [&resource_change_count](const rpc::NodeResourceChange &result) {
+      [&resource_change_count](const rpc::NodeResourceChange& result) {
         ++resource_change_count;
       };
   ASSERT_TRUE(SubscribeToResources(resource_subscribe));
@@ -1005,7 +1005,7 @@ TEST_F(ServiceBasedGcsClientTest, TestNodeTableResubscribe) {
   // Subscribe batched state of all nodes from GCS.
   std::atomic<int> batch_heartbeat_count(0);
   auto batch_heartbeat_subscribe =
-      [&batch_heartbeat_count](const rpc::HeartbeatBatchTableData &result) {
+      [&batch_heartbeat_count](const rpc::HeartbeatBatchTableData& result) {
         ++batch_heartbeat_count;
       };
   ASSERT_TRUE(SubscribeBatchHeartbeat(batch_heartbeat_subscribe));
@@ -1043,15 +1043,15 @@ TEST_F(ServiceBasedGcsClientTest, TestTaskTableResubscribe) {
 
   // Subscribe to the event that the given task is added in GCS.
   std::atomic<int> task_count(0);
-  auto task_subscribe = [&task_count](const TaskID &task_id,
-                                      const gcs::TaskTableData &data) { ++task_count; };
+  auto task_subscribe = [&task_count](const TaskID& task_id,
+                                      const gcs::TaskTableData& data) { ++task_count; };
   ASSERT_TRUE(SubscribeTask(task_id, task_subscribe));
 
   // Subscribe to the event that the given task lease is added in GCS.
   std::atomic<int> task_lease_count(0);
   auto task_lease_subscribe = [&task_lease_count](
-                                  const TaskID &task_id,
-                                  const boost::optional<rpc::TaskLeaseData> &data) {
+                                  const TaskID& task_id,
+                                  const boost::optional<rpc::TaskLeaseData>& data) {
     if (data) {
       ++task_lease_count;
     }
@@ -1078,8 +1078,8 @@ TEST_F(ServiceBasedGcsClientTest, TestTaskTableResubscribe) {
 TEST_F(ServiceBasedGcsClientTest, TestWorkerTableResubscribe) {
   // Subscribe to all unexpected failure of workers from GCS.
   std::atomic<int> worker_failure_count(0);
-  auto on_subscribe = [&worker_failure_count](const WorkerID &worker_id,
-                                              const rpc::WorkerTableData &result) {
+  auto on_subscribe = [&worker_failure_count](const WorkerID& worker_id,
+                                              const rpc::WorkerTableData& result) {
     ++worker_failure_count;
   };
   ASSERT_TRUE(SubscribeToWorkerFailures(on_subscribe));
@@ -1150,13 +1150,13 @@ TEST_F(ServiceBasedGcsClientTest, TestMultiThreadSubAndUnsub) {
       for (int index = 0; index < sub_and_unsub_loop_count; ++index) {
         auto actor_id = ActorID::Of(job_id, RandomTaskId(), 0);
         ASSERT_TRUE(SubscribeActor(
-            actor_id, [](const ActorID &id, const rpc::ActorTableData &result) {}));
+            actor_id, [](const ActorID& id, const rpc::ActorTableData& result) {}));
         gcs_client_->Actors().AsyncResubscribe(false);
         UnsubscribeActor(actor_id);
       }
     }));
   }
-  for (auto &thread : threads) {
+  for (auto& thread : threads) {
     thread->join();
     thread.reset();
   }
@@ -1168,13 +1168,13 @@ TEST_F(ServiceBasedGcsClientTest, TestMultiThreadSubAndUnsub) {
         auto object_id = ObjectID::FromRandom();
         ASSERT_TRUE(SubscribeToLocations(
             object_id,
-            [](const ObjectID &id, const gcs::ObjectChangeNotification &result) {}));
+            [](const ObjectID& id, const gcs::ObjectChangeNotification& result) {}));
         gcs_client_->Objects().AsyncResubscribe(false);
         UnsubscribeToLocations(object_id);
       }
     }));
   }
-  for (auto &thread : threads) {
+  for (auto& thread : threads) {
     thread->join();
     thread.reset();
   }
@@ -1182,7 +1182,7 @@ TEST_F(ServiceBasedGcsClientTest, TestMultiThreadSubAndUnsub) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
                                          ray::RayLog::ShutDownRayLog, argv[0],
                                          ray::RayLogLevel::INFO,

--- a/src/ray/gcs/gcs_server/error_info_handler_impl.cc
+++ b/src/ray/gcs/gcs_server/error_info_handler_impl.cc
@@ -18,7 +18,7 @@ namespace ray {
 namespace rpc {
 
 void DefaultErrorInfoHandler::HandleReportJobError(
-    const ReportJobErrorRequest &request, ReportJobErrorReply *reply,
+    const ReportJobErrorRequest& request, ReportJobErrorReply* reply,
     SendReplyCallback send_reply_callback) {
   JobID job_id = JobID::FromBinary(request.error_data().job_id());
   std::string type = request.error_data().type();

--- a/src/ray/gcs/gcs_server/error_info_handler_impl.h
+++ b/src/ray/gcs/gcs_server/error_info_handler_impl.h
@@ -23,15 +23,15 @@ namespace rpc {
 /// This implementation class of `ErrorInfoHandler`.
 class DefaultErrorInfoHandler : public rpc::ErrorInfoHandler {
  public:
-  explicit DefaultErrorInfoHandler(gcs::RedisGcsClient &gcs_client)
+  explicit DefaultErrorInfoHandler(gcs::RedisGcsClient& gcs_client)
       : gcs_client_(gcs_client) {}
 
-  void HandleReportJobError(const ReportJobErrorRequest &request,
-                            ReportJobErrorReply *reply,
+  void HandleReportJobError(const ReportJobErrorRequest& request,
+                            ReportJobErrorReply* reply,
                             SendReplyCallback send_reply_callback) override;
 
  private:
-  gcs::RedisGcsClient &gcs_client_;
+  gcs::RedisGcsClient& gcs_client_;
 };
 
 }  // namespace rpc

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -22,21 +22,21 @@ namespace ray {
 namespace gcs {
 
 ClientID GcsActor::GetNodeID() const {
-  const auto &raylet_id_binary = actor_table_data_.address().raylet_id();
+  const auto& raylet_id_binary = actor_table_data_.address().raylet_id();
   if (raylet_id_binary.empty()) {
     return ClientID::Nil();
   }
   return ClientID::FromBinary(raylet_id_binary);
 }
 
-void GcsActor::UpdateAddress(const rpc::Address &address) {
+void GcsActor::UpdateAddress(const rpc::Address& address) {
   actor_table_data_.mutable_address()->CopyFrom(address);
 }
 
-const rpc::Address &GcsActor::GetAddress() const { return actor_table_data_.address(); }
+const rpc::Address& GcsActor::GetAddress() const { return actor_table_data_.address(); }
 
 WorkerID GcsActor::GetWorkerID() const {
-  const auto &address = actor_table_data_.address();
+  const auto& address = actor_table_data_.address();
   if (address.worker_id().empty()) {
     return WorkerID::Nil();
   }
@@ -51,7 +51,7 @@ ClientID GcsActor::GetOwnerNodeID() const {
   return ClientID::FromBinary(GetOwnerAddress().raylet_id());
 }
 
-const rpc::Address &GcsActor::GetOwnerAddress() const {
+const rpc::Address& GcsActor::GetOwnerAddress() const {
   return actor_table_data_.owner_address();
 }
 
@@ -72,28 +72,28 @@ bool GcsActor::IsDetached() const { return actor_table_data_.is_detached(); }
 std::string GcsActor::GetName() const { return actor_table_data_.name(); }
 
 TaskSpecification GcsActor::GetCreationTaskSpecification() const {
-  const auto &task_spec = actor_table_data_.task_spec();
+  const auto& task_spec = actor_table_data_.task_spec();
   return TaskSpecification(task_spec);
 }
 
-const rpc::ActorTableData &GcsActor::GetActorTableData() const {
+const rpc::ActorTableData& GcsActor::GetActorTableData() const {
   return actor_table_data_;
 }
 
-rpc::ActorTableData *GcsActor::GetMutableActorTableData() { return &actor_table_data_; }
+rpc::ActorTableData* GcsActor::GetMutableActorTableData() { return &actor_table_data_; }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 GcsActorManager::GcsActorManager(std::shared_ptr<GcsActorSchedulerInterface> scheduler,
                                  std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
                                  std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub,
-                                 const rpc::ClientFactoryFn &worker_client_factory)
+                                 const rpc::ClientFactoryFn& worker_client_factory)
     : gcs_actor_scheduler_(std::move(scheduler)),
       gcs_table_storage_(std::move(gcs_table_storage)),
       gcs_pub_sub_(std::move(gcs_pub_sub)),
       worker_client_factory_(worker_client_factory) {}
 
-void GcsActorManager::HandleRegisterActor(const rpc::RegisterActorRequest &request,
-                                          rpc::RegisterActorReply *reply,
+void GcsActorManager::HandleRegisterActor(const rpc::RegisterActorRequest& request,
+                                          rpc::RegisterActorReply* reply,
                                           rpc::SendReplyCallback send_reply_callback) {
   RAY_CHECK(request.task_spec().type() == TaskType::ACTOR_CREATION_TASK);
   auto actor_id =
@@ -102,7 +102,7 @@ void GcsActorManager::HandleRegisterActor(const rpc::RegisterActorRequest &reque
   RAY_LOG(INFO) << "Registering actor, actor id = " << actor_id;
   Status status =
       RegisterActor(request, [reply, send_reply_callback,
-                              actor_id](const std::shared_ptr<gcs::GcsActor> &actor) {
+                              actor_id](const std::shared_ptr<gcs::GcsActor>& actor) {
         RAY_LOG(INFO) << "Registered actor, actor id = " << actor_id;
         GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
       });
@@ -112,8 +112,8 @@ void GcsActorManager::HandleRegisterActor(const rpc::RegisterActorRequest &reque
   }
 }
 
-void GcsActorManager::HandleCreateActor(const rpc::CreateActorRequest &request,
-                                        rpc::CreateActorReply *reply,
+void GcsActorManager::HandleCreateActor(const rpc::CreateActorRequest& request,
+                                        rpc::CreateActorReply* reply,
                                         rpc::SendReplyCallback send_reply_callback) {
   RAY_CHECK(request.task_spec().type() == TaskType::ACTOR_CREATION_TASK);
   auto actor_id =
@@ -121,7 +121,7 @@ void GcsActorManager::HandleCreateActor(const rpc::CreateActorRequest &request,
 
   RAY_LOG(INFO) << "Creating actor, actor id = " << actor_id;
   Status status = CreateActor(request, [reply, send_reply_callback, actor_id](
-                                           const std::shared_ptr<gcs::GcsActor> &actor) {
+                                           const std::shared_ptr<gcs::GcsActor>& actor) {
     RAY_LOG(INFO) << "Created actor, actor id = " << actor_id;
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
   });
@@ -132,16 +132,16 @@ void GcsActorManager::HandleCreateActor(const rpc::CreateActorRequest &request,
   }
 }
 
-void GcsActorManager::HandleGetActorInfo(const rpc::GetActorInfoRequest &request,
-                                         rpc::GetActorInfoReply *reply,
+void GcsActorManager::HandleGetActorInfo(const rpc::GetActorInfoRequest& request,
+                                         rpc::GetActorInfoReply* reply,
                                          rpc::SendReplyCallback send_reply_callback) {
   ActorID actor_id = ActorID::FromBinary(request.actor_id());
   RAY_LOG(DEBUG) << "Getting actor info"
                  << ", job id = " << actor_id.JobId() << ", actor id = " << actor_id;
 
   auto on_done = [actor_id, reply, send_reply_callback](
-                     const Status &status,
-                     const boost::optional<ActorTableData> &result) {
+                     const Status& status,
+                     const boost::optional<ActorTableData>& result) {
     if (result) {
       reply->mutable_actor_table_data()->CopyFrom(*result);
     }
@@ -157,14 +157,14 @@ void GcsActorManager::HandleGetActorInfo(const rpc::GetActorInfoRequest &request
   }
 }
 
-void GcsActorManager::HandleGetAllActorInfo(const rpc::GetAllActorInfoRequest &request,
-                                            rpc::GetAllActorInfoReply *reply,
+void GcsActorManager::HandleGetAllActorInfo(const rpc::GetAllActorInfoRequest& request,
+                                            rpc::GetAllActorInfoReply* reply,
                                             rpc::SendReplyCallback send_reply_callback) {
   RAY_LOG(DEBUG) << "Getting all actor info.";
 
   auto on_done = [reply, send_reply_callback](
-                     const std::unordered_map<ActorID, ActorTableData> &result) {
-    for (auto &it : result) {
+                     const std::unordered_map<ActorID, ActorTableData>& result) {
+    for (auto& it : result) {
       reply->add_actor_table_data()->CopyFrom(it.second);
     }
     RAY_LOG(DEBUG) << "Finished getting all actor info.";
@@ -178,15 +178,15 @@ void GcsActorManager::HandleGetAllActorInfo(const rpc::GetAllActorInfoRequest &r
 }
 
 void GcsActorManager::HandleGetNamedActorInfo(
-    const rpc::GetNamedActorInfoRequest &request, rpc::GetNamedActorInfoReply *reply,
+    const rpc::GetNamedActorInfoRequest& request, rpc::GetNamedActorInfoReply* reply,
     rpc::SendReplyCallback send_reply_callback) {
-  const std::string &name = request.name();
+  const std::string& name = request.name();
   RAY_LOG(DEBUG) << "Getting actor info"
                  << ", name = " << name;
 
   auto on_done = [name, reply, send_reply_callback](
-                     const Status &status,
-                     const boost::optional<ActorTableData> &result) {
+                     const Status& status,
+                     const boost::optional<ActorTableData>& result) {
     if (status.ok()) {
       if (result) {
         reply->mutable_actor_table_data()->CopyFrom(*result);
@@ -217,14 +217,14 @@ void GcsActorManager::HandleGetNamedActorInfo(
   }
 }
 void GcsActorManager::HandleRegisterActorInfo(
-    const rpc::RegisterActorInfoRequest &request, rpc::RegisterActorInfoReply *reply,
+    const rpc::RegisterActorInfoRequest& request, rpc::RegisterActorInfoReply* reply,
     rpc::SendReplyCallback send_reply_callback) {
   ActorID actor_id = ActorID::FromBinary(request.actor_table_data().actor_id());
   RAY_LOG(DEBUG) << "Registering actor info, job id = " << actor_id.JobId()
                  << ", actor id = " << actor_id;
-  const auto &actor_table_data = request.actor_table_data();
+  const auto& actor_table_data = request.actor_table_data();
   auto on_done = [this, actor_id, actor_table_data, reply,
-                  send_reply_callback](const Status &status) {
+                  send_reply_callback](const Status& status) {
     if (!status.ok()) {
       RAY_LOG(ERROR) << "Failed to register actor info: " << status.ToString()
                      << ", job id = " << actor_id.JobId() << ", actor id = " << actor_id;
@@ -244,15 +244,15 @@ void GcsActorManager::HandleRegisterActorInfo(
   }
 }
 
-void GcsActorManager::HandleUpdateActorInfo(const rpc::UpdateActorInfoRequest &request,
-                                            rpc::UpdateActorInfoReply *reply,
+void GcsActorManager::HandleUpdateActorInfo(const rpc::UpdateActorInfoRequest& request,
+                                            rpc::UpdateActorInfoReply* reply,
                                             rpc::SendReplyCallback send_reply_callback) {
   ActorID actor_id = ActorID::FromBinary(request.actor_id());
   RAY_LOG(DEBUG) << "Updating actor info, job id = " << actor_id.JobId()
                  << ", actor id = " << actor_id;
-  const auto &actor_table_data = request.actor_table_data();
+  const auto& actor_table_data = request.actor_table_data();
   auto on_done = [this, actor_id, actor_table_data, reply,
-                  send_reply_callback](const Status &status) {
+                  send_reply_callback](const Status& status) {
     if (!status.ok()) {
       RAY_LOG(ERROR) << "Failed to update actor info: " << status.ToString()
                      << ", job id = " << actor_id.JobId() << ", actor id = " << actor_id;
@@ -273,7 +273,7 @@ void GcsActorManager::HandleUpdateActorInfo(const rpc::UpdateActorInfoRequest &r
 }
 
 void GcsActorManager::HandleAddActorCheckpoint(
-    const rpc::AddActorCheckpointRequest &request, rpc::AddActorCheckpointReply *reply,
+    const rpc::AddActorCheckpointRequest& request, rpc::AddActorCheckpointReply* reply,
     rpc::SendReplyCallback send_reply_callback) {
   ActorID actor_id = ActorID::FromBinary(request.checkpoint_data().actor_id());
   ActorCheckpointID checkpoint_id =
@@ -281,15 +281,15 @@ void GcsActorManager::HandleAddActorCheckpoint(
   RAY_LOG(DEBUG) << "Adding actor checkpoint, job id = " << actor_id.JobId()
                  << ", actor id = " << actor_id << ", checkpoint id = " << checkpoint_id;
   auto on_done = [this, actor_id, checkpoint_id, reply,
-                  send_reply_callback](const Status &status) {
+                  send_reply_callback](const Status& status) {
     if (!status.ok()) {
       RAY_LOG(ERROR) << "Failed to add actor checkpoint: " << status.ToString()
                      << ", job id = " << actor_id.JobId() << ", actor id = " << actor_id
                      << ", checkpoint id = " << checkpoint_id;
     } else {
       auto on_get_done = [this, actor_id, checkpoint_id, reply, send_reply_callback](
-                             const Status &status,
-                             const boost::optional<ActorCheckpointIdData> &result) {
+                             const Status& status,
+                             const boost::optional<ActorCheckpointIdData>& result) {
         ActorCheckpointIdData actor_checkpoint_id;
         if (result) {
           actor_checkpoint_id.CopyFrom(*result);
@@ -299,7 +299,7 @@ void GcsActorManager::HandleAddActorCheckpoint(
         actor_checkpoint_id.add_checkpoint_ids(checkpoint_id.Binary());
         actor_checkpoint_id.add_timestamps(absl::GetCurrentTimeNanos() / 1000000);
         auto on_put_done = [actor_id, checkpoint_id, reply,
-                            send_reply_callback](const Status &status) {
+                            send_reply_callback](const Status& status) {
           RAY_LOG(DEBUG) << "Finished adding actor checkpoint, job id = "
                          << actor_id.JobId() << ", actor id = " << actor_id
                          << ", checkpoint id = " << checkpoint_id;
@@ -321,7 +321,7 @@ void GcsActorManager::HandleAddActorCheckpoint(
 }
 
 void GcsActorManager::HandleGetActorCheckpoint(
-    const rpc::GetActorCheckpointRequest &request, rpc::GetActorCheckpointReply *reply,
+    const rpc::GetActorCheckpointRequest& request, rpc::GetActorCheckpointReply* reply,
     rpc::SendReplyCallback send_reply_callback) {
   ActorID actor_id = ActorID::FromBinary(request.actor_id());
   ActorCheckpointID checkpoint_id =
@@ -329,8 +329,8 @@ void GcsActorManager::HandleGetActorCheckpoint(
   RAY_LOG(DEBUG) << "Getting actor checkpoint, job id = " << actor_id.JobId()
                  << ", checkpoint id = " << checkpoint_id;
   auto on_done = [actor_id, checkpoint_id, reply, send_reply_callback](
-                     const Status &status,
-                     const boost::optional<ActorCheckpointData> &result) {
+                     const Status& status,
+                     const boost::optional<ActorCheckpointData>& result) {
     if (status.ok()) {
       if (result) {
         reply->mutable_checkpoint_data()->CopyFrom(*result);
@@ -352,14 +352,14 @@ void GcsActorManager::HandleGetActorCheckpoint(
 }
 
 void GcsActorManager::HandleGetActorCheckpointID(
-    const rpc::GetActorCheckpointIDRequest &request,
-    rpc::GetActorCheckpointIDReply *reply, rpc::SendReplyCallback send_reply_callback) {
+    const rpc::GetActorCheckpointIDRequest& request,
+    rpc::GetActorCheckpointIDReply* reply, rpc::SendReplyCallback send_reply_callback) {
   ActorID actor_id = ActorID::FromBinary(request.actor_id());
   RAY_LOG(DEBUG) << "Getting actor checkpoint id, job id = " << actor_id.JobId()
                  << ", actor id = " << actor_id;
   auto on_done = [actor_id, reply, send_reply_callback](
-                     const Status &status,
-                     const boost::optional<ActorCheckpointIdData> &result) {
+                     const Status& status,
+                     const boost::optional<ActorCheckpointIdData>& result) {
     if (status.ok()) {
       if (result) {
         reply->mutable_checkpoint_id_data()->CopyFrom(*result);
@@ -380,10 +380,10 @@ void GcsActorManager::HandleGetActorCheckpointID(
 }
 
 Status GcsActorManager::RegisterActor(
-    const ray::rpc::RegisterActorRequest &request,
+    const ray::rpc::RegisterActorRequest& request,
     std::function<void(std::shared_ptr<GcsActor>)> callback) {
   RAY_CHECK(callback);
-  const auto &actor_creation_task_spec = request.task_spec().actor_creation_task_spec();
+  const auto& actor_creation_task_spec = request.task_spec().actor_creation_task_spec();
   auto actor_id = ActorID::FromBinary(actor_creation_task_spec.actor_id());
 
   auto iter = registered_actors_.find(actor_id);
@@ -421,7 +421,7 @@ Status GcsActorManager::RegisterActor(
   actor_to_register_callbacks_[actor_id].emplace_back(std::move(callback));
   RAY_CHECK(registered_actors_.emplace(actor->GetActorID(), actor).second);
 
-  const auto &owner_address = actor->GetOwnerAddress();
+  const auto& owner_address = actor->GetOwnerAddress();
   auto node_id = ClientID::FromBinary(owner_address.raylet_id());
   auto worker_id = WorkerID::FromBinary(owner_address.worker_id());
   RAY_CHECK(unresolved_actors_[node_id][worker_id].emplace(actor->GetActorID()).second);
@@ -435,7 +435,7 @@ Status GcsActorManager::RegisterActor(
   // The backend storage is supposed to be reliable, so the status must be ok.
   RAY_CHECK_OK(gcs_table_storage_->ActorTable().Put(
       actor->GetActorID(), *actor->GetMutableActorTableData(),
-      [this, actor](const Status &status) {
+      [this, actor](const Status& status) {
         // The backend storage is supposed to be reliable, so the status must be ok.
         RAY_CHECK_OK(status);
         // Invoke all callbacks for all registration requests of this actor (duplicated
@@ -446,17 +446,17 @@ Status GcsActorManager::RegisterActor(
         RAY_CHECK(iter != actor_to_register_callbacks_.end() && !iter->second.empty());
         auto callbacks = std::move(iter->second);
         actor_to_register_callbacks_.erase(iter);
-        for (auto &callback : callbacks) {
+        for (auto& callback : callbacks) {
           callback(actor);
         }
       }));
   return Status::OK();
 }
 
-Status GcsActorManager::CreateActor(const ray::rpc::CreateActorRequest &request,
+Status GcsActorManager::CreateActor(const ray::rpc::CreateActorRequest& request,
                                     CreateActorCallback callback) {
   RAY_CHECK(callback);
-  const auto &actor_creation_task_spec = request.task_spec().actor_creation_task_spec();
+  const auto& actor_creation_task_spec = request.task_spec().actor_creation_task_spec();
   auto actor_id = ActorID::FromBinary(actor_creation_task_spec.actor_id());
 
   auto iter = registered_actors_.find(actor_id);
@@ -483,7 +483,7 @@ Status GcsActorManager::CreateActor(const ray::rpc::CreateActorRequest &request,
   // Remove the actor from the unresolved actor map.
   auto actor = std::make_shared<GcsActor>(request.task_spec());
   actor->GetMutableActorTableData()->set_state(rpc::ActorTableData::PENDING_CREATION);
-  const auto &owner_address = actor->GetOwnerAddress();
+  const auto& owner_address = actor->GetOwnerAddress();
   auto node_id = ClientID::FromBinary(owner_address.raylet_id());
   auto worker_id = WorkerID::FromBinary(owner_address.worker_id());
   auto it = unresolved_actors_.find(node_id);
@@ -506,7 +506,7 @@ Status GcsActorManager::CreateActor(const ray::rpc::CreateActorRequest &request,
   return Status::OK();
 }
 
-ActorID GcsActorManager::GetActorIDByName(const std::string &name) {
+ActorID GcsActorManager::GetActorIDByName(const std::string& name) {
   ActorID actor_id = ActorID::Nil();
   auto it = named_actors_.find(name);
   if (it != named_actors_.end()) {
@@ -516,11 +516,11 @@ ActorID GcsActorManager::GetActorIDByName(const std::string &name) {
 }
 
 void GcsActorManager::PollOwnerForActorOutOfScope(
-    const std::shared_ptr<GcsActor> &actor) {
-  const auto &actor_id = actor->GetActorID();
-  const auto &owner_node_id = actor->GetOwnerNodeID();
-  const auto &owner_id = actor->GetOwnerID();
-  auto &workers = owners_[owner_node_id];
+    const std::shared_ptr<GcsActor>& actor) {
+  const auto& actor_id = actor->GetActorID();
+  const auto& owner_node_id = actor->GetOwnerNodeID();
+  const auto& owner_id = actor->GetOwnerID();
+  auto& workers = owners_[owner_node_id];
   auto it = workers.find(owner_id);
   if (it == workers.end()) {
     RAY_LOG(DEBUG) << "Adding owner " << owner_id << " of actor " << actor_id;
@@ -535,7 +535,7 @@ void GcsActorManager::PollOwnerForActorOutOfScope(
   wait_request.set_actor_id(actor_id.Binary());
   it->second.client->WaitForActorOutOfScope(
       wait_request, [this, owner_node_id, owner_id, actor_id](
-                        Status status, const rpc::WaitForActorOutOfScopeReply &reply) {
+                        Status status, const rpc::WaitForActorOutOfScopeReply& reply) {
         if (!status.ok()) {
           RAY_LOG(INFO) << "Worker " << owner_id << " failed, destroying actor child";
         }
@@ -549,7 +549,7 @@ void GcsActorManager::PollOwnerForActorOutOfScope(
       });
 }
 
-void GcsActorManager::DestroyActor(const ActorID &actor_id) {
+void GcsActorManager::DestroyActor(const ActorID& actor_id) {
   RAY_LOG(DEBUG) << "Destroying actor " << actor_id;
   actor_to_register_callbacks_.erase(actor_id);
   actor_to_create_callbacks_.erase(actor_id);
@@ -561,14 +561,14 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
 
   // Clean up the client to the actor's owner, if necessary.
   if (!actor->IsDetached()) {
-    const auto &owner_node_id = actor->GetOwnerNodeID();
-    const auto &owner_id = actor->GetOwnerID();
+    const auto& owner_node_id = actor->GetOwnerNodeID();
+    const auto& owner_id = actor->GetOwnerID();
     RAY_LOG(DEBUG) << "Erasing actor " << actor_id << " owned by " << owner_id;
 
-    auto &node = owners_[owner_node_id];
+    auto& node = owners_[owner_node_id];
     auto worker_it = node.find(owner_id);
     RAY_CHECK(worker_it != node.end());
-    auto &owner = worker_it->second;
+    auto& owner = worker_it->second;
     RAY_CHECK(owner.children_actor_ids.erase(actor_id));
     if (owner.children_actor_ids.empty()) {
       node.erase(worker_it);
@@ -586,7 +586,7 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
   if (actor->GetState() == rpc::ActorTableData::DEPENDENCIES_UNREADY) {
     // The actor creation task still has unresolved dependencies. Remove from the
     // unresolved actors map.
-    const auto &owner_address = actor->GetOwnerAddress();
+    const auto& owner_address = actor->GetOwnerAddress();
     auto node_id = ClientID::FromBinary(owner_address.raylet_id());
     auto worker_id = WorkerID::FromBinary(owner_address.worker_id());
     auto iter = unresolved_actors_.find(node_id);
@@ -604,8 +604,8 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
   } else {
     // The actor is still alive or pending creation. Clean up all remaining
     // state.
-    const auto &node_id = actor->GetNodeID();
-    const auto &worker_id = actor->GetWorkerID();
+    const auto& node_id = actor->GetNodeID();
+    const auto& worker_id = actor->GetWorkerID();
     auto node_it = created_actors_.find(node_id);
     if (node_it != created_actors_.end() && node_it->second.count(worker_id)) {
       // The actor has already been created. Destroy the process by force-killing
@@ -632,7 +632,7 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
       } else {
         auto pending_it =
             std::find_if(pending_actors_.begin(), pending_actors_.end(),
-                         [actor_id](const std::shared_ptr<GcsActor> &actor) {
+                         [actor_id](const std::shared_ptr<GcsActor>& actor) {
                            return actor->GetActorID() == actor_id;
                          });
 
@@ -670,11 +670,11 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
 }
 
 absl::flat_hash_set<ActorID> GcsActorManager::GetUnresolvedActorsByOwnerNode(
-    const ClientID &node_id) const {
+    const ClientID& node_id) const {
   absl::flat_hash_set<ActorID> actor_ids;
   auto iter = unresolved_actors_.find(node_id);
   if (iter != unresolved_actors_.end()) {
-    for (auto &entry : iter->second) {
+    for (auto& entry : iter->second) {
       actor_ids.insert(entry.second.begin(), entry.second.end());
     }
   }
@@ -682,7 +682,7 @@ absl::flat_hash_set<ActorID> GcsActorManager::GetUnresolvedActorsByOwnerNode(
 }
 
 absl::flat_hash_set<ActorID> GcsActorManager::GetUnresolvedActorsByOwnerWorker(
-    const ClientID &node_id, const WorkerID &worker_id) const {
+    const ClientID& node_id, const WorkerID& worker_id) const {
   absl::flat_hash_set<ActorID> actor_ids;
   auto iter = unresolved_actors_.find(node_id);
   if (iter != unresolved_actors_.end()) {
@@ -694,8 +694,8 @@ absl::flat_hash_set<ActorID> GcsActorManager::GetUnresolvedActorsByOwnerWorker(
   return actor_ids;
 }
 
-void GcsActorManager::OnWorkerDead(const ray::ClientID &node_id,
-                                   const ray::WorkerID &worker_id,
+void GcsActorManager::OnWorkerDead(const ray::ClientID& node_id,
+                                   const ray::WorkerID& worker_id,
                                    bool intentional_exit) {
   // Destroy all actors that are owned by this worker.
   const auto it = owners_.find(node_id);
@@ -704,7 +704,7 @@ void GcsActorManager::OnWorkerDead(const ray::ClientID &node_id,
     // Make a copy of the children actor IDs since we will delete from the
     // list.
     const auto children_ids = owner->second.children_actor_ids;
-    for (const auto &child_id : children_ids) {
+    for (const auto& child_id : children_ids) {
       DestroyActor(child_id);
     }
   }
@@ -713,7 +713,7 @@ void GcsActorManager::OnWorkerDead(const ray::ClientID &node_id,
   // case, these actors will never be created successfully. So we need to destroy them,
   // to prevent actor tasks hang forever.
   auto unresolved_actors = GetUnresolvedActorsByOwnerWorker(node_id, worker_id);
-  for (auto &actor_id : unresolved_actors) {
+  for (auto& actor_id : unresolved_actors) {
     if (registered_actors_.count(actor_id)) {
       DestroyActor(actor_id);
     }
@@ -744,25 +744,25 @@ void GcsActorManager::OnWorkerDead(const ray::ClientID &node_id,
   ReconstructActor(actor_id, /*need_reschedule=*/!intentional_exit);
 }
 
-void GcsActorManager::OnNodeDead(const ClientID &node_id) {
+void GcsActorManager::OnNodeDead(const ClientID& node_id) {
   RAY_LOG(WARNING) << "Node " << node_id << " failed, reconstructing actors.";
   const auto it = owners_.find(node_id);
   if (it != owners_.end()) {
     std::vector<ActorID> children_ids;
     // Make a copy of all the actor IDs owned by workers on the dead node.
-    for (const auto &owner : it->second) {
-      for (const auto &child_id : owner.second.children_actor_ids) {
+    for (const auto& owner : it->second) {
+      for (const auto& child_id : owner.second.children_actor_ids) {
         children_ids.push_back(child_id);
       }
     }
-    for (const auto &child_id : children_ids) {
+    for (const auto& child_id : children_ids) {
       DestroyActor(child_id);
     }
   }
 
   // Cancel the scheduling of all related actors.
   auto scheduling_actor_ids = gcs_actor_scheduler_->CancelOnNode(node_id);
-  for (auto &actor_id : scheduling_actor_ids) {
+  for (auto& actor_id : scheduling_actor_ids) {
     // Reconstruct the canceled actor.
     ReconstructActor(actor_id);
   }
@@ -773,7 +773,7 @@ void GcsActorManager::OnNodeDead(const ClientID &node_id) {
     auto created_actors = std::move(iter->second);
     // Remove all created actors from node_to_created_actors_.
     created_actors_.erase(iter);
-    for (auto &entry : created_actors) {
+    for (auto& entry : created_actors) {
       // Reconstruct the removed actor.
       ReconstructActor(entry.second);
     }
@@ -783,15 +783,15 @@ void GcsActorManager::OnNodeDead(const ClientID &node_id) {
   // case, these actors will never be created successfully. So we need to destroy them,
   // to prevent actor tasks hang forever.
   auto unresolved_actors = GetUnresolvedActorsByOwnerNode(node_id);
-  for (auto &actor_id : unresolved_actors) {
+  for (auto& actor_id : unresolved_actors) {
     if (registered_actors_.count(actor_id)) {
       DestroyActor(actor_id);
     }
   }
 }
 
-void GcsActorManager::ReconstructActor(const ActorID &actor_id, bool need_reschedule) {
-  auto &actor = registered_actors_[actor_id];
+void GcsActorManager::ReconstructActor(const ActorID& actor_id, bool need_reschedule) {
+  auto& actor = registered_actors_[actor_id];
   // If the owner and this actor is dead at the same time, the actor
   // could've been destroyed and dereigstered before reconstruction.
   if (actor == nullptr) {
@@ -869,7 +869,7 @@ void GcsActorManager::OnActorCreationFailed(std::shared_ptr<GcsActor> actor) {
   pending_actors_.emplace_back(std::move(actor));
 }
 
-void GcsActorManager::OnActorCreationSuccess(const std::shared_ptr<GcsActor> &actor) {
+void GcsActorManager::OnActorCreationSuccess(const std::shared_ptr<GcsActor>& actor) {
   auto actor_id = actor->GetActorID();
   RAY_LOG(DEBUG) << "Actor created successfully, actor id = " << actor_id;
   // NOTE: If an actor is deleted immediately after the user creates the actor, reference
@@ -896,7 +896,7 @@ void GcsActorManager::OnActorCreationSuccess(const std::shared_ptr<GcsActor> &ac
         // actor_to_create_callbacks_.
         auto iter = actor_to_create_callbacks_.find(actor_id);
         if (iter != actor_to_create_callbacks_.end()) {
-          for (auto &callback : iter->second) {
+          for (auto& callback : iter->second) {
             callback(actor);
           }
           actor_to_create_callbacks_.erase(iter);
@@ -917,17 +917,17 @@ void GcsActorManager::SchedulePendingActors() {
 
   RAY_LOG(DEBUG) << "Scheduling actor creation tasks, size = " << pending_actors_.size();
   auto actors = std::move(pending_actors_);
-  for (auto &actor : actors) {
+  for (auto& actor : actors) {
     gcs_actor_scheduler_->Schedule(std::move(actor));
   }
 }
 
-void GcsActorManager::LoadInitialData(const EmptyCallback &done) {
+void GcsActorManager::LoadInitialData(const EmptyCallback& done) {
   RAY_LOG(INFO) << "Loading initial data.";
   auto callback = [this,
-                   done](const std::unordered_map<ActorID, ActorTableData> &result) {
+                   done](const std::unordered_map<ActorID, ActorTableData>& result) {
     std::unordered_map<ClientID, std::vector<WorkerID>> node_to_workers;
-    for (auto &item : result) {
+    for (auto& item : result) {
       if (item.second.state() != ray::rpc::ActorTableData::DEAD) {
         auto actor = std::make_shared<GcsActor>(item.second);
         registered_actors_.emplace(item.first, actor);
@@ -937,9 +937,9 @@ void GcsActorManager::LoadInitialData(const EmptyCallback &done) {
         }
 
         if (item.second.state() == ray::rpc::ActorTableData::DEPENDENCIES_UNREADY) {
-          const auto &owner = actor->GetOwnerAddress();
-          const auto &owner_node = ClientID::FromBinary(owner.raylet_id());
-          const auto &owner_worker = WorkerID::FromBinary(owner.worker_id());
+          const auto& owner = actor->GetOwnerAddress();
+          const auto& owner_node = ClientID::FromBinary(owner.raylet_id());
+          const auto& owner_worker = WorkerID::FromBinary(owner.worker_id());
           RAY_CHECK(unresolved_actors_[owner_node][owner_worker]
                         .emplace(actor->GetActorID())
                         .second);
@@ -953,7 +953,7 @@ void GcsActorManager::LoadInitialData(const EmptyCallback &done) {
                                                       actor->GetActorID());
         }
 
-        auto &workers = owners_[actor->GetNodeID()];
+        auto& workers = owners_[actor->GetNodeID()];
         auto it = workers.find(actor->GetWorkerID());
         if (it == workers.end()) {
           std::shared_ptr<rpc::CoreWorkerClientInterface> client =
@@ -975,8 +975,8 @@ void GcsActorManager::LoadInitialData(const EmptyCallback &done) {
 
     RAY_LOG(DEBUG) << "The number of registered actors is " << registered_actors_.size()
                    << ", and the number of created actors is " << created_actors_.size();
-    for (auto &item : registered_actors_) {
-      auto &actor = item.second;
+    for (auto& item : registered_actors_) {
+      auto& actor = item.second;
       if (actor->GetState() == ray::rpc::ActorTableData::PENDING_CREATION ||
           actor->GetState() == ray::rpc::ActorTableData::RESTARTING) {
         // We should not reschedule actors in state of `ALIVE`.
@@ -994,13 +994,13 @@ void GcsActorManager::LoadInitialData(const EmptyCallback &done) {
   RAY_CHECK_OK(gcs_table_storage_->ActorTable().GetAll(callback));
 }
 
-void GcsActorManager::OnJobFinished(const JobID &job_id) {
+void GcsActorManager::OnJobFinished(const JobID& job_id) {
   auto on_done = [this,
-                  job_id](const std::unordered_map<ActorID, ActorTableData> &result) {
+                  job_id](const std::unordered_map<ActorID, ActorTableData>& result) {
     if (!result.empty()) {
       std::vector<ActorID> non_detached_actors;
       std::unordered_set<ActorID> non_detached_actors_set;
-      for (auto &item : result) {
+      for (auto& item : result) {
         if (!item.second.is_detached()) {
           non_detached_actors.push_back(item.first);
           non_detached_actors_set.insert(item.first);
@@ -1013,15 +1013,15 @@ void GcsActorManager::OnJobFinished(const JobID &job_id) {
       // related to this job
       RAY_CHECK_OK(gcs_table_storage_->ActorCheckpointIdTable().GetByJobId(
           job_id, [this, non_detached_actors_set](
-                      const std::unordered_map<ActorID, ActorCheckpointIdData> &result) {
+                      const std::unordered_map<ActorID, ActorCheckpointIdData>& result) {
             if (!result.empty()) {
               std::vector<ActorID> checkpoints;
               std::vector<ActorCheckpointID> checkpoint_ids;
-              for (auto &item : result) {
+              for (auto& item : result) {
                 if (non_detached_actors_set.find(item.first) !=
                     non_detached_actors_set.end()) {
                   checkpoints.push_back(item.first);
-                  for (auto &id : item.second.checkpoint_ids()) {
+                  for (auto& id : item.second.checkpoint_ids()) {
                     checkpoint_ids.push_back(ActorCheckpointID::FromBinary(id));
                   }
                 }
@@ -1041,18 +1041,18 @@ void GcsActorManager::OnJobFinished(const JobID &job_id) {
   RAY_CHECK_OK(gcs_table_storage_->ActorTable().GetByJobId(job_id, on_done));
 }
 
-const absl::flat_hash_map<ClientID, absl::flat_hash_map<WorkerID, ActorID>>
-    &GcsActorManager::GetCreatedActors() const {
+const absl::flat_hash_map<ClientID, absl::flat_hash_map<WorkerID, ActorID>>&
+GcsActorManager::GetCreatedActors() const {
   return created_actors_;
 }
 
-const absl::flat_hash_map<ActorID, std::shared_ptr<GcsActor>>
-    &GcsActorManager::GetRegisteredActors() const {
+const absl::flat_hash_map<ActorID, std::shared_ptr<GcsActor>>&
+GcsActorManager::GetRegisteredActors() const {
   return registered_actors_;
 }
 
-const absl::flat_hash_map<ActorID, std::vector<RegisterActorCallback>>
-    &GcsActorManager::GetActorRegisterCallbacks() const {
+const absl::flat_hash_map<ActorID, std::vector<RegisterActorCallback>>&
+GcsActorManager::GetActorRegisterCallbacks() const {
   return actor_to_register_callbacks_;
 }
 

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -45,9 +45,9 @@ class GcsActor {
   /// Create a GcsActor by TaskSpec.
   ///
   /// \param task_spec Contains the actor creation task specification.
-  explicit GcsActor(const ray::rpc::TaskSpec &task_spec) {
+  explicit GcsActor(const ray::rpc::TaskSpec& task_spec) {
     RAY_CHECK(task_spec.type() == TaskType::ACTOR_CREATION_TASK);
-    const auto &actor_creation_task_spec = task_spec.actor_creation_task_spec();
+    const auto& actor_creation_task_spec = task_spec.actor_creation_task_spec();
     actor_table_data_.set_actor_id(actor_creation_task_spec.actor_id());
     actor_table_data_.set_job_id(task_spec.job_id());
     actor_table_data_.set_max_restarts(actor_creation_task_spec.max_actor_restarts());
@@ -76,12 +76,12 @@ class GcsActor {
   /// Get the node ID of the actor's owner.
   ClientID GetOwnerNodeID() const;
   /// Get the address of the actor's owner.
-  const rpc::Address &GetOwnerAddress() const;
+  const rpc::Address& GetOwnerAddress() const;
 
   /// Update the `Address` of this actor (see gcs.proto).
-  void UpdateAddress(const rpc::Address &address);
+  void UpdateAddress(const rpc::Address& address);
   /// Get the `Address` of this actor.
-  const rpc::Address &GetAddress() const;
+  const rpc::Address& GetAddress() const;
 
   /// Update the state of this actor.
   void UpdateState(rpc::ActorTableData::ActorState state);
@@ -98,9 +98,9 @@ class GcsActor {
   TaskSpecification GetCreationTaskSpecification() const;
 
   /// Get the immutable ActorTableData of this actor.
-  const rpc::ActorTableData &GetActorTableData() const;
+  const rpc::ActorTableData& GetActorTableData() const;
   /// Get the mutable ActorTableData of this actor.
-  rpc::ActorTableData *GetMutableActorTableData();
+  rpc::ActorTableData* GetMutableActorTableData();
 
  private:
   /// The actor meta data which contains the task specification as well as the state of
@@ -164,48 +164,48 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   GcsActorManager(std::shared_ptr<GcsActorSchedulerInterface> scheduler,
                   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
                   std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub,
-                  const rpc::ClientFactoryFn &worker_client_factory = nullptr);
+                  const rpc::ClientFactoryFn& worker_client_factory = nullptr);
 
   ~GcsActorManager() = default;
 
-  void HandleRegisterActor(const rpc::RegisterActorRequest &request,
-                           rpc::RegisterActorReply *reply,
+  void HandleRegisterActor(const rpc::RegisterActorRequest& request,
+                           rpc::RegisterActorReply* reply,
                            rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleCreateActor(const rpc::CreateActorRequest &request,
-                         rpc::CreateActorReply *reply,
+  void HandleCreateActor(const rpc::CreateActorRequest& request,
+                         rpc::CreateActorReply* reply,
                          rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleGetActorInfo(const rpc::GetActorInfoRequest &request,
-                          rpc::GetActorInfoReply *reply,
+  void HandleGetActorInfo(const rpc::GetActorInfoRequest& request,
+                          rpc::GetActorInfoReply* reply,
                           rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleGetNamedActorInfo(const rpc::GetNamedActorInfoRequest &request,
-                               rpc::GetNamedActorInfoReply *reply,
+  void HandleGetNamedActorInfo(const rpc::GetNamedActorInfoRequest& request,
+                               rpc::GetNamedActorInfoReply* reply,
                                rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleGetAllActorInfo(const rpc::GetAllActorInfoRequest &request,
-                             rpc::GetAllActorInfoReply *reply,
+  void HandleGetAllActorInfo(const rpc::GetAllActorInfoRequest& request,
+                             rpc::GetAllActorInfoReply* reply,
                              rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleRegisterActorInfo(const rpc::RegisterActorInfoRequest &request,
-                               rpc::RegisterActorInfoReply *reply,
+  void HandleRegisterActorInfo(const rpc::RegisterActorInfoRequest& request,
+                               rpc::RegisterActorInfoReply* reply,
                                rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleUpdateActorInfo(const rpc::UpdateActorInfoRequest &request,
-                             rpc::UpdateActorInfoReply *reply,
+  void HandleUpdateActorInfo(const rpc::UpdateActorInfoRequest& request,
+                             rpc::UpdateActorInfoReply* reply,
                              rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleAddActorCheckpoint(const rpc::AddActorCheckpointRequest &request,
-                                rpc::AddActorCheckpointReply *reply,
+  void HandleAddActorCheckpoint(const rpc::AddActorCheckpointRequest& request,
+                                rpc::AddActorCheckpointReply* reply,
                                 rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleGetActorCheckpoint(const rpc::GetActorCheckpointRequest &request,
-                                rpc::GetActorCheckpointReply *reply,
+  void HandleGetActorCheckpoint(const rpc::GetActorCheckpointRequest& request,
+                                rpc::GetActorCheckpointReply* reply,
                                 rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleGetActorCheckpointID(const rpc::GetActorCheckpointIDRequest &request,
-                                  rpc::GetActorCheckpointIDReply *reply,
+  void HandleGetActorCheckpointID(const rpc::GetActorCheckpointIDRequest& request,
+                                  rpc::GetActorCheckpointIDReply* reply,
                                   rpc::SendReplyCallback send_reply_callback) override;
 
   /// Register actor asynchronously.
@@ -216,7 +216,7 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// its state is `ALIVE`.
   /// \return Status::Invalid if this is a named actor and an actor with the specified
   /// name already exists. The callback will not be called in this case.
-  Status RegisterActor(const rpc::RegisterActorRequest &request,
+  Status RegisterActor(const rpc::RegisterActorRequest& request,
                        RegisterActorCallback callback);
 
   /// Create actor asynchronously.
@@ -227,13 +227,13 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// its state is `ALIVE`.
   /// \return Status::Invalid if this is a named actor and an actor with the specified
   /// name already exists. The callback will not be called in this case.
-  Status CreateActor(const rpc::CreateActorRequest &request,
+  Status CreateActor(const rpc::CreateActorRequest& request,
                      CreateActorCallback callback);
 
   /// Get the actor ID for the named actor. Returns nil if the actor was not found.
   /// \param name The name of the detached actor to look up.
   /// \returns ActorID The ID of the actor. Nil if the actor was not found.
-  ActorID GetActorIDByName(const std::string &name);
+  ActorID GetActorIDByName(const std::string& name);
 
   /// Schedule actors in the `pending_actors_` queue.
   /// This method should be called when new nodes are registered or resources
@@ -247,7 +247,7 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// owned an actor, those actors will be destroyed.
   ///
   /// \param node_id The specified node id.
-  void OnNodeDead(const ClientID &node_id);
+  void OnNodeDead(const ClientID& node_id);
 
   /// Handle a worker failure. This will restart the associated actor, if any,
   /// which may be pending or already created. If the worker owned other
@@ -257,7 +257,7 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// \param worker_id ID of the dead worker.
   /// \param intentional_exit Whether the death was intentional. If yes and the
   /// worker was an actor, we should not attempt to restart the actor.
-  void OnWorkerDead(const ClientID &node_id, const WorkerID &worker_id,
+  void OnWorkerDead(const ClientID& node_id, const WorkerID& worker_id,
                     bool intentional_exit = false);
 
   /// Handle actor creation task failure. This should be called when scheduling
@@ -270,31 +270,31 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// creation task has been scheduled successfully.
   ///
   /// \param actor The actor that has been created.
-  void OnActorCreationSuccess(const std::shared_ptr<GcsActor> &actor);
+  void OnActorCreationSuccess(const std::shared_ptr<GcsActor>& actor);
 
   /// Load initial data from gcs storage to memory cache asynchronously.
   /// This should be called when GCS server restarts after a failure.
   ///
   /// \param done Callback that will be called when load is complete.
-  void LoadInitialData(const EmptyCallback &done);
+  void LoadInitialData(const EmptyCallback& done);
 
   /// Delete non-detached actor information from durable storage once the associated job
   /// finishes.
   ///
   /// \param job_id The id of finished job.
-  void OnJobFinished(const JobID &job_id);
+  void OnJobFinished(const JobID& job_id);
 
   /// Get the created actors.
   ///
   /// \return The created actors.
-  const absl::flat_hash_map<ClientID, absl::flat_hash_map<WorkerID, ActorID>>
-      &GetCreatedActors() const;
+  const absl::flat_hash_map<ClientID, absl::flat_hash_map<WorkerID, ActorID>>&
+  GetCreatedActors() const;
 
-  const absl::flat_hash_map<ActorID, std::shared_ptr<GcsActor>> &GetRegisteredActors()
+  const absl::flat_hash_map<ActorID, std::shared_ptr<GcsActor>>& GetRegisteredActors()
       const;
 
-  const absl::flat_hash_map<ActorID, std::vector<RegisterActorCallback>>
-      &GetActorRegisterCallbacks() const;
+  const absl::flat_hash_map<ActorID, std::vector<RegisterActorCallback>>&
+  GetActorRegisterCallbacks() const;
 
  private:
   /// A data structure representing an actor's owner.
@@ -310,7 +310,7 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// Poll an actor's owner so that we will receive a notification when the
   /// actor has gone out of scope, or the owner has died. This should not be
   /// called for detached actors.
-  void PollOwnerForActorOutOfScope(const std::shared_ptr<GcsActor> &actor);
+  void PollOwnerForActorOutOfScope(const std::shared_ptr<GcsActor>& actor);
 
   /// Destroy an actor that has gone out of scope. This cleans up all local
   /// state associated with the actor and marks the actor as dead. For owned
@@ -318,15 +318,15 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// scope or the owner has died.
   /// TODO: For detached actors, this should be called when the application
   /// deregisters the actor.
-  void DestroyActor(const ActorID &actor_id);
+  void DestroyActor(const ActorID& actor_id);
 
   /// Get unresolved actors that were submitted from the specified node.
   absl::flat_hash_set<ActorID> GetUnresolvedActorsByOwnerNode(
-      const ClientID &node_id) const;
+      const ClientID& node_id) const;
 
   /// Get unresolved actors that were submitted from the specified worker.
   absl::flat_hash_set<ActorID> GetUnresolvedActorsByOwnerWorker(
-      const ClientID &node_id, const WorkerID &worker_id) const;
+      const ClientID& node_id, const WorkerID& worker_id) const;
 
  private:
   /// Reconstruct the specified actor.
@@ -335,7 +335,7 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// \param need_reschedule Whether to reschedule the actor creation task, sometimes
   /// users want to kill an actor intentionally and don't want it to be reconstructed
   /// again.
-  void ReconstructActor(const ActorID &actor_id, bool need_reschedule = true);
+  void ReconstructActor(const ActorID& actor_id, bool need_reschedule = true);
 
   /// Callbacks of pending `RegisterActor` requests.
   /// Maps actor ID to actor registration callbacks, which is used to filter duplicated

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
@@ -249,9 +249,9 @@ void GcsActorScheduler::LeaseWorkerFromNode(std::shared_ptr<GcsActor> actor,
 
 void GcsActorScheduler::RetryLeasingWorkerFromNode(
     std::shared_ptr<GcsActor> actor, std::shared_ptr<rpc::GcsNodeInfo> node) {
-  execute_after(io_context_,
-                [this, node, actor] { DoRetryLeasingWorkerFromNode(actor, node); },
-                RayConfig::instance().gcs_lease_worker_retry_interval_ms());
+  execute_after(
+      io_context_, [this, node, actor] { DoRetryLeasingWorkerFromNode(actor, node); },
+      RayConfig::instance().gcs_lease_worker_retry_interval_ms());
 }
 
 void GcsActorScheduler::DoRetryLeasingWorkerFromNode(
@@ -370,9 +370,9 @@ void GcsActorScheduler::CreateActorOnWorker(std::shared_ptr<GcsActor> actor,
 
 void GcsActorScheduler::RetryCreatingActorOnWorker(
     std::shared_ptr<GcsActor> actor, std::shared_ptr<GcsLeasedWorker> worker) {
-  execute_after(io_context_,
-                [this, actor, worker] { DoRetryCreatingActorOnWorker(actor, worker); },
-                RayConfig::instance().gcs_create_actor_retry_interval_ms());
+  execute_after(
+      io_context_, [this, actor, worker] { DoRetryCreatingActorOnWorker(actor, worker); },
+      RayConfig::instance().gcs_create_actor_retry_interval_ms());
 }
 
 void GcsActorScheduler::DoRetryCreatingActorOnWorker(

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
@@ -33,7 +33,7 @@ namespace ray {
 namespace gcs {
 
 using LeaseClientFactoryFn =
-    std::function<std::shared_ptr<WorkerLeaseInterface>(const rpc::Address &address)>;
+    std::function<std::shared_ptr<WorkerLeaseInterface>(const rpc::Address& address)>;
 
 class GcsActor;
 
@@ -53,26 +53,26 @@ class GcsActorSchedulerInterface {
   ///
   /// \param node_id ID of the node where the worker is located.
   /// \return ID list of actors associated with the specified node id.
-  virtual std::vector<ActorID> CancelOnNode(const ClientID &node_id) = 0;
+  virtual std::vector<ActorID> CancelOnNode(const ClientID& node_id) = 0;
 
   /// Cancel a outstanding leasing request to raylets.
   ///
   /// \param node_id ID of the node where the actor leasing request has been sent.
   /// \param actor_id ID of an actor.
-  virtual void CancelOnLeasing(const ClientID &node_id, const ActorID &actor_id) = 0;
+  virtual void CancelOnLeasing(const ClientID& node_id, const ActorID& actor_id) = 0;
 
   /// Cancel the actor that is being scheduled to the specified worker.
   ///
   /// \param node_id ID of the node where the worker is located.
   /// \param worker_id ID of the worker that the actor is creating on.
   /// \return ID of actor associated with the specified node id and worker id.
-  virtual ActorID CancelOnWorker(const ClientID &node_id, const WorkerID &worker_id) = 0;
+  virtual ActorID CancelOnWorker(const ClientID& node_id, const WorkerID& worker_id) = 0;
 
   /// Notify raylets to release unused workers.
   ///
   /// \param node_to_workers Workers used by each node.
   virtual void ReleaseUnusedWorkers(
-      const std::unordered_map<ClientID, std::vector<WorkerID>> &node_to_workers) = 0;
+      const std::unordered_map<ClientID, std::vector<WorkerID>>& node_to_workers) = 0;
 
   virtual ~GcsActorSchedulerInterface() {}
 };
@@ -95,8 +95,8 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
   /// \param client_factory Factory to create remote core worker client, default factor
   /// will be used if not set.
   explicit GcsActorScheduler(
-      boost::asio::io_context &io_context, gcs::GcsActorTable &gcs_actor_table,
-      const GcsNodeManager &gcs_node_manager, std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub,
+      boost::asio::io_context& io_context, gcs::GcsActorTable& gcs_actor_table,
+      const GcsNodeManager& gcs_node_manager, std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub,
       std::function<void(std::shared_ptr<GcsActor>)> schedule_failure_handler,
       std::function<void(std::shared_ptr<GcsActor>)> schedule_success_handler,
       LeaseClientFactoryFn lease_client_factory = nullptr,
@@ -119,7 +119,7 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
   ///
   /// \param node_id ID of the node where the worker is located.
   /// \return ID list of actors associated with the specified node id.
-  std::vector<ActorID> CancelOnNode(const ClientID &node_id) override;
+  std::vector<ActorID> CancelOnNode(const ClientID& node_id) override;
 
   /// Cancel a outstanding leasing request to raylets.
   ///
@@ -129,20 +129,20 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
   ///
   /// \param node_id ID of the node where the actor leasing request has been sent.
   /// \param actor_id ID of an actor.
-  void CancelOnLeasing(const ClientID &node_id, const ActorID &actor_id) override;
+  void CancelOnLeasing(const ClientID& node_id, const ActorID& actor_id) override;
 
   /// Cancel the actor that is being scheduled to the specified worker.
   ///
   /// \param node_id ID of the node where the worker is located.
   /// \param worker_id ID of the worker that the actor is creating on.
   /// \return ID of actor associated with the specified node id and worker id.
-  ActorID CancelOnWorker(const ClientID &node_id, const WorkerID &worker_id) override;
+  ActorID CancelOnWorker(const ClientID& node_id, const WorkerID& worker_id) override;
 
   /// Notify raylets to release unused workers.
   ///
   /// \param node_to_workers Workers used by each node.
-  void ReleaseUnusedWorkers(const std::unordered_map<ClientID, std::vector<WorkerID>>
-                                &node_to_workers) override;
+  void ReleaseUnusedWorkers(const std::unordered_map<ClientID, std::vector<WorkerID>>&
+                                node_to_workers) override;
 
  protected:
   /// The GcsLeasedWorker is kind of abstraction of remote leased worker inside raylet. It
@@ -158,17 +158,17 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
     /// \param actor_id ID of the actor associated with this leased worker.
     explicit GcsLeasedWorker(rpc::Address address,
                              std::vector<rpc::ResourceMapEntry> resources,
-                             const ActorID &actor_id)
+                             const ActorID& actor_id)
         : address_(std::move(address)),
           resources_(std::move(resources)),
           assigned_actor_id_(actor_id) {}
     virtual ~GcsLeasedWorker() = default;
 
     /// Get the Address of this leased worker.
-    const rpc::Address &GetAddress() const { return address_; }
+    const rpc::Address& GetAddress() const { return address_; }
 
     /// Get the ip address of this leased worker.
-    const std::string &GetIpAddress() const { return address_.ip_address(); }
+    const std::string& GetIpAddress() const { return address_.ip_address(); }
 
     /// Get the listening port of the leased worker at remote side.
     uint16_t GetPort() const { return address_.port(); }
@@ -183,7 +183,7 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
     ActorID GetAssignedActorID() const { return assigned_actor_id_; }
 
     /// Get the leased resources.
-    const std::vector<rpc::ResourceMapEntry> &GetLeasedResources() const {
+    const std::vector<rpc::ResourceMapEntry>& GetLeasedResources() const {
       return resources_;
     }
 
@@ -227,7 +227,7 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
   /// \param actor Contains the resources needed to lease workers from the specified node.
   /// \param reply The reply of `RequestWorkerLeaseRequest`.
   void HandleWorkerLeasedReply(std::shared_ptr<GcsActor> actor,
-                               const rpc::RequestWorkerLeaseReply &reply);
+                               const rpc::RequestWorkerLeaseReply& reply);
 
   /// Create the specified actor on the specified worker.
   ///
@@ -257,18 +257,18 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
 
   /// Get an existing lease client or connect a new one.
   std::shared_ptr<WorkerLeaseInterface> GetOrConnectLeaseClient(
-      const rpc::Address &raylet_address);
+      const rpc::Address& raylet_address);
 
   /// Get or create CoreWorkerClient to communicate with the remote leased worker.
   std::shared_ptr<rpc::CoreWorkerClientInterface> GetOrConnectCoreWorkerClient(
-      const rpc::Address &worker_address);
+      const rpc::Address& worker_address);
 
  protected:
   /// The io loop that is used to delay execution of tasks (e.g.,
   /// execute_after).
-  boost::asio::io_context &io_context_;
+  boost::asio::io_context& io_context_;
   /// The actor info accessor.
-  gcs::GcsActorTable &gcs_actor_table_;
+  gcs::GcsActorTable& gcs_actor_table_;
   /// Map from node ID to the set of actors for whom we are trying to acquire a lease from
   /// that node. This is needed so that we can retry lease requests from the node until we
   /// receive a reply or the node is removed.
@@ -286,7 +286,7 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
   absl::flat_hash_map<WorkerID, std::shared_ptr<rpc::CoreWorkerClientInterface>>
       core_worker_clients_;
   /// Reference of GcsNodeManager.
-  const GcsNodeManager &gcs_node_manager_;
+  const GcsNodeManager& gcs_node_manager_;
   /// A publisher for publishing gcs messages.
   std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub_;
   /// The handler to handle the scheduling failures.

--- a/src/ray/gcs/gcs_server/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.cc
@@ -19,14 +19,14 @@
 namespace ray {
 namespace gcs {
 
-void GcsJobManager::HandleAddJob(const rpc::AddJobRequest &request,
-                                 rpc::AddJobReply *reply,
+void GcsJobManager::HandleAddJob(const rpc::AddJobRequest& request,
+                                 rpc::AddJobReply* reply,
                                  rpc::SendReplyCallback send_reply_callback) {
   JobID job_id = JobID::FromBinary(request.data().job_id());
   RAY_LOG(INFO) << "Adding job, job id = " << job_id
                 << ", driver pid = " << request.data().driver_pid();
   auto on_done = [this, job_id, request, reply,
-                  send_reply_callback](const Status &status) {
+                  send_reply_callback](const Status& status) {
     if (!status.ok()) {
       RAY_LOG(ERROR) << "Failed to add job, job id = " << job_id
                      << ", driver pid = " << request.data().driver_pid();
@@ -45,15 +45,15 @@ void GcsJobManager::HandleAddJob(const rpc::AddJobRequest &request,
   }
 }
 
-void GcsJobManager::HandleMarkJobFinished(const rpc::MarkJobFinishedRequest &request,
-                                          rpc::MarkJobFinishedReply *reply,
+void GcsJobManager::HandleMarkJobFinished(const rpc::MarkJobFinishedRequest& request,
+                                          rpc::MarkJobFinishedReply* reply,
                                           rpc::SendReplyCallback send_reply_callback) {
   JobID job_id = JobID::FromBinary(request.job_id());
   RAY_LOG(INFO) << "Marking job state, job id = " << job_id;
   auto job_table_data =
       gcs::CreateJobTableData(job_id, /*is_dead*/ true, std::time(nullptr), "", -1);
   auto on_done = [this, job_id, job_table_data, reply,
-                  send_reply_callback](const Status &status) {
+                  send_reply_callback](const Status& status) {
     if (!status.ok()) {
       RAY_LOG(ERROR) << "Failed to mark job state, job id = " << job_id;
     } else {
@@ -71,9 +71,9 @@ void GcsJobManager::HandleMarkJobFinished(const rpc::MarkJobFinishedRequest &req
   }
 }
 
-void GcsJobManager::ClearJobInfos(const JobID &job_id) {
+void GcsJobManager::ClearJobInfos(const JobID& job_id) {
   // Notify all listeners.
-  for (auto &listener : job_finished_listeners_) {
+  for (auto& listener : job_finished_listeners_) {
     listener(std::make_shared<JobID>(job_id));
   }
 }
@@ -87,13 +87,13 @@ void GcsJobManager::AddJobFinishedListener(
   job_finished_listeners_.emplace_back(std::move(listener));
 }
 
-void GcsJobManager::HandleGetAllJobInfo(const rpc::GetAllJobInfoRequest &request,
-                                        rpc::GetAllJobInfoReply *reply,
+void GcsJobManager::HandleGetAllJobInfo(const rpc::GetAllJobInfoRequest& request,
+                                        rpc::GetAllJobInfoReply* reply,
                                         rpc::SendReplyCallback send_reply_callback) {
   RAY_LOG(INFO) << "Getting all job info.";
   auto on_done = [reply, send_reply_callback](
-                     const std::unordered_map<JobID, JobTableData> &result) {
-    for (auto &data : result) {
+                     const std::unordered_map<JobID, JobTableData>& result) {
+    for (auto& data : result) {
       reply->add_job_info_list()->CopyFrom(data.second);
     }
     RAY_LOG(INFO) << "Finished getting all job info.";

--- a/src/ray/gcs/gcs_server/gcs_job_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.h
@@ -31,15 +31,15 @@ class GcsJobManager : public rpc::JobInfoHandler {
       : gcs_table_storage_(std::move(gcs_table_storage)),
         gcs_pub_sub_(std::move(gcs_pub_sub)) {}
 
-  void HandleAddJob(const rpc::AddJobRequest &request, rpc::AddJobReply *reply,
+  void HandleAddJob(const rpc::AddJobRequest& request, rpc::AddJobReply* reply,
                     rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleMarkJobFinished(const rpc::MarkJobFinishedRequest &request,
-                             rpc::MarkJobFinishedReply *reply,
+  void HandleMarkJobFinished(const rpc::MarkJobFinishedRequest& request,
+                             rpc::MarkJobFinishedReply* reply,
                              rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleGetAllJobInfo(const rpc::GetAllJobInfoRequest &request,
-                           rpc::GetAllJobInfoReply *reply,
+  void HandleGetAllJobInfo(const rpc::GetAllJobInfoRequest& request,
+                           rpc::GetAllJobInfoReply* reply,
                            rpc::SendReplyCallback send_reply_callback) override;
 
   void AddJobFinishedListener(
@@ -52,7 +52,7 @@ class GcsJobManager : public rpc::JobInfoHandler {
   /// Listeners which monitors the finish of jobs.
   std::vector<std::function<void(std::shared_ptr<JobID>)>> job_finished_listeners_;
 
-  void ClearJobInfos(const JobID &job_id);
+  void ClearJobInfos(const JobID& job_id);
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -40,55 +40,55 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// \param gcs_pub_sub GCS message publisher.
   /// \param gcs_table_storage GCS table external storage accessor.
   /// when detecting the death of nodes.
-  explicit GcsNodeManager(boost::asio::io_service &main_io_service,
-                          boost::asio::io_service &node_failure_detector_io_service,
-                          gcs::ErrorInfoAccessor &error_info_accessor,
+  explicit GcsNodeManager(boost::asio::io_service& main_io_service,
+                          boost::asio::io_service& node_failure_detector_io_service,
+                          gcs::ErrorInfoAccessor& error_info_accessor,
                           std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub,
                           std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage);
 
   /// Handle register rpc request come from raylet.
-  void HandleRegisterNode(const rpc::RegisterNodeRequest &request,
-                          rpc::RegisterNodeReply *reply,
+  void HandleRegisterNode(const rpc::RegisterNodeRequest& request,
+                          rpc::RegisterNodeReply* reply,
                           rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle unregister rpc request come from raylet.
-  void HandleUnregisterNode(const rpc::UnregisterNodeRequest &request,
-                            rpc::UnregisterNodeReply *reply,
+  void HandleUnregisterNode(const rpc::UnregisterNodeRequest& request,
+                            rpc::UnregisterNodeReply* reply,
                             rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle get all node info rpc request.
-  void HandleGetAllNodeInfo(const rpc::GetAllNodeInfoRequest &request,
-                            rpc::GetAllNodeInfoReply *reply,
+  void HandleGetAllNodeInfo(const rpc::GetAllNodeInfoRequest& request,
+                            rpc::GetAllNodeInfoReply* reply,
                             rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle heartbeat rpc come from raylet.
-  void HandleReportHeartbeat(const rpc::ReportHeartbeatRequest &request,
-                             rpc::ReportHeartbeatReply *reply,
+  void HandleReportHeartbeat(const rpc::ReportHeartbeatRequest& request,
+                             rpc::ReportHeartbeatReply* reply,
                              rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle get resource rpc request.
-  void HandleGetResources(const rpc::GetResourcesRequest &request,
-                          rpc::GetResourcesReply *reply,
+  void HandleGetResources(const rpc::GetResourcesRequest& request,
+                          rpc::GetResourcesReply* reply,
                           rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle update resource rpc request.
-  void HandleUpdateResources(const rpc::UpdateResourcesRequest &request,
-                             rpc::UpdateResourcesReply *reply,
+  void HandleUpdateResources(const rpc::UpdateResourcesRequest& request,
+                             rpc::UpdateResourcesReply* reply,
                              rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle delete resource rpc request.
-  void HandleDeleteResources(const rpc::DeleteResourcesRequest &request,
-                             rpc::DeleteResourcesReply *reply,
+  void HandleDeleteResources(const rpc::DeleteResourcesRequest& request,
+                             rpc::DeleteResourcesReply* reply,
                              rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle setting internal config.
-  void HandleSetInternalConfig(const rpc::SetInternalConfigRequest &request,
-                               rpc::SetInternalConfigReply *reply,
+  void HandleSetInternalConfig(const rpc::SetInternalConfigRequest& request,
+                               rpc::SetInternalConfigReply* reply,
                                rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle getting internal config.
-  void HandleGetInternalConfig(const rpc::GetInternalConfigRequest &request,
-                               rpc::GetInternalConfigReply *reply,
+  void HandleGetInternalConfig(const rpc::GetInternalConfigRequest& request,
+                               rpc::GetInternalConfigReply* reply,
                                rpc::SendReplyCallback send_reply_callback) override;
 
   /// Add an alive node.
@@ -101,20 +101,20 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// \param node_id The ID of the node to be removed.
   /// \param is_intended False if this is triggered by `node_failure_detector_`, else
   /// True.
-  std::shared_ptr<rpc::GcsNodeInfo> RemoveNode(const ClientID &node_id,
+  std::shared_ptr<rpc::GcsNodeInfo> RemoveNode(const ClientID& node_id,
                                                bool is_intended = false);
 
   /// Get alive node by ID.
   ///
   /// \param node_id The id of the node.
   /// \return the node if it is alive else return nullptr.
-  std::shared_ptr<rpc::GcsNodeInfo> GetNode(const ClientID &node_id) const;
+  std::shared_ptr<rpc::GcsNodeInfo> GetNode(const ClientID& node_id) const;
 
   /// Get all alive nodes.
   ///
   /// \return all alive nodes.
-  const absl::flat_hash_map<ClientID, std::shared_ptr<rpc::GcsNodeInfo>>
-      &GetAllAliveNodes() const {
+  const absl::flat_hash_map<ClientID, std::shared_ptr<rpc::GcsNodeInfo>>&
+  GetAllAliveNodes() const {
     return alive_nodes_;
   }
 
@@ -140,7 +140,7 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// This should be called when GCS server restarts after a failure.
   ///
   /// \param done Callback that will be called when load is complete.
-  void LoadInitialData(const EmptyCallback &done);
+  void LoadInitialData(const EmptyCallback& done);
 
   /// Start node failure detector.
   void StartNodeFailureDetector();
@@ -156,10 +156,10 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
     /// \param on_node_death_callback Callback that will be called when node death is
     /// detected.
     explicit NodeFailureDetector(
-        boost::asio::io_service &io_service,
+        boost::asio::io_service& io_service,
         std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
         std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub,
-        std::function<void(const ClientID &)> on_node_death_callback);
+        std::function<void(const ClientID&)> on_node_death_callback);
 
     // Note: To avoid heartbeats being delayed by main thread, all public methods below
     // should be posted to its own IO service.
@@ -171,14 +171,14 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
     /// Only if the node has registered, its heartbeat data will be accepted.
     ///
     /// \param node_id ID of the node to be registered.
-    void AddNode(const ClientID &node_id);
+    void AddNode(const ClientID& node_id);
 
     /// Handle a heartbeat from a Raylet.
     ///
     /// \param node_id The client ID of the Raylet that sent the heartbeat.
     /// \param heartbeat_data The heartbeat sent by the client.
-    void HandleHeartbeat(const ClientID &node_id,
-                         const rpc::HeartbeatTableData &heartbeat_data);
+    void HandleHeartbeat(const ClientID& node_id,
+                         const rpc::HeartbeatTableData& heartbeat_data);
 
    protected:
     /// A periodic timer that fires on every heartbeat period. Raylets that have
@@ -200,7 +200,7 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
     /// Storage for GCS tables.
     std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
     /// The callback of node death.
-    std::function<void(const ClientID &)> on_node_death_callback_;
+    std::function<void(const ClientID&)> on_node_death_callback_;
     /// The number of heartbeats that can be missed before a node is removed.
     int64_t num_heartbeats_timeout_;
     // Only the changed part will be included in heartbeat if this is true.
@@ -220,13 +220,13 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
 
  private:
   /// Error info accessor.
-  gcs::ErrorInfoAccessor &error_info_accessor_;
+  gcs::ErrorInfoAccessor& error_info_accessor_;
   /// The main event loop for node failure detector.
-  boost::asio::io_service &main_io_service_;
+  boost::asio::io_service& main_io_service_;
   /// Detector to detect the failure of node.
   std::unique_ptr<NodeFailureDetector> node_failure_detector_;
   /// The event loop for node failure detector.
-  boost::asio::io_service &node_failure_detector_service_;
+  boost::asio::io_service& node_failure_detector_service_;
   /// Alive nodes.
   absl::flat_hash_map<ClientID, std::shared_ptr<rpc::GcsNodeInfo>> alive_nodes_;
   /// Dead nodes.

--- a/src/ray/gcs/gcs_server/gcs_object_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_object_manager.h
@@ -26,38 +26,38 @@ namespace gcs {
 class GcsObjectManager : public rpc::ObjectInfoHandler {
  public:
   explicit GcsObjectManager(std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
-                            std::shared_ptr<gcs::GcsPubSub> &gcs_pub_sub,
-                            gcs::GcsNodeManager &gcs_node_manager)
+                            std::shared_ptr<gcs::GcsPubSub>& gcs_pub_sub,
+                            gcs::GcsNodeManager& gcs_node_manager)
       : gcs_table_storage_(std::move(gcs_table_storage)), gcs_pub_sub_(gcs_pub_sub) {
     gcs_node_manager.AddNodeRemovedListener(
-        [this](const std::shared_ptr<rpc::GcsNodeInfo> &node) {
+        [this](const std::shared_ptr<rpc::GcsNodeInfo>& node) {
           // All of the related actors should be reconstructed when a node is removed from
           // the GCS.
           OnNodeRemoved(ClientID::FromBinary(node->node_id()));
         });
   }
 
-  void HandleGetObjectLocations(const rpc::GetObjectLocationsRequest &request,
-                                rpc::GetObjectLocationsReply *reply,
+  void HandleGetObjectLocations(const rpc::GetObjectLocationsRequest& request,
+                                rpc::GetObjectLocationsReply* reply,
                                 rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleGetAllObjectLocations(const rpc::GetAllObjectLocationsRequest &request,
-                                   rpc::GetAllObjectLocationsReply *reply,
+  void HandleGetAllObjectLocations(const rpc::GetAllObjectLocationsRequest& request,
+                                   rpc::GetAllObjectLocationsReply* reply,
                                    rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleAddObjectLocation(const rpc::AddObjectLocationRequest &request,
-                               rpc::AddObjectLocationReply *reply,
+  void HandleAddObjectLocation(const rpc::AddObjectLocationRequest& request,
+                               rpc::AddObjectLocationReply* reply,
                                rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleRemoveObjectLocation(const rpc::RemoveObjectLocationRequest &request,
-                                  rpc::RemoveObjectLocationReply *reply,
+  void HandleRemoveObjectLocation(const rpc::RemoveObjectLocationRequest& request,
+                                  rpc::RemoveObjectLocationReply* reply,
                                   rpc::SendReplyCallback send_reply_callback) override;
 
   /// Load initial data from gcs storage to memory cache asynchronously.
   /// This should be called when GCS server restarts after a failure.
   ///
   /// \param done Callback that will be called when load is complete.
-  void LoadInitialData(const EmptyCallback &done);
+  void LoadInitialData(const EmptyCallback& done);
 
  protected:
   typedef absl::flat_hash_set<ClientID> LocationSet;
@@ -67,40 +67,40 @@ class GcsObjectManager : public rpc::ObjectInfoHandler {
   ///
   /// \param node_id The object location that will be added.
   /// \param object_ids The ids of objects which location will be added.
-  void AddObjectsLocation(const ClientID &node_id,
-                          const absl::flat_hash_set<ObjectID> &object_ids)
+  void AddObjectsLocation(const ClientID& node_id,
+                          const absl::flat_hash_set<ObjectID>& object_ids)
       LOCKS_EXCLUDED(mutex_);
 
   /// Add a new location for the given object in local cache.
   ///
   /// \param object_id The id of object.
   /// \param node_id The node id of the new location.
-  void AddObjectLocationInCache(const ObjectID &object_id, const ClientID &node_id)
+  void AddObjectLocationInCache(const ObjectID& object_id, const ClientID& node_id)
       LOCKS_EXCLUDED(mutex_);
 
   /// Get all locations of the given object.
   ///
   /// \param object_id The id of object to lookup.
   /// \return Object locations.
-  LocationSet GetObjectLocations(const ObjectID &object_id) LOCKS_EXCLUDED(mutex_);
+  LocationSet GetObjectLocations(const ObjectID& object_id) LOCKS_EXCLUDED(mutex_);
 
   /// Handler if a node is removed.
   ///
   /// \param node_id The node that will be removed.
-  void OnNodeRemoved(const ClientID &node_id) LOCKS_EXCLUDED(mutex_);
+  void OnNodeRemoved(const ClientID& node_id) LOCKS_EXCLUDED(mutex_);
 
   /// Remove object's location.
   ///
   /// \param object_id The id of the object which location will be removed.
   /// \param node_id The location that will be removed.
-  void RemoveObjectLocationInCache(const ObjectID &object_id, const ClientID &node_id)
+  void RemoveObjectLocationInCache(const ObjectID& object_id, const ClientID& node_id)
       LOCKS_EXCLUDED(mutex_);
 
  private:
   typedef absl::flat_hash_set<ObjectID> ObjectSet;
 
   std::shared_ptr<ObjectTableDataList> GenObjectTableDataList(
-      const GcsObjectManager::LocationSet &location_set) const;
+      const GcsObjectManager::LocationSet& location_set) const;
 
   /// Get object locations by object id from map.
   /// Will create it if not exist and the flag create_if_not_exist is set to true.
@@ -108,7 +108,7 @@ class GcsObjectManager : public rpc::ObjectInfoHandler {
   /// \param object_id The id of object to lookup.
   /// \param create_if_not_exist Whether to create a new one if not exist.
   /// \return LocationSet *
-  GcsObjectManager::LocationSet *GetObjectLocationSet(const ObjectID &object_id,
+  GcsObjectManager::LocationSet* GetObjectLocationSet(const ObjectID& object_id,
                                                       bool create_if_not_exist = false)
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
@@ -118,7 +118,7 @@ class GcsObjectManager : public rpc::ObjectInfoHandler {
   /// \param node_id The id of node to lookup.
   /// \param create_if_not_exist Whether to create a new one if not exist.
   /// \return ObjectSet *
-  GcsObjectManager::ObjectSet *GetObjectSetByNode(const ClientID &node_id,
+  GcsObjectManager::ObjectSet* GetObjectSetByNode(const ClientID& node_id,
                                                   bool create_if_not_exist = false)
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -51,14 +51,14 @@ rpc::PlacementStrategy GcsPlacementGroup::GetStrategy() const {
   return placement_group_table_data_.strategy();
 }
 
-const rpc::PlacementGroupTableData &GcsPlacementGroup::GetPlacementGroupTableData() {
+const rpc::PlacementGroupTableData& GcsPlacementGroup::GetPlacementGroupTableData() {
   return placement_group_table_data_;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
 GcsPlacementGroupManager::GcsPlacementGroupManager(
-    boost::asio::io_context &io_context,
+    boost::asio::io_context& io_context,
     std::shared_ptr<GcsPlacementGroupSchedulerInterface> scheduler,
     std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage)
     : gcs_placement_group_scheduler_(std::move(scheduler)),
@@ -66,10 +66,10 @@ GcsPlacementGroupManager::GcsPlacementGroupManager(
       reschedule_timer_(io_context) {}
 
 void GcsPlacementGroupManager::RegisterPlacementGroup(
-    const ray::rpc::CreatePlacementGroupRequest &request,
+    const ray::rpc::CreatePlacementGroupRequest& request,
     std::function<void(std::shared_ptr<GcsPlacementGroup>)> callback) {
   RAY_CHECK(callback);
-  const auto &placement_group_spec = request.placement_group_spec();
+  const auto& placement_group_spec = request.placement_group_spec();
   auto placement_group_id =
       PlacementGroupID::FromBinary(placement_group_spec.placement_group_id());
 
@@ -86,7 +86,7 @@ void GcsPlacementGroupManager::RegisterPlacementGroup(
 }
 
 PlacementGroupID GcsPlacementGroupManager::GetPlacementGroupIDByName(
-    const std::string &name) {
+    const std::string& name) {
   PlacementGroupID placement_group_id = PlacementGroupID::Nil();
   for (auto placement_group_pair : registered_placement_groups_) {
     auto placement_group = placement_group_pair.second;
@@ -123,7 +123,7 @@ void GcsPlacementGroupManager::OnPlacementGroupCreationSuccess(
   // placement_group_to_register_callbacks_.
   auto iter = placement_group_to_register_callbacks_.find(placement_group_id);
   if (iter != placement_group_to_register_callbacks_.end()) {
-    for (auto &callback : iter->second) {
+    for (auto& callback : iter->second) {
       callback(placement_group);
     }
     placement_group_to_register_callbacks_.erase(iter);
@@ -149,13 +149,13 @@ void GcsPlacementGroupManager::SchedulePendingPlacementGroups() {
 }
 
 void GcsPlacementGroupManager::HandleCreatePlacementGroup(
-    const ray::rpc::CreatePlacementGroupRequest &request,
-    ray::rpc::CreatePlacementGroupReply *reply,
+    const ray::rpc::CreatePlacementGroupRequest& request,
+    ray::rpc::CreatePlacementGroupReply* reply,
     ray::rpc::SendReplyCallback send_reply_callback) {
   auto placement_group_id =
       PlacementGroupID::FromBinary(request.placement_group_spec().placement_group_id());
-  const auto &strategy = request.placement_group_spec().strategy();
-  const auto &name = request.placement_group_spec().name();
+  const auto& strategy = request.placement_group_spec().strategy();
+  const auto& name = request.placement_group_spec().name();
   RAY_LOG(INFO) << "Registering placement group, placement group id = "
                 << placement_group_id << ", name = " << name
                 << ", strategy = " << PlacementStrategy_Name(strategy);
@@ -175,7 +175,7 @@ void GcsPlacementGroupManager::HandleCreatePlacementGroup(
 
 void GcsPlacementGroupManager::ScheduleTick() {
   reschedule_timer_.expires_from_now(boost::posix_time::milliseconds(500));
-  reschedule_timer_.async_wait([this](const boost::system::error_code &error) {
+  reschedule_timer_.async_wait([this](const boost::system::error_code& error) {
     if (error == boost::system::errc::operation_canceled) {
       return;
     } else {

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
@@ -43,8 +43,8 @@ class GcsPlacementGroup {
   /// Create a GcsPlacementGroup by CreatePlacementGroupRequest.
   ///
   /// \param request Contains the placement group creation task specification.
-  explicit GcsPlacementGroup(const ray::rpc::CreatePlacementGroupRequest &request) {
-    const auto &placement_group_spec = request.placement_group_spec();
+  explicit GcsPlacementGroup(const ray::rpc::CreatePlacementGroupRequest& request) {
+    const auto& placement_group_spec = request.placement_group_spec();
     placement_group_table_data_.set_placement_group_id(
         placement_group_spec.placement_group_id());
     placement_group_table_data_.set_name(placement_group_spec.name());
@@ -55,7 +55,7 @@ class GcsPlacementGroup {
   }
 
   /// Get the immutable PlacementGroupTableData of this placement group.
-  const rpc::PlacementGroupTableData &GetPlacementGroupTableData();
+  const rpc::PlacementGroupTableData& GetPlacementGroupTableData();
 
   /// Update the state of this placement_group.
   void UpdateState(rpc::PlacementGroupTableData::PlacementGroupState state);
@@ -96,14 +96,14 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoHandler {
   /// \param scheduler Used to schedule placement group creation tasks.
   /// \param gcs_table_storage Used to flush placement group data to storage.
   explicit GcsPlacementGroupManager(
-      boost::asio::io_context &io_context,
+      boost::asio::io_context& io_context,
       std::shared_ptr<GcsPlacementGroupSchedulerInterface> scheduler,
       std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage);
 
   ~GcsPlacementGroupManager() = default;
 
-  void HandleCreatePlacementGroup(const rpc::CreatePlacementGroupRequest &request,
-                                  rpc::CreatePlacementGroupReply *reply,
+  void HandleCreatePlacementGroup(const rpc::CreatePlacementGroupRequest& request,
+                                  rpc::CreatePlacementGroupReply* reply,
                                   rpc::SendReplyCallback send_reply_callback) override;
 
   /// Register placement_group asynchronously.
@@ -113,7 +113,7 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoHandler {
   /// be invoked immediately if the placement_group is already registered to
   /// `registered_placement_groups_` and its state is `ALIVE`. The callback will not be
   /// called in this case.
-  void RegisterPlacementGroup(const rpc::CreatePlacementGroupRequest &request,
+  void RegisterPlacementGroup(const rpc::CreatePlacementGroupRequest& request,
                               RegisterPlacementGroupCallback callback);
 
   /// Schedule placement_groups in the `pending_placement_groups_` queue.
@@ -125,7 +125,7 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoHandler {
   /// \param name The name of the  placement_group to look up.
   /// \returns PlacementGroupID The ID of the placement_group. Nil if the
   /// placement_group was not found.
-  PlacementGroupID GetPlacementGroupIDByName(const std::string &name);
+  PlacementGroupID GetPlacementGroupIDByName(const std::string& name);
 
   /// Handle placement_group creation task failure. This should be called when scheduling
   /// an placement_group creation task is infeasible.

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -21,9 +21,9 @@ namespace ray {
 namespace gcs {
 
 GcsPlacementGroupScheduler::GcsPlacementGroupScheduler(
-    boost::asio::io_context &io_context,
+    boost::asio::io_context& io_context,
     std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
-    const gcs::GcsNodeManager &gcs_node_manager,
+    const gcs::GcsNodeManager& gcs_node_manager,
     ReserveResourceClientFactoryFn lease_client_factory)
     : return_timer_(io_context),
       gcs_table_storage_(gcs_table_storage),
@@ -37,11 +37,11 @@ GcsPlacementGroupScheduler::GcsPlacementGroupScheduler(
 /// In this algorithm, we try to pack all the bundle in the first node
 /// and don't care the real resource.
 ScheduleMap GcsPackStrategy::Schedule(
-    std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
-    const GcsNodeManager &node_manager) {
+    std::vector<std::shared_ptr<ray::BundleSpecification>>& bundles,
+    const GcsNodeManager& node_manager) {
   ScheduleMap schedule_map;
-  auto &alive_nodes = node_manager.GetAllAliveNodes();
-  for (auto &bundle : bundles) {
+  auto& alive_nodes = node_manager.GetAllAliveNodes();
+  for (auto& bundle : bundles) {
     schedule_map[bundle->BundleId()] =
         ClientID::FromBinary(alive_nodes.begin()->second->node_id());
   }
@@ -52,10 +52,10 @@ ScheduleMap GcsPackStrategy::Schedule(
 /// In this algorithm, we try to spread all the bundle in different node
 /// and don't care the real resource.
 ScheduleMap GcsSpreadStrategy::Schedule(
-    std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
-    const GcsNodeManager &node_manager) {
+    std::vector<std::shared_ptr<ray::BundleSpecification>>& bundles,
+    const GcsNodeManager& node_manager) {
   ScheduleMap schedule_map;
-  auto &alive_nodes = node_manager.GetAllAliveNodes();
+  auto& alive_nodes = node_manager.GetAllAliveNodes();
   auto iter = alive_nodes.begin();
   size_t index = 0;
   size_t alive_nodes_size = alive_nodes.size();
@@ -108,7 +108,7 @@ void GcsPlacementGroupScheduler::Schedule(
         gcs_node_manager_.GetNode(schedule_map.at(bundles[pos]->BundleId())),
         [this, pos, bundles, schedule_map, placement_group, decision, finish_count,
          schedule_failure_handler, schedule_success_handler](
-            const Status &status, const rpc::RequestResourceReserveReply &reply) {
+            const Status& status, const rpc::RequestResourceReserveReply& reply) {
           (*finish_count)++;
           if (status.ok() && reply.success()) {
             (*decision)[bundles[pos]->BundleId()] =
@@ -166,7 +166,7 @@ void GcsPlacementGroupScheduler::ReserveResourceFromNode(
                  << bundle->BundleId().first << bundle->BundleId().second;
   lease_client->RequestResourceReserve(
       *bundle, [this, node_id, bundle, node, callback](
-                   const Status &status, const rpc::RequestResourceReserveReply &reply) {
+                   const Status& status, const rpc::RequestResourceReserveReply& reply) {
         // TODO(AlisaWu): Add placement group cancel.
         auto iter = node_to_bundles_when_leasing_.find(node_id);
         if (iter != node_to_bundles_when_leasing_.end()) {
@@ -210,12 +210,12 @@ void GcsPlacementGroupScheduler::CancelResourceReserve(
   auto return_client = GetOrConnectLeaseClient(remote_address);
   return_client->CancelResourceReserve(
       *bundle_spec,
-      [this, bundle_spec, node](const Status &status,
-                                const rpc::CancelResourceReserveReply &reply) {
+      [this, bundle_spec, node](const Status& status,
+                                const rpc::CancelResourceReserveReply& reply) {
         if (!status.ok()) {
           return_timer_.expires_from_now(boost::posix_time::milliseconds(5));
           return_timer_.async_wait(
-              [this, bundle_spec, node](const boost::system::error_code &error) {
+              [this, bundle_spec, node](const boost::system::error_code& error) {
                 if (error == boost::asio::error::operation_aborted) {
                   return;
                 } else {
@@ -227,7 +227,7 @@ void GcsPlacementGroupScheduler::CancelResourceReserve(
 }
 
 std::shared_ptr<ResourceReserveInterface>
-GcsPlacementGroupScheduler::GetOrConnectLeaseClient(const rpc::Address &raylet_address) {
+GcsPlacementGroupScheduler::GetOrConnectLeaseClient(const rpc::Address& raylet_address) {
   auto node_id = ClientID::FromBinary(raylet_address.raylet_id());
   auto iter = remote_lease_clients_.find(node_id);
   if (iter == remote_lease_clients_.end()) {

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -31,15 +31,15 @@ namespace ray {
 namespace gcs {
 
 using ReserveResourceClientFactoryFn =
-    std::function<std::shared_ptr<ResourceReserveInterface>(const rpc::Address &address)>;
+    std::function<std::shared_ptr<ResourceReserveInterface>(const rpc::Address& address)>;
 
 using ReserveResourceCallback =
-    std::function<void(const Status &, const rpc::RequestResourceReserveReply &)>;
+    std::function<void(const Status&, const rpc::RequestResourceReserveReply&)>;
 
 typedef std::pair<PlacementGroupID, int64_t> BundleID;
 struct pair_hash {
   template <class T1, class T2>
-  std::size_t operator()(const std::pair<T1, T2> &pair) const {
+  std::size_t operator()(const std::pair<T1, T2>& pair) const {
     return std::hash<T1>()(pair.first) ^ std::hash<T2>()(pair.second);
   }
 };
@@ -64,20 +64,20 @@ class GcsScheduleStrategy {
  public:
   virtual ~GcsScheduleStrategy() {}
   virtual ScheduleMap Schedule(
-      std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
-      const GcsNodeManager &node_manager) = 0;
+      std::vector<std::shared_ptr<ray::BundleSpecification>>& bundles,
+      const GcsNodeManager& node_manager) = 0;
 };
 
 class GcsPackStrategy : public GcsScheduleStrategy {
  public:
-  ScheduleMap Schedule(std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
-                       const GcsNodeManager &node_manager) override;
+  ScheduleMap Schedule(std::vector<std::shared_ptr<ray::BundleSpecification>>& bundles,
+                       const GcsNodeManager& node_manager) override;
 };
 
 class GcsSpreadStrategy : public GcsScheduleStrategy {
  public:
-  ScheduleMap Schedule(std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
-                       const GcsNodeManager &node_manager) override;
+  ScheduleMap Schedule(std::vector<std::shared_ptr<ray::BundleSpecification>>& bundles,
+                       const GcsNodeManager& node_manager) override;
 };
 
 /// GcsPlacementGroupScheduler is responsible for scheduling placement_groups registered
@@ -90,9 +90,9 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// \param placement_group_info_accessor Used to flush placement_group info to storage.
   /// \param gcs_node_manager The node manager which is used when scheduling.
   GcsPlacementGroupScheduler(
-      boost::asio::io_context &io_context,
+      boost::asio::io_context& io_context,
       std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
-      const GcsNodeManager &gcs_node_manager,
+      const GcsNodeManager& gcs_node_manager,
       ReserveResourceClientFactoryFn lease_client_factory = nullptr);
   virtual ~GcsPlacementGroupScheduler() = default;
   /// Schedule the specified placement_group.
@@ -122,13 +122,13 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
 
   /// Get an existing lease client or connect a new one.
   std::shared_ptr<ResourceReserveInterface> GetOrConnectLeaseClient(
-      const rpc::Address &raylet_address);
+      const rpc::Address& raylet_address);
   /// A timer that ticks every cancel resource failure milliseconds.
   boost::asio::deadline_timer return_timer_;
   /// Used to update placement group information upon creation, deletion, etc.
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
   /// Reference of GcsNodeManager.
-  const GcsNodeManager &gcs_node_manager_;
+  const GcsNodeManager& gcs_node_manager_;
   /// The cached node clients which are used to communicate with raylet to lease workers.
   absl::flat_hash_map<ClientID, std::shared_ptr<ResourceReserveInterface>>
       remote_lease_clients_;

--- a/src/ray/gcs/gcs_server/gcs_redis_failure_detector.cc
+++ b/src/ray/gcs/gcs_server/gcs_redis_failure_detector.cc
@@ -24,7 +24,7 @@ namespace ray {
 namespace gcs {
 
 GcsRedisFailureDetector::GcsRedisFailureDetector(
-    boost::asio::io_service &io_service, std::shared_ptr<RedisContext> redis_context,
+    boost::asio::io_service& io_service, std::shared_ptr<RedisContext> redis_context,
     std::function<void()> callback)
     : redis_context_(redis_context),
       detect_timer_(io_service),
@@ -36,8 +36,8 @@ void GcsRedisFailureDetector::Start() {
 }
 
 void GcsRedisFailureDetector::DetectRedis() {
-  auto *reply = reinterpret_cast<redisReply *>(
-      redisCommand(redis_context_->sync_context(), "PING"));
+  auto* reply =
+      reinterpret_cast<redisReply*>(redisCommand(redis_context_->sync_context(), "PING"));
   if (reply == nullptr || reply->type == REDIS_REPLY_NIL) {
     RAY_LOG(ERROR) << "Redis is inactive.";
     callback_();
@@ -56,7 +56,7 @@ void GcsRedisFailureDetector::ScheduleTick() {
   auto detect_period = boost::posix_time::milliseconds(
       RayConfig::instance().gcs_redis_heartbeat_interval_milliseconds());
   detect_timer_.expires_from_now(detect_period);
-  detect_timer_.async_wait([this](const boost::system::error_code &error) {
+  detect_timer_.async_wait([this](const boost::system::error_code& error) {
     if (error == boost::asio::error::operation_aborted) {
       return;
     }

--- a/src/ray/gcs/gcs_server/gcs_redis_failure_detector.h
+++ b/src/ray/gcs/gcs_server/gcs_redis_failure_detector.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <boost/asio.hpp>
+
 #include "ray/gcs/redis_context.h"
 
 namespace ray {

--- a/src/ray/gcs/gcs_server/gcs_redis_failure_detector.h
+++ b/src/ray/gcs/gcs_server/gcs_redis_failure_detector.h
@@ -36,7 +36,7 @@ class GcsRedisFailureDetector {
   /// \param io_service The event loop to run the monitor on.
   /// \param redis_context The redis context is used to ping redis.
   /// \param callback Callback that will be called when redis is detected as not alive.
-  explicit GcsRedisFailureDetector(boost::asio::io_service &io_service,
+  explicit GcsRedisFailureDetector(boost::asio::io_service& io_service,
                                    std::shared_ptr<RedisContext> redis_context,
                                    std::function<void()> callback);
 

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -29,8 +29,8 @@
 namespace ray {
 namespace gcs {
 
-GcsServer::GcsServer(const ray::gcs::GcsServerConfig &config,
-                     boost::asio::io_service &main_service)
+GcsServer::GcsServer(const ray::gcs::GcsServerConfig& config,
+                     boost::asio::io_service& main_service)
     : config_(config),
       main_service_(main_service),
       rpc_server_(config.grpc_server_name, config.grpc_server_port,
@@ -187,22 +187,22 @@ void GcsServer::InitGcsActorManager() {
         gcs_actor_manager_->OnActorCreationSuccess(std::move(actor));
       },
       /*lease_client_factory=*/
-      [this](const rpc::Address &address) {
+      [this](const rpc::Address& address) {
         auto node_manager_worker_client = rpc::NodeManagerWorkerClient::make(
             address.ip_address(), address.port(), client_call_manager_);
         return std::make_shared<ray::raylet::RayletClient>(
             std::move(node_manager_worker_client));
       },
       /*client_factory=*/
-      [this](const rpc::Address &address) {
+      [this](const rpc::Address& address) {
         return std::make_shared<rpc::CoreWorkerClient>(address, client_call_manager_);
       });
   gcs_actor_manager_ = std::make_shared<GcsActorManager>(
-      scheduler, gcs_table_storage_, gcs_pub_sub_, [this](const rpc::Address &address) {
+      scheduler, gcs_table_storage_, gcs_pub_sub_, [this](const rpc::Address& address) {
         return std::make_shared<rpc::CoreWorkerClient>(address, client_call_manager_);
       });
   gcs_node_manager_->AddNodeAddedListener(
-      [this](const std::shared_ptr<rpc::GcsNodeInfo> &) {
+      [this](const std::shared_ptr<rpc::GcsNodeInfo>&) {
         // Because a new node has been added, we need to try to schedule the pending
         // actors.
         gcs_actor_manager_->SchedulePendingActors();
@@ -215,10 +215,10 @@ void GcsServer::InitGcsActorManager() {
         gcs_actor_manager_->OnNodeDead(ClientID::FromBinary(node->node_id()));
       });
 
-  auto on_subscribe = [this](const std::string &id, const std::string &data) {
+  auto on_subscribe = [this](const std::string& id, const std::string& data) {
     rpc::WorkerTableData worker_failure_data;
     worker_failure_data.ParseFromString(data);
-    auto &worker_address = worker_failure_data.worker_address();
+    auto& worker_address = worker_failure_data.worker_address();
     WorkerID worker_id = WorkerID::FromBinary(id);
     ClientID node_id = ClientID::FromBinary(worker_address.raylet_id());
     gcs_actor_manager_->OnWorkerDead(node_id, worker_id,
@@ -240,7 +240,7 @@ void GcsServer::InitGcsPlacementGroupManager() {
   auto scheduler = std::make_shared<GcsPlacementGroupScheduler>(
       main_service_, gcs_table_storage_, *gcs_node_manager_,
       /*lease_client_factory=*/
-      [this](const rpc::Address &address) {
+      [this](const rpc::Address& address) {
         auto node_manager_worker_client = rpc::NodeManagerWorkerClient::make(
             address.ip_address(), address.port(), client_call_manager_);
         return std::make_shared<ray::raylet::RayletClient>(

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -50,8 +50,8 @@ class GcsPlacementGroupManager;
 /// https://docs.google.com/document/d/1d-9qBlsh2UQHo-AWMWR0GptI_Ajwu4SKx0Q0LHKPpeI/edit#heading=h.csi0gaglj2pv
 class GcsServer {
  public:
-  explicit GcsServer(const GcsServerConfig &config,
-                     boost::asio::io_service &main_service);
+  explicit GcsServer(const GcsServerConfig& config,
+                     boost::asio::io_service& main_service);
   virtual ~GcsServer();
 
   /// Start gcs server.
@@ -115,7 +115,7 @@ class GcsServer {
   /// Gcs server configuration
   GcsServerConfig config_;
   /// The main io service to drive event posted from grpc threads.
-  boost::asio::io_context &main_service_;
+  boost::asio::io_context& main_service_;
   /// The io service used by node manager in case of node failure detector being blocked
   /// by main thread.
   boost::asio::io_service node_manager_io_service_;

--- a/src/ray/gcs/gcs_server/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server/gcs_server_main.cc
@@ -28,7 +28,7 @@ DEFINE_string(config_list, "", "The config list of raylet.");
 DEFINE_string(redis_password, "", "The password of redis.");
 DEFINE_bool(retry_redis, false, "Whether we retry to connect to the redis.");
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
                                          ray::RayLog::ShutDownRayLog, argv[0],
                                          ray::RayLogLevel::INFO, /*log_dir=*/"");
@@ -80,7 +80,7 @@ int main(int argc, char *argv[]) {
   // Destroy the GCS server on a SIGTERM. The pointer to main_service is
   // guaranteed to be valid since this function will run the event loop
   // instead of returning immediately.
-  auto handler = [&main_service, &gcs_server](const boost::system::error_code &error,
+  auto handler = [&main_service, &gcs_server](const boost::system::error_code& error,
                                               int signal_number) {
     RAY_LOG(INFO) << "GCS server received SIGTERM, shutting down...";
     gcs_server.Stop();

--- a/src/ray/gcs/gcs_server/gcs_table_storage.cc
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.cc
@@ -22,17 +22,17 @@ namespace ray {
 namespace gcs {
 
 template <typename Key, typename Data>
-Status GcsTable<Key, Data>::Put(const Key &key, const Data &value,
-                                const StatusCallback &callback) {
+Status GcsTable<Key, Data>::Put(const Key& key, const Data& value,
+                                const StatusCallback& callback) {
   return store_client_->AsyncPut(table_name_, key.Binary(), value.SerializeAsString(),
                                  callback);
 }
 
 template <typename Key, typename Data>
-Status GcsTable<Key, Data>::Get(const Key &key,
-                                const OptionalItemCallback<Data> &callback) {
-  auto on_done = [callback](const Status &status,
-                            const boost::optional<std::string> &result) {
+Status GcsTable<Key, Data>::Get(const Key& key,
+                                const OptionalItemCallback<Data>& callback) {
+  auto on_done = [callback](const Status& status,
+                            const boost::optional<std::string>& result) {
     boost::optional<Data> value;
     if (result) {
       Data data;
@@ -45,10 +45,10 @@ Status GcsTable<Key, Data>::Get(const Key &key,
 }
 
 template <typename Key, typename Data>
-Status GcsTable<Key, Data>::GetAll(const MapCallback<Key, Data> &callback) {
-  auto on_done = [callback](const std::unordered_map<std::string, std::string> &result) {
+Status GcsTable<Key, Data>::GetAll(const MapCallback<Key, Data>& callback) {
+  auto on_done = [callback](const std::unordered_map<std::string, std::string>& result) {
     std::unordered_map<Key, Data> values;
-    for (auto &item : result) {
+    for (auto& item : result) {
       Data data;
       data.ParseFromString(item.second);
       values[Key::FromBinary(item.first)] = data;
@@ -59,16 +59,16 @@ Status GcsTable<Key, Data>::GetAll(const MapCallback<Key, Data> &callback) {
 }
 
 template <typename Key, typename Data>
-Status GcsTable<Key, Data>::Delete(const Key &key, const StatusCallback &callback) {
+Status GcsTable<Key, Data>::Delete(const Key& key, const StatusCallback& callback) {
   return store_client_->AsyncDelete(table_name_, key.Binary(), callback);
 }
 
 template <typename Key, typename Data>
-Status GcsTable<Key, Data>::BatchDelete(const std::vector<Key> &keys,
-                                        const StatusCallback &callback) {
+Status GcsTable<Key, Data>::BatchDelete(const std::vector<Key>& keys,
+                                        const StatusCallback& callback) {
   std::vector<std::string> keys_to_delete;
   keys_to_delete.reserve(keys.size());
-  for (auto &key : keys) {
+  for (auto& key : keys) {
     keys_to_delete.emplace_back(std::move(key.Binary()));
   }
   return this->store_client_->AsyncBatchDelete(this->table_name_, keys_to_delete,
@@ -76,19 +76,19 @@ Status GcsTable<Key, Data>::BatchDelete(const std::vector<Key> &keys,
 }
 
 template <typename Key, typename Data>
-Status GcsTableWithJobId<Key, Data>::Put(const Key &key, const Data &value,
-                                         const StatusCallback &callback) {
+Status GcsTableWithJobId<Key, Data>::Put(const Key& key, const Data& value,
+                                         const StatusCallback& callback) {
   return this->store_client_->AsyncPutWithIndex(this->table_name_, key.Binary(),
                                                 GetJobIdFromKey(key).Binary(),
                                                 value.SerializeAsString(), callback);
 }
 
 template <typename Key, typename Data>
-Status GcsTableWithJobId<Key, Data>::GetByJobId(const JobID &job_id,
-                                                const MapCallback<Key, Data> &callback) {
-  auto on_done = [callback](const std::unordered_map<std::string, std::string> &result) {
+Status GcsTableWithJobId<Key, Data>::GetByJobId(const JobID& job_id,
+                                                const MapCallback<Key, Data>& callback) {
+  auto on_done = [callback](const std::unordered_map<std::string, std::string>& result) {
     std::unordered_map<Key, Data> values;
-    for (auto &item : result) {
+    for (auto& item : result) {
       Data data;
       data.ParseFromString(item.second);
       values[Key::FromBinary(item.first)] = std::move(data);
@@ -100,8 +100,8 @@ Status GcsTableWithJobId<Key, Data>::GetByJobId(const JobID &job_id,
 }
 
 template <typename Key, typename Data>
-Status GcsTableWithJobId<Key, Data>::DeleteByJobId(const JobID &job_id,
-                                                   const StatusCallback &callback) {
+Status GcsTableWithJobId<Key, Data>::DeleteByJobId(const JobID& job_id,
+                                                   const StatusCallback& callback) {
   return this->store_client_->AsyncDeleteByIndex(this->table_name_, job_id.Binary(),
                                                  callback);
 }

--- a/src/ray/gcs/gcs_server/gcs_table_storage.h
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.h
@@ -53,7 +53,7 @@ using rpc::WorkerTableData;
 template <typename Key, typename Data>
 class GcsTable {
  public:
-  explicit GcsTable(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsTable(std::shared_ptr<StoreClient>& store_client)
       : store_client_(store_client) {}
 
   virtual ~GcsTable() = default;
@@ -64,34 +64,34 @@ class GcsTable {
   /// \param value The value of the key that will be written to the table.
   /// \param callback Callback that will be called after write finishes.
   /// \return Status
-  virtual Status Put(const Key &key, const Data &value, const StatusCallback &callback);
+  virtual Status Put(const Key& key, const Data& value, const StatusCallback& callback);
 
   /// Get data from the table asynchronously.
   ///
   /// \param key The key to lookup from the table.
   /// \param callback Callback that will be called after read finishes.
   /// \return Status
-  Status Get(const Key &key, const OptionalItemCallback<Data> &callback);
+  Status Get(const Key& key, const OptionalItemCallback<Data>& callback);
 
   /// Get all data from the table asynchronously.
   ///
   /// \param callback Callback that will be called after data has been received.
   /// \return Status
-  Status GetAll(const MapCallback<Key, Data> &callback);
+  Status GetAll(const MapCallback<Key, Data>& callback);
 
   /// Delete data from the table asynchronously.
   ///
   /// \param key The key that will be deleted from the table.
   /// \param callback Callback that will be called after delete finishes.
   /// \return Status
-  Status Delete(const Key &key, const StatusCallback &callback);
+  Status Delete(const Key& key, const StatusCallback& callback);
 
   /// Delete a batch of data from the table asynchronously.
   ///
   /// \param keys The batch key that will be deleted from the table.
   /// \param callback Callback that will be called after delete finishes.
   /// \return Status
-  Status BatchDelete(const std::vector<Key> &keys, const StatusCallback &callback);
+  Status BatchDelete(const std::vector<Key>& keys, const StatusCallback& callback);
 
  protected:
   std::string table_name_;
@@ -107,7 +107,7 @@ class GcsTable {
 template <typename Key, typename Data>
 class GcsTableWithJobId : public GcsTable<Key, Data> {
  public:
-  explicit GcsTableWithJobId(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsTableWithJobId(std::shared_ptr<StoreClient>& store_client)
       : GcsTable<Key, Data>(store_client) {}
 
   /// Write data to the table asynchronously.
@@ -116,29 +116,29 @@ class GcsTableWithJobId : public GcsTable<Key, Data> {
   /// from the key. \param value The value of the key that will be written to the table.
   /// \param callback Callback that will be called after write finishes.
   /// \return Status
-  Status Put(const Key &key, const Data &value, const StatusCallback &callback) override;
+  Status Put(const Key& key, const Data& value, const StatusCallback& callback) override;
 
   /// Get all the data of the specified job id from the table asynchronously.
   ///
   /// \param job_id The key to lookup from the table.
   /// \param callback Callback that will be called after read finishes.
   /// \return Status
-  Status GetByJobId(const JobID &job_id, const MapCallback<Key, Data> &callback);
+  Status GetByJobId(const JobID& job_id, const MapCallback<Key, Data>& callback);
 
   /// Delete all the data of the specified job id from the table asynchronously.
   ///
   /// \param job_id The key that will be deleted from the table.
   /// \param callback Callback that will be called after delete finishes.
   /// \return Status
-  Status DeleteByJobId(const JobID &job_id, const StatusCallback &callback);
+  Status DeleteByJobId(const JobID& job_id, const StatusCallback& callback);
 
  protected:
-  virtual JobID GetJobIdFromKey(const Key &key) = 0;
+  virtual JobID GetJobIdFromKey(const Key& key) = 0;
 };
 
 class GcsJobTable : public GcsTable<JobID, JobTableData> {
  public:
-  explicit GcsJobTable(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsJobTable(std::shared_ptr<StoreClient>& store_client)
       : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::JOB);
   }
@@ -146,19 +146,19 @@ class GcsJobTable : public GcsTable<JobID, JobTableData> {
 
 class GcsActorTable : public GcsTableWithJobId<ActorID, ActorTableData> {
  public:
-  explicit GcsActorTable(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsActorTable(std::shared_ptr<StoreClient>& store_client)
       : GcsTableWithJobId(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::ACTOR);
   }
 
  private:
-  JobID GetJobIdFromKey(const ActorID &key) override { return key.JobId(); }
+  JobID GetJobIdFromKey(const ActorID& key) override { return key.JobId(); }
 };
 
 class GcsPlacementGroupTable
     : public GcsTable<PlacementGroupID, PlacementGroupTableData> {
  public:
-  explicit GcsPlacementGroupTable(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsPlacementGroupTable(std::shared_ptr<StoreClient>& store_client)
       : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::PLACEMENT_GROUP);
   }
@@ -166,7 +166,7 @@ class GcsPlacementGroupTable
 
 class GcsActorCheckpointTable : public GcsTable<ActorCheckpointID, ActorCheckpointData> {
  public:
-  explicit GcsActorCheckpointTable(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsActorCheckpointTable(std::shared_ptr<StoreClient>& store_client)
       : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::ACTOR_CHECKPOINT);
   }
@@ -175,63 +175,63 @@ class GcsActorCheckpointTable : public GcsTable<ActorCheckpointID, ActorCheckpoi
 class GcsActorCheckpointIdTable
     : public GcsTableWithJobId<ActorID, ActorCheckpointIdData> {
  public:
-  explicit GcsActorCheckpointIdTable(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsActorCheckpointIdTable(std::shared_ptr<StoreClient>& store_client)
       : GcsTableWithJobId(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::ACTOR_CHECKPOINT_ID);
   }
 
  private:
-  JobID GetJobIdFromKey(const ActorID &key) override { return key.JobId(); }
+  JobID GetJobIdFromKey(const ActorID& key) override { return key.JobId(); }
 };
 
 class GcsTaskTable : public GcsTableWithJobId<TaskID, TaskTableData> {
  public:
-  explicit GcsTaskTable(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsTaskTable(std::shared_ptr<StoreClient>& store_client)
       : GcsTableWithJobId(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::TASK);
   }
 
  private:
-  JobID GetJobIdFromKey(const TaskID &key) override { return key.ActorId().JobId(); }
+  JobID GetJobIdFromKey(const TaskID& key) override { return key.ActorId().JobId(); }
 };
 
 class GcsTaskLeaseTable : public GcsTableWithJobId<TaskID, TaskLeaseData> {
  public:
-  explicit GcsTaskLeaseTable(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsTaskLeaseTable(std::shared_ptr<StoreClient>& store_client)
       : GcsTableWithJobId(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::TASK_LEASE);
   }
 
  private:
-  JobID GetJobIdFromKey(const TaskID &key) override { return key.ActorId().JobId(); }
+  JobID GetJobIdFromKey(const TaskID& key) override { return key.ActorId().JobId(); }
 };
 
 class GcsTaskReconstructionTable
     : public GcsTableWithJobId<TaskID, TaskReconstructionData> {
  public:
-  explicit GcsTaskReconstructionTable(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsTaskReconstructionTable(std::shared_ptr<StoreClient>& store_client)
       : GcsTableWithJobId(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::TASK_RECONSTRUCTION);
   }
 
  private:
-  JobID GetJobIdFromKey(const TaskID &key) override { return key.ActorId().JobId(); }
+  JobID GetJobIdFromKey(const TaskID& key) override { return key.ActorId().JobId(); }
 };
 
 class GcsObjectTable : public GcsTableWithJobId<ObjectID, ObjectTableDataList> {
  public:
-  explicit GcsObjectTable(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsObjectTable(std::shared_ptr<StoreClient>& store_client)
       : GcsTableWithJobId(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::OBJECT);
   }
 
  private:
-  JobID GetJobIdFromKey(const ObjectID &key) override { return key.TaskId().JobId(); }
+  JobID GetJobIdFromKey(const ObjectID& key) override { return key.TaskId().JobId(); }
 };
 
 class GcsNodeTable : public GcsTable<ClientID, GcsNodeInfo> {
  public:
-  explicit GcsNodeTable(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsNodeTable(std::shared_ptr<StoreClient>& store_client)
       : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::CLIENT);
   }
@@ -239,7 +239,7 @@ class GcsNodeTable : public GcsTable<ClientID, GcsNodeInfo> {
 
 class GcsNodeResourceTable : public GcsTable<ClientID, ResourceMap> {
  public:
-  explicit GcsNodeResourceTable(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsNodeResourceTable(std::shared_ptr<StoreClient>& store_client)
       : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::NODE_RESOURCE);
   }
@@ -247,7 +247,7 @@ class GcsNodeResourceTable : public GcsTable<ClientID, ResourceMap> {
 
 class GcsHeartbeatTable : public GcsTable<ClientID, HeartbeatTableData> {
  public:
-  explicit GcsHeartbeatTable(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsHeartbeatTable(std::shared_ptr<StoreClient>& store_client)
       : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::HEARTBEAT);
   }
@@ -255,7 +255,7 @@ class GcsHeartbeatTable : public GcsTable<ClientID, HeartbeatTableData> {
 
 class GcsPlacementGroupScheduleTable : public GcsTable<PlacementGroupID, ScheduleData> {
  public:
-  explicit GcsPlacementGroupScheduleTable(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsPlacementGroupScheduleTable(std::shared_ptr<StoreClient>& store_client)
       : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::PLACEMENT_GROUP_SCHEDULE);
   }
@@ -263,7 +263,7 @@ class GcsPlacementGroupScheduleTable : public GcsTable<PlacementGroupID, Schedul
 
 class GcsHeartbeatBatchTable : public GcsTable<ClientID, HeartbeatBatchTableData> {
  public:
-  explicit GcsHeartbeatBatchTable(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsHeartbeatBatchTable(std::shared_ptr<StoreClient>& store_client)
       : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::HEARTBEAT_BATCH);
   }
@@ -271,7 +271,7 @@ class GcsHeartbeatBatchTable : public GcsTable<ClientID, HeartbeatBatchTableData
 
 class GcsErrorInfoTable : public GcsTable<JobID, ErrorTableData> {
  public:
-  explicit GcsErrorInfoTable(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsErrorInfoTable(std::shared_ptr<StoreClient>& store_client)
       : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::ERROR_INFO);
   }
@@ -279,7 +279,7 @@ class GcsErrorInfoTable : public GcsTable<JobID, ErrorTableData> {
 
 class GcsProfileTable : public GcsTable<UniqueID, ProfileTableData> {
  public:
-  explicit GcsProfileTable(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsProfileTable(std::shared_ptr<StoreClient>& store_client)
       : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::PROFILE);
   }
@@ -287,7 +287,7 @@ class GcsProfileTable : public GcsTable<UniqueID, ProfileTableData> {
 
 class GcsWorkerTable : public GcsTable<WorkerID, WorkerTableData> {
  public:
-  explicit GcsWorkerTable(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsWorkerTable(std::shared_ptr<StoreClient>& store_client)
       : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::WORKERS);
   }
@@ -295,7 +295,7 @@ class GcsWorkerTable : public GcsTable<WorkerID, WorkerTableData> {
 
 class GcsInternalConfigTable : public GcsTable<UniqueID, StoredConfig> {
  public:
-  explicit GcsInternalConfigTable(std::shared_ptr<StoreClient> &store_client)
+  explicit GcsInternalConfigTable(std::shared_ptr<StoreClient>& store_client)
       : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::INTERNAL_CONFIG);
   }
@@ -307,92 +307,92 @@ class GcsInternalConfigTable : public GcsTable<UniqueID, StoredConfig> {
 /// derive from this class and override class member variables.
 class GcsTableStorage {
  public:
-  GcsJobTable &JobTable() {
+  GcsJobTable& JobTable() {
     RAY_CHECK(job_table_ != nullptr);
     return *job_table_;
   }
 
-  GcsActorTable &ActorTable() {
+  GcsActorTable& ActorTable() {
     RAY_CHECK(actor_table_ != nullptr);
     return *actor_table_;
   }
 
-  GcsPlacementGroupTable &PlacementGroupTable() {
+  GcsPlacementGroupTable& PlacementGroupTable() {
     RAY_CHECK(placement_group_table_ != nullptr);
     return *placement_group_table_;
   }
 
-  GcsActorCheckpointTable &ActorCheckpointTable() {
+  GcsActorCheckpointTable& ActorCheckpointTable() {
     RAY_CHECK(actor_checkpoint_table_ != nullptr);
     return *actor_checkpoint_table_;
   }
 
-  GcsActorCheckpointIdTable &ActorCheckpointIdTable() {
+  GcsActorCheckpointIdTable& ActorCheckpointIdTable() {
     RAY_CHECK(actor_checkpoint_id_table_ != nullptr);
     return *actor_checkpoint_id_table_;
   }
 
-  GcsTaskTable &TaskTable() {
+  GcsTaskTable& TaskTable() {
     RAY_CHECK(task_table_ != nullptr);
     return *task_table_;
   }
 
-  GcsTaskLeaseTable &TaskLeaseTable() {
+  GcsTaskLeaseTable& TaskLeaseTable() {
     RAY_CHECK(task_lease_table_ != nullptr);
     return *task_lease_table_;
   }
 
-  GcsTaskReconstructionTable &TaskReconstructionTable() {
+  GcsTaskReconstructionTable& TaskReconstructionTable() {
     RAY_CHECK(task_reconstruction_table_ != nullptr);
     return *task_reconstruction_table_;
   }
 
-  GcsObjectTable &ObjectTable() {
+  GcsObjectTable& ObjectTable() {
     RAY_CHECK(object_table_ != nullptr);
     return *object_table_;
   }
 
-  GcsNodeTable &NodeTable() {
+  GcsNodeTable& NodeTable() {
     RAY_CHECK(node_table_ != nullptr);
     return *node_table_;
   }
 
-  GcsNodeResourceTable &NodeResourceTable() {
+  GcsNodeResourceTable& NodeResourceTable() {
     RAY_CHECK(node_resource_table_ != nullptr);
     return *node_resource_table_;
   }
 
-  GcsPlacementGroupScheduleTable &PlacementGroupScheduleTable() {
+  GcsPlacementGroupScheduleTable& PlacementGroupScheduleTable() {
     RAY_CHECK(placement_group_schedule_table_ != nullptr);
     return *placement_group_schedule_table_;
   }
 
-  GcsHeartbeatTable &HeartbeatTable() {
+  GcsHeartbeatTable& HeartbeatTable() {
     RAY_CHECK(heartbeat_table_ != nullptr);
     return *heartbeat_table_;
   }
 
-  GcsHeartbeatBatchTable &HeartbeatBatchTable() {
+  GcsHeartbeatBatchTable& HeartbeatBatchTable() {
     RAY_CHECK(heartbeat_batch_table_ != nullptr);
     return *heartbeat_batch_table_;
   }
 
-  GcsErrorInfoTable &ErrorInfoTable() {
+  GcsErrorInfoTable& ErrorInfoTable() {
     RAY_CHECK(error_info_table_ != nullptr);
     return *error_info_table_;
   }
 
-  GcsProfileTable &ProfileTable() {
+  GcsProfileTable& ProfileTable() {
     RAY_CHECK(profile_table_ != nullptr);
     return *profile_table_;
   }
 
-  GcsWorkerTable &WorkerTable() {
+  GcsWorkerTable& WorkerTable() {
     RAY_CHECK(worker_table_ != nullptr);
     return *worker_table_;
   }
 
-  GcsInternalConfigTable &InternalConfigTable() {
+  GcsInternalConfigTable& InternalConfigTable() {
     RAY_CHECK(internal_config_table_ != nullptr);
     return *internal_config_table_;
   }
@@ -455,7 +455,7 @@ class RedisGcsTableStorage : public GcsTableStorage {
 /// that uses memory as storage.
 class InMemoryGcsTableStorage : public GcsTableStorage {
  public:
-  explicit InMemoryGcsTableStorage(boost::asio::io_service &main_io_service) {
+  explicit InMemoryGcsTableStorage(boost::asio::io_service& main_io_service) {
     store_client_ = std::make_shared<InMemoryStoreClient>(main_io_service);
     job_table_.reset(new GcsJobTable(store_client_));
     actor_table_.reset(new GcsActorTable(store_client_));

--- a/src/ray/gcs/gcs_server/gcs_worker_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_worker_manager.cc
@@ -18,7 +18,7 @@ namespace ray {
 namespace gcs {
 
 void GcsWorkerManager::HandleReportWorkerFailure(
-    const rpc::ReportWorkerFailureRequest &request, rpc::ReportWorkerFailureReply *reply,
+    const rpc::ReportWorkerFailureRequest& request, rpc::ReportWorkerFailureReply* reply,
     rpc::SendReplyCallback send_reply_callback) {
   const rpc::Address worker_address = request.worker_failure().worker_address();
   RAY_LOG(DEBUG) << "Reporting worker failure, " << worker_address.DebugString();
@@ -30,10 +30,10 @@ void GcsWorkerManager::HandleReportWorkerFailure(
   // Before handle ReportWorkerFailureRequest, you should check if the worker is exists.
   auto on_get_done =
       [this, worker_address, worker_id, worker_failure_data, reply, send_reply_callback](
-          const Status &status, const boost::optional<WorkerTableData> &result) {
+          const Status& status, const boost::optional<WorkerTableData>& result) {
         if (result) {
           auto on_put_done = [this, worker_address, worker_id, worker_failure_data, reply,
-                              send_reply_callback](const Status &status) {
+                              send_reply_callback](const Status& status) {
             if (!status.ok()) {
               RAY_LOG(ERROR) << "Failed to report worker failure, "
                              << worker_address.DebugString();
@@ -65,15 +65,15 @@ void GcsWorkerManager::HandleReportWorkerFailure(
   }
 }
 
-void GcsWorkerManager::HandleGetWorkerInfo(const rpc::GetWorkerInfoRequest &request,
-                                           rpc::GetWorkerInfoReply *reply,
+void GcsWorkerManager::HandleGetWorkerInfo(const rpc::GetWorkerInfoRequest& request,
+                                           rpc::GetWorkerInfoReply* reply,
                                            rpc::SendReplyCallback send_reply_callback) {
   WorkerID worker_id = WorkerID::FromBinary(request.worker_id());
   RAY_LOG(DEBUG) << "Getting worker info, worker id = " << worker_id;
 
   auto on_done = [worker_id, reply, send_reply_callback](
-                     const Status &status,
-                     const boost::optional<WorkerTableData> &result) {
+                     const Status& status,
+                     const boost::optional<WorkerTableData>& result) {
     if (result) {
       reply->mutable_worker_table_data()->CopyFrom(*result);
     }
@@ -88,12 +88,12 @@ void GcsWorkerManager::HandleGetWorkerInfo(const rpc::GetWorkerInfoRequest &requ
 }
 
 void GcsWorkerManager::HandleGetAllWorkerInfo(
-    const rpc::GetAllWorkerInfoRequest &request, rpc::GetAllWorkerInfoReply *reply,
+    const rpc::GetAllWorkerInfoRequest& request, rpc::GetAllWorkerInfoReply* reply,
     rpc::SendReplyCallback send_reply_callback) {
   RAY_LOG(DEBUG) << "Getting all worker info.";
   auto on_done = [reply, send_reply_callback](
-                     const std::unordered_map<WorkerID, WorkerTableData> &result) {
-    for (auto &data : result) {
+                     const std::unordered_map<WorkerID, WorkerTableData>& result) {
+    for (auto& data : result) {
       reply->add_worker_table_data()->CopyFrom(data.second);
     }
     RAY_LOG(DEBUG) << "Finished getting all worker info.";
@@ -105,8 +105,8 @@ void GcsWorkerManager::HandleGetAllWorkerInfo(
   }
 }
 
-void GcsWorkerManager::HandleAddWorkerInfo(const rpc::AddWorkerInfoRequest &request,
-                                           rpc::AddWorkerInfoReply *reply,
+void GcsWorkerManager::HandleAddWorkerInfo(const rpc::AddWorkerInfoRequest& request,
+                                           rpc::AddWorkerInfoReply* reply,
                                            rpc::SendReplyCallback send_reply_callback) {
   auto worker_data = std::make_shared<WorkerTableData>();
   worker_data->CopyFrom(request.worker_data());
@@ -114,7 +114,7 @@ void GcsWorkerManager::HandleAddWorkerInfo(const rpc::AddWorkerInfoRequest &requ
   RAY_LOG(DEBUG) << "Adding worker " << worker_id;
 
   auto on_done = [worker_id, worker_data, reply,
-                  send_reply_callback](const Status &status) {
+                  send_reply_callback](const Status& status) {
     if (!status.ok()) {
       RAY_LOG(ERROR) << "Failed to add worker information, "
                      << worker_data->DebugString();

--- a/src/ray/gcs/gcs_server/gcs_worker_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_worker_manager.h
@@ -26,23 +26,23 @@ namespace gcs {
 class GcsWorkerManager : public rpc::WorkerInfoHandler {
  public:
   explicit GcsWorkerManager(std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
-                            std::shared_ptr<gcs::GcsPubSub> &gcs_pub_sub)
+                            std::shared_ptr<gcs::GcsPubSub>& gcs_pub_sub)
       : gcs_table_storage_(gcs_table_storage), gcs_pub_sub_(gcs_pub_sub) {}
 
-  void HandleReportWorkerFailure(const rpc::ReportWorkerFailureRequest &request,
-                                 rpc::ReportWorkerFailureReply *reply,
+  void HandleReportWorkerFailure(const rpc::ReportWorkerFailureRequest& request,
+                                 rpc::ReportWorkerFailureReply* reply,
                                  rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleGetWorkerInfo(const rpc::GetWorkerInfoRequest &request,
-                           rpc::GetWorkerInfoReply *reply,
+  void HandleGetWorkerInfo(const rpc::GetWorkerInfoRequest& request,
+                           rpc::GetWorkerInfoReply* reply,
                            rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleGetAllWorkerInfo(const rpc::GetAllWorkerInfoRequest &request,
-                              rpc::GetAllWorkerInfoReply *reply,
+  void HandleGetAllWorkerInfo(const rpc::GetAllWorkerInfoRequest& request,
+                              rpc::GetAllWorkerInfoReply* reply,
                               rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleAddWorkerInfo(const rpc::AddWorkerInfoRequest &request,
-                           rpc::AddWorkerInfoReply *reply,
+  void HandleAddWorkerInfo(const rpc::AddWorkerInfoRequest& request,
+                           rpc::AddWorkerInfoReply* reply,
                            rpc::SendReplyCallback send_reply_callback) override;
 
  private:

--- a/src/ray/gcs/gcs_server/stats_handler_impl.cc
+++ b/src/ray/gcs/gcs_server/stats_handler_impl.cc
@@ -17,8 +17,8 @@
 namespace ray {
 namespace rpc {
 
-void DefaultStatsHandler::HandleAddProfileData(const AddProfileDataRequest &request,
-                                               AddProfileDataReply *reply,
+void DefaultStatsHandler::HandleAddProfileData(const AddProfileDataRequest& request,
+                                               AddProfileDataReply* reply,
                                                SendReplyCallback send_reply_callback) {
   ClientID node_id = ClientID::FromBinary(request.profile_data().component_id());
   RAY_LOG(DEBUG) << "Adding profile data, component type = "
@@ -44,12 +44,12 @@ void DefaultStatsHandler::HandleAddProfileData(const AddProfileDataRequest &requ
 }
 
 void DefaultStatsHandler::HandleGetAllProfileInfo(
-    const rpc::GetAllProfileInfoRequest &request, rpc::GetAllProfileInfoReply *reply,
+    const rpc::GetAllProfileInfoRequest& request, rpc::GetAllProfileInfoReply* reply,
     rpc::SendReplyCallback send_reply_callback) {
   RAY_LOG(DEBUG) << "Getting all profile info.";
   auto on_done = [reply, send_reply_callback](
-                     const std::unordered_map<UniqueID, ProfileTableData> &result) {
-    for (auto &data : result) {
+                     const std::unordered_map<UniqueID, ProfileTableData>& result) {
+    for (auto& data : result) {
       reply->add_profile_info_list()->CopyFrom(data.second);
     }
     RAY_LOG(DEBUG) << "Finished getting all profile info.";

--- a/src/ray/gcs/gcs_server/stats_handler_impl.h
+++ b/src/ray/gcs/gcs_server/stats_handler_impl.h
@@ -27,12 +27,12 @@ class DefaultStatsHandler : public rpc::StatsHandler {
   explicit DefaultStatsHandler(std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage)
       : gcs_table_storage_(std::move(gcs_table_storage)) {}
 
-  void HandleAddProfileData(const AddProfileDataRequest &request,
-                            AddProfileDataReply *reply,
+  void HandleAddProfileData(const AddProfileDataRequest& request,
+                            AddProfileDataReply* reply,
                             SendReplyCallback send_reply_callback) override;
 
-  void HandleGetAllProfileInfo(const rpc::GetAllProfileInfoRequest &request,
-                               rpc::GetAllProfileInfoReply *reply,
+  void HandleGetAllProfileInfo(const rpc::GetAllProfileInfoRequest& request,
+                               rpc::GetAllProfileInfoReply* reply,
                                rpc::SendReplyCallback send_reply_callback) override;
 
  private:

--- a/src/ray/gcs/gcs_server/task_info_handler_impl.cc
+++ b/src/ray/gcs/gcs_server/task_info_handler_impl.cc
@@ -17,14 +17,14 @@
 namespace ray {
 namespace rpc {
 
-void DefaultTaskInfoHandler::HandleAddTask(const AddTaskRequest &request,
-                                           AddTaskReply *reply,
+void DefaultTaskInfoHandler::HandleAddTask(const AddTaskRequest& request,
+                                           AddTaskReply* reply,
                                            SendReplyCallback send_reply_callback) {
   JobID job_id = JobID::FromBinary(request.task_data().task().task_spec().job_id());
   TaskID task_id = TaskID::FromBinary(request.task_data().task().task_spec().task_id());
   RAY_LOG(DEBUG) << "Adding task, job id = " << job_id << ", task id = " << task_id;
   auto on_done = [this, job_id, task_id, request, reply,
-                  send_reply_callback](const Status &status) {
+                  send_reply_callback](const Status& status) {
     if (!status.ok()) {
       RAY_LOG(ERROR) << "Failed to add task, job id = " << job_id
                      << ", task id = " << task_id;
@@ -44,14 +44,14 @@ void DefaultTaskInfoHandler::HandleAddTask(const AddTaskRequest &request,
   }
 }
 
-void DefaultTaskInfoHandler::HandleGetTask(const GetTaskRequest &request,
-                                           GetTaskReply *reply,
+void DefaultTaskInfoHandler::HandleGetTask(const GetTaskRequest& request,
+                                           GetTaskReply* reply,
                                            SendReplyCallback send_reply_callback) {
   TaskID task_id = TaskID::FromBinary(request.task_id());
   RAY_LOG(DEBUG) << "Getting task, job id = " << task_id.JobId()
                  << ", task id = " << task_id;
   auto on_done = [task_id, request, reply, send_reply_callback](
-                     const Status &status, const boost::optional<TaskTableData> &result) {
+                     const Status& status, const boost::optional<TaskTableData>& result) {
     if (status.ok() && result) {
       reply->mutable_task_data()->CopyFrom(*result);
     }
@@ -66,8 +66,8 @@ void DefaultTaskInfoHandler::HandleGetTask(const GetTaskRequest &request,
   }
 }
 
-void DefaultTaskInfoHandler::HandleDeleteTasks(const DeleteTasksRequest &request,
-                                               DeleteTasksReply *reply,
+void DefaultTaskInfoHandler::HandleDeleteTasks(const DeleteTasksRequest& request,
+                                               DeleteTasksReply* reply,
                                                SendReplyCallback send_reply_callback) {
   std::vector<TaskID> task_ids = IdVectorFromProtobuf<TaskID>(request.task_id_list());
   JobID job_id = task_ids.empty() ? JobID::Nil() : task_ids[0].JobId();
@@ -89,15 +89,15 @@ void DefaultTaskInfoHandler::HandleDeleteTasks(const DeleteTasksRequest &request
                  << ", task id list size = " << task_ids.size();
 }
 
-void DefaultTaskInfoHandler::HandleAddTaskLease(const AddTaskLeaseRequest &request,
-                                                AddTaskLeaseReply *reply,
+void DefaultTaskInfoHandler::HandleAddTaskLease(const AddTaskLeaseRequest& request,
+                                                AddTaskLeaseReply* reply,
                                                 SendReplyCallback send_reply_callback) {
   TaskID task_id = TaskID::FromBinary(request.task_lease_data().task_id());
   ClientID node_id = ClientID::FromBinary(request.task_lease_data().node_manager_id());
   RAY_LOG(DEBUG) << "Adding task lease, job id = " << task_id.JobId()
                  << ", task id = " << task_id << ", node id = " << node_id;
   auto on_done = [this, task_id, node_id, request, reply,
-                  send_reply_callback](const Status &status) {
+                  send_reply_callback](const Status& status) {
     if (!status.ok()) {
       RAY_LOG(ERROR) << "Failed to add task lease, job id = " << task_id.JobId()
                      << ", task id = " << task_id << ", node id = " << node_id;
@@ -118,14 +118,14 @@ void DefaultTaskInfoHandler::HandleAddTaskLease(const AddTaskLeaseRequest &reque
   }
 }
 
-void DefaultTaskInfoHandler::HandleGetTaskLease(const GetTaskLeaseRequest &request,
-                                                GetTaskLeaseReply *reply,
+void DefaultTaskInfoHandler::HandleGetTaskLease(const GetTaskLeaseRequest& request,
+                                                GetTaskLeaseReply* reply,
                                                 SendReplyCallback send_reply_callback) {
   TaskID task_id = TaskID::FromBinary(request.task_id());
   RAY_LOG(DEBUG) << "Getting task lease, job id = " << task_id.JobId()
                  << ", task id = " << task_id;
   auto on_done = [task_id, request, reply, send_reply_callback](
-                     const Status &status, const boost::optional<TaskLeaseData> &result) {
+                     const Status& status, const boost::optional<TaskLeaseData>& result) {
     if (status.ok() && result) {
       reply->mutable_task_lease_data()->CopyFrom(*result);
     }
@@ -141,8 +141,8 @@ void DefaultTaskInfoHandler::HandleGetTaskLease(const GetTaskLeaseRequest &reque
 }
 
 void DefaultTaskInfoHandler::HandleAttemptTaskReconstruction(
-    const AttemptTaskReconstructionRequest &request,
-    AttemptTaskReconstructionReply *reply, SendReplyCallback send_reply_callback) {
+    const AttemptTaskReconstructionRequest& request,
+    AttemptTaskReconstructionReply* reply, SendReplyCallback send_reply_callback) {
   TaskID task_id = TaskID::FromBinary(request.task_reconstruction().task_id());
   ClientID node_id =
       ClientID::FromBinary(request.task_reconstruction().node_manager_id());
@@ -151,7 +151,7 @@ void DefaultTaskInfoHandler::HandleAttemptTaskReconstruction(
                  << request.task_reconstruction().num_reconstructions()
                  << ", node id = " << node_id;
   auto on_done = [task_id, node_id, request, reply,
-                  send_reply_callback](const Status &status) {
+                  send_reply_callback](const Status& status) {
     if (!status.ok()) {
       RAY_LOG(ERROR) << "Failed to reconstruct task, job id = " << task_id.JobId()
                      << ", task id = " << task_id << ", reconstructions num = "

--- a/src/ray/gcs/gcs_server/task_info_handler_impl.h
+++ b/src/ray/gcs/gcs_server/task_info_handler_impl.h
@@ -26,31 +26,31 @@ namespace rpc {
 class DefaultTaskInfoHandler : public rpc::TaskInfoHandler {
  public:
   explicit DefaultTaskInfoHandler(std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
-                                  std::shared_ptr<gcs::GcsPubSub> &gcs_pub_sub)
+                                  std::shared_ptr<gcs::GcsPubSub>& gcs_pub_sub)
       : gcs_table_storage_(gcs_table_storage), gcs_pub_sub_(gcs_pub_sub) {}
 
-  void HandleAddTask(const AddTaskRequest &request, AddTaskReply *reply,
+  void HandleAddTask(const AddTaskRequest& request, AddTaskReply* reply,
                      SendReplyCallback send_reply_callback) override;
 
-  void HandleGetTask(const GetTaskRequest &request, GetTaskReply *reply,
+  void HandleGetTask(const GetTaskRequest& request, GetTaskReply* reply,
                      SendReplyCallback send_reply_callback) override;
 
-  void HandleDeleteTasks(const DeleteTasksRequest &request, DeleteTasksReply *reply,
+  void HandleDeleteTasks(const DeleteTasksRequest& request, DeleteTasksReply* reply,
                          SendReplyCallback send_reply_callback) override;
 
-  void HandleAddTaskLease(const AddTaskLeaseRequest &request, AddTaskLeaseReply *reply,
+  void HandleAddTaskLease(const AddTaskLeaseRequest& request, AddTaskLeaseReply* reply,
                           SendReplyCallback send_reply_callback) override;
 
-  void HandleGetTaskLease(const GetTaskLeaseRequest &request, GetTaskLeaseReply *reply,
+  void HandleGetTaskLease(const GetTaskLeaseRequest& request, GetTaskLeaseReply* reply,
                           SendReplyCallback send_reply_callback) override;
 
-  void HandleAttemptTaskReconstruction(const AttemptTaskReconstructionRequest &request,
-                                       AttemptTaskReconstructionReply *reply,
+  void HandleAttemptTaskReconstruction(const AttemptTaskReconstructionRequest& request,
+                                       AttemptTaskReconstructionReply* reply,
                                        SendReplyCallback send_reply_callback) override;
 
  private:
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
-  std::shared_ptr<gcs::GcsPubSub> &gcs_pub_sub_;
+  std::shared_ptr<gcs::GcsPubSub>& gcs_pub_sub_;
 };
 
 }  // namespace rpc

--- a/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_test.cc
@@ -43,9 +43,9 @@ class GcsActorSchedulerTest : public ::testing::Test {
           success_actors_.emplace_back(std::move(actor));
         },
         /*lease_client_factory=*/
-        [this](const rpc::Address &address) { return raylet_client_; },
+        [this](const rpc::Address& address) { return raylet_client_; },
         /*client_factory=*/
-        [this](const rpc::Address &address) { return worker_client_; });
+        [this](const rpc::Address& address) { return worker_client_; });
   }
 
  protected:
@@ -505,7 +505,7 @@ TEST_F(GcsActorSchedulerTest, TestReleaseUnusedWorkers) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
@@ -60,9 +60,9 @@ TEST_F(GcsNodeManagerTest, TestListener) {
   ASSERT_EQ(node_count, added_nodes.size());
 
   // Test GetAllAliveNodes.
-  auto &alive_nodes = node_manager.GetAllAliveNodes();
+  auto& alive_nodes = node_manager.GetAllAliveNodes();
   ASSERT_EQ(added_nodes.size(), alive_nodes.size());
-  for (const auto &node : added_nodes) {
+  for (const auto& node : added_nodes) {
     ASSERT_EQ(1, alive_nodes.count(ClientID::FromBinary(node->node_id())));
   }
 
@@ -84,7 +84,7 @@ TEST_F(GcsNodeManagerTest, TestListener) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/gcs/gcs_server/test/gcs_object_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_object_manager_test.cc
@@ -23,29 +23,29 @@ namespace ray {
 class MockedGcsObjectManager : public gcs::GcsObjectManager {
  public:
   explicit MockedGcsObjectManager(std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
-                                  std::shared_ptr<gcs::GcsPubSub> &gcs_pub_sub,
-                                  gcs::GcsNodeManager &gcs_node_manager)
+                                  std::shared_ptr<gcs::GcsPubSub>& gcs_pub_sub,
+                                  gcs::GcsNodeManager& gcs_node_manager)
       : gcs::GcsObjectManager(gcs_table_storage, gcs_pub_sub, gcs_node_manager) {}
 
  public:
-  void AddObjectsLocation(const ClientID &node_id,
-                          const absl::flat_hash_set<ObjectID> &object_ids) {
+  void AddObjectsLocation(const ClientID& node_id,
+                          const absl::flat_hash_set<ObjectID>& object_ids) {
     gcs::GcsObjectManager::AddObjectsLocation(node_id, object_ids);
   }
 
-  void AddObjectLocationInCache(const ObjectID &object_id, const ClientID &node_id) {
+  void AddObjectLocationInCache(const ObjectID& object_id, const ClientID& node_id) {
     gcs::GcsObjectManager::AddObjectLocationInCache(object_id, node_id);
   }
 
-  absl::flat_hash_set<ClientID> GetObjectLocations(const ObjectID &object_id) {
+  absl::flat_hash_set<ClientID> GetObjectLocations(const ObjectID& object_id) {
     return gcs::GcsObjectManager::GetObjectLocations(object_id);
   }
 
-  void OnNodeRemoved(const ClientID &node_id) {
+  void OnNodeRemoved(const ClientID& node_id) {
     gcs::GcsObjectManager::OnNodeRemoved(node_id);
   }
 
-  void RemoveObjectLocationInCache(const ObjectID &object_id, const ClientID &node_id) {
+  void RemoveObjectLocationInCache(const ObjectID& object_id, const ClientID& node_id) {
     gcs::GcsObjectManager::RemoveObjectLocationInCache(object_id, node_id);
   }
 };
@@ -72,9 +72,9 @@ class GcsObjectManagerTest : public ::testing::Test {
     }
   }
 
-  void CheckLocations(const absl::flat_hash_set<ClientID> &locations) {
+  void CheckLocations(const absl::flat_hash_set<ClientID>& locations) {
     ASSERT_EQ(locations.size(), node_ids_.size());
-    for (const auto &location : locations) {
+    for (const auto& location : locations) {
       auto it = node_ids_.find(location);
       ASSERT_TRUE(it != node_ids_.end());
       ASSERT_TRUE(location == *it);
@@ -97,30 +97,30 @@ class GcsObjectManagerTest : public ::testing::Test {
 };
 
 TEST_F(GcsObjectManagerTest, AddObjectsLocationAndGetLocationTest) {
-  for (const auto &node_id : node_ids_) {
+  for (const auto& node_id : node_ids_) {
     gcs_object_manager_->AddObjectsLocation(node_id, object_ids_);
   }
-  for (const auto &object_id : object_ids_) {
+  for (const auto& object_id : object_ids_) {
     auto locations = gcs_object_manager_->GetObjectLocations(object_id);
     CheckLocations(locations);
   }
 }
 
 TEST_F(GcsObjectManagerTest, AddObjectLocationInCacheTest) {
-  for (const auto &object_id : object_ids_) {
-    for (const auto &node_id : node_ids_) {
+  for (const auto& object_id : object_ids_) {
+    for (const auto& node_id : node_ids_) {
       gcs_object_manager_->AddObjectLocationInCache(object_id, node_id);
     }
   }
 
-  for (const auto &object_id : object_ids_) {
+  for (const auto& object_id : object_ids_) {
     auto locations = gcs_object_manager_->GetObjectLocations(object_id);
     CheckLocations(locations);
   }
 }
 
 TEST_F(GcsObjectManagerTest, RemoveNodeTest) {
-  for (const auto &node_id : node_ids_) {
+  for (const auto& node_id : node_ids_) {
     gcs_object_manager_->AddObjectsLocation(node_id, object_ids_);
   }
 
@@ -133,7 +133,7 @@ TEST_F(GcsObjectManagerTest, RemoveNodeTest) {
 }
 
 TEST_F(GcsObjectManagerTest, RemoveObjectLocationTest) {
-  for (const auto &node_id : node_ids_) {
+  for (const auto& node_id : node_ids_) {
     gcs_object_manager_->AddObjectsLocation(node_id, object_ids_);
   }
 
@@ -148,7 +148,7 @@ TEST_F(GcsObjectManagerTest, RemoveObjectLocationTest) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
@@ -125,7 +125,7 @@ TEST_F(GcsPlacementGroupManagerTest, TestGetPlacementGroupIDByName) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -34,7 +34,7 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
         std::make_shared<GcsServerMocker::MockedGcsPlacementGroupScheduler>(
             io_service_, gcs_table_storage_, *gcs_node_manager_,
             /*lease_client_fplacement_groupy=*/
-            [this](const rpc::Address &address) { return raylet_client_; });
+            [this](const rpc::Address& address) { return raylet_client_; });
   }
 
  protected:
@@ -172,7 +172,7 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestSchedulePlacementGroupReturnResource)
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
@@ -61,55 +61,55 @@ class GcsServerTest : public ::testing::Test {
     gcs_server_.reset();
   }
 
-  bool AddJob(const rpc::AddJobRequest &request) {
+  bool AddJob(const rpc::AddJobRequest& request) {
     std::promise<bool> promise;
     client_->AddJob(request,
-                    [&promise](const Status &status, const rpc::AddJobReply &reply) {
+                    [&promise](const Status& status, const rpc::AddJobReply& reply) {
                       RAY_CHECK_OK(status);
                       promise.set_value(true);
                     });
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool MarkJobFinished(const rpc::MarkJobFinishedRequest &request) {
+  bool MarkJobFinished(const rpc::MarkJobFinishedRequest& request) {
     std::promise<bool> promise;
-    client_->MarkJobFinished(request, [&promise](const Status &status,
-                                                 const rpc::MarkJobFinishedReply &reply) {
+    client_->MarkJobFinished(request, [&promise](const Status& status,
+                                                 const rpc::MarkJobFinishedReply& reply) {
       RAY_CHECK_OK(status);
       promise.set_value(true);
     });
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool RegisterActorInfo(const rpc::RegisterActorInfoRequest &request) {
+  bool RegisterActorInfo(const rpc::RegisterActorInfoRequest& request) {
     std::promise<bool> promise;
     client_->RegisterActorInfo(
         request,
-        [&promise](const Status &status, const rpc::RegisterActorInfoReply &reply) {
+        [&promise](const Status& status, const rpc::RegisterActorInfoReply& reply) {
           RAY_CHECK_OK(status);
           promise.set_value(true);
         });
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool UpdateActorInfo(const rpc::UpdateActorInfoRequest &request) {
+  bool UpdateActorInfo(const rpc::UpdateActorInfoRequest& request) {
     std::promise<bool> promise;
-    client_->UpdateActorInfo(request, [&promise](const Status &status,
-                                                 const rpc::UpdateActorInfoReply &reply) {
+    client_->UpdateActorInfo(request, [&promise](const Status& status,
+                                                 const rpc::UpdateActorInfoReply& reply) {
       RAY_CHECK_OK(status);
       promise.set_value(true);
     });
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  boost::optional<rpc::ActorTableData> GetActorInfo(const std::string &actor_id) {
+  boost::optional<rpc::ActorTableData> GetActorInfo(const std::string& actor_id) {
     rpc::GetActorInfoRequest request;
     request.set_actor_id(actor_id);
     boost::optional<rpc::ActorTableData> actor_table_data_opt;
     std::promise<bool> promise;
     client_->GetActorInfo(
-        request, [&actor_table_data_opt, &promise](const Status &status,
-                                                   const rpc::GetActorInfoReply &reply) {
+        request, [&actor_table_data_opt, &promise](const Status& status,
+                                                   const rpc::GetActorInfoReply& reply) {
           RAY_CHECK_OK(status);
           if (reply.has_actor_table_data()) {
             actor_table_data_opt = reply.actor_table_data();
@@ -122,11 +122,11 @@ class GcsServerTest : public ::testing::Test {
     return actor_table_data_opt;
   }
 
-  bool AddActorCheckpoint(const rpc::AddActorCheckpointRequest &request) {
+  bool AddActorCheckpoint(const rpc::AddActorCheckpointRequest& request) {
     std::promise<bool> promise;
     client_->AddActorCheckpoint(
         request,
-        [&promise](const Status &status, const rpc::AddActorCheckpointReply &reply) {
+        [&promise](const Status& status, const rpc::AddActorCheckpointReply& reply) {
           RAY_CHECK_OK(status);
           promise.set_value(true);
         });
@@ -134,7 +134,7 @@ class GcsServerTest : public ::testing::Test {
   }
 
   boost::optional<rpc::ActorCheckpointData> GetActorCheckpoint(
-      const std::string &actor_id, const std::string &checkpoint_id) {
+      const std::string& actor_id, const std::string& checkpoint_id) {
     rpc::GetActorCheckpointRequest request;
     request.set_actor_id(actor_id);
     request.set_checkpoint_id(checkpoint_id);
@@ -142,7 +142,7 @@ class GcsServerTest : public ::testing::Test {
     std::promise<bool> promise;
     client_->GetActorCheckpoint(
         request, [&checkpoint_data_opt, &promise](
-                     const Status &status, const rpc::GetActorCheckpointReply &reply) {
+                     const Status& status, const rpc::GetActorCheckpointReply& reply) {
           RAY_CHECK_OK(status);
           if (reply.has_checkpoint_data()) {
             checkpoint_data_opt = reply.checkpoint_data();
@@ -156,14 +156,14 @@ class GcsServerTest : public ::testing::Test {
   }
 
   boost::optional<rpc::ActorCheckpointIdData> GetActorCheckpointID(
-      const std::string &actor_id) {
+      const std::string& actor_id) {
     rpc::GetActorCheckpointIDRequest request;
     request.set_actor_id(actor_id);
     boost::optional<rpc::ActorCheckpointIdData> checkpoint_id_data_opt;
     std::promise<bool> promise;
     client_->GetActorCheckpointID(
         request, [&checkpoint_id_data_opt, &promise](
-                     const Status &status, const rpc::GetActorCheckpointIDReply &reply) {
+                     const Status& status, const rpc::GetActorCheckpointIDReply& reply) {
           RAY_CHECK_OK(status);
           if (reply.has_checkpoint_id_data()) {
             checkpoint_id_data_opt = reply.checkpoint_id_data();
@@ -176,10 +176,10 @@ class GcsServerTest : public ::testing::Test {
     return checkpoint_id_data_opt;
   }
 
-  bool RegisterNode(const rpc::RegisterNodeRequest &request) {
+  bool RegisterNode(const rpc::RegisterNodeRequest& request) {
     std::promise<bool> promise;
     client_->RegisterNode(
-        request, [&promise](const Status &status, const rpc::RegisterNodeReply &reply) {
+        request, [&promise](const Status& status, const rpc::RegisterNodeReply& reply) {
           RAY_CHECK_OK(status);
           promise.set_value(true);
         });
@@ -187,10 +187,10 @@ class GcsServerTest : public ::testing::Test {
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool UnregisterNode(const rpc::UnregisterNodeRequest &request) {
+  bool UnregisterNode(const rpc::UnregisterNodeRequest& request) {
     std::promise<bool> promise;
     client_->UnregisterNode(
-        request, [&promise](const Status &status, const rpc::UnregisterNodeReply &reply) {
+        request, [&promise](const Status& status, const rpc::UnregisterNodeReply& reply) {
           RAY_CHECK_OK(status);
           promise.set_value(true);
         });
@@ -202,8 +202,8 @@ class GcsServerTest : public ::testing::Test {
     rpc::GetAllNodeInfoRequest request;
     std::promise<bool> promise;
     client_->GetAllNodeInfo(
-        request, [&node_info_list, &promise](const Status &status,
-                                             const rpc::GetAllNodeInfoReply &reply) {
+        request, [&node_info_list, &promise](const Status& status,
+                                             const rpc::GetAllNodeInfoReply& reply) {
           RAY_CHECK_OK(status);
           for (int index = 0; index < reply.node_info_list_size(); ++index) {
             node_info_list.push_back(reply.node_info_list(index));
@@ -214,46 +214,46 @@ class GcsServerTest : public ::testing::Test {
     return node_info_list;
   }
 
-  bool ReportHeartbeat(const rpc::ReportHeartbeatRequest &request) {
+  bool ReportHeartbeat(const rpc::ReportHeartbeatRequest& request) {
     std::promise<bool> promise;
-    client_->ReportHeartbeat(request, [&promise](const Status &status,
-                                                 const rpc::ReportHeartbeatReply &reply) {
+    client_->ReportHeartbeat(request, [&promise](const Status& status,
+                                                 const rpc::ReportHeartbeatReply& reply) {
       RAY_CHECK_OK(status);
       promise.set_value(true);
     });
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool UpdateResources(const rpc::UpdateResourcesRequest &request) {
+  bool UpdateResources(const rpc::UpdateResourcesRequest& request) {
     std::promise<bool> promise;
-    client_->UpdateResources(request, [&promise](const Status &status,
-                                                 const rpc::UpdateResourcesReply &reply) {
+    client_->UpdateResources(request, [&promise](const Status& status,
+                                                 const rpc::UpdateResourcesReply& reply) {
       RAY_CHECK_OK(status);
       promise.set_value(true);
     });
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool DeleteResources(const rpc::DeleteResourcesRequest &request) {
+  bool DeleteResources(const rpc::DeleteResourcesRequest& request) {
     std::promise<bool> promise;
-    client_->DeleteResources(request, [&promise](const Status &status,
-                                                 const rpc::DeleteResourcesReply &reply) {
+    client_->DeleteResources(request, [&promise](const Status& status,
+                                                 const rpc::DeleteResourcesReply& reply) {
       RAY_CHECK_OK(status);
       promise.set_value(true);
     });
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  std::map<std::string, gcs::ResourceTableData> GetResources(const std::string &node_id) {
+  std::map<std::string, gcs::ResourceTableData> GetResources(const std::string& node_id) {
     rpc::GetResourcesRequest request;
     request.set_node_id(node_id);
     std::map<std::string, gcs::ResourceTableData> resources;
     std::promise<bool> promise;
     client_->GetResources(request,
-                          [&resources, &promise](const Status &status,
-                                                 const rpc::GetResourcesReply &reply) {
+                          [&resources, &promise](const Status& status,
+                                                 const rpc::GetResourcesReply& reply) {
                             RAY_CHECK_OK(status);
-                            for (auto &resource : reply.resources()) {
+                            for (auto& resource : reply.resources()) {
                               resources[resource.first] = resource.second;
                             }
                             promise.set_value(true);
@@ -262,11 +262,11 @@ class GcsServerTest : public ::testing::Test {
     return resources;
   }
 
-  bool AddObjectLocation(const rpc::AddObjectLocationRequest &request) {
+  bool AddObjectLocation(const rpc::AddObjectLocationRequest& request) {
     std::promise<bool> promise;
     client_->AddObjectLocation(
         request,
-        [&promise](const Status &status, const rpc::AddObjectLocationReply &reply) {
+        [&promise](const Status& status, const rpc::AddObjectLocationReply& reply) {
           RAY_CHECK_OK(status);
           promise.set_value(true);
         });
@@ -274,11 +274,11 @@ class GcsServerTest : public ::testing::Test {
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool RemoveObjectLocation(const rpc::RemoveObjectLocationRequest &request) {
+  bool RemoveObjectLocation(const rpc::RemoveObjectLocationRequest& request) {
     std::promise<bool> promise;
     client_->RemoveObjectLocation(
         request,
-        [&promise](const Status &status, const rpc::RemoveObjectLocationReply &reply) {
+        [&promise](const Status& status, const rpc::RemoveObjectLocationReply& reply) {
           RAY_CHECK_OK(status);
           promise.set_value(true);
         });
@@ -286,14 +286,14 @@ class GcsServerTest : public ::testing::Test {
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  std::vector<rpc::ObjectTableData> GetObjectLocations(const std::string &object_id) {
+  std::vector<rpc::ObjectTableData> GetObjectLocations(const std::string& object_id) {
     std::vector<rpc::ObjectTableData> object_locations;
     rpc::GetObjectLocationsRequest request;
     request.set_object_id(object_id);
     std::promise<bool> promise;
     client_->GetObjectLocations(
         request, [&object_locations, &promise](
-                     const Status &status, const rpc::GetObjectLocationsReply &reply) {
+                     const Status& status, const rpc::GetObjectLocationsReply& reply) {
           RAY_CHECK_OK(status);
           for (int index = 0; index < reply.object_table_data_list_size(); ++index) {
             object_locations.push_back(reply.object_table_data_list(index));
@@ -305,23 +305,23 @@ class GcsServerTest : public ::testing::Test {
     return object_locations;
   }
 
-  bool AddTask(const rpc::AddTaskRequest &request) {
+  bool AddTask(const rpc::AddTaskRequest& request) {
     std::promise<bool> promise;
     client_->AddTask(request,
-                     [&promise](const Status &status, const rpc::AddTaskReply &reply) {
+                     [&promise](const Status& status, const rpc::AddTaskReply& reply) {
                        RAY_CHECK_OK(status);
                        promise.set_value(true);
                      });
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  rpc::TaskTableData GetTask(const std::string &task_id) {
+  rpc::TaskTableData GetTask(const std::string& task_id) {
     rpc::TaskTableData task_data;
     rpc::GetTaskRequest request;
     request.set_task_id(task_id);
     std::promise<bool> promise;
-    client_->GetTask(request, [&task_data, &promise](const Status &status,
-                                                     const rpc::GetTaskReply &reply) {
+    client_->GetTask(request, [&task_data, &promise](const Status& status,
+                                                     const rpc::GetTaskReply& reply) {
       if (status.ok()) {
         if (reply.has_task_data()) {
           task_data.CopyFrom(reply.task_data());
@@ -334,76 +334,76 @@ class GcsServerTest : public ::testing::Test {
     return task_data;
   }
 
-  bool DeleteTasks(const rpc::DeleteTasksRequest &request) {
+  bool DeleteTasks(const rpc::DeleteTasksRequest& request) {
     std::promise<bool> promise;
     client_->DeleteTasks(
-        request, [&promise](const Status &status, const rpc::DeleteTasksReply &reply) {
+        request, [&promise](const Status& status, const rpc::DeleteTasksReply& reply) {
           RAY_CHECK_OK(status);
           promise.set_value(true);
         });
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool AddTaskLease(const rpc::AddTaskLeaseRequest &request) {
+  bool AddTaskLease(const rpc::AddTaskLeaseRequest& request) {
     std::promise<bool> promise;
     client_->AddTaskLease(
-        request, [&promise](const Status &status, const rpc::AddTaskLeaseReply &reply) {
+        request, [&promise](const Status& status, const rpc::AddTaskLeaseReply& reply) {
           RAY_CHECK_OK(status);
           promise.set_value(true);
         });
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool AttemptTaskReconstruction(const rpc::AttemptTaskReconstructionRequest &request) {
+  bool AttemptTaskReconstruction(const rpc::AttemptTaskReconstructionRequest& request) {
     std::promise<bool> promise;
     client_->AttemptTaskReconstruction(
-        request, [&promise](const Status &status,
-                            const rpc::AttemptTaskReconstructionReply &reply) {
+        request, [&promise](const Status& status,
+                            const rpc::AttemptTaskReconstructionReply& reply) {
           RAY_CHECK_OK(status);
           promise.set_value(true);
         });
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool AddProfileData(const rpc::AddProfileDataRequest &request) {
+  bool AddProfileData(const rpc::AddProfileDataRequest& request) {
     std::promise<bool> promise;
     client_->AddProfileData(
-        request, [&promise](const Status &status, const rpc::AddProfileDataReply &reply) {
+        request, [&promise](const Status& status, const rpc::AddProfileDataReply& reply) {
           RAY_CHECK_OK(status);
           promise.set_value(true);
         });
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool ReportJobError(const rpc::ReportJobErrorRequest &request) {
+  bool ReportJobError(const rpc::ReportJobErrorRequest& request) {
     std::promise<bool> promise;
     client_->ReportJobError(
-        request, [&promise](const Status &status, const rpc::ReportJobErrorReply &reply) {
+        request, [&promise](const Status& status, const rpc::ReportJobErrorReply& reply) {
           RAY_CHECK_OK(status);
           promise.set_value(true);
         });
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool ReportWorkerFailure(const rpc::ReportWorkerFailureRequest &request) {
+  bool ReportWorkerFailure(const rpc::ReportWorkerFailureRequest& request) {
     std::promise<bool> promise;
     client_->ReportWorkerFailure(
         request,
-        [&promise](const Status &status, const rpc::ReportWorkerFailureReply &reply) {
+        [&promise](const Status& status, const rpc::ReportWorkerFailureReply& reply) {
           RAY_CHECK_OK(status);
           promise.set_value(status.ok());
         });
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  boost::optional<rpc::WorkerTableData> GetWorkerInfo(const std::string &worker_id) {
+  boost::optional<rpc::WorkerTableData> GetWorkerInfo(const std::string& worker_id) {
     rpc::GetWorkerInfoRequest request;
     request.set_worker_id(worker_id);
     boost::optional<rpc::WorkerTableData> worker_table_data_opt;
     std::promise<bool> promise;
     client_->GetWorkerInfo(
         request, [&worker_table_data_opt, &promise](
-                     const Status &status, const rpc::GetWorkerInfoReply &reply) {
+                     const Status& status, const rpc::GetWorkerInfoReply& reply) {
           RAY_CHECK_OK(status);
           if (reply.has_worker_table_data()) {
             worker_table_data_opt = reply.worker_table_data();
@@ -421,8 +421,8 @@ class GcsServerTest : public ::testing::Test {
     rpc::GetAllWorkerInfoRequest request;
     std::promise<bool> promise;
     client_->GetAllWorkerInfo(
-        request, [&worker_table_data, &promise](const Status &status,
-                                                const rpc::GetAllWorkerInfoReply &reply) {
+        request, [&worker_table_data, &promise](const Status& status,
+                                                const rpc::GetAllWorkerInfoReply& reply) {
           RAY_CHECK_OK(status);
           for (int index = 0; index < reply.worker_table_data_size(); ++index) {
             worker_table_data.push_back(reply.worker_table_data(index));
@@ -433,17 +433,17 @@ class GcsServerTest : public ::testing::Test {
     return worker_table_data;
   }
 
-  bool AddWorkerInfo(const rpc::AddWorkerInfoRequest &request) {
+  bool AddWorkerInfo(const rpc::AddWorkerInfoRequest& request) {
     std::promise<bool> promise;
     client_->AddWorkerInfo(
-        request, [&promise](const Status &status, const rpc::AddWorkerInfoReply &reply) {
+        request, [&promise](const Status& status, const rpc::AddWorkerInfoReply& reply) {
           RAY_CHECK_OK(status);
           promise.set_value(true);
         });
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  bool WaitReady(const std::future<bool> &future, uint64_t timeout_ms) {
+  bool WaitReady(const std::future<bool>& future, uint64_t timeout_ms) {
     auto status = future.wait_for(std::chrono::milliseconds(timeout_ms));
     return status == std::future_status::ready;
   }
@@ -793,7 +793,7 @@ TEST_F(GcsServerTest, TestWorkerInfo) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   RAY_CHECK(argc == 4);
   ray::TEST_REDIS_SERVER_EXEC_PATH = argv[1];

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -34,7 +34,7 @@ struct GcsServerMocker {
    public:
     void PushNormalTask(
         std::unique_ptr<rpc::PushTaskRequest> request,
-        const rpc::ClientCallback<rpc::PushTaskReply> &callback) override {
+        const rpc::ClientCallback<rpc::PushTaskReply>& callback) override {
       callbacks.push_back(callback);
     }
 
@@ -57,7 +57,7 @@ struct GcsServerMocker {
 
   class MockRayletClient : public WorkerLeaseInterface {
    public:
-    ray::Status ReturnWorker(int worker_port, const WorkerID &worker_id,
+    ray::Status ReturnWorker(int worker_port, const WorkerID& worker_id,
                              bool disconnect_worker) override {
       if (disconnect_worker) {
         num_workers_disconnected++;
@@ -68,22 +68,22 @@ struct GcsServerMocker {
     }
 
     void RequestWorkerLease(
-        const ray::TaskSpecification &resource_spec,
-        const rpc::ClientCallback<rpc::RequestWorkerLeaseReply> &callback) override {
+        const ray::TaskSpecification& resource_spec,
+        const rpc::ClientCallback<rpc::RequestWorkerLeaseReply>& callback) override {
       num_workers_requested += 1;
       callbacks.push_back(callback);
     }
 
     void ReleaseUnusedWorkers(
-        const std::vector<WorkerID> &workers_in_use,
-        const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply> &callback) override {
+        const std::vector<WorkerID>& workers_in_use,
+        const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply>& callback) override {
       num_release_unused_workers += 1;
       release_callbacks.push_back(callback);
     }
 
     void CancelWorkerLease(
-        const TaskID &task_id,
-        const rpc::ClientCallback<rpc::CancelWorkerLeaseReply> &callback) override {
+        const TaskID& task_id,
+        const rpc::ClientCallback<rpc::CancelWorkerLeaseReply>& callback) override {
       num_leases_canceled += 1;
       cancel_callbacks.push_back(callback);
     }
@@ -93,8 +93,8 @@ struct GcsServerMocker {
     }
 
     // Trigger reply to RequestWorkerLease.
-    bool GrantWorkerLease(const std::string &address, int port, const WorkerID &worker_id,
-                          const ClientID &raylet_id, const ClientID &retry_at_raylet_id,
+    bool GrantWorkerLease(const std::string& address, int port, const WorkerID& worker_id,
+                          const ClientID& raylet_id, const ClientID& retry_at_raylet_id,
                           Status status = Status::OK()) {
       rpc::RequestWorkerLeaseReply reply;
       if (!retry_at_raylet_id.IsNil()) {
@@ -159,16 +159,16 @@ struct GcsServerMocker {
   class MockRayletResourceClient : public ResourceReserveInterface {
    public:
     void RequestResourceReserve(
-        const BundleSpecification &bundle_spec,
-        const ray::rpc::ClientCallback<ray::rpc::RequestResourceReserveReply> &callback)
+        const BundleSpecification& bundle_spec,
+        const ray::rpc::ClientCallback<ray::rpc::RequestResourceReserveReply>& callback)
         override {
       num_lease_requested += 1;
       lease_callbacks.push_back(callback);
     }
 
     void CancelResourceReserve(
-        BundleSpecification &bundle_spec,
-        const ray::rpc::ClientCallback<ray::rpc::CancelResourceReserveReply> &callback)
+        BundleSpecification& bundle_spec,
+        const ray::rpc::ClientCallback<ray::rpc::CancelResourceReserveReply>& callback)
         override {
       num_return_requested += 1;
       return_callbacks.push_back(callback);
@@ -248,8 +248,8 @@ struct GcsServerMocker {
     MockedGcsActorTable(std::shared_ptr<gcs::StoreClient> store_client)
         : GcsActorTable(store_client) {}
 
-    Status Put(const ActorID &key, const rpc::ActorTableData &value,
-               const gcs::StatusCallback &callback) override {
+    Status Put(const ActorID& key, const rpc::ActorTableData& value,
+               const gcs::StatusCallback& callback) override {
       auto status = Status::OK();
       callback(status);
       return status;
@@ -263,29 +263,29 @@ struct GcsServerMocker {
 
   class MockedNodeInfoAccessor : public gcs::NodeInfoAccessor {
    public:
-    Status RegisterSelf(const rpc::GcsNodeInfo &local_node_info) override {
+    Status RegisterSelf(const rpc::GcsNodeInfo& local_node_info) override {
       return Status::NotImplemented("");
     }
 
     Status UnregisterSelf() override { return Status::NotImplemented(""); }
 
-    const ClientID &GetSelfId() const override {
+    const ClientID& GetSelfId() const override {
       static ClientID node_id;
       return node_id;
     }
 
-    const rpc::GcsNodeInfo &GetSelfInfo() const override {
+    const rpc::GcsNodeInfo& GetSelfInfo() const override {
       static rpc::GcsNodeInfo node_info;
       return node_info;
     }
 
-    Status AsyncRegister(const rpc::GcsNodeInfo &node_info,
-                         const gcs::StatusCallback &callback) override {
+    Status AsyncRegister(const rpc::GcsNodeInfo& node_info,
+                         const gcs::StatusCallback& callback) override {
       return Status::NotImplemented("");
     }
 
-    Status AsyncUnregister(const ClientID &node_id,
-                           const gcs::StatusCallback &callback) override {
+    Status AsyncUnregister(const ClientID& node_id,
+                           const gcs::StatusCallback& callback) override {
       if (callback) {
         callback(Status::OK());
       }
@@ -293,7 +293,7 @@ struct GcsServerMocker {
     }
 
     Status AsyncGetAll(
-        const gcs::MultiItemCallback<rpc::GcsNodeInfo> &callback) override {
+        const gcs::MultiItemCallback<rpc::GcsNodeInfo>& callback) override {
       if (callback) {
         callback(Status::OK(), {});
       }
@@ -301,59 +301,59 @@ struct GcsServerMocker {
     }
 
     Status AsyncSubscribeToNodeChange(
-        const gcs::SubscribeCallback<ClientID, rpc::GcsNodeInfo> &subscribe,
-        const gcs::StatusCallback &done) override {
+        const gcs::SubscribeCallback<ClientID, rpc::GcsNodeInfo>& subscribe,
+        const gcs::StatusCallback& done) override {
       return Status::NotImplemented("");
     }
 
-    boost::optional<rpc::GcsNodeInfo> Get(const ClientID &node_id) const override {
+    boost::optional<rpc::GcsNodeInfo> Get(const ClientID& node_id) const override {
       return boost::none;
     }
 
-    const std::unordered_map<ClientID, rpc::GcsNodeInfo> &GetAll() const override {
+    const std::unordered_map<ClientID, rpc::GcsNodeInfo>& GetAll() const override {
       static std::unordered_map<ClientID, rpc::GcsNodeInfo> node_info_list;
       return node_info_list;
     }
 
-    bool IsRemoved(const ClientID &node_id) const override { return false; }
+    bool IsRemoved(const ClientID& node_id) const override { return false; }
 
     Status AsyncGetResources(
-        const ClientID &node_id,
-        const gcs::OptionalItemCallback<ResourceMap> &callback) override {
+        const ClientID& node_id,
+        const gcs::OptionalItemCallback<ResourceMap>& callback) override {
       return Status::NotImplemented("");
     }
 
-    Status AsyncUpdateResources(const ClientID &node_id, const ResourceMap &resources,
-                                const gcs::StatusCallback &callback) override {
+    Status AsyncUpdateResources(const ClientID& node_id, const ResourceMap& resources,
+                                const gcs::StatusCallback& callback) override {
       return Status::NotImplemented("");
     }
 
-    Status AsyncDeleteResources(const ClientID &node_id,
-                                const std::vector<std::string> &resource_names,
-                                const gcs::StatusCallback &callback) override {
+    Status AsyncDeleteResources(const ClientID& node_id,
+                                const std::vector<std::string>& resource_names,
+                                const gcs::StatusCallback& callback) override {
       return Status::NotImplemented("");
     }
 
     Status AsyncSubscribeToResources(
-        const gcs::ItemCallback<rpc::NodeResourceChange> &subscribe,
-        const gcs::StatusCallback &done) override {
+        const gcs::ItemCallback<rpc::NodeResourceChange>& subscribe,
+        const gcs::StatusCallback& done) override {
       return Status::NotImplemented("");
     }
 
-    Status AsyncReportHeartbeat(const std::shared_ptr<rpc::HeartbeatTableData> &data_ptr,
-                                const gcs::StatusCallback &callback) override {
+    Status AsyncReportHeartbeat(const std::shared_ptr<rpc::HeartbeatTableData>& data_ptr,
+                                const gcs::StatusCallback& callback) override {
       return Status::NotImplemented("");
     }
 
     Status AsyncSubscribeHeartbeat(
-        const gcs::SubscribeCallback<ClientID, rpc::HeartbeatTableData> &subscribe,
-        const gcs::StatusCallback &done) override {
+        const gcs::SubscribeCallback<ClientID, rpc::HeartbeatTableData>& subscribe,
+        const gcs::StatusCallback& done) override {
       return Status::NotImplemented("");
     }
 
     Status AsyncReportBatchHeartbeat(
-        const std::shared_ptr<rpc::HeartbeatBatchTableData> &data_ptr,
-        const gcs::StatusCallback &callback) override {
+        const std::shared_ptr<rpc::HeartbeatBatchTableData>& data_ptr,
+        const gcs::StatusCallback& callback) override {
       if (callback) {
         callback(Status::OK());
       }
@@ -361,8 +361,8 @@ struct GcsServerMocker {
     }
 
     Status AsyncSubscribeBatchHeartbeat(
-        const gcs::ItemCallback<rpc::HeartbeatBatchTableData> &subscribe,
-        const gcs::StatusCallback &done) override {
+        const gcs::ItemCallback<rpc::HeartbeatBatchTableData>& subscribe,
+        const gcs::StatusCallback& done) override {
       return Status::NotImplemented("");
     }
 
@@ -371,8 +371,8 @@ struct GcsServerMocker {
 
   class MockedErrorInfoAccessor : public gcs::ErrorInfoAccessor {
    public:
-    Status AsyncReportJobError(const std::shared_ptr<rpc::ErrorTableData> &data_ptr,
-                               const gcs::StatusCallback &callback) override {
+    Status AsyncReportJobError(const std::shared_ptr<rpc::ErrorTableData>& data_ptr,
+                               const gcs::StatusCallback& callback) override {
       if (callback) {
         callback(Status::OK());
       }
@@ -385,8 +385,8 @@ struct GcsServerMocker {
     MockGcsPubSub(std::shared_ptr<gcs::RedisClient> redis_client)
         : GcsPubSub(redis_client) {}
 
-    Status Publish(const std::string &channel, const std::string &id,
-                   const std::string &data, const gcs::StatusCallback &done) override {
+    Status Publish(const std::string& channel, const std::string& id,
+                   const std::string& data, const gcs::StatusCallback& done) override {
       return Status::OK();
     }
   };

--- a/src/ray/gcs/gcs_server/test/gcs_table_storage_test_base.h
+++ b/src/ray/gcs/gcs_server/test/gcs_table_storage_test_base.h
@@ -78,17 +78,17 @@ class GcsTableStorageTestBase : public ::testing::Test {
   }
 
   template <typename TABLE, typename KEY, typename VALUE>
-  void Put(TABLE &table, const KEY &key, const VALUE &value) {
-    auto on_done = [this](const Status &status) { --pending_count_; };
+  void Put(TABLE& table, const KEY& key, const VALUE& value) {
+    auto on_done = [this](const Status& status) { --pending_count_; };
     ++pending_count_;
     RAY_CHECK_OK(table.Put(key, value, on_done));
     WaitPendingDone();
   }
 
   template <typename TABLE, typename KEY, typename VALUE>
-  int Get(TABLE &table, const KEY &key, std::vector<VALUE> &values) {
-    auto on_done = [this, &values](const Status &status,
-                                   const boost::optional<VALUE> &result) {
+  int Get(TABLE& table, const KEY& key, std::vector<VALUE>& values) {
+    auto on_done = [this, &values](const Status& status,
+                                   const boost::optional<VALUE>& result) {
       RAY_CHECK_OK(status);
       values.clear();
       if (result) {
@@ -106,12 +106,12 @@ class GcsTableStorageTestBase : public ::testing::Test {
   }
 
   template <typename TABLE, typename KEY, typename VALUE>
-  int GetByJobId(TABLE &table, const JobID &job_id, const KEY &key,
-                 std::vector<VALUE> &values) {
-    auto on_done = [this, &values](const std::unordered_map<KEY, VALUE> &result) {
+  int GetByJobId(TABLE& table, const JobID& job_id, const KEY& key,
+                 std::vector<VALUE>& values) {
+    auto on_done = [this, &values](const std::unordered_map<KEY, VALUE>& result) {
       values.clear();
       if (!result.empty()) {
-        for (auto &item : result) {
+        for (auto& item : result) {
           values.push_back(item.second);
         }
       }
@@ -127,8 +127,8 @@ class GcsTableStorageTestBase : public ::testing::Test {
   }
 
   template <typename TABLE, typename KEY>
-  void Delete(TABLE &table, const KEY &key) {
-    auto on_done = [this](const Status &status) {
+  void Delete(TABLE& table, const KEY& key) {
+    auto on_done = [this](const Status& status) {
       RAY_CHECK_OK(status);
       --pending_count_;
     };
@@ -139,7 +139,7 @@ class GcsTableStorageTestBase : public ::testing::Test {
 
   void WaitPendingDone() { WaitPendingDone(pending_count_); }
 
-  void WaitPendingDone(std::atomic<int> &pending_count) {
+  void WaitPendingDone(std::atomic<int>& pending_count) {
     auto condition = [&pending_count]() { return pending_count == 0; };
     EXPECT_TRUE(WaitForCondition(condition, wait_pending_timeout_.count()));
   }

--- a/src/ray/gcs/gcs_server/test/in_memory_gcs_table_storage_test.cc
+++ b/src/ray/gcs/gcs_server/test/in_memory_gcs_table_storage_test.cc
@@ -36,7 +36,7 @@ TEST_F(InMemoryGcsTableStorageTest, TestGcsTableWithJobIdApi) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/gcs/gcs_server/test/redis_gcs_table_storage_test.cc
+++ b/src/ray/gcs/gcs_server/test/redis_gcs_table_storage_test.cc
@@ -47,7 +47,7 @@ TEST_F(RedisGcsTableStorageTest, TestGcsTableWithJobIdApi) { TestGcsTableWithJob
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   RAY_CHECK(argc == 4);
   ray::TEST_REDIS_SERVER_EXEC_PATH = argv[1];

--- a/src/ray/gcs/pb_util.h
+++ b/src/ray/gcs/pb_util.h
@@ -33,9 +33,9 @@ namespace gcs {
 /// \param driver_pid Process ID of the driver running this job.
 /// \return The job table data created by this method.
 inline std::shared_ptr<ray::rpc::JobTableData> CreateJobTableData(
-    const ray::JobID &job_id, bool is_dead, int64_t timestamp,
-    const std::string &driver_ip_address, int64_t driver_pid,
-    const ray::rpc::JobConfigs &job_configs = {}) {
+    const ray::JobID& job_id, bool is_dead, int64_t timestamp,
+    const std::string& driver_ip_address, int64_t driver_pid,
+    const ray::rpc::JobConfigs& job_configs = {}) {
   auto job_info_ptr = std::make_shared<ray::rpc::JobTableData>();
   job_info_ptr->set_job_id(job_id.Binary());
   job_info_ptr->set_is_dead(is_dead);
@@ -48,8 +48,8 @@ inline std::shared_ptr<ray::rpc::JobTableData> CreateJobTableData(
 
 /// Helper function to produce error table data.
 inline std::shared_ptr<ray::rpc::ErrorTableData> CreateErrorTableData(
-    const std::string &error_type, const std::string &error_msg, double timestamp,
-    const JobID &job_id = JobID::Nil()) {
+    const std::string& error_type, const std::string& error_msg, double timestamp,
+    const JobID& job_id = JobID::Nil()) {
   auto error_info_ptr = std::make_shared<ray::rpc::ErrorTableData>();
   error_info_ptr->set_type(error_type);
   error_info_ptr->set_error_message(error_msg);
@@ -60,7 +60,7 @@ inline std::shared_ptr<ray::rpc::ErrorTableData> CreateErrorTableData(
 
 /// Helper function to produce actor table data.
 inline std::shared_ptr<ray::rpc::ActorTableData> CreateActorTableData(
-    const TaskSpecification &task_spec, const ray::rpc::Address &address,
+    const TaskSpecification& task_spec, const ray::rpc::Address& address,
     ray::rpc::ActorTableData::ActorState state, uint64_t num_restarts) {
   RAY_CHECK(task_spec.IsActorCreationTask());
   auto actor_id = task_spec.ActorCreationId();
@@ -85,7 +85,7 @@ inline std::shared_ptr<ray::rpc::ActorTableData> CreateActorTableData(
 
 /// Helper function to produce worker failure data.
 inline std::shared_ptr<ray::rpc::WorkerTableData> CreateWorkerFailureData(
-    const ClientID &raylet_id, const WorkerID &worker_id, const std::string &address,
+    const ClientID& raylet_id, const WorkerID& worker_id, const std::string& address,
     int32_t port, int64_t timestamp = std::time(nullptr),
     bool intentional_disconnect = false) {
   auto worker_failure_info_ptr = std::make_shared<ray::rpc::WorkerTableData>();
@@ -104,7 +104,7 @@ inline std::shared_ptr<ray::rpc::WorkerTableData> CreateWorkerFailureData(
 /// \param is_add Whether the object is appeared on the node.
 /// \return The object location change created by this method.
 inline std::shared_ptr<ray::rpc::ObjectLocationChange> CreateObjectLocationChange(
-    const ClientID &node_id, bool is_add) {
+    const ClientID& node_id, bool is_add) {
   ray::rpc::ObjectTableData object_table_data;
   object_table_data.set_manager(node_id.Binary());
   auto object_location_change = std::make_shared<ray::rpc::ObjectLocationChange>();

--- a/src/ray/gcs/pubsub/gcs_pub_sub.cc
+++ b/src/ray/gcs/pubsub/gcs_pub_sub.cc
@@ -17,8 +17,8 @@
 namespace ray {
 namespace gcs {
 
-Status GcsPubSub::Publish(const std::string &channel, const std::string &id,
-                          const std::string &data, const StatusCallback &done) {
+Status GcsPubSub::Publish(const std::string& channel, const std::string& id,
+                          const std::string& data, const StatusCallback& done) {
   rpc::PubSubMessage message;
   message.set_id(id);
   message.set_data(data);
@@ -34,17 +34,17 @@ Status GcsPubSub::Publish(const std::string &channel, const std::string &id,
       message.SerializeAsString(), on_done);
 }
 
-Status GcsPubSub::Subscribe(const std::string &channel, const std::string &id,
-                            const Callback &subscribe, const StatusCallback &done) {
+Status GcsPubSub::Subscribe(const std::string& channel, const std::string& id,
+                            const Callback& subscribe, const StatusCallback& done) {
   return SubscribeInternal(channel, subscribe, done, boost::optional<std::string>(id));
 }
 
-Status GcsPubSub::SubscribeAll(const std::string &channel, const Callback &subscribe,
-                               const StatusCallback &done) {
+Status GcsPubSub::SubscribeAll(const std::string& channel, const Callback& subscribe,
+                               const StatusCallback& done) {
   return SubscribeInternal(channel, subscribe, done);
 }
 
-Status GcsPubSub::Unsubscribe(const std::string &channel_name, const std::string &id) {
+Status GcsPubSub::Unsubscribe(const std::string& channel_name, const std::string& id) {
   std::string pattern = GenChannelPattern(channel_name, id);
 
   absl::MutexLock lock(&mutex_);
@@ -57,9 +57,9 @@ Status GcsPubSub::Unsubscribe(const std::string &channel_name, const std::string
   return ExecuteCommandIfPossible(channel->first, channel->second);
 }
 
-Status GcsPubSub::SubscribeInternal(const std::string &channel_name,
-                                    const Callback &subscribe, const StatusCallback &done,
-                                    const boost::optional<std::string> &id) {
+Status GcsPubSub::SubscribeInternal(const std::string& channel_name,
+                                    const Callback& subscribe, const StatusCallback& done,
+                                    const boost::optional<std::string>& id) {
   std::string pattern = GenChannelPattern(channel_name, id);
 
   absl::MutexLock lock(&mutex_);
@@ -77,18 +77,18 @@ Status GcsPubSub::SubscribeInternal(const std::string &channel_name,
   return ExecuteCommandIfPossible(channel->first, channel->second);
 }
 
-Status GcsPubSub::ExecuteCommandIfPossible(const std::string &channel_key,
-                                           GcsPubSub::Channel &channel) {
+Status GcsPubSub::ExecuteCommandIfPossible(const std::string& channel_key,
+                                           GcsPubSub::Channel& channel) {
   // Process the first command on the queue, if possible.
   Status status;
-  auto &command = channel.command_queue.front();
+  auto& command = channel.command_queue.front();
   if (command.is_subscribe && channel.callback_index == -1) {
     // The next command is SUBSCRIBE and we are currently unsubscribed, so we
     // can execute the command.
     int64_t callback_index =
         ray::gcs::RedisCallbackManager::instance().AllocateCallbackIndex();
-    const auto &command_done_callback = command.done_callback;
-    const auto &command_subscribe_callback = command.subscribe_callback;
+    const auto& command_done_callback = command.done_callback;
+    const auto& command_subscribe_callback = command.subscribe_callback;
     auto callback = [this, channel_key, command_done_callback, command_subscribe_callback,
                      callback_index](std::shared_ptr<CallbackReply> reply) {
       if (reply->IsNil()) {
@@ -162,8 +162,8 @@ Status GcsPubSub::ExecuteCommandIfPossible(const std::string &channel_key,
   return status;
 }
 
-std::string GcsPubSub::GenChannelPattern(const std::string &channel,
-                                         const boost::optional<std::string> &id) {
+std::string GcsPubSub::GenChannelPattern(const std::string& channel,
+                                         const boost::optional<std::string>& id) {
   std::stringstream pattern;
   pattern << channel << ":";
   if (id) {

--- a/src/ray/gcs/pubsub/gcs_pub_sub.h
+++ b/src/ray/gcs/pubsub/gcs_pub_sub.h
@@ -42,7 +42,7 @@ namespace gcs {
 class GcsPubSub {
  public:
   /// The callback is called when a subscription message is received.
-  using Callback = std::function<void(const std::string &id, const std::string &data)>;
+  using Callback = std::function<void(const std::string& id, const std::string& data)>;
 
   explicit GcsPubSub(std::shared_ptr<RedisClient> redis_client)
       : redis_client_(redis_client) {}
@@ -56,8 +56,8 @@ class GcsPubSub {
   /// \param data The data of message to be published to redis.
   /// \param done Callback that will be called when the message is published to redis.
   /// \return Status
-  virtual Status Publish(const std::string &channel, const std::string &id,
-                         const std::string &data, const StatusCallback &done);
+  virtual Status Publish(const std::string& channel, const std::string& id,
+                         const std::string& data, const StatusCallback& done);
 
   /// Subscribe to messages with the specified ID under the specified channel.
   ///
@@ -67,8 +67,8 @@ class GcsPubSub {
   /// received.
   /// \param done Callback that will be called when subscription is complete.
   /// \return Status
-  Status Subscribe(const std::string &channel, const std::string &id,
-                   const Callback &subscribe, const StatusCallback &done);
+  Status Subscribe(const std::string& channel, const std::string& id,
+                   const Callback& subscribe, const StatusCallback& done);
 
   /// Subscribe to messages with the specified channel.
   ///
@@ -77,22 +77,22 @@ class GcsPubSub {
   /// received.
   /// \param done Callback that will be called when subscription is complete.
   /// \return Status
-  Status SubscribeAll(const std::string &channel, const Callback &subscribe,
-                      const StatusCallback &done);
+  Status SubscribeAll(const std::string& channel, const Callback& subscribe,
+                      const StatusCallback& done);
 
   /// Unsubscribe to messages with the specified ID under the specified channel.
   ///
   /// \param channel The channel to unsubscribe from redis.
   /// \param id The id of message to be unsubscribed from redis.
   /// \return Status
-  Status Unsubscribe(const std::string &channel, const std::string &id);
+  Status Unsubscribe(const std::string& channel, const std::string& id);
 
  private:
   /// Represents a caller's command to subscribe or unsubscribe to a given
   /// channel.
   struct Command {
     /// SUBSCRIBE constructor.
-    Command(const Callback &subscribe_callback, const StatusCallback &done_callback)
+    Command(const Callback& subscribe_callback, const StatusCallback& done_callback)
         : is_subscribe(true),
           subscribe_callback(subscribe_callback),
           done_callback(done_callback) {}
@@ -135,16 +135,16 @@ class GcsPubSub {
   /// subscribe command can execute if the channel's callback index is not set.
   /// An unsubscribe command can execute if the channel's callback index is
   /// set.
-  Status ExecuteCommandIfPossible(const std::string &channel_key,
-                                  GcsPubSub::Channel &channel)
+  Status ExecuteCommandIfPossible(const std::string& channel_key,
+                                  GcsPubSub::Channel& channel)
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
-  Status SubscribeInternal(const std::string &channel_name, const Callback &subscribe,
-                           const StatusCallback &done,
-                           const boost::optional<std::string> &id = boost::none);
+  Status SubscribeInternal(const std::string& channel_name, const Callback& subscribe,
+                           const StatusCallback& done,
+                           const boost::optional<std::string>& id = boost::none);
 
-  std::string GenChannelPattern(const std::string &channel,
-                                const boost::optional<std::string> &id);
+  std::string GenChannelPattern(const std::string& channel,
+                                const boost::optional<std::string>& id);
 
   std::shared_ptr<RedisClient> redis_client_;
 

--- a/src/ray/gcs/pubsub/test/gcs_pub_sub_test.cc
+++ b/src/ray/gcs/pubsub/test/gcs_pub_sub_test.cc
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "ray/gcs/pubsub/gcs_pub_sub.h"
+
 #include <memory>
 
 #include "gtest/gtest.h"
 #include "ray/common/test_util.h"
-#include "ray/gcs/pubsub/gcs_pub_sub.h"
 
 namespace ray {
 

--- a/src/ray/gcs/redis_accessor.cc
+++ b/src/ray/gcs/redis_accessor.cc
@@ -25,7 +25,7 @@ namespace ray {
 namespace gcs {
 
 RedisLogBasedActorInfoAccessor::RedisLogBasedActorInfoAccessor(
-    RedisGcsClient *client_impl)
+    RedisGcsClient* client_impl)
     : client_impl_(client_impl),
       log_based_actor_sub_executor_(client_impl_->log_based_actor_table()) {}
 
@@ -33,13 +33,13 @@ std::vector<ActorID> RedisLogBasedActorInfoAccessor::GetAllActorID() const {
   return client_impl_->log_based_actor_table().GetAllActorID();
 }
 
-Status RedisLogBasedActorInfoAccessor::Get(const ActorID &actor_id,
-                                           ActorTableData *actor_table_data) const {
+Status RedisLogBasedActorInfoAccessor::Get(const ActorID& actor_id,
+                                           ActorTableData* actor_table_data) const {
   return client_impl_->log_based_actor_table().Get(actor_id, actor_table_data);
 }
 
 Status RedisLogBasedActorInfoAccessor::GetAll(
-    std::vector<ActorTableData> *actor_table_data_list) {
+    std::vector<ActorTableData>* actor_table_data_list) {
   RAY_CHECK(actor_table_data_list);
   auto actor_id_list = GetAllActorID();
   actor_table_data_list->resize(actor_id_list.size());
@@ -50,10 +50,10 @@ Status RedisLogBasedActorInfoAccessor::GetAll(
 }
 
 Status RedisLogBasedActorInfoAccessor::AsyncGet(
-    const ActorID &actor_id, const OptionalItemCallback<ActorTableData> &callback) {
+    const ActorID& actor_id, const OptionalItemCallback<ActorTableData>& callback) {
   RAY_CHECK(callback != nullptr);
-  auto on_done = [callback](RedisGcsClient *client, const ActorID &actor_id,
-                            const std::vector<ActorTableData> &data) {
+  auto on_done = [callback](RedisGcsClient* client, const ActorID& actor_id,
+                            const std::vector<ActorTableData>& data) {
     boost::optional<ActorTableData> result;
     if (!data.empty()) {
       result = data.back();
@@ -66,7 +66,7 @@ Status RedisLogBasedActorInfoAccessor::AsyncGet(
 }
 
 Status RedisLogBasedActorInfoAccessor::AsyncRegisterActor(
-    const ray::TaskSpecification &task_spec, const ray::gcs::StatusCallback &callback) {
+    const ray::TaskSpecification& task_spec, const ray::gcs::StatusCallback& callback) {
   const std::string error_msg =
       "Unsupported method of AsyncRegisterActor in RedisLogBasedActorInfoAccessor.";
   RAY_LOG(FATAL) << error_msg;
@@ -74,7 +74,7 @@ Status RedisLogBasedActorInfoAccessor::AsyncRegisterActor(
 }
 
 Status RedisLogBasedActorInfoAccessor::AsyncCreateActor(
-    const ray::TaskSpecification &task_spec, const ray::gcs::StatusCallback &callback) {
+    const ray::TaskSpecification& task_spec, const ray::gcs::StatusCallback& callback) {
   const std::string error_msg =
       "Unsupported method of AsyncCreateActor in "
       "RedisLogBasedActorInfoAccessor.";
@@ -83,16 +83,16 @@ Status RedisLogBasedActorInfoAccessor::AsyncCreateActor(
 }
 
 Status RedisLogBasedActorInfoAccessor::AsyncRegister(
-    const std::shared_ptr<ActorTableData> &data_ptr, const StatusCallback &callback) {
-  auto on_success = [callback](RedisGcsClient *client, const ActorID &actor_id,
-                               const ActorTableData &data) {
+    const std::shared_ptr<ActorTableData>& data_ptr, const StatusCallback& callback) {
+  auto on_success = [callback](RedisGcsClient* client, const ActorID& actor_id,
+                               const ActorTableData& data) {
     if (callback != nullptr) {
       callback(Status::OK());
     }
   };
 
-  auto on_failure = [callback](RedisGcsClient *client, const ActorID &actor_id,
-                               const ActorTableData &data) {
+  auto on_failure = [callback](RedisGcsClient* client, const ActorID& actor_id,
+                               const ActorTableData& data) {
     if (callback != nullptr) {
       callback(Status::Invalid("Adding actor failed."));
     }
@@ -105,8 +105,8 @@ Status RedisLogBasedActorInfoAccessor::AsyncRegister(
 }
 
 Status RedisLogBasedActorInfoAccessor::AsyncUpdate(
-    const ActorID &actor_id, const std::shared_ptr<ActorTableData> &data_ptr,
-    const StatusCallback &callback) {
+    const ActorID& actor_id, const std::shared_ptr<ActorTableData>& data_ptr,
+    const StatusCallback& callback) {
   // The actor log starts with an ALIVE entry. This is followed by 0 to N pairs
   // of (RESTARTING, ALIVE) entries, where N is the maximum number of
   // reconstructions. This is followed optionally by a DEAD entry.
@@ -117,15 +117,15 @@ Status RedisLogBasedActorInfoAccessor::AsyncUpdate(
   }
   RAY_LOG(DEBUG) << "AsyncUpdate actor state to " << data_ptr->state()
                  << ", actor id: " << actor_id << ", log_length: " << log_length;
-  auto on_success = [callback](RedisGcsClient *client, const ActorID &actor_id,
-                               const ActorTableData &data) {
+  auto on_success = [callback](RedisGcsClient* client, const ActorID& actor_id,
+                               const ActorTableData& data) {
     if (callback != nullptr) {
       callback(Status::OK());
     }
   };
 
-  auto on_failure = [callback](RedisGcsClient *client, const ActorID &actor_id,
-                               const ActorTableData &data) {
+  auto on_failure = [callback](RedisGcsClient* client, const ActorID& actor_id,
+                               const ActorTableData& data) {
     if (callback != nullptr) {
       callback(Status::Invalid("Updating actor failed."));
     }
@@ -136,33 +136,33 @@ Status RedisLogBasedActorInfoAccessor::AsyncUpdate(
 }
 
 Status RedisLogBasedActorInfoAccessor::AsyncSubscribeAll(
-    const SubscribeCallback<ActorID, ActorTableData> &subscribe,
-    const StatusCallback &done) {
+    const SubscribeCallback<ActorID, ActorTableData>& subscribe,
+    const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr);
   return log_based_actor_sub_executor_.AsyncSubscribeAll(ClientID::Nil(), subscribe,
                                                          done);
 }
 
 Status RedisLogBasedActorInfoAccessor::AsyncSubscribe(
-    const ActorID &actor_id, const SubscribeCallback<ActorID, ActorTableData> &subscribe,
-    const StatusCallback &done) {
+    const ActorID& actor_id, const SubscribeCallback<ActorID, ActorTableData>& subscribe,
+    const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr);
   return log_based_actor_sub_executor_.AsyncSubscribe(subscribe_id_, actor_id, subscribe,
                                                       done);
 }
 
-Status RedisLogBasedActorInfoAccessor::AsyncUnsubscribe(const ActorID &actor_id) {
+Status RedisLogBasedActorInfoAccessor::AsyncUnsubscribe(const ActorID& actor_id) {
   return log_based_actor_sub_executor_.AsyncUnsubscribe(subscribe_id_, actor_id, nullptr);
 }
 
 Status RedisLogBasedActorInfoAccessor::AsyncAddCheckpoint(
-    const std::shared_ptr<ActorCheckpointData> &data_ptr,
-    const StatusCallback &callback) {
+    const std::shared_ptr<ActorCheckpointData>& data_ptr,
+    const StatusCallback& callback) {
   ActorID actor_id = ActorID::FromBinary(data_ptr->actor_id());
   auto on_add_data_done = [actor_id, callback, data_ptr, this](
-                              RedisGcsClient *client,
-                              const ActorCheckpointID &checkpoint_id,
-                              const ActorCheckpointData &data) {
+                              RedisGcsClient* client,
+                              const ActorCheckpointID& checkpoint_id,
+                              const ActorCheckpointData& data) {
     Status status = AsyncAddCheckpointID(actor_id, checkpoint_id, callback);
     if (!status.ok()) {
       callback(status);
@@ -171,64 +171,64 @@ Status RedisLogBasedActorInfoAccessor::AsyncAddCheckpoint(
 
   ActorCheckpointID checkpoint_id =
       ActorCheckpointID::FromBinary(data_ptr->checkpoint_id());
-  ActorCheckpointTable &actor_cp_table = client_impl_->actor_checkpoint_table();
+  ActorCheckpointTable& actor_cp_table = client_impl_->actor_checkpoint_table();
   return actor_cp_table.Add(actor_id.JobId(), checkpoint_id, data_ptr, on_add_data_done);
 }
 
 Status RedisLogBasedActorInfoAccessor::AsyncGetCheckpoint(
-    const ActorCheckpointID &checkpoint_id, const ActorID &actor_id,
-    const OptionalItemCallback<ActorCheckpointData> &callback) {
+    const ActorCheckpointID& checkpoint_id, const ActorID& actor_id,
+    const OptionalItemCallback<ActorCheckpointData>& callback) {
   RAY_CHECK(callback != nullptr);
-  auto on_success = [callback](RedisGcsClient *client,
-                               const ActorCheckpointID &checkpoint_id,
-                               const ActorCheckpointData &checkpoint_data) {
+  auto on_success = [callback](RedisGcsClient* client,
+                               const ActorCheckpointID& checkpoint_id,
+                               const ActorCheckpointData& checkpoint_data) {
     boost::optional<ActorCheckpointData> optional(checkpoint_data);
     callback(Status::OK(), std::move(optional));
   };
 
-  auto on_failure = [callback](RedisGcsClient *client,
-                               const ActorCheckpointID &checkpoint_id) {
+  auto on_failure = [callback](RedisGcsClient* client,
+                               const ActorCheckpointID& checkpoint_id) {
     boost::optional<ActorCheckpointData> optional;
     callback(Status::Invalid("Invalid checkpoint id."), std::move(optional));
   };
 
-  ActorCheckpointTable &actor_cp_table = client_impl_->actor_checkpoint_table();
+  ActorCheckpointTable& actor_cp_table = client_impl_->actor_checkpoint_table();
   return actor_cp_table.Lookup(actor_id.JobId(), checkpoint_id, on_success, on_failure);
 }
 
 Status RedisLogBasedActorInfoAccessor::AsyncGetCheckpointID(
-    const ActorID &actor_id,
-    const OptionalItemCallback<ActorCheckpointIdData> &callback) {
+    const ActorID& actor_id,
+    const OptionalItemCallback<ActorCheckpointIdData>& callback) {
   RAY_CHECK(callback != nullptr);
-  auto on_success = [callback](RedisGcsClient *client, const ActorID &actor_id,
-                               const ActorCheckpointIdData &data) {
+  auto on_success = [callback](RedisGcsClient* client, const ActorID& actor_id,
+                               const ActorCheckpointIdData& data) {
     boost::optional<ActorCheckpointIdData> optional(data);
     callback(Status::OK(), std::move(optional));
   };
 
-  auto on_failure = [callback](RedisGcsClient *client, const ActorID &actor_id) {
+  auto on_failure = [callback](RedisGcsClient* client, const ActorID& actor_id) {
     boost::optional<ActorCheckpointIdData> optional;
     callback(Status::Invalid("Checkpoint not found."), std::move(optional));
   };
 
-  ActorCheckpointIdTable &cp_id_table = client_impl_->actor_checkpoint_id_table();
+  ActorCheckpointIdTable& cp_id_table = client_impl_->actor_checkpoint_id_table();
   return cp_id_table.Lookup(actor_id.JobId(), actor_id, on_success, on_failure);
 }
 
 Status RedisLogBasedActorInfoAccessor::AsyncAddCheckpointID(
-    const ActorID &actor_id, const ActorCheckpointID &checkpoint_id,
-    const StatusCallback &callback) {
+    const ActorID& actor_id, const ActorCheckpointID& checkpoint_id,
+    const StatusCallback& callback) {
   ActorCheckpointIdTable::WriteCallback on_done = nullptr;
   if (callback != nullptr) {
-    on_done = [callback](RedisGcsClient *client, const ActorID &actor_id,
-                         const ActorCheckpointIdData &data) { callback(Status::OK()); };
+    on_done = [callback](RedisGcsClient* client, const ActorID& actor_id,
+                         const ActorCheckpointIdData& data) { callback(Status::OK()); };
   }
 
-  ActorCheckpointIdTable &cp_id_table = client_impl_->actor_checkpoint_id_table();
+  ActorCheckpointIdTable& cp_id_table = client_impl_->actor_checkpoint_id_table();
   return cp_id_table.AddCheckpointId(actor_id.JobId(), actor_id, checkpoint_id, on_done);
 }
 
-RedisActorInfoAccessor::RedisActorInfoAccessor(RedisGcsClient *client_impl)
+RedisActorInfoAccessor::RedisActorInfoAccessor(RedisGcsClient* client_impl)
     : RedisLogBasedActorInfoAccessor(client_impl),
       actor_sub_executor_(client_impl_->actor_table()) {}
 
@@ -236,18 +236,18 @@ std::vector<ActorID> RedisActorInfoAccessor::GetAllActorID() const {
   return client_impl_->actor_table().GetAllActorID();
 }
 
-Status RedisActorInfoAccessor::Get(const ActorID &actor_id,
-                                   ActorTableData *actor_table_data) const {
+Status RedisActorInfoAccessor::Get(const ActorID& actor_id,
+                                   ActorTableData* actor_table_data) const {
   return client_impl_->actor_table().Get(actor_id, actor_table_data);
 }
 
 Status RedisActorInfoAccessor::AsyncGet(
-    const ActorID &actor_id, const OptionalItemCallback<ActorTableData> &callback) {
+    const ActorID& actor_id, const OptionalItemCallback<ActorTableData>& callback) {
   RAY_CHECK(callback != nullptr);
-  auto on_done = [callback](RedisGcsClient *client, const ActorID &actor_id,
-                            const ActorTableData &data) { callback(Status::OK(), data); };
+  auto on_done = [callback](RedisGcsClient* client, const ActorID& actor_id,
+                            const ActorTableData& data) { callback(Status::OK(), data); };
 
-  auto on_failure = [callback](RedisGcsClient *client, const ActorID &actor_id) {
+  auto on_failure = [callback](RedisGcsClient* client, const ActorID& actor_id) {
     if (callback != nullptr) {
       callback(Status::Invalid("Get actor failed."), boost::none);
     }
@@ -257,7 +257,7 @@ Status RedisActorInfoAccessor::AsyncGet(
 }
 
 Status RedisActorInfoAccessor::AsyncGetAll(
-    const MultiItemCallback<rpc::ActorTableData> &callback) {
+    const MultiItemCallback<rpc::ActorTableData>& callback) {
   RAY_CHECK(callback != nullptr);
   auto actor_id_list = GetAllActorID();
   if (actor_id_list.empty()) {
@@ -268,10 +268,10 @@ Status RedisActorInfoAccessor::AsyncGetAll(
   auto finished_count = std::make_shared<int>(0);
   auto result = std::make_shared<std::vector<ActorTableData>>();
   int size = actor_id_list.size();
-  for (auto &actor_id : actor_id_list) {
+  for (auto& actor_id : actor_id_list) {
     auto on_done = [finished_count, size, result, callback](
-                       const Status &status,
-                       const boost::optional<ActorTableData> &data) {
+                       const Status& status,
+                       const boost::optional<ActorTableData>& data) {
       ++(*finished_count);
       if (data) {
         result->push_back(*data);
@@ -287,9 +287,9 @@ Status RedisActorInfoAccessor::AsyncGetAll(
 }
 
 Status RedisActorInfoAccessor::AsyncRegister(
-    const std::shared_ptr<ActorTableData> &data_ptr, const StatusCallback &callback) {
-  auto on_register_done = [callback](RedisGcsClient *client, const ActorID &actor_id,
-                                     const ActorTableData &data) {
+    const std::shared_ptr<ActorTableData>& data_ptr, const StatusCallback& callback) {
+  auto on_register_done = [callback](RedisGcsClient* client, const ActorID& actor_id,
+                                     const ActorTableData& data) {
     if (callback != nullptr) {
       callback(Status::OK());
     }
@@ -300,10 +300,10 @@ Status RedisActorInfoAccessor::AsyncRegister(
 }
 
 Status RedisActorInfoAccessor::AsyncUpdate(
-    const ActorID &actor_id, const std::shared_ptr<ActorTableData> &data_ptr,
-    const StatusCallback &callback) {
-  auto on_update_done = [callback](RedisGcsClient *client, const ActorID &actor_id,
-                                   const ActorTableData &data) {
+    const ActorID& actor_id, const std::shared_ptr<ActorTableData>& data_ptr,
+    const StatusCallback& callback) {
+  auto on_update_done = [callback](RedisGcsClient* client, const ActorID& actor_id,
+                                   const ActorTableData& data) {
     if (callback != nullptr) {
       callback(Status::OK());
     }
@@ -313,45 +313,45 @@ Status RedisActorInfoAccessor::AsyncUpdate(
 }
 
 Status RedisActorInfoAccessor::AsyncSubscribeAll(
-    const SubscribeCallback<ActorID, ActorTableData> &subscribe,
-    const StatusCallback &done) {
+    const SubscribeCallback<ActorID, ActorTableData>& subscribe,
+    const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr);
   return actor_sub_executor_.AsyncSubscribeAll(ClientID::Nil(), subscribe, done);
 }
 
 Status RedisActorInfoAccessor::AsyncSubscribe(
-    const ActorID &actor_id, const SubscribeCallback<ActorID, ActorTableData> &subscribe,
-    const StatusCallback &done) {
+    const ActorID& actor_id, const SubscribeCallback<ActorID, ActorTableData>& subscribe,
+    const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr);
   return actor_sub_executor_.AsyncSubscribe(subscribe_id_, actor_id, subscribe, done);
 }
 
-Status RedisActorInfoAccessor::AsyncUnsubscribe(const ActorID &actor_id) {
+Status RedisActorInfoAccessor::AsyncUnsubscribe(const ActorID& actor_id) {
   return actor_sub_executor_.AsyncUnsubscribe(subscribe_id_, actor_id, nullptr);
 }
 
-RedisJobInfoAccessor::RedisJobInfoAccessor(RedisGcsClient *client_impl)
+RedisJobInfoAccessor::RedisJobInfoAccessor(RedisGcsClient* client_impl)
     : client_impl_(client_impl), job_sub_executor_(client_impl->job_table()) {}
 
-Status RedisJobInfoAccessor::AsyncAdd(const std::shared_ptr<JobTableData> &data_ptr,
-                                      const StatusCallback &callback) {
+Status RedisJobInfoAccessor::AsyncAdd(const std::shared_ptr<JobTableData>& data_ptr,
+                                      const StatusCallback& callback) {
   return DoAsyncAppend(data_ptr, callback);
 }
 
-Status RedisJobInfoAccessor::AsyncMarkFinished(const JobID &job_id,
-                                               const StatusCallback &callback) {
+Status RedisJobInfoAccessor::AsyncMarkFinished(const JobID& job_id,
+                                               const StatusCallback& callback) {
   std::shared_ptr<JobTableData> data_ptr =
       CreateJobTableData(job_id, /*is_dead*/ true, /*time_stamp*/ std::time(nullptr),
                          /*driver_ip_address*/ "", /*driver_pid*/ -1);
   return DoAsyncAppend(data_ptr, callback);
 }
 
-Status RedisJobInfoAccessor::DoAsyncAppend(const std::shared_ptr<JobTableData> &data_ptr,
-                                           const StatusCallback &callback) {
+Status RedisJobInfoAccessor::DoAsyncAppend(const std::shared_ptr<JobTableData>& data_ptr,
+                                           const StatusCallback& callback) {
   JobTable::WriteCallback on_done = nullptr;
   if (callback != nullptr) {
-    on_done = [callback](RedisGcsClient *client, const JobID &job_id,
-                         const JobTableData &data) { callback(Status::OK()); };
+    on_done = [callback](RedisGcsClient* client, const JobID& job_id,
+                         const JobTableData& data) { callback(Status::OK()); };
   }
 
   JobID job_id = JobID::FromBinary(data_ptr->job_id());
@@ -359,50 +359,50 @@ Status RedisJobInfoAccessor::DoAsyncAppend(const std::shared_ptr<JobTableData> &
 }
 
 Status RedisJobInfoAccessor::AsyncSubscribeAll(
-    const SubscribeCallback<JobID, JobTableData> &subscribe, const StatusCallback &done) {
+    const SubscribeCallback<JobID, JobTableData>& subscribe, const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr);
   return job_sub_executor_.AsyncSubscribeAll(ClientID::Nil(), subscribe, done);
 }
 
-RedisTaskInfoAccessor::RedisTaskInfoAccessor(RedisGcsClient *client_impl)
+RedisTaskInfoAccessor::RedisTaskInfoAccessor(RedisGcsClient* client_impl)
     : client_impl_(client_impl),
       task_sub_executor_(client_impl->raylet_task_table()),
       task_lease_sub_executor_(client_impl->task_lease_table()) {}
 
-Status RedisTaskInfoAccessor::AsyncAdd(const std::shared_ptr<TaskTableData> &data_ptr,
-                                       const StatusCallback &callback) {
+Status RedisTaskInfoAccessor::AsyncAdd(const std::shared_ptr<TaskTableData>& data_ptr,
+                                       const StatusCallback& callback) {
   raylet::TaskTable::WriteCallback on_done = nullptr;
   if (callback != nullptr) {
-    on_done = [callback](RedisGcsClient *client, const TaskID &task_id,
-                         const TaskTableData &data) { callback(Status::OK()); };
+    on_done = [callback](RedisGcsClient* client, const TaskID& task_id,
+                         const TaskTableData& data) { callback(Status::OK()); };
   }
 
   TaskID task_id = TaskID::FromBinary(data_ptr->task().task_spec().task_id());
-  raylet::TaskTable &task_table = client_impl_->raylet_task_table();
+  raylet::TaskTable& task_table = client_impl_->raylet_task_table();
   return task_table.Add(task_id.JobId(), task_id, data_ptr, on_done);
 }
 
 Status RedisTaskInfoAccessor::AsyncGet(
-    const TaskID &task_id, const OptionalItemCallback<TaskTableData> &callback) {
+    const TaskID& task_id, const OptionalItemCallback<TaskTableData>& callback) {
   RAY_CHECK(callback != nullptr);
-  auto on_success = [callback](RedisGcsClient *client, const TaskID &task_id,
-                               const TaskTableData &data) {
+  auto on_success = [callback](RedisGcsClient* client, const TaskID& task_id,
+                               const TaskTableData& data) {
     boost::optional<TaskTableData> result(data);
     callback(Status::OK(), result);
   };
 
-  auto on_failure = [callback](RedisGcsClient *client, const TaskID &task_id) {
+  auto on_failure = [callback](RedisGcsClient* client, const TaskID& task_id) {
     boost::optional<TaskTableData> result;
     callback(Status::Invalid("Task not exist."), result);
   };
 
-  raylet::TaskTable &task_table = client_impl_->raylet_task_table();
+  raylet::TaskTable& task_table = client_impl_->raylet_task_table();
   return task_table.Lookup(task_id.JobId(), task_id, on_success, on_failure);
 }
 
-Status RedisTaskInfoAccessor::AsyncDelete(const std::vector<TaskID> &task_ids,
-                                          const StatusCallback &callback) {
-  raylet::TaskTable &task_table = client_impl_->raylet_task_table();
+Status RedisTaskInfoAccessor::AsyncDelete(const std::vector<TaskID>& task_ids,
+                                          const StatusCallback& callback) {
+  raylet::TaskTable& task_table = client_impl_->raylet_task_table();
   JobID job_id = task_ids.empty() ? JobID::Nil() : task_ids[0].JobId();
   task_table.Delete(job_id, task_ids);
   if (callback) {
@@ -414,206 +414,206 @@ Status RedisTaskInfoAccessor::AsyncDelete(const std::vector<TaskID> &task_ids,
 }
 
 Status RedisTaskInfoAccessor::AsyncSubscribe(
-    const TaskID &task_id, const SubscribeCallback<TaskID, TaskTableData> &subscribe,
-    const StatusCallback &done) {
+    const TaskID& task_id, const SubscribeCallback<TaskID, TaskTableData>& subscribe,
+    const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr);
   return task_sub_executor_.AsyncSubscribe(subscribe_id_, task_id, subscribe, done);
 }
 
-Status RedisTaskInfoAccessor::AsyncUnsubscribe(const TaskID &task_id) {
+Status RedisTaskInfoAccessor::AsyncUnsubscribe(const TaskID& task_id) {
   return task_sub_executor_.AsyncUnsubscribe(subscribe_id_, task_id, nullptr);
 }
 
 Status RedisTaskInfoAccessor::AsyncAddTaskLease(
-    const std::shared_ptr<TaskLeaseData> &data_ptr, const StatusCallback &callback) {
+    const std::shared_ptr<TaskLeaseData>& data_ptr, const StatusCallback& callback) {
   TaskLeaseTable::WriteCallback on_done = nullptr;
   if (callback != nullptr) {
-    on_done = [callback](RedisGcsClient *client, const TaskID &id,
-                         const TaskLeaseData &data) { callback(Status::OK()); };
+    on_done = [callback](RedisGcsClient* client, const TaskID& id,
+                         const TaskLeaseData& data) { callback(Status::OK()); };
   }
   TaskID task_id = TaskID::FromBinary(data_ptr->task_id());
-  TaskLeaseTable &task_lease_table = client_impl_->task_lease_table();
+  TaskLeaseTable& task_lease_table = client_impl_->task_lease_table();
   return task_lease_table.Add(task_id.JobId(), task_id, data_ptr, on_done);
 }
 
 Status RedisTaskInfoAccessor::AsyncGetTaskLease(
-    const TaskID &task_id, const OptionalItemCallback<TaskLeaseData> &callback) {
+    const TaskID& task_id, const OptionalItemCallback<TaskLeaseData>& callback) {
   RAY_CHECK(callback != nullptr);
-  auto on_success = [callback](RedisGcsClient *client, const TaskID &task_id,
-                               const TaskLeaseData &data) {
+  auto on_success = [callback](RedisGcsClient* client, const TaskID& task_id,
+                               const TaskLeaseData& data) {
     boost::optional<TaskLeaseData> result(data);
     callback(Status::OK(), result);
   };
 
-  auto on_failure = [callback](RedisGcsClient *client, const TaskID &task_id) {
+  auto on_failure = [callback](RedisGcsClient* client, const TaskID& task_id) {
     boost::optional<TaskLeaseData> result;
     callback(Status::Invalid("Task lease not exist."), result);
   };
 
-  TaskLeaseTable &task_lease_table = client_impl_->task_lease_table();
+  TaskLeaseTable& task_lease_table = client_impl_->task_lease_table();
   return task_lease_table.Lookup(task_id.JobId(), task_id, on_success, on_failure);
 }
 
 Status RedisTaskInfoAccessor::AsyncSubscribeTaskLease(
-    const TaskID &task_id,
-    const SubscribeCallback<TaskID, boost::optional<TaskLeaseData>> &subscribe,
-    const StatusCallback &done) {
+    const TaskID& task_id,
+    const SubscribeCallback<TaskID, boost::optional<TaskLeaseData>>& subscribe,
+    const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr);
   return task_lease_sub_executor_.AsyncSubscribe(subscribe_id_, task_id, subscribe, done);
 }
 
-Status RedisTaskInfoAccessor::AsyncUnsubscribeTaskLease(const TaskID &task_id) {
+Status RedisTaskInfoAccessor::AsyncUnsubscribeTaskLease(const TaskID& task_id) {
   return task_lease_sub_executor_.AsyncUnsubscribe(subscribe_id_, task_id, nullptr);
 }
 
 Status RedisTaskInfoAccessor::AttemptTaskReconstruction(
-    const std::shared_ptr<TaskReconstructionData> &data_ptr,
-    const StatusCallback &callback) {
+    const std::shared_ptr<TaskReconstructionData>& data_ptr,
+    const StatusCallback& callback) {
   TaskReconstructionLog::WriteCallback on_success = nullptr;
   TaskReconstructionLog::WriteCallback on_failure = nullptr;
   if (callback != nullptr) {
-    on_success = [callback](RedisGcsClient *client, const TaskID &id,
-                            const TaskReconstructionData &data) {
+    on_success = [callback](RedisGcsClient* client, const TaskID& id,
+                            const TaskReconstructionData& data) {
       callback(Status::OK());
     };
-    on_failure = [callback](RedisGcsClient *client, const TaskID &id,
-                            const TaskReconstructionData &data) {
+    on_failure = [callback](RedisGcsClient* client, const TaskID& id,
+                            const TaskReconstructionData& data) {
       callback(Status::Invalid("Updating task reconstruction failed."));
     };
   }
 
   TaskID task_id = TaskID::FromBinary(data_ptr->task_id());
   int reconstruction_attempt = data_ptr->num_reconstructions();
-  TaskReconstructionLog &task_reconstruction_log =
+  TaskReconstructionLog& task_reconstruction_log =
       client_impl_->task_reconstruction_log();
   return task_reconstruction_log.AppendAt(task_id.JobId(), task_id, data_ptr, on_success,
                                           on_failure, reconstruction_attempt);
 }
 
-RedisObjectInfoAccessor::RedisObjectInfoAccessor(RedisGcsClient *client_impl)
+RedisObjectInfoAccessor::RedisObjectInfoAccessor(RedisGcsClient* client_impl)
     : client_impl_(client_impl), object_sub_executor_(client_impl->object_table()) {}
 
 Status RedisObjectInfoAccessor::AsyncGetLocations(
-    const ObjectID &object_id, const MultiItemCallback<ObjectTableData> &callback) {
+    const ObjectID& object_id, const MultiItemCallback<ObjectTableData>& callback) {
   RAY_CHECK(callback != nullptr);
-  auto on_done = [callback](RedisGcsClient *client, const ObjectID &object_id,
-                            const std::vector<ObjectTableData> &data) {
+  auto on_done = [callback](RedisGcsClient* client, const ObjectID& object_id,
+                            const std::vector<ObjectTableData>& data) {
     callback(Status::OK(), data);
   };
 
-  ObjectTable &object_table = client_impl_->object_table();
+  ObjectTable& object_table = client_impl_->object_table();
   return object_table.Lookup(object_id.TaskId().JobId(), object_id, on_done);
 }
 
-Status RedisObjectInfoAccessor::AsyncAddLocation(const ObjectID &object_id,
-                                                 const ClientID &node_id,
-                                                 const StatusCallback &callback) {
-  std::function<void(RedisGcsClient * client, const ObjectID &id,
-                     const ObjectTableData &data)>
+Status RedisObjectInfoAccessor::AsyncAddLocation(const ObjectID& object_id,
+                                                 const ClientID& node_id,
+                                                 const StatusCallback& callback) {
+  std::function<void(RedisGcsClient * client, const ObjectID& id,
+                     const ObjectTableData& data)>
       on_done = nullptr;
   if (callback != nullptr) {
-    on_done = [callback](RedisGcsClient *client, const ObjectID &object_id,
-                         const ObjectTableData &data) { callback(Status::OK()); };
+    on_done = [callback](RedisGcsClient* client, const ObjectID& object_id,
+                         const ObjectTableData& data) { callback(Status::OK()); };
   }
 
   std::shared_ptr<ObjectTableData> data_ptr = std::make_shared<ObjectTableData>();
   data_ptr->set_manager(node_id.Binary());
 
-  ObjectTable &object_table = client_impl_->object_table();
+  ObjectTable& object_table = client_impl_->object_table();
   return object_table.Add(object_id.TaskId().JobId(), object_id, data_ptr, on_done);
 }
 
-Status RedisObjectInfoAccessor::AsyncRemoveLocation(const ObjectID &object_id,
-                                                    const ClientID &node_id,
-                                                    const StatusCallback &callback) {
-  std::function<void(RedisGcsClient * client, const ObjectID &id,
-                     const ObjectTableData &data)>
+Status RedisObjectInfoAccessor::AsyncRemoveLocation(const ObjectID& object_id,
+                                                    const ClientID& node_id,
+                                                    const StatusCallback& callback) {
+  std::function<void(RedisGcsClient * client, const ObjectID& id,
+                     const ObjectTableData& data)>
       on_done = nullptr;
   if (callback != nullptr) {
-    on_done = [callback](RedisGcsClient *client, const ObjectID &object_id,
-                         const ObjectTableData &data) { callback(Status::OK()); };
+    on_done = [callback](RedisGcsClient* client, const ObjectID& object_id,
+                         const ObjectTableData& data) { callback(Status::OK()); };
   }
 
   std::shared_ptr<ObjectTableData> data_ptr = std::make_shared<ObjectTableData>();
   data_ptr->set_manager(node_id.Binary());
 
-  ObjectTable &object_table = client_impl_->object_table();
+  ObjectTable& object_table = client_impl_->object_table();
   return object_table.Remove(object_id.TaskId().JobId(), object_id, data_ptr, on_done);
 }
 
 Status RedisObjectInfoAccessor::AsyncSubscribeToLocations(
-    const ObjectID &object_id,
-    const SubscribeCallback<ObjectID, ObjectChangeNotification> &subscribe,
-    const StatusCallback &done) {
+    const ObjectID& object_id,
+    const SubscribeCallback<ObjectID, ObjectChangeNotification>& subscribe,
+    const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr);
   return object_sub_executor_.AsyncSubscribe(subscribe_id_, object_id, subscribe, done);
 }
 
-Status RedisObjectInfoAccessor::AsyncUnsubscribeToLocations(const ObjectID &object_id) {
+Status RedisObjectInfoAccessor::AsyncUnsubscribeToLocations(const ObjectID& object_id) {
   return object_sub_executor_.AsyncUnsubscribe(subscribe_id_, object_id, nullptr);
 }
 
-RedisNodeInfoAccessor::RedisNodeInfoAccessor(RedisGcsClient *client_impl)
+RedisNodeInfoAccessor::RedisNodeInfoAccessor(RedisGcsClient* client_impl)
     : client_impl_(client_impl),
       resource_sub_executor_(client_impl_->resource_table()),
       heartbeat_sub_executor_(client_impl->heartbeat_table()),
       heartbeat_batch_sub_executor_(client_impl->heartbeat_batch_table()) {}
 
-Status RedisNodeInfoAccessor::RegisterSelf(const GcsNodeInfo &local_node_info) {
-  ClientTable &client_table = client_impl_->client_table();
+Status RedisNodeInfoAccessor::RegisterSelf(const GcsNodeInfo& local_node_info) {
+  ClientTable& client_table = client_impl_->client_table();
   return client_table.Connect(local_node_info);
 }
 
 Status RedisNodeInfoAccessor::UnregisterSelf() {
-  ClientTable &client_table = client_impl_->client_table();
+  ClientTable& client_table = client_impl_->client_table();
   return client_table.Disconnect();
 }
 
-const ClientID &RedisNodeInfoAccessor::GetSelfId() const {
-  ClientTable &client_table = client_impl_->client_table();
+const ClientID& RedisNodeInfoAccessor::GetSelfId() const {
+  ClientTable& client_table = client_impl_->client_table();
   return client_table.GetLocalClientId();
 }
 
-const GcsNodeInfo &RedisNodeInfoAccessor::GetSelfInfo() const {
-  ClientTable &client_table = client_impl_->client_table();
+const GcsNodeInfo& RedisNodeInfoAccessor::GetSelfInfo() const {
+  ClientTable& client_table = client_impl_->client_table();
   return client_table.GetLocalClient();
 }
 
-Status RedisNodeInfoAccessor::AsyncRegister(const GcsNodeInfo &node_info,
-                                            const StatusCallback &callback) {
+Status RedisNodeInfoAccessor::AsyncRegister(const GcsNodeInfo& node_info,
+                                            const StatusCallback& callback) {
   ClientTable::WriteCallback on_done = nullptr;
   if (callback != nullptr) {
-    on_done = [callback](RedisGcsClient *client, const ClientID &id,
-                         const GcsNodeInfo &data) { callback(Status::OK()); };
+    on_done = [callback](RedisGcsClient* client, const ClientID& id,
+                         const GcsNodeInfo& data) { callback(Status::OK()); };
   }
-  ClientTable &client_table = client_impl_->client_table();
+  ClientTable& client_table = client_impl_->client_table();
   return client_table.MarkConnected(node_info, on_done);
 }
 
-Status RedisNodeInfoAccessor::AsyncUnregister(const ClientID &node_id,
-                                              const StatusCallback &callback) {
+Status RedisNodeInfoAccessor::AsyncUnregister(const ClientID& node_id,
+                                              const StatusCallback& callback) {
   ClientTable::WriteCallback on_done = nullptr;
   if (callback != nullptr) {
-    on_done = [callback](RedisGcsClient *client, const ClientID &id,
-                         const GcsNodeInfo &data) { callback(Status::OK()); };
+    on_done = [callback](RedisGcsClient* client, const ClientID& id,
+                         const GcsNodeInfo& data) { callback(Status::OK()); };
   }
-  ClientTable &client_table = client_impl_->client_table();
+  ClientTable& client_table = client_impl_->client_table();
   return client_table.MarkDisconnected(node_id, on_done);
 }
 
 Status RedisNodeInfoAccessor::AsyncSubscribeToNodeChange(
-    const SubscribeCallback<ClientID, GcsNodeInfo> &subscribe,
-    const StatusCallback &done) {
+    const SubscribeCallback<ClientID, GcsNodeInfo>& subscribe,
+    const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr);
-  ClientTable &client_table = client_impl_->client_table();
+  ClientTable& client_table = client_impl_->client_table();
   return client_table.SubscribeToNodeChange(subscribe, done);
 }
 
 Status RedisNodeInfoAccessor::AsyncGetAll(
-    const MultiItemCallback<GcsNodeInfo> &callback) {
+    const MultiItemCallback<GcsNodeInfo>& callback) {
   RAY_CHECK(callback != nullptr);
-  auto on_done = [callback](RedisGcsClient *client, const ClientID &id,
-                            const std::vector<GcsNodeInfo> &data) {
+  auto on_done = [callback](RedisGcsClient* client, const ClientID& id,
+                            const std::vector<GcsNodeInfo>& data) {
     std::vector<GcsNodeInfo> result;
     std::set<std::string> node_ids;
     for (int index = data.size() - 1; index >= 0; --index) {
@@ -623,13 +623,13 @@ Status RedisNodeInfoAccessor::AsyncGetAll(
     }
     callback(Status::OK(), result);
   };
-  ClientTable &client_table = client_impl_->client_table();
+  ClientTable& client_table = client_impl_->client_table();
   return client_table.Lookup(on_done);
 }
 
-boost::optional<GcsNodeInfo> RedisNodeInfoAccessor::Get(const ClientID &node_id) const {
+boost::optional<GcsNodeInfo> RedisNodeInfoAccessor::Get(const ClientID& node_id) const {
   GcsNodeInfo node_info;
-  ClientTable &client_table = client_impl_->client_table();
+  ClientTable& client_table = client_impl_->client_table();
   bool found = client_table.GetClient(node_id, &node_info);
   boost::optional<GcsNodeInfo> optional_node;
   if (found) {
@@ -638,34 +638,34 @@ boost::optional<GcsNodeInfo> RedisNodeInfoAccessor::Get(const ClientID &node_id)
   return optional_node;
 }
 
-const std::unordered_map<ClientID, GcsNodeInfo> &RedisNodeInfoAccessor::GetAll() const {
-  ClientTable &client_table = client_impl_->client_table();
+const std::unordered_map<ClientID, GcsNodeInfo>& RedisNodeInfoAccessor::GetAll() const {
+  ClientTable& client_table = client_impl_->client_table();
   return client_table.GetAllClients();
 }
 
-bool RedisNodeInfoAccessor::IsRemoved(const ClientID &node_id) const {
-  ClientTable &client_table = client_impl_->client_table();
+bool RedisNodeInfoAccessor::IsRemoved(const ClientID& node_id) const {
+  ClientTable& client_table = client_impl_->client_table();
   return client_table.IsRemoved(node_id);
 }
 Status RedisNodeInfoAccessor::AsyncReportHeartbeat(
-    const std::shared_ptr<HeartbeatTableData> &data_ptr, const StatusCallback &callback) {
+    const std::shared_ptr<HeartbeatTableData>& data_ptr, const StatusCallback& callback) {
   HeartbeatTable::WriteCallback on_done = nullptr;
   if (callback != nullptr) {
-    on_done = [callback](RedisGcsClient *client, const ClientID &node_id,
-                         const HeartbeatTableData &data) { callback(Status::OK()); };
+    on_done = [callback](RedisGcsClient* client, const ClientID& node_id,
+                         const HeartbeatTableData& data) { callback(Status::OK()); };
   }
 
   ClientID node_id = ClientID::FromBinary(data_ptr->client_id());
-  HeartbeatTable &heartbeat_table = client_impl_->heartbeat_table();
+  HeartbeatTable& heartbeat_table = client_impl_->heartbeat_table();
   return heartbeat_table.Add(JobID::Nil(), node_id, data_ptr, on_done);
 }
 
 Status RedisNodeInfoAccessor::AsyncSubscribeHeartbeat(
-    const SubscribeCallback<ClientID, HeartbeatTableData> &subscribe,
-    const StatusCallback &done) {
+    const SubscribeCallback<ClientID, HeartbeatTableData>& subscribe,
+    const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr);
-  auto on_subscribe = [subscribe](const ClientID &node_id,
-                                  const HeartbeatTableData &data) {
+  auto on_subscribe = [subscribe](const ClientID& node_id,
+                                  const HeartbeatTableData& data) {
     subscribe(node_id, data);
   };
 
@@ -673,23 +673,23 @@ Status RedisNodeInfoAccessor::AsyncSubscribeHeartbeat(
 }
 
 Status RedisNodeInfoAccessor::AsyncReportBatchHeartbeat(
-    const std::shared_ptr<HeartbeatBatchTableData> &data_ptr,
-    const StatusCallback &callback) {
+    const std::shared_ptr<HeartbeatBatchTableData>& data_ptr,
+    const StatusCallback& callback) {
   HeartbeatBatchTable::WriteCallback on_done = nullptr;
   if (callback != nullptr) {
-    on_done = [callback](RedisGcsClient *client, const ClientID &node_id,
-                         const HeartbeatBatchTableData &data) { callback(Status::OK()); };
+    on_done = [callback](RedisGcsClient* client, const ClientID& node_id,
+                         const HeartbeatBatchTableData& data) { callback(Status::OK()); };
   }
 
-  HeartbeatBatchTable &hb_batch_table = client_impl_->heartbeat_batch_table();
+  HeartbeatBatchTable& hb_batch_table = client_impl_->heartbeat_batch_table();
   return hb_batch_table.Add(JobID::Nil(), ClientID::Nil(), data_ptr, on_done);
 }
 
 Status RedisNodeInfoAccessor::AsyncSubscribeBatchHeartbeat(
-    const ItemCallback<HeartbeatBatchTableData> &subscribe, const StatusCallback &done) {
+    const ItemCallback<HeartbeatBatchTableData>& subscribe, const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr);
-  auto on_subscribe = [subscribe](const ClientID &node_id,
-                                  const HeartbeatBatchTableData &data) {
+  auto on_subscribe = [subscribe](const ClientID& node_id,
+                                  const HeartbeatBatchTableData& data) {
     subscribe(data);
   };
 
@@ -698,10 +698,10 @@ Status RedisNodeInfoAccessor::AsyncSubscribeBatchHeartbeat(
 }
 
 Status RedisNodeInfoAccessor::AsyncGetResources(
-    const ClientID &node_id, const OptionalItemCallback<ResourceMap> &callback) {
+    const ClientID& node_id, const OptionalItemCallback<ResourceMap>& callback) {
   RAY_CHECK(callback != nullptr);
-  auto on_done = [callback](RedisGcsClient *client, const ClientID &id,
-                            const ResourceMap &data) {
+  auto on_done = [callback](RedisGcsClient* client, const ClientID& id,
+                            const ResourceMap& data) {
     boost::optional<ResourceMap> result;
     if (!data.empty()) {
       result = data;
@@ -709,52 +709,52 @@ Status RedisNodeInfoAccessor::AsyncGetResources(
     callback(Status::OK(), result);
   };
 
-  DynamicResourceTable &resource_table = client_impl_->resource_table();
+  DynamicResourceTable& resource_table = client_impl_->resource_table();
   return resource_table.Lookup(JobID::Nil(), node_id, on_done);
 }
 
-Status RedisNodeInfoAccessor::AsyncUpdateResources(const ClientID &node_id,
-                                                   const ResourceMap &resources,
-                                                   const StatusCallback &callback) {
+Status RedisNodeInfoAccessor::AsyncUpdateResources(const ClientID& node_id,
+                                                   const ResourceMap& resources,
+                                                   const StatusCallback& callback) {
   Hash<ClientID, ResourceTableData>::HashCallback on_done = nullptr;
   if (callback != nullptr) {
-    on_done = [callback](RedisGcsClient *client, const ClientID &node_id,
-                         const ResourceMap &resources) { callback(Status::OK()); };
+    on_done = [callback](RedisGcsClient* client, const ClientID& node_id,
+                         const ResourceMap& resources) { callback(Status::OK()); };
   }
 
-  DynamicResourceTable &resource_table = client_impl_->resource_table();
+  DynamicResourceTable& resource_table = client_impl_->resource_table();
   return resource_table.Update(JobID::Nil(), node_id, resources, on_done);
 }
 
 Status RedisNodeInfoAccessor::AsyncDeleteResources(
-    const ClientID &node_id, const std::vector<std::string> &resource_names,
-    const StatusCallback &callback) {
+    const ClientID& node_id, const std::vector<std::string>& resource_names,
+    const StatusCallback& callback) {
   Hash<ClientID, ResourceTableData>::HashRemoveCallback on_done = nullptr;
   if (callback != nullptr) {
-    on_done = [callback](RedisGcsClient *client, const ClientID &node_id,
-                         const std::vector<std::string> &resource_names) {
+    on_done = [callback](RedisGcsClient* client, const ClientID& node_id,
+                         const std::vector<std::string>& resource_names) {
       callback(Status::OK());
     };
   }
 
-  DynamicResourceTable &resource_table = client_impl_->resource_table();
+  DynamicResourceTable& resource_table = client_impl_->resource_table();
   return resource_table.RemoveEntries(JobID::Nil(), node_id, resource_names, on_done);
 }
 
 Status RedisNodeInfoAccessor::AsyncSubscribeToResources(
-    const ItemCallback<rpc::NodeResourceChange> &subscribe, const StatusCallback &done) {
+    const ItemCallback<rpc::NodeResourceChange>& subscribe, const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr);
-  auto on_subscribe = [subscribe](const ClientID &id,
-                                  const ResourceChangeNotification &result) {
+  auto on_subscribe = [subscribe](const ClientID& id,
+                                  const ResourceChangeNotification& result) {
     rpc::NodeResourceChange node_resource_change;
     node_resource_change.set_node_id(id.Binary());
     if (result.IsAdded()) {
-      for (auto &it : result.GetData()) {
+      for (auto& it : result.GetData()) {
         (*node_resource_change.mutable_updated_resources())[it.first] =
             it.second->resource_capacity();
       }
     } else {
-      for (auto &it : result.GetData()) {
+      for (auto& it : result.GetData()) {
         node_resource_change.add_deleted_resources(it.first);
       }
     }
@@ -763,80 +763,80 @@ Status RedisNodeInfoAccessor::AsyncSubscribeToResources(
   return resource_sub_executor_.AsyncSubscribeAll(ClientID::Nil(), on_subscribe, done);
 }
 
-RedisErrorInfoAccessor::RedisErrorInfoAccessor(RedisGcsClient *client_impl)
+RedisErrorInfoAccessor::RedisErrorInfoAccessor(RedisGcsClient* client_impl)
     : client_impl_(client_impl) {}
 
 Status RedisErrorInfoAccessor::AsyncReportJobError(
-    const std::shared_ptr<ErrorTableData> &data_ptr, const StatusCallback &callback) {
+    const std::shared_ptr<ErrorTableData>& data_ptr, const StatusCallback& callback) {
   ErrorTable::WriteCallback on_done = nullptr;
   if (callback != nullptr) {
-    on_done = [callback](RedisGcsClient *client, const JobID &job_id,
-                         const ErrorTableData &data) { callback(Status::OK()); };
+    on_done = [callback](RedisGcsClient* client, const JobID& job_id,
+                         const ErrorTableData& data) { callback(Status::OK()); };
   }
 
   JobID job_id = JobID::FromBinary(data_ptr->job_id());
-  ErrorTable &error_table = client_impl_->error_table();
+  ErrorTable& error_table = client_impl_->error_table();
   return error_table.Append(job_id, job_id, data_ptr, on_done);
 }
 
-RedisStatsInfoAccessor::RedisStatsInfoAccessor(RedisGcsClient *client_impl)
+RedisStatsInfoAccessor::RedisStatsInfoAccessor(RedisGcsClient* client_impl)
     : client_impl_(client_impl) {}
 
 Status RedisStatsInfoAccessor::AsyncAddProfileData(
-    const std::shared_ptr<ProfileTableData> &data_ptr, const StatusCallback &callback) {
+    const std::shared_ptr<ProfileTableData>& data_ptr, const StatusCallback& callback) {
   ProfileTable::WriteCallback on_done = nullptr;
   if (callback != nullptr) {
-    on_done = [callback](RedisGcsClient *client, const UniqueID &id,
-                         const ProfileTableData &data) { callback(Status::OK()); };
+    on_done = [callback](RedisGcsClient* client, const UniqueID& id,
+                         const ProfileTableData& data) { callback(Status::OK()); };
   }
 
-  ProfileTable &profile_table = client_impl_->profile_table();
+  ProfileTable& profile_table = client_impl_->profile_table();
   return profile_table.Append(JobID::Nil(), UniqueID::FromRandom(), data_ptr, on_done);
 }
 
-RedisWorkerInfoAccessor::RedisWorkerInfoAccessor(RedisGcsClient *client_impl)
+RedisWorkerInfoAccessor::RedisWorkerInfoAccessor(RedisGcsClient* client_impl)
     : client_impl_(client_impl),
       worker_failure_sub_executor_(client_impl->worker_table()) {}
 
 Status RedisWorkerInfoAccessor::AsyncSubscribeToWorkerFailures(
-    const SubscribeCallback<WorkerID, WorkerTableData> &subscribe,
-    const StatusCallback &done) {
+    const SubscribeCallback<WorkerID, WorkerTableData>& subscribe,
+    const StatusCallback& done) {
   RAY_CHECK(subscribe != nullptr);
   return worker_failure_sub_executor_.AsyncSubscribeAll(ClientID::Nil(), subscribe, done);
 }
 
 Status RedisWorkerInfoAccessor::AsyncReportWorkerFailure(
-    const std::shared_ptr<WorkerTableData> &data_ptr, const StatusCallback &callback) {
+    const std::shared_ptr<WorkerTableData>& data_ptr, const StatusCallback& callback) {
   WorkerTable::WriteCallback on_done = nullptr;
   if (callback != nullptr) {
-    on_done = [callback](RedisGcsClient *client, const WorkerID &id,
-                         const WorkerTableData &data) { callback(Status::OK()); };
+    on_done = [callback](RedisGcsClient* client, const WorkerID& id,
+                         const WorkerTableData& data) { callback(Status::OK()); };
   }
 
   WorkerID worker_id = WorkerID::FromBinary(data_ptr->worker_address().worker_id());
-  WorkerTable &worker_failure_table = client_impl_->worker_table();
+  WorkerTable& worker_failure_table = client_impl_->worker_table();
   return worker_failure_table.Add(JobID::Nil(), worker_id, data_ptr, on_done);
 }
 
 Status RedisWorkerInfoAccessor::AsyncGet(
-    const WorkerID &worker_id,
-    const OptionalItemCallback<rpc::WorkerTableData> &callback) {
+    const WorkerID& worker_id,
+    const OptionalItemCallback<rpc::WorkerTableData>& callback) {
   return Status::Invalid("Not implemented");
 }
 
 Status RedisWorkerInfoAccessor::AsyncGetAll(
-    const MultiItemCallback<rpc::WorkerTableData> &callback) {
+    const MultiItemCallback<rpc::WorkerTableData>& callback) {
   return Status::Invalid("Not implemented");
 }
 
 Status RedisWorkerInfoAccessor::AsyncAdd(
-    const std::shared_ptr<rpc::WorkerTableData> &data_ptr,
-    const StatusCallback &callback) {
+    const std::shared_ptr<rpc::WorkerTableData>& data_ptr,
+    const StatusCallback& callback) {
   return Status::Invalid("Not implemented");
 }
 
 Status RedisPlacementGroupInfoAccessor::AsyncCreatePlacementGroup(
-    const PlacementGroupSpecification &placement_group_spec) {
+    const PlacementGroupSpecification& placement_group_spec) {
   return Status::Invalid("Not implemented");
 }
 

--- a/src/ray/gcs/redis_accessor.h
+++ b/src/ray/gcs/redis_accessor.h
@@ -32,64 +32,64 @@ class RedisGcsClient;
 /// that uses Redis as the backend storage.
 class RedisLogBasedActorInfoAccessor : public ActorInfoAccessor {
  public:
-  explicit RedisLogBasedActorInfoAccessor(RedisGcsClient *client_impl);
+  explicit RedisLogBasedActorInfoAccessor(RedisGcsClient* client_impl);
 
   virtual ~RedisLogBasedActorInfoAccessor() {}
 
-  Status GetAll(std::vector<ActorTableData> *actor_table_data_list) override;
+  Status GetAll(std::vector<ActorTableData>* actor_table_data_list) override;
 
-  Status AsyncGet(const ActorID &actor_id,
-                  const OptionalItemCallback<ActorTableData> &callback) override;
+  Status AsyncGet(const ActorID& actor_id,
+                  const OptionalItemCallback<ActorTableData>& callback) override;
 
-  Status AsyncGetAll(const MultiItemCallback<rpc::ActorTableData> &callback) override {
+  Status AsyncGetAll(const MultiItemCallback<rpc::ActorTableData>& callback) override {
     return Status::NotImplemented(
         "RedisLogBasedActorInfoAccessor does not support AsyncGetAll.");
   }
 
-  Status AsyncGetByName(const std::string &name,
-                        const OptionalItemCallback<ActorTableData> &callback) override {
+  Status AsyncGetByName(const std::string& name,
+                        const OptionalItemCallback<ActorTableData>& callback) override {
     return Status::NotImplemented(
         "RedisLogBasedActorInfoAccessor does not support named detached actors.");
   }
 
-  Status AsyncRegisterActor(const TaskSpecification &task_spec,
-                            const StatusCallback &callback) override;
+  Status AsyncRegisterActor(const TaskSpecification& task_spec,
+                            const StatusCallback& callback) override;
 
-  Status AsyncCreateActor(const TaskSpecification &task_spec,
-                          const StatusCallback &callback) override;
+  Status AsyncCreateActor(const TaskSpecification& task_spec,
+                          const StatusCallback& callback) override;
 
-  Status AsyncRegister(const std::shared_ptr<ActorTableData> &data_ptr,
-                       const StatusCallback &callback) override;
+  Status AsyncRegister(const std::shared_ptr<ActorTableData>& data_ptr,
+                       const StatusCallback& callback) override;
 
-  Status AsyncUpdate(const ActorID &actor_id,
-                     const std::shared_ptr<ActorTableData> &data_ptr,
-                     const StatusCallback &callback) override;
+  Status AsyncUpdate(const ActorID& actor_id,
+                     const std::shared_ptr<ActorTableData>& data_ptr,
+                     const StatusCallback& callback) override;
 
-  Status AsyncSubscribeAll(const SubscribeCallback<ActorID, ActorTableData> &subscribe,
-                           const StatusCallback &done) override;
+  Status AsyncSubscribeAll(const SubscribeCallback<ActorID, ActorTableData>& subscribe,
+                           const StatusCallback& done) override;
 
-  Status AsyncSubscribe(const ActorID &actor_id,
-                        const SubscribeCallback<ActorID, ActorTableData> &subscribe,
-                        const StatusCallback &done) override;
+  Status AsyncSubscribe(const ActorID& actor_id,
+                        const SubscribeCallback<ActorID, ActorTableData>& subscribe,
+                        const StatusCallback& done) override;
 
-  Status AsyncUnsubscribe(const ActorID &actor_id) override;
+  Status AsyncUnsubscribe(const ActorID& actor_id) override;
 
-  Status AsyncAddCheckpoint(const std::shared_ptr<ActorCheckpointData> &data_ptr,
-                            const StatusCallback &callback) override;
+  Status AsyncAddCheckpoint(const std::shared_ptr<ActorCheckpointData>& data_ptr,
+                            const StatusCallback& callback) override;
 
   Status AsyncGetCheckpoint(
-      const ActorCheckpointID &checkpoint_id, const ActorID &actor_id,
-      const OptionalItemCallback<ActorCheckpointData> &callback) override;
+      const ActorCheckpointID& checkpoint_id, const ActorID& actor_id,
+      const OptionalItemCallback<ActorCheckpointData>& callback) override;
 
   Status AsyncGetCheckpointID(
-      const ActorID &actor_id,
-      const OptionalItemCallback<ActorCheckpointIdData> &callback) override;
+      const ActorID& actor_id,
+      const OptionalItemCallback<ActorCheckpointIdData>& callback) override;
 
   void AsyncResubscribe(bool is_pubsub_server_restarted) override {}
 
  protected:
   virtual std::vector<ActorID> GetAllActorID() const;
-  virtual Status Get(const ActorID &actor_id, ActorTableData *actor_table_data) const;
+  virtual Status Get(const ActorID& actor_id, ActorTableData* actor_table_data) const;
 
  private:
   /// Add checkpoint id to GCS asynchronously.
@@ -97,12 +97,12 @@ class RedisLogBasedActorInfoAccessor : public ActorInfoAccessor {
   /// \param actor_id The ID of actor that the checkpoint belongs to.
   /// \param checkpoint_id The ID of checkpoint that will be added to GCS.
   /// \return Status
-  Status AsyncAddCheckpointID(const ActorID &actor_id,
-                              const ActorCheckpointID &checkpoint_id,
-                              const StatusCallback &callback);
+  Status AsyncAddCheckpointID(const ActorID& actor_id,
+                              const ActorCheckpointID& checkpoint_id,
+                              const StatusCallback& callback);
 
  protected:
-  RedisGcsClient *client_impl_{nullptr};
+  RedisGcsClient* client_impl_{nullptr};
   // Use a random ClientID for actor subscription. Because:
   // If we use ClientID::Nil, GCS will still send all actors' updates to this GCS Client.
   // Even we can filter out irrelevant updates, but there will be extra overhead.
@@ -122,40 +122,40 @@ class RedisLogBasedActorInfoAccessor : public ActorInfoAccessor {
 /// that uses Redis as the backend storage.
 class RedisActorInfoAccessor : public RedisLogBasedActorInfoAccessor {
  public:
-  explicit RedisActorInfoAccessor(RedisGcsClient *client_impl);
+  explicit RedisActorInfoAccessor(RedisGcsClient* client_impl);
 
   virtual ~RedisActorInfoAccessor() {}
 
-  Status AsyncGet(const ActorID &actor_id,
-                  const OptionalItemCallback<ActorTableData> &callback) override;
+  Status AsyncGet(const ActorID& actor_id,
+                  const OptionalItemCallback<ActorTableData>& callback) override;
 
-  Status AsyncGetAll(const MultiItemCallback<rpc::ActorTableData> &callback) override;
+  Status AsyncGetAll(const MultiItemCallback<rpc::ActorTableData>& callback) override;
 
-  Status AsyncGetByName(const std::string &name,
-                        const OptionalItemCallback<ActorTableData> &callback) override {
+  Status AsyncGetByName(const std::string& name,
+                        const OptionalItemCallback<ActorTableData>& callback) override {
     return Status::NotImplemented(
         "RedisActorInfoAccessor does not support named detached actors.");
   }
 
-  Status AsyncRegister(const std::shared_ptr<ActorTableData> &data_ptr,
-                       const StatusCallback &callback) override;
+  Status AsyncRegister(const std::shared_ptr<ActorTableData>& data_ptr,
+                       const StatusCallback& callback) override;
 
-  Status AsyncUpdate(const ActorID &actor_id,
-                     const std::shared_ptr<ActorTableData> &data_ptr,
-                     const StatusCallback &callback) override;
+  Status AsyncUpdate(const ActorID& actor_id,
+                     const std::shared_ptr<ActorTableData>& data_ptr,
+                     const StatusCallback& callback) override;
 
-  Status AsyncSubscribeAll(const SubscribeCallback<ActorID, ActorTableData> &subscribe,
-                           const StatusCallback &done) override;
+  Status AsyncSubscribeAll(const SubscribeCallback<ActorID, ActorTableData>& subscribe,
+                           const StatusCallback& done) override;
 
-  Status AsyncSubscribe(const ActorID &actor_id,
-                        const SubscribeCallback<ActorID, ActorTableData> &subscribe,
-                        const StatusCallback &done) override;
+  Status AsyncSubscribe(const ActorID& actor_id,
+                        const SubscribeCallback<ActorID, ActorTableData>& subscribe,
+                        const StatusCallback& done) override;
 
-  Status AsyncUnsubscribe(const ActorID &actor_id) override;
+  Status AsyncUnsubscribe(const ActorID& actor_id) override;
 
  protected:
   std::vector<ActorID> GetAllActorID() const override;
-  Status Get(const ActorID &actor_id, ActorTableData *actor_table_data) const override;
+  Status Get(const ActorID& actor_id, ActorTableData* actor_table_data) const override;
 
  private:
   typedef SubscriptionExecutor<ActorID, ActorTableData, ActorTable>
@@ -168,19 +168,19 @@ class RedisActorInfoAccessor : public RedisLogBasedActorInfoAccessor {
 /// that uses Redis as the backend storage.
 class RedisJobInfoAccessor : public JobInfoAccessor {
  public:
-  explicit RedisJobInfoAccessor(RedisGcsClient *client_impl);
+  explicit RedisJobInfoAccessor(RedisGcsClient* client_impl);
 
   virtual ~RedisJobInfoAccessor() {}
 
-  Status AsyncAdd(const std::shared_ptr<JobTableData> &data_ptr,
-                  const StatusCallback &callback) override;
+  Status AsyncAdd(const std::shared_ptr<JobTableData>& data_ptr,
+                  const StatusCallback& callback) override;
 
-  Status AsyncMarkFinished(const JobID &job_id, const StatusCallback &callback) override;
+  Status AsyncMarkFinished(const JobID& job_id, const StatusCallback& callback) override;
 
-  Status AsyncSubscribeAll(const SubscribeCallback<JobID, JobTableData> &subscribe,
-                           const StatusCallback &done) override;
+  Status AsyncSubscribeAll(const SubscribeCallback<JobID, JobTableData>& subscribe,
+                           const StatusCallback& done) override;
 
-  Status AsyncGetAll(const MultiItemCallback<rpc::JobTableData> &callback) override {
+  Status AsyncGetAll(const MultiItemCallback<rpc::JobTableData>& callback) override {
     return Status::NotImplemented("AsyncGetAll not implemented");
   }
 
@@ -192,10 +192,10 @@ class RedisJobInfoAccessor : public JobInfoAccessor {
   /// \param data_ptr The job information that will be appended to GCS.
   /// \param callback Callback that will be called after append done.
   /// \return Status
-  Status DoAsyncAppend(const std::shared_ptr<JobTableData> &data_ptr,
-                       const StatusCallback &callback);
+  Status DoAsyncAppend(const std::shared_ptr<JobTableData>& data_ptr,
+                       const StatusCallback& callback);
 
-  RedisGcsClient *client_impl_{nullptr};
+  RedisGcsClient* client_impl_{nullptr};
 
   typedef SubscriptionExecutor<JobID, JobTableData, JobTable> JobSubscriptionExecutor;
   JobSubscriptionExecutor job_sub_executor_;
@@ -206,46 +206,46 @@ class RedisJobInfoAccessor : public JobInfoAccessor {
 /// that uses Redis as the backend storage.
 class RedisTaskInfoAccessor : public TaskInfoAccessor {
  public:
-  explicit RedisTaskInfoAccessor(RedisGcsClient *client_impl);
+  explicit RedisTaskInfoAccessor(RedisGcsClient* client_impl);
 
   virtual ~RedisTaskInfoAccessor() {}
 
-  Status AsyncAdd(const std::shared_ptr<TaskTableData> &data_ptr,
-                  const StatusCallback &callback) override;
+  Status AsyncAdd(const std::shared_ptr<TaskTableData>& data_ptr,
+                  const StatusCallback& callback) override;
 
-  Status AsyncGet(const TaskID &task_id,
-                  const OptionalItemCallback<TaskTableData> &callback) override;
+  Status AsyncGet(const TaskID& task_id,
+                  const OptionalItemCallback<TaskTableData>& callback) override;
 
-  Status AsyncDelete(const std::vector<TaskID> &task_ids,
-                     const StatusCallback &callback) override;
+  Status AsyncDelete(const std::vector<TaskID>& task_ids,
+                     const StatusCallback& callback) override;
 
-  Status AsyncSubscribe(const TaskID &task_id,
-                        const SubscribeCallback<TaskID, TaskTableData> &subscribe,
-                        const StatusCallback &done) override;
+  Status AsyncSubscribe(const TaskID& task_id,
+                        const SubscribeCallback<TaskID, TaskTableData>& subscribe,
+                        const StatusCallback& done) override;
 
-  Status AsyncUnsubscribe(const TaskID &task_id) override;
+  Status AsyncUnsubscribe(const TaskID& task_id) override;
 
-  Status AsyncAddTaskLease(const std::shared_ptr<TaskLeaseData> &data_ptr,
-                           const StatusCallback &callback) override;
+  Status AsyncAddTaskLease(const std::shared_ptr<TaskLeaseData>& data_ptr,
+                           const StatusCallback& callback) override;
 
-  Status AsyncGetTaskLease(const TaskID &task_id,
-                           const OptionalItemCallback<TaskLeaseData> &callback) override;
+  Status AsyncGetTaskLease(const TaskID& task_id,
+                           const OptionalItemCallback<TaskLeaseData>& callback) override;
 
   Status AsyncSubscribeTaskLease(
-      const TaskID &task_id,
-      const SubscribeCallback<TaskID, boost::optional<TaskLeaseData>> &subscribe,
-      const StatusCallback &done) override;
+      const TaskID& task_id,
+      const SubscribeCallback<TaskID, boost::optional<TaskLeaseData>>& subscribe,
+      const StatusCallback& done) override;
 
-  Status AsyncUnsubscribeTaskLease(const TaskID &task_id) override;
+  Status AsyncUnsubscribeTaskLease(const TaskID& task_id) override;
 
   Status AttemptTaskReconstruction(
-      const std::shared_ptr<TaskReconstructionData> &data_ptr,
-      const StatusCallback &callback) override;
+      const std::shared_ptr<TaskReconstructionData>& data_ptr,
+      const StatusCallback& callback) override;
 
   void AsyncResubscribe(bool is_pubsub_server_restarted) override {}
 
  private:
-  RedisGcsClient *client_impl_{nullptr};
+  RedisGcsClient* client_impl_{nullptr};
   // Use a random ClientID for task subscription. Because:
   // If we use ClientID::Nil, GCS will still send all tasks' updates to this GCS Client.
   // Even we can filter out irrelevant updates, but there will be extra overhead.
@@ -268,35 +268,35 @@ class RedisTaskInfoAccessor : public TaskInfoAccessor {
 /// that uses Redis as the backend storage.
 class RedisObjectInfoAccessor : public ObjectInfoAccessor {
  public:
-  explicit RedisObjectInfoAccessor(RedisGcsClient *client_impl);
+  explicit RedisObjectInfoAccessor(RedisGcsClient* client_impl);
 
   virtual ~RedisObjectInfoAccessor() {}
 
-  Status AsyncGetLocations(const ObjectID &object_id,
-                           const MultiItemCallback<ObjectTableData> &callback) override;
+  Status AsyncGetLocations(const ObjectID& object_id,
+                           const MultiItemCallback<ObjectTableData>& callback) override;
 
   Status AsyncGetAll(
-      const MultiItemCallback<rpc::ObjectLocationInfo> &callback) override {
+      const MultiItemCallback<rpc::ObjectLocationInfo>& callback) override {
     return Status::NotImplemented("AsyncGetAll not implemented");
   }
 
-  Status AsyncAddLocation(const ObjectID &object_id, const ClientID &node_id,
-                          const StatusCallback &callback) override;
+  Status AsyncAddLocation(const ObjectID& object_id, const ClientID& node_id,
+                          const StatusCallback& callback) override;
 
-  Status AsyncRemoveLocation(const ObjectID &object_id, const ClientID &node_id,
-                             const StatusCallback &callback) override;
+  Status AsyncRemoveLocation(const ObjectID& object_id, const ClientID& node_id,
+                             const StatusCallback& callback) override;
 
   Status AsyncSubscribeToLocations(
-      const ObjectID &object_id,
-      const SubscribeCallback<ObjectID, ObjectChangeNotification> &subscribe,
-      const StatusCallback &done) override;
+      const ObjectID& object_id,
+      const SubscribeCallback<ObjectID, ObjectChangeNotification>& subscribe,
+      const StatusCallback& done) override;
 
-  Status AsyncUnsubscribeToLocations(const ObjectID &object_id) override;
+  Status AsyncUnsubscribeToLocations(const ObjectID& object_id) override;
 
   void AsyncResubscribe(bool is_pubsub_server_restarted) override {}
 
  private:
-  RedisGcsClient *client_impl_{nullptr};
+  RedisGcsClient* client_impl_{nullptr};
 
   // Use a random ClientID for object subscription. Because:
   // If we use ClientID::Nil, GCS will still send all objects' updates to this GCS Client.
@@ -316,79 +316,79 @@ class RedisObjectInfoAccessor : public ObjectInfoAccessor {
 /// that uses Redis as the backend storage.
 class RedisNodeInfoAccessor : public NodeInfoAccessor {
  public:
-  explicit RedisNodeInfoAccessor(RedisGcsClient *client_impl);
+  explicit RedisNodeInfoAccessor(RedisGcsClient* client_impl);
 
   virtual ~RedisNodeInfoAccessor() {}
 
-  Status RegisterSelf(const GcsNodeInfo &local_node_info) override;
+  Status RegisterSelf(const GcsNodeInfo& local_node_info) override;
 
   Status UnregisterSelf() override;
 
-  const ClientID &GetSelfId() const override;
+  const ClientID& GetSelfId() const override;
 
-  const GcsNodeInfo &GetSelfInfo() const override;
+  const GcsNodeInfo& GetSelfInfo() const override;
 
-  Status AsyncRegister(const GcsNodeInfo &node_info,
-                       const StatusCallback &callback) override;
+  Status AsyncRegister(const GcsNodeInfo& node_info,
+                       const StatusCallback& callback) override;
 
-  Status AsyncUnregister(const ClientID &node_id,
-                         const StatusCallback &callback) override;
+  Status AsyncUnregister(const ClientID& node_id,
+                         const StatusCallback& callback) override;
 
-  Status AsyncGetAll(const MultiItemCallback<GcsNodeInfo> &callback) override;
+  Status AsyncGetAll(const MultiItemCallback<GcsNodeInfo>& callback) override;
 
   Status AsyncSubscribeToNodeChange(
-      const SubscribeCallback<ClientID, GcsNodeInfo> &subscribe,
-      const StatusCallback &done) override;
+      const SubscribeCallback<ClientID, GcsNodeInfo>& subscribe,
+      const StatusCallback& done) override;
 
-  boost::optional<GcsNodeInfo> Get(const ClientID &node_id) const override;
+  boost::optional<GcsNodeInfo> Get(const ClientID& node_id) const override;
 
-  const std::unordered_map<ClientID, GcsNodeInfo> &GetAll() const override;
+  const std::unordered_map<ClientID, GcsNodeInfo>& GetAll() const override;
 
-  bool IsRemoved(const ClientID &node_id) const override;
+  bool IsRemoved(const ClientID& node_id) const override;
 
-  Status AsyncGetResources(const ClientID &node_id,
-                           const OptionalItemCallback<ResourceMap> &callback) override;
+  Status AsyncGetResources(const ClientID& node_id,
+                           const OptionalItemCallback<ResourceMap>& callback) override;
 
-  Status AsyncUpdateResources(const ClientID &node_id, const ResourceMap &resources,
-                              const StatusCallback &callback) override;
+  Status AsyncUpdateResources(const ClientID& node_id, const ResourceMap& resources,
+                              const StatusCallback& callback) override;
 
-  Status AsyncDeleteResources(const ClientID &node_id,
-                              const std::vector<std::string> &resource_names,
-                              const StatusCallback &callback) override;
+  Status AsyncDeleteResources(const ClientID& node_id,
+                              const std::vector<std::string>& resource_names,
+                              const StatusCallback& callback) override;
 
-  Status AsyncSubscribeToResources(const ItemCallback<rpc::NodeResourceChange> &subscribe,
-                                   const StatusCallback &done) override;
+  Status AsyncSubscribeToResources(const ItemCallback<rpc::NodeResourceChange>& subscribe,
+                                   const StatusCallback& done) override;
 
-  Status AsyncReportHeartbeat(const std::shared_ptr<HeartbeatTableData> &data_ptr,
-                              const StatusCallback &callback) override;
+  Status AsyncReportHeartbeat(const std::shared_ptr<HeartbeatTableData>& data_ptr,
+                              const StatusCallback& callback) override;
 
   Status AsyncSubscribeHeartbeat(
-      const SubscribeCallback<ClientID, HeartbeatTableData> &subscribe,
-      const StatusCallback &done) override;
+      const SubscribeCallback<ClientID, HeartbeatTableData>& subscribe,
+      const StatusCallback& done) override;
 
   Status AsyncReportBatchHeartbeat(
-      const std::shared_ptr<HeartbeatBatchTableData> &data_ptr,
-      const StatusCallback &callback) override;
+      const std::shared_ptr<HeartbeatBatchTableData>& data_ptr,
+      const StatusCallback& callback) override;
 
   Status AsyncSubscribeBatchHeartbeat(
-      const ItemCallback<HeartbeatBatchTableData> &subscribe,
-      const StatusCallback &done) override;
+      const ItemCallback<HeartbeatBatchTableData>& subscribe,
+      const StatusCallback& done) override;
 
   void AsyncResubscribe(bool is_pubsub_server_restarted) override {}
 
   Status AsyncSetInternalConfig(
-      std::unordered_map<std::string, std::string> &config) override {
+      std::unordered_map<std::string, std::string>& config) override {
     return Status::NotImplemented("SetInternaConfig not implemented.");
   }
 
   Status AsyncGetInternalConfig(
-      const OptionalItemCallback<std::unordered_map<std::string, std::string>> &callback)
+      const OptionalItemCallback<std::unordered_map<std::string, std::string>>& callback)
       override {
     return Status::NotImplemented("GetInternalConfig not implemented.");
   }
 
  private:
-  RedisGcsClient *client_impl_{nullptr};
+  RedisGcsClient* client_impl_{nullptr};
 
   typedef SubscriptionExecutor<ClientID, ResourceChangeNotification, DynamicResourceTable>
       DynamicResourceSubscriptionExecutor;
@@ -408,15 +408,15 @@ class RedisNodeInfoAccessor : public NodeInfoAccessor {
 /// that uses Redis as the backend storage.
 class RedisErrorInfoAccessor : public ErrorInfoAccessor {
  public:
-  explicit RedisErrorInfoAccessor(RedisGcsClient *client_impl);
+  explicit RedisErrorInfoAccessor(RedisGcsClient* client_impl);
 
   virtual ~RedisErrorInfoAccessor() = default;
 
-  Status AsyncReportJobError(const std::shared_ptr<ErrorTableData> &data_ptr,
-                             const StatusCallback &callback) override;
+  Status AsyncReportJobError(const std::shared_ptr<ErrorTableData>& data_ptr,
+                             const StatusCallback& callback) override;
 
  private:
-  RedisGcsClient *client_impl_{nullptr};
+  RedisGcsClient* client_impl_{nullptr};
 };
 
 /// \class RedisStatsInfoAccessor
@@ -424,19 +424,19 @@ class RedisErrorInfoAccessor : public ErrorInfoAccessor {
 /// that uses Redis as the backend storage.
 class RedisStatsInfoAccessor : public StatsInfoAccessor {
  public:
-  explicit RedisStatsInfoAccessor(RedisGcsClient *client_impl);
+  explicit RedisStatsInfoAccessor(RedisGcsClient* client_impl);
 
   virtual ~RedisStatsInfoAccessor() = default;
 
-  Status AsyncAddProfileData(const std::shared_ptr<ProfileTableData> &data_ptr,
-                             const StatusCallback &callback) override;
+  Status AsyncAddProfileData(const std::shared_ptr<ProfileTableData>& data_ptr,
+                             const StatusCallback& callback) override;
 
-  Status AsyncGetAll(const MultiItemCallback<rpc::ProfileTableData> &callback) override {
+  Status AsyncGetAll(const MultiItemCallback<rpc::ProfileTableData>& callback) override {
     return Status::NotImplemented("AsyncGetAll not implemented");
   }
 
  private:
-  RedisGcsClient *client_impl_{nullptr};
+  RedisGcsClient* client_impl_{nullptr};
 };
 
 /// \class RedisWorkerInfoAccessor
@@ -444,29 +444,29 @@ class RedisStatsInfoAccessor : public StatsInfoAccessor {
 /// that uses Redis as the backend storage.
 class RedisWorkerInfoAccessor : public WorkerInfoAccessor {
  public:
-  explicit RedisWorkerInfoAccessor(RedisGcsClient *client_impl);
+  explicit RedisWorkerInfoAccessor(RedisGcsClient* client_impl);
 
   virtual ~RedisWorkerInfoAccessor() = default;
 
   Status AsyncSubscribeToWorkerFailures(
-      const SubscribeCallback<WorkerID, WorkerTableData> &subscribe,
-      const StatusCallback &done) override;
+      const SubscribeCallback<WorkerID, WorkerTableData>& subscribe,
+      const StatusCallback& done) override;
 
-  Status AsyncReportWorkerFailure(const std::shared_ptr<WorkerTableData> &data_ptr,
-                                  const StatusCallback &callback) override;
+  Status AsyncReportWorkerFailure(const std::shared_ptr<WorkerTableData>& data_ptr,
+                                  const StatusCallback& callback) override;
 
-  Status AsyncGet(const WorkerID &worker_id,
-                  const OptionalItemCallback<rpc::WorkerTableData> &callback) override;
+  Status AsyncGet(const WorkerID& worker_id,
+                  const OptionalItemCallback<rpc::WorkerTableData>& callback) override;
 
-  Status AsyncGetAll(const MultiItemCallback<rpc::WorkerTableData> &callback) override;
+  Status AsyncGetAll(const MultiItemCallback<rpc::WorkerTableData>& callback) override;
 
-  Status AsyncAdd(const std::shared_ptr<rpc::WorkerTableData> &data_ptr,
-                  const StatusCallback &callback) override;
+  Status AsyncAdd(const std::shared_ptr<rpc::WorkerTableData>& data_ptr,
+                  const StatusCallback& callback) override;
 
   void AsyncResubscribe(bool is_pubsub_server_restarted) override {}
 
  private:
-  RedisGcsClient *client_impl_{nullptr};
+  RedisGcsClient* client_impl_{nullptr};
 
   typedef SubscriptionExecutor<WorkerID, WorkerTableData, WorkerTable>
       WorkerFailureSubscriptionExecutor;
@@ -478,7 +478,7 @@ class RedisPlacementGroupInfoAccessor : public PlacementGroupInfoAccessor {
   virtual ~RedisPlacementGroupInfoAccessor() = default;
 
   Status AsyncCreatePlacementGroup(
-      const PlacementGroupSpecification &placement_group_spec) override;
+      const PlacementGroupSpecification& placement_group_spec) override;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/redis_async_context.cc
+++ b/src/ray/gcs/redis_async_context.cc
@@ -23,7 +23,7 @@ namespace ray {
 
 namespace gcs {
 
-RedisAsyncContext::RedisAsyncContext(redisAsyncContext *redis_async_context)
+RedisAsyncContext::RedisAsyncContext(redisAsyncContext* redis_async_context)
     : redis_async_context_(redis_async_context) {
   RAY_CHECK(redis_async_context_ != nullptr);
 }
@@ -35,7 +35,7 @@ RedisAsyncContext::~RedisAsyncContext() {
   }
 }
 
-redisAsyncContext *RedisAsyncContext::GetRawRedisAsyncContext() {
+redisAsyncContext* RedisAsyncContext::GetRawRedisAsyncContext() {
   return redis_async_context_;
 }
 
@@ -65,8 +65,8 @@ void RedisAsyncContext::RedisAsyncHandleWrite() {
   redisAsyncHandleWrite(redis_async_context_);
 }
 
-Status RedisAsyncContext::RedisAsyncCommand(redisCallbackFn *fn, void *privdata,
-                                            const char *format, ...) {
+Status RedisAsyncContext::RedisAsyncCommand(redisCallbackFn* fn, void* privdata,
+                                            const char* format, ...) {
   va_list ap;
   va_start(ap, format);
 
@@ -89,9 +89,9 @@ Status RedisAsyncContext::RedisAsyncCommand(redisCallbackFn *fn, void *privdata,
   return Status::OK();
 }
 
-Status RedisAsyncContext::RedisAsyncCommandArgv(redisCallbackFn *fn, void *privdata,
-                                                int argc, const char **argv,
-                                                const size_t *argvlen) {
+Status RedisAsyncContext::RedisAsyncCommandArgv(redisCallbackFn* fn, void* privdata,
+                                                int argc, const char** argv,
+                                                const size_t* argvlen) {
   int ret_code = 0;
   {
     // `redisAsyncCommandArgv` will mutate `redis_async_context_`, use a lock to protect

--- a/src/ray/gcs/redis_async_context.h
+++ b/src/ray/gcs/redis_async_context.h
@@ -15,7 +15,9 @@
 #pragma once
 
 #include <stdarg.h>
+
 #include <mutex>
+
 #include "ray/common/status.h"
 
 // These are forward declarations from hiredis.

--- a/src/ray/gcs/redis_async_context.h
+++ b/src/ray/gcs/redis_async_context.h
@@ -24,7 +24,7 @@
 extern "C" {
 struct redisAsyncContext;
 struct redisReply;
-typedef void redisCallbackFn(struct redisAsyncContext *, void *, void *);
+typedef void redisCallbackFn(struct redisAsyncContext*, void*, void*);
 }
 
 namespace ray {
@@ -36,14 +36,14 @@ namespace gcs {
 /// C++ style and thread-safe API.
 class RedisAsyncContext {
  public:
-  explicit RedisAsyncContext(redisAsyncContext *redis_async_context);
+  explicit RedisAsyncContext(redisAsyncContext* redis_async_context);
 
   ~RedisAsyncContext();
 
   /// Get the raw 'redisAsyncContext' pointer.
   ///
   /// \return redisAsyncContext *
-  redisAsyncContext *GetRawRedisAsyncContext();
+  redisAsyncContext* GetRawRedisAsyncContext();
 
   /// Reset the raw 'redisAsyncContext' pointer to nullptr.
   void ResetRawRedisAsyncContext();
@@ -61,7 +61,7 @@ class RedisAsyncContext {
   /// \param format Command format.
   /// \param ... Command list.
   /// \return Status
-  Status RedisAsyncCommand(redisCallbackFn *fn, void *privdata, const char *format, ...);
+  Status RedisAsyncCommand(redisCallbackFn* fn, void* privdata, const char* format, ...);
 
   /// Perform command 'redisAsyncCommandArgv'. Thread-safe.
   ///
@@ -71,8 +71,8 @@ class RedisAsyncContext {
   /// \param argv Array with arguments.
   /// \param argvlen Array with each argument's length.
   /// \return Status
-  Status RedisAsyncCommandArgv(redisCallbackFn *fn, void *privdata, int argc,
-                               const char **argv, const size_t *argvlen);
+  Status RedisAsyncCommandArgv(redisCallbackFn* fn, void* privdata, int argc,
+                               const char** argv, const size_t* argvlen);
 
  private:
   /// This mutex is used to protect `redis_async_context`.
@@ -80,7 +80,7 @@ class RedisAsyncContext {
   /// data and don't actually do any IO operations. So the perf impact of adding the lock
   /// should be minimum.
   std::mutex mutex_;
-  redisAsyncContext *redis_async_context_{nullptr};
+  redisAsyncContext* redis_async_context_{nullptr};
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/redis_client.cc
+++ b/src/ray/gcs/redis_client.cc
@@ -25,15 +25,15 @@ namespace ray {
 
 namespace gcs {
 
-static void GetRedisShards(redisContext *context, std::vector<std::string> *addresses,
-                           std::vector<int> *ports) {
+static void GetRedisShards(redisContext* context, std::vector<std::string>* addresses,
+                           std::vector<int>* ports) {
   // Get the total number of Redis shards in the system.
   int num_attempts = 0;
-  redisReply *reply = nullptr;
+  redisReply* reply = nullptr;
   while (num_attempts < RayConfig::instance().redis_db_connect_retries()) {
     // Try to read the number of Redis shards from the primary shard. If the
     // entry is present, exit.
-    reply = reinterpret_cast<redisReply *>(redisCommand(context, "GET NumRedisShards"));
+    reply = reinterpret_cast<redisReply*>(redisCommand(context, "GET NumRedisShards"));
     if (reply->type != REDIS_REPLY_NIL) {
       break;
     }
@@ -59,7 +59,7 @@ static void GetRedisShards(redisContext *context, std::vector<std::string> *addr
     // Try to read the Redis shard locations from the primary shard. If we find
     // that all of them are present, exit.
     reply =
-        reinterpret_cast<redisReply *>(redisCommand(context, "LRANGE RedisShards 0 -1"));
+        reinterpret_cast<redisReply*>(redisCommand(context, "LRANGE RedisShards 0 -1"));
     if (static_cast<int>(reply->elements) == num_redis_shards) {
       break;
     }
@@ -90,15 +90,15 @@ static void GetRedisShards(redisContext *context, std::vector<std::string> *addr
   freeReplyObject(reply);
 }
 
-RedisClient::RedisClient(const RedisClientOptions &options) : options_(options) {}
+RedisClient::RedisClient(const RedisClientOptions& options) : options_(options) {}
 
-Status RedisClient::Connect(boost::asio::io_service &io_service) {
-  std::vector<boost::asio::io_service *> io_services;
+Status RedisClient::Connect(boost::asio::io_service& io_service) {
+  std::vector<boost::asio::io_service*> io_services;
   io_services.emplace_back(&io_service);
   return Connect(io_services);
 }
 
-Status RedisClient::Connect(std::vector<boost::asio::io_service *> io_services) {
+Status RedisClient::Connect(std::vector<boost::asio::io_service*> io_services) {
   RAY_CHECK(!is_connected_);
   RAY_CHECK(!io_services.empty());
 
@@ -127,7 +127,7 @@ Status RedisClient::Connect(std::vector<boost::asio::io_service *> io_services) 
 
     for (size_t i = 0; i < addresses.size(); ++i) {
       size_t io_service_index = (i + 1) % io_services.size();
-      boost::asio::io_service &io_service = *io_services[io_service_index];
+      boost::asio::io_service& io_service = *io_services[io_service_index];
       // Populate shard_contexts.
       shard_contexts_.push_back(std::make_shared<RedisContext>(io_service));
       RAY_CHECK_OK(shard_contexts_[i]->Connect(addresses[i], ports[i], /*sharding=*/true,
@@ -152,14 +152,14 @@ void RedisClient::Attach() {
   // Take care of sharding contexts.
   RAY_CHECK(shard_asio_async_clients_.empty()) << "Attach shall be called only once";
   for (std::shared_ptr<RedisContext> context : shard_contexts_) {
-    boost::asio::io_service &io_service = context->io_service();
+    boost::asio::io_service& io_service = context->io_service();
     shard_asio_async_clients_.emplace_back(
         new RedisAsioClient(io_service, context->async_context()));
     shard_asio_subscribe_clients_.emplace_back(
         new RedisAsioClient(io_service, context->subscribe_context()));
   }
 
-  boost::asio::io_service &io_service = primary_context_->io_service();
+  boost::asio::io_service& io_service = primary_context_->io_service();
   asio_async_auxiliary_client_.reset(
       new RedisAsioClient(io_service, primary_context_->async_context()));
   asio_subscribe_auxiliary_client_.reset(
@@ -172,7 +172,7 @@ void RedisClient::Disconnect() {
   RAY_LOG(DEBUG) << "RedisClient disconnected.";
 }
 
-std::shared_ptr<RedisContext> RedisClient::GetShardContext(const std::string &shard_key) {
+std::shared_ptr<RedisContext> RedisClient::GetShardContext(const std::string& shard_key) {
   static std::hash<std::string> hash;
   size_t index = hash(shard_key) % shard_contexts_.size();
   return shard_contexts_[index];

--- a/src/ray/gcs/redis_client.h
+++ b/src/ray/gcs/redis_client.h
@@ -29,7 +29,7 @@ class RedisContext;
 
 class RedisClientOptions {
  public:
-  RedisClientOptions(const std::string &ip, int port, const std::string &password,
+  RedisClientOptions(const std::string& ip, int port, const std::string& password,
                      bool is_test_client = false)
       : server_ip_(ip),
         server_port_(port),
@@ -51,7 +51,7 @@ class RedisClientOptions {
 /// This class is used to send commands to Redis.
 class RedisClient {
  public:
-  RedisClient(const RedisClientOptions &options);
+  RedisClient(const RedisClientOptions& options);
 
   /// Connect to Redis. Non-thread safe.
   /// Call this function before calling other functions.
@@ -60,7 +60,7 @@ class RedisClient {
   /// This io_service must be single-threaded. Because `RedisAsioClient` is
   /// non-thread safe.
   /// \return Status
-  Status Connect(boost::asio::io_service &io_service);
+  Status Connect(boost::asio::io_service& io_service);
 
   // TODO(micafan) Maybe it's not necessary to use multi threads.
   /// Connect to Redis. Non-thread safe.
@@ -70,7 +70,7 @@ class RedisClient {
   /// an event loop. Each io_service must be single-threaded. Because `RedisAsioClient`
   /// is non-thread safe.
   /// \return Status
-  Status Connect(std::vector<boost::asio::io_service *> io_services);
+  Status Connect(std::vector<boost::asio::io_service*> io_services);
 
   /// Disconnect with Redis. Non-thread safe.
   void Disconnect();
@@ -79,7 +79,7 @@ class RedisClient {
     return shard_contexts_;
   }
 
-  std::shared_ptr<RedisContext> GetShardContext(const std::string &shard_key);
+  std::shared_ptr<RedisContext> GetShardContext(const std::string& shard_key);
 
   std::shared_ptr<RedisContext> GetPrimaryContext() { return primary_context_; }
 

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -40,7 +40,7 @@ using rpc::TablePubsub;
 /// A simple reply wrapper for redis reply.
 class CallbackReply {
  public:
-  explicit CallbackReply(redisReply *redis_reply);
+  explicit CallbackReply(redisReply* redis_reply);
 
   /// Whether this reply is `nil` type reply.
   bool IsNil() const;
@@ -55,19 +55,19 @@ class CallbackReply {
   ///
   /// Note that this will return an empty string if
   /// the type of this reply is `nil` or `status`.
-  const std::string &ReadAsString() const;
+  const std::string& ReadAsString() const;
 
   /// Read this reply data as pub-sub data.
-  const std::string &ReadAsPubsubData() const;
+  const std::string& ReadAsPubsubData() const;
 
   /// Read this reply data as a string array.
-  const std::vector<std::string> &ReadAsStringArray() const;
+  const std::vector<std::string>& ReadAsStringArray() const;
 
   /// Read this reply data as a scan array.
   ///
   /// \param array The result array of scan.
   /// \return size_t The next cursor for scan.
-  size_t ReadAsScanArray(std::vector<std::string> *array) const;
+  size_t ReadAsScanArray(std::vector<std::string>* array) const;
 
   bool IsSubscribeCallback() const { return is_subscribe_callback_; }
 
@@ -75,10 +75,10 @@ class CallbackReply {
 
  private:
   /// Parse redis reply as string array or scan array.
-  void ParseAsStringArrayOrScanArray(redisReply *redis_reply);
+  void ParseAsStringArrayOrScanArray(redisReply* redis_reply);
 
   /// Parse redis reply as string array.
-  void ParseAsStringArray(redisReply *redis_reply);
+  void ParseAsStringArray(redisReply* redis_reply);
 
   /// Flag indicating the type of reply this represents.
   int reply_type_;
@@ -107,11 +107,11 @@ class CallbackReply {
 /// operation.
 using RedisCallback = std::function<void(std::shared_ptr<CallbackReply>)>;
 
-void GlobalRedisCallback(void *c, void *r, void *privdata);
+void GlobalRedisCallback(void* c, void* r, void* privdata);
 
 class RedisCallbackManager {
  public:
-  static RedisCallbackManager &instance() {
+  static RedisCallbackManager& instance() {
     static RedisCallbackManager instance;
     return instance;
   }
@@ -119,14 +119,14 @@ class RedisCallbackManager {
   struct CallbackItem : public std::enable_shared_from_this<CallbackItem> {
     CallbackItem() = default;
 
-    CallbackItem(const RedisCallback &callback, bool is_subscription, int64_t start_time,
-                 boost::asio::io_service &io_service)
+    CallbackItem(const RedisCallback& callback, bool is_subscription, int64_t start_time,
+                 boost::asio::io_service& io_service)
         : callback_(callback),
           is_subscription_(is_subscription),
           start_time_(start_time),
           io_service_(&io_service) {}
 
-    void Dispatch(std::shared_ptr<CallbackReply> &reply) {
+    void Dispatch(std::shared_ptr<CallbackReply>& reply) {
       std::shared_ptr<CallbackItem> self = shared_from_this();
       if (callback_ != nullptr) {
         io_service_->post([self, reply]() { self->callback_(std::move(reply)); });
@@ -136,15 +136,15 @@ class RedisCallbackManager {
     RedisCallback callback_;
     bool is_subscription_;
     int64_t start_time_;
-    boost::asio::io_service *io_service_;
+    boost::asio::io_service* io_service_;
   };
 
   /// Allocate an index at which we can add a callback later on.
   int64_t AllocateCallbackIndex();
 
   /// Add a callback at an optionally specified index.
-  int64_t AddCallback(const RedisCallback &function, bool is_subscription,
-                      boost::asio::io_service &io_service, int64_t callback_index = -1);
+  int64_t AddCallback(const RedisCallback& function, bool is_subscription,
+                      boost::asio::io_service& io_service, int64_t callback_index = -1);
 
   /// Remove a callback.
   void RemoveCallback(int64_t callback_index);
@@ -165,13 +165,13 @@ class RedisCallbackManager {
 
 class RedisContext {
  public:
-  RedisContext(boost::asio::io_service &io_service)
+  RedisContext(boost::asio::io_service& io_service)
       : io_service_(io_service), context_(nullptr) {}
 
   ~RedisContext();
 
-  Status Connect(const std::string &address, int port, bool sharding,
-                 const std::string &password);
+  Status Connect(const std::string& address, int port, bool sharding,
+                 const std::string& password);
 
   /// Run an operation on some table key synchronously.
   ///
@@ -188,8 +188,8 @@ class RedisContext {
   /// -1 for unused. If set, then data must be provided.
   /// \return The reply from redis.
   template <typename ID>
-  std::shared_ptr<CallbackReply> RunSync(const std::string &command, const ID &id,
-                                         const void *data, size_t length,
+  std::shared_ptr<CallbackReply> RunSync(const std::string& command, const ID& id,
+                                         const void* data, size_t length,
                                          const TablePrefix prefix,
                                          const TablePubsub pubsub_channel,
                                          int log_length = -1);
@@ -198,7 +198,7 @@ class RedisContext {
   ///
   /// \param args The vector of command args to pass to Redis.
   /// \return CallbackReply(The reply from redis).
-  std::unique_ptr<CallbackReply> RunArgvSync(const std::vector<std::string> &args);
+  std::unique_ptr<CallbackReply> RunArgvSync(const std::vector<std::string>& args);
 
   /// Run an operation on some table key.
   ///
@@ -216,7 +216,7 @@ class RedisContext {
   /// -1 for unused. If set, then data must be provided.
   /// \return Status.
   template <typename ID>
-  Status RunAsync(const std::string &command, const ID &id, const void *data,
+  Status RunAsync(const std::string& command, const ID& id, const void* data,
                   size_t length, const TablePrefix prefix,
                   const TablePubsub pubsub_channel, RedisCallback redisCallback,
                   int log_length = -1);
@@ -226,8 +226,8 @@ class RedisContext {
   /// \param args The vector of command args to pass to Redis.
   /// \param redis_callback The Redis callback function.
   /// \return Status.
-  Status RunArgvAsync(const std::vector<std::string> &args,
-                      const RedisCallback &redis_callback = nullptr);
+  Status RunArgvAsync(const std::vector<std::string>& args,
+                      const RedisCallback& redis_callback = nullptr);
 
   /// Subscribe to a specific Pub-Sub channel.
   ///
@@ -236,8 +236,8 @@ class RedisContext {
   /// \param redisCallback The callback function that the notification calls.
   /// \param out_callback_index The output pointer to callback index.
   /// \return Status.
-  Status SubscribeAsync(const ClientID &client_id, const TablePubsub pubsub_channel,
-                        const RedisCallback &redisCallback, int64_t *out_callback_index);
+  Status SubscribeAsync(const ClientID& client_id, const TablePubsub pubsub_channel,
+                        const RedisCallback& redisCallback, int64_t* out_callback_index);
 
   /// Subscribes the client to the given pattern.
   ///
@@ -247,14 +247,14 @@ class RedisContext {
   /// must already be allocated in the callback manager via
   /// RedisCallbackManager::AllocateCallbackIndex.
   /// \return Status.
-  Status PSubscribeAsync(const std::string &pattern, const RedisCallback &redisCallback,
+  Status PSubscribeAsync(const std::string& pattern, const RedisCallback& redisCallback,
                          int64_t callback_index);
 
   /// Unsubscribes the client from the given pattern.
   ///
   /// \param pattern The pattern of unsubscription channel.
   /// \return Status.
-  Status PUnsubscribeAsync(const std::string &pattern);
+  Status PUnsubscribeAsync(const std::string& pattern);
 
   /// Posts a message to the given channel.
   ///
@@ -262,39 +262,39 @@ class RedisContext {
   /// \param message The message to be published to redis.
   /// \param redisCallback The callback will be called when the message is published to
   /// redis. \return Status.
-  Status PublishAsync(const std::string &channel, const std::string &message,
-                      const RedisCallback &redisCallback);
+  Status PublishAsync(const std::string& channel, const std::string& message,
+                      const RedisCallback& redisCallback);
 
-  redisContext *sync_context() {
+  redisContext* sync_context() {
     RAY_CHECK(context_);
     return context_;
   }
 
-  RedisAsyncContext &async_context() {
+  RedisAsyncContext& async_context() {
     RAY_CHECK(redis_async_context_);
     return *redis_async_context_;
   }
 
-  RedisAsyncContext &subscribe_context() {
+  RedisAsyncContext& subscribe_context() {
     RAY_CHECK(async_redis_subscribe_context_);
     return *async_redis_subscribe_context_;
   }
 
-  boost::asio::io_service &io_service() { return io_service_; }
+  boost::asio::io_service& io_service() { return io_service_; }
 
  private:
   // These functions avoid problems with dependence on hiredis headers with clang-cl.
-  static int GetRedisError(redisContext *context);
-  static void FreeRedisReply(void *reply);
+  static int GetRedisError(redisContext* context);
+  static void FreeRedisReply(void* reply);
 
-  boost::asio::io_service &io_service_;
-  redisContext *context_;
+  boost::asio::io_service& io_service_;
+  redisContext* context_;
   std::unique_ptr<RedisAsyncContext> redis_async_context_;
   std::unique_ptr<RedisAsyncContext> async_redis_subscribe_context_;
 };
 
 template <typename ID>
-Status RedisContext::RunAsync(const std::string &command, const ID &id, const void *data,
+Status RedisContext::RunAsync(const std::string& command, const ID& id, const void* data,
                               size_t length, const TablePrefix prefix,
                               const TablePubsub pubsub_channel,
                               RedisCallback redisCallback, int log_length) {
@@ -306,22 +306,22 @@ Status RedisContext::RunAsync(const std::string &command, const ID &id, const vo
     if (log_length >= 0) {
       std::string redis_command = command + " %d %d %b %b %d";
       status = redis_async_context_->RedisAsyncCommand(
-          reinterpret_cast<redisCallbackFn *>(&GlobalRedisCallback),
-          reinterpret_cast<void *>(callback_index), redis_command.c_str(), prefix,
+          reinterpret_cast<redisCallbackFn*>(&GlobalRedisCallback),
+          reinterpret_cast<void*>(callback_index), redis_command.c_str(), prefix,
           pubsub_channel, id.Data(), id.Size(), data, length, log_length);
     } else {
       std::string redis_command = command + " %d %d %b %b";
       status = redis_async_context_->RedisAsyncCommand(
-          reinterpret_cast<redisCallbackFn *>(&GlobalRedisCallback),
-          reinterpret_cast<void *>(callback_index), redis_command.c_str(), prefix,
+          reinterpret_cast<redisCallbackFn*>(&GlobalRedisCallback),
+          reinterpret_cast<void*>(callback_index), redis_command.c_str(), prefix,
           pubsub_channel, id.Data(), id.Size(), data, length);
     }
   } else {
     RAY_CHECK(log_length == -1);
     std::string redis_command = command + " %d %d %b";
     status = redis_async_context_->RedisAsyncCommand(
-        reinterpret_cast<redisCallbackFn *>(&GlobalRedisCallback),
-        reinterpret_cast<void *>(callback_index), redis_command.c_str(), prefix,
+        reinterpret_cast<redisCallbackFn*>(&GlobalRedisCallback),
+        reinterpret_cast<void*>(callback_index), redis_command.c_str(), prefix,
         pubsub_channel, id.Data(), id.Size());
   }
   return status;
@@ -329,10 +329,10 @@ Status RedisContext::RunAsync(const std::string &command, const ID &id, const vo
 
 template <typename ID>
 std::shared_ptr<CallbackReply> RedisContext::RunSync(
-    const std::string &command, const ID &id, const void *data, size_t length,
+    const std::string& command, const ID& id, const void* data, size_t length,
     const TablePrefix prefix, const TablePubsub pubsub_channel, int log_length) {
   RAY_CHECK(context_);
-  void *redis_reply = nullptr;
+  void* redis_reply = nullptr;
   if (length > 0) {
     if (log_length >= 0) {
       std::string redis_command = command + " %d %d %b %b %d";
@@ -354,7 +354,7 @@ std::shared_ptr<CallbackReply> RedisContext::RunSync(
     return nullptr;
   } else {
     std::shared_ptr<CallbackReply> callback_reply =
-        std::make_shared<CallbackReply>(reinterpret_cast<redisReply *>(redis_reply));
+        std::make_shared<CallbackReply>(reinterpret_cast<redisReply*>(redis_reply));
     FreeRedisReply(redis_reply);
     return callback_reply;
   }

--- a/src/ray/gcs/redis_gcs_client.cc
+++ b/src/ray/gcs/redis_gcs_client.cc
@@ -22,17 +22,17 @@ namespace ray {
 
 namespace gcs {
 
-RedisGcsClient::RedisGcsClient(const GcsClientOptions &options)
+RedisGcsClient::RedisGcsClient(const GcsClientOptions& options)
     : RedisGcsClient(options, CommandType::kRegular) {}
 
-RedisGcsClient::RedisGcsClient(const GcsClientOptions &options, CommandType command_type)
+RedisGcsClient::RedisGcsClient(const GcsClientOptions& options, CommandType command_type)
     : GcsClient(options), command_type_(command_type) {
   RedisClientOptions redis_client_options(options.server_ip_, options.server_port_,
                                           options.password_, options.is_test_client_);
   redis_client_.reset(new RedisClient(redis_client_options));
 }
 
-Status RedisGcsClient::Connect(boost::asio::io_service &io_service) {
+Status RedisGcsClient::Connect(boost::asio::io_service& io_service) {
   RAY_CHECK(!is_connected_);
 
   Status status = redis_client_->Connect(io_service);
@@ -114,47 +114,47 @@ std::string RedisGcsClient::DebugString() const {
   return result.str();
 }
 
-ObjectTable &RedisGcsClient::object_table() { return *object_table_; }
+ObjectTable& RedisGcsClient::object_table() { return *object_table_; }
 
-raylet::TaskTable &RedisGcsClient::raylet_task_table() { return *raylet_task_table_; }
+raylet::TaskTable& RedisGcsClient::raylet_task_table() { return *raylet_task_table_; }
 
-LogBasedActorTable &RedisGcsClient::log_based_actor_table() {
+LogBasedActorTable& RedisGcsClient::log_based_actor_table() {
   return *log_based_actor_table_;
 }
 
-ActorTable &RedisGcsClient::actor_table() { return *actor_table_; }
+ActorTable& RedisGcsClient::actor_table() { return *actor_table_; }
 
-WorkerTable &RedisGcsClient::worker_table() { return *worker_table_; }
+WorkerTable& RedisGcsClient::worker_table() { return *worker_table_; }
 
-TaskReconstructionLog &RedisGcsClient::task_reconstruction_log() {
+TaskReconstructionLog& RedisGcsClient::task_reconstruction_log() {
   return *task_reconstruction_log_;
 }
 
-TaskLeaseTable &RedisGcsClient::task_lease_table() { return *task_lease_table_; }
+TaskLeaseTable& RedisGcsClient::task_lease_table() { return *task_lease_table_; }
 
-ClientTable &RedisGcsClient::client_table() { return *client_table_; }
+ClientTable& RedisGcsClient::client_table() { return *client_table_; }
 
-HeartbeatTable &RedisGcsClient::heartbeat_table() { return *heartbeat_table_; }
+HeartbeatTable& RedisGcsClient::heartbeat_table() { return *heartbeat_table_; }
 
-HeartbeatBatchTable &RedisGcsClient::heartbeat_batch_table() {
+HeartbeatBatchTable& RedisGcsClient::heartbeat_batch_table() {
   return *heartbeat_batch_table_;
 }
 
-ErrorTable &RedisGcsClient::error_table() { return *error_table_; }
+ErrorTable& RedisGcsClient::error_table() { return *error_table_; }
 
-JobTable &RedisGcsClient::job_table() { return *job_table_; }
+JobTable& RedisGcsClient::job_table() { return *job_table_; }
 
-ProfileTable &RedisGcsClient::profile_table() { return *profile_table_; }
+ProfileTable& RedisGcsClient::profile_table() { return *profile_table_; }
 
-ActorCheckpointTable &RedisGcsClient::actor_checkpoint_table() {
+ActorCheckpointTable& RedisGcsClient::actor_checkpoint_table() {
   return *actor_checkpoint_table_;
 }
 
-ActorCheckpointIdTable &RedisGcsClient::actor_checkpoint_id_table() {
+ActorCheckpointIdTable& RedisGcsClient::actor_checkpoint_id_table() {
   return *actor_checkpoint_id_table_;
 }
 
-DynamicResourceTable &RedisGcsClient::resource_table() { return *resource_table_; }
+DynamicResourceTable& RedisGcsClient::resource_table() { return *resource_table_; }
 
 }  // namespace gcs
 

--- a/src/ray/gcs/redis_gcs_client.h
+++ b/src/ray/gcs/redis_gcs_client.h
@@ -39,14 +39,14 @@ class RAY_EXPORT RedisGcsClient : public GcsClient {
   /// call to Connect() to the client table. Will fix this in next pr.
   ///
   /// \param options Options of this client, e.g. server address, password and so on.
-  RedisGcsClient(const GcsClientOptions &options);
+  RedisGcsClient(const GcsClientOptions& options);
 
   /// This constructor is only used for testing.
   /// Connect() must be called(and return ok) before you call any other methods.
   ///
   /// \param options Options of this client, e.g. server address, password and so on.
   /// \param command_type The commands issued type.
-  RedisGcsClient(const GcsClientOptions &options, CommandType command_type);
+  RedisGcsClient(const GcsClientOptions& options, CommandType command_type);
 
   /// Connect to GCS Service. Non-thread safe.
   /// Call this function before calling other functions.
@@ -55,7 +55,7 @@ class RAY_EXPORT RedisGcsClient : public GcsClient {
   /// Must be single-threaded io_service (get more information from RedisAsioClient).
   ///
   /// \return Status
-  Status Connect(boost::asio::io_service &io_service) override;
+  Status Connect(boost::asio::io_service& io_service) override;
 
   /// Disconnect with GCS Service. Non-thread safe.
   void Disconnect() override;
@@ -67,10 +67,10 @@ class RAY_EXPORT RedisGcsClient : public GcsClient {
 
   // We also need something to export generic code to run on workers from the
   // driver (to set the PYTHONPATH)
-  using GetExportCallback = std::function<void(const std::string &data)>;
-  Status AddExport(const std::string &job_id, std::string &export_data);
-  Status GetExport(const std::string &job_id, int64_t export_index,
-                   const GetExportCallback &done_callback);
+  using GetExportCallback = std::function<void(const std::string& data)>;
+  Status AddExport(const std::string& job_id, std::string& export_data);
+  Status GetExport(const std::string& job_id, int64_t export_index,
+                   const GetExportCallback& done_callback);
 
   std::vector<std::shared_ptr<RedisContext>> shard_contexts() {
     return redis_client_->GetShardContexts();
@@ -84,30 +84,30 @@ class RAY_EXPORT RedisGcsClient : public GcsClient {
 
   /// The following xxx_table methods implement the Accessor interfaces.
   /// Implements the Actors() interface.
-  LogBasedActorTable &log_based_actor_table();
-  ActorTable &actor_table();
-  ActorCheckpointTable &actor_checkpoint_table();
-  ActorCheckpointIdTable &actor_checkpoint_id_table();
+  LogBasedActorTable& log_based_actor_table();
+  ActorTable& actor_table();
+  ActorCheckpointTable& actor_checkpoint_table();
+  ActorCheckpointIdTable& actor_checkpoint_id_table();
   /// Implements the Jobs() interface.
-  JobTable &job_table();
+  JobTable& job_table();
   /// Implements the Objects() interface.
-  ObjectTable &object_table();
+  ObjectTable& object_table();
   /// Implements the Nodes() interface.
-  ClientTable &client_table();
-  HeartbeatTable &heartbeat_table();
-  HeartbeatBatchTable &heartbeat_batch_table();
-  DynamicResourceTable &resource_table();
+  ClientTable& client_table();
+  HeartbeatTable& heartbeat_table();
+  HeartbeatBatchTable& heartbeat_batch_table();
+  DynamicResourceTable& resource_table();
   /// Implements the Tasks() interface.
-  virtual raylet::TaskTable &raylet_task_table();
-  TaskLeaseTable &task_lease_table();
-  TaskReconstructionLog &task_reconstruction_log();
+  virtual raylet::TaskTable& raylet_task_table();
+  TaskLeaseTable& task_lease_table();
+  TaskReconstructionLog& task_reconstruction_log();
   /// Implements the Errors() interface.
   // TODO: Some API for getting the error on the driver
-  ErrorTable &error_table();
+  ErrorTable& error_table();
   /// Implements the Stats() interface.
-  ProfileTable &profile_table();
+  ProfileTable& profile_table();
   /// Implements the Workers() interface.
-  WorkerTable &worker_table();
+  WorkerTable& worker_table();
 
  private:
   // GCS command type. If CommandType::kChain, chain-replicated versions of the tables

--- a/src/ray/gcs/redis_module/chain_module.h
+++ b/src/ray/gcs/redis_module/chain_module.h
@@ -51,12 +51,12 @@ class RedisChainModule {
   // It is okay for this NodeFunc to call "RM_FreeString(mutated_key_str)" after
   // assigning the fourth arg, since that call presumably only decrements a ref
   // count.
-  using NodeFunc = std::function<int(RedisModuleCtx *, RedisModuleString **, int,
-                                     RedisModuleString **)>;
+  using NodeFunc =
+      std::function<int(RedisModuleCtx*, RedisModuleString**, int, RedisModuleString**)>;
 
   // A function that (1) runs only after all NodeFunc's have run, and (2) runs
   // once on the tail.  A typical usage is to publish a write.
-  using TailFunc = std::function<int(RedisModuleCtx *, RedisModuleString **, int)>;
+  using TailFunc = std::function<int(RedisModuleCtx*, RedisModuleString**, int)>;
 
   // TODO(zongheng): document the RM_Reply semantics.
 
@@ -68,6 +68,6 @@ class RedisChainModule {
   // final tail_func().
   //
   // TODO(zongheng): currently only supports 1-node chain.
-  int ChainReplicate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+  int ChainReplicate(RedisModuleCtx* ctx, RedisModuleString** argv, int argc,
                      NodeFunc node_func, TailFunc tail_func);
 };

--- a/src/ray/gcs/redis_module/redis_string.h
+++ b/src/ray/gcs/redis_module/redis_string.h
@@ -29,13 +29,13 @@
  * @params ... The parameters to be formated.
  * @return The formatted RedisModuleString, needs to be freed by the caller.
  */
-RedisModuleString *RedisString_Format(RedisModuleCtx *ctx, const char *fmt, ...) {
-  RedisModuleString *result = RedisModule_CreateString(ctx, "", 0);
+RedisModuleString* RedisString_Format(RedisModuleCtx* ctx, const char* fmt, ...) {
+  RedisModuleString* result = RedisModule_CreateString(ctx, "", 0);
   size_t initlen = strlen(fmt);
   size_t l;
-  RedisModuleString *redisstr;
-  const char *s;
-  const char *f = fmt;
+  RedisModuleString* redisstr;
+  const char* s;
+  const char* f = fmt;
   int i;
   va_list ap;
 
@@ -50,18 +50,18 @@ RedisModuleString *RedisString_Format(RedisModuleCtx *ctx, const char *fmt, ...)
       f++;
       switch (next) {
       case 'S':
-        redisstr = va_arg(ap, RedisModuleString *);
+        redisstr = va_arg(ap, RedisModuleString*);
         s = RedisModule_StringPtrLen(redisstr, &l);
         RedisModule_StringAppendBuffer(ctx, result, s, l);
         i += 1;
         break;
       case 's':
-        s = va_arg(ap, const char *);
+        s = va_arg(ap, const char*);
         RedisModule_StringAppendBuffer(ctx, result, s, strlen(s));
         i += 1;
         break;
       case 'b':
-        s = va_arg(ap, const char *);
+        s = va_arg(ap, const char*);
         l = va_arg(ap, size_t);
         RedisModule_StringAppendBuffer(ctx, result, s, l);
         i += 1;
@@ -83,8 +83,8 @@ RedisModuleString *RedisString_Format(RedisModuleCtx *ctx, const char *fmt, ...)
   return result;
 }
 
-std::string RedisString_ToString(RedisModuleString *string) {
+std::string RedisString_ToString(RedisModuleString* string) {
   size_t size;
-  const char *data = RedisModule_StringPtrLen(string, &size);
+  const char* data = RedisModule_StringPtrLen(string, &size);
   return std::string(data, size);
 }

--- a/src/ray/gcs/redis_module/redismodule.h
+++ b/src/ray/gcs/redis_module/redismodule.h
@@ -73,7 +73,7 @@
 
 /* A special pointer that we can use between the core and the module to signal
  * field deletion, and that is impossible to be a valid pointer. */
-#define REDISMODULE_HASH_DELETE ((RedisModuleString *)(long)1)
+#define REDISMODULE_HASH_DELETE ((RedisModuleString*)(long)1)
 
 /* Error messages. */
 #define REDISMODULE_ERRORMSG_WRONGTYPE \
@@ -100,16 +100,16 @@ typedef struct RedisModuleType RedisModuleType;
 typedef struct RedisModuleDigest RedisModuleDigest;
 typedef struct RedisModuleBlockedClient RedisModuleBlockedClient;
 
-typedef int (*RedisModuleCmdFunc)(RedisModuleCtx *ctx, RedisModuleString **argv,
+typedef int (*RedisModuleCmdFunc)(RedisModuleCtx* ctx, RedisModuleString** argv,
                                   int argc);
 
-typedef void *(*RedisModuleTypeLoadFunc)(RedisModuleIO *rdb, int encver);
-typedef void (*RedisModuleTypeSaveFunc)(RedisModuleIO *rdb, void *value);
-typedef void (*RedisModuleTypeRewriteFunc)(RedisModuleIO *aof, RedisModuleString *key,
-                                           void *value);
-typedef size_t (*RedisModuleTypeMemUsageFunc)(void *value);
-typedef void (*RedisModuleTypeDigestFunc)(RedisModuleDigest *digest, void *value);
-typedef void (*RedisModuleTypeFreeFunc)(void *value);
+typedef void* (*RedisModuleTypeLoadFunc)(RedisModuleIO* rdb, int encver);
+typedef void (*RedisModuleTypeSaveFunc)(RedisModuleIO* rdb, void* value);
+typedef void (*RedisModuleTypeRewriteFunc)(RedisModuleIO* aof, RedisModuleString* key,
+                                           void* value);
+typedef size_t (*RedisModuleTypeMemUsageFunc)(void* value);
+typedef void (*RedisModuleTypeDigestFunc)(RedisModuleDigest* digest, void* value);
+typedef void (*RedisModuleTypeFreeFunc)(void* value);
 
 #define REDISMODULE_TYPE_METHOD_VERSION 1
 typedef struct RedisModuleTypeMethods {
@@ -123,182 +123,182 @@ typedef struct RedisModuleTypeMethods {
 } RedisModuleTypeMethods;
 
 #define REDISMODULE_GET_API(name) \
-  RedisModule_GetApi("RedisModule_" #name, ((void **)&RedisModule_##name))
+  RedisModule_GetApi("RedisModule_" #name, ((void**)&RedisModule_##name))
 
 #define REDISMODULE_API_FUNC(x) (*x)
 
-void *REDISMODULE_API_FUNC(RedisModule_Alloc)(size_t bytes);
-void *REDISMODULE_API_FUNC(RedisModule_Realloc)(void *ptr, size_t bytes);
-void REDISMODULE_API_FUNC(RedisModule_Free)(void *ptr);
-void *REDISMODULE_API_FUNC(RedisModule_Calloc)(size_t nmemb, size_t size);
-char *REDISMODULE_API_FUNC(RedisModule_Strdup)(const char *str);
-int REDISMODULE_API_FUNC(RedisModule_GetApi)(const char *, void *);
-int REDISMODULE_API_FUNC(RedisModule_CreateCommand)(RedisModuleCtx *ctx, const char *name,
+void* REDISMODULE_API_FUNC(RedisModule_Alloc)(size_t bytes);
+void* REDISMODULE_API_FUNC(RedisModule_Realloc)(void* ptr, size_t bytes);
+void REDISMODULE_API_FUNC(RedisModule_Free)(void* ptr);
+void* REDISMODULE_API_FUNC(RedisModule_Calloc)(size_t nmemb, size_t size);
+char* REDISMODULE_API_FUNC(RedisModule_Strdup)(const char* str);
+int REDISMODULE_API_FUNC(RedisModule_GetApi)(const char*, void*);
+int REDISMODULE_API_FUNC(RedisModule_CreateCommand)(RedisModuleCtx* ctx, const char* name,
                                                     RedisModuleCmdFunc cmdfunc,
-                                                    const char *strflags, int firstkey,
+                                                    const char* strflags, int firstkey,
                                                     int lastkey, int keystep);
-int REDISMODULE_API_FUNC(RedisModule_SetModuleAttribs)(RedisModuleCtx *ctx,
-                                                       const char *name, int ver,
+int REDISMODULE_API_FUNC(RedisModule_SetModuleAttribs)(RedisModuleCtx* ctx,
+                                                       const char* name, int ver,
                                                        int apiver);
-int REDISMODULE_API_FUNC(RedisModule_WrongArity)(RedisModuleCtx *ctx);
-int REDISMODULE_API_FUNC(RedisModule_ReplyWithLongLong)(RedisModuleCtx *ctx,
+int REDISMODULE_API_FUNC(RedisModule_WrongArity)(RedisModuleCtx* ctx);
+int REDISMODULE_API_FUNC(RedisModule_ReplyWithLongLong)(RedisModuleCtx* ctx,
                                                         long long ll);
-int REDISMODULE_API_FUNC(RedisModule_GetSelectedDb)(RedisModuleCtx *ctx);
-int REDISMODULE_API_FUNC(RedisModule_SelectDb)(RedisModuleCtx *ctx, int newid);
-void *REDISMODULE_API_FUNC(RedisModule_OpenKey)(RedisModuleCtx *ctx,
-                                                RedisModuleString *keyname, int mode);
-void REDISMODULE_API_FUNC(RedisModule_CloseKey)(RedisModuleKey *kp);
-int REDISMODULE_API_FUNC(RedisModule_KeyType)(RedisModuleKey *kp);
-size_t REDISMODULE_API_FUNC(RedisModule_ValueLength)(RedisModuleKey *kp);
-int REDISMODULE_API_FUNC(RedisModule_ListPush)(RedisModuleKey *kp, int where,
-                                               RedisModuleString *ele);
-RedisModuleString *REDISMODULE_API_FUNC(RedisModule_ListPop)(RedisModuleKey *key,
+int REDISMODULE_API_FUNC(RedisModule_GetSelectedDb)(RedisModuleCtx* ctx);
+int REDISMODULE_API_FUNC(RedisModule_SelectDb)(RedisModuleCtx* ctx, int newid);
+void* REDISMODULE_API_FUNC(RedisModule_OpenKey)(RedisModuleCtx* ctx,
+                                                RedisModuleString* keyname, int mode);
+void REDISMODULE_API_FUNC(RedisModule_CloseKey)(RedisModuleKey* kp);
+int REDISMODULE_API_FUNC(RedisModule_KeyType)(RedisModuleKey* kp);
+size_t REDISMODULE_API_FUNC(RedisModule_ValueLength)(RedisModuleKey* kp);
+int REDISMODULE_API_FUNC(RedisModule_ListPush)(RedisModuleKey* kp, int where,
+                                               RedisModuleString* ele);
+RedisModuleString* REDISMODULE_API_FUNC(RedisModule_ListPop)(RedisModuleKey* key,
                                                              int where);
-RedisModuleCallReply *REDISMODULE_API_FUNC(RedisModule_Call)(RedisModuleCtx *ctx,
-                                                             const char *cmdname,
-                                                             const char *fmt, ...);
-const char *REDISMODULE_API_FUNC(RedisModule_CallReplyProto)(RedisModuleCallReply *reply,
-                                                             size_t *len);
-void REDISMODULE_API_FUNC(RedisModule_FreeCallReply)(RedisModuleCallReply *reply);
-int REDISMODULE_API_FUNC(RedisModule_CallReplyType)(RedisModuleCallReply *reply);
-long long REDISMODULE_API_FUNC(RedisModule_CallReplyInteger)(RedisModuleCallReply *reply);
-size_t REDISMODULE_API_FUNC(RedisModule_CallReplyLength)(RedisModuleCallReply *reply);
-RedisModuleCallReply *REDISMODULE_API_FUNC(RedisModule_CallReplyArrayElement)(
-    RedisModuleCallReply *reply, size_t idx);
-RedisModuleString *REDISMODULE_API_FUNC(RedisModule_CreateString)(RedisModuleCtx *ctx,
-                                                                  const char *ptr,
+RedisModuleCallReply* REDISMODULE_API_FUNC(RedisModule_Call)(RedisModuleCtx* ctx,
+                                                             const char* cmdname,
+                                                             const char* fmt, ...);
+const char* REDISMODULE_API_FUNC(RedisModule_CallReplyProto)(RedisModuleCallReply* reply,
+                                                             size_t* len);
+void REDISMODULE_API_FUNC(RedisModule_FreeCallReply)(RedisModuleCallReply* reply);
+int REDISMODULE_API_FUNC(RedisModule_CallReplyType)(RedisModuleCallReply* reply);
+long long REDISMODULE_API_FUNC(RedisModule_CallReplyInteger)(RedisModuleCallReply* reply);
+size_t REDISMODULE_API_FUNC(RedisModule_CallReplyLength)(RedisModuleCallReply* reply);
+RedisModuleCallReply* REDISMODULE_API_FUNC(RedisModule_CallReplyArrayElement)(
+    RedisModuleCallReply* reply, size_t idx);
+RedisModuleString* REDISMODULE_API_FUNC(RedisModule_CreateString)(RedisModuleCtx* ctx,
+                                                                  const char* ptr,
                                                                   size_t len);
-RedisModuleString *REDISMODULE_API_FUNC(RedisModule_CreateStringFromLongLong)(
-    RedisModuleCtx *ctx, long long ll);
-RedisModuleString *REDISMODULE_API_FUNC(RedisModule_CreateStringFromString)(
-    RedisModuleCtx *ctx, const RedisModuleString *str);
-RedisModuleString *REDISMODULE_API_FUNC(RedisModule_CreateStringPrintf)(
-    RedisModuleCtx *ctx, const char *fmt, ...);
-void REDISMODULE_API_FUNC(RedisModule_FreeString)(RedisModuleCtx *ctx,
-                                                  RedisModuleString *str);
-const char *REDISMODULE_API_FUNC(RedisModule_StringPtrLen)(const RedisModuleString *str,
-                                                           size_t *len);
-int REDISMODULE_API_FUNC(RedisModule_ReplyWithError)(RedisModuleCtx *ctx,
-                                                     const char *err);
-int REDISMODULE_API_FUNC(RedisModule_ReplyWithSimpleString)(RedisModuleCtx *ctx,
-                                                            const char *msg);
-int REDISMODULE_API_FUNC(RedisModule_ReplyWithArray)(RedisModuleCtx *ctx, long len);
-void REDISMODULE_API_FUNC(RedisModule_ReplySetArrayLength)(RedisModuleCtx *ctx, long len);
-int REDISMODULE_API_FUNC(RedisModule_ReplyWithStringBuffer)(RedisModuleCtx *ctx,
-                                                            const char *buf, size_t len);
-int REDISMODULE_API_FUNC(RedisModule_ReplyWithString)(RedisModuleCtx *ctx,
-                                                      RedisModuleString *str);
-int REDISMODULE_API_FUNC(RedisModule_ReplyWithNull)(RedisModuleCtx *ctx);
-int REDISMODULE_API_FUNC(RedisModule_ReplyWithDouble)(RedisModuleCtx *ctx, double d);
-int REDISMODULE_API_FUNC(RedisModule_ReplyWithCallReply)(RedisModuleCtx *ctx,
-                                                         RedisModuleCallReply *reply);
-int REDISMODULE_API_FUNC(RedisModule_StringToLongLong)(const RedisModuleString *str,
-                                                       long long *ll);
-int REDISMODULE_API_FUNC(RedisModule_StringToDouble)(const RedisModuleString *str,
-                                                     double *d);
-void REDISMODULE_API_FUNC(RedisModule_AutoMemory)(RedisModuleCtx *ctx);
-int REDISMODULE_API_FUNC(RedisModule_Replicate)(RedisModuleCtx *ctx, const char *cmdname,
-                                                const char *fmt, ...);
-int REDISMODULE_API_FUNC(RedisModule_ReplicateVerbatim)(RedisModuleCtx *ctx);
-const char *REDISMODULE_API_FUNC(RedisModule_CallReplyStringPtr)(
-    RedisModuleCallReply *reply, size_t *len);
-RedisModuleString *REDISMODULE_API_FUNC(RedisModule_CreateStringFromCallReply)(
-    RedisModuleCallReply *reply);
-int REDISMODULE_API_FUNC(RedisModule_DeleteKey)(RedisModuleKey *key);
-int REDISMODULE_API_FUNC(RedisModule_StringSet)(RedisModuleKey *key,
-                                                RedisModuleString *str);
-char *REDISMODULE_API_FUNC(RedisModule_StringDMA)(RedisModuleKey *key, size_t *len,
+RedisModuleString* REDISMODULE_API_FUNC(RedisModule_CreateStringFromLongLong)(
+    RedisModuleCtx* ctx, long long ll);
+RedisModuleString* REDISMODULE_API_FUNC(RedisModule_CreateStringFromString)(
+    RedisModuleCtx* ctx, const RedisModuleString* str);
+RedisModuleString* REDISMODULE_API_FUNC(RedisModule_CreateStringPrintf)(
+    RedisModuleCtx* ctx, const char* fmt, ...);
+void REDISMODULE_API_FUNC(RedisModule_FreeString)(RedisModuleCtx* ctx,
+                                                  RedisModuleString* str);
+const char* REDISMODULE_API_FUNC(RedisModule_StringPtrLen)(const RedisModuleString* str,
+                                                           size_t* len);
+int REDISMODULE_API_FUNC(RedisModule_ReplyWithError)(RedisModuleCtx* ctx,
+                                                     const char* err);
+int REDISMODULE_API_FUNC(RedisModule_ReplyWithSimpleString)(RedisModuleCtx* ctx,
+                                                            const char* msg);
+int REDISMODULE_API_FUNC(RedisModule_ReplyWithArray)(RedisModuleCtx* ctx, long len);
+void REDISMODULE_API_FUNC(RedisModule_ReplySetArrayLength)(RedisModuleCtx* ctx, long len);
+int REDISMODULE_API_FUNC(RedisModule_ReplyWithStringBuffer)(RedisModuleCtx* ctx,
+                                                            const char* buf, size_t len);
+int REDISMODULE_API_FUNC(RedisModule_ReplyWithString)(RedisModuleCtx* ctx,
+                                                      RedisModuleString* str);
+int REDISMODULE_API_FUNC(RedisModule_ReplyWithNull)(RedisModuleCtx* ctx);
+int REDISMODULE_API_FUNC(RedisModule_ReplyWithDouble)(RedisModuleCtx* ctx, double d);
+int REDISMODULE_API_FUNC(RedisModule_ReplyWithCallReply)(RedisModuleCtx* ctx,
+                                                         RedisModuleCallReply* reply);
+int REDISMODULE_API_FUNC(RedisModule_StringToLongLong)(const RedisModuleString* str,
+                                                       long long* ll);
+int REDISMODULE_API_FUNC(RedisModule_StringToDouble)(const RedisModuleString* str,
+                                                     double* d);
+void REDISMODULE_API_FUNC(RedisModule_AutoMemory)(RedisModuleCtx* ctx);
+int REDISMODULE_API_FUNC(RedisModule_Replicate)(RedisModuleCtx* ctx, const char* cmdname,
+                                                const char* fmt, ...);
+int REDISMODULE_API_FUNC(RedisModule_ReplicateVerbatim)(RedisModuleCtx* ctx);
+const char* REDISMODULE_API_FUNC(RedisModule_CallReplyStringPtr)(
+    RedisModuleCallReply* reply, size_t* len);
+RedisModuleString* REDISMODULE_API_FUNC(RedisModule_CreateStringFromCallReply)(
+    RedisModuleCallReply* reply);
+int REDISMODULE_API_FUNC(RedisModule_DeleteKey)(RedisModuleKey* key);
+int REDISMODULE_API_FUNC(RedisModule_StringSet)(RedisModuleKey* key,
+                                                RedisModuleString* str);
+char* REDISMODULE_API_FUNC(RedisModule_StringDMA)(RedisModuleKey* key, size_t* len,
                                                   int mode);
-int REDISMODULE_API_FUNC(RedisModule_StringTruncate)(RedisModuleKey *key, size_t newlen);
-mstime_t REDISMODULE_API_FUNC(RedisModule_GetExpire)(RedisModuleKey *key);
-int REDISMODULE_API_FUNC(RedisModule_SetExpire)(RedisModuleKey *key, mstime_t expire);
-int REDISMODULE_API_FUNC(RedisModule_ZsetAdd)(RedisModuleKey *key, double score,
-                                              RedisModuleString *ele, int *flagsptr);
-int REDISMODULE_API_FUNC(RedisModule_ZsetIncrby)(RedisModuleKey *key, double score,
-                                                 RedisModuleString *ele, int *flagsptr,
-                                                 double *newscore);
-int REDISMODULE_API_FUNC(RedisModule_ZsetScore)(RedisModuleKey *key,
-                                                RedisModuleString *ele, double *score);
-int REDISMODULE_API_FUNC(RedisModule_ZsetRem)(RedisModuleKey *key, RedisModuleString *ele,
-                                              int *deleted);
-void REDISMODULE_API_FUNC(RedisModule_ZsetRangeStop)(RedisModuleKey *key);
-int REDISMODULE_API_FUNC(RedisModule_ZsetFirstInScoreRange)(RedisModuleKey *key,
+int REDISMODULE_API_FUNC(RedisModule_StringTruncate)(RedisModuleKey* key, size_t newlen);
+mstime_t REDISMODULE_API_FUNC(RedisModule_GetExpire)(RedisModuleKey* key);
+int REDISMODULE_API_FUNC(RedisModule_SetExpire)(RedisModuleKey* key, mstime_t expire);
+int REDISMODULE_API_FUNC(RedisModule_ZsetAdd)(RedisModuleKey* key, double score,
+                                              RedisModuleString* ele, int* flagsptr);
+int REDISMODULE_API_FUNC(RedisModule_ZsetIncrby)(RedisModuleKey* key, double score,
+                                                 RedisModuleString* ele, int* flagsptr,
+                                                 double* newscore);
+int REDISMODULE_API_FUNC(RedisModule_ZsetScore)(RedisModuleKey* key,
+                                                RedisModuleString* ele, double* score);
+int REDISMODULE_API_FUNC(RedisModule_ZsetRem)(RedisModuleKey* key, RedisModuleString* ele,
+                                              int* deleted);
+void REDISMODULE_API_FUNC(RedisModule_ZsetRangeStop)(RedisModuleKey* key);
+int REDISMODULE_API_FUNC(RedisModule_ZsetFirstInScoreRange)(RedisModuleKey* key,
                                                             double min, double max,
                                                             int minex, int maxex);
-int REDISMODULE_API_FUNC(RedisModule_ZsetLastInScoreRange)(RedisModuleKey *key,
+int REDISMODULE_API_FUNC(RedisModule_ZsetLastInScoreRange)(RedisModuleKey* key,
                                                            double min, double max,
                                                            int minex, int maxex);
-int REDISMODULE_API_FUNC(RedisModule_ZsetFirstInLexRange)(RedisModuleKey *key,
-                                                          RedisModuleString *min,
-                                                          RedisModuleString *max);
-int REDISMODULE_API_FUNC(RedisModule_ZsetLastInLexRange)(RedisModuleKey *key,
-                                                         RedisModuleString *min,
-                                                         RedisModuleString *max);
-RedisModuleString *REDISMODULE_API_FUNC(RedisModule_ZsetRangeCurrentElement)(
-    RedisModuleKey *key, double *score);
-int REDISMODULE_API_FUNC(RedisModule_ZsetRangeNext)(RedisModuleKey *key);
-int REDISMODULE_API_FUNC(RedisModule_ZsetRangePrev)(RedisModuleKey *key);
-int REDISMODULE_API_FUNC(RedisModule_ZsetRangeEndReached)(RedisModuleKey *key);
-int REDISMODULE_API_FUNC(RedisModule_HashSet)(RedisModuleKey *key, int flags, ...);
-int REDISMODULE_API_FUNC(RedisModule_HashGet)(RedisModuleKey *key, int flags, ...);
-int REDISMODULE_API_FUNC(RedisModule_IsKeysPositionRequest)(RedisModuleCtx *ctx);
-void REDISMODULE_API_FUNC(RedisModule_KeyAtPos)(RedisModuleCtx *ctx, int pos);
-unsigned long long REDISMODULE_API_FUNC(RedisModule_GetClientId)(RedisModuleCtx *ctx);
-void *REDISMODULE_API_FUNC(RedisModule_PoolAlloc)(RedisModuleCtx *ctx, size_t bytes);
-RedisModuleType *REDISMODULE_API_FUNC(RedisModule_CreateDataType)(
-    RedisModuleCtx *ctx, const char *name, int encver,
-    RedisModuleTypeMethods *typemethods);
-int REDISMODULE_API_FUNC(RedisModule_ModuleTypeSetValue)(RedisModuleKey *key,
-                                                         RedisModuleType *mt,
-                                                         void *value);
-RedisModuleType *REDISMODULE_API_FUNC(RedisModule_ModuleTypeGetType)(RedisModuleKey *key);
-void *REDISMODULE_API_FUNC(RedisModule_ModuleTypeGetValue)(RedisModuleKey *key);
-void REDISMODULE_API_FUNC(RedisModule_SaveUnsigned)(RedisModuleIO *io, uint64_t value);
-uint64_t REDISMODULE_API_FUNC(RedisModule_LoadUnsigned)(RedisModuleIO *io);
-void REDISMODULE_API_FUNC(RedisModule_SaveSigned)(RedisModuleIO *io, int64_t value);
-int64_t REDISMODULE_API_FUNC(RedisModule_LoadSigned)(RedisModuleIO *io);
-void REDISMODULE_API_FUNC(RedisModule_EmitAOF)(RedisModuleIO *io, const char *cmdname,
-                                               const char *fmt, ...);
-void REDISMODULE_API_FUNC(RedisModule_SaveString)(RedisModuleIO *io,
-                                                  RedisModuleString *s);
-void REDISMODULE_API_FUNC(RedisModule_SaveStringBuffer)(RedisModuleIO *io,
-                                                        const char *str, size_t len);
-RedisModuleString *REDISMODULE_API_FUNC(RedisModule_LoadString)(RedisModuleIO *io);
-char *REDISMODULE_API_FUNC(RedisModule_LoadStringBuffer)(RedisModuleIO *io,
-                                                         size_t *lenptr);
-void REDISMODULE_API_FUNC(RedisModule_SaveDouble)(RedisModuleIO *io, double value);
-double REDISMODULE_API_FUNC(RedisModule_LoadDouble)(RedisModuleIO *io);
-void REDISMODULE_API_FUNC(RedisModule_SaveFloat)(RedisModuleIO *io, float value);
-float REDISMODULE_API_FUNC(RedisModule_LoadFloat)(RedisModuleIO *io);
-void REDISMODULE_API_FUNC(RedisModule_Log)(RedisModuleCtx *ctx, const char *level,
-                                           const char *fmt, ...);
-void REDISMODULE_API_FUNC(RedisModule_LogIOError)(RedisModuleIO *io, const char *levelstr,
-                                                  const char *fmt, ...);
-int REDISMODULE_API_FUNC(RedisModule_StringAppendBuffer)(RedisModuleCtx *ctx,
-                                                         RedisModuleString *str,
-                                                         const char *buf, size_t len);
-void REDISMODULE_API_FUNC(RedisModule_RetainString)(RedisModuleCtx *ctx,
-                                                    RedisModuleString *str);
-int REDISMODULE_API_FUNC(RedisModule_StringCompare)(RedisModuleString *a,
-                                                    RedisModuleString *b);
-RedisModuleCtx *REDISMODULE_API_FUNC(RedisModule_GetContextFromIO)(RedisModuleIO *io);
-RedisModuleBlockedClient *REDISMODULE_API_FUNC(RedisModule_BlockClient)(
-    RedisModuleCtx *ctx, RedisModuleCmdFunc reply_callback,
-    RedisModuleCmdFunc timeout_callback, void (*free_privdata)(void *),
+int REDISMODULE_API_FUNC(RedisModule_ZsetFirstInLexRange)(RedisModuleKey* key,
+                                                          RedisModuleString* min,
+                                                          RedisModuleString* max);
+int REDISMODULE_API_FUNC(RedisModule_ZsetLastInLexRange)(RedisModuleKey* key,
+                                                         RedisModuleString* min,
+                                                         RedisModuleString* max);
+RedisModuleString* REDISMODULE_API_FUNC(RedisModule_ZsetRangeCurrentElement)(
+    RedisModuleKey* key, double* score);
+int REDISMODULE_API_FUNC(RedisModule_ZsetRangeNext)(RedisModuleKey* key);
+int REDISMODULE_API_FUNC(RedisModule_ZsetRangePrev)(RedisModuleKey* key);
+int REDISMODULE_API_FUNC(RedisModule_ZsetRangeEndReached)(RedisModuleKey* key);
+int REDISMODULE_API_FUNC(RedisModule_HashSet)(RedisModuleKey* key, int flags, ...);
+int REDISMODULE_API_FUNC(RedisModule_HashGet)(RedisModuleKey* key, int flags, ...);
+int REDISMODULE_API_FUNC(RedisModule_IsKeysPositionRequest)(RedisModuleCtx* ctx);
+void REDISMODULE_API_FUNC(RedisModule_KeyAtPos)(RedisModuleCtx* ctx, int pos);
+unsigned long long REDISMODULE_API_FUNC(RedisModule_GetClientId)(RedisModuleCtx* ctx);
+void* REDISMODULE_API_FUNC(RedisModule_PoolAlloc)(RedisModuleCtx* ctx, size_t bytes);
+RedisModuleType* REDISMODULE_API_FUNC(RedisModule_CreateDataType)(
+    RedisModuleCtx* ctx, const char* name, int encver,
+    RedisModuleTypeMethods* typemethods);
+int REDISMODULE_API_FUNC(RedisModule_ModuleTypeSetValue)(RedisModuleKey* key,
+                                                         RedisModuleType* mt,
+                                                         void* value);
+RedisModuleType* REDISMODULE_API_FUNC(RedisModule_ModuleTypeGetType)(RedisModuleKey* key);
+void* REDISMODULE_API_FUNC(RedisModule_ModuleTypeGetValue)(RedisModuleKey* key);
+void REDISMODULE_API_FUNC(RedisModule_SaveUnsigned)(RedisModuleIO* io, uint64_t value);
+uint64_t REDISMODULE_API_FUNC(RedisModule_LoadUnsigned)(RedisModuleIO* io);
+void REDISMODULE_API_FUNC(RedisModule_SaveSigned)(RedisModuleIO* io, int64_t value);
+int64_t REDISMODULE_API_FUNC(RedisModule_LoadSigned)(RedisModuleIO* io);
+void REDISMODULE_API_FUNC(RedisModule_EmitAOF)(RedisModuleIO* io, const char* cmdname,
+                                               const char* fmt, ...);
+void REDISMODULE_API_FUNC(RedisModule_SaveString)(RedisModuleIO* io,
+                                                  RedisModuleString* s);
+void REDISMODULE_API_FUNC(RedisModule_SaveStringBuffer)(RedisModuleIO* io,
+                                                        const char* str, size_t len);
+RedisModuleString* REDISMODULE_API_FUNC(RedisModule_LoadString)(RedisModuleIO* io);
+char* REDISMODULE_API_FUNC(RedisModule_LoadStringBuffer)(RedisModuleIO* io,
+                                                         size_t* lenptr);
+void REDISMODULE_API_FUNC(RedisModule_SaveDouble)(RedisModuleIO* io, double value);
+double REDISMODULE_API_FUNC(RedisModule_LoadDouble)(RedisModuleIO* io);
+void REDISMODULE_API_FUNC(RedisModule_SaveFloat)(RedisModuleIO* io, float value);
+float REDISMODULE_API_FUNC(RedisModule_LoadFloat)(RedisModuleIO* io);
+void REDISMODULE_API_FUNC(RedisModule_Log)(RedisModuleCtx* ctx, const char* level,
+                                           const char* fmt, ...);
+void REDISMODULE_API_FUNC(RedisModule_LogIOError)(RedisModuleIO* io, const char* levelstr,
+                                                  const char* fmt, ...);
+int REDISMODULE_API_FUNC(RedisModule_StringAppendBuffer)(RedisModuleCtx* ctx,
+                                                         RedisModuleString* str,
+                                                         const char* buf, size_t len);
+void REDISMODULE_API_FUNC(RedisModule_RetainString)(RedisModuleCtx* ctx,
+                                                    RedisModuleString* str);
+int REDISMODULE_API_FUNC(RedisModule_StringCompare)(RedisModuleString* a,
+                                                    RedisModuleString* b);
+RedisModuleCtx* REDISMODULE_API_FUNC(RedisModule_GetContextFromIO)(RedisModuleIO* io);
+RedisModuleBlockedClient* REDISMODULE_API_FUNC(RedisModule_BlockClient)(
+    RedisModuleCtx* ctx, RedisModuleCmdFunc reply_callback,
+    RedisModuleCmdFunc timeout_callback, void (*free_privdata)(void*),
     long long timeout_ms);
-int REDISMODULE_API_FUNC(RedisModule_UnblockClient)(RedisModuleBlockedClient *bc,
-                                                    void *privdata);
-int REDISMODULE_API_FUNC(RedisModule_IsBlockedReplyRequest)(RedisModuleCtx *ctx);
-int REDISMODULE_API_FUNC(RedisModule_IsBlockedTimeoutRequest)(RedisModuleCtx *ctx);
-void *REDISMODULE_API_FUNC(RedisModule_GetBlockedClientPrivateData)(RedisModuleCtx *ctx);
-int REDISMODULE_API_FUNC(RedisModule_AbortBlock)(RedisModuleBlockedClient *bc);
+int REDISMODULE_API_FUNC(RedisModule_UnblockClient)(RedisModuleBlockedClient* bc,
+                                                    void* privdata);
+int REDISMODULE_API_FUNC(RedisModule_IsBlockedReplyRequest)(RedisModuleCtx* ctx);
+int REDISMODULE_API_FUNC(RedisModule_IsBlockedTimeoutRequest)(RedisModuleCtx* ctx);
+void* REDISMODULE_API_FUNC(RedisModule_GetBlockedClientPrivateData)(RedisModuleCtx* ctx);
+int REDISMODULE_API_FUNC(RedisModule_AbortBlock)(RedisModuleBlockedClient* bc);
 long long REDISMODULE_API_FUNC(RedisModule_Milliseconds)(void);
 
 /* This is included inline inside each Redis module. */
-static inline int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver,
+static inline int RedisModule_Init(RedisModuleCtx* ctx, const char* name, int ver,
                                    int apiver) {
-  void *getapifuncptr = ((void **)ctx)[0];
-  RedisModule_GetApi = (int (*)(const char *, void *))getapifuncptr;
+  void* getapifuncptr = ((void**)ctx)[0];
+  RedisModule_GetApi = (int (*)(const char*, void*))getapifuncptr;
   REDISMODULE_GET_API(Alloc);
   REDISMODULE_GET_API(Calloc);
   REDISMODULE_GET_API(Free);

--- a/src/ray/gcs/store_client/in_memory_store_client.cc
+++ b/src/ray/gcs/store_client/in_memory_store_client.cc
@@ -18,9 +18,9 @@ namespace ray {
 
 namespace gcs {
 
-Status InMemoryStoreClient::AsyncPut(const std::string &table_name,
-                                     const std::string &key, const std::string &data,
-                                     const StatusCallback &callback) {
+Status InMemoryStoreClient::AsyncPut(const std::string& table_name,
+                                     const std::string& key, const std::string& data,
+                                     const StatusCallback& callback) {
   auto table = GetOrCreateTable(table_name);
   absl::MutexLock lock(&(table->mutex_));
   table->records_[key] = data;
@@ -28,11 +28,11 @@ Status InMemoryStoreClient::AsyncPut(const std::string &table_name,
   return Status::OK();
 }
 
-Status InMemoryStoreClient::AsyncPutWithIndex(const std::string &table_name,
-                                              const std::string &key,
-                                              const std::string &index_key,
-                                              const std::string &data,
-                                              const StatusCallback &callback) {
+Status InMemoryStoreClient::AsyncPutWithIndex(const std::string& table_name,
+                                              const std::string& key,
+                                              const std::string& index_key,
+                                              const std::string& data,
+                                              const StatusCallback& callback) {
   auto table = GetOrCreateTable(table_name);
   absl::MutexLock lock(&(table->mutex_));
   table->records_[key] = data;
@@ -41,9 +41,9 @@ Status InMemoryStoreClient::AsyncPutWithIndex(const std::string &table_name,
   return Status::OK();
 }
 
-Status InMemoryStoreClient::AsyncGet(const std::string &table_name,
-                                     const std::string &key,
-                                     const OptionalItemCallback<std::string> &callback) {
+Status InMemoryStoreClient::AsyncGet(const std::string& table_name,
+                                     const std::string& key,
+                                     const OptionalItemCallback<std::string>& callback) {
   auto table = GetOrCreateTable(table_name);
   absl::MutexLock lock(&(table->mutex_));
   auto iter = table->records_.find(key);
@@ -57,8 +57,8 @@ Status InMemoryStoreClient::AsyncGet(const std::string &table_name,
 }
 
 Status InMemoryStoreClient::AsyncGetAll(
-    const std::string &table_name,
-    const MapCallback<std::string, std::string> &callback) {
+    const std::string& table_name,
+    const MapCallback<std::string, std::string>& callback) {
   auto table = GetOrCreateTable(table_name);
   absl::MutexLock lock(&(table->mutex_));
   std::unordered_map<std::string, std::string> result;
@@ -67,9 +67,9 @@ Status InMemoryStoreClient::AsyncGetAll(
   return Status::OK();
 }
 
-Status InMemoryStoreClient::AsyncDelete(const std::string &table_name,
-                                        const std::string &key,
-                                        const StatusCallback &callback) {
+Status InMemoryStoreClient::AsyncDelete(const std::string& table_name,
+                                        const std::string& key,
+                                        const StatusCallback& callback) {
   auto table = GetOrCreateTable(table_name);
   absl::MutexLock lock(&(table->mutex_));
   table->records_.erase(key);
@@ -77,12 +77,12 @@ Status InMemoryStoreClient::AsyncDelete(const std::string &table_name,
   return Status::OK();
 }
 
-Status InMemoryStoreClient::AsyncBatchDelete(const std::string &table_name,
-                                             const std::vector<std::string> &keys,
-                                             const StatusCallback &callback) {
+Status InMemoryStoreClient::AsyncBatchDelete(const std::string& table_name,
+                                             const std::vector<std::string>& keys,
+                                             const StatusCallback& callback) {
   auto table = GetOrCreateTable(table_name);
   absl::MutexLock lock(&(table->mutex_));
-  for (auto &key : keys) {
+  for (auto& key : keys) {
     table->records_.erase(key);
   }
   main_io_service_.post([callback]() { callback(Status::OK()); });
@@ -90,14 +90,14 @@ Status InMemoryStoreClient::AsyncBatchDelete(const std::string &table_name,
 }
 
 Status InMemoryStoreClient::AsyncGetByIndex(
-    const std::string &table_name, const std::string &index_key,
-    const MapCallback<std::string, std::string> &callback) {
+    const std::string& table_name, const std::string& index_key,
+    const MapCallback<std::string, std::string>& callback) {
   auto table = GetOrCreateTable(table_name);
   absl::MutexLock lock(&(table->mutex_));
   auto iter = table->index_keys_.find(index_key);
   std::unordered_map<std::string, std::string> result;
   if (iter != table->index_keys_.end()) {
-    for (auto &key : iter->second) {
+    for (auto& key : iter->second) {
       auto kv_iter = table->records_.find(key);
       if (kv_iter != table->records_.end()) {
         result[kv_iter->first] = kv_iter->second;
@@ -109,14 +109,14 @@ Status InMemoryStoreClient::AsyncGetByIndex(
   return Status::OK();
 }
 
-Status InMemoryStoreClient::AsyncDeleteByIndex(const std::string &table_name,
-                                               const std::string &index_key,
-                                               const StatusCallback &callback) {
+Status InMemoryStoreClient::AsyncDeleteByIndex(const std::string& table_name,
+                                               const std::string& index_key,
+                                               const StatusCallback& callback) {
   auto table = GetOrCreateTable(table_name);
   absl::MutexLock lock(&(table->mutex_));
   auto iter = table->index_keys_.find(index_key);
   if (iter != table->index_keys_.end()) {
-    for (auto &key : iter->second) {
+    for (auto& key : iter->second) {
       table->records_.erase(key);
     }
     table->index_keys_.erase(iter);
@@ -130,7 +130,7 @@ Status InMemoryStoreClient::AsyncDeleteByIndex(const std::string &table_name,
 }
 
 std::shared_ptr<InMemoryStoreClient::InMemoryTable> InMemoryStoreClient::GetOrCreateTable(
-    const std::string &table_name) {
+    const std::string& table_name) {
   absl::MutexLock lock(&mutex_);
   auto iter = tables_.find(table_name);
   if (iter != tables_.end()) {

--- a/src/ray/gcs/store_client/in_memory_store_client.h
+++ b/src/ray/gcs/store_client/in_memory_store_client.h
@@ -28,34 +28,34 @@ namespace gcs {
 /// This class is thread safe.
 class InMemoryStoreClient : public StoreClient {
  public:
-  explicit InMemoryStoreClient(boost::asio::io_service &main_io_service)
+  explicit InMemoryStoreClient(boost::asio::io_service& main_io_service)
       : main_io_service_(main_io_service) {}
 
-  Status AsyncPut(const std::string &table_name, const std::string &key,
-                  const std::string &data, const StatusCallback &callback) override;
+  Status AsyncPut(const std::string& table_name, const std::string& key,
+                  const std::string& data, const StatusCallback& callback) override;
 
-  Status AsyncPutWithIndex(const std::string &table_name, const std::string &key,
-                           const std::string &index_key, const std::string &data,
-                           const StatusCallback &callback) override;
+  Status AsyncPutWithIndex(const std::string& table_name, const std::string& key,
+                           const std::string& index_key, const std::string& data,
+                           const StatusCallback& callback) override;
 
-  Status AsyncGet(const std::string &table_name, const std::string &key,
-                  const OptionalItemCallback<std::string> &callback) override;
+  Status AsyncGet(const std::string& table_name, const std::string& key,
+                  const OptionalItemCallback<std::string>& callback) override;
 
-  Status AsyncGetByIndex(const std::string &table_name, const std::string &index_key,
-                         const MapCallback<std::string, std::string> &callback) override;
+  Status AsyncGetByIndex(const std::string& table_name, const std::string& index_key,
+                         const MapCallback<std::string, std::string>& callback) override;
 
-  Status AsyncGetAll(const std::string &table_name,
-                     const MapCallback<std::string, std::string> &callback) override;
+  Status AsyncGetAll(const std::string& table_name,
+                     const MapCallback<std::string, std::string>& callback) override;
 
-  Status AsyncDelete(const std::string &table_name, const std::string &key,
-                     const StatusCallback &callback) override;
+  Status AsyncDelete(const std::string& table_name, const std::string& key,
+                     const StatusCallback& callback) override;
 
-  Status AsyncBatchDelete(const std::string &table_name,
-                          const std::vector<std::string> &keys,
-                          const StatusCallback &callback) override;
+  Status AsyncBatchDelete(const std::string& table_name,
+                          const std::vector<std::string>& keys,
+                          const StatusCallback& callback) override;
 
-  Status AsyncDeleteByIndex(const std::string &table_name, const std::string &index_key,
-                            const StatusCallback &callback) override;
+  Status AsyncDeleteByIndex(const std::string& table_name, const std::string& index_key,
+                            const StatusCallback& callback) override;
 
  private:
   struct InMemoryTable {
@@ -69,7 +69,7 @@ class InMemoryStoreClient : public StoreClient {
   };
 
   std::shared_ptr<InMemoryStoreClient::InMemoryTable> GetOrCreateTable(
-      const std::string &table_name);
+      const std::string& table_name);
 
   /// Mutex to protect the tables_ field.
   absl::Mutex mutex_;
@@ -78,7 +78,7 @@ class InMemoryStoreClient : public StoreClient {
 
   /// Async API Callback needs to post to main_io_service_ to ensure the orderly execution
   /// of the callback.
-  boost::asio::io_service &main_io_service_;
+  boost::asio::io_service& main_io_service_;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -15,6 +15,7 @@
 #include "ray/gcs/store_client/redis_store_client.h"
 
 #include <functional>
+
 #include "ray/common/ray_config.h"
 #include "ray/gcs/redis_context.h"
 #include "ray/util/logging.h"

--- a/src/ray/gcs/store_client/redis_store_client.h
+++ b/src/ray/gcs/store_client/redis_store_client.h
@@ -29,31 +29,31 @@ class RedisStoreClient : public StoreClient {
   explicit RedisStoreClient(std::shared_ptr<RedisClient> redis_client)
       : redis_client_(std::move(redis_client)) {}
 
-  Status AsyncPut(const std::string &table_name, const std::string &key,
-                  const std::string &data, const StatusCallback &callback) override;
+  Status AsyncPut(const std::string& table_name, const std::string& key,
+                  const std::string& data, const StatusCallback& callback) override;
 
-  Status AsyncPutWithIndex(const std::string &table_name, const std::string &key,
-                           const std::string &index_key, const std::string &data,
-                           const StatusCallback &callback) override;
+  Status AsyncPutWithIndex(const std::string& table_name, const std::string& key,
+                           const std::string& index_key, const std::string& data,
+                           const StatusCallback& callback) override;
 
-  Status AsyncGet(const std::string &table_name, const std::string &key,
-                  const OptionalItemCallback<std::string> &callback) override;
+  Status AsyncGet(const std::string& table_name, const std::string& key,
+                  const OptionalItemCallback<std::string>& callback) override;
 
-  Status AsyncGetByIndex(const std::string &table_name, const std::string &index_key,
-                         const MapCallback<std::string, std::string> &callback) override;
+  Status AsyncGetByIndex(const std::string& table_name, const std::string& index_key,
+                         const MapCallback<std::string, std::string>& callback) override;
 
-  Status AsyncGetAll(const std::string &table_name,
-                     const MapCallback<std::string, std::string> &callback) override;
+  Status AsyncGetAll(const std::string& table_name,
+                     const MapCallback<std::string, std::string>& callback) override;
 
-  Status AsyncDelete(const std::string &table_name, const std::string &key,
-                     const StatusCallback &callback) override;
+  Status AsyncDelete(const std::string& table_name, const std::string& key,
+                     const StatusCallback& callback) override;
 
-  Status AsyncBatchDelete(const std::string &table_name,
-                          const std::vector<std::string> &keys,
-                          const StatusCallback &callback) override;
+  Status AsyncBatchDelete(const std::string& table_name,
+                          const std::vector<std::string>& keys,
+                          const StatusCallback& callback) override;
 
-  Status AsyncDeleteByIndex(const std::string &table_name, const std::string &index_key,
-                            const StatusCallback &callback) override;
+  Status AsyncDeleteByIndex(const std::string& table_name, const std::string& index_key,
+                            const StatusCallback& callback) override;
 
  private:
   /// \class RedisScanner
@@ -67,17 +67,17 @@ class RedisStoreClient : public StoreClient {
                           std::string table_name);
 
     Status ScanKeysAndValues(std::string match_pattern,
-                             const MapCallback<std::string, std::string> &callback);
+                             const MapCallback<std::string, std::string>& callback);
 
     Status ScanKeys(std::string match_pattern,
-                    const MultiItemCallback<std::string> &callback);
+                    const MultiItemCallback<std::string>& callback);
 
    private:
-    void Scan(std::string match_pattern, const StatusCallback &callback);
+    void Scan(std::string match_pattern, const StatusCallback& callback);
 
     void OnScanCallback(std::string match_pattern, size_t shard_index,
-                        const std::shared_ptr<CallbackReply> &reply,
-                        const StatusCallback &callback);
+                        const std::shared_ptr<CallbackReply>& reply,
+                        const StatusCallback& callback);
 
     std::string table_name_;
 
@@ -97,40 +97,40 @@ class RedisStoreClient : public StoreClient {
     std::shared_ptr<RedisClient> redis_client_;
   };
 
-  Status DoPut(const std::string &key, const std::string &data,
-               const StatusCallback &callback);
+  Status DoPut(const std::string& key, const std::string& data,
+               const StatusCallback& callback);
 
-  Status DeleteByKeys(const std::vector<std::string> &keys,
-                      const StatusCallback &callback);
+  Status DeleteByKeys(const std::vector<std::string>& keys,
+                      const StatusCallback& callback);
 
-  static std::unordered_map<RedisContext *, std::vector<std::string>> GenCommandsByShards(
-      const std::shared_ptr<RedisClient> &redis_client, const std::string &command,
-      const std::vector<std::string> &keys);
+  static std::unordered_map<RedisContext*, std::vector<std::string>> GenCommandsByShards(
+      const std::shared_ptr<RedisClient>& redis_client, const std::string& command,
+      const std::vector<std::string>& keys);
 
   /// The separator is used when building redis key.
   static std::string table_separator_;
   static std::string index_table_separator_;
 
-  static std::string GenRedisKey(const std::string &table_name, const std::string &key);
+  static std::string GenRedisKey(const std::string& table_name, const std::string& key);
 
-  static std::string GenRedisKey(const std::string &table_name, const std::string &key,
-                                 const std::string &index_key);
+  static std::string GenRedisKey(const std::string& table_name, const std::string& key,
+                                 const std::string& index_key);
 
-  static std::string GenRedisMatchPattern(const std::string &table_name);
+  static std::string GenRedisMatchPattern(const std::string& table_name);
 
-  static std::string GenRedisMatchPattern(const std::string &table_name,
-                                          const std::string &index_key);
+  static std::string GenRedisMatchPattern(const std::string& table_name,
+                                          const std::string& index_key);
 
-  static std::string GetKeyFromRedisKey(const std::string &redis_key,
-                                        const std::string &table_name);
+  static std::string GetKeyFromRedisKey(const std::string& redis_key,
+                                        const std::string& table_name);
 
-  static std::string GetKeyFromRedisKey(const std::string &redis_key,
-                                        const std::string &table_name,
-                                        const std::string &index_key);
+  static std::string GetKeyFromRedisKey(const std::string& redis_key,
+                                        const std::string& table_name,
+                                        const std::string& index_key);
 
   static Status MGetValues(std::shared_ptr<RedisClient> redis_client,
-                           std::string table_name, const std::vector<std::string> &keys,
-                           const MapCallback<std::string, std::string> &callback);
+                           std::string table_name, const std::vector<std::string>& keys,
+                           const MapCallback<std::string, std::string>& callback);
 
   std::shared_ptr<RedisClient> redis_client_;
 };

--- a/src/ray/gcs/store_client/store_client.h
+++ b/src/ray/gcs/store_client/store_client.h
@@ -41,8 +41,8 @@ class StoreClient {
   /// \param data The value of the key that will be written to the table.
   /// \param callback Callback that will be called after write finishes.
   /// \return Status
-  virtual Status AsyncPut(const std::string &table_name, const std::string &key,
-                          const std::string &data, const StatusCallback &callback) = 0;
+  virtual Status AsyncPut(const std::string& table_name, const std::string& key,
+                          const std::string& data, const StatusCallback& callback) = 0;
 
   /// Write data to the given table asynchronously.
   ///
@@ -52,9 +52,9 @@ class StoreClient {
   /// \param data The value of the key that will be written to the table.
   /// \param callback Callback that will be called after write finishes.
   /// \return Status
-  virtual Status AsyncPutWithIndex(const std::string &table_name, const std::string &key,
-                                   const std::string &index_key, const std::string &data,
-                                   const StatusCallback &callback) = 0;
+  virtual Status AsyncPutWithIndex(const std::string& table_name, const std::string& key,
+                                   const std::string& index_key, const std::string& data,
+                                   const StatusCallback& callback) = 0;
 
   /// Get data from the given table asynchronously.
   ///
@@ -62,8 +62,8 @@ class StoreClient {
   /// \param key The key to lookup from the table.
   /// \param callback Callback that will be called after read finishes.
   /// \return Status
-  virtual Status AsyncGet(const std::string &table_name, const std::string &key,
-                          const OptionalItemCallback<std::string> &callback) = 0;
+  virtual Status AsyncGet(const std::string& table_name, const std::string& key,
+                          const OptionalItemCallback<std::string>& callback) = 0;
 
   /// Get data by index from the given table asynchronously.
   ///
@@ -72,16 +72,16 @@ class StoreClient {
   /// \param callback Callback that will be called after read finishes.
   /// \return Status
   virtual Status AsyncGetByIndex(
-      const std::string &table_name, const std::string &index_key,
-      const MapCallback<std::string, std::string> &callback) = 0;
+      const std::string& table_name, const std::string& index_key,
+      const MapCallback<std::string, std::string>& callback) = 0;
 
   /// Get all data from the given table asynchronously.
   ///
   /// \param table_name The name of the table to be read.
   /// \param callback Callback that will be called after data has been received.
   /// \return Status
-  virtual Status AsyncGetAll(const std::string &table_name,
-                             const MapCallback<std::string, std::string> &callback) = 0;
+  virtual Status AsyncGetAll(const std::string& table_name,
+                             const MapCallback<std::string, std::string>& callback) = 0;
 
   /// Delete data from the given table asynchronously.
   ///
@@ -89,8 +89,8 @@ class StoreClient {
   /// \param key The key that will be deleted from the table.
   /// \param callback Callback that will be called after delete finishes.
   /// \return Status
-  virtual Status AsyncDelete(const std::string &table_name, const std::string &key,
-                             const StatusCallback &callback) = 0;
+  virtual Status AsyncDelete(const std::string& table_name, const std::string& key,
+                             const StatusCallback& callback) = 0;
 
   /// Batch delete data from the given table asynchronously.
   ///
@@ -98,9 +98,9 @@ class StoreClient {
   /// \param keys The keys that will be deleted from the table.
   /// \param callback Callback that will be called after delete finishes.
   /// \return Status
-  virtual Status AsyncBatchDelete(const std::string &table_name,
-                                  const std::vector<std::string> &keys,
-                                  const StatusCallback &callback) = 0;
+  virtual Status AsyncBatchDelete(const std::string& table_name,
+                                  const std::vector<std::string>& keys,
+                                  const StatusCallback& callback) = 0;
 
   /// Delete by index from the given table asynchronously.
   ///
@@ -109,9 +109,9 @@ class StoreClient {
   /// from the table.
   /// \param callback Callback that will be called after delete finishes.
   /// \return Status
-  virtual Status AsyncDeleteByIndex(const std::string &table_name,
-                                    const std::string &index_key,
-                                    const StatusCallback &callback) = 0;
+  virtual Status AsyncDeleteByIndex(const std::string& table_name,
+                                    const std::string& index_key,
+                                    const StatusCallback& callback) = 0;
 
  protected:
   StoreClient() = default;

--- a/src/ray/gcs/store_client/test/in_memory_store_client_test.cc
+++ b/src/ray/gcs/store_client/test/in_memory_store_client_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "ray/gcs/store_client/in_memory_store_client.h"
+
 #include "ray/gcs/store_client/test/store_client_test_base.h"
 
 namespace ray {

--- a/src/ray/gcs/store_client/test/in_memory_store_client_test.cc
+++ b/src/ray/gcs/store_client/test/in_memory_store_client_test.cc
@@ -43,7 +43,7 @@ TEST_F(InMemoryStoreClientTest, AsyncGetAllAndBatchDeleteTest) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/gcs/store_client/test/redis_store_client_test.cc
+++ b/src/ray/gcs/store_client/test/redis_store_client_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "ray/gcs/store_client/redis_store_client.h"
+
 #include "ray/common/test_util.h"
 #include "ray/gcs/redis_client.h"
 #include "ray/gcs/store_client/test/store_client_test_base.h"

--- a/src/ray/gcs/store_client/test/redis_store_client_test.cc
+++ b/src/ray/gcs/store_client/test/redis_store_client_test.cc
@@ -60,7 +60,7 @@ TEST_F(RedisStoreClientTest, AsyncGetAllAndBatchDeleteTest) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
                                          ray::RayLog::ShutDownRayLog, argv[0],
                                          ray::RayLogLevel::INFO,

--- a/src/ray/gcs/store_client/test/store_client_test_base.h
+++ b/src/ray/gcs/store_client/test/store_client_test_base.h
@@ -61,11 +61,11 @@ class StoreClientTestBase : public ::testing::Test {
 
  protected:
   void Put() {
-    auto put_calllback = [this](const Status &status) {
+    auto put_calllback = [this](const Status& status) {
       RAY_CHECK_OK(status);
       --pending_count_;
     };
-    for (const auto &elem : key_to_value_) {
+    for (const auto& elem : key_to_value_) {
       ++pending_count_;
       RAY_CHECK_OK(store_client_->AsyncPut(table_name_, elem.first.Binary(),
                                            elem.second.SerializeAsString(),
@@ -75,11 +75,11 @@ class StoreClientTestBase : public ::testing::Test {
   }
 
   void Delete() {
-    auto delete_calllback = [this](const Status &status) {
+    auto delete_calllback = [this](const Status& status) {
       RAY_CHECK_OK(status);
       --pending_count_;
     };
-    for (const auto &elem : key_to_value_) {
+    for (const auto& elem : key_to_value_) {
       ++pending_count_;
       RAY_CHECK_OK(
           store_client_->AsyncDelete(table_name_, elem.first.Binary(), delete_calllback));
@@ -88,8 +88,8 @@ class StoreClientTestBase : public ::testing::Test {
   }
 
   void Get() {
-    auto get_callback = [this](const Status &status,
-                               const boost::optional<std::string> &result) {
+    auto get_callback = [this](const Status& status,
+                               const boost::optional<std::string>& result) {
       RAY_CHECK_OK(status);
       RAY_CHECK(result);
       rpc::ActorTableData data;
@@ -99,7 +99,7 @@ class StoreClientTestBase : public ::testing::Test {
       RAY_CHECK(it != key_to_value_.end());
       --pending_count_;
     };
-    for (const auto &elem : key_to_value_) {
+    for (const auto& elem : key_to_value_) {
       ++pending_count_;
       RAY_CHECK_OK(
           store_client_->AsyncGet(table_name_, elem.first.Binary(), get_callback));
@@ -108,10 +108,10 @@ class StoreClientTestBase : public ::testing::Test {
   }
 
   void GetEmpty() {
-    for (const auto &elem : key_to_value_) {
+    for (const auto& elem : key_to_value_) {
       auto key = elem.first.Binary();
-      auto get_callback = [this, key](const Status &status,
-                                      const boost::optional<std::string> &result) {
+      auto get_callback = [this, key](const Status& status,
+                                      const boost::optional<std::string>& result) {
         RAY_CHECK_OK(status);
         RAY_CHECK(!result);
         --pending_count_;
@@ -124,8 +124,8 @@ class StoreClientTestBase : public ::testing::Test {
   }
 
   void PutWithIndex() {
-    auto put_calllback = [this](const Status &status) { --pending_count_; };
-    for (const auto &elem : key_to_value_) {
+    auto put_calllback = [this](const Status& status) { --pending_count_; };
+    for (const auto& elem : key_to_value_) {
       ++pending_count_;
       RAY_CHECK_OK(store_client_->AsyncPutWithIndex(
           table_name_, elem.first.Binary(), key_to_index_[elem.first].Hex(),
@@ -136,7 +136,7 @@ class StoreClientTestBase : public ::testing::Test {
 
   void GetByIndex() {
     auto get_calllback =
-        [this](const std::unordered_map<std::string, std::string> &result) {
+        [this](const std::unordered_map<std::string, std::string>& result) {
           if (!result.empty()) {
             auto key = ActorID::FromBinary(result.begin()->first);
             auto it = key_to_index_.find(key);
@@ -153,11 +153,11 @@ class StoreClientTestBase : public ::testing::Test {
   }
 
   void DeleteByIndex() {
-    auto delete_calllback = [this](const Status &status) {
+    auto delete_calllback = [this](const Status& status) {
       RAY_CHECK_OK(status);
       --pending_count_;
     };
-    for (const auto &elem : index_to_keys_) {
+    for (const auto& elem : index_to_keys_) {
       ++pending_count_;
       RAY_CHECK_OK(store_client_->AsyncDeleteByIndex(table_name_, elem.first.Hex(),
                                                      delete_calllback));
@@ -167,10 +167,10 @@ class StoreClientTestBase : public ::testing::Test {
 
   void GetAll() {
     auto get_all_callback =
-        [this](const std::unordered_map<std::string, std::string> &result) {
+        [this](const std::unordered_map<std::string, std::string>& result) {
           static std::unordered_set<ActorID> received_keys;
-          for (const auto &item : result) {
-            const ActorID &actor_id = ActorID::FromBinary(item.first);
+          for (const auto& item : result) {
+            const ActorID& actor_id = ActorID::FromBinary(item.first);
             auto it = received_keys.find(actor_id);
             RAY_CHECK(it == received_keys.end());
             received_keys.emplace(actor_id);
@@ -188,13 +188,13 @@ class StoreClientTestBase : public ::testing::Test {
   }
 
   void BatchDelete() {
-    auto delete_calllback = [this](const Status &status) {
+    auto delete_calllback = [this](const Status& status) {
       RAY_CHECK_OK(status);
       --pending_count_;
     };
     ++pending_count_;
     std::vector<std::string> keys;
-    for (auto &elem : key_to_value_) {
+    for (auto& elem : key_to_value_) {
       keys.push_back(elem.first.Binary());
     }
     RAY_CHECK_OK(store_client_->AsyncBatchDelete(table_name_, keys, delete_calllback));
@@ -270,7 +270,7 @@ class StoreClientTestBase : public ::testing::Test {
 
   void WaitPendingDone() { WaitPendingDone(pending_count_); }
 
-  void WaitPendingDone(std::atomic<int> &pending_count) {
+  void WaitPendingDone(std::atomic<int>& pending_count) {
     auto condition = [&pending_count]() { return pending_count == 0; };
     EXPECT_TRUE(WaitForCondition(condition, wait_pending_timeout_.count()));
   }

--- a/src/ray/gcs/subscription_executor.cc
+++ b/src/ray/gcs/subscription_executor.cc
@@ -20,8 +20,8 @@ namespace gcs {
 
 template <typename ID, typename Data, typename Table>
 Status SubscriptionExecutor<ID, Data, Table>::AsyncSubscribeAll(
-    const ClientID &client_id, const SubscribeCallback<ID, Data> &subscribe,
-    const StatusCallback &done) {
+    const ClientID& client_id, const SubscribeCallback<ID, Data>& subscribe,
+    const StatusCallback& done) {
   // TODO(micafan) Optimize the lock when necessary.
   // Consider avoiding locking in single-threaded processes.
   std::unique_lock<std::mutex> lock(mutex_);
@@ -60,8 +60,8 @@ Status SubscriptionExecutor<ID, Data, Table>::AsyncSubscribeAll(
     return Status::OK();
   }
 
-  auto on_subscribe = [this](RedisGcsClient *client, const ID &id,
-                             const std::vector<Data> &result) {
+  auto on_subscribe = [this](RedisGcsClient* client, const ID& id,
+                             const std::vector<Data>& result) {
     if (result.empty()) {
       return;
     }
@@ -85,7 +85,7 @@ Status SubscriptionExecutor<ID, Data, Table>::AsyncSubscribeAll(
     }
   };
 
-  auto on_done = [this](RedisGcsClient *client) {
+  auto on_done = [this](RedisGcsClient* client) {
     std::list<StatusCallback> pending_callbacks;
     {
       std::unique_lock<std::mutex> lock(mutex_);
@@ -94,7 +94,7 @@ Status SubscriptionExecutor<ID, Data, Table>::AsyncSubscribeAll(
       RAY_CHECK(pending_subscriptions_.empty());
     }
 
-    for (const auto &callback : pending_callbacks) {
+    for (const auto& callback : pending_callbacks) {
       callback(Status::OK());
     }
   };
@@ -110,8 +110,8 @@ Status SubscriptionExecutor<ID, Data, Table>::AsyncSubscribeAll(
 
 template <typename ID, typename Data, typename Table>
 Status SubscriptionExecutor<ID, Data, Table>::AsyncSubscribe(
-    const ClientID &client_id, const ID &id, const SubscribeCallback<ID, Data> &subscribe,
-    const StatusCallback &done) {
+    const ClientID& client_id, const ID& id, const SubscribeCallback<ID, Data>& subscribe,
+    const StatusCallback& done) {
   RAY_CHECK(client_id != ClientID::Nil());
 
   // NOTE(zhijunfu): `Subscribe` and other operations use different redis contexts,
@@ -160,7 +160,7 @@ Status SubscriptionExecutor<ID, Data, Table>::AsyncSubscribe(
 
 template <typename ID, typename Data, typename Table>
 Status SubscriptionExecutor<ID, Data, Table>::AsyncUnsubscribe(
-    const ClientID &client_id, const ID &id, const StatusCallback &done) {
+    const ClientID& client_id, const ID& id, const StatusCallback& done) {
   SubscribeCallback<ID, Data> subscribe = nullptr;
   {
     std::unique_lock<std::mutex> lock(mutex_);

--- a/src/ray/gcs/subscription_executor.h
+++ b/src/ray/gcs/subscription_executor.h
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <list>
 #include <mutex>
+
 #include "ray/gcs/callback.h"
 #include "ray/gcs/tables.h"
 

--- a/src/ray/gcs/subscription_executor.h
+++ b/src/ray/gcs/subscription_executor.h
@@ -32,7 +32,7 @@ namespace gcs {
 template <typename ID, typename Data, typename Table>
 class SubscriptionExecutor {
  public:
-  explicit SubscriptionExecutor(Table &table) : table_(table) {}
+  explicit SubscriptionExecutor(Table& table) : table_(table) {}
 
   ~SubscriptionExecutor() {}
 
@@ -46,9 +46,9 @@ class SubscriptionExecutor {
   /// is registered or updated.
   /// \param done Callback that will be called when subscription is complete.
   /// \return Status
-  Status AsyncSubscribeAll(const ClientID &client_id,
-                           const SubscribeCallback<ID, Data> &subscribe,
-                           const StatusCallback &done);
+  Status AsyncSubscribeAll(const ClientID& client_id,
+                           const SubscribeCallback<ID, Data>& subscribe,
+                           const StatusCallback& done);
 
   /// Subscribe to operations of an element.
   /// Repeated subscription to an element will return a failure.
@@ -61,9 +61,9 @@ class SubscriptionExecutor {
   /// is registered or updated.
   /// \param done Callback that will be called when subscription is complete.
   /// \return Status
-  Status AsyncSubscribe(const ClientID &client_id, const ID &id,
-                        const SubscribeCallback<ID, Data> &subscribe,
-                        const StatusCallback &done);
+  Status AsyncSubscribe(const ClientID& client_id, const ID& id,
+                        const SubscribeCallback<ID, Data>& subscribe,
+                        const StatusCallback& done);
 
   /// Cancel subscription to an element.
   /// Unsubscribing can only be called after the subscription request is completed.
@@ -74,11 +74,11 @@ class SubscriptionExecutor {
   /// \param id The id of the element to be unsubscribed to.
   /// \param done Callback that will be called when cancel subscription is complete.
   /// \return Status
-  Status AsyncUnsubscribe(const ClientID &client_id, const ID &id,
-                          const StatusCallback &done);
+  Status AsyncUnsubscribe(const ClientID& client_id, const ID& id,
+                          const StatusCallback& done);
 
  private:
-  Table &table_;
+  Table& table_;
 
   std::mutex mutex_;
 

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -70,12 +70,12 @@ enum class CommandType { kRegular, kChain, kUnknown };
 template <typename ID>
 class PubsubInterface {
  public:
-  virtual Status RequestNotifications(const JobID &job_id, const ID &id,
-                                      const ClientID &client_id,
-                                      const StatusCallback &done) = 0;
-  virtual Status CancelNotifications(const JobID &job_id, const ID &id,
-                                     const ClientID &client_id,
-                                     const StatusCallback &done) = 0;
+  virtual Status RequestNotifications(const JobID& job_id, const ID& id,
+                                      const ClientID& client_id,
+                                      const StatusCallback& done) = 0;
+  virtual Status CancelNotifications(const JobID& job_id, const ID& id,
+                                     const ClientID& client_id,
+                                     const StatusCallback& done) = 0;
   virtual ~PubsubInterface(){};
 };
 
@@ -83,12 +83,12 @@ template <typename ID, typename Data>
 class LogInterface {
  public:
   using WriteCallback =
-      std::function<void(RedisGcsClient *client, const ID &id, const Data &data)>;
-  virtual Status Append(const JobID &job_id, const ID &id,
-                        const std::shared_ptr<Data> &data, const WriteCallback &done) = 0;
-  virtual Status AppendAt(const JobID &job_id, const ID &id,
-                          const std::shared_ptr<Data> &data, const WriteCallback &done,
-                          const WriteCallback &failure, int log_length) = 0;
+      std::function<void(RedisGcsClient* client, const ID& id, const Data& data)>;
+  virtual Status Append(const JobID& job_id, const ID& id,
+                        const std::shared_ptr<Data>& data, const WriteCallback& done) = 0;
+  virtual Status AppendAt(const JobID& job_id, const ID& id,
+                          const std::shared_ptr<Data>& data, const WriteCallback& done,
+                          const WriteCallback& failure, int log_length) = 0;
   virtual ~LogInterface(){};
 };
 
@@ -105,18 +105,18 @@ class LogInterface {
 template <typename ID, typename Data>
 class Log : public LogInterface<ID, Data>, virtual public PubsubInterface<ID> {
  public:
-  using Callback = std::function<void(RedisGcsClient *client, const ID &id,
-                                      const std::vector<Data> &data)>;
+  using Callback = std::function<void(RedisGcsClient* client, const ID& id,
+                                      const std::vector<Data>& data)>;
 
   using NotificationCallback =
-      std::function<void(RedisGcsClient *client, const ID &id,
-                         const GcsChangeMode change_mode, const std::vector<Data> &data)>;
+      std::function<void(RedisGcsClient* client, const ID& id,
+                         const GcsChangeMode change_mode, const std::vector<Data>& data)>;
 
   /// The callback to call when a write to a key succeeds.
   using WriteCallback = typename LogInterface<ID, Data>::WriteCallback;
   /// The callback to call when a SUBSCRIBE call completes and we are ready to
   /// request and receive notifications.
-  using SubscriptionCallback = std::function<void(RedisGcsClient *client)>;
+  using SubscriptionCallback = std::function<void(RedisGcsClient* client)>;
 
   struct CallbackData {
     ID id;
@@ -125,11 +125,11 @@ class Log : public LogInterface<ID, Data>, virtual public PubsubInterface<ID> {
     // An optional callback to call for subscription operations, where the
     // first message is a notification of subscription success.
     SubscriptionCallback subscription_callback;
-    Log<ID, Data> *log;
-    RedisGcsClient *client;
+    Log<ID, Data>* log;
+    RedisGcsClient* client;
   };
 
-  Log(const std::vector<std::shared_ptr<RedisContext>> &contexts, RedisGcsClient *client)
+  Log(const std::vector<std::shared_ptr<RedisContext>>& contexts, RedisGcsClient* client)
       : shard_contexts_(contexts),
         client_(client),
         pubsub_channel_(TablePubsub::NO_PUBLISH),
@@ -145,8 +145,8 @@ class Log : public LogInterface<ID, Data>, virtual public PubsubInterface<ID> {
   /// \param done Callback that is called once the data has been written to the
   /// GCS.
   /// \return Status
-  Status Append(const JobID &job_id, const ID &id, const std::shared_ptr<Data> &data,
-                const WriteCallback &done);
+  Status Append(const JobID& job_id, const ID& id, const std::shared_ptr<Data>& data,
+                const WriteCallback& done);
 
   /// Append a log entry to a key synchronously.
   ///
@@ -154,7 +154,7 @@ class Log : public LogInterface<ID, Data>, virtual public PubsubInterface<ID> {
   /// \param id The ID of the data that is added to the GCS.
   /// \param data Data to append to the log.
   /// \return Status
-  Status SyncAppend(const JobID &job_id, const ID &id, const std::shared_ptr<Data> &data);
+  Status SyncAppend(const JobID& job_id, const ID& id, const std::shared_ptr<Data>& data);
 
   /// Append a log entry to a key if and only if the log has the given number
   /// of entries.
@@ -168,8 +168,8 @@ class Log : public LogInterface<ID, Data>, virtual public PubsubInterface<ID> {
   /// \param log_length The number of entries that the log must have for the
   /// append to succeed.
   /// \return Status
-  Status AppendAt(const JobID &job_id, const ID &id, const std::shared_ptr<Data> &data,
-                  const WriteCallback &done, const WriteCallback &failure,
+  Status AppendAt(const JobID& job_id, const ID& id, const std::shared_ptr<Data>& data,
+                  const WriteCallback& done, const WriteCallback& failure,
                   int log_length);
 
   /// Lookup the log values at a key asynchronously.
@@ -179,7 +179,7 @@ class Log : public LogInterface<ID, Data>, virtual public PubsubInterface<ID> {
   /// \param lookup Callback that is called after lookup. If the callback is
   /// called with an empty vector, then there was no data at the key.
   /// \return Status
-  Status Lookup(const JobID &job_id, const ID &id, const Callback &lookup);
+  Status Lookup(const JobID& job_id, const ID& id, const Callback& lookup);
 
   /// Subscribe to any Append operations to this table. The caller may choose
   /// requests notifications for. This may only be called once per Log
@@ -195,8 +195,8 @@ class Log : public LogInterface<ID, Data>, virtual public PubsubInterface<ID> {
   /// \param done Callback that is called when subscription is complete and we
   /// are ready to receive messages.
   /// \return Status
-  Status Subscribe(const JobID &job_id, const ClientID &client_id,
-                   const Callback &subscribe, const SubscriptionCallback &done);
+  Status Subscribe(const JobID& job_id, const ClientID& client_id,
+                   const Callback& subscribe, const SubscriptionCallback& done);
 
   /// Request notifications about a key in this table.
   ///
@@ -214,8 +214,8 @@ class Log : public LogInterface<ID, Data>, virtual public PubsubInterface<ID> {
   /// notifications can be requested, a call to `Subscribe` to this
   /// table with the same `client_id` must complete successfully.
   /// \return Status
-  Status RequestNotifications(const JobID &job_id, const ID &id,
-                              const ClientID &client_id, const StatusCallback &done);
+  Status RequestNotifications(const JobID& job_id, const ID& id,
+                              const ClientID& client_id, const StatusCallback& done);
 
   /// Cancel notifications about a key in this table.
   ///
@@ -224,8 +224,8 @@ class Log : public LogInterface<ID, Data>, virtual public PubsubInterface<ID> {
   /// \param client_id The client who originally requested notifications.
   /// \param done Callback that is called when cancel notifications is complete.
   /// \return Status
-  Status CancelNotifications(const JobID &job_id, const ID &id, const ClientID &client_id,
-                             const StatusCallback &done);
+  Status CancelNotifications(const JobID& job_id, const ID& id, const ClientID& client_id,
+                             const StatusCallback& done);
 
   /// Subscribe to any modifications to the key. The caller may choose
   /// to subscribe to all modifications, or to subscribe only to keys that it
@@ -245,23 +245,23 @@ class Log : public LogInterface<ID, Data>, virtual public PubsubInterface<ID> {
   /// \param done Callback that is called when subscription is complete and we
   /// are ready to receive messages.
   /// \return Status
-  Status Subscribe(const JobID &job_id, const ClientID &client_id,
-                   const NotificationCallback &subscribe,
-                   const SubscriptionCallback &done);
+  Status Subscribe(const JobID& job_id, const ClientID& client_id,
+                   const NotificationCallback& subscribe,
+                   const SubscriptionCallback& done);
 
   /// Delete an entire key from redis.
   ///
   /// \param job_id The ID of the job.
   /// \param id The ID of the data to delete from the GCS.
   /// \return Void.
-  void Delete(const JobID &job_id, const ID &id);
+  void Delete(const JobID& job_id, const ID& id);
 
   /// Delete several keys from redis.
   ///
   /// \param job_id The ID of the job.
   /// \param ids The vector of IDs to delete from the GCS.
   /// \return Void.
-  void Delete(const JobID &job_id, const std::vector<ID> &ids);
+  void Delete(const JobID& job_id, const std::vector<ID>& ids);
 
   /// Returns debug string for class.
   ///
@@ -269,7 +269,7 @@ class Log : public LogInterface<ID, Data>, virtual public PubsubInterface<ID> {
   std::string DebugString() const;
 
  protected:
-  std::shared_ptr<RedisContext> GetRedisContext(const ID &id) {
+  std::shared_ptr<RedisContext> GetRedisContext(const ID& id) {
     static std::hash<ID> index;
     return shard_contexts_[index(id) % shard_contexts_.size()];
   }
@@ -277,7 +277,7 @@ class Log : public LogInterface<ID, Data>, virtual public PubsubInterface<ID> {
   /// The connection to the GCS.
   std::vector<std::shared_ptr<RedisContext>> shard_contexts_;
   /// The GCS client.
-  RedisGcsClient *client_;
+  RedisGcsClient* client_;
   /// The pubsub channel to subscribe to for notifications about keys in this
   /// table. If no notifications are required, this should be set to
   /// TablePubsub_NO_PUBLISH. If notifications are required, then this must be
@@ -302,8 +302,8 @@ template <typename ID, typename Data>
 class TableInterface {
  public:
   using WriteCallback = typename Log<ID, Data>::WriteCallback;
-  virtual Status Add(const JobID &job_id, const ID &task_id,
-                     const std::shared_ptr<Data> &data, const WriteCallback &done) = 0;
+  virtual Status Add(const JobID& job_id, const ID& task_id,
+                     const std::shared_ptr<Data>& data, const WriteCallback& done) = 0;
   virtual ~TableInterface(){};
 };
 
@@ -322,16 +322,16 @@ class Table : private Log<ID, Data>,
               virtual public PubsubInterface<ID> {
  public:
   using Callback =
-      std::function<void(RedisGcsClient *client, const ID &id, const Data &data)>;
+      std::function<void(RedisGcsClient* client, const ID& id, const Data& data)>;
   using WriteCallback = typename Log<ID, Data>::WriteCallback;
   /// The callback to call when a Lookup call returns an empty entry.
-  using FailureCallback = std::function<void(RedisGcsClient *client, const ID &id)>;
+  using FailureCallback = std::function<void(RedisGcsClient* client, const ID& id)>;
   /// The callback to call when a Subscribe call completes and we are ready to
   /// request and receive notifications.
   using SubscriptionCallback = typename Log<ID, Data>::SubscriptionCallback;
 
-  Table(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-        RedisGcsClient *client)
+  Table(const std::vector<std::shared_ptr<RedisContext>>& contexts,
+        RedisGcsClient* client)
       : Log<ID, Data>(contexts, client) {}
 
   using Log<ID, Data>::RequestNotifications;
@@ -348,8 +348,8 @@ class Table : private Log<ID, Data>,
   /// \param done Callback that is called once the data has been written to the
   /// GCS.
   /// \return Status
-  Status Add(const JobID &job_id, const ID &id, const std::shared_ptr<Data> &data,
-             const WriteCallback &done);
+  Status Add(const JobID& job_id, const ID& id, const std::shared_ptr<Data>& data,
+             const WriteCallback& done);
 
   /// Lookup an entry asynchronously.
   ///
@@ -360,8 +360,8 @@ class Table : private Log<ID, Data>,
   /// \param failure Callback that is called after lookup if there was no data
   /// at the key.
   /// \return Status
-  Status Lookup(const JobID &job_id, const ID &id, const Callback &lookup,
-                const FailureCallback &failure);
+  Status Lookup(const JobID& job_id, const ID& id, const Callback& lookup,
+                const FailureCallback& failure);
 
   /// Subscribe to any Add operations to this table. The caller may choose to
   /// subscribe to all Adds, or to subscribe only to keys that it requests
@@ -380,9 +380,9 @@ class Table : private Log<ID, Data>,
   /// \param done Callback that is called when subscription is complete and we
   /// are ready to receive messages.
   /// \return Status
-  Status Subscribe(const JobID &job_id, const ClientID &client_id,
-                   const Callback &subscribe, const FailureCallback &failure,
-                   const SubscriptionCallback &done);
+  Status Subscribe(const JobID& job_id, const ClientID& client_id,
+                   const Callback& subscribe, const FailureCallback& failure,
+                   const SubscriptionCallback& done);
 
   /// Subscribe to any Add operations to this table. The caller may choose to
   /// subscribe to all Adds, or to subscribe only to keys that it requests
@@ -399,12 +399,12 @@ class Table : private Log<ID, Data>,
   /// \param done Callback that is called when subscription is complete and we
   /// are ready to receive messages.
   /// \return Status
-  Status Subscribe(const JobID &job_id, const ClientID &client_id,
-                   const Callback &subscribe, const SubscriptionCallback &done);
+  Status Subscribe(const JobID& job_id, const ClientID& client_id,
+                   const Callback& subscribe, const SubscriptionCallback& done);
 
-  void Delete(const JobID &job_id, const ID &id) { Log<ID, Data>::Delete(job_id, id); }
+  void Delete(const JobID& job_id, const ID& id) { Log<ID, Data>::Delete(job_id, id); }
 
-  void Delete(const JobID &job_id, const std::vector<ID> &ids) {
+  void Delete(const JobID& job_id, const std::vector<ID>& ids) {
     Log<ID, Data>::Delete(job_id, ids);
   }
 
@@ -429,10 +429,10 @@ template <typename ID, typename Data>
 class SetInterface {
  public:
   using WriteCallback = typename Log<ID, Data>::WriteCallback;
-  virtual Status Add(const JobID &job_id, const ID &id, const std::shared_ptr<Data> &data,
-                     const WriteCallback &done) = 0;
-  virtual Status Remove(const JobID &job_id, const ID &id,
-                        const std::shared_ptr<Data> &data, const WriteCallback &done) = 0;
+  virtual Status Add(const JobID& job_id, const ID& id, const std::shared_ptr<Data>& data,
+                     const WriteCallback& done) = 0;
+  virtual Status Remove(const JobID& job_id, const ID& id,
+                        const std::shared_ptr<Data>& data, const WriteCallback& done) = 0;
   virtual ~SetInterface(){};
 };
 
@@ -454,7 +454,7 @@ class Set : private Log<ID, Data>,
   using WriteCallback = typename Log<ID, Data>::WriteCallback;
   using SubscriptionCallback = typename Log<ID, Data>::SubscriptionCallback;
 
-  Set(const std::vector<std::shared_ptr<RedisContext>> &contexts, RedisGcsClient *client)
+  Set(const std::vector<std::shared_ptr<RedisContext>>& contexts, RedisGcsClient* client)
       : Log<ID, Data>(contexts, client) {}
 
   using Log<ID, Data>::RequestNotifications;
@@ -470,8 +470,8 @@ class Set : private Log<ID, Data>,
   /// \param done Callback that is called once the data has been written to the
   /// GCS.
   /// \return Status
-  Status Add(const JobID &job_id, const ID &id, const std::shared_ptr<Data> &data,
-             const WriteCallback &done);
+  Status Add(const JobID& job_id, const ID& id, const std::shared_ptr<Data>& data,
+             const WriteCallback& done);
 
   /// Remove an entry from the set.
   ///
@@ -481,12 +481,12 @@ class Set : private Log<ID, Data>,
   /// \param done Callback that is called once the data has been written to the
   /// GCS.
   /// \return Status
-  Status Remove(const JobID &job_id, const ID &id, const std::shared_ptr<Data> &data,
-                const WriteCallback &done);
+  Status Remove(const JobID& job_id, const ID& id, const std::shared_ptr<Data>& data,
+                const WriteCallback& done);
 
   using NotificationCallback =
-      std::function<void(RedisGcsClient *client, const ID &id,
-                         const std::vector<ArrayNotification<Data>> &data)>;
+      std::function<void(RedisGcsClient* client, const ID& id,
+                         const std::vector<ArrayNotification<Data>>& data)>;
   /// Subscribe to any add or remove operations to this table.
   ///
   /// \param job_id The ID of the job.
@@ -499,9 +499,9 @@ class Set : private Log<ID, Data>,
   /// \param done Callback that is called when subscription is complete and we
   /// are ready to receive messages.
   /// \return Status
-  Status Subscribe(const JobID &job_id, const ClientID &client_id,
-                   const NotificationCallback &subscribe,
-                   const SubscriptionCallback &done);
+  Status Subscribe(const JobID& job_id, const ClientID& client_id,
+                   const NotificationCallback& subscribe,
+                   const SubscriptionCallback& done);
 
   /// Returns debug string for class.
   ///
@@ -534,7 +534,7 @@ class HashInterface {
   /// \param data Map data contains the change to the Hash Table.
   /// \return Void
   using HashCallback =
-      std::function<void(RedisGcsClient *client, const ID &id, const DataMap &pairs)>;
+      std::function<void(RedisGcsClient* client, const ID& id, const DataMap& pairs)>;
 
   /// The callback function used by function RemoveEntries.
   ///
@@ -542,8 +542,8 @@ class HashInterface {
   /// \param id The ID of the Hash Table whose entries are removed.
   /// \param keys The keys that are moved from this Hash Table.
   /// \return Void
-  using HashRemoveCallback = std::function<void(RedisGcsClient *client, const ID &id,
-                                                const std::vector<std::string> &keys)>;
+  using HashRemoveCallback = std::function<void(RedisGcsClient* client, const ID& id,
+                                                const std::vector<std::string>& keys)>;
 
   /// The notification function used by function Subscribe.
   ///
@@ -552,8 +552,8 @@ class HashInterface {
   /// \param data Map data contains the change to the Hash Table.
   /// \return Void
   using HashNotificationCallback =
-      std::function<void(RedisGcsClient *client, const ID &id,
-                         const std::vector<MapNotification<std::string, Data>> &data)>;
+      std::function<void(RedisGcsClient* client, const ID& id,
+                         const std::vector<MapNotification<std::string, Data>>& data)>;
 
   /// Add entries of a hash table.
   ///
@@ -563,8 +563,8 @@ class HashInterface {
   /// \param done HashCallback that is called once the request data has been written to
   /// the GCS.
   /// \return Status
-  virtual Status Update(const JobID &job_id, const ID &id, const DataMap &pairs,
-                        const HashCallback &done) = 0;
+  virtual Status Update(const JobID& job_id, const ID& id, const DataMap& pairs,
+                        const HashCallback& done) = 0;
 
   /// Remove entries from the hash table.
   ///
@@ -574,9 +574,9 @@ class HashInterface {
   /// \param remove_callback HashRemoveCallback that is called once the data has been
   /// written to the GCS no matter whether the key exists in the hash table.
   /// \return Status
-  virtual Status RemoveEntries(const JobID &job_id, const ID &id,
-                               const std::vector<std::string> &keys,
-                               const HashRemoveCallback &remove_callback) = 0;
+  virtual Status RemoveEntries(const JobID& job_id, const ID& id,
+                               const std::vector<std::string>& keys,
+                               const HashRemoveCallback& remove_callback) = 0;
 
   /// Lookup the map data of a hash table.
   ///
@@ -585,8 +585,8 @@ class HashInterface {
   /// \param lookup HashCallback that is called after lookup. If the callback is
   /// called with an empty hash table, then there was no data in the callback.
   /// \return Status
-  virtual Status Lookup(const JobID &job_id, const ID &id,
-                        const HashCallback &lookup) = 0;
+  virtual Status Lookup(const JobID& job_id, const ID& id,
+                        const HashCallback& lookup) = 0;
 
   /// Subscribe to any Update or Remove operations to this hash table.
   ///
@@ -600,9 +600,9 @@ class HashInterface {
   /// \param done SubscriptionCallback that is called when subscription is complete and
   /// we are ready to receive messages.
   /// \return Status
-  virtual Status Subscribe(const JobID &job_id, const ClientID &client_id,
-                           const HashNotificationCallback &subscribe,
-                           const SubscriptionCallback &done) = 0;
+  virtual Status Subscribe(const JobID& job_id, const ClientID& client_id,
+                           const HashNotificationCallback& subscribe,
+                           const SubscriptionCallback& done) = 0;
 
   virtual ~HashInterface(){};
 };
@@ -619,24 +619,24 @@ class Hash : private Log<ID, Data>,
       typename HashInterface<ID, Data>::HashNotificationCallback;
   using SubscriptionCallback = typename Log<ID, Data>::SubscriptionCallback;
 
-  Hash(const std::vector<std::shared_ptr<RedisContext>> &contexts, RedisGcsClient *client)
+  Hash(const std::vector<std::shared_ptr<RedisContext>>& contexts, RedisGcsClient* client)
       : Log<ID, Data>(contexts, client) {}
 
   using Log<ID, Data>::RequestNotifications;
   using Log<ID, Data>::CancelNotifications;
 
-  Status Update(const JobID &job_id, const ID &id, const DataMap &pairs,
-                const HashCallback &done) override;
+  Status Update(const JobID& job_id, const ID& id, const DataMap& pairs,
+                const HashCallback& done) override;
 
-  Status Subscribe(const JobID &job_id, const ClientID &client_id,
-                   const HashNotificationCallback &subscribe,
-                   const SubscriptionCallback &done) override;
+  Status Subscribe(const JobID& job_id, const ClientID& client_id,
+                   const HashNotificationCallback& subscribe,
+                   const SubscriptionCallback& done) override;
 
-  Status Lookup(const JobID &job_id, const ID &id, const HashCallback &lookup) override;
+  Status Lookup(const JobID& job_id, const ID& id, const HashCallback& lookup) override;
 
-  Status RemoveEntries(const JobID &job_id, const ID &id,
-                       const std::vector<std::string> &keys,
-                       const HashRemoveCallback &remove_callback) override;
+  Status RemoveEntries(const JobID& job_id, const ID& id,
+                       const std::vector<std::string>& keys,
+                       const HashRemoveCallback& remove_callback) override;
 
   /// Returns debug string for class.
   ///
@@ -658,8 +658,8 @@ class Hash : private Log<ID, Data>,
 
 class DynamicResourceTable : public Hash<ClientID, ResourceTableData> {
  public:
-  DynamicResourceTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-                       RedisGcsClient *client)
+  DynamicResourceTable(const std::vector<std::shared_ptr<RedisContext>>& contexts,
+                       RedisGcsClient* client)
       : Hash(contexts, client) {
     pubsub_channel_ = TablePubsub::NODE_RESOURCE_PUBSUB;
     prefix_ = TablePrefix::NODE_RESOURCE;
@@ -670,8 +670,8 @@ class DynamicResourceTable : public Hash<ClientID, ResourceTableData> {
 
 class ObjectTable : public Set<ObjectID, ObjectTableData> {
  public:
-  ObjectTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-              RedisGcsClient *client)
+  ObjectTable(const std::vector<std::shared_ptr<RedisContext>>& contexts,
+              RedisGcsClient* client)
       : Set(contexts, client) {
     pubsub_channel_ = TablePubsub::OBJECT_PUBSUB;
     prefix_ = TablePrefix::OBJECT;
@@ -682,8 +682,8 @@ class ObjectTable : public Set<ObjectID, ObjectTableData> {
 
 class HeartbeatTable : public Table<ClientID, HeartbeatTableData> {
  public:
-  HeartbeatTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-                 RedisGcsClient *client)
+  HeartbeatTable(const std::vector<std::shared_ptr<RedisContext>>& contexts,
+                 RedisGcsClient* client)
       : Table(contexts, client) {
     pubsub_channel_ = TablePubsub::HEARTBEAT_PUBSUB;
     prefix_ = TablePrefix::HEARTBEAT;
@@ -693,8 +693,8 @@ class HeartbeatTable : public Table<ClientID, HeartbeatTableData> {
 
 class HeartbeatBatchTable : public Table<ClientID, HeartbeatBatchTableData> {
  public:
-  HeartbeatBatchTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-                      RedisGcsClient *client)
+  HeartbeatBatchTable(const std::vector<std::shared_ptr<RedisContext>>& contexts,
+                      RedisGcsClient* client)
       : Table(contexts, client) {
     pubsub_channel_ = TablePubsub::HEARTBEAT_BATCH_PUBSUB;
     prefix_ = TablePrefix::HEARTBEAT_BATCH;
@@ -704,8 +704,8 @@ class HeartbeatBatchTable : public Table<ClientID, HeartbeatBatchTableData> {
 
 class JobTable : public Log<JobID, JobTableData> {
  public:
-  JobTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-           RedisGcsClient *client)
+  JobTable(const std::vector<std::shared_ptr<RedisContext>>& contexts,
+           RedisGcsClient* client)
       : Log(contexts, client) {
     pubsub_channel_ = TablePubsub::JOB_PUBSUB;
     prefix_ = TablePrefix::JOB;
@@ -721,8 +721,8 @@ class JobTable : public Log<JobID, JobTableData> {
 /// and will not be reconstructed.
 class LogBasedActorTable : public Log<ActorID, ActorTableData> {
  public:
-  LogBasedActorTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-                     RedisGcsClient *client)
+  LogBasedActorTable(const std::vector<std::shared_ptr<RedisContext>>& contexts,
+                     RedisGcsClient* client)
       : Log(contexts, client) {
     pubsub_channel_ = TablePubsub::ACTOR_PUBSUB;
     prefix_ = TablePrefix::ACTOR;
@@ -732,7 +732,7 @@ class LogBasedActorTable : public Log<ActorID, ActorTableData> {
   std::vector<ActorID> GetAllActorID();
 
   /// Get actor table data by actor id synchronously.
-  Status Get(const ActorID &actor_id, ActorTableData *actor_table_data);
+  Status Get(const ActorID& actor_id, ActorTableData* actor_table_data);
 };
 
 /// Actor table.
@@ -740,8 +740,8 @@ class LogBasedActorTable : public Log<ActorID, ActorTableData> {
 /// GCS service, the log-based actor table could be removed.
 class ActorTable : public Table<ActorID, ActorTableData> {
  public:
-  ActorTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-             RedisGcsClient *client)
+  ActorTable(const std::vector<std::shared_ptr<RedisContext>>& contexts,
+             RedisGcsClient* client)
       : Table(contexts, client) {
     pubsub_channel_ = TablePubsub::ACTOR_PUBSUB;
     prefix_ = TablePrefix::ACTOR;
@@ -751,13 +751,13 @@ class ActorTable : public Table<ActorID, ActorTableData> {
   std::vector<ActorID> GetAllActorID();
 
   /// Get actor table data by actor id synchronously.
-  Status Get(const ActorID &actor_id, ActorTableData *actor_table_data);
+  Status Get(const ActorID& actor_id, ActorTableData* actor_table_data);
 };
 
 class WorkerTable : public Table<WorkerID, WorkerTableData> {
  public:
-  WorkerTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-              RedisGcsClient *client)
+  WorkerTable(const std::vector<std::shared_ptr<RedisContext>>& contexts,
+              RedisGcsClient* client)
       : Table(contexts, client) {
     pubsub_channel_ = TablePubsub::WORKER_FAILURE_PUBSUB;
     prefix_ = TablePrefix::WORKERS;
@@ -767,8 +767,8 @@ class WorkerTable : public Table<WorkerID, WorkerTableData> {
 
 class TaskReconstructionLog : public Log<TaskID, TaskReconstructionData> {
  public:
-  TaskReconstructionLog(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-                        RedisGcsClient *client)
+  TaskReconstructionLog(const std::vector<std::shared_ptr<RedisContext>>& contexts,
+                        RedisGcsClient* client)
       : Log(contexts, client) {
     prefix_ = TablePrefix::TASK_RECONSTRUCTION;
   }
@@ -779,19 +779,19 @@ class TaskLeaseTable : public Table<TaskID, TaskLeaseData> {
   /// Use boost::optional to represent subscription results, so that we can
   /// notify raylet whether the entry of task lease is empty.
   using Callback =
-      std::function<void(RedisGcsClient *client, const TaskID &task_id,
-                         const std::vector<boost::optional<TaskLeaseData>> &data)>;
+      std::function<void(RedisGcsClient* client, const TaskID& task_id,
+                         const std::vector<boost::optional<TaskLeaseData>>& data)>;
 
-  TaskLeaseTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-                 RedisGcsClient *client)
+  TaskLeaseTable(const std::vector<std::shared_ptr<RedisContext>>& contexts,
+                 RedisGcsClient* client)
       : Table(contexts, client) {
     pubsub_channel_ = TablePubsub::TASK_LEASE_PUBSUB;
     prefix_ = TablePrefix::TASK_LEASE;
   }
 
-  Status Add(const JobID &job_id, const TaskID &id,
-             const std::shared_ptr<TaskLeaseData> &data,
-             const WriteCallback &done) override {
+  Status Add(const JobID& job_id, const TaskID& id,
+             const std::shared_ptr<TaskLeaseData>& data,
+             const WriteCallback& done) override {
     RAY_RETURN_NOT_OK((Table<TaskID, TaskLeaseData>::Add(job_id, id, data, done)));
     // Mark the entry for expiration in Redis. It's okay if this command fails
     // since the lease entry itself contains the expiration period. In the
@@ -807,14 +807,14 @@ class TaskLeaseTable : public Table<TaskID, TaskLeaseData> {
 
   /// Implement this method for the subscription tools class SubscriptionExecutor.
   /// In this way TaskLeaseTable() can also reuse class SubscriptionExecutor.
-  Status Subscribe(const JobID &job_id, const ClientID &client_id,
-                   const Callback &subscribe, const SubscriptionCallback &done);
+  Status Subscribe(const JobID& job_id, const ClientID& client_id,
+                   const Callback& subscribe, const SubscriptionCallback& done);
 };
 
 class ActorCheckpointTable : public Table<ActorCheckpointID, ActorCheckpointData> {
  public:
-  ActorCheckpointTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-                       RedisGcsClient *client)
+  ActorCheckpointTable(const std::vector<std::shared_ptr<RedisContext>>& contexts,
+                       RedisGcsClient* client)
       : Table(contexts, client) {
     prefix_ = TablePrefix::ACTOR_CHECKPOINT;
   };
@@ -822,8 +822,8 @@ class ActorCheckpointTable : public Table<ActorCheckpointID, ActorCheckpointData
 
 class ActorCheckpointIdTable : public Table<ActorID, ActorCheckpointIdData> {
  public:
-  ActorCheckpointIdTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-                         RedisGcsClient *client)
+  ActorCheckpointIdTable(const std::vector<std::shared_ptr<RedisContext>>& contexts,
+                         RedisGcsClient* client)
       : Table(contexts, client) {
     prefix_ = TablePrefix::ACTOR_CHECKPOINT_ID;
   };
@@ -835,24 +835,24 @@ class ActorCheckpointIdTable : public Table<ActorID, ActorCheckpointIdData> {
   /// \param actor_id ID of the actor.
   /// \param checkpoint_id ID of the checkpoint.
   /// \return Status.
-  Status AddCheckpointId(const JobID &job_id, const ActorID &actor_id,
-                         const ActorCheckpointID &checkpoint_id,
-                         const WriteCallback &done);
+  Status AddCheckpointId(const JobID& job_id, const ActorID& actor_id,
+                         const ActorCheckpointID& checkpoint_id,
+                         const WriteCallback& done);
 };
 
 namespace raylet {
 
 class TaskTable : public Table<TaskID, TaskTableData> {
  public:
-  TaskTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-            RedisGcsClient *client)
+  TaskTable(const std::vector<std::shared_ptr<RedisContext>>& contexts,
+            RedisGcsClient* client)
       : Table(contexts, client) {
     pubsub_channel_ = TablePubsub::RAYLET_TASK_PUBSUB;
     prefix_ = TablePrefix::RAYLET_TASK;
   }
 
-  TaskTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-            RedisGcsClient *client, gcs::CommandType command_type)
+  TaskTable(const std::vector<std::shared_ptr<RedisContext>>& contexts,
+            RedisGcsClient* client, gcs::CommandType command_type)
       : TaskTable(contexts, client) {
     command_type_ = command_type;
   };
@@ -862,8 +862,8 @@ class TaskTable : public Table<TaskID, TaskTableData> {
 
 class ErrorTable : public Log<JobID, ErrorTableData> {
  public:
-  ErrorTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-             RedisGcsClient *client)
+  ErrorTable(const std::vector<std::shared_ptr<RedisContext>>& contexts,
+             RedisGcsClient* client)
       : Log(contexts, client) {
     pubsub_channel_ = TablePubsub::ERROR_INFO_PUBSUB;
     prefix_ = TablePrefix::ERROR_INFO;
@@ -877,8 +877,8 @@ class ErrorTable : public Log<JobID, ErrorTableData> {
 
 class ProfileTable : public Log<UniqueID, ProfileTableData> {
  public:
-  ProfileTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-               RedisGcsClient *client)
+  ProfileTable(const std::vector<std::shared_ptr<RedisContext>>& contexts,
+               RedisGcsClient* client)
       : Log(contexts, client) {
     prefix_ = TablePrefix::PROFILE;
   };
@@ -900,8 +900,8 @@ class ProfileTable : public Log<UniqueID, ProfileTableData> {
 /// to reconnect, it must connect with a different ClientID.
 class ClientTable : public Log<ClientID, GcsNodeInfo> {
  public:
-  ClientTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-              RedisGcsClient *client)
+  ClientTable(const std::vector<std::shared_ptr<RedisContext>>& contexts,
+              RedisGcsClient* client)
       : Log(contexts, client) {
     pubsub_channel_ = TablePubsub::CLIENT_PUBSUB;
     prefix_ = TablePrefix::CLIENT;
@@ -913,7 +913,7 @@ class ClientTable : public Log<ClientID, GcsNodeInfo> {
   /// \param local_node_info Information about the connecting client. This must have the
   /// same id as the one set in the client table.
   /// \return Status
-  ray::Status Connect(const GcsNodeInfo &local_node_info);
+  ray::Status Connect(const GcsNodeInfo& local_node_info);
 
   /// Disconnect the client from the GCS. The client ID assigned during
   /// registration should never be reused after disconnecting.
@@ -926,7 +926,7 @@ class ClientTable : public Log<ClientID, GcsNodeInfo> {
   /// \param node_info Information about the node.
   /// \param done Callback that is called once the node has been marked to connected.
   /// \return Status
-  ray::Status MarkConnected(const GcsNodeInfo &node_info, const WriteCallback &done);
+  ray::Status MarkConnected(const GcsNodeInfo& node_info, const WriteCallback& done);
 
   /// Mark a different node as disconnected. The client ID should never be
   /// reused for a new node.
@@ -935,11 +935,11 @@ class ClientTable : public Log<ClientID, GcsNodeInfo> {
   /// \param done Callback that is called once the node has been marked to
   /// disconnected.
   /// \return Status
-  ray::Status MarkDisconnected(const ClientID &dead_node_id, const WriteCallback &done);
+  ray::Status MarkDisconnected(const ClientID& dead_node_id, const WriteCallback& done);
 
   ray::Status SubscribeToNodeChange(
-      const SubscribeCallback<ClientID, GcsNodeInfo> &subscribe,
-      const StatusCallback &done);
+      const SubscribeCallback<ClientID, GcsNodeInfo>& subscribe,
+      const StatusCallback& done);
 
   /// Get a client's information from the cache. The cache only contains
   /// information for clients that we've heard a notification for.
@@ -949,35 +949,35 @@ class ClientTable : public Log<ClientID, GcsNodeInfo> {
   /// we have the client in the cache.
   /// a nil client ID.
   /// \return Whether teh client is in the cache.
-  bool GetClient(const ClientID &client, GcsNodeInfo *node_info) const;
+  bool GetClient(const ClientID& client, GcsNodeInfo* node_info) const;
 
   /// Get the local client's ID.
   ///
   /// \return The local client's ID.
-  const ClientID &GetLocalClientId() const;
+  const ClientID& GetLocalClientId() const;
 
   /// Get the local client's information.
   ///
   /// \return The local client's information.
-  const GcsNodeInfo &GetLocalClient() const;
+  const GcsNodeInfo& GetLocalClient() const;
 
   /// Check whether the given client is removed.
   ///
   /// \param node_id The ID of the client to check.
   /// \return Whether the client with ID client_id is removed.
-  bool IsRemoved(const ClientID &node_id) const;
+  bool IsRemoved(const ClientID& node_id) const;
 
   /// Get the information of all clients.
   ///
   /// \return The client ID to client information map.
-  const std::unordered_map<ClientID, GcsNodeInfo> &GetAllClients() const;
+  const std::unordered_map<ClientID, GcsNodeInfo>& GetAllClients() const;
 
   /// Lookup the client data in the client table.
   ///
   /// \param lookup Callback that is called after lookup. If the callback is
   /// called with an empty vector, then there was no data at the key.
   /// \return Status.
-  Status Lookup(const Callback &lookup);
+  Status Lookup(const Callback& lookup);
 
   /// Returns debug string for class.
   ///
@@ -991,15 +991,15 @@ class ClientTable : public Log<ClientID, GcsNodeInfo> {
 
  private:
   using NodeChangeCallback =
-      std::function<void(const ClientID &id, const GcsNodeInfo &node_info)>;
+      std::function<void(const ClientID& id, const GcsNodeInfo& node_info)>;
 
   /// Register a callback to call when a new node is added or a node is removed.
   ///
   /// \param callback The callback to register.
-  void RegisterNodeChangeCallback(const NodeChangeCallback &callback);
+  void RegisterNodeChangeCallback(const NodeChangeCallback& callback);
 
   /// Handle a client table notification.
-  void HandleNotification(RedisGcsClient *client, const GcsNodeInfo &node_info);
+  void HandleNotification(RedisGcsClient* client, const GcsNodeInfo& node_info);
 
   /// Whether this client has called Disconnect().
   bool disconnected_{false};

--- a/src/ray/gcs/test/accessor_test_base.h
+++ b/src/ray/gcs/test/accessor_test_base.h
@@ -72,7 +72,7 @@ class AccessorTestBase : public ::testing::Test {
     WaitPendingDone(pending_count_, timeout);
   }
 
-  void WaitPendingDone(std::atomic<int> &pending_count,
+  void WaitPendingDone(std::atomic<int>& pending_count,
                        std::chrono::milliseconds timeout) {
     auto condition = [&pending_count]() { return pending_count == 0; };
     EXPECT_TRUE(WaitForCondition(condition, timeout.count()));

--- a/src/ray/gcs/test/asio_test.cc
+++ b/src/ray/gcs/test/asio_test.cc
@@ -31,18 +31,18 @@ namespace gcs {
 
 boost::asio::io_service io_service;
 
-void ConnectCallback(const redisAsyncContext *c, int status) {
+void ConnectCallback(const redisAsyncContext* c, int status) {
   ASSERT_EQ(status, REDIS_OK);
 }
 
-void DisconnectCallback(const redisAsyncContext *c, int status) {
+void DisconnectCallback(const redisAsyncContext* c, int status) {
   ASSERT_EQ(status, REDIS_OK);
 }
 
-void GetCallback(redisAsyncContext *c, void *r, void *privdata) {
-  redisReply *reply = reinterpret_cast<redisReply *>(r);
+void GetCallback(redisAsyncContext* c, void* r, void* privdata) {
+  redisReply* reply = reinterpret_cast<redisReply*>(r);
   ASSERT_TRUE(reply != nullptr);
-  ASSERT_TRUE(std::string(reinterpret_cast<char *>(reply->str)) == "test");
+  ASSERT_TRUE(std::string(reinterpret_cast<char*>(reply->str)) == "test");
   io_service.stop();
 }
 
@@ -54,7 +54,7 @@ class RedisAsioTest : public ::testing::Test {
 };
 
 TEST_F(RedisAsioTest, TestRedisCommands) {
-  redisAsyncContext *ac = redisAsyncConnect("127.0.0.1", TEST_REDIS_SERVER_PORTS.front());
+  redisAsyncContext* ac = redisAsyncConnect("127.0.0.1", TEST_REDIS_SERVER_PORTS.front());
   ASSERT_TRUE(ac->err == 0);
   ray::gcs::RedisAsyncContext redis_async_context(ac);
 
@@ -73,7 +73,7 @@ TEST_F(RedisAsioTest, TestRedisCommands) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
                                          ray::RayLog::ShutDownRayLog, argv[0],
                                          ray::RayLogLevel::INFO,

--- a/src/ray/gcs/test/gcs_test_util.h
+++ b/src/ray/gcs/test/gcs_test_util.h
@@ -28,9 +28,9 @@
 namespace ray {
 
 struct Mocker {
-  static TaskSpecification GenActorCreationTask(const JobID &job_id, int max_restarts,
-                                                bool detached, const std::string &name,
-                                                const rpc::Address &owner_address) {
+  static TaskSpecification GenActorCreationTask(const JobID& job_id, int max_restarts,
+                                                bool detached, const std::string& name,
+                                                const rpc::Address& owner_address) {
     TaskSpecBuilder builder;
     rpc::Address empty_address;
     ray::FunctionDescriptor empty_descriptor =
@@ -45,7 +45,7 @@ struct Mocker {
     return builder.Build();
   }
 
-  static rpc::CreateActorRequest GenCreateActorRequest(const JobID &job_id,
+  static rpc::CreateActorRequest GenCreateActorRequest(const JobID& job_id,
                                                        int max_restarts = 0,
                                                        bool detached = false,
                                                        const std::string name = "") {
@@ -61,7 +61,7 @@ struct Mocker {
     return request;
   }
 
-  static rpc::RegisterActorRequest GenRegisterActorRequest(const JobID &job_id,
+  static rpc::RegisterActorRequest GenRegisterActorRequest(const JobID& job_id,
                                                            int max_restarts = 0,
                                                            bool detached = false,
                                                            const std::string name = "") {
@@ -78,8 +78,8 @@ struct Mocker {
   }
 
   static PlacementGroupSpecification GenPlacementGroupCreation(
-      const std::string &name,
-      std::vector<std::unordered_map<std::string, double>> &bundles,
+      const std::string& name,
+      std::vector<std::unordered_map<std::string, double>>& bundles,
       rpc::PlacementStrategy strategy) {
     PlacementGroupSpecBuilder builder;
 
@@ -122,7 +122,7 @@ struct Mocker {
     return job_table_data;
   }
 
-  static std::shared_ptr<rpc::ActorTableData> GenActorTableData(const JobID &job_id) {
+  static std::shared_ptr<rpc::ActorTableData> GenActorTableData(const JobID& job_id) {
     auto actor_table_data = std::make_shared<rpc::ActorTableData>();
     ActorID actor_id = ActorID::Of(job_id, RandomTaskId(), 0);
     actor_table_data->set_actor_id(actor_id.Binary());
@@ -134,7 +134,7 @@ struct Mocker {
   }
 
   static std::shared_ptr<rpc::TaskTableData> GenTaskTableData(
-      const std::string &job_id, const std::string &task_id) {
+      const std::string& job_id, const std::string& task_id) {
     auto task_table_data = std::make_shared<rpc::TaskTableData>();
     rpc::Task task;
     rpc::TaskSpec task_spec;
@@ -146,7 +146,7 @@ struct Mocker {
   }
 
   static std::shared_ptr<rpc::TaskLeaseData> GenTaskLeaseData(
-      const std::string &task_id, const std::string &node_id) {
+      const std::string& task_id, const std::string& node_id) {
     auto task_lease_data = std::make_shared<rpc::TaskLeaseData>();
     task_lease_data->set_task_id(task_id);
     task_lease_data->set_node_manager_id(node_id);
@@ -155,13 +155,13 @@ struct Mocker {
   }
 
   static std::shared_ptr<rpc::ProfileTableData> GenProfileTableData(
-      const ClientID &node_id) {
+      const ClientID& node_id) {
     auto profile_table_data = std::make_shared<rpc::ProfileTableData>();
     profile_table_data->set_component_id(node_id.Binary());
     return profile_table_data;
   }
 
-  static std::shared_ptr<rpc::ErrorTableData> GenErrorTableData(const JobID &job_id) {
+  static std::shared_ptr<rpc::ErrorTableData> GenErrorTableData(const JobID& job_id) {
     auto error_table_data = std::make_shared<rpc::ErrorTableData>();
     error_table_data->set_job_id(job_id.Binary());
     return error_table_data;

--- a/src/ray/gcs/test/redis_actor_info_accessor_test.cc
+++ b/src/ray/gcs/test/redis_actor_info_accessor_test.cc
@@ -45,8 +45,8 @@ class ActorInfoAccessorTest : public AccessorTestBase<ActorID, ActorTableData> {
   }
 
   void GenCheckpointData() {
-    for (const auto &item : id_to_data_) {
-      const ActorID &id = item.first;
+    for (const auto& item : id_to_data_) {
+      const ActorID& id = item.first;
       ActorCheckpointList checkpoints;
       for (size_t i = 0; i < checkpoint_number_; ++i) {
         ActorCheckpointID checkpoint_id = ActorCheckpointID::FromRandom();
@@ -66,10 +66,10 @@ class ActorInfoAccessorTest : public AccessorTestBase<ActorID, ActorTableData> {
 };
 
 TEST_F(ActorInfoAccessorTest, RegisterAndGet) {
-  ActorInfoAccessor &actor_accessor = gcs_client_->Actors();
+  ActorInfoAccessor& actor_accessor = gcs_client_->Actors();
   // register
-  for (const auto &elem : id_to_data_) {
-    const auto &actor = elem.second;
+  for (const auto& elem : id_to_data_) {
+    const auto& actor = elem.second;
     ++pending_count_;
     RAY_CHECK_OK(actor_accessor.AsyncRegister(actor, [this](Status status) {
       RAY_CHECK_OK(status);
@@ -80,10 +80,10 @@ TEST_F(ActorInfoAccessorTest, RegisterAndGet) {
   WaitPendingDone(wait_pending_timeout_);
 
   // async get
-  for (const auto &elem : id_to_data_) {
+  for (const auto& elem : id_to_data_) {
     ++pending_count_;
     RAY_CHECK_OK(actor_accessor.AsyncGet(
-        elem.first, [this](Status status, const boost::optional<ActorTableData> &data) {
+        elem.first, [this](Status status, const boost::optional<ActorTableData>& data) {
           ASSERT_TRUE(data);
           ActorID actor_id = ActorID::FromBinary(data->actor_id());
           auto it = id_to_data_.find(actor_id);
@@ -98,19 +98,19 @@ TEST_F(ActorInfoAccessorTest, RegisterAndGet) {
   std::vector<ActorTableData> actor_table_data_list;
   RAY_CHECK_OK(actor_accessor.GetAll(&actor_table_data_list));
   ASSERT_EQ(id_to_data_.size(), actor_table_data_list.size());
-  for (auto &data : actor_table_data_list) {
+  for (auto& data : actor_table_data_list) {
     ActorID actor_id = ActorID::FromBinary(data.actor_id());
     ASSERT_TRUE(id_to_data_.count(actor_id) != 0);
   }
 }
 
 TEST_F(ActorInfoAccessorTest, Subscribe) {
-  ActorInfoAccessor &actor_accessor = gcs_client_->Actors();
+  ActorInfoAccessor& actor_accessor = gcs_client_->Actors();
   // subscribe
   std::atomic<int> sub_pending_count(0);
   std::atomic<int> do_sub_pending_count(0);
-  auto subscribe = [this, &sub_pending_count](const ActorID &actor_id,
-                                              const ActorTableData &data) {
+  auto subscribe = [this, &sub_pending_count](const ActorID& actor_id,
+                                              const ActorTableData& data) {
     const auto it = id_to_data_.find(actor_id);
     ASSERT_TRUE(it != id_to_data_.end());
     --sub_pending_count;
@@ -127,8 +127,8 @@ TEST_F(ActorInfoAccessorTest, Subscribe) {
 
   // register
   std::atomic<int> register_pending_count(0);
-  for (const auto &elem : id_to_data_) {
-    const auto &actor = elem.second;
+  for (const auto& elem : id_to_data_) {
+    const auto& actor = elem.second;
     ++sub_pending_count;
     ++register_pending_count;
     RAY_CHECK_OK(
@@ -145,15 +145,15 @@ TEST_F(ActorInfoAccessorTest, Subscribe) {
 }
 
 TEST_F(ActorInfoAccessorTest, GetActorCheckpointTest) {
-  ActorInfoAccessor &actor_accessor = gcs_client_->Actors();
+  ActorInfoAccessor& actor_accessor = gcs_client_->Actors();
   auto on_add_done = [this](Status status) {
     RAY_CHECK_OK(status);
     --pending_count_;
   };
   for (size_t index = 0; index < checkpoint_number_; ++index) {
-    for (const auto &actor_checkpoints : id_to_checkpoints_) {
-      const ActorCheckpointList &checkpoints = actor_checkpoints.second;
-      const auto &checkpoint = checkpoints[index];
+    for (const auto& actor_checkpoints : id_to_checkpoints_) {
+      const ActorCheckpointList& checkpoints = actor_checkpoints.second;
+      const auto& checkpoint = checkpoints[index];
       ++pending_count_;
       Status status = actor_accessor.AsyncAddCheckpoint(checkpoint, on_add_done);
       RAY_CHECK_OK(status);
@@ -161,14 +161,14 @@ TEST_F(ActorInfoAccessorTest, GetActorCheckpointTest) {
     WaitPendingDone(wait_pending_timeout_);
   }
 
-  for (const auto &actor_checkpoints : id_to_checkpoints_) {
-    const ActorCheckpointList &checkpoints = actor_checkpoints.second;
-    for (const auto &checkpoint : checkpoints) {
+  for (const auto& actor_checkpoints : id_to_checkpoints_) {
+    const ActorCheckpointList& checkpoints = actor_checkpoints.second;
+    for (const auto& checkpoint : checkpoints) {
       ActorCheckpointID checkpoint_id =
           ActorCheckpointID::FromBinary(checkpoint->checkpoint_id());
       auto on_get_done = [this, checkpoint_id](
                              Status status,
-                             const boost::optional<ActorCheckpointData> &result) {
+                             const boost::optional<ActorCheckpointData>& result) {
         RAY_CHECK(result);
         ActorCheckpointID result_checkpoint_id =
             ActorCheckpointID::FromBinary(result->checkpoint_id());
@@ -183,17 +183,17 @@ TEST_F(ActorInfoAccessorTest, GetActorCheckpointTest) {
   }
   WaitPendingDone(wait_pending_timeout_);
 
-  for (const auto &actor_checkpoints : id_to_checkpoints_) {
-    const ActorID &actor_id = actor_checkpoints.first;
-    const ActorCheckpointList &checkpoints = actor_checkpoints.second;
+  for (const auto& actor_checkpoints : id_to_checkpoints_) {
+    const ActorID& actor_id = actor_checkpoints.first;
+    const ActorCheckpointList& checkpoints = actor_checkpoints.second;
     auto on_get_done = [this, &checkpoints](
                            Status status,
-                           const boost::optional<ActorCheckpointIdData> &result) {
+                           const boost::optional<ActorCheckpointIdData>& result) {
       RAY_CHECK(result);
       ASSERT_EQ(checkpoints.size(), result->checkpoint_ids_size());
       for (size_t i = 0; i < checkpoints.size(); ++i) {
         const std::string checkpoint_id_str = checkpoints[i]->checkpoint_id();
-        const std::string &result_checkpoint_id_str = result->checkpoint_ids(i);
+        const std::string& result_checkpoint_id_str = result->checkpoint_ids(i);
         ASSERT_EQ(checkpoint_id_str, result_checkpoint_id_str);
       }
       --pending_count_;
@@ -209,7 +209,7 @@ TEST_F(ActorInfoAccessorTest, GetActorCheckpointTest) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   RAY_CHECK(argc == 4);
   ray::TEST_REDIS_SERVER_EXEC_PATH = argv[1];

--- a/src/ray/gcs/test/redis_gcs_client_test.cc
+++ b/src/ray/gcs/test/redis_gcs_client_test.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gtest/gtest.h"
+#include "ray/gcs/redis_gcs_client.h"
 
+#include "gtest/gtest.h"
 #include "ray/common/ray_config.h"
 #include "ray/common/test_util.h"
 #include "ray/gcs/pb_util.h"
-#include "ray/gcs/redis_gcs_client.h"
 #include "ray/gcs/tables.h"
 
 extern "C" {

--- a/src/ray/gcs/test/redis_gcs_client_test.cc
+++ b/src/ray/gcs/test/redis_gcs_client_test.cc
@@ -30,7 +30,7 @@ namespace gcs {
 
 /* Flush redis. */
 static inline void flushall_redis(void) {
-  redisContext *context = redisConnect("127.0.0.1", TEST_REDIS_SERVER_PORTS.front());
+  redisContext* context = redisConnect("127.0.0.1", TEST_REDIS_SERVER_PORTS.front());
   freeReplyObject(redisCommand(context, "FLUSHALL"));
   redisFree(context);
 }
@@ -69,7 +69,7 @@ class TestGcs : public ::testing::Test {
   JobID job_id_;
 };
 
-TestGcs *test;
+TestGcs* test;
 ClientID local_client_id = ClientID::FromRandom();
 
 class TestGcsWithAsio : public TestGcs {
@@ -109,7 +109,7 @@ class TestGcsWithChainAsio : public TestGcsWithAsio {
 class TaskTableTestHelper {
  public:
   /// A helper function that creates a GCS `TaskTableData` object.
-  static std::shared_ptr<TaskTableData> CreateTaskTableData(const TaskID &task_id,
+  static std::shared_ptr<TaskTableData> CreateTaskTableData(const TaskID& task_id,
                                                             uint64_t num_returns = 0) {
     auto data = std::make_shared<TaskTableData>();
     data->mutable_task()->mutable_task_spec()->set_task_id(task_id.Binary());
@@ -119,35 +119,35 @@ class TaskTableTestHelper {
 
   /// A helper function that compare whether 2 `TaskTableData` objects are equal.
   /// Note, this function only compares fields set by `CreateTaskTableData`.
-  static bool TaskTableDataEqual(const TaskTableData &data1, const TaskTableData &data2) {
-    const auto &spec1 = data1.task().task_spec();
-    const auto &spec2 = data2.task().task_spec();
+  static bool TaskTableDataEqual(const TaskTableData& data1, const TaskTableData& data2) {
+    const auto& spec1 = data1.task().task_spec();
+    const auto& spec2 = data2.task().task_spec();
     return (spec1.task_id() == spec2.task_id() &&
             spec1.num_returns() == spec2.num_returns());
   }
 
-  static void TestTableLookup(const JobID &job_id,
+  static void TestTableLookup(const JobID& job_id,
                               std::shared_ptr<gcs::RedisGcsClient> client) {
     const auto task_id = RandomTaskId();
     const auto data = CreateTaskTableData(task_id);
 
     // Check that we added the correct task.
-    auto add_callback = [task_id, data](gcs::RedisGcsClient *client, const TaskID &id,
-                                        const TaskTableData &d) {
+    auto add_callback = [task_id, data](gcs::RedisGcsClient* client, const TaskID& id,
+                                        const TaskTableData& d) {
       ASSERT_EQ(id, task_id);
       ASSERT_TRUE(TaskTableDataEqual(*data, d));
     };
 
     // Check that the lookup returns the added task.
-    auto lookup_callback = [task_id, data](gcs::RedisGcsClient *client, const TaskID &id,
-                                           const TaskTableData &d) {
+    auto lookup_callback = [task_id, data](gcs::RedisGcsClient* client, const TaskID& id,
+                                           const TaskTableData& d) {
       ASSERT_EQ(id, task_id);
       ASSERT_TRUE(TaskTableDataEqual(*data, d));
       test->Stop();
     };
 
     // Check that the lookup does not return an empty entry.
-    auto failure_callback = [](gcs::RedisGcsClient *client, const TaskID &id) {
+    auto failure_callback = [](gcs::RedisGcsClient* client, const TaskID& id) {
       RAY_CHECK(false);
     };
 
@@ -160,16 +160,16 @@ class TaskTableTestHelper {
     test->Start();
   }
 
-  static void TestTableLookupFailure(const JobID &job_id,
+  static void TestTableLookupFailure(const JobID& job_id,
                                      std::shared_ptr<gcs::RedisGcsClient> client) {
     TaskID task_id = RandomTaskId();
 
     // Check that the lookup does not return data.
-    auto lookup_callback = [](gcs::RedisGcsClient *client, const TaskID &id,
-                              const TaskTableData &d) { RAY_CHECK(false); };
+    auto lookup_callback = [](gcs::RedisGcsClient* client, const TaskID& id,
+                              const TaskTableData& d) { RAY_CHECK(false); };
 
     // Check that the lookup returns an empty entry.
-    auto failure_callback = [task_id](gcs::RedisGcsClient *client, const TaskID &id) {
+    auto failure_callback = [task_id](gcs::RedisGcsClient* client, const TaskID& id) {
       ASSERT_EQ(id, task_id);
       test->Stop();
     };
@@ -183,25 +183,25 @@ class TaskTableTestHelper {
   }
 
   static void TestDeleteKeysFromTable(
-      const JobID &job_id, std::shared_ptr<gcs::RedisGcsClient> client,
-      std::vector<std::shared_ptr<TaskTableData>> &data_vector, bool stop_at_end) {
+      const JobID& job_id, std::shared_ptr<gcs::RedisGcsClient> client,
+      std::vector<std::shared_ptr<TaskTableData>>& data_vector, bool stop_at_end) {
     std::vector<TaskID> ids;
     TaskID task_id;
-    for (auto &data : data_vector) {
+    for (auto& data : data_vector) {
       task_id = RandomTaskId();
       ids.push_back(task_id);
       // Check that we added the correct object entries.
-      auto add_callback = [task_id, data](gcs::RedisGcsClient *client, const TaskID &id,
-                                          const TaskTableData &d) {
+      auto add_callback = [task_id, data](gcs::RedisGcsClient* client, const TaskID& id,
+                                          const TaskTableData& d) {
         ASSERT_EQ(id, task_id);
         ASSERT_TRUE(TaskTableDataEqual(*data, d));
         test->IncrementNumCallbacks();
       };
       RAY_CHECK_OK(client->raylet_task_table().Add(job_id, task_id, data, add_callback));
     }
-    for (const auto &task_id : ids) {
-      auto task_lookup_callback = [task_id](gcs::RedisGcsClient *client, const TaskID &id,
-                                            const TaskTableData &data) {
+    for (const auto& task_id : ids) {
+      auto task_lookup_callback = [task_id](gcs::RedisGcsClient* client, const TaskID& id,
+                                            const TaskTableData& data) {
         ASSERT_EQ(id, task_id);
         test->IncrementNumCallbacks();
       };
@@ -213,24 +213,24 @@ class TaskTableTestHelper {
     } else {
       client->raylet_task_table().Delete(job_id, ids);
     }
-    auto expected_failure_callback = [](RedisGcsClient *client, const TaskID &id) {
+    auto expected_failure_callback = [](RedisGcsClient* client, const TaskID& id) {
       ASSERT_TRUE(true);
       test->IncrementNumCallbacks();
     };
-    auto undesired_callback = [](gcs::RedisGcsClient *client, const TaskID &id,
-                                 const TaskTableData &data) { ASSERT_TRUE(false); };
+    auto undesired_callback = [](gcs::RedisGcsClient* client, const TaskID& id,
+                                 const TaskTableData& data) { ASSERT_TRUE(false); };
     for (size_t i = 0; i < ids.size(); ++i) {
       RAY_CHECK_OK(client->raylet_task_table().Lookup(job_id, task_id, undesired_callback,
                                                       expected_failure_callback));
     }
     if (stop_at_end) {
-      auto stop_callback = [](RedisGcsClient *client, const TaskID &id) { test->Stop(); };
+      auto stop_callback = [](RedisGcsClient* client, const TaskID& id) { test->Stop(); };
       RAY_CHECK_OK(
           client->raylet_task_table().Lookup(job_id, ids[0], nullptr, stop_callback));
     }
   }
 
-  static void TestTableSubscribeId(const JobID &job_id,
+  static void TestTableSubscribeId(const JobID& job_id,
                                    std::shared_ptr<gcs::RedisGcsClient> client) {
     size_t num_modifications = 3;
 
@@ -243,8 +243,8 @@ class TaskTableTestHelper {
     // The callback for a notification from the table. This should only be
     // received for keys that we requested notifications for.
     auto notification_callback = [task_id2, num_modifications](
-                                     gcs::RedisGcsClient *client, const TaskID &id,
-                                     const TaskTableData &data) {
+                                     gcs::RedisGcsClient* client, const TaskID& id,
+                                     const TaskTableData& data) {
       // Check that we only get notifications for the requested key.
       ASSERT_EQ(id, task_id2);
       // Check that we get notifications in the same order as the writes.
@@ -259,7 +259,7 @@ class TaskTableTestHelper {
     // The failure callback should be called once since both keys start as empty.
     bool failure_notification_received = false;
     auto failure_callback = [task_id2, &failure_notification_received](
-                                gcs::RedisGcsClient *client, const TaskID &id) {
+                                gcs::RedisGcsClient* client, const TaskID& id) {
       ASSERT_EQ(id, task_id2);
       // The failure notification should be the first notification received.
       ASSERT_EQ(test->NumCallbacks(), 0);
@@ -269,7 +269,7 @@ class TaskTableTestHelper {
     // The callback for subscription success. Once we've subscribed, request
     // notifications for only one of the keys, then write to both keys.
     auto subscribe_callback = [job_id, task_id1, task_id2,
-                               num_modifications](gcs::RedisGcsClient *client) {
+                               num_modifications](gcs::RedisGcsClient* client) {
       // Request notifications for one of the keys.
       RAY_CHECK_OK(client->raylet_task_table().RequestNotifications(
           job_id, task_id2, local_client_id, nullptr));
@@ -301,7 +301,7 @@ class TaskTableTestHelper {
     ASSERT_EQ(test->NumCallbacks(), num_modifications);
   }
 
-  static void TestTableSubscribeCancel(const JobID &job_id,
+  static void TestTableSubscribeCancel(const JobID& job_id,
                                        std::shared_ptr<gcs::RedisGcsClient> client) {
     // Add a table entry.
     const auto task_id = RandomTaskId();
@@ -311,15 +311,15 @@ class TaskTableTestHelper {
 
     // The failure callback should not be called since all keys are non-empty
     // when notifications are requested.
-    auto failure_callback = [](gcs::RedisGcsClient *client, const TaskID &id) {
+    auto failure_callback = [](gcs::RedisGcsClient* client, const TaskID& id) {
       RAY_CHECK(false);
     };
 
     // The callback for a notification from the table. This should only be
     // received for keys that we requested notifications for.
-    auto notification_callback = [task_id, num_modifications](gcs::RedisGcsClient *client,
-                                                              const TaskID &id,
-                                                              const TaskTableData &data) {
+    auto notification_callback = [task_id, num_modifications](gcs::RedisGcsClient* client,
+                                                              const TaskID& id,
+                                                              const TaskTableData& data) {
       ASSERT_EQ(id, task_id);
       // Check that we only get notifications for the first and last writes,
       // since notifications are canceled in between.
@@ -338,7 +338,7 @@ class TaskTableTestHelper {
     // The callback for a notification from the table. This should only be
     // received for keys that we requested notifications for.
     auto subscribe_callback = [job_id, task_id,
-                               num_modifications](gcs::RedisGcsClient *client) {
+                               num_modifications](gcs::RedisGcsClient* client) {
       // Request notifications, then cancel immediately. We should receive a
       // notification for the current value at the key.
       RAY_CHECK_OK(client->raylet_task_table().RequestNotifications(
@@ -383,17 +383,17 @@ TEST_TASK_TABLE_MACRO(TestGcsWithAsio, TestTableLookup);
 
 class LogLookupTestHelper {
  public:
-  static void TestLogLookup(const JobID &job_id,
+  static void TestLogLookup(const JobID& job_id,
                             std::shared_ptr<gcs::RedisGcsClient> client) {
     // Append some entries to the log at an object ID.
     TaskID task_id = RandomTaskId();
     std::vector<std::string> node_manager_ids = {"abc", "def", "ghi"};
-    for (auto &node_manager_id : node_manager_ids) {
+    for (auto& node_manager_id : node_manager_ids) {
       auto data = std::make_shared<TaskReconstructionData>();
       data->set_node_manager_id(node_manager_id);
       // Check that we added the correct object entries.
-      auto add_callback = [task_id, data](gcs::RedisGcsClient *client, const TaskID &id,
-                                          const TaskReconstructionData &d) {
+      auto add_callback = [task_id, data](gcs::RedisGcsClient* client, const TaskID& id,
+                                          const TaskReconstructionData& d) {
         ASSERT_EQ(id, task_id);
         ASSERT_EQ(data->node_manager_id(), d.node_manager_id());
       };
@@ -403,10 +403,10 @@ class LogLookupTestHelper {
 
     // Check that lookup returns the added object entries.
     auto lookup_callback = [task_id, node_manager_ids](
-                               gcs::RedisGcsClient *client, const TaskID &id,
-                               const std::vector<TaskReconstructionData> &data) {
+                               gcs::RedisGcsClient* client, const TaskID& id,
+                               const std::vector<TaskReconstructionData>& data) {
       ASSERT_EQ(id, task_id);
-      for (const auto &entry : data) {
+      for (const auto& entry : data) {
         ASSERT_EQ(entry.node_manager_id(), node_manager_ids[test->NumCallbacks()]);
         test->IncrementNumCallbacks();
       }
@@ -424,20 +424,20 @@ class LogLookupTestHelper {
     ASSERT_EQ(test->NumCallbacks(), node_manager_ids.size());
   }
 
-  static void TestLogAppendAt(const JobID &job_id,
+  static void TestLogAppendAt(const JobID& job_id,
                               std::shared_ptr<gcs::RedisGcsClient> client) {
     TaskID task_id = RandomTaskId();
     std::vector<std::string> node_manager_ids = {"A", "B"};
     std::vector<std::shared_ptr<TaskReconstructionData>> data_log;
-    for (const auto &node_manager_id : node_manager_ids) {
+    for (const auto& node_manager_id : node_manager_ids) {
       auto data = std::make_shared<TaskReconstructionData>();
       data->set_node_manager_id(node_manager_id);
       data_log.push_back(data);
     }
 
     // Check that we added the correct task.
-    auto failure_callback = [task_id](gcs::RedisGcsClient *client, const TaskID &id,
-                                      const TaskReconstructionData &d) {
+    auto failure_callback = [task_id](gcs::RedisGcsClient* client, const TaskID& id,
+                                      const TaskReconstructionData& d) {
       ASSERT_EQ(id, task_id);
       test->IncrementNumCallbacks();
     };
@@ -462,10 +462,10 @@ class LogLookupTestHelper {
         /*done callback=*/nullptr, failure_callback, /*log_length=*/1));
 
     auto lookup_callback = [node_manager_ids](
-                               gcs::RedisGcsClient *client, const TaskID &id,
-                               const std::vector<TaskReconstructionData> &data) {
+                               gcs::RedisGcsClient* client, const TaskID& id,
+                               const std::vector<TaskReconstructionData>& data) {
       std::vector<std::string> appended_managers;
-      for (const auto &entry : data) {
+      for (const auto& entry : data) {
         appended_managers.push_back(entry.node_manager_id());
       }
       ASSERT_EQ(appended_managers, node_manager_ids);
@@ -494,17 +494,17 @@ TEST_F(TestGcsWithAsio, TestLogAppendAt) {
 
 class SetTestHelper {
  public:
-  static void TestSet(const JobID &job_id, std::shared_ptr<gcs::RedisGcsClient> client) {
+  static void TestSet(const JobID& job_id, std::shared_ptr<gcs::RedisGcsClient> client) {
     // Add some entries to the set at an object ID.
     ObjectID object_id = ObjectID::FromRandom();
     std::vector<std::string> managers = {"abc", "def", "ghi"};
-    for (auto &manager : managers) {
+    for (auto& manager : managers) {
       auto data = std::make_shared<ObjectTableData>();
       data->set_manager(manager);
       // Check that we added the correct object entries.
-      auto add_callback = [object_id, data](gcs::RedisGcsClient *client,
-                                            const ObjectID &id,
-                                            const ObjectTableData &d) {
+      auto add_callback = [object_id, data](gcs::RedisGcsClient* client,
+                                            const ObjectID& id,
+                                            const ObjectTableData& d) {
         ASSERT_EQ(id, object_id);
         ASSERT_EQ(data->manager(), d.manager());
         test->IncrementNumCallbacks();
@@ -514,8 +514,8 @@ class SetTestHelper {
 
     // Check that lookup returns the added object entries.
     auto lookup_callback = [object_id, managers](
-                               gcs::RedisGcsClient *client, const ObjectID &id,
-                               const std::vector<ObjectTableData> &data) {
+                               gcs::RedisGcsClient* client, const ObjectID& id,
+                               const std::vector<ObjectTableData>& data) {
       ASSERT_EQ(id, object_id);
       ASSERT_EQ(data.size(), managers.size());
       test->IncrementNumCallbacks();
@@ -524,13 +524,13 @@ class SetTestHelper {
     // Do a lookup at the object ID.
     RAY_CHECK_OK(client->object_table().Lookup(job_id, object_id, lookup_callback));
 
-    for (auto &manager : managers) {
+    for (auto& manager : managers) {
       auto data = std::make_shared<ObjectTableData>();
       data->set_manager(manager);
       // Check that we added the correct object entries.
-      auto remove_entry_callback = [object_id, data](gcs::RedisGcsClient *client,
-                                                     const ObjectID &id,
-                                                     const ObjectTableData &d) {
+      auto remove_entry_callback = [object_id, data](gcs::RedisGcsClient* client,
+                                                     const ObjectID& id,
+                                                     const ObjectTableData& d) {
         ASSERT_EQ(id, object_id);
         ASSERT_EQ(data->manager(), d.manager());
         test->IncrementNumCallbacks();
@@ -541,8 +541,8 @@ class SetTestHelper {
 
     // Check that the entries are removed.
     auto lookup_callback2 = [object_id, managers](
-                                gcs::RedisGcsClient *client, const ObjectID &id,
-                                const std::vector<ObjectTableData> &data) {
+                                gcs::RedisGcsClient* client, const ObjectID& id,
+                                const std::vector<ObjectTableData>& data) {
       ASSERT_EQ(id, object_id);
       ASSERT_EQ(data.size(), 0);
       test->IncrementNumCallbacks();
@@ -558,28 +558,28 @@ class SetTestHelper {
   }
 
   static void TestDeleteKeysFromSet(
-      const JobID &job_id, std::shared_ptr<gcs::RedisGcsClient> client,
-      std::vector<std::shared_ptr<ObjectTableData>> &data_vector) {
+      const JobID& job_id, std::shared_ptr<gcs::RedisGcsClient> client,
+      std::vector<std::shared_ptr<ObjectTableData>>& data_vector) {
     std::vector<ObjectID> ids;
     ObjectID object_id;
-    for (auto &data : data_vector) {
+    for (auto& data : data_vector) {
       object_id = ObjectID::FromRandom();
       ids.push_back(object_id);
       // Check that we added the correct object entries.
-      auto add_callback = [object_id, data](gcs::RedisGcsClient *client,
-                                            const ObjectID &id,
-                                            const ObjectTableData &d) {
+      auto add_callback = [object_id, data](gcs::RedisGcsClient* client,
+                                            const ObjectID& id,
+                                            const ObjectTableData& d) {
         ASSERT_EQ(id, object_id);
         ASSERT_EQ(data->manager(), d.manager());
         test->IncrementNumCallbacks();
       };
       RAY_CHECK_OK(client->object_table().Add(job_id, object_id, data, add_callback));
     }
-    for (const auto &object_id : ids) {
+    for (const auto& object_id : ids) {
       // Check that lookup returns the added object entries.
       auto lookup_callback = [object_id, data_vector](
-                                 gcs::RedisGcsClient *client, const ObjectID &id,
-                                 const std::vector<ObjectTableData> &data) {
+                                 gcs::RedisGcsClient* client, const ObjectID& id,
+                                 const std::vector<ObjectTableData>& data) {
         ASSERT_EQ(id, object_id);
         ASSERT_EQ(data.size(), 1);
         test->IncrementNumCallbacks();
@@ -591,9 +591,9 @@ class SetTestHelper {
     } else {
       client->object_table().Delete(job_id, ids);
     }
-    for (const auto &object_id : ids) {
-      auto lookup_callback = [object_id](gcs::RedisGcsClient *client, const ObjectID &id,
-                                         const std::vector<ObjectTableData> &data) {
+    for (const auto& object_id : ids) {
+      auto lookup_callback = [object_id](gcs::RedisGcsClient* client, const ObjectID& id,
+                                         const std::vector<ObjectTableData>& data) {
         ASSERT_EQ(id, object_id);
         ASSERT_TRUE(data.size() == 0);
         test->IncrementNumCallbacks();
@@ -602,7 +602,7 @@ class SetTestHelper {
     }
   }
 
-  static void TestSetSubscribeAll(const JobID &job_id,
+  static void TestSetSubscribeAll(const JobID& job_id,
                                   std::shared_ptr<gcs::RedisGcsClient> client) {
     std::vector<ObjectID> object_ids;
     for (int i = 0; i < 3; i++) {
@@ -613,8 +613,8 @@ class SetTestHelper {
     // Callback for a notification.
     auto notification_callback =
         [object_ids, managers](
-            gcs::RedisGcsClient *client, const ObjectID &id,
-            const std::vector<ObjectChangeNotification> &notifications) {
+            gcs::RedisGcsClient* client, const ObjectID& id,
+            const std::vector<ObjectChangeNotification>& notifications) {
           if (test->NumCallbacks() < 3 * 3) {
             ASSERT_EQ(notifications[0].GetGcsChangeMode(), GcsChangeMode::APPEND_OR_ADD);
           } else {
@@ -622,7 +622,7 @@ class SetTestHelper {
           }
           ASSERT_EQ(id, object_ids[test->NumCallbacks() / 3 % 3]);
           // Check that we get notifications in the same order as the writes.
-          for (const auto &entry : notifications[0].GetData()) {
+          for (const auto& entry : notifications[0].GetData()) {
             ASSERT_EQ(entry.manager(), managers[test->NumCallbacks() % 3]);
             test->IncrementNumCallbacks();
           }
@@ -634,7 +634,7 @@ class SetTestHelper {
     // Callback for subscription success. We are guaranteed to receive
     // notifications after this is called.
     auto subscribe_callback = [job_id, object_ids,
-                               managers](gcs::RedisGcsClient *client) {
+                               managers](gcs::RedisGcsClient* client) {
       // We have subscribed. Do the writes to the table.
       for (size_t i = 0; i < object_ids.size(); i++) {
         for (size_t j = 0; j < managers.size(); j++) {
@@ -675,7 +675,7 @@ class SetTestHelper {
     ASSERT_EQ(test->NumCallbacks(), object_ids.size() * 3 * 2);
   }
 
-  static void TestSetSubscribeId(const JobID &job_id,
+  static void TestSetSubscribeId(const JobID& job_id,
                                  std::shared_ptr<gcs::RedisGcsClient> client) {
     // Add a set entry.
     ObjectID object_id1 = ObjectID::FromRandom();
@@ -695,13 +695,13 @@ class SetTestHelper {
     // received for keys that we requested notifications for.
     auto notification_callback =
         [object_id2, managers2](
-            gcs::RedisGcsClient *client, const ObjectID &id,
-            const std::vector<ObjectChangeNotification> &notifications) {
+            gcs::RedisGcsClient* client, const ObjectID& id,
+            const std::vector<ObjectChangeNotification>& notifications) {
           ASSERT_EQ(notifications[0].GetGcsChangeMode(), GcsChangeMode::APPEND_OR_ADD);
           // Check that we only get notifications for the requested key.
           ASSERT_EQ(id, object_id2);
           // Check that we get notifications in the same order as the writes.
-          for (const auto &entry : notifications[0].GetData()) {
+          for (const auto& entry : notifications[0].GetData()) {
             ASSERT_EQ(entry.manager(), managers2[test->NumCallbacks()]);
             test->IncrementNumCallbacks();
           }
@@ -713,20 +713,20 @@ class SetTestHelper {
     // The callback for subscription success. Once we've subscribed, request
     // notifications for only one of the keys, then write to both keys.
     auto subscribe_callback = [job_id, object_id1, object_id2, managers1,
-                               managers2](gcs::RedisGcsClient *client) {
+                               managers2](gcs::RedisGcsClient* client) {
       // Request notifications for one of the keys.
       RAY_CHECK_OK(client->object_table().RequestNotifications(job_id, object_id2,
                                                                local_client_id, nullptr));
       // Write both keys. We should only receive notifications for the key that
       // we requested them for.
       auto remaining = std::vector<std::string>(++managers1.begin(), managers1.end());
-      for (const auto &manager : remaining) {
+      for (const auto& manager : remaining) {
         auto data = std::make_shared<ObjectTableData>();
         data->set_manager(manager);
         RAY_CHECK_OK(client->object_table().Add(job_id, object_id1, data, nullptr));
       }
       remaining = std::vector<std::string>(++managers2.begin(), managers2.end());
-      for (const auto &manager : remaining) {
+      for (const auto& manager : remaining) {
         auto data = std::make_shared<ObjectTableData>();
         data->set_manager(manager);
         RAY_CHECK_OK(client->object_table().Add(job_id, object_id2, data, nullptr));
@@ -745,7 +745,7 @@ class SetTestHelper {
     ASSERT_EQ(test->NumCallbacks(), managers2.size());
   }
 
-  static void TestSetSubscribeCancel(const JobID &job_id,
+  static void TestSetSubscribeCancel(const JobID& job_id,
                                      std::shared_ptr<gcs::RedisGcsClient> client) {
     // Add a set entry.
     ObjectID object_id = ObjectID::FromRandom();
@@ -758,14 +758,14 @@ class SetTestHelper {
     // received for the object that we requested notifications for.
     auto notification_callback =
         [object_id, managers](
-            gcs::RedisGcsClient *client, const ObjectID &id,
-            const std::vector<ObjectChangeNotification> &notifications) {
+            gcs::RedisGcsClient* client, const ObjectID& id,
+            const std::vector<ObjectChangeNotification>& notifications) {
           ASSERT_EQ(notifications[0].GetGcsChangeMode(), GcsChangeMode::APPEND_OR_ADD);
           ASSERT_EQ(id, object_id);
           // Check that we get a duplicate notification for the first write. We get a
           // duplicate notification because notifications
           // are canceled after the first write, then requested again.
-          const std::vector<ObjectTableData> &data = notifications[0].GetData();
+          const std::vector<ObjectTableData>& data = notifications[0].GetData();
           if (data.size() == 1) {
             // first notification
             ASSERT_EQ(data[0].manager(), managers[0]);
@@ -776,7 +776,7 @@ class SetTestHelper {
             std::unordered_set<std::string> managers_set(managers.begin(),
                                                          managers.end());
             std::unordered_set<std::string> data_managers_set;
-            for (const auto &entry : data) {
+            for (const auto& entry : data) {
               data_managers_set.insert(entry.manager());
               test->IncrementNumCallbacks();
             }
@@ -789,7 +789,7 @@ class SetTestHelper {
 
     // The callback for a notification from the table. This should only be
     // received for keys that we requested notifications for.
-    auto subscribe_callback = [job_id, object_id, managers](gcs::RedisGcsClient *client) {
+    auto subscribe_callback = [job_id, object_id, managers](gcs::RedisGcsClient* client) {
       // Request notifications, then cancel immediately. We should receive a
       // notification for the current value at the key.
       RAY_CHECK_OK(client->object_table().RequestNotifications(job_id, object_id,
@@ -799,7 +799,7 @@ class SetTestHelper {
       // Add to the key. Since we canceled notifications, we should not
       // receive a notification for these writes.
       auto remaining = std::vector<std::string>(++managers.begin(), managers.end());
-      for (const auto &manager : remaining) {
+      for (const auto& manager : remaining) {
         auto data = std::make_shared<ObjectTableData>();
         data->set_manager(manager);
         RAY_CHECK_OK(client->object_table().Add(job_id, object_id, data, nullptr));
@@ -832,16 +832,16 @@ TEST_F(TestGcsWithAsio, TestSet) {
 class LogDeleteTestHelper {
  public:
   static void TestDeleteKeysFromLog(
-      const JobID &job_id, std::shared_ptr<gcs::RedisGcsClient> client,
-      std::vector<std::shared_ptr<TaskReconstructionData>> &data_vector) {
+      const JobID& job_id, std::shared_ptr<gcs::RedisGcsClient> client,
+      std::vector<std::shared_ptr<TaskReconstructionData>>& data_vector) {
     std::vector<TaskID> ids;
     TaskID task_id;
-    for (auto &data : data_vector) {
+    for (auto& data : data_vector) {
       task_id = RandomTaskId();
       ids.push_back(task_id);
       // Check that we added the correct object entries.
-      auto add_callback = [task_id, data](gcs::RedisGcsClient *client, const TaskID &id,
-                                          const TaskReconstructionData &d) {
+      auto add_callback = [task_id, data](gcs::RedisGcsClient* client, const TaskID& id,
+                                          const TaskReconstructionData& d) {
         ASSERT_EQ(id, task_id);
         ASSERT_EQ(data->node_manager_id(), d.node_manager_id());
         test->IncrementNumCallbacks();
@@ -849,11 +849,11 @@ class LogDeleteTestHelper {
       RAY_CHECK_OK(
           client->task_reconstruction_log().Append(job_id, task_id, data, add_callback));
     }
-    for (const auto &task_id : ids) {
+    for (const auto& task_id : ids) {
       // Check that lookup returns the added object entries.
       auto lookup_callback = [task_id, data_vector](
-                                 gcs::RedisGcsClient *client, const TaskID &id,
-                                 const std::vector<TaskReconstructionData> &data) {
+                                 gcs::RedisGcsClient* client, const TaskID& id,
+                                 const std::vector<TaskReconstructionData>& data) {
         ASSERT_EQ(id, task_id);
         ASSERT_EQ(data.size(), 1);
         test->IncrementNumCallbacks();
@@ -866,9 +866,9 @@ class LogDeleteTestHelper {
     } else {
       client->task_reconstruction_log().Delete(job_id, ids);
     }
-    for (const auto &task_id : ids) {
-      auto lookup_callback = [task_id](gcs::RedisGcsClient *client, const TaskID &id,
-                                       const std::vector<TaskReconstructionData> &data) {
+    for (const auto& task_id : ids) {
+      auto lookup_callback = [task_id](gcs::RedisGcsClient* client, const TaskID& id,
+                                       const std::vector<TaskReconstructionData>& data) {
         ASSERT_EQ(id, task_id);
         ASSERT_TRUE(data.size() == 0);
         test->IncrementNumCallbacks();
@@ -880,7 +880,7 @@ class LogDeleteTestHelper {
 };
 
 // Test delete function for keys of Log or Table.
-void TestDeleteKeys(const JobID &job_id, std::shared_ptr<gcs::RedisGcsClient> client) {
+void TestDeleteKeys(const JobID& job_id, std::shared_ptr<gcs::RedisGcsClient> client) {
   // Test delete function for keys of Log.
   std::vector<std::shared_ptr<TaskReconstructionData>> task_reconstruction_vector;
   auto AppendTaskReconstructionData = [&task_reconstruction_vector](size_t add_count) {
@@ -970,18 +970,18 @@ TEST_F(TestGcsWithAsio, TestDeleteKey) {
 /// A helper class for Log Subscribe testing.
 class LogSubscribeTestHelper {
  public:
-  static void TestLogSubscribeAll(const JobID &job_id,
+  static void TestLogSubscribeAll(const JobID& job_id,
                                   std::shared_ptr<gcs::RedisGcsClient> client) {
     std::vector<JobID> job_ids;
     for (int i = 0; i < 3; i++) {
       job_ids.emplace_back(NextJobID());
     }
     // Callback for a notification.
-    auto notification_callback = [job_ids](gcs::RedisGcsClient *client, const JobID &id,
+    auto notification_callback = [job_ids](gcs::RedisGcsClient* client, const JobID& id,
                                            const std::vector<JobTableData> data) {
       ASSERT_EQ(id, job_ids[test->NumCallbacks()]);
       // Check that we get notifications in the same order as the writes.
-      for (const auto &entry : data) {
+      for (const auto& entry : data) {
         ASSERT_EQ(entry.job_id(), job_ids[test->NumCallbacks()].Binary());
         test->IncrementNumCallbacks();
       }
@@ -992,7 +992,7 @@ class LogSubscribeTestHelper {
 
     // Callback for subscription success. We are guaranteed to receive
     // notifications after this is called.
-    auto subscribe_callback = [job_ids](gcs::RedisGcsClient *client) {
+    auto subscribe_callback = [job_ids](gcs::RedisGcsClient* client) {
       // We have subscribed. Do the writes to the table.
       for (size_t i = 0; i < job_ids.size(); i++) {
         auto job_info_ptr = CreateJobTableData(job_ids[i], false, 0, "localhost", 1);
@@ -1014,7 +1014,7 @@ class LogSubscribeTestHelper {
     ASSERT_EQ(test->NumCallbacks(), job_ids.size());
   }
 
-  static void TestLogSubscribeId(const JobID &job_id,
+  static void TestLogSubscribeId(const JobID& job_id,
                                  std::shared_ptr<gcs::RedisGcsClient> client) {
     // Add a log entry.
     JobID job_id1 = NextJobID();
@@ -1033,12 +1033,12 @@ class LogSubscribeTestHelper {
     // The callback for a notification from the table. This should only be
     // received for keys that we requested notifications for.
     auto notification_callback = [job_id2, job_ids2](
-                                     gcs::RedisGcsClient *client, const JobID &id,
-                                     const std::vector<JobTableData> &data) {
+                                     gcs::RedisGcsClient* client, const JobID& id,
+                                     const std::vector<JobTableData>& data) {
       // Check that we only get notifications for the requested key.
       ASSERT_EQ(id, job_id2);
       // Check that we get notifications in the same order as the writes.
-      for (const auto &entry : data) {
+      for (const auto& entry : data) {
         ASSERT_EQ(entry.job_id(), job_ids2[test->NumCallbacks()]);
         test->IncrementNumCallbacks();
       }
@@ -1050,20 +1050,20 @@ class LogSubscribeTestHelper {
     // The callback for subscription success. Once we've subscribed, request
     // notifications for only one of the keys, then write to both keys.
     auto subscribe_callback = [job_id, job_id1, job_id2, job_ids1,
-                               job_ids2](gcs::RedisGcsClient *client) {
+                               job_ids2](gcs::RedisGcsClient* client) {
       // Request notifications for one of the keys.
       RAY_CHECK_OK(client->job_table().RequestNotifications(job_id, job_id2,
                                                             local_client_id, nullptr));
       // Write both keys. We should only receive notifications for the key that
       // we requested them for.
       auto remaining = std::vector<std::string>(++job_ids1.begin(), job_ids1.end());
-      for (const auto &job_id_it : remaining) {
+      for (const auto& job_id_it : remaining) {
         auto data = std::make_shared<JobTableData>();
         data->set_job_id(job_id_it);
         RAY_CHECK_OK(client->job_table().Append(job_id, job_id1, data, nullptr));
       }
       remaining = std::vector<std::string>(++job_ids2.begin(), job_ids2.end());
-      for (const auto &job_id_it : remaining) {
+      for (const auto& job_id_it : remaining) {
         auto data = std::make_shared<JobTableData>();
         data->set_job_id(job_id_it);
         RAY_CHECK_OK(client->job_table().Append(job_id, job_id2, data, nullptr));
@@ -1082,7 +1082,7 @@ class LogSubscribeTestHelper {
     ASSERT_EQ(test->NumCallbacks(), job_ids2.size());
   }
 
-  static void TestLogSubscribeCancel(const JobID &job_id,
+  static void TestLogSubscribeCancel(const JobID& job_id,
                                      std::shared_ptr<gcs::RedisGcsClient> client) {
     // Add a log entry.
     JobID random_job_id = NextJobID();
@@ -1094,15 +1094,15 @@ class LogSubscribeTestHelper {
     // The callback for a notification from the object table. This should only be
     // received for the object that we requested notifications for.
     auto notification_callback = [random_job_id, job_ids](
-                                     gcs::RedisGcsClient *client, const JobID &id,
-                                     const std::vector<JobTableData> &data) {
+                                     gcs::RedisGcsClient* client, const JobID& id,
+                                     const std::vector<JobTableData>& data) {
       ASSERT_EQ(id, random_job_id);
       // Check that we get a duplicate notification for the first write. We get a
       // duplicate notification because the log is append-only and notifications
       // are canceled after the first write, then requested again.
       auto job_ids_copy = job_ids;
       job_ids_copy.insert(job_ids_copy.begin(), job_ids_copy.front());
-      for (const auto &entry : data) {
+      for (const auto& entry : data) {
         ASSERT_EQ(entry.job_id(), job_ids_copy[test->NumCallbacks()]);
         test->IncrementNumCallbacks();
       }
@@ -1114,7 +1114,7 @@ class LogSubscribeTestHelper {
     // The callback for a notification from the table. This should only be
     // received for keys that we requested notifications for.
     auto subscribe_callback = [job_id, random_job_id,
-                               job_ids](gcs::RedisGcsClient *client) {
+                               job_ids](gcs::RedisGcsClient* client) {
       // Request notifications, then cancel immediately. We should receive a
       // notification for the current value at the key.
       RAY_CHECK_OK(client->job_table().RequestNotifications(job_id, random_job_id,
@@ -1124,7 +1124,7 @@ class LogSubscribeTestHelper {
       // Append to the key. Since we canceled notifications, we should not
       // receive a notification for these writes.
       auto remaining = std::vector<std::string>(++job_ids.begin(), job_ids.end());
-      for (const auto &remaining_job_id : remaining) {
+      for (const auto& remaining_job_id : remaining) {
         auto data = std::make_shared<JobTableData>();
         data->set_job_id(remaining_job_id);
         RAY_CHECK_OK(client->job_table().Append(job_id, random_job_id, data, nullptr));
@@ -1187,7 +1187,7 @@ TEST_F(TestGcsWithAsio, TestSetSubscribeCancel) {
 class ClientTableTestHelper {
  public:
   static void ClientTableNotification(std::shared_ptr<gcs::RedisGcsClient> client,
-                                      const ClientID &client_id, const GcsNodeInfo &data,
+                                      const ClientID& client_id, const GcsNodeInfo& data,
                                       bool is_alive) {
     ClientID added_id = local_client_id;
     ASSERT_EQ(client_id, added_id);
@@ -1200,12 +1200,12 @@ class ClientTableTestHelper {
     ASSERT_EQ(cached_client.state() == GcsNodeInfo::ALIVE, is_alive);
   }
 
-  static void TestClientTableConnect(const JobID &job_id,
+  static void TestClientTableConnect(const JobID& job_id,
                                      std::shared_ptr<gcs::RedisGcsClient> client) {
     // Subscribe to a node gets added and removed. The latter
     // event will stop the event loop.
     RAY_CHECK_OK(client->client_table().SubscribeToNodeChange(
-        [client](const ClientID &id, const GcsNodeInfo &data) {
+        [client](const ClientID& id, const GcsNodeInfo& data) {
           // TODO(micafan)
           RAY_LOG(INFO) << "Test alive=" << data.state() << " id=" << id;
           if (data.state() == GcsNodeInfo::ALIVE) {
@@ -1226,12 +1226,12 @@ class ClientTableTestHelper {
     test->Start();
   }
 
-  static void TestClientTableDisconnect(const JobID &job_id,
+  static void TestClientTableDisconnect(const JobID& job_id,
                                         std::shared_ptr<gcs::RedisGcsClient> client) {
     // Register callbacks for when a client gets added and removed. The latter
     // event will stop the event loop.
     RAY_CHECK_OK(client->client_table().SubscribeToNodeChange(
-        [client](const ClientID &id, const GcsNodeInfo &data) {
+        [client](const ClientID& id, const GcsNodeInfo& data) {
           if (data.state() == GcsNodeInfo::ALIVE) {
             ClientTableNotification(client, id, data, /*is_insertion=*/true);
             // Disconnect from the client table. We should receive a notification
@@ -1256,11 +1256,11 @@ class ClientTableTestHelper {
   }
 
   static void TestClientTableImmediateDisconnect(
-      const JobID &job_id, std::shared_ptr<gcs::RedisGcsClient> client) {
+      const JobID& job_id, std::shared_ptr<gcs::RedisGcsClient> client) {
     // Register callbacks for when a client gets added and removed. The latter
     // event will stop the event loop.
     RAY_CHECK_OK(client->client_table().SubscribeToNodeChange(
-        [client](const ClientID &id, const GcsNodeInfo &data) {
+        [client](const ClientID& id, const GcsNodeInfo& data) {
           if (data.state() == GcsNodeInfo::ALIVE) {
             ClientTableNotification(client, id, data, true);
           } else {
@@ -1282,7 +1282,7 @@ class ClientTableTestHelper {
   }
 
   static void TestClientTableMarkDisconnected(
-      const JobID &job_id, std::shared_ptr<gcs::RedisGcsClient> client) {
+      const JobID& job_id, std::shared_ptr<gcs::RedisGcsClient> client) {
     GcsNodeInfo local_node_info;
     local_node_info.set_node_id(local_client_id.Binary());
     local_node_info.set_node_manager_address("127.0.0.1");
@@ -1296,7 +1296,7 @@ class ClientTableTestHelper {
     // Make sure we only get a notification for the removal of the client we
     // marked as dead.
     RAY_CHECK_OK(client->client_table().SubscribeToNodeChange(
-        [dead_client_id](const UniqueID &id, const GcsNodeInfo &data) {
+        [dead_client_id](const UniqueID& id, const GcsNodeInfo& data) {
           if (data.state() == GcsNodeInfo::DEAD) {
             ASSERT_EQ(ClientID::FromBinary(data.node_id()), dead_client_id);
             test->Stop();
@@ -1329,7 +1329,7 @@ TEST_F(TestGcsWithAsio, TestClientTableMarkDisconnected) {
 
 class HashTableTestHelper {
  public:
-  static void TestHashTable(const JobID &job_id,
+  static void TestHashTable(const JobID& job_id,
                             std::shared_ptr<gcs::RedisGcsClient> client) {
     uint64_t expected_count = 14;
     ClientID client_id = ClientID::FromRandom();
@@ -1355,25 +1355,25 @@ class HashTableTestHelper {
     data_map2.emplace("CUSTOM", data_custom);
     data_map2["CPU"]->set_resource_capacity(50);
     // This is a common comparison function for the test.
-    auto compare_test = [](const DynamicResourceTable::DataMap &data1,
-                           const DynamicResourceTable::DataMap &data2) {
+    auto compare_test = [](const DynamicResourceTable::DataMap& data1,
+                           const DynamicResourceTable::DataMap& data2) {
       ASSERT_EQ(data1.size(), data2.size());
-      for (const auto &data : data1) {
+      for (const auto& data : data1) {
         auto iter = data2.find(data.first);
         ASSERT_TRUE(iter != data2.end());
         ASSERT_EQ(iter->second->resource_capacity(), data.second->resource_capacity());
       }
     };
-    auto subscribe_callback = [](RedisGcsClient *client) {
+    auto subscribe_callback = [](RedisGcsClient* client) {
       ASSERT_TRUE(true);
       test->IncrementNumCallbacks();
     };
     auto notification_callback =
         [data_map1, data_map2, compare_test, expected_count](
-            RedisGcsClient *client, const ClientID &id,
-            const std::vector<ResourceChangeNotification> &result) {
+            RedisGcsClient* client, const ClientID& id,
+            const std::vector<ResourceChangeNotification>& result) {
           RAY_CHECK(result.size() == 1);
-          const ResourceChangeNotification &notification = result.back();
+          const ResourceChangeNotification& notification = result.back();
           if (notification.IsRemoved()) {
             ASSERT_EQ(notification.GetData().size(), 2);
             ASSERT_TRUE(notification.GetData().find("GPU") !=
@@ -1405,16 +1405,16 @@ class HashTableTestHelper {
 
     // Step 1: Add elements to the hash table.
     auto update_callback1 = [data_map1, compare_test](
-                                RedisGcsClient *client, const ClientID &id,
-                                const DynamicResourceTable::DataMap &callback_data) {
+                                RedisGcsClient* client, const ClientID& id,
+                                const DynamicResourceTable::DataMap& callback_data) {
       compare_test(data_map1, callback_data);
       test->IncrementNumCallbacks();
     };
     RAY_CHECK_OK(
         client->resource_table().Update(job_id, client_id, data_map1, update_callback1));
     auto lookup_callback1 = [data_map1, compare_test](
-                                RedisGcsClient *client, const ClientID &id,
-                                const DynamicResourceTable::DataMap &callback_data) {
+                                RedisGcsClient* client, const ClientID& id,
+                                const DynamicResourceTable::DataMap& callback_data) {
       compare_test(data_map1, callback_data);
       test->IncrementNumCallbacks();
     };
@@ -1423,15 +1423,15 @@ class HashTableTestHelper {
     // Step 2: Decrease one element, increase one and add a new one.
     RAY_CHECK_OK(client->resource_table().Update(job_id, client_id, data_map2, nullptr));
     auto lookup_callback2 = [data_map2, compare_test](
-                                RedisGcsClient *client, const ClientID &id,
-                                const DynamicResourceTable::DataMap &callback_data) {
+                                RedisGcsClient* client, const ClientID& id,
+                                const DynamicResourceTable::DataMap& callback_data) {
       compare_test(data_map2, callback_data);
       test->IncrementNumCallbacks();
     };
     RAY_CHECK_OK(client->resource_table().Lookup(job_id, client_id, lookup_callback2));
     std::vector<std::string> delete_keys({"GPU", "CUSTOM", "None-Existent"});
-    auto remove_callback = [delete_keys](RedisGcsClient *client, const ClientID &id,
-                                         const std::vector<std::string> &callback_data) {
+    auto remove_callback = [delete_keys](RedisGcsClient* client, const ClientID& id,
+                                         const std::vector<std::string>& callback_data) {
       for (size_t i = 0; i < callback_data.size(); ++i) {
         // All deleting keys exist in this argument even if the key doesn't exist.
         ASSERT_EQ(callback_data[i], delete_keys[i]);
@@ -1444,8 +1444,8 @@ class HashTableTestHelper {
     data_map3.erase("GPU");
     data_map3.erase("CUSTOM");
     auto lookup_callback3 = [data_map3, compare_test](
-                                RedisGcsClient *client, const ClientID &id,
-                                const DynamicResourceTable::DataMap &callback_data) {
+                                RedisGcsClient* client, const ClientID& id,
+                                const DynamicResourceTable::DataMap& callback_data) {
       compare_test(data_map3, callback_data);
       test->IncrementNumCallbacks();
     };
@@ -1455,8 +1455,8 @@ class HashTableTestHelper {
     RAY_CHECK_OK(
         client->resource_table().Update(job_id, client_id, data_map1, update_callback1));
     auto lookup_callback4 = [data_map1, compare_test](
-                                RedisGcsClient *client, const ClientID &id,
-                                const DynamicResourceTable::DataMap &callback_data) {
+                                RedisGcsClient* client, const ClientID& id,
+                                const DynamicResourceTable::DataMap& callback_data) {
       compare_test(data_map1, callback_data);
       test->IncrementNumCallbacks();
     };
@@ -1466,8 +1466,8 @@ class HashTableTestHelper {
     RAY_CHECK_OK(client->resource_table().RemoveEntries(
         job_id, client_id, {"GPU", "CPU", "CUSTOM", "None-Existent"}, nullptr));
     auto lookup_callback5 = [expected_count](
-                                RedisGcsClient *client, const ClientID &id,
-                                const DynamicResourceTable::DataMap &callback_data) {
+                                RedisGcsClient* client, const ClientID& id,
+                                const DynamicResourceTable::DataMap& callback_data) {
       ASSERT_EQ(callback_data.size(), 0);
       test->IncrementNumCallbacks();
       // It is not sure which of notification or lookup callback will come first.
@@ -1491,7 +1491,7 @@ TEST_F(TestGcsWithAsio, TestHashTable) {
 }  // namespace gcs
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
                                          ray::RayLog::ShutDownRayLog, argv[0],
                                          ray::RayLogLevel::INFO,

--- a/src/ray/gcs/test/redis_job_info_accessor_test.cc
+++ b/src/ray/gcs/test/redis_job_info_accessor_test.cc
@@ -40,9 +40,9 @@ class RedisJobInfoAccessorTest : public AccessorTestBase<JobID, JobTableData> {
 };
 
 TEST_F(RedisJobInfoAccessorTest, AddAndSubscribe) {
-  JobInfoAccessor &job_accessor = gcs_client_->Jobs();
+  JobInfoAccessor& job_accessor = gcs_client_->Jobs();
   // SubscribeAll
-  auto on_subscribe = [this](const JobID &job_id, const JobTableData &data) {
+  auto on_subscribe = [this](const JobID& job_id, const JobTableData& data) {
     const auto it = id_to_data_.find(job_id);
     RAY_CHECK(it != id_to_data_.end());
     if (data.is_dead()) {
@@ -62,7 +62,7 @@ TEST_F(RedisJobInfoAccessorTest, AddAndSubscribe) {
   WaitPendingDone(subscribe_pending_count_, wait_pending_timeout_);
 
   // Register
-  for (const auto &item : id_to_data_) {
+  for (const auto& item : id_to_data_) {
     ++pending_count_;
     RAY_CHECK_OK(job_accessor.AsyncAdd(item.second, [this](Status status) {
       RAY_CHECK_OK(status);
@@ -73,7 +73,7 @@ TEST_F(RedisJobInfoAccessorTest, AddAndSubscribe) {
   WaitPendingDone(subscribe_pending_count_, wait_pending_timeout_);
 
   // Update
-  for (auto &item : id_to_data_) {
+  for (auto& item : id_to_data_) {
     ++pending_count_;
     ++subscribe_pending_count_;
     RAY_CHECK_OK(job_accessor.AsyncMarkFinished(item.first, [this](Status status) {
@@ -89,7 +89,7 @@ TEST_F(RedisJobInfoAccessorTest, AddAndSubscribe) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   RAY_CHECK(argc == 4);
   ray::TEST_REDIS_SERVER_EXEC_PATH = argv[1];

--- a/src/ray/gcs/test/redis_node_info_accessor_test.cc
+++ b/src/ray/gcs/test/redis_node_info_accessor_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <memory>
+
 #include "gtest/gtest.h"
 #include "ray/gcs/redis_accessor.h"
 #include "ray/gcs/redis_gcs_client.h"

--- a/src/ray/gcs/test/redis_node_info_accessor_test.cc
+++ b/src/ray/gcs/test/redis_node_info_accessor_test.cc
@@ -56,16 +56,16 @@ class NodeDynamicResourceTest : public AccessorTestBase<ClientID, ResourceTableD
 };
 
 TEST_F(NodeDynamicResourceTest, UpdateAndGet) {
-  NodeInfoAccessor &node_accessor = gcs_client_->Nodes();
-  for (const auto &node_rs : id_to_resource_map_) {
+  NodeInfoAccessor& node_accessor = gcs_client_->Nodes();
+  for (const auto& node_rs : id_to_resource_map_) {
     ++pending_count_;
-    const ClientID &id = node_rs.first;
+    const ClientID& id = node_rs.first;
     // Update
     Status status = node_accessor.AsyncUpdateResources(
         node_rs.first, node_rs.second, [this, &node_accessor, id](Status status) {
           RAY_CHECK_OK(status);
           auto get_callback = [this, id](Status status,
-                                         const boost::optional<ResourceMap> &result) {
+                                         const boost::optional<ResourceMap>& result) {
             --pending_count_;
             RAY_CHECK_OK(status);
             const auto it = id_to_resource_map_.find(id);
@@ -81,8 +81,8 @@ TEST_F(NodeDynamicResourceTest, UpdateAndGet) {
 }
 
 TEST_F(NodeDynamicResourceTest, Delete) {
-  NodeInfoAccessor &node_accessor = gcs_client_->Nodes();
-  for (const auto &node_rs : id_to_resource_map_) {
+  NodeInfoAccessor& node_accessor = gcs_client_->Nodes();
+  for (const auto& node_rs : id_to_resource_map_) {
     ++pending_count_;
     // Update
     Status status = node_accessor.AsyncUpdateResources(node_rs.first, node_rs.second,
@@ -93,16 +93,16 @@ TEST_F(NodeDynamicResourceTest, Delete) {
   }
   WaitPendingDone(wait_pending_timeout_);
 
-  for (const auto &node_rs : id_to_resource_map_) {
+  for (const auto& node_rs : id_to_resource_map_) {
     ++pending_count_;
-    const ClientID &id = node_rs.first;
+    const ClientID& id = node_rs.first;
     // Delete
     Status status = node_accessor.AsyncDeleteResources(
         id, resource_to_delete_, [this, &node_accessor, id](Status status) {
           RAY_CHECK_OK(status);
           // Get
           status = node_accessor.AsyncGetResources(
-              id, [this, id](Status status, const boost::optional<ResourceMap> &result) {
+              id, [this, id](Status status, const boost::optional<ResourceMap>& result) {
                 --pending_count_;
                 RAY_CHECK_OK(status);
                 const auto it = id_to_resource_map_.find(id);
@@ -115,8 +115,8 @@ TEST_F(NodeDynamicResourceTest, Delete) {
 }
 
 TEST_F(NodeDynamicResourceTest, Subscribe) {
-  NodeInfoAccessor &node_accessor = gcs_client_->Nodes();
-  for (const auto &node_rs : id_to_resource_map_) {
+  NodeInfoAccessor& node_accessor = gcs_client_->Nodes();
+  for (const auto& node_rs : id_to_resource_map_) {
     ++pending_count_;
     // Update
     Status status = node_accessor.AsyncUpdateResources(node_rs.first, node_rs.second,
@@ -127,7 +127,7 @@ TEST_F(NodeDynamicResourceTest, Subscribe) {
   }
   WaitPendingDone(wait_pending_timeout_);
 
-  auto subscribe = [this](const rpc::NodeResourceChange &notification) {
+  auto subscribe = [this](const rpc::NodeResourceChange& notification) {
     auto id = ClientID::FromBinary(notification.node_id());
     RAY_LOG(INFO) << "receive client id=" << id;
     auto it = id_to_resource_map_.find(id);
@@ -150,7 +150,7 @@ TEST_F(NodeDynamicResourceTest, Subscribe) {
   Status status = node_accessor.AsyncSubscribeToResources(subscribe, done);
   RAY_CHECK_OK(status);
 
-  for (const auto &node_rs : id_to_resource_map_) {
+  for (const auto& node_rs : id_to_resource_map_) {
     // Delete
     ++pending_count_;
     ++sub_pending_count_;
@@ -170,7 +170,7 @@ TEST_F(NodeDynamicResourceTest, Subscribe) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   RAY_CHECK(argc == 4);
   ray::TEST_REDIS_SERVER_EXEC_PATH = argv[1];

--- a/src/ray/gcs/test/redis_object_info_accessor_test.cc
+++ b/src/ray/gcs/test/redis_object_info_accessor_test.cc
@@ -49,11 +49,11 @@ class RedisObjectInfoAccessorTest : public AccessorTestBase<ObjectID, ObjectTabl
 };
 
 TEST_F(RedisObjectInfoAccessorTest, TestGetAddRemove) {
-  ObjectInfoAccessor &object_accessor = gcs_client_->Objects();
+  ObjectInfoAccessor& object_accessor = gcs_client_->Objects();
   // add && get
   // add
-  for (const auto &elem : object_id_to_data_) {
-    for (const auto &item : elem.second) {
+  for (const auto& elem : object_id_to_data_) {
+    for (const auto& item : elem.second) {
       ++pending_count_;
       ClientID node_id = ClientID::FromBinary(item->manager());
       RAY_CHECK_OK(
@@ -65,12 +65,12 @@ TEST_F(RedisObjectInfoAccessorTest, TestGetAddRemove) {
   }
   WaitPendingDone(wait_pending_timeout_);
   // get
-  for (const auto &elem : object_id_to_data_) {
+  for (const auto& elem : object_id_to_data_) {
     ++pending_count_;
     size_t total_size = elem.second.size();
     RAY_CHECK_OK(object_accessor.AsyncGetLocations(
         elem.first,
-        [this, total_size](Status status, const std::vector<ObjectTableData> &result) {
+        [this, total_size](Status status, const std::vector<ObjectTableData>& result) {
           RAY_CHECK_OK(status);
           RAY_CHECK(total_size == result.size());
           --pending_count_;
@@ -83,8 +83,8 @@ TEST_F(RedisObjectInfoAccessorTest, TestGetAddRemove) {
   // subscribe && delete
   // subscribe
   std::atomic<int> sub_pending_count(0);
-  auto subscribe = [this, &sub_pending_count](const ObjectID &object_id,
-                                              const ObjectChangeNotification &result) {
+  auto subscribe = [this, &sub_pending_count](const ObjectID& object_id,
+                                              const ObjectChangeNotification& result) {
     const auto it = object_id_to_data_.find(object_id);
     ASSERT_TRUE(it != object_id_to_data_.end());
     static size_t response_count = 1;
@@ -97,7 +97,7 @@ TEST_F(RedisObjectInfoAccessorTest, TestGetAddRemove) {
     ++response_count;
     --sub_pending_count;
   };
-  for (const auto &elem : object_id_to_data_) {
+  for (const auto& elem : object_id_to_data_) {
     ++pending_count_;
     ++sub_pending_count;
     RAY_CHECK_OK(object_accessor.AsyncSubscribeToLocations(elem.first, subscribe,
@@ -109,10 +109,10 @@ TEST_F(RedisObjectInfoAccessorTest, TestGetAddRemove) {
   WaitPendingDone(wait_pending_timeout_);
   WaitPendingDone(sub_pending_count, wait_pending_timeout_);
   // delete
-  for (const auto &elem : object_id_to_data_) {
+  for (const auto& elem : object_id_to_data_) {
     ++pending_count_;
     ++sub_pending_count;
-    const ObjectVector &object_vec = elem.second;
+    const ObjectVector& object_vec = elem.second;
     ClientID node_id = ClientID::FromBinary(object_vec[0]->manager());
     RAY_CHECK_OK(
         object_accessor.AsyncRemoveLocation(elem.first, node_id, [this](Status status) {
@@ -123,12 +123,12 @@ TEST_F(RedisObjectInfoAccessorTest, TestGetAddRemove) {
   WaitPendingDone(wait_pending_timeout_);
   WaitPendingDone(sub_pending_count, wait_pending_timeout_);
   // get
-  for (const auto &elem : object_id_to_data_) {
+  for (const auto& elem : object_id_to_data_) {
     ++pending_count_;
     size_t total_size = elem.second.size();
     RAY_CHECK_OK(object_accessor.AsyncGetLocations(
         elem.first,
-        [this, total_size](Status status, const std::vector<ObjectTableData> &result) {
+        [this, total_size](Status status, const std::vector<ObjectTableData>& result) {
           RAY_CHECK_OK(status);
           ASSERT_EQ(total_size - 1, result.size());
           --pending_count_;
@@ -143,7 +143,7 @@ TEST_F(RedisObjectInfoAccessorTest, TestGetAddRemove) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
                                          ray::RayLog::ShutDownRayLog, argv[0],
                                          ray::RayLogLevel::INFO,

--- a/src/ray/gcs/test/subscription_executor_test.cc
+++ b/src/ray/gcs/test/subscription_executor_test.cc
@@ -34,7 +34,7 @@ class SubscriptionExecutorTest : public AccessorTestBase<ActorID, ActorTableData
 
     actor_sub_executor_.reset(new ActorSubExecutor(gcs_client_->log_based_actor_table()));
 
-    subscribe_ = [this](const ActorID &id, const ActorTableData &data) {
+    subscribe_ = [this](const ActorID& id, const ActorTableData& data) {
       const auto it = id_to_data_.find(id);
       ASSERT_TRUE(it != id_to_data_.end());
       --sub_pending_count_;
@@ -74,9 +74,9 @@ class SubscriptionExecutorTest : public AccessorTestBase<ActorID, ActorTableData
   }
 
   size_t AsyncRegisterActorToGcs() {
-    ActorInfoAccessor &actor_accessor = gcs_client_->Actors();
-    for (const auto &elem : id_to_data_) {
-      const auto &actor = elem.second;
+    ActorInfoAccessor& actor_accessor = gcs_client_->Actors();
+    for (const auto& elem : id_to_data_) {
+      const auto& actor = elem.second;
       auto done = [this](Status status) {
         ASSERT_TRUE(status.ok());
         --pending_count_;
@@ -114,7 +114,7 @@ TEST_F(SubscriptionExecutorTest, SubscribeAllTest) {
 }
 
 TEST_F(SubscriptionExecutorTest, SubscribeOneWithClientIDTest) {
-  const auto &item = id_to_data_.begin();
+  const auto& item = id_to_data_.begin();
   ++do_sub_pending_count_;
   ++sub_pending_count_;
   Status status = actor_sub_executor_->AsyncSubscribe(ClientID::FromRandom(), item->first,
@@ -129,7 +129,7 @@ TEST_F(SubscriptionExecutorTest, SubscribeOneWithClientIDTest) {
 }
 
 TEST_F(SubscriptionExecutorTest, SubscribeOneAfterActorRegistrationWithClientIDTest) {
-  const auto &item = id_to_data_.begin();
+  const auto& item = id_to_data_.begin();
   ++do_sub_pending_count_;
   ++sub_pending_count_;
   AsyncRegisterActorToGcs();
@@ -149,7 +149,7 @@ TEST_F(SubscriptionExecutorTest, SubscribeAllAndSubscribeOneTest) {
       actor_sub_executor_->AsyncSubscribeAll(ClientID::Nil(), subscribe_, sub_done_);
   ASSERT_TRUE(status.ok());
   WaitPendingDone(do_sub_pending_count_, wait_pending_timeout_);
-  for (const auto &item : id_to_data_) {
+  for (const auto& item : id_to_data_) {
     status = actor_sub_executor_->AsyncSubscribe(ClientID::FromRandom(), item.first,
                                                  subscribe_, sub_done_);
     ASSERT_FALSE(status.ok());
@@ -162,43 +162,43 @@ TEST_F(SubscriptionExecutorTest, SubscribeAllAndSubscribeOneTest) {
 TEST_F(SubscriptionExecutorTest, UnsubscribeTest) {
   ClientID client_id = ClientID::FromRandom();
   Status status;
-  for (const auto &item : id_to_data_) {
+  for (const auto& item : id_to_data_) {
     status = actor_sub_executor_->AsyncUnsubscribe(client_id, item.first, unsub_done_);
     ASSERT_TRUE(status.IsInvalid());
   }
 
-  for (const auto &item : id_to_data_) {
+  for (const auto& item : id_to_data_) {
     ++do_sub_pending_count_;
     status =
         actor_sub_executor_->AsyncSubscribe(client_id, item.first, subscribe_, sub_done_);
     ASSERT_TRUE(status.ok());
   }
   WaitPendingDone(do_sub_pending_count_, wait_pending_timeout_);
-  for (const auto &item : id_to_data_) {
+  for (const auto& item : id_to_data_) {
     ++do_unsub_pending_count_;
     status = actor_sub_executor_->AsyncUnsubscribe(client_id, item.first, unsub_done_);
     ASSERT_TRUE(status.ok());
   }
   WaitPendingDone(do_unsub_pending_count_, wait_pending_timeout_);
-  for (const auto &item : id_to_data_) {
+  for (const auto& item : id_to_data_) {
     status = actor_sub_executor_->AsyncUnsubscribe(client_id, item.first, unsub_done_);
     ASSERT_TRUE(!status.ok());
   }
 
-  for (const auto &item : id_to_data_) {
+  for (const auto& item : id_to_data_) {
     ++do_sub_pending_count_;
     status =
         actor_sub_executor_->AsyncSubscribe(client_id, item.first, subscribe_, sub_done_);
     ASSERT_TRUE(status.ok());
   }
   WaitPendingDone(do_sub_pending_count_, wait_pending_timeout_);
-  for (const auto &item : id_to_data_) {
+  for (const auto& item : id_to_data_) {
     ++do_unsub_pending_count_;
     status = actor_sub_executor_->AsyncUnsubscribe(client_id, item.first, unsub_done_);
     ASSERT_TRUE(status.ok());
   }
   WaitPendingDone(do_unsub_pending_count_, wait_pending_timeout_);
-  for (const auto &item : id_to_data_) {
+  for (const auto& item : id_to_data_) {
     ++do_sub_pending_count_;
     status =
         actor_sub_executor_->AsyncSubscribe(client_id, item.first, subscribe_, sub_done_);
@@ -215,7 +215,7 @@ TEST_F(SubscriptionExecutorTest, UnsubscribeTest) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   RAY_CHECK(argc == 4);
   ray::TEST_REDIS_SERVER_EXEC_PATH = argv[1];

--- a/src/ray/object_manager/notification/object_store_notification_manager.h
+++ b/src/ray/object_manager/notification/object_store_notification_manager.h
@@ -15,14 +15,12 @@
 #ifndef RAY_OBJECT_STORE_NOTIFICATION_MANAGER_H
 #define RAY_OBJECT_STORE_NOTIFICATION_MANAGER_H
 
+#include <boost/asio.hpp>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include <boost/asio.hpp>
-
 #include "absl/synchronization/mutex.h"
-
 #include "ray/common/id.h"
 #include "ray/common/status.h"
 #include "ray/object_manager/format/object_manager_generated.h"

--- a/src/ray/object_manager/notification/object_store_notification_manager.h
+++ b/src/ray/object_manager/notification/object_store_notification_manager.h
@@ -32,7 +32,7 @@ namespace ray {
 /// Encapsulates notification handling from the object store.
 class ObjectStoreNotificationManager {
  public:
-  ObjectStoreNotificationManager(boost::asio::io_service &io_service)
+  ObjectStoreNotificationManager(boost::asio::io_service& io_service)
       : main_service_(&io_service), num_adds_processed_(0), num_removes_processed_(0) {}
   virtual ~ObjectStoreNotificationManager() {}
   /// Subscribe to notifications of objects added to local store.
@@ -41,7 +41,7 @@ class ObjectStoreNotificationManager {
   ///
   /// \param callback A callback expecting an ObjectID.
   void SubscribeObjAdded(
-      std::function<void(const object_manager::protocol::ObjectInfoT &)> callback) {
+      std::function<void(const object_manager::protocol::ObjectInfoT&)> callback) {
     absl::MutexLock lock(&store_add_mutex_);
     add_handlers_.push_back(std::move(callback));
   }
@@ -49,24 +49,24 @@ class ObjectStoreNotificationManager {
   /// Subscribe to notifications of objects deleted from local store.
   ///
   /// \param callback A callback expecting an ObjectID.
-  void SubscribeObjDeleted(std::function<void(const ray::ObjectID &)> callback) {
+  void SubscribeObjDeleted(std::function<void(const ray::ObjectID&)> callback) {
     absl::MutexLock lock(&store_remove_mutex_);
     rem_handlers_.push_back(std::move(callback));
   }
 
   /// Support for rebroadcasting object add/rem events.
-  void ProcessStoreAdd(const object_manager::protocol::ObjectInfoT &object_info) {
+  void ProcessStoreAdd(const object_manager::protocol::ObjectInfoT& object_info) {
     // TODO(suquark): Use strand in boost asio to enforce sequential execution.
     absl::MutexLock lock(&store_add_mutex_);
-    for (auto &handler : add_handlers_) {
+    for (auto& handler : add_handlers_) {
       main_service_->post([handler, object_info]() { handler(object_info); });
     }
     num_adds_processed_++;
   }
 
-  void ProcessStoreRemove(const ObjectID &object_id) {
+  void ProcessStoreRemove(const ObjectID& object_id) {
     absl::MutexLock lock(&store_remove_mutex_);
-    for (auto &handler : rem_handlers_) {
+    for (auto& handler : rem_handlers_) {
       main_service_->post([handler, object_id]() { handler(object_id); });
     }
     num_removes_processed_++;
@@ -86,10 +86,10 @@ class ObjectStoreNotificationManager {
  private:
   /// Weak reference to main service. We ensure this object is destroyed before
   /// main_service_ is stopped.
-  boost::asio::io_service *main_service_;
-  std::vector<std::function<void(const object_manager::protocol::ObjectInfoT &)>>
+  boost::asio::io_service* main_service_;
+  std::vector<std::function<void(const object_manager::protocol::ObjectInfoT&)>>
       add_handlers_;
-  std::vector<std::function<void(const ray::ObjectID &)>> rem_handlers_;
+  std::vector<std::function<void(const ray::ObjectID&)>> rem_handlers_;
   absl::Mutex store_add_mutex_;
   absl::Mutex store_remove_mutex_;
   int64_t num_adds_processed_;

--- a/src/ray/object_manager/notification/object_store_notification_manager_ipc.cc
+++ b/src/ray/object_manager/notification/object_store_notification_manager_ipc.cc
@@ -20,7 +20,7 @@
 namespace ray {
 
 ObjectStoreNotificationManagerIPC::ObjectStoreNotificationManagerIPC(
-    boost::asio::io_service &io_service, const std::string &store_socket_name,
+    boost::asio::io_service& io_service, const std::string& store_socket_name,
     bool exit_on_error)
     : ObjectStoreNotificationManager(io_service),
       length_(0),
@@ -47,10 +47,10 @@ void ObjectStoreNotificationManagerIPC::Shutdown() { store_client_->Close(); }
 
 void ObjectStoreNotificationManagerIPC::NotificationWait() {
   store_client_->ReadBufferAsync({boost::asio::buffer(&length_, sizeof(length_))},
-                                 [this](const ray::Status &s) { ProcessStoreLength(s); });
+                                 [this](const ray::Status& s) { ProcessStoreLength(s); });
 }
 
-void ObjectStoreNotificationManagerIPC::ProcessStoreLength(const ray::Status &s) {
+void ObjectStoreNotificationManagerIPC::ProcessStoreLength(const ray::Status& s) {
   notification_.resize(length_);
   if (!s.ok()) {
     if (exit_on_error_) {
@@ -73,10 +73,10 @@ void ObjectStoreNotificationManagerIPC::ProcessStoreLength(const ray::Status &s)
 
   store_client_->ReadBufferAsync(
       {boost::asio::buffer(notification_)},
-      [this](const ray::Status &s) { ProcessStoreNotification(s); });
+      [this](const ray::Status& s) { ProcessStoreNotification(s); });
 }
 
-void ObjectStoreNotificationManagerIPC::ProcessStoreNotification(const ray::Status &s) {
+void ObjectStoreNotificationManagerIPC::ProcessStoreNotification(const ray::Status& s) {
   if (!s.ok()) {
     if (exit_on_error_) {
       RAY_LOG(FATAL)
@@ -93,7 +93,7 @@ void ObjectStoreNotificationManagerIPC::ProcessStoreNotification(const ray::Stat
     }
   }
 
-  const auto &object_notification =
+  const auto& object_notification =
       flatbuffers::GetRoot<object_manager::protocol::PlasmaNotification>(
           notification_.data());
   for (size_t i = 0; i < object_notification->object_info()->size(); ++i) {

--- a/src/ray/object_manager/notification/object_store_notification_manager_ipc.h
+++ b/src/ray/object_manager/notification/object_store_notification_manager_ipc.h
@@ -35,8 +35,8 @@ class ObjectStoreNotificationManagerIPC : public ObjectStoreNotificationManager 
   /// \param store_socket_name The store socket to connect to.
   /// \param exit_on_error The manager will exit with error when it fails
   ///                      to process messages from socket.
-  ObjectStoreNotificationManagerIPC(boost::asio::io_service &io_service,
-                                    const std::string &store_socket_name,
+  ObjectStoreNotificationManagerIPC(boost::asio::io_service& io_service,
+                                    const std::string& store_socket_name,
                                     bool exit_on_error = true);
 
   ~ObjectStoreNotificationManagerIPC() override;
@@ -47,8 +47,8 @@ class ObjectStoreNotificationManagerIPC : public ObjectStoreNotificationManager 
  private:
   /// Async loop for handling object store notifications.
   void NotificationWait();
-  void ProcessStoreLength(const ray::Status &s);
-  void ProcessStoreNotification(const ray::Status &s);
+  void ProcessStoreLength(const ray::Status& s);
+  void ProcessStoreNotification(const ray::Status& s);
 
   std::shared_ptr<ServerConnection> store_client_;
   int64_t length_;

--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -14,14 +14,13 @@
 
 #pragma once
 
+#include <boost/asio.hpp>
+#include <boost/asio/error.hpp>
+#include <boost/bind.hpp>
 #include <list>
 #include <memory>
 #include <mutex>
 #include <vector>
-
-#include <boost/asio.hpp>
-#include <boost/asio/error.hpp>
-#include <boost/bind.hpp>
 
 #include "ray/common/id.h"
 #include "ray/common/status.h"

--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -35,12 +35,12 @@ class ObjectBufferPool {
   /// This is the structure returned whenever an object chunk is
   /// accessed via Get and Create.
   struct ChunkInfo {
-    ChunkInfo(uint64_t chunk_index, uint8_t *data, uint64_t buffer_length)
+    ChunkInfo(uint64_t chunk_index, uint8_t* data, uint64_t buffer_length)
         : chunk_index(chunk_index), data(data), buffer_length(buffer_length){};
     /// A pointer to the start position of this object chunk.
     uint64_t chunk_index;
     /// A pointer to the start position of this object chunk.
-    uint8_t *data;
+    uint8_t* data;
     /// The size of this object chunk.
     uint64_t buffer_length;
   };
@@ -50,7 +50,7 @@ class ObjectBufferPool {
   /// \param store_socket_name The socket name of the store to which plasma clients
   /// connect.
   /// \param chunk_size The chunk size into which objects are to be split.
-  ObjectBufferPool(const std::string &store_socket_name, const uint64_t chunk_size);
+  ObjectBufferPool(const std::string& store_socket_name, const uint64_t chunk_size);
 
   ~ObjectBufferPool();
 
@@ -80,8 +80,8 @@ class ObjectBufferPool {
   /// \param chunk_index The index of the chunk.
   /// \return A pair consisting of a ChunkInfo and status of invoking this method.
   /// An IOError status is returned if the Get call on the plasma store fails.
-  std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> GetChunk(
-      const ObjectID &object_id, uint64_t data_size, uint64_t metadata_size,
+  std::pair<const ObjectBufferPool::ChunkInfo&, ray::Status> GetChunk(
+      const ObjectID& object_id, uint64_t data_size, uint64_t metadata_size,
       uint64_t chunk_index);
 
   /// When a chunk is done being used as part of a get, this method releases the chunk.
@@ -89,7 +89,7 @@ class ObjectBufferPool {
   ///
   /// \param object_id The object_id of the buffer to release.
   /// \param chunk_index The index of the chunk.
-  void ReleaseGetChunk(const ObjectID &object_id, uint64_t chunk_index);
+  void ReleaseGetChunk(const ObjectID& object_id, uint64_t chunk_index);
 
   /// Returns a chunk of an empty object at the given chunk_index. The object chunk
   /// serves as the buffer that is to be written to by a connection receiving an object
@@ -107,8 +107,8 @@ class ObjectBufferPool {
   /// An IOError status is returned if object creation on the store client fails,
   /// or if create is invoked consecutively on the same chunk
   /// (with no intermediate AbortCreateChunk).
-  std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> CreateChunk(
-      const ObjectID &object_id, uint64_t data_size, uint64_t metadata_size,
+  std::pair<const ObjectBufferPool::ChunkInfo&, ray::Status> CreateChunk(
+      const ObjectID& object_id, uint64_t data_size, uint64_t metadata_size,
       uint64_t chunk_index);
 
   /// Abort the create operation associated with a chunk at chunk_index.
@@ -118,7 +118,7 @@ class ObjectBufferPool {
   ///
   /// \param object_id The ObjectID.
   /// \param chunk_index The index of the chunk.
-  void AbortCreateChunk(const ObjectID &object_id, uint64_t chunk_index);
+  void AbortCreateChunk(const ObjectID& object_id, uint64_t chunk_index);
 
   /// Seal the object associated with a create operation. This is invoked whenever
   /// a chunk is successfully written to.
@@ -128,13 +128,13 @@ class ObjectBufferPool {
   ///
   /// \param object_id The ObjectID.
   /// \param chunk_index The index of the chunk.
-  void SealChunk(const ObjectID &object_id, uint64_t chunk_index);
+  void SealChunk(const ObjectID& object_id, uint64_t chunk_index);
 
   /// Free a list of objects from object store.
   ///
   /// \param object_ids the The list of ObjectIDs to be deleted.
   /// \return Void.
-  void FreeObjects(const std::vector<ObjectID> &object_ids);
+  void FreeObjects(const std::vector<ObjectID>& object_ids);
 
   /// Returns debug string for class.
   ///
@@ -144,14 +144,14 @@ class ObjectBufferPool {
  private:
   /// Abort the create operation associated with an object. This destroys the buffer
   /// state, including create operations in progress for all chunks of the object.
-  void AbortCreate(const ObjectID &object_id);
+  void AbortCreate(const ObjectID& object_id);
 
   /// Abort the get operation associated with an object.
-  void AbortGet(const ObjectID &object_id);
+  void AbortGet(const ObjectID& object_id);
 
   /// Splits an object into ceil(data_size/chunk_size) chunks, which will
   /// either be read or written to in parallel.
-  std::vector<ChunkInfo> BuildChunks(const ObjectID &object_id, uint8_t *data,
+  std::vector<ChunkInfo> BuildChunks(const ObjectID& object_id, uint8_t* data,
                                      uint64_t data_size);
 
   /// Holds the state of a get buffer.

--- a/src/ray/object_manager/object_directory.h
+++ b/src/ray/object_manager/object_directory.h
@@ -29,7 +29,7 @@ namespace ray {
 
 /// Connection information for remote object managers.
 struct RemoteConnectionInfo {
-  RemoteConnectionInfo(const ClientID &id) : client_id(id) {}
+  RemoteConnectionInfo(const ClientID& id) : client_id(id) {}
 
   // Returns whether there is enough information to connect to the remote
   // object manager.
@@ -51,7 +51,7 @@ class ObjectDirectoryInterface {
   /// has information about the requested client, then the rest of the fields
   /// in this struct will be populated accordingly.
   virtual void LookupRemoteConnectionInfo(
-      RemoteConnectionInfo &connection_info) const = 0;
+      RemoteConnectionInfo& connection_info) const = 0;
 
   /// Get information for all connected remote object managers.
   ///
@@ -59,23 +59,23 @@ class ObjectDirectoryInterface {
   virtual std::vector<RemoteConnectionInfo> LookupAllRemoteConnections() const = 0;
 
   /// Callback for object location notifications.
-  using OnLocationsFound = std::function<void(const ray::ObjectID &object_id,
-                                              const std::unordered_set<ray::ClientID> &)>;
+  using OnLocationsFound = std::function<void(const ray::ObjectID& object_id,
+                                              const std::unordered_set<ray::ClientID>&)>;
 
   /// Lookup object locations. Callback may be invoked with empty list of client ids.
   ///
   /// \param object_id The object's ObjectID.
   /// \param callback Invoked with (possibly empty) list of client ids and object_id.
   /// \return Status of whether async call to backend succeeded.
-  virtual ray::Status LookupLocations(const ObjectID &object_id,
-                                      const OnLocationsFound &callback) = 0;
+  virtual ray::Status LookupLocations(const ObjectID& object_id,
+                                      const OnLocationsFound& callback) = 0;
 
   /// Handle the removal of an object manager client. This updates the
   /// locations of all subscribed objects that have the removed client as a
   /// location, and fires the subscribed callbacks for those objects.
   ///
   /// \param client_id The object manager client that was removed.
-  virtual void HandleClientRemoved(const ClientID &client_id) = 0;
+  virtual void HandleClientRemoved(const ClientID& client_id) = 0;
 
   /// Subscribe to be notified of locations (ClientID) of the given object.
   /// The callback will be invoked with the complete list of known locations
@@ -90,9 +90,9 @@ class ObjectDirectoryInterface {
   /// \param object_id The required object's ObjectID.
   /// \param success_cb Invoked with non-empty list of client ids and object_id.
   /// \return Status of whether subscription succeeded.
-  virtual ray::Status SubscribeObjectLocations(const UniqueID &callback_id,
-                                               const ObjectID &object_id,
-                                               const OnLocationsFound &callback) = 0;
+  virtual ray::Status SubscribeObjectLocations(const UniqueID& callback_id,
+                                               const ObjectID& object_id,
+                                               const OnLocationsFound& callback) = 0;
 
   /// Unsubscribe to object location notifications.
   ///
@@ -101,8 +101,8 @@ class ObjectDirectoryInterface {
   /// further notifications about the given object's location.
   /// \param object_id The object id invoked with Subscribe.
   /// \return Status of unsubscribing from object location notifications.
-  virtual ray::Status UnsubscribeObjectLocations(const UniqueID &callback_id,
-                                                 const ObjectID &object_id) = 0;
+  virtual ray::Status UnsubscribeObjectLocations(const UniqueID& callback_id,
+                                                 const ObjectID& object_id) = 0;
 
   /// Report objects added to this node's store to the object directory.
   ///
@@ -111,8 +111,8 @@ class ObjectDirectoryInterface {
   /// \param object_info Additional information about the object.
   /// \return Status of whether this method succeeded.
   virtual ray::Status ReportObjectAdded(
-      const ObjectID &object_id, const ClientID &client_id,
-      const object_manager::protocol::ObjectInfoT &object_info) = 0;
+      const ObjectID& object_id, const ClientID& client_id,
+      const object_manager::protocol::ObjectInfoT& object_info) = 0;
 
   /// Report objects removed from this client's store to the object directory.
   ///
@@ -121,8 +121,8 @@ class ObjectDirectoryInterface {
   /// \param object_info Additional information about the object.
   /// \return Status of whether this method succeeded.
   virtual ray::Status ReportObjectRemoved(
-      const ObjectID &object_id, const ClientID &client_id,
-      const object_manager::protocol::ObjectInfoT &object_info) = 0;
+      const ObjectID& object_id, const ClientID& client_id,
+      const object_manager::protocol::ObjectInfoT& object_info) = 0;
 
   /// Returns debug string for class.
   ///
@@ -139,32 +139,32 @@ class ObjectDirectory : public ObjectDirectoryInterface {
   /// usually be the same event loop that the given gcs_client runs on.
   /// \param gcs_client A Ray GCS client to request object and client
   /// information from.
-  ObjectDirectory(boost::asio::io_service &io_service,
-                  std::shared_ptr<gcs::GcsClient> &gcs_client);
+  ObjectDirectory(boost::asio::io_service& io_service,
+                  std::shared_ptr<gcs::GcsClient>& gcs_client);
 
   virtual ~ObjectDirectory() {}
 
-  void LookupRemoteConnectionInfo(RemoteConnectionInfo &connection_info) const override;
+  void LookupRemoteConnectionInfo(RemoteConnectionInfo& connection_info) const override;
 
   std::vector<RemoteConnectionInfo> LookupAllRemoteConnections() const override;
 
-  ray::Status LookupLocations(const ObjectID &object_id,
-                              const OnLocationsFound &callback) override;
+  ray::Status LookupLocations(const ObjectID& object_id,
+                              const OnLocationsFound& callback) override;
 
-  void HandleClientRemoved(const ClientID &client_id) override;
+  void HandleClientRemoved(const ClientID& client_id) override;
 
-  ray::Status SubscribeObjectLocations(const UniqueID &callback_id,
-                                       const ObjectID &object_id,
-                                       const OnLocationsFound &callback) override;
-  ray::Status UnsubscribeObjectLocations(const UniqueID &callback_id,
-                                         const ObjectID &object_id) override;
+  ray::Status SubscribeObjectLocations(const UniqueID& callback_id,
+                                       const ObjectID& object_id,
+                                       const OnLocationsFound& callback) override;
+  ray::Status UnsubscribeObjectLocations(const UniqueID& callback_id,
+                                         const ObjectID& object_id) override;
 
   ray::Status ReportObjectAdded(
-      const ObjectID &object_id, const ClientID &client_id,
-      const object_manager::protocol::ObjectInfoT &object_info) override;
+      const ObjectID& object_id, const ClientID& client_id,
+      const object_manager::protocol::ObjectInfoT& object_info) override;
   ray::Status ReportObjectRemoved(
-      const ObjectID &object_id, const ClientID &client_id,
-      const object_manager::protocol::ObjectInfoT &object_info) override;
+      const ObjectID& object_id, const ClientID& client_id,
+      const object_manager::protocol::ObjectInfoT& object_info) override;
 
   std::string DebugString() const override;
 
@@ -187,7 +187,7 @@ class ObjectDirectory : public ObjectDirectoryInterface {
   };
 
   /// Reference to the event loop.
-  boost::asio::io_service &io_service_;
+  boost::asio::io_service& io_service_;
   /// Reference to the gcs client.
   std::shared_ptr<gcs::GcsClient> gcs_client_;
   /// Info about subscribers to object locations.

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -15,6 +15,9 @@
 #pragma once
 
 #include <algorithm>
+#include <boost/asio.hpp>
+#include <boost/asio/error.hpp>
+#include <boost/bind.hpp>
 #include <cstdint>
 #include <deque>
 #include <map>
@@ -22,10 +25,6 @@
 #include <mutex>
 #include <random>
 #include <thread>
-
-#include <boost/asio.hpp>
-#include <boost/asio/error.hpp>
-#include <boost/bind.hpp>
 
 #include "absl/time/clock.h"
 #include "ray/common/id.h"

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -78,7 +78,7 @@ struct LocalObjectInfo {
 
 class ObjectStoreRunner {
  public:
-  ObjectStoreRunner(const ObjectManagerConfig &config);
+  ObjectStoreRunner(const ObjectManagerConfig& config);
   ~ObjectStoreRunner();
 
  private:
@@ -87,8 +87,8 @@ class ObjectStoreRunner {
 
 class ObjectManagerInterface {
  public:
-  virtual ray::Status Pull(const ObjectID &object_id) = 0;
-  virtual void CancelPull(const ObjectID &object_id) = 0;
+  virtual ray::Status Pull(const ObjectID& object_id) = 0;
+  virtual void CancelPull(const ObjectID& object_id) = 0;
   virtual ~ObjectManagerInterface(){};
 };
 
@@ -106,7 +106,7 @@ class ObjectManager : public ObjectManagerInterface,
   /// \param request Push request including the object chunk data
   /// \param reply Reply to the sender
   /// \param send_reply_callback Callback of the request
-  void HandlePush(const rpc::PushRequest &request, rpc::PushReply *reply,
+  void HandlePush(const rpc::PushRequest& request, rpc::PushReply* reply,
                   rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle pull request from remote object manager
@@ -114,7 +114,7 @@ class ObjectManager : public ObjectManagerInterface,
   /// \param request Pull request
   /// \param reply Reply
   /// \param send_reply_callback Callback of request
-  void HandlePull(const rpc::PullRequest &request, rpc::PullReply *reply,
+  void HandlePull(const rpc::PullRequest& request, rpc::PullReply* reply,
                   rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle free objects request
@@ -122,8 +122,8 @@ class ObjectManager : public ObjectManagerInterface,
   /// \param request Free objects request
   /// \param reply Reply
   /// \param send_reply_callback
-  void HandleFreeObjects(const rpc::FreeObjectsRequest &request,
-                         rpc::FreeObjectsReply *reply,
+  void HandleFreeObjects(const rpc::FreeObjectsRequest& request,
+                         rpc::FreeObjectsReply* reply,
                          rpc::SendReplyCallback send_reply_callback) override;
 
   /// Send object to remote object manager
@@ -136,8 +136,8 @@ class ObjectManager : public ObjectManagerInterface,
   /// \param metadata_size Metadata size
   /// \param chunk_index Chunk index of this object chunk, start with 0
   /// \param rpc_client Rpc client used to send message to remote object manager
-  ray::Status SendObjectChunk(const UniqueID &push_id, const ObjectID &object_id,
-                              const ClientID &client_id, uint64_t data_size,
+  ray::Status SendObjectChunk(const UniqueID& push_id, const ObjectID& object_id,
+                              const ClientID& client_id, uint64_t data_size,
                               uint64_t metadata_size, uint64_t chunk_index,
                               std::shared_ptr<rpc::ObjectManagerClient> rpc_client);
 
@@ -149,21 +149,21 @@ class ObjectManager : public ObjectManagerInterface,
   /// \param metadata_size Metadata size
   /// \param chunk_index Chunk index
   /// \param data Chunk data
-  ray::Status ReceiveObjectChunk(const ClientID &client_id, const ObjectID &object_id,
+  ray::Status ReceiveObjectChunk(const ClientID& client_id, const ObjectID& object_id,
                                  uint64_t data_size, uint64_t metadata_size,
-                                 uint64_t chunk_index, const std::string &data);
+                                 uint64_t chunk_index, const std::string& data);
 
   /// Send pull request
   ///
   /// \param object_id Object id
   /// \param client_id Remote server client id
-  void SendPullRequest(const ObjectID &object_id, const ClientID &client_id,
+  void SendPullRequest(const ObjectID& object_id, const ClientID& client_id,
                        std::shared_ptr<rpc::ObjectManagerClient> rpc_client);
 
   /// Get the rpc client according to the client ID
   ///
   /// \param client_id Remote client id, will send rpc request to it
-  std::shared_ptr<rpc::ObjectManagerClient> GetRpcClient(const ClientID &client_id);
+  std::shared_ptr<rpc::ObjectManagerClient> GetRpcClient(const ClientID& client_id);
 
   /// Get the port of the object manager rpc server.
   int GetServerPort() const { return object_manager_server_.GetPort(); }
@@ -176,8 +176,8 @@ class ObjectManager : public ObjectManagerInterface,
   /// \param main_service The main asio io_service.
   /// \param config ObjectManager configuration.
   /// \param object_directory An object implementing the object directory interface.
-  explicit ObjectManager(boost::asio::io_service &main_service,
-                         const ClientID &self_node_id, const ObjectManagerConfig &config,
+  explicit ObjectManager(boost::asio::io_service& main_service,
+                         const ClientID& self_node_id, const ObjectManagerConfig& config,
                          std::shared_ptr<ObjectDirectoryInterface> object_directory);
 
   ~ObjectManager();
@@ -193,14 +193,14 @@ class ObjectManager : public ObjectManagerInterface,
   /// \param callback The callback to invoke when objects are added to the local store.
   /// \return Status of whether adding the subscription succeeded.
   ray::Status SubscribeObjAdded(
-      std::function<void(const object_manager::protocol::ObjectInfoT &)> callback);
+      std::function<void(const object_manager::protocol::ObjectInfoT&)> callback);
 
   /// Subscribe to notifications of objects deleted from local store.
   ///
   /// \param callback The callback to invoke when objects are removed from the local
   /// store.
   /// \return Status of whether adding the subscription succeeded.
-  ray::Status SubscribeObjDeleted(std::function<void(const ray::ObjectID &)> callback);
+  ray::Status SubscribeObjDeleted(std::function<void(const ray::ObjectID&)> callback);
 
   /// Consider pushing an object to a remote object manager. This object manager
   /// may choose to ignore the Push call (e.g., if Push is called twice in a row
@@ -209,13 +209,13 @@ class ObjectManager : public ObjectManagerInterface,
   /// \param object_id The object's object id.
   /// \param client_id The remote node's client id.
   /// \return Void.
-  void Push(const ObjectID &object_id, const ClientID &client_id);
+  void Push(const ObjectID& object_id, const ClientID& client_id);
 
   /// Pull an object from ClientID.
   ///
   /// \param object_id The object's object id.
   /// \return Status of whether the pull request successfully initiated.
-  ray::Status Pull(const ObjectID &object_id) override;
+  ray::Status Pull(const ObjectID& object_id) override;
 
   /// Try to Pull an object from one of its expected client locations. If there
   /// are more client locations to try after this attempt, then this method
@@ -226,18 +226,18 @@ class ObjectManager : public ObjectManagerInterface,
   ///
   /// \param object_id The object's object id.
   /// \return Void.
-  void TryPull(const ObjectID &object_id);
+  void TryPull(const ObjectID& object_id);
 
   /// Cancels all requests (Push/Pull) associated with the given ObjectID. This
   /// method is idempotent.
   ///
   /// \param object_id The ObjectID.
   /// \return Void.
-  void CancelPull(const ObjectID &object_id) override;
+  void CancelPull(const ObjectID& object_id) override;
 
   /// Callback definition for wait.
-  using WaitCallback = std::function<void(const std::vector<ray::ObjectID> &found,
-                                          const std::vector<ray::ObjectID> &remaining)>;
+  using WaitCallback = std::function<void(const std::vector<ray::ObjectID>& found,
+                                          const std::vector<ray::ObjectID>& remaining)>;
   /// Wait until either num_required_objects are located or wait_ms has elapsed,
   /// then invoke the provided callback.
   ///
@@ -249,16 +249,16 @@ class ObjectManager : public ObjectManagerInterface,
   /// \param callback Invoked when either timeout_ms is satisfied OR num_ready_objects
   /// is satisfied.
   /// \return Status of whether the wait successfully initiated.
-  ray::Status Wait(const std::vector<ObjectID> &object_ids, int64_t timeout_ms,
+  ray::Status Wait(const std::vector<ObjectID>& object_ids, int64_t timeout_ms,
                    uint64_t num_required_objects, bool wait_local,
-                   const WaitCallback &callback);
+                   const WaitCallback& callback);
 
   /// Free a list of objects from object store.
   ///
   /// \param object_ids the The list of ObjectIDs to be deleted.
   /// \param local_only Whether keep this request with local object store
   ///                   or send it to all the object stores.
-  void FreeObjects(const std::vector<ObjectID> &object_ids, bool local_only);
+  void FreeObjects(const std::vector<ObjectID>& object_ids, bool local_only);
 
   /// Return profiling information and reset the profiling information.
   ///
@@ -285,8 +285,8 @@ class ObjectManager : public ObjectManagerInterface,
   };
 
   struct WaitState {
-    WaitState(boost::asio::io_service &service, int64_t timeout_ms,
-              const WaitCallback &callback)
+    WaitState(boost::asio::io_service& service, int64_t timeout_ms,
+              const WaitCallback& callback)
         : timeout_ms(timeout_ms),
           timeout_timer(std::unique_ptr<boost::asio::deadline_timer>(
               new boost::asio::deadline_timer(
@@ -314,27 +314,27 @@ class ObjectManager : public ObjectManagerInterface,
   };
 
   /// Creates a wait request and adds it to active_wait_requests_.
-  ray::Status AddWaitRequest(const UniqueID &wait_id,
-                             const std::vector<ObjectID> &object_ids, int64_t timeout_ms,
+  ray::Status AddWaitRequest(const UniqueID& wait_id,
+                             const std::vector<ObjectID>& object_ids, int64_t timeout_ms,
                              uint64_t num_required_objects, bool wait_local,
-                             const WaitCallback &callback);
+                             const WaitCallback& callback);
 
   /// Lookup any remaining objects that are not local. This is invoked after
   /// the wait request is created and local objects are identified.
-  ray::Status LookupRemainingWaitObjects(const UniqueID &wait_id);
+  ray::Status LookupRemainingWaitObjects(const UniqueID& wait_id);
 
   /// Invoked when lookup for remaining objects has been invoked. This method subscribes
   /// to any remaining objects if wait conditions have not yet been satisfied.
-  void SubscribeRemainingWaitObjects(const UniqueID &wait_id);
+  void SubscribeRemainingWaitObjects(const UniqueID& wait_id);
   /// Completion handler for Wait.
-  void WaitComplete(const UniqueID &wait_id);
+  void WaitComplete(const UniqueID& wait_id);
 
   /// Spread the Free request to all objects managers.
   ///
   /// \param object_ids the The list of ObjectIDs to be deleted.
   void SpreadFreeObjectsRequest(
-      const std::vector<ObjectID> &object_ids,
-      const std::vector<std::shared_ptr<rpc::ObjectManagerClient>> &rpc_clients);
+      const std::vector<ObjectID>& object_ids,
+      const std::vector<std::shared_ptr<rpc::ObjectManagerClient>>& rpc_clients);
 
   /// Handle starting, running, and stopping asio rpc_service.
   void StartRpcService();
@@ -344,10 +344,10 @@ class ObjectManager : public ObjectManagerInterface,
   /// Handle an object being added to this node. This adds the object to the
   /// directory, pushes the object to other nodes if necessary, and cancels any
   /// outstanding Pull requests for the object.
-  void HandleObjectAdded(const object_manager::protocol::ObjectInfoT &object_info);
+  void HandleObjectAdded(const object_manager::protocol::ObjectInfoT& object_info);
 
   /// Register object remove with directory.
-  void NotifyDirectoryObjectDeleted(const ObjectID &object_id);
+  void NotifyDirectoryObjectDeleted(const ObjectID& object_id);
 
   /// This is used to notify the main thread that the sending of a chunk has
   /// completed.
@@ -361,7 +361,7 @@ class ObjectManager : public ObjectManagerInterface,
   /// chunk.
   /// \param status The status of the send (e.g., did it succeed or fail).
   /// \return Void.
-  void HandleSendFinished(const ObjectID &object_id, const ClientID &client_id,
+  void HandleSendFinished(const ObjectID& object_id, const ClientID& client_id,
                           uint64_t chunk_index, double start_time_us, double end_time_us,
                           ray::Status status);
 
@@ -377,12 +377,12 @@ class ObjectManager : public ObjectManagerInterface,
   /// chunk.
   /// \param status The status of the receive (e.g., did it succeed or fail).
   /// \return Void.
-  void HandleReceiveFinished(const ObjectID &object_id, const ClientID &client_id,
+  void HandleReceiveFinished(const ObjectID& object_id, const ClientID& client_id,
                              uint64_t chunk_index, double start_time_us,
                              double end_time_us, ray::Status status);
 
   /// Handle Push task timeout.
-  void HandlePushTaskTimeout(const ObjectID &object_id, const ClientID &client_id);
+  void HandlePushTaskTimeout(const ObjectID& object_id, const ClientID& client_id);
 
   ClientID self_node_id_;
   const ObjectManagerConfig config_;
@@ -396,7 +396,7 @@ class ObjectManager : public ObjectManagerInterface,
 
   /// Weak reference to main service. We ensure this object is destroyed before
   /// main_service_ is stopped.
-  boost::asio::io_service *main_service_;
+  boost::asio::io_service* main_service_;
 
   /// Multi-thread asio service, deal with all outgoing and incoming RPC request.
   boost::asio::io_service rpc_service_;

--- a/src/ray/object_manager/test/object_manager_stress_test.cc
+++ b/src/ray/object_manager/test/object_manager_stress_test.cc
@@ -32,7 +32,7 @@ namespace ray {
 using rpc::GcsNodeInfo;
 
 static inline void flushall_redis(void) {
-  redisContext *context = redisConnect("127.0.0.1", 6379);
+  redisContext* context = redisConnect("127.0.0.1", 6379);
   freeReplyObject(redisCommand(context, "FLUSHALL"));
   redisFree(context);
 }
@@ -46,8 +46,8 @@ int64_t current_time_ms() {
 
 class MockServer {
  public:
-  MockServer(boost::asio::io_service &main_service,
-             const ObjectManagerConfig &object_manager_config,
+  MockServer(boost::asio::io_service& main_service,
+             const ObjectManagerConfig& object_manager_config,
              std::shared_ptr<gcs::GcsClient> gcs_client)
       : node_id_(ClientID::FromRandom()),
         config_(object_manager_config),
@@ -60,7 +60,7 @@ class MockServer {
   ~MockServer() { RAY_CHECK_OK(gcs_client_->Nodes().UnregisterSelf()); }
 
  private:
-  ray::Status RegisterGcs(boost::asio::io_service &io_service) {
+  ray::Status RegisterGcs(boost::asio::io_service& io_service) {
     auto object_manager_port = object_manager_.GetServerPort();
     GcsNodeInfo node_info;
     node_info.set_node_id(node_id_.Binary());
@@ -139,7 +139,7 @@ class TestObjectManagerBase : public ::testing::Test {
     TestSetupUtil::StopObjectStore(socket_name_2);
   }
 
-  ObjectID WriteDataToClient(plasma::PlasmaClient &client, int64_t data_size) {
+  ObjectID WriteDataToClient(plasma::PlasmaClient& client, int64_t data_size) {
     ObjectID object_id = ObjectID::FromRandom();
     RAY_LOG(DEBUG) << "ObjectID Created: " << object_id;
     uint8_t metadata[] = {5};
@@ -206,7 +206,7 @@ class StressTestObjectManager : public TestObjectManagerBase {
     node_id_1 = gcs_client_1->Nodes().GetSelfId();
     node_id_2 = gcs_client_2->Nodes().GetSelfId();
     RAY_CHECK_OK(gcs_client_1->Nodes().AsyncSubscribeToNodeChange(
-        [this](const ClientID &node_id, const GcsNodeInfo &data) {
+        [this](const ClientID& node_id, const GcsNodeInfo& data) {
           if (node_id == node_id_1 || node_id == node_id_2) {
             num_connected_clients += 1;
           }
@@ -216,7 +216,7 @@ class StressTestObjectManager : public TestObjectManagerBase {
         },
         nullptr));
     RAY_CHECK_OK(gcs_client_2->Nodes().AsyncSubscribeToNodeChange(
-        [this](const ClientID &node_id, const GcsNodeInfo &data) {
+        [this](const ClientID& node_id, const GcsNodeInfo& data) {
           if (node_id == node_id_1 || node_id == node_id_2) {
             num_connected_clients += 1;
           }
@@ -236,7 +236,7 @@ class StressTestObjectManager : public TestObjectManagerBase {
   void AddTransferTestHandlers() {
     ray::Status status = ray::Status::OK();
     status = server1->object_manager_.SubscribeObjAdded(
-        [this](const object_manager::protocol::ObjectInfoT &object_info) {
+        [this](const object_manager::protocol::ObjectInfoT& object_info) {
           object_added_handler_1(ObjectID::FromBinary(object_info.object_id));
           if (v1.size() == num_expected_objects && v1.size() == v2.size()) {
             TransferTestComplete();
@@ -244,7 +244,7 @@ class StressTestObjectManager : public TestObjectManagerBase {
         });
     RAY_CHECK_OK(status);
     status = server2->object_manager_.SubscribeObjAdded(
-        [this](const object_manager::protocol::ObjectInfoT &object_info) {
+        [this](const object_manager::protocol::ObjectInfoT& object_info) {
           object_added_handler_2(ObjectID::FromBinary(object_info.object_id));
           if (v2.size() == num_expected_objects && v1.size() == v2.size()) {
             TransferTestComplete();
@@ -263,17 +263,17 @@ class StressTestObjectManager : public TestObjectManagerBase {
     }
   }
 
-  plasma::ObjectBuffer GetObject(plasma::PlasmaClient &client, ObjectID &object_id) {
+  plasma::ObjectBuffer GetObject(plasma::PlasmaClient& client, ObjectID& object_id) {
     plasma::ObjectBuffer object_buffer;
     RAY_CHECK_OK(client.Get(&object_id, 1, 0, &object_buffer));
     return object_buffer;
   }
 
-  void CompareObjects(ObjectID &object_id_1, ObjectID &object_id_2) {
+  void CompareObjects(ObjectID& object_id_1, ObjectID& object_id_2) {
     plasma::ObjectBuffer object_buffer_1 = GetObject(client1, object_id_1);
     plasma::ObjectBuffer object_buffer_2 = GetObject(client2, object_id_2);
-    uint8_t *data_1 = const_cast<uint8_t *>(object_buffer_1.data->data());
-    uint8_t *data_2 = const_cast<uint8_t *>(object_buffer_2.data->data());
+    uint8_t* data_1 = const_cast<uint8_t*>(object_buffer_1.data->data());
+    uint8_t* data_2 = const_cast<uint8_t*>(object_buffer_2.data->data());
     ASSERT_EQ(object_buffer_1.data->size(), object_buffer_2.data->size());
     ASSERT_EQ(object_buffer_1.metadata->size(), object_buffer_2.metadata->size());
     int64_t total_size = object_buffer_1.data->size() + object_buffer_1.metadata->size();
@@ -413,7 +413,7 @@ TEST_F(StressTestObjectManager, StartStressTestObjectManager) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   ray::TEST_STORE_EXEC_PATH = std::string(argv[1]);
   return RUN_ALL_TESTS();

--- a/src/ray/object_manager/test/object_manager_test.cc
+++ b/src/ray/object_manager/test/object_manager_test.cc
@@ -35,15 +35,15 @@ namespace ray {
 using rpc::GcsNodeInfo;
 
 static inline void flushall_redis(void) {
-  redisContext *context = redisConnect("127.0.0.1", 6379);
+  redisContext* context = redisConnect("127.0.0.1", 6379);
   freeReplyObject(redisCommand(context, "FLUSHALL"));
   redisFree(context);
 }
 
 class MockServer {
  public:
-  MockServer(boost::asio::io_service &main_service,
-             const ObjectManagerConfig &object_manager_config,
+  MockServer(boost::asio::io_service& main_service,
+             const ObjectManagerConfig& object_manager_config,
              std::shared_ptr<gcs::GcsClient> gcs_client)
       : node_id_(ClientID::FromRandom()),
         config_(object_manager_config),
@@ -56,7 +56,7 @@ class MockServer {
   ~MockServer() { RAY_CHECK_OK(gcs_client_->Nodes().UnregisterSelf()); }
 
  private:
-  ray::Status RegisterGcs(boost::asio::io_service &io_service) {
+  ray::Status RegisterGcs(boost::asio::io_service& io_service) {
     auto object_manager_port = object_manager_.GetServerPort();
     GcsNodeInfo node_info;
     node_info.set_node_id(node_id_.Binary());
@@ -134,11 +134,11 @@ class TestObjectManagerBase : public ::testing::Test {
     TestSetupUtil::StopObjectStore(socket_name_2);
   }
 
-  ObjectID WriteDataToClient(plasma::PlasmaClient &client, int64_t data_size) {
+  ObjectID WriteDataToClient(plasma::PlasmaClient& client, int64_t data_size) {
     return WriteDataToClient(client, data_size, ObjectID::FromRandom());
   }
 
-  ObjectID WriteDataToClient(plasma::PlasmaClient &client, int64_t data_size,
+  ObjectID WriteDataToClient(plasma::PlasmaClient& client, int64_t data_size,
                              ObjectID object_id) {
     RAY_LOG(DEBUG) << "ObjectID Created: " << object_id;
     uint8_t metadata[] = {5};
@@ -190,7 +190,7 @@ class TestObjectManager : public TestObjectManagerBase {
     node_id_1 = gcs_client_1->Nodes().GetSelfId();
     node_id_2 = gcs_client_2->Nodes().GetSelfId();
     RAY_CHECK_OK(gcs_client_1->Nodes().AsyncSubscribeToNodeChange(
-        [this](const ClientID &node_id, const GcsNodeInfo &data) {
+        [this](const ClientID& node_id, const GcsNodeInfo& data) {
           if (node_id == node_id_1 || node_id == node_id_2) {
             num_connected_clients += 1;
           }
@@ -209,13 +209,13 @@ class TestObjectManager : public TestObjectManagerBase {
   void TestNotifications() {
     ray::Status status = ray::Status::OK();
     status = server1->object_manager_.SubscribeObjAdded(
-        [this](const object_manager::protocol::ObjectInfoT &object_info) {
+        [this](const object_manager::protocol::ObjectInfoT& object_info) {
           object_added_handler_1(ObjectID::FromBinary(object_info.object_id));
           NotificationTestCompleteIfSatisfied();
         });
     RAY_CHECK_OK(status);
     status = server2->object_manager_.SubscribeObjAdded(
-        [this](const object_manager::protocol::ObjectInfoT &object_info) {
+        [this](const object_manager::protocol::ObjectInfoT& object_info) {
           object_added_handler_2(ObjectID::FromBinary(object_info.object_id));
           NotificationTestCompleteIfSatisfied();
         });
@@ -237,7 +237,7 @@ class TestObjectManager : public TestObjectManagerBase {
     auto period = boost::posix_time::milliseconds(push_timeout_ms + 10);
     timer->expires_from_now(period);
     created_object_id2 = ObjectID::FromRandom();
-    timer->async_wait([this, data_size](const boost::system::error_code &error) {
+    timer->async_wait([this, data_size](const boost::system::error_code& error) {
       WriteDataToClient(client2, data_size, created_object_id2);
     });
   }
@@ -261,8 +261,8 @@ class TestObjectManager : public TestObjectManagerBase {
     RAY_CHECK_OK(server1->object_manager_.object_directory_->SubscribeObjectLocations(
         sub_id, object_1,
         [this, sub_id, object_1, object_2](
-            const ray::ObjectID &object_id,
-            const std::unordered_set<ray::ClientID> &clients) {
+            const ray::ObjectID& object_id,
+            const std::unordered_set<ray::ClientID>& clients) {
           if (!clients.empty()) {
             TestWaitWhileSubscribed(sub_id, object_1, object_2);
           }
@@ -281,8 +281,8 @@ class TestObjectManager : public TestObjectManagerBase {
     RAY_CHECK_OK(server1->object_manager_.AddWaitRequest(
         wait_id, object_ids, timeout_ms, required_objects, false,
         [this, sub_id, object_1, object_ids, start_time](
-            const std::vector<ray::ObjectID> &found,
-            const std::vector<ray::ObjectID> &remaining) {
+            const std::vector<ray::ObjectID>& found,
+            const std::vector<ray::ObjectID>& remaining) {
           int64_t elapsed = (boost::posix_time::second_clock::local_time() - start_time)
                                 .total_milliseconds();
           RAY_LOG(DEBUG) << "elapsed " << elapsed;
@@ -354,8 +354,8 @@ class TestObjectManager : public TestObjectManagerBase {
     RAY_CHECK_OK(server1->object_manager_.Wait(
         object_ids, timeout_ms, required_objects, false,
         [this, object_ids, num_objects, timeout_ms, required_objects, start_time](
-            const std::vector<ray::ObjectID> &found,
-            const std::vector<ray::ObjectID> &remaining) {
+            const std::vector<ray::ObjectID>& found,
+            const std::vector<ray::ObjectID>& remaining) {
           int64_t elapsed = (boost::posix_time::second_clock::local_time() - start_time)
                                 .total_milliseconds();
           RAY_LOG(DEBUG) << "elapsed " << elapsed;
@@ -448,7 +448,7 @@ TEST_F(TestObjectManager, StartTestObjectManager) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   ray::TEST_STORE_EXEC_PATH = std::string(argv[1]);
   wait_timeout_ms = std::stoi(std::string(argv[2]));

--- a/src/ray/plasma/store_exec.cc
+++ b/src/ray/plasma/store_exec.cc
@@ -1,10 +1,9 @@
+#include <gflags/gflags.h>
 #include <signal.h>
 
 #include <chrono>
 #include <iostream>
 #include <thread>
-
-#include <gflags/gflags.h>
 
 #include "ray/object_manager/plasma/store_runner.h"
 

--- a/src/ray/plasma/store_exec.cc
+++ b/src/ray/plasma/store_exec.cc
@@ -27,7 +27,7 @@ DEFINE_bool(z, false, "Run idle as a placeholder, optional");
 // Function to use (instead of ARROW_LOG(FATAL)) for usage, etc. errors before
 // the main server loop starts, so users don't get a backtrace if they
 // simply forgot a command-line switch.
-void ExitWithUsageError(const char *error_msg) {
+void ExitWithUsageError(const char* error_msg) {
   std::cerr << gflags::ProgramInvocationShortName() << ": " << error_msg << std::endl;
   exit(1);
 }
@@ -39,7 +39,7 @@ void HandleSignal(int signal) {
   }
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   gflags::SetUsageMessage("Plasma store server.\nUsage: ");
   gflags::ParseCommandLineFlags(&argc, &argv, /*remove_flags=*/true);
 

--- a/src/ray/raylet/actor_registration.h
+++ b/src/ray/raylet/actor_registration.h
@@ -40,13 +40,13 @@ class ActorRegistration {
   ///
   /// \param actor_table_data Information from the global actor table about
   /// this actor. This includes the actor's node manager location.
-  explicit ActorRegistration(const ActorTableData &actor_table_data);
+  explicit ActorRegistration(const ActorTableData& actor_table_data);
 
   /// Recreate an actor's registration from a checkpoint.
   ///
   /// \param checkpoint_data The checkpoint used to restore the actor.
-  ActorRegistration(const ActorTableData &actor_table_data,
-                    const ActorCheckpointData &checkpoint_data);
+  ActorRegistration(const ActorTableData& actor_table_data,
+                    const ActorCheckpointData& checkpoint_data);
 
   /// Each actor may have multiple callers, or "handles". A frontier leaf
   /// represents the execution state of the actor with respect to a single
@@ -63,7 +63,7 @@ class ActorRegistration {
   /// Get the actor table data.
   ///
   /// \return The actor table data.
-  const ActorTableData &GetTableData() const { return actor_table_data_; }
+  const ActorTableData& GetTableData() const { return actor_table_data_; }
 
   /// Get the actor's current state (ALIVE or DEAD).
   ///
@@ -71,7 +71,7 @@ class ActorRegistration {
   const ActorState GetState() const { return actor_table_data_.state(); }
 
   /// Update actor's state.
-  void SetState(const ActorState &state) { actor_table_data_.set_state(state); }
+  void SetState(const ActorState& state) { actor_table_data_.set_state(state); }
 
   /// Get the actor's node manager location.
   ///
@@ -113,10 +113,10 @@ class ActorRegistration {
   ///
   /// \return The actor frontier, a map from handle ID to execution state for
   /// that handle.
-  const std::unordered_map<TaskID, FrontierLeaf> &GetFrontier() const;
+  const std::unordered_map<TaskID, FrontierLeaf>& GetFrontier() const;
 
   /// Get all the dummy objects of this actor's tasks.
-  const std::unordered_map<ObjectID, int64_t> &GetDummyObjects() const {
+  const std::unordered_map<ObjectID, int64_t>& GetDummyObjects() const {
     return dummy_objects_;
   }
 
@@ -128,7 +128,7 @@ class ActorRegistration {
   /// state. This is the execution dependency returned by the task.
   /// \return The dummy object that can be released as a result of the executed
   /// task. If no dummy object can be released, then this is nil.
-  ObjectID ExtendFrontier(const TaskID &caller_id, const ObjectID &execution_dependency);
+  ObjectID ExtendFrontier(const TaskID& caller_id, const ObjectID& execution_dependency);
 
   /// Returns num handles to this actor entry.
   ///
@@ -141,8 +141,8 @@ class ActorRegistration {
   /// \param task The task that just finished on the actor. (nullptr when it's direct
   /// call.)
   /// \return A shared pointer to the generated checkpoint data.
-  std::shared_ptr<ActorCheckpointData> GenerateCheckpointData(const ActorID &actor_id,
-                                                              const Task *task);
+  std::shared_ptr<ActorCheckpointData> GenerateCheckpointData(const ActorID& actor_id,
+                                                              const Task* task);
 
  private:
   /// Information from the global actor table about this actor, including the

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <gtest/gtest_prod.h>
+
 #include <boost/optional.hpp>
 
 #include "ray/common/id.h"

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -60,7 +60,7 @@ class LineageEntry {
   /// \param task The task data to eventually be written back to the GCS.
   /// \param status The status of this entry, according to its write status in
   /// the GCS.
-  LineageEntry(const Task &task, GcsStatus status);
+  LineageEntry(const Task& task, GcsStatus status);
 
   /// Get this entry's GCS status.
   ///
@@ -85,13 +85,13 @@ class LineageEntry {
   /// Mark this entry as having been explicitly forwarded to a remote node manager.
   ///
   /// \param node_id The ID of the remote node manager.
-  void MarkExplicitlyForwarded(const ClientID &node_id);
+  void MarkExplicitlyForwarded(const ClientID& node_id);
 
   /// Gets whether this entry was explicitly forwarded to a remote node.
   ///
   /// \param node_id The ID of the remote node manager.
   /// \return Whether this entry was explicitly forwarded to the remote node.
-  bool WasExplicitlyForwarded(const ClientID &node_id) const;
+  bool WasExplicitlyForwarded(const ClientID& node_id) const;
 
   /// Get this entry's ID.
   ///
@@ -102,23 +102,23 @@ class LineageEntry {
   /// that created its arguments.
   ///
   /// \return The IDs of the parent entries.
-  const std::unordered_set<TaskID> &GetParentTaskIds() const;
+  const std::unordered_set<TaskID>& GetParentTaskIds() const;
 
   /// Get the task data.
   ///
   /// \return The task data.
-  const Task &TaskData() const;
+  const Task& TaskData() const;
 
   /// Get a mutable version of the task data.
   ///
   /// \return The task data.
   /// TODO(swang): This is pretty ugly.
-  Task &TaskDataMutable();
+  Task& TaskDataMutable();
 
   /// Update the task data with a new task.
   ///
   /// \return Void.
-  void UpdateTaskData(const Task &task);
+  void UpdateTaskData(const Task& task);
 
  private:
   /// Compute cached parent task IDs. This task is dependent on values returned
@@ -154,8 +154,8 @@ class Lineage {
   /// \param entry_id The ID of the entry to get.
   /// \return An optional reference to the entry. If this is empty, then the
   /// entry ID is not in the lineage.
-  boost::optional<const LineageEntry &> GetEntry(const TaskID &entry_id) const;
-  boost::optional<LineageEntry &> GetEntryMutable(const TaskID &task_id);
+  boost::optional<const LineageEntry&> GetEntry(const TaskID& entry_id) const;
+  boost::optional<LineageEntry&> GetEntryMutable(const TaskID& task_id);
 
   /// Set an entry in the lineage. If an entry with this ID already exists,
   /// then the entry is overwritten if and only if the new entry has a higher
@@ -165,19 +165,19 @@ class Lineage {
   /// \param task The task data to set, if status is greater than the current entry.
   /// \param status The GCS status.
   /// \return Whether the entry was set.
-  bool SetEntry(const Task &task, GcsStatus status);
+  bool SetEntry(const Task& task, GcsStatus status);
 
   /// Delete and return an entry from the lineage.
   ///
   /// \param entry_id The ID of the entry to pop.
   /// \return An optional reference to the popped entry. If this is empty, then
   /// the entry ID is not in the lineage.
-  boost::optional<LineageEntry> PopEntry(const TaskID &entry_id);
+  boost::optional<LineageEntry> PopEntry(const TaskID& entry_id);
 
   /// Get all entries in the lineage.
   ///
   /// \return A const reference to the lineage entries.
-  const std::unordered_map<const TaskID, LineageEntry> &GetEntries() const;
+  const std::unordered_map<const TaskID, LineageEntry>& GetEntries() const;
 
   /// Return the IDs of tasks in the lineage that are dependent on the given
   /// task.
@@ -185,7 +185,7 @@ class Lineage {
   /// \param The ID of the task whose children to get.
   /// \return The list of IDs for tasks that are in the lineage and dependent
   /// on the given task.
-  const std::unordered_set<TaskID> &GetChildren(const TaskID &task_id) const;
+  const std::unordered_set<TaskID>& GetChildren(const TaskID& task_id) const;
 
   /// Return the size of the children_ map. This is used for debugging purposes
   /// only.
@@ -198,9 +198,9 @@ class Lineage {
   std::unordered_map<TaskID, std::unordered_set<TaskID>> children_;
 
   /// Record the fact that the child task depends on the parent task.
-  void AddChild(const TaskID &parent_id, const TaskID &child_id);
+  void AddChild(const TaskID& parent_id, const TaskID& child_id);
   /// Erase the fact that the child task depends on the parent task.
-  void RemoveChild(const TaskID &parent_id, const TaskID &child_id);
+  void RemoveChild(const TaskID& parent_id, const TaskID& child_id);
 };
 
 /// \class LineageCache
@@ -218,7 +218,7 @@ class LineageCache {
  public:
   /// Create a lineage cache for the given task storage system.
   /// TODO(swang): Pass in the policy (interface?).
-  LineageCache(const ClientID &self_node_id, std::shared_ptr<gcs::GcsClient> gcs_client,
+  LineageCache(const ClientID& self_node_id, std::shared_ptr<gcs::GcsClient> gcs_client,
                uint64_t max_lineage_size);
 
   /// Asynchronously commit a task to the GCS.
@@ -226,7 +226,7 @@ class LineageCache {
   /// \param task The task to commit. It will be moved to the COMMITTING state.
   /// \return Whether the task was successfully committed. This can fail if the
   /// task was already in the COMMITTING state.
-  bool CommitTask(const Task &task);
+  bool CommitTask(const Task& task);
 
   /// Flush all tasks in the local cache that are not already being
   /// committed. This is equivalent to all tasks in the UNCOMMITTED
@@ -244,14 +244,14 @@ class LineageCache {
   /// tasks that the given task is data-dependent on, but that have not
   /// been committed to the GCS. This must contain the given task ID.
   /// \return Void.
-  void AddUncommittedLineage(const TaskID &task_id, const Lineage &uncommitted_lineage);
+  void AddUncommittedLineage(const TaskID& task_id, const Lineage& uncommitted_lineage);
 
   /// Mark a task as having been explicitly forwarded to a node.
   /// The lineage of the task is implicitly assumed to have also been forwarded.
   ///
   /// \param task_id The ID of the task to get the uncommitted lineage for.
   /// \param node_id The ID of the node to get the uncommitted lineage for.
-  void MarkTaskAsForwarded(const TaskID &task_id, const ClientID &node_id);
+  void MarkTaskAsForwarded(const TaskID& task_id, const ClientID& node_id);
 
   /// Get the uncommitted lineage of a task that hasn't been forwarded to a node yet.
   /// The uncommitted lineage consists of all tasks in the given task's lineage
@@ -262,30 +262,30 @@ class LineageCache {
   /// \param node_id The ID of the receiving node.
   /// \return The uncommitted, unforwarded lineage of the task. The returned lineage
   /// includes the entry for the requested entry_id.
-  Lineage GetUncommittedLineage(const TaskID &task_id, const ClientID &node_id) const;
+  Lineage GetUncommittedLineage(const TaskID& task_id, const ClientID& node_id) const;
 
   /// Handle the commit of a task entry in the GCS. This attempts to evict the
   /// task if possible.
   ///
   /// \param task_id The ID of the task entry that was committed.
-  void HandleEntryCommitted(const TaskID &task_id);
+  void HandleEntryCommitted(const TaskID& task_id);
 
   /// Get a task. The task must be in the lineage cache.
   ///
   /// \param task_id The ID of the task to get.
   /// \return A const reference to the task data.
-  const Task &GetTaskOrDie(const TaskID &task_id) const;
+  const Task& GetTaskOrDie(const TaskID& task_id) const;
 
   /// Get whether the lineage cache contains the task.
   ///
   /// \param task_id The ID of the task to get.
   /// \return Whether the task is in the lineage cache.
-  bool ContainsTask(const TaskID &task_id) const;
+  bool ContainsTask(const TaskID& task_id) const;
 
   /// Get all lineage in the lineage cache.
   ///
   /// \return A const reference to the lineage.
-  const Lineage &GetLineage() const;
+  const Lineage& GetLineage() const;
 
   /// Returns debug string for class.
   ///
@@ -298,18 +298,18 @@ class LineageCache {
  private:
   FRIEND_TEST(LineageCacheTest, BarReturnsZeroOnNull);
   /// Flush a task that is in UNCOMMITTED_READY state.
-  void FlushTask(const TaskID &task_id);
+  void FlushTask(const TaskID& task_id);
   /// Evict a single task. This should only be called if we are sure that the
   /// task has been committed. The task will only be evicted if all of its
   /// parents have also been evicted. If successful, then we will also attempt
   /// to evict the task's children.
-  void EvictTask(const TaskID &task_id);
+  void EvictTask(const TaskID& task_id);
   /// Subscribe to notifications for a task. Returns whether the operation
   /// was successful (whether we were not already subscribed).
-  bool SubscribeTask(const TaskID &task_id);
+  bool SubscribeTask(const TaskID& task_id);
   /// Unsubscribe from notifications for a task. Returns whether the operation
   /// was successful (whether we were subscribed).
-  bool UnsubscribeTask(const TaskID &task_id);
+  bool UnsubscribeTask(const TaskID& task_id);
 
   /// ID of this node.
   ClientID self_node_id_;

--- a/src/ray/raylet/lineage_cache_test.cc
+++ b/src/ray/raylet/lineage_cache_test.cc
@@ -41,18 +41,18 @@ class MockGcsClient;
 
 class MockTaskInfoAccessor : public gcs::RedisTaskInfoAccessor {
  public:
-  MockTaskInfoAccessor(gcs::RedisGcsClient *gcs_client)
+  MockTaskInfoAccessor(gcs::RedisGcsClient* gcs_client)
       : RedisTaskInfoAccessor(gcs_client) {}
 
   virtual ~MockTaskInfoAccessor() {}
 
   void RegisterSubscribeCallback(
-      const gcs::SubscribeCallback<TaskID, rpc::TaskTableData> &notification_callback) {
+      const gcs::SubscribeCallback<TaskID, rpc::TaskTableData>& notification_callback) {
     notification_callback_ = notification_callback;
   }
 
-  Status AsyncAdd(const std::shared_ptr<TaskTableData> &task_data,
-                  const gcs::StatusCallback &done) {
+  Status AsyncAdd(const std::shared_ptr<TaskTableData>& task_data,
+                  const gcs::StatusCallback& done) {
     TaskID task_id = TaskID::FromBinary(task_data->task().task_spec().task_id());
     task_table_[task_id] = task_data;
     auto callback = done;
@@ -87,9 +87,9 @@ class MockTaskInfoAccessor : public gcs::RedisTaskInfoAccessor {
   }
 
   Status AsyncSubscribe(
-      const TaskID &task_id,
-      const gcs::SubscribeCallback<TaskID, rpc::TaskTableData> &notification_callback,
-      const gcs::StatusCallback &done) {
+      const TaskID& task_id,
+      const gcs::SubscribeCallback<TaskID, rpc::TaskTableData>& notification_callback,
+      const gcs::StatusCallback& done) {
     subscribed_tasks_.insert(task_id);
     if (task_table_.count(task_id) == 1) {
       notification_callbacks_.push_back({notification_callback_, task_id});
@@ -98,7 +98,7 @@ class MockTaskInfoAccessor : public gcs::RedisTaskInfoAccessor {
     return ray::Status::OK();
   }
 
-  Status AsyncUnsubscribe(const TaskID &task_id) {
+  Status AsyncUnsubscribe(const TaskID& task_id) {
     subscribed_tasks_.erase(task_id);
     return ray::Status::OK();
   }
@@ -106,19 +106,19 @@ class MockTaskInfoAccessor : public gcs::RedisTaskInfoAccessor {
   void Flush() {
     auto callbacks = std::move(callbacks_);
     callbacks_.clear();
-    for (const auto &callback : callbacks) {
+    for (const auto& callback : callbacks) {
       callback.first(Status::OK());
     }
-    for (const auto &callback : notification_callbacks_) {
+    for (const auto& callback : notification_callbacks_) {
       callback.first(callback.second, *task_table_[callback.second]);
     }
   }
 
-  const std::unordered_map<TaskID, std::shared_ptr<TaskTableData>> &TaskTable() const {
+  const std::unordered_map<TaskID, std::shared_ptr<TaskTableData>>& TaskTable() const {
     return task_table_;
   }
 
-  const std::unordered_set<TaskID> &SubscribedTasks() const { return subscribed_tasks_; }
+  const std::unordered_set<TaskID>& SubscribedTasks() const { return subscribed_tasks_; }
 
   const int NumRequestedNotifications() const { return num_requested_notifications_; }
 
@@ -139,10 +139,10 @@ class MockTaskInfoAccessor : public gcs::RedisTaskInfoAccessor {
 
 class MockNodeInfoAccessor : public gcs::RedisNodeInfoAccessor {
  public:
-  MockNodeInfoAccessor(gcs::RedisGcsClient *gcs_client, const ClientID &node_id)
+  MockNodeInfoAccessor(gcs::RedisGcsClient* gcs_client, const ClientID& node_id)
       : RedisNodeInfoAccessor(gcs_client), node_id_(node_id) {}
 
-  const ClientID &GetSelfId() const override { return node_id_; }
+  const ClientID& GetSelfId() const override { return node_id_; }
 
  private:
   ClientID node_id_;
@@ -150,17 +150,17 @@ class MockNodeInfoAccessor : public gcs::RedisNodeInfoAccessor {
 
 class MockGcsClient : public gcs::RedisGcsClient {
  public:
-  MockGcsClient(const gcs::GcsClientOptions &options, const ClientID &node_id)
+  MockGcsClient(const gcs::GcsClientOptions& options, const ClientID& node_id)
       : RedisGcsClient(options) {
     task_table_fake_.reset(new gcs::raylet::TaskTable({nullptr}, this));
     task_accessor_.reset(new MockTaskInfoAccessor(this));
     node_accessor_.reset(new MockNodeInfoAccessor(this, node_id));
   }
 
-  gcs::raylet::TaskTable &raylet_task_table() override { return *task_table_fake_; }
+  gcs::raylet::TaskTable& raylet_task_table() override { return *task_table_fake_; }
 
-  MockTaskInfoAccessor &MockTasks() {
-    return *dynamic_cast<MockTaskInfoAccessor *>(task_accessor_.get());
+  MockTaskInfoAccessor& MockTasks() {
+    return *dynamic_cast<MockTaskInfoAccessor*>(task_accessor_.get());
   }
 
  private:
@@ -176,7 +176,7 @@ class LineageCacheTest : public ::testing::Test {
     lineage_cache_.reset(new LineageCache(node_id_, mock_gcs_, max_lineage_size_));
 
     mock_gcs_->MockTasks().RegisterSubscribeCallback(
-        [this](const TaskID &task_id, const TaskTableData &data) {
+        [this](const TaskID& task_id, const TaskTableData& data) {
           lineage_cache_->HandleEntryCommitted(task_id);
           num_notifications_++;
         });
@@ -190,7 +190,7 @@ class LineageCacheTest : public ::testing::Test {
   std::unique_ptr<LineageCache> lineage_cache_;
 };
 
-static inline Task ExampleTask(const std::vector<ObjectID> &arguments,
+static inline Task ExampleTask(const std::vector<ObjectID>& arguments,
                                uint64_t num_returns) {
   TaskSpecBuilder builder;
   rpc::Address address;
@@ -198,7 +198,7 @@ static inline Task ExampleTask(const std::vector<ObjectID> &arguments,
                             ray::FunctionDescriptorBuilder::BuildPython("", "", "", ""),
                             JobID::Nil(), RandomTaskId(), 0, RandomTaskId(), address,
                             num_returns, {}, {});
-  for (const auto &arg : arguments) {
+  for (const auto& arg : arguments) {
     builder.AddArg(TaskArgByReference(arg, rpc::Address()));
   }
   rpc::TaskExecutionSpec execution_spec_message;
@@ -207,15 +207,15 @@ static inline Task ExampleTask(const std::vector<ObjectID> &arguments,
 }
 
 /// Helper method to create a Lineage object with a single task.
-Lineage CreateSingletonLineage(const Task &task) {
+Lineage CreateSingletonLineage(const Task& task) {
   Lineage singleton_lineage;
   singleton_lineage.SetEntry(task, GcsStatus::UNCOMMITTED);
   return singleton_lineage;
 }
 
-std::vector<ObjectID> InsertTaskChain(LineageCache &lineage_cache,
-                                      std::vector<Task> &inserted_tasks, int chain_size,
-                                      const std::vector<ObjectID> &initial_arguments,
+std::vector<ObjectID> InsertTaskChain(LineageCache& lineage_cache,
+                                      std::vector<Task>& inserted_tasks, int chain_size,
+                                      const std::vector<ObjectID>& initial_arguments,
                                       int64_t num_returns) {
   std::vector<ObjectID> arguments = initial_arguments;
   for (int i = 0; i < chain_size; i++) {
@@ -237,7 +237,7 @@ TEST_F(LineageCacheTest, TestGetUncommittedLineage) {
   auto return_values1 =
       InsertTaskChain(*lineage_cache_, tasks1, 3, std::vector<ObjectID>(), 1);
   std::vector<TaskID> task_ids1;
-  for (const auto &task : tasks1) {
+  for (const auto& task : tasks1) {
     task_ids1.push_back(task.GetTaskSpecification().TaskId());
   }
 
@@ -245,7 +245,7 @@ TEST_F(LineageCacheTest, TestGetUncommittedLineage) {
   auto return_values2 =
       InsertTaskChain(*lineage_cache_, tasks2, 2, std::vector<ObjectID>(), 2);
   std::vector<TaskID> task_ids2;
-  for (const auto &task : tasks2) {
+  for (const auto& task : tasks2) {
     task_ids2.push_back(task.GetTaskSpecification().TaskId());
   }
 
@@ -254,7 +254,7 @@ TEST_F(LineageCacheTest, TestGetUncommittedLineage) {
       lineage_cache_->GetUncommittedLineage(task_ids1.back(), ClientID::Nil());
   // Check that the uncommitted lineage is exactly equal to the first chain of tasks.
   ASSERT_EQ(task_ids1.size(), uncommitted_lineage.GetEntries().size());
-  for (auto &task_id : task_ids1) {
+  for (auto& task_id : task_ids1) {
     ASSERT_TRUE(uncommitted_lineage.GetEntry(task_id));
   }
 
@@ -266,7 +266,7 @@ TEST_F(LineageCacheTest, TestGetUncommittedLineage) {
                             return_values2.end());
   InsertTaskChain(*lineage_cache_, combined_tasks, 1, combined_arguments, 1);
   std::vector<TaskID> combined_task_ids;
-  for (const auto &task : combined_tasks) {
+  for (const auto& task : combined_tasks) {
     combined_task_ids.push_back(task.GetTaskSpecification().TaskId());
   }
 
@@ -276,7 +276,7 @@ TEST_F(LineageCacheTest, TestGetUncommittedLineage) {
   // Check that the uncommitted lineage is exactly equal to the entire set of
   // tasks inserted so far.
   ASSERT_EQ(combined_task_ids.size(), uncommitted_lineage.GetEntries().size());
-  for (auto &task_id : combined_task_ids) {
+  for (auto& task_id : combined_task_ids) {
     ASSERT_TRUE(uncommitted_lineage.GetEntry(task_id));
   }
 }
@@ -287,7 +287,7 @@ TEST_F(LineageCacheTest, TestDuplicateUncommittedLineage) {
   auto return_values =
       InsertTaskChain(*lineage_cache_, tasks, 3, std::vector<ObjectID>(), 1);
   std::vector<TaskID> task_ids;
-  for (const auto &task : tasks) {
+  for (const auto& task : tasks) {
     task_ids.push_back(task.GetTaskSpecification().TaskId());
   }
   // Check that we subscribed to each of the uncommitted tasks.
@@ -296,7 +296,7 @@ TEST_F(LineageCacheTest, TestDuplicateUncommittedLineage) {
   // Check that if we add the same tasks as UNCOMMITTED again, we do not issue
   // duplicate subscribe requests.
   Lineage duplicate_lineage;
-  for (const auto &task : tasks) {
+  for (const auto& task : tasks) {
     duplicate_lineage.SetEntry(task, GcsStatus::UNCOMMITTED);
   }
   lineage_cache_->AddUncommittedLineage(task_ids.back(), duplicate_lineage);
@@ -315,7 +315,7 @@ TEST_F(LineageCacheTest, TestMarkTaskAsForwarded) {
   auto return_values =
       InsertTaskChain(*lineage_cache_, tasks, 4, std::vector<ObjectID>(), 1);
   std::vector<TaskID> task_ids;
-  for (const auto &task : tasks) {
+  for (const auto& task : tasks) {
     task_ids.push_back(task.GetTaskSpecification().TaskId());
   }
 
@@ -364,7 +364,7 @@ TEST_F(LineageCacheTest, TestWritebackOrder) {
   size_t num_tasks_flushed = tasks.size();
 
   // Mark all tasks as ready. All tasks should be flushed.
-  for (const auto &task : tasks) {
+  for (const auto& task : tasks) {
     ASSERT_TRUE(lineage_cache_->CommitTask(task));
   }
 
@@ -383,7 +383,7 @@ TEST_F(LineageCacheTest, TestEvictChain) {
   }
 
   Lineage uncommitted_lineage;
-  for (const auto &task : tasks) {
+  for (const auto& task : tasks) {
     uncommitted_lineage.SetEntry(task, GcsStatus::UNCOMMITTED);
   }
   // Mark the last task as ready to flush.
@@ -460,7 +460,7 @@ TEST_F(LineageCacheTest, TestEvictManyParents) {
             total_tasks);
 
   // Flush each parent task and check for eviction safety.
-  for (const auto &parent_task : parent_tasks) {
+  for (const auto& parent_task : parent_tasks) {
     lineage_cache_->CommitTask(parent_task);
     mock_gcs_->MockTasks().Flush();
     total_tasks--;
@@ -594,7 +594,7 @@ TEST_F(LineageCacheTest, TestEvictionUncommittedChildren) {
 
   // Add more tasks to the lineage cache that will remain local. Each of these
   // tasks is dependent one of the tasks that was forwarded above.
-  for (const auto &task : tasks) {
+  for (const auto& task : tasks) {
     auto return_id = task.GetTaskSpecification().ReturnId(0);
     auto dependent_task = ExampleTask({return_id}, 1);
     auto lineage = CreateSingletonLineage(dependent_task);
@@ -633,7 +633,7 @@ TEST_F(LineageCacheTest, TestFlushAllUncommittedTasks) {
   auto return_values =
       InsertTaskChain(*lineage_cache_, tasks, 3, std::vector<ObjectID>(), 1);
   std::vector<TaskID> task_ids;
-  for (const auto &task : tasks) {
+  for (const auto& task : tasks) {
     task_ids.push_back(task.GetTaskSpecification().TaskId());
   }
   // Check that we subscribed to each of the uncommitted tasks.
@@ -664,7 +664,7 @@ TEST_F(LineageCacheTest, TestFlushAllUncommittedTasks) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -52,7 +52,7 @@ DEFINE_bool(huge_pages, false, "Whether enable huge pages");
 
 #ifndef RAYLET_TEST
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
                                          ray::RayLog::ShutDownRayLog, argv[0],
                                          ray::RayLogLevel::INFO,
@@ -235,7 +235,7 @@ int main(int argc, char *argv[]) {
   // instead of returning immediately.
   // We should stop the service and remove the local socket file.
   auto handler = [&main_service, &raylet_socket_name, &server, &gcs_client](
-                     const boost::system::error_code &error, int signal_number) {
+                     const boost::system::error_code& error, int signal_number) {
     RAY_LOG(INFO) << "Raylet received SIGTERM, shutting down...";
     server->Stop();
     gcs_client->Disconnect();

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -101,8 +101,8 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   ///
   /// \param resource_config The initial set of node resources.
   /// \param object_manager A reference to the local object manager.
-  NodeManager(boost::asio::io_service &io_service, const ClientID &self_node_id,
-              const NodeManagerConfig &config, ObjectManager &object_manager,
+  NodeManager(boost::asio::io_service& io_service, const ClientID& self_node_id,
+              const NodeManagerConfig& config, ObjectManager& object_manager,
               std::shared_ptr<gcs::GcsClient> gcs_client,
               std::shared_ptr<ObjectDirectoryInterface> object_directory_);
 
@@ -110,7 +110,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   ///
   /// \param client The client to process.
   /// \return Void.
-  void ProcessNewClient(ClientConnection &client);
+  void ProcessNewClient(ClientConnection& client);
 
   /// Process a message from a client. This method is responsible for
   /// explicitly listening for more messages from the client if the client is
@@ -120,8 +120,8 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// \param message_type The message type (e.g., a flatbuffer enum).
   /// \param message_data A pointer to the message data.
   /// \return Void.
-  void ProcessClientMessage(const std::shared_ptr<ClientConnection> &client,
-                            int64_t message_type, const uint8_t *message_data);
+  void ProcessClientMessage(const std::shared_ptr<ClientConnection>& client,
+                            int64_t message_type, const uint8_t* message_data);
 
   /// Subscribe to the relevant GCS tables and set up handlers.
   ///
@@ -129,7 +129,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   ray::Status RegisterGcs();
 
   /// Get initial node manager configuration.
-  const NodeManagerConfig &GetInitialConfig() const;
+  const NodeManagerConfig& GetInitialConfig() const;
 
   /// Returns debug string for class.
   ///
@@ -148,32 +148,32 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// Handle an unexpected failure notification from GCS pubsub.
   ///
   /// \param worker_address The address of the worker that died.
-  void HandleUnexpectedWorkerFailure(const rpc::Address &worker_address);
+  void HandleUnexpectedWorkerFailure(const rpc::Address& worker_address);
 
   /// Handler for the addition of a new node.
   ///
   /// \param data Data associated with the new node.
   /// \return Void.
-  void NodeAdded(const GcsNodeInfo &data);
+  void NodeAdded(const GcsNodeInfo& data);
 
   /// Handler for the removal of a GCS node.
   /// \param node_info Data associated with the removed node.
   /// \return Void.
-  void NodeRemoved(const GcsNodeInfo &node_info);
+  void NodeRemoved(const GcsNodeInfo& node_info);
 
   /// Handler for the addition or updation of a resource in the GCS
   /// \param client_id ID of the node that created or updated resources.
   /// \param createUpdatedResources Created or updated resources.
   /// \return Void.
-  void ResourceCreateUpdated(const ClientID &client_id,
-                             const ResourceSet &createUpdatedResources);
+  void ResourceCreateUpdated(const ClientID& client_id,
+                             const ResourceSet& createUpdatedResources);
 
   /// Handler for the deletion of a resource in the GCS
   /// \param client_id ID of the node that deleted resources.
   /// \param resource_names Names of deleted resources.
   /// \return Void.
-  void ResourceDeleted(const ClientID &client_id,
-                       const std::vector<std::string> &resource_names);
+  void ResourceDeleted(const ClientID& client_id,
+                       const std::vector<std::string>& resource_names);
 
   /// Evaluates the local infeasible queue to check if any tasks can be scheduled.
   /// This is called whenever there's an update to the resources on the local client.
@@ -200,11 +200,11 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// \param id The ID of the node manager that sent the heartbeat.
   /// \param data The heartbeat data including load information.
   /// \return Void.
-  void HeartbeatAdded(const ClientID &id, const HeartbeatTableData &data);
+  void HeartbeatAdded(const ClientID& id, const HeartbeatTableData& data);
   /// Handler for a heartbeat batch notification from the GCS
   ///
   /// \param heartbeat_batch The batch of heartbeat data.
-  void HeartbeatBatchAdded(const HeartbeatBatchTableData &heartbeat_batch);
+  void HeartbeatBatchAdded(const HeartbeatBatchTableData& heartbeat_batch);
 
   /// Methods for task scheduling.
 
@@ -213,7 +213,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   ///
   /// \param task The task in question.
   /// \return Void.
-  void EnqueuePlaceableTask(const Task &task);
+  void EnqueuePlaceableTask(const Task& task);
   /// This will treat a task removed from the local queue as if it had been
   /// executed and failed. This is done by looping over the task return IDs and
   /// for each ID storing an object that represents a failure in the object
@@ -225,14 +225,14 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// \param task The task to fail.
   /// \param error_type The type of the error that caused this task to fail.
   /// \return Void.
-  void TreatTaskAsFailed(const Task &task, const ErrorType &error_type);
+  void TreatTaskAsFailed(const Task& task, const ErrorType& error_type);
   /// Mark the specified objects as failed with the given error type.
   ///
   /// \param error_type The type of the error that caused this task to fail.
   /// \param object_ids The object ids to store error messages into.
   /// \param job_id The optional job to push errors to if the writes fail.
-  void MarkObjectsAsFailed(const ErrorType &error_type,
-                           const std::vector<ObjectID> object_ids, const JobID &job_id);
+  void MarkObjectsAsFailed(const ErrorType& error_type,
+                           const std::vector<ObjectID> object_ids, const JobID& job_id);
   /// This is similar to TreatTaskAsFailed, but it will only mark the task as
   /// failed if at least one of the task's return values is lost. A return
   /// value is lost if it has been created before, but no longer exists on any
@@ -240,7 +240,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   ///
   /// \param task The task to potentially fail.
   /// \return Void.
-  void TreatTaskAsFailedIfLost(const Task &task);
+  void TreatTaskAsFailedIfLost(const Task& task);
   /// Handle specified task's submission to the local node manager.
   ///
   /// \param task The task being submitted.
@@ -248,7 +248,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// \param forwarded True if the task has been forwarded from a different
   /// node manager and false if it was submitted by a local worker.
   /// \return Void.
-  void SubmitTask(const Task &task, const Lineage &uncommitted_lineage,
+  void SubmitTask(const Task& task, const Lineage& uncommitted_lineage,
                   bool forwarded = false);
   /// Assign a task to a worker. The task is assumed to not be queued in local_queues_.
   ///
@@ -256,27 +256,27 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// \param[in] task The task in question.
   /// \param[out] post_assign_callbacks Vector of callbacks that will be appended
   /// to with any logic that should run after the DispatchTasks loop runs.
-  void AssignTask(const std::shared_ptr<WorkerInterface> &worker, const Task &task,
-                  std::vector<std::function<void()>> *post_assign_callbacks);
+  void AssignTask(const std::shared_ptr<WorkerInterface>& worker, const Task& task,
+                  std::vector<std::function<void()>>* post_assign_callbacks);
   /// Handle a worker finishing its assigned task.
   ///
   /// \param worker The worker that finished the task.
   /// \return Whether the worker should be returned to the idle pool. This is
   /// only false for direct actor creation calls, which should never be
   /// returned to idle.
-  bool FinishAssignedTask(WorkerInterface &worker);
+  bool FinishAssignedTask(WorkerInterface& worker);
   /// Helper function to produce actor table data for a newly created actor.
   ///
   /// \param task_spec Task specification of the actor creation task that created the
   /// actor.
   /// \param worker The port that the actor is listening on.
   std::shared_ptr<ActorTableData> CreateActorTableDataFromCreationTask(
-      const TaskSpecification &task_spec, int port, const WorkerID &worker_id);
+      const TaskSpecification& task_spec, int port, const WorkerID& worker_id);
   /// Handle a worker finishing an assigned actor task or actor creation task.
   /// \param worker The worker that finished the task.
   /// \param task The actor task or actor creation task.
   /// \return Void.
-  void FinishAssignedActorTask(WorkerInterface &worker, const Task &task);
+  void FinishAssignedActorTask(WorkerInterface& worker, const Task& task);
   /// Helper function for handling worker to finish its assigned actor task
   /// or actor creation task. Gets invoked when tasks's parent actor is known.
   ///
@@ -287,10 +287,10 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// \param resumed_from_checkpoint If the actor was resumed from a checkpoint.
   /// \param port Rpc server port that the actor is listening on.
   /// \return Void.
-  void FinishAssignedActorCreationTask(const ActorID &parent_actor_id,
-                                       const TaskSpecification &task_spec,
+  void FinishAssignedActorCreationTask(const ActorID& parent_actor_id,
+                                       const TaskSpecification& task_spec,
                                        bool resumed_from_checkpoint, int port,
-                                       const WorkerID &worker_id);
+                                       const WorkerID& worker_id);
   /// Make a placement decision for placeable tasks given the resource_map
   /// provided. This will perform task state transitions and task forwarding.
   ///
@@ -299,7 +299,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// consider the local node manager and the node managers in the keys of the
   /// resource_map argument.
   /// \return Void.
-  void ScheduleTasks(std::unordered_map<ClientID, SchedulingResources> &resource_map);
+  void ScheduleTasks(std::unordered_map<ClientID, SchedulingResources>& resource_map);
 
   /// Make a placement decision for the resource_map.
   ///
@@ -309,39 +309,38 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// resource_map argument.
   /// \return ResourceIdSet.
   ResourceIdSet ScheduleBundle(
-      std::unordered_map<ClientID, SchedulingResources> &resource_map,
-      const BundleSpecification &bundle_spec);
+      std::unordered_map<ClientID, SchedulingResources>& resource_map,
+      const BundleSpecification& bundle_spec);
 
   /// Handle a task whose return value(s) must be reconstructed.
   ///
   /// \param task_id The relevant task ID.
   /// \param required_object_id The object id we are reconstructing for.
   /// \return Void.
-  void HandleTaskReconstruction(const TaskID &task_id,
-                                const ObjectID &required_object_id);
+  void HandleTaskReconstruction(const TaskID& task_id,
+                                const ObjectID& required_object_id);
   /// Resubmit a task for execution. This is a task that was previously already
   /// submitted to a raylet but which must now be re-executed.
   ///
   /// \param task The task being resubmitted.
   /// \param required_object_id The object id that triggered the resubmission.
   /// \return Void.
-  void ResubmitTask(const Task &task, const ObjectID &required_object_id);
+  void ResubmitTask(const Task& task, const ObjectID& required_object_id);
   /// Attempt to forward a task to a remote different node manager. If this
   /// fails, the task will be resubmit locally.
   ///
   /// \param task The task in question.
   /// \param node_manager_id The ID of the remote node manager.
   /// \return Void.
-  void ForwardTaskOrResubmit(const Task &task, const ClientID &node_manager_id);
+  void ForwardTaskOrResubmit(const Task& task, const ClientID& node_manager_id);
   /// Forward a task to another node to execute. The task is assumed to not be
   /// queued in local_queues_.
   ///
   /// \param task The task to forward.
   /// \param node_id The ID of the node to forward the task to.
   /// \param on_error Callback on run on non-ok status.
-  void ForwardTask(
-      const Task &task, const ClientID &node_id,
-      const std::function<void(const ray::Status &, const Task &)> &on_error);
+  void ForwardTask(const Task& task, const ClientID& node_id,
+                   const std::function<void(const ray::Status&, const Task&)>& on_error);
 
   /// Dispatch locally scheduled tasks. This attempts the transition from "scheduled" to
   /// "running" task state.
@@ -359,7 +358,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// \param tasks_with_resources Mapping from resource shapes to tasks with
   /// that resource shape.
   void DispatchTasks(
-      const std::unordered_map<SchedulingClass, ordered_set<TaskID>> &tasks_by_class);
+      const std::unordered_map<SchedulingClass, ordered_set<TaskID>>& tasks_by_class);
 
   /// Handle blocking gets of objects. This could be a task assigned to a worker,
   /// an out-of-band task (e.g., a thread created by the application), or a
@@ -373,9 +372,9 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// \param mark_worker_blocked Whether to mark the worker as blocked. This
   ///                            should be False for direct calls.
   /// \return Void.
-  void AsyncResolveObjects(const std::shared_ptr<ClientConnection> &client,
-                           const std::vector<rpc::ObjectReference> &required_object_refs,
-                           const TaskID &current_task_id, bool ray_get,
+  void AsyncResolveObjects(const std::shared_ptr<ClientConnection>& client,
+                           const std::vector<rpc::ObjectReference>& required_object_refs,
+                           const TaskID& current_task_id, bool ray_get,
                            bool mark_worker_blocked);
 
   /// Handle end of a blocking object get. This could be a task assigned to a
@@ -389,21 +388,21 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// \param worker_was_blocked Whether we previously marked the worker as
   ///                           blocked in AsyncResolveObjects().
   /// \return Void.
-  void AsyncResolveObjectsFinish(const std::shared_ptr<ClientConnection> &client,
-                                 const TaskID &current_task_id, bool was_blocked);
+  void AsyncResolveObjectsFinish(const std::shared_ptr<ClientConnection>& client,
+                                 const TaskID& current_task_id, bool was_blocked);
 
   /// Handle a direct call task that is blocked. Note that this callback may
   /// arrive after the worker lease has been returned to the node manager.
   ///
   /// \param worker Shared ptr to the worker, or nullptr if lost.
-  void HandleDirectCallTaskBlocked(const std::shared_ptr<WorkerInterface> &worker);
+  void HandleDirectCallTaskBlocked(const std::shared_ptr<WorkerInterface>& worker);
 
   /// Handle a direct call task that is unblocked. Note that this callback may
   /// arrive after the worker lease has been returned to the node manager.
   /// However, it is guaranteed to arrive after DirectCallTaskBlocked.
   ///
   /// \param worker Shared ptr to the worker, or nullptr if lost.
-  void HandleDirectCallTaskUnblocked(const std::shared_ptr<WorkerInterface> &worker);
+  void HandleDirectCallTaskUnblocked(const std::shared_ptr<WorkerInterface>& worker);
 
   /// Kill a worker.
   ///
@@ -420,42 +419,42 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// \param actor_registration The ActorRegistration object that represents actor's
   /// new state.
   /// \return Void.
-  void HandleActorStateTransition(const ActorID &actor_id,
-                                  ActorRegistration &&actor_registration);
+  void HandleActorStateTransition(const ActorID& actor_id,
+                                  ActorRegistration&& actor_registration);
 
   /// When a job finished, loop over all of the queued tasks for that job and
   /// treat them as failed.
   ///
   /// \param job_id The job that exited.
   /// \return Void.
-  void CleanUpTasksForFinishedJob(const JobID &job_id);
+  void CleanUpTasksForFinishedJob(const JobID& job_id);
 
   /// Handle an object becoming local. This updates any local accounting, but
   /// does not write to any global accounting in the GCS.
   ///
   /// \param object_id The object that is locally available.
   /// \return Void.
-  void HandleObjectLocal(const ObjectID &object_id);
+  void HandleObjectLocal(const ObjectID& object_id);
   /// Handle an object that is no longer local. This updates any local
   /// accounting, but does not write to any global accounting in the GCS.
   ///
   /// \param object_id The object that has been evicted locally.
   /// \return Void.
-  void HandleObjectMissing(const ObjectID &object_id);
+  void HandleObjectMissing(const ObjectID& object_id);
 
   /// Handles the event that a job is started.
   ///
   /// \param job_id ID of the started job.
   /// \param job_data Data associated with the started job.
   /// \return Void
-  void HandleJobStarted(const JobID &job_id, const JobTableData &job_data);
+  void HandleJobStarted(const JobID& job_id, const JobTableData& job_data);
 
   /// Handles the event that a job is finished.
   ///
   /// \param job_id ID of the finished job.
   /// \param job_data Data associated with the finished job.
   /// \return Void.
-  void HandleJobFinished(const JobID &job_id, const JobTableData &job_data);
+  void HandleJobFinished(const JobID& job_id, const JobTableData& job_data);
 
   /// Check if certain invariants associated with the task dependency manager
   /// and the local queues are satisfied. This is only used for debugging
@@ -468,7 +467,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   ///
   /// \param message_data A pointer to the message data.
   /// \return Void.
-  void ProcessSubmitTaskMessage(const uint8_t *message_data);
+  void ProcessSubmitTaskMessage(const uint8_t* message_data);
 
   /// Process client message of RegisterClientRequest
   ///
@@ -476,27 +475,27 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// \param message_data A pointer to the message data.
   /// \return Void.
   void ProcessRegisterClientRequestMessage(
-      const std::shared_ptr<ClientConnection> &client, const uint8_t *message_data);
+      const std::shared_ptr<ClientConnection>& client, const uint8_t* message_data);
 
   /// Process client message of AnnounceWorkerPort
   ///
   /// \param client The client that sent the message.
   /// \param message_data A pointer to the message data.
   /// \return Void.
-  void ProcessAnnounceWorkerPortMessage(const std::shared_ptr<ClientConnection> &client,
-                                        const uint8_t *message_data);
+  void ProcessAnnounceWorkerPortMessage(const std::shared_ptr<ClientConnection>& client,
+                                        const uint8_t* message_data);
 
   /// Handle the case that a worker is available.
   ///
   /// \param client The connection for the worker.
   /// \return Void.
-  void HandleWorkerAvailable(const std::shared_ptr<ClientConnection> &client);
+  void HandleWorkerAvailable(const std::shared_ptr<ClientConnection>& client);
 
   /// Handle the case that a worker is available.
   ///
   /// \param worker The pointer to the worker
   /// \return Void.
-  void HandleWorkerAvailable(const std::shared_ptr<WorkerInterface> &worker);
+  void HandleWorkerAvailable(const std::shared_ptr<WorkerInterface>& worker);
 
   /// Handle a client that has disconnected. This can be called multiple times
   /// on the same client because this is triggered both when a client
@@ -506,7 +505,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// \param client The client that sent the message.
   /// \param intentional_disconnect Whether the client was intentionally disconnected.
   /// \return Void.
-  void ProcessDisconnectClientMessage(const std::shared_ptr<ClientConnection> &client,
+  void ProcessDisconnectClientMessage(const std::shared_ptr<ClientConnection>& client,
                                       bool intentional_disconnect = false);
 
   /// Process client message of FetchOrReconstruct
@@ -514,16 +513,16 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// \param client The client that sent the message.
   /// \param message_data A pointer to the message data.
   /// \return Void.
-  void ProcessFetchOrReconstructMessage(const std::shared_ptr<ClientConnection> &client,
-                                        const uint8_t *message_data);
+  void ProcessFetchOrReconstructMessage(const std::shared_ptr<ClientConnection>& client,
+                                        const uint8_t* message_data);
 
   /// Process client message of WaitRequest
   ///
   /// \param client The client that sent the message.
   /// \param message_data A pointer to the message data.
   /// \return Void.
-  void ProcessWaitRequestMessage(const std::shared_ptr<ClientConnection> &client,
-                                 const uint8_t *message_data);
+  void ProcessWaitRequestMessage(const std::shared_ptr<ClientConnection>& client,
+                                 const uint8_t* message_data);
 
   /// Process client message of WaitForDirectActorCallArgsRequest
   ///
@@ -531,39 +530,39 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// \param message_data A pointer to the message data.
   /// \return Void.
   void ProcessWaitForDirectActorCallArgsRequestMessage(
-      const std::shared_ptr<ClientConnection> &client, const uint8_t *message_data);
+      const std::shared_ptr<ClientConnection>& client, const uint8_t* message_data);
 
   /// Process client message of PushErrorRequest
   ///
   /// \param message_data A pointer to the message data.
   /// \return Void.
-  void ProcessPushErrorRequestMessage(const uint8_t *message_data);
+  void ProcessPushErrorRequestMessage(const uint8_t* message_data);
 
   /// Process client message of PrepareActorCheckpointRequest.
   ///
   /// \param client The client that sent the message.
   /// \param message_data A pointer to the message data.
   void ProcessPrepareActorCheckpointRequest(
-      const std::shared_ptr<ClientConnection> &client, const uint8_t *message_data);
+      const std::shared_ptr<ClientConnection>& client, const uint8_t* message_data);
 
   /// Process client message of NotifyActorResumedFromCheckpoint.
   ///
   /// \param message_data A pointer to the message data.
-  void ProcessNotifyActorResumedFromCheckpoint(const uint8_t *message_data);
+  void ProcessNotifyActorResumedFromCheckpoint(const uint8_t* message_data);
 
   /// Update actor frontier when a task finishes.
   /// If the task is an actor creation task and the actor was resumed from a checkpoint,
   /// restore the frontier from the checkpoint. Otherwise, just extend actor frontier.
   ///
   /// \param task The task that just finished.
-  void UpdateActorFrontier(const Task &task);
+  void UpdateActorFrontier(const Task& task);
 
   /// Process client message of SetResourceRequest
   /// \param client The client that sent the message.
   /// \param message_data A pointer to the message data.
   /// \return Void.
-  void ProcessSetResourceRequest(const std::shared_ptr<ClientConnection> &client,
-                                 const uint8_t *message_data);
+  void ProcessSetResourceRequest(const std::shared_ptr<ClientConnection>& client,
+                                 const uint8_t* message_data);
 
   /// Handle the case where an actor is disconnected, determine whether this
   /// actor needs to be restarted and then update actor table.
@@ -574,7 +573,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// \param was_local Whether the disconnected was on this local node.
   /// \param intentional_disconnect Wether the client was intentionally disconnected.
   /// \return Void.
-  void HandleDisconnectedActor(const ActorID &actor_id, bool was_local,
+  void HandleDisconnectedActor(const ActorID& actor_id, bool was_local,
                                bool intentional_disconnect);
 
   /// Finish assigning a task to a worker.
@@ -583,16 +582,16 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// \param task_id Id of the task.
   /// \param success Whether or not assigning the task was successful.
   /// \return void.
-  void FinishAssignTask(const std::shared_ptr<WorkerInterface> &worker,
-                        const TaskID &task_id, bool success);
+  void FinishAssignTask(const std::shared_ptr<WorkerInterface>& worker,
+                        const TaskID& task_id, bool success);
 
   /// Process worker subscribing to plasma.
   ///
   /// \param client The client that sent the message.
   /// \param message_data A pointer to the message data.
   /// \return void.
-  void ProcessSubscribePlasmaReady(const std::shared_ptr<ClientConnection> &client,
-                                   const uint8_t *message_data);
+  void ProcessSubscribePlasmaReady(const std::shared_ptr<ClientConnection>& client,
+                                   const uint8_t* message_data);
 
   /// Setup callback with Object Manager.
   ///
@@ -600,57 +599,57 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   ray::Status SetupPlasmaSubscription();
 
   /// Handle a `ResourcesLease` request.
-  void HandleRequestResourceReserve(const rpc::RequestResourceReserveRequest &request,
-                                    rpc::RequestResourceReserveReply *reply,
+  void HandleRequestResourceReserve(const rpc::RequestResourceReserveRequest& request,
+                                    rpc::RequestResourceReserveReply* reply,
                                     rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle a `ResourcesReturn` request.
-  void HandleCancelResourceReserve(const rpc::CancelResourceReserveRequest &request,
-                                   rpc::CancelResourceReserveReply *reply,
+  void HandleCancelResourceReserve(const rpc::CancelResourceReserveRequest& request,
+                                   rpc::CancelResourceReserveReply* reply,
                                    rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle a `WorkerLease` request.
-  void HandleRequestWorkerLease(const rpc::RequestWorkerLeaseRequest &request,
-                                rpc::RequestWorkerLeaseReply *reply,
+  void HandleRequestWorkerLease(const rpc::RequestWorkerLeaseRequest& request,
+                                rpc::RequestWorkerLeaseReply* reply,
                                 rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle a `ReturnWorker` request.
-  void HandleReturnWorker(const rpc::ReturnWorkerRequest &request,
-                          rpc::ReturnWorkerReply *reply,
+  void HandleReturnWorker(const rpc::ReturnWorkerRequest& request,
+                          rpc::ReturnWorkerReply* reply,
                           rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle a `ReleaseUnusedWorkers` request.
-  void HandleReleaseUnusedWorkers(const rpc::ReleaseUnusedWorkersRequest &request,
-                                  rpc::ReleaseUnusedWorkersReply *reply,
+  void HandleReleaseUnusedWorkers(const rpc::ReleaseUnusedWorkersRequest& request,
+                                  rpc::ReleaseUnusedWorkersReply* reply,
                                   rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle a `ReturnWorker` request.
-  void HandleCancelWorkerLease(const rpc::CancelWorkerLeaseRequest &request,
-                               rpc::CancelWorkerLeaseReply *reply,
+  void HandleCancelWorkerLease(const rpc::CancelWorkerLeaseRequest& request,
+                               rpc::CancelWorkerLeaseReply* reply,
                                rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle a `ForwardTask` request.
-  void HandleForwardTask(const rpc::ForwardTaskRequest &request,
-                         rpc::ForwardTaskReply *reply,
+  void HandleForwardTask(const rpc::ForwardTaskRequest& request,
+                         rpc::ForwardTaskReply* reply,
                          rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle a `PinObjectIDs` request.
-  void HandlePinObjectIDs(const rpc::PinObjectIDsRequest &request,
-                          rpc::PinObjectIDsReply *reply,
+  void HandlePinObjectIDs(const rpc::PinObjectIDsRequest& request,
+                          rpc::PinObjectIDsReply* reply,
                           rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle a `NodeStats` request.
-  void HandleGetNodeStats(const rpc::GetNodeStatsRequest &request,
-                          rpc::GetNodeStatsReply *reply,
+  void HandleGetNodeStats(const rpc::GetNodeStatsRequest& request,
+                          rpc::GetNodeStatsReply* reply,
                           rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle a `GlobalGC` request.
-  void HandleGlobalGC(const rpc::GlobalGCRequest &request, rpc::GlobalGCReply *reply,
+  void HandleGlobalGC(const rpc::GlobalGCRequest& request, rpc::GlobalGCReply* reply,
                       rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle a `FormatGlobalMemoryInfo`` request.
-  void HandleFormatGlobalMemoryInfo(const rpc::FormatGlobalMemoryInfoRequest &request,
-                                    rpc::FormatGlobalMemoryInfoReply *reply,
+  void HandleFormatGlobalMemoryInfo(const rpc::FormatGlobalMemoryInfoRequest& request,
+                                    rpc::FormatGlobalMemoryInfoReply* reply,
                                     rpc::SendReplyCallback send_reply_callback) override;
 
   /// Trigger global GC across the cluster to free up references to actors or
@@ -675,12 +674,12 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   void ScheduleAndDispatch();
 
   /// Whether a task is an actor creation task.
-  bool IsActorCreationTask(const TaskID &task_id);
+  bool IsActorCreationTask(const TaskID& task_id);
 
   /// ID of this node.
   ClientID self_node_id_;
-  boost::asio::io_service &io_service_;
-  ObjectManager &object_manager_;
+  boost::asio::io_service& io_service_;
+  ObjectManager& object_manager_;
   /// A Plasma object store client. This is used for creating new objects in
   /// the object store (e.g., for actor tasks that can't be run because the
   /// actor died) and to pin objects that are in scope in the cluster.

--- a/src/ray/raylet/object_manager_integration_test.cc
+++ b/src/ray/raylet/object_manager_integration_test.cc
@@ -97,7 +97,7 @@ class TestObjectManagerBase : public ::testing::Test {
     ASSERT_EQ(unlink((cmd_str + "/raylet_2").c_str()), 0);
   }
 
-  ObjectID WriteDataToClient(plasma::PlasmaClient &client, int64_t data_size) {
+  ObjectID WriteDataToClient(plasma::PlasmaClient& client, int64_t data_size) {
     ObjectID object_id = ObjectID::FromRandom();
     RAY_LOG(DEBUG) << "ObjectID Created: " << object_id;
     uint8_t metadata[] = {5};
@@ -135,7 +135,7 @@ class TestObjectManagerIntegration : public TestObjectManagerBase {
     node_id_1 = gcs_client_1->Nodes().GetSelfId();
     node_id_2 = gcs_client_2->Nodes().GetSelfId();
     gcs_client_1->Nodes().AsyncSubscribeToNodeChange(
-        [this](const ClientID &node_id, const rpc::GcsNodeInfo &data) {
+        [this](const ClientID& node_id, const rpc::GcsNodeInfo& data) {
           if (node_id == node_id_1 || node_id == node_id_2) {
             num_connected_clients += 1;
           }
@@ -155,7 +155,7 @@ class TestObjectManagerIntegration : public TestObjectManagerBase {
   void AddTransferTestHandlers() {
     ray::Status status = ray::Status::OK();
     status = server1->object_manager_.SubscribeObjAdded(
-        [this](const object_manager::protocol::ObjectInfoT &object_info) {
+        [this](const object_manager::protocol::ObjectInfoT& object_info) {
           v1.push_back(ObjectID::FromBinary(object_info.object_id));
           if (v1.size() == num_expected_objects && v1.size() == v2.size()) {
             TestPushComplete();
@@ -163,7 +163,7 @@ class TestObjectManagerIntegration : public TestObjectManagerBase {
         });
     RAY_CHECK_OK(status);
     status = server2->object_manager_.SubscribeObjAdded(
-        [this](const object_manager::protocol::ObjectInfoT &object_info) {
+        [this](const object_manager::protocol::ObjectInfoT& object_info) {
           v2.push_back(ObjectID::FromBinary(object_info.object_id));
           if (v2.size() == num_expected_objects && v1.size() == v2.size()) {
             TestPushComplete();
@@ -227,7 +227,7 @@ TEST_F(TestObjectManagerIntegration, StartTestObjectManagerPush) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   ray::raylet::test_executable = std::string(argv[0]);
   ray::TEST_STORE_EXEC_PATH = std::string(argv[1]);

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -24,7 +24,7 @@
 
 namespace {
 
-const std::vector<std::string> GenerateEnumNames(const char *const *enum_names_ptr,
+const std::vector<std::string> GenerateEnumNames(const char* const* enum_names_ptr,
                                                  int start_index, int end_index) {
   std::vector<std::string> enum_names;
   for (int i = 0; i < start_index; ++i) {
@@ -32,7 +32,7 @@ const std::vector<std::string> GenerateEnumNames(const char *const *enum_names_p
   }
   size_t i = 0;
   while (true) {
-    const char *name = enum_names_ptr[i];
+    const char* name = enum_names_ptr[i];
     if (name == nullptr) {
       break;
     }
@@ -54,11 +54,11 @@ namespace ray {
 
 namespace raylet {
 
-Raylet::Raylet(boost::asio::io_service &main_service, const std::string &socket_name,
-               const std::string &node_ip_address, const std::string &redis_address,
-               int redis_port, const std::string &redis_password,
-               const NodeManagerConfig &node_manager_config,
-               const ObjectManagerConfig &object_manager_config,
+Raylet::Raylet(boost::asio::io_service& main_service, const std::string& socket_name,
+               const std::string& node_ip_address, const std::string& redis_address,
+               int redis_port, const std::string& redis_password,
+               const NodeManagerConfig& node_manager_config,
+               const ObjectManagerConfig& object_manager_config,
                std::shared_ptr<gcs::GcsClient> gcs_client)
     : self_node_id_(ClientID::FromRandom()),
       gcs_client_(gcs_client),
@@ -106,9 +106,9 @@ ray::Status Raylet::RegisterGcs() {
                  << self_node_info_.node_manager_hostname();
 
   // Add resource information.
-  const NodeManagerConfig &node_manager_config = node_manager_.GetInitialConfig();
+  const NodeManagerConfig& node_manager_config = node_manager_.GetInitialConfig();
   std::unordered_map<std::string, std::shared_ptr<gcs::ResourceTableData>> resources;
-  for (const auto &resource_pair : node_manager_config.resource_config.GetResourceMap()) {
+  for (const auto& resource_pair : node_manager_config.resource_config.GetResourceMap()) {
     auto resource = std::make_shared<gcs::ResourceTableData>();
     resource->set_resource_capacity(resource_pair.second);
     resources.emplace(resource_pair.first, resource);
@@ -126,15 +126,15 @@ void Raylet::DoAccept() {
                                               boost::asio::placeholders::error));
 }
 
-void Raylet::HandleAccept(const boost::system::error_code &error) {
+void Raylet::HandleAccept(const boost::system::error_code& error) {
   if (!error) {
     // TODO: typedef these handlers.
-    ClientHandler client_handler = [this](ClientConnection &client) {
+    ClientHandler client_handler = [this](ClientConnection& client) {
       node_manager_.ProcessNewClient(client);
     };
     MessageHandler message_handler = [this](std::shared_ptr<ClientConnection> client,
                                             int64_t message_type,
-                                            const std::vector<uint8_t> &message) {
+                                            const std::vector<uint8_t>& message) {
       node_manager_.ProcessClientMessage(client, message_type, message.data());
     };
     // Accept a new local client and dispatch it to the node manager.

--- a/src/ray/raylet/raylet.h
+++ b/src/ray/raylet/raylet.h
@@ -14,10 +14,9 @@
 
 #pragma once
 
-#include <list>
-
 #include <boost/asio.hpp>
 #include <boost/asio/error.hpp>
+#include <list>
 
 // clang-format off
 #include "ray/raylet/node_manager.h"

--- a/src/ray/raylet/raylet.h
+++ b/src/ray/raylet/raylet.h
@@ -48,11 +48,11 @@ class Raylet {
   /// \param object_manager_config Configuration to initialize the object
   /// manager.
   /// \param gcs_client A client connection to the GCS.
-  Raylet(boost::asio::io_service &main_service, const std::string &socket_name,
-         const std::string &node_ip_address, const std::string &redis_address,
-         int redis_port, const std::string &redis_password,
-         const NodeManagerConfig &node_manager_config,
-         const ObjectManagerConfig &object_manager_config,
+  Raylet(boost::asio::io_service& main_service, const std::string& socket_name,
+         const std::string& node_ip_address, const std::string& redis_address,
+         int redis_port, const std::string& redis_password,
+         const NodeManagerConfig& node_manager_config,
+         const ObjectManagerConfig& object_manager_config,
          std::shared_ptr<gcs::GcsClient> gcs_client);
 
   /// Start this raylet.
@@ -71,7 +71,7 @@ class Raylet {
   /// Accept a client connection.
   void DoAccept();
   /// Handle an accepted client connection.
-  void HandleAccept(const boost::system::error_code &error);
+  void HandleAccept(const boost::system::error_code& error);
 
   friend class TestObjectManagerIntegration;
 

--- a/src/ray/raylet/reconstruction_policy.h
+++ b/src/ray/raylet/reconstruction_policy.h
@@ -14,15 +14,13 @@
 
 #pragma once
 
+#include <boost/asio.hpp>
 #include <functional>
 #include <unordered_map>
 #include <unordered_set>
 
-#include <boost/asio.hpp>
-
 #include "ray/common/id.h"
 #include "ray/gcs/tables.h"
-
 #include "ray/object_manager/object_directory.h"
 
 namespace ray {

--- a/src/ray/raylet/reconstruction_policy.h
+++ b/src/ray/raylet/reconstruction_policy.h
@@ -31,8 +31,8 @@ using rpc::TaskReconstructionData;
 
 class ReconstructionPolicyInterface {
  public:
-  virtual void ListenAndMaybeReconstruct(const ObjectID &object_id) = 0;
-  virtual void Cancel(const ObjectID &object_id) = 0;
+  virtual void ListenAndMaybeReconstruct(const ObjectID& object_id) = 0;
+  virtual void Cancel(const ObjectID& object_id) = 0;
   virtual ~ReconstructionPolicyInterface(){};
 };
 
@@ -51,9 +51,9 @@ class ReconstructionPolicy : public ReconstructionPolicyInterface {
   /// \param gcs_client The Client of GCS.
   /// lease notifications from.
   ReconstructionPolicy(
-      boost::asio::io_service &io_service,
-      std::function<void(const TaskID &, const ObjectID &)> reconstruction_handler,
-      int64_t initial_reconstruction_timeout_ms, const ClientID &client_id,
+      boost::asio::io_service& io_service,
+      std::function<void(const TaskID&, const ObjectID&)> reconstruction_handler,
+      int64_t initial_reconstruction_timeout_ms, const ClientID& client_id,
       std::shared_ptr<gcs::GcsClient> gcs_client,
       std::shared_ptr<ObjectDirectoryInterface> object_directory);
 
@@ -63,14 +63,14 @@ class ReconstructionPolicy : public ReconstructionPolicyInterface {
   /// for the task that created the object.
   ///
   /// \param object_id The object to check for reconstruction.
-  void ListenAndMaybeReconstruct(const ObjectID &object_id);
+  void ListenAndMaybeReconstruct(const ObjectID& object_id);
 
   /// Cancel listening for an object. Notifications for the object will be
   /// ignored. This does not cancel a reconstruction attempt that is already in
   /// progress.
   ///
   /// \param object_id The object to cancel.
-  void Cancel(const ObjectID &object_id);
+  void Cancel(const ObjectID& object_id);
 
   /// Handle a notification for a task lease. This handler should be called to
   /// indicate that a task is currently being executed, so any objects that it
@@ -80,7 +80,7 @@ class ReconstructionPolicy : public ReconstructionPolicyInterface {
   /// \param lease_timeout_ms After this timeout, the task's lease is
   /// guaranteed to be expired. If a second notification is not received within
   /// this timeout, then objects that the task creates may be reconstructed.
-  void HandleTaskLeaseNotification(const TaskID &task_id, int64_t lease_timeout_ms);
+  void HandleTaskLeaseNotification(const TaskID& task_id, int64_t lease_timeout_ms);
 
   /// Returns debug string for class.
   ///
@@ -92,7 +92,7 @@ class ReconstructionPolicy : public ReconstructionPolicyInterface {
 
  private:
   struct ReconstructionTask {
-    ReconstructionTask(boost::asio::io_service &io_service)
+    ReconstructionTask(boost::asio::io_service& io_service)
         : expires_at(INT64_MAX),
           subscribed(false),
           reconstruction_attempt(0),
@@ -120,8 +120,8 @@ class ReconstructionPolicy : public ReconstructionPolicyInterface {
                       int64_t timeout_ms);
 
   /// Handle task lease notification from GCS.
-  void OnTaskLeaseNotification(const TaskID &task_id,
-                               const boost::optional<rpc::TaskLeaseData> &task_lease);
+  void OnTaskLeaseNotification(const TaskID& task_id,
+                               const boost::optional<rpc::TaskLeaseData>& task_lease);
 
   /// Attempt to re-execute a task to reconstruct the required object.
   ///
@@ -132,21 +132,21 @@ class ReconstructionPolicy : public ReconstructionPolicyInterface {
   /// reconstructing the task. This is used to suppress duplicate
   /// reconstructions of the same task (e.g., if a task creates two objects
   /// that both require reconstruction).
-  void AttemptReconstruction(const TaskID &task_id, const ObjectID &required_object_id,
+  void AttemptReconstruction(const TaskID& task_id, const ObjectID& required_object_id,
                              int reconstruction_attempt);
 
   /// Handle expiration of a task lease.
-  void HandleTaskLeaseExpired(const TaskID &task_id);
+  void HandleTaskLeaseExpired(const TaskID& task_id);
 
   /// Handle the response for an attempt at adding an entry to the task
   /// reconstruction log.
-  void HandleReconstructionLogAppend(const TaskID &task_id, const ObjectID &object_id,
+  void HandleReconstructionLogAppend(const TaskID& task_id, const ObjectID& object_id,
                                      bool success);
 
   /// The event loop.
-  boost::asio::io_service &io_service_;
+  boost::asio::io_service& io_service_;
   /// The handler to call for tasks that require reconstruction.
-  const std::function<void(const TaskID &, const ObjectID &)> reconstruction_handler_;
+  const std::function<void(const TaskID&, const ObjectID&)> reconstruction_handler_;
   /// The initial timeout within which a task lease notification must be
   /// received. Otherwise, reconstruction will be triggered.
   const int64_t initial_reconstruction_timeout_ms_;

--- a/src/ray/raylet/reconstruction_policy_test.cc
+++ b/src/ray/raylet/reconstruction_policy_test.cc
@@ -12,21 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "ray/raylet/reconstruction_policy.h"
+
+#include <boost/asio.hpp>
 #include <list>
 
 #include "absl/time/clock.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-
-#include <boost/asio.hpp>
-
 #include "ray/gcs/callback.h"
 #include "ray/gcs/redis_accessor.h"
-
-#include "ray/raylet/format/node_manager_generated.h"
-#include "ray/raylet/reconstruction_policy.h"
-
 #include "ray/object_manager/object_directory.h"
+#include "ray/raylet/format/node_manager_generated.h"
 
 namespace ray {
 

--- a/src/ray/raylet/reconstruction_policy_test.cc
+++ b/src/ray/raylet/reconstruction_policy_test.cc
@@ -44,14 +44,14 @@ class MockObjectDirectory : public ObjectDirectoryInterface {
  public:
   MockObjectDirectory() {}
 
-  ray::Status LookupLocations(const ObjectID &object_id,
-                              const OnLocationsFound &callback) override {
+  ray::Status LookupLocations(const ObjectID& object_id,
+                              const OnLocationsFound& callback) override {
     callbacks_.push_back({object_id, callback});
     return ray::Status::OK();
   }
 
   void FlushCallbacks() {
-    for (const auto &callback : callbacks_) {
+    for (const auto& callback : callbacks_) {
       const ObjectID object_id = callback.first;
       auto it = locations_.find(object_id);
       if (it == locations_.end()) {
@@ -63,13 +63,13 @@ class MockObjectDirectory : public ObjectDirectoryInterface {
     callbacks_.clear();
   }
 
-  void SetObjectLocations(const ObjectID &object_id,
-                          const std::unordered_set<ClientID> &locations) {
+  void SetObjectLocations(const ObjectID& object_id,
+                          const std::unordered_set<ClientID>& locations) {
     locations_[object_id] = locations;
   }
 
-  void HandleClientRemoved(const ClientID &client_id) override {
-    for (auto &locations : locations_) {
+  void HandleClientRemoved(const ClientID& client_id) override {
+    for (auto& locations : locations_) {
       locations.second.erase(client_id);
     }
   }
@@ -77,19 +77,19 @@ class MockObjectDirectory : public ObjectDirectoryInterface {
   std::string DebugString() const override { return ""; }
 
   MOCK_METHOD0(GetLocalClientID, ray::ClientID());
-  MOCK_CONST_METHOD1(LookupRemoteConnectionInfo, void(RemoteConnectionInfo &));
+  MOCK_CONST_METHOD1(LookupRemoteConnectionInfo, void(RemoteConnectionInfo&));
   MOCK_CONST_METHOD0(LookupAllRemoteConnections, std::vector<RemoteConnectionInfo>());
   MOCK_METHOD3(SubscribeObjectLocations,
-               ray::Status(const ray::UniqueID &, const ObjectID &,
-                           const OnLocationsFound &));
+               ray::Status(const ray::UniqueID&, const ObjectID&,
+                           const OnLocationsFound&));
   MOCK_METHOD2(UnsubscribeObjectLocations,
-               ray::Status(const ray::UniqueID &, const ObjectID &));
+               ray::Status(const ray::UniqueID&, const ObjectID&));
   MOCK_METHOD3(ReportObjectAdded,
-               ray::Status(const ObjectID &, const ClientID &,
-                           const object_manager::protocol::ObjectInfoT &));
+               ray::Status(const ObjectID&, const ClientID&,
+                           const object_manager::protocol::ObjectInfoT&));
   MOCK_METHOD3(ReportObjectRemoved,
-               ray::Status(const ObjectID &, const ClientID &,
-                           const object_manager::protocol::ObjectInfoT &));
+               ray::Status(const ObjectID&, const ClientID&,
+                           const object_manager::protocol::ObjectInfoT&));
 
  private:
   std::vector<std::pair<ObjectID, OnLocationsFound>> callbacks_;
@@ -98,20 +98,20 @@ class MockObjectDirectory : public ObjectDirectoryInterface {
 
 class MockNodeInfoAccessor : public gcs::RedisNodeInfoAccessor {
  public:
-  MockNodeInfoAccessor(gcs::RedisGcsClient *client)
+  MockNodeInfoAccessor(gcs::RedisGcsClient* client)
       : gcs::RedisNodeInfoAccessor(client) {}
 
-  bool IsRemoved(const ClientID &node_id) const override { return false; }
+  bool IsRemoved(const ClientID& node_id) const override { return false; }
 };
 
 class MockTaskInfoAccessor : public gcs::RedisTaskInfoAccessor {
  public:
-  MockTaskInfoAccessor(gcs::RedisGcsClient *client) : RedisTaskInfoAccessor(client) {}
+  MockTaskInfoAccessor(gcs::RedisGcsClient* client) : RedisTaskInfoAccessor(client) {}
 
   Status AsyncSubscribeTaskLease(
-      const TaskID &task_id,
-      const gcs::SubscribeCallback<TaskID, boost::optional<TaskLeaseData>> &subscribe,
-      const gcs::StatusCallback &done) override {
+      const TaskID& task_id,
+      const gcs::SubscribeCallback<TaskID, boost::optional<TaskLeaseData>>& subscribe,
+      const gcs::StatusCallback& done) override {
     subscribe_callback_ = subscribe;
     subscribed_tasks_.insert(task_id);
     auto entry = task_lease_table_.find(task_id);
@@ -125,13 +125,13 @@ class MockTaskInfoAccessor : public gcs::RedisTaskInfoAccessor {
     return ray::Status::OK();
   }
 
-  Status AsyncUnsubscribeTaskLease(const TaskID &task_id) override {
+  Status AsyncUnsubscribeTaskLease(const TaskID& task_id) override {
     subscribed_tasks_.erase(task_id);
     return ray::Status::OK();
   }
 
-  Status AsyncAddTaskLease(const std::shared_ptr<TaskLeaseData> &task_lease_data,
-                           const gcs::StatusCallback &done) override {
+  Status AsyncAddTaskLease(const std::shared_ptr<TaskLeaseData>& task_lease_data,
+                           const gcs::StatusCallback& done) override {
     TaskID task_id = TaskID::FromBinary(task_lease_data->task_id());
     task_lease_table_[task_id] = task_lease_data;
     if (subscribed_tasks_.count(task_id) == 1) {
@@ -142,8 +142,8 @@ class MockTaskInfoAccessor : public gcs::RedisTaskInfoAccessor {
   }
 
   Status AsyncGetTaskLease(
-      const TaskID &task_id,
-      const gcs::OptionalItemCallback<rpc::TaskLeaseData> &callback) override {
+      const TaskID& task_id,
+      const gcs::OptionalItemCallback<rpc::TaskLeaseData>& callback) override {
     auto iter = task_lease_table_.find(task_id);
     if (iter != task_lease_table_.end()) {
       callback(Status::OK(), *iter->second);
@@ -154,8 +154,8 @@ class MockTaskInfoAccessor : public gcs::RedisTaskInfoAccessor {
   }
 
   Status AttemptTaskReconstruction(
-      const std::shared_ptr<TaskReconstructionData> &task_data,
-      const gcs::StatusCallback &done) override {
+      const std::shared_ptr<TaskReconstructionData>& task_data,
+      const gcs::StatusCallback& done) override {
     int log_index = task_data->num_reconstructions();
     TaskID task_id = TaskID::FromBinary(task_data->task_id());
     if (task_reconstruction_log_[task_id].size() == static_cast<size_t>(log_index)) {
@@ -183,7 +183,7 @@ class MockGcs : public gcs::RedisGcsClient {
  public:
   MockGcs() : gcs::RedisGcsClient(gcs::GcsClientOptions("", 0, "")){};
 
-  void Init(gcs::TaskInfoAccessor *task_accessor, gcs::NodeInfoAccessor *node_accessor) {
+  void Init(gcs::TaskInfoAccessor* task_accessor, gcs::NodeInfoAccessor* node_accessor) {
     task_accessor_.reset(task_accessor);
     node_accessor_.reset(node_accessor);
   }
@@ -200,14 +200,14 @@ class ReconstructionPolicyTest : public ::testing::Test {
         reconstruction_timeout_ms_(50),
         reconstruction_policy_(std::make_shared<ReconstructionPolicy>(
             io_service_,
-            [this](const TaskID &task_id, const ObjectID &obj) {
+            [this](const TaskID& task_id, const ObjectID& obj) {
               TriggerReconstruction(task_id);
             },
             reconstruction_timeout_ms_, ClientID::FromRandom(), mock_gcs_,
             mock_object_directory_)),
         timer_canceled_(false) {
-    subscribe_callback_ = [this](const TaskID &task_id,
-                                 const boost::optional<TaskLeaseData> &task_lease) {
+    subscribe_callback_ = [this](const TaskID& task_id,
+                                 const boost::optional<TaskLeaseData>& task_lease) {
       if (task_lease) {
         reconstruction_policy_->HandleTaskLeaseNotification(task_id,
                                                             task_lease->timeout());
@@ -219,12 +219,12 @@ class ReconstructionPolicyTest : public ::testing::Test {
     mock_gcs_->Init(task_accessor_, node_accessor_);
   }
 
-  void TriggerReconstruction(const TaskID &task_id) { reconstructed_tasks_[task_id]++; }
+  void TriggerReconstruction(const TaskID& task_id) { reconstructed_tasks_[task_id]++; }
 
-  void Tick(const std::function<void(void)> &handler,
+  void Tick(const std::function<void(void)>& handler,
             std::shared_ptr<boost::asio::deadline_timer> timer,
             boost::posix_time::milliseconds timer_period,
-            const boost::system::error_code &error) {
+            const boost::system::error_code& error) {
     if (timer_canceled_) {
       return;
     }
@@ -233,17 +233,17 @@ class ReconstructionPolicyTest : public ::testing::Test {
     // Fire the timer again after another period.
     timer->expires_from_now(timer_period);
     timer->async_wait(
-        [this, handler, timer, timer_period](const boost::system::error_code &error) {
+        [this, handler, timer, timer_period](const boost::system::error_code& error) {
           Tick(handler, timer, timer_period, error);
         });
   }
 
-  void SetPeriodicTimer(uint64_t period_ms, const std::function<void(void)> &handler) {
+  void SetPeriodicTimer(uint64_t period_ms, const std::function<void(void)>& handler) {
     timer_canceled_ = false;
     auto timer_period = boost::posix_time::milliseconds(period_ms);
     auto timer = std::make_shared<boost::asio::deadline_timer>(io_service_, timer_period);
     timer->async_wait(
-        [this, handler, timer, timer_period](const boost::system::error_code &error) {
+        [this, handler, timer, timer_period](const boost::system::error_code& error) {
           Tick(handler, timer, timer_period, error);
         });
   }
@@ -253,7 +253,7 @@ class ReconstructionPolicyTest : public ::testing::Test {
   void Run(uint64_t reconstruction_timeout_ms) {
     auto timer_period = boost::posix_time::milliseconds(reconstruction_timeout_ms);
     auto timer = std::make_shared<boost::asio::deadline_timer>(io_service_, timer_period);
-    timer->async_wait([this, timer](const boost::system::error_code &error) {
+    timer->async_wait([this, timer](const boost::system::error_code& error) {
       ASSERT_FALSE(error);
       io_service_.stop();
     });
@@ -266,8 +266,8 @@ class ReconstructionPolicyTest : public ::testing::Test {
  protected:
   boost::asio::io_service io_service_;
   std::shared_ptr<MockGcs> mock_gcs_;
-  MockTaskInfoAccessor *task_accessor_;
-  MockNodeInfoAccessor *node_accessor_;
+  MockTaskInfoAccessor* task_accessor_;
+  MockNodeInfoAccessor* node_accessor_;
   gcs::SubscribeCallback<TaskID, boost::optional<TaskLeaseData>> subscribe_callback_;
   std::shared_ptr<MockObjectDirectory> mock_object_directory_;
   uint64_t reconstruction_timeout_ms_;
@@ -426,7 +426,7 @@ TEST_F(ReconstructionPolicyTest, TestReconstructionCanceled) {
   // reconstruction.
   auto timer_period = boost::posix_time::milliseconds(reconstruction_timeout_ms_);
   auto timer = std::make_shared<boost::asio::deadline_timer>(io_service_, timer_period);
-  timer->async_wait([this, timer, object_id](const boost::system::error_code &error) {
+  timer->async_wait([this, timer, object_id](const boost::system::error_code& error) {
     ASSERT_FALSE(error);
     reconstruction_policy_->Cancel(object_id);
   });
@@ -479,7 +479,7 @@ TEST_F(ReconstructionPolicyTest, TestSimultaneousReconstructionSuppressed) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -14,7 +14,7 @@
 
 #include "ray/raylet/scheduling/cluster_resource_scheduler.h"
 
-std::string VectorToString(const std::vector<FixedPoint> &vector) {
+std::string VectorToString(const std::vector<FixedPoint>& vector) {
   std::stringstream buffer;
 
   buffer << "[";
@@ -28,7 +28,7 @@ std::string VectorToString(const std::vector<FixedPoint> &vector) {
   return buffer.str();
 }
 
-std::string UnorderedMapToString(const std::unordered_map<std::string, double> &map) {
+std::string UnorderedMapToString(const std::unordered_map<std::string, double>& map) {
   std::stringstream buffer;
 
   buffer << "[";
@@ -41,7 +41,7 @@ std::string UnorderedMapToString(const std::unordered_map<std::string, double> &
 
 /// Convert a vector of doubles to a vector of resource units.
 std::vector<FixedPoint> VectorDoubleToVectorFixedPoint(
-    const std::vector<double> &vector) {
+    const std::vector<double>& vector) {
   std::vector<FixedPoint> vector_fp(vector.size());
   for (size_t i = 0; i < vector.size(); i++) {
     vector_fp[i] = vector[i];
@@ -51,7 +51,7 @@ std::vector<FixedPoint> VectorDoubleToVectorFixedPoint(
 
 /// Convert a vector of resource units to a vector of doubles.
 std::vector<double> VectorFixedPointToVectorDouble(
-    const std::vector<FixedPoint> &vector_fp) {
+    const std::vector<FixedPoint>& vector_fp) {
   std::vector<double> vector(vector_fp.size());
   for (size_t i = 0; i < vector_fp.size(); i++) {
     vector[i] = FixedPoint(vector_fp[i]).Double();
@@ -61,8 +61,8 @@ std::vector<double> VectorFixedPointToVectorDouble(
 
 /// Convert a map of resources to a TaskRequest data structure.
 TaskRequest ResourceMapToTaskRequest(
-    StringIdMap &string_to_int_map,
-    const std::unordered_map<std::string, double> &resource_map) {
+    StringIdMap& string_to_int_map,
+    const std::unordered_map<std::string, double>& resource_map) {
   size_t i = 0;
 
   TaskRequest task_request;
@@ -74,7 +74,7 @@ TaskRequest ResourceMapToTaskRequest(
     task_request.predefined_resources[0].soft = false;
   }
 
-  for (auto const &resource : resource_map) {
+  for (auto const& resource : resource_map) {
     if (resource.first == ray::kCPU_ResourceLabel) {
       task_request.predefined_resources[CPU].demand = resource.second;
     } else if (resource.first == ray::kGPU_ResourceLabel) {
@@ -129,9 +129,9 @@ TaskRequest TaskResourceInstances::ToTaskRequest() const {
 ///
 /// \request Conversion result to a TaskRequest data structure.
 NodeResources ResourceMapToNodeResources(
-    StringIdMap &string_to_int_map,
-    const std::unordered_map<std::string, double> &resource_map_total,
-    const std::unordered_map<std::string, double> &resource_map_available) {
+    StringIdMap& string_to_int_map,
+    const std::unordered_map<std::string, double>& resource_map_total,
+    const std::unordered_map<std::string, double>& resource_map_available) {
   NodeResources node_resources;
   node_resources.predefined_resources.resize(PredefinedResources_MAX);
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
@@ -139,7 +139,7 @@ NodeResources ResourceMapToNodeResources(
         node_resources.predefined_resources[i].available = 0;
   }
 
-  for (auto const &resource : resource_map_total) {
+  for (auto const& resource : resource_map_total) {
     ResourceCapacity resource_capacity;
     resource_capacity.total = resource.second;
     auto it = resource_map_available.find(resource.first);
@@ -165,31 +165,31 @@ NodeResources ResourceMapToNodeResources(
   return node_resources;
 }
 
-bool operator<(FixedPoint const &ru1, FixedPoint const &ru2) {
+bool operator<(FixedPoint const& ru1, FixedPoint const& ru2) {
   return (ru1.i_ < ru2.i_);
 };
-bool operator>(FixedPoint const &ru1, FixedPoint const &ru2) {
+bool operator>(FixedPoint const& ru1, FixedPoint const& ru2) {
   return (ru1.i_ > ru2.i_);
 };
-bool operator<=(FixedPoint const &ru1, FixedPoint const &ru2) {
+bool operator<=(FixedPoint const& ru1, FixedPoint const& ru2) {
   return (ru1.i_ <= ru2.i_);
 };
-bool operator>=(FixedPoint const &ru1, FixedPoint const &ru2) {
+bool operator>=(FixedPoint const& ru1, FixedPoint const& ru2) {
   return (ru1.i_ >= ru2.i_);
 };
-bool operator==(FixedPoint const &ru1, FixedPoint const &ru2) {
+bool operator==(FixedPoint const& ru1, FixedPoint const& ru2) {
   return (ru1.i_ == ru2.i_);
 };
-bool operator!=(FixedPoint const &ru1, FixedPoint const &ru2) {
+bool operator!=(FixedPoint const& ru1, FixedPoint const& ru2) {
   return (ru1.i_ != ru2.i_);
 };
 
-std::ostream &operator<<(std::ostream &out, const FixedPoint &ru) {
+std::ostream& operator<<(std::ostream& out, const FixedPoint& ru) {
   out << ru.i_;
   return out;
 }
 
-bool NodeResources::operator==(const NodeResources &other) {
+bool NodeResources::operator==(const NodeResources& other) {
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
     if (this->predefined_resources[i].total != other.predefined_resources[i].total) {
       return false;
@@ -254,7 +254,7 @@ std::string NodeResources::DebugString(StringIdMap string_to_in_map) const {
   return buffer.str();
 }
 
-bool NodeResourceInstances::operator==(const NodeResourceInstances &other) {
+bool NodeResourceInstances::operator==(const NodeResourceInstances& other) {
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
     if (!EqualVectors(this->predefined_resources[i].total,
                       other.predefined_resources[i].total)) {
@@ -329,7 +329,7 @@ TaskResourceInstances NodeResourceInstances::GetAvailableResourceInstances() {
     task_resources.predefined_resources[i] = this->predefined_resources[i].available;
   }
 
-  for (const auto &it : this->custom_resources) {
+  for (const auto& it : this->custom_resources) {
     task_resources.custom_resources.emplace(it.first, it.second.available);
   }
 
@@ -357,16 +357,16 @@ std::string TaskRequest::DebugString() const {
 
 bool TaskResourceInstances::IsEmpty() const {
   // Check whether all resource instances of a task are zero.
-  for (const auto &predefined_resource : predefined_resources) {
-    for (const auto &predefined_resource_instance : predefined_resource) {
+  for (const auto& predefined_resource : predefined_resources) {
+    for (const auto& predefined_resource_instance : predefined_resource) {
       if (predefined_resource_instance != 0) {
         return false;
       }
     }
   }
 
-  for (const auto &custom_resource : custom_resources) {
-    for (const auto &custom_resource_instances : custom_resource.second) {
+  for (const auto& custom_resource : custom_resources) {
+    for (const auto& custom_resource_instances : custom_resource.second) {
       if (custom_resource_instances != 0) {
         return false;
       }
@@ -393,11 +393,11 @@ std::string TaskResourceInstances::DebugString() const {
   return buffer.str();
 }
 
-bool EqualVectors(const std::vector<FixedPoint> &v1, const std::vector<FixedPoint> &v2) {
+bool EqualVectors(const std::vector<FixedPoint>& v1, const std::vector<FixedPoint>& v2) {
   return (v1.size() == v2.size() && std::equal(v1.begin(), v1.end(), v2.begin()));
 }
 
-bool TaskResourceInstances::operator==(const TaskResourceInstances &other) {
+bool TaskResourceInstances::operator==(const TaskResourceInstances& other) {
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
     if (!EqualVectors(this->predefined_resources[i], other.predefined_resources[i])) {
       return false;
@@ -422,15 +422,15 @@ bool TaskResourceInstances::operator==(const TaskResourceInstances &other) {
 }
 
 ClusterResourceScheduler::ClusterResourceScheduler(
-    int64_t local_node_id, const NodeResources &local_node_resources)
+    int64_t local_node_id, const NodeResources& local_node_resources)
     : local_node_id_(local_node_id) {
   AddOrUpdateNode(local_node_id_, local_node_resources);
   InitLocalResources(local_node_resources);
 }
 
 ClusterResourceScheduler::ClusterResourceScheduler(
-    const std::string &local_node_id,
-    const std::unordered_map<std::string, double> &local_node_resources) {
+    const std::string& local_node_id,
+    const std::unordered_map<std::string, double>& local_node_resources) {
   local_node_id_ = string_to_int_map_.Insert(local_node_id);
   NodeResources node_resources = ResourceMapToNodeResources(
       string_to_int_map_, local_node_resources, local_node_resources);
@@ -440,16 +440,16 @@ ClusterResourceScheduler::ClusterResourceScheduler(
 }
 
 void ClusterResourceScheduler::AddOrUpdateNode(
-    const std::string &node_id,
-    const std::unordered_map<std::string, double> &resources_total,
-    const std::unordered_map<std::string, double> &resources_available) {
+    const std::string& node_id,
+    const std::unordered_map<std::string, double>& resources_total,
+    const std::unordered_map<std::string, double>& resources_available) {
   NodeResources node_resources = ResourceMapToNodeResources(
       string_to_int_map_, resources_total, resources_available);
   AddOrUpdateNode(string_to_int_map_.Insert(node_id), node_resources);
 }
 
-void ClusterResourceScheduler::SetPredefinedResources(const NodeResources &new_resources,
-                                                      NodeResources *old_resources) {
+void ClusterResourceScheduler::SetPredefinedResources(const NodeResources& new_resources,
+                                                      NodeResources* old_resources) {
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
     old_resources->predefined_resources[i].total =
         new_resources.predefined_resources[i].total;
@@ -459,23 +459,23 @@ void ClusterResourceScheduler::SetPredefinedResources(const NodeResources &new_r
 }
 
 void ClusterResourceScheduler::SetCustomResources(
-    const absl::flat_hash_map<int64_t, ResourceCapacity> &new_custom_resources,
-    absl::flat_hash_map<int64_t, ResourceCapacity> *old_custom_resources) {
+    const absl::flat_hash_map<int64_t, ResourceCapacity>& new_custom_resources,
+    absl::flat_hash_map<int64_t, ResourceCapacity>* old_custom_resources) {
   old_custom_resources->clear();
-  for (auto &elem : new_custom_resources) {
+  for (auto& elem : new_custom_resources) {
     old_custom_resources->insert(elem);
   }
 }
 
 void ClusterResourceScheduler::AddOrUpdateNode(int64_t node_id,
-                                               const NodeResources &node_resources) {
+                                               const NodeResources& node_resources) {
   auto it = nodes_.find(node_id);
   if (it == nodes_.end()) {
     // This node is new, so add it to the map.
     nodes_.emplace(node_id, node_resources);
   } else {
     // This node exists, so update its resources.
-    NodeResources &resources = it->second;
+    NodeResources& resources = it->second;
     SetPredefinedResources(node_resources, &resources);
     SetCustomResources(node_resources.custom_resources, &resources.custom_resources);
   }
@@ -494,7 +494,7 @@ bool ClusterResourceScheduler::RemoveNode(int64_t node_id) {
   }
 }
 
-bool ClusterResourceScheduler::RemoveNode(const std::string &node_id_string) {
+bool ClusterResourceScheduler::RemoveNode(const std::string& node_id_string) {
   auto node_id = string_to_int_map_.Get(node_id_string);
   if (node_id == -1) {
     return false;
@@ -503,9 +503,9 @@ bool ClusterResourceScheduler::RemoveNode(const std::string &node_id_string) {
   return RemoveNode(node_id);
 }
 
-int64_t ClusterResourceScheduler::IsSchedulable(const TaskRequest &task_req,
+int64_t ClusterResourceScheduler::IsSchedulable(const TaskRequest& task_req,
                                                 int64_t node_id,
-                                                const NodeResources &resources) {
+                                                const NodeResources& resources) {
   int violations = 0;
 
   // First, check predefined resources.
@@ -526,7 +526,7 @@ int64_t ClusterResourceScheduler::IsSchedulable(const TaskRequest &task_req,
   }
 
   // Now check custom resources.
-  for (const auto &task_req_custom_resource : task_req.custom_resources) {
+  for (const auto& task_req_custom_resource : task_req.custom_resources) {
     auto it = resources.custom_resources.find(task_req_custom_resource.id);
 
     if (it == resources.custom_resources.end()) {
@@ -563,8 +563,8 @@ int64_t ClusterResourceScheduler::IsSchedulable(const TaskRequest &task_req,
   return violations;
 }
 
-int64_t ClusterResourceScheduler::GetBestSchedulableNode(const TaskRequest &task_req,
-                                                         int64_t *total_violations) {
+int64_t ClusterResourceScheduler::GetBestSchedulableNode(const TaskRequest& task_req,
+                                                         int64_t* total_violations) {
   // Minimum number of soft violations across all nodes that can schedule the request.
   // We will pick the node with the smallest number of soft violations.
   int64_t min_violations = INT_MAX;
@@ -583,7 +583,7 @@ int64_t ClusterResourceScheduler::GetBestSchedulableNode(const TaskRequest &task
 
   // Check whether any node in the request placement_hints, satisfes
   // all resource constraints of the request.
-  for (const auto &task_req_placement_hint : task_req.placement_hints) {
+  for (const auto& task_req_placement_hint : task_req.placement_hints) {
     auto it = nodes_.find(task_req_placement_hint);
     if (it != nodes_.end()) {
       if (IsSchedulable(task_req, it->first, it->second) == 0) {
@@ -592,7 +592,7 @@ int64_t ClusterResourceScheduler::GetBestSchedulableNode(const TaskRequest &task
     }
   }
 
-  for (const auto &node : nodes_) {
+  for (const auto& node : nodes_) {
     // Return -1 if node not schedulable. otherwise return the number
     // of soft constraint violations.
     int64_t violations;
@@ -616,8 +616,8 @@ int64_t ClusterResourceScheduler::GetBestSchedulableNode(const TaskRequest &task
 }
 
 std::string ClusterResourceScheduler::GetBestSchedulableNode(
-    const std::unordered_map<std::string, double> &task_resources,
-    int64_t *total_violations) {
+    const std::unordered_map<std::string, double>& task_resources,
+    int64_t* total_violations) {
   TaskRequest task_request = ResourceMapToTaskRequest(string_to_int_map_, task_resources);
   int64_t node_id = GetBestSchedulableNode(task_request, total_violations);
 
@@ -631,12 +631,12 @@ std::string ClusterResourceScheduler::GetBestSchedulableNode(
 }
 
 bool ClusterResourceScheduler::SubtractNodeAvailableResources(
-    int64_t node_id, const TaskRequest &task_req) {
+    int64_t node_id, const TaskRequest& task_req) {
   auto it = nodes_.find(node_id);
   if (it == nodes_.end()) {
     return false;
   }
-  NodeResources &resources = it->second;
+  NodeResources& resources = it->second;
 
   // Just double check this node can still schedule the task request.
   if (IsSchedulable(task_req, node_id, resources) == -1) {
@@ -651,7 +651,7 @@ bool ClusterResourceScheduler::SubtractNodeAvailableResources(
                                     task_req.predefined_resources[i].demand);
   }
 
-  for (const auto &task_req_custom_resource : task_req.custom_resources) {
+  for (const auto& task_req_custom_resource : task_req.custom_resources) {
     auto it = resources.custom_resources.find(task_req_custom_resource.id);
     if (it != resources.custom_resources.end()) {
       it->second.available =
@@ -662,19 +662,19 @@ bool ClusterResourceScheduler::SubtractNodeAvailableResources(
 }
 
 bool ClusterResourceScheduler::SubtractNodeAvailableResources(
-    const std::string &node_id,
-    const std::unordered_map<std::string, double> &resource_map) {
+    const std::string& node_id,
+    const std::unordered_map<std::string, double>& resource_map) {
   TaskRequest task_request = ResourceMapToTaskRequest(string_to_int_map_, resource_map);
   return SubtractNodeAvailableResources(string_to_int_map_.Get(node_id), task_request);
 }
 
 bool ClusterResourceScheduler::AddNodeAvailableResources(int64_t node_id,
-                                                         const TaskRequest &task_req) {
+                                                         const TaskRequest& task_req) {
   auto it = nodes_.find(node_id);
   if (it == nodes_.end()) {
     return false;
   }
-  NodeResources &resources = it->second;
+  NodeResources& resources = it->second;
 
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
     resources.predefined_resources[i].available =
@@ -683,7 +683,7 @@ bool ClusterResourceScheduler::AddNodeAvailableResources(int64_t node_id,
                  resources.predefined_resources[i].total);
   }
 
-  for (const auto &task_req_custom_resource : task_req.custom_resources) {
+  for (const auto& task_req_custom_resource : task_req.custom_resources) {
     auto it = resources.custom_resources.find(task_req_custom_resource.id);
     if (it != resources.custom_resources.end()) {
       it->second.available = std::min(
@@ -694,14 +694,14 @@ bool ClusterResourceScheduler::AddNodeAvailableResources(int64_t node_id,
 }
 
 bool ClusterResourceScheduler::AddNodeAvailableResources(
-    const std::string &node_id,
-    const std::unordered_map<std::string, double> &resource_map) {
+    const std::string& node_id,
+    const std::unordered_map<std::string, double>& resource_map) {
   TaskRequest task_request = ResourceMapToTaskRequest(string_to_int_map_, resource_map);
   return AddNodeAvailableResources(string_to_int_map_.Get(node_id), task_request);
 }
 
 bool ClusterResourceScheduler::GetNodeResources(int64_t node_id,
-                                                NodeResources *ret_resources) {
+                                                NodeResources* ret_resources) {
   auto it = nodes_.find(node_id);
   if (it != nodes_.end()) {
     *ret_resources = it->second;
@@ -713,8 +713,8 @@ bool ClusterResourceScheduler::GetNodeResources(int64_t node_id,
 
 int64_t ClusterResourceScheduler::NumNodes() { return nodes_.size(); }
 
-void ClusterResourceScheduler::UpdateResourceCapacity(const std::string &client_id_string,
-                                                      const std::string &resource_name,
+void ClusterResourceScheduler::UpdateResourceCapacity(const std::string& client_id_string,
+                                                      const std::string& resource_name,
                                                       double resource_total) {
   int64_t client_id = string_to_int_map_.Get(client_id_string);
 
@@ -771,8 +771,8 @@ void ClusterResourceScheduler::UpdateResourceCapacity(const std::string &client_
   }
 }
 
-void ClusterResourceScheduler::DeleteResource(const std::string &client_id_string,
-                                              const std::string &resource_name) {
+void ClusterResourceScheduler::DeleteResource(const std::string& client_id_string,
+                                              const std::string& resource_name) {
   int64_t client_id = string_to_int_map_.Get(client_id_string);
   auto it = nodes_.find(client_id);
   if (it == nodes_.end()) {
@@ -805,7 +805,7 @@ std::string ClusterResourceScheduler::DebugString(void) const {
   std::stringstream buffer;
   buffer << "\nLocal id: " << local_node_id_;
   buffer << " Local resources: " << local_resources_.DebugString(string_to_int_map_);
-  for (auto &node : nodes_) {
+  for (auto& node : nodes_) {
     buffer << "node id: " << node.first;
     buffer << node.second.DebugString(string_to_int_map_);
   }
@@ -813,7 +813,7 @@ std::string ClusterResourceScheduler::DebugString(void) const {
 }
 
 void ClusterResourceScheduler::InitResourceInstances(
-    FixedPoint total, bool unit_instances, ResourceInstanceCapacities *instance_list) {
+    FixedPoint total, bool unit_instances, ResourceInstanceCapacities* instance_list) {
   if (unit_instances) {
     size_t num_instances = static_cast<size_t>(total.Double());
     instance_list->total.resize(num_instances);
@@ -828,7 +828,7 @@ void ClusterResourceScheduler::InitResourceInstances(
   }
 }
 
-void ClusterResourceScheduler::InitLocalResources(const NodeResources &node_resources) {
+void ClusterResourceScheduler::InitLocalResources(const NodeResources& node_resources) {
   local_resources_.predefined_resources.resize(PredefinedResources_MAX);
 
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
@@ -855,7 +855,7 @@ void ClusterResourceScheduler::InitLocalResources(const NodeResources &node_reso
 }
 
 std::vector<FixedPoint> ClusterResourceScheduler::AddAvailableResourceInstances(
-    std::vector<FixedPoint> available, ResourceInstanceCapacities *resource_instances) {
+    std::vector<FixedPoint> available, ResourceInstanceCapacities* resource_instances) {
   std::vector<FixedPoint> overflow(available.size(), 0.);
   for (size_t i = 0; i < available.size(); i++) {
     resource_instances->available[i] = resource_instances->available[i] + available[i];
@@ -869,7 +869,7 @@ std::vector<FixedPoint> ClusterResourceScheduler::AddAvailableResourceInstances(
 }
 
 std::vector<FixedPoint> ClusterResourceScheduler::SubtractAvailableResourceInstances(
-    std::vector<FixedPoint> available, ResourceInstanceCapacities *resource_instances) {
+    std::vector<FixedPoint> available, ResourceInstanceCapacities* resource_instances) {
   RAY_CHECK(available.size() == resource_instances->available.size());
 
   std::vector<FixedPoint> underflow(available.size(), 0.);
@@ -884,8 +884,8 @@ std::vector<FixedPoint> ClusterResourceScheduler::SubtractAvailableResourceInsta
 }
 
 bool ClusterResourceScheduler::AllocateResourceInstances(
-    FixedPoint demand, bool soft, std::vector<FixedPoint> &available,
-    std::vector<FixedPoint> *allocation) {
+    FixedPoint demand, bool soft, std::vector<FixedPoint>& available,
+    std::vector<FixedPoint>* allocation) {
   allocation->resize(available.size());
   FixedPoint remaining_demand = demand;
 
@@ -975,7 +975,7 @@ bool ClusterResourceScheduler::AllocateResourceInstances(
 }
 
 bool ClusterResourceScheduler::AllocateTaskResourceInstances(
-    const TaskRequest &task_req, std::shared_ptr<TaskResourceInstances> task_allocation) {
+    const TaskRequest& task_req, std::shared_ptr<TaskResourceInstances> task_allocation) {
   RAY_CHECK(task_allocation != nullptr);
   if (nodes_.find(local_node_id_) == nodes_.end()) {
     return false;
@@ -996,7 +996,7 @@ bool ClusterResourceScheduler::AllocateTaskResourceInstances(
     }
   }
 
-  for (const auto &task_req_custom_resource : task_req.custom_resources) {
+  for (const auto& task_req_custom_resource : task_req.custom_resources) {
     auto it = local_resources_.custom_resources.find(task_req_custom_resource.id);
     if (it != local_resources_.custom_resources.end()) {
       if (task_req_custom_resource.demand > 0) {
@@ -1034,11 +1034,11 @@ void ClusterResourceScheduler::UpdateLocalAvailableResourcesFromResourceInstance
     }
   }
 
-  for (auto &custom_resource : it_local_node->second.custom_resources) {
+  for (auto& custom_resource : it_local_node->second.custom_resources) {
     auto it = local_resources_.custom_resources.find(custom_resource.first);
     if (it != local_resources_.custom_resources.end()) {
       custom_resource.second.available = 0;
-      for (const auto &available : it->second.available) {
+      for (const auto& available : it->second.available) {
         custom_resource.second.available += available;
       }
     }
@@ -1053,7 +1053,7 @@ void ClusterResourceScheduler::FreeTaskResourceInstances(
                                   &local_resources_.predefined_resources[i]);
   }
 
-  for (const auto &task_allocation_custom_resource : task_allocation->custom_resources) {
+  for (const auto& task_allocation_custom_resource : task_allocation->custom_resources) {
     auto it =
         local_resources_.custom_resources.find(task_allocation_custom_resource.first);
     if (it != local_resources_.custom_resources.end()) {
@@ -1063,7 +1063,7 @@ void ClusterResourceScheduler::FreeTaskResourceInstances(
 }
 
 std::vector<double> ClusterResourceScheduler::AddCPUResourceInstances(
-    std::vector<double> &cpu_instances) {
+    std::vector<double>& cpu_instances) {
   std::vector<FixedPoint> cpu_instances_fp =
       VectorDoubleToVectorFixedPoint(cpu_instances);
 
@@ -1080,7 +1080,7 @@ std::vector<double> ClusterResourceScheduler::AddCPUResourceInstances(
 }
 
 std::vector<double> ClusterResourceScheduler::SubtractCPUResourceInstances(
-    std::vector<double> &cpu_instances) {
+    std::vector<double>& cpu_instances) {
   std::vector<FixedPoint> cpu_instances_fp =
       VectorDoubleToVectorFixedPoint(cpu_instances);
 
@@ -1097,7 +1097,7 @@ std::vector<double> ClusterResourceScheduler::SubtractCPUResourceInstances(
 }
 
 std::vector<double> ClusterResourceScheduler::AddGPUResourceInstances(
-    std::vector<double> &gpu_instances) {
+    std::vector<double>& gpu_instances) {
   std::vector<FixedPoint> gpu_instances_fp =
       VectorDoubleToVectorFixedPoint(gpu_instances);
 
@@ -1114,7 +1114,7 @@ std::vector<double> ClusterResourceScheduler::AddGPUResourceInstances(
 }
 
 std::vector<double> ClusterResourceScheduler::SubtractGPUResourceInstances(
-    std::vector<double> &gpu_instances) {
+    std::vector<double>& gpu_instances) {
   std::vector<FixedPoint> gpu_instances_fp =
       VectorDoubleToVectorFixedPoint(gpu_instances);
 
@@ -1131,7 +1131,7 @@ std::vector<double> ClusterResourceScheduler::SubtractGPUResourceInstances(
 }
 
 bool ClusterResourceScheduler::AllocateTaskResources(
-    int64_t node_id, const TaskRequest &task_req,
+    int64_t node_id, const TaskRequest& task_req,
     std::shared_ptr<TaskResourceInstances> task_allocation) {
   if (node_id == local_node_id_) {
     RAY_CHECK(task_allocation != nullptr);
@@ -1148,7 +1148,7 @@ bool ClusterResourceScheduler::AllocateTaskResources(
 }
 
 bool ClusterResourceScheduler::AllocateLocalTaskResources(
-    const std::unordered_map<std::string, double> &task_resources,
+    const std::unordered_map<std::string, double>& task_resources,
     std::shared_ptr<TaskResourceInstances> task_allocation) {
   RAY_CHECK(task_allocation != nullptr);
   TaskRequest task_request = ResourceMapToTaskRequest(string_to_int_map_, task_resources);
@@ -1170,8 +1170,8 @@ std::string ClusterResourceScheduler::GetResourceNameFromIndex(int64_t res_idx) 
 }
 
 void ClusterResourceScheduler::AllocateRemoteTaskResources(
-    std::string &node_string,
-    const std::unordered_map<std::string, double> &task_resources) {
+    std::string& node_string,
+    const std::unordered_map<std::string, double>& task_resources) {
   TaskRequest task_request = ResourceMapToTaskRequest(string_to_int_map_, task_resources);
   auto node_id = string_to_int_map_.Insert(node_string);
   RAY_CHECK(node_id != local_node_id_);

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -31,14 +31,14 @@ enum PredefinedResources { CPU, MEM, GPU, TPU, PredefinedResources_MAX };
 static std::unordered_set<int64_t> UnitInstanceResources{CPU, GPU, TPU};
 
 /// Helper function to compare two vectors with FixedPoint values.
-bool EqualVectors(const std::vector<FixedPoint> &v1, const std::vector<FixedPoint> &v2);
+bool EqualVectors(const std::vector<FixedPoint>& v1, const std::vector<FixedPoint>& v2);
 
 /// Convert a vector of doubles to a vector of resource units.
-std::vector<FixedPoint> VectorDoubleToVectorFixedPoint(const std::vector<double> &vector);
+std::vector<FixedPoint> VectorDoubleToVectorFixedPoint(const std::vector<double>& vector);
 
 /// Convert a vector of resource units to a vector of doubles.
 std::vector<double> VectorFixedPointToVectorDouble(
-    const std::vector<FixedPoint> &vector_fp);
+    const std::vector<FixedPoint>& vector_fp);
 
 struct ResourceCapacity {
   FixedPoint total;
@@ -91,7 +91,7 @@ class TaskResourceInstances {
   std::vector<std::vector<FixedPoint>> predefined_resources;
   /// The list of instances of each custom resource allocated to a task.
   absl::flat_hash_map<int64_t, std::vector<FixedPoint>> custom_resources;
-  bool operator==(const TaskResourceInstances &other);
+  bool operator==(const TaskResourceInstances& other);
   /// For each resource of this request aggregate its instances.
   TaskRequest ToTaskRequest() const;
   /// Get CPU instances only.
@@ -154,7 +154,7 @@ class NodeResources {
   /// custom resource ID.
   absl::flat_hash_map<int64_t, ResourceCapacity> custom_resources;
   /// Returns if this equals another node resources.
-  bool operator==(const NodeResources &other);
+  bool operator==(const NodeResources& other);
   /// Returns human-readable string for these resources.
   std::string DebugString(StringIdMap string_to_int_map) const;
 };
@@ -171,7 +171,7 @@ class NodeResourceInstances {
   /// Extract available resource instances.
   TaskResourceInstances GetAvailableResourceInstances();
   /// Returns if this equals another node resources.
-  bool operator==(const NodeResourceInstances &other);
+  bool operator==(const NodeResourceInstances& other);
   /// Returns human-readable string for these resources.
   std::string DebugString(StringIdMap string_to_int_map) const;
 };
@@ -195,15 +195,15 @@ class ClusterResourceScheduler {
   ///
   /// \param[in] new_resources: New predefined resources.
   /// \param[out] old_resources: Predefined resources to be updated.
-  void SetPredefinedResources(const NodeResources &new_resources,
-                              NodeResources *old_resources);
+  void SetPredefinedResources(const NodeResources& new_resources,
+                              NodeResources* old_resources);
   /// Set custom resources.
   ///
   /// \param[in] new_resources: New custom resources.
   /// \param[out] old_resources: Custom resources to be updated.
   void SetCustomResources(
-      const absl::flat_hash_map<int64_t, ResourceCapacity> &new_custom_resources,
-      absl::flat_hash_map<int64_t, ResourceCapacity> *old_custom_resources);
+      const absl::flat_hash_map<int64_t, ResourceCapacity>& new_custom_resources,
+      absl::flat_hash_map<int64_t, ResourceCapacity>* old_custom_resources);
 
   /// Subtract the resources required by a given task request (task_req) from
   /// a given node (node_id).
@@ -215,7 +215,7 @@ class ClusterResourceScheduler {
   ///
   /// \return True if the node has enough resources to satisfy the task request.
   /// False otherwise.
-  bool AllocateTaskResources(int64_t node_id, const TaskRequest &task_req,
+  bool AllocateTaskResources(int64_t node_id, const TaskRequest& task_req,
                              std::shared_ptr<TaskResourceInstances> task_allocation);
 
  public:
@@ -227,10 +227,10 @@ class ClusterResourceScheduler {
   /// \param local_node_resources: The total and the available resources associated
   /// with the local node.
   ClusterResourceScheduler(int64_t local_node_id,
-                           const NodeResources &local_node_resources);
+                           const NodeResources& local_node_resources);
   ClusterResourceScheduler(
-      const std::string &local_node_id,
-      const std::unordered_map<std::string, double> &local_node_resources);
+      const std::string& local_node_id,
+      const std::unordered_map<std::string, double>& local_node_resources);
 
   // Mapping from predefined resource indexes to resource strings
   std::string GetResourceNameFromIndex(int64_t res_idx);
@@ -239,18 +239,18 @@ class ClusterResourceScheduler {
   ///
   /// \param node_id: Node ID.
   /// \param node_resources: Up to date total and available resources of the node.
-  void AddOrUpdateNode(int64_t node_id, const NodeResources &node_resources);
+  void AddOrUpdateNode(int64_t node_id, const NodeResources& node_resources);
   void AddOrUpdateNode(
-      const std::string &node_id,
-      const std::unordered_map<std::string, double> &resource_map_total,
-      const std::unordered_map<std::string, double> &resource_map_available);
+      const std::string& node_id,
+      const std::unordered_map<std::string, double>& resource_map_total,
+      const std::unordered_map<std::string, double>& resource_map_available);
 
   /// Remove node from the cluster data structure. This happens
   /// when a node fails or it is removed from the cluster.
   ///
   /// \param ID of the node to be removed.
   bool RemoveNode(int64_t node_id);
-  bool RemoveNode(const std::string &node_id_string);
+  bool RemoveNode(const std::string& node_id_string);
 
   /// Check whether a task request can be scheduled given a node.
   ///
@@ -266,8 +266,8 @@ class ClusterResourceScheduler {
   ///           least a hard constraints is violated.
   ///           >= 0, the number soft constraint violations. If 0, no
   ///           constraint is violated.
-  int64_t IsSchedulable(const TaskRequest &task_req, int64_t node_id,
-                        const NodeResources &resources);
+  int64_t IsSchedulable(const TaskRequest& task_req, int64_t node_id,
+                        const NodeResources& resources);
 
   ///  Find a node in the cluster on which we can schedule a given task request.
   ///
@@ -292,7 +292,7 @@ class ClusterResourceScheduler {
   ///
   ///  \return -1, if no node can schedule the current request; otherwise,
   ///          return the ID of a node that can schedule the task request.
-  int64_t GetBestSchedulableNode(const TaskRequest &task_request, int64_t *violations);
+  int64_t GetBestSchedulableNode(const TaskRequest& task_request, int64_t* violations);
 
   /// Similar to
   ///    int64_t GetBestSchedulableNode(const TaskRequest &task_request, int64_t
@@ -302,7 +302,7 @@ class ClusterResourceScheduler {
   ///          return the ID in string format of a node that can schedule the
   //           task request.
   std::string GetBestSchedulableNode(
-      const std::unordered_map<std::string, double> &task_request, int64_t *violations);
+      const std::unordered_map<std::string, double>& task_request, int64_t* violations);
 
   /// Decrease the available resources of a node when a task request is
   /// scheduled on the given node.
@@ -312,10 +312,10 @@ class ClusterResourceScheduler {
   ///
   /// \return true, if task_req can be indeed scheduled on the node,
   /// and false otherwise.
-  bool SubtractNodeAvailableResources(int64_t node_id, const TaskRequest &task_request);
+  bool SubtractNodeAvailableResources(int64_t node_id, const TaskRequest& task_request);
   bool SubtractNodeAvailableResources(
-      const std::string &node_id,
-      const std::unordered_map<std::string, double> &task_request);
+      const std::string& node_id,
+      const std::unordered_map<std::string, double>& task_request);
 
   /// Increase available resources of a node when a worker has finished
   /// a task.
@@ -325,14 +325,14 @@ class ClusterResourceScheduler {
   ///
   /// \return true, if task_req can be indeed scheduled on the node,
   /// and false otherwise.
-  bool AddNodeAvailableResources(int64_t node_id, const TaskRequest &task_request);
+  bool AddNodeAvailableResources(int64_t node_id, const TaskRequest& task_request);
   bool AddNodeAvailableResources(
-      const std::string &node_id,
-      const std::unordered_map<std::string, double> &task_request);
+      const std::string& node_id,
+      const std::unordered_map<std::string, double>& task_request);
 
   /// Return resources associated to the given node_id in ret_resources.
   /// If node_id not found, return false; otherwise return true.
-  bool GetNodeResources(int64_t node_id, NodeResources *ret_resources);
+  bool GetNodeResources(int64_t node_id, NodeResources* ret_resources);
 
   /// Get number of nodes in the cluster.
   int64_t NumNodes();
@@ -342,14 +342,14 @@ class ClusterResourceScheduler {
   /// \param node_name: Node whose resource we want to update.
   /// \param resource_name: Resource which we want to update.
   /// \param resource_total: New capacity of the resource.
-  void UpdateResourceCapacity(const std::string &node_name,
-                              const std::string &resource_name, double resource_total);
+  void UpdateResourceCapacity(const std::string& node_name,
+                              const std::string& resource_name, double resource_total);
 
   /// Delete a given resource from a given node.
   ///
   /// \param node_name: Node whose resource we want to delete.
   /// \param resource_name: Resource we want to delete
-  void DeleteResource(const std::string &node_name, const std::string &resource_name);
+  void DeleteResource(const std::string& node_name, const std::string& resource_name);
 
   /// Return local resources.
   NodeResourceInstances GetLocalResources() { return local_resources_; };
@@ -358,7 +358,7 @@ class ClusterResourceScheduler {
   /// the node's resources.
   ///
   /// \param local_resources: Total resources of the node.
-  void InitLocalResources(const NodeResources &local_resources);
+  void InitLocalResources(const NodeResources& local_resources);
 
   /// Initialize the instances of a given resource given the resource's total capacity.
   /// If unit_instances is true we split the resources in unit-size instances. For
@@ -370,7 +370,7 @@ class ClusterResourceScheduler {
   /// If false, we create a single instance of capacity "total".
   /// \param instance_list: The list of capacities this resource instances.
   void InitResourceInstances(FixedPoint total, bool unit_instances,
-                             ResourceInstanceCapacities *instance_list);
+                             ResourceInstanceCapacities* instance_list);
 
   /// Allocate enough capacity across the instances of a resource to satisfy "demand".
   /// If resource has multiple unit-capacity instances, we consider two cases.
@@ -404,8 +404,8 @@ class ClusterResourceScheduler {
   /// \return true, if allocation successful. In this case, the sum of the elements in
   /// "allocation" is equal to "demand".
   bool AllocateResourceInstances(FixedPoint demand, bool soft,
-                                 std::vector<FixedPoint> &available,
-                                 std::vector<FixedPoint> *allocation);
+                                 std::vector<FixedPoint>& available,
+                                 std::vector<FixedPoint>* allocation);
 
   /// Allocate local resources to satisfy a given request (task_req).
   ///
@@ -415,7 +415,7 @@ class ClusterResourceScheduler {
   /// \return true, if allocation successful. If false, the caller needs to free the
   /// allocated resources, i.e., task_allocation.
   bool AllocateTaskResourceInstances(
-      const TaskRequest &task_req,
+      const TaskRequest& task_req,
       std::shared_ptr<TaskResourceInstances> task_allocation);
 
   /// Free resources which were allocated with a task. The freed resources are
@@ -433,7 +433,7 @@ class ClusterResourceScheduler {
   /// capacities in "available", i.e.,
   /// min(available + resource_instances.available, resource_instances.total)
   std::vector<FixedPoint> AddAvailableResourceInstances(
-      std::vector<FixedPoint> available, ResourceInstanceCapacities *resource_instances);
+      std::vector<FixedPoint> available, ResourceInstanceCapacities* resource_instances);
 
   /// Decrease the available capacities of the instances of a given resource.
   ///
@@ -443,7 +443,7 @@ class ClusterResourceScheduler {
   /// capacities in "available", i.e.,.
   /// max(available - reasource_instances.available, 0)
   std::vector<FixedPoint> SubtractAvailableResourceInstances(
-      std::vector<FixedPoint> available, ResourceInstanceCapacities *resource_instances);
+      std::vector<FixedPoint> available, ResourceInstanceCapacities* resource_instances);
 
   /// Increase the available CPU instances of this node.
   ///
@@ -451,7 +451,7 @@ class ClusterResourceScheduler {
   ///
   /// \return Overflow capacities of CPU instances after adding CPU
   /// capacities in cpu_instances.
-  std::vector<double> AddCPUResourceInstances(std::vector<double> &cpu_instances);
+  std::vector<double> AddCPUResourceInstances(std::vector<double>& cpu_instances);
 
   /// Decrease the available CPU instances of this node.
   ///
@@ -459,7 +459,7 @@ class ClusterResourceScheduler {
   ///
   /// \return Underflow capacities of CPU instances after subtracting CPU
   /// capacities in cpu_instances.
-  std::vector<double> SubtractCPUResourceInstances(std::vector<double> &cpu_instances);
+  std::vector<double> SubtractCPUResourceInstances(std::vector<double>& cpu_instances);
 
   /// Increase the available GPU instances of this node.
   ///
@@ -467,7 +467,7 @@ class ClusterResourceScheduler {
   ///
   /// \return Overflow capacities of GPU instances after adding GPU
   /// capacities in gpu_instances.
-  std::vector<double> AddGPUResourceInstances(std::vector<double> &gpu_instances);
+  std::vector<double> AddGPUResourceInstances(std::vector<double>& gpu_instances);
 
   /// Decrease the available GPU instances of this node.
   ///
@@ -475,7 +475,7 @@ class ClusterResourceScheduler {
   ///
   /// \return Underflow capacities of GPU instances after subtracting GPU
   /// capacities in gpu_instances.
-  std::vector<double> SubtractGPUResourceInstances(std::vector<double> &gpu_instances);
+  std::vector<double> SubtractGPUResourceInstances(std::vector<double>& gpu_instances);
 
   /// Subtract the resources required by a given task request (task_req) from the
   /// local node. This function also updates the local node resources
@@ -488,7 +488,7 @@ class ClusterResourceScheduler {
   /// \return True if local node has enough resources to satisfy the task request.
   /// False otherwise.
   bool AllocateLocalTaskResources(
-      const std::unordered_map<std::string, double> &task_resources,
+      const std::unordered_map<std::string, double>& task_resources,
       std::shared_ptr<TaskResourceInstances> task_allocation);
 
   /// Subtract the resources required by a given task request (task_req) from a given
@@ -497,8 +497,8 @@ class ClusterResourceScheduler {
   /// \param node_id Remote node whose resources we allocate.
   /// \param task_req Task for which we allocate resources.
   void AllocateRemoteTaskResources(
-      std::string &node_id,
-      const std::unordered_map<std::string, double> &task_resources);
+      std::string& node_id,
+      const std::unordered_map<std::string, double>& task_resources);
 
   void FreeLocalTaskResources(std::shared_ptr<TaskResourceInstances> task_allocation);
 

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
@@ -33,10 +33,10 @@ vector<int64_t> EmptyIntVector;
 vector<bool> EmptyBoolVector;
 vector<FixedPoint> EmptyFixedPointVector;
 
-void initTaskRequest(TaskRequest &tr, vector<FixedPoint> &pred_demands,
-                     vector<bool> &pred_soft, vector<int64_t> &cust_ids,
-                     vector<FixedPoint> &cust_demands, vector<bool> &cust_soft,
-                     vector<int64_t> &placement_hints) {
+void initTaskRequest(TaskRequest& tr, vector<FixedPoint>& pred_demands,
+                     vector<bool>& pred_soft, vector<int64_t>& cust_ids,
+                     vector<FixedPoint>& cust_demands, vector<bool>& cust_soft,
+                     vector<int64_t>& placement_hints) {
   for (size_t i = 0; i < pred_demands.size(); i++) {
     ResourceRequest rq;
     rq.demand = pred_demands[i];
@@ -65,7 +65,7 @@ void initTaskRequest(TaskRequest &tr, vector<FixedPoint> &pred_demands,
 };
 
 void addTaskResourceInstances(bool predefined, vector<double> allocation, uint64_t idx,
-                              TaskResourceInstances *task_allocation) {
+                              TaskResourceInstances* task_allocation) {
   std::vector<FixedPoint> allocation_fp = VectorDoubleToVectorFixedPoint(allocation);
 
   if (task_allocation->predefined_resources.size() < PredefinedResources_MAX) {
@@ -79,8 +79,8 @@ void addTaskResourceInstances(bool predefined, vector<double> allocation, uint64
   }
 };
 
-void initNodeResources(NodeResources &node, vector<FixedPoint> &pred_capacities,
-                       vector<int64_t> &cust_ids, vector<FixedPoint> &cust_capacities) {
+void initNodeResources(NodeResources& node, vector<FixedPoint>& pred_capacities,
+                       vector<int64_t>& cust_ids, vector<FixedPoint>& cust_capacities) {
   for (size_t i = 0; i < pred_capacities.size(); i++) {
     ResourceCapacity rc;
     rc.total = rc.available = pred_capacities[i];
@@ -102,7 +102,7 @@ void initNodeResources(NodeResources &node, vector<FixedPoint> &pred_capacities,
   }
 }
 
-void initCluster(ClusterResourceScheduler &cluster_resources, int n) {
+void initCluster(ClusterResourceScheduler& cluster_resources, int n) {
   vector<FixedPoint> pred_capacities;
   vector<int64_t> cust_ids;
   vector<FixedPoint> cust_capacities;
@@ -135,7 +135,7 @@ void initCluster(ClusterResourceScheduler &cluster_resources, int n) {
   }
 }
 
-bool nodeResourcesEqual(const NodeResources &nr1, const NodeResources &nr2) {
+bool nodeResourcesEqual(const NodeResources& nr1, const NodeResources& nr2) {
   if (nr1.predefined_resources.size() != nr2.predefined_resources.size()) {
     cout << nr1.predefined_resources.size() << " " << nr2.predefined_resources.size()
          << endl;
@@ -972,7 +972,7 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstanceWithHardRequestTest) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -6,9 +6,9 @@ namespace ray {
 namespace raylet {
 
 ClusterTaskManager::ClusterTaskManager(
-    const ClientID &self_node_id,
+    const ClientID& self_node_id,
     std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler,
-    std::function<bool(const Task &)> fulfills_dependencies_func,
+    std::function<bool(const Task&)> fulfills_dependencies_func,
     NodeInfoGetter get_node_info)
     : self_node_id_(self_node_id),
       cluster_resource_scheduler_(cluster_resource_scheduler),
@@ -81,8 +81,8 @@ bool ClusterTaskManager::WaitForTaskArgsRequests(Work work) {
 }
 
 void ClusterTaskManager::DispatchScheduledTasksToWorkers(
-    WorkerPoolInterface &worker_pool,
-    std::unordered_map<WorkerID, std::shared_ptr<WorkerInterface>> &leased_workers) {
+    WorkerPoolInterface& worker_pool,
+    std::unordered_map<WorkerID, std::shared_ptr<WorkerInterface>>& leased_workers) {
   // Check every task in task_to_dispatch queue to see
   // whether it can be dispatched and ran. This avoids head-of-line
   // blocking where a task which cannot be dispatched because
@@ -131,14 +131,14 @@ void ClusterTaskManager::DispatchScheduledTasksToWorkers(
   }
 }
 
-void ClusterTaskManager::QueueTask(const Task &task, rpc::RequestWorkerLeaseReply *reply,
+void ClusterTaskManager::QueueTask(const Task& task, rpc::RequestWorkerLeaseReply* reply,
                                    std::function<void(void)> callback) {
   Work work = std::make_tuple(task, reply, callback);
   tasks_to_schedule_.push_back(work);
 }
 
 void ClusterTaskManager::TasksUnblocked(const std::vector<TaskID> ready_ids) {
-  for (const auto &task_id : ready_ids) {
+  for (const auto& task_id : ready_ids) {
     auto it = waiting_tasks_.find(task_id);
     if (it != waiting_tasks_.end()) {
       tasks_to_dispatch_.push_back(it->second);
@@ -149,8 +149,8 @@ void ClusterTaskManager::TasksUnblocked(const std::vector<TaskID> ready_ids) {
 
 void ClusterTaskManager::Dispatch(
     std::shared_ptr<WorkerInterface> worker,
-    std::unordered_map<WorkerID, std::shared_ptr<WorkerInterface>> &leased_workers_,
-    const TaskSpecification &task_spec, rpc::RequestWorkerLeaseReply *reply,
+    std::unordered_map<WorkerID, std::shared_ptr<WorkerInterface>>& leased_workers_,
+    const TaskSpecification& task_spec, rpc::RequestWorkerLeaseReply* reply,
     std::function<void(void)> send_reply_callback) {
   reply->mutable_worker_address()->set_ip_address(worker->IpAddress());
   reply->mutable_worker_address()->set_port(worker->Port());
@@ -165,7 +165,7 @@ void ClusterTaskManager::Dispatch(
     allocated_resources = worker->GetAllocatedInstances();
   }
   auto predefined_resources = allocated_resources->predefined_resources;
-  ::ray::rpc::ResourceMapEntry *resource;
+  ::ray::rpc::ResourceMapEntry* resource;
   for (size_t res_idx = 0; res_idx < predefined_resources.size(); res_idx++) {
     bool first = true;  // Set resource name only if at least one of its
                         // instances has available capacity.
@@ -206,7 +206,7 @@ void ClusterTaskManager::Dispatch(
 }
 
 void ClusterTaskManager::Spillback(ClientID spillback_to, std::string address, int port,
-                                   rpc::RequestWorkerLeaseReply *reply,
+                                   rpc::RequestWorkerLeaseReply* reply,
                                    std::function<void(void)> send_reply_callback) {
   reply->mutable_retry_at_raylet_address()->set_ip_address(address);
   reply->mutable_retry_at_raylet_address()->set_port(port);

--- a/src/ray/raylet/scheduling/cluster_task_manager.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager.h
@@ -15,9 +15,9 @@ namespace raylet {
 /// Work represents all the information needed to make a scheduling decision.
 /// This includes the task, the information we need to communicate to
 /// dispatch/spillback and the callback to trigger it.
-typedef std::tuple<Task, rpc::RequestWorkerLeaseReply *, std::function<void(void)>> Work;
+typedef std::tuple<Task, rpc::RequestWorkerLeaseReply*, std::function<void(void)>> Work;
 
-typedef std::function<boost::optional<rpc::GcsNodeInfo>(const ClientID &node_id)>
+typedef std::function<boost::optional<rpc::GcsNodeInfo>(const ClientID& node_id)>
     NodeInfoGetter;
 
 /// Manages the queuing and dispatching of tasks. The logic is as follows:
@@ -45,9 +45,9 @@ class ClusterTaskManager {
   /// \param fulfills_dependencies_func: Returns true if all of a task's
   /// dependencies are fulfilled.
   /// \param gcs_client: A gcs client.
-  ClusterTaskManager(const ClientID &self_node_id,
+  ClusterTaskManager(const ClientID& self_node_id,
                      std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler,
-                     std::function<bool(const Task &)> fulfills_dependencies_func,
+                     std::function<bool(const Task&)> fulfills_dependencies_func,
                      NodeInfoGetter get_node_info);
 
   /// (Step 2) For each task in tasks_to_schedule_, pick a node in the system
@@ -64,13 +64,13 @@ class ClusterTaskManager {
   /// `worker_pool` state will be modified (idle workers will be popped) during
   /// dispatching.
   void DispatchScheduledTasksToWorkers(
-      WorkerPoolInterface &worker_pool,
-      std::unordered_map<WorkerID, std::shared_ptr<WorkerInterface>> &leased_workers);
+      WorkerPoolInterface& worker_pool,
+      std::unordered_map<WorkerID, std::shared_ptr<WorkerInterface>>& leased_workers);
 
   /// (Step 1) Queue tasks for scheduling.
   /// \param fn: The function used during dispatching.
   /// \param task: The incoming task to schedule.
-  void QueueTask(const Task &task, rpc::RequestWorkerLeaseReply *reply,
+  void QueueTask(const Task& task, rpc::RequestWorkerLeaseReply* reply,
                  std::function<void(void)>);
 
   /// Move tasks from waiting to ready for dispatch. Called when a task's
@@ -80,9 +80,9 @@ class ClusterTaskManager {
   void TasksUnblocked(const std::vector<TaskID> ready_ids);
 
  private:
-  const ClientID &self_node_id_;
+  const ClientID& self_node_id_;
   std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler_;
-  std::function<bool(const Task &)> fulfills_dependencies_func_;
+  std::function<bool(const Task&)> fulfills_dependencies_func_;
   NodeInfoGetter get_node_info_;
 
   /// Queue of lease requests that are waiting for resources to become available.
@@ -101,12 +101,12 @@ class ClusterTaskManager {
 
   void Dispatch(
       std::shared_ptr<WorkerInterface> worker,
-      std::unordered_map<WorkerID, std::shared_ptr<WorkerInterface>> &leased_workers_,
-      const TaskSpecification &task_spec, rpc::RequestWorkerLeaseReply *reply,
+      std::unordered_map<WorkerID, std::shared_ptr<WorkerInterface>>& leased_workers_,
+      const TaskSpecification& task_spec, rpc::RequestWorkerLeaseReply* reply,
       std::function<void(void)> send_reply_callback);
 
   void Spillback(ClientID spillback_to, std::string address, int port,
-                 rpc::RequestWorkerLeaseReply *reply,
+                 rpc::RequestWorkerLeaseReply* reply,
                  std::function<void(void)> send_reply_callback);
 };
 }  // namespace raylet

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -40,7 +40,7 @@ namespace raylet {
 
 class MockWorkerPool : public WorkerPoolInterface {
  public:
-  std::shared_ptr<WorkerInterface> PopWorker(const TaskSpecification &task_spec) {
+  std::shared_ptr<WorkerInterface> PopWorker(const TaskSpecification& task_spec) {
     if (workers.empty()) {
       return nullptr;
     }
@@ -49,7 +49,7 @@ class MockWorkerPool : public WorkerPoolInterface {
     return worker_ptr;
   }
 
-  void PushWorker(const std::shared_ptr<WorkerInterface> &worker) {
+  void PushWorker(const std::shared_ptr<WorkerInterface>& worker) {
     workers.push_front(worker);
   }
 
@@ -64,23 +64,23 @@ class MockWorker : public WorkerInterface {
 
   int Port() const { return port_; }
 
-  void SetOwnerAddress(const rpc::Address &address) { address_ = address; }
+  void SetOwnerAddress(const rpc::Address& address) { address_ = address; }
 
-  void AssignTaskId(const TaskID &task_id) {}
+  void AssignTaskId(const TaskID& task_id) {}
 
-  void AssignJobId(const JobID &job_id) {}
+  void AssignJobId(const JobID& job_id) {}
 
-  void SetAssignedTask(Task &assigned_task) {}
+  void SetAssignedTask(Task& assigned_task) {}
 
   const std::string IpAddress() const { return address_.ip_address(); }
 
   void SetAllocatedInstances(
-      std::shared_ptr<TaskResourceInstances> &allocated_instances) {
+      std::shared_ptr<TaskResourceInstances>& allocated_instances) {
     allocated_instances_ = allocated_instances;
   }
 
   void SetLifetimeAllocatedInstances(
-      std::shared_ptr<TaskResourceInstances> &allocated_instances) {
+      std::shared_ptr<TaskResourceInstances>& allocated_instances) {
     lifetime_allocated_instances_ = allocated_instances;
   }
 
@@ -120,29 +120,29 @@ class MockWorker : public WorkerInterface {
     return -1;
   }
   void SetAssignedPort(int port) { RAY_CHECK(false) << "Method unused"; }
-  const TaskID &GetAssignedTaskId() const {
+  const TaskID& GetAssignedTaskId() const {
     RAY_CHECK(false) << "Method unused";
     return TaskID::Nil();
   }
-  bool AddBlockedTaskId(const TaskID &task_id) {
+  bool AddBlockedTaskId(const TaskID& task_id) {
     RAY_CHECK(false) << "Method unused";
     return false;
   }
-  bool RemoveBlockedTaskId(const TaskID &task_id) {
+  bool RemoveBlockedTaskId(const TaskID& task_id) {
     RAY_CHECK(false) << "Method unused";
     return false;
   }
-  const std::unordered_set<TaskID> &GetBlockedTaskIds() const {
+  const std::unordered_set<TaskID>& GetBlockedTaskIds() const {
     RAY_CHECK(false) << "Method unused";
-    auto *t = new std::unordered_set<TaskID>();
+    auto* t = new std::unordered_set<TaskID>();
     return *t;
   }
-  const JobID &GetAssignedJobId() const {
+  const JobID& GetAssignedJobId() const {
     RAY_CHECK(false) << "Method unused";
     return JobID::Nil();
   }
-  void AssignActorId(const ActorID &actor_id) { RAY_CHECK(false) << "Method unused"; }
-  const ActorID &GetActorId() const {
+  void AssignActorId(const ActorID& actor_id) { RAY_CHECK(false) << "Method unused"; }
+  const ActorID& GetActorId() const {
     RAY_CHECK(false) << "Method unused";
     return ActorID::Nil();
   }
@@ -155,40 +155,40 @@ class MockWorker : public WorkerInterface {
     RAY_CHECK(false) << "Method unused";
     return nullptr;
   }
-  const rpc::Address &GetOwnerAddress() const {
+  const rpc::Address& GetOwnerAddress() const {
     RAY_CHECK(false) << "Method unused";
     return address_;
   }
 
-  const ResourceIdSet &GetLifetimeResourceIds() const {
+  const ResourceIdSet& GetLifetimeResourceIds() const {
     RAY_CHECK(false) << "Method unused";
-    auto *t = new ResourceIdSet();
+    auto* t = new ResourceIdSet();
     return *t;
   }
-  void SetLifetimeResourceIds(ResourceIdSet &resource_ids) {
+  void SetLifetimeResourceIds(ResourceIdSet& resource_ids) {
     RAY_CHECK(false) << "Method unused";
   }
   void ResetLifetimeResourceIds() { RAY_CHECK(false) << "Method unused"; }
 
-  const ResourceIdSet &GetTaskResourceIds() const {
+  const ResourceIdSet& GetTaskResourceIds() const {
     RAY_CHECK(false) << "Method unused";
-    auto *t = new ResourceIdSet();
+    auto* t = new ResourceIdSet();
     return *t;
   }
-  void SetTaskResourceIds(ResourceIdSet &resource_ids) {
+  void SetTaskResourceIds(ResourceIdSet& resource_ids) {
     RAY_CHECK(false) << "Method unused";
   }
   void ResetTaskResourceIds() { RAY_CHECK(false) << "Method unused"; }
   ResourceIdSet ReleaseTaskCpuResources() {
     RAY_CHECK(false) << "Method unused";
-    auto *t = new ResourceIdSet();
+    auto* t = new ResourceIdSet();
     return *t;
   }
-  void AcquireTaskCpuResources(const ResourceIdSet &cpu_resources) {
+  void AcquireTaskCpuResources(const ResourceIdSet& cpu_resources) {
     RAY_CHECK(false) << "Method unused";
   }
 
-  Status AssignTask(const Task &task, const ResourceIdSet &resource_id_set) {
+  Status AssignTask(const Task& task, const ResourceIdSet& resource_id_set) {
     RAY_CHECK(false) << "Method unused";
     Status s;
     return s;
@@ -201,21 +201,21 @@ class MockWorker : public WorkerInterface {
 
   void ClearLifetimeAllocatedInstances() { RAY_CHECK(false) << "Method unused"; }
 
-  void SetBorrowedCPUInstances(std::vector<double> &cpu_instances) {
+  void SetBorrowedCPUInstances(std::vector<double>& cpu_instances) {
     RAY_CHECK(false) << "Method unused";
   }
 
-  std::vector<double> &GetBorrowedCPUInstances() {
+  std::vector<double>& GetBorrowedCPUInstances() {
     RAY_CHECK(false) << "Method unused";
-    auto *t = new std::vector<double>();
+    auto* t = new std::vector<double>();
     return *t;
   }
 
   void ClearBorrowedCPUInstances() { RAY_CHECK(false) << "Method unused"; }
 
-  Task &GetAssignedTask() {
+  Task& GetAssignedTask() {
     RAY_CHECK(false) << "Method unused";
-    auto *t = new Task();
+    auto* t = new Task();
     return *t;
   }
 
@@ -224,7 +224,7 @@ class MockWorker : public WorkerInterface {
     return false;
   }
 
-  rpc::CoreWorkerClient *rpc_client() {
+  rpc::CoreWorkerClient* rpc_client() {
     RAY_CHECK(false) << "Method unused";
     return nullptr;
   }
@@ -238,7 +238,7 @@ class MockWorker : public WorkerInterface {
 };
 
 std::shared_ptr<ClusterResourceScheduler> CreateSingleNodeScheduler(
-    const std::string &id) {
+    const std::string& id) {
   std::unordered_map<std::string, double> local_node_resources;
   local_node_resources[ray::kCPU_ResourceLabel] = 8;
   local_node_resources[ray::kGPU_ResourceLabel] = 4;
@@ -250,7 +250,7 @@ std::shared_ptr<ClusterResourceScheduler> CreateSingleNodeScheduler(
   return scheduler;
 }
 
-Task CreateTask(const std::unordered_map<std::string, double> &required_resources) {
+Task CreateTask(const std::unordered_map<std::string, double>& required_resources) {
   TaskSpecBuilder spec_builder;
   TaskID id = RandomTaskId();
   JobID job_id = RandomJobId();
@@ -274,11 +274,11 @@ class ClusterTaskManagerTest : public ::testing::Test {
         node_info_(boost::optional<rpc::GcsNodeInfo>{}),
         task_manager_(
             id_, single_node_resource_scheduler_,
-            [this](const Task &_task) {
+            [this](const Task& _task) {
               fulfills_dependencies_calls_++;
               return dependencies_fulfilled_;
             },
-            [this](const ClientID &node_id) {
+            [this](const ClientID& node_id) {
               node_info_calls_++;
               return node_info_;
             }) {}
@@ -310,7 +310,7 @@ TEST_F(ClusterTaskManagerTest, BasicTest) {
   Task task = CreateTask({{ray::kCPU_ResourceLabel, 4}});
   rpc::RequestWorkerLeaseReply reply;
   bool callback_occurred = false;
-  bool *callback_occurred_ptr = &callback_occurred;
+  bool* callback_occurred_ptr = &callback_occurred;
   auto callback = [callback_occurred_ptr]() { *callback_occurred_ptr = true; };
 
   task_manager_.QueueTask(task, &reply, callback);
@@ -338,7 +338,7 @@ TEST_F(ClusterTaskManagerTest, BasicTest) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -272,15 +272,16 @@ class ClusterTaskManagerTest : public ::testing::Test {
         dependencies_fulfilled_(true),
         node_info_calls_(0),
         node_info_(boost::optional<rpc::GcsNodeInfo>{}),
-        task_manager_(id_, single_node_resource_scheduler_,
-                      [this](const Task &_task) {
-                        fulfills_dependencies_calls_++;
-                        return dependencies_fulfilled_;
-                      },
-                      [this](const ClientID &node_id) {
-                        node_info_calls_++;
-                        return node_info_;
-                      }) {}
+        task_manager_(
+            id_, single_node_resource_scheduler_,
+            [this](const Task &_task) {
+              fulfills_dependencies_calls_++;
+              return dependencies_fulfilled_;
+            },
+            [this](const ClientID &node_id) {
+              node_info_calls_++;
+              return node_info_;
+            }) {}
 
   void SetUp() {}
 

--- a/src/ray/raylet/scheduling/fixed_point.cc
+++ b/src/ray/raylet/scheduling/fixed_point.cc
@@ -8,24 +8,24 @@ FixedPoint::FixedPoint(double d) {
   i_ = (uint64_t)((d * RESOURCE_UNIT_SCALING) + 0.5);
 }
 
-FixedPoint FixedPoint::operator+(FixedPoint const &ru) {
+FixedPoint FixedPoint::operator+(FixedPoint const& ru) {
   FixedPoint res;
   res.i_ = i_ + ru.i_;
   return res;
 }
 
-FixedPoint FixedPoint::operator+=(FixedPoint const &ru) {
+FixedPoint FixedPoint::operator+=(FixedPoint const& ru) {
   i_ += ru.i_;
   return *this;
 }
 
-FixedPoint FixedPoint::operator-(FixedPoint const &ru) {
+FixedPoint FixedPoint::operator-(FixedPoint const& ru) {
   FixedPoint res;
   res.i_ = i_ - ru.i_;
   return res;
 }
 
-FixedPoint FixedPoint::operator-=(FixedPoint const &ru) {
+FixedPoint FixedPoint::operator-=(FixedPoint const& ru) {
   i_ -= ru.i_;
   return *this;
 }

--- a/src/ray/raylet/scheduling/fixed_point.h
+++ b/src/ray/raylet/scheduling/fixed_point.h
@@ -13,13 +13,13 @@ class FixedPoint {
  public:
   FixedPoint(double d = 0);
 
-  FixedPoint operator+(FixedPoint const &ru);
+  FixedPoint operator+(FixedPoint const& ru);
 
-  FixedPoint operator+=(FixedPoint const &ru);
+  FixedPoint operator+=(FixedPoint const& ru);
 
-  FixedPoint operator-(FixedPoint const &ru);
+  FixedPoint operator-(FixedPoint const& ru);
 
-  FixedPoint operator-=(FixedPoint const &ru);
+  FixedPoint operator-=(FixedPoint const& ru);
 
   FixedPoint operator-() const;
 
@@ -29,14 +29,14 @@ class FixedPoint {
 
   FixedPoint operator=(double const d);
 
-  friend bool operator<(FixedPoint const &ru1, FixedPoint const &ru2);
-  friend bool operator>(FixedPoint const &ru1, FixedPoint const &ru2);
-  friend bool operator<=(FixedPoint const &ru1, FixedPoint const &ru2);
-  friend bool operator>=(FixedPoint const &ru1, FixedPoint const &ru2);
-  friend bool operator==(FixedPoint const &ru1, FixedPoint const &ru2);
-  friend bool operator!=(FixedPoint const &ru1, FixedPoint const &ru2);
+  friend bool operator<(FixedPoint const& ru1, FixedPoint const& ru2);
+  friend bool operator>(FixedPoint const& ru1, FixedPoint const& ru2);
+  friend bool operator<=(FixedPoint const& ru1, FixedPoint const& ru2);
+  friend bool operator>=(FixedPoint const& ru1, FixedPoint const& ru2);
+  friend bool operator==(FixedPoint const& ru1, FixedPoint const& ru2);
+  friend bool operator!=(FixedPoint const& ru1, FixedPoint const& ru2);
 
   double Double();
 
-  friend std::ostream &operator<<(std::ostream &out, const FixedPoint &ru);
+  friend std::ostream& operator<<(std::ostream& out, const FixedPoint& ru);
 };

--- a/src/ray/raylet/scheduling/scheduling_ids.cc
+++ b/src/ray/raylet/scheduling/scheduling_ids.cc
@@ -14,7 +14,7 @@
 
 #include "ray/raylet/scheduling/scheduling_ids.h"
 
-int64_t StringIdMap::Get(const std::string &string_id) {
+int64_t StringIdMap::Get(const std::string& string_id) {
   auto it = string_to_int_.find(string_id);
   if (it == string_to_int_.end()) {
     return -1;
@@ -34,7 +34,7 @@ std::string StringIdMap::Get(uint64_t id) {
   return id_string;
 };
 
-int64_t StringIdMap::Insert(const std::string &string_id, uint8_t max_id) {
+int64_t StringIdMap::Insert(const std::string& string_id, uint8_t max_id) {
   auto sit = string_to_int_.find(string_id);
   if (sit == string_to_int_.end()) {
     int64_t id = hasher_(string_id);
@@ -60,7 +60,7 @@ int64_t StringIdMap::Insert(const std::string &string_id, uint8_t max_id) {
   }
 };
 
-void StringIdMap::Remove(const std::string &string_id) {
+void StringIdMap::Remove(const std::string& string_id) {
   auto sit = string_to_int_.find(string_id);
   if (sit != string_to_int_.end()) {
     int_to_string_.erase(string_to_int_[string_id]);

--- a/src/ray/raylet/scheduling/scheduling_ids.h
+++ b/src/ray/raylet/scheduling/scheduling_ids.h
@@ -36,7 +36,7 @@ class StringIdMap {
   ///
   /// \param String ID.
   /// \return The integer ID associated with the given string ID.
-  int64_t Get(const std::string &string_id);
+  int64_t Get(const std::string& string_id);
 
   /// Get string ID associated with an existing integer ID.
   ///
@@ -50,12 +50,12 @@ class StringIdMap {
   /// \param max_id The number of unique possible ids. This is used
   ///               to force collisions for testing. If -1, it is not used.
   /// \return The integer ID associated with string ID string_id.
-  int64_t Insert(const std::string &string_id, uint8_t num_ids = 0);
+  int64_t Insert(const std::string& string_id, uint8_t num_ids = 0);
 
   /// Delete an ID identified by its string format.
   ///
   /// \param ID to be deleted.
-  void Remove(const std::string &string_id);
+  void Remove(const std::string& string_id);
 
   /// Delete an ID identified by its integer format.
   ///

--- a/src/ray/raylet/scheduling_policy.h
+++ b/src/ray/raylet/scheduling_policy.h
@@ -34,7 +34,7 @@ class SchedulingPolicy {
   /// \param scheduling_queue: reference to a scheduler queues object for access to
   /// tasks.
   /// \return Void.
-  SchedulingPolicy(const SchedulingQueue &scheduling_queue);
+  SchedulingPolicy(const SchedulingQueue& scheduling_queue);
 
   /// \brief Perform a scheduling operation, given a set of cluster resources and
   /// producing a mapping of tasks to raylets.
@@ -47,8 +47,8 @@ class SchedulingPolicy {
   /// SchedulingPolicy object.
   /// \return Scheduling decision, mapping tasks to raylets for placement.
   std::unordered_map<TaskID, ClientID> Schedule(
-      std::unordered_map<ClientID, SchedulingResources> &cluster_resources,
-      const ClientID &local_client_id);
+      std::unordered_map<ClientID, SchedulingResources>& cluster_resources,
+      const ClientID& local_client_id);
 
   /// \param cluster_resources: a set of cluster resources containing resource and load
   /// information for some subset of the cluster.
@@ -58,8 +58,8 @@ class SchedulingPolicy {
   /// need. \return If this bundle can be scheduled in this node, return true; else return
   /// false.
   bool ScheduleBundle(
-      std::unordered_map<ClientID, SchedulingResources> &cluster_resources,
-      const ClientID &local_client_id, const ray::BundleSpecification &bundle_spec);
+      std::unordered_map<ClientID, SchedulingResources>& cluster_resources,
+      const ClientID& local_client_id, const ray::BundleSpecification& bundle_spec);
 
   /// \brief Given a set of cluster resources perform a spill-over scheduling operation.
   ///
@@ -68,14 +68,14 @@ class SchedulingPolicy {
   /// placement map, the corresponding SchedulingResources::resources_load_ is
   /// incremented by the aggregate resource demand of the tasks assigned to it.
   /// \return Scheduling decision, mapping tasks to raylets for placement.
-  std::vector<TaskID> SpillOver(SchedulingResources &remote_scheduling_resources) const;
+  std::vector<TaskID> SpillOver(SchedulingResources& remote_scheduling_resources) const;
 
   /// \brief SchedulingPolicy destructor.
   virtual ~SchedulingPolicy();
 
  private:
   /// An immutable reference to the scheduling task queues.
-  const SchedulingQueue &scheduling_queue_;
+  const SchedulingQueue& scheduling_queue_;
   /// Internally maintained random number generator.
   std::mt19937_64 gen_;
 };

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -21,25 +21,25 @@
 
 namespace {
 
-static constexpr const char *task_state_strings[] = {
+static constexpr const char* task_state_strings[] = {
     "placeable", "waiting",    "ready",
     "running",   "infeasible", "waiting for actor creation",
     "swap"};
-static_assert(sizeof(task_state_strings) / sizeof(const char *) ==
+static_assert(sizeof(task_state_strings) / sizeof(const char*) ==
                   static_cast<int>(ray::raylet::TaskState::kNumTaskQueues),
               "Must specify a TaskState name for every task queue");
 
-inline const char *GetTaskStateString(ray::raylet::TaskState task_state) {
+inline const char* GetTaskStateString(ray::raylet::TaskState task_state) {
   return task_state_strings[static_cast<int>(task_state)];
 }
 
 // Helper function to get tasks for a job from a given state.
 template <typename TaskQueue>
-inline void GetTasksForJobFromQueue(const TaskQueue &queue, const ray::JobID &job_id,
-                                    std::unordered_set<ray::TaskID> &task_ids) {
-  const auto &tasks = queue.GetTasks();
-  for (const auto &task : tasks) {
-    auto const &spec = task.GetTaskSpecification();
+inline void GetTasksForJobFromQueue(const TaskQueue& queue, const ray::JobID& job_id,
+                                    std::unordered_set<ray::TaskID>& task_ids) {
+  const auto& tasks = queue.GetTasks();
+  for (const auto& task : tasks) {
+    auto const& spec = task.GetTaskSpecification();
     if (job_id == spec.JobId()) {
       task_ids.insert(spec.TaskId());
     }
@@ -48,11 +48,11 @@ inline void GetTasksForJobFromQueue(const TaskQueue &queue, const ray::JobID &jo
 
 // Helper function to get tasks for an actor from a given state.
 template <typename TaskQueue>
-inline void GetActorTasksFromQueue(const TaskQueue &queue, const ray::ActorID &actor_id,
-                                   std::unordered_set<ray::TaskID> &task_ids) {
-  const auto &tasks = queue.GetTasks();
-  for (const auto &task : tasks) {
-    auto const &spec = task.GetTaskSpecification();
+inline void GetActorTasksFromQueue(const TaskQueue& queue, const ray::ActorID& actor_id,
+                                   std::unordered_set<ray::TaskID>& task_ids) {
+  const auto& tasks = queue.GetTasks();
+  for (const auto& task : tasks) {
+    auto const& spec = task.GetTaskSpecification();
     if (spec.IsActorTask() && actor_id == spec.ActorId()) {
       task_ids.insert(spec.TaskId());
     }
@@ -65,7 +65,7 @@ namespace ray {
 
 namespace raylet {
 
-bool TaskQueue::AppendTask(const TaskID &task_id, const Task &task) {
+bool TaskQueue::AppendTask(const TaskID& task_id, const Task& task) {
   RAY_CHECK(task_map_.find(task_id) == task_map_.end());
   auto list_iterator = task_list_.insert(task_list_.end(), task);
   task_map_[task_id] = list_iterator;
@@ -75,7 +75,7 @@ bool TaskQueue::AppendTask(const TaskID &task_id, const Task &task) {
   return true;
 }
 
-bool TaskQueue::RemoveTask(const TaskID &task_id, std::vector<Task> *removed_tasks) {
+bool TaskQueue::RemoveTask(const TaskID& task_id, std::vector<Task>* removed_tasks) {
   auto task_found_iterator = task_map_.find(task_id);
   if (task_found_iterator == task_map_.end()) {
     return false;
@@ -98,60 +98,60 @@ bool TaskQueue::RemoveTask(const TaskID &task_id, std::vector<Task> *removed_tas
   return true;
 }
 
-bool TaskQueue::HasTask(const TaskID &task_id) const {
+bool TaskQueue::HasTask(const TaskID& task_id) const {
   return task_map_.find(task_id) != task_map_.end();
 }
 
-const std::list<Task> &TaskQueue::GetTasks() const { return task_list_; }
+const std::list<Task>& TaskQueue::GetTasks() const { return task_list_; }
 
-const Task &TaskQueue::GetTask(const TaskID &task_id) const {
+const Task& TaskQueue::GetTask(const TaskID& task_id) const {
   auto it = task_map_.find(task_id);
   RAY_CHECK(it != task_map_.end());
   return *it->second;
 }
 
-const ResourceSet &TaskQueue::GetTotalResourceLoad() const {
+const ResourceSet& TaskQueue::GetTotalResourceLoad() const {
   return total_resource_load_;
 }
 
-const std::unordered_map<SchedulingClass, uint64_t> &TaskQueue::GetResourceLoadByShape()
+const std::unordered_map<SchedulingClass, uint64_t>& TaskQueue::GetResourceLoadByShape()
     const {
   return resource_load_by_shape_;
 }
 
-bool ReadyQueue::AppendTask(const TaskID &task_id, const Task &task) {
-  const auto &scheduling_class = task.GetTaskSpecification().GetSchedulingClass();
+bool ReadyQueue::AppendTask(const TaskID& task_id, const Task& task) {
+  const auto& scheduling_class = task.GetTaskSpecification().GetSchedulingClass();
   tasks_by_class_[scheduling_class].push_back(task_id);
   return TaskQueue::AppendTask(task_id, task);
 }
 
-bool ReadyQueue::RemoveTask(const TaskID &task_id, std::vector<Task> *removed_tasks) {
+bool ReadyQueue::RemoveTask(const TaskID& task_id, std::vector<Task>* removed_tasks) {
   if (task_map_.find(task_id) != task_map_.end()) {
-    const auto &scheduling_class =
+    const auto& scheduling_class =
         task_map_[task_id]->GetTaskSpecification().GetSchedulingClass();
     tasks_by_class_[scheduling_class].erase(task_id);
   }
   return TaskQueue::RemoveTask(task_id, removed_tasks);
 }
 
-const std::unordered_map<SchedulingClass, ordered_set<TaskID>>
-    &ReadyQueue::GetTasksByClass() const {
+const std::unordered_map<SchedulingClass, ordered_set<TaskID>>&
+ReadyQueue::GetTasksByClass() const {
   return tasks_by_class_;
 }
 
-const std::list<Task> &SchedulingQueue::GetTasks(TaskState task_state) const {
-  const auto &queue = GetTaskQueue(task_state);
+const std::list<Task>& SchedulingQueue::GetTasks(TaskState task_state) const {
+  const auto& queue = GetTaskQueue(task_state);
   return queue->GetTasks();
 }
 
-const std::unordered_map<SchedulingClass, ordered_set<TaskID>>
-    &SchedulingQueue::GetReadyTasksByClass() const {
+const std::unordered_map<SchedulingClass, ordered_set<TaskID>>&
+SchedulingQueue::GetReadyTasksByClass() const {
   return ready_queue_->GetTasksByClass();
 }
 
-const Task &SchedulingQueue::GetTaskOfState(const TaskID &task_id,
+const Task& SchedulingQueue::GetTaskOfState(const TaskID& task_id,
                                             TaskState task_state) const {
-  const auto &queue = GetTaskQueue(task_state);
+  const auto& queue = GetTaskQueue(task_state);
   return queue->GetTask(task_id);
 }
 
@@ -207,12 +207,12 @@ rpc::ResourceLoad SchedulingQueue::GetResourceLoadByShape(int64_t max_shapes) co
 
   // Set the resource shapes.
   rpc::ResourceLoad load_proto;
-  for (auto &demand : load) {
+  for (auto& demand : load) {
     auto demand_proto = load_proto.add_resource_demands();
     demand_proto->Swap(&demand.second);
-    const auto &resource_map =
+    const auto& resource_map =
         TaskSpecification::GetSchedulingClassDescriptor(demand.first).GetResourceMap();
-    for (const auto &resource_pair : resource_map) {
+    for (const auto& resource_pair : resource_map) {
       (*demand_proto->mutable_shape())[resource_pair.first] = resource_pair.second;
     }
   }
@@ -220,13 +220,13 @@ rpc::ResourceLoad SchedulingQueue::GetResourceLoadByShape(int64_t max_shapes) co
   return load_proto;
 }
 
-const std::unordered_set<TaskID> &SchedulingQueue::GetBlockedTaskIds() const {
+const std::unordered_set<TaskID>& SchedulingQueue::GetBlockedTaskIds() const {
   return blocked_task_ids_;
 }
 
-void SchedulingQueue::FilterStateFromQueue(std::unordered_set<ray::TaskID> &task_ids,
+void SchedulingQueue::FilterStateFromQueue(std::unordered_set<ray::TaskID>& task_ids,
                                            TaskState task_state) const {
-  auto &queue = GetTaskQueue(task_state);
+  auto& queue = GetTaskQueue(task_state);
   for (auto it = task_ids.begin(); it != task_ids.end();) {
     if (queue->HasTask(*it)) {
       it = task_ids.erase(it);
@@ -236,7 +236,7 @@ void SchedulingQueue::FilterStateFromQueue(std::unordered_set<ray::TaskID> &task
   }
 }
 
-void SchedulingQueue::FilterState(std::unordered_set<TaskID> &task_ids,
+void SchedulingQueue::FilterState(std::unordered_set<TaskID>& task_ids,
                                   TaskState filter_state) const {
   switch (filter_state) {
   case TaskState::PLACEABLE:
@@ -286,7 +286,7 @@ void SchedulingQueue::FilterState(std::unordered_set<TaskID> &task_ids,
   }
 }
 
-const std::shared_ptr<TaskQueue> &SchedulingQueue::GetTaskQueue(
+const std::shared_ptr<TaskQueue>& SchedulingQueue::GetTaskQueue(
     TaskState task_state) const {
   RAY_CHECK(task_state < TaskState::kNumTaskQueues)
       << static_cast<int>(task_state) << "Task state " << static_cast<int>(task_state)
@@ -297,11 +297,11 @@ const std::shared_ptr<TaskQueue> &SchedulingQueue::GetTaskQueue(
 // Helper function to remove tasks in the given set of task_ids from a
 // queue, and append them to the given vector removed_tasks.
 void SchedulingQueue::RemoveTasksFromQueue(ray::raylet::TaskState task_state,
-                                           std::unordered_set<ray::TaskID> &task_ids,
-                                           std::vector<ray::Task> *removed_tasks) {
-  auto &queue = GetTaskQueue(task_state);
+                                           std::unordered_set<ray::TaskID>& task_ids,
+                                           std::vector<ray::Task>* removed_tasks) {
+  auto& queue = GetTaskQueue(task_state);
   for (auto it = task_ids.begin(); it != task_ids.end();) {
-    const auto &task_id = *it;
+    const auto& task_id = *it;
     if (queue->RemoveTask(task_id, removed_tasks)) {
       RAY_LOG(DEBUG) << "Removed task " << task_id << " from "
                      << GetTaskStateString(task_state) << " queue";
@@ -316,11 +316,11 @@ void SchedulingQueue::RemoveTasksFromQueue(ray::raylet::TaskState task_state,
   }
 }
 
-std::vector<Task> SchedulingQueue::RemoveTasks(std::unordered_set<TaskID> &task_ids) {
+std::vector<Task> SchedulingQueue::RemoveTasks(std::unordered_set<TaskID>& task_ids) {
   // List of removed tasks to be returned.
   std::vector<Task> removed_tasks;
   // Try to find the tasks to remove from the queues.
-  for (const auto &task_state : {
+  for (const auto& task_state : {
            TaskState::PLACEABLE,
            TaskState::WAITING,
            TaskState::READY,
@@ -336,12 +336,12 @@ std::vector<Task> SchedulingQueue::RemoveTasks(std::unordered_set<TaskID> &task_
   return removed_tasks;
 }
 
-bool SchedulingQueue::RemoveTask(const TaskID &task_id, Task *removed_task,
-                                 TaskState *removed_task_state) {
+bool SchedulingQueue::RemoveTask(const TaskID& task_id, Task* removed_task,
+                                 TaskState* removed_task_state) {
   std::vector<Task> removed_tasks;
   std::unordered_set<TaskID> task_id_set = {task_id};
   // Try to find the task to remove in the queues.
-  for (const auto &task_state : {
+  for (const auto& task_state : {
            TaskState::PLACEABLE,
            TaskState::WAITING,
            TaskState::READY,
@@ -374,7 +374,7 @@ bool SchedulingQueue::RemoveTask(const TaskID &task_id, Task *removed_task,
   return false;
 }
 
-void SchedulingQueue::MoveTasks(std::unordered_set<TaskID> &task_ids, TaskState src_state,
+void SchedulingQueue::MoveTasks(std::unordered_set<TaskID>& task_ids, TaskState src_state,
                                 TaskState dst_state) {
   std::vector<Task> removed_tasks;
 
@@ -432,9 +432,9 @@ void SchedulingQueue::MoveTasks(std::unordered_set<TaskID> &task_ids, TaskState 
   }
 }
 
-void SchedulingQueue::QueueTasks(const std::vector<Task> &tasks, TaskState task_state) {
-  auto &queue = GetTaskQueue(task_state);
-  for (const auto &task : tasks) {
+void SchedulingQueue::QueueTasks(const std::vector<Task>& tasks, TaskState task_state) {
+  auto& queue = GetTaskQueue(task_state);
+  for (const auto& task : tasks) {
     RAY_LOG(DEBUG) << "Added task " << task.GetTaskSpecification().TaskId() << " to "
                    << GetTaskStateString(task_state) << " queue";
     if (task_state == TaskState::RUNNING) {
@@ -444,8 +444,8 @@ void SchedulingQueue::QueueTasks(const std::vector<Task> &tasks, TaskState task_
   }
 }
 
-bool SchedulingQueue::HasTask(const TaskID &task_id) const {
-  for (const auto &task_queue : task_queues_) {
+bool SchedulingQueue::HasTask(const TaskID& task_id) const {
+  for (const auto& task_queue : task_queues_) {
     if (task_queue->HasTask(task_id)) {
       return true;
     }
@@ -453,20 +453,20 @@ bool SchedulingQueue::HasTask(const TaskID &task_id) const {
   return false;
 }
 
-std::unordered_set<TaskID> SchedulingQueue::GetTaskIdsForJob(const JobID &job_id) const {
+std::unordered_set<TaskID> SchedulingQueue::GetTaskIdsForJob(const JobID& job_id) const {
   std::unordered_set<TaskID> task_ids;
-  for (const auto &task_queue : task_queues_) {
+  for (const auto& task_queue : task_queues_) {
     GetTasksForJobFromQueue(*task_queue, job_id, task_ids);
   }
   return task_ids;
 }
 
 std::unordered_set<TaskID> SchedulingQueue::GetTaskIdsForActor(
-    const ActorID &actor_id) const {
+    const ActorID& actor_id) const {
   std::unordered_set<TaskID> task_ids;
   int swap = static_cast<int>(TaskState::SWAP);
   int i = 0;
-  for (const auto &task_queue : task_queues_) {
+  for (const auto& task_queue : task_queues_) {
     // This is a hack to make sure that we don't remove tasks from the SWAP
     // queue, since these are always guaranteed to be removed and eventually
     // resubmitted if necessary by the node manager.
@@ -478,35 +478,35 @@ std::unordered_set<TaskID> SchedulingQueue::GetTaskIdsForActor(
   return task_ids;
 }
 
-void SchedulingQueue::AddBlockedTaskId(const TaskID &task_id) {
+void SchedulingQueue::AddBlockedTaskId(const TaskID& task_id) {
   RAY_LOG(DEBUG) << "Added blocked task " << task_id;
   auto inserted = blocked_task_ids_.insert(task_id);
   RAY_CHECK(inserted.second);
 }
 
-void SchedulingQueue::RemoveBlockedTaskId(const TaskID &task_id) {
+void SchedulingQueue::RemoveBlockedTaskId(const TaskID& task_id) {
   RAY_LOG(DEBUG) << "Removed blocked task " << task_id;
   auto erased = blocked_task_ids_.erase(task_id);
   RAY_CHECK(erased == 1);
 }
 
-void SchedulingQueue::AddDriverTaskId(const TaskID &task_id) {
+void SchedulingQueue::AddDriverTaskId(const TaskID& task_id) {
   RAY_LOG(DEBUG) << "Added driver task " << task_id;
   auto inserted = driver_task_ids_.insert(task_id);
   RAY_CHECK(inserted.second);
 }
 
-void SchedulingQueue::RemoveDriverTaskId(const TaskID &task_id) {
+void SchedulingQueue::RemoveDriverTaskId(const TaskID& task_id) {
   RAY_LOG(DEBUG) << "Removed driver task " << task_id;
   auto erased = driver_task_ids_.erase(task_id);
   RAY_CHECK(erased == 1);
 }
 
-const std::unordered_set<TaskID> &SchedulingQueue::GetDriverTaskIds() const {
+const std::unordered_set<TaskID>& SchedulingQueue::GetDriverTaskIds() const {
   return driver_task_ids_;
 }
 
-int SchedulingQueue::NumRunning(const SchedulingClass &cls) const {
+int SchedulingQueue::NumRunning(const SchedulingClass& cls) const {
   auto it = num_running_tasks_.find(cls);
   if (it == num_running_tasks_.end()) {
     return 0;
@@ -526,7 +526,7 @@ std::string SchedulingQueue::DebugString() const {
   result << "\n- num tasks blocked: " << blocked_task_ids_.size();
   result << "\nScheduledTaskCounts:";
   size_t total = 0;
-  for (const auto &pair : num_running_tasks_) {
+  for (const auto& pair : num_running_tasks_) {
     result << "\n- ";
     auto desc = TaskSpecification::GetSchedulingClassDescriptor(pair.first);
     result << desc.ToString();

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -78,7 +78,7 @@ class TaskQueue {
   /// \param task_id The task ID for the task to append.
   /// \param task The task to append to the queue.
   /// \return Whether the append operation succeeds.
-  virtual bool AppendTask(const TaskID &task_id, const Task &task);
+  virtual bool AppendTask(const TaskID& task_id, const Task& task);
 
   /// \brief Remove a task from queue.
   ///
@@ -87,36 +87,36 @@ class TaskQueue {
   ///  removed from the queue, the task data is appended to the vector. Can
   ///  be a nullptr, in which case nothing is appended.
   /// \return Whether the removal succeeds.
-  virtual bool RemoveTask(const TaskID &task_id,
-                          std::vector<Task> *removed_tasks = nullptr);
+  virtual bool RemoveTask(const TaskID& task_id,
+                          std::vector<Task>* removed_tasks = nullptr);
 
   /// \brief Check if the queue contains a specific task id.
   ///
   /// \param task_id The task ID for the task.
   /// \return Whether the task_id exists in this queue.
-  bool HasTask(const TaskID &task_id) const;
+  bool HasTask(const TaskID& task_id) const;
 
   /// \brief Return the task list of the queue.
   ///
   /// \return A list of tasks contained in this queue.
-  const std::list<Task> &GetTasks() const;
+  const std::list<Task>& GetTasks() const;
 
   /// Get a task from the queue. The caller must ensure that the task is in
   /// the queue.
   ///
   /// \return The task.
-  const Task &GetTask(const TaskID &task_id) const;
+  const Task& GetTask(const TaskID& task_id) const;
 
   /// \brief Return all resource demand associated with the ready queue.
   ///
   /// \return Aggregate resource demand from ready tasks.
-  const ResourceSet &GetTotalResourceLoad() const;
+  const ResourceSet& GetTotalResourceLoad() const;
 
   /// \brief Get the resources required by the tasks in the queue.
   ///
   /// \return A map from resource shape key to the number of tasks queued that
   /// require that shape.
-  const std::unordered_map<SchedulingClass, uint64_t> &GetResourceLoadByShape() const;
+  const std::unordered_map<SchedulingClass, uint64_t>& GetResourceLoadByShape() const;
 
  protected:
   /// A list of tasks.
@@ -135,7 +135,7 @@ class ReadyQueue : public TaskQueue {
  public:
   ReadyQueue(){};
 
-  ReadyQueue(const ReadyQueue &other) = delete;
+  ReadyQueue(const ReadyQueue& other) = delete;
 
   /// ReadyQueue destructor.
   virtual ~ReadyQueue() {}
@@ -145,18 +145,18 @@ class ReadyQueue : public TaskQueue {
   /// \param task_id The task ID for the task to append.
   /// \param task The task to append to the queue.
   /// \return Whether the append operation succeeds.
-  bool AppendTask(const TaskID &task_id, const Task &task) override;
+  bool AppendTask(const TaskID& task_id, const Task& task) override;
 
   /// \brief Remove a task from queue.
   ///
   /// \param task_id The task ID for the task to remove from the queue.
   /// \return Whether the removal succeeds.
-  bool RemoveTask(const TaskID &task_id, std::vector<Task> *removed_tasks) override;
+  bool RemoveTask(const TaskID& task_id, std::vector<Task>* removed_tasks) override;
 
   /// \brief Get a mapping from resource shape to tasks.
   ///
   /// \return Mapping from resource set to task IDs with these resource requirements.
-  const std::unordered_map<SchedulingClass, ordered_set<TaskID>> &GetTasksByClass() const;
+  const std::unordered_map<SchedulingClass, ordered_set<TaskID>>& GetTasksByClass() const;
 
  private:
   /// Index from task description to tasks queued of that type.
@@ -171,7 +171,7 @@ class SchedulingQueue {
  public:
   /// Create a scheduling queue.
   SchedulingQueue() : ready_queue_(std::make_shared<ReadyQueue>()) {
-    for (const auto &task_state : {
+    for (const auto& task_state : {
              TaskState::PLACEABLE,
              TaskState::WAITING,
              TaskState::READY,
@@ -195,18 +195,18 @@ class SchedulingQueue {
   ///
   /// \param task_id The task ID for the task.
   /// \return Whether the task_id exists in the queue.
-  bool HasTask(const TaskID &task_id) const;
+  bool HasTask(const TaskID& task_id) const;
 
   /// \brief Get all tasks in the given state.
   ///
   /// \param task_state The requested task state. This must correspond to one
   /// of the task queues (has value < TaskState::kNumTaskQueues).
-  const std::list<Task> &GetTasks(TaskState task_state) const;
+  const std::list<Task>& GetTasks(TaskState task_state) const;
 
   /// Get a reference to the queue of ready tasks.
   ///
   /// \return A reference to the queue of ready tasks.
-  const std::unordered_map<SchedulingClass, ordered_set<TaskID>> &GetReadyTasksByClass()
+  const std::unordered_map<SchedulingClass, ordered_set<TaskID>>& GetReadyTasksByClass()
       const;
 
   /// Get a task from the queue of a given state. The caller must ensure that
@@ -215,7 +215,7 @@ class SchedulingQueue {
   /// \param task_id The task to get.
   /// \param task_state The state that the requested task should be in.
   /// \return The task.
-  const Task &GetTaskOfState(const TaskID &task_id, TaskState task_state) const;
+  const Task& GetTaskOfState(const TaskID& task_id, TaskState task_state) const;
 
   /// \brief Return an aggregate resource set for all tasks exerting load on this raylet.
   ///
@@ -237,13 +237,13 @@ class SchedulingQueue {
   /// tasks that were explicitly assigned to a worker by us, as well as tasks
   /// that were created out-of-band (e.g., the application created
   // multiple threads) are only BLOCKED.
-  const std::unordered_set<TaskID> &GetBlockedTaskIds() const;
+  const std::unordered_set<TaskID>& GetBlockedTaskIds() const;
 
   /// Get the set of driver task IDs.
   ///
   /// \return A const reference to the set of driver task IDs. These are empty
   /// tasks used to represent drivers.
-  const std::unordered_set<TaskID> &GetDriverTaskIds() const;
+  const std::unordered_set<TaskID>& GetDriverTaskIds() const;
 
   /// Remove tasks from the task queue.
   ///
@@ -251,7 +251,7 @@ class SchedulingQueue {
   /// corresponding tasks must be contained in the queue. The IDs of removed
   /// tasks will be erased from the set.
   /// \return A vector of the tasks that were removed.
-  std::vector<Task> RemoveTasks(std::unordered_set<TaskID> &task_ids);
+  std::vector<Task> RemoveTasks(std::unordered_set<TaskID>& task_ids);
 
   /// Remove a task from the task queue.
   ///
@@ -261,13 +261,13 @@ class SchedulingQueue {
   /// \param task_state If this is not nullptr, then the state of the removed
   /// task will be written here.
   /// \return true if the task was removed, false if it is not in the queue.
-  bool RemoveTask(const TaskID &task_id, Task *removed_task,
-                  TaskState *removed_task_state = nullptr);
+  bool RemoveTask(const TaskID& task_id, Task* removed_task,
+                  TaskState* removed_task_state = nullptr);
 
   /// Remove a driver task ID. This is an empty task used to represent a driver.
   ///
   /// \param The driver task ID to remove.
-  void RemoveDriverTaskId(const TaskID &task_id);
+  void RemoveDriverTaskId(const TaskID& task_id);
 
   /// Add tasks to the given queue.
   ///
@@ -275,26 +275,26 @@ class SchedulingQueue {
   /// \param task_state The state of the tasks to queue. The requested task
   /// state must correspond to one of the task queues (has value <
   /// TaskState::kNumTaskQueues).
-  void QueueTasks(const std::vector<Task> &tasks, TaskState task_state);
+  void QueueTasks(const std::vector<Task>& tasks, TaskState task_state);
 
   /// Add a task ID in the blocked state. These are tasks that have been
   /// dispatched to a worker but are blocked on a data dependency that was
   /// discovered to be missing at runtime.
   ///
   /// \param task_id The task to mark as blocked.
-  void AddBlockedTaskId(const TaskID &task_id);
+  void AddBlockedTaskId(const TaskID& task_id);
 
   /// Remove a task ID in the blocked state. These are tasks that have been
   /// dispatched to a worker but were blocked on a data dependency that was
   /// discovered to be missing at runtime.
   ///
   /// \param task_id The task to mark as unblocked.
-  void RemoveBlockedTaskId(const TaskID &task_id);
+  void RemoveBlockedTaskId(const TaskID& task_id);
 
   /// Add a driver task ID. This is an empty task used to represent a driver.
   ///
   /// \param The driver task ID to add.
-  void AddDriverTaskId(const TaskID &task_id);
+  void AddDriverTaskId(const TaskID& task_id);
 
   /// \brief Move the specified tasks from the source state to the destination
   /// state.
@@ -305,7 +305,7 @@ class SchedulingQueue {
   /// task queues.
   /// \param dst_state Destination state, corresponding to one of the internal
   /// task queues.
-  void MoveTasks(std::unordered_set<TaskID> &tasks, TaskState src_state,
+  void MoveTasks(std::unordered_set<TaskID>& tasks, TaskState src_state,
                  TaskState dst_state);
 
   /// \brief Filter out task IDs based on their scheduling state.
@@ -313,24 +313,24 @@ class SchedulingQueue {
   /// \param task_ids The set of task IDs to filter. All tasks that have the
   /// given filter_state will be removed from this set.
   /// \param filter_state The task state to filter out.
-  void FilterState(std::unordered_set<TaskID> &task_ids, TaskState filter_state) const;
+  void FilterState(std::unordered_set<TaskID>& task_ids, TaskState filter_state) const;
 
   /// \brief Get all the task IDs for a job.
   ///
   /// \param job_id All the tasks that have the given job_id are returned.
   /// \return All the tasks that have the given job ID.
-  std::unordered_set<TaskID> GetTaskIdsForJob(const JobID &job_id) const;
+  std::unordered_set<TaskID> GetTaskIdsForJob(const JobID& job_id) const;
 
   /// \brief Get all the task IDs for an actor.
   ///
   /// \param actor_id All the tasks that have the given actor_id are returned.
   /// \return All the tasks that have the given actor ID.
-  std::unordered_set<TaskID> GetTaskIdsForActor(const ActorID &actor_id) const;
+  std::unordered_set<TaskID> GetTaskIdsForActor(const ActorID& actor_id) const;
 
   /// Returns the number of running tasks in this class.
   ///
   /// \return int.
-  int NumRunning(const SchedulingClass &cls) const;
+  int NumRunning(const SchedulingClass& cls) const;
 
   /// Returns debug string for class.
   ///
@@ -344,19 +344,19 @@ class SchedulingQueue {
   /// Get the task queue in the given state. The requested task state must
   /// correspond to one of the task queues (has value <
   /// TaskState::kNumTaskQueues).
-  const std::shared_ptr<TaskQueue> &GetTaskQueue(TaskState task_state) const;
+  const std::shared_ptr<TaskQueue>& GetTaskQueue(TaskState task_state) const;
 
   /// A helper function to remove tasks from a given queue. The requested task
   /// state must correspond to one of the task queues (has value <
   /// TaskState::kNumTaskQueues).
   void RemoveTasksFromQueue(ray::raylet::TaskState task_state,
-                            std::unordered_set<ray::TaskID> &task_ids,
-                            std::vector<ray::Task> *removed_tasks);
+                            std::unordered_set<ray::TaskID>& task_ids,
+                            std::vector<ray::Task>* removed_tasks);
 
   /// A helper function to filter out tasks of a given state from the set of
   /// task IDs. The requested task state must correspond to one of the task
   /// queues (has value < TaskState::kNumTaskQueues).
-  void FilterStateFromQueue(std::unordered_set<ray::TaskID> &task_ids,
+  void FilterStateFromQueue(std::unordered_set<ray::TaskID>& task_ids,
                             TaskState task_state) const;
 
   // A pointer to the ready queue.

--- a/src/ray/raylet/task_dependency_manager.h
+++ b/src/ray/raylet/task_dependency_manager.h
@@ -43,9 +43,9 @@ class ReconstructionPolicy;
 class TaskDependencyManager {
  public:
   /// Create a task dependency manager.
-  TaskDependencyManager(ObjectManagerInterface &object_manager,
-                        ReconstructionPolicyInterface &reconstruction_policy,
-                        boost::asio::io_service &io_service, const ClientID &client_id,
+  TaskDependencyManager(ObjectManagerInterface& object_manager,
+                        ReconstructionPolicyInterface& reconstruction_policy,
+                        boost::asio::io_service& io_service, const ClientID& client_id,
                         int64_t initial_lease_period_ms,
                         std::shared_ptr<gcs::GcsClient> gcs_client);
 
@@ -53,7 +53,7 @@ class TaskDependencyManager {
   ///
   /// \param object_id The object to check for.
   /// \return Whether the object is local.
-  bool CheckObjectLocal(const ObjectID &object_id) const;
+  bool CheckObjectLocal(const ObjectID& object_id) const;
 
   /// Subscribe to object depedencies required by the task and check whether
   /// all dependencies are fulfilled. This should be called for task arguments and
@@ -72,7 +72,7 @@ class TaskDependencyManager {
   /// \return Whether all of the given dependencies for the given task are
   /// local.
   bool SubscribeGetDependencies(
-      const TaskID &task_id, const std::vector<rpc::ObjectReference> &required_objects);
+      const TaskID& task_id, const std::vector<rpc::ObjectReference>& required_objects);
 
   /// Subscribe to object depedencies required by the worker. This should be called for
   /// ray.wait calls during task execution.
@@ -87,8 +87,8 @@ class TaskDependencyManager {
   /// \param required_objects The objects required by the worker.
   /// \return Void.
   void SubscribeWaitDependencies(
-      const WorkerID &worker_id,
-      const std::vector<rpc::ObjectReference> &required_objects);
+      const WorkerID& worker_id,
+      const std::vector<rpc::ObjectReference>& required_objects);
 
   /// Unsubscribe from the object dependencies required by this task through the task
   /// arguments or `ray.get`. If the objects were remote and are no longer required by any
@@ -96,7 +96,7 @@ class TaskDependencyManager {
   ///
   /// \param task_id The ID of the task whose dependencies we should unsubscribe from.
   /// \return Whether the task was subscribed before.
-  bool UnsubscribeGetDependencies(const TaskID &task_id);
+  bool UnsubscribeGetDependencies(const TaskID& task_id);
 
   /// Unsubscribe from the object dependencies required by this worker through `ray.wait`.
   /// If the objects were remote and are no longer required by any subscribed task, then
@@ -104,14 +104,14 @@ class TaskDependencyManager {
   ///
   /// \param worker_id The ID of the worker whose dependencies we should unsubscribe from.
   /// \return The objects that the worker was waiting on.
-  void UnsubscribeWaitDependencies(const WorkerID &worker_id);
+  void UnsubscribeWaitDependencies(const WorkerID& worker_id);
 
   /// Mark that the given task is pending execution. Any objects that it creates
   /// are now considered to be pending creation. If there are any subscribed
   /// tasks that depend on these objects, then the objects will be canceled.
   ///
   /// \param task The task that is pending execution.
-  void TaskPending(const Task &task);
+  void TaskPending(const Task& task);
 
   /// Mark that the given task is no longer pending execution. Any objects that
   /// it creates that are not already local are now considered to be remote. If
@@ -119,7 +119,7 @@ class TaskDependencyManager {
   /// objects will be requested.
   ///
   /// \param task_id The ID of the task to cancel.
-  void TaskCanceled(const TaskID &task_id);
+  void TaskCanceled(const TaskID& task_id);
 
   /// Handle an object becoming locally available. If there are any subscribed
   /// tasks that depend on this object, then the object will be canceled.
@@ -129,7 +129,7 @@ class TaskDependencyManager {
   /// \return A list of task IDs. This contains all subscribed tasks that now
   /// have all of their dependencies fulfilled, once this object was made
   /// local.
-  std::vector<TaskID> HandleObjectLocal(const ray::ObjectID &object_id);
+  std::vector<TaskID> HandleObjectLocal(const ray::ObjectID& object_id);
 
   /// Handle an object that is no longer locally available. If there are any
   /// subscribed tasks that depend on this object, then the object will be
@@ -140,7 +140,7 @@ class TaskDependencyManager {
   /// \return A list of task IDs. This contains all subscribed tasks that
   /// previously had all of their dependencies fulfilled, but are now missing
   /// this object dependency.
-  std::vector<TaskID> HandleObjectMissing(const ray::ObjectID &object_id);
+  std::vector<TaskID> HandleObjectMissing(const ray::ObjectID& object_id);
 
   /// Get a list of all Tasks currently marked as pending object dependencies in the task
   /// dependency manager.
@@ -154,7 +154,7 @@ class TaskDependencyManager {
   ///
   /// \param task_ids The collection of task IDs. For a given task in this set,
   /// all tasks that depend on the task must also be included in the set.
-  void RemoveTasksAndRelatedObjects(const std::unordered_set<TaskID> &task_ids);
+  void RemoveTasksAndRelatedObjects(const std::unordered_set<TaskID>& task_ids);
 
   /// Returns debug string for class.
   ///
@@ -173,11 +173,11 @@ class TaskDependencyManager {
   /// \param[out] owner_address The address of the object's owner, if
   /// available.
   /// \return True if we have owner information for the object.
-  bool GetOwnerAddress(const ObjectID &object_id, rpc::Address *owner_address) const;
+  bool GetOwnerAddress(const ObjectID& object_id, rpc::Address* owner_address) const;
 
  private:
   struct ObjectDependencies {
-    ObjectDependencies(const rpc::ObjectReference &ref)
+    ObjectDependencies(const rpc::ObjectReference& ref)
         : owner_address(ref.owner_address()) {}
     /// The tasks that depend on this object, either because the object is a task argument
     /// or because the task called `ray.get` on the object.
@@ -209,7 +209,7 @@ class TaskDependencyManager {
   using WorkerDependencies = std::unordered_set<ObjectID>;
 
   struct PendingTask {
-    PendingTask(int64_t initial_lease_period_ms, boost::asio::io_service &io_service)
+    PendingTask(int64_t initial_lease_period_ms, boost::asio::io_service& io_service)
         : lease_period(initial_lease_period_ms),
           expires_at(INT64_MAX),
           lease_timer(new boost::asio::deadline_timer(io_service)) {}
@@ -227,29 +227,29 @@ class TaskDependencyManager {
   /// transfer or reconstruction. These are objects for which: (1) there is a
   /// subscribed task dependent on it, (2) the object is not local, and (3) the
   /// task that creates the object is not pending execution locally.
-  bool CheckObjectRequired(const ObjectID &object_id) const;
+  bool CheckObjectRequired(const ObjectID& object_id) const;
   /// If the given object is required, then request that the object be made
   /// available through object transfer or reconstruction.
-  void HandleRemoteDependencyRequired(const ObjectID &object_id);
+  void HandleRemoteDependencyRequired(const ObjectID& object_id);
   /// If the given object is no longer required, then cancel any in-progress
   /// operations to make the object available through object transfer or
   /// reconstruction.
-  void HandleRemoteDependencyCanceled(const ObjectID &object_id);
+  void HandleRemoteDependencyCanceled(const ObjectID& object_id);
   /// Acquire the task lease in the GCS for the given task. This is used to
   /// indicate to other nodes that the task is currently pending on this node.
   /// The task lease has an expiration time. If we do not renew the lease
   /// before that time, then other nodes may choose to execute the task.
-  void AcquireTaskLease(const TaskID &task_id);
+  void AcquireTaskLease(const TaskID& task_id);
 
   /// The object manager, used to fetch required objects from remote nodes.
-  ObjectManagerInterface &object_manager_;
+  ObjectManagerInterface& object_manager_;
   /// The reconstruction policy, used to reconstruct required objects that no
   /// longer exist on any live nodes.
-  ReconstructionPolicyInterface &reconstruction_policy_;
+  ReconstructionPolicyInterface& reconstruction_policy_;
   /// The event loop, used to set timers for renewing task leases. The task
   /// leases are used to indicate which tasks are pending execution on this
   /// node and must be periodically renewed.
-  boost::asio::io_service &io_service_;
+  boost::asio::io_service& io_service_;
   /// This node's GCS client ID, used in the task lease information.
   const ClientID client_id_;
   /// For a given task, the expiration period of the initial task lease that is

--- a/src/ray/raylet/worker.cc
+++ b/src/ray/raylet/worker.cc
@@ -26,10 +26,10 @@ namespace ray {
 namespace raylet {
 
 /// A constructor responsible for initializing the state of a worker.
-Worker::Worker(const WorkerID &worker_id, const Language &language,
-               const std::string &ip_address,
+Worker::Worker(const WorkerID& worker_id, const Language& language,
+               const std::string& ip_address,
                std::shared_ptr<ClientConnection> connection,
-               rpc::ClientCallManager &client_call_manager)
+               rpc::ClientCallManager& client_call_manager)
     : worker_id_(worker_id),
       language_(language),
       ip_address_(ip_address),
@@ -88,36 +88,36 @@ void Worker::Connect(int port) {
       new rpc::CoreWorkerClient(addr, client_call_manager_));
 }
 
-void Worker::AssignTaskId(const TaskID &task_id) { assigned_task_id_ = task_id; }
+void Worker::AssignTaskId(const TaskID& task_id) { assigned_task_id_ = task_id; }
 
-const TaskID &Worker::GetAssignedTaskId() const { return assigned_task_id_; }
+const TaskID& Worker::GetAssignedTaskId() const { return assigned_task_id_; }
 
-bool Worker::AddBlockedTaskId(const TaskID &task_id) {
+bool Worker::AddBlockedTaskId(const TaskID& task_id) {
   auto inserted = blocked_task_ids_.insert(task_id);
   return inserted.second;
 }
 
-bool Worker::RemoveBlockedTaskId(const TaskID &task_id) {
+bool Worker::RemoveBlockedTaskId(const TaskID& task_id) {
   auto erased = blocked_task_ids_.erase(task_id);
   return erased == 1;
 }
 
-const std::unordered_set<TaskID> &Worker::GetBlockedTaskIds() const {
+const std::unordered_set<TaskID>& Worker::GetBlockedTaskIds() const {
   return blocked_task_ids_;
 }
 
-void Worker::AssignJobId(const JobID &job_id) { assigned_job_id_ = job_id; }
+void Worker::AssignJobId(const JobID& job_id) { assigned_job_id_ = job_id; }
 
-const JobID &Worker::GetAssignedJobId() const { return assigned_job_id_; }
+const JobID& Worker::GetAssignedJobId() const { return assigned_job_id_; }
 
-void Worker::AssignActorId(const ActorID &actor_id) {
+void Worker::AssignActorId(const ActorID& actor_id) {
   RAY_CHECK(actor_id_.IsNil())
       << "A worker that is already an actor cannot be assigned an actor ID again.";
   RAY_CHECK(!actor_id.IsNil());
   actor_id_ = actor_id;
 }
 
-const ActorID &Worker::GetActorId() const { return actor_id_; }
+const ActorID& Worker::GetActorId() const { return actor_id_; }
 
 void Worker::MarkDetachedActor() { is_detached_actor_ = true; }
 
@@ -125,24 +125,24 @@ bool Worker::IsDetachedActor() const { return is_detached_actor_; }
 
 const std::shared_ptr<ClientConnection> Worker::Connection() const { return connection_; }
 
-void Worker::SetOwnerAddress(const rpc::Address &address) { owner_address_ = address; }
-const rpc::Address &Worker::GetOwnerAddress() const { return owner_address_; }
+void Worker::SetOwnerAddress(const rpc::Address& address) { owner_address_ = address; }
+const rpc::Address& Worker::GetOwnerAddress() const { return owner_address_; }
 
-const ResourceIdSet &Worker::GetLifetimeResourceIds() const {
+const ResourceIdSet& Worker::GetLifetimeResourceIds() const {
   return lifetime_resource_ids_;
 }
 
 void Worker::ResetLifetimeResourceIds() { lifetime_resource_ids_.Clear(); }
 
-void Worker::SetLifetimeResourceIds(ResourceIdSet &resource_ids) {
+void Worker::SetLifetimeResourceIds(ResourceIdSet& resource_ids) {
   lifetime_resource_ids_ = resource_ids;
 }
 
-const ResourceIdSet &Worker::GetTaskResourceIds() const { return task_resource_ids_; }
+const ResourceIdSet& Worker::GetTaskResourceIds() const { return task_resource_ids_; }
 
 void Worker::ResetTaskResourceIds() { task_resource_ids_.Clear(); }
 
-void Worker::SetTaskResourceIds(ResourceIdSet &resource_ids) {
+void Worker::SetTaskResourceIds(ResourceIdSet& resource_ids) {
   task_resource_ids_ = resource_ids;
 }
 
@@ -155,13 +155,13 @@ ResourceIdSet Worker::ReleaseTaskCpuResources() {
   return cpu_resources;
 }
 
-void Worker::AcquireTaskCpuResources(const ResourceIdSet &cpu_resources) {
+void Worker::AcquireTaskCpuResources(const ResourceIdSet& cpu_resources) {
   // The "release" terminology is a bit confusing here. The resources are being
   // given back to the worker and so "released" by the caller.
   task_resource_ids_.Release(cpu_resources);
 }
 
-Status Worker::AssignTask(const Task &task, const ResourceIdSet &resource_id_set) {
+Status Worker::AssignTask(const Task& task, const ResourceIdSet& resource_id_set) {
   RAY_CHECK(port_ > 0);
   rpc::AssignTaskRequest request;
   request.set_intended_worker_id(worker_id_.Binary());
@@ -171,7 +171,7 @@ Status Worker::AssignTask(const Task &task, const ResourceIdSet &resource_id_set
       task.GetTaskExecutionSpec().GetMessage());
   request.set_resource_ids(resource_id_set.Serialize());
 
-  rpc_client_->AssignTask(request, [](Status status, const rpc::AssignTaskReply &reply) {
+  rpc_client_->AssignTask(request, [](Status status, const rpc::AssignTaskReply& reply) {
     if (!status.ok()) {
       RAY_LOG(DEBUG) << "Worker failed to finish executing task: " << status.ToString();
     }
@@ -188,7 +188,7 @@ void Worker::DirectActorCallArgWaitComplete(int64_t tag) {
   request.set_tag(tag);
   request.set_intended_worker_id(worker_id_.Binary());
   rpc_client_->DirectActorCallArgWaitComplete(
-      request, [](Status status, const rpc::DirectActorCallArgWaitCompleteReply &reply) {
+      request, [](Status status, const rpc::DirectActorCallArgWaitCompleteReply& reply) {
         if (!status.ok()) {
           RAY_LOG(ERROR) << "Failed to send wait complete: " << status.ToString();
         }

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -54,61 +54,61 @@ class WorkerInterface {
   virtual int Port() const = 0;
   virtual int AssignedPort() const = 0;
   virtual void SetAssignedPort(int port) = 0;
-  virtual void AssignTaskId(const TaskID &task_id) = 0;
-  virtual const TaskID &GetAssignedTaskId() const = 0;
-  virtual bool AddBlockedTaskId(const TaskID &task_id) = 0;
-  virtual bool RemoveBlockedTaskId(const TaskID &task_id) = 0;
-  virtual const std::unordered_set<TaskID> &GetBlockedTaskIds() const = 0;
-  virtual void AssignJobId(const JobID &job_id) = 0;
-  virtual const JobID &GetAssignedJobId() const = 0;
-  virtual void AssignActorId(const ActorID &actor_id) = 0;
-  virtual const ActorID &GetActorId() const = 0;
+  virtual void AssignTaskId(const TaskID& task_id) = 0;
+  virtual const TaskID& GetAssignedTaskId() const = 0;
+  virtual bool AddBlockedTaskId(const TaskID& task_id) = 0;
+  virtual bool RemoveBlockedTaskId(const TaskID& task_id) = 0;
+  virtual const std::unordered_set<TaskID>& GetBlockedTaskIds() const = 0;
+  virtual void AssignJobId(const JobID& job_id) = 0;
+  virtual const JobID& GetAssignedJobId() const = 0;
+  virtual void AssignActorId(const ActorID& actor_id) = 0;
+  virtual const ActorID& GetActorId() const = 0;
   virtual void MarkDetachedActor() = 0;
   virtual bool IsDetachedActor() const = 0;
   virtual const std::shared_ptr<ClientConnection> Connection() const = 0;
-  virtual void SetOwnerAddress(const rpc::Address &address) = 0;
-  virtual const rpc::Address &GetOwnerAddress() const = 0;
+  virtual void SetOwnerAddress(const rpc::Address& address) = 0;
+  virtual const rpc::Address& GetOwnerAddress() const = 0;
 
-  virtual const ResourceIdSet &GetLifetimeResourceIds() const = 0;
-  virtual void SetLifetimeResourceIds(ResourceIdSet &resource_ids) = 0;
+  virtual const ResourceIdSet& GetLifetimeResourceIds() const = 0;
+  virtual void SetLifetimeResourceIds(ResourceIdSet& resource_ids) = 0;
   virtual void ResetLifetimeResourceIds() = 0;
 
-  virtual const ResourceIdSet &GetTaskResourceIds() const = 0;
-  virtual void SetTaskResourceIds(ResourceIdSet &resource_ids) = 0;
+  virtual const ResourceIdSet& GetTaskResourceIds() const = 0;
+  virtual void SetTaskResourceIds(ResourceIdSet& resource_ids) = 0;
   virtual void ResetTaskResourceIds() = 0;
   virtual ResourceIdSet ReleaseTaskCpuResources() = 0;
-  virtual void AcquireTaskCpuResources(const ResourceIdSet &cpu_resources) = 0;
+  virtual void AcquireTaskCpuResources(const ResourceIdSet& cpu_resources) = 0;
 
-  virtual Status AssignTask(const Task &task, const ResourceIdSet &resource_id_set) = 0;
+  virtual Status AssignTask(const Task& task, const ResourceIdSet& resource_id_set) = 0;
   virtual void DirectActorCallArgWaitComplete(int64_t tag) = 0;
 
   // Setter, geter, and clear methods  for allocated_instances_.
   virtual void SetAllocatedInstances(
-      std::shared_ptr<TaskResourceInstances> &allocated_instances) = 0;
+      std::shared_ptr<TaskResourceInstances>& allocated_instances) = 0;
 
   virtual std::shared_ptr<TaskResourceInstances> GetAllocatedInstances() = 0;
 
   virtual void ClearAllocatedInstances() = 0;
 
   virtual void SetLifetimeAllocatedInstances(
-      std::shared_ptr<TaskResourceInstances> &allocated_instances) = 0;
+      std::shared_ptr<TaskResourceInstances>& allocated_instances) = 0;
   virtual std::shared_ptr<TaskResourceInstances> GetLifetimeAllocatedInstances() = 0;
 
   virtual void ClearLifetimeAllocatedInstances() = 0;
 
-  virtual void SetBorrowedCPUInstances(std::vector<double> &cpu_instances) = 0;
+  virtual void SetBorrowedCPUInstances(std::vector<double>& cpu_instances) = 0;
 
-  virtual std::vector<double> &GetBorrowedCPUInstances() = 0;
+  virtual std::vector<double>& GetBorrowedCPUInstances() = 0;
 
   virtual void ClearBorrowedCPUInstances() = 0;
 
-  virtual Task &GetAssignedTask() = 0;
+  virtual Task& GetAssignedTask() = 0;
 
-  virtual void SetAssignedTask(Task &assigned_task) = 0;
+  virtual void SetAssignedTask(Task& assigned_task) = 0;
 
   virtual bool IsRegistered() = 0;
 
-  virtual rpc::CoreWorkerClient *rpc_client() = 0;
+  virtual rpc::CoreWorkerClient* rpc_client() = 0;
 };
 
 /// Worker class encapsulates the implementation details of a worker. A worker
@@ -118,9 +118,9 @@ class Worker : public WorkerInterface {
  public:
   /// A constructor that initializes a worker object.
   /// NOTE: You MUST manually set the worker process.
-  Worker(const WorkerID &worker_id, const Language &language,
-         const std::string &ip_address, std::shared_ptr<ClientConnection> connection,
-         rpc::ClientCallManager &client_call_manager);
+  Worker(const WorkerID& worker_id, const Language& language,
+         const std::string& ip_address, std::shared_ptr<ClientConnection> connection,
+         rpc::ClientCallManager& client_call_manager);
   /// A destructor responsible for freeing all worker state.
   ~Worker() {}
   void MarkDead();
@@ -140,37 +140,37 @@ class Worker : public WorkerInterface {
   int Port() const;
   int AssignedPort() const;
   void SetAssignedPort(int port);
-  void AssignTaskId(const TaskID &task_id);
-  const TaskID &GetAssignedTaskId() const;
-  bool AddBlockedTaskId(const TaskID &task_id);
-  bool RemoveBlockedTaskId(const TaskID &task_id);
-  const std::unordered_set<TaskID> &GetBlockedTaskIds() const;
-  void AssignJobId(const JobID &job_id);
-  const JobID &GetAssignedJobId() const;
-  void AssignActorId(const ActorID &actor_id);
-  const ActorID &GetActorId() const;
+  void AssignTaskId(const TaskID& task_id);
+  const TaskID& GetAssignedTaskId() const;
+  bool AddBlockedTaskId(const TaskID& task_id);
+  bool RemoveBlockedTaskId(const TaskID& task_id);
+  const std::unordered_set<TaskID>& GetBlockedTaskIds() const;
+  void AssignJobId(const JobID& job_id);
+  const JobID& GetAssignedJobId() const;
+  void AssignActorId(const ActorID& actor_id);
+  const ActorID& GetActorId() const;
   void MarkDetachedActor();
   bool IsDetachedActor() const;
   const std::shared_ptr<ClientConnection> Connection() const;
-  void SetOwnerAddress(const rpc::Address &address);
-  const rpc::Address &GetOwnerAddress() const;
+  void SetOwnerAddress(const rpc::Address& address);
+  const rpc::Address& GetOwnerAddress() const;
 
-  const ResourceIdSet &GetLifetimeResourceIds() const;
-  void SetLifetimeResourceIds(ResourceIdSet &resource_ids);
+  const ResourceIdSet& GetLifetimeResourceIds() const;
+  void SetLifetimeResourceIds(ResourceIdSet& resource_ids);
   void ResetLifetimeResourceIds();
 
-  const ResourceIdSet &GetTaskResourceIds() const;
-  void SetTaskResourceIds(ResourceIdSet &resource_ids);
+  const ResourceIdSet& GetTaskResourceIds() const;
+  void SetTaskResourceIds(ResourceIdSet& resource_ids);
   void ResetTaskResourceIds();
   ResourceIdSet ReleaseTaskCpuResources();
-  void AcquireTaskCpuResources(const ResourceIdSet &cpu_resources);
+  void AcquireTaskCpuResources(const ResourceIdSet& cpu_resources);
 
-  Status AssignTask(const Task &task, const ResourceIdSet &resource_id_set);
+  Status AssignTask(const Task& task, const ResourceIdSet& resource_id_set);
   void DirectActorCallArgWaitComplete(int64_t tag);
 
   // Setter, geter, and clear methods  for allocated_instances_.
   void SetAllocatedInstances(
-      std::shared_ptr<TaskResourceInstances> &allocated_instances) {
+      std::shared_ptr<TaskResourceInstances>& allocated_instances) {
     allocated_instances_ = allocated_instances;
   };
 
@@ -181,7 +181,7 @@ class Worker : public WorkerInterface {
   void ClearAllocatedInstances() { allocated_instances_ = nullptr; };
 
   void SetLifetimeAllocatedInstances(
-      std::shared_ptr<TaskResourceInstances> &allocated_instances) {
+      std::shared_ptr<TaskResourceInstances>& allocated_instances) {
     lifetime_allocated_instances_ = allocated_instances;
   };
 
@@ -191,21 +191,21 @@ class Worker : public WorkerInterface {
 
   void ClearLifetimeAllocatedInstances() { lifetime_allocated_instances_ = nullptr; };
 
-  void SetBorrowedCPUInstances(std::vector<double> &cpu_instances) {
+  void SetBorrowedCPUInstances(std::vector<double>& cpu_instances) {
     borrowed_cpu_instances_ = cpu_instances;
   };
 
-  std::vector<double> &GetBorrowedCPUInstances() { return borrowed_cpu_instances_; };
+  std::vector<double>& GetBorrowedCPUInstances() { return borrowed_cpu_instances_; };
 
   void ClearBorrowedCPUInstances() { return borrowed_cpu_instances_.clear(); };
 
-  Task &GetAssignedTask() { return assigned_task_; };
+  Task& GetAssignedTask() { return assigned_task_; };
 
-  void SetAssignedTask(Task &assigned_task) { assigned_task_ = assigned_task; };
+  void SetAssignedTask(Task& assigned_task) { assigned_task_ = assigned_task; };
 
   bool IsRegistered() { return rpc_client_ != nullptr; }
 
-  rpc::CoreWorkerClient *rpc_client() {
+  rpc::CoreWorkerClient* rpc_client() {
     RAY_CHECK(IsRegistered());
     return rpc_client_.get();
   }
@@ -248,7 +248,7 @@ class Worker : public WorkerInterface {
   std::unordered_set<TaskID> blocked_task_ids_;
   /// The `ClientCallManager` object that is shared by `CoreWorkerClient` from all
   /// workers.
-  rpc::ClientCallManager &client_call_manager_;
+  rpc::ClientCallManager& client_call_manager_;
   /// The rpc client to send tasks to this worker.
   std::unique_ptr<rpc::CoreWorkerClient> rpc_client_;
   /// Whether the worker is detached. This is applies when the worker is actor.

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -48,11 +48,11 @@ class WorkerPoolInterface {
   /// \return An idle worker with the requested task spec. Returns nullptr if no
   /// such worker exists.
   virtual std::shared_ptr<WorkerInterface> PopWorker(
-      const TaskSpecification &task_spec) = 0;
+      const TaskSpecification& task_spec) = 0;
   /// Add an idle worker to the pool.
   ///
   /// \param The idle worker to add.
-  virtual void PushWorker(const std::shared_ptr<WorkerInterface> &worker) = 0;
+  virtual void PushWorker(const std::shared_ptr<WorkerInterface>& worker) = 0;
 
   virtual ~WorkerPoolInterface(){};
 };
@@ -85,11 +85,11 @@ class WorkerPool : public WorkerPoolInterface {
   /// \param raylet_config The raylet config list of this node.
   /// \param starting_worker_timeout_callback The callback that will be triggered once
   /// it times out to start a worker.
-  WorkerPool(boost::asio::io_service &io_service, int num_workers,
+  WorkerPool(boost::asio::io_service& io_service, int num_workers,
              int maximum_startup_concurrency, int min_worker_port, int max_worker_port,
              std::shared_ptr<gcs::GcsClient> gcs_client,
-             const WorkerCommandMap &worker_commands,
-             const std::unordered_map<std::string, std::string> &raylet_config,
+             const WorkerCommandMap& worker_commands,
+             const std::unordered_map<std::string, std::string>& raylet_config,
              std::function<void()> starting_worker_timeout_callback);
 
   /// Destructor responsible for freeing a set of workers owned by this class.
@@ -103,8 +103,8 @@ class WorkerPool : public WorkerPoolInterface {
   /// \param[out] port The port that this worker's gRPC server should listen on.
   /// Returns 0 if the worker should bind on a random port.
   /// \return If the registration is successful.
-  Status RegisterWorker(const std::shared_ptr<WorkerInterface> &worker, pid_t pid,
-                        int *port);
+  Status RegisterWorker(const std::shared_ptr<WorkerInterface>& worker, pid_t pid,
+                        int* port);
 
   /// Register a new driver.
   ///
@@ -112,7 +112,7 @@ class WorkerPool : public WorkerPoolInterface {
   /// \param[out] port The port that this driver's gRPC server should listen on.
   /// Returns 0 if the driver should bind on a random port.
   /// \return If the registration is successful.
-  Status RegisterDriver(const std::shared_ptr<WorkerInterface> &worker, int *port);
+  Status RegisterDriver(const std::shared_ptr<WorkerInterface>& worker, int* port);
 
   /// Get the client connection's registered worker.
   ///
@@ -120,7 +120,7 @@ class WorkerPool : public WorkerPoolInterface {
   /// \return The Worker that owns the given client connection. Returns nullptr
   /// if the client has not registered a worker yet.
   std::shared_ptr<WorkerInterface> GetRegisteredWorker(
-      const std::shared_ptr<ClientConnection> &connection) const;
+      const std::shared_ptr<ClientConnection>& connection) const;
 
   /// Get the client connection's registered driver.
   ///
@@ -128,23 +128,23 @@ class WorkerPool : public WorkerPoolInterface {
   /// \return The Worker that owns the given client connection. Returns nullptr
   /// if the client has not registered a driver.
   std::shared_ptr<WorkerInterface> GetRegisteredDriver(
-      const std::shared_ptr<ClientConnection> &connection) const;
+      const std::shared_ptr<ClientConnection>& connection) const;
 
   /// Disconnect a registered worker.
   ///
   /// \param The worker to disconnect. The worker must be registered.
   /// \return Whether the given worker was in the pool of idle workers.
-  bool DisconnectWorker(const std::shared_ptr<WorkerInterface> &worker);
+  bool DisconnectWorker(const std::shared_ptr<WorkerInterface>& worker);
 
   /// Disconnect a registered driver.
   ///
   /// \param The driver to disconnect. The driver must be registered.
-  void DisconnectDriver(const std::shared_ptr<WorkerInterface> &driver);
+  void DisconnectDriver(const std::shared_ptr<WorkerInterface>& driver);
 
   /// Add an idle worker to the pool.
   ///
   /// \param The idle worker to add.
-  void PushWorker(const std::shared_ptr<WorkerInterface> &worker);
+  void PushWorker(const std::shared_ptr<WorkerInterface>& worker);
 
   /// Pop an idle worker from the pool. The caller is responsible for pushing
   /// the worker back onto the pool once the worker has completed its work.
@@ -152,21 +152,21 @@ class WorkerPool : public WorkerPoolInterface {
   /// \param task_spec The returned worker must be able to execute this task.
   /// \return An idle worker with the requested task spec. Returns nullptr if no
   /// such worker exists.
-  std::shared_ptr<WorkerInterface> PopWorker(const TaskSpecification &task_spec);
+  std::shared_ptr<WorkerInterface> PopWorker(const TaskSpecification& task_spec);
 
   /// Return the current size of the worker pool for the requested language. Counts only
   /// idle workers.
   ///
   /// \param language The requested language.
   /// \return The total count of all workers (actor and non-actor) in the pool.
-  uint32_t Size(const Language &language) const;
+  uint32_t Size(const Language& language) const;
 
   /// Get all the workers which are running tasks for a given job.
   ///
   /// \param job_id The job ID.
   /// \return A list containing all the workers which are running tasks for the job.
   std::vector<std::shared_ptr<WorkerInterface>> GetWorkersRunningTasksForJob(
-      const JobID &job_id) const;
+      const JobID& job_id) const;
 
   /// Get all the registered workers.
   ///
@@ -185,7 +185,7 @@ class WorkerPool : public WorkerPoolInterface {
   ///
   /// \param language The required language.
   /// \param task_id The task that we want to query.
-  bool HasPendingWorkerForTask(const Language &language, const TaskID &task_id);
+  bool HasPendingWorkerForTask(const Language& language, const TaskID& task_id);
 
   /// Get the set of active object IDs from all workers in the worker pool.
   /// \return A set containing the active object IDs.
@@ -211,8 +211,8 @@ class WorkerPool : public WorkerPoolInterface {
   /// \param dynamic_options The dynamic options that we should add for worker command.
   /// \return The id of the process that we started if it's positive,
   /// otherwise it means we didn't start a process.
-  Process StartWorkerProcess(const Language &language,
-                             const std::vector<std::string> &dynamic_options = {});
+  Process StartWorkerProcess(const Language& language,
+                             const std::vector<std::string>& dynamic_options = {});
 
   /// The implementation of how to start a new worker process with command arguments.
   /// The lifetime of the process is tied to that of the returned object,
@@ -220,7 +220,7 @@ class WorkerPool : public WorkerPoolInterface {
   ///
   /// \param worker_command_args The command arguments of new worker process.
   /// \return An object representing the started worker process.
-  virtual Process StartProcess(const std::vector<std::string> &worker_command_args);
+  virtual Process StartProcess(const std::vector<std::string>& worker_command_args);
 
   /// Push an warning message to user if worker pool is getting to big.
   virtual void WarnAboutSize();
@@ -271,7 +271,7 @@ class WorkerPool : public WorkerPoolInterface {
 
   /// A helper function that returns the reference of the pool state
   /// for a given language.
-  State &GetStateForLanguage(const Language &language);
+  State& GetStateForLanguage(const Language& language);
 
   /// Start a timer to monitor the starting worker process.
   ///
@@ -279,7 +279,7 @@ class WorkerPool : public WorkerPoolInterface {
   /// (due to worker process crash or any other reasons), remove them
   /// from `starting_worker_processes`. Otherwise if we'll mistakenly
   /// think there are unregistered workers, and won't start new workers.
-  void MonitorStartingWorkerProcess(const Process &proc, const Language &language);
+  void MonitorStartingWorkerProcess(const Process& proc, const Language& language);
 
   /// Get the next unallocated port in the free ports list. If a port range isn't
   /// configured, returns 0.
@@ -287,14 +287,14 @@ class WorkerPool : public WorkerPoolInterface {
   /// There is a race condition where another service binds to the port sometime
   /// after this function returns and before the Worker/Driver uses the port.
   /// \param[out] port The next available port.
-  Status GetNextFreePort(int *port);
+  Status GetNextFreePort(int* port);
 
   /// Mark this port as free to be used by another worker.
   /// \param[in] port The port to mark as free.
   void MarkPortAsFree(int port);
 
   /// For Process class for managing subprocesses (e.g. reaping zombies).
-  boost::asio::io_service *io_service_;
+  boost::asio::io_service* io_service_;
   /// The maximum number of worker processes that can be started concurrently.
   int maximum_startup_concurrency_;
   /// Keeps track of unused ports that newly-created workers can bind on.

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -48,8 +48,8 @@ class PinObjectsInterface {
  public:
   /// Request to a raylet to pin a plasma object. The callback will be sent via gRPC.
   virtual void PinObjectIDs(
-      const rpc::Address &caller_address, const std::vector<ObjectID> &object_ids,
-      const ray::rpc::ClientCallback<ray::rpc::PinObjectIDsReply> &callback) = 0;
+      const rpc::Address& caller_address, const std::vector<ObjectID>& object_ids,
+      const ray::rpc::ClientCallback<ray::rpc::PinObjectIDsReply>& callback) = 0;
 
   virtual ~PinObjectsInterface(){};
 };
@@ -61,15 +61,15 @@ class WorkerLeaseInterface {
   /// \param resource_spec Resources that should be allocated for the worker.
   /// \return ray::Status
   virtual void RequestWorkerLease(
-      const ray::TaskSpecification &resource_spec,
-      const ray::rpc::ClientCallback<ray::rpc::RequestWorkerLeaseReply> &callback) = 0;
+      const ray::TaskSpecification& resource_spec,
+      const ray::rpc::ClientCallback<ray::rpc::RequestWorkerLeaseReply>& callback) = 0;
 
   /// Returns a worker to the raylet.
   /// \param worker_port The local port of the worker on the raylet node.
   /// \param worker_id The unique worker id of the worker on the raylet node.
   /// \param disconnect_worker Whether the raylet should disconnect the worker.
   /// \return ray::Status
-  virtual ray::Status ReturnWorker(int worker_port, const WorkerID &worker_id,
+  virtual ray::Status ReturnWorker(int worker_port, const WorkerID& worker_id,
                                    bool disconnect_worker) = 0;
 
   /// Notify raylets to release unused workers.
@@ -77,12 +77,12 @@ class WorkerLeaseInterface {
   /// \param callback Callback that will be called after raylet completes the release of
   /// unused workers. \return ray::Status
   virtual void ReleaseUnusedWorkers(
-      const std::vector<WorkerID> &workers_in_use,
-      const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply> &callback) = 0;
+      const std::vector<WorkerID>& workers_in_use,
+      const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply>& callback) = 0;
 
   virtual void CancelWorkerLease(
-      const TaskID &task_id,
-      const rpc::ClientCallback<rpc::CancelWorkerLeaseReply> &callback) = 0;
+      const TaskID& task_id,
+      const rpc::ClientCallback<rpc::CancelWorkerLeaseReply>& callback) = 0;
 
   virtual ~WorkerLeaseInterface(){};
 };
@@ -94,13 +94,13 @@ class ResourceReserveInterface {
   /// \param resource_spec Resources that should be allocated for the worker.
   /// \return ray::Status
   virtual void RequestResourceReserve(
-      const BundleSpecification &bundle_spec,
-      const ray::rpc::ClientCallback<ray::rpc::RequestResourceReserveReply>
-          &callback) = 0;
+      const BundleSpecification& bundle_spec,
+      const ray::rpc::ClientCallback<ray::rpc::RequestResourceReserveReply>&
+          callback) = 0;
 
   virtual void CancelResourceReserve(
-      BundleSpecification &bundle_spec,
-      const ray::rpc::ClientCallback<ray::rpc::CancelResourceReserveReply> &callback) = 0;
+      BundleSpecification& bundle_spec,
+      const ray::rpc::ClientCallback<ray::rpc::CancelResourceReserveReply>& callback) = 0;
 
   virtual ~ResourceReserveInterface(){};
 };
@@ -115,7 +115,7 @@ class DependencyWaiterInterface {
   /// \param tag Value that will be sent to the core worker via gRPC on completion.
   /// \return ray::Status.
   virtual ray::Status WaitForDirectActorCallArgs(
-      const std::vector<rpc::ObjectReference> &references, int64_t tag) = 0;
+      const std::vector<rpc::ObjectReference>& references, int64_t tag) = 0;
 
   virtual ~DependencyWaiterInterface(){};
 };
@@ -133,15 +133,15 @@ class RayletConnection {
   /// \param job_id The ID of the driver. This is non-nil if the client is a
   ///        driver.
   /// \return The connection information.
-  RayletConnection(boost::asio::io_service &io_service, const std::string &raylet_socket,
+  RayletConnection(boost::asio::io_service& io_service, const std::string& raylet_socket,
                    int num_retries, int64_t timeout);
 
   ray::Status WriteMessage(MessageType type,
-                           flatbuffers::FlatBufferBuilder *fbb = nullptr);
+                           flatbuffers::FlatBufferBuilder* fbb = nullptr);
 
   ray::Status AtomicRequestReply(MessageType request_type, MessageType reply_type,
-                                 std::vector<uint8_t> *reply_message,
-                                 flatbuffers::FlatBufferBuilder *fbb = nullptr);
+                                 std::vector<uint8_t>* reply_message,
+                                 flatbuffers::FlatBufferBuilder* fbb = nullptr);
 
  private:
   /// The connection to raylet.
@@ -172,12 +172,12 @@ class RayletClient : public PinObjectsInterface,
   /// provided by the raylet.
   /// \param port The port that the worker should listen on for gRPC requests. If
   /// 0, the worker should choose a random port.
-  RayletClient(boost::asio::io_service &io_service,
+  RayletClient(boost::asio::io_service& io_service,
                std::shared_ptr<ray::rpc::NodeManagerWorkerClient> grpc_client,
-               const std::string &raylet_socket, const WorkerID &worker_id,
-               bool is_worker, const JobID &job_id, const Language &language,
-               const std::string &ip_address, ClientID *raylet_id, int *port,
-               std::unordered_map<std::string, std::string> *internal_config);
+               const std::string& raylet_socket, const WorkerID& worker_id,
+               bool is_worker, const JobID& job_id, const Language& language,
+               const std::string& ip_address, ClientID* raylet_id, int* port,
+               std::unordered_map<std::string, std::string>* internal_config);
 
   /// Connect to the raylet via grpc only.
   ///
@@ -201,7 +201,7 @@ class RayletClient : public PinObjectsInterface,
   ///
   /// \param The task specification.
   /// \return ray::Status.
-  ray::Status SubmitTask(const ray::TaskSpecification &task_spec);
+  ray::Status SubmitTask(const ray::TaskSpecification& task_spec);
 
   /// Tell the raylet that the client has finished executing a task.
   ///
@@ -216,16 +216,16 @@ class RayletClient : public PinObjectsInterface,
   /// \param mark_worker_blocked Set to false if current task is a direct call task.
   /// \param current_task_id The task that needs the objects.
   /// \return int 0 means correct, other numbers mean error.
-  ray::Status FetchOrReconstruct(const std::vector<ObjectID> &object_ids,
-                                 const std::vector<rpc::Address> &owner_addresses,
+  ray::Status FetchOrReconstruct(const std::vector<ObjectID>& object_ids,
+                                 const std::vector<rpc::Address>& owner_addresses,
                                  bool fetch_only, bool mark_worker_blocked,
-                                 const TaskID &current_task_id);
+                                 const TaskID& current_task_id);
 
   /// Notify the raylet that this client (worker) is no longer blocked.
   ///
   /// \param current_task_id The task that is no longer blocked.
   /// \return ray::Status.
-  ray::Status NotifyUnblocked(const TaskID &current_task_id);
+  ray::Status NotifyUnblocked(const TaskID& current_task_id);
 
   /// Notify the raylet that this client is blocked. This is only used for direct task
   /// calls. Note that ordering of this with respect to Unblock calls is important.
@@ -252,11 +252,11 @@ class RayletClient : public PinObjectsInterface,
   /// \param result A pair with the first element containing the object ids that were
   /// found, and the second element the objects that were not found.
   /// \return ray::Status.
-  ray::Status Wait(const std::vector<ObjectID> &object_ids,
-                   const std::vector<rpc::Address> &owner_addresses, int num_returns,
+  ray::Status Wait(const std::vector<ObjectID>& object_ids,
+                   const std::vector<rpc::Address>& owner_addresses, int num_returns,
                    int64_t timeout_milliseconds, bool wait_local,
-                   bool mark_worker_blocked, const TaskID &current_task_id,
-                   WaitResultPair *result);
+                   bool mark_worker_blocked, const TaskID& current_task_id,
+                   WaitResultPair* result);
 
   /// Wait for the given objects, asynchronously. The core worker is notified when
   /// the wait completes.
@@ -265,7 +265,7 @@ class RayletClient : public PinObjectsInterface,
   /// \param tag Value that will be sent to the core worker via gRPC on completion.
   /// \return ray::Status.
   ray::Status WaitForDirectActorCallArgs(
-      const std::vector<rpc::ObjectReference> &references, int64_t tag) override;
+      const std::vector<rpc::ObjectReference>& references, int64_t tag) override;
 
   /// Push an error to the relevant driver.
   ///
@@ -274,14 +274,14 @@ class RayletClient : public PinObjectsInterface,
   /// \param The error message.
   /// \param The timestamp of the error.
   /// \return ray::Status.
-  ray::Status PushError(const ray::JobID &job_id, const std::string &type,
-                        const std::string &error_message, double timestamp);
+  ray::Status PushError(const ray::JobID& job_id, const std::string& type,
+                        const std::string& error_message, double timestamp);
 
   /// Store some profile events in the GCS.
   ///
   /// \param profile_events A batch of profiling event information.
   /// \return ray::Status.
-  ray::Status PushProfileEvents(const ProfileTableData &profile_events);
+  ray::Status PushProfileEvents(const ProfileTableData& profile_events);
 
   /// Free a list of objects from object stores.
   ///
@@ -290,7 +290,7 @@ class RayletClient : public PinObjectsInterface,
   /// or send it to all the object stores.
   /// \param delete_creating_tasks Whether also delete objects' creating tasks from GCS.
   /// \return ray::Status.
-  ray::Status FreeObjects(const std::vector<ray::ObjectID> &object_ids, bool local_only,
+  ray::Status FreeObjects(const std::vector<ray::ObjectID>& object_ids, bool local_only,
                           bool deleteCreatingTasks);
 
   /// Request raylet backend to prepare a checkpoint for an actor.
@@ -298,70 +298,70 @@ class RayletClient : public PinObjectsInterface,
   /// \param[in] actor_id ID of the actor.
   /// \param[out] checkpoint_id ID of the new checkpoint (output parameter).
   /// \return ray::Status.
-  ray::Status PrepareActorCheckpoint(const ActorID &actor_id,
-                                     ActorCheckpointID *checkpoint_id);
+  ray::Status PrepareActorCheckpoint(const ActorID& actor_id,
+                                     ActorCheckpointID* checkpoint_id);
 
   /// Notify raylet backend that an actor was resumed from a checkpoint.
   ///
   /// \param actor_id ID of the actor.
   /// \param checkpoint_id ID of the checkpoint from which the actor was resumed.
   /// \return ray::Status.
-  ray::Status NotifyActorResumedFromCheckpoint(const ActorID &actor_id,
-                                               const ActorCheckpointID &checkpoint_id);
+  ray::Status NotifyActorResumedFromCheckpoint(const ActorID& actor_id,
+                                               const ActorCheckpointID& checkpoint_id);
 
   /// Sets a resource with the specified capacity and client id
   /// \param resource_name Name of the resource to be set
   /// \param capacity Capacity of the resource
   /// \param client_Id ClientID where the resource is to be set
   /// \return ray::Status
-  ray::Status SetResource(const std::string &resource_name, const double capacity,
-                          const ray::ClientID &client_Id);
+  ray::Status SetResource(const std::string& resource_name, const double capacity,
+                          const ray::ClientID& client_Id);
 
   /// Implements WorkerLeaseInterface.
   void RequestWorkerLease(
-      const ray::TaskSpecification &resource_spec,
-      const ray::rpc::ClientCallback<ray::rpc::RequestWorkerLeaseReply> &callback)
+      const ray::TaskSpecification& resource_spec,
+      const ray::rpc::ClientCallback<ray::rpc::RequestWorkerLeaseReply>& callback)
       override;
 
   /// Implements WorkerLeaseInterface.
-  ray::Status ReturnWorker(int worker_port, const WorkerID &worker_id,
+  ray::Status ReturnWorker(int worker_port, const WorkerID& worker_id,
                            bool disconnect_worker) override;
 
   /// Implements WorkerLeaseInterface.
   void ReleaseUnusedWorkers(
-      const std::vector<WorkerID> &workers_in_use,
-      const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply> &callback) override;
+      const std::vector<WorkerID>& workers_in_use,
+      const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply>& callback) override;
 
   void CancelWorkerLease(
-      const TaskID &task_id,
-      const rpc::ClientCallback<rpc::CancelWorkerLeaseReply> &callback) override;
+      const TaskID& task_id,
+      const rpc::ClientCallback<rpc::CancelWorkerLeaseReply>& callback) override;
 
   /// Implements ResourceReserveInterface.
   void RequestResourceReserve(
-      const BundleSpecification &bundle_spec,
-      const ray::rpc::ClientCallback<ray::rpc::RequestResourceReserveReply> &callback)
+      const BundleSpecification& bundle_spec,
+      const ray::rpc::ClientCallback<ray::rpc::RequestResourceReserveReply>& callback)
       override;
 
   /// Implements ResourceReserveInterface.
   void CancelResourceReserve(
-      BundleSpecification &bundle_spec,
-      const ray::rpc::ClientCallback<ray::rpc::CancelResourceReserveReply> &callback)
+      BundleSpecification& bundle_spec,
+      const ray::rpc::ClientCallback<ray::rpc::CancelResourceReserveReply>& callback)
       override;
 
   void PinObjectIDs(
-      const rpc::Address &caller_address, const std::vector<ObjectID> &object_ids,
-      const ray::rpc::ClientCallback<ray::rpc::PinObjectIDsReply> &callback) override;
+      const rpc::Address& caller_address, const std::vector<ObjectID>& object_ids,
+      const ray::rpc::ClientCallback<ray::rpc::PinObjectIDsReply>& callback) override;
 
-  void GlobalGC(const rpc::ClientCallback<rpc::GlobalGCReply> &callback);
+  void GlobalGC(const rpc::ClientCallback<rpc::GlobalGCReply>& callback);
 
   // Subscribe to receive notification on plasma object
-  ray::Status SubscribeToPlasma(const ObjectID &object_id);
+  ray::Status SubscribeToPlasma(const ObjectID& object_id);
 
   WorkerID GetWorkerID() const { return worker_id_; }
 
   JobID GetJobID() const { return job_id_; }
 
-  const ResourceMappingType &GetResourceIDs() const { return resource_ids_; }
+  const ResourceMappingType& GetResourceIDs() const { return resource_ids_; }
 
  private:
   /// gRPC client to the raylet. Right now, this is only used for a couple

--- a/src/ray/rpc/client_call.h
+++ b/src/ray/rpc/client_call.h
@@ -15,9 +15,10 @@
 #pragma once
 
 #include <grpcpp/grpcpp.h>
-#include <boost/asio.hpp>
-#include "absl/synchronization/mutex.h"
 
+#include <boost/asio.hpp>
+
+#include "absl/synchronization/mutex.h"
 #include "ray/common/grpc_util.h"
 #include "ray/common/status.h"
 

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -27,12 +27,12 @@ class GcsRpcClient;
 /// Executor saves operation and support retries.
 class Executor {
  public:
-  explicit Executor(GcsRpcClient *gcs_rpc_client) : gcs_rpc_client_(gcs_rpc_client) {}
+  explicit Executor(GcsRpcClient* gcs_rpc_client) : gcs_rpc_client_(gcs_rpc_client) {}
 
   /// This function is used to execute the given operation.
   ///
   /// \param operation The operation to be executed.
-  void Execute(const std::function<void(GcsRpcClient *gcs_rpc_client)> &operation) {
+  void Execute(const std::function<void(GcsRpcClient* gcs_rpc_client)>& operation) {
     operation_ = operation;
     operation(gcs_rpc_client_);
   }
@@ -41,18 +41,18 @@ class Executor {
   void Retry() { operation_(gcs_rpc_client_); }
 
  private:
-  GcsRpcClient *gcs_rpc_client_;
-  std::function<void(GcsRpcClient *gcs_rpc_client)> operation_;
+  GcsRpcClient* gcs_rpc_client_;
+  std::function<void(GcsRpcClient* gcs_rpc_client)> operation_;
 };
 
 // Define a void GCS RPC client method.
 #define VOID_GCS_RPC_CLIENT_METHOD(SERVICE, METHOD, grpc_client, SPECS)                \
-  void METHOD(const METHOD##Request &request,                                          \
-              const ClientCallback<METHOD##Reply> &callback) SPECS {                   \
+  void METHOD(const METHOD##Request& request,                                          \
+              const ClientCallback<METHOD##Reply>& callback) SPECS {                   \
     auto executor = new Executor(this);                                                \
     auto operation_callback = [this, request, callback, executor](                     \
-                                  const ray::Status &status,                           \
-                                  const METHOD##Reply &reply) {                        \
+                                  const ray::Status& status,                           \
+                                  const METHOD##Reply& reply) {                        \
       if (!status.IsIOError()) {                                                       \
         auto status =                                                                  \
             reply.status().code() == (int)StatusCode::OK                               \
@@ -65,7 +65,7 @@ class Executor {
         executor->Retry();                                                             \
       }                                                                                \
     };                                                                                 \
-    auto operation = [request, operation_callback](GcsRpcClient *gcs_rpc_client) {     \
+    auto operation = [request, operation_callback](GcsRpcClient* gcs_rpc_client) {     \
       RAY_UNUSED(INVOKE_RPC_CALL(SERVICE, METHOD, request, operation_callback,         \
                                  gcs_rpc_client->grpc_client));                        \
     };                                                                                 \
@@ -83,14 +83,14 @@ class GcsRpcClient {
   /// \param[in] gcs_service_failure_detected The function is used to redo subscription
   /// and reconnect to GCS RPC server when gcs service failure is detected.
   GcsRpcClient(
-      const std::string &address, const int port, ClientCallManager &client_call_manager,
+      const std::string& address, const int port, ClientCallManager& client_call_manager,
       std::function<void(GcsServiceFailureType)> gcs_service_failure_detected = nullptr)
       : gcs_service_failure_detected_(std::move(gcs_service_failure_detected)) {
     Reset(address, port, client_call_manager);
   };
 
-  void Reset(const std::string &address, const int port,
-             ClientCallManager &client_call_manager) {
+  void Reset(const std::string& address, const int port,
+             ClientCallManager& client_call_manager) {
     job_info_grpc_client_ = std::unique_ptr<GrpcClient<JobInfoGcsService>>(
         new GrpcClient<JobInfoGcsService>(address, port, client_call_manager));
     actor_info_grpc_client_ = std::unique_ptr<GrpcClient<ActorInfoGcsService>>(

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -56,15 +56,15 @@ class JobInfoGcsServiceHandler {
  public:
   virtual ~JobInfoGcsServiceHandler() = default;
 
-  virtual void HandleAddJob(const AddJobRequest &request, AddJobReply *reply,
+  virtual void HandleAddJob(const AddJobRequest& request, AddJobReply* reply,
                             SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleMarkJobFinished(const MarkJobFinishedRequest &request,
-                                     MarkJobFinishedReply *reply,
+  virtual void HandleMarkJobFinished(const MarkJobFinishedRequest& request,
+                                     MarkJobFinishedReply* reply,
                                      SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleGetAllJobInfo(const GetAllJobInfoRequest &request,
-                                   GetAllJobInfoReply *reply,
+  virtual void HandleGetAllJobInfo(const GetAllJobInfoRequest& request,
+                                   GetAllJobInfoReply* reply,
                                    SendReplyCallback send_reply_callback) = 0;
 
   virtual void AddJobFinishedListener(
@@ -77,16 +77,16 @@ class JobInfoGrpcService : public GrpcService {
   /// Constructor.
   ///
   /// \param[in] handler The service handler that actually handle the requests.
-  explicit JobInfoGrpcService(boost::asio::io_service &io_service,
-                              JobInfoGcsServiceHandler &handler)
+  explicit JobInfoGrpcService(boost::asio::io_service& io_service,
+                              JobInfoGcsServiceHandler& handler)
       : GrpcService(io_service), service_handler_(handler){};
 
  protected:
-  grpc::Service &GetGrpcService() override { return service_; }
+  grpc::Service& GetGrpcService() override { return service_; }
 
   void InitServerCallFactories(
-      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
-      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories) override {
+      const std::unique_ptr<grpc::ServerCompletionQueue>& cq,
+      std::vector<std::unique_ptr<ServerCallFactory>>* server_call_factories) override {
     JOB_INFO_SERVICE_RPC_HANDLER(AddJob);
     JOB_INFO_SERVICE_RPC_HANDLER(MarkJobFinished);
     JOB_INFO_SERVICE_RPC_HANDLER(GetAllJobInfo);
@@ -96,51 +96,51 @@ class JobInfoGrpcService : public GrpcService {
   /// The grpc async service object.
   JobInfoGcsService::AsyncService service_;
   /// The service handler that actually handle the requests.
-  JobInfoGcsServiceHandler &service_handler_;
+  JobInfoGcsServiceHandler& service_handler_;
 };
 
 class ActorInfoGcsServiceHandler {
  public:
   virtual ~ActorInfoGcsServiceHandler() = default;
 
-  virtual void HandleRegisterActor(const RegisterActorRequest &request,
-                                   RegisterActorReply *reply,
+  virtual void HandleRegisterActor(const RegisterActorRequest& request,
+                                   RegisterActorReply* reply,
                                    SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleCreateActor(const CreateActorRequest &request,
-                                 CreateActorReply *reply,
+  virtual void HandleCreateActor(const CreateActorRequest& request,
+                                 CreateActorReply* reply,
                                  SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleGetActorInfo(const GetActorInfoRequest &request,
-                                  GetActorInfoReply *reply,
+  virtual void HandleGetActorInfo(const GetActorInfoRequest& request,
+                                  GetActorInfoReply* reply,
                                   SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleGetNamedActorInfo(const GetNamedActorInfoRequest &request,
-                                       GetNamedActorInfoReply *reply,
+  virtual void HandleGetNamedActorInfo(const GetNamedActorInfoRequest& request,
+                                       GetNamedActorInfoReply* reply,
                                        SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleGetAllActorInfo(const GetAllActorInfoRequest &request,
-                                     GetAllActorInfoReply *reply,
+  virtual void HandleGetAllActorInfo(const GetAllActorInfoRequest& request,
+                                     GetAllActorInfoReply* reply,
                                      SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleRegisterActorInfo(const RegisterActorInfoRequest &request,
-                                       RegisterActorInfoReply *reply,
+  virtual void HandleRegisterActorInfo(const RegisterActorInfoRequest& request,
+                                       RegisterActorInfoReply* reply,
                                        SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleUpdateActorInfo(const UpdateActorInfoRequest &request,
-                                     UpdateActorInfoReply *reply,
+  virtual void HandleUpdateActorInfo(const UpdateActorInfoRequest& request,
+                                     UpdateActorInfoReply* reply,
                                      SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleAddActorCheckpoint(const AddActorCheckpointRequest &request,
-                                        AddActorCheckpointReply *reply,
+  virtual void HandleAddActorCheckpoint(const AddActorCheckpointRequest& request,
+                                        AddActorCheckpointReply* reply,
                                         SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleGetActorCheckpoint(const GetActorCheckpointRequest &request,
-                                        GetActorCheckpointReply *reply,
+  virtual void HandleGetActorCheckpoint(const GetActorCheckpointRequest& request,
+                                        GetActorCheckpointReply* reply,
                                         SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleGetActorCheckpointID(const GetActorCheckpointIDRequest &request,
-                                          GetActorCheckpointIDReply *reply,
+  virtual void HandleGetActorCheckpointID(const GetActorCheckpointIDRequest& request,
+                                          GetActorCheckpointIDReply* reply,
                                           SendReplyCallback send_reply_callback) = 0;
 };
 
@@ -150,16 +150,16 @@ class ActorInfoGrpcService : public GrpcService {
   /// Constructor.
   ///
   /// \param[in] handler The service handler that actually handle the requests.
-  explicit ActorInfoGrpcService(boost::asio::io_service &io_service,
-                                ActorInfoGcsServiceHandler &handler)
+  explicit ActorInfoGrpcService(boost::asio::io_service& io_service,
+                                ActorInfoGcsServiceHandler& handler)
       : GrpcService(io_service), service_handler_(handler){};
 
  protected:
-  grpc::Service &GetGrpcService() override { return service_; }
+  grpc::Service& GetGrpcService() override { return service_; }
 
   void InitServerCallFactories(
-      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
-      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories) override {
+      const std::unique_ptr<grpc::ServerCompletionQueue>& cq,
+      std::vector<std::unique_ptr<ServerCallFactory>>* server_call_factories) override {
     ACTOR_INFO_SERVICE_RPC_HANDLER(RegisterActor);
     ACTOR_INFO_SERVICE_RPC_HANDLER(CreateActor);
     ACTOR_INFO_SERVICE_RPC_HANDLER(GetActorInfo);
@@ -176,47 +176,47 @@ class ActorInfoGrpcService : public GrpcService {
   /// The grpc async service object.
   ActorInfoGcsService::AsyncService service_;
   /// The service handler that actually handle the requests.
-  ActorInfoGcsServiceHandler &service_handler_;
+  ActorInfoGcsServiceHandler& service_handler_;
 };
 
 class NodeInfoGcsServiceHandler {
  public:
   virtual ~NodeInfoGcsServiceHandler() = default;
 
-  virtual void HandleRegisterNode(const RegisterNodeRequest &request,
-                                  RegisterNodeReply *reply,
+  virtual void HandleRegisterNode(const RegisterNodeRequest& request,
+                                  RegisterNodeReply* reply,
                                   SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleUnregisterNode(const UnregisterNodeRequest &request,
-                                    UnregisterNodeReply *reply,
+  virtual void HandleUnregisterNode(const UnregisterNodeRequest& request,
+                                    UnregisterNodeReply* reply,
                                     SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleGetAllNodeInfo(const GetAllNodeInfoRequest &request,
-                                    GetAllNodeInfoReply *reply,
+  virtual void HandleGetAllNodeInfo(const GetAllNodeInfoRequest& request,
+                                    GetAllNodeInfoReply* reply,
                                     SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleReportHeartbeat(const ReportHeartbeatRequest &request,
-                                     ReportHeartbeatReply *reply,
+  virtual void HandleReportHeartbeat(const ReportHeartbeatRequest& request,
+                                     ReportHeartbeatReply* reply,
                                      SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleGetResources(const GetResourcesRequest &request,
-                                  GetResourcesReply *reply,
+  virtual void HandleGetResources(const GetResourcesRequest& request,
+                                  GetResourcesReply* reply,
                                   SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleUpdateResources(const UpdateResourcesRequest &request,
-                                     UpdateResourcesReply *reply,
+  virtual void HandleUpdateResources(const UpdateResourcesRequest& request,
+                                     UpdateResourcesReply* reply,
                                      SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleDeleteResources(const DeleteResourcesRequest &request,
-                                     DeleteResourcesReply *reply,
+  virtual void HandleDeleteResources(const DeleteResourcesRequest& request,
+                                     DeleteResourcesReply* reply,
                                      SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleSetInternalConfig(const SetInternalConfigRequest &request,
-                                       SetInternalConfigReply *reply,
+  virtual void HandleSetInternalConfig(const SetInternalConfigRequest& request,
+                                       SetInternalConfigReply* reply,
                                        SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleGetInternalConfig(const GetInternalConfigRequest &request,
-                                       GetInternalConfigReply *reply,
+  virtual void HandleGetInternalConfig(const GetInternalConfigRequest& request,
+                                       GetInternalConfigReply* reply,
                                        SendReplyCallback send_reply_callback) = 0;
 };
 
@@ -226,16 +226,16 @@ class NodeInfoGrpcService : public GrpcService {
   /// Constructor.
   ///
   /// \param[in] handler The service handler that actually handle the requests.
-  explicit NodeInfoGrpcService(boost::asio::io_service &io_service,
-                               NodeInfoGcsServiceHandler &handler)
+  explicit NodeInfoGrpcService(boost::asio::io_service& io_service,
+                               NodeInfoGcsServiceHandler& handler)
       : GrpcService(io_service), service_handler_(handler){};
 
  protected:
-  grpc::Service &GetGrpcService() override { return service_; }
+  grpc::Service& GetGrpcService() override { return service_; }
 
   void InitServerCallFactories(
-      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
-      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories) override {
+      const std::unique_ptr<grpc::ServerCompletionQueue>& cq,
+      std::vector<std::unique_ptr<ServerCallFactory>>* server_call_factories) override {
     NODE_INFO_SERVICE_RPC_HANDLER(RegisterNode);
     NODE_INFO_SERVICE_RPC_HANDLER(UnregisterNode);
     NODE_INFO_SERVICE_RPC_HANDLER(GetAllNodeInfo);
@@ -251,27 +251,27 @@ class NodeInfoGrpcService : public GrpcService {
   /// The grpc async service object.
   NodeInfoGcsService::AsyncService service_;
   /// The service handler that actually handle the requests.
-  NodeInfoGcsServiceHandler &service_handler_;
+  NodeInfoGcsServiceHandler& service_handler_;
 };
 
 class ObjectInfoGcsServiceHandler {
  public:
   virtual ~ObjectInfoGcsServiceHandler() = default;
 
-  virtual void HandleGetObjectLocations(const GetObjectLocationsRequest &request,
-                                        GetObjectLocationsReply *reply,
+  virtual void HandleGetObjectLocations(const GetObjectLocationsRequest& request,
+                                        GetObjectLocationsReply* reply,
                                         SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleGetAllObjectLocations(const GetAllObjectLocationsRequest &request,
-                                           GetAllObjectLocationsReply *reply,
+  virtual void HandleGetAllObjectLocations(const GetAllObjectLocationsRequest& request,
+                                           GetAllObjectLocationsReply* reply,
                                            SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleAddObjectLocation(const AddObjectLocationRequest &request,
-                                       AddObjectLocationReply *reply,
+  virtual void HandleAddObjectLocation(const AddObjectLocationRequest& request,
+                                       AddObjectLocationReply* reply,
                                        SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleRemoveObjectLocation(const RemoveObjectLocationRequest &request,
-                                          RemoveObjectLocationReply *reply,
+  virtual void HandleRemoveObjectLocation(const RemoveObjectLocationRequest& request,
+                                          RemoveObjectLocationReply* reply,
                                           SendReplyCallback send_reply_callback) = 0;
 };
 
@@ -281,16 +281,16 @@ class ObjectInfoGrpcService : public GrpcService {
   /// Constructor.
   ///
   /// \param[in] handler The service handler that actually handle the requests.
-  explicit ObjectInfoGrpcService(boost::asio::io_service &io_service,
-                                 ObjectInfoGcsServiceHandler &handler)
+  explicit ObjectInfoGrpcService(boost::asio::io_service& io_service,
+                                 ObjectInfoGcsServiceHandler& handler)
       : GrpcService(io_service), service_handler_(handler){};
 
  protected:
-  grpc::Service &GetGrpcService() override { return service_; }
+  grpc::Service& GetGrpcService() override { return service_; }
 
   void InitServerCallFactories(
-      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
-      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories) override {
+      const std::unique_ptr<grpc::ServerCompletionQueue>& cq,
+      std::vector<std::unique_ptr<ServerCallFactory>>* server_call_factories) override {
     OBJECT_INFO_SERVICE_RPC_HANDLER(GetObjectLocations);
     OBJECT_INFO_SERVICE_RPC_HANDLER(GetAllObjectLocations);
     OBJECT_INFO_SERVICE_RPC_HANDLER(AddObjectLocation);
@@ -301,34 +301,34 @@ class ObjectInfoGrpcService : public GrpcService {
   /// The grpc async service object.
   ObjectInfoGcsService::AsyncService service_;
   /// The service handler that actually handle the requests.
-  ObjectInfoGcsServiceHandler &service_handler_;
+  ObjectInfoGcsServiceHandler& service_handler_;
 };
 
 class TaskInfoGcsServiceHandler {
  public:
   virtual ~TaskInfoGcsServiceHandler() = default;
 
-  virtual void HandleAddTask(const AddTaskRequest &request, AddTaskReply *reply,
+  virtual void HandleAddTask(const AddTaskRequest& request, AddTaskReply* reply,
                              SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleGetTask(const GetTaskRequest &request, GetTaskReply *reply,
+  virtual void HandleGetTask(const GetTaskRequest& request, GetTaskReply* reply,
                              SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleDeleteTasks(const DeleteTasksRequest &request,
-                                 DeleteTasksReply *reply,
+  virtual void HandleDeleteTasks(const DeleteTasksRequest& request,
+                                 DeleteTasksReply* reply,
                                  SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleAddTaskLease(const AddTaskLeaseRequest &request,
-                                  AddTaskLeaseReply *reply,
+  virtual void HandleAddTaskLease(const AddTaskLeaseRequest& request,
+                                  AddTaskLeaseReply* reply,
                                   SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleGetTaskLease(const GetTaskLeaseRequest &request,
-                                  GetTaskLeaseReply *reply,
+  virtual void HandleGetTaskLease(const GetTaskLeaseRequest& request,
+                                  GetTaskLeaseReply* reply,
                                   SendReplyCallback send_reply_callback) = 0;
 
   virtual void HandleAttemptTaskReconstruction(
-      const AttemptTaskReconstructionRequest &request,
-      AttemptTaskReconstructionReply *reply, SendReplyCallback send_reply_callback) = 0;
+      const AttemptTaskReconstructionRequest& request,
+      AttemptTaskReconstructionReply* reply, SendReplyCallback send_reply_callback) = 0;
 };
 
 /// The `GrpcService` for `TaskInfoGcsService`.
@@ -337,16 +337,16 @@ class TaskInfoGrpcService : public GrpcService {
   /// Constructor.
   ///
   /// \param[in] handler The service handler that actually handle the requests.
-  explicit TaskInfoGrpcService(boost::asio::io_service &io_service,
-                               TaskInfoGcsServiceHandler &handler)
+  explicit TaskInfoGrpcService(boost::asio::io_service& io_service,
+                               TaskInfoGcsServiceHandler& handler)
       : GrpcService(io_service), service_handler_(handler){};
 
  protected:
-  grpc::Service &GetGrpcService() override { return service_; }
+  grpc::Service& GetGrpcService() override { return service_; }
 
   void InitServerCallFactories(
-      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
-      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories) override {
+      const std::unique_ptr<grpc::ServerCompletionQueue>& cq,
+      std::vector<std::unique_ptr<ServerCallFactory>>* server_call_factories) override {
     TASK_INFO_SERVICE_RPC_HANDLER(AddTask);
     TASK_INFO_SERVICE_RPC_HANDLER(GetTask);
     TASK_INFO_SERVICE_RPC_HANDLER(DeleteTasks);
@@ -359,19 +359,19 @@ class TaskInfoGrpcService : public GrpcService {
   /// The grpc async service object.
   TaskInfoGcsService::AsyncService service_;
   /// The service handler that actually handle the requests.
-  TaskInfoGcsServiceHandler &service_handler_;
+  TaskInfoGcsServiceHandler& service_handler_;
 };
 
 class StatsGcsServiceHandler {
  public:
   virtual ~StatsGcsServiceHandler() = default;
 
-  virtual void HandleAddProfileData(const AddProfileDataRequest &request,
-                                    AddProfileDataReply *reply,
+  virtual void HandleAddProfileData(const AddProfileDataRequest& request,
+                                    AddProfileDataReply* reply,
                                     SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleGetAllProfileInfo(const GetAllProfileInfoRequest &request,
-                                       GetAllProfileInfoReply *reply,
+  virtual void HandleGetAllProfileInfo(const GetAllProfileInfoRequest& request,
+                                       GetAllProfileInfoReply* reply,
                                        SendReplyCallback send_reply_callback) = 0;
 };
 
@@ -381,16 +381,16 @@ class StatsGrpcService : public GrpcService {
   /// Constructor.
   ///
   /// \param[in] handler The service handler that actually handle the requests.
-  explicit StatsGrpcService(boost::asio::io_service &io_service,
-                            StatsGcsServiceHandler &handler)
+  explicit StatsGrpcService(boost::asio::io_service& io_service,
+                            StatsGcsServiceHandler& handler)
       : GrpcService(io_service), service_handler_(handler){};
 
  protected:
-  grpc::Service &GetGrpcService() override { return service_; }
+  grpc::Service& GetGrpcService() override { return service_; }
 
   void InitServerCallFactories(
-      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
-      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories) override {
+      const std::unique_ptr<grpc::ServerCompletionQueue>& cq,
+      std::vector<std::unique_ptr<ServerCallFactory>>* server_call_factories) override {
     STATS_SERVICE_RPC_HANDLER(AddProfileData);
     STATS_SERVICE_RPC_HANDLER(GetAllProfileInfo);
   }
@@ -399,15 +399,15 @@ class StatsGrpcService : public GrpcService {
   /// The grpc async service object.
   StatsGcsService::AsyncService service_;
   /// The service handler that actually handle the requests.
-  StatsGcsServiceHandler &service_handler_;
+  StatsGcsServiceHandler& service_handler_;
 };
 
 class ErrorInfoGcsServiceHandler {
  public:
   virtual ~ErrorInfoGcsServiceHandler() = default;
 
-  virtual void HandleReportJobError(const ReportJobErrorRequest &request,
-                                    ReportJobErrorReply *reply,
+  virtual void HandleReportJobError(const ReportJobErrorRequest& request,
+                                    ReportJobErrorReply* reply,
                                     SendReplyCallback send_reply_callback) = 0;
 };
 
@@ -417,16 +417,16 @@ class ErrorInfoGrpcService : public GrpcService {
   /// Constructor.
   ///
   /// \param[in] handler The service handler that actually handle the requests.
-  explicit ErrorInfoGrpcService(boost::asio::io_service &io_service,
-                                ErrorInfoGcsServiceHandler &handler)
+  explicit ErrorInfoGrpcService(boost::asio::io_service& io_service,
+                                ErrorInfoGcsServiceHandler& handler)
       : GrpcService(io_service), service_handler_(handler){};
 
  protected:
-  grpc::Service &GetGrpcService() override { return service_; }
+  grpc::Service& GetGrpcService() override { return service_; }
 
   void InitServerCallFactories(
-      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
-      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories) override {
+      const std::unique_ptr<grpc::ServerCompletionQueue>& cq,
+      std::vector<std::unique_ptr<ServerCallFactory>>* server_call_factories) override {
     ERROR_INFO_SERVICE_RPC_HANDLER(ReportJobError);
   }
 
@@ -434,27 +434,27 @@ class ErrorInfoGrpcService : public GrpcService {
   /// The grpc async service object.
   ErrorInfoGcsService::AsyncService service_;
   /// The service handler that actually handle the requests.
-  ErrorInfoGcsServiceHandler &service_handler_;
+  ErrorInfoGcsServiceHandler& service_handler_;
 };
 
 class WorkerInfoGcsServiceHandler {
  public:
   virtual ~WorkerInfoGcsServiceHandler() = default;
 
-  virtual void HandleReportWorkerFailure(const ReportWorkerFailureRequest &request,
-                                         ReportWorkerFailureReply *reply,
+  virtual void HandleReportWorkerFailure(const ReportWorkerFailureRequest& request,
+                                         ReportWorkerFailureReply* reply,
                                          SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleGetWorkerInfo(const GetWorkerInfoRequest &request,
-                                   GetWorkerInfoReply *reply,
+  virtual void HandleGetWorkerInfo(const GetWorkerInfoRequest& request,
+                                   GetWorkerInfoReply* reply,
                                    SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleGetAllWorkerInfo(const GetAllWorkerInfoRequest &request,
-                                      GetAllWorkerInfoReply *reply,
+  virtual void HandleGetAllWorkerInfo(const GetAllWorkerInfoRequest& request,
+                                      GetAllWorkerInfoReply* reply,
                                       SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleAddWorkerInfo(const AddWorkerInfoRequest &request,
-                                   AddWorkerInfoReply *reply,
+  virtual void HandleAddWorkerInfo(const AddWorkerInfoRequest& request,
+                                   AddWorkerInfoReply* reply,
                                    SendReplyCallback send_reply_callback) = 0;
 };
 
@@ -464,16 +464,16 @@ class WorkerInfoGrpcService : public GrpcService {
   /// Constructor.
   ///
   /// \param[in] handler The service handler that actually handle the requests.
-  explicit WorkerInfoGrpcService(boost::asio::io_service &io_service,
-                                 WorkerInfoGcsServiceHandler &handler)
+  explicit WorkerInfoGrpcService(boost::asio::io_service& io_service,
+                                 WorkerInfoGcsServiceHandler& handler)
       : GrpcService(io_service), service_handler_(handler){};
 
  protected:
-  grpc::Service &GetGrpcService() override { return service_; }
+  grpc::Service& GetGrpcService() override { return service_; }
 
   void InitServerCallFactories(
-      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
-      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories) override {
+      const std::unique_ptr<grpc::ServerCompletionQueue>& cq,
+      std::vector<std::unique_ptr<ServerCallFactory>>* server_call_factories) override {
     WORKER_INFO_SERVICE_RPC_HANDLER(ReportWorkerFailure);
     WORKER_INFO_SERVICE_RPC_HANDLER(GetWorkerInfo);
     WORKER_INFO_SERVICE_RPC_HANDLER(GetAllWorkerInfo);
@@ -484,15 +484,15 @@ class WorkerInfoGrpcService : public GrpcService {
   /// The grpc async service object.
   WorkerInfoGcsService::AsyncService service_;
   /// The service handler that actually handle the requests.
-  WorkerInfoGcsServiceHandler &service_handler_;
+  WorkerInfoGcsServiceHandler& service_handler_;
 };
 
 class PlacementGroupInfoGcsServiceHandler {
  public:
   virtual ~PlacementGroupInfoGcsServiceHandler() = default;
 
-  virtual void HandleCreatePlacementGroup(const CreatePlacementGroupRequest &request,
-                                          CreatePlacementGroupReply *reply,
+  virtual void HandleCreatePlacementGroup(const CreatePlacementGroupRequest& request,
+                                          CreatePlacementGroupReply* reply,
                                           SendReplyCallback send_reply_callback) = 0;
 };
 
@@ -502,16 +502,16 @@ class PlacementGroupInfoGrpcService : public GrpcService {
   /// Constructor.
   ///
   /// \param[in] handler The service handler that actually handle the requests.
-  explicit PlacementGroupInfoGrpcService(boost::asio::io_service &io_service,
-                                         PlacementGroupInfoGcsServiceHandler &handler)
+  explicit PlacementGroupInfoGrpcService(boost::asio::io_service& io_service,
+                                         PlacementGroupInfoGcsServiceHandler& handler)
       : GrpcService(io_service), service_handler_(handler){};
 
  protected:
-  grpc::Service &GetGrpcService() override { return service_; }
+  grpc::Service& GetGrpcService() override { return service_; }
 
   void InitServerCallFactories(
-      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
-      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories) override {
+      const std::unique_ptr<grpc::ServerCompletionQueue>& cq,
+      std::vector<std::unique_ptr<ServerCallFactory>>* server_call_factories) override {
     PLACEMENT_GROUP_INFO_SERVICE_RPC_HANDLER(CreatePlacementGroup);
   }
 
@@ -519,7 +519,7 @@ class PlacementGroupInfoGrpcService : public GrpcService {
   /// The grpc async service object.
   PlacementGroupInfoGcsService::AsyncService service_;
   /// The service handler that actually handle the requests.
-  PlacementGroupInfoGcsServiceHandler &service_handler_;
+  PlacementGroupInfoGcsServiceHandler& service_handler_;
 };
 
 using JobInfoHandler = JobInfoGcsServiceHandler;

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <grpcpp/grpcpp.h>
+
 #include <boost/asio.hpp>
 
 #include "ray/common/grpc_util.h"

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -34,15 +34,15 @@ namespace rpc {
 
 // Define a void RPC client method.
 #define VOID_RPC_CLIENT_METHOD(SERVICE, METHOD, rpc_client, SPECS)   \
-  void METHOD(const METHOD##Request &request,                        \
-              const ClientCallback<METHOD##Reply> &callback) SPECS { \
+  void METHOD(const METHOD##Request& request,                        \
+              const ClientCallback<METHOD##Reply>& callback) SPECS { \
     INVOKE_RPC_CALL(SERVICE, METHOD, request, callback, rpc_client); \
   }
 
 template <class GrpcService>
 class GrpcClient {
  public:
-  GrpcClient(const std::string &address, const int port, ClientCallManager &call_manager)
+  GrpcClient(const std::string& address, const int port, ClientCallManager& call_manager)
       : client_call_manager_(call_manager) {
     grpc::ChannelArguments argument;
     // Disable http proxy since it disrupts local connections. TODO(ekl) we should make
@@ -56,7 +56,7 @@ class GrpcClient {
     stub_ = GrpcService::NewStub(channel);
   }
 
-  GrpcClient(const std::string &address, const int port, ClientCallManager &call_manager,
+  GrpcClient(const std::string& address, const int port, ClientCallManager& call_manager,
              int num_threads)
       : client_call_manager_(call_manager) {
     grpc::ResourceQuota quota;
@@ -86,14 +86,14 @@ class GrpcClient {
   template <class Request, class Reply>
   void CallMethod(
       const PrepareAsyncFunction<GrpcService, Request, Reply> prepare_async_function,
-      const Request &request, const ClientCallback<Reply> &callback) {
+      const Request& request, const ClientCallback<Reply>& callback) {
     auto call = client_call_manager_.CreateCall<GrpcService, Request, Reply>(
         *stub_, prepare_async_function, request, callback);
     RAY_CHECK(call != nullptr);
   }
 
  private:
-  ClientCallManager &client_call_manager_;
+  ClientCallManager& client_call_manager_;
   /// The gRPC-generated stub.
   std::unique_ptr<typename GrpcService::Stub> stub_;
 };

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -48,7 +48,7 @@ void GrpcServer::Run() {
     if (services_.empty()) {
       RAY_LOG(WARNING) << "No service is found when start grpc server " << name_;
     }
-    for (auto &entry : services_) {
+    for (auto& entry : services_) {
       builder.RegisterService(&entry.get());
     }
     // Get hold of the completion queue used for the asynchronous communication
@@ -74,7 +74,7 @@ void GrpcServer::Run() {
   RAY_LOG(INFO) << name_ << " server started, listening on port " << port_ << ".";
 
   // Create calls for all the server call factories.
-  for (auto &entry : server_call_factories_) {
+  for (auto& entry : server_call_factories_) {
     for (int i = 0; i < num_threads_; i++) {
       // Create a buffer of 100 calls for each RPC handler.
       // TODO(edoakes): a small buffer should be fine and seems to have better
@@ -92,7 +92,7 @@ void GrpcServer::Run() {
   is_closed_ = false;
 }
 
-void GrpcServer::RegisterService(GrpcService &service) {
+void GrpcServer::RegisterService(GrpcService& service) {
   services_.emplace_back(service.GetGrpcService());
 
   for (int i = 0; i < num_threads_; i++) {
@@ -101,12 +101,12 @@ void GrpcServer::RegisterService(GrpcService &service) {
 }
 
 void GrpcServer::PollEventsFromCompletionQueue(int index) {
-  void *tag;
+  void* tag;
   bool ok;
 
   // Keep reading events from the `CompletionQueue` until it's shutdown.
   while (cqs_[index]->Next(&tag, &ok)) {
-    auto *server_call = static_cast<ServerCall *>(tag);
+    auto* server_call = static_cast<ServerCall*>(tag);
     bool delete_call = false;
     if (ok) {
       switch (server_call->GetState()) {

--- a/src/ray/rpc/grpc_server.h
+++ b/src/ray/rpc/grpc_server.h
@@ -36,8 +36,8 @@ namespace rpc {
 
 // Define a void RPC client method.
 #define DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(METHOD)            \
-  virtual void Handle##METHOD(const rpc::METHOD##Request &request, \
-                              rpc::METHOD##Reply *reply,           \
+  virtual void Handle##METHOD(const rpc::METHOD##Request& request, \
+                              rpc::METHOD##Reply* reply,           \
                               rpc::SendReplyCallback send_reply_callback) = 0;
 
 class GrpcService;
@@ -72,10 +72,10 @@ class GrpcServer {
       // Shutdown the server with an immediate deadline.
       // TODO(edoakes): do we want to do this in all cases?
       server_->Shutdown(gpr_now(GPR_CLOCK_REALTIME));
-      for (const auto &cq : cqs_) {
+      for (const auto& cq : cqs_) {
         cq->Shutdown();
       }
-      for (auto &polling_thread : polling_threads_) {
+      for (auto& polling_thread : polling_threads_) {
         polling_thread.join();
       }
       is_closed_ = true;
@@ -91,7 +91,7 @@ class GrpcServer {
   /// `GrpcServer`, as it holds the underlying `grpc::Service`.
   ///
   /// \param[in] service A `GrpcService` to register to this server.
-  void RegisterService(GrpcService &service);
+  void RegisterService(GrpcService& service);
 
  protected:
   /// This function runs in a background thread. It keeps polling events from the
@@ -129,7 +129,7 @@ class GrpcService {
   ///
   /// \param[in] main_service The main event loop, to which service handler functions
   /// will be posted.
-  explicit GrpcService(boost::asio::io_service &main_service)
+  explicit GrpcService(boost::asio::io_service& main_service)
       : main_service_(main_service) {}
 
   /// Destruct this gRPC service.
@@ -138,7 +138,7 @@ class GrpcService {
  protected:
   /// Return the underlying grpc::Service object for this class.
   /// This is passed to `GrpcServer` to be registered to grpc `ServerBuilder`.
-  virtual grpc::Service &GetGrpcService() = 0;
+  virtual grpc::Service& GetGrpcService() = 0;
 
   /// Subclasses should implement this method to initialize the `ServerCallFactory`
   /// instances, as well as specify maximum number of concurrent requests that gRPC
@@ -148,11 +148,11 @@ class GrpcService {
   /// \param[out] server_call_factories The `ServerCallFactory` objects,
   /// and the maximum number of concurrent requests that this gRPC server can handle.
   virtual void InitServerCallFactories(
-      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
-      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories) = 0;
+      const std::unique_ptr<grpc::ServerCompletionQueue>& cq,
+      std::vector<std::unique_ptr<ServerCallFactory>>* server_call_factories) = 0;
 
   /// The main event loop, to which the service handler functions will be posted.
-  boost::asio::io_service &main_service_;
+  boost::asio::io_service& main_service_;
 
   friend class GrpcServer;
 };

--- a/src/ray/rpc/metrics_agent_client.h
+++ b/src/ray/rpc/metrics_agent_client.h
@@ -35,8 +35,8 @@ class MetricsAgentClient {
   /// \param[in] address Address of the metrics agent server.
   /// \param[in] port Port of the metrics agent server.
   /// \param[in] client_call_manager The `ClientCallManager` used for managing requests.
-  MetricsAgentClient(const std::string &address, const int port,
-                     ClientCallManager &client_call_manager) {
+  MetricsAgentClient(const std::string& address, const int port,
+                     ClientCallManager& client_call_manager) {
     grpc_client_ = std::unique_ptr<GrpcClient<ReporterService>>(
         new GrpcClient<ReporterService>(address, port, client_call_manager));
   };

--- a/src/ray/rpc/node_manager/node_manager_client.h
+++ b/src/ray/rpc/node_manager/node_manager_client.h
@@ -35,8 +35,8 @@ class NodeManagerClient {
   /// \param[in] address Address of the node manager server.
   /// \param[in] port Port of the node manager server.
   /// \param[in] client_call_manager The `ClientCallManager` used for managing requests.
-  NodeManagerClient(const std::string &address, const int port,
-                    ClientCallManager &client_call_manager) {
+  NodeManagerClient(const std::string& address, const int port,
+                    ClientCallManager& client_call_manager) {
     grpc_client_ = std::unique_ptr<GrpcClient<NodeManagerService>>(
         new GrpcClient<NodeManagerService>(address, port, client_call_manager));
   };
@@ -50,7 +50,7 @@ class NodeManagerClient {
   /// Get current node stats.
   VOID_RPC_CLIENT_METHOD(NodeManagerService, GetNodeStats, grpc_client_, )
 
-  void GetNodeStats(const ClientCallback<GetNodeStatsReply> &callback) {
+  void GetNodeStats(const ClientCallback<GetNodeStatsReply>& callback) {
     GetNodeStatsRequest request;
     GetNodeStats(request, callback);
   }
@@ -70,8 +70,8 @@ class NodeManagerWorkerClient
   /// \param[in] port Port of the node manager server.
   /// \param[in] client_call_manager The `ClientCallManager` used for managing requests.
   static std::shared_ptr<NodeManagerWorkerClient> make(
-      const std::string &address, const int port,
-      ClientCallManager &client_call_manager) {
+      const std::string& address, const int port,
+      ClientCallManager& client_call_manager) {
     auto instance = new NodeManagerWorkerClient(address, port, client_call_manager);
     return std::shared_ptr<NodeManagerWorkerClient>(instance);
   }
@@ -106,8 +106,8 @@ class NodeManagerWorkerClient
   /// \param[in] address Address of the node manager server.
   /// \param[in] port Port of the node manager server.
   /// \param[in] client_call_manager The `ClientCallManager` used for managing requests.
-  NodeManagerWorkerClient(const std::string &address, const int port,
-                          ClientCallManager &client_call_manager) {
+  NodeManagerWorkerClient(const std::string& address, const int port,
+                          ClientCallManager& client_call_manager) {
     grpc_client_ = std::unique_ptr<GrpcClient<NodeManagerService>>(
         new GrpcClient<NodeManagerService>(address, port, client_call_manager));
   };

--- a/src/ray/rpc/node_manager/node_manager_server.h
+++ b/src/ray/rpc/node_manager/node_manager_server.h
@@ -50,49 +50,49 @@ class NodeManagerServiceHandler {
   /// \param[out] reply The reply message.
   /// \param[in] send_reply_callback The callback to be called when the request is done.
 
-  virtual void HandleRequestWorkerLease(const RequestWorkerLeaseRequest &request,
-                                        RequestWorkerLeaseReply *reply,
+  virtual void HandleRequestWorkerLease(const RequestWorkerLeaseRequest& request,
+                                        RequestWorkerLeaseReply* reply,
                                         SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleReturnWorker(const ReturnWorkerRequest &request,
-                                  ReturnWorkerReply *reply,
+  virtual void HandleReturnWorker(const ReturnWorkerRequest& request,
+                                  ReturnWorkerReply* reply,
                                   SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleReleaseUnusedWorkers(const ReleaseUnusedWorkersRequest &request,
-                                          ReleaseUnusedWorkersReply *reply,
+  virtual void HandleReleaseUnusedWorkers(const ReleaseUnusedWorkersRequest& request,
+                                          ReleaseUnusedWorkersReply* reply,
                                           SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleCancelWorkerLease(const rpc::CancelWorkerLeaseRequest &request,
-                                       rpc::CancelWorkerLeaseReply *reply,
+  virtual void HandleCancelWorkerLease(const rpc::CancelWorkerLeaseRequest& request,
+                                       rpc::CancelWorkerLeaseReply* reply,
                                        rpc::SendReplyCallback send_reply_callback) = 0;
 
   virtual void HandleRequestResourceReserve(
-      const rpc::RequestResourceReserveRequest &request,
-      rpc::RequestResourceReserveReply *reply,
+      const rpc::RequestResourceReserveRequest& request,
+      rpc::RequestResourceReserveReply* reply,
       rpc::SendReplyCallback send_reply_callback) = 0;
 
   virtual void HandleCancelResourceReserve(
-      const rpc::CancelResourceReserveRequest &request,
-      rpc::CancelResourceReserveReply *reply,
+      const rpc::CancelResourceReserveRequest& request,
+      rpc::CancelResourceReserveReply* reply,
       rpc::SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleForwardTask(const ForwardTaskRequest &request,
-                                 ForwardTaskReply *reply,
+  virtual void HandleForwardTask(const ForwardTaskRequest& request,
+                                 ForwardTaskReply* reply,
                                  SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandlePinObjectIDs(const PinObjectIDsRequest &request,
-                                  PinObjectIDsReply *reply,
+  virtual void HandlePinObjectIDs(const PinObjectIDsRequest& request,
+                                  PinObjectIDsReply* reply,
                                   SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleGetNodeStats(const GetNodeStatsRequest &request,
-                                  GetNodeStatsReply *reply,
+  virtual void HandleGetNodeStats(const GetNodeStatsRequest& request,
+                                  GetNodeStatsReply* reply,
                                   SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleGlobalGC(const GlobalGCRequest &request, GlobalGCReply *reply,
+  virtual void HandleGlobalGC(const GlobalGCRequest& request, GlobalGCReply* reply,
                               SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleFormatGlobalMemoryInfo(const FormatGlobalMemoryInfoRequest &request,
-                                            FormatGlobalMemoryInfoReply *reply,
+  virtual void HandleFormatGlobalMemoryInfo(const FormatGlobalMemoryInfoRequest& request,
+                                            FormatGlobalMemoryInfoReply* reply,
                                             SendReplyCallback send_reply_callback) = 0;
 };
 
@@ -103,16 +103,16 @@ class NodeManagerGrpcService : public GrpcService {
   ///
   /// \param[in] io_service See super class.
   /// \param[in] handler The service handler that actually handle the requests.
-  NodeManagerGrpcService(boost::asio::io_service &io_service,
-                         NodeManagerServiceHandler &service_handler)
+  NodeManagerGrpcService(boost::asio::io_service& io_service,
+                         NodeManagerServiceHandler& service_handler)
       : GrpcService(io_service), service_handler_(service_handler){};
 
  protected:
-  grpc::Service &GetGrpcService() override { return service_; }
+  grpc::Service& GetGrpcService() override { return service_; }
 
   void InitServerCallFactories(
-      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
-      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories) override {
+      const std::unique_ptr<grpc::ServerCompletionQueue>& cq,
+      std::vector<std::unique_ptr<ServerCallFactory>>* server_call_factories) override {
     RAY_NODE_MANAGER_RPC_HANDLERS
   }
 
@@ -121,7 +121,7 @@ class NodeManagerGrpcService : public GrpcService {
   NodeManagerService::AsyncService service_;
 
   /// The service handler that actually handle the requests.
-  NodeManagerServiceHandler &service_handler_;
+  NodeManagerServiceHandler& service_handler_;
 };
 
 }  // namespace rpc

--- a/src/ray/rpc/object_manager/object_manager_client.h
+++ b/src/ray/rpc/object_manager/object_manager_client.h
@@ -37,8 +37,8 @@ class ObjectManagerClient {
   /// \param[in] address Address of the node manager server.
   /// \param[in] port Port of the node manager server.
   /// \param[in] client_call_manager The `ClientCallManager` used for managing requests.
-  ObjectManagerClient(const std::string &address, const int port,
-                      ClientCallManager &client_call_manager, int num_connections = 4)
+  ObjectManagerClient(const std::string& address, const int port,
+                      ClientCallManager& client_call_manager, int num_connections = 4)
       : num_connections_(num_connections) {
     push_rr_index_ = rand() % num_connections_;
     pull_rr_index_ = rand() % num_connections_;

--- a/src/ray/rpc/object_manager/object_manager_server.h
+++ b/src/ray/rpc/object_manager/object_manager_server.h
@@ -38,14 +38,14 @@ class ObjectManagerServiceHandler {
   /// \param[in] request The request message.
   /// \param[out] reply The reply message.
   /// \param[in] send_reply_callback The callback to be called when the request is done.
-  virtual void HandlePush(const PushRequest &request, PushReply *reply,
+  virtual void HandlePush(const PushRequest& request, PushReply* reply,
                           SendReplyCallback send_reply_callback) = 0;
   /// Handle a `Pull` request
-  virtual void HandlePull(const PullRequest &request, PullReply *reply,
+  virtual void HandlePull(const PullRequest& request, PullReply* reply,
                           SendReplyCallback send_reply_callback) = 0;
   /// Handle a `FreeObjects` request
-  virtual void HandleFreeObjects(const FreeObjectsRequest &request,
-                                 FreeObjectsReply *reply,
+  virtual void HandleFreeObjects(const FreeObjectsRequest& request,
+                                 FreeObjectsReply* reply,
                                  SendReplyCallback send_reply_callback) = 0;
 };
 
@@ -56,16 +56,16 @@ class ObjectManagerGrpcService : public GrpcService {
   ///
   /// \param[in] port See `GrpcService`.
   /// \param[in] handler The service handler that actually handle the requests.
-  ObjectManagerGrpcService(boost::asio::io_service &io_service,
-                           ObjectManagerServiceHandler &service_handler)
+  ObjectManagerGrpcService(boost::asio::io_service& io_service,
+                           ObjectManagerServiceHandler& service_handler)
       : GrpcService(io_service), service_handler_(service_handler){};
 
  protected:
-  grpc::Service &GetGrpcService() override { return service_; }
+  grpc::Service& GetGrpcService() override { return service_; }
 
   void InitServerCallFactories(
-      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
-      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories) override {
+      const std::unique_ptr<grpc::ServerCompletionQueue>& cq,
+      std::vector<std::unique_ptr<ServerCallFactory>>* server_call_factories) override {
     RAY_OBJECT_MANAGER_RPC_HANDLERS
   }
 
@@ -73,7 +73,7 @@ class ObjectManagerGrpcService : public GrpcService {
   /// The grpc async service object.
   ObjectManagerService::AsyncService service_;
   /// The service handler that actually handle the requests.
-  ObjectManagerServiceHandler &service_handler_;
+  ObjectManagerServiceHandler& service_handler_;
 };
 
 }  // namespace rpc

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <grpcpp/grpcpp.h>
+
 #include <boost/asio.hpp>
 
 #include "ray/common/grpc_util.h"

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -71,7 +71,7 @@ class ServerCall {
   virtual ServerCallState GetState() const = 0;
 
   /// Set state of this `ServerCall`.
-  virtual void SetState(const ServerCallState &new_state) = 0;
+  virtual void SetState(const ServerCallState& new_state) = 0;
 
   /// Handle the requst. This is the callback function to be called by
   /// `GrpcServer` when the request is received.
@@ -104,7 +104,7 @@ class ServerCallFactory {
 /// \tparam Request Type of the request message.
 /// \tparam Reply Type of the reply message.
 template <class ServiceHandler, class Request, class Reply>
-using HandleRequestFunction = void (ServiceHandler::*)(const Request &, Reply *,
+using HandleRequestFunction = void (ServiceHandler::*)(const Request&, Reply*,
                                                        SendReplyCallback);
 
 /// Implementation of `ServerCall`. It represents `ServerCall` for a particular
@@ -123,9 +123,9 @@ class ServerCallImpl : public ServerCall {
   /// \param[in] handle_request_function Pointer to the service handler function.
   /// \param[in] io_service The event loop.
   ServerCallImpl(
-      const ServerCallFactory &factory, ServiceHandler &service_handler,
+      const ServerCallFactory& factory, ServiceHandler& service_handler,
       HandleRequestFunction<ServiceHandler, Request, Reply> handle_request_function,
-      boost::asio::io_service &io_service)
+      boost::asio::io_service& io_service)
       : state_(ServerCallState::PENDING),
         factory_(factory),
         service_handler_(service_handler),
@@ -135,7 +135,7 @@ class ServerCallImpl : public ServerCall {
 
   ServerCallState GetState() const override { return state_; }
 
-  void SetState(const ServerCallState &new_state) override { state_ = new_state; }
+  void SetState(const ServerCallState& new_state) override { state_ = new_state; }
 
   void HandleRequest() override {
     if (!io_service_.stopped()) {
@@ -152,7 +152,7 @@ class ServerCallImpl : public ServerCall {
     state_ = ServerCallState::PROCESSING;
     // NOTE(hchen): This `factory` local variable is needed. Because `SendReply` runs in
     // a different thread, and will cause `this` to be deleted.
-    const auto &factory = factory_;
+    const auto& factory = factory_;
     // Create a new `ServerCall` to accept the next incoming request.
     // We create this before handling the request so that the it can be populated by
     // the completion queue in the background if a new request comes in.
@@ -189,7 +189,7 @@ class ServerCallImpl : public ServerCall {
 
  private:
   /// Tell gRPC to finish this request and send reply asynchronously.
-  void SendReply(const Status &status) {
+  void SendReply(const Status& status) {
     state_ = ServerCallState::SENDING_REPLY;
     response_writer_.Finish(reply_, RayStatusToGrpcStatus(status), this);
   }
@@ -198,10 +198,10 @@ class ServerCallImpl : public ServerCall {
   ServerCallState state_;
 
   /// The factory which created this call.
-  const ServerCallFactory &factory_;
+  const ServerCallFactory& factory_;
 
   /// The service handler that handles the request.
-  ServiceHandler &service_handler_;
+  ServiceHandler& service_handler_;
 
   /// Pointer to the service handler function.
   HandleRequestFunction<ServiceHandler, Request, Reply> handle_request_function_;
@@ -214,7 +214,7 @@ class ServerCallImpl : public ServerCall {
   grpc_impl::ServerAsyncResponseWriter<Reply> response_writer_;
 
   /// The event loop.
-  boost::asio::io_service &io_service_;
+  boost::asio::io_service& io_service_;
 
   /// The request message.
   Request request_;
@@ -239,8 +239,8 @@ class ServerCallImpl : public ServerCall {
 /// \tparam Reply Type of the reply message.
 template <class GrpcService, class Request, class Reply>
 using RequestCallFunction = void (GrpcService::AsyncService::*)(
-    grpc::ServerContext *, Request *, grpc_impl::ServerAsyncResponseWriter<Reply> *,
-    grpc::CompletionQueue *, grpc::ServerCompletionQueue *, void *);
+    grpc::ServerContext*, Request*, grpc_impl::ServerAsyncResponseWriter<Reply>*,
+    grpc::CompletionQueue*, grpc::ServerCompletionQueue*, void*);
 
 /// Implementation of `ServerCallFactory`
 ///
@@ -263,12 +263,12 @@ class ServerCallFactoryImpl : public ServerCallFactory {
   /// \param[in] cq The `CompletionQueue`.
   /// \param[in] io_service The event loop.
   ServerCallFactoryImpl(
-      AsyncService &service,
+      AsyncService& service,
       RequestCallFunction<GrpcService, Request, Reply> request_call_function,
-      ServiceHandler &service_handler,
+      ServiceHandler& service_handler,
       HandleRequestFunction<ServiceHandler, Request, Reply> handle_request_function,
-      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
-      boost::asio::io_service &io_service)
+      const std::unique_ptr<grpc::ServerCompletionQueue>& cq,
+      boost::asio::io_service& io_service)
       : service_(service),
         request_call_function_(request_call_function),
         service_handler_(service_handler),
@@ -290,22 +290,22 @@ class ServerCallFactoryImpl : public ServerCallFactory {
 
  private:
   /// The gRPC-generated `AsyncService`.
-  AsyncService &service_;
+  AsyncService& service_;
 
   /// Pointer to the `AsyncService::RequestMethod` function.
   RequestCallFunction<GrpcService, Request, Reply> request_call_function_;
 
   /// The service handler that handles the request.
-  ServiceHandler &service_handler_;
+  ServiceHandler& service_handler_;
 
   /// Pointer to the service handler function.
   HandleRequestFunction<ServiceHandler, Request, Reply> handle_request_function_;
 
   /// The `CompletionQueue`.
-  const std::unique_ptr<grpc::ServerCompletionQueue> &cq_;
+  const std::unique_ptr<grpc::ServerCompletionQueue>& cq_;
 
   /// The event loop.
-  boost::asio::io_service &io_service_;
+  boost::asio::io_service& io_service_;
 };
 
 }  // namespace rpc

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -45,9 +45,9 @@ const int64_t kMaxBytesInFlight = 16 * 1024 * 1024;
 const int64_t kBaseRequestSize = 1024;
 
 /// Get the estimated size in bytes of the given task.
-const static int64_t RequestSizeInBytes(const PushTaskRequest &request) {
+const static int64_t RequestSizeInBytes(const PushTaskRequest& request) {
   int64_t size = kBaseRequestSize;
-  for (auto &arg : request.task_spec().args()) {
+  for (auto& arg : request.task_spec().args()) {
     size += arg.data().size();
   }
   return size;
@@ -59,17 +59,17 @@ class CoreWorkerClientInterface;
 // TODO(swang): Remove and replace with rpc::Address.
 class WorkerAddress {
  public:
-  WorkerAddress(const rpc::Address &address)
+  WorkerAddress(const rpc::Address& address)
       : ip_address(address.ip_address()),
         port(address.port()),
         worker_id(WorkerID::FromBinary(address.worker_id())),
         raylet_id(ClientID::FromBinary(address.raylet_id())) {}
   template <typename H>
-  friend H AbslHashValue(H h, const WorkerAddress &w) {
+  friend H AbslHashValue(H h, const WorkerAddress& w) {
     return H::combine(std::move(h), w.ip_address, w.port, w.worker_id, w.raylet_id);
   }
 
-  bool operator==(const WorkerAddress &other) const {
+  bool operator==(const WorkerAddress& other) const {
     return other.ip_address == ip_address && other.port == port &&
            other.worker_id == worker_id && other.raylet_id == raylet_id;
   }
@@ -93,13 +93,13 @@ class WorkerAddress {
   const ClientID raylet_id;
 };
 
-typedef std::function<std::shared_ptr<CoreWorkerClientInterface>(const rpc::Address &)>
+typedef std::function<std::shared_ptr<CoreWorkerClientInterface>(const rpc::Address&)>
     ClientFactoryFn;
 
 /// Abstract client interface for testing.
 class CoreWorkerClientInterface {
  public:
-  virtual const rpc::Address &Addr() const {
+  virtual const rpc::Address& Addr() const {
     static const rpc::Address empty_addr_;
     return empty_addr_;
   }
@@ -109,8 +109,8 @@ class CoreWorkerClientInterface {
   /// \param[in] request The request message.
   /// \param[in] callback The callback function that handles reply.
   /// \return if the rpc call succeeds
-  virtual void AssignTask(const AssignTaskRequest &request,
-                          const ClientCallback<AssignTaskReply> &callback) {}
+  virtual void AssignTask(const AssignTaskRequest& request,
+                          const ClientCallback<AssignTaskReply>& callback) {}
 
   /// Push an actor task directly from worker to worker.
   ///
@@ -120,12 +120,12 @@ class CoreWorkerClientInterface {
   /// \param[in] callback The callback function that handles reply.
   /// \return if the rpc call succeeds
   virtual void PushActorTask(std::unique_ptr<PushTaskRequest> request, bool skip_queue,
-                             const ClientCallback<PushTaskReply> &callback) {}
+                             const ClientCallback<PushTaskReply>& callback) {}
 
   /// Similar to PushActorTask, but sets no ordering constraint. This is used to
   /// push non-actor tasks directly to a worker.
   virtual void PushNormalTask(std::unique_ptr<PushTaskRequest> request,
-                              const ClientCallback<PushTaskReply> &callback) {}
+                              const ClientCallback<PushTaskReply>& callback) {}
 
   /// Notify a wait has completed for direct actor call arguments.
   ///
@@ -133,46 +133,46 @@ class CoreWorkerClientInterface {
   /// \param[in] callback The callback function that handles reply.
   /// \return if the rpc call succeeds
   virtual void DirectActorCallArgWaitComplete(
-      const DirectActorCallArgWaitCompleteRequest &request,
-      const ClientCallback<DirectActorCallArgWaitCompleteReply> &callback) {}
+      const DirectActorCallArgWaitCompleteRequest& request,
+      const ClientCallback<DirectActorCallArgWaitCompleteReply>& callback) {}
 
   /// Ask the owner of an object about the object's current status.
-  virtual void GetObjectStatus(const GetObjectStatusRequest &request,
-                               const ClientCallback<GetObjectStatusReply> &callback) {}
+  virtual void GetObjectStatus(const GetObjectStatusRequest& request,
+                               const ClientCallback<GetObjectStatusReply>& callback) {}
 
   /// Ask the actor's owner to reply when the actor has gone out of scope.
   virtual void WaitForActorOutOfScope(
-      const WaitForActorOutOfScopeRequest &request,
-      const ClientCallback<WaitForActorOutOfScopeReply> &callback) {}
+      const WaitForActorOutOfScopeRequest& request,
+      const ClientCallback<WaitForActorOutOfScopeReply>& callback) {}
 
   /// Notify the owner of an object that the object has been pinned.
   virtual void WaitForObjectEviction(
-      const WaitForObjectEvictionRequest &request,
-      const ClientCallback<WaitForObjectEvictionReply> &callback) {}
+      const WaitForObjectEvictionRequest& request,
+      const ClientCallback<WaitForObjectEvictionReply>& callback) {}
 
   /// Tell this actor to exit immediately.
-  virtual void KillActor(const KillActorRequest &request,
-                         const ClientCallback<KillActorReply> &callback) {}
+  virtual void KillActor(const KillActorRequest& request,
+                         const ClientCallback<KillActorReply>& callback) {}
 
-  virtual void CancelTask(const CancelTaskRequest &request,
-                          const ClientCallback<CancelTaskReply> &callback) {}
+  virtual void CancelTask(const CancelTaskRequest& request,
+                          const ClientCallback<CancelTaskReply>& callback) {}
 
-  virtual void RemoteCancelTask(const RemoteCancelTaskRequest &request,
-                                const ClientCallback<RemoteCancelTaskReply> &callback) {}
+  virtual void RemoteCancelTask(const RemoteCancelTaskRequest& request,
+                                const ClientCallback<RemoteCancelTaskReply>& callback) {}
 
   virtual void GetCoreWorkerStats(
-      const GetCoreWorkerStatsRequest &request,
-      const ClientCallback<GetCoreWorkerStatsReply> &callback) {}
+      const GetCoreWorkerStatsRequest& request,
+      const ClientCallback<GetCoreWorkerStatsReply>& callback) {}
 
-  virtual void LocalGC(const LocalGCRequest &request,
-                       const ClientCallback<LocalGCReply> &callback) {}
+  virtual void LocalGC(const LocalGCRequest& request,
+                       const ClientCallback<LocalGCReply>& callback) {}
 
-  virtual void WaitForRefRemoved(const WaitForRefRemovedRequest &request,
-                                 const ClientCallback<WaitForRefRemovedReply> &callback) {
+  virtual void WaitForRefRemoved(const WaitForRefRemovedRequest& request,
+                                 const ClientCallback<WaitForRefRemovedReply>& callback) {
   }
 
-  virtual void PlasmaObjectReady(const PlasmaObjectReadyRequest &request,
-                                 const ClientCallback<PlasmaObjectReadyReply> &callback) {
+  virtual void PlasmaObjectReady(const PlasmaObjectReadyRequest& request,
+                                 const ClientCallback<PlasmaObjectReadyReply>& callback) {
   }
 
   virtual ~CoreWorkerClientInterface(){};
@@ -187,14 +187,14 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
   /// \param[in] address Address of the worker server.
   /// \param[in] port Port of the worker server.
   /// \param[in] client_call_manager The `ClientCallManager` used for managing requests.
-  CoreWorkerClient(const rpc::Address &address, ClientCallManager &client_call_manager)
+  CoreWorkerClient(const rpc::Address& address, ClientCallManager& client_call_manager)
       : addr_(address) {
     grpc_client_ =
         std::unique_ptr<GrpcClient<CoreWorkerService>>(new GrpcClient<CoreWorkerService>(
             addr_.ip_address(), addr_.port(), client_call_manager));
   };
 
-  const rpc::Address &Addr() const override { return addr_; }
+  const rpc::Address& Addr() const override { return addr_; }
 
   VOID_RPC_CLIENT_METHOD(CoreWorkerService, AssignTask, grpc_client_, override)
 
@@ -223,7 +223,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
   VOID_RPC_CLIENT_METHOD(CoreWorkerService, PlasmaObjectReady, grpc_client_, override)
 
   void PushActorTask(std::unique_ptr<PushTaskRequest> request, bool skip_queue,
-                     const ClientCallback<PushTaskReply> &callback) override {
+                     const ClientCallback<PushTaskReply>& callback) override {
     if (skip_queue) {
       // Set this value so that the actor does not skip any tasks when
       // processing this request. We could also set it to max_finished_seq_no_,
@@ -241,7 +241,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
   }
 
   void PushNormalTask(std::unique_ptr<PushTaskRequest> request,
-                      const ClientCallback<PushTaskReply> &callback) override {
+                      const ClientCallback<PushTaskReply>& callback) override {
     request->set_sequence_number(-1);
     request->set_client_processed_up_to(-1);
     INVOKE_RPC_CALL(CoreWorkerService, PushTask, *request, callback, grpc_client_);
@@ -268,7 +268,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
       rpc_bytes_in_flight_ += task_size;
 
       auto rpc_callback = [this, this_ptr, seq_no, task_size, callback](
-                              Status status, const rpc::PushTaskReply &reply) {
+                              Status status, const rpc::PushTaskReply& reply) {
         {
           absl::MutexLock lock(&mutex_);
           if (seq_no > max_finished_seq_no_) {

--- a/src/ray/rpc/worker/core_worker_server.h
+++ b/src/ray/rpc/worker/core_worker_server.h
@@ -80,16 +80,16 @@ class CoreWorkerGrpcService : public GrpcService {
   ///
   /// \param[in] main_service See super class.
   /// \param[in] handler The service handler that actually handle the requests.
-  CoreWorkerGrpcService(boost::asio::io_service &main_service,
-                        CoreWorkerServiceHandler &service_handler)
+  CoreWorkerGrpcService(boost::asio::io_service& main_service,
+                        CoreWorkerServiceHandler& service_handler)
       : GrpcService(main_service), service_handler_(service_handler) {}
 
  protected:
-  grpc::Service &GetGrpcService() override { return service_; }
+  grpc::Service& GetGrpcService() override { return service_; }
 
   void InitServerCallFactories(
-      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
-      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories) override {
+      const std::unique_ptr<grpc::ServerCompletionQueue>& cq,
+      std::vector<std::unique_ptr<ServerCallFactory>>* server_call_factories) override {
     RAY_CORE_WORKER_RPC_HANDLERS
   }
 
@@ -98,7 +98,7 @@ class CoreWorkerGrpcService : public GrpcService {
   CoreWorkerService::AsyncService service_;
 
   /// The service handler that actually handles the requests.
-  CoreWorkerServiceHandler &service_handler_;
+  CoreWorkerServiceHandler& service_handler_;
 };
 
 }  // namespace rpc

--- a/src/ray/stats/metric.cc
+++ b/src/ray/stats/metric.cc
@@ -22,14 +22,14 @@ namespace ray {
 namespace stats {
 
 static void RegisterAsView(opencensus::stats::ViewDescriptor view_descriptor,
-                           const std::vector<opencensus::tags::TagKey> &keys) {
+                           const std::vector<opencensus::tags::TagKey>& keys) {
   // Register global keys.
-  for (const auto &tag : ray::stats::StatsConfig::instance().GetGlobalTags()) {
+  for (const auto& tag : ray::stats::StatsConfig::instance().GetGlobalTags()) {
     view_descriptor = view_descriptor.add_column(tag.first);
   }
 
   // Register custom keys.
-  for (const auto &key : keys) {
+  for (const auto& key : keys) {
     view_descriptor = view_descriptor.add_column(key);
   }
   opencensus::stats::View view(view_descriptor);
@@ -40,16 +40,16 @@ static void RegisterAsView(opencensus::stats::ViewDescriptor view_descriptor,
 /// Stats Config
 ///
 
-StatsConfig &StatsConfig::instance() {
+StatsConfig& StatsConfig::instance() {
   static StatsConfig instance;
   return instance;
 }
 
-void StatsConfig::SetGlobalTags(const TagsType &global_tags) {
+void StatsConfig::SetGlobalTags(const TagsType& global_tags) {
   global_tags_ = global_tags;
 }
 
-const TagsType &StatsConfig::GetGlobalTags() const { return global_tags_; }
+const TagsType& StatsConfig::GetGlobalTags() const { return global_tags_; }
 
 void StatsConfig::SetIsDisableStats(bool disable_stats) {
   is_stats_disabled_ = disable_stats;
@@ -61,13 +61,13 @@ void StatsConfig::SetReportInterval(const absl::Duration interval) {
   report_interval_ = interval;
 }
 
-const absl::Duration &StatsConfig::GetReportInterval() const { return report_interval_; }
+const absl::Duration& StatsConfig::GetReportInterval() const { return report_interval_; }
 
 void StatsConfig::SetHarvestInterval(const absl::Duration interval) {
   harvest_interval_ = interval;
 }
 
-const absl::Duration &StatsConfig::GetHarvestInterval() const {
+const absl::Duration& StatsConfig::GetHarvestInterval() const {
   return harvest_interval_;
 }
 
@@ -78,7 +78,7 @@ bool StatsConfig::IsInitialized() const { return is_initialized_; }
 ///
 /// Metric
 ///
-void Metric::Record(double value, const TagsType &tags) {
+void Metric::Record(double value, const TagsType& tags) {
   if (StatsConfig::instance().IsStatsDisabled()) {
     return;
   }
@@ -97,7 +97,7 @@ void Metric::Record(double value, const TagsType &tags) {
   opencensus::stats::Record({{*measure_, value}}, combined_tags);
 }
 
-void Metric::Record(double value, std::unordered_map<std::string, std::string> &tags) {
+void Metric::Record(double value, std::unordered_map<std::string, std::string>& tags) {
   TagsType tags_pair_vec;
   std::for_each(
       tags.begin(), tags.end(),

--- a/src/ray/stats/metric.h
+++ b/src/ray/stats/metric.h
@@ -34,17 +34,17 @@ namespace stats {
 /// outside stats::Init() or stats::Shutdown() method.
 class StatsConfig final {
  public:
-  static StatsConfig &instance();
+  static StatsConfig& instance();
 
   /// Get the current global tags.
-  const TagsType &GetGlobalTags() const;
+  const TagsType& GetGlobalTags() const;
 
   /// Get whether or not stats are enabled.
   bool IsStatsDisabled() const;
 
-  const absl::Duration &GetReportInterval() const;
+  const absl::Duration& GetReportInterval() const;
 
-  const absl::Duration &GetHarvestInterval() const;
+  const absl::Duration& GetHarvestInterval() const;
 
   bool IsInitialized() const;
 
@@ -63,13 +63,13 @@ class StatsConfig final {
   /// Set if the stats are enabled in this process.
   void SetIsDisableStats(bool disable_stats);
   /// Set the global tags that will be appended to all metrics in this process.
-  void SetGlobalTags(const TagsType &global_tags);
+  void SetGlobalTags(const TagsType& global_tags);
 
  private:
   StatsConfig() = default;
   ~StatsConfig() = default;
-  StatsConfig(const StatsConfig &) = delete;
-  StatsConfig &operator=(const StatsConfig &) = delete;
+  StatsConfig(const StatsConfig&) = delete;
+  StatsConfig& operator=(const StatsConfig&) = delete;
 
  private:
   TagsType global_tags_;
@@ -89,8 +89,8 @@ class StatsConfig final {
 /// A thin wrapper that wraps the `opencensus::tag::measure` for using it simply.
 class Metric {
  public:
-  Metric(const std::string &name, const std::string &description, const std::string &unit,
-         const std::vector<opencensus::tags::TagKey> &tag_keys = {})
+  Metric(const std::string& name, const std::string& description, const std::string& unit,
+         const std::vector<opencensus::tags::TagKey>& tag_keys = {})
       : name_(name),
         description_(description),
         unit_(unit),
@@ -99,7 +99,7 @@ class Metric {
 
   virtual ~Metric() { opencensus::stats::StatsExporter::RemoveView(name_); }
 
-  Metric &operator()() { return *this; }
+  Metric& operator()() { return *this; }
 
   /// Get the name of this metric.
   std::string GetName() const { return name_; }
@@ -111,13 +111,13 @@ class Metric {
   ///
   /// \param value The value that we record.
   /// \param tags The tag values that we want to record for this metric record.
-  void Record(double value, const TagsType &tags);
+  void Record(double value, const TagsType& tags);
 
   /// Record the value for this metric.
   ///
   /// \param value The value that we record.
   /// \param tags The map tag values that we want to record for this metric record.
-  void Record(double value, std::unordered_map<std::string, std::string> &tags);
+  void Record(double value, std::unordered_map<std::string, std::string>& tags);
 
  protected:
   virtual void RegisterView() = 0;
@@ -133,8 +133,8 @@ class Metric {
 
 class Gauge : public Metric {
  public:
-  Gauge(const std::string &name, const std::string &description, const std::string &unit,
-        const std::vector<opencensus::tags::TagKey> &tag_keys = {})
+  Gauge(const std::string& name, const std::string& description, const std::string& unit,
+        const std::vector<opencensus::tags::TagKey>& tag_keys = {})
       : Metric(name, description, unit, tag_keys) {}
 
  private:
@@ -144,9 +144,9 @@ class Gauge : public Metric {
 
 class Histogram : public Metric {
  public:
-  Histogram(const std::string &name, const std::string &description,
-            const std::string &unit, const std::vector<double> boundaries,
-            const std::vector<opencensus::tags::TagKey> &tag_keys = {})
+  Histogram(const std::string& name, const std::string& description,
+            const std::string& unit, const std::vector<double> boundaries,
+            const std::vector<opencensus::tags::TagKey>& tag_keys = {})
       : Metric(name, description, unit, tag_keys), boundaries_(boundaries) {}
 
  private:
@@ -159,8 +159,8 @@ class Histogram : public Metric {
 
 class Count : public Metric {
  public:
-  Count(const std::string &name, const std::string &description, const std::string &unit,
-        const std::vector<opencensus::tags::TagKey> &tag_keys = {})
+  Count(const std::string& name, const std::string& description, const std::string& unit,
+        const std::vector<opencensus::tags::TagKey>& tag_keys = {})
       : Metric(name, description, unit, tag_keys) {}
 
  private:
@@ -170,8 +170,8 @@ class Count : public Metric {
 
 class Sum : public Metric {
  public:
-  Sum(const std::string &name, const std::string &description, const std::string &unit,
-      const std::vector<opencensus::tags::TagKey> &tag_keys = {})
+  Sum(const std::string& name, const std::string& description, const std::string& unit,
+      const std::vector<opencensus::tags::TagKey>& tag_keys = {})
       : Metric(name, description, unit, tag_keys) {}
 
  private:
@@ -185,7 +185,7 @@ struct MetricPoint {
   int64_t timestamp;
   double value;
   std::unordered_map<std::string, std::string> tags;
-  const opencensus::stats::MeasureDescriptor &measure_descriptor;
+  const opencensus::stats::MeasureDescriptor& measure_descriptor;
 };
 
 }  // namespace stats

--- a/src/ray/stats/metric_exporter.cc
+++ b/src/ray/stats/metric_exporter.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <future>
-
 #include "ray/stats/metric_exporter.h"
+
+#include <future>
 
 namespace ray {
 namespace stats {

--- a/src/ray/stats/metric_exporter.cc
+++ b/src/ray/stats/metric_exporter.cc
@@ -21,16 +21,16 @@ namespace stats {
 
 template <>
 void MetricExporter::ExportToPoints(
-    const opencensus::stats::ViewData::DataMap<opencensus::stats::Distribution>
-        &view_data,
-    const opencensus::stats::MeasureDescriptor &measure_descriptor,
-    std::vector<std::string> &keys, std::vector<MetricPoint> &points) {
+    const opencensus::stats::ViewData::DataMap<opencensus::stats::Distribution>&
+        view_data,
+    const opencensus::stats::MeasureDescriptor& measure_descriptor,
+    std::vector<std::string>& keys, std::vector<MetricPoint>& points) {
   // Return if no raw data found in view map.
   if (view_data.size() == 0) {
     return;
   }
 
-  const auto &metric_name = measure_descriptor.name();
+  const auto& metric_name = measure_descriptor.name();
 
   // NOTE(lingxuan.zlx): No sampling in histogram data, so all points all be filled in.
   std::unordered_map<std::string, std::string> tags;
@@ -42,7 +42,7 @@ void MetricExporter::ExportToPoints(
   double hist_max = 0.0;
   double hist_min = 0.0;
   bool in_first_hist_data = true;
-  for (const auto &row : view_data) {
+  for (const auto& row : view_data) {
     if (in_first_hist_data) {
       hist_mean = static_cast<double>(row.second.mean());
       hist_max = static_cast<double>(row.second.max());
@@ -77,19 +77,19 @@ void MetricExporter::ExportToPoints(
 
 void MetricExporter::ExportViewData(
     const std::vector<std::pair<opencensus::stats::ViewDescriptor,
-                                opencensus::stats::ViewData>> &data) {
+                                opencensus::stats::ViewData>>& data) {
   std::vector<MetricPoint> points;
   // NOTE(lingxuan.zlx): There is no sampling in view data, so all raw metric
   // data will be processed.
-  for (const auto &datum : data) {
-    auto &descriptor = datum.first;
-    auto &view_data = datum.second;
+  for (const auto& datum : data) {
+    auto& descriptor = datum.first;
+    auto& view_data = datum.second;
 
     std::vector<std::string> keys;
     for (size_t i = 0; i < descriptor.columns().size(); ++i) {
       keys.push_back(descriptor.columns()[i].name());
     }
-    const auto &measure_descriptor = descriptor.measure_descriptor();
+    const auto& measure_descriptor = descriptor.measure_descriptor();
     switch (view_data.type()) {
     case opencensus::stats::ViewData::Type::kDouble:
       ExportToPoints<double>(view_data.double_data(), measure_descriptor, keys, points);

--- a/src/ray/stats/metric_exporter.h
+++ b/src/ray/stats/metric_exporter.h
@@ -16,7 +16,6 @@
 #include "absl/memory/memory.h"
 #include "opencensus/stats/stats.h"
 #include "opencensus/tags/tag_key.h"
-
 #include "ray/stats/metric.h"
 #include "ray/stats/metric_exporter_client.h"
 #include "ray/util/logging.h"

--- a/src/ray/stats/metric_exporter.h
+++ b/src/ray/stats/metric_exporter.h
@@ -45,7 +45,7 @@ class MetricExporter final : public opencensus::stats::StatsExporter::Handler {
 
   void ExportViewData(
       const std::vector<std::pair<opencensus::stats::ViewDescriptor,
-                                  opencensus::stats::ViewData>> &data) override;
+                                  opencensus::stats::ViewData>>& data) override;
 
  private:
   template <class DTYPE>
@@ -55,11 +55,11 @@ class MetricExporter final : public opencensus::stats::StatsExporter::Handler {
   /// \param metric_name, metric name of view data
   /// \param keys, metric tags map
   /// \param points, memory metric vector instance
-  void ExportToPoints(const opencensus::stats::ViewData::DataMap<DTYPE> &view_data,
-                      const opencensus::stats::MeasureDescriptor &measure_descriptor,
-                      std::vector<std::string> &keys, std::vector<MetricPoint> &points) {
-    const auto &metric_name = measure_descriptor.name();
-    for (const auto &row : view_data) {
+  void ExportToPoints(const opencensus::stats::ViewData::DataMap<DTYPE>& view_data,
+                      const opencensus::stats::MeasureDescriptor& measure_descriptor,
+                      std::vector<std::string>& keys, std::vector<MetricPoint>& points) {
+    const auto& metric_name = measure_descriptor.name();
+    for (const auto& row : view_data) {
       std::unordered_map<std::string, std::string> tags;
       for (size_t i = 0; i < keys.size(); ++i) {
         tags[keys[i]] = row.first[i];

--- a/src/ray/stats/metric_exporter_client.cc
+++ b/src/ray/stats/metric_exporter_client.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <algorithm>
-
 #include "ray/stats/metric_exporter_client.h"
+
+#include <algorithm>
 
 namespace ray {
 namespace stats {

--- a/src/ray/stats/metric_exporter_client.cc
+++ b/src/ray/stats/metric_exporter_client.cc
@@ -22,7 +22,7 @@ namespace stats {
 ///
 /// Stdout Exporter
 ///
-void StdoutExporterClient::ReportMetrics(const std::vector<MetricPoint> &points) {
+void StdoutExporterClient::ReportMetrics(const std::vector<MetricPoint>& points) {
   RAY_LOG(DEBUG) << "Metric point size : " << points.size();
 }
 
@@ -33,7 +33,7 @@ MetricExporterDecorator::MetricExporterDecorator(
     std::shared_ptr<MetricExporterClient> exporter)
     : exporter_(exporter) {}
 
-void MetricExporterDecorator::ReportMetrics(const std::vector<MetricPoint> &points) {
+void MetricExporterDecorator::ReportMetrics(const std::vector<MetricPoint>& points) {
   if (exporter_) {
     exporter_->ReportMetrics(points);
   }
@@ -44,13 +44,13 @@ void MetricExporterDecorator::ReportMetrics(const std::vector<MetricPoint> &poin
 ///
 MetricsAgentExporter::MetricsAgentExporter(std::shared_ptr<MetricExporterClient> exporter,
                                            const int port,
-                                           boost::asio::io_service &io_service,
+                                           boost::asio::io_service& io_service,
                                            const std::string address)
     : MetricExporterDecorator(exporter), client_call_manager_(io_service) {
   client_.reset(new rpc::MetricsAgentClient(address, port, client_call_manager_));
 }
 
-void MetricsAgentExporter::ReportMetrics(const std::vector<MetricPoint> &points) {
+void MetricsAgentExporter::ReportMetrics(const std::vector<MetricPoint>& points) {
   MetricExporterDecorator::ReportMetrics(points);
   rpc::ReportMetricsRequest request;
   for (auto point : points) {
@@ -59,7 +59,7 @@ void MetricsAgentExporter::ReportMetrics(const std::vector<MetricPoint> &points)
     metric_point->set_timestamp(point.timestamp);
     metric_point->set_value(point.value);
     auto mutable_tags = metric_point->mutable_tags();
-    for (auto &tag : point.tags) {
+    for (auto& tag : point.tags) {
       (*mutable_tags)[tag.first] = tag.second;
     }
     // If description and units information is requested from
@@ -75,7 +75,7 @@ void MetricsAgentExporter::ReportMetrics(const std::vector<MetricPoint> &points)
 
   // TODO(sang): Should retry metrics report if it fails.
   client_->ReportMetrics(
-      request, [this](const Status &status, const rpc::ReportMetricsReply &reply) {
+      request, [this](const Status& status, const rpc::ReportMetricsReply& reply) {
         should_update_description_ = reply.metrcs_description_required();
       });
 }

--- a/src/ray/stats/metric_exporter_client.h
+++ b/src/ray/stats/metric_exporter_client.h
@@ -25,7 +25,7 @@ namespace stats {
 /// Interface class for abstract metrics exporter client.
 class MetricExporterClient {
  public:
-  virtual void ReportMetrics(const std::vector<MetricPoint> &points) = 0;
+  virtual void ReportMetrics(const std::vector<MetricPoint>& points) = 0;
   virtual ~MetricExporterClient() = default;
 };
 
@@ -34,7 +34,7 @@ class MetricExporterClient {
 /// use stdout as the default concrete class.
 class StdoutExporterClient : public MetricExporterClient {
  public:
-  void ReportMetrics(const std::vector<MetricPoint> &points) override;
+  void ReportMetrics(const std::vector<MetricPoint>& points) override;
 };
 
 /// The decoration mode is that the user can apply it by configuring different
@@ -49,7 +49,7 @@ class StdoutExporterClient : public MetricExporterClient {
 class MetricExporterDecorator : public MetricExporterClient {
  public:
   MetricExporterDecorator(std::shared_ptr<MetricExporterClient> exporter);
-  virtual void ReportMetrics(const std::vector<MetricPoint> &points);
+  virtual void ReportMetrics(const std::vector<MetricPoint>& points);
 
  private:
   std::shared_ptr<MetricExporterClient> exporter_;
@@ -58,11 +58,11 @@ class MetricExporterDecorator : public MetricExporterClient {
 class MetricsAgentExporter : public MetricExporterDecorator {
  public:
   MetricsAgentExporter(std::shared_ptr<MetricExporterClient> exporter, const int port,
-                       boost::asio::io_service &io_service, const std::string address);
+                       boost::asio::io_service& io_service, const std::string address);
 
   ~MetricsAgentExporter() {}
 
-  void ReportMetrics(const std::vector<MetricPoint> &points) override;
+  void ReportMetrics(const std::vector<MetricPoint>& points) override;
 
  private:
   /// Client to call a metrics agent gRPC server.

--- a/src/ray/stats/metric_exporter_client_test.cc
+++ b/src/ray/stats/metric_exporter_client_test.cc
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include "ray/stats/metric_exporter_client.h"
 
 #include <chrono>
 #include <iostream>
@@ -21,10 +20,11 @@
 #include <vector>
 
 #include "absl/memory/memory.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "opencensus/stats/internal/delta_producer.h"
 #include "opencensus/stats/internal/stats_exporter_impl.h"
 #include "ray/stats/metric_exporter.h"
-#include "ray/stats/metric_exporter_client.h"
 #include "ray/stats/stats.h"
 
 namespace ray {

--- a/src/ray/stats/metric_exporter_client_test.cc
+++ b/src/ray/stats/metric_exporter_client_test.cc
@@ -43,7 +43,7 @@ class MockExporterClient1 : public MetricExporterDecorator {
         lastest_hist_mean(0.0),
         lastest_hist_max(0.0) {}
 
-  void ReportMetrics(const std::vector<MetricPoint> &points) override {
+  void ReportMetrics(const std::vector<MetricPoint>& points) override {
     if (points.empty()) {
       return;
     }
@@ -63,8 +63,8 @@ class MockExporterClient1 : public MetricExporterDecorator {
   double GetLastestHistMax() { return lastest_hist_max; }
 
  private:
-  void RecordLastHistData(const std::vector<MetricPoint> &points) {
-    for (auto &point : points) {
+  void RecordLastHistData(const std::vector<MetricPoint>& points) {
+    for (auto& point : points) {
       if (point.metric_name.find(".min") != std::string::npos) {
         lastest_hist_min = point.value;
       }
@@ -89,7 +89,7 @@ class MockExporterClient2 : public MetricExporterDecorator {
  public:
   MockExporterClient2(std::shared_ptr<MetricExporterClient> exporter)
       : MetricExporterDecorator(exporter), client2_count(0), client2_value(0) {}
-  void ReportMetrics(const std::vector<MetricPoint> &points) override {
+  void ReportMetrics(const std::vector<MetricPoint>& points) override {
     if (points.empty()) {
       return;
     }
@@ -184,7 +184,7 @@ TEST_F(MetricExporterClientTest, exporter_client_caculation_test) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/stats/stats.h
+++ b/src/ray/stats/stats.h
@@ -19,7 +19,6 @@
 #include <unordered_map>
 
 #include "absl/synchronization/mutex.h"
-
 #include "opencensus/stats/internal/delta_producer.h"
 #include "opencensus/stats/stats.h"
 #include "opencensus/tags/tag_key.h"

--- a/src/ray/stats/stats.h
+++ b/src/ray/stats/stats.h
@@ -54,7 +54,7 @@ static absl::Mutex stats_mutex;
 /// \param global_tags[in] Tags that will be appended to all metrics in this process.
 /// \param metrics_agent_port[in] The port to export metrics at each node.
 /// \param exporter_to_use[in] The exporter client you will use for this process' metrics.
-static inline void Init(const TagsType &global_tags, const int metrics_agent_port,
+static inline void Init(const TagsType& global_tags, const int metrics_agent_port,
                         std::shared_ptr<MetricExporterClient> exporter_to_use = nullptr,
                         int64_t metrics_report_batch_size =
                             RayConfig::instance().metrics_report_batch_size()) {
@@ -77,7 +77,7 @@ static inline void Init(const TagsType &global_tags, const int metrics_agent_por
 
   metrics_io_service_pool = std::make_shared<IOServicePool>(1);
   metrics_io_service_pool->Run();
-  boost::asio::io_service *metrics_io_service = metrics_io_service_pool->Get();
+  boost::asio::io_service* metrics_io_service = metrics_io_service_pool->Get();
   RAY_CHECK(metrics_io_service != nullptr);
 
   // Default exporter is a metrics agent exporter.

--- a/src/ray/stats/stats_test.cc
+++ b/src/ray/stats/stats_test.cc
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include "ray/stats/stats.h"
 
 #include <chrono>
 #include <iostream>
@@ -21,7 +20,8 @@
 #include <vector>
 
 #include "absl/memory/memory.h"
-#include "ray/stats/stats.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace ray {
 

--- a/src/ray/stats/stats_test.cc
+++ b/src/ray/stats/stats_test.cc
@@ -36,14 +36,14 @@ class MockExporter : public opencensus::stats::StatsExporter::Handler {
 
   void ExportViewData(
       const std::vector<std::pair<opencensus::stats::ViewDescriptor,
-                                  opencensus::stats::ViewData>> &data) override {
-    for (const auto &datum : data) {
-      auto &descriptor = datum.first;
-      auto &view_data = datum.second;
+                                  opencensus::stats::ViewData>>& data) override {
+    for (const auto& datum : data) {
+      auto& descriptor = datum.first;
+      auto& view_data = datum.second;
 
       ASSERT_EQ("current_worker", descriptor.name());
       ASSERT_EQ(opencensus::stats::ViewData::Type::kDouble, view_data.type());
-      for (const auto &row : view_data.double_data()) {
+      for (const auto& row : view_data.double_data()) {
         for (size_t i = 0; i < descriptor.columns().size(); ++i) {
           if (descriptor.columns()[i].name() == "WorkerPidKey") {
             ASSERT_EQ("1000", row.first[i]);
@@ -101,7 +101,7 @@ TEST_F(StatsTest, InitializationTest) {
                      MetricsAgentPort, exporter);
   }
 
-  auto &first_tag = ray::stats::StatsConfig::instance().GetGlobalTags()[0];
+  auto& first_tag = ray::stats::StatsConfig::instance().GetGlobalTags()[0];
   ASSERT_TRUE(first_tag.second != test_tag_value_that_shouldnt_be_applied);
 
   ray::stats::Shutdown();
@@ -115,7 +115,7 @@ TEST_F(StatsTest, InitializationTest) {
 
   ray::stats::Init(global_tags, MetricsAgentPort, exporter);
   ASSERT_TRUE(ray::stats::StatsConfig::instance().IsInitialized());
-  auto &new_first_tag = ray::stats::StatsConfig::instance().GetGlobalTags()[0];
+  auto& new_first_tag = ray::stats::StatsConfig::instance().GetGlobalTags()[0];
   ASSERT_TRUE(new_first_tag.second == test_tag_value_that_shouldnt_be_applied);
 }
 
@@ -143,7 +143,7 @@ TEST_F(StatsTest, MultiThreadedInitializationTest) {
       }
     });
   }
-  for (auto &thread : threads) {
+  for (auto& thread : threads) {
     thread.join();
   }
   ray::stats::Shutdown();
@@ -177,7 +177,7 @@ TEST_F(StatsTest, TestShutdownTakesLongTime) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/util/asio_util.h
+++ b/src/ray/util/asio_util.h
@@ -16,11 +16,11 @@
 
 #include <boost/asio.hpp>
 
-inline void execute_after(boost::asio::io_context &io_context,
-                          const std::function<void()> &fn, uint32_t delay_milliseconds) {
+inline void execute_after(boost::asio::io_context& io_context,
+                          const std::function<void()>& fn, uint32_t delay_milliseconds) {
   auto timer = std::make_shared<boost::asio::deadline_timer>(io_context);
   timer->expires_from_now(boost::posix_time::milliseconds(delay_milliseconds));
-  timer->async_wait([timer, fn](const boost::system::error_code &error) {
+  timer->async_wait([timer, fn](const boost::system::error_code& error) {
     if (error != boost::asio::error::operation_aborted && fn) {
       fn();
     }

--- a/src/ray/util/filesystem.cc
+++ b/src/ray/util/filesystem.cc
@@ -18,7 +18,7 @@ std::string GetExeSuffix() {
   return result;
 }
 
-std::string GetFileName(const std::string &path) {
+std::string GetFileName(const std::string& path) {
   size_t i = GetRootPathLength(path), j = path.size();
   while (j > i && !IsDirSep(path[j - 1])) {
     --j;
@@ -26,7 +26,7 @@ std::string GetFileName(const std::string &path) {
   return path.substr(j);
 }
 
-size_t GetRootPathLength(const std::string &path) {
+size_t GetRootPathLength(const std::string& path) {
   size_t i = 0;
 #ifdef _WIN32
   if (i + 2 < path.size() && IsDirSep(path[i]) && IsDirSep(path[i + 1]) &&
@@ -67,9 +67,9 @@ std::string GetUserTempDir() {
   }
   result.resize(0 < n && n <= result.size() ? static_cast<size_t>(n) : 0);
 #else  // not Linux, Darwin, or Windows
-  const char *candidates[] = {"TMPDIR", "TMP", "TEMP", "TEMPDIR"};
-  const char *found = NULL;
-  for (char const *candidate : candidates) {
+  const char* candidates[] = {"TMPDIR", "TMP", "TEMP", "TEMPDIR"};
+  const char* found = NULL;
+  for (char const* candidate : candidates) {
     found = getenv(candidate);
     if (found) {
       break;

--- a/src/ray/util/filesystem.h
+++ b/src/ray/util/filesystem.h
@@ -37,9 +37,9 @@ static inline char GetPathSep() {
 std::string GetExeSuffix();
 
 /// Equivalent to Python's os.path.basename() for file system paths.
-std::string GetFileName(const std::string &path);
+std::string GetFileName(const std::string& path);
 
-size_t GetRootPathLength(const std::string &path);
+size_t GetRootPathLength(const std::string& path);
 
 /// \return A non-volatile temporary directory in which Ray can stores its files.
 std::string GetRayTempDir();
@@ -64,7 +64,7 @@ template <class... Paths>
 std::string JoinPaths(std::string base, Paths... components) {
   std::string to_append[] = {components...};
   for (size_t i = 0; i < sizeof(to_append) / sizeof(*to_append); ++i) {
-    const std::string &s = to_append[i];
+    const std::string& s = to_append[i];
     if (!base.empty() && !IsDirSep(base.back()) && !s.empty() && !IsDirSep(s[0])) {
       base += GetDirSep();
     }

--- a/src/ray/util/filesystem_test.cc
+++ b/src/ray/util/filesystem_test.cc
@@ -20,7 +20,7 @@ TEST(FileSystemTest, PathParseTest) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/util/io_service_pool.cc
+++ b/src/ray/util/io_service_pool.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "ray/util/io_service_pool.h"
+
 #include "ray/util/logging.h"
 
 namespace ray {

--- a/src/ray/util/io_service_pool.cc
+++ b/src/ray/util/io_service_pool.cc
@@ -26,7 +26,7 @@ void IOServicePool::Run() {
   for (size_t i = 0; i < io_service_num_; ++i) {
     io_services_.emplace_back(
         std::unique_ptr<boost::asio::io_service>(new boost::asio::io_service));
-    boost::asio::io_service &io_service = *io_services_[i];
+    boost::asio::io_service& io_service = *io_services_[i];
     threads_.emplace_back([&io_service] {
       boost::asio::io_service::work work(io_service);
       io_service.run();
@@ -37,11 +37,11 @@ void IOServicePool::Run() {
 }
 
 void IOServicePool::Stop() {
-  for (auto &io_service : io_services_) {
+  for (auto& io_service : io_services_) {
     io_service->stop();
   }
 
-  for (auto &thread : threads_) {
+  for (auto& thread : threads_) {
     thread.join();
   }
 

--- a/src/ray/util/io_service_pool.h
+++ b/src/ray/util/io_service_pool.h
@@ -37,18 +37,18 @@ class IOServicePool {
   /// Select io_service by round robin.
   ///
   /// \return io_service
-  boost::asio::io_service *Get();
+  boost::asio::io_service* Get();
 
   /// Select io_service by hash.
   ///
   /// \param hash Use this hash to pick a io_service.
   /// The same hash will alway get the same io_service.
   /// \return io_service
-  boost::asio::io_service *Get(size_t hash);
+  boost::asio::io_service* Get(size_t hash);
 
   /// Get all io_service.
   /// This is only use for RedisClient::Connect().
-  std::vector<boost::asio::io_service *> GetAll();
+  std::vector<boost::asio::io_service*> GetAll();
 
  private:
   size_t io_service_num_{0};
@@ -59,19 +59,19 @@ class IOServicePool {
   std::atomic<size_t> current_index_;
 };
 
-inline boost::asio::io_service *IOServicePool::Get() {
+inline boost::asio::io_service* IOServicePool::Get() {
   size_t index = ++current_index_ % io_service_num_;
   return io_services_[index].get();
 }
 
-inline boost::asio::io_service *IOServicePool::Get(size_t hash) {
+inline boost::asio::io_service* IOServicePool::Get(size_t hash) {
   size_t index = hash % io_service_num_;
   return io_services_[index].get();
 }
 
-inline std::vector<boost::asio::io_service *> IOServicePool::GetAll() {
-  std::vector<boost::asio::io_service *> io_services;
-  for (auto &io_service : io_services_) {
+inline std::vector<boost::asio::io_service*> IOServicePool::GetAll() {
+  std::vector<boost::asio::io_service*> io_services;
+  for (auto& io_service : io_services_) {
     io_services.emplace_back(io_service.get());
   }
   return io_services;

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -51,9 +51,9 @@ namespace ray {
 struct StreamLogger : public google::base::Logger {
   std::ofstream out_;
 
-  std::ostream &out() { return out_.is_open() ? out_ : std::cout; }
+  std::ostream& out() { return out_.is_open() ? out_ : std::cout; }
 
-  virtual void Write(bool /* should flush */, time_t /* timestamp */, const char *message,
+  virtual void Write(bool /* should flush */, time_t /* timestamp */, const char* message,
                      int length) {
     // note: always flush otherwise it never shows up in raylet.out
     out().write(message, length) << std::flush;
@@ -83,13 +83,13 @@ class CerrLog {
     }
   }
 
-  std::ostream &Stream() {
+  std::ostream& Stream() {
     has_logged_ = true;
     return std::cerr;
   }
 
   template <class T>
-  CerrLog &operator<<(const T &t) {
+  CerrLog& operator<<(const T& t) {
     if (severity_ != RayLogLevel::DEBUG) {
       has_logged_ = true;
       std::cerr << t;
@@ -103,8 +103,8 @@ class CerrLog {
 
   void PrintBackTrace() {
 #if defined(_EXECINFO_H) || !defined(_WIN32)
-    void *buffer[255];
-    const int calls = backtrace(buffer, sizeof(buffer) / sizeof(void *));
+    void* buffer[255];
+    const int calls = backtrace(buffer, sizeof(buffer) / sizeof(void*));
     backtrace_symbols_fd(buffer, calls, 1);
 #endif
   }
@@ -146,9 +146,9 @@ static int GetMappedSeverity(RayLogLevel severity) {
 
 #endif
 
-void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_threshold,
-                         const std::string &log_dir) {
-  const char *var_value = getenv("RAY_BACKEND_LOG_LEVEL");
+void RayLog::StartRayLog(const std::string& app_name, RayLogLevel severity_threshold,
+                         const std::string& log_dir) {
+  const char* var_value = getenv("RAY_BACKEND_LOG_LEVEL");
   if (var_value != nullptr) {
     std::string data = var_value;
     std::transform(data.begin(), data.end(), data.begin(), ::tolower);
@@ -265,7 +265,7 @@ bool RayLog::IsLevelEnabled(RayLogLevel log_level) {
   return log_level >= severity_threshold_;
 }
 
-RayLog::RayLog(const char *file_name, int line_number, RayLogLevel severity)
+RayLog::RayLog(const char* file_name, int line_number, RayLogLevel severity)
     // glog does not have DEBUG level, we can handle it using is_enabled_.
     : logging_provider_(nullptr), is_enabled_(severity >= severity_threshold_) {
 #ifdef RAY_USE_GLOG
@@ -280,8 +280,8 @@ RayLog::RayLog(const char *file_name, int line_number, RayLogLevel severity)
 #endif
 }
 
-std::ostream &RayLog::Stream() {
-  auto logging_provider = reinterpret_cast<LoggingProvider *>(logging_provider_);
+std::ostream& RayLog::Stream() {
+  auto logging_provider = reinterpret_cast<LoggingProvider*>(logging_provider_);
 #ifdef RAY_USE_GLOG
   // Before calling this function, user should check IsEnabled.
   // When IsEnabled == false, logging_provider_ will be empty.
@@ -295,7 +295,7 @@ bool RayLog::IsEnabled() const { return is_enabled_; }
 
 RayLog::~RayLog() {
   if (logging_provider_ != nullptr) {
-    delete reinterpret_cast<LoggingProvider *>(logging_provider_);
+    delete reinterpret_cast<LoggingProvider*>(logging_provider_);
     logging_provider_ = nullptr;
   }
 }

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -89,7 +89,7 @@ class RayLogBase {
   virtual bool IsEnabled() const { return false; };
 
   template <typename T>
-  RayLogBase &operator<<(const T &t) {
+  RayLogBase& operator<<(const T& t) {
     if (IsEnabled()) {
       Stream() << t;
     }
@@ -97,12 +97,12 @@ class RayLogBase {
   }
 
  protected:
-  virtual std::ostream &Stream() { return std::cerr; };
+  virtual std::ostream& Stream() { return std::cerr; };
 };
 
 class RayLog : public RayLogBase {
  public:
-  RayLog(const char *file_name, int line_number, RayLogLevel severity);
+  RayLog(const char* file_name, int line_number, RayLogLevel severity);
 
   virtual ~RayLog();
 
@@ -116,9 +116,9 @@ class RayLog : public RayLogBase {
   /// \parem appName The app name which starts the log.
   /// \param severity_threshold Logging threshold for the program.
   /// \param logDir Logging output file name. If empty, the log won't output to file.
-  static void StartRayLog(const std::string &appName,
+  static void StartRayLog(const std::string& appName,
                           RayLogLevel severity_threshold = RayLogLevel::INFO,
-                          const std::string &logDir = "");
+                          const std::string& logDir = "");
 
   /// The shutdown function of ray log which should be used with StartRayLog as a pair.
   static void ShutDownRayLog();
@@ -141,7 +141,7 @@ class RayLog : public RayLogBase {
  private:
   // Hide the implementation of log provider by void *.
   // Otherwise, lib user may define the same macro to use the correct header file.
-  void *logging_provider_;
+  void* logging_provider_;
   /// True if log messages should be logged and false if they should be ignored.
   bool is_enabled_;
   static RayLogLevel severity_threshold_;
@@ -156,7 +156,7 @@ class RayLog : public RayLogBase {
   static bool is_failure_signal_handler_installed_;
 
  protected:
-  virtual std::ostream &Stream();
+  virtual std::ostream& Stream();
 };
 
 // This class make RAY_CHECK compilation pass to change the << operator to void.
@@ -166,7 +166,7 @@ class Voidify {
   Voidify() {}
   // This has to be an operator with a precedence lower than << but
   // higher than ?:
-  void operator&(RayLogBase &) {}
+  void operator&(RayLogBase&) {}
 };
 
 }  // namespace ray

--- a/src/ray/util/logging_test.cc
+++ b/src/ray/util/logging_test.cc
@@ -99,7 +99,7 @@ TEST(LogPerfTest, PerfTest) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/util/macros.h
+++ b/src/ray/util/macros.h
@@ -17,8 +17,8 @@
 // From Google gutil
 #ifndef RAY_DISALLOW_COPY_AND_ASSIGN
 #define RAY_DISALLOW_COPY_AND_ASSIGN(TypeName) \
-  TypeName(const TypeName &) = delete;         \
-  void operator=(const TypeName &) = delete
+  TypeName(const TypeName&) = delete;          \
+  void operator=(const TypeName&) = delete
 #endif
 
 #define RAY_UNUSED(x) (void)x

--- a/src/ray/util/memory.cc
+++ b/src/ray/util/memory.cc
@@ -20,16 +20,16 @@
 
 namespace ray {
 
-uint8_t *pointer_logical_and(const uint8_t *address, uintptr_t bits) {
+uint8_t* pointer_logical_and(const uint8_t* address, uintptr_t bits) {
   uintptr_t value = reinterpret_cast<uintptr_t>(address);
-  return reinterpret_cast<uint8_t *>(value & bits);
+  return reinterpret_cast<uint8_t*>(value & bits);
 }
 
-void parallel_memcopy(uint8_t *dst, const uint8_t *src, int64_t nbytes,
+void parallel_memcopy(uint8_t* dst, const uint8_t* src, int64_t nbytes,
                       uintptr_t block_size, int num_threads) {
   std::vector<std::thread> threadpool(num_threads);
-  uint8_t *left = pointer_logical_and(src + block_size - 1, ~(block_size - 1));
-  uint8_t *right = pointer_logical_and(src + nbytes, ~(block_size - 1));
+  uint8_t* left = pointer_logical_and(src + block_size - 1, ~(block_size - 1));
+  uint8_t* right = pointer_logical_and(src + nbytes, ~(block_size - 1));
   int64_t num_blocks = (right - left) / block_size;
 
   // Update right address
@@ -54,7 +54,7 @@ void parallel_memcopy(uint8_t *dst, const uint8_t *src, int64_t nbytes,
   std::memcpy(dst, src, prefix);
   std::memcpy(dst + prefix + num_threads * chunk_size, right, suffix);
 
-  for (auto &t : threadpool) {
+  for (auto& t : threadpool) {
     if (t.joinable()) {
       t.join();
     }

--- a/src/ray/util/memory.h
+++ b/src/ray/util/memory.h
@@ -20,7 +20,7 @@ namespace ray {
 
 // A helper function for doing memcpy with multiple threads. This is required
 // to saturate the memory bandwidth of modern cpus.
-void parallel_memcopy(uint8_t *dst, const uint8_t *src, int64_t nbytes,
+void parallel_memcopy(uint8_t* dst, const uint8_t* src, int64_t nbytes,
                       uintptr_t block_size, int num_threads);
 
 }  // namespace ray

--- a/src/ray/util/ordered_set.h
+++ b/src/ray/util/ordered_set.h
@@ -35,28 +35,28 @@ class ordered_set {
  public:
   ordered_set() {}
 
-  ordered_set(const ordered_set &other) = delete;
+  ordered_set(const ordered_set& other) = delete;
 
-  ordered_set &operator=(const ordered_set &other) = delete;
+  ordered_set& operator=(const ordered_set& other) = delete;
 
-  void push_back(const T &value) {
+  void push_back(const T& value) {
     RAY_CHECK(positions_.find(value) == positions_.end());
     auto list_iterator = elements_.insert(elements_.end(), value);
     positions_[value] = list_iterator;
   }
 
-  size_t count(const T &k) const { return positions_.count(k); }
+  size_t count(const T& k) const { return positions_.count(k); }
 
   void pop_front() {
     positions_.erase(elements_.front());
     elements_.pop_front();
   }
 
-  const T &front() const { return elements_.front(); }
+  const T& front() const { return elements_.front(); }
 
   size_t size() const noexcept { return positions_.size(); }
 
-  size_t erase(const T &k) {
+  size_t erase(const T& k) {
     auto it = positions_.find(k);
     RAY_CHECK(it != positions_.end());
     elements_.erase(it->second);

--- a/src/ray/util/process.h
+++ b/src/ray/util/process.h
@@ -51,24 +51,24 @@ class Process {
   ~Process();
   /// Creates a null process object. Two null process objects are assumed equal.
   Process();
-  Process(const Process &);
-  Process(Process &&);
-  Process &operator=(Process other);
+  Process(const Process&);
+  Process(Process&&);
+  Process& operator=(Process other);
   /// Creates a new process.
   /// \param[in] argv The command-line of the process to spawn (terminated with NULL).
   /// \param[in] io_service Boost.Asio I/O service (optional).
   /// \param[in] ec Returns any error that occurred when spawning the process.
   /// \param[in] decouple True iff the parent will not wait for the child to exit.
-  explicit Process(const char *argv[], void *io_service, std::error_code &ec,
+  explicit Process(const char* argv[], void* io_service, std::error_code& ec,
                    bool decouple = false);
   /// Convenience function to run the given command line and wait for it to finish.
-  static std::error_code Call(const std::vector<std::string> &args);
+  static std::error_code Call(const std::vector<std::string>& args);
   static Process CreateNewDummy();
   static Process FromPid(pid_t pid);
   pid_t GetId() const;
   /// Returns an opaque pointer or handle to the underlying process object.
   /// Implementation detail, used only for identity testing. Do not dereference.
-  const void *Get() const;
+  const void* Get() const;
   bool IsNull() const;
   bool IsValid() const;
   /// Forcefully kills the process. Unsafe for unowned processes.
@@ -76,8 +76,8 @@ class Process {
   /// Convenience function to start a process in the background.
   /// \param pid_file A file to write the PID of the spawned process in.
   static std::pair<Process, std::error_code> Spawn(
-      const std::vector<std::string> &args, bool decouple,
-      const std::string &pid_file = std::string());
+      const std::vector<std::string>& args, bool decouple,
+      const std::string& pid_file = std::string());
   /// Waits for process to terminate. Not supported for unowned processes.
   /// \return The process's exit code. Returns 0 for a dummy process, -1 for a null one.
   int Wait() const;
@@ -98,12 +98,12 @@ namespace std {
 
 template <>
 struct equal_to<ray::Process> {
-  bool operator()(const ray::Process &x, const ray::Process &y) const;
+  bool operator()(const ray::Process& x, const ray::Process& y) const;
 };
 
 template <>
 struct hash<ray::Process> {
-  size_t operator()(const ray::Process &value) const;
+  size_t operator()(const ray::Process& value) const;
 };
 
 }  // namespace std

--- a/src/ray/util/sample.h
+++ b/src/ray/util/sample.h
@@ -22,7 +22,7 @@
 // sampling.
 template <class Iterator, class T = typename std::iterator_traits<Iterator>::value_type>
 void random_sample(Iterator begin, Iterator end, size_t num_elements,
-                   std::vector<T> *out) {
+                   std::vector<T>* out) {
   out->resize(0);
   if (num_elements == 0) {
     return;

--- a/src/ray/util/sample_test.cc
+++ b/src/ray/util/sample_test.cc
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "ray/util/sample.h"
+
 #include <vector>
 
 #include "gtest/gtest.h"
-#include "ray/util/sample.h"
 
 namespace ray {
 

--- a/src/ray/util/sample_test.cc
+++ b/src/ray/util/sample_test.cc
@@ -22,8 +22,8 @@ namespace ray {
 
 class RandomSampleTest : public ::testing::Test {
  protected:
-  std::vector<int> *sample;
-  std::vector<int> *test_vector;
+  std::vector<int>* sample;
+  std::vector<int>* test_vector;
   virtual void SetUp() {
     sample = new std::vector<int>();
     test_vector = new std::vector<int>();
@@ -77,7 +77,7 @@ TEST_F(RandomSampleTest, TestEqualOccurrenceChance) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/util/sequencer.h
+++ b/src/ray/util/sequencer.h
@@ -17,6 +17,7 @@
 #include <deque>
 #include <functional>
 #include <unordered_map>
+
 #include "absl/synchronization/mutex.h"
 
 namespace ray {

--- a/src/ray/util/sequencer_test.cc
+++ b/src/ray/util/sequencer_test.cc
@@ -48,7 +48,7 @@ TEST(SequencerTest, ExecuteOrderedTest) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/util/signal_test.cc
+++ b/src/ray/util/signal_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <signal.h>
+
 #include <cstdlib>
 #include <iostream>
 

--- a/src/ray/util/signal_test.cc
+++ b/src/ray/util/signal_test.cc
@@ -27,7 +27,7 @@ namespace ray {
 
 void Sleep() { std::this_thread::sleep_for(std::chrono::milliseconds(100)); }
 
-void TestSendSignal(const std::string &test_name, int signal) {
+void TestSendSignal(const std::string& test_name, int signal) {
   pid_t pid;
   pid = fork();
   ASSERT_TRUE(pid >= 0);
@@ -69,7 +69,7 @@ TEST(SignalTest, SIGSEGV_Test) {
   pid = fork();
   ASSERT_TRUE(pid >= 0);
   if (pid == 0) {
-    int *pointer = reinterpret_cast<int *>(0x1237896);
+    int* pointer = reinterpret_cast<int*>(0x1237896);
     *pointer = 100;
   } else {
     Sleep();
@@ -96,7 +96,7 @@ TEST(SignalTest, SIGILL_Test) {
 #endif  // !_WIN32
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
                                          ray::RayLog::ShutDownRayLog, argv[0],
                                          ray::RayLogLevel::INFO,

--- a/src/ray/util/util.cc
+++ b/src/ray/util/util.cc
@@ -7,11 +7,10 @@
 #endif
 
 #include <algorithm>
+#include <boost/asio/generic/stream_protocol.hpp>
 #include <sstream>
 #include <string>
 #include <vector>
-
-#include <boost/asio/generic/stream_protocol.hpp>
 #ifndef _WIN32
 #include <boost/asio/local/stream_protocol.hpp>
 #endif

--- a/src/ray/util/util.cc
+++ b/src/ray/util/util.cc
@@ -23,7 +23,7 @@
 /// \param c_str A string iterator that is dereferenceable. (i.e.: c_str < string::end())
 /// \param format The pattern. It must not produce any output. (e.g., use %*d, not %d.)
 /// \return The scanned prefix of the string, if any.
-static std::string ScanToken(std::string::const_iterator &c_str, std::string format) {
+static std::string ScanToken(std::string::const_iterator& c_str, std::string format) {
   int i = 0;
   std::string result;
   format += "%n";
@@ -35,7 +35,7 @@ static std::string ScanToken(std::string::const_iterator &c_str, std::string for
 }
 
 std::string EndpointToUrl(
-    const boost::asio::generic::basic_endpoint<boost::asio::generic::stream_protocol> &ep,
+    const boost::asio::generic::basic_endpoint<boost::asio::generic::stream_protocol>& ep,
     bool include_scheme) {
   std::string result, scheme;
   switch (ep.protocol().family()) {
@@ -43,9 +43,9 @@ std::string EndpointToUrl(
     scheme = "tcp://";
     boost::asio::ip::tcp::endpoint e(boost::asio::ip::tcp::v4(), 0);
     RAY_CHECK(e.size() == ep.size());
-    const sockaddr *src = ep.data();
-    sockaddr *dst = e.data();
-    *reinterpret_cast<sockaddr_in *>(dst) = *reinterpret_cast<const sockaddr_in *>(src);
+    const sockaddr* src = ep.data();
+    sockaddr* dst = e.data();
+    *reinterpret_cast<sockaddr_in*>(dst) = *reinterpret_cast<const sockaddr_in*>(src);
     std::ostringstream ss;
     ss << e;
     result = ss.str();
@@ -55,9 +55,9 @@ std::string EndpointToUrl(
     scheme = "tcp://";
     boost::asio::ip::tcp::endpoint e(boost::asio::ip::tcp::v6(), 0);
     RAY_CHECK(e.size() == ep.size());
-    const sockaddr *src = ep.data();
-    sockaddr *dst = e.data();
-    *reinterpret_cast<sockaddr_in6 *>(dst) = *reinterpret_cast<const sockaddr_in6 *>(src);
+    const sockaddr* src = ep.data();
+    sockaddr* dst = e.data();
+    *reinterpret_cast<sockaddr_in6*>(dst) = *reinterpret_cast<const sockaddr_in6*>(src);
     std::ostringstream ss;
     ss << e;
     result = ss.str();
@@ -66,7 +66,7 @@ std::string EndpointToUrl(
 #ifdef BOOST_ASIO_HAS_LOCAL_SOCKETS
   case AF_UNIX:
     scheme = "unix://";
-    result.append(reinterpret_cast<const struct sockaddr_un *>(ep.data())->sun_path,
+    result.append(reinterpret_cast<const struct sockaddr_un*>(ep.data())->sun_path,
                   ep.size() - offsetof(sockaddr_un, sun_path));
     break;
 #endif
@@ -81,7 +81,7 @@ std::string EndpointToUrl(
 }
 
 boost::asio::generic::basic_endpoint<boost::asio::generic::stream_protocol>
-ParseUrlEndpoint(const std::string &endpoint, int default_port) {
+ParseUrlEndpoint(const std::string& endpoint, int default_port) {
   // Syntax reference: https://en.wikipedia.org/wiki/URL#Syntax
   // Note that we're a bit more flexible, to allow parsing "127.0.0.1" as a URL.
   boost::asio::generic::stream_protocol::endpoint result;
@@ -130,7 +130,7 @@ ParseUrlEndpoint(const std::string &endpoint, int default_port) {
 /// To compare against the platform's behavior, try a command like the following:
 /// $ python3 -c "import sys; [print(a) for a in sys.argv[1:]]" \x\\y "\x\\y" '\x\\y'
 /// Python analog: shlex.split(s)
-static std::vector<std::string> ParsePosixCommandLine(const std::string &s) {
+static std::vector<std::string> ParsePosixCommandLine(const std::string& s) {
   RAY_CHECK(s.find('\0') >= s.size()) << "Invalid null character in command line";
   const char space = ' ', tab = '\t', backslash = '\\', squote = '\'', dquote = '\"';
   char surroundings = space;
@@ -185,7 +185,7 @@ static std::vector<std::string> ParsePosixCommandLine(const std::string &s) {
 /// To compare against the platform's behavior, try a command like the following:
 /// > python3 -c "import sys; [print(a) for a in sys.argv[1:]]" \x\\y "\x\\y"
 /// Python analog: None (would be shlex.split(s, posix=False), but it doesn't unquote)
-static std::vector<std::string> ParseWindowsCommandLine(const std::string &s) {
+static std::vector<std::string> ParseWindowsCommandLine(const std::string& s) {
   RAY_CHECK(s.find('\0') >= s.size()) << "Invalid null character in command line";
   std::vector<std::string> result;
   std::string arg, c_str = s + '\0';
@@ -210,7 +210,7 @@ static std::vector<std::string> ParseWindowsCommandLine(const std::string &s) {
   return result;
 }
 
-std::vector<std::string> ParseCommandLine(const std::string &s, CommandLineSyntax kind) {
+std::vector<std::string> ParseCommandLine(const std::string& s, CommandLineSyntax kind) {
   if (kind == CommandLineSyntax::System) {
 #ifdef _WIN32
     kind = CommandLineSyntax::Windows;
@@ -234,7 +234,7 @@ std::vector<std::string> ParseCommandLine(const std::string &s, CommandLineSynta
 }
 
 /// Python analog: shlex.join(args)
-std::string CreatePosixCommandLine(const std::vector<std::string> &args) {
+std::string CreatePosixCommandLine(const std::vector<std::string>& args) {
   std::string result;
   const std::string safe_chars("%*[-A-Za-z0-9%_=+]");
   const char single_quote = '\'';
@@ -267,7 +267,7 @@ std::string CreatePosixCommandLine(const std::vector<std::string> &args) {
 }
 
 // Python analog: subprocess.list2cmdline(args)
-static std::string CreateWindowsCommandLine(const std::vector<std::string> &args) {
+static std::string CreateWindowsCommandLine(const std::vector<std::string>& args) {
   std::string result;
   const std::string safe_chars("%*[-A-Za-z0-9%_=+]");
   const char double_quote = '\"';
@@ -299,7 +299,7 @@ static std::string CreateWindowsCommandLine(const std::vector<std::string> &args
   return result;
 }
 
-std::string CreateCommandLine(const std::vector<std::string> &args,
+std::string CreateCommandLine(const std::vector<std::string>& args,
                               CommandLineSyntax kind) {
   if (kind == CommandLineSyntax::System) {
 #ifdef _WIN32

--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -72,7 +72,7 @@ inline int64_t current_sys_time_ms() {
 ///
 /// \return The command-line arguments, after processing any escape sequences.
 std::vector<std::string> ParseCommandLine(
-    const std::string &cmdline, CommandLineSyntax syntax = CommandLineSyntax::System);
+    const std::string& cmdline, CommandLineSyntax syntax = CommandLineSyntax::System);
 
 /// A helper function to combine command-line arguments in a platform-compatible manner.
 /// The result of this function is intended to be suitable for the shell used by popen().
@@ -80,14 +80,14 @@ std::vector<std::string> ParseCommandLine(
 /// \param cmdline The command-line arguments to combine.
 ///
 /// \return The command-line string, including any necessary escape sequences.
-std::string CreateCommandLine(const std::vector<std::string> &args,
+std::string CreateCommandLine(const std::vector<std::string>& args,
                               CommandLineSyntax syntax = CommandLineSyntax::System);
 
 /// Converts the given endpoint (such as TCP or UNIX domain socket address) to a string.
 /// \param include_scheme Whether to include the scheme prefix (such as tcp://).
 ///                       This is recommended to avoid later ambiguity when parsing.
 std::string EndpointToUrl(
-    const boost::asio::generic::basic_endpoint<boost::asio::generic::stream_protocol> &ep,
+    const boost::asio::generic::basic_endpoint<boost::asio::generic::stream_protocol>& ep,
     bool include_scheme = true);
 
 /// Parses the endpoint socket address of a URL.
@@ -95,7 +95,7 @@ std::string EndpointToUrl(
 /// For TCP/IP, the endpoint comprises the IP address and port number in the URL.
 /// For UNIX domain sockets, the endpoint comprises the socket path.
 boost::asio::generic::basic_endpoint<boost::asio::generic::stream_protocol>
-ParseUrlEndpoint(const std::string &endpoint, int default_port = 0);
+ParseUrlEndpoint(const std::string& endpoint, int default_port = 0);
 
 class InitShutdownRAII {
  public:
@@ -109,7 +109,7 @@ class InitShutdownRAII {
   /// \param shutdown_func The shutdown function.
   /// \param args The arguments for the init function.
   template <class InitFunc, class... Args>
-  InitShutdownRAII(InitFunc init_func, ShutdownFunc shutdown_func, Args &&... args)
+  InitShutdownRAII(InitFunc init_func, ShutdownFunc shutdown_func, Args&&... args)
       : shutdown_(shutdown_func) {
     init_func(args...);
   }
@@ -139,7 +139,7 @@ using EnumUnorderedMap = std::unordered_map<Key, T, EnumClassHash>;
 /// A helper function to fill random bytes into the `data`.
 /// Warning: this is not fork-safe, we need to re-seed after that.
 template <typename T>
-void FillRandom(T *data) {
+void FillRandom(T* data) {
   RAY_CHECK(data != nullptr);
   auto randomly_seeded_mersenne_twister = []() {
     auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();

--- a/src/ray/util/util_test.cc
+++ b/src/ray/util/util_test.cc
@@ -6,12 +6,12 @@
 
 #include "gtest/gtest.h"
 
-static const char *argv0 = NULL;
+static const char* argv0 = NULL;
 
 namespace ray {
 
 template <class T>
-static std::string to_str(const T &obj, bool include_scheme) {
+static std::string to_str(const T& obj, bool include_scheme) {
   return EndpointToUrl(obj, include_scheme);
 }
 
@@ -108,7 +108,7 @@ TEST(UtilTest, CreateCommandLineTest) {
       ArgList({R"(a")", R"('x)", R"(?'"{)", R"(]))", R"(!)", R"(~`\)"}),
   });
   for (CommandLineSyntax syn : all) {
-    for (const ArgList &arglist : test_cases) {
+    for (const ArgList& arglist : test_cases) {
       ASSERT_EQ(ParseCommandLine(CreateCommandLine(arglist, syn), syn), arglist);
       std::string cmdline = CreateCommandLine(arglist, syn);
       std::string buf((2 + cmdline.size()) * 6, '\0');
@@ -121,7 +121,7 @@ TEST(UtilTest, CreateCommandLineTest) {
 #ifdef _WIN32
       test_command = test_command + "\"";
 #endif
-      FILE *proc;
+      FILE* proc;
 #ifdef _WIN32
       proc = syn == win32 ? _popen(test_command.c_str(), "r") : NULL;
 #else
@@ -145,7 +145,7 @@ TEST(UtilTest, CreateCommandLineTest) {
 
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   argv0 = argv[0];
   int result = 0;
   if (argc > 1 && strcmp(argv[1], "--println") == 0) {

--- a/streaming/src/channel.cc
+++ b/streaming/src/channel.cc
@@ -4,16 +4,16 @@
 namespace ray {
 namespace streaming {
 
-ProducerChannel::ProducerChannel(std::shared_ptr<Config> &transfer_config,
-                                 ProducerChannelInfo &p_channel_info)
+ProducerChannel::ProducerChannel(std::shared_ptr<Config>& transfer_config,
+                                 ProducerChannelInfo& p_channel_info)
     : transfer_config_(transfer_config), channel_info_(p_channel_info) {}
 
-ConsumerChannel::ConsumerChannel(std::shared_ptr<Config> &transfer_config,
-                                 ConsumerChannelInfo &c_channel_info)
+ConsumerChannel::ConsumerChannel(std::shared_ptr<Config>& transfer_config,
+                                 ConsumerChannelInfo& c_channel_info)
     : transfer_config_(transfer_config), channel_info_(c_channel_info) {}
 
-StreamingQueueProducer::StreamingQueueProducer(std::shared_ptr<Config> &transfer_config,
-                                               ProducerChannelInfo &p_channel_info)
+StreamingQueueProducer::StreamingQueueProducer(std::shared_ptr<Config>& transfer_config,
+                                               ProducerChannelInfo& p_channel_info)
     : ProducerChannel(transfer_config, p_channel_info) {
   STREAMING_LOG(INFO) << "Producer Init";
 }
@@ -98,7 +98,7 @@ StreamingStatus StreamingQueueProducer::NotifyChannelConsumed(uint64_t channel_o
   return StreamingStatus::OK;
 }
 
-StreamingStatus StreamingQueueProducer::ProduceItemToChannel(uint8_t *data,
+StreamingStatus StreamingQueueProducer::ProduceItemToChannel(uint8_t* data,
                                                              uint32_t data_size) {
   Status status =
       PushQueueItem(channel_info_.current_seq_id + 1, data, data_size, current_time_ms());
@@ -119,7 +119,7 @@ StreamingStatus StreamingQueueProducer::ProduceItemToChannel(uint8_t *data,
   return StreamingStatus::OK;
 }
 
-Status StreamingQueueProducer::PushQueueItem(uint64_t seq_id, uint8_t *data,
+Status StreamingQueueProducer::PushQueueItem(uint64_t seq_id, uint8_t* data,
                                              uint32_t data_size, uint64_t timestamp) {
   STREAMING_LOG(INFO) << "StreamingQueueProducer::PushQueueItem:"
                       << " qid: " << channel_info_.channel_id << " seq_id: " << seq_id
@@ -139,8 +139,8 @@ Status StreamingQueueProducer::PushQueueItem(uint64_t seq_id, uint8_t *data,
   return status;
 }
 
-StreamingQueueConsumer::StreamingQueueConsumer(std::shared_ptr<Config> &transfer_config,
-                                               ConsumerChannelInfo &c_channel_info)
+StreamingQueueConsumer::StreamingQueueConsumer(std::shared_ptr<Config>& transfer_config,
+                                               ConsumerChannelInfo& c_channel_info)
     : ConsumerChannel(transfer_config, c_channel_info) {
   STREAMING_LOG(INFO) << "Consumer Init";
 }
@@ -183,9 +183,9 @@ StreamingStatus StreamingQueueConsumer::RefreshChannelInfo() {
   return StreamingStatus::OK;
 }
 
-StreamingStatus StreamingQueueConsumer::ConsumeItemFromChannel(uint64_t &offset_id,
-                                                               uint8_t *&data,
-                                                               uint32_t &data_size,
+StreamingStatus StreamingQueueConsumer::ConsumeItemFromChannel(uint64_t& offset_id,
+                                                               uint8_t*& data,
+                                                               uint32_t& data_size,
                                                                uint32_t timeout) {
   STREAMING_LOG(INFO) << "GetQueueItem qid: " << channel_info_.channel_id;
   STREAMING_CHECK(queue_ != nullptr);
@@ -229,7 +229,7 @@ class MockQueue {
       consumed_buffer;
   std::unordered_map<ObjectID, StreamingQueueInfo> queue_info_map;
   static std::mutex mutex;
-  static MockQueue &GetMockQueue() {
+  static MockQueue& GetMockQueue() {
     static MockQueue mock_queue;
     return mock_queue;
   }
@@ -238,7 +238,7 @@ std::mutex MockQueue::mutex;
 
 StreamingStatus MockProducer::CreateTransferChannel() {
   std::unique_lock<std::mutex> lock(MockQueue::mutex);
-  MockQueue &mock_queue = MockQueue::GetMockQueue();
+  MockQueue& mock_queue = MockQueue::GetMockQueue();
   mock_queue.message_bffer[channel_info_.channel_id] =
       std::make_shared<RingBufferImplThreadSafe<MockQueueItem>>(10000);
   mock_queue.consumed_buffer[channel_info_.channel_id] =
@@ -248,16 +248,16 @@ StreamingStatus MockProducer::CreateTransferChannel() {
 
 StreamingStatus MockProducer::DestroyTransferChannel() {
   std::unique_lock<std::mutex> lock(MockQueue::mutex);
-  MockQueue &mock_queue = MockQueue::GetMockQueue();
+  MockQueue& mock_queue = MockQueue::GetMockQueue();
   mock_queue.message_bffer.erase(channel_info_.channel_id);
   mock_queue.consumed_buffer.erase(channel_info_.channel_id);
   return StreamingStatus::OK;
 }
 
-StreamingStatus MockProducer::ProduceItemToChannel(uint8_t *data, uint32_t data_size) {
+StreamingStatus MockProducer::ProduceItemToChannel(uint8_t* data, uint32_t data_size) {
   std::unique_lock<std::mutex> lock(MockQueue::mutex);
-  MockQueue &mock_queue = MockQueue::GetMockQueue();
-  auto &ring_buffer = mock_queue.message_bffer[channel_info_.channel_id];
+  MockQueue& mock_queue = MockQueue::GetMockQueue();
+  auto& ring_buffer = mock_queue.message_bffer[channel_info_.channel_id];
   if (ring_buffer->Full()) {
     return StreamingStatus::OutOfMemory;
   }
@@ -272,18 +272,18 @@ StreamingStatus MockProducer::ProduceItemToChannel(uint8_t *data, uint32_t data_
 }
 
 StreamingStatus MockProducer::RefreshChannelInfo() {
-  MockQueue &mock_queue = MockQueue::GetMockQueue();
+  MockQueue& mock_queue = MockQueue::GetMockQueue();
   channel_info_.queue_info.consumed_seq_id =
       mock_queue.queue_info_map[channel_info_.channel_id].consumed_seq_id;
   return StreamingStatus::OK;
 }
 
-StreamingStatus MockConsumer::ConsumeItemFromChannel(uint64_t &offset_id, uint8_t *&data,
-                                                     uint32_t &data_size,
+StreamingStatus MockConsumer::ConsumeItemFromChannel(uint64_t& offset_id, uint8_t*& data,
+                                                     uint32_t& data_size,
                                                      uint32_t timeout) {
   std::unique_lock<std::mutex> lock(MockQueue::mutex);
-  MockQueue &mock_queue = MockQueue::GetMockQueue();
-  auto &channel_id = channel_info_.channel_id;
+  MockQueue& mock_queue = MockQueue::GetMockQueue();
+  auto& channel_id = channel_info_.channel_id;
   if (mock_queue.message_bffer.find(channel_id) == mock_queue.message_bffer.end()) {
     return StreamingStatus::NoSuchItem;
   }
@@ -302,9 +302,9 @@ StreamingStatus MockConsumer::ConsumeItemFromChannel(uint64_t &offset_id, uint8_
 
 StreamingStatus MockConsumer::NotifyChannelConsumed(uint64_t offset_id) {
   std::unique_lock<std::mutex> lock(MockQueue::mutex);
-  MockQueue &mock_queue = MockQueue::GetMockQueue();
-  auto &channel_id = channel_info_.channel_id;
-  auto &ring_buffer = mock_queue.consumed_buffer[channel_id];
+  MockQueue& mock_queue = MockQueue::GetMockQueue();
+  auto& channel_id = channel_info_.channel_id;
+  auto& ring_buffer = mock_queue.consumed_buffer[channel_id];
   while (!ring_buffer->Empty() && ring_buffer->Front().seq_id <= offset_id) {
     ring_buffer->Pop();
   }
@@ -313,7 +313,7 @@ StreamingStatus MockConsumer::NotifyChannelConsumed(uint64_t offset_id) {
 }
 
 StreamingStatus MockConsumer::RefreshChannelInfo() {
-  MockQueue &mock_queue = MockQueue::GetMockQueue();
+  MockQueue& mock_queue = MockQueue::GetMockQueue();
   channel_info_.queue_info.last_seq_id =
       mock_queue.queue_info_map[channel_info_.channel_id].last_seq_id;
   return StreamingStatus::OK;

--- a/streaming/src/channel.h
+++ b/streaming/src/channel.h
@@ -77,58 +77,58 @@ struct ConsumerChannelInfo {
 ///  ConsumeItemFrom channel)
 class ProducerChannel {
  public:
-  explicit ProducerChannel(std::shared_ptr<Config> &transfer_config,
-                           ProducerChannelInfo &p_channel_info);
+  explicit ProducerChannel(std::shared_ptr<Config>& transfer_config,
+                           ProducerChannelInfo& p_channel_info);
   virtual ~ProducerChannel() = default;
   virtual StreamingStatus CreateTransferChannel() = 0;
   virtual StreamingStatus DestroyTransferChannel() = 0;
   virtual StreamingStatus ClearTransferCheckpoint(uint64_t checkpoint_id,
                                                   uint64_t checkpoint_offset) = 0;
   virtual StreamingStatus RefreshChannelInfo() = 0;
-  virtual StreamingStatus ProduceItemToChannel(uint8_t *data, uint32_t data_size) = 0;
+  virtual StreamingStatus ProduceItemToChannel(uint8_t* data, uint32_t data_size) = 0;
   virtual StreamingStatus NotifyChannelConsumed(uint64_t channel_offset) = 0;
 
  protected:
   std::shared_ptr<Config> transfer_config_;
-  ProducerChannelInfo &channel_info_;
+  ProducerChannelInfo& channel_info_;
 };
 
 class ConsumerChannel {
  public:
-  explicit ConsumerChannel(std::shared_ptr<Config> &transfer_config,
-                           ConsumerChannelInfo &c_channel_info);
+  explicit ConsumerChannel(std::shared_ptr<Config>& transfer_config,
+                           ConsumerChannelInfo& c_channel_info);
   virtual ~ConsumerChannel() = default;
   virtual StreamingStatus CreateTransferChannel() = 0;
   virtual StreamingStatus DestroyTransferChannel() = 0;
   virtual StreamingStatus ClearTransferCheckpoint(uint64_t checkpoint_id,
                                                   uint64_t checkpoint_offset) = 0;
   virtual StreamingStatus RefreshChannelInfo() = 0;
-  virtual StreamingStatus ConsumeItemFromChannel(uint64_t &offset_id, uint8_t *&data,
-                                                 uint32_t &data_size,
+  virtual StreamingStatus ConsumeItemFromChannel(uint64_t& offset_id, uint8_t*& data,
+                                                 uint32_t& data_size,
                                                  uint32_t timeout) = 0;
   virtual StreamingStatus NotifyChannelConsumed(uint64_t offset_id) = 0;
 
  protected:
   std::shared_ptr<Config> transfer_config_;
-  ConsumerChannelInfo &channel_info_;
+  ConsumerChannelInfo& channel_info_;
 };
 
 class StreamingQueueProducer : public ProducerChannel {
  public:
-  explicit StreamingQueueProducer(std::shared_ptr<Config> &transfer_config,
-                                  ProducerChannelInfo &p_channel_info);
+  explicit StreamingQueueProducer(std::shared_ptr<Config>& transfer_config,
+                                  ProducerChannelInfo& p_channel_info);
   ~StreamingQueueProducer() override;
   StreamingStatus CreateTransferChannel() override;
   StreamingStatus DestroyTransferChannel() override;
   StreamingStatus ClearTransferCheckpoint(uint64_t checkpoint_id,
                                           uint64_t checkpoint_offset) override;
   StreamingStatus RefreshChannelInfo() override;
-  StreamingStatus ProduceItemToChannel(uint8_t *data, uint32_t data_size) override;
+  StreamingStatus ProduceItemToChannel(uint8_t* data, uint32_t data_size) override;
   StreamingStatus NotifyChannelConsumed(uint64_t offset_id) override;
 
  private:
   StreamingStatus CreateQueue();
-  Status PushQueueItem(uint64_t seq_id, uint8_t *data, uint32_t data_size,
+  Status PushQueueItem(uint64_t seq_id, uint8_t* data, uint32_t data_size,
                        uint64_t timestamp);
 
  private:
@@ -137,16 +137,16 @@ class StreamingQueueProducer : public ProducerChannel {
 
 class StreamingQueueConsumer : public ConsumerChannel {
  public:
-  explicit StreamingQueueConsumer(std::shared_ptr<Config> &transfer_config,
-                                  ConsumerChannelInfo &c_channel_info);
+  explicit StreamingQueueConsumer(std::shared_ptr<Config>& transfer_config,
+                                  ConsumerChannelInfo& c_channel_info);
   ~StreamingQueueConsumer() override;
   StreamingStatus CreateTransferChannel() override;
   StreamingStatus DestroyTransferChannel() override;
   StreamingStatus ClearTransferCheckpoint(uint64_t checkpoint_id,
                                           uint64_t checkpoint_offset) override;
   StreamingStatus RefreshChannelInfo() override;
-  StreamingStatus ConsumeItemFromChannel(uint64_t &offset_id, uint8_t *&data,
-                                         uint32_t &data_size, uint32_t timeout) override;
+  StreamingStatus ConsumeItemFromChannel(uint64_t& offset_id, uint8_t*& data,
+                                         uint32_t& data_size, uint32_t timeout) override;
   StreamingStatus NotifyChannelConsumed(uint64_t offset_id) override;
 
  private:
@@ -157,8 +157,8 @@ class StreamingQueueConsumer : public ConsumerChannel {
 /// conduct a very simple memory channel for unit tests or intergation test.
 class MockProducer : public ProducerChannel {
  public:
-  explicit MockProducer(std::shared_ptr<Config> &transfer_config,
-                        ProducerChannelInfo &channel_info)
+  explicit MockProducer(std::shared_ptr<Config>& transfer_config,
+                        ProducerChannelInfo& channel_info)
       : ProducerChannel(transfer_config, channel_info){};
   StreamingStatus CreateTransferChannel() override;
 
@@ -171,7 +171,7 @@ class MockProducer : public ProducerChannel {
 
   StreamingStatus RefreshChannelInfo() override;
 
-  StreamingStatus ProduceItemToChannel(uint8_t *data, uint32_t data_size) override;
+  StreamingStatus ProduceItemToChannel(uint8_t* data, uint32_t data_size) override;
 
   StreamingStatus NotifyChannelConsumed(uint64_t channel_offset) override {
     return StreamingStatus::OK;
@@ -180,8 +180,8 @@ class MockProducer : public ProducerChannel {
 
 class MockConsumer : public ConsumerChannel {
  public:
-  explicit MockConsumer(std::shared_ptr<Config> &transfer_config,
-                        ConsumerChannelInfo &c_channel_info)
+  explicit MockConsumer(std::shared_ptr<Config>& transfer_config,
+                        ConsumerChannelInfo& c_channel_info)
       : ConsumerChannel(transfer_config, c_channel_info){};
   StreamingStatus CreateTransferChannel() override { return StreamingStatus::OK; }
   StreamingStatus DestroyTransferChannel() override { return StreamingStatus::OK; }
@@ -190,8 +190,8 @@ class MockConsumer : public ConsumerChannel {
     return StreamingStatus::OK;
   }
   StreamingStatus RefreshChannelInfo() override;
-  StreamingStatus ConsumeItemFromChannel(uint64_t &offset_id, uint8_t *&data,
-                                         uint32_t &data_size, uint32_t timeout) override;
+  StreamingStatus ConsumeItemFromChannel(uint64_t& offset_id, uint8_t*& data,
+                                         uint32_t& data_size, uint32_t timeout) override;
   StreamingStatus NotifyChannelConsumed(uint64_t offset_id) override;
 };
 

--- a/streaming/src/config/streaming_config.cc
+++ b/streaming/src/config/streaming_config.cc
@@ -24,7 +24,7 @@ const uint32_t StreamingConfig::MESSAGE_BUNDLE_MAX_SIZE = 2048;
     Set##KEY(VALUE);                                   \
   }
 
-void StreamingConfig::FromProto(const uint8_t *data, uint32_t size) {
+void StreamingConfig::FromProto(const uint8_t* data, uint32_t size) {
   proto::StreamingConfig config;
   STREAMING_CHECK(config.ParseFromArray(data, size)) << "Parse streaming conf failed";
   RESET_IF_STR_CONF(JobName, config.job_name())

--- a/streaming/src/config/streaming_config.h
+++ b/streaming/src/config/streaming_config.h
@@ -41,17 +41,17 @@ class StreamingConfig {
   uint32_t event_driven_flow_control_interval_ = 1;
 
  public:
-  void FromProto(const uint8_t *, uint32_t size);
+  void FromProto(const uint8_t*, uint32_t size);
 
 #define DECL_GET_SET_PROPERTY(TYPE, NAME, VALUE) \
   TYPE Get##NAME() const { return VALUE; }       \
   void Set##NAME(TYPE value) { VALUE = value; }
 
-  DECL_GET_SET_PROPERTY(const std::string &, WorkerName, worker_name_)
-  DECL_GET_SET_PROPERTY(const std::string &, OpName, op_name_)
+  DECL_GET_SET_PROPERTY(const std::string&, WorkerName, worker_name_)
+  DECL_GET_SET_PROPERTY(const std::string&, OpName, op_name_)
   DECL_GET_SET_PROPERTY(uint32_t, EmptyMessageTimeInterval, empty_message_time_interval_)
   DECL_GET_SET_PROPERTY(streaming::proto::NodeType, NodeType, node_type_)
-  DECL_GET_SET_PROPERTY(const std::string &, JobName, job_name_)
+  DECL_GET_SET_PROPERTY(const std::string&, JobName, job_name_)
   DECL_GET_SET_PROPERTY(uint32_t, WriterConsumedStep, writer_consumed_step_)
   DECL_GET_SET_PROPERTY(uint32_t, ReaderConsumedStep, reader_consumed_step_)
   DECL_GET_SET_PROPERTY(streaming::proto::FlowControlType, FlowControlType,

--- a/streaming/src/data_reader.h
+++ b/streaming/src/data_reader.h
@@ -18,7 +18,7 @@ namespace streaming {
 /// Databundle is super-bundle that contains channel information (upstream
 /// channel id & bundle meta data) and raw buffer pointer.
 struct DataBundle {
-  uint8_t *data = nullptr;
+  uint8_t* data = nullptr;
   uint32_t data_size;
   ObjectID from;
   uint64_t seq_id;
@@ -28,8 +28,8 @@ struct DataBundle {
 /// This is implementation of merger policy in StreamingReaderMsgPtrComparator.
 struct StreamingReaderMsgPtrComparator {
   StreamingReaderMsgPtrComparator() = default;
-  bool operator()(const std::shared_ptr<DataBundle> &a,
-                  const std::shared_ptr<DataBundle> &b);
+  bool operator()(const std::shared_ptr<DataBundle>& a,
+                  const std::shared_ptr<DataBundle>& b);
 };
 
 /// DataReader will fetch data bundles from channels of upstream workers, once
@@ -67,7 +67,7 @@ class DataReader {
   std::shared_ptr<RuntimeContext> runtime_context_;
 
  public:
-  explicit DataReader(std::shared_ptr<RuntimeContext> &runtime_context);
+  explicit DataReader(std::shared_ptr<RuntimeContext>& runtime_context);
   virtual ~DataReader();
 
   /// During initialization, only the channel parameters and necessary member properties
@@ -77,23 +77,23 @@ class DataReader {
   ///  \param channel_seq_ids
   ///  \param msg_ids
   ///  \param timer_interval
-  void Init(const std::vector<ObjectID> &input_ids,
-            const std::vector<ChannelCreationParameter> &init_params,
-            const std::vector<uint64_t> &channel_seq_ids,
-            const std::vector<uint64_t> &msg_ids, int64_t timer_interval);
+  void Init(const std::vector<ObjectID>& input_ids,
+            const std::vector<ChannelCreationParameter>& init_params,
+            const std::vector<uint64_t>& channel_seq_ids,
+            const std::vector<uint64_t>& msg_ids, int64_t timer_interval);
 
-  void Init(const std::vector<ObjectID> &input_ids,
-            const std::vector<ChannelCreationParameter> &init_params,
+  void Init(const std::vector<ObjectID>& input_ids,
+            const std::vector<ChannelCreationParameter>& init_params,
             int64_t timer_interval);
 
   /// Get latest message from input queues.
   ///  \param timeout_ms
   ///  \param message, return the latest message
-  StreamingStatus GetBundle(uint32_t timeout_ms, std::shared_ptr<DataBundle> &message);
+  StreamingStatus GetBundle(uint32_t timeout_ms, std::shared_ptr<DataBundle>& message);
 
   /// Get offset information about channels for checkpoint.
   ///  \param offset_map (return value)
-  void GetOffsetInfo(std::unordered_map<ObjectID, ConsumerChannelInfo> *&offset_map);
+  void GetOffsetInfo(std::unordered_map<ObjectID, ConsumerChannelInfo>*& offset_map);
 
   void Stop();
 
@@ -101,10 +101,10 @@ class DataReader {
   /// It's used when checkpoint is done.
   ///  \param channel_info consumer's channel info
   ///  \param offset consumed channel offset
-  void NotifyConsumedItem(ConsumerChannelInfo &channel_info, uint64_t offset);
+  void NotifyConsumedItem(ConsumerChannelInfo& channel_info, uint64_t offset);
 
   //// Notify message related channel to clear data.
-  void NotifyConsumed(std::shared_ptr<DataBundle> &message);
+  void NotifyConsumed(std::shared_ptr<DataBundle>& message);
 
  private:
   /// Create channels and connect to all upstream.
@@ -116,14 +116,14 @@ class DataReader {
   /// in merged queue.
   StreamingStatus InitChannelMerger();
 
-  StreamingStatus StashNextMessage(std::shared_ptr<DataBundle> &message);
+  StreamingStatus StashNextMessage(std::shared_ptr<DataBundle>& message);
 
-  StreamingStatus GetMessageFromChannel(ConsumerChannelInfo &channel_info,
-                                        std::shared_ptr<DataBundle> &message);
+  StreamingStatus GetMessageFromChannel(ConsumerChannelInfo& channel_info,
+                                        std::shared_ptr<DataBundle>& message);
 
   /// Get top item from prioprity queue.
-  StreamingStatus GetMergedMessageBundle(std::shared_ptr<DataBundle> &message,
-                                         bool &is_valid_break);
+  StreamingStatus GetMergedMessageBundle(std::shared_ptr<DataBundle>& message,
+                                         bool& is_valid_break);
 };
 }  // namespace streaming
 }  // namespace ray

--- a/streaming/src/data_writer.h
+++ b/streaming/src/data_writer.h
@@ -31,7 +31,7 @@ namespace streaming {
 /// buffers have no data in that moment.
 class DataWriter {
  public:
-  explicit DataWriter(std::shared_ptr<RuntimeContext> &runtime_context);
+  explicit DataWriter(std::shared_ptr<RuntimeContext>& runtime_context);
   virtual ~DataWriter();
 
   /// Streaming writer client initialization.
@@ -39,10 +39,10 @@ class DataWriter {
   /// \param init_params some parameters for initializing channels
   /// \param channel_message_id_vec channel seq id is related with message checkpoint
   /// \param queue_size queue size (memory size not length)
-  StreamingStatus Init(const std::vector<ObjectID> &channel_ids,
-                       const std::vector<ChannelCreationParameter> &init_params,
-                       const std::vector<uint64_t> &channel_message_id_vec,
-                       const std::vector<uint64_t> &queue_size_vec);
+  StreamingStatus Init(const std::vector<ObjectID>& channel_ids,
+                       const std::vector<ChannelCreationParameter>& init_params,
+                       const std::vector<uint64_t>& channel_message_id_vec,
+                       const std::vector<uint64_t>& queue_size_vec);
 
   ///  To increase throughout, we employed an output buffer for message transformation,
   ///  which means we merge a lot of message to a message bundle and no message will be
@@ -54,7 +54,7 @@ class DataWriter {
   ///  \param message_type
   ///  \return message seq iq
   uint64_t WriteMessageToBufferRing(
-      const ObjectID &q_id, uint8_t *data, uint32_t data_size,
+      const ObjectID& q_id, uint8_t* data, uint32_t data_size,
       StreamingMessageType message_type = StreamingMessageType::Message);
 
   void Run();
@@ -63,10 +63,10 @@ class DataWriter {
 
   /// Get offset information about channels for checkpoint.
   ///  \param offset_map (return value)
-  void GetOffsetInfo(std::unordered_map<ObjectID, ProducerChannelInfo> *&offset_map);
+  void GetOffsetInfo(std::unordered_map<ObjectID, ProducerChannelInfo>*& offset_map);
 
  private:
-  bool IsMessageAvailableInBuffer(ProducerChannelInfo &channel_info);
+  bool IsMessageAvailableInBuffer(ProducerChannelInfo& channel_info);
 
   /// This function handles two scenarios. When there is data in the transient
   /// buffer, the existing data is written into the channel first, otherwise a
@@ -74,41 +74,41 @@ class DataWriter {
   /// into the transient buffer, and finally written to the channel.
   /// \\param channel_info
   /// \\param buffer_remain
-  StreamingStatus WriteBufferToChannel(ProducerChannelInfo &channel_info,
-                                       uint64_t &buffer_remain);
+  StreamingStatus WriteBufferToChannel(ProducerChannelInfo& channel_info,
+                                       uint64_t& buffer_remain);
 
   /// Push empty message when no valid message or bundle was produced each time
   /// interval.
   /// \param channel_info
-  StreamingStatus WriteEmptyMessage(ProducerChannelInfo &channel_info);
+  StreamingStatus WriteEmptyMessage(ProducerChannelInfo& channel_info);
 
   /// Flush all data from transient buffer to channel for transporting.
   /// \param channel_info
-  StreamingStatus WriteTransientBufferToChannel(ProducerChannelInfo &channel_info);
+  StreamingStatus WriteTransientBufferToChannel(ProducerChannelInfo& channel_info);
 
-  bool CollectFromRingBuffer(ProducerChannelInfo &channel_info, uint64_t &buffer_remain);
+  bool CollectFromRingBuffer(ProducerChannelInfo& channel_info, uint64_t& buffer_remain);
 
-  StreamingStatus WriteChannelProcess(ProducerChannelInfo &channel_info,
-                                      bool *is_empty_message);
+  StreamingStatus WriteChannelProcess(ProducerChannelInfo& channel_info,
+                                      bool* is_empty_message);
 
-  StreamingStatus InitChannel(const ObjectID &q_id, const ChannelCreationParameter &param,
+  StreamingStatus InitChannel(const ObjectID& q_id, const ChannelCreationParameter& param,
                               uint64_t channel_message_id, uint64_t queue_size);
 
   /// Write all messages to channel util ringbuffer is empty.
   /// \param channel_info
-  bool WriteAllToChannel(ProducerChannelInfo *channel_info);
+  bool WriteAllToChannel(ProducerChannelInfo* channel_info);
 
   /// Trigger an empty message for channel with no valid data.
   /// \param channel_info
-  bool SendEmptyToChannel(ProducerChannelInfo *channel_info);
+  bool SendEmptyToChannel(ProducerChannelInfo* channel_info);
 
   void EmptyMessageTimerCallback();
 
   /// Notify channel consumed  refreshing downstream queue stats.
-  void RefreshChannelAndNotifyConsumed(ProducerChannelInfo &channel_info);
+  void RefreshChannelAndNotifyConsumed(ProducerChannelInfo& channel_info);
 
   /// Notify channel consumed by given offset.
-  void NotifyConsumedItem(ProducerChannelInfo &channel_info, uint32_t offset);
+  void NotifyConsumedItem(ProducerChannelInfo& channel_info, uint32_t offset);
 
   void FlowControlTimer();
 

--- a/streaming/src/event_service.cc
+++ b/streaming/src/event_service.cc
@@ -20,7 +20,7 @@ void EventQueue::Freeze() {
   no_full_cv_.notify_all();
 }
 
-void EventQueue::Push(const Event &t) {
+void EventQueue::Push(const Event& t) {
   std::unique_lock<std::mutex> lock(ring_buffer_mutex_);
   while (Size() >= capacity_ && is_active_) {
     STREAMING_LOG(WARNING) << " EventQueue is full, its size:" << Size()
@@ -57,7 +57,7 @@ void EventQueue::Pop() {
   no_full_cv_.notify_all();
 }
 
-void EventQueue::WaitFor(std::unique_lock<std::mutex> &lock) {
+void EventQueue::WaitFor(std::unique_lock<std::mutex>& lock) {
   // To avoid deadlock when EventQueue is empty but is_active is changed in other
   // thread, Event queue should awaken this condtion variable and check it again.
   while (is_active_ && Empty()) {
@@ -70,7 +70,7 @@ void EventQueue::WaitFor(std::unique_lock<std::mutex> &lock) {
   }
 }
 
-bool EventQueue::Get(Event &evt) {
+bool EventQueue::Get(Event& evt) {
   std::unique_lock<std::mutex> lock(ring_buffer_mutex_);
   WaitFor(lock);
   if (!is_active_) {
@@ -107,7 +107,7 @@ Event EventQueue::PopAndGet() {
   return res;
 }
 
-Event &EventQueue::Front() {
+Event& EventQueue::Front() {
   std::unique_lock<std::mutex> lock(ring_buffer_mutex_);
   if (urgent_buffer_.size()) {
     return urgent_buffer_.front();
@@ -146,7 +146,7 @@ void EventService::Stop() {
   STREAMING_LOG(WARNING) << "event_server stop";
 }
 
-bool EventService::Register(const EventType &type, const Handle &handle) {
+bool EventService::Register(const EventType& type, const Handle& handle) {
   if (event_handle_map_.find(type) != event_handle_map_.end()) {
     STREAMING_LOG(WARNING) << "EventType had been registered!";
   }
@@ -154,15 +154,15 @@ bool EventService::Register(const EventType &type, const Handle &handle) {
   return true;
 }
 
-void EventService::Push(const Event &event) { event_queue_->Push(event); }
+void EventService::Push(const Event& event) { event_queue_->Push(event); }
 
-void EventService::Execute(Event &event) {
+void EventService::Execute(Event& event) {
   if (event_handle_map_.find(event.type) == event_handle_map_.end()) {
     STREAMING_LOG(WARNING) << "Handle has never been registered yet, type => "
                            << static_cast<int>(event.type);
     return;
   }
-  Handle &handle = event_handle_map_[event.type];
+  Handle& handle = event_handle_map_[event.type];
   if (handle(event.channel_info)) {
     event_queue_->Pop();
   }
@@ -183,7 +183,7 @@ void EventService::LoopThreadHandler() {
   }
 }
 
-void EventService::RemoveDestroyedChannelEvent(const std::vector<ObjectID> &removed_ids) {
+void EventService::RemoveDestroyedChannelEvent(const std::vector<ObjectID>& removed_ids) {
   // NOTE(lingxuan.zlx): To prevent producing invalid event for removed
   // channels, we pop out all invalid channel related events(push it to
   // original queue if it has no connection with removed channels).

--- a/streaming/src/event_service.h
+++ b/streaming/src/event_service.h
@@ -30,13 +30,13 @@ enum class EventType : uint8_t {
 
 struct EnumTypeHash {
   template <typename T>
-  std::size_t operator()(const T &t) const {
+  std::size_t operator()(const T& t) const {
     return static_cast<std::size_t>(t);
   }
 };
 
 struct Event {
-  ProducerChannelInfo *channel_info;
+  ProducerChannelInfo* channel_info;
   EventType type;
   bool urgent;
 };
@@ -60,15 +60,15 @@ class EventQueue {
   /// Push is prohibited when event queue is not active.
   void Freeze();
 
-  void Push(const Event &t);
+  void Push(const Event& t);
 
   void Pop();
 
-  bool Get(Event &evt);
+  bool Get(Event& evt);
 
   Event PopAndGet();
 
-  Event &Front();
+  Event& Front();
 
   inline size_t Capacity() const { return capacity_; }
 
@@ -85,7 +85,7 @@ class EventQueue {
   inline bool Full() const { return buffer_.size() + urgent_buffer_.size() == capacity_; }
 
   /// Wait for queue util it's timeout or any stuff in.
-  void WaitFor(std::unique_lock<std::mutex> &lock);
+  void WaitFor(std::unique_lock<std::mutex>& lock);
 
  private:
   std::mutex ring_buffer_mutex_;
@@ -107,7 +107,7 @@ class EventQueue {
 class EventService {
  public:
   /// User-define event handle for different types.
-  typedef std::function<bool(ProducerChannelInfo *info)> Handle;
+  typedef std::function<bool(ProducerChannelInfo* info)> Handle;
 
   EventService(uint32_t event_size = kEventQueueCapacity);
 
@@ -117,16 +117,16 @@ class EventService {
 
   void Stop();
 
-  bool Register(const EventType &type, const Handle &handle);
+  bool Register(const EventType& type, const Handle& handle);
 
-  void Push(const Event &event);
+  void Push(const Event& event);
 
   inline size_t EventNums() const { return event_queue_->Size(); }
 
-  void RemoveDestroyedChannelEvent(const std::vector<ObjectID> &removed_ids);
+  void RemoveDestroyedChannelEvent(const std::vector<ObjectID>& removed_ids);
 
  private:
-  void Execute(Event &event);
+  void Execute(Event& event);
 
   /// A single thread should be invoked to run this loop function, so that
   /// event server can poll and execute registered callback function event

--- a/streaming/src/flow_control.cc
+++ b/streaming/src/flow_control.cc
@@ -4,12 +4,12 @@ namespace ray {
 namespace streaming {
 
 UnconsumedSeqFlowControl::UnconsumedSeqFlowControl(
-    std::unordered_map<ObjectID, std::shared_ptr<ProducerChannel>> &channel_map,
+    std::unordered_map<ObjectID, std::shared_ptr<ProducerChannel>>& channel_map,
     uint32_t step)
     : channel_map_(channel_map), consumed_step_(step){};
 
-bool UnconsumedSeqFlowControl::ShouldFlowControl(ProducerChannelInfo &channel_info) {
-  auto &queue_info = channel_info.queue_info;
+bool UnconsumedSeqFlowControl::ShouldFlowControl(ProducerChannelInfo& channel_info) {
+  auto& queue_info = channel_info.queue_info;
   if (queue_info.target_seq_id <= channel_info.current_seq_id) {
     channel_map_[channel_info.channel_id]->RefreshChannelInfo();
     // Target seq id is maximum upper limit in current condition.

--- a/streaming/src/flow_control.h
+++ b/streaming/src/flow_control.h
@@ -15,29 +15,29 @@ class ProducerTransfer;
 class FlowControl {
  public:
   virtual ~FlowControl() = default;
-  virtual bool ShouldFlowControl(ProducerChannelInfo &channel_info) = 0;
+  virtual bool ShouldFlowControl(ProducerChannelInfo& channel_info) = 0;
 };
 
 class NoFlowControl : public FlowControl {
  public:
-  bool ShouldFlowControl(ProducerChannelInfo &channel_info) { return false; }
+  bool ShouldFlowControl(ProducerChannelInfo& channel_info) { return false; }
   ~NoFlowControl() = default;
 };
 
 class UnconsumedSeqFlowControl : public FlowControl {
  public:
   UnconsumedSeqFlowControl(
-      std::unordered_map<ObjectID, std::shared_ptr<ProducerChannel>> &channel_map,
+      std::unordered_map<ObjectID, std::shared_ptr<ProducerChannel>>& channel_map,
       uint32_t step);
   ~UnconsumedSeqFlowControl() = default;
-  bool ShouldFlowControl(ProducerChannelInfo &channel_info);
+  bool ShouldFlowControl(ProducerChannelInfo& channel_info);
 
  private:
   /// NOTE(wanxing.wwx) Reference to channel_map_ variable in DataWriter.
   /// Flow-control is checked in FlowControlThread, so channel_map_ is accessed
   /// in multithread situation. Especially, while rescaling, channel_map_ maybe
   /// changed. But for now, FlowControlThread is stopped before rescaling.
-  std::unordered_map<ObjectID, std::shared_ptr<ProducerChannel>> &channel_map_;
+  std::unordered_map<ObjectID, std::shared_ptr<ProducerChannel>>& channel_map_;
   uint32_t consumed_step_;
 };
 }  // namespace streaming

--- a/streaming/src/lib/java/io_ray_streaming_runtime_transfer_ChannelId.cc
+++ b/streaming/src/lib/java/io_ray_streaming_runtime_transfer_ChannelId.cc
@@ -5,15 +5,15 @@
 using namespace ray::streaming;
 
 JNIEXPORT jlong JNICALL Java_io_ray_streaming_runtime_transfer_ChannelId_createNativeId(
-    JNIEnv *env, jclass cls, jlong qid_address) {
+    JNIEnv* env, jclass cls, jlong qid_address) {
   auto id = ray::ObjectID::FromBinary(
-      std::string(reinterpret_cast<const char *>(qid_address), ray::ObjectID::Size()));
+      std::string(reinterpret_cast<const char*>(qid_address), ray::ObjectID::Size()));
   return reinterpret_cast<jlong>(new ray::ObjectID(id));
 }
 
 JNIEXPORT void JNICALL Java_io_ray_streaming_runtime_transfer_ChannelId_destroyNativeId(
-    JNIEnv *env, jclass cls, jlong native_id_ptr) {
-  auto id = reinterpret_cast<ray::ObjectID *>(native_id_ptr);
+    JNIEnv* env, jclass cls, jlong native_id_ptr) {
+  auto id = reinterpret_cast<ray::ObjectID*>(native_id_ptr);
   STREAMING_CHECK(id != nullptr);
   delete id;
 }

--- a/streaming/src/lib/java/io_ray_streaming_runtime_transfer_ChannelId.h
+++ b/streaming/src/lib/java/io_ray_streaming_runtime_transfer_ChannelId.h
@@ -14,16 +14,16 @@ extern "C" {
  * Method:    createNativeId
  * Signature: (J)J
  */
-JNIEXPORT jlong JNICALL Java_io_ray_streaming_runtime_transfer_ChannelId_createNativeId
-  (JNIEnv *, jclass, jlong);
+JNIEXPORT jlong JNICALL
+Java_io_ray_streaming_runtime_transfer_ChannelId_createNativeId(JNIEnv *, jclass, jlong);
 
 /*
  * Class:     io_ray_streaming_runtime_transfer_ChannelId
  * Method:    destroyNativeId
  * Signature: (J)V
  */
-JNIEXPORT void JNICALL Java_io_ray_streaming_runtime_transfer_ChannelId_destroyNativeId
-  (JNIEnv *, jclass, jlong);
+JNIEXPORT void JNICALL
+Java_io_ray_streaming_runtime_transfer_ChannelId_destroyNativeId(JNIEnv *, jclass, jlong);
 
 #ifdef __cplusplus
 }

--- a/streaming/src/lib/java/io_ray_streaming_runtime_transfer_ChannelId.h
+++ b/streaming/src/lib/java/io_ray_streaming_runtime_transfer_ChannelId.h
@@ -15,7 +15,7 @@ extern "C" {
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL
-Java_io_ray_streaming_runtime_transfer_ChannelId_createNativeId(JNIEnv *, jclass, jlong);
+Java_io_ray_streaming_runtime_transfer_ChannelId_createNativeId(JNIEnv*, jclass, jlong);
 
 /*
  * Class:     io_ray_streaming_runtime_transfer_ChannelId
@@ -23,7 +23,7 @@ Java_io_ray_streaming_runtime_transfer_ChannelId_createNativeId(JNIEnv *, jclass
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL
-Java_io_ray_streaming_runtime_transfer_ChannelId_destroyNativeId(JNIEnv *, jclass, jlong);
+Java_io_ray_streaming_runtime_transfer_ChannelId_destroyNativeId(JNIEnv*, jclass, jlong);
 
 #ifdef __cplusplus
 }

--- a/streaming/src/lib/java/io_ray_streaming_runtime_transfer_DataReader.cc
+++ b/streaming/src/lib/java/io_ray_streaming_runtime_transfer_DataReader.cc
@@ -1,6 +1,7 @@
 #include "io_ray_streaming_runtime_transfer_DataReader.h"
 
 #include <cstdlib>
+
 #include "data_reader.h"
 #include "runtime_context.h"
 #include "streaming_jni_common.h"

--- a/streaming/src/lib/java/io_ray_streaming_runtime_transfer_DataReader.cc
+++ b/streaming/src/lib/java/io_ray_streaming_runtime_transfer_DataReader.cc
@@ -11,7 +11,7 @@ using namespace ray::streaming;
 
 JNIEXPORT jlong JNICALL
 Java_io_ray_streaming_runtime_transfer_DataReader_createDataReaderNative(
-    JNIEnv *env, jclass, jobject streaming_queue_initial_parameters,
+    JNIEnv* env, jclass, jobject streaming_queue_initial_parameters,
     jobjectArray input_channels, jlongArray seq_id_array, jlongArray msg_id_array,
     jlong timer_interval, jboolean isRecreate, jbyteArray config_bytes,
     jboolean is_mock) {
@@ -39,10 +39,10 @@ Java_io_ray_streaming_runtime_transfer_DataReader_createDataReaderNative(
 }
 
 JNIEXPORT void JNICALL Java_io_ray_streaming_runtime_transfer_DataReader_getBundleNative(
-    JNIEnv *env, jobject, jlong reader_ptr, jlong timeout_millis, jlong out,
+    JNIEnv* env, jobject, jlong reader_ptr, jlong timeout_millis, jlong out,
     jlong meta_addr) {
   std::shared_ptr<ray::streaming::DataBundle> bundle;
-  auto reader = reinterpret_cast<ray::streaming::DataReader *>(reader_ptr);
+  auto reader = reinterpret_cast<ray::streaming::DataReader*>(reader_ptr);
   auto status = reader->GetBundle((uint32_t)timeout_millis, bundle);
 
   // over timeout, return empty array.
@@ -56,20 +56,20 @@ JNIEXPORT void JNICALL Java_io_ray_streaming_runtime_transfer_DataReader_getBund
   }
 
   if (StreamingStatus::OK != status) {
-    *reinterpret_cast<uint64_t *>(out) = 0;
-    *reinterpret_cast<uint32_t *>(out + 8) = 0;
+    *reinterpret_cast<uint64_t*>(out) = 0;
+    *reinterpret_cast<uint32_t*>(out + 8) = 0;
     return;
   }
 
   // bundle data
   // In streaming queue, bundle data and metadata will be different args of direct call,
   // so we separate it here for future extensibility.
-  *reinterpret_cast<uint64_t *>(out) =
+  *reinterpret_cast<uint64_t*>(out) =
       reinterpret_cast<uint64_t>(bundle->data + kMessageBundleHeaderSize);
-  *reinterpret_cast<uint32_t *>(out + 8) = bundle->data_size - kMessageBundleHeaderSize;
+  *reinterpret_cast<uint32_t*>(out + 8) = bundle->data_size - kMessageBundleHeaderSize;
 
   // bundle metadata
-  auto meta = reinterpret_cast<uint8_t *>(meta_addr);
+  auto meta = reinterpret_cast<uint8_t*>(meta_addr);
   // bundle header written by writer
   std::memcpy(meta, bundle->data, kMessageBundleHeaderSize);
   // append qid
@@ -77,14 +77,14 @@ JNIEXPORT void JNICALL Java_io_ray_streaming_runtime_transfer_DataReader_getBund
 }
 
 JNIEXPORT void JNICALL Java_io_ray_streaming_runtime_transfer_DataReader_stopReaderNative(
-    JNIEnv *env, jobject thisObj, jlong ptr) {
-  auto reader = reinterpret_cast<DataReader *>(ptr);
+    JNIEnv* env, jobject thisObj, jlong ptr) {
+  auto reader = reinterpret_cast<DataReader*>(ptr);
   reader->Stop();
 }
 
 JNIEXPORT void JNICALL
-Java_io_ray_streaming_runtime_transfer_DataReader_closeReaderNative(JNIEnv *env,
+Java_io_ray_streaming_runtime_transfer_DataReader_closeReaderNative(JNIEnv* env,
                                                                     jobject thisObj,
                                                                     jlong ptr) {
-  delete reinterpret_cast<DataReader *>(ptr);
+  delete reinterpret_cast<DataReader*>(ptr);
 }

--- a/streaming/src/lib/java/io_ray_streaming_runtime_transfer_DataReader.h
+++ b/streaming/src/lib/java/io_ray_streaming_runtime_transfer_DataReader.h
@@ -10,7 +10,8 @@ extern "C" {
 /*
  * Class:     io_ray_streaming_runtime_transfer_DataReader
  * Method:    createDataReaderNative
- * Signature: (Lio/ray/streaming/runtime/transfer/ChannelCreationParametersBuilder;[[B[J[JJZ[BZ)J
+ * Signature:
+ * (Lio/ray/streaming/runtime/transfer/ChannelCreationParametersBuilder;[[B[J[JJZ[BZ)J
  */
 JNIEXPORT jlong JNICALL
 Java_io_ray_streaming_runtime_transfer_DataReader_createDataReaderNative(

--- a/streaming/src/lib/java/io_ray_streaming_runtime_transfer_DataReader.h
+++ b/streaming/src/lib/java/io_ray_streaming_runtime_transfer_DataReader.h
@@ -15,7 +15,7 @@ extern "C" {
  */
 JNIEXPORT jlong JNICALL
 Java_io_ray_streaming_runtime_transfer_DataReader_createDataReaderNative(
-    JNIEnv *, jclass, jobject, jobjectArray, jlongArray, jlongArray, jlong, jboolean,
+    JNIEnv*, jclass, jobject, jobjectArray, jlongArray, jlongArray, jlong, jboolean,
     jbyteArray, jboolean);
 
 /*
@@ -24,7 +24,7 @@ Java_io_ray_streaming_runtime_transfer_DataReader_createDataReaderNative(
  * Signature: (JJJJ)V
  */
 JNIEXPORT void JNICALL Java_io_ray_streaming_runtime_transfer_DataReader_getBundleNative(
-    JNIEnv *, jobject, jlong, jlong, jlong, jlong);
+    JNIEnv*, jobject, jlong, jlong, jlong, jlong);
 
 /*
  * Class:     io_ray_streaming_runtime_transfer_DataReader
@@ -32,7 +32,7 @@ JNIEXPORT void JNICALL Java_io_ray_streaming_runtime_transfer_DataReader_getBund
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL Java_io_ray_streaming_runtime_transfer_DataReader_stopReaderNative(
-    JNIEnv *, jobject, jlong);
+    JNIEnv*, jobject, jlong);
 
 /*
  * Class:     io_ray_streaming_runtime_transfer_DataReader
@@ -40,7 +40,7 @@ JNIEXPORT void JNICALL Java_io_ray_streaming_runtime_transfer_DataReader_stopRea
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL
-Java_io_ray_streaming_runtime_transfer_DataReader_closeReaderNative(JNIEnv *, jobject,
+Java_io_ray_streaming_runtime_transfer_DataReader_closeReaderNative(JNIEnv*, jobject,
                                                                     jlong);
 
 #ifdef __cplusplus

--- a/streaming/src/lib/java/io_ray_streaming_runtime_transfer_DataWriter.cc
+++ b/streaming/src/lib/java/io_ray_streaming_runtime_transfer_DataWriter.cc
@@ -8,7 +8,7 @@ using namespace ray::streaming;
 
 JNIEXPORT jlong JNICALL
 Java_io_ray_streaming_runtime_transfer_DataWriter_createWriterNative(
-    JNIEnv *env, jclass, jobject initial_parameters, jobjectArray output_queue_ids,
+    JNIEnv* env, jclass, jobject initial_parameters, jobjectArray output_queue_ids,
     jlongArray msg_ids, jlong channel_size, jbyteArray conf_bytes_array,
     jboolean is_mock) {
   STREAMING_LOG(INFO) << "[JNI]: createDataWriterNative.";
@@ -36,7 +36,7 @@ Java_io_ray_streaming_runtime_transfer_DataWriter_createWriterNative(
   if (is_mock) {
     runtime_context->MarkMockTest();
   }
-  auto *data_writer = new DataWriter(runtime_context);
+  auto* data_writer = new DataWriter(runtime_context);
   auto status =
       data_writer->Init(queue_id_vec, parameter_vec, msg_ids_vec, queue_size_vec);
   if (status != StreamingStatus::OK) {
@@ -51,10 +51,10 @@ Java_io_ray_streaming_runtime_transfer_DataWriter_createWriterNative(
 
 JNIEXPORT jlong JNICALL
 Java_io_ray_streaming_runtime_transfer_DataWriter_writeMessageNative(
-    JNIEnv *env, jobject, jlong writer_ptr, jlong qid_ptr, jlong address, jint size) {
-  auto *data_writer = reinterpret_cast<DataWriter *>(writer_ptr);
-  auto qid = *reinterpret_cast<ray::ObjectID *>(qid_ptr);
-  auto data = reinterpret_cast<uint8_t *>(address);
+    JNIEnv* env, jobject, jlong writer_ptr, jlong qid_ptr, jlong address, jint size) {
+  auto* data_writer = reinterpret_cast<DataWriter*>(writer_ptr);
+  auto qid = *reinterpret_cast<ray::ObjectID*>(qid_ptr);
+  auto data = reinterpret_cast<uint8_t*>(address);
   auto data_size = static_cast<uint32_t>(size);
   jlong result = data_writer->WriteMessageToBufferRing(qid, data, data_size,
                                                        StreamingMessageType::Message);
@@ -67,16 +67,16 @@ Java_io_ray_streaming_runtime_transfer_DataWriter_writeMessageNative(
 }
 
 JNIEXPORT void JNICALL Java_io_ray_streaming_runtime_transfer_DataWriter_stopWriterNative(
-    JNIEnv *env, jobject thisObj, jlong ptr) {
+    JNIEnv* env, jobject thisObj, jlong ptr) {
   STREAMING_LOG(INFO) << "jni: stop writer.";
-  auto *data_writer = reinterpret_cast<DataWriter *>(ptr);
+  auto* data_writer = reinterpret_cast<DataWriter*>(ptr);
   data_writer->Stop();
 }
 
 JNIEXPORT void JNICALL
-Java_io_ray_streaming_runtime_transfer_DataWriter_closeWriterNative(JNIEnv *env,
+Java_io_ray_streaming_runtime_transfer_DataWriter_closeWriterNative(JNIEnv* env,
                                                                     jobject thisObj,
                                                                     jlong ptr) {
-  auto *data_writer = reinterpret_cast<DataWriter *>(ptr);
+  auto* data_writer = reinterpret_cast<DataWriter*>(ptr);
   delete data_writer;
 }

--- a/streaming/src/lib/java/io_ray_streaming_runtime_transfer_DataWriter.h
+++ b/streaming/src/lib/java/io_ray_streaming_runtime_transfer_DataWriter.h
@@ -10,7 +10,8 @@ extern "C" {
 /*
  * Class:     io_ray_streaming_runtime_transfer_DataWriter
  * Method:    createWriterNative
- * Signature: (Lio/ray/streaming/runtime/transfer/ChannelCreationParametersBuilder;[[B[JJ[BZ)J
+ * Signature:
+ * (Lio/ray/streaming/runtime/transfer/ChannelCreationParametersBuilder;[[B[JJ[BZ)J
  */
 JNIEXPORT jlong JNICALL
 Java_io_ray_streaming_runtime_transfer_DataWriter_createWriterNative(

--- a/streaming/src/lib/java/io_ray_streaming_runtime_transfer_DataWriter.h
+++ b/streaming/src/lib/java/io_ray_streaming_runtime_transfer_DataWriter.h
@@ -15,7 +15,7 @@ extern "C" {
  */
 JNIEXPORT jlong JNICALL
 Java_io_ray_streaming_runtime_transfer_DataWriter_createWriterNative(
-    JNIEnv *, jclass, jobject, jobjectArray, jlongArray, jlong, jbyteArray, jboolean);
+    JNIEnv*, jclass, jobject, jobjectArray, jlongArray, jlong, jbyteArray, jboolean);
 
 /*
  * Class:     io_ray_streaming_runtime_transfer_DataWriter
@@ -23,7 +23,7 @@ Java_io_ray_streaming_runtime_transfer_DataWriter_createWriterNative(
  * Signature: (JJJI)J
  */
 JNIEXPORT jlong JNICALL
-Java_io_ray_streaming_runtime_transfer_DataWriter_writeMessageNative(JNIEnv *, jobject,
+Java_io_ray_streaming_runtime_transfer_DataWriter_writeMessageNative(JNIEnv*, jobject,
                                                                      jlong, jlong, jlong,
                                                                      jint);
 
@@ -33,7 +33,7 @@ Java_io_ray_streaming_runtime_transfer_DataWriter_writeMessageNative(JNIEnv *, j
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL Java_io_ray_streaming_runtime_transfer_DataWriter_stopWriterNative(
-    JNIEnv *, jobject, jlong);
+    JNIEnv*, jobject, jlong);
 
 /*
  * Class:     io_ray_streaming_runtime_transfer_DataWriter
@@ -41,7 +41,7 @@ JNIEXPORT void JNICALL Java_io_ray_streaming_runtime_transfer_DataWriter_stopWri
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL
-Java_io_ray_streaming_runtime_transfer_DataWriter_closeWriterNative(JNIEnv *, jobject,
+Java_io_ray_streaming_runtime_transfer_DataWriter_closeWriterNative(JNIEnv*, jobject,
                                                                     jlong);
 
 #ifdef __cplusplus

--- a/streaming/src/lib/java/io_ray_streaming_runtime_transfer_TransferHandler.cc
+++ b/streaming/src/lib/java/io_ray_streaming_runtime_transfer_TransferHandler.cc
@@ -5,7 +5,7 @@
 
 using namespace ray::streaming;
 
-static std::shared_ptr<ray::LocalMemoryBuffer> JByteArrayToBuffer(JNIEnv *env,
+static std::shared_ptr<ray::LocalMemoryBuffer> JByteArrayToBuffer(JNIEnv* env,
                                                                   jbyteArray bytes) {
   RawDataFromJByteArray buf(env, bytes);
   STREAMING_CHECK(buf.data != nullptr);
@@ -15,52 +15,52 @@ static std::shared_ptr<ray::LocalMemoryBuffer> JByteArrayToBuffer(JNIEnv *env,
 
 JNIEXPORT jlong JNICALL
 Java_io_ray_streaming_runtime_transfer_TransferHandler_createWriterClientNative(
-    JNIEnv *env, jobject this_obj) {
-  auto *writer_client = new WriterClient();
+    JNIEnv* env, jobject this_obj) {
+  auto* writer_client = new WriterClient();
   return reinterpret_cast<jlong>(writer_client);
 }
 
 JNIEXPORT jlong JNICALL
 Java_io_ray_streaming_runtime_transfer_TransferHandler_createReaderClientNative(
-    JNIEnv *env, jobject this_obj) {
-  auto *reader_client = new ReaderClient();
+    JNIEnv* env, jobject this_obj) {
+  auto* reader_client = new ReaderClient();
   return reinterpret_cast<jlong>(reader_client);
 }
 
 JNIEXPORT void JNICALL
 Java_io_ray_streaming_runtime_transfer_TransferHandler_handleWriterMessageNative(
-    JNIEnv *env, jobject this_obj, jlong ptr, jbyteArray bytes) {
-  auto *writer_client = reinterpret_cast<WriterClient *>(ptr);
+    JNIEnv* env, jobject this_obj, jlong ptr, jbyteArray bytes) {
+  auto* writer_client = reinterpret_cast<WriterClient*>(ptr);
   writer_client->OnWriterMessage(JByteArrayToBuffer(env, bytes));
 }
 
 JNIEXPORT jbyteArray JNICALL
 Java_io_ray_streaming_runtime_transfer_TransferHandler_handleWriterMessageSyncNative(
-    JNIEnv *env, jobject this_obj, jlong ptr, jbyteArray bytes) {
-  auto *writer_client = reinterpret_cast<WriterClient *>(ptr);
+    JNIEnv* env, jobject this_obj, jlong ptr, jbyteArray bytes) {
+  auto* writer_client = reinterpret_cast<WriterClient*>(ptr);
   std::shared_ptr<ray::LocalMemoryBuffer> result_buffer =
       writer_client->OnWriterMessageSync(JByteArrayToBuffer(env, bytes));
   jbyteArray arr = env->NewByteArray(result_buffer->Size());
   env->SetByteArrayRegion(arr, 0, result_buffer->Size(),
-                          reinterpret_cast<jbyte *>(result_buffer->Data()));
+                          reinterpret_cast<jbyte*>(result_buffer->Data()));
   return arr;
 }
 
 JNIEXPORT void JNICALL
 Java_io_ray_streaming_runtime_transfer_TransferHandler_handleReaderMessageNative(
-    JNIEnv *env, jobject this_obj, jlong ptr, jbyteArray bytes) {
-  auto *reader_client = reinterpret_cast<ReaderClient *>(ptr);
+    JNIEnv* env, jobject this_obj, jlong ptr, jbyteArray bytes) {
+  auto* reader_client = reinterpret_cast<ReaderClient*>(ptr);
   reader_client->OnReaderMessage(JByteArrayToBuffer(env, bytes));
 }
 
 JNIEXPORT jbyteArray JNICALL
 Java_io_ray_streaming_runtime_transfer_TransferHandler_handleReaderMessageSyncNative(
-    JNIEnv *env, jobject this_obj, jlong ptr, jbyteArray bytes) {
-  auto *reader_client = reinterpret_cast<ReaderClient *>(ptr);
+    JNIEnv* env, jobject this_obj, jlong ptr, jbyteArray bytes) {
+  auto* reader_client = reinterpret_cast<ReaderClient*>(ptr);
   auto result_buffer = reader_client->OnReaderMessageSync(JByteArrayToBuffer(env, bytes));
 
   jbyteArray arr = env->NewByteArray(result_buffer->Size());
   env->SetByteArrayRegion(arr, 0, result_buffer->Size(),
-                          reinterpret_cast<jbyte *>(result_buffer->Data()));
+                          reinterpret_cast<jbyte*>(result_buffer->Data()));
   return arr;
 }

--- a/streaming/src/lib/java/io_ray_streaming_runtime_transfer_TransferHandler.h
+++ b/streaming/src/lib/java/io_ray_streaming_runtime_transfer_TransferHandler.h
@@ -12,16 +12,18 @@ extern "C" {
  * Method:    createWriterClientNative
  * Signature: (J)J
  */
-JNIEXPORT jlong JNICALL Java_io_ray_streaming_runtime_transfer_TransferHandler_createWriterClientNative
-  (JNIEnv *, jobject);
+JNIEXPORT jlong JNICALL
+Java_io_ray_streaming_runtime_transfer_TransferHandler_createWriterClientNative(JNIEnv *,
+                                                                                jobject);
 
 /*
  * Class:     io_ray_streaming_runtime_transfer_TransferHandler
  * Method:    createReaderClientNative
  * Signature: (J)J
  */
-JNIEXPORT jlong JNICALL Java_io_ray_streaming_runtime_transfer_TransferHandler_createReaderClientNative
-  (JNIEnv *, jobject);
+JNIEXPORT jlong JNICALL
+Java_io_ray_streaming_runtime_transfer_TransferHandler_createReaderClientNative(JNIEnv *,
+                                                                                jobject);
 
 /*
  * Class:     io_ray_streaming_runtime_transfer_TransferHandler

--- a/streaming/src/lib/java/io_ray_streaming_runtime_transfer_TransferHandler.h
+++ b/streaming/src/lib/java/io_ray_streaming_runtime_transfer_TransferHandler.h
@@ -13,7 +13,7 @@ extern "C" {
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL
-Java_io_ray_streaming_runtime_transfer_TransferHandler_createWriterClientNative(JNIEnv *,
+Java_io_ray_streaming_runtime_transfer_TransferHandler_createWriterClientNative(JNIEnv*,
                                                                                 jobject);
 
 /*
@@ -22,7 +22,7 @@ Java_io_ray_streaming_runtime_transfer_TransferHandler_createWriterClientNative(
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL
-Java_io_ray_streaming_runtime_transfer_TransferHandler_createReaderClientNative(JNIEnv *,
+Java_io_ray_streaming_runtime_transfer_TransferHandler_createReaderClientNative(JNIEnv*,
                                                                                 jobject);
 
 /*
@@ -32,7 +32,7 @@ Java_io_ray_streaming_runtime_transfer_TransferHandler_createReaderClientNative(
  */
 JNIEXPORT void JNICALL
 Java_io_ray_streaming_runtime_transfer_TransferHandler_handleWriterMessageNative(
-    JNIEnv *, jobject, jlong, jbyteArray);
+    JNIEnv*, jobject, jlong, jbyteArray);
 
 /*
  * Class:     io_ray_streaming_runtime_transfer_TransferHandler
@@ -41,7 +41,7 @@ Java_io_ray_streaming_runtime_transfer_TransferHandler_handleWriterMessageNative
  */
 JNIEXPORT jbyteArray JNICALL
 Java_io_ray_streaming_runtime_transfer_TransferHandler_handleWriterMessageSyncNative(
-    JNIEnv *, jobject, jlong, jbyteArray);
+    JNIEnv*, jobject, jlong, jbyteArray);
 
 /*
  * Class:     io_ray_streaming_runtime_transfer_TransferHandler
@@ -50,7 +50,7 @@ Java_io_ray_streaming_runtime_transfer_TransferHandler_handleWriterMessageSyncNa
  */
 JNIEXPORT void JNICALL
 Java_io_ray_streaming_runtime_transfer_TransferHandler_handleReaderMessageNative(
-    JNIEnv *, jobject, jlong, jbyteArray);
+    JNIEnv*, jobject, jlong, jbyteArray);
 
 /*
  * Class:     io_ray_streaming_runtime_transfer_TransferHandler
@@ -59,7 +59,7 @@ Java_io_ray_streaming_runtime_transfer_TransferHandler_handleReaderMessageNative
  */
 JNIEXPORT jbyteArray JNICALL
 Java_io_ray_streaming_runtime_transfer_TransferHandler_handleReaderMessageSyncNative(
-    JNIEnv *, jobject, jlong, jbyteArray);
+    JNIEnv*, jobject, jlong, jbyteArray);
 
 #ifdef __cplusplus
 }

--- a/streaming/src/lib/java/streaming_jni_common.cc
+++ b/streaming/src/lib/java/streaming_jni_common.cc
@@ -1,6 +1,6 @@
 #include "streaming_jni_common.h"
 
-std::vector<ray::ObjectID> jarray_to_object_id_vec(JNIEnv *env, jobjectArray jarr) {
+std::vector<ray::ObjectID> jarray_to_object_id_vec(JNIEnv* env, jobjectArray jarr) {
   int stringCount = env->GetArrayLength(jarr);
   std::vector<ray::ObjectID> object_id_vec;
   for (int i = 0; i < stringCount; i++) {
@@ -11,40 +11,40 @@ std::vector<ray::ObjectID> jarray_to_object_id_vec(JNIEnv *env, jobjectArray jar
   return object_id_vec;
 }
 
-std::vector<ray::ActorID> jarray_to_actor_id_vec(JNIEnv *env, jobjectArray jarr) {
+std::vector<ray::ActorID> jarray_to_actor_id_vec(JNIEnv* env, jobjectArray jarr) {
   int count = env->GetArrayLength(jarr);
   std::vector<ray::ActorID> actor_id_vec;
   for (int i = 0; i < count; i++) {
     auto bytes = (jbyteArray)(env->GetObjectArrayElement(jarr, i));
     std::string id_str(ray::ActorID::Size(), 0);
     env->GetByteArrayRegion(bytes, 0, ray::ActorID::Size(),
-                            reinterpret_cast<jbyte *>(&id_str.front()));
+                            reinterpret_cast<jbyte*>(&id_str.front()));
     actor_id_vec.push_back(ActorID::FromBinary(id_str));
   }
 
   return actor_id_vec;
 }
 
-jint throwRuntimeException(JNIEnv *env, const char *message) {
+jint throwRuntimeException(JNIEnv* env, const char* message) {
   jclass exClass;
   char className[] = "java/lang/RuntimeException";
   exClass = env->FindClass(className);
   return env->ThrowNew(exClass, message);
 }
 
-jint throwChannelInitException(JNIEnv *env, const char *message,
-                               const std::vector<ray::ObjectID> &abnormal_queues) {
+jint throwChannelInitException(JNIEnv* env, const char* message,
+                               const std::vector<ray::ObjectID>& abnormal_queues) {
   jclass array_list_class = env->FindClass("java/util/ArrayList");
   jmethodID array_list_constructor = env->GetMethodID(array_list_class, "<init>", "()V");
   jmethodID array_list_add =
       env->GetMethodID(array_list_class, "add", "(Ljava/lang/Object;)Z");
   jobject array_list = env->NewObject(array_list_class, array_list_constructor);
 
-  for (auto &q_id : abnormal_queues) {
+  for (auto& q_id : abnormal_queues) {
     jbyteArray jbyte_array = env->NewByteArray(kUniqueIDSize);
     env->SetByteArrayRegion(
         jbyte_array, 0, kUniqueIDSize,
-        const_cast<jbyte *>(reinterpret_cast<const jbyte *>(q_id.Data())));
+        const_cast<jbyte*>(reinterpret_cast<const jbyte*>(q_id.Data())));
     env->CallBooleanMethod(array_list, array_list_add, jbyte_array);
   }
 
@@ -58,13 +58,13 @@ jint throwChannelInitException(JNIEnv *env, const char *message,
   return env->Throw((jthrowable)ex_obj);
 }
 
-jint throwChannelInterruptException(JNIEnv *env, const char *message) {
+jint throwChannelInterruptException(JNIEnv* env, const char* message) {
   jclass ex_class =
       env->FindClass("io/ray/streaming/runtime/transfer/ChannelInterruptException");
   return env->ThrowNew(ex_class, message);
 }
 
-jclass LoadClass(JNIEnv *env, const char *class_name) {
+jclass LoadClass(JNIEnv* env, const char* class_name) {
   jclass tempLocalClassRef = env->FindClass(class_name);
   jclass ret = (jclass)env->NewGlobalRef(tempLocalClassRef);
   STREAMING_CHECK(ret) << "Can't load Java class " << class_name;
@@ -73,9 +73,9 @@ jclass LoadClass(JNIEnv *env, const char *class_name) {
 }
 
 template <typename NativeT>
-void JavaListToNativeVector(JNIEnv *env, jobject java_list,
-                            std::vector<NativeT> *native_vector,
-                            std::function<NativeT(JNIEnv *, jobject)> element_converter) {
+void JavaListToNativeVector(JNIEnv* env, jobject java_list,
+                            std::vector<NativeT>* native_vector,
+                            std::function<NativeT(JNIEnv*, jobject)> element_converter) {
   jclass java_list_class = LoadClass(env, "java/util/List");
   jmethodID java_list_size = env->GetMethodID(java_list_class, "size", "()I");
   jmethodID java_list_get =
@@ -90,32 +90,32 @@ void JavaListToNativeVector(JNIEnv *env, jobject java_list,
 
 /// Convert a Java byte array to a C++ UniqueID.
 template <typename ID>
-inline ID JavaByteArrayToId(JNIEnv *env, const jbyteArray &bytes) {
+inline ID JavaByteArrayToId(JNIEnv* env, const jbyteArray& bytes) {
   std::string id_str(ID::Size(), 0);
   env->GetByteArrayRegion(bytes, 0, ID::Size(),
-                          reinterpret_cast<jbyte *>(&id_str.front()));
+                          reinterpret_cast<jbyte*>(&id_str.front()));
   return ID::FromBinary(id_str);
 }
 
 /// Convert a Java String to C++ std::string.
-std::string JavaStringToNativeString(JNIEnv *env, jstring jstr) {
-  const char *c_str = env->GetStringUTFChars(jstr, nullptr);
+std::string JavaStringToNativeString(JNIEnv* env, jstring jstr) {
+  const char* c_str = env->GetStringUTFChars(jstr, nullptr);
   std::string result(c_str);
   env->ReleaseStringUTFChars(static_cast<jstring>(jstr), c_str);
   return result;
 }
 
 /// Convert a Java List<String> to C++ std::vector<std::string>.
-void JavaStringListToNativeStringVector(JNIEnv *env, jobject java_list,
-                                        std::vector<std::string> *native_vector) {
+void JavaStringListToNativeStringVector(JNIEnv* env, jobject java_list,
+                                        std::vector<std::string>* native_vector) {
   JavaListToNativeVector<std::string>(
-      env, java_list, native_vector, [](JNIEnv *env, jobject jstr) {
+      env, java_list, native_vector, [](JNIEnv* env, jobject jstr) {
         return JavaStringToNativeString(env, static_cast<jstring>(jstr));
       });
 }
 
 std::shared_ptr<ray::RayFunction> FunctionDescriptorToRayFunction(
-    JNIEnv *env, jobject functionDescriptor) {
+    JNIEnv* env, jobject functionDescriptor) {
   jclass java_language_class = LoadClass(env, "io/ray/runtime/generated/Common$Language");
   jclass java_function_descriptor_class =
       LoadClass(env, "io/ray/runtime/functionmanager/FunctionDescriptor");
@@ -141,8 +141,8 @@ std::shared_ptr<ray::RayFunction> FunctionDescriptorToRayFunction(
 }
 
 void ParseChannelInitParameters(
-    JNIEnv *env, jobject param_obj,
-    std::vector<ray::streaming::ChannelCreationParameter> &parameter_vec) {
+    JNIEnv* env, jobject param_obj,
+    std::vector<ray::streaming::ChannelCreationParameter>& parameter_vec) {
   jclass java_streaming_queue_initial_parameters_class =
       LoadClass(env,
                 "io/ray/streaming/runtime/transfer/"
@@ -173,7 +173,7 @@ void ParseChannelInitParameters(
   JavaListToNativeVector<ray::streaming::ChannelCreationParameter>(
       env, parameter_list, &parameter_vec,
       [java_getActorIdBytes_method, java_getAsyncFunctionDescriptor_method,
-       java_getSyncFunctionDescriptor_method](JNIEnv *env, jobject jobject_parameter) {
+       java_getSyncFunctionDescriptor_method](JNIEnv* env, jobject jobject_parameter) {
         ray::streaming::ChannelCreationParameter native_parameter;
         jbyteArray jobject_actor_id_bytes = (jbyteArray)env->CallObjectMethod(
             jobject_parameter, java_getActorIdBytes_method);

--- a/streaming/src/lib/java/streaming_jni_common.h
+++ b/streaming/src/lib/java/streaming_jni_common.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <jni.h>
+
 #include <string>
+
 #include "channel.h"
 #include "ray/core_worker/common.h"
 #include "util/streaming_logging.h"

--- a/streaming/src/lib/java/streaming_jni_common.h
+++ b/streaming/src/lib/java/streaming_jni_common.h
@@ -10,20 +10,20 @@
 
 class UniqueIdFromJByteArray {
  private:
-  JNIEnv *_env;
+  JNIEnv* _env;
   jbyteArray _bytes;
-  jbyte *b;
+  jbyte* b;
 
  public:
   ray::ObjectID PID;
 
-  UniqueIdFromJByteArray(JNIEnv *env, jbyteArray wid) {
+  UniqueIdFromJByteArray(JNIEnv* env, jbyteArray wid) {
     _env = env;
     _bytes = wid;
 
-    b = reinterpret_cast<jbyte *>(_env->GetByteArrayElements(_bytes, nullptr));
+    b = reinterpret_cast<jbyte*>(_env->GetByteArrayElements(_bytes, nullptr));
     PID = ray::ObjectID::FromBinary(
-        std::string(reinterpret_cast<const char *>(b), ray::ObjectID::Size()));
+        std::string(reinterpret_cast<const char*>(b), ray::ObjectID::Size()));
   }
 
   ~UniqueIdFromJByteArray() { _env->ReleaseByteArrayElements(_bytes, b, 0); }
@@ -31,36 +31,36 @@ class UniqueIdFromJByteArray {
 
 class RawDataFromJByteArray {
  private:
-  JNIEnv *_env;
+  JNIEnv* _env;
   jbyteArray _bytes;
 
  public:
-  uint8_t *data;
+  uint8_t* data;
   uint32_t data_size;
 
-  RawDataFromJByteArray(JNIEnv *env, jbyteArray bytes) {
+  RawDataFromJByteArray(JNIEnv* env, jbyteArray bytes) {
     _env = env;
     _bytes = bytes;
     data_size = _env->GetArrayLength(_bytes);
-    jbyte *b = reinterpret_cast<jbyte *>(_env->GetByteArrayElements(_bytes, nullptr));
-    data = reinterpret_cast<uint8_t *>(b);
+    jbyte* b = reinterpret_cast<jbyte*>(_env->GetByteArrayElements(_bytes, nullptr));
+    data = reinterpret_cast<uint8_t*>(b);
   }
 
   ~RawDataFromJByteArray() {
-    _env->ReleaseByteArrayElements(_bytes, reinterpret_cast<jbyte *>(data), 0);
+    _env->ReleaseByteArrayElements(_bytes, reinterpret_cast<jbyte*>(data), 0);
   }
 };
 
 class StringFromJString {
  private:
-  JNIEnv *_env;
-  const char *j_str;
+  JNIEnv* _env;
+  const char* j_str;
   jstring jni_str;
 
  public:
   std::string str;
 
-  StringFromJString(JNIEnv *env, jstring jni_str_) {
+  StringFromJString(JNIEnv* env, jstring jni_str_) {
     jni_str = jni_str_;
     _env = env;
     j_str = env->GetStringUTFChars(jni_str, nullptr);
@@ -72,14 +72,14 @@ class StringFromJString {
 
 class LongVectorFromJLongArray {
  private:
-  JNIEnv *_env;
+  JNIEnv* _env;
   jlongArray long_array;
-  jlong *long_array_ptr = nullptr;
+  jlong* long_array_ptr = nullptr;
 
  public:
   std::vector<uint64_t> data;
 
-  LongVectorFromJLongArray(JNIEnv *env, jlongArray long_array_) {
+  LongVectorFromJLongArray(JNIEnv* env, jlongArray long_array_) {
     _env = env;
     long_array = long_array_;
 
@@ -93,15 +93,15 @@ class LongVectorFromJLongArray {
   }
 };
 
-std::vector<ray::ObjectID> jarray_to_object_id_vec(JNIEnv *env, jobjectArray jarr);
-std::vector<ray::ActorID> jarray_to_actor_id_vec(JNIEnv *env, jobjectArray jarr);
+std::vector<ray::ObjectID> jarray_to_object_id_vec(JNIEnv* env, jobjectArray jarr);
+std::vector<ray::ActorID> jarray_to_actor_id_vec(JNIEnv* env, jobjectArray jarr);
 
-jint throwRuntimeException(JNIEnv *env, const char *message);
-jint throwChannelInitException(JNIEnv *env, const char *message,
-                               const std::vector<ray::ObjectID> &abnormal_queues);
-jint throwChannelInterruptException(JNIEnv *env, const char *message);
+jint throwRuntimeException(JNIEnv* env, const char* message);
+jint throwChannelInitException(JNIEnv* env, const char* message,
+                               const std::vector<ray::ObjectID>& abnormal_queues);
+jint throwChannelInterruptException(JNIEnv* env, const char* message);
 std::shared_ptr<ray::RayFunction> FunctionDescriptorToRayFunction(
-    JNIEnv *env, jobject functionDescriptor);
+    JNIEnv* env, jobject functionDescriptor);
 void ParseChannelInitParameters(
-    JNIEnv *env, jobject param_obj,
-    std::vector<ray::streaming::ChannelCreationParameter> &parameter_vec);
+    JNIEnv* env, jobject param_obj,
+    std::vector<ray::streaming::ChannelCreationParameter>& parameter_vec);

--- a/streaming/src/message/message.cc
+++ b/streaming/src/message/message.cc
@@ -10,45 +10,45 @@
 namespace ray {
 namespace streaming {
 
-StreamingMessage::StreamingMessage(std::shared_ptr<uint8_t> &data, uint32_t data_size,
+StreamingMessage::StreamingMessage(std::shared_ptr<uint8_t>& data, uint32_t data_size,
                                    uint64_t seq_id, StreamingMessageType message_type)
     : message_data_(data),
       data_size_(data_size),
       message_type_(message_type),
       message_id_(seq_id) {}
 
-StreamingMessage::StreamingMessage(std::shared_ptr<uint8_t> &&data, uint32_t data_size,
+StreamingMessage::StreamingMessage(std::shared_ptr<uint8_t>&& data, uint32_t data_size,
                                    uint64_t seq_id, StreamingMessageType message_type)
     : message_data_(data),
       data_size_(data_size),
       message_type_(message_type),
       message_id_(seq_id) {}
 
-StreamingMessage::StreamingMessage(const uint8_t *data, uint32_t data_size,
+StreamingMessage::StreamingMessage(const uint8_t* data, uint32_t data_size,
                                    uint64_t seq_id, StreamingMessageType message_type)
     : data_size_(data_size), message_type_(message_type), message_id_(seq_id) {
   message_data_.reset(new uint8_t[data_size], std::default_delete<uint8_t[]>());
   std::memcpy(message_data_.get(), data, data_size_);
 }
 
-StreamingMessage::StreamingMessage(const StreamingMessage &msg) {
+StreamingMessage::StreamingMessage(const StreamingMessage& msg) {
   data_size_ = msg.data_size_;
   message_data_ = msg.message_data_;
   message_id_ = msg.message_id_;
   message_type_ = msg.message_type_;
 }
 
-StreamingMessagePtr StreamingMessage::FromBytes(const uint8_t *bytes,
+StreamingMessagePtr StreamingMessage::FromBytes(const uint8_t* bytes,
                                                 bool verifer_check) {
   uint32_t byte_offset = 0;
-  uint32_t data_size = *reinterpret_cast<const uint32_t *>(bytes + byte_offset);
+  uint32_t data_size = *reinterpret_cast<const uint32_t*>(bytes + byte_offset);
   byte_offset += sizeof(data_size);
 
-  uint64_t seq_id = *reinterpret_cast<const uint64_t *>(bytes + byte_offset);
+  uint64_t seq_id = *reinterpret_cast<const uint64_t*>(bytes + byte_offset);
   byte_offset += sizeof(seq_id);
 
   StreamingMessageType msg_type =
-      *reinterpret_cast<const StreamingMessageType *>(bytes + byte_offset);
+      *reinterpret_cast<const StreamingMessageType*>(bytes + byte_offset);
   byte_offset += sizeof(msg_type);
 
   auto buf = new uint8_t[data_size];
@@ -57,29 +57,29 @@ StreamingMessagePtr StreamingMessage::FromBytes(const uint8_t *bytes,
   return std::make_shared<StreamingMessage>(data_ptr, data_size, seq_id, msg_type);
 }
 
-void StreamingMessage::ToBytes(uint8_t *serlizable_data) {
+void StreamingMessage::ToBytes(uint8_t* serlizable_data) {
   uint32_t byte_offset = 0;
-  std::memcpy(serlizable_data + byte_offset, reinterpret_cast<char *>(&data_size_),
+  std::memcpy(serlizable_data + byte_offset, reinterpret_cast<char*>(&data_size_),
               sizeof(data_size_));
   byte_offset += sizeof(data_size_);
 
-  std::memcpy(serlizable_data + byte_offset, reinterpret_cast<char *>(&message_id_),
+  std::memcpy(serlizable_data + byte_offset, reinterpret_cast<char*>(&message_id_),
               sizeof(message_id_));
   byte_offset += sizeof(message_id_);
 
-  std::memcpy(serlizable_data + byte_offset, reinterpret_cast<char *>(&message_type_),
+  std::memcpy(serlizable_data + byte_offset, reinterpret_cast<char*>(&message_type_),
               sizeof(message_type_));
   byte_offset += sizeof(message_type_);
 
-  std::memcpy(serlizable_data + byte_offset,
-              reinterpret_cast<char *>(message_data_.get()), data_size_);
+  std::memcpy(serlizable_data + byte_offset, reinterpret_cast<char*>(message_data_.get()),
+              data_size_);
 
   byte_offset += data_size_;
 
   STREAMING_CHECK(byte_offset == this->ClassBytesSize());
 }
 
-bool StreamingMessage::operator==(const StreamingMessage &message) const {
+bool StreamingMessage::operator==(const StreamingMessage& message) const {
   return GetDataSize() == message.GetDataSize() &&
          GetMessageSeqId() == message.GetMessageSeqId() &&
          GetMessageType() == message.GetMessageType() &&

--- a/streaming/src/message/message.h
+++ b/streaming/src/message/message.h
@@ -45,7 +45,7 @@ class StreamingMessage {
   /// \param data_size raw data size
   /// \param seq_id message id
   /// \param message_type
-  StreamingMessage(std::shared_ptr<uint8_t> &data, uint32_t data_size, uint64_t seq_id,
+  StreamingMessage(std::shared_ptr<uint8_t>& data, uint32_t data_size, uint64_t seq_id,
                    StreamingMessageType message_type);
 
   /// Move outsite raw data to message data.
@@ -53,7 +53,7 @@ class StreamingMessage {
   /// \param data_size raw data size
   /// \param seq_id message id
   /// \param message_type
-  StreamingMessage(std::shared_ptr<uint8_t> &&data, uint32_t data_size, uint64_t seq_id,
+  StreamingMessage(std::shared_ptr<uint8_t>&& data, uint32_t data_size, uint64_t seq_id,
                    StreamingMessageType message_type);
 
   /// Copy raw data from outside buffer.
@@ -61,16 +61,16 @@ class StreamingMessage {
   /// \param data_size raw data size
   /// \param seq_id message id
   /// \param message_type
-  StreamingMessage(const uint8_t *data, uint32_t data_size, uint64_t seq_id,
+  StreamingMessage(const uint8_t* data, uint32_t data_size, uint64_t seq_id,
                    StreamingMessageType message_type);
 
-  StreamingMessage(const StreamingMessage &);
+  StreamingMessage(const StreamingMessage&);
 
-  StreamingMessage operator=(const StreamingMessage &) = delete;
+  StreamingMessage operator=(const StreamingMessage&) = delete;
 
   virtual ~StreamingMessage() = default;
 
-  inline uint8_t *RawData() const { return message_data_.get(); }
+  inline uint8_t* RawData() const { return message_data_.get(); }
 
   inline uint32_t GetDataSize() const { return data_size_; }
   inline StreamingMessageType GetMessageType() const { return message_type_; }
@@ -78,10 +78,10 @@ class StreamingMessage {
   inline bool IsMessage() { return StreamingMessageType::Message == message_type_; }
   inline bool IsBarrier() { return StreamingMessageType::Barrier == message_type_; }
 
-  bool operator==(const StreamingMessage &) const;
+  bool operator==(const StreamingMessage&) const;
 
-  virtual void ToBytes(uint8_t *data);
-  static StreamingMessagePtr FromBytes(const uint8_t *data, bool verifer_check = true);
+  virtual void ToBytes(uint8_t* data);
+  static StreamingMessagePtr FromBytes(const uint8_t* data, bool verifer_check = true);
 
   inline virtual uint32_t ClassBytesSize() { return kMessageHeaderSize + data_size_; }
 };

--- a/streaming/src/message/message_bundle.cc
+++ b/streaming/src/message/message_bundle.cc
@@ -16,7 +16,7 @@ StreamingMessageBundle::StreamingMessageBundle(uint64_t last_offset_seq_id,
   this->raw_bundle_size_ = 0;
 }
 
-StreamingMessageBundleMeta::StreamingMessageBundleMeta(const uint8_t *bytes) {
+StreamingMessageBundleMeta::StreamingMessageBundleMeta(const uint8_t* bytes) {
   std::memcpy(GetFirstMemberAddress(), bytes,
               kMessageBundleMetaHeaderSize - sizeof(uint32_t));
 }
@@ -31,14 +31,14 @@ StreamingMessageBundleMeta::StreamingMessageBundleMeta(
   STREAMING_CHECK(message_list_size <= StreamingConfig::MESSAGE_BUNDLE_MAX_SIZE);
 }
 
-void StreamingMessageBundleMeta::ToBytes(uint8_t *bytes) {
+void StreamingMessageBundleMeta::ToBytes(uint8_t* bytes) {
   uint32_t magicNum = StreamingMessageBundleMeta::StreamingMessageBundleMagicNum;
-  std::memcpy(bytes, reinterpret_cast<const uint8_t *>(&magicNum), sizeof(uint32_t));
+  std::memcpy(bytes, reinterpret_cast<const uint8_t*>(&magicNum), sizeof(uint32_t));
   std::memcpy(bytes + sizeof(uint32_t), GetFirstMemberAddress(),
               kMessageBundleMetaHeaderSize - sizeof(uint32_t));
 }
 
-StreamingMessageBundleMetaPtr StreamingMessageBundleMeta::FromBytes(const uint8_t *bytes,
+StreamingMessageBundleMetaPtr StreamingMessageBundleMeta::FromBytes(const uint8_t* bytes,
                                                                     bool check) {
   STREAMING_CHECK(bytes);
 
@@ -52,14 +52,14 @@ StreamingMessageBundleMetaPtr StreamingMessageBundleMeta::FromBytes(const uint8_
   return result;
 }
 
-bool StreamingMessageBundleMeta::operator==(StreamingMessageBundleMeta &meta) const {
+bool StreamingMessageBundleMeta::operator==(StreamingMessageBundleMeta& meta) const {
   return this->message_list_size_ == meta.GetMessageListSize() &&
          this->message_bundle_ts_ == meta.GetMessageBundleTs() &&
          this->bundle_type_ == meta.GetBundleType() &&
          this->last_message_id_ == meta.GetLastMessageId();
 }
 
-bool StreamingMessageBundleMeta::operator==(StreamingMessageBundleMeta *meta) const {
+bool StreamingMessageBundleMeta::operator==(StreamingMessageBundleMeta* meta) const {
   return operator==(*meta);
 }
 
@@ -67,7 +67,7 @@ StreamingMessageBundleMeta::StreamingMessageBundleMeta()
     : bundle_type_(StreamingMessageBundleType::Empty) {}
 
 StreamingMessageBundle::StreamingMessageBundle(
-    std::list<StreamingMessagePtr> &&message_list, uint64_t message_ts,
+    std::list<StreamingMessagePtr>&& message_list, uint64_t message_ts,
     uint64_t last_offset_seq_id, StreamingMessageBundleType bundle_type,
     uint32_t raw_data_size)
     : StreamingMessageBundleMeta(message_ts, last_offset_seq_id, message_list.size(),
@@ -78,19 +78,19 @@ StreamingMessageBundle::StreamingMessageBundle(
     if (!raw_bundle_size_) {
       raw_bundle_size_ = std::accumulate(
           message_list_.begin(), message_list_.end(), 0,
-          [](uint32_t x, StreamingMessagePtr &y) { return x + y->ClassBytesSize(); });
+          [](uint32_t x, StreamingMessagePtr& y) { return x + y->ClassBytesSize(); });
     }
   }
 }
 
 StreamingMessageBundle::StreamingMessageBundle(
-    std::list<StreamingMessagePtr> &message_list, uint64_t message_ts,
+    std::list<StreamingMessagePtr>& message_list, uint64_t message_ts,
     uint64_t last_offset_seq_id, StreamingMessageBundleType bundle_type,
     uint32_t raw_data_size)
     : StreamingMessageBundle(std::list<StreamingMessagePtr>(message_list), message_ts,
                              last_offset_seq_id, bundle_type, raw_data_size) {}
 
-StreamingMessageBundle::StreamingMessageBundle(StreamingMessageBundle &bundle) {
+StreamingMessageBundle::StreamingMessageBundle(StreamingMessageBundle& bundle) {
   message_bundle_ts_ = bundle.message_bundle_ts_;
   message_list_size_ = bundle.message_list_size_;
   raw_bundle_size_ = bundle.raw_bundle_size_;
@@ -99,13 +99,13 @@ StreamingMessageBundle::StreamingMessageBundle(StreamingMessageBundle &bundle) {
   message_list_ = bundle.message_list_;
 }
 
-void StreamingMessageBundle::ToBytes(uint8_t *bytes) {
+void StreamingMessageBundle::ToBytes(uint8_t* bytes) {
   uint32_t byte_offset = 0;
   StreamingMessageBundleMeta::ToBytes(bytes + byte_offset);
 
   byte_offset += StreamingMessageBundleMeta::ClassBytesSize();
 
-  std::memcpy(bytes + byte_offset, reinterpret_cast<char *>(&raw_bundle_size_),
+  std::memcpy(bytes + byte_offset, reinterpret_cast<char*>(&raw_bundle_size_),
               sizeof(uint32_t));
   byte_offset += sizeof(uint32_t);
 
@@ -114,14 +114,14 @@ void StreamingMessageBundle::ToBytes(uint8_t *bytes) {
   }
 }
 
-StreamingMessageBundlePtr StreamingMessageBundle::FromBytes(const uint8_t *bytes,
+StreamingMessageBundlePtr StreamingMessageBundle::FromBytes(const uint8_t* bytes,
                                                             bool verifer_check) {
   uint32_t byte_offset = 0;
   StreamingMessageBundleMetaPtr meta_ptr =
       StreamingMessageBundleMeta::FromBytes(bytes + byte_offset);
   byte_offset += meta_ptr->ClassBytesSize();
 
-  uint32_t raw_data_size = *reinterpret_cast<const uint32_t *>(bytes + byte_offset);
+  uint32_t raw_data_size = *reinterpret_cast<const uint32_t*>(bytes + byte_offset);
   byte_offset += sizeof(uint32_t);
 
   std::list<StreamingMessagePtr> message_list;
@@ -139,8 +139,8 @@ StreamingMessageBundlePtr StreamingMessageBundle::FromBytes(const uint8_t *bytes
 }
 
 void StreamingMessageBundle::GetMessageListFromRawData(
-    const uint8_t *bytes, uint32_t byte_size, uint32_t message_list_size,
-    std::list<StreamingMessagePtr> &message_list) {
+    const uint8_t* bytes, uint32_t byte_size, uint32_t message_list_size,
+    std::list<StreamingMessagePtr>& message_list) {
   uint32_t byte_offset = 0;
   // only message bundle own raw data
   for (size_t i = 0; i < message_list_size; ++i) {
@@ -152,22 +152,22 @@ void StreamingMessageBundle::GetMessageListFromRawData(
 }
 
 void StreamingMessageBundle::GetMessageList(
-    std::list<StreamingMessagePtr> &message_list) {
+    std::list<StreamingMessagePtr>& message_list) {
   message_list = message_list_;
 }
 
 void StreamingMessageBundle::ConvertMessageListToRawData(
-    const std::list<StreamingMessagePtr> &message_list, uint32_t raw_data_size,
-    uint8_t *raw_data) {
+    const std::list<StreamingMessagePtr>& message_list, uint32_t raw_data_size,
+    uint8_t* raw_data) {
   uint32_t byte_offset = 0;
-  for (auto &message : message_list) {
+  for (auto& message : message_list) {
     message->ToBytes(raw_data + byte_offset);
     byte_offset += message->ClassBytesSize();
   }
   STREAMING_CHECK(byte_offset == raw_data_size);
 }
 
-bool StreamingMessageBundle::operator==(StreamingMessageBundle &bundle) const {
+bool StreamingMessageBundle::operator==(StreamingMessageBundle& bundle) const {
   if (!(StreamingMessageBundleMeta::operator==(&bundle) &&
         this->GetRawBundleSize() == bundle.GetRawBundleSize() &&
         this->GetMessageListSize() == bundle.GetMessageListSize())) {
@@ -185,7 +185,7 @@ bool StreamingMessageBundle::operator==(StreamingMessageBundle &bundle) const {
   return true;
 }
 
-bool StreamingMessageBundle::operator==(StreamingMessageBundle *bundle) const {
+bool StreamingMessageBundle::operator==(StreamingMessageBundle* bundle) const {
   return this->operator==(*bundle);
 }
 }  // namespace streaming

--- a/streaming/src/message/message_bundle.h
+++ b/streaming/src/message/message_bundle.h
@@ -51,27 +51,27 @@ class StreamingMessageBundleMeta {
   /// first member property.
   /// Reference
   /// :/http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1113r0.html#2254).
-  inline uint8_t *GetFirstMemberAddress() {
-    return reinterpret_cast<uint8_t *>(&message_bundle_ts_);
+  inline uint8_t* GetFirstMemberAddress() {
+    return reinterpret_cast<uint8_t*>(&message_bundle_ts_);
   }
 
  public:
-  explicit StreamingMessageBundleMeta(const uint8_t *bytes);
+  explicit StreamingMessageBundleMeta(const uint8_t* bytes);
 
   explicit StreamingMessageBundleMeta(const uint64_t message_bunddle_tes,
                                       const uint64_t last_offset_seq_id,
                                       const uint32_t message_list_size,
                                       const StreamingMessageBundleType bundle_type);
 
-  explicit StreamingMessageBundleMeta(StreamingMessageBundleMeta *);
+  explicit StreamingMessageBundleMeta(StreamingMessageBundleMeta*);
 
   explicit StreamingMessageBundleMeta();
 
   virtual ~StreamingMessageBundleMeta() = default;
 
-  bool operator==(StreamingMessageBundleMeta &) const;
+  bool operator==(StreamingMessageBundleMeta&) const;
 
-  bool operator==(StreamingMessageBundleMeta *) const;
+  bool operator==(StreamingMessageBundleMeta*) const;
 
   inline uint64_t GetMessageBundleTs() const { return message_bundle_ts_; }
 
@@ -84,13 +84,13 @@ class StreamingMessageBundleMeta {
   inline bool IsBarrier() { return StreamingMessageBundleType::Barrier == bundle_type_; }
   inline bool IsBundle() { return StreamingMessageBundleType::Bundle == bundle_type_; }
 
-  virtual void ToBytes(uint8_t *data);
-  static StreamingMessageBundleMetaPtr FromBytes(const uint8_t *data,
+  virtual void ToBytes(uint8_t* data);
+  static StreamingMessageBundleMetaPtr FromBytes(const uint8_t* data,
                                                  bool verifer_check = true);
   inline virtual uint32_t ClassBytesSize() { return kMessageBundleMetaHeaderSize; }
 
-  inline static bool CheckBundleMagicNum(const uint8_t *bytes) {
-    const uint32_t *magic_num = reinterpret_cast<const uint32_t *>(bytes);
+  inline static bool CheckBundleMagicNum(const uint8_t* bytes) {
+    const uint32_t* magic_num = reinterpret_cast<const uint32_t*>(bytes);
     return *magic_num == StreamingMessageBundleMagicNum;
   }
 
@@ -134,13 +134,13 @@ class StreamingMessageBundle : public StreamingMessageBundleMeta {
   std::list<StreamingMessagePtr> message_list_;
 
  public:
-  explicit StreamingMessageBundle(std::list<StreamingMessagePtr> &&message_list,
+  explicit StreamingMessageBundle(std::list<StreamingMessagePtr>&& message_list,
                                   uint64_t bundle_ts, uint64_t offset,
                                   StreamingMessageBundleType bundle_type,
                                   uint32_t raw_data_size = 0);
 
   // Duplicated copy if left reference in constructor.
-  explicit StreamingMessageBundle(std::list<StreamingMessagePtr> &message_list,
+  explicit StreamingMessageBundle(std::list<StreamingMessagePtr>& message_list,
                                   uint64_t bundle_ts, uint64_t offset,
                                   StreamingMessageBundleType bundle_type,
                                   uint32_t raw_data_size = 0);
@@ -148,34 +148,34 @@ class StreamingMessageBundle : public StreamingMessageBundleMeta {
   // New a empty bundle by passing last message id and timestamp.
   explicit StreamingMessageBundle(uint64_t, uint64_t);
 
-  explicit StreamingMessageBundle(StreamingMessageBundle &bundle);
+  explicit StreamingMessageBundle(StreamingMessageBundle& bundle);
 
   virtual ~StreamingMessageBundle() = default;
 
   inline uint32_t GetRawBundleSize() const { return raw_bundle_size_; }
 
-  bool operator==(StreamingMessageBundle &bundle) const;
+  bool operator==(StreamingMessageBundle& bundle) const;
 
-  bool operator==(StreamingMessageBundle *bundle_ptr) const;
+  bool operator==(StreamingMessageBundle* bundle_ptr) const;
 
-  void GetMessageList(std::list<StreamingMessagePtr> &message_list);
+  void GetMessageList(std::list<StreamingMessagePtr>& message_list);
 
-  const std::list<StreamingMessagePtr> &GetMessageList() const { return message_list_; }
+  const std::list<StreamingMessagePtr>& GetMessageList() const { return message_list_; }
 
-  virtual void ToBytes(uint8_t *data);
-  static StreamingMessageBundlePtr FromBytes(const uint8_t *data,
+  virtual void ToBytes(uint8_t* data);
+  static StreamingMessageBundlePtr FromBytes(const uint8_t* data,
                                              bool verifer_check = true);
   inline virtual uint32_t ClassBytesSize() {
     return kMessageBundleHeaderSize + raw_bundle_size_;
   };
 
-  static void GetMessageListFromRawData(const uint8_t *bytes, uint32_t bytes_size,
+  static void GetMessageListFromRawData(const uint8_t* bytes, uint32_t bytes_size,
                                         uint32_t message_list_size,
-                                        std::list<StreamingMessagePtr> &message_list);
+                                        std::list<StreamingMessagePtr>& message_list);
 
   static void ConvertMessageListToRawData(
-      const std::list<StreamingMessagePtr> &message_list, uint32_t raw_data_size,
-      uint8_t *raw_data);
+      const std::list<StreamingMessagePtr>& message_list, uint32_t raw_data_size,
+      uint8_t* raw_data);
 };
 }  // namespace streaming
 }  // namespace ray

--- a/streaming/src/message/priority_queue.h
+++ b/streaming/src/message/priority_queue.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <memory>
 #include <vector>
+
 #include "util/streaming_logging.h"
 
 namespace ray {

--- a/streaming/src/message/priority_queue.h
+++ b/streaming/src/message/priority_queue.h
@@ -17,14 +17,14 @@ class PriorityQueue {
   C comparator_;
 
  public:
-  PriorityQueue(C &comparator) : comparator_(comparator){};
+  PriorityQueue(C& comparator) : comparator_(comparator){};
 
-  inline void push(T &&item) {
+  inline void push(T&& item) {
     merge_vec_.push_back(std::forward<T>(item));
     std::push_heap(merge_vec_.begin(), merge_vec_.end(), comparator_);
   }
 
-  inline void push(const T &item) {
+  inline void push(const T& item) {
     merge_vec_.push_back(item);
     std::push_heap(merge_vec_.begin(), merge_vec_.end(), comparator_);
   }
@@ -39,13 +39,13 @@ class PriorityQueue {
     std::make_heap(merge_vec_.begin(), merge_vec_.end(), comparator_);
   }
 
-  inline T &top() { return merge_vec_.front(); }
+  inline T& top() { return merge_vec_.front(); }
 
   inline uint32_t size() { return merge_vec_.size(); }
 
   inline bool isEmpty() { return merge_vec_.empty(); }
 
-  std::vector<T> &getRawVector() { return merge_vec_; }
+  std::vector<T>& getRawVector() { return merge_vec_; }
 };
 }  // namespace streaming
 }  // namespace ray

--- a/streaming/src/queue/message.cc
+++ b/streaming/src/queue/message.cc
@@ -5,7 +5,7 @@ namespace streaming {
 const uint32_t Message::MagicNum = 0xBABA0510;
 
 std::unique_ptr<LocalMemoryBuffer> Message::ToBytes() {
-  uint8_t *bytes = nullptr;
+  uint8_t* bytes = nullptr;
 
   std::string pboutput;
   ToProtobuf(&pboutput);
@@ -20,7 +20,7 @@ std::unique_ptr<LocalMemoryBuffer> Message::ToBytes() {
   bytes = new uint8_t[total_len];
   STREAMING_CHECK(bytes != nullptr) << "allocate bytes fail.";
 
-  uint8_t *p_cur = bytes;
+  uint8_t* p_cur = bytes;
   memcpy(p_cur, &Message::MagicNum, sizeof(Message::MagicNum));
 
   p_cur += sizeof(Message::MagicNum);
@@ -30,7 +30,7 @@ std::unique_ptr<LocalMemoryBuffer> Message::ToBytes() {
   memcpy(p_cur, &fbs_length, sizeof(fbs_length));
 
   p_cur += sizeof(fbs_length);
-  uint8_t *fbs_bytes = (uint8_t *)pboutput.data();
+  uint8_t* fbs_bytes = (uint8_t*)pboutput.data();
   memcpy(p_cur, fbs_bytes, fbs_length);
   p_cur += fbs_length;
 
@@ -45,7 +45,7 @@ std::unique_ptr<LocalMemoryBuffer> Message::ToBytes() {
   return buffer;
 }
 
-void DataMessage::ToProtobuf(std::string *output) {
+void DataMessage::ToProtobuf(std::string* output) {
   queue::protobuf::StreamingQueueDataMsg msg;
   msg.set_src_actor_id(actor_id_.Binary());
   msg.set_dst_actor_id(peer_actor_id_.Binary());
@@ -56,12 +56,12 @@ void DataMessage::ToProtobuf(std::string *output) {
   msg.SerializeToString(output);
 }
 
-std::shared_ptr<DataMessage> DataMessage::FromBytes(uint8_t *bytes) {
+std::shared_ptr<DataMessage> DataMessage::FromBytes(uint8_t* bytes) {
   bytes += sizeof(uint32_t) + sizeof(queue::protobuf::StreamingQueueMessageType);
-  uint64_t *fbs_length = (uint64_t *)bytes;
+  uint64_t* fbs_length = (uint64_t*)bytes;
   bytes += sizeof(uint64_t);
 
-  std::string inputpb(reinterpret_cast<char const *>(bytes), *fbs_length);
+  std::string inputpb(reinterpret_cast<char const*>(bytes), *fbs_length);
   queue::protobuf::StreamingQueueDataMsg message;
   message.ParseFromString(inputpb);
   ActorID src_actor_id = ActorID::FromBinary(message.src_actor_id());
@@ -81,7 +81,7 @@ std::shared_ptr<DataMessage> DataMessage::FromBytes(uint8_t *bytes) {
   return data_msg;
 }
 
-void NotificationMessage::ToProtobuf(std::string *output) {
+void NotificationMessage::ToProtobuf(std::string* output) {
   queue::protobuf::StreamingQueueNotificationMsg msg;
   msg.set_src_actor_id(actor_id_.Binary());
   msg.set_dst_actor_id(peer_actor_id_.Binary());
@@ -90,12 +90,12 @@ void NotificationMessage::ToProtobuf(std::string *output) {
   msg.SerializeToString(output);
 }
 
-std::shared_ptr<NotificationMessage> NotificationMessage::FromBytes(uint8_t *bytes) {
+std::shared_ptr<NotificationMessage> NotificationMessage::FromBytes(uint8_t* bytes) {
   bytes += sizeof(uint32_t) + sizeof(queue::protobuf::StreamingQueueMessageType);
-  uint64_t *length = (uint64_t *)bytes;
+  uint64_t* length = (uint64_t*)bytes;
   bytes += sizeof(uint64_t);
 
-  std::string inputpb(reinterpret_cast<char const *>(bytes), *length);
+  std::string inputpb(reinterpret_cast<char const*>(bytes), *length);
   queue::protobuf::StreamingQueueNotificationMsg message;
   message.ParseFromString(inputpb);
   STREAMING_LOG(INFO) << "message.src_actor_id: " << message.src_actor_id();
@@ -110,7 +110,7 @@ std::shared_ptr<NotificationMessage> NotificationMessage::FromBytes(uint8_t *byt
   return notify_msg;
 }
 
-void CheckMessage::ToProtobuf(std::string *output) {
+void CheckMessage::ToProtobuf(std::string* output) {
   queue::protobuf::StreamingQueueCheckMsg msg;
   msg.set_src_actor_id(actor_id_.Binary());
   msg.set_dst_actor_id(peer_actor_id_.Binary());
@@ -118,12 +118,12 @@ void CheckMessage::ToProtobuf(std::string *output) {
   msg.SerializeToString(output);
 }
 
-std::shared_ptr<CheckMessage> CheckMessage::FromBytes(uint8_t *bytes) {
+std::shared_ptr<CheckMessage> CheckMessage::FromBytes(uint8_t* bytes) {
   bytes += sizeof(uint32_t) + sizeof(queue::protobuf::StreamingQueueMessageType);
-  uint64_t *length = (uint64_t *)bytes;
+  uint64_t* length = (uint64_t*)bytes;
   bytes += sizeof(uint64_t);
 
-  std::string inputpb(reinterpret_cast<char const *>(bytes), *length);
+  std::string inputpb(reinterpret_cast<char const*>(bytes), *length);
   queue::protobuf::StreamingQueueCheckMsg message;
   message.ParseFromString(inputpb);
   ActorID src_actor_id = ActorID::FromBinary(message.src_actor_id());
@@ -136,7 +136,7 @@ std::shared_ptr<CheckMessage> CheckMessage::FromBytes(uint8_t *bytes) {
   return check_msg;
 }
 
-void CheckRspMessage::ToProtobuf(std::string *output) {
+void CheckRspMessage::ToProtobuf(std::string* output) {
   queue::protobuf::StreamingQueueCheckRspMsg msg;
   msg.set_src_actor_id(actor_id_.Binary());
   msg.set_dst_actor_id(peer_actor_id_.Binary());
@@ -145,12 +145,12 @@ void CheckRspMessage::ToProtobuf(std::string *output) {
   msg.SerializeToString(output);
 }
 
-std::shared_ptr<CheckRspMessage> CheckRspMessage::FromBytes(uint8_t *bytes) {
+std::shared_ptr<CheckRspMessage> CheckRspMessage::FromBytes(uint8_t* bytes) {
   bytes += sizeof(uint32_t) + sizeof(queue::protobuf::StreamingQueueMessageType);
-  uint64_t *length = (uint64_t *)bytes;
+  uint64_t* length = (uint64_t*)bytes;
   bytes += sizeof(uint64_t);
 
-  std::string inputpb(reinterpret_cast<char const *>(bytes), *length);
+  std::string inputpb(reinterpret_cast<char const*>(bytes), *length);
   queue::protobuf::StreamingQueueCheckRspMsg message;
   message.ParseFromString(inputpb);
   ActorID src_actor_id = ActorID::FromBinary(message.src_actor_id());
@@ -164,16 +164,16 @@ std::shared_ptr<CheckRspMessage> CheckRspMessage::FromBytes(uint8_t *bytes) {
   return check_rsp_msg;
 }
 
-void TestInitMessage::ToProtobuf(std::string *output) {
+void TestInitMessage::ToProtobuf(std::string* output) {
   queue::protobuf::StreamingQueueTestInitMsg msg;
   msg.set_role(role_);
   msg.set_src_actor_id(actor_id_.Binary());
   msg.set_dst_actor_id(peer_actor_id_.Binary());
   msg.set_actor_handle(actor_handle_serialized_);
-  for (auto &queue_id : queue_ids_) {
+  for (auto& queue_id : queue_ids_) {
     msg.add_queue_ids(queue_id.Binary());
   }
-  for (auto &queue_id : rescale_queue_ids_) {
+  for (auto& queue_id : rescale_queue_ids_) {
     msg.add_rescale_queue_ids(queue_id.Binary());
   }
   msg.set_test_suite_name(test_suite_name_);
@@ -182,12 +182,12 @@ void TestInitMessage::ToProtobuf(std::string *output) {
   msg.SerializeToString(output);
 }
 
-std::shared_ptr<TestInitMessage> TestInitMessage::FromBytes(uint8_t *bytes) {
+std::shared_ptr<TestInitMessage> TestInitMessage::FromBytes(uint8_t* bytes) {
   bytes += sizeof(uint32_t) + sizeof(queue::protobuf::StreamingQueueMessageType);
-  uint64_t *length = (uint64_t *)bytes;
+  uint64_t* length = (uint64_t*)bytes;
   bytes += sizeof(uint64_t);
 
-  std::string inputpb(reinterpret_cast<char const *>(bytes), *length);
+  std::string inputpb(reinterpret_cast<char const*>(bytes), *length);
   queue::protobuf::StreamingQueueTestInitMsg message;
   message.ParseFromString(inputpb);
   queue::protobuf::StreamingQueueTestRole role = message.role();
@@ -213,19 +213,19 @@ std::shared_ptr<TestInitMessage> TestInitMessage::FromBytes(uint8_t *bytes) {
   return test_init_msg;
 }
 
-void TestCheckStatusRspMsg::ToProtobuf(std::string *output) {
+void TestCheckStatusRspMsg::ToProtobuf(std::string* output) {
   queue::protobuf::StreamingQueueTestCheckStatusRspMsg msg;
   msg.set_test_name(test_name_);
   msg.set_status(status_);
   msg.SerializeToString(output);
 }
 
-std::shared_ptr<TestCheckStatusRspMsg> TestCheckStatusRspMsg::FromBytes(uint8_t *bytes) {
+std::shared_ptr<TestCheckStatusRspMsg> TestCheckStatusRspMsg::FromBytes(uint8_t* bytes) {
   bytes += sizeof(uint32_t) + sizeof(queue::protobuf::StreamingQueueMessageType);
-  uint64_t *length = (uint64_t *)bytes;
+  uint64_t* length = (uint64_t*)bytes;
   bytes += sizeof(uint64_t);
 
-  std::string inputpb(reinterpret_cast<char const *>(bytes), *length);
+  std::string inputpb(reinterpret_cast<char const*>(bytes), *length);
   queue::protobuf::StreamingQueueTestCheckStatusRspMsg message;
   message.ParseFromString(inputpb);
   std::string test_name = message.test_name();

--- a/streaming/src/queue/message.h
+++ b/streaming/src/queue/message.h
@@ -20,7 +20,7 @@ class Message {
   /// \param[in] peer_actor_id ActorID of message receiver.
   /// \param[in] queue_id queue id to identify which queue the message is sent to.
   /// \param[in] buffer an optional param, a chunk of data to send.
-  Message(const ActorID &actor_id, const ActorID &peer_actor_id, const ObjectID &queue_id,
+  Message(const ActorID& actor_id, const ActorID& peer_actor_id, const ObjectID& queue_id,
           std::shared_ptr<LocalMemoryBuffer> buffer = nullptr)
       : actor_id_(actor_id),
         peer_actor_id_(peer_actor_id),
@@ -42,7 +42,7 @@ class Message {
   virtual queue::protobuf::StreamingQueueMessageType Type() = 0;
 
   /// All subclasses should implement `ToProtobuf` to serialize its own protobuf data.
-  virtual void ToProtobuf(std::string *output) = 0;
+  virtual void ToProtobuf(std::string* output) = 0;
 
  protected:
   ActorID actor_id_;
@@ -60,13 +60,13 @@ class Message {
 /// exists between DataMessage and QueueItem.
 class DataMessage : public Message {
  public:
-  DataMessage(const ActorID &actor_id, const ActorID &peer_actor_id, ObjectID queue_id,
+  DataMessage(const ActorID& actor_id, const ActorID& peer_actor_id, ObjectID queue_id,
               uint64_t seq_id, std::shared_ptr<LocalMemoryBuffer> buffer, bool raw)
       : Message(actor_id, peer_actor_id, queue_id, buffer), seq_id_(seq_id), raw_(raw) {}
   virtual ~DataMessage() {}
 
-  static std::shared_ptr<DataMessage> FromBytes(uint8_t *bytes);
-  virtual void ToProtobuf(std::string *output);
+  static std::shared_ptr<DataMessage> FromBytes(uint8_t* bytes);
+  virtual void ToProtobuf(std::string* output);
   uint64_t SeqId() { return seq_id_; }
   bool IsRaw() { return raw_; }
   queue::protobuf::StreamingQueueMessageType Type() { return type_; }
@@ -84,14 +84,14 @@ class DataMessage : public Message {
 /// to inform the data writer of the consumed offset.
 class NotificationMessage : public Message {
  public:
-  NotificationMessage(const ActorID &actor_id, const ActorID &peer_actor_id,
-                      const ObjectID &queue_id, uint64_t seq_id)
+  NotificationMessage(const ActorID& actor_id, const ActorID& peer_actor_id,
+                      const ObjectID& queue_id, uint64_t seq_id)
       : Message(actor_id, peer_actor_id, queue_id), seq_id_(seq_id) {}
 
   virtual ~NotificationMessage() {}
 
-  static std::shared_ptr<NotificationMessage> FromBytes(uint8_t *bytes);
-  virtual void ToProtobuf(std::string *output);
+  static std::shared_ptr<NotificationMessage> FromBytes(uint8_t* bytes);
+  virtual void ToProtobuf(std::string* output);
 
   uint64_t SeqId() { return seq_id_; }
   queue::protobuf::StreamingQueueMessageType Type() { return type_; }
@@ -107,13 +107,13 @@ class NotificationMessage : public Message {
 /// whether the corresponded downstream queue is read or not.
 class CheckMessage : public Message {
  public:
-  CheckMessage(const ActorID &actor_id, const ActorID &peer_actor_id,
-               const ObjectID &queue_id)
+  CheckMessage(const ActorID& actor_id, const ActorID& peer_actor_id,
+               const ObjectID& queue_id)
       : Message(actor_id, peer_actor_id, queue_id) {}
   virtual ~CheckMessage() {}
 
-  static std::shared_ptr<CheckMessage> FromBytes(uint8_t *bytes);
-  virtual void ToProtobuf(std::string *output);
+  static std::shared_ptr<CheckMessage> FromBytes(uint8_t* bytes);
+  virtual void ToProtobuf(std::string* output);
 
   queue::protobuf::StreamingQueueMessageType Type() { return type_; }
 
@@ -127,13 +127,13 @@ class CheckMessage : public Message {
 /// CheckMessage to indicate whether downstream queue is ready or not.
 class CheckRspMessage : public Message {
  public:
-  CheckRspMessage(const ActorID &actor_id, const ActorID &peer_actor_id,
-                  const ObjectID &queue_id, queue::protobuf::StreamingQueueError err_code)
+  CheckRspMessage(const ActorID& actor_id, const ActorID& peer_actor_id,
+                  const ObjectID& queue_id, queue::protobuf::StreamingQueueError err_code)
       : Message(actor_id, peer_actor_id, queue_id), err_code_(err_code) {}
   virtual ~CheckRspMessage() {}
 
-  static std::shared_ptr<CheckRspMessage> FromBytes(uint8_t *bytes);
-  virtual void ToProtobuf(std::string *output);
+  static std::shared_ptr<CheckRspMessage> FromBytes(uint8_t* bytes);
+  virtual void ToProtobuf(std::string* output);
   queue::protobuf::StreamingQueueMessageType Type() { return type_; }
   queue::protobuf::StreamingQueueError Error() { return err_code_; }
 
@@ -148,10 +148,10 @@ class CheckRspMessage : public Message {
 class TestInitMessage : public Message {
  public:
   TestInitMessage(const queue::protobuf::StreamingQueueTestRole role,
-                  const ActorID &actor_id, const ActorID &peer_actor_id,
+                  const ActorID& actor_id, const ActorID& peer_actor_id,
                   const std::string actor_handle_serialized,
-                  const std::vector<ObjectID> &queue_ids,
-                  const std::vector<ObjectID> &rescale_queue_ids,
+                  const std::vector<ObjectID>& queue_ids,
+                  const std::vector<ObjectID>& rescale_queue_ids,
                   std::string test_suite_name, std::string test_name, uint64_t param)
       : Message(actor_id, peer_actor_id, queue_ids[0]),
         actor_handle_serialized_(actor_handle_serialized),
@@ -163,8 +163,8 @@ class TestInitMessage : public Message {
         param_(param) {}
   virtual ~TestInitMessage() {}
 
-  static std::shared_ptr<TestInitMessage> FromBytes(uint8_t *bytes);
-  virtual void ToProtobuf(std::string *output);
+  static std::shared_ptr<TestInitMessage> FromBytes(uint8_t* bytes);
+  virtual void ToProtobuf(std::string* output);
   queue::protobuf::StreamingQueueMessageType Type() { return type_; }
   std::string ActorHandleSerialized() { return actor_handle_serialized_; }
   queue::protobuf::StreamingQueueTestRole Role() { return role_; }
@@ -180,11 +180,11 @@ class TestInitMessage : public Message {
     os << " actor_id: " << ActorId();
     os << " peer_actor_id: " << PeerActorId();
     os << " queue_ids:[";
-    for (auto &qid : queue_ids_) {
+    for (auto& qid : queue_ids_) {
       os << qid << ",";
     }
     os << "], rescale_queue_ids:[";
-    for (auto &qid : rescale_queue_ids_) {
+    for (auto& qid : rescale_queue_ids_) {
       os << qid << ",";
     }
     os << "],";
@@ -216,8 +216,8 @@ class TestCheckStatusRspMsg : public Message {
       : test_name_(test_name), status_(status) {}
   virtual ~TestCheckStatusRspMsg() {}
 
-  static std::shared_ptr<TestCheckStatusRspMsg> FromBytes(uint8_t *bytes);
-  virtual void ToProtobuf(std::string *output);
+  static std::shared_ptr<TestCheckStatusRspMsg> FromBytes(uint8_t* bytes);
+  virtual void ToProtobuf(std::string* output);
   queue::protobuf::StreamingQueueMessageType Type() { return type_; }
   std::string TestName() { return test_name_; }
   bool Status() { return status_; }

--- a/streaming/src/queue/queue.cc
+++ b/streaming/src/queue/queue.cc
@@ -113,7 +113,7 @@ size_t Queue::PendingCount() {
   return begin->SeqId() - end->SeqId() + 1;
 }
 
-Status WriterQueue::Push(uint64_t seq_id, uint8_t *data, uint32_t data_size,
+Status WriterQueue::Push(uint64_t seq_id, uint8_t* data, uint32_t data_size,
                          uint64_t timestamp, bool raw) {
   if (IsPendingFull(data_size)) {
     return Status::OutOfMemory("Queue Push OutOfMemory");
@@ -192,9 +192,9 @@ void ReaderQueue::Notify(uint64_t seq_id) {
   transport_->Send(std::move(buffer));
 }
 
-void ReaderQueue::CreateNotifyTask(uint64_t seq_id, std::vector<TaskArg> &task_args) {}
+void ReaderQueue::CreateNotifyTask(uint64_t seq_id, std::vector<TaskArg>& task_args) {}
 
-void ReaderQueue::OnData(QueueItem &item) {
+void ReaderQueue::OnData(QueueItem& item) {
   if (item.SeqId() != expect_seq_id_) {
     STREAMING_LOG(WARNING) << "OnData ignore seq_id: " << item.SeqId()
                            << " expect_seq_id_: " << expect_seq_id_;

--- a/streaming/src/queue/queue.h
+++ b/streaming/src/queue/queue.h
@@ -104,8 +104,8 @@ class WriterQueue : public Queue {
   /// \param peer_actor_id, the actor id of downstream worker
   /// \param size, max data size in bytes
   /// \param transport, transport
-  WriterQueue(const ObjectID &queue_id, const ActorID &actor_id,
-              const ActorID &peer_actor_id, uint64_t size,
+  WriterQueue(const ObjectID& queue_id, const ActorID& actor_id,
+              const ActorID& peer_actor_id, uint64_t size,
               std::shared_ptr<Transport> transport)
       : Queue(queue_id, size, transport),
         actor_id_(actor_id),
@@ -119,7 +119,7 @@ class WriterQueue : public Queue {
 
   /// Push a continuous buffer into queue.
   /// NOTE: the buffer should be copied.
-  Status Push(uint64_t seq_id, uint8_t *data, uint32_t data_size, uint64_t timestamp,
+  Status Push(uint64_t seq_id, uint8_t* data, uint32_t data_size, uint64_t timestamp,
               bool raw = false);
 
   /// Callback function, will be called when downstream queue notifies
@@ -171,8 +171,8 @@ class ReaderQueue : public Queue {
   /// \param peer_actor_id, the actor id of downstream worker
   /// \param transport, transport
   /// NOTE: we do not restrict queue size of ReaderQueue
-  ReaderQueue(const ObjectID &queue_id, const ActorID &actor_id,
-              const ActorID &peer_actor_id, std::shared_ptr<Transport> transport)
+  ReaderQueue(const ObjectID& queue_id, const ActorID& actor_id,
+              const ActorID& peer_actor_id, std::shared_ptr<Transport> transport)
       : Queue(queue_id, std::numeric_limits<uint64_t>::max(), transport),
         actor_id_(actor_id),
         peer_actor_id_(peer_actor_id),
@@ -185,7 +185,7 @@ class ReaderQueue : public Queue {
   /// then notify upstream queue.
   void OnConsumed(uint64_t seq_id);
 
-  void OnData(QueueItem &item);
+  void OnData(QueueItem& item);
 
   uint64_t GetMinConsumedSeqID() { return min_consumed_id_; }
 
@@ -195,7 +195,7 @@ class ReaderQueue : public Queue {
 
  private:
   void Notify(uint64_t seq_id);
-  void CreateNotifyTask(uint64_t seq_id, std::vector<TaskArg> &task_args);
+  void CreateNotifyTask(uint64_t seq_id, std::vector<TaskArg>& task_args);
 
  private:
   ActorID actor_id_;

--- a/streaming/src/queue/queue_handler.cc
+++ b/streaming/src/queue/queue_handler.cc
@@ -15,15 +15,15 @@ std::shared_ptr<DownstreamQueueMessageHandler>
 
 std::shared_ptr<Message> QueueMessageHandler::ParseMessage(
     std::shared_ptr<LocalMemoryBuffer> buffer) {
-  uint8_t *bytes = buffer->Data();
-  uint8_t *p_cur = bytes;
-  uint32_t *magic_num = (uint32_t *)p_cur;
+  uint8_t* bytes = buffer->Data();
+  uint8_t* p_cur = bytes;
+  uint32_t* magic_num = (uint32_t*)p_cur;
   STREAMING_CHECK(*magic_num == Message::MagicNum)
       << *magic_num << " " << Message::MagicNum;
 
   p_cur += sizeof(Message::MagicNum);
-  queue::protobuf::StreamingQueueMessageType *type =
-      (queue::protobuf::StreamingQueueMessageType *)p_cur;
+  queue::protobuf::StreamingQueueMessageType* type =
+      (queue::protobuf::StreamingQueueMessageType*)p_cur;
 
   std::shared_ptr<Message> message = nullptr;
   switch (*type) {
@@ -71,22 +71,22 @@ std::shared_ptr<LocalMemoryBuffer> QueueMessageHandler::DispatchMessageSync(
 }
 
 std::shared_ptr<Transport> QueueMessageHandler::GetOutTransport(
-    const ObjectID &queue_id) {
+    const ObjectID& queue_id) {
   auto it = out_transports_.find(queue_id);
   if (it == out_transports_.end()) return nullptr;
 
   return it->second;
 }
 
-void QueueMessageHandler::SetPeerActorID(const ObjectID &queue_id,
-                                         const ActorID &actor_id, RayFunction &async_func,
-                                         RayFunction &sync_func) {
+void QueueMessageHandler::SetPeerActorID(const ObjectID& queue_id,
+                                         const ActorID& actor_id, RayFunction& async_func,
+                                         RayFunction& sync_func) {
   actors_.emplace(queue_id, actor_id);
   out_transports_.emplace(queue_id, std::make_shared<ray::streaming::Transport>(
                                         actor_id, async_func, sync_func));
 }
 
-ActorID QueueMessageHandler::GetPeerActorID(const ObjectID &queue_id) {
+ActorID QueueMessageHandler::GetPeerActorID(const ObjectID& queue_id) {
   auto it = actors_.find(queue_id);
   STREAMING_CHECK(it != actors_.end());
   return it->second;
@@ -110,7 +110,7 @@ void QueueMessageHandler::Stop() {
 }
 
 std::shared_ptr<UpstreamQueueMessageHandler> UpstreamQueueMessageHandler::CreateService(
-    const ActorID &actor_id) {
+    const ActorID& actor_id) {
   if (nullptr == upstream_handler_) {
     upstream_handler_ = std::make_shared<UpstreamQueueMessageHandler>(actor_id);
   }
@@ -122,7 +122,7 @@ std::shared_ptr<UpstreamQueueMessageHandler> UpstreamQueueMessageHandler::GetSer
 }
 
 std::shared_ptr<WriterQueue> UpstreamQueueMessageHandler::CreateUpstreamQueue(
-    const ObjectID &queue_id, const ActorID &peer_actor_id, uint64_t size) {
+    const ObjectID& queue_id, const ActorID& peer_actor_id, uint64_t size) {
   STREAMING_LOG(INFO) << "CreateUpstreamQueue: " << queue_id << " " << actor_id_ << "->"
                       << peer_actor_id;
   std::shared_ptr<WriterQueue> queue = GetUpQueue(queue_id);
@@ -138,19 +138,19 @@ std::shared_ptr<WriterQueue> UpstreamQueueMessageHandler::CreateUpstreamQueue(
   return queue;
 }
 
-bool UpstreamQueueMessageHandler::UpstreamQueueExists(const ObjectID &queue_id) {
+bool UpstreamQueueMessageHandler::UpstreamQueueExists(const ObjectID& queue_id) {
   return nullptr != GetUpQueue(queue_id);
 }
 
 std::shared_ptr<streaming::WriterQueue> UpstreamQueueMessageHandler::GetUpQueue(
-    const ObjectID &queue_id) {
+    const ObjectID& queue_id) {
   auto it = upstream_queues_.find(queue_id);
   if (it == upstream_queues_.end()) return nullptr;
 
   return it->second;
 }
 
-bool UpstreamQueueMessageHandler::CheckQueueSync(const ObjectID &queue_id) {
+bool UpstreamQueueMessageHandler::CheckQueueSync(const ObjectID& queue_id) {
   ActorID peer_actor_id = GetPeerActorID(queue_id);
   STREAMING_LOG(INFO) << "CheckQueueSync queue_id: " << queue_id
                       << " peer_actor_id: " << peer_actor_id;
@@ -178,9 +178,9 @@ bool UpstreamQueueMessageHandler::CheckQueueSync(const ObjectID &queue_id) {
   return queue::protobuf::StreamingQueueError::OK == check_rsp_msg->Error();
 }
 
-void UpstreamQueueMessageHandler::WaitQueues(const std::vector<ObjectID> &queue_ids,
+void UpstreamQueueMessageHandler::WaitQueues(const std::vector<ObjectID>& queue_ids,
                                              int64_t timeout_ms,
-                                             std::vector<ObjectID> &failed_queues) {
+                                             std::vector<ObjectID>& failed_queues) {
   failed_queues.insert(failed_queues.begin(), queue_ids.begin(), queue_ids.end());
   uint64_t start_time_us = current_time_ms();
   uint64_t current_time_us = start_time_us;
@@ -242,7 +242,7 @@ void UpstreamQueueMessageHandler::ReleaseAllUpQueues() {
 }
 
 std::shared_ptr<DownstreamQueueMessageHandler>
-DownstreamQueueMessageHandler::CreateService(const ActorID &actor_id) {
+DownstreamQueueMessageHandler::CreateService(const ActorID& actor_id) {
   if (nullptr == downstream_handler_) {
     downstream_handler_ = std::make_shared<DownstreamQueueMessageHandler>(actor_id);
   }
@@ -254,12 +254,12 @@ DownstreamQueueMessageHandler::GetService() {
   return downstream_handler_;
 }
 
-bool DownstreamQueueMessageHandler::DownstreamQueueExists(const ObjectID &queue_id) {
+bool DownstreamQueueMessageHandler::DownstreamQueueExists(const ObjectID& queue_id) {
   return nullptr != GetDownQueue(queue_id);
 }
 
 std::shared_ptr<ReaderQueue> DownstreamQueueMessageHandler::CreateDownstreamQueue(
-    const ObjectID &queue_id, const ActorID &peer_actor_id) {
+    const ObjectID& queue_id, const ActorID& peer_actor_id) {
   STREAMING_LOG(INFO) << "CreateDownstreamQueue: " << queue_id << " " << peer_actor_id
                       << "->" << actor_id_;
   auto it = downstream_queues_.find(queue_id);
@@ -276,7 +276,7 @@ std::shared_ptr<ReaderQueue> DownstreamQueueMessageHandler::CreateDownstreamQueu
 }
 
 std::shared_ptr<streaming::ReaderQueue> DownstreamQueueMessageHandler::GetDownQueue(
-    const ObjectID &queue_id) {
+    const ObjectID& queue_id) {
   auto it = downstream_queues_.find(queue_id);
   if (it == downstream_queues_.end()) return nullptr;
 

--- a/streaming/src/queue/queue_handler.h
+++ b/streaming/src/queue/queue_handler.h
@@ -24,7 +24,7 @@ class QueueMessageHandler {
  public:
   /// Construct a QueueMessageHandler instance.
   /// \param[in] actor_id actor id of current actor.
-  QueueMessageHandler(const ActorID &actor_id)
+  QueueMessageHandler(const ActorID& actor_id)
       : actor_id_(actor_id), queue_dummy_work_(queue_service_) {
     Start();
   }
@@ -44,7 +44,7 @@ class QueueMessageHandler {
   /// Get transport to a peer actor specified by actor_id.
   /// \param[in] actor_id actor id of peer actor
   /// \return transport
-  std::shared_ptr<Transport> GetOutTransport(const ObjectID &actor_id);
+  std::shared_ptr<Transport> GetOutTransport(const ObjectID& actor_id);
 
   /// The actual function where message being dispatched, called by DispatchMessageAsync
   /// and DispatchMessageSync.
@@ -61,12 +61,12 @@ class QueueMessageHandler {
   /// downstream queue with same queue_id, and vice versa.
   /// \param[in] queue_id queue id of current queue.
   /// \param[in] actor_id actor_id actor id of corresponded peer actor.
-  void SetPeerActorID(const ObjectID &queue_id, const ActorID &actor_id,
-                      RayFunction &async_func, RayFunction &sync_func);
+  void SetPeerActorID(const ObjectID& queue_id, const ActorID& actor_id,
+                      RayFunction& async_func, RayFunction& sync_func);
 
   /// Obtain the actor id of the peer actor specified by queue_id.
   /// \return actor id
-  ActorID GetPeerActorID(const ObjectID &queue_id);
+  ActorID GetPeerActorID(const ObjectID& queue_id);
 
   /// Release all queues in current queue service.
   void Release();
@@ -102,26 +102,26 @@ class QueueMessageHandler {
 class UpstreamQueueMessageHandler : public QueueMessageHandler {
  public:
   /// Construct a UpstreamQueueMessageHandler instance.
-  UpstreamQueueMessageHandler(const ActorID &actor_id) : QueueMessageHandler(actor_id) {}
+  UpstreamQueueMessageHandler(const ActorID& actor_id) : QueueMessageHandler(actor_id) {}
   /// Create a upstream queue.
   /// \param[in] queue_id queue id of the queue to be created.
   /// \param[in] peer_actor_id actor id of peer actor.
   /// \param[in] size the max memory size of the queue.
-  std::shared_ptr<WriterQueue> CreateUpstreamQueue(const ObjectID &queue_id,
-                                                   const ActorID &peer_actor_id,
+  std::shared_ptr<WriterQueue> CreateUpstreamQueue(const ObjectID& queue_id,
+                                                   const ActorID& peer_actor_id,
                                                    uint64_t size);
   /// Check whether the upstream queue specified by queue_id exists or not.
-  bool UpstreamQueueExists(const ObjectID &queue_id);
+  bool UpstreamQueueExists(const ObjectID& queue_id);
   /// Wait all queues in queue_ids vector ready, until timeout.
   /// \param[in] queue_ids a group of queues.
   /// \param[in] timeout_ms max timeout time interval for wait all queues.
   /// \param[out] failed_queues a group of queues which are not ready when timeout.
-  void WaitQueues(const std::vector<ObjectID> &queue_ids, int64_t timeout_ms,
-                  std::vector<ObjectID> &failed_queues);
+  void WaitQueues(const std::vector<ObjectID>& queue_ids, int64_t timeout_ms,
+                  std::vector<ObjectID>& failed_queues);
   /// Handle notify message from corresponded downstream queue.
   void OnNotify(std::shared_ptr<NotificationMessage> notify_msg);
   /// Obtain upstream queue specified by queue_id.
-  std::shared_ptr<streaming::WriterQueue> GetUpQueue(const ObjectID &queue_id);
+  std::shared_ptr<streaming::WriterQueue> GetUpQueue(const ObjectID& queue_id);
   /// Release all upstream queues
   void ReleaseAllUpQueues();
 
@@ -130,11 +130,11 @@ class UpstreamQueueMessageHandler : public QueueMessageHandler {
       std::function<void(std::shared_ptr<LocalMemoryBuffer>)> callback) override;
 
   static std::shared_ptr<UpstreamQueueMessageHandler> CreateService(
-      const ActorID &actor_id);
+      const ActorID& actor_id);
   static std::shared_ptr<UpstreamQueueMessageHandler> GetService();
 
  private:
-  bool CheckQueueSync(const ObjectID &queue_ids);
+  bool CheckQueueSync(const ObjectID& queue_ids);
 
  private:
   std::unordered_map<ObjectID, std::shared_ptr<streaming::WriterQueue>> upstream_queues_;
@@ -144,18 +144,18 @@ class UpstreamQueueMessageHandler : public QueueMessageHandler {
 /// UpstreamQueueMessageHandler holds and manages all downstream queues of current actor.
 class DownstreamQueueMessageHandler : public QueueMessageHandler {
  public:
-  DownstreamQueueMessageHandler(const ActorID &actor_id)
+  DownstreamQueueMessageHandler(const ActorID& actor_id)
       : QueueMessageHandler(actor_id) {}
-  std::shared_ptr<ReaderQueue> CreateDownstreamQueue(const ObjectID &queue_id,
-                                                     const ActorID &peer_actor_id);
-  bool DownstreamQueueExists(const ObjectID &queue_id);
+  std::shared_ptr<ReaderQueue> CreateDownstreamQueue(const ObjectID& queue_id,
+                                                     const ActorID& peer_actor_id);
+  bool DownstreamQueueExists(const ObjectID& queue_id);
 
-  void UpdateDownActor(const ObjectID &queue_id, const ActorID &actor_id);
+  void UpdateDownActor(const ObjectID& queue_id, const ActorID& actor_id);
 
   std::shared_ptr<LocalMemoryBuffer> OnCheckQueue(
       std::shared_ptr<CheckMessage> check_msg);
 
-  std::shared_ptr<streaming::ReaderQueue> GetDownQueue(const ObjectID &queue_id);
+  std::shared_ptr<streaming::ReaderQueue> GetDownQueue(const ObjectID& queue_id);
 
   void ReleaseAllDownQueues();
 
@@ -165,7 +165,7 @@ class DownstreamQueueMessageHandler : public QueueMessageHandler {
       std::function<void(std::shared_ptr<LocalMemoryBuffer>)> callback);
 
   static std::shared_ptr<DownstreamQueueMessageHandler> CreateService(
-      const ActorID &actor_id);
+      const ActorID& actor_id);
   static std::shared_ptr<DownstreamQueueMessageHandler> GetService();
 
  private:

--- a/streaming/src/queue/queue_item.h
+++ b/streaming/src/queue/queue_item.h
@@ -30,7 +30,7 @@ class QueueItem {
   /// \param[in] data_size the data size in bytes.
   /// \param[in] timestamp the time when this QueueItem created.
   /// \param[in] raw whether the data content is raw bytes, only used in some tests.
-  QueueItem(uint64_t seq_id, uint8_t *data, uint32_t data_size, uint64_t timestamp,
+  QueueItem(uint64_t seq_id, uint8_t* data, uint32_t data_size, uint64_t timestamp,
             bool raw = false)
       : seq_id_(seq_id),
         timestamp_(timestamp),
@@ -46,21 +46,21 @@ class QueueItem {
         raw_(data_msg->IsRaw()),
         buffer_(data_msg->Buffer()) {}
 
-  QueueItem(const QueueItem &&item) {
+  QueueItem(const QueueItem&& item) {
     buffer_ = item.buffer_;
     seq_id_ = item.seq_id_;
     timestamp_ = item.timestamp_;
     raw_ = item.raw_;
   }
 
-  QueueItem(const QueueItem &item) {
+  QueueItem(const QueueItem& item) {
     buffer_ = item.buffer_;
     seq_id_ = item.seq_id_;
     timestamp_ = item.timestamp_;
     raw_ = item.raw_;
   }
 
-  QueueItem &operator=(const QueueItem &item) {
+  QueueItem& operator=(const QueueItem& item) {
     buffer_ = item.buffer_;
     seq_id_ = item.seq_id_;
     timestamp_ = item.timestamp_;

--- a/streaming/src/queue/transport.cc
+++ b/streaming/src/queue/transport.cc
@@ -9,20 +9,20 @@ static constexpr int TASK_OPTION_RETURN_NUM_0 = 0;
 static constexpr int TASK_OPTION_RETURN_NUM_1 = 1;
 
 void Transport::SendInternal(std::shared_ptr<LocalMemoryBuffer> buffer,
-                             RayFunction &function, int return_num,
-                             std::vector<ObjectID> &return_ids) {
+                             RayFunction& function, int return_num,
+                             std::vector<ObjectID>& return_ids) {
   std::unordered_map<std::string, double> resources;
   TaskOptions options{return_num, resources};
 
   char meta_data[3] = {'R', 'A', 'W'};
   std::shared_ptr<LocalMemoryBuffer> meta =
-      std::make_shared<LocalMemoryBuffer>((uint8_t *)meta_data, 3, true);
+      std::make_shared<LocalMemoryBuffer>((uint8_t*)meta_data, 3, true);
 
   std::vector<std::unique_ptr<TaskArg>> args;
   if (function.GetLanguage() == Language::PYTHON) {
     auto dummy = "__RAY_DUMMY__";
     std::shared_ptr<LocalMemoryBuffer> dummyBuffer =
-        std::make_shared<LocalMemoryBuffer>((uint8_t *)dummy, 13, true);
+        std::make_shared<LocalMemoryBuffer>((uint8_t*)dummy, 13, true);
     args.emplace_back(new TaskArgByValue(std::make_shared<RayObject>(
         std::move(dummyBuffer), meta, std::vector<ObjectID>(), true)));
   }

--- a/streaming/src/queue/transport.h
+++ b/streaming/src/queue/transport.h
@@ -13,7 +13,7 @@ class Transport {
  public:
   /// Construct a Transport object.
   /// \param[in] peer_actor_id actor id of peer actor.
-  Transport(const ActorID &peer_actor_id, RayFunction &async_func, RayFunction &sync_func)
+  Transport(const ActorID& peer_actor_id, RayFunction& async_func, RayFunction& sync_func)
       : peer_actor_id_(peer_actor_id), async_func_(async_func), sync_func_(sync_func) {
     STREAMING_LOG(INFO) << "Transport constructor:";
     STREAMING_LOG(INFO) << "async_func lang: " << async_func_.GetLanguage();
@@ -54,8 +54,8 @@ class Transport {
   /// \param[in] return_num return value number of the call.
   /// \param[out] return_ids return ids from SubmitActorTask.
   virtual void SendInternal(std::shared_ptr<LocalMemoryBuffer> buffer,
-                            RayFunction &function, int return_num,
-                            std::vector<ObjectID> &return_ids);
+                            RayFunction& function, int return_num,
+                            std::vector<ObjectID>& return_ids);
 
  private:
   WorkerID worker_id_;

--- a/streaming/src/queue/utils.h
+++ b/streaming/src/queue/utils.h
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <future>
 #include <thread>
+
 #include "ray/util/util.h"
 
 namespace ray {

--- a/streaming/src/ring_buffer.cc
+++ b/streaming/src/ring_buffer.cc
@@ -19,12 +19,12 @@ StreamingRingBuffer::StreamingRingBuffer(size_t buf_size,
   }
 }
 
-bool StreamingRingBuffer::Push(const StreamingMessagePtr &msg) {
+bool StreamingRingBuffer::Push(const StreamingMessagePtr& msg) {
   message_buffer_->Push(msg);
   return true;
 }
 
-StreamingMessagePtr &StreamingRingBuffer::Front() {
+StreamingMessagePtr& StreamingRingBuffer::Front() {
   STREAMING_CHECK(!message_buffer_->Empty());
   return message_buffer_->Front();
 }
@@ -54,11 +54,11 @@ size_t StreamingRingBuffer::GetMaxTransientBufferSize() const {
   return transient_buffer_.GetMaxTransientBufferSize();
 }
 
-const uint8_t *StreamingRingBuffer::GetTransientBuffer() const {
+const uint8_t* StreamingRingBuffer::GetTransientBuffer() const {
   return transient_buffer_.GetTransientBuffer();
 }
 
-uint8_t *StreamingRingBuffer::GetTransientBufferMutable() const {
+uint8_t* StreamingRingBuffer::GetTransientBufferMutable() const {
   return transient_buffer_.GetTransientBufferMutable();
 }
 

--- a/streaming/src/ring_buffer.h
+++ b/streaming/src/ring_buffer.h
@@ -37,9 +37,9 @@ class StreamingTransientBuffer {
 
   inline size_t GetMaxTransientBufferSize() const { return max_transient_buffer_size_; }
 
-  inline const uint8_t *GetTransientBuffer() const { return transient_buffer_.get(); }
+  inline const uint8_t* GetTransientBuffer() const { return transient_buffer_.get(); }
 
-  inline uint8_t *GetTransientBufferMutable() const { return transient_buffer_.get(); }
+  inline uint8_t* GetTransientBufferMutable() const { return transient_buffer_.get(); }
 
   ///  To reuse transient buffer, we will realloc buffer memory if size of needed
   ///  message bundle raw data is greater-than original buffer size.
@@ -77,9 +77,9 @@ class StreamingTransientBuffer {
 template <class T>
 class AbstractRingBuffer {
  public:
-  virtual void Push(const T &) = 0;
+  virtual void Push(const T&) = 0;
   virtual void Pop() = 0;
-  virtual T &Front() = 0;
+  virtual T& Front() = 0;
   virtual bool Empty() const = 0;
   virtual bool Full() const = 0;
   virtual size_t Size() const = 0;
@@ -91,7 +91,7 @@ class RingBufferImplThreadSafe : public AbstractRingBuffer<T> {
  public:
   RingBufferImplThreadSafe(size_t size) : buffer_(size) {}
   virtual ~RingBufferImplThreadSafe() = default;
-  void Push(const T &t) {
+  void Push(const T& t) {
     boost::unique_lock<boost::shared_mutex> lock(ring_buffer_mutex_);
     buffer_.push_back(t);
   }
@@ -99,7 +99,7 @@ class RingBufferImplThreadSafe : public AbstractRingBuffer<T> {
     boost::unique_lock<boost::shared_mutex> lock(ring_buffer_mutex_);
     buffer_.pop_front();
   }
-  T &Front() {
+  T& Front() {
     boost::shared_lock<boost::shared_mutex> lock(ring_buffer_mutex_);
     return buffer_.front();
   }
@@ -135,7 +135,7 @@ class RingBufferImplLockFree : public AbstractRingBuffer<T> {
       : buffer_(size, nullptr), capacity_(size), read_index_(0), write_index_(0) {}
   virtual ~RingBufferImplLockFree() = default;
 
-  void Push(const T &t) {
+  void Push(const T& t) {
     STREAMING_CHECK(!Full());
     buffer_[write_index_] = t;
     write_index_ = IncreaseIndex(write_index_);
@@ -146,7 +146,7 @@ class RingBufferImplLockFree : public AbstractRingBuffer<T> {
     read_index_ = IncreaseIndex(read_index_);
   }
 
-  T &Front() {
+  T& Front() {
     STREAMING_CHECK(!Empty());
     return buffer_[read_index_];
   }
@@ -181,9 +181,9 @@ class StreamingRingBuffer {
   explicit StreamingRingBuffer(size_t buf_size, StreamingRingBufferType buffer_type =
                                                     StreamingRingBufferType::SPSC_LOCK);
 
-  bool Push(const StreamingMessagePtr &msg);
+  bool Push(const StreamingMessagePtr& msg);
 
-  StreamingMessagePtr &Front();
+  StreamingMessagePtr& Front();
 
   void Pop();
 
@@ -201,9 +201,9 @@ class StreamingRingBuffer {
 
   size_t GetMaxTransientBufferSize() const;
 
-  const uint8_t *GetTransientBuffer() const;
+  const uint8_t* GetTransientBuffer() const;
 
-  uint8_t *GetTransientBufferMutable() const;
+  uint8_t* GetTransientBufferMutable() const;
 
   void ReallocTransientBuffer(uint32_t size);
 

--- a/streaming/src/runtime_context.cc
+++ b/streaming/src/runtime_context.cc
@@ -8,13 +8,13 @@
 namespace ray {
 namespace streaming {
 
-void RuntimeContext::SetConfig(const StreamingConfig &streaming_config) {
+void RuntimeContext::SetConfig(const StreamingConfig& streaming_config) {
   STREAMING_CHECK(runtime_status_ == RuntimeStatus::Init)
       << "set config must be at beginning";
   config_ = streaming_config;
 }
 
-void RuntimeContext::SetConfig(const uint8_t *data, uint32_t size) {
+void RuntimeContext::SetConfig(const uint8_t* data, uint32_t size) {
   STREAMING_CHECK(runtime_status_ == RuntimeStatus::Init)
       << "set config must be at beginning";
   if (!data) {

--- a/streaming/src/runtime_context.h
+++ b/streaming/src/runtime_context.h
@@ -22,9 +22,9 @@ class RuntimeContext {
  public:
   RuntimeContext();
   virtual ~RuntimeContext();
-  inline const StreamingConfig &GetConfig() const { return config_; };
-  void SetConfig(const StreamingConfig &config);
-  void SetConfig(const uint8_t *data, uint32_t buffer_len);
+  inline const StreamingConfig& GetConfig() const { return config_; };
+  void SetConfig(const StreamingConfig& config);
+  void SetConfig(const uint8_t* data, uint32_t buffer_len);
   inline RuntimeStatus GetRuntimeStatus() { return runtime_status_; }
   inline void SetRuntimeStatus(RuntimeStatus status) { runtime_status_ = status; }
   inline void MarkMockTest() { is_mock_test_ = true; }

--- a/streaming/src/status.h
+++ b/streaming/src/status.h
@@ -28,7 +28,7 @@ enum class StreamingStatus : uint32_t {
   MAX = TailStatus
 };
 
-static inline std::ostream &operator<<(std::ostream &os, const StreamingStatus &status) {
+static inline std::ostream& operator<<(std::ostream& os, const StreamingStatus& status) {
   os << static_cast<std::underlying_type<StreamingStatus>::type>(status);
   return os;
 }

--- a/streaming/src/test/event_service_tests.cc
+++ b/streaming/src/test/event_service_tests.cc
@@ -1,4 +1,5 @@
 #include <thread>
+
 #include "event_service.h"
 #include "gtest/gtest.h"
 

--- a/streaming/src/test/event_service_tests.cc
+++ b/streaming/src/test/event_service_tests.cc
@@ -6,10 +6,10 @@
 using namespace ray::streaming;
 
 /// Mock function for send empty message.
-bool SendEmptyToChannel(ProducerChannelInfo *info) { return true; }
+bool SendEmptyToChannel(ProducerChannelInfo* info) { return true; }
 
 /// Mock function for write all messages to channel.
-bool WriteAllToChannel(ProducerChannelInfo *info) { return true; }
+bool WriteAllToChannel(ProducerChannelInfo* info) { return true; }
 
 TEST(EventServiceTest, Test1) {
   std::shared_ptr<EventService> server = std::make_shared<EventService>();
@@ -75,7 +75,7 @@ TEST(EventServiceTest, remove_delete_channel_event) {
   mock_channel_info2.channel_id = channel_vec.back();
   mock_channel_info_vec.push_back(mock_channel_info2);
 
-  for (auto &id : mock_channel_info_vec) {
+  for (auto& id : mock_channel_info_vec) {
     Event empty_event{&id, EventType::EmptyEvent, true};
     Event user_event{&id, EventType::UserEvent, true};
     Event flow_event{&id, EventType::FlowEvent, true};
@@ -87,7 +87,7 @@ TEST(EventServiceTest, remove_delete_channel_event) {
   server->RemoveDestroyedChannelEvent(removed_vec);
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/streaming/src/test/message_serialization_tests.cc
+++ b/streaming/src/test/message_serialization_tests.cc
@@ -2,7 +2,6 @@
 #include <string>
 
 #include "gtest/gtest.h"
-
 #include "message/message.h"
 #include "message/message_bundle.h"
 

--- a/streaming/src/test/message_serialization_tests.cc
+++ b/streaming/src/test/message_serialization_tests.cc
@@ -13,7 +13,7 @@ TEST(StreamingSerializationTest, streaming_message_serialization_test) {
   StreamingMessagePtr message =
       std::make_shared<StreamingMessage>(data, 3, 7, StreamingMessageType::Message);
   uint32_t message_length = message->ClassBytesSize();
-  uint8_t *bytes = new uint8_t[message_length];
+  uint8_t* bytes = new uint8_t[message_length];
   message->ToBytes(bytes);
   StreamingMessagePtr new_message = StreamingMessage::FromBytes(bytes);
   EXPECT_EQ(std::memcmp(new_message->RawData(), data, 3), 0);
@@ -24,7 +24,7 @@ TEST(StreamingSerializationTest, streaming_message_empty_bundle_serialization_te
   for (int i = 0; i < 10; ++i) {
     StreamingMessageBundle bundle(i, i);
     uint64_t bundle_size = bundle.ClassBytesSize();
-    uint8_t *bundle_bytes = new uint8_t[bundle_size];
+    uint8_t* bundle_bytes = new uint8_t[bundle_size];
     bundle.ToBytes(bundle_bytes);
     StreamingMessageBundlePtr bundle_ptr =
         StreamingMessageBundle::FromBytes(bundle_bytes);
@@ -64,7 +64,7 @@ TEST(StreamingSerializationTest, streaming_message_barrier_bundle_serialization_
     StreamingMessageBundle bundle(message_list_cpy, i, i,
                                   StreamingMessageBundleType::Barrier);
     uint64_t bundle_size = bundle.ClassBytesSize();
-    uint8_t *bundle_bytes = new uint8_t[bundle_size];
+    uint8_t* bundle_bytes = new uint8_t[bundle_size];
     bundle.ToBytes(bundle_bytes);
     StreamingMessageBundlePtr bundle_ptr =
         StreamingMessageBundle::FromBytes(bundle_bytes);
@@ -95,7 +95,7 @@ TEST(StreamingSerializationTest, streaming_message_bundle_serialization_test) {
     std::list<StreamingMessagePtr> message_list;
 
     for (int i = 0; i < 100; ++i) {
-      uint8_t *data = new uint8_t[i + 1];
+      uint8_t* data = new uint8_t[i + 1];
       data[0] = i;
       StreamingMessagePtr message = std::make_shared<StreamingMessage>(
           data, i + 1, i + 1, StreamingMessageType::Message);
@@ -105,7 +105,7 @@ TEST(StreamingSerializationTest, streaming_message_bundle_serialization_test) {
     StreamingMessageBundle messageBundle(message_list, 0, 1,
                                          StreamingMessageBundleType::Bundle);
     size_t message_length = messageBundle.ClassBytesSize();
-    uint8_t *bytes = new uint8_t[message_length];
+    uint8_t* bytes = new uint8_t[message_length];
     messageBundle.ToBytes(bytes);
 
     StreamingMessageBundlePtr bundle_ptr = StreamingMessageBundle::FromBytes(bytes);
@@ -129,7 +129,7 @@ TEST(StreamingSerializationTest, streaming_message_bundle_equal_test) {
   std::list<StreamingMessagePtr> message_list_same;
   std::list<StreamingMessagePtr> message_list_cpy;
   for (int i = 0; i < 100; ++i) {
-    uint8_t *data = new uint8_t[i + 1];
+    uint8_t* data = new uint8_t[i + 1];
     for (int j = 0; j < i + 1; ++j) {
       data[j] = i;
     }
@@ -140,7 +140,7 @@ TEST(StreamingSerializationTest, streaming_message_bundle_equal_test) {
     delete[] data;
   }
   for (int i = 0; i < 100; ++i) {
-    uint8_t *data = new uint8_t[i + 1];
+    uint8_t* data = new uint8_t[i + 1];
     for (int j = 0; j < i + 1; ++j) {
       data[j] = i;
     }
@@ -158,7 +158,7 @@ TEST(StreamingSerializationTest, streaming_message_bundle_equal_test) {
   EXPECT_TRUE(message_bundle_same == message_bundle);
   EXPECT_FALSE(message_bundle_reverse == message_bundle);
   size_t message_length = message_bundle.ClassBytesSize();
-  uint8_t *bytes = new uint8_t[message_length];
+  uint8_t* bytes = new uint8_t[message_length];
   message_bundle.ToBytes(bytes);
 
   StreamingMessageBundlePtr bundle_ptr = StreamingMessageBundle::FromBytes(bytes);
@@ -169,7 +169,7 @@ TEST(StreamingSerializationTest, streaming_message_bundle_equal_test) {
   delete[] bytes;
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/streaming/src/test/mock_actor.cc
+++ b/streaming/src/test/mock_actor.cc
@@ -20,7 +20,7 @@ namespace streaming {
 
 class StreamingQueueTestSuite {
  public:
-  StreamingQueueTestSuite(ActorID &peer_actor_id, std::vector<ObjectID> queue_ids,
+  StreamingQueueTestSuite(ActorID& peer_actor_id, std::vector<ObjectID> queue_ids,
                           std::vector<ObjectID> rescale_queue_ids)
       : peer_actor_id_(peer_actor_id),
         queue_ids_(queue_ids),
@@ -57,7 +57,7 @@ class StreamingQueueTestSuite {
 
 class StreamingQueueWriterTestSuite : public StreamingQueueTestSuite {
  public:
-  StreamingQueueWriterTestSuite(ActorID &peer_actor_id, std::vector<ObjectID> queue_ids,
+  StreamingQueueWriterTestSuite(ActorID& peer_actor_id, std::vector<ObjectID> queue_ids,
                                 std::vector<ObjectID> rescale_queue_ids)
       : StreamingQueueTestSuite(peer_actor_id, queue_ids, rescale_queue_ids) {
     test_func_map_ = {
@@ -68,14 +68,14 @@ class StreamingQueueWriterTestSuite : public StreamingQueueTestSuite {
 
  private:
   void TestWriteMessageToBufferRing(std::shared_ptr<DataWriter> writer_client,
-                                    std::vector<ray::ObjectID> &q_list) {
+                                    std::vector<ray::ObjectID>& q_list) {
     // const uint8_t temp_data[] = {1, 2, 4, 5};
 
     uint32_t i = 1;
     while (i <= MESSAGE_BOUND_SIZE) {
-      for (auto &q_id : q_list) {
+      for (auto& q_id : q_list) {
         uint64_t buffer_len = (i % DEFAULT_STREAMING_MESSAGE_BUFFER_SIZE);
-        uint8_t *data = new uint8_t[buffer_len];
+        uint8_t* data = new uint8_t[buffer_len];
         for (uint32_t j = 0; j < buffer_len; ++j) {
           data[j] = j % 128;
         }
@@ -90,8 +90,8 @@ class StreamingQueueWriterTestSuite : public StreamingQueueTestSuite {
     std::this_thread::sleep_for(std::chrono::milliseconds(5000));
   }
 
-  void StreamingWriterStrategyTest(StreamingConfig &config) {
-    for (auto &queue_id : queue_ids_) {
+  void StreamingWriterStrategyTest(StreamingConfig& config) {
+    for (auto& queue_id : queue_ids_) {
       STREAMING_LOG(INFO) << "queue_id: " << queue_id;
     }
     ChannelCreationParameter param{
@@ -152,11 +152,11 @@ class StreamingQueueReaderTestSuite : public StreamingQueueTestSuite {
  private:
   void ReaderLoopForward(std::shared_ptr<DataReader> reader_client,
                          std::shared_ptr<DataWriter> writer_client,
-                         std::vector<ray::ObjectID> &queue_id_vec) {
+                         std::vector<ray::ObjectID>& queue_id_vec) {
     uint64_t recevied_message_cnt = 0;
     std::unordered_map<ray::ObjectID, uint64_t> queue_last_cp_id;
 
-    for (auto &q_id : queue_id_vec) {
+    for (auto& q_id : queue_id_vec) {
       queue_last_cp_id[q_id] = 0;
     }
     STREAMING_LOG(INFO) << "Start read message bundle";
@@ -175,10 +175,10 @@ class StreamingQueueReaderTestSuite : public StreamingQueueTestSuite {
       if (msg->meta->GetBundleType() == StreamingMessageBundleType::Barrier) {
         STREAMING_LOG(DEBUG) << "barrier message recevied => "
                              << msg->meta->GetMessageBundleTs();
-        std::unordered_map<ray::ObjectID, ConsumerChannelInfo> *offset_map;
+        std::unordered_map<ray::ObjectID, ConsumerChannelInfo>* offset_map;
         reader_client->GetOffsetInfo(offset_map);
 
-        for (auto &q_id : queue_id_vec) {
+        for (auto& q_id : queue_id_vec) {
           reader_client->NotifyConsumedItem((*offset_map)[q_id],
                                             (*offset_map)[q_id].current_seq_id);
         }
@@ -200,14 +200,14 @@ class StreamingQueueReaderTestSuite : public StreamingQueueTestSuite {
                           << " last message id => " << msg->meta->GetLastMessageId();
 
       recevied_message_cnt += message_list.size();
-      for (auto &item : message_list) {
+      for (auto& item : message_list) {
         uint64_t i = item->GetMessageSeqId();
 
         uint32_t buff_len = i % DEFAULT_STREAMING_MESSAGE_BUFFER_SIZE;
         if (i > MESSAGE_BOUND_SIZE) break;
 
         EXPECT_EQ(buff_len, item->GetDataSize());
-        uint8_t *compared_data = new uint8_t[buff_len];
+        uint8_t* compared_data = new uint8_t[buff_len];
         for (uint32_t j = 0; j < item->GetDataSize(); ++j) {
           compared_data[j] = j % 128;
         }
@@ -223,7 +223,7 @@ class StreamingQueueReaderTestSuite : public StreamingQueueTestSuite {
     }
   }
 
-  void StreamingReaderStrategyTest(StreamingConfig &config) {
+  void StreamingReaderStrategyTest(StreamingConfig& config) {
     ChannelCreationParameter param{
         peer_actor_id_,
         std::make_shared<RayFunction>(
@@ -264,8 +264,8 @@ class TestSuiteFactory {
     std::shared_ptr<StreamingQueueTestSuite> test_suite = nullptr;
     std::string suite_name = message->TestSuiteName();
     queue::protobuf::StreamingQueueTestRole role = message->Role();
-    const std::vector<ObjectID> &queue_ids = message->QueueIds();
-    const std::vector<ObjectID> &rescale_queue_ids = message->RescaleQueueIds();
+    const std::vector<ObjectID>& queue_ids = message->QueueIds();
+    const std::vector<ObjectID>& rescale_queue_ids = message->RescaleQueueIds();
     ActorID peer_actor_id = message->PeerActorId();
 
     if (role == queue::protobuf::StreamingQueueTestRole::WRITER) {
@@ -290,8 +290,8 @@ class TestSuiteFactory {
 
 class StreamingWorker {
  public:
-  StreamingWorker(const std::string &store_socket, const std::string &raylet_socket,
-                  int node_manager_port, const gcs::GcsClientOptions &gcs_options)
+  StreamingWorker(const std::string& store_socket, const std::string& raylet_socket,
+                  int node_manager_port, const gcs::GcsClientOptions& gcs_options)
       : test_suite_(nullptr), peer_actor_handle_(nullptr) {
     CoreWorkerOptions options = {
         WorkerType::WORKER,  // worker_type
@@ -332,12 +332,12 @@ class StreamingWorker {
   }
 
  private:
-  Status ExecuteTask(TaskType task_type, const RayFunction &ray_function,
-                     const std::unordered_map<std::string, double> &required_resources,
-                     const std::vector<std::shared_ptr<RayObject>> &args,
-                     const std::vector<ObjectID> &arg_reference_ids,
-                     const std::vector<ObjectID> &return_ids,
-                     std::vector<std::shared_ptr<RayObject>> *results) {
+  Status ExecuteTask(TaskType task_type, const RayFunction& ray_function,
+                     const std::unordered_map<std::string, double>& required_resources,
+                     const std::vector<std::shared_ptr<RayObject>>& args,
+                     const std::vector<ObjectID>& arg_reference_ids,
+                     const std::vector<ObjectID>& return_ids,
+                     std::vector<std::shared_ptr<RayObject>>* results) {
     // Only one arg param used in streaming.
     STREAMING_CHECK(args.size() >= 1) << "args.size() = " << args.size();
 
@@ -409,14 +409,14 @@ class StreamingWorker {
 
  private:
   void HandleInitTask(std::shared_ptr<LocalMemoryBuffer> buffer) {
-    uint8_t *bytes = buffer->Data();
-    uint8_t *p_cur = bytes;
-    uint32_t *magic_num = (uint32_t *)p_cur;
+    uint8_t* bytes = buffer->Data();
+    uint8_t* p_cur = bytes;
+    uint32_t* magic_num = (uint32_t*)p_cur;
     STREAMING_CHECK(*magic_num == Message::MagicNum);
 
     p_cur += sizeof(Message::MagicNum);
-    queue::protobuf::StreamingQueueMessageType *type =
-        (queue::protobuf::StreamingQueueMessageType *)p_cur;
+    queue::protobuf::StreamingQueueMessageType* type =
+        (queue::protobuf::StreamingQueueMessageType*)p_cur;
     STREAMING_CHECK(
         *type ==
         queue::protobuf::StreamingQueueMessageType::StreamingQueueTestInitMsgType);
@@ -457,7 +457,7 @@ class StreamingWorker {
 }  // namespace streaming
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   RAY_CHECK(argc == 4);
   auto store_socket = std::string(argv[1]);
   auto raylet_socket = std::string(argv[2]);

--- a/streaming/src/test/mock_transfer_tests.cc
+++ b/streaming/src/test/mock_transfer_tests.cc
@@ -20,7 +20,7 @@ TEST(StreamingMockTransfer, mock_produce_consume) {
   producer.CreateTransferChannel();
   uint8_t data[3] = {1, 2, 3};
   producer.ProduceItemToChannel(data, 3);
-  uint8_t *data_consumed;
+  uint8_t* data_consumed;
   uint32_t data_size_consumed;
   uint64_t data_seq_id;
   consumer.ConsumeItemFromChannel(data_seq_id, data_consumed, data_size_consumed, -1);
@@ -77,8 +77,8 @@ TEST_F(StreamingTransferTest, exchange_single_channel_test) {
   std::shared_ptr<DataBundle> msg;
   reader->GetBundle(5000, msg);
   StreamingMessageBundlePtr bundle_ptr = StreamingMessageBundle::FromBytes(msg->data);
-  auto &message_list = bundle_ptr->GetMessageList();
-  auto &message = message_list.front();
+  auto& message_list = bundle_ptr->GetMessageList();
+  auto& message = message_list.front();
   EXPECT_EQ(std::memcmp(message->RawData(), data, data_size), 0);
 }
 
@@ -94,8 +94,8 @@ TEST_F(StreamingTransferTest, exchange_multichannel_test) {
     reader->GetBundle(5000, msg);
     EXPECT_EQ(msg->from, queue_vec[i]);
     StreamingMessageBundlePtr bundle_ptr = StreamingMessageBundle::FromBytes(msg->data);
-    auto &message_list = bundle_ptr->GetMessageList();
-    auto &message = message_list.front();
+    auto& message_list = bundle_ptr->GetMessageList();
+    auto& message = message_list.front();
     EXPECT_EQ(std::memcmp(message->RawData(), data, data_size), 0);
   }
 }
@@ -120,12 +120,12 @@ TEST_F(StreamingTransferTest, exchange_consumed_test) {
     std::shared_ptr<DataBundle> msg;
     reader->GetBundle(5000, msg);
     StreamingMessageBundlePtr bundle_ptr = StreamingMessageBundle::FromBytes(msg->data);
-    auto &message_list = bundle_ptr->GetMessageList();
+    auto& message_list = bundle_ptr->GetMessageList();
     std::copy(message_list.begin(), message_list.end(),
               std::back_inserter(read_message_list));
   }
   int index = 0;
-  for (auto &message : read_message_list) {
+  for (auto& message : read_message_list) {
     func(index++);
     EXPECT_EQ(std::memcmp(message->RawData(), data.get(), data_size), 0);
   }
@@ -146,16 +146,16 @@ TEST_F(StreamingTransferTest, flow_control_test) {
       writer->WriteMessageToBufferRing(queue_vec[0], data.get(), data_size);
     }
   });
-  std::unordered_map<ObjectID, ProducerChannelInfo> *writer_offset_info = nullptr;
-  std::unordered_map<ObjectID, ConsumerChannelInfo> *reader_offset_info = nullptr;
+  std::unordered_map<ObjectID, ProducerChannelInfo>* writer_offset_info = nullptr;
+  std::unordered_map<ObjectID, ConsumerChannelInfo>* reader_offset_info = nullptr;
   writer->GetOffsetInfo(writer_offset_info);
   reader->GetOffsetInfo(reader_offset_info);
   uint32_t writer_step = writer_runtime_context->GetConfig().GetWriterConsumedStep();
   uint32_t reader_step = reader_runtime_context->GetConfig().GetReaderConsumedStep();
-  uint64_t &writer_current_seq_id = (*writer_offset_info)[queue_vec[0]].current_seq_id;
-  uint64_t &writer_current_message_id =
+  uint64_t& writer_current_seq_id = (*writer_offset_info)[queue_vec[0]].current_seq_id;
+  uint64_t& writer_current_message_id =
       (*writer_offset_info)[queue_vec[0]].current_message_id;
-  uint64_t &reader_target_seq_id =
+  uint64_t& reader_target_seq_id =
       (*reader_offset_info)[queue_vec[0]].queue_info.target_seq_id;
   while (writer_current_seq_id < writer_step) {
     STREAMING_LOG(INFO) << "Writer currrent seq id " << writer_current_seq_id
@@ -170,21 +170,21 @@ TEST_F(StreamingTransferTest, flow_control_test) {
     std::shared_ptr<DataBundle> msg;
     reader->GetBundle(1000, msg);
     StreamingMessageBundlePtr bundle_ptr = StreamingMessageBundle::FromBytes(msg->data);
-    auto &message_list = bundle_ptr->GetMessageList();
+    auto& message_list = bundle_ptr->GetMessageList();
     std::copy(message_list.begin(), message_list.end(),
               std::back_inserter(read_message_list));
     ASSERT_GE(writer_step, writer_current_seq_id - msg->seq_id);
     ASSERT_GE(msg->seq_id + reader_step, reader_target_seq_id);
   }
   int index = 0;
-  for (auto &message : read_message_list) {
+  for (auto& message : read_message_list) {
     func(index++);
     EXPECT_EQ(std::memcmp(message->RawData(), data.get(), data_size), 0);
   }
   write_thread.join();
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/streaming/src/test/queue_tests_base.h
+++ b/streaming/src/test/queue_tests_base.h
@@ -1,9 +1,8 @@
 #pragma once
 
+#include "hiredis/hiredis.h"
 #include "ray/common/test_util.h"
 #include "ray/util/filesystem.h"
-
-#include "hiredis/hiredis.h"
 
 namespace ray {
 namespace streaming {

--- a/streaming/src/test/queue_tests_base.h
+++ b/streaming/src/test/queue_tests_base.h
@@ -10,7 +10,7 @@ namespace streaming {
 ray::ObjectID RandomObjectID() { return ObjectID::FromRandom(); }
 
 static void flushall_redis(void) {
-  redisContext *context = redisConnect("127.0.0.1", 6379);
+  redisContext* context = redisConnect("127.0.0.1", 6379);
   freeReplyObject(redisCommand(context, "FLUSHALL"));
   freeReplyObject(redisCommand(context, "SET NumRedisShards 1"));
   freeReplyObject(redisCommand(context, "LPUSH RedisShards 127.0.0.1:6380"));
@@ -33,7 +33,7 @@ class StreamingQueueTestBase : public ::testing::TestWithParam<uint64_t> {
     }
 
     // start plasma store.
-    for (auto &store_socket : raylet_store_socket_names_) {
+    for (auto& store_socket : raylet_store_socket_names_) {
       store_socket = TestSetupUtil::StartObjectStore();
     }
 
@@ -51,11 +51,11 @@ class StreamingQueueTestBase : public ::testing::TestWithParam<uint64_t> {
 
   ~StreamingQueueTestBase() {
     STREAMING_LOG(INFO) << "Stop raylet store and actors";
-    for (const auto &raylet_socket_name : raylet_socket_names_) {
+    for (const auto& raylet_socket_name : raylet_socket_names_) {
       TestSetupUtil::StopRaylet(raylet_socket_name);
     }
 
-    for (const auto &store_socket_name : raylet_store_socket_names_) {
+    for (const auto& store_socket_name : raylet_store_socket_names_) {
       TestSetupUtil::StopObjectStore(store_socket_name);
     }
 
@@ -68,12 +68,12 @@ class StreamingQueueTestBase : public ::testing::TestWithParam<uint64_t> {
     return JobID::FromInt(job_counter++);
   }
 
-  void InitWorker(ActorID &self_actor_id, ActorID &peer_actor_id,
+  void InitWorker(ActorID& self_actor_id, ActorID& peer_actor_id,
                   const queue::protobuf::StreamingQueueTestRole role,
-                  const std::vector<ObjectID> &queue_ids,
-                  const std::vector<ObjectID> &rescale_queue_ids, std::string suite_name,
+                  const std::vector<ObjectID>& queue_ids,
+                  const std::vector<ObjectID>& rescale_queue_ids, std::string suite_name,
                   std::string test_name, uint64_t param) {
-    auto &driver = CoreWorkerProcess::GetCoreWorker();
+    auto& driver = CoreWorkerProcess::GetCoreWorker();
     std::string forked_serialized_str;
     ObjectID actor_handle_id;
     Status st = driver.SerializeActorHandle(peer_actor_id, &forked_serialized_str,
@@ -95,8 +95,8 @@ class StreamingQueueTestBase : public ::testing::TestWithParam<uint64_t> {
     driver.SubmitActorTask(self_actor_id, func, args, options, &return_ids);
   }
 
-  void SubmitTestToActor(ActorID &actor_id, const std::string test) {
-    auto &driver = CoreWorkerProcess::GetCoreWorker();
+  void SubmitTestToActor(ActorID& actor_id, const std::string test) {
+    auto& driver = CoreWorkerProcess::GetCoreWorker();
     uint8_t data[8];
     auto buffer = std::make_shared<LocalMemoryBuffer>(data, 8, true);
     std::vector<std::unique_ptr<TaskArg>> args;
@@ -111,8 +111,8 @@ class StreamingQueueTestBase : public ::testing::TestWithParam<uint64_t> {
     driver.SubmitActorTask(actor_id, func, args, options, &return_ids);
   }
 
-  bool CheckCurTest(ActorID &actor_id, const std::string test_name) {
-    auto &driver = CoreWorkerProcess::GetCoreWorker();
+  bool CheckCurTest(ActorID& actor_id, const std::string test_name) {
+    auto& driver = CoreWorkerProcess::GetCoreWorker();
     uint8_t data[8];
     auto buffer = std::make_shared<LocalMemoryBuffer>(data, 8, true);
     std::vector<std::unique_ptr<TaskArg>> args;
@@ -157,14 +157,14 @@ class StreamingQueueTestBase : public ::testing::TestWithParam<uint64_t> {
         std::make_shared<LocalMemoryBuffer>(result_buffer->Data(), result_buffer->Size(),
                                             true);
 
-    uint8_t *bytes = result_buffer->Data();
-    uint8_t *p_cur = bytes;
-    uint32_t *magic_num = (uint32_t *)p_cur;
+    uint8_t* bytes = result_buffer->Data();
+    uint8_t* p_cur = bytes;
+    uint32_t* magic_num = (uint32_t*)p_cur;
     STREAMING_CHECK(*magic_num == Message::MagicNum);
 
     p_cur += sizeof(Message::MagicNum);
-    queue::protobuf::StreamingQueueMessageType *type =
-        (queue::protobuf::StreamingQueueMessageType *)p_cur;
+    queue::protobuf::StreamingQueueMessageType* type =
+        (queue::protobuf::StreamingQueueMessageType*)p_cur;
     STREAMING_CHECK(*type == queue::protobuf::StreamingQueueMessageType::
                                  StreamingQueueTestCheckStatusRspMsgType);
     std::shared_ptr<TestCheckStatusRspMsg> message =
@@ -173,7 +173,7 @@ class StreamingQueueTestBase : public ::testing::TestWithParam<uint64_t> {
     return message->Status();
   }
 
-  ActorID CreateActorHelper(const std::unordered_map<std::string, double> &resources,
+  ActorID CreateActorHelper(const std::unordered_map<std::string, double>& resources,
                             bool is_direct_call, int64_t max_restarts) {
     std::unique_ptr<ActorHandle> actor_handle;
 
@@ -218,7 +218,7 @@ class StreamingQueueTestBase : public ::testing::TestWithParam<uint64_t> {
     for (size_t i = 0; i < queue_id_vec.size(); ++i) {
       STREAMING_LOG(INFO) << " qid hex => " << queue_id_vec[i].Hex();
     }
-    for (auto &qid : rescale_queue_id_vec) {
+    for (auto& qid : rescale_queue_id_vec) {
       STREAMING_LOG(INFO) << " rescale qid hex => " << qid.Hex();
     }
     STREAMING_LOG(INFO) << "Sub process: writer.";

--- a/streaming/src/test/ring_buffer_tests.cc
+++ b/streaming/src/test/ring_buffer_tests.cc
@@ -40,7 +40,7 @@ TEST(StreamingRingBufferTest, spsc_test) {
   std::thread thread([&ring_buffer]() {
     for (size_t j = 0; j < data_n; ++j) {
       StreamingMessagePtr message = std::make_shared<StreamingMessage>(
-          reinterpret_cast<uint8_t *>(&j), static_cast<uint32_t>(sizeof(size_t)), j,
+          reinterpret_cast<uint8_t*>(&j), static_cast<uint32_t>(sizeof(size_t)), j,
           StreamingMessageType::Message);
       while (ring_buffer.IsFull()) {
       }
@@ -51,7 +51,7 @@ TEST(StreamingRingBufferTest, spsc_test) {
   while (count < data_n) {
     while (ring_buffer.IsEmpty()) {
     }
-    auto &msg = ring_buffer.Front();
+    auto& msg = ring_buffer.Front();
     EXPECT_EQ(std::memcmp(msg->RawData(), &count, sizeof(size_t)), 0);
     ring_buffer.Pop();
     count++;
@@ -66,7 +66,7 @@ TEST(StreamingRingBufferTest, mutex_test) {
   std::thread thread([&ring_buffer]() {
     for (size_t j = 0; j < data_n; ++j) {
       StreamingMessagePtr message = std::make_shared<StreamingMessage>(
-          reinterpret_cast<uint8_t *>(&j), static_cast<uint32_t>(sizeof(size_t)), j,
+          reinterpret_cast<uint8_t*>(&j), static_cast<uint32_t>(sizeof(size_t)), j,
           StreamingMessageType::Message);
       while (ring_buffer.IsFull()) {
       }
@@ -86,7 +86,7 @@ TEST(StreamingRingBufferTest, mutex_test) {
   EXPECT_EQ(count, data_n);
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/streaming/src/test/streaming_queue_tests.cc
+++ b/streaming/src/test/streaming_queue_tests.cc
@@ -44,7 +44,7 @@ INSTANTIATE_TEST_CASE_P(StreamingTest, StreamingExactlySameTest,
 }  // namespace streaming
 }  // namespace ray
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   // set_streaming_log_config("streaming_writer_test", StreamingLogLevel::INFO, 0);
   ::testing::InitGoogleTest(&argc, argv);
   RAY_CHECK(argc == 9);

--- a/streaming/src/test/streaming_util_tests.cc
+++ b/streaming/src/test/streaming_util_tests.cc
@@ -1,5 +1,4 @@
 #include "gtest/gtest.h"
-
 #include "util/streaming_util.h"
 
 using namespace ray;

--- a/streaming/src/test/streaming_util_tests.cc
+++ b/streaming/src/test/streaming_util_tests.cc
@@ -17,7 +17,7 @@ TEST(StreamingUtilTest, test_Hex2str) {
   EXPECT_TRUE(std::memcmp(Util::Hexqid2str("100f").c_str(), data2, 2) == 0);
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/streaming/src/util/streaming_util.cc
+++ b/streaming/src/util/streaming_util.cc
@@ -4,7 +4,7 @@
 namespace ray {
 namespace streaming {
 
-boost::any &Config::Get(ConfigEnum key) const {
+boost::any& Config::Get(ConfigEnum key) const {
   auto item = config_map_.find(key);
   STREAMING_CHECK(item != config_map_.end());
   return item->second;
@@ -18,7 +18,7 @@ boost::any Config::Get(ConfigEnum key, boost::any default_value) const {
   return item->second;
 }
 
-std::string Util::Byte2hex(const uint8_t *data, uint32_t data_size) {
+std::string Util::Byte2hex(const uint8_t* data, uint32_t data_size) {
   constexpr char hex[] = "0123456789abcdef";
   std::string result;
   for (uint32_t i = 0; i < data_size; i++) {
@@ -29,7 +29,7 @@ std::string Util::Byte2hex(const uint8_t *data, uint32_t data_size) {
   return result;
 }
 
-std::string Util::Hexqid2str(const std::string &q_id_hex) {
+std::string Util::Hexqid2str(const std::string& q_id_hex) {
   std::string result;
   for (uint32_t i = 0; i < q_id_hex.size(); i += 2) {
     std::string byte = q_id_hex.substr(i, 2);

--- a/streaming/src/util/streaming_util.h
+++ b/streaming/src/util/streaming_util.h
@@ -27,14 +27,14 @@ enum class ConfigEnum : uint32_t {
 namespace std {
 template <>
 struct hash<::ray::streaming::ConfigEnum> {
-  size_t operator()(const ::ray::streaming::ConfigEnum &config_enum_key) const {
+  size_t operator()(const ::ray::streaming::ConfigEnum& config_enum_key) const {
     return static_cast<uint32_t>(config_enum_key);
   }
 };
 
 template <>
 struct hash<const ::ray::streaming::ConfigEnum> {
-  size_t operator()(const ::ray::streaming::ConfigEnum &config_enum_key) const {
+  size_t operator()(const ::ray::streaming::ConfigEnum& config_enum_key) const {
     return static_cast<uint32_t>(config_enum_key);
   }
 };
@@ -46,17 +46,17 @@ namespace streaming {
 class Config {
  public:
   template <typename ValueType>
-  inline void Set(ConfigEnum key, const ValueType &any) {
+  inline void Set(ConfigEnum key, const ValueType& any) {
     config_map_.emplace(key, any);
   }
 
   template <typename ValueType>
-  inline void Set(ConfigEnum key, ValueType &&any) {
+  inline void Set(ConfigEnum key, ValueType&& any) {
     config_map_.emplace(key, any);
   }
 
   template <typename ValueType>
-  inline boost::any &GetOrDefault(ConfigEnum key, ValueType &&any) {
+  inline boost::any& GetOrDefault(ConfigEnum key, ValueType&& any) {
     auto item = config_map_.find(key);
     if (item != config_map_.end()) {
       return item->second;
@@ -65,7 +65,7 @@ class Config {
     return any;
   }
 
-  boost::any &Get(ConfigEnum key) const;
+  boost::any& Get(ConfigEnum key) const;
 
   boost::any Get(ConfigEnum key, boost::any default_value) const;
 
@@ -89,9 +89,9 @@ class Config {
 
 class Util {
  public:
-  static std::string Byte2hex(const uint8_t *data, uint32_t data_size);
+  static std::string Byte2hex(const uint8_t* data, uint32_t data_size);
 
-  static std::string Hexqid2str(const std::string &q_id_hex);
+  static std::string Hexqid2str(const std::string& q_id_hex);
 };
 }  // namespace streaming
 }  // namespace ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Stylistically, an int pointer is better as an `int* foo` instead of `int *foo` -- the latter is more like dereferencing, whereas aligned with the type it more clearly follows the mental model that the thing being passed is of a pointer type, not a type -- and then dereferenced into the variable.

So, this changes `.clang-format` to do that automatically, and reformats the codebase appropriately.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)

Completely automated change:

Commit 1: 
`git ls-files | grep '\.\(cc\|h\)' | xargs -n 1 clang-format -i`
Commit 2:
Change .clang-format as shown and repeat the above command.