### PR TITLE
Fix wrong java pattern of DateTimeFormatter

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/config/RayConfig.java
+++ b/java/runtime/src/main/java/io/ray/runtime/config/RayConfig.java
@@ -32,7 +32,7 @@ public class RayConfig {
   private static final Random RANDOM = new Random();
 
   private static final DateTimeFormatter DATE_TIME_FORMATTER =
-      DateTimeFormatter.ofPattern("YYYY-MM-dd_HH-mm-ss");
+      DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss");
 
   private static final String DEFAULT_TEMP_DIR = "/tmp/ray";
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
In order to get year, we should use `yyyy` (year-of-era) instead of `YYYY` (week-based-year)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
