### PR TITLE
[Placement Group]Trigger placement group scheduling when a new node is added

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -285,6 +285,8 @@ RAY_CONFIG(int64_t, gcs_redis_heartbeat_interval_milliseconds, 100)
 RAY_CONFIG(uint32_t, gcs_lease_worker_retry_interval_ms, 200)
 /// Duration to wait between retries for creating actor in gcs server.
 RAY_CONFIG(uint32_t, gcs_create_actor_retry_interval_ms, 200)
+/// Duration to wait between retries for creating placement group in gcs server.
+RAY_CONFIG(uint32_t, gcs_create_placement_group_retry_interval_ms, 200)
 
 /// Maximum number of times to retry putting an object when the plasma store is full.
 /// Can be set to -1 to enable unlimited retries.

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -14,8 +14,6 @@
 
 #include "ray/gcs/gcs_server/gcs_placement_group_manager.h"
 
-#include <utility>
-
 #include "ray/common/ray_config.h"
 #include "ray/gcs/pb_util.h"
 #include "src/ray/protobuf/gcs.pb.h"

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -14,6 +14,8 @@
 
 #include "ray/gcs/gcs_server/gcs_placement_group_manager.h"
 
+#include <utility>
+
 #include "ray/common/ray_config.h"
 #include "ray/gcs/pb_util.h"
 #include "src/ray/protobuf/gcs.pb.h"

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -16,6 +16,7 @@
 
 #include "ray/common/ray_config.h"
 #include "ray/gcs/pb_util.h"
+#include "ray/util/asio_util.h"
 #include "src/ray/protobuf/gcs.pb.h"
 
 namespace ray {
@@ -61,9 +62,9 @@ GcsPlacementGroupManager::GcsPlacementGroupManager(
     boost::asio::io_context &io_context,
     std::shared_ptr<GcsPlacementGroupSchedulerInterface> scheduler,
     std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage)
-    : gcs_placement_group_scheduler_(std::move(scheduler)),
-      gcs_table_storage_(std::move(gcs_table_storage)),
-      reschedule_timer_(io_context) {}
+    : io_context_(io_context),
+      gcs_placement_group_scheduler_(std::move(scheduler)),
+      gcs_table_storage_(std::move(gcs_table_storage)) {}
 
 void GcsPlacementGroupManager::RegisterPlacementGroup(
     const ray::rpc::CreatePlacementGroupRequest &request, EmptyCallback callback) {
@@ -105,7 +106,7 @@ void GcsPlacementGroupManager::OnPlacementGroupCreationFailed(
   // registered.
   pending_placement_groups_.emplace_back(std::move(placement_group));
   is_creating_ = false;
-  ScheduleTick();
+  RetryCreatingPlacementGroup();
 }
 
 void GcsPlacementGroupManager::OnPlacementGroupCreationSuccess(
@@ -173,15 +174,9 @@ void GcsPlacementGroupManager::HandleCreatePlacementGroup(
       }));
 }
 
-void GcsPlacementGroupManager::ScheduleTick() {
-  reschedule_timer_.expires_from_now(boost::posix_time::milliseconds(500));
-  reschedule_timer_.async_wait([this](const boost::system::error_code &error) {
-    if (error == boost::asio::error::operation_aborted) {
-      return;
-    } else {
-      SchedulePendingPlacementGroups();
-    }
-  });
+void GcsPlacementGroupManager::RetryCreatingPlacementGroup() {
+  execute_after(io_context_, [this] { SchedulePendingPlacementGroups(); },
+                RayConfig::instance().gcs_create_placement_group_retry_interval_ms());
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -110,7 +110,7 @@ void GcsPlacementGroupManager::OnPlacementGroupCreationFailed(
 }
 
 void GcsPlacementGroupManager::OnPlacementGroupCreationSuccess(
-    std::shared_ptr<GcsPlacementGroup> placement_group) {
+    const std::shared_ptr<GcsPlacementGroup> &placement_group) {
   RAY_LOG(INFO) << "Successfully created placement group " << placement_group->GetName();
   placement_group->UpdateState(rpc::PlacementGroupTableData::ALIVE);
   auto placement_group_id = placement_group->GetPlacementGroupID();

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
@@ -142,6 +142,7 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoHandler {
       const std::shared_ptr<GcsPlacementGroup> &placement_group);
 
  private:
+  /// Try to create placement group after a short time.
   void RetryCreatingPlacementGroup();
 
   /// The io loop that is used to delay execution of tasks (e.g.,

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
@@ -139,11 +139,14 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoHandler {
   ///
   /// \param placement_group The placement_group that has been created.
   void OnPlacementGroupCreationSuccess(
-      std::shared_ptr<GcsPlacementGroup> placement_group);
+      const std::shared_ptr<GcsPlacementGroup> &placement_group);
 
  private:
-  /// Schedule another tick after a short time.
-  void ScheduleTick();
+  void RetryCreatingPlacementGroup();
+
+  /// The io loop that is used to delay execution of tasks (e.g.,
+  /// execute_after).
+  boost::asio::io_context &io_context_;
 
   /// Callback of placement_group registration requests that are not yet flushed.
   absl::flat_hash_map<PlacementGroupID, EmptyCallback>
@@ -162,9 +165,6 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoHandler {
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
   /// If a placement group is creating
   bool is_creating_ = false;
-
-  /// A timer that ticks every schedule failure milliseconds.
-  boost::asio::deadline_timer reschedule_timer_;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
@@ -148,6 +148,7 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoHandler {
   /// Callback of placement_group registration requests that are not yet flushed.
   absl::flat_hash_map<PlacementGroupID, EmptyCallback>
       placement_group_to_register_callback_;
+
   /// All registered placement_groups (pending placement_groups are also included).
   absl::flat_hash_map<PlacementGroupID, std::shared_ptr<GcsPlacementGroup>>
       registered_placement_groups_;

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -197,7 +197,8 @@ void GcsServer::InitGcsActorManager() {
   gcs_node_manager_->AddNodeAddedListener(
       [this](const std::shared_ptr<rpc::GcsNodeInfo> &) {
         // Because a new node has been added, we need to try to schedule the pending
-        // actors.
+        // placement groups and the pending actors.
+        gcs_placement_group_manager_->SchedulePendingPlacementGroups();
         gcs_actor_manager_->SchedulePendingActors();
       });
 

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
@@ -64,6 +64,8 @@ class GcsPlacementGroupManagerTest : public ::testing::Test {
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
   std::shared_ptr<MockPlacementGroupScheduler> mock_placement_group_scheduler_;
   std::unique_ptr<gcs::GcsPlacementGroupManager> gcs_placement_group_manager_;
+
+  const std::chrono::milliseconds timeout_ms_{60000};
 };
 
 TEST_F(GcsPlacementGroupManagerTest, TestBasic) {

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
@@ -64,8 +64,6 @@ class GcsPlacementGroupManagerTest : public ::testing::Test {
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
   std::shared_ptr<MockPlacementGroupScheduler> mock_placement_group_scheduler_;
   std::unique_ptr<gcs::GcsPlacementGroupManager> gcs_placement_group_manager_;
-
-  const std::chrono::milliseconds timeout_ms_{60000};
 };
 
 TEST_F(GcsPlacementGroupManagerTest, TestBasic) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
When nodes are added or deleted, placement group scheduler needs to be triggered. In this PR, we reschedule placement group when the node is added. We will reschedule placement group when the node is deleted in the next PR.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/9906
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
