### PR TITLE
Fix vector<bool> for loop

### DIFF
--- a/src/ray/core_worker/lib/java/jni_utils.h
+++ b/src/ray/core_worker/lib/java/jni_utils.h
@@ -346,8 +346,8 @@ inline jobject NativeVectorToJavaList(
       env->NewObject(java_array_list_class, java_array_list_init_with_capacity,
                      (jint)native_vector.size());
   RAY_CHECK_JAVA_EXCEPTION(env);
-  for (const auto &item : native_vector) {
-    auto element = element_converter(env, item);
+  for (auto it = native_vector.begin(); it != native_vector.end(); ++it){
+    auto element = element_converter(env, *it);
     env->CallVoidMethod(java_list, java_list_add, element);
     RAY_CHECK_JAVA_EXCEPTION(env);
     env->DeleteLocalRef(element);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
In `range-based for` loop of `vector<bool>`, it returns a copy not a reference.

```
In file included from src/ray/core_worker/lib/java/io_ray_runtime_object_NativeObjectStore.cc:17:
src/ray/core_worker/lib/java/jni_utils.h:341:20: error: loop variable 'item' is always a copy because the range of type 'const std::vector<bool>' does not return a reference [-Werror,-Wrange-loop-analysis]
  for (const auto &item : native_vector) {
                   ^
src/ray/core_worker/lib/java/io_ray_runtime_object_NativeObjectStore.cc:110:10: note: in instantiation of function template specialization 'NativeVectorToJavaList<bool>' requested here
  return NativeVectorToJavaList<bool>(env, results, [](JNIEnv *env, const bool &item) {
         ^
src/ray/core_worker/lib/java/jni_utils.h:341:8: note: use non-reference type 'std::__1::__bit_const_reference<std::__1::vector<bool, std::__1::allocator<bool> > >'
  for (const auto &item : native_vector) {
       ^~~~~~~~~~~~~~~~~~
1 error generated.
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
