### PR TITLE
[RLlib] Support windows drives other than C drive for the offline json API

### DIFF
--- a/rllib/offline/json_reader.py
+++ b/rllib/offline/json_reader.py
@@ -21,6 +21,8 @@ from typing import List
 
 logger = logging.getLogger(__name__)
 
+WINDOWS_DRIVES = [chr(i) for i in range(ord("a"), ord("z") + 1)]
+
 
 @PublicAPI
 class JsonReader(InputReader):
@@ -47,7 +49,7 @@ class JsonReader(InputReader):
                 logger.warning(
                     "Treating input directory as glob pattern: {}".format(
                         inputs))
-            if urlparse(inputs).scheme not in ["", "c"]:
+            if urlparse(inputs).scheme not in [""] + WINDOWS_DRIVES:
                 raise ValueError(
                     "Don't know how to glob over `{}`, ".format(inputs) +
                     "please specify a list of files to read instead.")
@@ -126,7 +128,7 @@ class JsonReader(InputReader):
 
     def _next_file(self) -> FileType:
         path = random.choice(self.files)
-        if urlparse(path).scheme not in ["", "c"]:
+        if urlparse(path).scheme not in [""] + WINDOWS_DRIVES:
             if smart_open is None:
                 raise ValueError(
                     "You must install the `smart_open` module to read "

--- a/rllib/offline/json_reader.py
+++ b/rllib/offline/json_reader.py
@@ -21,7 +21,7 @@ from typing import List
 
 logger = logging.getLogger(__name__)
 
-WINDOWS_DRIVES = [chr(i) for i in range(ord("a"), ord("z") + 1)]
+WINDOWS_DRIVES = [chr(i) for i in range(ord("c"), ord("z") + 1)]
 
 
 @PublicAPI

--- a/rllib/offline/json_writer.py
+++ b/rllib/offline/json_writer.py
@@ -21,7 +21,7 @@ from typing import Any, List
 
 logger = logging.getLogger(__name__)
 
-WINDOWS_DRIVES = [chr(i) for i in range(ord("a"), ord("z") + 1)]
+WINDOWS_DRIVES = [chr(i) for i in range(ord("c"), ord("z") + 1)]
 
 
 @PublicAPI

--- a/rllib/offline/json_writer.py
+++ b/rllib/offline/json_writer.py
@@ -21,6 +21,8 @@ from typing import Any, List
 
 logger = logging.getLogger(__name__)
 
+WINDOWS_DRIVES = [chr(i) for i in range(ord("a"), ord("z") + 1)]
+
 
 @PublicAPI
 class JsonWriter(OutputWriter):
@@ -44,7 +46,7 @@ class JsonWriter(OutputWriter):
         self.ioctx = ioctx or IOContext()
         self.max_file_size = max_file_size
         self.compress_columns = compress_columns
-        if urlparse(path).scheme not in ["", "c"]:
+        if urlparse(path).scheme not in [""] + WINDOWS_DRIVES:
             self.path_is_uri = True
         else:
             path = os.path.abspath(os.path.expanduser(path))


### PR DESCRIPTION
## Why are these changes needed?

Adds support for drive paths other than the C drive on windows. These are letter drives from C through Z.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
