### PR TITLE
[docker] Fix rsyncs & filesync for docker

### DIFF
--- a/python/ray/autoscaler/command_runner.py
+++ b/python/ray/autoscaler/command_runner.py
@@ -476,14 +476,24 @@ class DockerCommandRunner(SSHCommandRunner):
             ssh_options_override=ssh_options_override)
 
     def run_rsync_up(self, source, target):
+        protected_path = ""
+        if target.find("/root") == 0:
+            protected_path = target
+            target = target.replace("/root","/tmp/root")
+            self.ssh_command_runner.run("mkdir -p /tmp/root/",run_env="host")
         self.ssh_command_runner.run_rsync_up(source, target)
         if self._check_container_status():
             self.ssh_command_runner.run("docker cp {} {}:{}".format(
-                target, self.docker_name, self._docker_expand_user(target)))
+                target, self.docker_name, self._docker_expand_user(protected_path)))
 
     def run_rsync_down(self, source, target):
+        protected_path = ""
+        if source.find("/root") == 0:
+            protected_path = source
+            source = source.replace("/root","/tmp/root")
+            self.ssh_command_runner.run("mkdir -p /tmp/root/",run_env="host")
         self.ssh_command_runner.run("docker cp {}:{} {}".format(
-            self.docker_name, self._docker_expand_user(source), source))
+            self.docker_name, self._docker_expand_user(protected_path), source))
         self.ssh_command_runner.run_rsync_down(source, target)
 
     def remote_shell_command_str(self):

--- a/python/ray/autoscaler/command_runner.py
+++ b/python/ray/autoscaler/command_runner.py
@@ -479,21 +479,25 @@ class DockerCommandRunner(SSHCommandRunner):
         protected_path = ""
         if target.find("/root") == 0:
             protected_path = target
-            target = target.replace("/root","/tmp/root")
-            self.ssh_command_runner.run(f"mkdir -p {os.path.dirname(target)}",run_env="host")
+            target = target.replace("/root", "/tmp/root")
+            self.ssh_command_runner.run(
+                f"mkdir -p {os.path.dirname(target)}", run_env="host")
         self.ssh_command_runner.run_rsync_up(source, target)
         if self._check_container_status():
             self.ssh_command_runner.run("docker cp {} {}:{}".format(
-                target, self.docker_name, self._docker_expand_user(protected_path)))
+                target, self.docker_name,
+                self._docker_expand_user(protected_path)))
 
     def run_rsync_down(self, source, target):
         protected_path = ""
         if source.find("/root") == 0:
             protected_path = source
-            source = source.replace("/root","/tmp/root")
-            self.ssh_command_runner.run("mkdir -p /tmp/root/",run_env="host")
+            source = source.replace("/root", "/tmp/root")
+            self.ssh_command_runner.run(
+                f"mkdir -p {os.path.dirname(source)}", run_env="host")
         self.ssh_command_runner.run("docker cp {}:{} {}".format(
-            self.docker_name, self._docker_expand_user(protected_path), source))
+            self.docker_name, self._docker_expand_user(protected_path),
+            source))
         self.ssh_command_runner.run_rsync_down(source, target)
 
     def remote_shell_command_str(self):

--- a/python/ray/autoscaler/command_runner.py
+++ b/python/ray/autoscaler/command_runner.py
@@ -480,7 +480,7 @@ class DockerCommandRunner(SSHCommandRunner):
         if target.find("/root") == 0:
             protected_path = target
             target = target.replace("/root","/tmp/root")
-            self.ssh_command_runner.run("mkdir -p /tmp/root/",run_env="host")
+            self.ssh_command_runner.run(f"mkdir -p {os.path.dirname(target)}",run_env="host")
         self.ssh_command_runner.run_rsync_up(source, target)
         if self._check_container_status():
             self.ssh_command_runner.run("docker cp {} {}:{}".format(

--- a/python/ray/autoscaler/docker.py
+++ b/python/ray/autoscaler/docker.py
@@ -93,8 +93,9 @@ def docker_start_cmds(user, image, mount, cname, user_options):
         "-p {port}:{port}".format(port=port)
         for port in ["6379", "8076", "4321"]
     ])
+    # TODO(ilr) Move away from defaulting to /root/
     mount_flags = " ".join(
-        ["-v {src}:{dest}".format(src=k, dest=v) for k, v in mount.items()])
+        ["-v {src}:{dest}".format(src=k, dest=v.replace("~/", "/root/")) for k, v in mount.items()])
 
     # for click, used in ray cli
     env_vars = {"LC_ALL": "C.UTF-8", "LANG": "C.UTF-8"}

--- a/python/ray/autoscaler/docker.py
+++ b/python/ray/autoscaler/docker.py
@@ -94,8 +94,10 @@ def docker_start_cmds(user, image, mount, cname, user_options):
         for port in ["6379", "8076", "4321"]
     ])
     # TODO(ilr) Move away from defaulting to /root/
-    mount_flags = " ".join(
-        ["-v {src}:{dest}".format(src=k, dest=v.replace("~/", "/root/")) for k, v in mount.items()])
+    mount_flags = " ".join([
+        "-v {src}:{dest}".format(src=k, dest=v.replace("~/", "/root/"))
+        for k, v in mount.items()
+    ])
 
     # for click, used in ray cli
     env_vars = {"LC_ALL": "C.UTF-8", "LANG": "C.UTF-8"}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
* Fixes filesyncs for docker when a `~` is used. (Docker can not bind mount to a relative path)
* Allows `rsync` to/from `/root` locations. These are fine inside a container because root is used, but are not okay on the host.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
