### PR TITLE
[Placement Group]Optimize placement group strict pack strategy

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -22,10 +22,10 @@ namespace ray {
 namespace gcs {
 
 bool GcsNodeResource::IsSubset(
-    const std::unordered_map<std::string, double> &request_resources) const {
-  for (const auto &request_resource : request_resources) {
-    auto iter = resources_available_.find(request_resource.first);
-    if (iter == resources_available_.end() || iter->second < request_resource.second) {
+    const std::unordered_map<std::string, double> &required_resources) const {
+  for (const auto &required_resource : required_resources) {
+    auto iter = resources_available_.find(required_resource.first);
+    if (iter == resources_available_.end() || iter->second < required_resource.second) {
       return false;
     }
   }

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -21,18 +21,6 @@
 namespace ray {
 namespace gcs {
 
-bool GcsNodeResource::IsSubset(
-    const std::unordered_map<std::string, double> &required_resources) const {
-  for (const auto &required_resource : required_resources) {
-    auto iter = resources_available_.find(required_resource.first);
-    if (iter == resources_available_.end() || iter->second < required_resource.second) {
-      return false;
-    }
-  }
-  return true;
-}
-
-//////////////////////////////////////////////////////////////////////////////////////////
 GcsNodeManager::NodeFailureDetector::NodeFailureDetector(
     boost::asio::io_service &io_service,
     std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
@@ -470,16 +458,11 @@ void GcsNodeManager::StartNodeFailureDetector() {
 void GcsNodeManager::UpdateNodeRealtimeResources(
     const ClientID &node_id, const rpc::HeartbeatTableData &heartbeat) {
   auto resources_available = MapFromProtobuf(heartbeat.resources_available());
-  auto iter = cluster_realtime_resources_.find(node_id);
-  if (iter != cluster_realtime_resources_.end()) {
-    iter->second->resources_available_ = resources_available;
-  } else {
-    cluster_realtime_resources_[node_id] =
-        std::make_shared<GcsNodeResource>(resources_available);
-  }
+  cluster_realtime_resources_[node_id] =
+      std::make_shared<ResourceSet>(resources_available);
 }
 
-const absl::flat_hash_map<ClientID, std::shared_ptr<GcsNodeResource>>
+const absl::flat_hash_map<ClientID, std::shared_ptr<ResourceSet>>
     &GcsNodeManager::GetClusterRealtimeResources() const {
   return cluster_realtime_resources_;
 }

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -73,6 +73,10 @@ void GcsNodeManager::NodeFailureDetector::HandleHeartbeat(
       heartbeat_data.resource_load_size() > 0) {
     heartbeat_buffer_[node_id] = heartbeat_data;
   }
+
+  if (heartbeat_listener_) {
+    heartbeat_listener_(heartbeat_data);
+  }
 }
 
 /// A periodic timer that checks for timed out clients.

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -73,10 +73,6 @@ void GcsNodeManager::NodeFailureDetector::HandleHeartbeat(
       heartbeat_data.resource_load_size() > 0) {
     heartbeat_buffer_[node_id] = heartbeat_data;
   }
-
-  if (heartbeat_listener_) {
-    heartbeat_listener_(heartbeat_data);
-  }
 }
 
 /// A periodic timer that checks for timed out clients.

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -27,18 +27,6 @@
 namespace ray {
 namespace gcs {
 
-/// Node resource information.
-class GcsNodeResource {
- public:
-  explicit GcsNodeResource(std::unordered_map<std::string, double> resources_available)
-      : resources_available_(std::move(resources_available)) {}
-
-  bool IsSubset(const std::unordered_map<std::string, double> &required_resources) const;
-
-  /// Dynamic resource capacity.
-  std::unordered_map<std::string, double> resources_available_;
-};
-
 /// GcsNodeManager is responsible for managing and monitoring nodes as well as handing
 /// node and resource related rpc requests.
 /// This class is not thread-safe.
@@ -160,7 +148,7 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
                                    const rpc::HeartbeatTableData &heartbeat);
 
   /// Get cluster realtime resources.
-  const absl::flat_hash_map<ClientID, std::shared_ptr<GcsNodeResource>>
+  const absl::flat_hash_map<ClientID, std::shared_ptr<ResourceSet>>
       &GetClusterRealtimeResources() const;
 
  protected:
@@ -260,8 +248,7 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// Storage for GCS tables.
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
   /// Cluster realtime resources.
-  absl::flat_hash_map<ClientID, std::shared_ptr<GcsNodeResource>>
-      cluster_realtime_resources_;
+  absl::flat_hash_map<ClientID, std::shared_ptr<ResourceSet>> cluster_realtime_resources_;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -198,14 +198,6 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
     void HandleHeartbeat(const ClientID &node_id,
                          const rpc::HeartbeatTableData &heartbeat_data);
 
-    /// Add listener to monitor the heartbeat of nodes.
-    ///
-    /// \param listener The handler which process the add of nodes.
-    void AddHeartbeatListener(
-        std::function<void(const rpc::HeartbeatTableData &heartbeat_data)> listener) {
-      heartbeat_listener_ = std::move(listener);
-    }
-
    protected:
     /// A periodic timer that fires on every heartbeat period. Raylets that have
     /// not sent a heartbeat within the last num_heartbeats_timeout ticks will be
@@ -242,9 +234,6 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
     std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub_;
     /// Is the detect started.
     bool is_started_ = false;
-    /// Listener which monitor the heartbeat of nodes.
-    std::function<void(const rpc::HeartbeatTableData &heartbeat_data)>
-        heartbeat_listener_;
   };
 
  private:

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -33,7 +33,7 @@ class GcsNodeResource {
   explicit GcsNodeResource(std::unordered_map<std::string, double> resources_available)
       : resources_available_(std::move(resources_available)) {}
 
-  bool IsSubset(const std::unordered_map<std::string, double> &request_resources) const;
+  bool IsSubset(const std::unordered_map<std::string, double> &required_resources) const;
 
   /// Dynamic resource capacity.
   std::unordered_map<std::string, double> resources_available_;

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -198,6 +198,14 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
     void HandleHeartbeat(const ClientID &node_id,
                          const rpc::HeartbeatTableData &heartbeat_data);
 
+    /// Add listener to monitor the heartbeat of nodes.
+    ///
+    /// \param listener The handler which process the add of nodes.
+    void AddHeartbeatListener(
+        std::function<void(const rpc::HeartbeatTableData &heartbeat_data)> listener) {
+      heartbeat_listener_ = std::move(listener);
+    }
+
    protected:
     /// A periodic timer that fires on every heartbeat period. Raylets that have
     /// not sent a heartbeat within the last num_heartbeats_timeout ticks will be
@@ -234,6 +242,9 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
     std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub_;
     /// Is the detect started.
     bool is_started_ = false;
+    /// Listener which monitor the heartbeat of nodes.
+    std::function<void(const rpc::HeartbeatTableData &heartbeat_data)>
+        heartbeat_listener_;
   };
 
  private:

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -14,8 +14,6 @@
 
 #include "ray/gcs/gcs_server/gcs_placement_group_manager.h"
 
-#include <utility>
-
 #include "ray/common/ray_config.h"
 #include "ray/gcs/pb_util.h"
 #include "ray/util/asio_util.h"

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -14,6 +14,8 @@
 
 #include "ray/gcs/gcs_server/gcs_placement_group_manager.h"
 
+#include <utility>
+
 #include "ray/common/ray_config.h"
 #include "ray/gcs/pb_util.h"
 #include "ray/util/asio_util.h"

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -38,12 +38,22 @@ GcsPlacementGroupScheduler::GcsPlacementGroupScheduler(
 /// and don't care the real resource.
 ScheduleMap GcsPackStrategy::Schedule(
     std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
-    const GcsNodeManager &node_manager) {
+    const std::shared_ptr<ScheduleContext> &context) {
   ScheduleMap schedule_map;
-  auto &alive_nodes = node_manager.GetAllAliveNodes();
+  const auto &alive_nodes = context->node_to_bundles_;
+
+  // Select the node with the least number of bundles.
+  std::vector<const std::pair<int64_t, ClientID>> order;
+  for (auto &it : *alive_nodes) {
+    order.emplace_back(it.second, it.first);
+  }
+  std::sort(
+      std::begin(order), std::end(order),
+      [](const std::pair<int64_t, ClientID> &left,
+         const std::pair<int64_t, ClientID> &right) { return left.first > right.first; });
+
   for (auto &bundle : bundles) {
-    schedule_map[bundle->BundleId()] =
-        ClientID::FromBinary(alive_nodes.begin()->second->node_id());
+    schedule_map[bundle->BundleId()] = order.front().second;
   }
   return schedule_map;
 }
@@ -53,19 +63,18 @@ ScheduleMap GcsPackStrategy::Schedule(
 /// and don't care the real resource.
 ScheduleMap GcsSpreadStrategy::Schedule(
     std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
-    const GcsNodeManager &node_manager) {
+    const std::shared_ptr<ScheduleContext> &context) {
   ScheduleMap schedule_map;
-  auto &alive_nodes = node_manager.GetAllAliveNodes();
-  auto iter = alive_nodes.begin();
+  auto &alive_nodes = context->node_to_bundles_;
+  auto iter = alive_nodes->begin();
   size_t index = 0;
-  size_t alive_nodes_size = alive_nodes.size();
-  for (; iter != alive_nodes.end(); iter++, index++) {
+  size_t alive_nodes_size = alive_nodes->size();
+  for (; iter != alive_nodes->end(); iter++, index++) {
     for (size_t base = 0;; base++) {
       if (index + base * alive_nodes_size >= bundles.size()) {
         break;
       } else {
-        schedule_map[bundles[index + base * alive_nodes_size]->BundleId()] =
-            ClientID::FromBinary(iter->second->node_id());
+        schedule_map[bundles[index + base * alive_nodes_size]->BundleId()] = iter->first;
       }
     }
   }
@@ -79,8 +88,8 @@ void GcsPlacementGroupScheduler::Schedule(
   RAY_LOG(INFO) << "Scheduling placement group " << placement_group->GetName();
   auto bundles = placement_group->GetBundles();
   auto strategy = placement_group->GetStrategy();
-  auto selected_nodes =
-      scheduler_strategies_[strategy]->Schedule(bundles, gcs_node_manager_);
+  auto selected_nodes = scheduler_strategies_[strategy]->Schedule(
+      bundles, GetScheduleContext(placement_group->GetPlacementGroupID()));
 
   // If no nodes are available, scheduling fails.
   if (selected_nodes.empty()) {
@@ -120,13 +129,23 @@ void GcsPlacementGroupScheduler::Schedule(
                 data.mutable_schedule_plan()->insert(
                     {key, (*bundle_locations)[iter->BundleId()].first.Binary()});
               }
+
+              // Update `node_to_leased_bundles_` and `bundle_locations_`.
+              for (const auto &iter : *bundle_locations) {
+                const auto &location = iter.second;
+                node_to_leased_bundles_[location.first].insert(location.second);
+                placement_group_bundle_locations_[placement_group->GetPlacementGroupID()]
+                                                 [location.second->Index()] =
+                                                     location.first;
+              }
+
               RAY_CHECK_OK(gcs_table_storage_->PlacementGroupScheduleTable().Put(
                   placement_group->GetPlacementGroupID(), data,
                   [schedule_success_handler, placement_group](Status status) {
                     schedule_success_handler(placement_group);
                   }));
             } else {
-              for (auto &iter : *bundle_locations) {
+              for (const auto &iter : *bundle_locations) {
                 CancelResourceReserve(iter.second.second,
                                       gcs_node_manager_.GetNode(node_id));
               }
@@ -203,6 +222,16 @@ GcsPlacementGroupScheduler::GetOrConnectLeaseClient(const rpc::Address &raylet_a
     iter = remote_lease_clients_.emplace(node_id, std::move(lease_client)).first;
   }
   return iter->second;
+}
+
+std::shared_ptr<ScheduleContext> GcsPlacementGroupScheduler::GetScheduleContext(
+    const PlacementGroupID &placement_group_id) {
+  auto node_to_bundles = std::make_shared<absl::flat_hash_map<ClientID, int64_t>>();
+  for (const auto &iter : node_to_leased_bundles_) {
+    node_to_bundles->emplace(iter.first, iter.second.size());
+  }
+  return std::make_shared<ScheduleContext>(
+      node_to_bundles, placement_group_bundle_locations_[placement_group_id]);
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -235,12 +235,7 @@ std::shared_ptr<ScheduleContext> GcsPlacementGroupScheduler::GetScheduleContext(
     }
   }
 
-  auto node_to_bundles = std::make_shared<absl::flat_hash_map<ClientID, int64_t>>();
-  for (const auto &iter : node_to_leased_bundles_) {
-    node_to_bundles->emplace(iter.first, iter.second.size());
-  }
-  return std::make_shared<ScheduleContext>(
-      node_to_bundles, placement_group_bundle_locations_[placement_group_id]);
+  return std::make_shared<ScheduleContext>(placement_group_bundle_locations_[placement_group_id]);
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -42,14 +42,10 @@ ScheduleMap GcsPackStrategy::Schedule(
     std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
     const std::unique_ptr<ScheduleContext> &context) {
   // Aggregate required resources.
-  std::unordered_map<std::string, double> bundle_resources;
+  ResourceSet required_resources;
   for (const auto &bundle : bundles) {
-    const auto &resources = bundle->GetRequiredResources().GetResourceMap();
-    for (const auto &iter : resources) {
-      bundle_resources[iter.first] += iter.second;
-    }
+    required_resources.AddResources(bundle->GetRequiredResources());
   }
-  ResourceSet required_resources(bundle_resources);
 
   // Filter candidate nodes.
   const auto &alive_nodes = context->node_manager_.GetClusterRealtimeResources();

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -40,7 +40,7 @@ GcsPlacementGroupScheduler::GcsPlacementGroupScheduler(
 /// it in the next pr.
 ScheduleMap GcsPackStrategy::Schedule(
     std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
-    const std::shared_ptr<ScheduleContext> &context) {
+    const std::unique_ptr<ScheduleContext> &context) {
   // Aggregate required resources.
   std::unordered_map<std::string, double> required_resources;
   for (const auto &bundle : bundles) {
@@ -81,7 +81,7 @@ ScheduleMap GcsPackStrategy::Schedule(
 /// and don't care the real resource.
 ScheduleMap GcsSpreadStrategy::Schedule(
     std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
-    const std::shared_ptr<ScheduleContext> &context) {
+    const std::unique_ptr<ScheduleContext> &context) {
   ScheduleMap schedule_map;
   auto &alive_nodes = context->node_manager_.GetClusterRealtimeResources();
   auto iter = alive_nodes.begin();
@@ -238,7 +238,7 @@ GcsPlacementGroupScheduler::GetOrConnectLeaseClient(const rpc::Address &raylet_a
   return iter->second;
 }
 
-std::shared_ptr<ScheduleContext> GcsPlacementGroupScheduler::GetScheduleContext() {
+std::unique_ptr<ScheduleContext> GcsPlacementGroupScheduler::GetScheduleContext() {
   // TODO(ffbin): We will add listener to the GCS node manager to handle node deletion.
   auto &alive_nodes = gcs_node_manager_.GetAllAliveNodes();
   for (const auto &iter : alive_nodes) {
@@ -252,7 +252,7 @@ std::shared_ptr<ScheduleContext> GcsPlacementGroupScheduler::GetScheduleContext(
   for (const auto &iter : node_to_leased_bundles_) {
     node_to_bundles->emplace(iter.first, iter.second.size());
   }
-  return std::make_shared<ScheduleContext>(node_to_bundles, gcs_node_manager_);
+  return std::unique_ptr<ScheduleContext>(new ScheduleContext(node_to_bundles, gcs_node_manager_));
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -155,8 +155,9 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   absl::flat_hash_map<ClientID, absl::flat_hash_set<BundleID>>
       node_to_bundles_when_leasing_;
 
-  /// Map from node ID to the set of bundles.
-  absl::flat_hash_map<ClientID, absl::flat_hash_set<std::shared_ptr<BundleSpecification>>>
+  /// Map from node ID to the set of bundles. This is needed so that we can reschedule
+  /// bundles when a node is dead.
+  absl::flat_hash_map<ClientID, std::vector<std::shared_ptr<BundleSpecification>>>
       node_to_leased_bundles_;
   absl::flat_hash_map<PlacementGroupID, absl::flat_hash_map<int64_t, ClientID>>
       placement_group_bundle_locations_;

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -56,13 +56,9 @@ class GcsPlacementGroupSchedulerInterface {
 
 class ScheduleContext {
  public:
-  ScheduleContext(std::shared_ptr<absl::flat_hash_map<ClientID, int64_t>> node_to_bundles,
-                  const absl::flat_hash_map<int64_t, ClientID> &bundle_locations)
-      : node_to_bundles_(std::move(node_to_bundles)),
-        bundle_locations_(bundle_locations) {}
+  ScheduleContext(const absl::flat_hash_map<int64_t, ClientID> &bundle_locations)
+      : bundle_locations_(bundle_locations) {}
 
-  // Key is node id, value is the number of bundles on the node.
-  std::shared_ptr<absl::flat_hash_map<ClientID, int64_t>> node_to_bundles_;
   // Distribution of bundles in nodes. Key is bundle index, value is node id.
   const absl::flat_hash_map<int64_t, ClientID> &bundle_locations_;
 };

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -13,9 +13,6 @@
 // limitations under the License.
 #pragma once
 
-#include <queue>
-#include <tuple>
-
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "ray/common/id.h"

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -71,19 +71,19 @@ class GcsScheduleStrategy {
   virtual ~GcsScheduleStrategy() {}
   virtual ScheduleMap Schedule(
       std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
-      const std::shared_ptr<ScheduleContext> &context) = 0;
+      const std::unique_ptr<ScheduleContext> &context) = 0;
 };
 
 class GcsPackStrategy : public GcsScheduleStrategy {
  public:
   ScheduleMap Schedule(std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
-                       const std::shared_ptr<ScheduleContext> &context) override;
+                       const std::unique_ptr<ScheduleContext> &context) override;
 };
 
 class GcsSpreadStrategy : public GcsScheduleStrategy {
  public:
   ScheduleMap Schedule(std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
-                       const std::shared_ptr<ScheduleContext> &context) override;
+                       const std::unique_ptr<ScheduleContext> &context) override;
 };
 
 /// GcsPlacementGroupScheduler is responsible for scheduling placement_groups registered
@@ -134,7 +134,7 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
       const rpc::Address &raylet_address);
 
   /// Generate schedule conetext.
-  std::shared_ptr<ScheduleContext> GetScheduleContext();
+  std::unique_ptr<ScheduleContext> GetScheduleContext();
 
   /// A timer that ticks every cancel resource failure milliseconds.
   boost::asio::deadline_timer return_timer_;

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -30,6 +30,7 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     }));
 
     raylet_client_ = std::make_shared<GcsServerMocker::MockRayletResourceClient>();
+    raylet_client1_ = std::make_shared<GcsServerMocker::MockRayletResourceClient>();
     gcs_table_storage_ = std::make_shared<gcs::InMemoryGcsTableStorage>(io_service_);
     gcs_pub_sub_ = std::make_shared<GcsServerMocker::MockGcsPubSub>(redis_client_);
     gcs_node_manager_ = std::make_shared<gcs::GcsNodeManager>(
@@ -40,7 +41,13 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
         std::make_shared<GcsServerMocker::MockedGcsPlacementGroupScheduler>(
             io_service_, gcs_table_storage_, *gcs_node_manager_,
             /*lease_client_fplacement_groupy=*/
-            [this](const rpc::Address &address) { return raylet_client_; });
+            [this](const rpc::Address &address) {
+              if (0 == address.port()) {
+                return raylet_client_;
+              } else {
+                return raylet_client1_;
+              }
+            });
   }
 
   void TearDown() override {
@@ -65,6 +72,7 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
   std::shared_ptr<gcs::StoreClient> store_client_;
 
   std::shared_ptr<GcsServerMocker::MockRayletResourceClient> raylet_client_;
+  std::shared_ptr<GcsServerMocker::MockRayletResourceClient> raylet_client1_;
   std::shared_ptr<gcs::GcsNodeManager> gcs_node_manager_;
   std::shared_ptr<GcsServerMocker::MockedGcsPlacementGroupScheduler>
       gcs_placement_group_scheduler_;
@@ -196,6 +204,46 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestSchedulePlacementGroupReturnResource)
   WaitPendingDone(failure_placement_groups_, 1);
   WaitPendingDone(success_placement_groups_, 0);
   ASSERT_EQ(placement_group, failure_placement_groups_.front());
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest, TestScheduleWithPackStrategy) {
+  gcs_node_manager_->AddNode(Mocker::GenNodeInfo(0));
+  gcs_node_manager_->AddNode(Mocker::GenNodeInfo(1));
+  ASSERT_EQ(2, gcs_node_manager_->GetAllAliveNodes().size());
+
+  auto failure_handler = [this](std::shared_ptr<gcs::GcsPlacementGroup> placement_group) {
+    absl::MutexLock lock(&vector_mutex_);
+    failure_placement_groups_.emplace_back(std::move(placement_group));
+  };
+  auto success_handler = [this](std::shared_ptr<gcs::GcsPlacementGroup> placement_group) {
+    absl::MutexLock lock(&vector_mutex_);
+    success_placement_groups_.emplace_back(std::move(placement_group));
+  };
+
+  // Schedule placement group, it will be evenly distributed over the two nodes.
+  int select_node0_count = 0;
+  int select_node1_count = 0;
+  for (int index = 0; index < 10; ++index) {
+    auto create_placement_group_request =
+        Mocker::GenCreatePlacementGroupRequest("", rpc::PlacementStrategy::PACK);
+    auto placement_group =
+        std::make_shared<gcs::GcsPlacementGroup>(create_placement_group_request);
+    gcs_placement_group_scheduler_->Schedule(placement_group, failure_handler,
+                                             success_handler);
+
+    if (!raylet_client_->lease_callbacks.empty()) {
+      ASSERT_TRUE(raylet_client_->GrantResourceReserve());
+      ASSERT_TRUE(raylet_client_->GrantResourceReserve());
+      ++select_node0_count;
+    } else {
+      ASSERT_TRUE(raylet_client1_->GrantResourceReserve());
+      ASSERT_TRUE(raylet_client1_->GrantResourceReserve());
+      ++select_node1_count;
+    }
+  }
+  WaitPendingDone(success_placement_groups_, 10);
+  ASSERT_EQ(select_node0_count, 5);
+  ASSERT_EQ(select_node1_count, 5);
 }
 
 }  // namespace ray

--- a/src/ray/gcs/test/gcs_test_util.h
+++ b/src/ray/gcs/test/gcs_test_util.h
@@ -89,10 +89,10 @@ struct Mocker {
   }
 
   static rpc::CreatePlacementGroupRequest GenCreatePlacementGroupRequest(
-      const std::string name = "") {
+      const std::string name = "",
+      rpc::PlacementStrategy strategy = rpc::PlacementStrategy::SPREAD) {
     rpc::CreatePlacementGroupRequest request;
     std::vector<std::unordered_map<std::string, double>> bundles;
-    rpc::PlacementStrategy strategy = rpc::PlacementStrategy::SPREAD;
     std::unordered_map<std::string, double> bundle;
     bundle["CPU"] = 1.0;
     bundles.push_back(bundle);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Problem:
At present, the pack strategy always selects the first node, which will cause placement group creation failure.
Solution:
Choose node that satisfies the resource requirement and has the least number of bundles.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/9895
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
