### PR TITLE
fix gcs table get all nodes npe

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/gcs/GcsClient.java
+++ b/java/runtime/src/main/java/io/ray/runtime/gcs/GcsClient.java
@@ -68,19 +68,12 @@ public class GcsClient {
       final UniqueId nodeId = UniqueId
           .fromByteBuffer(data.getNodeId().asReadOnlyByteBuffer());
 
-      if (data.getState() == GcsNodeInfo.GcsNodeState.ALIVE) {
-        //Code path of node insertion.
-        NodeInfo nodeInfo = new NodeInfo(
-            nodeId, data.getNodeManagerAddress(),
-            data.getNodeManagerHostname(),
-            true, new HashMap<>());
-        nodes.put(nodeId, nodeInfo);
-      } else {
-        // Code path of node deletion.
-        NodeInfo nodeInfo = new NodeInfo(nodeId, nodes.get(nodeId).nodeAddress,
-            nodes.get(nodeId).nodeHostname, false, new HashMap<>());
-        nodes.put(nodeId, nodeInfo);
-      }
+      // NOTE(lingxuan.zlx): we assume no duplicated node id in fetched node list
+      // and it's only one final state for each node in recorded table.
+      NodeInfo nodeInfo = new NodeInfo(
+          nodeId, data.getNodeManagerAddress(), data.getNodeManagerHostname(),
+          data.getState() == GcsNodeInfo.GcsNodeState.ALIVE, new HashMap<>());
+      nodes.put(nodeId, nodeInfo);
     }
 
     // Fill resources.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
GcsAllNodeInfo will throw exception when node is dead, so we can not assume node id exist in created node map and all state nodes should be unified in one code path.
```json
[ {'NodeID': 'cbe06de143783c289223071cfde58aef2811c9f3',
  'Alive': False,
  'NodeManagerAddress': '11.159.250.23',
  'NodeManagerHostname': 'arconkube-40-011159250023',
  'NodeManagerPort': 19999,
  'ObjectManagerPort': 41577,
  'ObjectStoreSocketName': '/home/admin/ray-pack/tmp/sockets/plasma_store',
  'RayletSocketName': '/home/admin/ray-pack/tmp/sockets/raylet',
  'RayletHttpPort': 37833,
  'alive': False,
  'Resources': {}}]
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
