### PR TITLE
[Dashboard] Fix Bug in Machine View when Unsorted with Multiple Machines

### DIFF
--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
@@ -70,7 +70,7 @@ const makeGroupedTableContents = (
   rayletInfo: RayletInfoResponse | null,
   nodeInfoFeatures: NodeInfoFeature[],
 ) => {
-  const sortedGroups = stableSort(nodes, sortGroupComparator);
+  const sortedGroups = sortGroupComparator ? stableSort(nodes, sortGroupComparator) : nodes;
   return sortedGroups.map((node) => {
     const workerFeatureData: WorkerFeatureData[] = node.workers.map(
       (worker) => {
@@ -183,7 +183,6 @@ const NodeInfo: React.FC<{}> = () => {
   const [orderBy, setOrderBy] = React.useState<nodeInfoColumnId | null>(null);
   const classes = useNodeInfoStyles();
   const { nodeInfo, rayletInfo } = useSelector(nodeInfoSelector);
-
   if (nodeInfo === null || rayletInfo === null) {
     return <Typography color="textSecondary">Loading...</Typography>;
   }

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
@@ -70,7 +70,9 @@ const makeGroupedTableContents = (
   rayletInfo: RayletInfoResponse | null,
   nodeInfoFeatures: NodeInfoFeature[],
 ) => {
-  const sortedGroups = sortGroupComparator ? stableSort(nodes, sortGroupComparator) : nodes;
+  const sortedGroups = sortGroupComparator
+    ? stableSort(nodes, sortGroupComparator)
+    : nodes;
   return sortedGroups.map((node) => {
     const workerFeatureData: WorkerFeatureData[] = node.workers.map(
       (worker) => {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
These changes are needed because the machine view crashes when there are multiple nodes in a cluster, and there is no column chosen by which to sort. This happens because we attempt to sort with a comparator function that is undefined.

Specifically, the following criteria being met causes NodeInfo to fail to render:
1. orderBy === null
2. more than one node in the cluster
3. isGrouped === True

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested (please justify below)
