### PR TITLE
[Autoscaler] Run resource demand scheduler in CI

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -98,8 +98,7 @@ class StandardAutoscaler:
                 queue=self.launch_queue,
                 index=i,
                 pending=self.pending_launches,
-                node_resource_mapping=self.node_resource_mapping
-            )
+                node_resource_mapping=self.node_resource_mapping)
             node_launcher.daemon = True
             node_launcher.start()
 
@@ -244,8 +243,8 @@ class StandardAutoscaler:
         # problems. They should at a minimum be spawned as daemon threads.
         # See https://github.com/ray-project/ray/pull/5903 for more info.
         T = []
-        for node_id, commands, ray_start, node_resources in (self.should_update(node_id)
-                                             for node_id in nodes):
+        for node_id, commands, ray_start, node_resources in (
+                self.should_update(node_id) for node_id in nodes):
             if node_id is not None:
                 T.append(
                     threading.Thread(
@@ -403,7 +402,8 @@ class StandardAutoscaler:
 
         return (node_id, init_commands, ray_commands, resources)
 
-    def spawn_updater(self, node_id, init_commands, ray_start_commands, node_resources):
+    def spawn_updater(self, node_id, init_commands, ray_start_commands,
+                      node_resources):
         updater = NodeUpdaterThread(
             node_id=node_id,
             provider_config=self.config["provider"],

--- a/python/ray/autoscaler/aws/example-auto-instance-type.yaml
+++ b/python/ray/autoscaler/aws/example-auto-instance-type.yaml
@@ -17,10 +17,10 @@ available_instance_types:
         resources: {"CPU": 4}
         max_workers: 10
     m4.4xlarge:
-        resources: {"CPU": 16}
+        resources: {"CPU": 16, "Custom1": 1}
         max_workers: 10
     p2.xlarge:
-        resources: {"CPU": 4, "GPU": 1}
+        resources: {"CPU": 4, "GPU": 1, "Custom2": 2}
         max_workers: 4
     p2.8xlarge:
         resources: {"CPU": 32, "GPU": 8}

--- a/python/ray/autoscaler/command_runner.py
+++ b/python/ray/autoscaler/command_runner.py
@@ -41,6 +41,7 @@ class ProcessRunnerError(Exception):
 
         self.message_discovered = message_discovered
 
+
 def _with_environment_variables(cmd, environment_variables):
     def dict_as_one_line_yaml(d):
         items = []
@@ -48,15 +49,17 @@ def _with_environment_variables(cmd, environment_variables):
             item_str = "{}:{}".format(quote(key), quote(val))
             items.append(item_str)
 
-        return "{%s}" % ','.join(items)
+        return "{%s}" % ",".join(items)
+
     as_strings = []
     for key, val in environment_variables.items():
         if isinstance(val, dict):
             val = dict_as_one_line_yaml(val)
         s = "{}={};".format(key, quote(val))
         as_strings.append(s)
-    all_vars = ''.join(as_strings)
+    all_vars = "".join(as_strings)
     return all_vars + cmd
+
 
 def _with_interactive(cmd):
     force_interactive = ("true && source ~/.bashrc && "

--- a/python/ray/autoscaler/node_launcher.py
+++ b/python/ray/autoscaler/node_launcher.py
@@ -13,7 +13,14 @@ logger = logging.getLogger(__name__)
 class NodeLauncher(threading.Thread):
     """Launches nodes asynchronously in the background."""
 
-    def __init__(self, provider, queue, pending, index=None, node_resource_mapping=None, *args, **kwargs):
+    def __init__(self,
+                 provider,
+                 queue,
+                 pending,
+                 index=None,
+                 node_resource_mapping=None,
+                 *args,
+                 **kwargs):
         self.queue = queue
         self.pending = pending
         self.provider = provider
@@ -25,15 +32,16 @@ class NodeLauncher(threading.Thread):
         instance_type = self.provider.get_instance_type(node_config)
         worker_filter = {TAG_RAY_NODE_TYPE: NODE_TYPE_WORKER}
         before = self.provider.non_terminated_nodes(tag_filters=worker_filter)
-        launch_hash = hash_launch_conf(autoscaler_config["worker_nodes"], autoscaler_config["auth"])
+        launch_hash = hash_launch_conf(autoscaler_config["worker_nodes"],
+                                       autoscaler_config["auth"])
         self.log("Launching {} nodes, type {}.".format(count, instance_type))
         node_tags = {
-            TAG_RAY_NODE_NAME: "ray-{}-worker".format(autoscaler_config["cluster_name"]),
+            TAG_RAY_NODE_NAME: "ray-{}-worker".format(
+                autoscaler_config["cluster_name"]),
             TAG_RAY_NODE_TYPE: NODE_TYPE_WORKER,
             TAG_RAY_NODE_STATUS: STATUS_UNINITIALIZED,
             TAG_RAY_LAUNCH_CONFIG: launch_hash,
         }
-
 
         node_tags[TAG_RAY_INSTANCE_TYPE] = instance_type
         self.provider.create_node(node_config, node_tags, count)

--- a/python/ray/autoscaler/node_launcher.py
+++ b/python/ray/autoscaler/node_launcher.py
@@ -13,38 +13,44 @@ logger = logging.getLogger(__name__)
 class NodeLauncher(threading.Thread):
     """Launches nodes asynchronously in the background."""
 
-    def __init__(self, provider, queue, pending, index=None, *args, **kwargs):
+    def __init__(self, provider, queue, pending, index=None, node_resource_mapping=None, *args, **kwargs):
         self.queue = queue
         self.pending = pending
         self.provider = provider
         self.index = str(index) if index is not None else ""
+        self.node_resource_mapping = node_resource_mapping
         super(NodeLauncher, self).__init__(*args, **kwargs)
 
-    def _launch_node(self, config, count, instance_type):
+    def _launch_node(self, autoscaler_config, count, node_config):
+        instance_type = self.provider.get_instance_type(node_config)
         worker_filter = {TAG_RAY_NODE_TYPE: NODE_TYPE_WORKER}
         before = self.provider.non_terminated_nodes(tag_filters=worker_filter)
-        launch_hash = hash_launch_conf(config["worker_nodes"], config["auth"])
+        launch_hash = hash_launch_conf(autoscaler_config["worker_nodes"], autoscaler_config["auth"])
         self.log("Launching {} nodes, type {}.".format(count, instance_type))
-        node_config = config["worker_nodes"]
         node_tags = {
-            TAG_RAY_NODE_NAME: "ray-{}-worker".format(config["cluster_name"]),
+            TAG_RAY_NODE_NAME: "ray-{}-worker".format(autoscaler_config["cluster_name"]),
             TAG_RAY_NODE_TYPE: NODE_TYPE_WORKER,
             TAG_RAY_NODE_STATUS: STATUS_UNINITIALIZED,
             TAG_RAY_LAUNCH_CONFIG: launch_hash,
         }
-        if instance_type:
-            node_tags[TAG_RAY_INSTANCE_TYPE] = instance_type
-            self.provider.create_node_of_type(node_config, node_tags,
-                                              instance_type, count)
-        else:
-            self.provider.create_node(node_config, node_tags, count)
+
+
+        node_tags[TAG_RAY_INSTANCE_TYPE] = instance_type
+        self.provider.create_node(node_config, node_tags, count)
+
         after = self.provider.non_terminated_nodes(tag_filters=worker_filter)
         if set(after).issubset(before):
             self.log("No new nodes reported after node creation.")
+        elif self.node_resource_mapping is not None:
+            new_nodes = set(after) - set(before)
+            resources = node_config.get("resources", None)
+            for node_id in new_nodes:
+                self.node_resource_mapping[node_id] = resources
 
     def run(self):
         while True:
-            config, count, instance_type = self.queue.get()
+            config, count, node_config = self.queue.get()
+            instance_type = self.provider.get_instance_type(node_config)
             self.log("Got {} nodes to launch.".format(count))
             try:
                 self._launch_node(config, count, instance_type)

--- a/python/ray/autoscaler/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/resource_demand_scheduler.py
@@ -107,7 +107,6 @@ class ResourceDemandScheduler:
         logger.info("Instance requests: {}".format(instances))
         return instances
 
-
     def _resolve_defaults(self):
         for instance_name, instance_config in self.instance_types.items():
             instance_config.setdefault("InstanceType", instance_name)

--- a/python/ray/autoscaler/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/resource_demand_scheduler.py
@@ -13,10 +13,10 @@ logger = logging.getLogger(__name__)
 InstanceType = str
 
 # e.g., {"resources": ..., "max_workers": ...}.
-InstanceTypeConfigDict = str
+InstanceTypeConfigDict = dict
 
 # e.g., {"GPU": 1}.
-ResourceDict = str
+ResourceDict = dict
 
 # e.g., IP address of the node.
 NodeID = str
@@ -29,6 +29,7 @@ class ResourceDemandScheduler:
         self.provider = provider
         self.instance_types = instance_types
         self.max_workers = max_workers
+        self._resolve_defaults()
 
     def debug_string(self, nodes: List[NodeID],
                      pending_nodes: Dict[NodeID, int]) -> str:
@@ -105,6 +106,12 @@ class ResourceDemandScheduler:
             self.max_workers - len(nodes), unfulfilled)
         logger.info("Instance requests: {}".format(instances))
         return instances
+
+
+    def _resolve_defaults(self):
+        for instance_name, instance_config in self.instance_types.items():
+            instance_config.setdefault("InstanceType", instance_name)
+            instance_config.setdefault("max_workers", self.max_workers)
 
 
 def get_instances_for(

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -297,11 +297,12 @@ class NodeUpdater:
                     self.log_prefix + "Ray start commands", show_status=True):
                 for cmd in self.ray_start_commands:
                     if self.node_resources:
-                        env_vars = {"RAY_OVERRIDE_RESOURCES": self.node_resources}
+                        env_vars = {
+                            "RAY_OVERRIDE_RESOURCES": self.node_resources
+                        }
                     else:
                         env_vars = {}
                     self.cmd_runner.run(cmd, environment_variables=env_vars)
-
 
     def rsync_up(self, source, target):
         cli_logger.old_info(logger, "{}Syncing {} to {}...", self.log_prefix,

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -34,6 +34,7 @@ class NodeUpdater:
                  initialization_commands,
                  setup_commands,
                  ray_start_commands,
+                 node_resources,
                  runtime_hash,
                  file_mounts_contents_hash,
                  cluster_synced_files=None,
@@ -59,6 +60,7 @@ class NodeUpdater:
         self.initialization_commands = initialization_commands
         self.setup_commands = setup_commands
         self.ray_start_commands = ray_start_commands
+        self.node_resources = node_resources
         self.runtime_hash = runtime_hash
         self.file_mounts_contents_hash = file_mounts_contents_hash
         self.cluster_synced_files = cluster_synced_files
@@ -294,7 +296,12 @@ class NodeUpdater:
             with LogTimer(
                     self.log_prefix + "Ray start commands", show_status=True):
                 for cmd in self.ray_start_commands:
-                    self.cmd_runner.run(cmd)
+                    if self.node_resources:
+                        env_vars = {"RAY_OVERRIDE_RESOURCES": self.node_resources}
+                    else:
+                        env_vars = {}
+                    self.cmd_runner.run(cmd, environment_variables=env_vars)
+
 
     def rsync_up(self, source, target):
         cli_logger.old_info(logger, "{}Syncing {} to {}...", self.log_prefix,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Autoscaler's resource demand scheduler naturally fell a little out of sync because it isn't hooked up to the CI. This fixes that. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
