### PR TITLE
[serve] Add min and max limits to autoscaling

### DIFF
--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -137,7 +137,9 @@ class ReplicaConfig:
             raise ValueError("Specifying max_restarts in "
                              "actor_init_args is not allowed.")
         else:
-            num_cpus = self.ray_actor_options.get("num_cpus", 1)
+            if "num_cpus" not in self.ray_actor_options:
+                self.ray_actor_options["num_cpus"] = 1
+            num_cpus = self.ray_actor_options["num_cpus"]
             if not isinstance(num_cpus, (int, float)):
                 raise TypeError(
                     "num_cpus in ray_actor_options must be an int or a float.")

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -137,6 +137,7 @@ class ReplicaConfig:
             raise ValueError("Specifying max_restarts in "
                              "actor_init_args is not allowed.")
         else:
+            # Ray defaults to zero CPUs for placement, we default to one here.
             if "num_cpus" not in self.ray_actor_options:
                 self.ray_actor_options["num_cpus"] = 1
             num_cpus = self.ray_actor_options["num_cpus"]

--- a/python/ray/serve/examples/doc/snippet_model_composition.py
+++ b/python/ray/serve/examples/doc/snippet_model_composition.py
@@ -1,7 +1,9 @@
 from random import random
 import requests
+import ray
 from ray import serve
 
+ray.init(num_cpus=10)
 serve.init()
 
 # Our pipeline will be structured as follows:

--- a/python/ray/serve/examples/doc/tutorial_batch.py
+++ b/python/ray/serve/examples/doc/tutorial_batch.py
@@ -29,6 +29,7 @@ def batch_adder_v0(flask_requests: List):
 # __doc_define_servable_v0_end__
 
 # __doc_deploy_begin__
+ray.init(num_cpus=10)
 serve.init()
 serve.create_backend("adder:v0", batch_adder_v0, config={"max_batch_size": 4})
 serve.create_endpoint(

--- a/python/ray/serve/examples/echo_full.py
+++ b/python/ray/serve/examples/echo_full.py
@@ -7,7 +7,7 @@ import ray.serve as serve
 from ray.serve.metric import PrometheusExporter
 
 # initialize ray serve system.
-serve.init(metric_exporter=PrometheusExporter)
+serve.init(num_cpus=10, metric_exporter=PrometheusExporter)
 
 
 # a backend can be a function or class.

--- a/python/ray/serve/examples/echo_full.py
+++ b/python/ray/serve/examples/echo_full.py
@@ -7,7 +7,8 @@ import ray.serve as serve
 from ray.serve.metric import PrometheusExporter
 
 # initialize ray serve system.
-serve.init(num_cpus=10, metric_exporter=PrometheusExporter)
+ray.init(num_cpus=10)
+serve.init(metric_exporter=PrometheusExporter)
 
 
 # a backend can be a function or class.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Adds a min replicas and max replicas to the autoscaling policy. Also fixes it so that we actually default to 1 CPU for replicas.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
