### PR TITLE
Fix bug in Logical View when required_resources not present

### DIFF
--- a/python/ray/dashboard/client/src/api.ts
+++ b/python/ray/dashboard/client/src/api.ts
@@ -189,7 +189,7 @@ export type FullActorInfo = {
 export type PartialActorInfo = {
   actorId: string;
   actorTitle: string;
-  requiredResources: { [key: string]: number };
+  requiredResources?: { [key: string]: number };
   state: ActorState.Invalid;
   invalidStateType?: InvalidStateType;
 };

--- a/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
@@ -192,6 +192,7 @@ class Actor extends React.Component<Props & WithStyles<typeof styles>, State> {
           {
             label: "Required resources",
             value:
+              actor.requiredResources &&
               Object.entries(actor.requiredResources).length > 0 &&
               Object.entries(actor.requiredResources)
                 .sort((a, b) => a[0].localeCompare(b[0]))


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
The logical view assumes that, for each actor, the required resources field will always be present (albeit it may be an empty object), but it turns out the field is sometimes not included in the payload. This leads to the page crashing trying to render an actor when that value is not present.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested (please justify below)
