### PR TITLE
Dashboard Bugfix: Windows directory structure crashes machine view

### DIFF
--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/features/Disk.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/features/Disk.tsx
@@ -15,8 +15,10 @@ export const ClusterDisk: ClusterFeatureRenderFn = ({ nodes }) => {
   let used = 0;
   let total = 0;
   for (const node of nodes) {
-    used += node.disk["/"].used;
-    total += node.disk["/"].total;
+    if ("/" in node.disk) {
+      used += node.disk["/"].used;
+      total += node.disk["/"].total;
+    }
   }
   return (
     <UsageBar


### PR DESCRIPTION
… not correctly report stat still)

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
When a Windows machine is connected to a cluster, the machine view would attempt to read how much data it has stored at the "/" entry, which does not exist on Windows. This would lead the page to not render.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested (please justify below)
