### PR TITLE
[autoscaler] Throw error with missing `cluster_synced_files`.

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -265,6 +265,7 @@ class StandardAutoscaler:
             with open(self.config_path) as f:
                 new_config = yaml.safe_load(f.read())
             validate_config(new_config)
+            new_config.setdefault("cluster_synced_files", [])
             new_launch_hash = hash_launch_conf(new_config["worker_nodes"],
                                                new_config["auth"])
             (new_runtime_hash,

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 import threading
 import time
+from typing import Any, Dict
 import yaml
 
 from ray.experimental.internal_kv import _internal_kv_put, \
@@ -265,7 +266,6 @@ class StandardAutoscaler:
             with open(self.config_path) as f:
                 new_config = yaml.safe_load(f.read())
             validate_config(new_config)
-            new_config.setdefault("cluster_synced_files", [])
             new_launch_hash = hash_launch_conf(new_config["worker_nodes"],
                                                new_config["auth"])
             (new_runtime_hash,

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -7,7 +7,6 @@ import os
 import subprocess
 import threading
 import time
-from typing import Any, Dict
 import yaml
 
 from ray.experimental.internal_kv import _internal_kv_put, \

--- a/python/ray/autoscaler/util.py
+++ b/python/ray/autoscaler/util.py
@@ -58,6 +58,14 @@ def validate_config(config: Dict[str, Any]) -> None:
     except jsonschema.ValidationError as e:
         raise jsonschema.ValidationError(message=e.message) from None
 
+    # Detect out of date defaults. This happens when the autoscaler that filled
+    # out the default values is older than the version of the autoscaler that
+    # is running on the cluster.
+    if "cluster_synced_files" not in config:
+        raise RuntimeError("Config default values missing. The version of ray "
+                           "running in the cluster cannot be greater than the "
+                           "version running on your laptop.")
+
 
 def prepare_config(config):
     with_defaults = fillout_defaults(config)

--- a/python/ray/autoscaler/util.py
+++ b/python/ray/autoscaler/util.py
@@ -62,9 +62,13 @@ def validate_config(config: Dict[str, Any]) -> None:
     # out the default values is older than the version of the autoscaler that
     # is running on the cluster.
     if "cluster_synced_files" not in config:
-        raise RuntimeError("Config default values missing. The version of ray "
-                           "running in the cluster cannot be greater than the "
-                           "version running on your laptop.")
+        raise RuntimeError(
+            "Missing 'cluster_synced_files' field in the cluster "
+            "configuration. This is likely due to the Ray version running "
+            "in the cluster {ray_version} is greater than the Ray version "
+            "running on your laptop. Please try updating Ray on your local "
+            "machine and make sure the versions match.".format(
+                ray_version=ray.__version__))
 
 
 def prepare_config(config):


### PR DESCRIPTION
## Why are these changes needed?

This makes the autoscaler backwards compatible with old versions of the default cluster.yamls.
This specifically addresses the issue when a laptop running the autoscaler doesn't fill out all the necessary default configs because its running on an older version of ray.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
