### PR TITLE
[TEST]Check if port is free before start up redis

### DIFF
--- a/src/ray/common/test_util.cc
+++ b/src/ray/common/test_util.cc
@@ -18,6 +18,7 @@
 #include <functional>
 
 #include "ray/common/buffer.h"
+#include "ray/common/network_util.h"
 #include "ray/common/ray_object.h"
 #include "ray/common/test_util.h"
 #include "ray/util/filesystem.h"
@@ -47,6 +48,9 @@ int TestSetupUtil::StartUpRedisServer(const int &port) {
     }
     // Use random port (in range [2000, 7000) to avoid port conflicts between UTs.
     actual_port = rand() % 5000 + 2000;
+    while (!CheckFree(actual_port)) {
+      actual_port = rand() % 5000 + 2000;
+    }
   }
 
   std::string program = TEST_REDIS_SERVER_EXEC_PATH;

--- a/src/ray/common/test_util.cc
+++ b/src/ray/common/test_util.cc
@@ -47,10 +47,9 @@ int TestSetupUtil::StartUpRedisServer(const int &port) {
       srand(current_time_ms() % RAND_MAX);
     }
     // Use random port (in range [2000, 7000) to avoid port conflicts between UTs.
-    actual_port = rand() % 5000 + 2000;
-    while (!CheckFree(actual_port)) {
+    do {
       actual_port = rand() % 5000 + 2000;
-    }
+    } while (!CheckFree(actual_port));
   }
 
   std::string program = TEST_REDIS_SERVER_EXEC_PATH;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Redis may use the port already used. We need to check if a port is free before assigning it to redis.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
