### PR TITLE
Update com_github_nelhage_rules_boost version in ray_deps_setup.bzl

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -144,8 +144,8 @@ def ray_deps_setup():
     auto_http_archive(
         name = "com_github_nelhage_rules_boost",
         # If you update the Boost version, remember to update the 'boost' rule.
-        url = "https://github.com/nelhage/rules_boost/archive/5b53112431ef916381d6969f114727cc4f83960b.tar.gz",
-        sha256 = "32080749fdb8e4015815694a5c7d009f479e5f6a4da443d262bd7f28b8bd1b55",
+        url = "https://github.com/nelhage/rules_boost/archive/2613d04ab3d22dfc4543ea0a083d9adeaa0daf09.tar.gz",
+        sha256 = "512f913240e026099d4ca4a98b1ce8048c99de77fdc8e8584e9e2539ee119ca2",
         patches = [
             "//thirdparty/patches:rules_boost-undefine-boost_fallthrough.patch",
             "//thirdparty/patches:rules_boost-windows-linkopts.patch",


### PR DESCRIPTION
support boost.dll

## Why are these changes needed?
cpp-worker need boost.dll to operate the dynamic library, but the current com_github_nelhage_rules_boost does not contain boost.dll. 

I made a pr to support boost.dll for nelhage_rules_boost, they have merged the pr(https://github.com/nelhage/rules_boost/pull/187).

So we need to update com_github_nelhage_rules_boost to support boost.dll

## Checks
tests passed.