### PR TITLE
[Serve] uncomment injected failure test

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -117,16 +117,15 @@ py_test(
 
 
 # Runs test_api and test_failure with injected failures in the controller.
-# TODO(edoakes): reenable this once we're using GCS actor fault tolerance.
-# py_test(
-    # name = "test_controller_crashes",
-    # size = "medium",
-    # srcs = glob(["tests/test_controller_crashes.py",
-                 # "tests/test_api.py",
-                 # "tests/test_failure.py"],
-                # exclude=["tests/test_nonblocking.py",
-                         # "tests/test_serve.py"]),
-# )
+py_test(
+    name = "test_controller_crashes",
+    size = "medium",
+    srcs = glob(["tests/test_controller_crashes.py",
+                 "tests/test_api.py",
+                 "tests/test_failure.py"],
+                exclude=["tests/test_nonblocking.py",
+                         "tests/test_serve.py"]),
+)
 
 py_test(
     name = "echo_full",

--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -6,7 +6,7 @@ import ray
 from ray import serve
 
 if os.environ.get("RAY_SERVE_INTENTIONALLY_CRASH", False):
-    serve.controller._CRASH_AFTER_CHECKPOINT_PROBABILITY = 0.5
+    serve.controller._CRASH_AFTER_CHECKPOINT_PROBABILITY = 0.25
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
GCS actor management is now turned on, so we should reenable certain tests that have injected failures.  Pushing this PR to see if it passes in CI now.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
