### PR TITLE
Use correct actor ID as react key for dead actors in logical view

### DIFF
--- a/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actors.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actors.tsx
@@ -8,8 +8,8 @@ type ActorProps = {
 
 const Actors = (props: ActorProps) => {
   const { actors } = props;
-  const actorChildren = Object.values(actors)
-    .sort((actor1, actor2) => {
+  const actorChildren = Object.entries(actors)
+    .sort(([, actor1], [, actor2]) => {
       if (
         actor1.state === ActorState.Dead &&
         actor2.state === ActorState.Dead
@@ -21,7 +21,7 @@ const Actors = (props: ActorProps) => {
         return 1;
       }
     })
-    .map((actor) => <Actor actor={actor} key={actor.actorId} />);
+    .map(([aid, actor]) => <Actor actor={actor} key={aid} />);
   return <Fragment>{actorChildren}</Fragment>;
 };
 


### PR DESCRIPTION
This fixes a bug where duplicate actor entries were being rendered in the UI

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
The `Actors` component renders a bunch of individual `Actor` components. Currently, it uses a field of the actor, called the `actorId` that is not present in the actor payload being sent from the backend when the actor is dead.
This field is used as the react “key” for the item in the list, meaning a large number of actors in the list have an unset “key” prop, leading to the duplicate entries that Sang observed.
However, though the `actorId` field is not present, the actor’s id is still available because the backend passes the actors as a dictionary from actor ID to actor.
This change makes the switch.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #9229 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [] Unit tests
   - [x] Release tests
   - [] This PR is not tested (please justify below)
