### PR TITLE
[docker] Remove port flags

### DIFF
--- a/python/ray/autoscaler/docker.py
+++ b/python/ray/autoscaler/docker.py
@@ -87,12 +87,6 @@ def check_docker_running_cmd(cname):
 def docker_start_cmds(user, image, mount, cname, user_options):
     cmds = []
 
-    # create flags
-    # ports for the redis, object manager, and tune client
-    port_flags = " ".join([
-        "-p {port}:{port}".format(port=port)
-        for port in ["6379", "8076", "4321"]
-    ])
     # TODO(ilr) Move away from defaulting to /root/
     mount_flags = " ".join([
         "-v {src}:{dest}".format(src=k, dest=v.replace("~/", "/root/"))
@@ -110,7 +104,7 @@ def docker_start_cmds(user, image, mount, cname, user_options):
     docker_check = check_docker_running_cmd(cname) + " || "
     docker_run = [
         "docker", "run", "--rm", "--name {}".format(cname), "-d", "-it",
-        port_flags, mount_flags, env_flags, user_options_str, "--net=host",
+        mount_flags, env_flags, user_options_str, "--net=host",
         image, "bash"
     ]
     cmds.append(docker_check + " ".join(docker_run))

--- a/python/ray/autoscaler/docker.py
+++ b/python/ray/autoscaler/docker.py
@@ -104,8 +104,7 @@ def docker_start_cmds(user, image, mount, cname, user_options):
     docker_check = check_docker_running_cmd(cname) + " || "
     docker_run = [
         "docker", "run", "--rm", "--name {}".format(cname), "-d", "-it",
-        mount_flags, env_flags, user_options_str, "--net=host",
-        image, "bash"
+        mount_flags, env_flags, user_options_str, "--net=host", image, "bash"
     ]
     cmds.append(docker_check + " ".join(docker_run))
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Port flags are ignored with `--net=host`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
