### PR TITLE
[Tune] Better error when using checkpoint_freq

### DIFF
--- a/python/ray/tune/examples/cifar10_pytorch.py
+++ b/python/ray/tune/examples/cifar10_pytorch.py
@@ -195,8 +195,7 @@ def main(num_samples=10, max_num_epochs=10, gpus_per_trial=2):
         config=config,
         num_samples=num_samples,
         scheduler=scheduler,
-        progress_reporter=reporter,
-        checkpoint_at_end=True)
+        progress_reporter=reporter)
 
     best_trial = result.get_best_trial("loss", "min", "last")
     print("Best trial config: {}".format(best_trial.config))

--- a/python/ray/tune/experiment.py
+++ b/python/ray/tune/experiment.py
@@ -4,7 +4,6 @@ import os
 from typing import Sequence
 
 from ray.tune.error import TuneError
-from ray.tune.function_runner import detect_checkpoint_function
 from ray.tune.registry import register_trainable, get_trainable_cls
 from ray.tune.result import DEFAULT_RESULTS_DIR
 from ray.tune.sample import sample_from

--- a/python/ray/tune/experiment.py
+++ b/python/ray/tune/experiment.py
@@ -4,6 +4,7 @@ import os
 from typing import Sequence
 
 from ray.tune.error import TuneError
+from ray.tune.function_runner import detect_checkpoint_function
 from ray.tune.registry import register_trainable, get_trainable_cls
 from ray.tune.result import DEFAULT_RESULTS_DIR
 from ray.tune.sample import sample_from
@@ -119,6 +120,17 @@ class Experiment:
                  restore=None):
 
         config = config or {}
+        if callable(run) and detect_checkpoint_function(run):
+            if checkpoint_at_end:
+                raise ValueError("'checkpoint_at_end' cannot be used with a "
+                                 "checkpointable function. You can specify "
+                                 "and register checkpoints within "
+                                 "your trainable function.")
+            if checkpoint_freq:
+                raise ValueError(
+                    "'checkpoint_freq' cannot be used with a "
+                    "checkpointable function. You can specify checkpoints "
+                    "within your trainable function.")
         self._run_identifier = Experiment.register_if_needed(run)
         self.name = name or self._run_identifier
         if upload_dir:

--- a/python/ray/tune/experiment.py
+++ b/python/ray/tune/experiment.py
@@ -120,18 +120,6 @@ class Experiment:
                  restore=None):
 
         config = config or {}
-
-        if callable(run) and detect_checkpoint_function(run):
-            if checkpoint_at_end:
-                raise ValueError(
-                    "'checkpoint_at_end' cannot be used with a "
-                    "checkpointable function. You can specify and register "
-                    "checkpoints within your trainable function.")
-            if checkpoint_freq:
-                raise ValueError(
-                    "'checkpoint_freq' cannot be used with a "
-                    "checkpointable function. You can specify checkpoints "
-                    "within your trainable function.")
         self._run_identifier = Experiment.register_if_needed(run)
         self.name = name or self._run_identifier
         if upload_dir:

--- a/python/ray/tune/tests/test_function_api.py
+++ b/python/ray/tune/tests/test_function_api.py
@@ -8,7 +8,6 @@ import ray
 from ray.rllib import _register_all
 
 from ray import tune
-from ray.tune import Experiment
 from ray.tune.logger import NoopLogger
 from ray.tune.trainable import TrainableUtil
 from ray.tune.function_runner import wrap_function, FuncCheckpointUtil

--- a/python/ray/tune/tests/test_function_api.py
+++ b/python/ray/tune/tests/test_function_api.py
@@ -300,6 +300,15 @@ class FunctionApiTest(unittest.TestCase):
         ray.shutdown()
         _register_all()  # re-register the evicted objects
 
+
+    def testCheckpointError(self):
+        def train(config, checkpoint_dir=False):
+            pass
+        with self.assertRaises(ValueError):
+            tune.run(train, checkpoint_freq=1)
+        with self.assertRaises(ValueError):
+            tune.run(train, checkpoint_at_end=True)
+
     def testCheckpointFunctionAtEnd(self):
         def train(config, checkpoint_dir=False):
             for i in range(10):

--- a/python/ray/tune/tests/test_function_api.py
+++ b/python/ray/tune/tests/test_function_api.py
@@ -8,6 +8,7 @@ import ray
 from ray.rllib import _register_all
 
 from ray import tune
+from ray.tune import Experiment
 from ray.tune.logger import NoopLogger
 from ray.tune.trainable import TrainableUtil
 from ray.tune.function_runner import wrap_function, FuncCheckpointUtil

--- a/python/ray/tune/tests/test_function_api.py
+++ b/python/ray/tune/tests/test_function_api.py
@@ -300,10 +300,10 @@ class FunctionApiTest(unittest.TestCase):
         ray.shutdown()
         _register_all()  # re-register the evicted objects
 
-
     def testCheckpointError(self):
         def train(config, checkpoint_dir=False):
             pass
+
         with self.assertRaises(ValueError):
             tune.run(train, checkpoint_freq=1)
         with self.assertRaises(ValueError):

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -261,22 +261,22 @@ def run(run_or_experiment,
     if isinstance(run_or_experiment, list):
         experiments = run_or_experiment
     else:
+        if callable(run_or_experiment) and detect_checkpoint_function(run_or_experiment):
+            if checkpoint_at_end:
+                raise ValueError(
+                    "'checkpoint_at_end' cannot be used with a "
+                    "checkpointable function. You can specify "
+                    "and register checkpoints within "
+                    "your trainable function.")
+            if checkpoint_freq:
+                raise ValueError(
+                    "'checkpoint_freq' cannot be used with a "
+                    "checkpointable function. You can specify checkpoints "
+                    "within your trainable function.")
         experiments = [run_or_experiment]
 
     for i, exp in enumerate(experiments):
         if not isinstance(exp, Experiment):
-            if callable(exp) and detect_checkpoint_function(exp):
-                if checkpoint_at_end:
-                    raise ValueError(
-                        "'checkpoint_at_end' cannot be used with a "
-                        "checkpointable function. You can specify "
-                        "and register checkpoints within "
-                        "your trainable function.")
-                if checkpoint_freq:
-                    raise ValueError(
-                        "'checkpoint_freq' cannot be used with a "
-                        "checkpointable function. You can specify checkpoints "
-                        "within your trainable function.")
             run_identifier = Experiment.register_if_needed(exp)
             experiments[i] = Experiment(
                 name=name,

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -261,13 +261,13 @@ def run(run_or_experiment,
     if isinstance(run_or_experiment, list):
         experiments = run_or_experiment
     else:
-        if callable(run_or_experiment) and detect_checkpoint_function(run_or_experiment):
+        if callable(run_or_experiment) and detect_checkpoint_function(
+                run_or_experiment):
             if checkpoint_at_end:
-                raise ValueError(
-                    "'checkpoint_at_end' cannot be used with a "
-                    "checkpointable function. You can specify "
-                    "and register checkpoints within "
-                    "your trainable function.")
+                raise ValueError("'checkpoint_at_end' cannot be used with a "
+                                 "checkpointable function. You can specify "
+                                 "and register checkpoints within "
+                                 "your trainable function.")
             if checkpoint_freq:
                 raise ValueError(
                     "'checkpoint_freq' cannot be used with a "

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -3,6 +3,7 @@ import logging
 from ray.tune.error import TuneError
 from ray.tune.experiment import convert_to_experiment_list, Experiment
 from ray.tune.analysis import ExperimentAnalysis
+from ray.tune.function_runner import detect_checkpoint_function
 from ray.tune.suggest import BasicVariantGenerator
 from ray.tune.suggest.suggestion import Searcher, SearchGenerator
 from ray.tune.trial import Trial
@@ -264,6 +265,17 @@ def run(run_or_experiment,
 
     for i, exp in enumerate(experiments):
         if not isinstance(exp, Experiment):
+            if callable(run) and detect_checkpoint_function(exp):
+                if checkpoint_at_end:
+                    raise ValueError(
+                        "'checkpoint_at_end' cannot be used with a "
+                        "checkpointable function. You can specify and register "
+                        "checkpoints within your trainable function.")
+                if checkpoint_freq:
+                    raise ValueError(
+                        "'checkpoint_freq' cannot be used with a "
+                        "checkpointable function. You can specify checkpoints "
+                        "within your trainable function.")
             run_identifier = Experiment.register_if_needed(exp)
             experiments[i] = Experiment(
                 name=name,

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -265,7 +265,7 @@ def run(run_or_experiment,
 
     for i, exp in enumerate(experiments):
         if not isinstance(exp, Experiment):
-            if callable(run) and detect_checkpoint_function(exp):
+            if callable(exp) and detect_checkpoint_function(exp):
                 if checkpoint_at_end:
                     raise ValueError(
                         "'checkpoint_at_end' cannot be used with a "

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -261,26 +261,13 @@ def run(run_or_experiment,
     if isinstance(run_or_experiment, list):
         experiments = run_or_experiment
     else:
-        if callable(run_or_experiment) and detect_checkpoint_function(
-                run_or_experiment):
-            if checkpoint_at_end:
-                raise ValueError("'checkpoint_at_end' cannot be used with a "
-                                 "checkpointable function. You can specify "
-                                 "and register checkpoints within "
-                                 "your trainable function.")
-            if checkpoint_freq:
-                raise ValueError(
-                    "'checkpoint_freq' cannot be used with a "
-                    "checkpointable function. You can specify checkpoints "
-                    "within your trainable function.")
         experiments = [run_or_experiment]
 
     for i, exp in enumerate(experiments):
         if not isinstance(exp, Experiment):
-            run_identifier = Experiment.register_if_needed(exp)
             experiments[i] = Experiment(
                 name=name,
-                run=run_identifier,
+                run=exp,
                 stop=stop,
                 config=config,
                 resources_per_trial=resources_per_trial,

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -269,8 +269,9 @@ def run(run_or_experiment,
                 if checkpoint_at_end:
                     raise ValueError(
                         "'checkpoint_at_end' cannot be used with a "
-                        "checkpointable function. You can specify and register "
-                        "checkpoints within your trainable function.")
+                        "checkpointable function. You can specify "
+                        "and register checkpoints within "
+                        "your trainable function.")
                 if checkpoint_freq:
                     raise ValueError(
                         "'checkpoint_freq' cannot be used with a "

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -3,7 +3,6 @@ import logging
 from ray.tune.error import TuneError
 from ray.tune.experiment import convert_to_experiment_list, Experiment
 from ray.tune.analysis import ExperimentAnalysis
-from ray.tune.function_runner import detect_checkpoint_function
 from ray.tune.suggest import BasicVariantGenerator
 from ray.tune.suggest.suggestion import Searcher, SearchGenerator
 from ray.tune.trial import Trial


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Previously, code existed to raise a ValueError if `checkpoint_freq` and `checkpoint_at_end` args are used with a trainable function. However, this code path was never executed since we first would register the experiment which returns a string so `callable(run)` would always return False. Instead, we move this code path before we register the experiment.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
