### PR TITLE
[rllib] Learning rate schedule for DDPPO.

### DIFF
--- a/rllib/agents/ppo/tests/test_ddppo.py
+++ b/rllib/agents/ppo/tests/test_ddppo.py
@@ -28,6 +28,21 @@ class TestDDPPO(unittest.TestCase):
             check_compute_single_action(trainer)
             trainer.stop()
 
+    def test_ddppo_schedule(self):
+        """Test whether lr_schedule will anneal lr to 0"""
+        config = ppo.ddppo.DEFAULT_CONFIG.copy()
+        config["num_gpus_per_worker"] = 0
+        config["lr_schedule"] = [[0, config["lr"]], [1000, 0.0]]
+        num_iterations = 3
+
+        for _ in framework_iterator(config, "torch"):
+            trainer = ppo.ddppo.DDPPOTrainer(config=config, env="CartPole-v0")
+            for _ in range(num_iterations):
+                result = trainer.train()
+                lr = result["info"]["learner"]["default_policy"]["cur_lr"]
+            trainer.stop()
+            assert lr == 0.0, "lr should anneal to 0.0"
+
 
 if __name__ == "__main__":
     import pytest


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Schedule classes (i.e: `LearningRateSchedule`) are available but `DDPPOTrainer` (despite extending `PPOtrainer`) didn't utilized them for the following (possible) reasons:

(1) `metrics.counters[STEPS_SAMPLED_COUNTER]` is not setup for remote workers & is always 0.

(2) `set_global_vars` is not called by the remote workers, hence `lr` will not be updated.

This PR aims to resolve the above. 

A small unit test function is also added which asserts that `lr` anneals to 0.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#9929

<!-- For example: "Closes #1234" -->

## Checks

- [✓ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [✓ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [✓ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
