### PR TITLE
[Tests] Fix flaky sample test

### DIFF
--- a/src/ray/util/sample_test.cc
+++ b/src/ray/util/sample_test.cc
@@ -61,7 +61,7 @@ TEST_F(RandomSampleTest, TestLargerThanSampleSize) {
 }
 
 TEST_F(RandomSampleTest, TestEqualOccurrenceChance) {
-  int trials = 100000;
+  int trials = 1000000;
   std::vector<int> occurrences(test_vector->size(), 0);
   for (int i = 0; i < trials; i++) {
     random_sample(test_vector->begin(), test_vector->end(), test_vector->size() / 2,


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Cpp sample test, `TestEqualOccurrenceChance`, occasionally fails with very small error offset. This PR increases the number of trials 10 times to reduce the probability of failure. It will make the `TestEqualOccurrenceChance` test 10 times slower, 22ms -> 222ms. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
