### PR TITLE
[Placement Group]Reschedule bundles when the node of bundles is dead

### DIFF
--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -12,6 +12,7 @@ from ray.test_utils import get_other_nodes, wait_for_condition
 import ray.cluster_utils
 from ray._raylet import PlacementGroupID
 
+
 def test_placement_group_pack(ray_start_cluster):
     @ray.remote(num_cpus=2)
     class Actor(object):
@@ -362,7 +363,7 @@ def test_placement_group_reschedule_when_node_dead(ray_start_cluster):
     cluster.add_node(num_cpus=4)
     cluster.add_node(num_cpus=4)
     cluster.add_node(num_cpus=4)
-    cluster.wait_for_nodes(3)
+    cluster.wait_for_nodes()
     ray.init(address=cluster.address)
 
     # Make sure both head and worker node are alive.
@@ -371,7 +372,9 @@ def test_placement_group_reschedule_when_node_dead(ray_start_cluster):
     assert nodes[0]["alive"] and nodes[1]["alive"] and nodes[2]["alive"]
 
     placement_group_id = ray.experimental.placement_group(
-        name="name", strategy="SPREAD", bundles=[{
+        name="name",
+        strategy="SPREAD",
+        bundles=[{
             "CPU": 2
         }, {
             "CPU": 2
@@ -395,7 +398,7 @@ def test_placement_group_reschedule_when_node_dead(ray_start_cluster):
     print(ray.get(actor_3.value.remote()))
 
     cluster.remove_node(get_other_nodes(cluster, exclude_head=True)[-1])
-    cluster.wait_for_nodes(2)
+    cluster.wait_for_nodes()
 
     actor_4 = Actor.options(
         placement_group_id=placement_group_id,

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -8,10 +8,9 @@ except ImportError:
     pytest_timeout = None
 
 import ray
-from ray.test_utils import wait_for_condition
+from ray.test_utils import get_other_nodes, wait_for_condition
 import ray.cluster_utils
 from ray._raylet import PlacementGroupID
-
 
 def test_placement_group_pack(ray_start_cluster):
     @ray.remote(num_cpus=2)
@@ -348,6 +347,72 @@ def test_cuda_visible_devices(ray_start_cluster):
 
     devices = ray.get(o1)
     assert devices == "0", devices
+
+
+def test_placement_group_reschedule_when_node_dead(ray_start_cluster):
+    @ray.remote(num_cpus=1)
+    class Actor(object):
+        def __init__(self):
+            self.n = 0
+
+        def value(self):
+            return self.n
+
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=4)
+    cluster.add_node(num_cpus=4)
+    cluster.add_node(num_cpus=4)
+    cluster.wait_for_nodes(3)
+    ray.init(address=cluster.address)
+
+    # Make sure both head and worker node are alive.
+    nodes = ray.nodes()
+    assert len(nodes) == 3
+    assert nodes[0]["alive"] and nodes[1]["alive"] and nodes[2]["alive"]
+
+    placement_group_id = ray.experimental.placement_group(
+        name="name", strategy="SPREAD", bundles=[{
+            "CPU": 2
+        }, {
+            "CPU": 2
+        }, {
+            "CPU": 2
+        }])
+    actor_1 = Actor.options(
+        placement_group_id=placement_group_id,
+        placement_group_bundle_index=0,
+        detached=True).remote()
+    actor_2 = Actor.options(
+        placement_group_id=placement_group_id,
+        placement_group_bundle_index=1,
+        detached=True).remote()
+    actor_3 = Actor.options(
+        placement_group_id=placement_group_id,
+        placement_group_bundle_index=2,
+        detached=True).remote()
+    print(ray.get(actor_1.value.remote()))
+    print(ray.get(actor_2.value.remote()))
+    print(ray.get(actor_3.value.remote()))
+
+    cluster.remove_node(get_other_nodes(cluster, exclude_head=True)[-1])
+    cluster.wait_for_nodes(2)
+
+    actor_4 = Actor.options(
+        placement_group_id=placement_group_id,
+        placement_group_bundle_index=0,
+        detached=True).remote()
+    actor_5 = Actor.options(
+        placement_group_id=placement_group_id,
+        placement_group_bundle_index=1,
+        detached=True).remote()
+    actor_6 = Actor.options(
+        placement_group_id=placement_group_id,
+        placement_group_bundle_index=2,
+        detached=True).remote()
+    print(ray.get(actor_4.value.remote()))
+    print(ray.get(actor_5.value.remote()))
+    print(ray.get(actor_6.value.remote()))
+    ray.shutdown()
 
 
 if __name__ == "__main__":

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -395,6 +395,8 @@ std::shared_ptr<rpc::GcsNodeInfo> GcsNodeManager::RemoveNode(
     alive_nodes_.erase(iter);
     // Remove from cluster resources.
     cluster_resources_.erase(node_id);
+    // Remove from cluster realtime resources.
+    cluster_realtime_resources_.erase(node_id);
     if (!is_intended) {
       // Broadcast a warning to all of the drivers indicating that the node
       // has been marked as dead.

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -61,6 +61,10 @@ void GcsNodeManager::NodeFailureDetector::HandleHeartbeat(
       heartbeat_data.resource_load_size() > 0) {
     heartbeat_buffer_[node_id] = heartbeat_data;
   }
+
+  if (heartbeat_listener_) {
+    heartbeat_listener_(heartbeat_data);
+  }
 }
 
 /// A periodic timer that checks for timed out clients.

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -61,10 +61,6 @@ void GcsNodeManager::NodeFailureDetector::HandleHeartbeat(
       heartbeat_data.resource_load_size() > 0) {
     heartbeat_buffer_[node_id] = heartbeat_data;
   }
-
-  if (heartbeat_listener_) {
-    heartbeat_listener_(heartbeat_data);
-  }
 }
 
 /// A periodic timer that checks for timed out clients.

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -186,14 +186,6 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
     void HandleHeartbeat(const ClientID &node_id,
                          const rpc::HeartbeatTableData &heartbeat_data);
 
-    /// Add listener to monitor the heartbeat of nodes.
-    ///
-    /// \param listener The handler which process the add of nodes.
-    void AddHeartbeatListener(
-        std::function<void(const rpc::HeartbeatTableData &heartbeat_data)> listener) {
-      heartbeat_listener_ = std::move(listener);
-    }
-
    protected:
     /// A periodic timer that fires on every heartbeat period. Raylets that have
     /// not sent a heartbeat within the last num_heartbeats_timeout ticks will be
@@ -230,9 +222,6 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
     std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub_;
     /// Is the detect started.
     bool is_started_ = false;
-    /// Listener which monitor the heartbeat of nodes.
-    std::function<void(const rpc::HeartbeatTableData &heartbeat_data)>
-        heartbeat_listener_;
   };
 
  private:

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -186,6 +186,14 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
     void HandleHeartbeat(const ClientID &node_id,
                          const rpc::HeartbeatTableData &heartbeat_data);
 
+    /// Add listener to monitor the heartbeat of nodes.
+    ///
+    /// \param listener The handler which process the add of nodes.
+    void AddHeartbeatListener(
+        std::function<void(const rpc::HeartbeatTableData &heartbeat_data)> listener) {
+      heartbeat_listener_ = std::move(listener);
+    }
+
    protected:
     /// A periodic timer that fires on every heartbeat period. Raylets that have
     /// not sent a heartbeat within the last num_heartbeats_timeout ticks will be
@@ -222,6 +230,9 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
     std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub_;
     /// Is the detect started.
     bool is_started_ = false;
+    /// Listener which monitor the heartbeat of nodes.
+    std::function<void(const rpc::HeartbeatTableData &heartbeat_data)>
+        heartbeat_listener_;
   };
 
  private:

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -14,8 +14,6 @@
 
 #include "ray/gcs/gcs_server/gcs_placement_group_manager.h"
 
-#include <utility>
-
 #include "ray/common/ray_config.h"
 #include "ray/gcs/pb_util.h"
 #include "ray/util/asio_util.h"

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -14,6 +14,8 @@
 
 #include "ray/gcs/gcs_server/gcs_placement_group_manager.h"
 
+#include <utility>
+
 #include "ray/common/ray_config.h"
 #include "ray/gcs/pb_util.h"
 #include "ray/util/asio_util.h"

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -321,6 +321,7 @@ void GcsPlacementGroupManager::OnNodeDead(const ClientID &node_id) {
           .mutable_bundles(bundle_index)
           ->set_is_placed(false);
     }
+    placement_group->UpdateState(rpc::PlacementGroupTableData::RESCHEDULING);
     to_reschedule_groups.insert(placement_group);
   }
 

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -299,5 +299,15 @@ void GcsPlacementGroupManager::RetryCreatingPlacementGroup() {
                 RayConfig::instance().gcs_create_placement_group_retry_interval_ms());
 }
 
+void GcsPlacementGroupManager::OnNodeDead(const ClientID &node_id) {
+  auto bundles = gcs_placement_group_scheduler_->GetBundlesOfDeadNode(node_id);
+  for (const auto &bundle : bundles) {
+    auto &placement_group = registered_placement_groups_[bundle->first];
+    for (const auto &bundle_index : bundle->second) {
+
+    }
+  }
+}
+
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -312,16 +312,16 @@ void GcsPlacementGroupManager::RetryCreatingPlacementGroup() {
 }
 
 void GcsPlacementGroupManager::OnNodeDead(const ClientID &node_id) {
-  auto bundles = gcs_placement_group_scheduler_->GetBundlesOfDeadNode(node_id);
+  auto bundles = gcs_placement_group_scheduler_->GetBundlesOnDeadNode(node_id);
   absl::flat_hash_set<std::shared_ptr<GcsPlacementGroup>> to_reschedule_groups;
   for (const auto &bundle : bundles) {
     auto &placement_group = registered_placement_groups_[bundle.first];
-    to_reschedule_groups.insert(placement_group);
     for (const auto &bundle_index : bundle.second) {
       placement_group->GetMutablePlacementGroupTableData()
           .mutable_bundles(bundle_index)
           ->set_is_placed(false);
     }
+    to_reschedule_groups.insert(placement_group);
   }
 
   for (const auto &group : to_reschedule_groups) {

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -312,7 +312,7 @@ void GcsPlacementGroupManager::RetryCreatingPlacementGroup() {
 }
 
 void GcsPlacementGroupManager::OnNodeDead(const ClientID &node_id) {
-  auto bundles = gcs_placement_group_scheduler_->GetBundlesOnDeadNode(node_id);
+  auto bundles = gcs_placement_group_scheduler_->GetBundlesOnNode(node_id);
   absl::flat_hash_set<std::shared_ptr<GcsPlacementGroup>> to_reschedule_groups;
   for (const auto &bundle : bundles) {
     auto &placement_group = registered_placement_groups_[bundle.first];

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -319,6 +319,8 @@ void GcsPlacementGroupManager::RetryCreatingPlacementGroup() {
 }
 
 void GcsPlacementGroupManager::OnNodeDead(const ClientID &node_id) {
+  RAY_LOG(WARNING) << "Node " << node_id
+                   << " failed, rescheduling the placement groups on the dead node.";
   auto bundles = gcs_placement_group_scheduler_->GetBundlesOnNode(node_id);
   for (const auto &bundle : bundles) {
     const auto iter = registered_placement_groups_.find(bundle.first);

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -302,9 +302,9 @@ void GcsPlacementGroupManager::RetryCreatingPlacementGroup() {
 void GcsPlacementGroupManager::OnNodeDead(const ClientID &node_id) {
   auto bundles = gcs_placement_group_scheduler_->GetBundlesOfDeadNode(node_id);
   for (const auto &bundle : bundles) {
-    auto &placement_group = registered_placement_groups_[bundle->first];
-    for (const auto &bundle_index : bundle->second) {
-
+    auto &placement_group = registered_placement_groups_[bundle.first];
+    for (const auto &bundle_index : bundle.second) {
+      placement_group->GetMutablePlacementGroupTableData().mutable_bundles(bundle_index).
     }
   }
 }

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -75,6 +75,10 @@ const std::string GcsPlacementGroup::DebugString() const {
   return stream.str();
 }
 
+rpc::Bundle *GcsPlacementGroup::GetMutableBundle(int bundle_index) {
+  return placement_group_table_data_.mutable_bundles(bundle_index);
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////
 
 GcsPlacementGroupManager::GcsPlacementGroupManager(
@@ -317,9 +321,7 @@ void GcsPlacementGroupManager::OnNodeDead(const ClientID &node_id) {
   for (const auto &bundle : bundles) {
     auto &placement_group = registered_placement_groups_[bundle.first];
     for (const auto &bundle_index : bundle.second) {
-      placement_group->GetMutablePlacementGroupTableData()
-          .mutable_bundles(bundle_index)
-          ->set_is_placed(false);
+      placement_group->GetMutableBundle(bundle_index)->set_is_placed(false);
     }
     placement_group->UpdateState(rpc::PlacementGroupTableData::RESCHEDULING);
     to_reschedule_groups.insert(placement_group);

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
@@ -72,7 +72,7 @@ class GcsPlacementGroup {
   /// Get the name of this placement_group.
   std::string GetName() const;
 
-  /// Get the bundles of this placement_group.
+  /// Get the bundles of this placement_group (including unplaced).
   std::vector<std::shared_ptr<BundleSpecification>> GetBundles() const;
 
   /// Get the unplaced bundles of this placement group.

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
@@ -57,6 +57,9 @@ class GcsPlacementGroup {
   /// Get the immutable PlacementGroupTableData of this placement group.
   const rpc::PlacementGroupTableData &GetPlacementGroupTableData();
 
+  /// Get the mutable PlacementGroupTableData of this placement group.
+  rpc::PlacementGroupTableData &GetMutablePlacementGroupTableData();
+
   /// Update the state of this placement_group.
   void UpdateState(rpc::PlacementGroupTableData::PlacementGroupState state);
   /// Get the state of this gcs placement_group.
@@ -155,6 +158,12 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoHandler {
   /// TODO-SANG Fill it up.
   void RemovePlacementGroup(const PlacementGroupID &placement_group_id,
                             StatusCallback on_placement_group_removed);
+
+  /// Handle a node death. This will reschedule all bundles associated with the
+  /// specified node id.
+  ///
+  /// \param node_id The specified node id.
+  void OnNodeDead(const ClientID &node_id);
 
  private:
   /// Try to create placement group after a short time.

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
@@ -57,16 +57,18 @@ class GcsPlacementGroup {
   /// Get the immutable PlacementGroupTableData of this placement group.
   const rpc::PlacementGroupTableData &GetPlacementGroupTableData();
 
-  /// Get the mutable PlacementGroupTableData of this placement group.
-  rpc::PlacementGroupTableData &GetMutablePlacementGroupTableData();
+  /// Get the mutable bundle of this placement group.
+  rpc::Bundle *GetMutableBundle(int bundle_index);
 
   /// Update the state of this placement_group.
   void UpdateState(rpc::PlacementGroupTableData::PlacementGroupState state);
+
   /// Get the state of this gcs placement_group.
   rpc::PlacementGroupTableData::PlacementGroupState GetState() const;
 
   /// Get the id of this placement_group.
   PlacementGroupID GetPlacementGroupID() const;
+
   /// Get the name of this placement_group.
   std::string GetName() const;
 

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
@@ -70,8 +70,11 @@ class GcsPlacementGroup {
   /// Get the name of this placement_group.
   std::string GetName() const;
 
-  /// Get the bundles of this placement_group
+  /// Get the bundles of this placement_group.
   std::vector<std::shared_ptr<BundleSpecification>> GetBundles() const;
+
+  /// Get the unplaced bundles of this placement group.
+  std::vector<std::shared_ptr<BundleSpecification>> GetUnplacedBundles() const;
 
   /// Get the Strategy
   rpc::PlacementStrategy GetStrategy() const;

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
@@ -171,7 +171,7 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoHandler {
   void OnNodeDead(const ClientID &node_id);
 
  private:
-  /// Scheduling priority of placement group: RESCHEDULING > PENDING
+  /// Scheduling priority of placement group: RESCHEDULING > PENDING.
   struct PlacementGroupCompare {
     bool operator()(const std::shared_ptr<GcsPlacementGroup> &left,
                     const std::shared_ptr<GcsPlacementGroup> &right) {

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -349,8 +349,8 @@ std::unique_ptr<ScheduleContext> GcsPlacementGroupScheduler::GetScheduleContext(
   }
 
   return std::unique_ptr<ScheduleContext>(new ScheduleContext(
-      std::move(node_to_bundles), placement_group_bundle_locations_[placement_group_id],
-      gcs_node_manager_));
+      std::move(node_to_bundles),
+      placement_group_to_bundle_locations_[placement_group_id], gcs_node_manager_));
 }
 
 absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>>

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -354,7 +354,7 @@ std::unique_ptr<ScheduleContext> GcsPlacementGroupScheduler::GetScheduleContext(
 }
 
 absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>>
-GcsPlacementGroupScheduler::GetBundlesOnDeadNode(const ClientID &node_id) {
+GcsPlacementGroupScheduler::GetBundlesOnNode(const ClientID &node_id) {
   absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>> bundles_on_dead_node;
   const auto node_iter = node_to_leased_bundles_.find(node_id);
   if (node_iter != node_to_leased_bundles_.end()) {

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -63,8 +63,6 @@ ScheduleMap GcsStrictPackStrategy::Schedule(
       [](const std::pair<int64_t, ClientID> &left,
          const std::pair<int64_t, ClientID> &right) { return left.first < right.first; });
 
-  std::uniform_int_distribution<int> distribution(0, candidate_nodes.size() - 1);
-  int node_index = distribution(gen_);
   for (auto &bundle : bundles) {
     schedule_map[bundle->BundleId()] = candidate_nodes.front().second;
   }

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -63,6 +63,8 @@ ScheduleMap GcsStrictPackStrategy::Schedule(
       [](const std::pair<int64_t, ClientID> &left,
          const std::pair<int64_t, ClientID> &right) { return left.first < right.first; });
 
+  std::uniform_int_distribution<int> distribution(0, candidate_nodes.size() - 1);
+  int node_index = distribution(gen_);
   for (auto &bundle : bundles) {
     schedule_map[bundle->BundleId()] = candidate_nodes.front().second;
   }
@@ -101,8 +103,8 @@ ScheduleMap GcsSpreadStrategy::Schedule(
   auto &alive_nodes = context->node_manager_.GetClusterRealtimeResources();
   auto iter = alive_nodes.begin();
   size_t index = 0;
-  size_t alive_nodes_size = alive_nodes->size();
-  for (; iter != alive_nodes->end(); iter++, index++) {
+  size_t alive_nodes_size = alive_nodes.size();
+  for (; iter != alive_nodes.end(); iter++, index++) {
     for (size_t base = 0;; base++) {
       if (index + base * alive_nodes_size >= bundles.size()) {
         break;

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -118,9 +118,11 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
     std::shared_ptr<GcsPlacementGroup> placement_group,
     std::function<void(std::shared_ptr<GcsPlacementGroup>)> failure_callback,
     std::function<void(std::shared_ptr<GcsPlacementGroup>)> success_callback) {
-  RAY_LOG(INFO) << "Scheduling placement group " << placement_group->GetName();
   auto bundles = placement_group->GetUnplacedBundles();
   auto strategy = placement_group->GetStrategy();
+
+  RAY_LOG(INFO) << "Scheduling placement group " << placement_group->GetName()
+                << ", bundles size = " << bundles.size();
   auto selected_nodes = scheduler_strategies_[strategy]->Schedule(
       bundles, GetScheduleContext(placement_group->GetPlacementGroupID()));
 
@@ -177,10 +179,10 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
 
 void GcsPlacementGroupScheduler::DestroyPlacementGroupBundleResourcesIfExists(
     const PlacementGroupID &placement_group_id) {
-  auto it = placement_group_to_bundle_location_.find(placement_group_id);
+  auto it = placement_group_to_bundle_locations_.find(placement_group_id);
   // If bundle location has been already removed, it means bundles
   // are already destroyed. Do nothing.
-  if (it == placement_group_to_bundle_location_.end()) {
+  if (it == placement_group_to_bundle_locations_.end()) {
     return;
   }
 
@@ -190,7 +192,7 @@ void GcsPlacementGroupScheduler::DestroyPlacementGroupBundleResourcesIfExists(
     auto &node_id = iter.second.first;
     CancelResourceReserve(bundle_spec, gcs_node_manager_.GetNode(node_id));
   }
-  placement_group_to_bundle_location_.erase(it);
+  placement_group_to_bundle_locations_.erase(it);
 
   // Remove bundles from node_to_leased_bundles_ because bundels are removed now.
   for (const auto &bundle_location : *bundle_locations) {
@@ -243,7 +245,7 @@ void GcsPlacementGroupScheduler::CancelResourceReserve(
     const std::shared_ptr<BundleSpecification> &bundle_spec,
     const std::shared_ptr<ray::rpc::GcsNodeInfo> &node) {
   if (node == nullptr) {
-    RAY_LOG(WARNING) << "Node id " << node->node_id() << " for a placement group id "
+    RAY_LOG(WARNING) << "Node for a placement group id "
                      << bundle_spec->PlacementGroupId() << " and a bundle index, "
                      << bundle_spec->Index()
                      << " has already removed. Cancellation request will be ignored.";
@@ -285,9 +287,7 @@ void GcsPlacementGroupScheduler::OnAllBundleSchedulingRequestReturned(
     const std::function<void(std::shared_ptr<GcsPlacementGroup>)>
         &schedule_success_handler) {
   const auto &placement_group_id = placement_group->GetPlacementGroupID();
-  RAY_CHECK(
-      placement_group_to_bundle_location_.emplace(placement_group_id, bundle_locations)
-          .second);
+  placement_group_to_bundle_locations_.emplace(placement_group_id, bundle_locations);
 
   if (placement_group_leasing_in_progress_.find(placement_group_id) ==
           placement_group_leasing_in_progress_.end() ||
@@ -310,18 +310,14 @@ void GcsPlacementGroupScheduler::OnAllBundleSchedulingRequestReturned(
         [schedule_success_handler, placement_group](Status status) {
           schedule_success_handler(placement_group);
         }));
-    // Update `node_to_leased_bundles_`.
+
     for (const auto &iter : *bundle_locations) {
       const auto &location = iter.second;
       const auto &bundle_sepc = location.second;
       node_to_leased_bundles_[location.first].emplace(bundle_sepc->BundleId(),
                                                       bundle_sepc);
-      placement_group_bundle_locations_[placement_group->GetPlacementGroupID()]
-      [location.second->Index()] =
-          location.first;
-      placement_group->GetMutablePlacementGroupTableData()
-          .mutable_bundles(location.second->Index())
-          ->set_is_placed(true);
+      placement_group->GetMutableBundle(location.second->Index())
+          ->set_node_id(location.first.Binary());
     }
   }
   // Erase leasing in progress placement group.
@@ -332,7 +328,8 @@ void GcsPlacementGroupScheduler::OnAllBundleSchedulingRequestReturned(
   }
 }
 
-std::unique_ptr<ScheduleContext> GcsPlacementGroupScheduler::GetScheduleContext() {
+std::unique_ptr<ScheduleContext> GcsPlacementGroupScheduler::GetScheduleContext(
+    const PlacementGroupID &placement_group_id) {
   // TODO(ffbin): We will add listener to the GCS node manager to handle node deletion.
   auto &alive_nodes = gcs_node_manager_.GetAllAliveNodes();
   for (const auto &iter : alive_nodes) {
@@ -348,23 +345,27 @@ std::unique_ptr<ScheduleContext> GcsPlacementGroupScheduler::GetScheduleContext(
     node_to_bundles->emplace(iter.first, iter.second.size());
   }
 
+  std::shared_ptr<BundleLocations> bundle_locations = nullptr;
+  auto iter = placement_group_to_bundle_locations_.find(placement_group_id);
+  if (iter != placement_group_to_bundle_locations_.end()) {
+    bundle_locations = iter->second;
+  }
   return std::unique_ptr<ScheduleContext>(new ScheduleContext(
-      std::move(node_to_bundles),
-      placement_group_to_bundle_locations_[placement_group_id], gcs_node_manager_));
+      std::move(node_to_bundles), bundle_locations, gcs_node_manager_));
 }
 
 absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>>
 GcsPlacementGroupScheduler::GetBundlesOnNode(const ClientID &node_id) {
-  absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>> bundles_on_dead_node;
+  absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>> bundles_on_node;
   const auto node_iter = node_to_leased_bundles_.find(node_id);
   if (node_iter != node_to_leased_bundles_.end()) {
     const auto &bundles = node_iter->second;
     for (auto &bundle : bundles) {
-      bundles_on_dead_node[bundle->BundleId().first].push_back(bundle->BundleId().second);
+      bundles_on_node[bundle.first.first].push_back(bundle.second->BundleId().second);
     }
     node_to_leased_bundles_.erase(node_iter);
   }
-  return bundles_on_dead_node;
+  return bundles_on_node;
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -114,7 +114,7 @@ ScheduleMap GcsSpreadStrategy::Schedule(
   return schedule_map;
 }
 
-void GcsPlacementGroupScheduler::Schedule(
+void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
     std::shared_ptr<GcsPlacementGroup> placement_group,
     std::function<void(std::shared_ptr<GcsPlacementGroup>)> failure_callback,
     std::function<void(std::shared_ptr<GcsPlacementGroup>)> success_callback) {
@@ -349,7 +349,7 @@ std::unique_ptr<ScheduleContext> GcsPlacementGroupScheduler::GetScheduleContext(
   }
 
   return std::unique_ptr<ScheduleContext>(new ScheduleContext(
-      node_to_bundles, placement_group_bundle_locations_[placement_group_id],
+      std::move(node_to_bundles), placement_group_bundle_locations_[placement_group_id],
       gcs_node_manager_));
 }
 

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -101,8 +101,8 @@ ScheduleMap GcsSpreadStrategy::Schedule(
   auto &alive_nodes = context->node_manager_.GetClusterRealtimeResources();
   auto iter = alive_nodes.begin();
   size_t index = 0;
-  size_t alive_nodes_size = alive_nodes.size();
-  for (; iter != alive_nodes.end(); iter++, index++) {
+  size_t alive_nodes_size = alive_nodes->size();
+  for (; iter != alive_nodes->end(); iter++, index++) {
     for (size_t base = 0;; base++) {
       if (index + base * alive_nodes_size >= bundles.size()) {
         break;

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -165,6 +165,10 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// cancelled.
   void MarkScheduleCancelled(const PlacementGroupID &placement_group_id) override;
 
+  /// Get bundles belong to the specified node.
+  ///
+  /// \param node_id ID of the dead node.
+  /// \return The bundles belong to the dead node.
   absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>> GetBundlesOnNode(
       const ClientID &node_id) override;
 
@@ -184,7 +188,7 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// Get an existing lease client or connect a new one.
   std::shared_ptr<ResourceReserveInterface> GetOrConnectLeaseClient(
       const rpc::Address &raylet_address);
-  
+
   void OnAllBundleSchedulingRequestReturned(
       const std::shared_ptr<GcsPlacementGroup> &placement_group,
       const std::vector<std::shared_ptr<BundleSpecification>> &bundles,
@@ -227,12 +231,6 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
                       absl::flat_hash_map<BundleID, std::shared_ptr<BundleSpecification>>>
       node_to_leased_bundles_;
 
-  /// A map from placement group id to bundle locations.
-  /// It is used to destroy bundles for the placement group. When we reschedule bundles,
-  /// we can get the location of other bundles from here.
-  absl::flat_hash_map<PlacementGroupID, std::shared_ptr<BundleLocations>>
-      placement_group_to_bundle_locations_;
-
   /// A vector to store all the schedule strategy.
   std::vector<std::shared_ptr<GcsScheduleStrategy>> scheduler_strategies_;
 
@@ -241,10 +239,11 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   absl::flat_hash_set<PlacementGroupID> placement_group_leasing_in_progress_;
 
   /// A map from placement group id to bundle locations.
-  /// It is used to destroy bundles for the placement group.
+  /// It is used to destroy bundles for the placement group. When we reschedule bundles,
+  /// we can get the location of other bundles from here.
   /// NOTE: It is a reverse index of `node_to_leased_bundles`.
   absl::flat_hash_map<PlacementGroupID, std::shared_ptr<BundleLocations>>
-      placement_group_to_bundle_location_;
+      placement_group_to_bundle_locations_;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -54,12 +54,12 @@ class GcsPlacementGroupSchedulerInterface {
       std::function<void(std::shared_ptr<GcsPlacementGroup>)> failure_callback,
       std::function<void(std::shared_ptr<GcsPlacementGroup>)> success_callback) = 0;
 
-  /// Get bundles belong to the dead node.
+  /// Get bundles belong to the specified node.
   ///
   /// \param node_id ID of the dead node.
   /// \return The bundles belong to the dead node.
-  virtual absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>>
-  GetBundlesOnDeadNode(const ClientID &node_id) = 0;
+  virtual absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>> GetBundlesOnNode(
+      const ClientID &node_id) = 0;
 
   /// Destroy bundle resources from all nodes in the placement group.
   virtual void DestroyPlacementGroupBundleResourcesIfExists(
@@ -164,7 +164,7 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// cancelled.
   void MarkScheduleCancelled(const PlacementGroupID &placement_group_id) override;
 
-  absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>> GetBundlesOfDeadNode(
+  absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>> GetBundlesOnNode(
       const ClientID &node_id) override;
 
  protected:

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -44,12 +44,12 @@ class GcsPlacementGroup;
 
 class GcsPlacementGroupSchedulerInterface {
  public:
-  /// Schedule the specified placement_group.
+  /// Schedule unplaced bundles of the specified placement group.
   ///
-  /// \param placement_group to be scheduled.
+  /// \param placement_group The placement group to be scheduled.
   /// \param failure_callback This function is called if the schedule is failed.
   /// \param success_callback This function is called if the schedule is successful.
-  virtual void Schedule(
+  virtual void ScheduleUnplacedBundles(
       std::shared_ptr<GcsPlacementGroup> placement_group,
       std::function<void(std::shared_ptr<GcsPlacementGroup>)> failure_callback,
       std::function<void(std::shared_ptr<GcsPlacementGroup>)> success_callback) = 0;
@@ -81,7 +81,7 @@ class ScheduleContext {
         node_manager_(node_manager) {}
 
   // Key is node id, value is the number of bundles on the node.
-  std::shared_ptr<absl::flat_hash_map<ClientID, int64_t>> node_to_bundles_;
+  const std::shared_ptr<absl::flat_hash_map<ClientID, int64_t>> node_to_bundles_;
   // Distribution of bundles in nodes. Key is bundle index, value is node id.
   const absl::flat_hash_map<int64_t, ClientID> &bundle_locations_;
 
@@ -137,7 +137,7 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
 
   virtual ~GcsPlacementGroupScheduler() = default;
 
-  /// Schedule the specified placement_group.
+  /// Schedule unplaced bundles of the specified placement group.
   /// If there is no available nodes then the `schedule_failed_handler` will be
   /// triggered, otherwise the bundle in placement_group will be add into a queue and
   /// schedule all bundle by calling ReserveResourceFromNode().
@@ -145,7 +145,7 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// \param placement_group to be scheduled.
   /// \param failure_callback This function is called if the schedule is failed.
   /// \param success_callback This function is called if the schedule is successful.
-  void Schedule(
+  void ScheduleUnplacedBundles(
       std::shared_ptr<GcsPlacementGroup> placement_group,
       std::function<void(std::shared_ptr<GcsPlacementGroup>)> failure_handler,
       std::function<void(std::shared_ptr<GcsPlacementGroup>)> success_handler) override;

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -88,9 +88,6 @@ class GcsScheduleStrategy {
 /// nodes.
 class GcsPackStrategy : public GcsScheduleStrategy {
  public:
-  GcsPackStrategy()
-      : gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {}
-
   ScheduleMap Schedule(std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
                        const std::unique_ptr<ScheduleContext> &context) override;
 };

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -58,8 +58,8 @@ class GcsPlacementGroupSchedulerInterface {
   ///
   /// \param node_id ID of the dead node.
   /// \return The bundles belong to the dead node.
-  virtual absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>> GetBundlesOfDeadNode(
-      const ClientID &node_id) = 0;
+  virtual absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>>
+  GetBundlesOfDeadNode(const ClientID &node_id) = 0;
 
   /// Destroy bundle resources from all nodes in the placement group.
   virtual void DestroyPlacementGroupBundleResourcesIfExists(
@@ -159,7 +159,7 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// cancelled.
   void MarkScheduleCancelled(const PlacementGroupID &placement_group_id) override;
 
-  void absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>> GetBundlesOfDeadNode(
+  absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>> GetBundlesOfDeadNode(
       const ClientID &node_id) override;
 
  protected:

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -88,6 +88,9 @@ class GcsScheduleStrategy {
 /// nodes.
 class GcsPackStrategy : public GcsScheduleStrategy {
  public:
+  GcsPackStrategy()
+      : gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {}
+
   ScheduleMap Schedule(std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
                        const std::unique_ptr<ScheduleContext> &context) override;
 };

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -47,11 +47,19 @@ class GcsPlacementGroupSchedulerInterface {
   /// Schedule the specified placement_group.
   ///
   /// \param placement_group to be scheduled.
+  /// \param failure_callback This function is called if the schedule is failed.
+  /// \param success_callback This function is called if the schedule is successful.
   virtual void Schedule(
       std::shared_ptr<GcsPlacementGroup> placement_group,
-      std::function<void(std::shared_ptr<GcsPlacementGroup>)> schedule_failure_handler,
-      std::function<void(std::shared_ptr<GcsPlacementGroup>)>
-          schedule_success_handler) = 0;
+      std::function<void(std::shared_ptr<GcsPlacementGroup>)> failure_callback,
+      std::function<void(std::shared_ptr<GcsPlacementGroup>)> success_callback) = 0;
+
+  /// Get bundles belong to the dead node.
+  ///
+  /// \param node_id ID of the dead node.
+  /// \return The bundles belong to the dead node.
+  virtual absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>> GetBundlesOfDeadNode(
+      const ClientID &node_id) = 0;
 
   /// Destroy bundle resources from all nodes in the placement group.
   virtual void DestroyPlacementGroupBundleResourcesIfExists(
@@ -150,6 +158,9 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// \param placement_group_id The id of a placement group to mark that scheduling is
   /// cancelled.
   void MarkScheduleCancelled(const PlacementGroupID &placement_group_id) override;
+
+  void absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>> GetBundlesOfDeadNode(
+      const ClientID &node_id) override;
 
  protected:
   /// Lease resource from the specified node for the specified bundle.

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -83,7 +83,7 @@ class ScheduleContext {
 
   // Key is node id, value is the number of bundles on the node.
   const std::shared_ptr<absl::flat_hash_map<ClientID, int64_t>> node_to_bundles_;
-  // Bundle locations.
+  // The locations of existing bundles for this placement group.
   const std::shared_ptr<BundleLocations> &bundle_locations_;
 
   const GcsNodeManager &node_manager_;

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -183,7 +183,7 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// Get an existing lease client or connect a new one.
   std::shared_ptr<ResourceReserveInterface> GetOrConnectLeaseClient(
       const rpc::Address &raylet_address);
-
+  
   void OnAllBundleSchedulingRequestReturned(
       const std::shared_ptr<GcsPlacementGroup> &placement_group,
       const std::vector<std::shared_ptr<BundleSpecification>> &bundles,
@@ -193,7 +193,7 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
       const std::function<void(std::shared_ptr<GcsPlacementGroup>)>
           &schedule_success_handler);
 
-  /// Generate schedule conetext.
+  /// Generate schedule context.
   std::unique_ptr<ScheduleContext> GetScheduleContext(
       const PlacementGroupID &placement_group_id);
 

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -204,8 +204,9 @@ void GcsServer::InitGcsActorManager() {
 
   gcs_node_manager_->AddNodeRemovedListener(
       [this](std::shared_ptr<rpc::GcsNodeInfo> node) {
-        // All of the related actors should be reconstructed when a node is removed from
-        // the GCS.
+        // All of the related placement groups and actors should be reconstructed when a
+        // node is removed from the GCS.
+        gcs_placement_group_manager_->OnNodeDead(ClientID::FromBinary(node->node_id()));
         gcs_actor_manager_->OnNodeDead(ClientID::FromBinary(node->node_id()));
       });
 

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
@@ -298,10 +298,8 @@ TEST_F(GcsPlacementGroupManagerTest, TestRescheduleWhenNodeDead) {
   ASSERT_EQ(finished_placement_group_count, 0);
   ASSERT_EQ(mock_placement_group_scheduler_->placement_groups_.size(), 1);
   auto placement_group = mock_placement_group_scheduler_->placement_groups_.back();
-  placement_group->GetMutablePlacementGroupTableData().mutable_bundles(0)->set_is_placed(
-      true);
-  placement_group->GetMutablePlacementGroupTableData().mutable_bundles(1)->set_is_placed(
-      true);
+  placement_group->GetMutableBundle(0)->set_is_placed(true);
+  placement_group->GetMutableBundle(1)->set_is_placed(true);
   mock_placement_group_scheduler_->placement_groups_.pop_back();
 
   // If a node dies, we will set the bundles above it to be unplaced and reschedule the

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
@@ -39,7 +39,7 @@ class MockPlacementGroupScheduler : public gcs::GcsPlacementGroupSchedulerInterf
 
   MOCK_METHOD1(MarkScheduleCancelled, void(const PlacementGroupID &placement_group_id));
 
-  absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>> GetBundlesOnDeadNode(
+  absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>> GetBundlesOnNode(
       const ClientID &node_id) override {
     absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>> bundles;
     bundles[group_on_dead_node_] = bundles_on_dead_node_;

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
@@ -298,8 +298,8 @@ TEST_F(GcsPlacementGroupManagerTest, TestRescheduleWhenNodeDead) {
   ASSERT_EQ(finished_placement_group_count, 0);
   ASSERT_EQ(mock_placement_group_scheduler_->placement_groups_.size(), 1);
   auto placement_group = mock_placement_group_scheduler_->placement_groups_.back();
-  placement_group->GetMutableBundle(0)->set_is_placed(true);
-  placement_group->GetMutableBundle(1)->set_is_placed(true);
+  placement_group->GetMutableBundle(0)->set_node_id(ClientID::FromRandom().Binary());
+  placement_group->GetMutableBundle(1)->set_node_id(ClientID::FromRandom().Binary());
   mock_placement_group_scheduler_->placement_groups_.pop_back();
 
   // If a node dies, we will set the bundles above it to be unplaced and reschedule the
@@ -320,8 +320,8 @@ TEST_F(GcsPlacementGroupManagerTest, TestRescheduleWhenNodeDead) {
             placement_group->GetPlacementGroupID());
   const auto &bundles =
       mock_placement_group_scheduler_->placement_groups_[0]->GetBundles();
-  EXPECT_FALSE(bundles[0]->GetMutableMessage().is_placed());
-  EXPECT_TRUE(bundles[1]->GetMutableMessage().is_placed());
+  EXPECT_TRUE(ClientID::FromBinary(bundles[0]->GetMutableMessage().node_id()).IsNil());
+  EXPECT_FALSE(ClientID::FromBinary(bundles[1]->GetMutableMessage().node_id()).IsNil());
 
   // If `RESCHEDULING` placement group fails to create, we will schedule it again first.
   placement_group = mock_placement_group_scheduler_->placement_groups_.back();

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
@@ -39,6 +39,11 @@ class MockPlacementGroupScheduler : public gcs::GcsPlacementGroupSchedulerInterf
 
   MOCK_METHOD1(MarkScheduleCancelled, void(const PlacementGroupID &placement_group_id));
 
+  absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>> GetBundlesOfDeadNode(
+      const ClientID &node_id) {
+    return absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>>();
+  }
+
   std::vector<std::shared_ptr<gcs::GcsPlacementGroup>> placement_groups;
 };
 

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
@@ -26,7 +26,7 @@ class MockPlacementGroupScheduler : public gcs::GcsPlacementGroupSchedulerInterf
  public:
   MockPlacementGroupScheduler() = default;
 
-  void Schedule(
+  void ScheduleUnplacedBundles(
       std::shared_ptr<gcs::GcsPlacementGroup> placement_group,
       std::function<void(std::shared_ptr<gcs::GcsPlacementGroup>)> failure_handler,
       std::function<void(std::shared_ptr<gcs::GcsPlacementGroup>)> success_handler)

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -451,7 +451,7 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestRescheduleWhenNodeDead) {
 
   // Node1 is dead, reschedule the placement group.
   auto bundle_on_dead_node = placement_group->GetMutableBundle(0);
-  bundle_on_dead_node->set_is_placed(false);
+  bundle_on_dead_node->clear_node_id();
   scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler, success_handler);
   if (0 == bundles_on_node0[placement_group->GetPlacementGroupID()][0]) {
     ASSERT_TRUE(raylet_client_->GrantResourceReserve());

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -87,13 +87,15 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     // Failed to schedule the placement group, because the node resources is not enough.
     auto request = Mocker::GenCreatePlacementGroupRequest("", strategy);
     auto placement_group = std::make_shared<gcs::GcsPlacementGroup>(request);
-    scheduler_->Schedule(placement_group, failure_handler, success_handler);
+    scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler,
+                                        success_handler);
     WaitPendingDone(failure_placement_groups_, 1);
     ASSERT_EQ(0, success_placement_groups_.size());
 
     // A new node is added, and the rescheduling is successful.
     AddNode(Mocker::GenNodeInfo(0), 2);
-    scheduler_->Schedule(placement_group, failure_handler, success_handler);
+    scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler,
+                                        success_handler);
     ASSERT_TRUE(raylet_client_->GrantResourceReserve());
     ASSERT_TRUE(raylet_client_->GrantResourceReserve());
     WaitPendingDone(success_placement_groups_, 1);
@@ -255,7 +257,8 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestStrictPackStrategyBalancedScheduling)
     auto request =
         Mocker::GenCreatePlacementGroupRequest("", rpc::PlacementStrategy::STRICT_PACK);
     auto placement_group = std::make_shared<gcs::GcsPlacementGroup>(request);
-    scheduler_->Schedule(placement_group, failure_handler, success_handler);
+    scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler,
+                                        success_handler);
 
     if (!raylet_client_->lease_callbacks.empty()) {
       ASSERT_TRUE(raylet_client_->GrantResourceReserve());
@@ -290,7 +293,7 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestStrictPackStrategyResourceCheck) {
   auto request =
       Mocker::GenCreatePlacementGroupRequest("", rpc::PlacementStrategy::STRICT_PACK);
   auto placement_group = std::make_shared<gcs::GcsPlacementGroup>(request);
-  scheduler_->Schedule(placement_group, failure_handler, success_handler);
+  scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler, success_handler);
   ASSERT_TRUE(raylet_client_->GrantResourceReserve());
   ASSERT_TRUE(raylet_client_->GrantResourceReserve());
   WaitPendingDone(success_placement_groups_, 1);
@@ -401,7 +404,7 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestPackStrategyLargeBundlesScheduling) {
   auto request =
       Mocker::GenCreatePlacementGroupRequest("", rpc::PlacementStrategy::PACK, 15);
   auto placement_group = std::make_shared<gcs::GcsPlacementGroup>(request);
-  scheduler_->Schedule(placement_group, failure_handler, success_handler);
+  scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler, success_handler);
   RAY_CHECK(raylet_client_->num_lease_requested > 0);
   RAY_CHECK(raylet_client1_->num_lease_requested > 0);
   for (int index = 0; index < raylet_client_->num_lease_requested; ++index) {

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -146,6 +146,8 @@ message Bundle {
   }
   BundleIdentifier bundle_id = 1;
   map<string, double> unit_resources = 2;
+  // Whether the bundle is placed.
+  bool is_placed = 3;
 }
 
 message PlacementGroupSpec {
@@ -192,11 +194,11 @@ message ActorCreationTaskSpec {
   repeated string dynamic_worker_options = 4;
   // The max number of concurrent calls for direct call actors.
   int32 max_concurrency = 5;
-  // Whether the actor is persistent
+  // Whether the actor is persistent.
   bool is_detached = 6;
   // Globally-unique name of the actor. Should only be populated when is_detached is true.
   string name = 7;
-  // Whether the actor use async actor calls
+  // Whether the actor use async actor calls.
   bool is_asyncio = 8;
   // Field used for storing application-level extensions to the actor definition.
   string extension_data = 9;

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -146,8 +146,8 @@ message Bundle {
   }
   BundleIdentifier bundle_id = 1;
   map<string, double> unit_resources = 2;
-  // Whether the bundle is placed.
-  bool is_placed = 3;
+  // The location of this bundle.
+  bytes node_id = 3;
 }
 
 message PlacementGroupSpec {

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -169,6 +169,8 @@ message PlacementGroupTableData {
     CREATED = 1;
     // Placement Group is already removed and won't be reschedule.
     REMOVED = 2;
+    // Placement Group is rescheduling because the node it placed is dead.
+    RESCHEDULING = 3;
   }
 
   // ID of the PlacementGroup.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
If a node is dead, the placement group scheduler should try to recover the group by rescheduling the bundles of the dead node. This should have higher priority than trying to place other placement groups.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/9794
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
