### PR TITLE
[Tune] Remove `checkpoint_at_end` from tune+serve docs

### DIFF
--- a/doc/source/tune/_tutorials/tune-serve-integration-mnist.py
+++ b/doc/source/tune/_tutorials/tune-serve-integration-mnist.py
@@ -322,7 +322,6 @@ def tune_from_scratch(num_samples=10, num_epochs=10, gpus_per_trial=0., day=0):
         num_samples=num_samples,
         scheduler=scheduler,
         progress_reporter=reporter,
-        checkpoint_at_end=True,
         verbose=0,
         name="tune_serve_mnist_fromscratch")
 
@@ -387,7 +386,6 @@ def tune_from_existing(start_model,
         num_samples=num_samples,
         scheduler=scheduler,
         progress_reporter=reporter,
-        checkpoint_at_end=True,
         verbose=0,
         name="tune_serve_mnist_fromsexisting")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
