### PR TITLE
[GCS Actor Management] Race condition around creating -> created phase.

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -858,30 +858,30 @@ void GcsActorManager::OnActorCreationSuccess(const std::shared_ptr<GcsActor> &ac
   }
   actor->UpdateState(rpc::ActorTableData::ALIVE);
   auto actor_table_data = actor->GetActorTableData();
+  // Invoke all callbacks for all registration requests of this actor (duplicated
+  // requests are included) and remove all of them from
+  // actor_to_create_callbacks_.
+  auto iter = actor_to_create_callbacks_.find(actor_id);
+  if (iter != actor_to_create_callbacks_.end()) {
+    for (auto &callback : iter->second) {
+      callback(actor);
+    }
+    actor_to_create_callbacks_.erase(iter);
+  }
+
+  // We should register the entry to the in-memory index before flushing them to
+  // GCS because otherwise, there could be timing problems due to asynchronous Put.
+  auto worker_id = actor->GetWorkerID();
+  auto node_id = actor->GetNodeID();
+  RAY_CHECK(!worker_id.IsNil());
+  RAY_CHECK(!node_id.IsNil());
+  RAY_CHECK(created_actors_[node_id].emplace(worker_id, actor_id).second);
   // The backend storage is reliable in the future, so the status must be ok.
   RAY_CHECK_OK(gcs_table_storage_->ActorTable().Put(
-      actor_id, actor_table_data,
-      [this, actor_id, actor_table_data, actor](Status status) {
+      actor_id, actor_table_data, [this, actor_id, actor_table_data](Status status) {
         RAY_CHECK_OK(gcs_pub_sub_->Publish(ACTOR_CHANNEL, actor_id.Hex(),
                                            actor_table_data.SerializeAsString(),
                                            nullptr));
-
-        // Invoke all callbacks for all registration requests of this actor (duplicated
-        // requests are included) and remove all of them from
-        // actor_to_create_callbacks_.
-        auto iter = actor_to_create_callbacks_.find(actor_id);
-        if (iter != actor_to_create_callbacks_.end()) {
-          for (auto &callback : iter->second) {
-            callback(actor);
-          }
-          actor_to_create_callbacks_.erase(iter);
-        }
-
-        auto worker_id = actor->GetWorkerID();
-        auto node_id = actor->GetNodeID();
-        RAY_CHECK(!worker_id.IsNil());
-        RAY_CHECK(!node_id.IsNil());
-        RAY_CHECK(created_actors_[node_id].emplace(worker_id, actor_id).second);
       }));
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

I detected this test failure from `test_dead_actors.py`.

After some analysis, it seems like the issue is coming from the fact that when we go from created => creating map, there's a slight timing that actor entry is not in any of the map. At this time, if `DestroyActor` is called, it will have check failure because the actor entry won't be in any of in-memory map. This PR addresses that issue. 

Adding tests are extremely difficult unless you can totally mock out Redis calls. Also, this should be P0, so I'd like to merge and see if the same gcs failures are detected by `test_dead_actors.py`.

<img width="1352" alt="Screen Shot 2020-08-10 at 9 35 27 PM" src="https://user-images.githubusercontent.com/18510752/89857614-6a459380-db51-11ea-8210-6432a5213fff.png">


## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
