### PR TITLE
[GCS] Re-report heartbeat when gcs server restarts

### DIFF
--- a/src/ray/gcs/accessor.h
+++ b/src/ray/gcs/accessor.h
@@ -551,6 +551,12 @@ class NodeInfoAccessor {
       const std::shared_ptr<rpc::HeartbeatTableData> &data_ptr,
       const StatusCallback &callback) = 0;
 
+  /// Resend heartbeat when GCS restarts from a failure.
+  ///
+  /// \param is_pubsub_server_restarted If the pubsub server restarts. Only invoke this
+  /// when it's false.
+  virtual void AsyncReReportHeartbeat(bool is_pubsub_server_restarted) = 0;
+
   /// Subscribe to the heartbeat of each node from GCS.
   ///
   /// \param subscribe Callback that will be called each time when heartbeat is updated.

--- a/src/ray/gcs/accessor.h
+++ b/src/ray/gcs/accessor.h
@@ -552,10 +552,7 @@ class NodeInfoAccessor {
       const StatusCallback &callback) = 0;
 
   /// Resend heartbeat when GCS restarts from a failure.
-  ///
-  /// \param is_pubsub_server_restarted If the pubsub server restarts. Only invoke this
-  /// when it's false.
-  virtual void AsyncReReportHeartbeat(bool is_pubsub_server_restarted) = 0;
+  virtual void AsyncReReportHeartbeat() = 0;
 
   /// Subscribe to the heartbeat of each node from GCS.
   ///

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -721,9 +721,8 @@ Status ServiceBasedNodeInfoAccessor::AsyncReportHeartbeat(
   return Status::OK();
 }
 
-void ServiceBasedNodeInfoAccessor::AsyncReReportHeartbeat(
-    bool is_pubsub_server_restarted) {
-  if (!is_pubsub_server_restarted && cached_heartbeat_.has_heartbeat()) {
+void ServiceBasedNodeInfoAccessor::AsyncReReportHeartbeat() {
+  if (cached_heartbeat_.has_heartbeat()) {
     RAY_LOG(INFO) << "Rereport heartbeat.";
     client_impl_->GetGcsRpcClient().ReportHeartbeat(
         cached_heartbeat_,

--- a/src/ray/gcs/gcs_client/service_based_accessor.h
+++ b/src/ray/gcs/gcs_client/service_based_accessor.h
@@ -228,9 +228,12 @@ class ServiceBasedNodeInfoAccessor : public NodeInfoAccessor {
   /// server restarts from a failure.
   FetchDataOperation fetch_node_data_operation_;
 
+  // Mutex to protect the cached_heartbeat_ field.
+  absl::Mutex mutex_;
+
   /// Save the heartbeat data, so we can resend it again when GCS server restarts from a
   /// failure.
-  rpc::ReportHeartbeatRequest cached_heartbeat_;
+  rpc::ReportHeartbeatRequest cached_heartbeat_ GUARDED_BY(mutex_);
 
   void HandleNotification(const GcsNodeInfo &node_info);
 

--- a/src/ray/gcs/gcs_client/service_based_accessor.h
+++ b/src/ray/gcs/gcs_client/service_based_accessor.h
@@ -18,6 +18,7 @@
 #include "ray/gcs/accessor.h"
 #include "ray/gcs/subscription_executor.h"
 #include "ray/util/sequencer.h"
+#include "src/ray/protobuf/gcs_service.pb.h"
 
 namespace ray {
 namespace gcs {
@@ -193,6 +194,8 @@ class ServiceBasedNodeInfoAccessor : public NodeInfoAccessor {
   Status AsyncReportHeartbeat(const std::shared_ptr<rpc::HeartbeatTableData> &data_ptr,
                               const StatusCallback &callback) override;
 
+  void AsyncReReportHeartbeat(bool is_pubsub_server_restarted) override;
+
   Status AsyncSubscribeHeartbeat(
       const SubscribeCallback<ClientID, rpc::HeartbeatTableData> &subscribe,
       const StatusCallback &done) override;
@@ -224,6 +227,10 @@ class ServiceBasedNodeInfoAccessor : public NodeInfoAccessor {
   /// Save the fetch data operation in this function, so we can call it again when GCS
   /// server restarts from a failure.
   FetchDataOperation fetch_node_data_operation_;
+
+  /// Save the heartbeat data, so we can resend it again when GCS server restarts from a
+  /// failure.
+  rpc::ReportHeartbeatRequest cached_heartbeat_;
 
   void HandleNotification(const GcsNodeInfo &node_info);
 

--- a/src/ray/gcs/gcs_client/service_based_accessor.h
+++ b/src/ray/gcs/gcs_client/service_based_accessor.h
@@ -194,7 +194,7 @@ class ServiceBasedNodeInfoAccessor : public NodeInfoAccessor {
   Status AsyncReportHeartbeat(const std::shared_ptr<rpc::HeartbeatTableData> &data_ptr,
                               const StatusCallback &callback) override;
 
-  void AsyncReReportHeartbeat(bool is_pubsub_server_restarted) override;
+  void AsyncReReportHeartbeat() override;
 
   Status AsyncSubscribeHeartbeat(
       const SubscribeCallback<ClientID, rpc::HeartbeatTableData> &subscribe,

--- a/src/ray/gcs/gcs_client/service_based_gcs_client.cc
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.cc
@@ -61,7 +61,7 @@ Status ServiceBasedGcsClient::Connect(boost::asio::io_service &io_service) {
     object_accessor_->AsyncResubscribe(is_pubsub_server_restarted);
     worker_accessor_->AsyncResubscribe(is_pubsub_server_restarted);
 
-    node_accessor_->AsyncReReportHeartbeat(is_pubsub_server_restarted);
+    node_accessor_->AsyncReReportHeartbeat();
   };
 
   // Connect to gcs service.

--- a/src/ray/gcs/gcs_client/service_based_gcs_client.h
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.h
@@ -70,7 +70,7 @@ class RAY_EXPORT ServiceBasedGcsClient : public GcsClient {
   // A timer used to check if gcs server address changed.
   std::unique_ptr<boost::asio::deadline_timer> detect_timer_;
   std::function<bool(std::pair<std::string, int> *)> get_server_address_func_;
-  std::function<void(bool)> resubscribe_func_;
+  std::function<void(bool)> restart_functions_;
   std::pair<std::string, int> current_gcs_server_address_;
 };
 

--- a/src/ray/gcs/gcs_client/service_based_gcs_client.h
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.h
@@ -70,7 +70,7 @@ class RAY_EXPORT ServiceBasedGcsClient : public GcsClient {
   // A timer used to check if gcs server address changed.
   std::unique_ptr<boost::asio::deadline_timer> detect_timer_;
   std::function<bool(std::pair<std::string, int> *)> get_server_address_func_;
-  std::function<void(bool)> restart_functions_;
+  std::function<void(bool)> resubscribe_func_;
   std::pair<std::string, int> current_gcs_server_address_;
 };
 

--- a/src/ray/gcs/redis_accessor.cc
+++ b/src/ray/gcs/redis_accessor.cc
@@ -660,6 +660,8 @@ Status RedisNodeInfoAccessor::AsyncReportHeartbeat(
   return heartbeat_table.Add(JobID::Nil(), node_id, data_ptr, on_done);
 }
 
+void RedisNodeInfoAccessor::AsyncReReportHeartbeat(bool is_pubsub_server_restarted) {}
+
 Status RedisNodeInfoAccessor::AsyncSubscribeHeartbeat(
     const SubscribeCallback<ClientID, HeartbeatTableData> &subscribe,
     const StatusCallback &done) {

--- a/src/ray/gcs/redis_accessor.cc
+++ b/src/ray/gcs/redis_accessor.cc
@@ -660,7 +660,7 @@ Status RedisNodeInfoAccessor::AsyncReportHeartbeat(
   return heartbeat_table.Add(JobID::Nil(), node_id, data_ptr, on_done);
 }
 
-void RedisNodeInfoAccessor::AsyncReReportHeartbeat(bool is_pubsub_server_restarted) {}
+void RedisNodeInfoAccessor::AsyncReReportHeartbeat() {}
 
 Status RedisNodeInfoAccessor::AsyncSubscribeHeartbeat(
     const SubscribeCallback<ClientID, HeartbeatTableData> &subscribe,

--- a/src/ray/gcs/redis_accessor.h
+++ b/src/ray/gcs/redis_accessor.h
@@ -362,7 +362,7 @@ class RedisNodeInfoAccessor : public NodeInfoAccessor {
   Status AsyncReportHeartbeat(const std::shared_ptr<HeartbeatTableData> &data_ptr,
                               const StatusCallback &callback) override;
 
-  void AsyncReReportHeartbeat(bool is_pubsub_server_restarted) override;
+  void AsyncReReportHeartbeat() override;
 
   Status AsyncSubscribeHeartbeat(
       const SubscribeCallback<ClientID, HeartbeatTableData> &subscribe,

--- a/src/ray/gcs/redis_accessor.h
+++ b/src/ray/gcs/redis_accessor.h
@@ -362,6 +362,8 @@ class RedisNodeInfoAccessor : public NodeInfoAccessor {
   Status AsyncReportHeartbeat(const std::shared_ptr<HeartbeatTableData> &data_ptr,
                               const StatusCallback &callback) override;
 
+  void AsyncReReportHeartbeat(bool is_pubsub_server_restarted) override;
+
   Status AsyncSubscribeHeartbeat(
       const SubscribeCallback<ClientID, HeartbeatTableData> &subscribe,
       const StatusCallback &done) override;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -464,12 +464,8 @@ void NodeManager::Heartbeat() {
     should_local_gc_ = false;
   }
 
-  ray::Status status = gcs_client_->Nodes().AsyncReportHeartbeat(heartbeat_data,
-                                                                 /*done*/ nullptr);
-  RAY_CHECK_OK_PREPEND(status, "Heartbeat failed");
-  if (light_heartbeat_enabled_ && !status.ok()) {
-    last_heartbeat_resources_ = SchedulingResources();
-  }
+  RAY_CHECK_OK(
+      gcs_client_->Nodes().AsyncReportHeartbeat(heartbeat_data, /*done*/ nullptr));
 
   if (debug_dump_period_ > 0 &&
       static_cast<int64_t>(now_ms - last_debug_dump_at_ms_) > debug_dump_period_) {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -467,6 +467,9 @@ void NodeManager::Heartbeat() {
   ray::Status status = gcs_client_->Nodes().AsyncReportHeartbeat(heartbeat_data,
                                                                  /*done*/ nullptr);
   RAY_CHECK_OK_PREPEND(status, "Heartbeat failed");
+  if (light_heartbeat_enabled_ && !status.ok()) {
+    last_heartbeat_resources_ = SchedulingResources();
+  }
 
   if (debug_dump_period_ > 0 &&
       static_cast<int64_t>(now_ms - last_debug_dump_at_ms_) > debug_dump_period_) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

When light heartbeat enabled, raylet sends heartbeat only when its content changed, which is checked by comparing with a copy sent before.

Once a heartbeat is failed to be sent, we should clear the copy to force sending in next round, otherwise the heartbeat will never be sent until next change(could be a very long time).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
