### PR TITLE
Generate *.pyi stubs for Python Protobuf

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1797,10 +1797,15 @@ filegroup(
     name = "all_py_proto",
     srcs = [
         "//src/ray/protobuf:common_py_proto",
+        "//src/ray/protobuf:common_mypy_proto",
         "//src/ray/protobuf:core_worker_py_proto",
+        "//src/ray/protobuf:core_worker_mypy_proto",
         "//src/ray/protobuf:gcs_py_proto",
+        "//src/ray/protobuf:gcs_mypy_proto",
         "//src/ray/protobuf:node_manager_py_proto",
+        "//src/ray/protobuf:node_manager_mypy_proto",
         "//src/ray/protobuf:reporter_py_proto",
+        "//src/ray/protobuf:reporter_mypy_proto",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,3 +14,8 @@ ray_deps_build_all()
 load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 
 grpc_extra_deps()
+
+
+load("@mypy_protobuf_dep//:requirements.bzl", "pip_install")
+
+pip_install()

--- a/bazel/ray_deps_build_all.bzl
+++ b/bazel/ray_deps_build_all.bzl
@@ -7,7 +7,7 @@ load("@com_github_checkstyle_java//:repo.bzl", "checkstyle_deps")
 load("@com_github_grpc_grpc//third_party/py:python_configure.bzl", "python_configure")
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_toolchains")
-
+load("@rules_python//python:pip.bzl", "pip_import")
 
 def ray_deps_build_all():
   bazel_skylib_workspace()
@@ -19,3 +19,7 @@ def ray_deps_build_all():
   python_configure(name = "local_config_python")
   grpc_deps()
   rules_proto_grpc_toolchains()
+  pip_import(
+    name = "mypy_protobuf_dep",
+    requirements = "@mypy_protobuf//:requirements.txt",
+  )

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -264,3 +264,15 @@ def ray_deps_setup():
             "//thirdparty/patches:msgpack-windows-iovec.patch",
         ],
     )
+
+    auto_http_archive(
+        name = "mypy_protobuf",
+        url = "https://github.com/simon-mo/mypy-protobuf/archive/7e41f194c601c0958ec61dd55499780bf57af58c.tar.gz",
+        sha256 = "6211021ceeac28d207d0a63cc0c9f8b6601085b7f82542d91850d10d70172a8c"
+    )
+
+    auto_http_archive(
+        name = "rules_python",
+        url = "https://github.com/bazelbuild/rules_python/releases/download/0.0.2/rules_python-0.0.2.tar.gz",
+        sha256 = "b5668cde8bb6e3515057ef465a35ad712214962f0b3a314e551204266c7be90c"
+    )

--- a/src/ray/protobuf/BUILD
+++ b/src/ray/protobuf/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library", "cc_test")
 load("@rules_proto_grpc//python:defs.bzl", "python_grpc_compile")
+load("@mypy_protobuf//:plugin.bzl", "mypy_proto_compile")
 
 proto_library(
     name = "common_proto",
@@ -18,6 +19,11 @@ cc_proto_library(
 python_grpc_compile(
     name = "common_py_proto",
     deps = [":common_proto"],
+)
+
+mypy_proto_compile(
+    name = "common_mypy_proto",
+    deps = [":common_proto"]
 )
 
 proto_library(
@@ -37,6 +43,11 @@ python_grpc_compile(
     deps = [":gcs_proto"],
 )
 
+mypy_proto_compile(
+    name = "gcs_mypy_proto",
+    deps = [":gcs_proto"]
+)
+
 proto_library(
     name = "node_manager_proto",
     srcs = ["node_manager.proto"],
@@ -53,6 +64,11 @@ python_grpc_compile(
     deps = [":node_manager_proto"],
 )
 
+mypy_proto_compile(
+    name = "node_manager_mypy_proto",
+    deps = [":node_manager_proto"]
+)
+
 proto_library(
     name = "reporter_proto",
     srcs = ["reporter.proto"],
@@ -67,6 +83,11 @@ cc_proto_library(
 python_grpc_compile(
     name = "reporter_py_proto",
     deps = [":reporter_proto"],
+)
+
+mypy_proto_compile(
+    name = "reporter_mypy_proto",
+    deps = [":reporter_proto"]
 )
 
 proto_library(
@@ -102,6 +123,11 @@ proto_library(
 python_grpc_compile(
     name = "core_worker_py_proto",
     deps = [":core_worker_proto"],
+)
+
+mypy_proto_compile(
+    name = "core_worker_mypy_proto",
+    deps = [":core_worker_proto"]
 )
 
 cc_proto_library(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
This PR automatically generates *.pyi type stubs for Python protobuf, facilitate type checking and hinting especially for dashboard and metrics. (cc @rkooo567)

We uses mypy-protobuf from dropbox. I have to bazelify it. Happy to move to ray-project repo once it's stabilized.

If you are curious, generated stubs look like this https://gist.github.com/2d2c412102c0d6347aad9a6bd20f59b1

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
