### PR TITLE
[GCS]Add node realtime resource view

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -21,6 +21,18 @@
 namespace ray {
 namespace gcs {
 
+bool GcsNodeResource::IsSubset(
+    const std::unordered_map<std::string, double> &request_resources) const {
+  for (const auto &request_resource : request_resources) {
+    auto iter = resources_available_.find(request_resource.first);
+    if (iter == resources_available_.end() || iter->second < request_resource.second) {
+      return false;
+    }
+  }
+  return true;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
 GcsNodeManager::NodeFailureDetector::NodeFailureDetector(
     boost::asio::io_service &io_service,
     std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
@@ -60,10 +72,6 @@ void GcsNodeManager::NodeFailureDetector::HandleHeartbeat(
       heartbeat_data.resources_total_size() > 0 ||
       heartbeat_data.resource_load_size() > 0) {
     heartbeat_buffer_[node_id] = heartbeat_data;
-  }
-
-  if (heartbeat_listener_) {
-    heartbeat_listener_(heartbeat_data);
   }
 }
 
@@ -235,6 +243,10 @@ void GcsNodeManager::HandleReportHeartbeat(const rpc::ReportHeartbeatRequest &re
   ClientID node_id = ClientID::FromBinary(request.heartbeat().client_id());
   auto heartbeat_data = std::make_shared<rpc::HeartbeatTableData>();
   heartbeat_data->CopyFrom(request.heartbeat());
+
+  // Update node realtime resources.
+  UpdateNodeRealtimeResources(node_id, *heartbeat_data);
+
   // Note: To avoid heartbeats being delayed by main thread, make sure heartbeat is always
   // handled by its own IO service.
   node_failure_detector_service_.post([this, node_id, heartbeat_data] {
@@ -453,6 +465,23 @@ void GcsNodeManager::StartNodeFailureDetector() {
   // Note: To avoid heartbeats being delayed by main thread, make sure detector start is
   // always handled by its own IO service.
   node_failure_detector_service_.post([this] { node_failure_detector_->Start(); });
+}
+
+void GcsNodeManager::UpdateNodeRealtimeResources(
+    const ClientID &node_id, const rpc::HeartbeatTableData &heartbeat) {
+  auto resources_available = MapFromProtobuf(heartbeat.resources_available());
+  auto iter = cluster_realtime_resources_.find(node_id);
+  if (iter != cluster_realtime_resources_.end()) {
+    iter->second->resources_available_ = resources_available;
+  } else {
+    cluster_realtime_resources_[node_id] =
+        std::make_shared<GcsNodeResource>(resources_available);
+  }
+}
+
+const absl::flat_hash_map<ClientID, std::shared_ptr<GcsNodeResource>>
+    &GcsNodeManager::GetClusterRealtimeResources() const {
+  return cluster_realtime_resources_;
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -61,6 +61,10 @@ void GcsNodeManager::NodeFailureDetector::HandleHeartbeat(
       heartbeat_data.resource_load_size() > 0) {
     heartbeat_buffer_[node_id] = heartbeat_data;
   }
+
+  if (heartbeat_listener_) {
+    heartbeat_listener_(heartbeat_data);
+  }
 }
 
 /// A periodic timer that checks for timed out clients.

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -27,6 +27,11 @@
 namespace ray {
 namespace gcs {
 
+class GcsNodeResource {
+ public:
+  absl::flat_hash_map << std::string, double > resources_available;
+};
+
 /// GcsNodeManager is responsible for managing and monitoring nodes as well as handing
 /// node and resource related rpc requests.
 /// This class is not thread-safe.
@@ -178,6 +183,14 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
     void HandleHeartbeat(const ClientID &node_id,
                          const rpc::HeartbeatTableData &heartbeat_data);
 
+    /// Add listener to monitor the heartbeat of nodes.
+    ///
+    /// \param listener The handler which process the add of nodes.
+    void AddHeartbeatListener(
+        std::function<void(const rpc::HeartbeatTableData &heartbeat_data)> listener) {
+      heartbeat_listener_ = std::move(listener);
+    }
+
    protected:
     /// A periodic timer that fires on every heartbeat period. Raylets that have
     /// not sent a heartbeat within the last num_heartbeats_timeout ticks will be
@@ -214,6 +227,9 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
     std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub_;
     /// Is the detect started.
     bool is_started_ = false;
+    /// Listener which monitor the heartbeat of nodes.
+    std::function<void(const rpc::HeartbeatTableData &heartbeat_data)>
+        heartbeat_listener_;
   };
 
  private:

--- a/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
@@ -103,6 +103,7 @@ TEST_F(GcsNodeManagerTest, TestGetClusterRealtimeResources) {
   ASSERT_TRUE(node_resources[node_id]->IsSubset(request_resources));
   request_resources["CPU"] = 10.1;
   ASSERT_FALSE(node_resources[node_id]->IsSubset(request_resources));
+  request_resources.clear();
   request_resources["GPU"] = 1;
   ASSERT_FALSE(node_resources[node_id]->IsSubset(request_resources));
 }

--- a/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
@@ -86,6 +86,27 @@ TEST_F(GcsNodeManagerTest, TestListener) {
   }
 }
 
+TEST_F(GcsNodeManagerTest, TestGetClusterRealtimeResources) {
+  boost::asio::io_service io_service;
+  gcs::GcsNodeManager node_manager(io_service, io_service, gcs_pub_sub_,
+                                   gcs_table_storage_);
+
+  auto node_id = ClientID::FromRandom();
+  rpc::HeartbeatTableData heartbeat;
+  (*heartbeat.mutable_resources_available())["CPU"] = 10;
+  node_manager.UpdateNodeRealtimeResources(node_id, heartbeat);
+  auto node_resources = node_manager.GetClusterRealtimeResources();
+  std::unordered_map<std::string, double> request_resources;
+  request_resources["CPU"] = 9;
+  ASSERT_TRUE(node_resources[node_id]->IsSubset(request_resources));
+  request_resources["CPU"] = 10;
+  ASSERT_TRUE(node_resources[node_id]->IsSubset(request_resources));
+  request_resources["CPU"] = 10.1;
+  ASSERT_FALSE(node_resources[node_id]->IsSubset(request_resources));
+  request_resources["GPU"] = 1;
+  ASSERT_FALSE(node_resources[node_id]->IsSubset(request_resources));
+}
+
 }  // namespace ray
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
When selecting nodes for placement group(https://github.com/ray-project/ray/pull/9924 ), we need to look at the resource heartbeat data to calculate how many can be packed onto the node. So we abstract the `GetClusterRealtimeResources` function. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
