### PR TITLE
Upload Travis in after_script phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -364,6 +364,9 @@ script:
   - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then ./ci/keep_alive bazel test --config=ci $(./scripts/bazel_export_options) --test_tag_filters=-jenkins_only python/ray/tests/...; fi
   # NO MORE TESTS BELOW, keep them above.
 
+after_script:
+  - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi
+
 deploy:
   - provider: s3
     edge: true # This supposedly opts in to deploy v2.
@@ -429,26 +432,6 @@ deploy:
       repo: ray-project/ray
       branch: master
       condition: $MULTIPLATFORM_JARS = 1 || $MAC_JARS = 1
-
-  - provider: script
-    edge: true # This supposedly opts in to deploy v2.
-    script: ./ci/travis/get_build_info.py > /tmp/bazel_event_logs/metadata.json
-    skip_cleanup: true
-
-  # Upload bazel event logs to s3
-  - provider: s3
-    edge: true
-    access_key_id: AKIAQQPDA73RF7PSLH5N
-    secret_access_key:
-      secure: ai2YP/R3G86HuARvaMKG6tjzei5EqL/TR5pMDuT5JKjpWt4YFcvdAXcN4F2EEvKdJ+gwVEbACa37M5fJ3YMlforCrk/YiOQI15Ixjo9NhNonLp95NhCDKgKwQIgXXKBzk2ylXUm8FbLqnW6MRJyOb7ioufRLEtpy35XcYCyzqeDZgdhn9eIsP4O2W17ws3WqKvbbMFs2rTnDqlRYqDBO+dCGcaWdaKdX8VDjoCMkko7Yh8Mh1zne3KFHZvcknGTI3DggJMtaY77Fx3FfJSO2Gp7R8ARWGWTJqNkK/H0YGnlnJ84Za15qeozkvP5Ct9SvRQf0Pg96oj73IevVrs0lLjFfCkp+fC+gVYAXfMhDfXO7rVRUyXoXrsFcEBbGNGzu3awCsZIkECD0JVadsV4ypxUCmygd2+3aHgRY1+crwbnBvNmHk+qyoN82TH1FmtOP4FyvF3/OJaL0Cn9KVoeoRW3yH2SLbyE/yNDHwsADMJEFVXv4VuHctdRoAPujt+mxU8Jz0AzJd2CqUPXePriWTyRqPBDi3mOhAu0KyX+G/r7o7C+ZIUU1bTXRHtKQqFuWq9KF43H80G7EnN1Bwq1wXpGQjzGH6SdflLRC8uf2vCUeD9Xgd/E2b0wJM07PfQ0aPuKUoZfJZECuA7o+5adB7mSfVg+brF0xvl67DIp2lDE=
-    bucket: ray-travis-log
-    # acl: public_read # This data won't be used externally. We can always turn on public_read later.
-    region: us-west-2
-    local_dir: /tmp/bazel_event_logs
-    upload-dir: "bazel_events/$TRAVIS_BRANCH/$TRAVIS_COMMIT/$TRAVIS_JOB_ID"
-    on:
-      repo: ray-project/ray
-      branch: master
 
   - provider: script
     edge: true # This supposedly opts in to deploy v2.

--- a/ci/travis/get_build_info.py
+++ b/ci/travis/get_build_info.py
@@ -21,7 +21,7 @@ def get_build_env():
         "TRAVIS_BRANCH", "TRAVIS_BUILD_ID", "TRAVIS_BUILD_NUMBER",
         "TRAVIS_BUILD_WEB_URL", "TRAVIS_COMMIT", "TRAVIS_COMMIT_MESSAGE",
         "TRAVIS_DIST", "TRAVIS_JOB_ID", "TRAVIS_JOB_NUMBER",
-        "TRAVIS_JOB_WEB_URL", "TRAVIS_OS_NAME"
+        "TRAVIS_JOB_WEB_URL", "TRAVIS_OS_NAME", "TRAVIS_TEST_RESULT"
     ]
     return {key: os.environ.get(key) for key in keys}
 

--- a/ci/travis/upload_build_info.sh
+++ b/ci/travis/upload_build_info.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Cause the script to exit if a single command fails.
+set -e
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
+RAY_DIR=$(cd "${ROOT_DIR}/../../"; pwd)
+
+cd "${RAY_DIR}"
+
+mkdir -p /tmp/bazel_event_logs
+./ci/travis/get_build_info.py > /tmp/bazel_event_logs/metadata.json
+
+pip install -q awscli
+
+export AWS_ACCESS_KEY_ID=AKIAQQPDA73RF7PSLH5N
+export AWS_SECRET_ACCESS_KEY=${BAZEL_LOG_BUCKET_ACCESS_KEY}
+export AWS_DEFAULT_REGION=us-west-2
+
+DST="s3://ray-travis-log/bazel_events/$TRAVIS_BRANCH/$TRAVIS_COMMIT/$TRAVIS_JOB_ID"
+echo "Uploading log to ${DST}"
+
+aws s3 cp --recursive /tmp/bazel_event_logs "${DST}"


### PR DESCRIPTION
The deploy phase is skipped when script/tests fails. This prevent us
from uploading failed result to S3.

This PR change it to after_script phase and the secret is injected
via Travis Env Var.

https://docs.travis-ci.com/user/job-lifecycle/

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
