### PR TITLE
[tune] fix flaky PBT replay test

### DIFF
--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -1075,11 +1075,24 @@ class PopulationBasedTestingSuite(unittest.TestCase):
         shutil.rmtree(tmpdir)
 
     def testReplay(self):
+        # Returns unique increasing parameter mutations
+        class _Counter:
+            def __init__(self, start=0):
+                self.count = start - 1
+
+            def __call__(self, *args, **kwargs):
+                self.count += 1
+                return self.count
+
         pbt, runner = self.basicSetup(
             num_trials=4,
             perturbation_interval=5,
             log_config=True,
-            step_once=False)
+            step_once=False,
+            hyperparam_mutations={
+                "float_factor": lambda: 100.0,
+                "int_factor": _Counter(1000)
+            })
         trials = runner.get_trials()
         tmpdir = tempfile.mkdtemp()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

The PBT replay test was flaky. The main reason seems to be that sometimes trials ended up mutating their hyperparameters to the same values, which lead to errors in the simple tracking mechanism for trial perturbations.

This PR should fix this by not mutating the `id_factor` and adding a unique integer generator for the `int_factor`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests

