### PR TITLE
[Tune]tune/examples/pbt_convnet_example.py bug fixed

### DIFF
--- a/python/ray/tune/examples/pbt_convnet_example.py
+++ b/python/ray/tune/examples/pbt_convnet_example.py
@@ -133,7 +133,7 @@ if __name__ == "__main__":
 
     best_trial = analysis.get_best_trial("mean_accuracy")
     best_checkpoint = max(
-        analysis.get_trial_checkpoints_paths(best_trial, "mean_accuracy"))
+        analysis.get_trial_checkpoints_paths(best_trial, "mean_accuracy"), lambda x:x[1])
     restored_trainable = PytorchTrainable()
     restored_trainable.restore(best_checkpoint[0])
     best_model = restored_trainable.model


### PR DESCRIPTION
## Why are these changes needed?

Fix bug in tune/examples/pbt_convnet_example.py.
The code:
`analysis.get_trial_checkpoints_paths(best_trial, "mean_accuracy")`
In fact return a list like :
`[['009' , 0.7] , ['007' , 0.9]]`
This mean the list's item is a list which first item is a file path , and second item is 'mean_accuracy'.
So when use max function , it is compare the file path ,but not the mean_accuracy.
```
 best_checkpoint = max( 
     analysis.get_trial_checkpoints_paths(best_trial, "mean_accuracy")) 
```

## Related issue number

10038

## Checks
 
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
