### PR TITLE
[docs] fix typo in deployment.rst

### DIFF
--- a/doc/source/serve/deployment.rst
+++ b/doc/source/serve/deployment.rst
@@ -279,7 +279,7 @@ To learn more, in general, about Ray Clusters see :ref:`cluster-index`.
 
 
 Deploying Multiple Serve Instances on a Single Ray Cluster
----------------------------------------------------------
+----------------------------------------------------------
 
 You can run multiple serve instances on the same Ray cluster by providing a ``name`` in :mod:`serve.init() <ray.serve.init>`.
 

--- a/doc/source/serve/deployment.rst
+++ b/doc/source/serve/deployment.rst
@@ -278,7 +278,7 @@ opt for launching a Ray Cluster locally. Specify a Ray cluster like we did in :r
 To learn more, in general, about Ray Clusters see :ref:`cluster-index`.
 
 
-Deploying Multiple Serve Instaces on a Single Ray Cluster
+Deploying Multiple Serve Instances on a Single Ray Cluster
 ---------------------------------------------------------
 
 You can run multiple serve instances on the same Ray cluster by providing a ``name`` in :mod:`serve.init() <ray.serve.init>`.


### PR DESCRIPTION
"instaces" -> "instances"