### PR TITLE
[Core] Add cached memory to unsued memory in Linux/BSD

### DIFF
--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -113,7 +113,7 @@ class MemoryMonitor:
             used_gb = total_gb - psutil_mem.available / (1024**3)
 
             # Linux, BSD has cached memory, which should also be considered as unused
-            if has_attr(psutil_mem, 'cached'):
+            if hasattr(psutil_mem, 'cached'):
                 used_gb -= psutil_mem.cached / (1024**3)
 
             if self.cgroup_memory_limit_gb < total_gb:

--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -109,7 +109,7 @@ class MemoryMonitor:
 
             self.last_checked = time.time()
             total_gb = psutil.virtual_memory().total / (1024**3)
-            used_gb = total_gb - psutil.virtual_memory().available / (1024**3)
+            used_gb = total_gb - psutil.virtual_memory().available - psutil.virtual_memory().cached / (1024**3)
             if self.cgroup_memory_limit_gb < total_gb:
                 total_gb = self.cgroup_memory_limit_gb
                 with open("/sys/fs/cgroup/memory/memory.usage_in_bytes",

--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -112,8 +112,9 @@ class MemoryMonitor:
             total_gb = psutil_mem.total / (1024**3)
             used_gb = total_gb - psutil_mem.available / (1024**3)
 
-            # Linux, BSD has cached memory, which should also be considered as unused
-            if hasattr(psutil_mem, 'cached'):
+            # Linux, BSD has cached memory, which should
+            # also be considered as unused memory
+            if hasattr(psutil_mem, "cached"):
                 used_gb -= psutil_mem.cached / (1024**3)
 
             if self.cgroup_memory_limit_gb < total_gb:

--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -109,8 +109,9 @@ class MemoryMonitor:
 
             self.last_checked = time.time()
             total_gb = psutil.virtual_memory().total / (1024**3)
-            used_gb = total_gb - psutil.virtual_memory(
-            ).available - psutil.virtual_memory().cached / (1024**3)
+            psutil_mem = psutil.virtual_memory()
+            used_gb = total_gb - (psutil_mem.available + psutil_mem.cached) / (
+                1024**3)
             if self.cgroup_memory_limit_gb < total_gb:
                 total_gb = self.cgroup_memory_limit_gb
                 with open("/sys/fs/cgroup/memory/memory.usage_in_bytes",

--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -109,7 +109,8 @@ class MemoryMonitor:
 
             self.last_checked = time.time()
             total_gb = psutil.virtual_memory().total / (1024**3)
-            used_gb = total_gb - psutil.virtual_memory().available - psutil.virtual_memory().cached / (1024**3)
+            used_gb = total_gb - psutil.virtual_memory(
+            ).available - psutil.virtual_memory().cached / (1024**3)
             if self.cgroup_memory_limit_gb < total_gb:
                 total_gb = self.cgroup_memory_limit_gb
                 with open("/sys/fs/cgroup/memory/memory.usage_in_bytes",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Cached memory should also be considered as unused memory.

When I start ray cluster in a machine that has low available mem but high buff/cache memory, a rayOutOfMemoryError is raised.

```
2020-08-10 16:26:03,954 ERROR worker.py:1085 -- Possible unhandled error from worker: ray::JobWorker.__init__() (pid=42130, ip=11.166.237.22)
  File "python/ray/_raylet.pyx", line 435, in ray._raylet.execute_task
  File "/home/admin/ray/python/ray/memory_monitor.py", line 128, in raise_if_low_memory
    self.error_threshold))
ray.memory_monitor.RayOutOfMemoryError: More than 95% of the memory on node corgiunit-eu95-5.rz00b.stable.alipay.net is used (15.59 / 16.0 GB). 
```

```
$ free -h
              total        used        free      shared  buff/cache   available
Mem:            16G        5.9G        980M        3.6G        9.1G        980M
Swap:            0B          0B          0B
```


This PR has been merged but reverted because it breaks master, see <https://github.com/ray-project/ray/pull/10064>. 

And this time I fixed the problem mentioned in the reverting PR.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
