### PR TITLE
[Tests] Make test_multi_driver light.

### DIFF
--- a/python/ray/tests/test_multi_tenancy.py
+++ b/python/ray/tests/test_multi_tenancy.py
@@ -44,6 +44,7 @@ def test_initial_workers(shutdown_only):
 # of different jobs were not correctly isolated during execution.
 def test_multi_drivers(shutdown_only):
     info = ray.init(
+        num_cpus=10,
         _internal_config=json.dumps({
             "enable_multi_tenancy": True
         }))
@@ -67,9 +68,9 @@ def get_pid():
 
 pid_objs = []
 # Submit some normal tasks and get the PIDs of workers which execute the tasks.
-pid_objs = pid_objs + [get_pid.remote() for _ in range(5)]
+pid_objs = pid_objs + [get_pid.remote() for _ in range(2)]
 # Create some actors and get the PIDs of actors.
-actors = [Actor.remote() for _ in range(5)]
+actors = [Actor.remote() for _ in range(2)]
 pid_objs = pid_objs + [actor.get_pid.remote() for actor in actors]
 
 pids = set([ray.get(obj) for obj in pid_objs])
@@ -79,7 +80,7 @@ print("PID:" + str.join(",", [str(_) for _ in pids]))
 ray.shutdown()
     """.format(info["redis_address"])
 
-    driver_count = 10
+    driver_count = 3
     processes = [
         run_string_as_driver_nonblocking(driver_code)
         for _ in range(driver_count)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

The current `test_multi_driver` requires lots of processes to be started, and it causes tests to be heavy and timed out (not sure if it is timed out because of lots of processes). This PR makes it lighter by reducing number of required processes to start. In my local env, this test started more than 60 workers.

This also set the num_cpus properly (which are bigger than num_required_workers * driver), so that we can avoid hanging due to ray get on infeasible tasks.

## Related issue number


## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
