### PR TITLE
[Tests] Make test_output debugging easy

### DIFF
--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -36,9 +36,9 @@ def test_output():
         [sys.executable, __file__, "_ray_instance"],
         stderr=subprocess.STDOUT).decode()
     lines = outputs.split("\n")
-    assert len(lines) == 3, lines
     for line in lines:
         print(line)
+    assert len(lines) == 3, lines
     logging_header = r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\sINFO\s"
     assert re.match(
         logging_header + r"resource_spec.py:\d+ -- Starting Ray with [0-9\.]+ "

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -37,6 +37,8 @@ def test_output():
         stderr=subprocess.STDOUT).decode()
     lines = outputs.split("\n")
     assert len(lines) == 3, lines
+    for line in lines:
+        print(line)
     logging_header = r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\sINFO\s"
     assert re.match(
         logging_header + r"resource_spec.py:\d+ -- Starting Ray with [0-9\.]+ "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Currently, when test output fails, the assertion doesn't print the whole sentences. This PR makes the test print the output line by line to make debugging easy.

### NOTE
I am not sure if the logs won't be cut if I am printing in this way. Please let me know if it doesn't have impact. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
