### PR TITLE
[RLlib] Add missing int-casts for all shape calculating code (using np.produc…

### DIFF
--- a/rllib/models/tf/fcnet.py
+++ b/rllib/models/tf/fcnet.py
@@ -33,7 +33,7 @@ class FullyConnectedNetwork(TFModelV2):
 
         # We are using obs_flat, so take the flattened shape as input.
         inputs = tf.keras.layers.Input(
-            shape=(np.product(obs_space.shape), ), name="observations")
+            shape=(int(np.product(obs_space.shape)), ), name="observations")
         # Last hidden layer output (before logits outputs).
         last_layer = inputs
         # The action distribution outputs.
@@ -75,7 +75,7 @@ class FullyConnectedNetwork(TFModelV2):
             # Adjust num_outputs to be the number of nodes in the last layer.
             else:
                 self.num_outputs = (
-                    [np.product(obs_space.shape)] + hiddens[-1:])[-1]
+                    [int(np.product(obs_space.shape))] + hiddens[-1:])[-1]
 
         # Concat the log std vars to the end of the state-dependent means.
         if free_log_std and logits_out is not None:

--- a/rllib/models/torch/fcnet.py
+++ b/rllib/models/torch/fcnet.py
@@ -78,7 +78,7 @@ class FullyConnectedNetwork(TorchModelV2, nn.Module):
                     activation_fn=None)
             else:
                 self.num_outputs = (
-                    [np.product(obs_space.shape)] + hiddens[-1:])[-1]
+                    [int(np.product(obs_space.shape))] + hiddens[-1:])[-1]
 
         # Layer to add the log std vars to the state-dependent means.
         if self.free_log_std and self._logits:


### PR DESCRIPTION
…t([some shape])).

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Empty shapes (`()`) break tf/torch code in some locations due to np.product() returning 1.0 (float), instead of 1 (int).()

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
