### PR TITLE
[tune] Added Kubernetes syncer and sync client

### DIFF
--- a/doc/source/cluster/cloud.rst
+++ b/doc/source/cluster/cloud.rst
@@ -178,6 +178,8 @@ Test that it works by running the following commands from your local machine:
 
 .. tip:: This section describes the easiest way to launch a Ray cluster on Kubernetes. See this :ref:`document for advanced usage <ray-k8s-deploy>` of Kubernetes with Ray.
 
+.. tip:: If you would like to use Ray Tune in your Kubernetes cluster, have a look at :ref:`this short guide to make it work <tune-kubernetes>`.
+
 .. _cluster-private-setup:
 
 Local On Premise Cluster (List of nodes)

--- a/doc/source/tune/user-guide.rst
+++ b/doc/source/tune/user-guide.rst
@@ -445,12 +445,14 @@ You have to specify your Kubernetes namespace explicitly:
 
     from ray.tune.integration.kubernetes import NamespacedKubernetesSyncer
     tune.run(train,
-             sync_to_driver=NamespacedKubernetesSyncer("ray"))
+             sync_to_driver=NamespacedKubernetesSyncer("ray", use_rsync=True))
 
 
-The ``KubernetesSyncer`` uses a special version of ``rsync`` that runs using
-``kubectl exec``. Your pod needs to have ``rsync`` installed for this to work.
-
+The ``KubernetesSyncer`` supports two modes for file synchronisation. Per
+default, files are synchronized with ``kubectl cp``, requiring the ``tar``
+binary in your pods. If you would like to use ``rsync`` instead your pods
+will have to have ``rsync`` installed. Use the ``use_rsync`` parameter to
+decide between the two options.
 
 .. _tune-log_to_file:
 

--- a/doc/source/tune/user-guide.rst
+++ b/doc/source/tune/user-guide.rst
@@ -448,6 +448,10 @@ You have to specify your Kubernetes namespace explicitly:
              sync_to_driver=NamespacedKubernetesSyncer("ray"))
 
 
+The ``KubernetesSyncer`` uses a special version of ``rsync`` that runs using
+``kubectl exec``. Your pod needs to have ``rsync`` installed for this to work.
+
+
 .. _tune-log_to_file:
 
 Redirecting stdout and stderr to files

--- a/doc/source/tune/user-guide.rst
+++ b/doc/source/tune/user-guide.rst
@@ -431,6 +431,23 @@ If a string is provided, then it must include replacement fields ``{source}`` an
 
 By default, syncing occurs every 300 seconds. To change the frequency of syncing, set the ``TUNE_CLOUD_SYNC_S`` environment variable in the driver to the desired syncing period. Note that uploading only happens when global experiment state is collected, and the frequency of this is determined by the ``global_checkpoint_period`` argument. So the true upload period is given by ``max(TUNE_CLOUD_SYNC_S, global_checkpoint_period)``.
 
+.. _tune-kubernetes:
+
+Using Tune with Kubernetes
+--------------------------
+Tune automatically syncs files and checkpoints between different remote
+nodes as needed.
+To make this work in your Kubernetes cluster, you will need to pass a
+``KubernetesSyncer`` to the ``sync_to_driver`` argument of ``tune.run()``.
+You have to specify your Kubernetes namespace explicitly:
+
+.. code-block:: python
+
+    from ray.tune.integration.kubernetes import NamespacedKubernetesSyncer
+    tune.run(train,
+             sync_to_driver=NamespacedKubernetesSyncer("ray"))
+
+
 .. _tune-log_to_file:
 
 Redirecting stdout and stderr to files

--- a/python/ray/autoscaler/command_runner.py
+++ b/python/ray/autoscaler/command_runner.py
@@ -178,6 +178,10 @@ class KubernetesCommandRunner(CommandRunnerInterface):
         if target.startswith("~"):
             target = "/root" + target[1:]
 
+        # Add trailing slashes for rsync
+        source += "/" if not source.endswith("/") else ""
+        target += "/" if not target.endswith("/") else ""
+
         try:
             self.process_runner.check_call([
                 KUBECTL_RSYNC,
@@ -197,6 +201,10 @@ class KubernetesCommandRunner(CommandRunnerInterface):
     def run_rsync_down(self, source, target):
         if target.startswith("~"):
             target = "/root" + target[1:]
+
+        # Add trailing slashes for rsync
+        source += "/" if not source.endswith("/") else ""
+        target += "/" if not target.endswith("/") else ""
 
         try:
             self.process_runner.check_call([

--- a/python/ray/autoscaler/kubernetes/kubectl-rsync.sh
+++ b/python/ray/autoscaler/kubernetes/kubectl-rsync.sh
@@ -18,7 +18,8 @@ shift
 if [ "X$pod" = "X-l" ]; then
     pod=$1
     shift
-    namespace="-n $1"
+    # Space before $1 leads to namespace errors
+    namespace="-n$1"
     shift
 fi
 

--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -94,6 +94,14 @@ py_test(
 )
 
 py_test(
+    name = "test_integration_kubernetes",
+    size = "small",
+    srcs = ["tests/test_integration_kubernetes.py"],
+    deps = [":tune_lib"],
+    tags = ["exclusive"],
+)
+
+py_test(
     name = "test_integration_wandb",
     size = "small",
     srcs = ["tests/test_integration_wandb.py"],

--- a/python/ray/tune/integration/kubernetes.py
+++ b/python/ray/tune/integration/kubernetes.py
@@ -1,11 +1,10 @@
+import kubernetes
 import subprocess
 
+from ray import services, logger
+from ray.autoscaler.command_runner import KubernetesCommandRunner
 from ray.tune.syncer import NodeSyncer
 from ray.tune.sync_client import SyncClient
-from ray.autoscaler.command_runner import KubernetesCommandRunner
-from ray import services, logger
-
-import kubernetes
 
 
 def NamespacedKubernetesSyncer(namespace):
@@ -149,5 +148,4 @@ class KubernetesSyncClient(SyncClient):
     def delete(self, target):
         """No delete function because it is only used by
         the KubernetesSyncer, which doesn't call delete."""
-        pass
         return True

--- a/python/ray/tune/integration/kubernetes.py
+++ b/python/ray/tune/integration/kubernetes.py
@@ -125,10 +125,6 @@ class KubernetesSyncClient(SyncClient):
         """Here target is a tuple (target_node, target_dir)"""
         target_node, target_dir = target
 
-        # Add trailing slashes for rsync
-        source += "/" if not source.endswith("/") else ""
-        target_dir += "/" if not target_dir.endswith("/") else ""
-
         command_runner = self._get_command_runner(target_node)
         command_runner.run_rsync_up(source, target_dir)
         return True
@@ -136,10 +132,6 @@ class KubernetesSyncClient(SyncClient):
     def sync_down(self, source, target):
         """Here source is a tuple (source_node, source_dir)"""
         source_node, source_dir = source
-
-        # Add trailing slashes for rsync
-        source_dir += "/" if not source_dir.endswith("/") else ""
-        target += "/" if not target.endswith("/") else ""
 
         command_runner = self._get_command_runner(source_node)
         command_runner.run_rsync_down(source_dir, target)

--- a/python/ray/tune/integration/kubernetes.py
+++ b/python/ray/tune/integration/kubernetes.py
@@ -115,6 +115,10 @@ class KubernetesSyncClient(SyncClient):
 
     def _create_command_runner(self, node_id):
         """Create a command runner for one Kubernetes node"""
+        # Todo(krfricke): These cached runners are currently
+        # never cleaned up. They are cheap so this shouldn't
+        # cause much problems, but should be addressed if
+        # the SyncClient is used more extensively in the future.
         return KubernetesCommandRunner(
             log_prefix="KubernetesSyncClient: {}:".format(node_id),
             namespace=self.namespace,

--- a/python/ray/tune/integration/kubernetes.py
+++ b/python/ray/tune/integration/kubernetes.py
@@ -115,10 +115,6 @@ class KubernetesSyncClient(SyncClient):
 
     def _create_command_runner(self, node_id):
         """Create a command runner for one Kubernetes node"""
-        # Todo(krfricke): These cached runners are currently
-        # never cleaned up. They are cheap so this shouldn't
-        # cause much problems, but should be addressed if
-        # the SyncClient is used more extensively in the future.
         return KubernetesCommandRunner(
             log_prefix="KubernetesSyncClient: {}:".format(node_id),
             namespace=self.namespace,
@@ -128,6 +124,10 @@ class KubernetesSyncClient(SyncClient):
 
     def _get_command_runner(self, node_id):
         """Create command runner if it doesn't exist"""
+        # Todo(krfricke): These cached runners are currently
+        # never cleaned up. They are cheap so this shouldn't
+        # cause much problems, but should be addressed if
+        # the SyncClient is used more extensively in the future.
         if node_id not in self._command_runners:
             command_runner = self._create_command_runner(node_id)
             self._command_runners[node_id] = command_runner

--- a/python/ray/tune/integration/kubernetes.py
+++ b/python/ray/tune/integration/kubernetes.py
@@ -8,9 +8,7 @@ from ray.tune.sync_client import SyncClient
 
 
 def NamespacedKubernetesSyncer(namespace):
-    """
-    Wrapper to return a ``KubernetesSyncer`` for a specific
-    Kubernetes namespace.
+    """Wrapper to return a ``KubernetesSyncer`` for a Kubernetes namespace.
 
     Args:
         namespace (str): Kubernetes namespace.
@@ -35,9 +33,7 @@ def NamespacedKubernetesSyncer(namespace):
 
 
 class KubernetesSyncer(NodeSyncer):
-    """
-    KubernetesSyncer used for synchronization of checkpoints between
-    Kubernetes pods.
+    """KubernetesSyncer used for synchronization between Kubernetes pods.
 
     This syncer extends the node syncer, but is usually instantiated
     without a custom sync client. The sync client defaults to

--- a/python/ray/tune/integration/kubernetes.py
+++ b/python/ray/tune/integration/kubernetes.py
@@ -7,11 +7,15 @@ from ray.tune.syncer import NodeSyncer
 from ray.tune.sync_client import SyncClient
 
 
-def NamespacedKubernetesSyncer(namespace):
+def NamespacedKubernetesSyncer(namespace, use_rsync=False):
     """Wrapper to return a ``KubernetesSyncer`` for a Kubernetes namespace.
 
     Args:
         namespace (str): Kubernetes namespace.
+        use_rsync (bool):  Use ``rsync`` if True or ``kubectl cp``
+            if False. If True, ``rsync`` will need to be
+            installed in the Kubernetes pods for this to work.
+            If False, ``tar`` will need to be installed instead.
 
     Returns: A ``KubernetesSyncer`` class to be passed to
         ``tune.run(sync_to_driver)``.
@@ -28,6 +32,7 @@ def NamespacedKubernetesSyncer(namespace):
 
     class _NamespacedKubernetesSyncer(KubernetesSyncer):
         _namespace = namespace
+        _use_rsync = use_rsync
 
     return _NamespacedKubernetesSyncer
 
@@ -45,6 +50,7 @@ class KubernetesSyncer(NodeSyncer):
     """
 
     _namespace = "ray"
+    _use_rsync = False
 
     def __init__(self, local_dir, remote_dir, sync_client=None):
         self.local_ip = services.get_node_ip_address()
@@ -53,7 +59,8 @@ class KubernetesSyncer(NodeSyncer):
         self.worker_node = None
 
         sync_client = sync_client or KubernetesSyncClient(
-            namespace=self.__class__._namespace)
+            namespace=self.__class__._namespace,
+            use_rsync=self.__class__._use_rsync)
 
         super(NodeSyncer, self).__init__(local_dir, remote_dir, sync_client)
 
@@ -91,13 +98,18 @@ class KubernetesSyncClient(SyncClient):
 
     Args:
         namespace (str): Namespace in which the pods live.
+        use_rsync (bool): Use ``rsync`` if True or ``kubectl cp``
+            if False. If True, ``rsync`` will need to be
+            installed in the Kubernetes pods for this to work.
+            If False, ``tar`` will need to be installed instead.
         process_runner: How commands should be called.
             Defaults to ``subprocess``.
 
     """
 
-    def __init__(self, namespace, process_runner=subprocess):
+    def __init__(self, namespace, use_rsync=False, process_runner=subprocess):
         self.namespace = namespace
+        self.use_rsync = use_rsync
         self._process_runner = process_runner
         self._command_runners = {}
 
@@ -126,7 +138,10 @@ class KubernetesSyncClient(SyncClient):
         target_dir += "/" if not target_dir.endswith("/") else ""
 
         command_runner = self._get_command_runner(target_node)
-        command_runner.run_rsync_up(source, target_dir)
+        if self.use_rsync:
+            command_runner.run_rsync_up(source, target_dir)
+        else:
+            command_runner.run_cp_up(source, target_dir)
         return True
 
     def sync_down(self, source, target):
@@ -138,7 +153,10 @@ class KubernetesSyncClient(SyncClient):
         target += "/" if not target.endswith("/") else ""
 
         command_runner = self._get_command_runner(source_node)
-        command_runner.run_rsync_down(source_dir, target)
+        if self.use_rsync:
+            command_runner.run_rsync_down(source_dir, target)
+        else:
+            command_runner.run_cp_down(source_dir, target)
         return True
 
     def delete(self, target):

--- a/python/ray/tune/integration/kubernetes.py
+++ b/python/ray/tune/integration/kubernetes.py
@@ -43,7 +43,7 @@ class KubernetesSyncer(NodeSyncer):
     without a custom sync client. The sync client defaults to
     ``KubernetesSyncClient`` instead.
 
-    KubernetesSyncer uses the default namespce ``ray``. You should
+    KubernetesSyncer uses the default namespace ``ray``. You should
     probably use ``NamespacedKubernetesSyncer`` to return a class
     with a custom namespace instead.
     """

--- a/python/ray/tune/integration/kubernetes.py
+++ b/python/ray/tune/integration/kubernetes.py
@@ -20,7 +20,7 @@ def NamespacedKubernetesSyncer(namespace):
 
     Example:
 
-        .. code-block:: python
+    .. code-block:: python
 
         from ray.tune.integration.kubernetes import NamespacedKubernetesSyncer
         tune.run(train,

--- a/python/ray/tune/integration/kubernetes.py
+++ b/python/ray/tune/integration/kubernetes.py
@@ -125,6 +125,10 @@ class KubernetesSyncClient(SyncClient):
         """Here target is a tuple (target_node, target_dir)"""
         target_node, target_dir = target
 
+        # Add trailing slashes for rsync
+        source += "/" if not source.endswith("/") else ""
+        target_dir += "/" if not target_dir.endswith("/") else ""
+
         command_runner = self._get_command_runner(target_node)
         command_runner.run_rsync_up(source, target_dir)
         return True
@@ -132,6 +136,10 @@ class KubernetesSyncClient(SyncClient):
     def sync_down(self, source, target):
         """Here source is a tuple (source_node, source_dir)"""
         source_node, source_dir = source
+
+        # Add trailing slashes for rsync
+        source_dir += "/" if not source_dir.endswith("/") else ""
+        target += "/" if not target.endswith("/") else ""
 
         command_runner = self._get_command_runner(source_node)
         command_runner.run_rsync_down(source_dir, target)

--- a/python/ray/tune/integration/kubernetes.py
+++ b/python/ray/tune/integration/kubernetes.py
@@ -76,7 +76,7 @@ class KubernetesSyncer(NodeSyncer):
                 return pod.metadata.name
 
         logger.error(
-            "Could not find Kubernetes node name for IP {}".format(node_ip))
+            "Could not find Kubernetes pod name for IP {}".format(node_ip))
         return None
 
     @property

--- a/python/ray/tune/integration/kubernetes.py
+++ b/python/ray/tune/integration/kubernetes.py
@@ -1,0 +1,153 @@
+import subprocess
+
+from ray.tune.syncer import NodeSyncer
+from ray.tune.sync_client import SyncClient
+from ray.autoscaler.command_runner import KubernetesCommandRunner
+from ray import services, logger
+
+import kubernetes
+
+
+def NamespacedKubernetesSyncer(namespace):
+    """
+    Wrapper to return a ``KubernetesSyncer`` for a specific
+    Kubernetes namespace.
+
+    Args:
+        namespace (str): Kubernetes namespace.
+
+    Returns: A ``KubernetesSyncer`` class to be passed to
+        ``tune.run(sync_to_driver)``.
+
+    Example:
+
+        .. code-block:: python
+
+        from ray.tune.integration.kubernetes import NamespacedKubernetesSyncer
+        tune.run(train,
+                 sync_to_driver=NamespacedKubernetesSyncer("ray"))
+
+    """
+
+    class _NamespacedKubernetesSyncer(KubernetesSyncer):
+        _namespace = namespace
+
+    return _NamespacedKubernetesSyncer
+
+
+class KubernetesSyncer(NodeSyncer):
+    """
+    KubernetesSyncer used for synchronization of checkpoints between
+    Kubernetes pods.
+
+    This syncer extends the node syncer, but is usually instantiated
+    without a custom sync client. The sync client defaults to
+    ``KubernetesSyncClient`` instead.
+
+    KubernetesSyncer uses the default namespce ``ray``. You should
+    probably use ``NamespacedKubernetesSyncer`` to return a class
+    with a custom namespace instead.
+    """
+
+    _namespace = "ray"
+
+    def __init__(self, local_dir, remote_dir, sync_client=None):
+        self.local_ip = services.get_node_ip_address()
+        self.local_node = self._get_kubernetes_node_by_ip(self.local_ip)
+        self.worker_ip = None
+        self.worker_node = None
+
+        sync_client = sync_client or KubernetesSyncClient(
+            namespace=self.__class__._namespace)
+
+        super(NodeSyncer, self).__init__(local_dir, remote_dir, sync_client)
+
+    def set_worker_ip(self, worker_ip):
+        self.worker_ip = worker_ip
+        self.worker_node = self._get_kubernetes_node_by_ip(worker_ip)
+
+    def _get_kubernetes_node_by_ip(self, node_ip):
+        """Return node name by internal or external IP"""
+        kubernetes.config.load_incluster_config()
+        api = kubernetes.client.CoreV1Api()
+        pods = api.list_namespaced_pod(self._namespace)
+        for pod in pods.items:
+            if pod.status.host_ip == node_ip or \
+               pod.status.pod_ip == node_ip:
+                return pod.metadata.name
+
+        logger.error(
+            "Could not find Kubernetes node name for IP {}".format(node_ip))
+        return None
+
+    @property
+    def _remote_path(self):
+        return (self.worker_node, self._remote_dir)
+
+
+class KubernetesSyncClient(SyncClient):
+    """KubernetesSyncClient to be used by KubernetesSyncer.
+
+    This client takes care of executing the synchronization
+    commands for Kubernetes clients. In its ``sync_down`` and
+    ``sync_up`` commands, it expects tuples for the source
+    and target, respectively, for compatibility with the
+    KubernetesCommandRunner.
+
+    Args:
+        namespace (str): Namespace in which the pods live.
+        process_runner: How commands should be called.
+            Defaults to ``subprocess``.
+
+    """
+
+    def __init__(self, namespace, process_runner=subprocess):
+        self.namespace = namespace
+        self._process_runner = process_runner
+        self._command_runners = {}
+
+    def _create_command_runner(self, node_id):
+        """Create a command runner for one Kubernetes node"""
+        return KubernetesCommandRunner(
+            log_prefix="KubernetesSyncClient: {}:".format(node_id),
+            namespace=self.namespace,
+            node_id=node_id,
+            auth_config=None,
+            process_runner=self._process_runner)
+
+    def _get_command_runner(self, node_id):
+        """Create command runner if it doesn't exist"""
+        if node_id not in self._command_runners:
+            command_runner = self._create_command_runner(node_id)
+            self._command_runners[node_id] = command_runner
+        return self._command_runners[node_id]
+
+    def sync_up(self, source, target):
+        """Here target is a tuple (target_node, target_dir)"""
+        target_node, target_dir = target
+
+        # Add trailing slashes for rsync
+        source += "/" if not source.endswith("/") else ""
+        target_dir += "/" if not target_dir.endswith("/") else ""
+
+        command_runner = self._get_command_runner(target_node)
+        command_runner.run_rsync_up(source, target_dir)
+        return True
+
+    def sync_down(self, source, target):
+        """Here source is a tuple (source_node, source_dir)"""
+        source_node, source_dir = source
+
+        # Add trailing slashes for rsync
+        source_dir += "/" if not source_dir.endswith("/") else ""
+        target += "/" if not target.endswith("/") else ""
+
+        command_runner = self._get_command_runner(source_node)
+        command_runner.run_rsync_down(source_dir, target)
+        return True
+
+    def delete(self, target):
+        """No delete function because it is only used by
+        the KubernetesSyncer, which doesn't call delete."""
+        pass
+        return True

--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -2,8 +2,8 @@ import distutils
 import logging
 import os
 import time
-from inspect import isclass
 
+from inspect import isclass
 from shlex import quote
 
 from ray import ray_constants

--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -2,6 +2,7 @@ import distutils
 import logging
 import os
 import time
+from inspect import isclass
 
 from shlex import quote
 
@@ -284,6 +285,9 @@ def get_node_syncer(local_dir, remote_dir=None, sync_function=None):
     """
     key = (local_dir, remote_dir)
     if key in _syncers:
+        return _syncers[key]
+    elif isclass(sync_function) and issubclass(sync_function, Syncer):
+        _syncers[key] = sync_function(local_dir, remote_dir, None)
         return _syncers[key]
     elif not remote_dir or sync_function is False:
         sync_client = NOOP

--- a/python/ray/tune/tests/test_integration_kubernetes.py
+++ b/python/ray/tune/tests/test_integration_kubernetes.py
@@ -81,7 +81,7 @@ class KubernetesIntegrationTest(unittest.TestCase):
 
         syncer.set_worker_ip(self.lookup.get_ip("w1"))
 
-        # Test sync up. Should add / to the dirs and call the rsync command
+        # Test sync up. Should add / to the dirs and call kubectl cp
         syncer.sync_up()
 
         self.assertEqual(self.process_runner.history[-1], [
@@ -114,7 +114,7 @@ class KubernetesIntegrationTest(unittest.TestCase):
 
         syncer.set_worker_ip(self.lookup.get_ip("w1"))
 
-        # Test sync up. Should add / to the dirs and call the rsync command
+        # Test sync up. Should add / to the dirs and call rsync
         syncer.sync_up()
         self.assertEqual(self.process_runner.history[-1][0], KUBECTL_RSYNC)
         self.assertEqual(self.process_runner.history[-1][-2],

--- a/python/ray/tune/tests/test_integration_kubernetes.py
+++ b/python/ray/tune/tests/test_integration_kubernetes.py
@@ -1,0 +1,111 @@
+import unittest
+
+from ray.autoscaler.command_runner import KUBECTL_RSYNC
+from ray.tune.integration.kubernetes import KubernetesSyncer, \
+    KubernetesSyncClient
+from ray.tune.syncer import NodeSyncer
+
+
+class _MockProcessRunner:
+    def __init__(self):
+        self.history = []
+
+    def check_call(self, command):
+        self.history.append(command)
+        return True
+
+
+class _MockLookup:
+    def __init__(self, node_ips):
+        self.node_to_ip = {}
+        self.ip_to_node = {}
+        for node, ip in node_ips.items():
+            self.node_to_ip[node] = ip
+            self.ip_to_node[ip] = node
+
+    def get_ip(self, node):
+        return self.node_to_ip[node]
+
+    def get_node(self, ip):
+        return self.ip_to_node[ip]
+
+    def __call__(self, ip):
+        return self.ip_to_node[ip]
+
+
+def _create_mock_syncer(namespace, lookup, process_runner, local_ip, local_dir,
+                        remote_dir):
+    class _MockSyncer(KubernetesSyncer):
+        _namespace = namespace
+        _get_kubernetes_node_by_ip = lookup
+
+        def __init__(self, local_dir, remote_dir, sync_client):
+            self.local_ip = local_ip
+            self.local_node = self._get_kubernetes_node_by_ip(self.local_ip)
+            self.worker_ip = None
+            self.worker_node = None
+
+            sync_client = sync_client
+            super(NodeSyncer, self).__init__(local_dir, remote_dir,
+                                             sync_client)
+
+    return _MockSyncer(
+        local_dir,
+        remote_dir,
+        sync_client=KubernetesSyncClient(
+            namespace=namespace, process_runner=process_runner))
+
+
+class KubernetesIntegrationTest(unittest.TestCase):
+    def setUp(self):
+        self.namespace = "test_ray"
+        self.lookup = _MockLookup({
+            "head": "1.0.0.0",
+            "w1": "1.0.0.1",
+            "w2": "1.0.0.2"
+        })
+        self.process_runner = _MockProcessRunner()
+        self.local_dir = "/tmp/local"
+        self.remote_dir = "/tmp/remote"
+
+        self.syncer = _create_mock_syncer(
+            self.namespace, self.lookup, self.process_runner,
+            self.lookup.get_ip("head"), self.local_dir, self.remote_dir)
+
+    def tearDown(self):
+        pass
+
+    def testKubernetesSyncUpDown(self):
+        self.syncer.set_worker_ip(self.lookup.get_ip("w1"))
+
+        # Test sync up. Should add / to the dirs and call the rsync command
+        self.syncer.sync_up()
+        self.assertEqual(self.process_runner.history[-1][0], KUBECTL_RSYNC)
+        self.assertEqual(self.process_runner.history[-1][-2],
+                         self.local_dir + "/")
+        self.assertEqual(
+            self.process_runner.history[-1][-1], "{}@{}:{}".format(
+                "w1", self.namespace, self.remote_dir + "/"))
+
+        # Test sync down.
+        self.syncer.sync_down()
+        self.assertEqual(self.process_runner.history[-1][0], KUBECTL_RSYNC)
+        self.assertEqual(
+            self.process_runner.history[-1][-2], "{}@{}:{}".format(
+                "w1", self.namespace, self.remote_dir + "/"))
+        self.assertEqual(self.process_runner.history[-1][-1],
+                         self.local_dir + "/")
+
+        # Sync to same node should be ignored
+        self.syncer.set_worker_ip(self.lookup.get_ip("head"))
+        self.syncer.sync_up()
+        self.assertTrue(len(self.process_runner.history) == 2)
+
+        self.syncer.sync_down()
+        self.assertTrue(len(self.process_runner.history) == 2)
+
+
+if __name__ == "__main__":
+    import pytest
+    import sys
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tune/tests/test_integration_kubernetes.py
+++ b/python/ray/tune/tests/test_integration_kubernetes.py
@@ -37,6 +37,7 @@ def _create_mock_syncer(namespace, lookup, process_runner, local_ip, local_dir,
                         remote_dir):
     class _MockSyncer(KubernetesSyncer):
         _namespace = namespace
+        _use_rsync = True
         _get_kubernetes_node_by_ip = lookup
 
         def __init__(self, local_dir, remote_dir, sync_client):
@@ -53,7 +54,8 @@ def _create_mock_syncer(namespace, lookup, process_runner, local_ip, local_dir,
         local_dir,
         remote_dir,
         sync_client=KubernetesSyncClient(
-            namespace=namespace, process_runner=process_runner))
+            namespace=namespace, use_rsync=True,
+            process_runner=process_runner))
 
 
 class KubernetesIntegrationTest(unittest.TestCase):

--- a/python/requirements_tune.txt
+++ b/python/requirements_tune.txt
@@ -9,6 +9,7 @@ hpbandster
 hyperopt==0.1.2
 jupyter
 keras
+kubernetes
 lightgbm
 matplotlib
 mlflow


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Syncing checkpoints between nodes relies on rsync, which failed when used within Kubernetes clusters. A workaround was to use shared volumes, but this required overhead on the users side.
This PR introduces a Tune `KubernetesSyncer` and `KubernetesSyncClient` syncing checkpoints between different Kubernetes nodes. A `NamespacedKubernetesSyncer` can be passed as a `sync_to_driver` argument to `tune.run` to enable automatic checkpoint syncing.

```
        from ray.tune.integration.kubernetes import NamespacedKubernetesSyncer
        tune.run(train,
                 sync_to_driver=NamespacedKubernetesSyncer("ray"))
```

## Related issue number

Should close #9558

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests

