### PR TITLE
[autoscaler] Hash contents of SSH key instead of key path

### DIFF
--- a/python/ray/autoscaler/util.py
+++ b/python/ray/autoscaler/util.py
@@ -103,8 +103,17 @@ def with_head_node_ip(cmds):
 
 def hash_launch_conf(node_conf, auth):
     hasher = hashlib.sha1()
+    # For hashing, we replace the path to the key with the
+    # key itself. This is to make sure the hashes are the
+    # same even if keys live at different locations on different
+    # machines.
+    full_auth = auth.copy()
+    for key_type in ["ssh_private_key", "ssh_public_key"]:
+        if key_type in auth:
+            with open(auth[key_type]) as key:
+                full_auth[key_type] = key.read()
     hasher.update(
-        json.dumps([node_conf, auth], sort_keys=True).encode("utf-8"))
+        json.dumps([node_conf, full_auth], sort_keys=True).encode("utf-8"))
     return hasher.hexdigest()
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
