### PR TITLE
Add capability to exclude directories/file types from file_mounts within cluster YAML

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -404,6 +404,7 @@ class StandardAutoscaler:
             auth_config=self.config["auth"],
             cluster_name=self.config["cluster_name"],
             file_mounts=self.config["file_mounts"],
+            exclude_list=self.config["exclude_list"],
             initialization_commands=with_head_node_ip(
                 self.config["initialization_commands"]),
             setup_commands=with_head_node_ip(init_commands),

--- a/python/ray/autoscaler/command_runner.py
+++ b/python/ray/autoscaler/command_runner.py
@@ -287,7 +287,7 @@ class SSHOptions:
 
 class SSHCommandRunner(CommandRunnerInterface):
     def __init__(self, log_prefix, node_id, provider, auth_config,
-                 cluster_name, process_runner, use_internal_ip):
+                 cluster_name, process_runner, use_internal_ip, exclude_list=None):
 
         ssh_control_hash = hashlib.md5(cluster_name.encode()).hexdigest()
         ssh_user_hash = hashlib.md5(getuser().encode()).hexdigest()
@@ -309,6 +309,7 @@ class SSHCommandRunner(CommandRunnerInterface):
             self.ssh_private_key,
             self.ssh_control_path,
             ProxyCommand=self.ssh_proxy_command)
+        self.exclude_list = exclude_list
 
     def _get_node_ip(self):
         if self.use_internal_ip:
@@ -484,13 +485,15 @@ class SSHCommandRunner(CommandRunnerInterface):
 
     def run_rsync_up(self, source, target):
         self._set_ssh_ip_if_required()
+        exclude_cmds = ["--exclude={}".format(item) for item in self.exclude_list]
         command = [
             "rsync", "--rsh",
             subprocess.list2cmdline(
                 ["ssh"] + self.ssh_options.to_ssh_options_list(timeout=120)),
-            "-avz", source, "{}@{}:{}".format(self.ssh_user, self.ssh_ip,
+            "-avz", *exclude_cmds, source, "{}@{}:{}".format(self.ssh_user, self.ssh_ip,
                                               target)
         ]
+
         cli_logger.verbose("Running `{}`", cf.bold(" ".join(command)))
         self._run_helper(command, silent=is_rsync_silent())
 
@@ -536,7 +539,7 @@ class DockerCommandRunner(SSHCommandRunner):
             ssh_options_override_ssh_key="",
     ):
         if run_env == "auto":
-            run_env = "docker" if (cmd.find("docker") > -1 and cmd.find("docker pull") == -1) else "host"
+            run_env = "host" if cmd.find("docker") == 0 else "docker"
 
         if run_env == "docker":
             cmd = self._docker_expand_user(cmd, any_char=True)

--- a/python/ray/autoscaler/command_runner.py
+++ b/python/ray/autoscaler/command_runner.py
@@ -536,7 +536,7 @@ class DockerCommandRunner(SSHCommandRunner):
             ssh_options_override_ssh_key="",
     ):
         if run_env == "auto":
-            run_env = "host" if cmd.find("docker") == 0 else "docker"
+            run_env = "docker" if (cmd.find("docker") > -1 and cmd.find("docker pull") == -1) else "host"
 
         if run_env == "docker":
             cmd = self._docker_expand_user(cmd, any_char=True)

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -386,6 +386,7 @@ def kill_node(config_file, yes, hard, override_cluster_name):
                 auth_config=config["auth"],
                 cluster_name=config["cluster_name"],
                 file_mounts=config["file_mounts"],
+                exclude_list=config["exclude_list"],
                 initialization_commands=[],
                 setup_commands=[],
                 ray_start_commands=[],
@@ -623,6 +624,7 @@ def get_or_create_head_node(config, config_file, no_restart, restart_only, yes,
                 auth_config=config["auth"],
                 cluster_name=config["cluster_name"],
                 file_mounts=config["file_mounts"],
+                exclude_list=config["exclude_list"],
                 initialization_commands=config["initialization_commands"],
                 setup_commands=init_commands,
                 ray_start_commands=ray_start_commands,
@@ -774,6 +776,7 @@ def exec_cluster(config_file: str,
             auth_config=config["auth"],
             cluster_name=config["cluster_name"],
             file_mounts=config["file_mounts"],
+            exclude_list=config['exclude_list'],
             initialization_commands=[],
             setup_commands=[],
             ray_start_commands=[],
@@ -905,6 +908,7 @@ def rsync(config_file: str,
                 auth_config=config["auth"],
                 cluster_name=config["cluster_name"],
                 file_mounts=config["file_mounts"],
+                exclude_list=config['exclude_list'],
                 initialization_commands=[],
                 setup_commands=[],
                 ray_start_commands=[],
@@ -920,8 +924,10 @@ def rsync(config_file: str,
                 # print rsync progress for single file rsync
                 cmd_output_util.set_output_redirected(False)
                 set_rsync_silent(False)
-
-                rsync(source, target)
+                try:
+                    rsync(source, target)
+                except:
+                    print(f"Rsync failed for node {node_id} \n")
             else:
                 updater.sync_file_mounts(rsync)
 

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -262,7 +262,8 @@ class NodeProvider:
                            cluster_name,
                            process_runner,
                            use_internal_ip,
-                           docker_config=None) -> Any:
+                           docker_config=None,
+                           exclude_list=None) -> Any:
         """ Returns the CommandRunner class used to perform SSH commands.
 
         Args:
@@ -286,7 +287,8 @@ class NodeProvider:
             "auth_config": auth_config,
             "cluster_name": cluster_name,
             "process_runner": process_runner,
-            "use_internal_ip": use_internal_ip
+            "use_internal_ip": use_internal_ip,
+            "exclude_list": exclude_list
         }
         if docker_config and docker_config["container_name"] != "":
             return DockerCommandRunner(docker_config, **common_args)

--- a/python/ray/autoscaler/ray-schema.json
+++ b/python/ray/autoscaler/ray-schema.json
@@ -232,6 +232,9 @@
             "type": "object",
             "description": "Map of remote paths to local paths, e.g. {\"/tmp/data\": \"/my/local/data\"}"
         },
+        "exclude_list": {
+            "description": "List of file types or directories to exclude when rsyncing to and from remote servers."
+        },
         "cluster_synced_files": {
             "type": "array",
             "description": "List of paths on the head node which should sync to the worker nodes, e.g. [\"/some/data/somehwere\"]"

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -33,6 +33,7 @@ class NodeUpdater:
                  auth_config,
                  cluster_name,
                  file_mounts,
+                 exclude_list,
                  initialization_commands,
                  setup_commands,
                  ray_start_commands,
@@ -48,7 +49,7 @@ class NodeUpdater:
                            or provider_config.get("use_internal_ips", False))
         self.cmd_runner = provider.get_command_runner(
             self.log_prefix, node_id, auth_config, cluster_name,
-            process_runner, use_internal_ip, docker_config)
+            process_runner, use_internal_ip, docker_config,  exclude_list)
 
         self.daemon = True
         self.process_runner = process_runner
@@ -146,7 +147,7 @@ class NodeUpdater:
             with LogTimer(self.log_prefix +
                           "Synced {} to {}".format(local_path, remote_path)):
                 self.cmd_runner.run("mkdir -p {}".format(
-                    os.path.dirname(remote_path)))
+                    os.path.dirname(remote_path)), run_env="host")
                 sync_cmd(local_path, remote_path)
 
                 if remote_path not in nolog_paths:
@@ -188,7 +189,7 @@ class NodeUpdater:
                                              "{}Waiting for remote shell...",
                                              self.log_prefix)
 
-                        self.cmd_runner.run("uptime")
+                        self.cmd_runner.run("uptime", run_env="host")
                         cli_logger.old_debug(logger, "Uptime succeeded.")
                         cli_logger.success("Success.")
                         return True

--- a/python/ray/tune/suggest/suggestion.py
+++ b/python/ray/tune/suggest/suggestion.py
@@ -198,7 +198,7 @@ class Searcher:
         try:
             self.save(tmp_search_ckpt_path)
         except NotImplementedError:
-            with log_once("suggest:save_to_dir"):
+            if log_once("suggest:save_to_dir"):
                 logger.warning(
                     "save not implemented for Searcher. Skipping save.")
             success = False

--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -44,7 +44,7 @@ def log_sync_template(options=""):
         unavailable.
     """
     if not distutils.spawn.find_executable("rsync"):
-        with log_once("tune:rsync"):
+        if log_once("tune:rsync"):
             logger.error("Log sync requires rsync to be installed.")
         return None
     global _log_sync_warned


### PR DESCRIPTION
## Why are these changes needed?
Small syntax error fixes that prevent running  various functions like "ray submit" successfully and add functionality for excluding files when syncing directories to clusters.
<!-- Please give a short summary of the change and the problem this solves. -->


## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR. -> No, I get this error and I don't know what it means: 
`flake8: error: unrecognized arguments: --inline-quotes --no-avoid-escape python/ray/autoscaler/autoscaler.py python/ray/autoscaler/command_runner.py python/ray/autoscaler/commands.py python/ray/autoscaler/node_provider.py python/ray/autoscaler/updater.py python/ray/scripts/scripts.py python/ray/tune/suggest/suggestion.py python/ray/tune/syncer.py
`
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [X] This PR is not tested (please justify below)
Not sure what to run. Are there explicit instructions anywhere?