### PR TITLE
torch policy now includes model.metrics

### DIFF
--- a/rllib/examples/models/custom_loss_model.py
+++ b/rllib/examples/models/custom_loss_model.py
@@ -181,7 +181,7 @@ class TorchCustomLossModel(TorchModelV2, nn.Module):
         # return policy_loss + [10 * self.imitation_loss]
         return [loss_ + 10 * self.imitation_loss for loss_ in policy_loss]
 
-    def custom_stats(self):
+    def metrics(self):
         return {
             "policy_loss": torch.mean(self.policy_loss),
             "imitation_loss": self.imitation_loss,

--- a/rllib/examples/models/custom_loss_model.py
+++ b/rllib/examples/models/custom_loss_model.py
@@ -174,7 +174,8 @@ class TorchCustomLossModel(TorchModelV2, nn.Module):
 
         # Compute the IL loss.
         action_dist = TorchCategorical(logits, self.model_config)
-        imitation_loss = torch.mean(-action_dist.logp(torch.from_numpy(batch["actions"])))
+        imitation_loss = torch.mean(
+            -action_dist.logp(torch.from_numpy(batch["actions"])))
         self.imitation_loss_metric = imitation_loss.item()
         self.policy_loss_metric = np.mean([l.item() for l in policy_loss])
 

--- a/rllib/examples/models/custom_loss_model.py
+++ b/rllib/examples/models/custom_loss_model.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from ray.rllib.models.model import Model, restore_original_dimensions
 from ray.rllib.models.modelv2 import ModelV2
 from ray.rllib.models.tf.tf_action_dist import Categorical
@@ -172,17 +174,17 @@ class TorchCustomLossModel(TorchModelV2, nn.Module):
 
         # Compute the IL loss.
         action_dist = TorchCategorical(logits, self.model_config)
-        self.policy_loss = policy_loss
-        self.imitation_loss = torch.mean(
-            -action_dist.logp(torch.from_numpy(batch["actions"])))
+        imitation_loss = torch.mean(-action_dist.logp(torch.from_numpy(batch["actions"])))
+        self.imitation_loss_metric = imitation_loss.item()
+        self.policy_loss_metric = np.mean([l.item() for l in policy_loss])
 
         # Add the imitation loss to each already calculated policy loss term.
         # Alternatively (if custom loss has its own optimizer):
         # return policy_loss + [10 * self.imitation_loss]
-        return [loss_ + 10 * self.imitation_loss for loss_ in policy_loss]
+        return [loss_ + 10 * imitation_loss for loss_ in policy_loss]
 
     def metrics(self):
         return {
-            "policy_loss": torch.mean(self.policy_loss),
-            "imitation_loss": self.imitation_loss,
+            "policy_loss": self.policy_loss_metric,
+            "imitation_loss": self.imitation_loss_metric,
         }

--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -388,6 +388,8 @@ class TorchPolicy(Policy):
 
         grad_info["allreduce_latency"] /= len(self._optimizers)
         grad_info.update(self.extra_grad_info(train_batch))
+        if self.model:
+            grad_info["model"] = self.model.metrics()
         return dict(fetches, **{LEARNER_STATS_KEY: grad_info})
 
     @override(Policy)


### PR DESCRIPTION
## Why are these changes needed?

I'm playing around with pytorch and imitation loss in model but I couldn't get custom metrics to be shown anywhere. If I understood correctly the policy should handle saving custom model.metrics. [torch_policy.py](https://github.com/ray-project/ray/blob/master/rllib/policy/torch_policy.py) does not have any references to model.metrics where as [tf_policy.py#L259](https://github.com/ray-project/ray/blob/master/rllib/policy/tf_policy.py#L259) has. I copied similar to pytorch_policy so that it works in my project.

pytorch_policy custom_loss support was added only recently in https://github.com/ray-project/ray/issues/8507 / https://github.com/ray-project/ray/pull/9142 so I guess this change was just missing from that.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
