### PR TITLE
Include info about flake8_quotes in format.sh

### DIFF
--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -68,6 +68,10 @@ else
     echo "WARNING: clang-format is not installed!"
 fi
 
+if [[ $(flake8 --version) != *"flake8_quotes"* ]]; then
+    echo "WARNING: Ray uses flake8 with flake8_quotes. Might error without it. Install with: pip install flake8-quotes"
+fi
+
 SHELLCHECK_FLAGS=(
   --exclude=1090  # "Can't follow non-constant source. Use a directive to specify location."
   --exclude=1091  # "Not following {file} due to some error"


### PR DESCRIPTION
## Why are these changes needed?

Making first contributions and it took some time to setup the environment. format.sh checked flake8 installation but didn't alert about missing flake8_quotes. Now it makes a quick check to see if flake8_quotes is found and if not then how to install it.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
  - yep it passes itself, hurrah
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
