### PR TITLE
[autoscaler] Fix run_env='host' for initialization commands

### DIFF
--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -286,7 +286,8 @@ class NodeUpdater:
                                     self.cmd_runner.run(
                                         cmd,
                                         ssh_options_override_ssh_key=self.
-                                        auth_config.get("ssh_private_key"))
+                                        auth_config.get("ssh_private_key"),
+                                        run_env="host")
                                 except ProcessRunnerError as e:
                                     if e.msg_type == "ssh_command_failed":
                                         cli_logger.error("Failed.")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Initialization commands need to be run on the host.

AFAIK this has been broken since https://github.com/ray-project/ray/pull/10014

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
