### PR TITLE
[Core][Python Worker] Add pid to log file name

### DIFF
--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -20,7 +20,7 @@ import ray.utils
 logger = logging.getLogger(__name__)
 
 # First group is worker id. Second group is job id.
-JOB_LOG_PATTERN = re.compile(".*worker-([0-9a-f]{40})-(\d+)")
+JOB_LOG_PATTERN = re.compile(".*worker-([0-9a-f]{40})-(\d+)-(\d+)")
 
 
 class LogFileInfo:

--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -19,7 +19,7 @@ import ray.utils
 # entry/init points.
 logger = logging.getLogger(__name__)
 
-# First group is worker id. Second group is job id.
+# The groups are worker id, job id, and pid.
 JOB_LOG_PATTERN = re.compile(".*worker-([0-9a-f]{40})-(\d+)-(\d+)")
 
 

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -748,11 +748,12 @@ class Node:
             return None, None
 
         if job_id is not None:
-            name = "worker-{}-{}".format(
+            name = "worker-{}-{}-{}".format(
                 ray.utils.binary_to_hex(worker_id),
-                ray.utils.binary_to_hex(job_id))
+                ray.utils.binary_to_hex(job_id), os.getpid())
         else:
-            name = "worker-{}".format(ray.utils.binary_to_hex(worker_id))
+            name = "worker-{}-{}".format(
+                ray.utils.binary_to_hex(worker_id), os.getpid())
 
         worker_stdout_file, worker_stderr_file = self._get_log_file_names(
             name, unique=False)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

I add pid to python worker's log file name. This is very useful  to find worker's log when debugging.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
