### PR TITLE
cpp: Fix include order in the cpp api.h for generated files

### DIFF
--- a/cpp/include/ray/api.h
+++ b/cpp/include/ray/api.h
@@ -233,10 +233,21 @@ inline ActorTaskCaller<ReturnType> Ray::CallActorInternal(FuncType &actor_func,
   return ActorTaskCaller<ReturnType>(runtime_, actor.ID(), ptr, buffer);
 }
 
-#include <ray/api/generated/call_actors_impl.generated.h>
-#include <ray/api/generated/call_funcs_impl.generated.h>
-#include <ray/api/generated/create_actors_impl.generated.h>
+// TODO(barakmich): These includes are generated files that do not contain their
+// relevant headers. Since they're only used here, they must appear in this
+// particular order, which is a code smell and breaks lint.
+//
+// The generated files, and their generator, should be fixed. Until then, we can
+// force the order by way of comments
+//
+// #1
 #include <ray/api/generated/exec_funcs.generated.h>
+// #2
+#include <ray/api/generated/call_funcs_impl.generated.h>
+// #3
+#include <ray/api/generated/create_actors_impl.generated.h>
+// #4
+#include <ray/api/generated/call_actors_impl.generated.h>
 
 }  // namespace api
 }  // namespace ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Fixes a problem introduced by enforcing better formatting

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
