### PR TITLE
[Tune] PBT hyperparam_mutations improvements

### DIFF
--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -76,8 +76,11 @@ def explore(config, mutations, resample_probability, custom_explore_fn):
         new_config = custom_explore_fn(new_config)
         assert new_config is not None, \
             "Custom explore fn failed to return new config"
+    # Only log mutated hyperparameters and not entire config.
+    old_hparams = {k:v for k, v in config.items() if k in mutations}
+    new_hparams = {k:v for k, v in new_config.items() if k in mutations}
     logger.info("[explore] perturbed config from {} -> {}".format(
-        config, new_config))
+        old_hparams, new_hparams))
     return new_config
 
 

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -132,10 +132,10 @@ class PopulationBasedTraining(FIFOScheduler):
             to be too frequent.
         hyperparam_mutations (dict): Hyperparams to mutate. The format is
             as follows: for each key, either a list, function,
-            or tune.sample_from instance can be
-            provided. A list specifies an allowed set of categorical values.
-            A function or tune.sample_from instance specifies the distribution
-            of a continuous parameter.
+            or a tune search space object (tune.sample_from, tune.uniform,
+            etc.) can be provided. A list specifies an allowed set of
+            categorical values. A function or tune search space object
+            specifies the distribution of a continuous parameter.
             You must specify at least one of `hyperparam_mutations` or
             `custom_explore_fn`.
             Tune will use the search space provided by
@@ -202,7 +202,7 @@ class PopulationBasedTraining(FIFOScheduler):
             if not (isinstance(value,
                                (list, dict, sample_from)) or callable(value)):
                 raise TypeError("`hyperparam_mutation` values must be either "
-                                "a List, Dict, a tune.sample_from instance or "
+                                "a List, Dict, a tune search space object, or "
                                 "callable.")
 
         if not hyperparam_mutations and not custom_explore_fn:
@@ -263,8 +263,8 @@ class PopulationBasedTraining(FIFOScheduler):
         for attr in self._hyperparam_mutations.keys():
             if attr not in trial.config:
                 if log_once(attr + "-missing"):
-                    logger.info("Cannot find {} in config. Using search "
-                                "space provided by hyperparam_mutations.")
+                    logger.debug("Cannot find {} in config. Using search "
+                                 "space provided by hyperparam_mutations.")
                 self.fill_config(trial.config, attr,
                                  self._hyperparam_mutations[attr])
             # Make sure this attribute is added to CLI output.

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -393,9 +393,15 @@ class PopulationBasedTraining(FIFOScheduler):
                         trial_to_clone, new_state.last_score, trial,
                         trial_state.last_score))
         # Only log mutated hyperparameters and not entire config.
-        old_hparams = {k: v for k, v in trial_to_clone.config.items() if k
-                       in self._hyperparam_mutations}
-        new_hparams = {k: v for k, v in new_config.items() if k in self._hyperparam_mutations}
+        old_hparams = {
+            k: v
+            for k, v in trial_to_clone.config.items()
+            if k in self._hyperparam_mutations
+        }
+        new_hparams = {
+            k: v
+            for k, v in new_config.items() if k in self._hyperparam_mutations
+        }
         logger.info("[explore] perturbed config from {} -> {}".format(
             old_hparams, new_hparams))
 

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -79,11 +79,6 @@ def explore(config, mutations, resample_probability, custom_explore_fn):
         new_config = custom_explore_fn(new_config)
         assert new_config is not None, \
             "Custom explore fn failed to return new config"
-    # Only log mutated hyperparameters and not entire config.
-    old_hparams = {k: v for k, v in config.items() if k in mutations}
-    new_hparams = {k: v for k, v in new_config.items() if k in mutations}
-    logger.info("[explore] perturbed config from {} -> {}".format(
-        old_hparams, new_hparams))
     return new_config
 
 
@@ -397,6 +392,12 @@ class PopulationBasedTraining(FIFOScheduler):
                     "{} (score {}) -> {} (score {})".format(
                         trial_to_clone, new_state.last_score, trial,
                         trial_state.last_score))
+        # Only log mutated hyperparameters and not entire config.
+        old_hparams = {k: v for k, v in trial_to_clone.config.items() if k
+                       in self._hyperparam_mutations}
+        new_hparams = {k: v for k, v in new_config.items() if k in self._hyperparam_mutations}
+        logger.info("[explore] perturbed config from {} -> {}".format(
+            old_hparams, new_hparams))
 
         if self._log_config:
             self._log_config_on_step(trial_state, new_state, trial,

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -13,7 +13,6 @@ from ray.tune.sample import sample_from
 from ray.tune.schedulers import FIFOScheduler, TrialScheduler
 from ray.tune.suggest.variant_generator import format_vars
 from ray.tune.trial import Trial, Checkpoint
-from ray.util import log_once
 
 from ray.util.debug import log_once
 
@@ -81,8 +80,8 @@ def explore(config, mutations, resample_probability, custom_explore_fn):
         assert new_config is not None, \
             "Custom explore fn failed to return new config"
     # Only log mutated hyperparameters and not entire config.
-    old_hparams = {k:v for k, v in config.items() if k in mutations}
-    new_hparams = {k:v for k, v in new_config.items() if k in mutations}
+    old_hparams = {k: v for k, v in config.items() if k in mutations}
+    new_hparams = {k: v for k, v in new_config.items() if k in mutations}
     logger.info("[explore] perturbed config from {} -> {}".format(
         old_hparams, new_hparams))
     return new_config

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -199,8 +199,8 @@ class PopulationBasedTraining(FIFOScheduler):
                  custom_explore_fn=None,
                  log_config=True):
         for value in hyperparam_mutations.values():
-            if not (isinstance(value, (list, dict, sample_from)) or callable(
-                value)):
+            if not (isinstance(value,
+                               (list, dict, sample_from)) or callable(value)):
                 raise TypeError("`hyperparam_mutation` values must be either "
                                 "a List, Dict, a tune.sample_from instance or "
                                 "callable.")
@@ -257,13 +257,12 @@ class PopulationBasedTraining(FIFOScheduler):
             for k, v in search_space.items():
                 self.fill_config(config[attr], k, v)
 
-
     def on_trial_add(self, trial_runner, trial):
         self._trial_state[trial] = PBTTrialState(trial)
 
         for attr in self._hyperparam_mutations.keys():
             if attr not in trial.config:
-                if log_once(attr+"-missing"):
+                if log_once(attr + "-missing"):
                     logger.info("Cannot find {} in config. Using search "
                                 "space provided by hyperparam_mutations.")
                 self.fill_config(trial.config, attr,

--- a/python/ray/tune/tests/test_trial_scheduler_pbt.py
+++ b/python/ray/tune/tests/test_trial_scheduler_pbt.py
@@ -37,6 +37,7 @@ def MockTrainingFunc(config, checkpoint_dir=None):
     iter = 0
     a = config["a"]
     b = config["b"]
+    c = config["c"]
 
     if checkpoint_dir:
         checkpoint_path = os.path.join(checkpoint_dir, "model.mock")
@@ -62,6 +63,36 @@ class MockParam(object):
         self._index += 1
         return val
 
+class PopulationBasedTrainingConfigTest(unittest.TestCase):
+    def setUp(self):
+        ray.init()
+
+    def tearDown(self):
+        ray.shutdown()
+
+    def testNoConfig(self):
+        scheduler = PopulationBasedTraining(
+            time_attr="training_iteration",
+            metric="mean_accuracy",
+            mode="max",
+            perturbation_interval=1,
+            hyperparam_mutations={"a": tune.uniform(0, 0.3)},
+            resample_probability=0,
+        )
+
+        tune.run(
+            MockTrainingFunc,
+            config={
+                #"a": tune.uniform(0, 0.3),
+                "b": 1,
+                "c": 1
+            },
+            fail_fast=True,
+            num_samples=4,
+            scheduler=scheduler,
+            name="testNoConfig",
+            stop={"training_iteration": 3}
+        )
 
 class PopulationBasedTrainingResumeTest(unittest.TestCase):
     def setUp(self):

--- a/python/ray/tune/tests/test_trial_scheduler_pbt.py
+++ b/python/ray/tune/tests/test_trial_scheduler_pbt.py
@@ -37,7 +37,6 @@ def MockTrainingFunc(config, checkpoint_dir=None):
     iter = 0
     a = config["a"]
     b = config["b"]
-    c = config["c"]
 
     if checkpoint_dir:
         checkpoint_path = os.path.join(checkpoint_dir, "model.mock")
@@ -52,6 +51,7 @@ def MockTrainingFunc(config, checkpoint_dir=None):
                 pickle.dump((a, b, iter), fp)
         tune.report(mean_accuracy=(a - iter) * b)
 
+
 def MockTrainingFunc2(config):
     a = config["a"]
     b = config["b"]
@@ -59,7 +59,7 @@ def MockTrainingFunc2(config):
     c2 = config["c"]["c2"]
 
     while True:
-        tune.report(mean_accuracy=a*b*(c1+c2))
+        tune.report(mean_accuracy=a * b * (c1 + c2))
 
 
 class MockParam(object):
@@ -71,6 +71,7 @@ class MockParam(object):
         val = self._params[self._index % len(self._params)]
         self._index += 1
         return val
+
 
 class PopulationBasedTrainingConfigTest(unittest.TestCase):
     def setUp(self):
@@ -101,8 +102,8 @@ class PopulationBasedTrainingConfigTest(unittest.TestCase):
             num_samples=4,
             scheduler=scheduler,
             name="testNoConfig",
-            stop={"training_iteration": 3}
-        )
+            stop={"training_iteration": 3})
+
 
 class PopulationBasedTrainingResumeTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
This PR does the following:
1) Allow tune sampling functions to be used in hyperparam_mutations, i.e. `tune.uniform(x)` can be used instead of `lambda: np.random.uniform(x)`.
2) No longer requires search spaces to be specified in both hyperparam_mutations and config. If not present in config, the search space in hyperparam_mutations is used for the initial samples.
3) Only logs perturbed hyperparams during exploration instead of entire configs. Related issue: https://github.com/ray-project/ray/issues/7215

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
