### PR TITLE
[Object spilling] Look up the location of the primary raylet from the owner's metadata

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1457,7 +1457,7 @@ cdef class CoreWorker:
         object_ids = ObjectRefsToVector(object_refs)
         with nogil:
             check_status(CCoreWorkerProcess.GetCoreWorker()
-                         .ForceSpillObjects(object_ids))
+                         .SpillObjects(object_ids))
 
     def force_restore_spilled_objects(self, object_refs):
         cdef c_vector[CObjectID] object_ids

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -195,7 +195,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         CRayStatus SetResource(const c_string &resource_name,
                                const double capacity,
                                const CClientID &client_Id)
-        CRayStatus ForceSpillObjects(const c_vector[CObjectID] &object_ids)
+        CRayStatus SpillObjects(const c_vector[CObjectID] &object_ids)
         CRayStatus ForceRestoreSpilledObjects(
                 const c_vector[CObjectID] &object_ids)
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1199,8 +1199,8 @@ void CoreWorker::SpillOwnedObject(const ObjectID &object_id,
           node->node_manager_address(), node->node_manager_port(),
           *client_call_manager_));
   raylet_client->RequestObjectSpillage(
-      object_id, [this, object_id, callback](
-                     const Status &status, const rpc::RequestObjectSpillageReply &reply) {
+      object_id, [object_id, callback](const Status &status,
+                                       const rpc::RequestObjectSpillageReply &reply) {
         if (!status.ok() || !reply.success()) {
           RAY_LOG(ERROR) << "Failed to spill object " << object_id
                          << ", raylet unreachable or object could not be spilled.";
@@ -1215,7 +1215,7 @@ Status CoreWorker::SpillObjects(const std::vector<ObjectID> &object_ids) {
   auto ready_promise = std::make_shared<std::promise<void>>(std::promise<void>());
   Status final_status;
 
-  auto callback = [this, mutex, num_remaining, ready_promise]() {
+  auto callback = [mutex, num_remaining, ready_promise]() {
     absl::MutexLock lock(mutex.get());
     (*num_remaining)--;
     if (*num_remaining == 0) {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1174,8 +1174,77 @@ Status CoreWorker::SetResource(const std::string &resource_name, const double ca
   return local_raylet_client_->SetResource(resource_name, capacity, client_id);
 }
 
-Status CoreWorker::ForceSpillObjects(const std::vector<ObjectID> &object_ids) {
-  return local_raylet_client_->ForceSpillObjects(object_ids);
+Status CoreWorker::SpillObjects(const std::vector<ObjectID> &object_ids) {
+  absl::Mutex mutex;
+  auto num_remaining = std::make_shared<size_t>(object_ids.size());
+  auto final_status = std::make_shared<Status>();
+  auto ready_promise = std::make_shared<std::promise<void>>(std::promise<void>());
+
+  for (const auto &object_id : object_ids) {
+    RAY_LOG(DEBUG) << "Requesting spill for object " << object_id;
+    AddLocalReference(object_id, "<temporary (get object status)>");
+
+    rpc::Address owner_address;
+    auto has_owner = reference_counter_->GetOwner(object_id, &owner_address);
+    if (!has_owner) {
+      return Status::Invalid("Cannot call spill on objects that have gone out of scope.");
+    } else if (WorkerID::FromBinary(owner_address.worker_id()) !=
+               worker_context_.GetWorkerID()) {
+      return Status::Invalid("Cannot call spill on objects that we do not own.");
+    } else {
+      memory_store_->GetAsync(object_id, [this, object_id, num_remaining, final_status,
+                                          ready_promise](std::shared_ptr<RayObject> obj) {
+        // Find the raylet that hosts the primary copy of the object.
+        ClientID pinned_at;
+        RAY_CHECK(reference_counter_->IsPlasmaObjectPinned(object_id, &pinned_at));
+        if (pinned_at.IsNil()) {
+          absl::MutexLock lock(&mutex_);
+          *final_status =
+              Status::Invalid("Objects not stored in plasma cannot be spilled");
+          (*num_remaining)--;
+          if (*num_remaining == 0) {
+            ready_promise->set_value();
+          }
+          return;
+        }
+        auto node = gcs_client_->Nodes().Get(pinned_at);
+        if (!node) {
+          absl::MutexLock lock(&mutex_);
+          *final_status = Status::Invalid("No address registered for the primary raylet");
+          (*num_remaining)--;
+          if (*num_remaining == 0) {
+            ready_promise->set_value();
+          }
+          return;
+        }
+
+        // Ask the raylet to spill the object.
+        auto raylet_client =
+            std::make_shared<raylet::RayletClient>(rpc::NodeManagerWorkerClient::make(
+                node->node_manager_address(), node->node_manager_port(),
+                *client_call_manager_));
+        raylet_client->RequestObjectSpillage(
+            object_id,
+            [this, num_remaining, final_status, ready_promise, object_id](
+                const Status &status, const rpc::RequestObjectSpillageReply &reply) {
+              absl::MutexLock lock(&mutex_);
+              if (!status.ok()) {
+                *final_status = status;
+              } else if (!reply.success()) {
+                *final_status =
+                    Status::Invalid("Raylet reachable but object could not be spilled");
+              }
+              (*num_remaining)--;
+              if (*num_remaining == 0) {
+                ready_promise->set_value();
+              }
+            });
+      });
+    }
+  }
+
+  ready_promise->get_future().wait();
+  return *final_status;
 }
 
 Status CoreWorker::ForceRestoreSpilledObjects(const std::vector<ObjectID> &object_ids) {

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -586,10 +586,10 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   Status SetResource(const std::string &resource_name, const double capacity,
                      const ClientID &client_id);
 
-  /// Force spilling objects to external storage.
+  /// Request an object to be spilled to external storage.
   /// \param[in] object_ids The objects to be spilled.
   /// \return Status
-  Status ForceSpillObjects(const std::vector<ObjectID> &object_ids);
+  Status SpillObjects(const std::vector<ObjectID> &object_ids);
 
   /// Restore objects from external storage.
   /// \param[in] object_ids The objects to be restored.

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -588,7 +588,10 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
 
   /// Request an object to be spilled to external storage.
   /// \param[in] object_ids The objects to be spilled.
-  /// \return Status
+  /// \return Status. Returns Status::Invalid if any of the objects are not
+  /// eligible for spilling (they have gone out of scope or we do not own the
+  /// object). Otherwise, the return status is ok and we will use best effort
+  /// to spill the object.
   Status SpillObjects(const std::vector<ObjectID> &object_ids);
 
   /// Restore objects from external storage.
@@ -995,6 +998,11 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
 
   /// Handler if a raylet node is removed from the cluster.
   void OnNodeRemoved(const rpc::GcsNodeInfo &node_info);
+
+  /// Request the spillage of an object that we own from the primary that hosts
+  /// the primary copy to spill.
+  void SpillOwnedObject(const ObjectID &object_id, const std::shared_ptr<RayObject> &obj,
+                        std::function<void()> callback);
 
   const CoreWorkerOptions options_;
 

--- a/src/ray/core_worker/object_recovery_manager.cc
+++ b/src/ray/core_worker/object_recovery_manager.cc
@@ -20,8 +20,8 @@ namespace ray {
 
 Status ObjectRecoveryManager::RecoverObject(const ObjectID &object_id) {
   // Check the ReferenceCounter to see if there is a location for the object.
-  bool pinned = false;
-  bool owned_by_us = reference_counter_->IsPlasmaObjectPinned(object_id, &pinned);
+  ClientID pinned_at;
+  bool owned_by_us = reference_counter_->IsPlasmaObjectPinned(object_id, &pinned_at);
   if (!owned_by_us) {
     return Status::Invalid(
         "Object reference no longer exists or is not owned by us. Either lineage pinning "
@@ -29,7 +29,7 @@ Status ObjectRecoveryManager::RecoverObject(const ObjectID &object_id) {
   }
 
   bool already_pending_recovery = true;
-  if (!pinned) {
+  if (pinned_at.IsNil()) {
     {
       absl::MutexLock lock(&mu_);
       // Mark that we are attempting recovery for this object to prevent

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -539,12 +539,12 @@ void ReferenceCounter::UpdateObjectPinnedAtRaylet(const ObjectID &object_id,
 }
 
 bool ReferenceCounter::IsPlasmaObjectPinned(const ObjectID &object_id,
-                                            bool *pinned) const {
+                                            ClientID *pinned_at) const {
   absl::MutexLock lock(&mutex_);
   auto it = object_id_refs_.find(object_id);
   if (it != object_id_refs_.end()) {
     if (it->second.owned_by_us) {
-      *pinned = it->second.pinned_at_raylet_id.has_value();
+      *pinned_at = it->second.pinned_at_raylet_id.value_or(ClientID::Nil());
       return true;
     }
   }

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -327,12 +327,12 @@ class ReferenceCounter : public ReferenceCounterInterface {
   /// Check whether the object is pinned at a remote plasma store node.
   ///
   /// \param[in] object_id The object to check.
-  /// \param[out] pinned Whether the object was pinned at a remote plasma store
-  /// node.
+  /// \param[out] pinned_at The node ID of the raylet at which this object is
+  /// pinned. Set to nil if the object is not pinned.
   /// \return True if the object exists and is owned by us, false otherwise. We
   /// return false here because a borrower should not know the pinned location
   /// for an object.
-  bool IsPlasmaObjectPinned(const ObjectID &object_id, bool *pinned) const
+  bool IsPlasmaObjectPinned(const ObjectID &object_id, ClientID *pinned_at) const
       LOCKS_EXCLUDED(mutex_);
 
   /// Get and reset the objects that were pinned on the given node.  This

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -185,10 +185,10 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
     if (return_object.in_plasma()) {
       const auto pinned_at_raylet_id = ClientID::FromBinary(worker_addr.raylet_id());
       if (check_node_alive_(pinned_at_raylet_id)) {
+        reference_counter_->UpdateObjectPinnedAtRaylet(object_id, pinned_at_raylet_id);
         // Mark it as in plasma with a dummy object.
         RAY_CHECK(in_memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_IN_PLASMA),
                                         object_id));
-        reference_counter_->UpdateObjectPinnedAtRaylet(object_id, pinned_at_raylet_id);
       } else {
         RAY_LOG(INFO) << "Task " << task_id << " returned object " << object_id
                       << " in plasma on a dead node, attempting to recover";

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -139,6 +139,16 @@ message FormatGlobalMemoryInfoReply {
   string memory_summary = 1;
 }
 
+message RequestObjectSpillageRequest {
+  // ObjectID to spill.
+  bytes object_id = 1;
+}
+
+message RequestObjectSpillageReply {
+  // Whether the object spilling was successful or not.
+  bool success = 1;
+}
+
 // Service for inter-node-manager communication.
 service NodeManagerService {
   // Request a worker from the raylet.
@@ -169,4 +179,6 @@ service NodeManagerService {
   // Get global object reference stats in formatted form.
   rpc FormatGlobalMemoryInfo(FormatGlobalMemoryInfoRequest)
       returns (FormatGlobalMemoryInfoReply);
+  // Ask the raylet to spill an object to external storage.
+  rpc RequestObjectSpillage(RequestObjectSpillageRequest) returns (RequestObjectSpillageReply);
 }

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -180,5 +180,6 @@ service NodeManagerService {
   rpc FormatGlobalMemoryInfo(FormatGlobalMemoryInfoRequest)
       returns (FormatGlobalMemoryInfoReply);
   // Ask the raylet to spill an object to external storage.
-  rpc RequestObjectSpillage(RequestObjectSpillageRequest) returns (RequestObjectSpillageReply);
+  rpc RequestObjectSpillage(RequestObjectSpillageRequest)
+      returns (RequestObjectSpillageReply);
 }

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -82,9 +82,6 @@ enum MessageType:int {
   SetResourceRequest,
   // Subscribe to Plasma updates
   SubscribePlasmaReady,
-  // Manually spill objects to external storage.
-  ForceSpillObjectsRequest,
-  ForceSpillObjectsReply,
   // Manually restore objects from external storage.
   ForceRestoreSpilledObjectsRequest,
   ForceRestoreSpilledObjectsReply,

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -506,6 +506,18 @@ void NodeManager::DoLocalGC() {
   }
 }
 
+void NodeManager::HandleRequestObjectSpillage(
+    const rpc::RequestObjectSpillageRequest &request,
+    rpc::RequestObjectSpillageReply *reply, rpc::SendReplyCallback send_reply_callback) {
+  SpillObjects({ObjectID::FromBinary(request.object_id())},
+               [this, reply, send_reply_callback](const ray::Status &status) {
+                 if (status.ok()) {
+                   reply->set_success(true);
+                 }
+                 send_reply_callback(Status::OK(), nullptr, nullptr);
+               });
+}
+
 void NodeManager::SpillObjects(const std::vector<ObjectID> &objects_ids_to_spill,
                                std::function<void(const ray::Status &)> callback) {
   std::vector<ObjectID> objects_ids;
@@ -514,6 +526,13 @@ void NodeManager::SpillObjects(const std::vector<ObjectID> &objects_ids_to_spill
     if (spilled_objects_.count(id) == 0) {
       objects_ids.push_back(id);
     }
+    // We should not spill an object that we are not the primary copy for.
+    if (pinned_objects_.count(id) == 0) {
+      RAY_LOG(ERROR) << "The object to spill " << id << " is not pinned.";
+      callback(
+          Status::Invalid("Requested object spillage on a non-primary object copy."));
+      return;
+    }
   }
   if (objects_ids.empty()) {
     if (callback) {
@@ -521,42 +540,43 @@ void NodeManager::SpillObjects(const std::vector<ObjectID> &objects_ids_to_spill
     }
     return;
   }
-  worker_pool_.PopIOWorker(
-      [this, objects_ids, callback](std::shared_ptr<WorkerInterface> io_worker) {
-        RAY_LOG(DEBUG) << "Sending object spilling request";
-        rpc::SpillObjectsRequest request;
-        for (const auto &object_id : objects_ids) {
-          request.add_object_ids_to_spill(object_id.Binary());
-        }
-        io_worker->rpc_client()->SpillObjects(
-            request, [this, objects_ids, callback, io_worker](
-                         const ray::Status &status, const rpc::SpillObjectsReply &r) {
-              worker_pool_.PushIOWorker(io_worker);
-              if (!status.ok()) {
-                RAY_LOG(ERROR) << "Failed to send object spilling request: "
-                               << status.ToString();
+  worker_pool_.PopIOWorker([this, objects_ids,
+                            callback](std::shared_ptr<WorkerInterface> io_worker) {
+    rpc::SpillObjectsRequest request;
+    for (const auto &object_id : objects_ids) {
+      RAY_LOG(DEBUG) << "Sending spill request for object " << object_id;
+      request.add_object_ids_to_spill(object_id.Binary());
+    }
+    io_worker->rpc_client()->SpillObjects(
+        request, [this, objects_ids, callback, io_worker](
+                     const ray::Status &status, const rpc::SpillObjectsReply &r) {
+          worker_pool_.PushIOWorker(io_worker);
+          if (!status.ok()) {
+            RAY_LOG(ERROR) << "Failed to send object spilling request: "
+                           << status.ToString();
+          } else {
+            RAY_CHECK(static_cast<size_t>(r.spilled_objects_url_size()) ==
+                      objects_ids.size());
+            for (size_t i = 0; i < objects_ids.size(); ++i) {
+              const ObjectID &object_id = objects_ids[i];
+              const std::string &object_url = r.spilled_objects_url(i);
+              RAY_LOG(DEBUG) << "Object " << object_id << " spilled at " << object_url;
+              // TODO(suquark): write to object directory.
+              spilled_objects_[object_id] = object_url;
+              auto search = pinned_objects_.find(object_id);
+              if (search != pinned_objects_.end()) {
+                pinned_objects_.erase(search);
               } else {
-                RAY_CHECK(static_cast<size_t>(r.spilled_objects_url_size()) ==
-                          objects_ids.size());
-                for (size_t i = 0; i < objects_ids.size(); ++i) {
-                  const ObjectID &object_id = objects_ids[i];
-                  const std::string &object_url = r.spilled_objects_url(i);
-                  // TODO(suquark): write to object directory.
-                  spilled_objects_[object_id] = object_url;
-                  auto search = pinned_objects_.find(object_id);
-                  if (search != pinned_objects_.end()) {
-                    pinned_objects_.erase(search);
-                  } else {
-                    RAY_LOG(ERROR)
-                        << "The spilled object " << object_id.Hex() << " is not pinned.";
-                  }
-                }
+                RAY_LOG(ERROR) << "The spilled object " << object_id.Hex()
+                               << " is not pinned.";
               }
-              if (callback) {
-                callback(status);
-              }
-            });
-      });
+            }
+          }
+          if (callback) {
+            callback(status);
+          }
+        });
+  });
 }
 
 void NodeManager::RestoreSpilledObjects(
@@ -565,6 +585,10 @@ void NodeManager::RestoreSpilledObjects(
   std::vector<std::string> object_urls;
   object_urls.reserve(object_ids.size());
   for (const auto &object_id : object_ids) {
+    if (spilled_objects_.count(object_id) == 0) {
+      callback(Status::Invalid("No object URL recorded"));
+      return;
+    }
     object_urls.push_back(spilled_objects_[object_id]);
   }
   worker_pool_.PopIOWorker([this, object_urls,
@@ -1225,23 +1249,6 @@ void NodeManager::ProcessClientMessage(const std::shared_ptr<ClientConnection> &
   } break;
   case protocol::MessageType::SubscribePlasmaReady: {
     ProcessSubscribePlasmaReady(client, message_data);
-  } break;
-  case protocol::MessageType::ForceSpillObjectsRequest: {
-    auto message = flatbuffers::GetRoot<protocol::ForceSpillObjectsRequest>(message_data);
-    std::vector<ObjectID> object_ids = from_flatbuf<ObjectID>(*message->object_ids());
-    SpillObjects(object_ids, [this, client](const ray::Status &status) {
-      flatbuffers::FlatBufferBuilder fbb;
-      flatbuffers::Offset<protocol::ForceSpillObjectsReply> reply =
-          protocol::CreateForceSpillObjectsReply(fbb);
-      fbb.Finish(reply);
-      auto reply_status = client->WriteMessage(
-          static_cast<int64_t>(protocol::MessageType::ForceSpillObjectsReply),
-          fbb.GetSize(), fbb.GetBufferPointer());
-      if (!reply_status.ok()) {
-        // We failed to write to the client, so disconnect the client.
-        ProcessDisconnectClientMessage(client);
-      }
-    });
   } break;
   case protocol::MessageType::ForceRestoreSpilledObjectsRequest: {
     auto message =

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -510,7 +510,7 @@ void NodeManager::HandleRequestObjectSpillage(
     const rpc::RequestObjectSpillageRequest &request,
     rpc::RequestObjectSpillageReply *reply, rpc::SendReplyCallback send_reply_callback) {
   SpillObjects({ObjectID::FromBinary(request.object_id())},
-               [this, reply, send_reply_callback](const ray::Status &status) {
+               [reply, send_reply_callback](const ray::Status &status) {
                  if (status.ok()) {
                    reply->set_success(true);
                  }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -527,11 +527,13 @@ void NodeManager::SpillObjects(const std::vector<ObjectID> &objects_ids_to_spill
       objects_ids.push_back(id);
     }
     // We should not spill an object that we are not the primary copy for.
+    // TODO(swang): We should really return an error here but right now there
+    // is a race condition where the raylet receives the owner's request to
+    // spill an object before it receives the message to pin the objects from
+    // the local worker.
     if (pinned_objects_.count(id) == 0) {
-      RAY_LOG(ERROR) << "The object to spill " << id << " is not pinned.";
-      callback(
-          Status::Invalid("Requested object spillage on a non-primary object copy."));
-      return;
+      RAY_LOG(WARNING) << "Requested spill for object that has not yet been marked as "
+                          "the primary copy";
     }
   }
   if (objects_ids.empty()) {

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -607,6 +607,11 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
                                     rpc::FormatGlobalMemoryInfoReply *reply,
                                     rpc::SendReplyCallback send_reply_callback) override;
 
+  /// Handle a `RequestObjectSpillage` request.
+  void HandleRequestObjectSpillage(const rpc::RequestObjectSpillageRequest &request,
+                                   rpc::RequestObjectSpillageReply *reply,
+                                   rpc::SendReplyCallback send_reply_callback) override;
+
   /// Trigger global GC across the cluster to free up references to actors or
   /// object ids.
   void TriggerGlobalGC();

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -311,18 +311,12 @@ void raylet::RayletClient::RequestWorkerLease(
 }
 
 /// Spill objects to external storage.
-/// \param object_ids The IDs of objects to be spilled.
-Status raylet::RayletClient::ForceSpillObjects(const std::vector<ObjectID> &object_ids) {
-  flatbuffers::FlatBufferBuilder fbb;
-  auto message =
-      protocol::CreateForceSpillObjectsRequest(fbb, to_flatbuf(fbb, object_ids));
-  fbb.Finish(message);
-  std::vector<uint8_t> reply;
-  RAY_RETURN_NOT_OK(conn_->AtomicRequestReply(MessageType::ForceSpillObjectsRequest,
-                                              MessageType::ForceSpillObjectsReply, &reply,
-                                              &fbb));
-  RAY_UNUSED(flatbuffers::GetRoot<protocol::ForceSpillObjectsReply>(reply.data()));
-  return Status::OK();
+void raylet::RayletClient::RequestObjectSpillage(
+    const ObjectID &object_id,
+    const rpc::ClientCallback<rpc::RequestObjectSpillageReply> &callback) {
+  rpc::RequestObjectSpillageRequest request;
+  request.set_object_id(object_id.Binary());
+  grpc_client_->RequestObjectSpillage(request, callback);
 }
 
 /// Restore spilled objects from external storage.

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -319,10 +319,13 @@ class RayletClient : public PinObjectsInterface,
   ray::Status SetResource(const std::string &resource_name, const double capacity,
                           const ray::ClientID &client_Id);
 
-  /// Spill objects to external storage.
-  /// \param object_ids The IDs of objects to be spilled.
-  /// \return ray::Status
-  ray::Status ForceSpillObjects(const std::vector<ObjectID> &object_ids);
+  /// Ask the raylet to spill an object to external storage.
+  /// \param object_id The ID of the object to be spilled.
+  /// \param callback Callback that will be called after raylet completes the
+  /// object spilling (or it fails).
+  void RequestObjectSpillage(
+      const ObjectID &object_id,
+      const rpc::ClientCallback<rpc::RequestObjectSpillageReply> &callback);
 
   /// Restore spilled objects from external storage.
   /// \param object_ids The IDs of objects to be restored.

--- a/src/ray/rpc/node_manager/node_manager_client.h
+++ b/src/ray/rpc/node_manager/node_manager_client.h
@@ -94,6 +94,9 @@ class NodeManagerWorkerClient
   /// Trigger global GC across the cluster.
   VOID_RPC_CLIENT_METHOD(NodeManagerService, GlobalGC, grpc_client_, )
 
+  /// Ask the raylet to spill an object to external storage.
+  VOID_RPC_CLIENT_METHOD(NodeManagerService, RequestObjectSpillage, grpc_client_, )
+
  private:
   /// Constructor.
   ///

--- a/src/ray/rpc/node_manager/node_manager_server.h
+++ b/src/ray/rpc/node_manager/node_manager_server.h
@@ -33,7 +33,8 @@ namespace rpc {
   RPC_SERVICE_HANDLER(NodeManagerService, GlobalGC)               \
   RPC_SERVICE_HANDLER(NodeManagerService, FormatGlobalMemoryInfo) \
   RPC_SERVICE_HANDLER(NodeManagerService, RequestResourceReserve) \
-  RPC_SERVICE_HANDLER(NodeManagerService, CancelResourceReserve)
+  RPC_SERVICE_HANDLER(NodeManagerService, CancelResourceReserve)  \
+  RPC_SERVICE_HANDLER(NodeManagerService, RequestObjectSpillage)
 
 /// Interface of the `NodeManagerService`, see `src/ray/protobuf/node_manager.proto`.
 class NodeManagerServiceHandler {
@@ -89,6 +90,10 @@ class NodeManagerServiceHandler {
   virtual void HandleFormatGlobalMemoryInfo(const FormatGlobalMemoryInfoRequest &request,
                                             FormatGlobalMemoryInfoReply *reply,
                                             SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleRequestObjectSpillage(const RequestObjectSpillageRequest &request,
+                                           RequestObjectSpillageReply *reply,
+                                           SendReplyCallback send_reply_callback) = 0;
 };
 
 /// The `GrpcService` for `NodeManagerService`.


### PR DESCRIPTION
## Why are these changes needed?

The experimental object spilling in #9818 contacts the local raylet to request objects to be spilled. This will fail if the local raylet does not actually have the object. It's also not ideal even if the local raylet does have the object but it is not the primary copy (since this copy is evictable anyway).

This PR gets the location of the primary copy from the owner's metadata and requests the object to be spilled from the raylet.

This PR also makes some small changes and fixes:
- Use grpc/protobuf instead of asio/flatbuffers for request to spill an object
- Some internal renames
- Warn if the contacted raylet does not actually have the primary copy - this should never happen now that we're going through the owner but there is a possible race condition where the raylet receives the object spilling request before it discovers that it's the primary copy.
- Fail object restore if there is no URL listed for the object - this can happen when restoration is requested from a raylet that did not do the spilling. Should not be an issue once we write the metadata to the object directory.

## Related issue number

Closes #10182.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
