### PR TITLE
rpc: Follow-up by sharing the core worker client pool within the core worker.

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -446,10 +446,10 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
     }
     SetCurrentTaskId(task_id);
   }
-  auto client_factory = [this](const rpc::Address &addr) {
-    return std::shared_ptr<rpc::CoreWorkerClient>(
-        new rpc::CoreWorkerClient(addr, *client_call_manager_));
-  };
+
+  core_worker_client_pool_ = std::make_shared<rpc::CoreWorkerClientPool>(
+      *client_call_manager_);
+
   auto raylet_client_factory = [this](const std::string ip_address, int port) {
     auto grpc_client =
         rpc::NodeManagerWorkerClient::make(ip_address, port, *client_call_manager_);
@@ -461,22 +461,22 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
       std::make_shared<DefaultActorCreator>(gcs_client_);
 
   direct_actor_submitter_ = std::shared_ptr<CoreWorkerDirectActorTaskSubmitter>(
-      new CoreWorkerDirectActorTaskSubmitter(client_factory, memory_store_,
+      new CoreWorkerDirectActorTaskSubmitter(core_worker_client_pool_, memory_store_,
                                              task_manager_));
 
   direct_task_submitter_ =
       std::unique_ptr<CoreWorkerDirectTaskSubmitter>(new CoreWorkerDirectTaskSubmitter(
-          rpc_address_, local_raylet_client_, client_factory, raylet_client_factory,
+          rpc_address_, local_raylet_client_, core_worker_client_pool_, raylet_client_factory,
           memory_store_, task_manager_, local_raylet_id,
           RayConfig::instance().worker_lease_timeout_milliseconds(),
           std::move(actor_creator),
           RayConfig::instance().max_tasks_in_flight_per_worker(),
           boost::asio::steady_timer(io_service_)));
-  future_resolver_.reset(new FutureResolver(memory_store_, client_factory, rpc_address_));
+  future_resolver_.reset(new FutureResolver(memory_store_, core_worker_client_pool_, rpc_address_));
   // Unfortunately the raylet client has to be constructed after the receivers.
   if (direct_task_receiver_ != nullptr) {
     task_argument_waiter_.reset(new DependencyWaiterImpl(*local_raylet_client_));
-    direct_task_receiver_->Init(client_factory, rpc_address_, task_argument_waiter_);
+    direct_task_receiver_->Init(core_worker_client_pool_, rpc_address_, task_argument_waiter_);
   }
 
   actor_manager_ = std::unique_ptr<ActorManager>(

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -447,8 +447,8 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
     SetCurrentTaskId(task_id);
   }
 
-  core_worker_client_pool_ = std::make_shared<rpc::CoreWorkerClientPool>(
-      *client_call_manager_);
+  core_worker_client_pool_ =
+      std::make_shared<rpc::CoreWorkerClientPool>(*client_call_manager_);
 
   auto raylet_client_factory = [this](const std::string ip_address, int port) {
     auto grpc_client =
@@ -466,17 +466,19 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
 
   direct_task_submitter_ =
       std::unique_ptr<CoreWorkerDirectTaskSubmitter>(new CoreWorkerDirectTaskSubmitter(
-          rpc_address_, local_raylet_client_, core_worker_client_pool_, raylet_client_factory,
-          memory_store_, task_manager_, local_raylet_id,
+          rpc_address_, local_raylet_client_, core_worker_client_pool_,
+          raylet_client_factory, memory_store_, task_manager_, local_raylet_id,
           RayConfig::instance().worker_lease_timeout_milliseconds(),
           std::move(actor_creator),
           RayConfig::instance().max_tasks_in_flight_per_worker(),
           boost::asio::steady_timer(io_service_)));
-  future_resolver_.reset(new FutureResolver(memory_store_, core_worker_client_pool_, rpc_address_));
+  future_resolver_.reset(
+      new FutureResolver(memory_store_, core_worker_client_pool_, rpc_address_));
   // Unfortunately the raylet client has to be constructed after the receivers.
   if (direct_task_receiver_ != nullptr) {
     task_argument_waiter_.reset(new DependencyWaiterImpl(*local_raylet_client_));
-    direct_task_receiver_->Init(core_worker_client_pool_, rpc_address_, task_argument_waiter_);
+    direct_task_receiver_->Init(core_worker_client_pool_, rpc_address_,
+                                task_argument_waiter_);
   }
 
   actor_manager_ = std::unique_ptr<ActorManager>(

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1032,6 +1032,9 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// Shared client call manager.
   std::unique_ptr<rpc::ClientCallManager> client_call_manager_;
 
+  /// Shared core worker client pool.
+  std::shared_ptr<rpc::CoreWorkerClientPool> core_worker_client_pool_;
+
   /// Timer used to periodically check if the raylet has died.
   boost::asio::steady_timer death_check_timer_;
 

--- a/src/ray/core_worker/future_resolver.cc
+++ b/src/ray/core_worker/future_resolver.cc
@@ -23,7 +23,7 @@ void FutureResolver::ResolveFutureAsync(const ObjectID &object_id,
     // with a borrowed reference executes on the object's owning worker.
     return;
   }
-  auto conn = owner_clients_.GetOrConnect(owner_address);
+  auto conn = owner_clients_->GetOrConnect(owner_address);
 
   rpc::GetObjectStatusRequest request;
   request.set_object_id(object_id.Binary());

--- a/src/ray/core_worker/future_resolver.h
+++ b/src/ray/core_worker/future_resolver.h
@@ -28,13 +28,12 @@ namespace ray {
 // was available. This class is thread-safe.
 class FutureResolver {
  public:
-  FutureResolver(
-      std::shared_ptr<CoreWorkerMemoryStore> store,
-      std::shared_ptr<rpc::CoreWorkerClientPool> core_worker_client_pool,
-      const rpc::Address &rpc_address)
+  FutureResolver(std::shared_ptr<CoreWorkerMemoryStore> store,
+                 std::shared_ptr<rpc::CoreWorkerClientPool> core_worker_client_pool,
+                 const rpc::Address &rpc_address)
       : in_memory_store_(store),
-      owner_clients_(core_worker_client_pool),
-      rpc_address_(rpc_address) {}
+        owner_clients_(core_worker_client_pool),
+        rpc_address_(rpc_address) {}
 
   /// Resolve the value for a future. This will periodically contact the given
   /// owner until the owner dies or the owner has finished creating the object.

--- a/src/ray/core_worker/future_resolver.h
+++ b/src/ray/core_worker/future_resolver.h
@@ -28,11 +28,13 @@ namespace ray {
 // was available. This class is thread-safe.
 class FutureResolver {
  public:
-  FutureResolver(std::shared_ptr<CoreWorkerMemoryStore> store,
-                 rpc::ClientFactoryFn client_factory, const rpc::Address &rpc_address)
+  FutureResolver(
+      std::shared_ptr<CoreWorkerMemoryStore> store,
+      std::shared_ptr<rpc::CoreWorkerClientPool> core_worker_client_pool,
+      const rpc::Address &rpc_address)
       : in_memory_store_(store),
-        owner_clients_(client_factory),
-        rpc_address_(rpc_address) {}
+      owner_clients_(core_worker_client_pool),
+      rpc_address_(rpc_address) {}
 
   /// Resolve the value for a future. This will periodically contact the given
   /// owner until the owner dies or the owner has finished creating the object.
@@ -48,7 +50,7 @@ class FutureResolver {
   /// Used to store values of resolved futures.
   std::shared_ptr<CoreWorkerMemoryStore> in_memory_store_;
 
-  rpc::CoreWorkerClientPool owner_clients_;
+  std::shared_ptr<rpc::CoreWorkerClientPool> owner_clients_;
 
   /// Address of our RPC server. Used to notify borrowed objects' owners of our
   /// address, so the owner can contact us to ask when our reference to the

--- a/src/ray/core_worker/test/direct_actor_transport_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_test.cc
@@ -429,11 +429,9 @@ class DirectActorReceiverTest : public ::testing::Test {
     receiver_ = std::unique_ptr<CoreWorkerDirectTaskReceiver>(
         new CoreWorkerDirectTaskReceiver(worker_context_, main_io_service_, execute_task,
                                          [] { return Status::OK(); }));
-    receiver_->Init(
-        std::make_shared<rpc::CoreWorkerClientPool>(
-            [&](const rpc::Address &addr) { return worker_client_; }),
-        rpc_address_,
-        dependency_waiter_);
+    receiver_->Init(std::make_shared<rpc::CoreWorkerClientPool>(
+                        [&](const rpc::Address &addr) { return worker_client_; }),
+                    rpc_address_, dependency_waiter_);
   }
 
   Status MockExecuteTask(const TaskSpecification &task_spec,

--- a/src/ray/core_worker/test/direct_actor_transport_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_test.cc
@@ -102,10 +102,10 @@ class DirectActorSubmitterTest : public ::testing::Test {
         store_(std::shared_ptr<CoreWorkerMemoryStore>(new CoreWorkerMemoryStore())),
         task_finisher_(std::make_shared<MockTaskFinisher>()),
         submitter_(
-            [&](const rpc::Address &addr) {
+            std::make_shared<rpc::CoreWorkerClientPool>([&](const rpc::Address &addr) {
               num_clients_connected_++;
               return worker_client_;
-            },
+            }),
             store_, task_finisher_) {}
 
   int num_clients_connected_ = 0;
@@ -364,6 +364,7 @@ TEST_F(DirectActorSubmitterTest, TestActorRestartOutOfOrderGcs) {
 
   // We receive the RESTART message late. Nothing happens.
   submitter_.DisconnectActor(actor_id, 0, /*dead=*/false);
+
   ASSERT_EQ(num_clients_connected_, 2);
   // Submit a task.
   task = CreateActorTaskHelper(actor_id, worker_id, 2);
@@ -428,8 +429,11 @@ class DirectActorReceiverTest : public ::testing::Test {
     receiver_ = std::unique_ptr<CoreWorkerDirectTaskReceiver>(
         new CoreWorkerDirectTaskReceiver(worker_context_, main_io_service_, execute_task,
                                          [] { return Status::OK(); }));
-    receiver_->Init([&](const rpc::Address &addr) { return worker_client_; },
-                    rpc_address_, dependency_waiter_);
+    receiver_->Init(
+        std::make_shared<rpc::CoreWorkerClientPool>(
+            [&](const rpc::Address &addr) { return worker_client_; }),
+        rpc_address_,
+        dependency_waiter_);
   }
 
   Status MockExecuteTask(const TaskSpecification &task_spec,

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -339,9 +339,9 @@ TEST(DirectTaskTransportTest, TestSubmitOneTask) {
       [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
-                                          task_finisher, ClientID::Nil(), kLongTimeout,
-                                          actor_creator);
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr,
+                                          store, task_finisher, ClientID::Nil(),
+                                          kLongTimeout, actor_creator);
 
   std::unordered_map<std::string, double> empty_resources;
   ray::FunctionDescriptor empty_descriptor =
@@ -376,9 +376,9 @@ TEST(DirectTaskTransportTest, TestHandleTaskFailure) {
       [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
-                                          task_finisher, ClientID::Nil(), kLongTimeout,
-                                          actor_creator);
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr,
+                                          store, task_finisher, ClientID::Nil(),
+                                          kLongTimeout, actor_creator);
   std::unordered_map<std::string, double> empty_resources;
   ray::FunctionDescriptor empty_descriptor =
       ray::FunctionDescriptorBuilder::BuildPython("", "", "", "");
@@ -406,9 +406,9 @@ TEST(DirectTaskTransportTest, TestConcurrentWorkerLeases) {
       [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
-                                          task_finisher, ClientID::Nil(), kLongTimeout,
-                                          actor_creator);
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr,
+                                          store, task_finisher, ClientID::Nil(),
+                                          kLongTimeout, actor_creator);
   std::unordered_map<std::string, double> empty_resources;
   ray::FunctionDescriptor empty_descriptor =
       ray::FunctionDescriptorBuilder::BuildPython("", "", "", "");
@@ -457,9 +457,9 @@ TEST(DirectTaskTransportTest, TestReuseWorkerLease) {
       [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
-                                          task_finisher, ClientID::Nil(), kLongTimeout,
-                                          actor_creator);
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr,
+                                          store, task_finisher, ClientID::Nil(),
+                                          kLongTimeout, actor_creator);
   std::unordered_map<std::string, double> empty_resources;
   ray::FunctionDescriptor empty_descriptor =
       ray::FunctionDescriptorBuilder::BuildPython("", "", "", "");
@@ -515,9 +515,9 @@ TEST(DirectTaskTransportTest, TestRetryLeaseCancellation) {
       [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
-                                          task_finisher, ClientID::Nil(), kLongTimeout,
-                                          actor_creator);
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr,
+                                          store, task_finisher, ClientID::Nil(),
+                                          kLongTimeout, actor_creator);
   std::unordered_map<std::string, double> empty_resources;
   ray::FunctionDescriptor empty_descriptor =
       ray::FunctionDescriptorBuilder::BuildPython("", "", "", "");
@@ -571,9 +571,9 @@ TEST(DirectTaskTransportTest, TestConcurrentCancellationAndSubmission) {
       [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
-                                          task_finisher, ClientID::Nil(), kLongTimeout,
-                                          actor_creator);
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr,
+                                          store, task_finisher, ClientID::Nil(),
+                                          kLongTimeout, actor_creator);
   std::unordered_map<std::string, double> empty_resources;
   ray::FunctionDescriptor empty_descriptor =
       ray::FunctionDescriptorBuilder::BuildPython("", "", "", "");
@@ -624,9 +624,9 @@ TEST(DirectTaskTransportTest, TestWorkerNotReusedOnError) {
       [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
-                                          task_finisher, ClientID::Nil(), kLongTimeout,
-                                          actor_creator);
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr,
+                                          store, task_finisher, ClientID::Nil(),
+                                          kLongTimeout, actor_creator);
   std::unordered_map<std::string, double> empty_resources;
   ray::FunctionDescriptor empty_descriptor =
       ray::FunctionDescriptorBuilder::BuildPython("", "", "", "");
@@ -668,9 +668,9 @@ TEST(DirectTaskTransportTest, TestWorkerNotReturnedOnExit) {
       [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
-                                          task_finisher, ClientID::Nil(), kLongTimeout,
-                                          actor_creator);
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr,
+                                          store, task_finisher, ClientID::Nil(),
+                                          kLongTimeout, actor_creator);
   std::unordered_map<std::string, double> empty_resources;
   ray::FunctionDescriptor empty_descriptor =
       ray::FunctionDescriptorBuilder::BuildPython("", "", "", "");
@@ -827,9 +827,9 @@ void TestSchedulingKey(const std::shared_ptr<CoreWorkerMemoryStore> store,
       [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
-                                          task_finisher, ClientID::Nil(), kLongTimeout,
-                                          actor_creator);
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr,
+                                          store, task_finisher, ClientID::Nil(),
+                                          kLongTimeout, actor_creator);
 
   ASSERT_TRUE(submitter.SubmitTask(same1).ok());
   ASSERT_TRUE(submitter.SubmitTask(same2).ok());
@@ -940,8 +940,8 @@ TEST(DirectTaskTransportTest, TestWorkerLeaseTimeout) {
       [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
-                                          task_finisher, ClientID::Nil(),
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr,
+                                          store, task_finisher, ClientID::Nil(),
                                           /*lease_timeout_ms=*/5, actor_creator);
   std::unordered_map<std::string, double> empty_resources;
   ray::FunctionDescriptor empty_descriptor =
@@ -995,9 +995,9 @@ TEST(DirectTaskTransportTest, TestKillExecutingTask) {
 
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
-                                          task_finisher, ClientID::Nil(), kLongTimeout,
-                                          actor_creator);
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr,
+                                          store, task_finisher, ClientID::Nil(),
+                                          kLongTimeout, actor_creator);
   std::unordered_map<std::string, double> empty_resources;
   ray::FunctionDescriptor empty_descriptor =
       ray::FunctionDescriptorBuilder::BuildPython("", "", "", "");
@@ -1043,9 +1043,9 @@ TEST(DirectTaskTransportTest, TestKillPendingTask) {
       [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
-                                          task_finisher, ClientID::Nil(), kLongTimeout,
-                                          actor_creator);
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr,
+                                          store, task_finisher, ClientID::Nil(),
+                                          kLongTimeout, actor_creator);
   std::unordered_map<std::string, double> empty_resources;
   ray::FunctionDescriptor empty_descriptor =
       ray::FunctionDescriptorBuilder::BuildPython("", "", "", "");
@@ -1072,9 +1072,9 @@ TEST(DirectTaskTransportTest, TestKillResolvingTask) {
       [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
-                                          task_finisher, ClientID::Nil(), kLongTimeout,
-                                          actor_creator);
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr,
+                                          store, task_finisher, ClientID::Nil(),
+                                          kLongTimeout, actor_creator);
   std::unordered_map<std::string, double> empty_resources;
   ray::FunctionDescriptor empty_descriptor =
       ray::FunctionDescriptorBuilder::BuildPython("", "", "", "");
@@ -1108,9 +1108,9 @@ TEST(DirectTaskTransportTest, TestPipeliningConcurrentWorkerLeases) {
   // of task submissions. This is done by passing a max_tasks_in_flight_per_worker
   // parameter to the CoreWorkerDirectTaskSubmitter.
   uint32_t max_tasks_in_flight_per_worker = 10;
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
-                                          task_finisher, ClientID::Nil(), kLongTimeout,
-                                          actor_creator, max_tasks_in_flight_per_worker);
+  CoreWorkerDirectTaskSubmitter submitter(
+      address, raylet_client, client_pool, nullptr, store, task_finisher, ClientID::Nil(),
+      kLongTimeout, actor_creator, max_tasks_in_flight_per_worker);
 
   // Prepare 20 tasks and save them in a vector.
   std::unordered_map<std::string, double> empty_resources;
@@ -1178,9 +1178,9 @@ TEST(DirectTaskTransportTest, TestPipeliningReuseWorkerLease) {
   // of task submissions. This is done by passing a max_tasks_in_flight_per_worker
   // parameter to the CoreWorkerDirectTaskSubmitter.
   uint32_t max_tasks_in_flight_per_worker = 10;
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
-                                          task_finisher, ClientID::Nil(), kLongTimeout,
-                                          actor_creator, max_tasks_in_flight_per_worker);
+  CoreWorkerDirectTaskSubmitter submitter(
+      address, raylet_client, client_pool, nullptr, store, task_finisher, ClientID::Nil(),
+      kLongTimeout, actor_creator, max_tasks_in_flight_per_worker);
 
   // prepare 30 tasks and save them in a vector
   std::unordered_map<std::string, double> empty_resources;

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -335,10 +335,11 @@ TEST(DirectTaskTransportTest, TestSubmitOneTask) {
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
   auto store = std::make_shared<CoreWorkerMemoryStore>();
-  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
                                           task_finisher, ClientID::Nil(), kLongTimeout,
                                           actor_creator);
 
@@ -371,10 +372,11 @@ TEST(DirectTaskTransportTest, TestHandleTaskFailure) {
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
   auto store = std::make_shared<CoreWorkerMemoryStore>();
-  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
                                           task_finisher, ClientID::Nil(), kLongTimeout,
                                           actor_creator);
   std::unordered_map<std::string, double> empty_resources;
@@ -400,10 +402,11 @@ TEST(DirectTaskTransportTest, TestConcurrentWorkerLeases) {
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
   auto store = std::make_shared<CoreWorkerMemoryStore>();
-  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
                                           task_finisher, ClientID::Nil(), kLongTimeout,
                                           actor_creator);
   std::unordered_map<std::string, double> empty_resources;
@@ -450,10 +453,11 @@ TEST(DirectTaskTransportTest, TestReuseWorkerLease) {
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
   auto store = std::make_shared<CoreWorkerMemoryStore>();
-  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
                                           task_finisher, ClientID::Nil(), kLongTimeout,
                                           actor_creator);
   std::unordered_map<std::string, double> empty_resources;
@@ -507,10 +511,11 @@ TEST(DirectTaskTransportTest, TestRetryLeaseCancellation) {
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
   auto store = std::make_shared<CoreWorkerMemoryStore>();
-  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
                                           task_finisher, ClientID::Nil(), kLongTimeout,
                                           actor_creator);
   std::unordered_map<std::string, double> empty_resources;
@@ -562,10 +567,11 @@ TEST(DirectTaskTransportTest, TestConcurrentCancellationAndSubmission) {
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
   auto store = std::make_shared<CoreWorkerMemoryStore>();
-  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
                                           task_finisher, ClientID::Nil(), kLongTimeout,
                                           actor_creator);
   std::unordered_map<std::string, double> empty_resources;
@@ -614,10 +620,11 @@ TEST(DirectTaskTransportTest, TestWorkerNotReusedOnError) {
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
   auto store = std::make_shared<CoreWorkerMemoryStore>();
-  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
                                           task_finisher, ClientID::Nil(), kLongTimeout,
                                           actor_creator);
   std::unordered_map<std::string, double> empty_resources;
@@ -657,10 +664,11 @@ TEST(DirectTaskTransportTest, TestWorkerNotReturnedOnExit) {
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
   auto store = std::make_shared<CoreWorkerMemoryStore>();
-  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
                                           task_finisher, ClientID::Nil(), kLongTimeout,
                                           actor_creator);
   std::unordered_map<std::string, double> empty_resources;
@@ -690,7 +698,8 @@ TEST(DirectTaskTransportTest, TestSpillback) {
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
   auto store = std::make_shared<CoreWorkerMemoryStore>();
-  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
 
   std::unordered_map<int, std::shared_ptr<MockRayletClient>> remote_lease_clients;
   auto lease_client_factory = [&](const std::string &ip, int port) {
@@ -702,7 +711,7 @@ TEST(DirectTaskTransportTest, TestSpillback) {
   };
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory,
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool,
                                           lease_client_factory, store, task_finisher,
                                           ClientID::Nil(), kLongTimeout, actor_creator);
   std::unordered_map<std::string, double> empty_resources;
@@ -747,7 +756,8 @@ TEST(DirectTaskTransportTest, TestSpillbackRoundTrip) {
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
   auto store = std::make_shared<CoreWorkerMemoryStore>();
-  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
 
   std::unordered_map<int, std::shared_ptr<MockRayletClient>> remote_lease_clients;
   auto lease_client_factory = [&](const std::string &ip, int port) {
@@ -760,7 +770,7 @@ TEST(DirectTaskTransportTest, TestSpillbackRoundTrip) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto local_raylet_id = ClientID::FromRandom();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory,
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool,
                                           lease_client_factory, store, task_finisher,
                                           local_raylet_id, kLongTimeout, actor_creator);
   std::unordered_map<std::string, double> empty_resources;
@@ -813,10 +823,11 @@ void TestSchedulingKey(const std::shared_ptr<CoreWorkerMemoryStore> store,
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
-  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
                                           task_finisher, ClientID::Nil(), kLongTimeout,
                                           actor_creator);
 
@@ -925,10 +936,11 @@ TEST(DirectTaskTransportTest, TestWorkerLeaseTimeout) {
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
   auto store = std::make_shared<CoreWorkerMemoryStore>();
-  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
                                           task_finisher, ClientID::Nil(),
                                           /*lease_timeout_ms=*/5, actor_creator);
   std::unordered_map<std::string, double> empty_resources;
@@ -978,10 +990,12 @@ TEST(DirectTaskTransportTest, TestKillExecutingTask) {
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
   auto store = std::make_shared<CoreWorkerMemoryStore>();
-  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
+
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
                                           task_finisher, ClientID::Nil(), kLongTimeout,
                                           actor_creator);
   std::unordered_map<std::string, double> empty_resources;
@@ -1025,10 +1039,11 @@ TEST(DirectTaskTransportTest, TestKillPendingTask) {
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
   auto store = std::make_shared<CoreWorkerMemoryStore>();
-  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
                                           task_finisher, ClientID::Nil(), kLongTimeout,
                                           actor_creator);
   std::unordered_map<std::string, double> empty_resources;
@@ -1053,10 +1068,11 @@ TEST(DirectTaskTransportTest, TestKillResolvingTask) {
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
   auto store = std::make_shared<CoreWorkerMemoryStore>();
-  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
                                           task_finisher, ClientID::Nil(), kLongTimeout,
                                           actor_creator);
   std::unordered_map<std::string, double> empty_resources;
@@ -1083,7 +1099,8 @@ TEST(DirectTaskTransportTest, TestPipeliningConcurrentWorkerLeases) {
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
   auto store = std::make_shared<CoreWorkerMemoryStore>();
-  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
 
@@ -1091,7 +1108,7 @@ TEST(DirectTaskTransportTest, TestPipeliningConcurrentWorkerLeases) {
   // of task submissions. This is done by passing a max_tasks_in_flight_per_worker
   // parameter to the CoreWorkerDirectTaskSubmitter.
   uint32_t max_tasks_in_flight_per_worker = 10;
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
                                           task_finisher, ClientID::Nil(), kLongTimeout,
                                           actor_creator, max_tasks_in_flight_per_worker);
 
@@ -1152,7 +1169,8 @@ TEST(DirectTaskTransportTest, TestPipeliningReuseWorkerLease) {
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
   auto store = std::make_shared<CoreWorkerMemoryStore>();
-  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
 
@@ -1160,7 +1178,7 @@ TEST(DirectTaskTransportTest, TestPipeliningReuseWorkerLease) {
   // of task submissions. This is done by passing a max_tasks_in_flight_per_worker
   // parameter to the CoreWorkerDirectTaskSubmitter.
   uint32_t max_tasks_in_flight_per_worker = 10;
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr, store,
                                           task_finisher, ClientID::Nil(), kLongTimeout,
                                           actor_creator, max_tasks_in_flight_per_worker);
 

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -63,9 +63,10 @@ class CoreWorkerDirectActorTaskSubmitterInterface {
 class CoreWorkerDirectActorTaskSubmitter
     : public CoreWorkerDirectActorTaskSubmitterInterface {
  public:
-  CoreWorkerDirectActorTaskSubmitter(std::shared_ptr<rpc::CoreWorkerClientPool> core_worker_client_pool,
-                                     std::shared_ptr<CoreWorkerMemoryStore> store,
-                                     std::shared_ptr<TaskFinisherInterface> task_finisher)
+  CoreWorkerDirectActorTaskSubmitter(
+      std::shared_ptr<rpc::CoreWorkerClientPool> core_worker_client_pool,
+      std::shared_ptr<CoreWorkerMemoryStore> store,
+      std::shared_ptr<TaskFinisherInterface> task_finisher)
       : core_worker_client_pool_(core_worker_client_pool),
         resolver_(store, task_finisher),
         task_finisher_(task_finisher) {}

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -63,10 +63,10 @@ class CoreWorkerDirectActorTaskSubmitterInterface {
 class CoreWorkerDirectActorTaskSubmitter
     : public CoreWorkerDirectActorTaskSubmitterInterface {
  public:
-  CoreWorkerDirectActorTaskSubmitter(rpc::ClientFactoryFn client_factory,
+  CoreWorkerDirectActorTaskSubmitter(std::shared_ptr<rpc::CoreWorkerClientPool> core_worker_client_pool,
                                      std::shared_ptr<CoreWorkerMemoryStore> store,
                                      std::shared_ptr<TaskFinisherInterface> task_finisher)
-      : client_factory_(client_factory),
+      : core_worker_client_pool_(core_worker_client_pool),
         resolver_(store, task_finisher),
         task_finisher_(task_finisher) {}
 
@@ -217,8 +217,8 @@ class CoreWorkerDirectActorTaskSubmitter
   /// \return Whether this actor is alive.
   bool IsActorAlive(const ActorID &actor_id) const;
 
-  /// Factory for producing new core worker clients.
-  rpc::ClientFactoryFn client_factory_;
+  /// Pool for producing new core worker clients.
+  std::shared_ptr<rpc::CoreWorkerClientPool> core_worker_client_pool_;
 
   /// Mutex to protect the various maps below.
   mutable absl::Mutex mu_;
@@ -493,7 +493,7 @@ class CoreWorkerDirectTaskReceiver {
         task_done_(task_done) {}
 
   /// Initialize this receiver. This must be called prior to use.
-  void Init(rpc::ClientFactoryFn client_factory, rpc::Address rpc_address,
+  void Init(std::shared_ptr<rpc::CoreWorkerClientPool>, rpc::Address rpc_address,
             std::shared_ptr<DependencyWaiter> dependency_waiter);
 
   /// Handle a `PushTask` request.
@@ -513,8 +513,8 @@ class CoreWorkerDirectTaskReceiver {
   boost::asio::io_service &task_main_io_service_;
   /// The callback function to be invoked when finishing a task.
   OnTaskDone task_done_;
-  /// Factory for producing new core worker clients.
-  rpc::ClientFactoryFn client_factory_;
+  /// Shared pool for producing new core worker clients.
+  std::shared_ptr<rpc::CoreWorkerClientPool> client_pool_;
   /// Address of our RPC server.
   rpc::Address rpc_address_;
   /// Shared waiter for dependencies required by incoming tasks.

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -52,7 +52,8 @@ class CoreWorkerDirectTaskSubmitter {
  public:
   explicit CoreWorkerDirectTaskSubmitter(
       rpc::Address rpc_address, std::shared_ptr<WorkerLeaseInterface> lease_client,
-      rpc::ClientFactoryFn client_factory, LeaseClientFactoryFn lease_client_factory,
+      std::shared_ptr<rpc::CoreWorkerClientPool> core_worker_client_pool,
+      LeaseClientFactoryFn lease_client_factory,
       std::shared_ptr<CoreWorkerMemoryStore> store,
       std::shared_ptr<TaskFinisherInterface> task_finisher, ClientID local_raylet_id,
       int64_t lease_timeout_ms, std::shared_ptr<ActorCreatorInterface> actor_creator,
@@ -67,7 +68,7 @@ class CoreWorkerDirectTaskSubmitter {
         lease_timeout_ms_(lease_timeout_ms),
         local_raylet_id_(local_raylet_id),
         actor_creator_(std::move(actor_creator)),
-        client_cache_(client_factory),
+        client_cache_(core_worker_client_pool),
         max_tasks_in_flight_per_worker_(max_tasks_in_flight_per_worker),
         cancel_retry_timer_(std::move(cancel_timer)) {}
 
@@ -167,7 +168,7 @@ class CoreWorkerDirectTaskSubmitter {
   absl::Mutex mu_;
 
   /// Cache of gRPC clients to other workers.
-  rpc::CoreWorkerClientPool client_cache_;
+  std::shared_ptr<rpc::CoreWorkerClientPool> client_cache_;
 
   // max_tasks_in_flight_per_worker_ limits the number of tasks that can be pipelined to a
   // worker using a single lease.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Using a CoreWorkerClientPool per object that needs one is great, but it doesn't give us much savings across different parts of CoreWorker, which may be able to reuse clients.

This change supplants the root ClientFactory with a shared ClientPool, that subsystems can share, reducing the overall number of connections.

## Related issue number


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
