### PR TITLE
add single quotes

### DIFF
--- a/doc/source/rllib.rst
+++ b/doc/source/rllib.rst
@@ -23,7 +23,7 @@ RLlib has extra dependencies on top of ``ray``. First, you'll need to install ei
 
 .. code-block:: bash
 
-  pip install ray[rllib]  # also recommended: ray[debug]
+  pip install 'ray[rllib]'  # also recommended: ray[debug]
 
 Then, you can try out training in the following equivalent ways:
 


### PR DESCRIPTION
added single quotes in the instruction `pip install 'ray[rllib]' `so it works in zsh.  It used to give the error `zsh: no matches found: ray[rllib].` (I checked and it still works in bash with single quotes)

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
