### PR TITLE
[build] remove osx and linux gha builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,17 +17,11 @@ jobs:
       matrix:
         # Useful info: https://help.github.com/en/articles/workflow-syntax-for-github-actions
         include:
-          - name: ubuntu
-            os: ubuntu-18.04
-            python-version: 3.6
           - name: windows-msvc
             os: windows-2019
             python-version: 3.8
             # Can be 'msvc' or 'clang-cl'
             config: msvc
-          - name: macos
-            os: macos-10.15
-            python-version: 3.6
     env:
       BAZEL_CONFIG: ${{ matrix.config }}
       PYTHON: ${{ matrix.python-version }}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

These builds are not needed any more; we are migrating off of GHA for all but the windows build.