### PR TITLE
[cli] enable log-new-style by default

### DIFF
--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -102,11 +102,11 @@ def create_or_update_cluster(config_file: str,
                              yes: bool,
                              override_cluster_name: Optional[str],
                              no_config_cache: bool,
-                             dump_command_output: bool = True,
+                             redirect_command_output: bool = False,
                              use_login_shells: bool = True) -> None:
     """Create or updates an autoscaling Ray cluster from a config json."""
     set_using_login_shells(use_login_shells)
-    cmd_output_util.set_output_redirected(not dump_command_output)
+    cmd_output_util.set_output_redirected(redirect_command_output)
 
     if use_login_shells:
         cli_logger.warning(

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -929,7 +929,7 @@ def stop(force, verbose, log_new_style, log_color):
           "this can be disabled for a better user experience."))
 @add_click_options(logging_options)
 def up(cluster_config_file, min_workers, max_workers, no_restart, restart_only,
-       yes, cluster_name, no_config_cache, dump_command_output,
+       yes, cluster_name, no_config_cache, redirect_command_output,
        use_login_shells, log_new_style, log_color, verbose):
     """Create or update a Ray cluster."""
     cli_logger.old_style = not log_new_style
@@ -956,10 +956,17 @@ def up(cluster_config_file, min_workers, max_workers, no_restart, restart_only,
             cli_logger.warning(
                 "Could not download remote cluster configuration file.")
             cli_logger.old_info(logger, "Error downloading file: ", e)
-    create_or_update_cluster(cluster_config_file, min_workers, max_workers,
-                             no_restart, restart_only, yes, cluster_name,
-                             no_config_cache, dump_command_output,
-                             use_login_shells)
+    create_or_update_cluster(
+        config_file=cluster_config_file,
+        override_min_workers=min_workers,
+        override_max_workers=max_workers,
+        no_restart=no_restart,
+        restart_only=restart_only,
+        yes=yes,
+        override_cluster_name=cluster_name,
+        no_config_cache=no_config_cache,
+        redirect_command_output=redirect_command_output,
+        use_login_shells=use_login_shells)
 
 
 @cli.command()
@@ -1236,7 +1243,7 @@ def submit(cluster_config_file, screen, tmux, stop, start, cluster_name,
             yes=True,
             override_cluster_name=cluster_name,
             no_config_cache=False,
-            dump_command_output=True,
+            redirect_command_output=False,
             use_login_shells=True)
     target = os.path.basename(script)
     target = os.path.join("~", target)

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -57,7 +57,7 @@ logging_options = [
     click.option(
         "--log-new-style/--log-old-style",
         is_flag=True,
-        default=False,
+        default=True,
         envvar="RAY_LOG_NEWSTYLE",
         help=("Whether to use the old or the new CLI UX. "
               "The new UX supports colored, formatted output and was "
@@ -917,7 +917,7 @@ def stop(force, verbose, log_new_style, log_color):
 @click.option(
     "--dump-command-output",
     is_flag=True,
-    default=False,
+    default=True,
     help=("Print command output straight to "
           "the terminal instead of redirecting to a file."))
 @click.option(

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -915,11 +915,11 @@ def stop(force, verbose, log_new_style, log_color):
     default=False,
     help="Disable the local cluster config cache.")
 @click.option(
-    "--dump-command-output",
+    "--redirect-command-output",
     is_flag=True,
-    default=True,
-    help=("Print command output straight to "
-          "the terminal instead of redirecting to a file."))
+    default=False,
+    help=("Redirect command output to a file instead "
+          "of straight to the terminal."))
 @click.option(
     "--use-login-shells/--use-normal-shells",
     is_flag=True,

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -60,6 +60,7 @@ logging_options = [
         default=True,
         envvar="RAY_LOG_NEWSTYLE",
         help=("Whether to use the old or the new CLI UX. "
+              "You can also toggle this via the env var RAY_LOG_NEWSTYLE. "
               "The new UX supports colored, formatted output and was "
               "designed to display only the most important information for "
               "human users. The old UX uses the standard `logging` module. "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

1. Allows us to avoid surprises in 1.0
2. Forces dump command output, similar to previous behavior.

You can turn this off via RAY_LOG_NEWSTYLE=1 or RAY_LOG_NEWSTYLE=0.
@ericl @maximsmol
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)