### PR TITLE
[Placement Group] Remove API part 2

### DIFF
--- a/cpp/src/ray/runtime/task/local_mode_task_submitter.cc
+++ b/cpp/src/ray/runtime/task/local_mode_task_submitter.cc
@@ -34,7 +34,8 @@ ObjectID LocalModeTaskSubmitter::Submit(const InvocationSpec &invocation, TaskTy
                             local_mode_ray_tuntime_.GetCurrentJobID(),
                             local_mode_ray_tuntime_.GetCurrentTaskId(), 0,
                             local_mode_ray_tuntime_.GetCurrentTaskId(), address, 1,
-                            required_resources, required_placement_resources);
+                            required_resources, required_placement_resources,
+                            PlacementGroupID::Nil());
   if (type == TaskType::NORMAL_TASK) {
   } else if (type == TaskType::ACTOR_CREATION_TASK) {
     builder.SetActorCreationTaskSpec(invocation.actor_id);

--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -377,7 +377,6 @@ class GlobalState:
 
         return dict(result)
 
-    # SANG-TODO Add functions.
     def placement_group_table(self, placement_group_id=None):
         self._check_connected()
 

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -268,7 +268,7 @@ def test_remove_placement_group(ray_start_cluster):
     assert ray.get(a.f.remote()) == 3
 
     ray.experimental.remove_placement_group(pid)
-    # Subsequent remove request shouldn't do anything
+    # Subsequent remove request shouldn't do anything.
     for _ in range(3):
         ray.experimental.remove_placement_group(pid)
 

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -246,9 +246,8 @@ def test_remove_placement_group(ray_start_cluster):
     # # Now let's create a placement group.
     pid = ray.experimental.placement_group([{"CPU": 2}, {"CPU": 2}])
 
-    # # This is a hack to wait for placement group creation.
-    # # TODO(sang): Remove it when wait is implemented.
-    @ray.remote(num_cpus=0)
+    # Create an actor that occupies resources.
+    @ray.remote(num_cpus=4)
     class A:
         def f(self):
             return 3
@@ -271,8 +270,8 @@ def test_remove_placement_group(ray_start_cluster):
     # Since the placement group is removed,
     # the actor should've been killed.
     # That means this request should fail.
-    # TODO(sang): Turn it on.
-    # ray.get(a.f.remote())
+    with pytest.raises(ray.exceptions.RayActorError, match="actor died"):
+        ray.get(a.f.remote(), timeout=3.0)
 
 
 def test_remove_pending_placement_group(ray_start_cluster):

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -247,31 +247,45 @@ def test_remove_placement_group(ray_start_cluster):
     pid = ray.experimental.placement_group([{"CPU": 2}, {"CPU": 2}])
 
     # Create an actor that occupies resources.
-    @ray.remote(num_cpus=4)
+    @ray.remote(num_cpus=2)
     class A:
         def f(self):
             return 3
 
+    # Currently, there's no way to prevent
+    # tasks to be retried for removed placement group.
+    # Set max_retrie=0 for testing.
+    # TODO(sang): Handle this edge case.
+    @ray.remote(num_cpus=2, max_retries=0)
+    def long_running_task():
+        print(os.getpid())
+        import time
+        time.sleep(50)
+
+    # Schedule a long running task and actor.
+    task_ref = long_running_task.options(placement_group_id=pid).remote()
     a = A.options(placement_group_id=pid).remote()
     assert ray.get(a.f.remote()) == 3
+
     ray.experimental.remove_placement_group(pid)
-    # # Subsequent remove request shouldn't do anything
+    # Subsequent remove request shouldn't do anything
     for _ in range(3):
         ray.experimental.remove_placement_group(pid)
 
-    # # Make sure placement group resources are
-    # # released and we can schedule this task.
+    # Make sure placement group resources are
+    # released and we can schedule this task.
     @ray.remote(num_cpus=4)
     def f():
         return 3
 
     assert ray.get(f.remote()) == 3
-
     # Since the placement group is removed,
     # the actor should've been killed.
     # That means this request should fail.
     with pytest.raises(ray.exceptions.RayActorError, match="actor died"):
         ray.get(a.f.remote(), timeout=3.0)
+    with pytest.raises(ray.exceptions.RayWorkerError):
+        ray.get(task_ref)
 
 
 def test_remove_pending_placement_group(ray_start_cluster):

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -43,6 +43,10 @@ SchedulingClass TaskSpecification::GetSchedulingClass(const ResourceSet &sched_c
   return sched_cls_id;
 }
 
+const PlacementGroupID TaskSpecification::PlacementGroupId() const {
+  return PlacementGroupID::FromBinary(message_->placement_group_id());
+}
+
 void TaskSpecification::ComputeResources() {
   auto required_resources = MapFromProtobuf(message_->required_resources());
   auto required_placement_resources =

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -189,6 +189,7 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   // Compute a static key that represents the given resource shape.
   static SchedulingClass GetSchedulingClass(const ResourceSet &sched_cls);
 
+  // Placement Group ID that this task or actor creation is associated with.
   const PlacementGroupID PlacementGroupId() const;
 
  private:

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -189,6 +189,8 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   // Compute a static key that represents the given resource shape.
   static SchedulingClass GetSchedulingClass(const ResourceSet &sched_cls);
 
+  const PlacementGroupID PlacementGroupId() const;
+
  private:
   void ComputeResources();
 

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -85,7 +85,8 @@ class TaskSpecBuilder {
       const TaskID &parent_task_id, uint64_t parent_counter, const TaskID &caller_id,
       const rpc::Address &caller_address, uint64_t num_returns,
       const std::unordered_map<std::string, double> &required_resources,
-      const std::unordered_map<std::string, double> &required_placement_resources) {
+      const std::unordered_map<std::string, double> &required_placement_resources,
+      const PlacementGroupID &placement_group_id) {
     message_->set_type(TaskType::NORMAL_TASK);
     message_->set_language(language);
     *message_->mutable_function_descriptor() = function_descriptor->GetMessage();
@@ -100,6 +101,7 @@ class TaskSpecBuilder {
                                                    required_resources.end());
     message_->mutable_required_placement_resources()->insert(
         required_placement_resources.begin(), required_placement_resources.end());
+    message_->set_placement_group_id(placement_group_id.Binary());
     return *this;
   }
 

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -546,7 +546,8 @@ TEST_F(ZeroNodeTest, TestTaskSpecPerf) {
     TaskSpecBuilder builder;
     builder.SetCommonTaskSpec(RandomTaskId(), function.GetLanguage(),
                               function.GetFunctionDescriptor(), job_id, RandomTaskId(), 0,
-                              RandomTaskId(), address, num_returns, resources, resources);
+                              RandomTaskId(), address, num_returns, resources, resources,
+                              PlacementGroupID::Nil());
     // Set task arguments.
     for (const auto &arg : args) {
       builder.AddArg(*arg);

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -326,7 +326,7 @@ TaskSpecification BuildTaskSpec(const std::unordered_map<std::string, double> &r
   rpc::Address empty_address;
   builder.SetCommonTaskSpec(TaskID::Nil(), Language::PYTHON, function_descriptor,
                             JobID::Nil(), TaskID::Nil(), 0, TaskID::Nil(), empty_address,
-                            1, resources, resources);
+                            1, resources, resources, PlacementGroupID::Nil());
   return builder.Build();
 }
 

--- a/src/ray/gcs/test/gcs_test_util.h
+++ b/src/ray/gcs/test/gcs_test_util.h
@@ -40,7 +40,7 @@ struct Mocker {
     auto resource = std::unordered_map<std::string, double>();
     builder.SetCommonTaskSpec(task_id, Language::PYTHON, empty_descriptor, job_id,
                               TaskID::Nil(), 0, TaskID::Nil(), owner_address, 1, resource,
-                              resource);
+                              resource, PlacementGroupID::Nil());
     builder.SetActorCreationTaskSpec(actor_id, max_restarts, {}, 1, detached, name);
     return builder.Build();
   }

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -137,6 +137,8 @@ message TaskSpec {
   ActorTaskSpec actor_task_spec = 15;
   // Number of times this task may be retried on worker failure.
   int32 max_retries = 16;
+  // Placement group that is associated with this task.
+  bytes placement_group_id = 17;
 }
 
 message Bundle {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1858,7 +1858,9 @@ void NodeManager::HandleCancelResourceReserve(
   for (const auto &worker : workers_associated_with_pg) {
     RAY_LOG(DEBUG)
         << "Destroying worker since its placement group was removed. Placement group id: "
-        << worker->GetPlacementGroupId() << ", task id: " << worker->GetAssignedTaskId()
+        << worker->GetPlacementGroupId()
+        << ", bundle index: " << bundle_spec.BundleId().second
+        << ", task id: " << worker->GetAssignedTaskId()
         << ", actor id: " << worker->GetActorId()
         << ", worker id: " << worker->WorkerId();
     // We should disconnect the client first. Otherwise, we'll remove bundle resources

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1843,8 +1843,8 @@ void NodeManager::HandleCancelResourceReserve(
     rpc::CancelResourceReserveReply *reply, rpc::SendReplyCallback send_reply_callback) {
   RAY_CHECK(!new_scheduler_enabled_) << "Not implemented";
   auto bundle_spec = BundleSpecification(request.bundle_spec());
-  RAY_LOG(DEBUG) << "bundle return resource request " << bundle_spec.BundleId().first
-                 << bundle_spec.BundleId().second;
+  RAY_LOG(INFO) << "bundle return resource request " << bundle_spec.BundleId().first
+                << bundle_spec.BundleId().second;
   auto resource_set = bundle_spec.GetRequiredResources();
 
   // Kill all workers that are currently associated with the placement group.
@@ -1857,7 +1857,7 @@ void NodeManager::HandleCancelResourceReserve(
   }
   for (const auto &worker : workers_associated_with_pg) {
     RAY_LOG(DEBUG)
-        << "Placement group cancellation disconnects a worker. Plcaement group id: "
+        << "Destroying worker since its placement group was removed. Placement group id: "
         << worker->GetPlacementGroupId() << ", task id: " << worker->GetAssignedTaskId()
         << ", actor id: " << worker->GetActorId()
         << ", worker id: " << worker->WorkerId();

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -207,6 +207,15 @@ class MockWorker : public WorkerInterface {
     RAY_CHECK(false) << "Method unused";
   }
 
+  const PlacementGroupID &GetPlacementGroupId() const {
+    RAY_CHECK(false) << "Method unused";
+    return PlacementGroupID::Nil();
+  }
+
+  void SetPlacementGroupId(const PlacementGroupID &placement_group_id) {
+    RAY_CHECK(false) << "Method unused";
+  }
+
   std::vector<double> &GetBorrowedCPUInstances() {
     RAY_CHECK(false) << "Method unused";
     auto *t = new std::vector<double>();
@@ -258,9 +267,10 @@ Task CreateTask(const std::unordered_map<std::string, double> &required_resource
   TaskID id = RandomTaskId();
   JobID job_id = RandomJobId();
   rpc::Address address;
-  spec_builder.SetCommonTaskSpec(
-      id, Language::PYTHON, FunctionDescriptorBuilder::BuildPython("", "", "", ""),
-      job_id, TaskID::Nil(), 0, TaskID::Nil(), address, 0, required_resources, {});
+  spec_builder.SetCommonTaskSpec(id, Language::PYTHON,
+                                 FunctionDescriptorBuilder::BuildPython("", "", "", ""),
+                                 job_id, TaskID::Nil(), 0, TaskID::Nil(), address, 0,
+                                 required_resources, {}, PlacementGroupID::Nil());
 
   for (int i = 0; i < num_args; i++) {
     ObjectID put_id = ObjectID::ForPut(TaskID::Nil(), /*index=*/i + 1);

--- a/src/ray/raylet/task_dependency_manager_test.cc
+++ b/src/ray/raylet/task_dependency_manager_test.cc
@@ -112,7 +112,7 @@ static inline Task ExampleTask(const std::vector<ObjectID> &arguments,
   builder.SetCommonTaskSpec(RandomTaskId(), Language::PYTHON,
                             FunctionDescriptorBuilder::BuildPython("", "", "", ""),
                             JobID::Nil(), RandomTaskId(), 0, RandomTaskId(), address,
-                            num_returns, {}, {});
+                            num_returns, {}, {}, PlacementGroupID::Nil());
   builder.SetActorCreationTaskSpec(ActorID::Nil(), 1, {}, 1, false, "", false);
   for (const auto &arg : arguments) {
     builder.AddArg(TaskArgByReference(arg, rpc::Address()));

--- a/src/ray/raylet/worker.cc
+++ b/src/ray/raylet/worker.cc
@@ -37,6 +37,7 @@ Worker::Worker(const WorkerID &worker_id, const Language &language,
       assigned_port_(-1),
       port_(-1),
       connection_(connection),
+      placement_group_id_(PlacementGroupID::Nil()),
       dead_(false),
       blocked_(false),
       client_call_manager_(client_call_manager),
@@ -188,6 +189,14 @@ void Worker::DirectActorCallArgWaitComplete(int64_t tag) {
           RAY_LOG(ERROR) << "Failed to send wait complete: " << status.ToString();
         }
       });
+}
+
+const PlacementGroupID &Worker::GetPlacementGroupId() const {
+  return placement_group_id_;
+}
+
+void Worker::SetPlacementGroupId(const PlacementGroupID &placement_group_id) {
+  placement_group_id_ = placement_group_id;
 }
 
 }  // namespace raylet

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -82,6 +82,9 @@ class WorkerInterface {
 
   virtual void DirectActorCallArgWaitComplete(int64_t tag) = 0;
 
+  virtual const PlacementGroupID &GetPlacementGroupId() const = 0;
+  virtual void SetPlacementGroupId(const PlacementGroupID &placement_group_id) = 0;
+
   // Setter, geter, and clear methods  for allocated_instances_.
   virtual void SetAllocatedInstances(
       std::shared_ptr<TaskResourceInstances> &allocated_instances) = 0;
@@ -168,6 +171,9 @@ class Worker : public WorkerInterface {
 
   void DirectActorCallArgWaitComplete(int64_t tag);
 
+  const PlacementGroupID &GetPlacementGroupId() const;
+  void SetPlacementGroupId(const PlacementGroupID &placement_group_id);
+
   // Setter, geter, and clear methods  for allocated_instances_.
   void SetAllocatedInstances(
       std::shared_ptr<TaskResourceInstances> &allocated_instances) {
@@ -236,6 +242,9 @@ class Worker : public WorkerInterface {
   JobID assigned_job_id_;
   /// The worker's actor ID. If this is nil, then the worker is not an actor.
   ActorID actor_id_;
+  /// The worker's placement group ID. It is used to detect if the worker is
+  /// associated with a placement group.
+  PlacementGroupID placement_group_id_;
   /// Whether the worker is dead.
   bool dead_;
   /// Whether the worker is blocked. Workers become blocked in a `ray.get`, if


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Previously, when placement groups were removed, we didn't actually kill workers that are already occupying resources. This PR addresses this problem. 

Logic:
Each task spec now will contain placement group id. This way, we can associate all workers with placement groups. When the cancel request is received, we kill all associated workers.

## Limitation
There are still several limitations. This will require me to implement https://github.com/ray-project/ray/issues/10066. 
- All pending tasks or subsequent tasks will be just infeasible. We should remove them properly from local_queue. I will deprioritize this because we need to reimplement after new scheduler is turned on.
- Each core workers still submit pending tasks. For example, core worker will retry task submission although we kill workers. We should disallow this by creating Placement group handle that subscribes the placement group state (similar to actor handles). 

## Related issue number

https://github.com/ray-project/ray/issues/9793

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
