### PR TITLE
Keeping pipelines full

### DIFF
--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -368,7 +368,7 @@ TEST(DirectTaskTransportTest, TestSubmitOneTask) {
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
 TEST(DirectTaskTransportTest, TestHandleTaskFailure) {
@@ -402,7 +402,7 @@ TEST(DirectTaskTransportTest, TestHandleTaskFailure) {
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
 TEST(DirectTaskTransportTest, TestConcurrentWorkerLeases) {
@@ -457,7 +457,7 @@ TEST(DirectTaskTransportTest, TestConcurrentWorkerLeases) {
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
 TEST(DirectTaskTransportTest, TestReuseWorkerLease) {
@@ -518,7 +518,7 @@ TEST(DirectTaskTransportTest, TestReuseWorkerLease) {
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
 TEST(DirectTaskTransportTest, TestRetryLeaseCancellation) {
@@ -578,7 +578,7 @@ TEST(DirectTaskTransportTest, TestRetryLeaseCancellation) {
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
 TEST(DirectTaskTransportTest, TestConcurrentCancellationAndSubmission) {
@@ -635,7 +635,7 @@ TEST(DirectTaskTransportTest, TestConcurrentCancellationAndSubmission) {
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
 TEST(DirectTaskTransportTest, TestWorkerNotReusedOnError) {
@@ -683,7 +683,7 @@ TEST(DirectTaskTransportTest, TestWorkerNotReusedOnError) {
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
 TEST(DirectTaskTransportTest, TestWorkerNotReturnedOnExit) {
@@ -721,7 +721,7 @@ TEST(DirectTaskTransportTest, TestWorkerNotReturnedOnExit) {
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
 TEST(DirectTaskTransportTest, TestSpillback) {
@@ -783,7 +783,7 @@ TEST(DirectTaskTransportTest, TestSpillback) {
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
 TEST(DirectTaskTransportTest, TestSpillbackRoundTrip) {
@@ -851,7 +851,7 @@ TEST(DirectTaskTransportTest, TestSpillbackRoundTrip) {
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
 // Helper to run a test that checks that 'same1' and 'same2' are treated as the same
@@ -914,7 +914,7 @@ void TestSchedulingKey(const std::shared_ptr<CoreWorkerMemoryStore> store,
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
 TEST(DirectTaskTransportTest, TestSchedulingKeys) {
@@ -1038,7 +1038,7 @@ TEST(DirectTaskTransportTest, TestWorkerLeaseTimeout) {
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
 TEST(DirectTaskTransportTest, TestKillExecutingTask) {
@@ -1091,7 +1091,7 @@ TEST(DirectTaskTransportTest, TestKillExecutingTask) {
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
 TEST(DirectTaskTransportTest, TestKillPendingTask) {
@@ -1127,7 +1127,7 @@ TEST(DirectTaskTransportTest, TestKillPendingTask) {
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
 TEST(DirectTaskTransportTest, TestKillResolvingTask) {
@@ -1162,7 +1162,7 @@ TEST(DirectTaskTransportTest, TestKillResolvingTask) {
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
 TEST(DirectTaskTransportTest, TestPipeliningConcurrentWorkerLeases) {
@@ -1236,7 +1236,7 @@ TEST(DirectTaskTransportTest, TestPipeliningConcurrentWorkerLeases) {
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
 TEST(DirectTaskTransportTest, TestPipeliningReuseWorkerLease) {
@@ -1315,7 +1315,7 @@ TEST(DirectTaskTransportTest, TestPipeliningReuseWorkerLease) {
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
 TEST(DirectTaskTransportTest, TestPipeliningNumberOfWorkersRequested) {
@@ -1493,7 +1493,7 @@ TEST(DirectTaskTransportTest, TestPipeliningNumberOfWorkersRequested) {
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
 }  // namespace ray

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -366,8 +366,9 @@ TEST(DirectTaskTransportTest, TestSubmitOneTask) {
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
 
-  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
+  // would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
 }
 
 TEST(DirectTaskTransportTest, TestHandleTaskFailure) {
@@ -399,8 +400,9 @@ TEST(DirectTaskTransportTest, TestHandleTaskFailure) {
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
 
-  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
+  // would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
 }
 
 TEST(DirectTaskTransportTest, TestConcurrentWorkerLeases) {
@@ -453,8 +455,9 @@ TEST(DirectTaskTransportTest, TestConcurrentWorkerLeases) {
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
 
-  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
+  // would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
 }
 
 TEST(DirectTaskTransportTest, TestReuseWorkerLease) {
@@ -502,7 +505,7 @@ TEST(DirectTaskTransportTest, TestReuseWorkerLease) {
   // Task 3 finishes, the worker is returned.
   ASSERT_TRUE(worker_client->ReplyPushTask());
   ASSERT_EQ(raylet_client->num_workers_returned, 1);
-  
+
   // The second lease request is returned immediately.
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1001, ClientID::Nil()));
   ASSERT_EQ(worker_client->callbacks.size(), 0);
@@ -513,8 +516,9 @@ TEST(DirectTaskTransportTest, TestReuseWorkerLease) {
   ASSERT_EQ(raylet_client->num_leases_canceled, 1);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
 
-  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
+  // would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
 }
 
 TEST(DirectTaskTransportTest, TestRetryLeaseCancellation) {
@@ -572,8 +576,9 @@ TEST(DirectTaskTransportTest, TestRetryLeaseCancellation) {
   ASSERT_EQ(task_finisher->num_tasks_complete, 3);
   ASSERT_EQ(task_finisher->num_tasks_failed, 0);
 
-  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
+  // would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
 }
 
 TEST(DirectTaskTransportTest, TestConcurrentCancellationAndSubmission) {
@@ -628,8 +633,9 @@ TEST(DirectTaskTransportTest, TestConcurrentCancellationAndSubmission) {
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
   ASSERT_EQ(raylet_client->num_leases_canceled, 1);
 
-  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
+  // would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
 }
 
 TEST(DirectTaskTransportTest, TestWorkerNotReusedOnError) {
@@ -675,8 +681,9 @@ TEST(DirectTaskTransportTest, TestWorkerNotReusedOnError) {
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
 
-  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
+  // would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
 }
 
 TEST(DirectTaskTransportTest, TestWorkerNotReturnedOnExit) {
@@ -712,8 +719,9 @@ TEST(DirectTaskTransportTest, TestWorkerNotReturnedOnExit) {
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
 
-  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
+  // would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
 }
 
 TEST(DirectTaskTransportTest, TestSpillback) {
@@ -773,8 +781,9 @@ TEST(DirectTaskTransportTest, TestSpillback) {
     ASSERT_FALSE(remote_client.second->ReplyCancelWorkerLease());
   }
 
-  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
+  // would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
 }
 
 TEST(DirectTaskTransportTest, TestSpillbackRoundTrip) {
@@ -840,8 +849,9 @@ TEST(DirectTaskTransportTest, TestSpillbackRoundTrip) {
     ASSERT_FALSE(remote_client.second->ReplyCancelWorkerLease());
   }
 
-  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
+  // would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
 }
 
 // Helper to run a test that checks that 'same1' and 'same2' are treated as the same
@@ -859,7 +869,7 @@ void TestSchedulingKey(const std::shared_ptr<CoreWorkerMemoryStore> store,
   CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr,
                                           store, task_finisher, ClientID::Nil(),
                                           kLongTimeout, actor_creator);
-  
+
   ASSERT_TRUE(submitter.SubmitTask(same1).ok());
   ASSERT_TRUE(submitter.SubmitTask(same2).ok());
   ASSERT_TRUE(submitter.SubmitTask(different).ok());
@@ -878,7 +888,7 @@ void TestSchedulingKey(const std::shared_ptr<CoreWorkerMemoryStore> store,
   ASSERT_EQ(raylet_client->num_workers_disconnected, 0);
   // same2 is pushed.
   ASSERT_EQ(worker_client->callbacks.size(), 1);
-  ASSERT_EQ(raylet_client->num_leases_canceled, 1);  
+  ASSERT_EQ(raylet_client->num_leases_canceled, 1);
   ASSERT_TRUE(raylet_client->ReplyCancelWorkerLease());
 
   // different is pushed.
@@ -890,20 +900,21 @@ void TestSchedulingKey(const std::shared_ptr<CoreWorkerMemoryStore> store,
   ASSERT_TRUE(worker_client->ReplyPushTask());
   ASSERT_EQ(raylet_client->num_workers_returned, 1);
   ASSERT_EQ(raylet_client->num_workers_disconnected, 0);
-  
+
   // different runs successfully. Worker is returned.
   ASSERT_TRUE(worker_client->ReplyPushTask());
   ASSERT_EQ(raylet_client->num_workers_returned, 2);
   ASSERT_EQ(raylet_client->num_workers_disconnected, 0);
-  
+
   ASSERT_EQ(raylet_client->num_leases_canceled, 1);
 
   // Trigger reply to RequestWorkerLease to remove the canceled pending lease request
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1002, ClientID::Nil(), true));
   ASSERT_EQ(raylet_client->num_workers_returned, 2);
 
-  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
+  // would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
 }
 
 TEST(DirectTaskTransportTest, TestSchedulingKeys) {
@@ -1025,8 +1036,9 @@ TEST(DirectTaskTransportTest, TestWorkerLeaseTimeout) {
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
 
-  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
+  // would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
 }
 
 TEST(DirectTaskTransportTest, TestKillExecutingTask) {
@@ -1077,8 +1089,9 @@ TEST(DirectTaskTransportTest, TestKillExecutingTask) {
   ASSERT_EQ(task_finisher->num_tasks_complete, 1);
   ASSERT_EQ(task_finisher->num_tasks_failed, 1);
 
-  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
+  // would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
 }
 
 TEST(DirectTaskTransportTest, TestKillPendingTask) {
@@ -1112,8 +1125,9 @@ TEST(DirectTaskTransportTest, TestKillPendingTask) {
   // Trigger reply to RequestWorkerLease to remove the canceled pending lease request
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1000, ClientID::Nil(), true));
 
-  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
+  // would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
 }
 
 TEST(DirectTaskTransportTest, TestKillResolvingTask) {
@@ -1146,8 +1160,9 @@ TEST(DirectTaskTransportTest, TestKillResolvingTask) {
   ASSERT_EQ(task_finisher->num_tasks_complete, 0);
   ASSERT_EQ(task_finisher->num_tasks_failed, 1);
 
-  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
+  // would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
 }
 
 TEST(DirectTaskTransportTest, TestPipeliningConcurrentWorkerLeases) {
@@ -1219,8 +1234,9 @@ TEST(DirectTaskTransportTest, TestPipeliningConcurrentWorkerLeases) {
 
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
 
-  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
+  // would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
 }
 
 TEST(DirectTaskTransportTest, TestPipeliningReuseWorkerLease) {
@@ -1297,8 +1313,9 @@ TEST(DirectTaskTransportTest, TestPipeliningReuseWorkerLease) {
   ASSERT_EQ(raylet_client->num_leases_canceled, 1);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
 
-  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
+  // would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
 }
 
 TEST(DirectTaskTransportTest, TestPipeliningNumberOfWorkersRequested) {
@@ -1474,8 +1491,9 @@ TEST(DirectTaskTransportTest, TestPipeliningNumberOfWorkersRequested) {
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
   ASSERT_EQ(worker_client->callbacks.size(), 0);
 
-  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
-  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
+  // would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries());
 }
 
 }  // namespace ray

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -365,6 +365,9 @@ TEST(DirectTaskTransportTest, TestSubmitOneTask) {
   ASSERT_EQ(task_finisher->num_tasks_failed, 0);
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
+
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
 }
 
 TEST(DirectTaskTransportTest, TestHandleTaskFailure) {
@@ -395,6 +398,9 @@ TEST(DirectTaskTransportTest, TestHandleTaskFailure) {
   ASSERT_EQ(task_finisher->num_tasks_failed, 1);
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
+
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
 }
 
 TEST(DirectTaskTransportTest, TestConcurrentWorkerLeases) {
@@ -446,6 +452,9 @@ TEST(DirectTaskTransportTest, TestConcurrentWorkerLeases) {
   ASSERT_EQ(task_finisher->num_tasks_failed, 0);
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
+
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
 }
 
 TEST(DirectTaskTransportTest, TestReuseWorkerLease) {
@@ -490,11 +499,10 @@ TEST(DirectTaskTransportTest, TestReuseWorkerLease) {
   ASSERT_EQ(raylet_client->num_workers_returned, 0);
   ASSERT_EQ(raylet_client->num_leases_canceled, 1);
   ASSERT_TRUE(raylet_client->ReplyCancelWorkerLease());
-
   // Task 3 finishes, the worker is returned.
   ASSERT_TRUE(worker_client->ReplyPushTask());
   ASSERT_EQ(raylet_client->num_workers_returned, 1);
-
+  
   // The second lease request is returned immediately.
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1001, ClientID::Nil()));
   ASSERT_EQ(worker_client->callbacks.size(), 0);
@@ -504,6 +512,9 @@ TEST(DirectTaskTransportTest, TestReuseWorkerLease) {
   ASSERT_EQ(task_finisher->num_tasks_failed, 0);
   ASSERT_EQ(raylet_client->num_leases_canceled, 1);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
+
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
 }
 
 TEST(DirectTaskTransportTest, TestRetryLeaseCancellation) {
@@ -560,6 +571,9 @@ TEST(DirectTaskTransportTest, TestRetryLeaseCancellation) {
   ASSERT_EQ(raylet_client->num_workers_disconnected, 0);
   ASSERT_EQ(task_finisher->num_tasks_complete, 3);
   ASSERT_EQ(task_finisher->num_tasks_failed, 0);
+
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
 }
 
 TEST(DirectTaskTransportTest, TestConcurrentCancellationAndSubmission) {
@@ -613,6 +627,9 @@ TEST(DirectTaskTransportTest, TestConcurrentCancellationAndSubmission) {
   ASSERT_EQ(raylet_client->num_workers_returned, 2);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
   ASSERT_EQ(raylet_client->num_leases_canceled, 1);
+
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
 }
 
 TEST(DirectTaskTransportTest, TestWorkerNotReusedOnError) {
@@ -657,6 +674,9 @@ TEST(DirectTaskTransportTest, TestWorkerNotReusedOnError) {
   ASSERT_EQ(task_finisher->num_tasks_failed, 1);
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
+
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
 }
 
 TEST(DirectTaskTransportTest, TestWorkerNotReturnedOnExit) {
@@ -691,6 +711,9 @@ TEST(DirectTaskTransportTest, TestWorkerNotReturnedOnExit) {
   ASSERT_EQ(task_finisher->num_tasks_failed, 0);
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
+
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
 }
 
 TEST(DirectTaskTransportTest, TestSpillback) {
@@ -749,6 +772,9 @@ TEST(DirectTaskTransportTest, TestSpillback) {
     ASSERT_EQ(remote_client.second->num_leases_canceled, 0);
     ASSERT_FALSE(remote_client.second->ReplyCancelWorkerLease());
   }
+
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
 }
 
 TEST(DirectTaskTransportTest, TestSpillbackRoundTrip) {
@@ -813,6 +839,9 @@ TEST(DirectTaskTransportTest, TestSpillbackRoundTrip) {
     ASSERT_EQ(remote_client.second->num_leases_canceled, 0);
     ASSERT_FALSE(remote_client.second->ReplyCancelWorkerLease());
   }
+
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
 }
 
 // Helper to run a test that checks that 'same1' and 'same2' are treated as the same
@@ -830,7 +859,7 @@ void TestSchedulingKey(const std::shared_ptr<CoreWorkerMemoryStore> store,
   CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, client_pool, nullptr,
                                           store, task_finisher, ClientID::Nil(),
                                           kLongTimeout, actor_creator);
-
+  
   ASSERT_TRUE(submitter.SubmitTask(same1).ok());
   ASSERT_TRUE(submitter.SubmitTask(same2).ok());
   ASSERT_TRUE(submitter.SubmitTask(different).ok());
@@ -841,13 +870,16 @@ void TestSchedulingKey(const std::shared_ptr<CoreWorkerMemoryStore> store,
   ASSERT_EQ(worker_client->callbacks.size(), 1);
   // Another worker is requested because same2 is pending.
   ASSERT_EQ(raylet_client->num_workers_requested, 3);
+  ASSERT_EQ(raylet_client->num_leases_canceled, 0);
 
   // same1 runs successfully. Worker isn't returned.
   ASSERT_TRUE(worker_client->ReplyPushTask());
   ASSERT_EQ(raylet_client->num_workers_returned, 0);
   ASSERT_EQ(raylet_client->num_workers_disconnected, 0);
-  // taske1_2 is pushed.
+  // same2 is pushed.
   ASSERT_EQ(worker_client->callbacks.size(), 1);
+  ASSERT_EQ(raylet_client->num_leases_canceled, 1);  
+  ASSERT_TRUE(raylet_client->ReplyCancelWorkerLease());
 
   // different is pushed.
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1001, ClientID::Nil()));
@@ -858,11 +890,20 @@ void TestSchedulingKey(const std::shared_ptr<CoreWorkerMemoryStore> store,
   ASSERT_TRUE(worker_client->ReplyPushTask());
   ASSERT_EQ(raylet_client->num_workers_returned, 1);
   ASSERT_EQ(raylet_client->num_workers_disconnected, 0);
-
+  
   // different runs successfully. Worker is returned.
   ASSERT_TRUE(worker_client->ReplyPushTask());
   ASSERT_EQ(raylet_client->num_workers_returned, 2);
   ASSERT_EQ(raylet_client->num_workers_disconnected, 0);
+  
+  ASSERT_EQ(raylet_client->num_leases_canceled, 1);
+
+  // Trigger reply to RequestWorkerLease to remove the canceled pending lease request
+  ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1002, ClientID::Nil(), true));
+  ASSERT_EQ(raylet_client->num_workers_returned, 2);
+
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
 }
 
 TEST(DirectTaskTransportTest, TestSchedulingKeys) {
@@ -983,6 +1024,9 @@ TEST(DirectTaskTransportTest, TestWorkerLeaseTimeout) {
   ASSERT_EQ(raylet_client->num_workers_disconnected, 1);
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
+
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
 }
 
 TEST(DirectTaskTransportTest, TestKillExecutingTask) {
@@ -1032,6 +1076,9 @@ TEST(DirectTaskTransportTest, TestKillExecutingTask) {
   ASSERT_EQ(raylet_client->num_workers_disconnected, 0);
   ASSERT_EQ(task_finisher->num_tasks_complete, 1);
   ASSERT_EQ(task_finisher->num_tasks_failed, 1);
+
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
 }
 
 TEST(DirectTaskTransportTest, TestKillPendingTask) {
@@ -1061,6 +1108,12 @@ TEST(DirectTaskTransportTest, TestKillPendingTask) {
   ASSERT_EQ(task_finisher->num_tasks_failed, 1);
   ASSERT_EQ(raylet_client->num_leases_canceled, 1);
   ASSERT_TRUE(raylet_client->ReplyCancelWorkerLease());
+
+  // Trigger reply to RequestWorkerLease to remove the canceled pending lease request
+  ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1000, ClientID::Nil(), true));
+
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
 }
 
 TEST(DirectTaskTransportTest, TestKillResolvingTask) {
@@ -1092,6 +1145,9 @@ TEST(DirectTaskTransportTest, TestKillResolvingTask) {
   ASSERT_EQ(raylet_client->num_workers_disconnected, 0);
   ASSERT_EQ(task_finisher->num_tasks_complete, 0);
   ASSERT_EQ(task_finisher->num_tasks_failed, 1);
+
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
 }
 
 TEST(DirectTaskTransportTest, TestPipeliningConcurrentWorkerLeases) {
@@ -1162,6 +1218,9 @@ TEST(DirectTaskTransportTest, TestPipeliningConcurrentWorkerLeases) {
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
 
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
+
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
 }
 
 TEST(DirectTaskTransportTest, TestPipeliningReuseWorkerLease) {
@@ -1237,6 +1296,9 @@ TEST(DirectTaskTransportTest, TestPipeliningReuseWorkerLease) {
   ASSERT_EQ(task_finisher->num_tasks_failed, 0);
   ASSERT_EQ(raylet_client->num_leases_canceled, 1);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
+
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
 }
 
 TEST(DirectTaskTransportTest, TestPipeliningNumberOfWorkersRequested) {
@@ -1411,6 +1473,9 @@ TEST(DirectTaskTransportTest, TestPipeliningNumberOfWorkersRequested) {
   ASSERT_EQ(task_finisher->num_tasks_failed, 0);
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
   ASSERT_EQ(worker_client->callbacks.size(), 0);
+
+  // Check that there are no entries left in the scheduling_key_entries_ hashmap. These would otherwise cause a memory leak.
+  ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntries()); 
 }
 
 }  // namespace ray

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -1239,8 +1239,6 @@ TEST(DirectTaskTransportTest, TestPipeliningReuseWorkerLease) {
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
 }
 
-
-
 TEST(DirectTaskTransportTest, TestPipeliningNumberOfWorkersRequested) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -1239,12 +1239,15 @@ TEST(DirectTaskTransportTest, TestPipeliningReuseWorkerLease) {
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
 }
 
+
+
 TEST(DirectTaskTransportTest, TestPipeliningNumberOfWorkersRequested) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
   auto store = std::make_shared<CoreWorkerMemoryStore>();
-  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
 
@@ -1252,9 +1255,9 @@ TEST(DirectTaskTransportTest, TestPipeliningNumberOfWorkersRequested) {
   // of task submissions. This is done by passing a max_tasks_in_flight_per_worker
   // parameter to the CoreWorkerDirectTaskSubmitter.
   uint32_t max_tasks_in_flight_per_worker = 10;
-  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
-                                          task_finisher, ClientID::Nil(), kLongTimeout,
-                                          actor_creator, max_tasks_in_flight_per_worker);
+  CoreWorkerDirectTaskSubmitter submitter(
+      address, raylet_client, client_pool, nullptr, store, task_finisher, ClientID::Nil(),
+      kLongTimeout, actor_creator, max_tasks_in_flight_per_worker);
 
   // prepare 30 tasks and save them in a vector
   std::unordered_map<std::string, double> empty_resources;

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -264,7 +264,7 @@ void CoreWorkerDirectTaskSubmitter::RequestNewWorkerIfNeeded(
     return;
   }
 
-  // Check whether we really need a new worer or whether we have
+  // Check whether we really need a new worker or whether we have
   // enough room in an existing worker's pipeline to send the new tasks
   if (scheduling_key_entry.tot_tasks_in_flight <
       scheduling_key_entry.active_workers_.size() * max_tasks_in_flight_per_worker_) {

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -77,7 +77,8 @@ Status CoreWorkerDirectTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
                                             : ActorID::Nil());
         auto &scheduling_key_entry = scheduling_key_entries_[scheduling_key];
         scheduling_key_entry.task_queue.push_back(task_spec);
-        if (!scheduling_key_entry.AllPipelinesToWorkersFull(max_tasks_in_flight_per_worker_)) {
+        if (!scheduling_key_entry.AllPipelinesToWorkersFull(
+                max_tasks_in_flight_per_worker_)) {
           // The pipelines to the current workers are not full yet, so we don't need more
           // workers.
 
@@ -149,7 +150,7 @@ void CoreWorkerDirectTaskSubmitter::OnWorkerIdle(
       // Decrement the number of active workers consuming tasks from the queue associated
       // with the current scheduling_key
       scheduling_key_entry.active_workers.erase(addr);
-      if (scheduling_key_entry.CanDelete() ) {
+      if (scheduling_key_entry.CanDelete()) {
         // We can safely remove the entry keyed by scheduling_key from the
         // scheduling_key_entries_ hashmap.
         scheduling_key_entries_.erase(scheduling_key);
@@ -166,7 +167,8 @@ void CoreWorkerDirectTaskSubmitter::OnWorkerIdle(
   } else {
     auto &client = *client_cache_->GetOrConnect(addr.ToProto());
 
-    while (!current_queue.empty() && !lease_entry.PipelineToWorkerFull(max_tasks_in_flight_per_worker_)) {
+    while (!current_queue.empty() &&
+           !lease_entry.PipelineToWorkerFull(max_tasks_in_flight_per_worker_)) {
       auto task_spec = current_queue.front();
       lease_entry
           .tasks_in_flight++;  // Increment the number of tasks in flight to the worker
@@ -221,9 +223,9 @@ void CoreWorkerDirectTaskSubmitter::CancelWorkerLeaseIfNeeded(
             // should already have been removed from our local state, so we no
             // longer need to cancel.
             CancelWorkerLeaseIfNeeded(scheduling_key);
-          } 
+          }
         });
-  } 
+  }
 }
 
 std::shared_ptr<WorkerLeaseInterface>
@@ -294,7 +296,7 @@ void CoreWorkerDirectTaskSubmitter::RequestNewWorkerIfNeeded(
         auto lease_client = std::move(pending_lease_request.first);
         const auto task_id = pending_lease_request.second;
         pending_lease_request = std::make_pair(nullptr, TaskID::Nil());
-        
+
         if (status.ok()) {
           if (reply.canceled()) {
             RAY_LOG(DEBUG) << "Lease canceled " << task_id;
@@ -421,7 +423,6 @@ Status CoreWorkerDirectTaskSubmitter::CancelTask(TaskSpecification task_spec,
     // This cancels tasks that have completed dependencies and are awaiting
     // a worker lease.
     if (!scheduled_tasks.empty()) {
-
       for (auto spec = scheduled_tasks.begin(); spec != scheduled_tasks.end(); spec++) {
         if (spec->TaskId() == task_spec.TaskId()) {
           scheduled_tasks.erase(spec);
@@ -444,7 +445,7 @@ Status CoreWorkerDirectTaskSubmitter::CancelTask(TaskSpecification task_spec,
     if (rpc_client == executing_tasks_.end()) {
       // This case is reached for tasks that have unresolved dependencies.
       // No executing tasks, so cancelling is a noop.
-      if (scheduling_key_entry.CanDelete() ) {
+      if (scheduling_key_entry.CanDelete()) {
         // We can safely remove the entry keyed by scheduling_key from the
         // scheduling_key_entries_ hashmap.
         scheduling_key_entries_.erase(scheduling_key);

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -364,7 +364,7 @@ void CoreWorkerDirectTaskSubmitter::PushNormalTask(
       lease_entry.tasks_in_flight_--;
 
       // Decrement the total number of tasks in flight to any worker with the current
-      // scheduling_key
+      // scheduling_key.
       auto &scheduling_key_entry = scheduling_key_entries_[scheduling_key];
       RAY_CHECK(scheduling_key_entry.active_workers_.size() >= 1);
       RAY_CHECK(scheduling_key_entry.tot_tasks_in_flight >= 1);

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -93,7 +93,7 @@ void CoreWorkerDirectTaskSubmitter::AddWorkerLeaseClient(
     const rpc::WorkerAddress &addr, std::shared_ptr<WorkerLeaseInterface> lease_client,
     const google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry> &assigned_resources,
     const SchedulingKey &scheduling_key) {
-  client_cache_.GetOrConnect(addr.ToProto());
+  client_cache_->GetOrConnect(addr.ToProto());
   int64_t expiration = current_time_ms() + lease_timeout_ms_;
   LeaseEntry new_lease_entry = LeaseEntry(std::move(lease_client), expiration, 0,
                                           assigned_resources, scheduling_key);

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -208,20 +208,24 @@ class CoreWorkerDirectTaskSubmitter {
 
   struct SchedulingKeyEntry {
     // Keep track of pending worker lease requests to the raylet.
-    std::pair<std::shared_ptr<WorkerLeaseInterface>, TaskID> pending_lease_request_ = std::make_pair(nullptr, TaskID::Nil());
+    std::pair<std::shared_ptr<WorkerLeaseInterface>, TaskID> pending_lease_request_ =
+        std::make_pair(nullptr, TaskID::Nil());
     // Tasks that are queued for execution. We keep an individual queue per
     // scheduling class to ensure fairness.
     std::deque<TaskSpecification> task_queue_ = std::deque<TaskSpecification>();
-    // Keep track of the active workers, so that we can quickly check if one of them has room for more tasks in flight
-    absl::flat_hash_set<rpc::WorkerAddress> active_workers_ = absl::flat_hash_set<rpc::WorkerAddress>();
+    // Keep track of the active workers, so that we can quickly check if one of them has
+    // room for more tasks in flight
+    absl::flat_hash_set<rpc::WorkerAddress> active_workers_ =
+        absl::flat_hash_set<rpc::WorkerAddress>();
     // Keep track of how many tasks with this SchedulingKey are in flight, in total
-    uint32_t tot_tasks_in_flight=0;
+    uint32_t tot_tasks_in_flight = 0;
   };
 
-  // For each Scheduling Key, scheduling_key_entries_ contains a SchedulingKeyEntry struct with
-  // the queue of tasks belonging to that SchedulingKey, together with the other fields that are
-  // needed to orchestrate the execution of those tasks by the workers.
-  absl::flat_hash_map<SchedulingKey, SchedulingKeyEntry> scheduling_key_entries_ GUARDED_BY(mu_);
+  // For each Scheduling Key, scheduling_key_entries_ contains a SchedulingKeyEntry struct
+  // with the queue of tasks belonging to that SchedulingKey, together with the other
+  // fields that are needed to orchestrate the execution of those tasks by the workers.
+  absl::flat_hash_map<SchedulingKey, SchedulingKeyEntry> scheduling_key_entries_
+      GUARDED_BY(mu_);
 
   // Tasks that were cancelled while being resolved.
   absl::flat_hash_set<TaskID> cancelled_tasks_ GUARDED_BY(mu_);

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -88,9 +88,7 @@ class CoreWorkerDirectTaskSubmitter {
 
   /// Check that the scheduling_key_entries_ hashmap is empty. Can be used at the end of
   /// a unit test (or normal program) to check that we are not leaking memory
-  bool CheckNoSchedulingKeyEntries() const {
-    return scheduling_key_entries_.empty();
-  }
+  bool CheckNoSchedulingKeyEntries() const { return scheduling_key_entries_.empty(); }
 
  private:
   /// Schedule more work onto an idle worker or return it back to the raylet if

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -122,11 +122,10 @@ class CoreWorkerDirectTaskSubmitter {
       EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   /// Set up client state for newly granted worker lease.
-  void AddWorkerLeaseClient(const rpc::WorkerAddress &addr,
-                            std::shared_ptr<WorkerLeaseInterface> lease_client,
-                            const google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry> &assigned_resources,
-                            const SchedulingKey &scheduling_key)
-      EXCLUSIVE_LOCKS_REQUIRED(mu_);
+  void AddWorkerLeaseClient(
+      const rpc::WorkerAddress &addr, std::shared_ptr<WorkerLeaseInterface> lease_client,
+      const google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry> &assigned_resources,
+      const SchedulingKey &scheduling_key) EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   /// Push a task to a specific worker.
   void PushNormalTask(const rpc::WorkerAddress &addr,
@@ -189,10 +188,13 @@ class CoreWorkerDirectTaskSubmitter {
     google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry> assigned_resources_;
     SchedulingKey scheduling_key_;
 
-    LeaseEntry(std::shared_ptr<WorkerLeaseInterface> lease_client = nullptr,
-               int64_t lease_expiration_time = 0, uint32_t tasks_in_flight = 0,
-               google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry> assigned_resources = google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry>(),
-               SchedulingKey scheduling_key = std::make_tuple(0, std::vector<ObjectID>(), ActorID::Nil()))
+    LeaseEntry(
+        std::shared_ptr<WorkerLeaseInterface> lease_client = nullptr,
+        int64_t lease_expiration_time = 0, uint32_t tasks_in_flight = 0,
+        google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry> assigned_resources =
+            google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry>(),
+        SchedulingKey scheduling_key = std::make_tuple(0, std::vector<ObjectID>(),
+                                                       ActorID::Nil()))
         : lease_client_(lease_client),
           lease_expiration_time_(lease_expiration_time),
           tasks_in_flight_(tasks_in_flight),
@@ -215,8 +217,8 @@ class CoreWorkerDirectTaskSubmitter {
   absl::flat_hash_map<SchedulingKey, std::deque<TaskSpecification>> task_queues_
       GUARDED_BY(mu_);
 
-  // For each SchedulingKey, a pair of unsigned integers keeps track of 
-  // (1) how many worker leases have been granted to execute tasks with 
+  // For each SchedulingKey, a pair of unsigned integers keeps track of
+  // (1) how many worker leases have been granted to execute tasks with
   //     the current SchedulingKey
   // (2) how many tasks are in flight to all the workers from (1)
   absl::flat_hash_map<SchedulingKey, std::pair<uint32_t, uint32_t>> worker_info_

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -182,11 +182,11 @@ class CoreWorkerDirectTaskSubmitter {
   /// (4) The resources assigned to the worker
   /// (5) The SchedulingKey assigned to tasks that will be sent to the worker
   struct LeaseEntry {
-    std::shared_ptr<WorkerLeaseInterface> lease_client_;
-    int64_t lease_expiration_time_;
-    uint32_t tasks_in_flight_;
-    google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry> assigned_resources_;
-    SchedulingKey scheduling_key_;
+    std::shared_ptr<WorkerLeaseInterface> lease_client;
+    int64_t lease_expiration_time;
+    uint32_t tasks_in_flight;
+    google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry> assigned_resources;
+    SchedulingKey scheduling_key;
 
     LeaseEntry(
         std::shared_ptr<WorkerLeaseInterface> lease_client = nullptr,
@@ -195,11 +195,11 @@ class CoreWorkerDirectTaskSubmitter {
             google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry>(),
         SchedulingKey scheduling_key = std::make_tuple(0, std::vector<ObjectID>(),
                                                        ActorID::Nil()))
-        : lease_client_(lease_client),
-          lease_expiration_time_(lease_expiration_time),
-          tasks_in_flight_(tasks_in_flight),
-          assigned_resources_(assigned_resources),
-          scheduling_key_(scheduling_key) {}
+        : lease_client(lease_client),
+          lease_expiration_time(lease_expiration_time),
+          tasks_in_flight(tasks_in_flight),
+          assigned_resources(assigned_resources),
+          scheduling_key(scheduling_key) {}
   };
 
   // Map from worker address to a LeaseEntry struct containing the lease's metadata.
@@ -208,17 +208,25 @@ class CoreWorkerDirectTaskSubmitter {
 
   struct SchedulingKeyEntry {
     // Keep track of pending worker lease requests to the raylet.
-    std::pair<std::shared_ptr<WorkerLeaseInterface>, TaskID> pending_lease_request_ =
+    std::pair<std::shared_ptr<WorkerLeaseInterface>, TaskID> pending_lease_request =
         std::make_pair(nullptr, TaskID::Nil());
     // Tasks that are queued for execution. We keep an individual queue per
     // scheduling class to ensure fairness.
-    std::deque<TaskSpecification> task_queue_ = std::deque<TaskSpecification>();
+    std::deque<TaskSpecification> task_queue = std::deque<TaskSpecification>();
     // Keep track of the active workers, so that we can quickly check if one of them has
     // room for more tasks in flight
-    absl::flat_hash_set<rpc::WorkerAddress> active_workers_ =
+    absl::flat_hash_set<rpc::WorkerAddress> active_workers =
         absl::flat_hash_set<rpc::WorkerAddress>();
     // Keep track of how many tasks with this SchedulingKey are in flight, in total
-    uint32_t tot_tasks_in_flight = 0;
+    uint32_t total_tasks_in_flight = 0;
+
+    bool SafeToDeleteEntry() {
+      if (!pending_lease_request.first && task_queue.empty() &&
+          active_workers.size() == 0 && total_tasks_in_flight == 0) {
+        return true;
+      }
+      return false;
+    }
   };
 
   // For each Scheduling Key, scheduling_key_entries_ contains a SchedulingKeyEntry struct

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -220,7 +220,7 @@ class CoreWorkerDirectTaskSubmitter {
     // Keep track of how many tasks with this SchedulingKey are in flight, in total
     uint32_t total_tasks_in_flight = 0;
 
-    bool SafeToDeleteEntry() {
+    bool CanDelete() {
       if (!pending_lease_request.first && task_queue.empty() &&
           active_workers.size() == 0 && total_tasks_in_flight == 0) {
         return true;

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -88,7 +88,7 @@ class CoreWorkerDirectTaskSubmitter {
 
   /// Check that the scheduling_key_entries_ hashmap is empty. Can be used at the end of
   /// a unit test (or normal program) to check that we are not leaking memory
-  bool CheckNoSchedulingKeyEntries() const { return scheduling_key_entries_.empty(); }
+  bool CheckNoSchedulingKeyEntries() const EXCLUSIVE_LOCKS_REQUIRED(mu_) { return scheduling_key_entries_.empty(); }
 
  private:
   /// Schedule more work onto an idle worker or return it back to the raylet if

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -86,7 +86,7 @@ class CoreWorkerDirectTaskSubmitter {
   Status CancelRemoteTask(const ObjectID &object_id, const rpc::Address &worker_addr,
                           bool force_kill);
 
-  /// Check that the scheduling_key_entries_ hashmap is empty. Can be used at the end of 
+  /// Check that the scheduling_key_entries_ hashmap is empty. Can be used at the end of
   /// a unit test (or normal program) to check that we are not leaking memory
   bool CheckNoSchedulingKeyEntries() const {
     if (scheduling_key_entries_.size() != 0) {
@@ -241,18 +241,17 @@ class CoreWorkerDirectTaskSubmitter {
           active_workers.size() == 0 && total_tasks_in_flight == 0) {
         return true;
       }
-      
+
       return false;
     }
 
     // Check whether the pipelines to the active workers associated with a
-    // SchedulingKeyEntry are all full. 
+    // SchedulingKeyEntry are all full.
     bool AllPipelinesToWorkersFull(uint32_t max_tasks_in_flight_per_worker) const {
-      return total_tasks_in_flight == (active_workers.size() * max_tasks_in_flight_per_worker);
+      return total_tasks_in_flight ==
+             (active_workers.size() * max_tasks_in_flight_per_worker);
     }
   };
-
-  
 
   // For each Scheduling Key, scheduling_key_entries_ contains a SchedulingKeyEntry struct
   // with the queue of tasks belonging to that SchedulingKey, together with the other

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -86,9 +86,11 @@ class CoreWorkerDirectTaskSubmitter {
   Status CancelRemoteTask(const ObjectID &object_id, const rpc::Address &worker_addr,
                           bool force_kill);
 
-  /// Check that the scheduling_key_entries_ hashmap is empty. Can be used at the end of
-  /// a unit test (or normal program) to check that we are not leaking memory
-  bool CheckNoSchedulingKeyEntries() const EXCLUSIVE_LOCKS_REQUIRED(mu_) { return scheduling_key_entries_.empty(); }
+  /// Check that the scheduling_key_entries_ hashmap is empty by calling the private CheckNoSchedulingKeyEntries function after acquiring the lock.
+  bool CheckNoSchedulingKeyEntriesPublic() { 
+    absl::MutexLock lock(&mu_);
+    return scheduling_key_entries_.empty(); 
+  }
 
  private:
   /// Schedule more work onto an idle worker or return it back to the raylet if
@@ -138,6 +140,9 @@ class CoreWorkerDirectTaskSubmitter {
                       const TaskSpecification &task_spec,
                       const google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry>
                           &assigned_resources);
+
+  /// Check that the scheduling_key_entries_ hashmap is empty. 
+  bool CheckNoSchedulingKeyEntries() const EXCLUSIVE_LOCKS_REQUIRED(mu_) { return scheduling_key_entries_.empty(); }
 
   /// Address of our RPC server.
   rpc::Address rpc_address_;

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -89,10 +89,7 @@ class CoreWorkerDirectTaskSubmitter {
   /// Check that the scheduling_key_entries_ hashmap is empty. Can be used at the end of
   /// a unit test (or normal program) to check that we are not leaking memory
   bool CheckNoSchedulingKeyEntries() const {
-    if (scheduling_key_entries_.size() != 0) {
-      RAY_LOG(INFO) << "size: " << scheduling_key_entries_.size();
-    }
-    return scheduling_key_entries_.size() == 0;
+    return scheduling_key_entries_.empty();
   }
 
  private:

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -86,10 +86,11 @@ class CoreWorkerDirectTaskSubmitter {
   Status CancelRemoteTask(const ObjectID &object_id, const rpc::Address &worker_addr,
                           bool force_kill);
 
-  /// Check that the scheduling_key_entries_ hashmap is empty by calling the private CheckNoSchedulingKeyEntries function after acquiring the lock.
-  bool CheckNoSchedulingKeyEntriesPublic() { 
+  /// Check that the scheduling_key_entries_ hashmap is empty by calling the private
+  /// CheckNoSchedulingKeyEntries function after acquiring the lock.
+  bool CheckNoSchedulingKeyEntriesPublic() {
     absl::MutexLock lock(&mu_);
-    return scheduling_key_entries_.empty(); 
+    return scheduling_key_entries_.empty();
   }
 
  private:
@@ -141,8 +142,10 @@ class CoreWorkerDirectTaskSubmitter {
                       const google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry>
                           &assigned_resources);
 
-  /// Check that the scheduling_key_entries_ hashmap is empty. 
-  bool CheckNoSchedulingKeyEntries() const EXCLUSIVE_LOCKS_REQUIRED(mu_) { return scheduling_key_entries_.empty(); }
+  /// Check that the scheduling_key_entries_ hashmap is empty.
+  bool CheckNoSchedulingKeyEntries() const EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+    return scheduling_key_entries_.empty();
+  }
 
   /// Address of our RPC server.
   rpc::Address rpc_address_;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

These changes are needed to avoid over-requesting new workers when using pipelining to submit tasks from owners to their workers. When a new task is submitted to an owner, the code first tries to send the task to an existing worker if the number of tasks in flight to that worker is less than the maximum allowed by the pipelining settings. If all pipelines to all workers are full, then it requests a new worker.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
