### PR TITLE
Prevent Local Worker creation from blocking remote worker creation by creating remote workers before local worker

### DIFF
--- a/rllib/evaluation/worker_set.py
+++ b/rllib/evaluation/worker_set.py
@@ -64,14 +64,15 @@ class WorkerSet:
                 trainer_config,
                 {"tf_session_args": trainer_config["local_tf_session_args"]})
 
+            # Create a number of remote workers
+            self._remote_workers = []
+            self.add_workers(num_workers)
+
             # Always create a local worker
             self._local_worker = self._make_worker(RolloutWorker, env_creator,
                                                    self._policy_class, 0,
                                                    self._local_config)
 
-            # Create a number of remote workers
-            self._remote_workers = []
-            self.add_workers(num_workers)
 
     def local_worker(self) -> RolloutWorker:
         """Return the local rollout worker."""

--- a/rllib/evaluation/worker_set.py
+++ b/rllib/evaluation/worker_set.py
@@ -73,7 +73,6 @@ class WorkerSet:
                                                    self._policy_class, 0,
                                                    self._local_config)
 
-
     def local_worker(self) -> RolloutWorker:
         """Return the local rollout worker."""
         return self._local_worker


### PR DESCRIPTION
## Why are these changes needed?

In my experiments, our environment can take ~1 minute to start up. I have noticed that the local worker blocks the creation of the remote workers. This means I end up paying 2 minutes for the environment startup. However, since the creation of the remote workers is non-blocking if we simply create them first we save this cost.


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
I have not created new tests for this since existing test makes sure the logic does not break and my local testing has shown that this speeds up experiment initialization. 
