### PR TITLE
[tune/rllib] made wandb compatible with rllib trainables

### DIFF
--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -248,9 +248,9 @@ class WandbLogger(Logger):
         config = self.config.copy()
 
         try:
-            if "logger_config" in config:
+            if config.get("logger_config", {}).get("wandb"):
                 logger_config = config.pop("logger_config")
-                wandb_config = logger_config.get("wandb")
+                wandb_config = logger_config.get("wandb").copy()
             else:
                 wandb_config = config.pop("wandb").copy()
         except KeyError:

--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -4,7 +4,6 @@ from multiprocessing import Process, Queue
 from numbers import Number
 
 from ray import logger
-from ray.rllib.agents import Trainer
 from ray.tune import Trainable
 from ray.tune.function_runner import FunctionRunner
 from ray.tune.logger import Logger
@@ -324,13 +323,9 @@ class WandbTrainableMixin:
                 "class inherits from both. For example: "
                 "`class YourTrainable(WandbTrainableMixin)`.")
 
-        _config = config.copy()
-
-        # Remove extra config field for rllib Trainer init
-        if isinstance(self, Trainer):
-            config.pop("wandb")
-
         super().__init__(config, *args, **kwargs)
+
+        _config = config.copy()
 
         try:
             wandb_config = _config.pop("wandb").copy()

--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -164,6 +164,10 @@ class WandbLogger(Logger):
     Wandb configuration is done by passing a ``wandb`` key to
     the ``config`` parameter of ``tune.run()`` (see example below).
 
+    The ``wandb`` config key can be optionally included in the
+    ``logger_config`` subkey of ``config`` to be compatible with RLLib
+    trainables (see second example below).
+
     The content of the ``wandb`` config entry is passed to ``wandb.init()``
     as keyword arguments. The exception are the following settings, which
     are used to configure the WandbLogger itself:
@@ -206,6 +210,27 @@ class WandbLogger(Logger):
             },
             loggers=DEFAULT_LOGGERS + (WandbLogger, ))
 
+    Example for RLLib:
+
+    .. code-block :: python
+
+        from ray import tune
+        from ray.tune.integration.wandb import WandbLogger
+
+        tune.run(
+            "PPO",
+            config={
+                "env": "CartPole-v0",
+                "logger_config": {
+                    "wandb": {
+                        "project": "PPO",
+                        "api_key_file": "~/.wandb_api_key"
+                    }
+                }
+            },
+            loggers=[WandbLogger])
+
+
     """
 
     # Do not log these result keys
@@ -223,7 +248,11 @@ class WandbLogger(Logger):
         config = self.config.copy()
 
         try:
-            wandb_config = config.pop("wandb").copy()
+            if "logger_config" in config:
+                logger_config = config.pop("logger_config")
+                wandb_config = logger_config.get("wandb")
+            else:
+                wandb_config = config.pop("wandb").copy()
         except KeyError:
             raise ValueError(
                 "Wandb logger specified but no configuration has been passed. "

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -372,7 +372,8 @@ COMMON_CONFIG: TrainerConfigDict = {
 
     # === Logger ===
     # Define logger-specific configuration to be used inside Logger
-    "logger_config": {},
+    # Default value None allows overwriting with nested dicts
+    "logger_config": None,
 
     # === Replay Settings ===
     # The number of contiguous environment steps to replay at once. This may


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

RLLib complains about unexpected configuration fields. This affects configuration for the Weights and Biases integration. This PR makes the W&B Logger look in the `logger_config` item in addition to the regular `wandb` config key. See #8521

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests

