### PR TITLE
[autoscaler] Fix logging regression

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -487,8 +487,9 @@ class StandardAutoscaler:
             resources: Either a list of resource bundles or a single resource
                 demand dictionary.
         """
-        logger.info(
-            "StandardAutoscaler: resource_requests={}".format(resources))
+        if resources:
+            logger.info(
+                "StandardAutoscaler: resource_requests={}".format(resources))
         if isinstance(resources, list):
             self.resource_demand_vector = resources
         else:


### PR DESCRIPTION
Current logging behavior:

```
2020-08-24 02:59:03,956	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
2020-08-24 02:59:04,069	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
2020-08-24 02:59:04,182	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
2020-08-24 02:59:04,294	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
2020-08-24 02:59:04,407	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
2020-08-24 02:59:04,520	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
2020-08-24 02:59:04,633	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
2020-08-24 02:59:04,633	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
2020-08-24 02:59:04,746	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
2020-08-24 02:59:04,859	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
2020-08-24 02:59:04,972	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
2020-08-24 02:59:05,135	INFO autoscaler.py:467 -- Cluster status: 1/1 target nodes (0 pending) (1 updating)
 - MostDelayedHeartbeats: {'172.31.4.202': 0.16255450248718262}
 - NodeIdleSeconds: Min=80 Mean=80 Max=80
 - NumNodesConnected: 1
 - NumNodesUsed: 0.0
 - ResourceUsage: 0.0/32.0 CPU, 0.0/4.0 GPU, 0.0/1.0 GPUType:V100, 0.0 GiB/245.94 GiB memory, 0.0 GiB/0.68 GiB object_store_memory
 - TimeSinceLastHeartbeat: Min=0 Mean=0 Max=0

2020-08-24 02:59:05,135	INFO autoscaler.py:467 -- Cluster status: 1/1 target nodes (0 pending) (1 updating)
 - MostDelayedHeartbeats: {'172.31.4.202': 0.16311907768249512}
 - NodeIdleSeconds: Min=80 Mean=80 Max=80
 - NumNodesConnected: 1
 - NumNodesUsed: 0.0
 - ResourceUsage: 0.0/32.0 CPU, 0.0/4.0 GPU, 0.0/1.0 GPUType:V100, 0.0 GiB/245.94 GiB memory, 0.0 GiB/0.68 GiB object_store_memory
 - TimeSinceLastHeartbeat: Min=0 Mean=0 Max=0

2020-08-24 02:59:05,135	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
2020-08-24 02:59:05,135	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
2020-08-24 02:59:05,249	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
2020-08-24 02:59:05,362	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
2020-08-24 02:59:05,475	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
2020-08-24 02:59:05,588	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
2020-08-24 02:59:05,701	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
2020-08-24 02:59:05,814	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
2020-08-24 02:59:05,927	INFO autoscaler.py:491 -- StandardAutoscaler: resource_requests=[]
```