### PR TITLE
[core] Try to schedule tasks locally before spilling over to remote nodes

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -919,7 +919,8 @@ void NodeManager::TryLocalInfeasibleTaskScheduling() {
   SchedulingResources &new_local_resources = cluster_resource_map_[self_node_id_];
 
   // SpillOver locally to figure out which infeasible tasks can be placed now
-  std::vector<TaskID> decision = scheduling_policy_.SpillOver(new_local_resources);
+  std::vector<TaskID> decision =
+      scheduling_policy_.SpillOverInfeasibleTasks(new_local_resources);
 
   std::unordered_set<TaskID> local_task_ids(decision.begin(), decision.end());
 
@@ -986,7 +987,8 @@ void NodeManager::HeartbeatAdded(const ClientID &client_id,
   }
 
   // Extract decision for this raylet.
-  auto decision = scheduling_policy_.SpillOver(remote_resources);
+  auto decision = scheduling_policy_.SpillOver(remote_resources,
+                                               cluster_resource_map_[self_node_id_]);
   std::unordered_set<TaskID> local_task_ids;
   for (const auto &task_id : decision) {
     // (See design_docs/task_states.rst for the state transition diagram.)

--- a/src/ray/raylet/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling_policy.cc
@@ -224,22 +224,20 @@ std::vector<TaskID> SchedulingPolicy::SpillOver(
     for (const auto &task_id : queue.second) {
       const auto &task = scheduling_queue_.GetTaskOfState(task_id, TaskState::READY);
       const auto &spec = task.GetTaskSpecification();
-      if (!spec.IsActorTask()) {
-        // Make sure the node has enough available resources to prevent forwarding cycles.
-        if (spec.GetRequiredPlacementResources().IsSubset(
-                remote_resources.GetAvailableResources())) {
-          // Update the scheduling resources.
-          ResourceSet new_remote_load(remote_resources.GetLoadResources());
-          new_remote_load.AddResources(spec.GetRequiredResources());
-          remote_resources.SetLoadResources(std::move(new_remote_load));
-          ResourceSet new_local_load(local_resources.GetLoadResources());
-          new_local_load.SubtractResources(spec.GetRequiredResources());
-          local_resources.SetLoadResources(std::move(new_local_load));
+      // Make sure the node has enough available resources to prevent forwarding cycles.
+      if (spec.GetRequiredPlacementResources().IsSubset(
+              remote_resources.GetAvailableResources())) {
+        // Update the scheduling resources.
+        ResourceSet new_remote_load(remote_resources.GetLoadResources());
+        new_remote_load.AddResources(spec.GetRequiredResources());
+        remote_resources.SetLoadResources(std::move(new_remote_load));
+        ResourceSet new_local_load(local_resources.GetLoadResources());
+        new_local_load.SubtractResources(spec.GetRequiredResources());
+        local_resources.SetLoadResources(std::move(new_local_load));
 
-          decision.push_back(spec.TaskId());
-          task_spilled = true;
-          break;
-        }
+        decision.push_back(spec.TaskId());
+        task_spilled = true;
+        break;
       }
     }
     if (task_spilled) {

--- a/src/ray/raylet/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling_policy.cc
@@ -53,7 +53,25 @@ std::unordered_map<TaskID, ClientID> SchedulingPolicy::Schedule(
     const auto &resource_demand = spec.GetRequiredPlacementResources();
     const TaskID &task_id = spec.TaskId();
 
-    // TODO(atumanov): try to place tasks locally first.
+    // Try to place tasks locally first.
+    const auto &local_resources = cluster_resources[local_client_id];
+    ResourceSet available_local_resources =
+        ResourceSet(local_resources.GetAvailableResources());
+    // We have to subtract the current "load" because we set the current "load"
+    // to be the resources used by tasks that are in the
+    // `SchedulingQueue::ready_queue_` in NodeManager::HandleWorkerAvailable's
+    // call to SchedulingQueue::GetResourceLoad.
+    available_local_resources.SubtractResources(local_resources.GetLoadResources());
+    if (resource_demand.IsSubset(available_local_resources)) {
+      // This node is a feasible candidate.
+      decision[task_id] = local_client_id;
+
+      ResourceSet new_load(cluster_resources[local_client_id].GetLoadResources());
+      new_load.AddResources(resource_demand);
+      cluster_resources[local_client_id].SetLoadResources(std::move(new_load));
+      continue;
+    }
+
     // Construct a set of viable node candidates and randomly pick between them.
     // Get all the client id keys and randomly pick.
     std::vector<ClientID> client_keys;
@@ -165,37 +183,69 @@ bool SchedulingPolicy::ScheduleBundle(
   return resource_demand.IsSubset(available_node_resources);
 }
 
-std::vector<TaskID> SchedulingPolicy::SpillOver(
-    SchedulingResources &remote_scheduling_resources) const {
+std::vector<TaskID> SchedulingPolicy::SpillOverInfeasibleTasks(
+    SchedulingResources &node_resources) const {
   // The policy decision to be returned.
   std::vector<TaskID> decision;
-
-  ResourceSet new_load(remote_scheduling_resources.GetLoadResources());
+  ResourceSet new_load(node_resources.GetLoadResources());
 
   // Check if we can accommodate infeasible tasks.
   for (const auto &task : scheduling_queue_.GetTasks(TaskState::INFEASIBLE)) {
     const auto &spec = task.GetTaskSpecification();
     const auto &placement_resources = spec.GetRequiredPlacementResources();
-    if (placement_resources.IsSubset(remote_scheduling_resources.GetTotalResources())) {
+    if (placement_resources.IsSubset(node_resources.GetTotalResources())) {
       decision.push_back(spec.TaskId());
       new_load.AddResources(spec.GetRequiredResources());
     }
   }
+  node_resources.SetLoadResources(std::move(new_load));
+  return decision;
+}
 
+std::vector<TaskID> SchedulingPolicy::SpillOver(
+    SchedulingResources &remote_resources, SchedulingResources &local_resources) const {
+  // First try to spill infeasible tasks.
+  auto decision = SpillOverInfeasibleTasks(remote_resources);
+
+  // Get local available resources.
+  ResourceSet available_local_resources =
+      ResourceSet(local_resources.GetAvailableResources());
+  available_local_resources.SubtractResources(local_resources.GetLoadResources());
   // Try to accommodate up to a single ready task.
-  for (const auto &task : scheduling_queue_.GetTasks(TaskState::READY)) {
-    const auto &spec = task.GetTaskSpecification();
-    if (!spec.IsActorTask()) {
-      // Make sure the node has enough available resources to prevent forwarding cycles.
-      if (spec.GetRequiredPlacementResources().IsSubset(
-              remote_scheduling_resources.GetAvailableResources())) {
-        decision.push_back(spec.TaskId());
-        new_load.AddResources(spec.GetRequiredResources());
-        break;
+  bool task_spilled = false;
+  for (const auto &queue : scheduling_queue_.GetReadyTasksByClass()) {
+    // Skip tasks for which there are resources available locally.
+    const auto &task_resources =
+        TaskSpecification::GetSchedulingClassDescriptor(queue.first);
+    if (task_resources.IsSubset(available_local_resources)) {
+      continue;
+    }
+    // Try to spill one task.
+    for (const auto &task_id : queue.second) {
+      const auto &task = scheduling_queue_.GetTaskOfState(task_id, TaskState::READY);
+      const auto &spec = task.GetTaskSpecification();
+      if (!spec.IsActorTask()) {
+        // Make sure the node has enough available resources to prevent forwarding cycles.
+        if (spec.GetRequiredPlacementResources().IsSubset(
+                remote_resources.GetAvailableResources())) {
+          // Update the scheduling resources.
+          ResourceSet new_remote_load(remote_resources.GetLoadResources());
+          new_remote_load.AddResources(spec.GetRequiredResources());
+          remote_resources.SetLoadResources(std::move(new_remote_load));
+          ResourceSet new_local_load(local_resources.GetLoadResources());
+          new_local_load.SubtractResources(spec.GetRequiredResources());
+          local_resources.SetLoadResources(std::move(new_local_load));
+
+          decision.push_back(spec.TaskId());
+          task_spilled = true;
+          break;
+        }
       }
     }
+    if (task_spilled) {
+      break;
+    }
   }
-  remote_scheduling_resources.SetLoadResources(std::move(new_load));
 
   return decision;
 }

--- a/src/ray/raylet/scheduling_policy.h
+++ b/src/ray/raylet/scheduling_policy.h
@@ -61,14 +61,23 @@ class SchedulingPolicy {
       std::unordered_map<ClientID, SchedulingResources> &cluster_resources,
       const ClientID &local_client_id, const ray::BundleSpecification &bundle_spec);
 
+  /// \brief Given a set of cluster resources, try to spillover infeasible tasks.
+  ///
+  /// \param node_resources The resource information for a node. This may be
+  /// the local node.
+  /// \return Tasks that should be spilled to this node.
+  std::vector<TaskID> SpillOverInfeasibleTasks(SchedulingResources &node_resources) const;
+
   /// \brief Given a set of cluster resources perform a spill-over scheduling operation.
   ///
-  /// \param cluster_resources: a set of cluster resources containing resource and load
-  /// information for some subset of the cluster. For all client IDs in the returned
-  /// placement map, the corresponding SchedulingResources::resources_load_ is
-  /// incremented by the aggregate resource demand of the tasks assigned to it.
-  /// \return Scheduling decision, mapping tasks to raylets for placement.
-  std::vector<TaskID> SpillOver(SchedulingResources &remote_scheduling_resources) const;
+  /// \param remote_resources The resource information for a remote node. This
+  /// is guaranteed to not be the local node. The load info is updated if a
+  /// task is spilled.
+  /// \param local_resources The resource information for the local node. The
+  /// load info is updated if a task is spilled.
+  /// \return Tasks that should be spilled to this node.
+  std::vector<TaskID> SpillOver(SchedulingResources &remote_resources,
+                                SchedulingResources &local_resources) const;
 
   /// \brief SchedulingPolicy destructor.
   virtual ~SchedulingPolicy();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

On receiving a task, the current raylet scheduling policy collects a set of all nodes in the cluster that could feasibly execute the task, then randomly chooses one to execute the task. Therefore, with a cluster size of n nodes and a single task, the raylet has a 1/n chance of keeping the task local. This can lead to bad behavior with large cluster sizes because the task will keep getting randomly spilled to a new node, even though any of the nodes could execute the task. There is a similar problem for tasks in the ready queue: the scheduling policy spills over at most 1 ready task per heartbeat per remote node.

This PR adds a temporary fix for this problem while the new scheduler is under development. There are two changes:
- When scheduling a new task, try to schedule locally first. This checks whether the local node has available resources and falls back to the existing policy if not.
- When spilling over a ready task upon receiving a heartbeat from a remote node, first check whether the local node has available resources. If yes, do not spill the task. If no, fall back to the existing policy.

This also splits out the spillover code into `SpillOverInfeasibleTasks` and `SpillOver`. This is a bit clearer than before, when `SpillOver` was being used for both spillover to remote nodes and spillover from the local infeasible task queue to the local node.

## Related issue number

(Potentially) closes #10150.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)
     This doesn't test the original issue reported in #10150 because it requires a large cluster setup. However, assuming that the local scheduling is the problem, this should address that issue.