### PR TITLE
[autoscaler] Make KeyName optional in AWS autoscaler

### DIFF
--- a/python/ray/autoscaler/aws/config.py
+++ b/python/ray/autoscaler/aws/config.py
@@ -159,7 +159,9 @@ def log_to_cli(config):
             _arn_to_name(config["head_node"]["IamInstanceProfile"]["Arn"]),
             _tags=tags)
 
-        print_info("EC2 Key pair", "KeyName", "keypair_src", "keypair_src")
+        if "KeyName" in config["head_node"] and "KeyName" in config["worker_nodes"]:
+            print_info("EC2 Key pair", "KeyName", "keypair_src", "keypair_src")
+
         print_info(
             "VPC Subnets",
             "SubnetIds",
@@ -275,16 +277,8 @@ def _configure_key_pair(config):
     if "ssh_private_key" in config["auth"]:
         _set_config_info(keypair_src="config")
 
-        cli_logger.doassert(  # todo: verify schema beforehand?
-            "KeyName" in config["head_node"],
-            "`KeyName` missing for head node.")  # todo: err msg
-        cli_logger.doassert(
-            "KeyName" in config["worker_nodes"],
-            "`KeyName` missing for worker nodes.")  # todo: err msg
-
-        assert "KeyName" in config["head_node"]
-        assert "KeyName" in config["worker_nodes"]
         return config
+
     _set_config_info(keypair_src="default")
 
     ec2 = _resource("ec2", config)

--- a/python/ray/autoscaler/aws/config.py
+++ b/python/ray/autoscaler/aws/config.py
@@ -277,6 +277,23 @@ def _configure_key_pair(config):
     if "ssh_private_key" in config["auth"]:
         _set_config_info(keypair_src="config")
 
+        # If the key is not configured via the cloudinit
+        # UserData, it should be configured via KeyName or
+        # else we will risk starting a node that we cannot
+        # SSH into:
+
+        if "UserData" not in config["head_node"]:
+            cli_logger.doassert(  # todo: verify schema beforehand?
+                "KeyName" in config["head_node"],
+                "`KeyName` missing for head node.")  # todo: err msg
+            assert "KeyName" in config["head_node"]
+
+        if "UserData" not in config["worker_nodes"]:
+            cli_logger.doassert(
+                "KeyName" in config["worker_nodes"],
+                "`KeyName` missing for worker nodes.")  # todo: err msg
+            assert "KeyName" in config["worker_nodes"]
+
         return config
 
     _set_config_info(keypair_src="default")

--- a/python/ray/autoscaler/aws/config.py
+++ b/python/ray/autoscaler/aws/config.py
@@ -161,8 +161,7 @@ def log_to_cli(config):
 
         if ("KeyName" in config["head_node"]
                 and "KeyName" in config["worker_nodes"]):
-            print_info(
-                "EC2 Key pair", "KeyName", "keypair_src", "keypair_src")
+            print_info("EC2 Key pair", "KeyName", "keypair_src", "keypair_src")
 
         print_info(
             "VPC Subnets",

--- a/python/ray/autoscaler/aws/config.py
+++ b/python/ray/autoscaler/aws/config.py
@@ -159,8 +159,10 @@ def log_to_cli(config):
             _arn_to_name(config["head_node"]["IamInstanceProfile"]["Arn"]),
             _tags=tags)
 
-        if "KeyName" in config["head_node"] and "KeyName" in config["worker_nodes"]:
-            print_info("EC2 Key pair", "KeyName", "keypair_src", "keypair_src")
+        if ("KeyName" in config["head_node"]
+                and "KeyName" in config["worker_nodes"]):
+            print_info(
+                "EC2 Key pair", "KeyName", "keypair_src", "keypair_src")
 
         print_info(
             "VPC Subnets",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR makes it possible to install private SSH keys into an EC2 machine via cloudinit (https://cloudinit.readthedocs.io/en/latest/topics/examples.html#configure-instances-ssh-keys) without having to use the EC2 create_key_pair API. This allows us to not be limited by the number of registered keys in an AWS account.

The key can be configured in the cluster yaml like so:

```

[...]

head_node:
    UserData: |
        #cloud-config
        ssh_authorized_keys:
            - ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAGEA3FSyQwBI6Z+nCSjUUk8EEAnnkhXlukKoUPND/RRClWz2s5TCzIkd3Ou5+Cyz71X0XmazM3l5WgeErvtIwQMyT1KjNoMhoJMrJnWqQPOt5Q8zWd9qG7PBl9+eiH5qV7NZ mykey@host
worker_nodes:
    UserData: |
        #cloud-config
        ssh_authorized_keys:
            - ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAGEA3FSyQwBI6Z+nCSjUUk8EEAnnkhXlukKoUPND/RRClWz2s5TCzIkd3Ou5+Cyz71X0XmazM3l5WgeErvtIwQMyT1KjNoMhoJMrJnWqQPOt5Q8zWd9qG7PBl9+eiH5qV7NZ mykey@host

[...]
```

The main change to make this work was to make sure the `KeyName` is not mandatory for head and worker nodes.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
