### PR TITLE
Fix docs - atexit is not called when you ray.kill() an actor

### DIFF
--- a/doc/source/actors.rst
+++ b/doc/source/actors.rst
@@ -149,9 +149,11 @@ approach should generally not be necessary as actors are automatically garbage
 collected. The ``ObjectRef`` resulting from the task can be waited on to wait
 for the actor to exit (calling ``ray.get()`` on it will raise a ``RayActorError``).
 Note that this method of termination will wait until any previously submitted
-tasks finish executing. If you want to terminate an actor immediately, you can
-call ``ray.kill(actor_handle)``. This will cause the actor to exit immediately
-and any pending tasks to fail. Any exit handlers installed in the actor using
+tasks finish executing and then exit the process gracefully with sys.exit. If you
+want to terminate an actor forcefully, you can call ``ray.kill(actor_handle)``.
+This will call the exit syscall from within the actor, causing it to exit
+immediately and any pending tasks to fail. This will not go through the normal
+Python sys.exit teardown logic, so any exit handlers installed in the actor using
 ``atexit`` will not be called.
 
 Passing Around Actor Handles

--- a/doc/source/actors.rst
+++ b/doc/source/actors.rst
@@ -152,7 +152,7 @@ Note that this method of termination will wait until any previously submitted
 tasks finish executing. If you want to terminate an actor immediately, you can
 call ``ray.kill(actor_handle)``. This will cause the actor to exit immediately
 and any pending tasks to fail. Any exit handlers installed in the actor using
-``atexit`` will be called.
+``atexit`` will not be called.
 
 Passing Around Actor Handles
 ----------------------------


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
