### PR TITLE
[docker] Run profiling without sudo

### DIFF
--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -75,7 +75,8 @@ class ReporterAgent(dashboard_utils.DashboardAgentModule,
                                            "{}_profiling.txt".format(pid))
         sudo = "sudo" if ray.utils.get_user() != "root" else ""
         process = subprocess.Popen(
-            f"{sudo} $(which py-spy) record -o {profiling_file_path} -p {pid} -d {duration} -f speedscope",
+            (f"{sudo} $(which py-spy) record -o {profiling_file_path} -p {pid}"
+             f" -d {duration} -f speedscope"),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             shell=True)

--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -73,9 +73,9 @@ class ReporterAgent(dashboard_utils.DashboardAgentModule,
         duration = request.duration
         profiling_file_path = os.path.join(ray.utils.get_ray_temp_dir(),
                                            "{}_profiling.txt".format(pid))
+        sudo = "sudo" if ray.utils.get_user() != "root" else ""
         process = subprocess.Popen(
-            "sudo $(which py-spy) record -o {} -p {} -d {} -f speedscope"
-            .format(profiling_file_path, pid, duration),
+            f"{sudo} $(which py-spy) record -o {profiling_file_path} -p {pid} -d {duration} -f speedscope",
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             shell=True)

--- a/python/ray/reporter.py
+++ b/python/ray/reporter.py
@@ -45,7 +45,8 @@ class ReporterServer(reporter_pb2_grpc.ReporterServiceServicer):
                                            f"{pid}_profiling.txt")
         sudo = "sudo" if ray.utils.get_user() != "root" else ""
         process = subprocess.Popen(
-            f"{sudo} $(which py-spy) record -o {profiling_file_path} -p {pid} -d {duration} -f speedscope",
+            (f"{sudo} $(which py-spy) record -o {profiling_file_path} -p {pid}"
+             f" -d {duration} -f speedscope"),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             shell=True)

--- a/python/ray/reporter.py
+++ b/python/ray/reporter.py
@@ -43,9 +43,9 @@ class ReporterServer(reporter_pb2_grpc.ReporterServiceServicer):
         duration = request.duration
         profiling_file_path = os.path.join(ray.utils.get_ray_temp_dir(),
                                            f"{pid}_profiling.txt")
+        sudo = "sudo" if ray.utils.get_user() != "root" else ""
         process = subprocess.Popen(
-            "sudo $(which py-spy) record -o {} -p {} -d {} -f speedscope"
-            .format(profiling_file_path, pid, duration),
+            f"{sudo} $(which py-spy) record -o {profiling_file_path} -p {pid} -d {duration} -f speedscope",
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             shell=True)

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -5,7 +5,6 @@ import inspect
 import logging
 import numpy as np
 import os
-import pwd
 import signal
 import subprocess
 import sys
@@ -18,6 +17,10 @@ import ray
 import ray.gcs_utils
 import ray.ray_constants as ray_constants
 import psutil
+
+pwd = None
+if sys.platform != "win32":
+    import pwd
 
 logger = logging.getLogger(__name__)
 
@@ -784,6 +787,8 @@ def try_to_symlink(symlink_path, target_path):
 
 
 def get_user():
+    if pwd is None:
+        return ""
     try:
         return pwd.getpwuid(os.getuid()).pw_name
     except Exception:

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -786,5 +786,5 @@ def try_to_symlink(symlink_path, target_path):
 def get_user():
     try:
         return pwd.getpwuid(os.getuid())[0]
-    except:
+    except Exception:
         return ""

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -5,6 +5,7 @@ import inspect
 import logging
 import numpy as np
 import os
+import pwd
 import signal
 import subprocess
 import sys
@@ -780,3 +781,10 @@ def try_to_symlink(symlink_path, target_path):
         os.symlink(target_path, symlink_path)
     except OSError:
         return
+
+
+def get_user():
+    try:
+        return pwd.getpwuid(os.getuid())[0]
+    except:
+        return ""

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -785,6 +785,6 @@ def try_to_symlink(symlink_path, target_path):
 
 def get_user():
     try:
-        return pwd.getpwuid(os.getuid())[0]
+        return pwd.getpwuid(os.getuid()).pw_name
     except Exception:
         return ""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Sudo is not necessary in docker when the current user is `root`. This PR only uses `sudo` for profiling when the user is not `root`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
