### PR TITLE
[docker] Run docker stop in teardown_cluster

### DIFF
--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -344,10 +344,7 @@ def teardown_cluster(config_file: str, yes: bool, workers_only: bool,
 
             return head + workers
 
-        def try_docker_stop(node):
-            container_name = config.get("docker", {}).get("container_name")
-            if container_name is None:
-                return
+        def run_docker_stop(node, container_name):
             try:
                 updater = NodeUpdaterThread(
                     node_id=node,
@@ -377,8 +374,10 @@ def teardown_cluster(config_file: str, yes: bool, workers_only: bool,
         #   really gone
         A = remaining_nodes()
 
-        for node in A:
-            try_docker_stop(node)
+        container_name = config.get("docker", {}).get("container_name")
+        if container_name:
+            for node in A:
+                run_docker_stop(node, container_name)
 
         with LogTimer("teardown_cluster: done."):
             while A:

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -384,6 +384,7 @@ def teardown_cluster(config_file: str, yes: bool, workers_only: bool,
                 cli_logger.old_info(
                     logger, "teardown_cluster: "
                     "Shutting down {} nodes...", len(A))
+
                 provider.terminate_nodes(A)
 
                 cli_logger.print(

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -368,7 +368,7 @@ def teardown_cluster(config_file: str, yes: bool, workers_only: bool,
                     run_env="host")
             except Exception:
                 cli_logger.warning(f"Docker stop failed on {node}")
-                cli_logger.old_warning(f"Docker stopped on {node}")
+                cli_logger.old_warning(logger, f"Docker stop failed on {node}")
 
         # Loop here to check that both the head and worker nodes are actually
         #   really gone


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This ensures that the state on teardown is that docker is **stopped**. This is especially important for `local` clusters where shutdown does not actually happen.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
