### PR TITLE
Fix errors in ActorPool documentation

### DIFF
--- a/python/ray/util/actor_pool.py
+++ b/python/ray/util/actor_pool.py
@@ -54,7 +54,7 @@ class ActorPool:
 
         Examples:
             >>> pool = ActorPool(...)
-            >>> results = pool.map(lambda a, v: a.double.remote(v),
+            >>> results = pool.map(lambda a, v: a.double.remote(v),\
             ...                    [1, 2, 3, 4])
             >>> for r in results:
             ...     print(r)
@@ -84,7 +84,7 @@ class ActorPool:
 
         Examples:
             >>> pool = ActorPool(...)
-            >>> results = pool.map_unordered(lambda a, v: a.double.remote(v),
+            >>> results = pool.map_unordered(lambda a, v: a.double.remote(v),\
             ...                              [1, 2, 3, 4])
             >>> for r in results:
             ...     print(r)

--- a/python/ray/util/actor_pool.py
+++ b/python/ray/util/actor_pool.py
@@ -10,9 +10,8 @@ class ActorPool:
     Examples:
         >>> a1, a2 = Actor.remote(), Actor.remote()
         >>> pool = ActorPool([a1, a2])
-        >>> results = pool.map(lambda a, v: a.double.remote(v), [1, 2, 3, 4])
-        >>> for r in results:
-        ...     print(r)
+        >>> print(list(pool.map(lambda a, v: a.double.remote(v),\
+        ...                     [1, 2, 3, 4])))
         [2, 4, 6, 8]
     """
 
@@ -54,10 +53,8 @@ class ActorPool:
 
         Examples:
             >>> pool = ActorPool(...)
-            >>> results = pool.map(lambda a, v: a.double.remote(v),
-            ...                    [1, 2, 3, 4])
-            >>> for r in results:
-            ...     print(r)
+            >>> print(list(pool.map(lambda a, v: a.double.remote(v),\
+            ...                     [1, 2, 3, 4])))
             [2, 4, 6, 8]
         """
         for v in values:
@@ -84,10 +81,8 @@ class ActorPool:
 
         Examples:
             >>> pool = ActorPool(...)
-            >>> results = pool.map_unordered(lambda a, v: a.double.remote(v),
-            ...                              [1, 2, 3, 4])
-            >>> for r in results:
-            ...     print(r)
+            >>> print(list(pool.map_unordered(lambda a, v: a.double.remote(v),\
+            ...                               [1, 2, 3, 4])))
             [6, 2, 4, 8]
         """
         for v in values:

--- a/python/ray/util/actor_pool.py
+++ b/python/ray/util/actor_pool.py
@@ -10,7 +10,9 @@ class ActorPool:
     Examples:
         >>> a1, a2 = Actor.remote(), Actor.remote()
         >>> pool = ActorPool([a1, a2])
-        >>> print(pool.map(lambda a, v: a.double.remote(v), [1, 2, 3, 4]))
+        >>> results = pool.map(lambda a, v: a.double.remote(v), [1, 2, 3, 4])
+        >>> for r in results:
+        ...     print(r)
         [2, 4, 6, 8]
     """
 
@@ -52,7 +54,10 @@ class ActorPool:
 
         Examples:
             >>> pool = ActorPool(...)
-            >>> print(pool.map(lambda a, v: a.double.remote(v), [1, 2, 3, 4]))
+            >>> results = pool.map(lambda a, v: a.double.remote(v),
+            ...                    [1, 2, 3, 4])
+            >>> for r in results:
+            ...     print(r)
             [2, 4, 6, 8]
         """
         for v in values:
@@ -79,7 +84,10 @@ class ActorPool:
 
         Examples:
             >>> pool = ActorPool(...)
-            >>> print(pool.map(lambda a, v: a.double.remote(v), [1, 2, 3, 4]))
+            >>> results = pool.map_unordered(lambda a, v: a.double.remote(v),
+            ...                              [1, 2, 3, 4])
+            >>> for r in results:
+            ...     print(r)
             [6, 2, 4, 8]
         """
         for v in values:


### PR DESCRIPTION
1. map() and map_unordered() name
2. The print statement doesn't work

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
I was trying out the ray.io documentation on ActorPool and found 2 issues (as described in git commit message).
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
