### PR TITLE
Add option to disable profiling and task timeline

### DIFF
--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -64,3 +64,5 @@ cdef extern from "ray/common/ray_config.h" nogil:
         uint32_t max_tasks_in_flight_per_worker() const
 
         uint64_t metrics_report_interval_ms() const
+
+        c_bool enable_timeline() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -111,3 +111,7 @@ cdef class Config:
     @staticmethod
     def metrics_report_interval_ms():
         return RayConfig.instance().metrics_report_interval_ms()
+
+    @staticmethod
+    def enable_timeline():
+        return RayConfig.instance().enable_timeline()

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -294,3 +294,7 @@ RAY_CONFIG(uint64_t, metrics_report_interval_ms, 10000)
 
 /// The maximum number of I/O worker that raylet starts.
 RAY_CONFIG(int, max_io_workers, 1)
+
+/// Enable the task timeline. If this is enabled, certain events such as task
+/// execution are profiled and sent to the GCS.
+RAY_CONFIG(bool, enable_timeline, true)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

System event profiling can generate a lot of Redis data and load. This PR adds an option to disable event profiling completely. This can be controlled with the `enable_timeline` parameter in the `_system_config` (default true).

## Related issue number

May mitigate #10234.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
