### PR TITLE
[tune/rllib/wandb] Flatten result dict so that nested result dicts are shown in W&B logger

### DIFF
--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -146,7 +146,7 @@ class _WandbLoggingProcess(Process):
     def _handle_result(self, result):
         config_update = result.get("config", {}).copy()
         log = {}
-        flat_result = flatten_dict(result.copy(), delimiter="/")
+        flat_result = flatten_dict(result, delimiter="/")
 
         for k, v in flat_result.items():
             if any(k.startswith(item) for item in self._to_config):

--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -149,9 +149,9 @@ class _WandbLoggingProcess(Process):
         flat_result = flatten_dict(result.copy(), delimiter="/")
 
         for k, v in flat_result.items():
-            if any([k.startswith(item) for item in self._to_config]):
+            if any(k.startswith(item) for item in self._to_config):
                 config_update[k] = v
-            elif any([k.startswith(item) for item in self._exclude]):
+            elif any(k.startswith(item) for item in self._exclude):
                 continue
             elif not isinstance(v, Number):
                 continue

--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -149,9 +149,13 @@ class _WandbLoggingProcess(Process):
         flat_result = flatten_dict(result, delimiter="/")
 
         for k, v in flat_result.items():
-            if any(k.startswith(item) for item in self._to_config):
+            if any(
+                    k.startswith(item + "/") or k == item
+                    for item in self._to_config):
                 config_update[k] = v
-            elif any(k.startswith(item) for item in self._exclude):
+            elif any(
+                    k.startswith(item + "/") or k == item
+                    for item in self._exclude):
                 continue
             elif not isinstance(v, Number):
                 continue

--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -7,6 +7,7 @@ from ray import logger
 from ray.tune import Trainable
 from ray.tune.function_runner import FunctionRunner
 from ray.tune.logger import Logger
+from ray.tune.utils import flatten_dict
 
 try:
     import wandb
@@ -145,11 +146,12 @@ class _WandbLoggingProcess(Process):
     def _handle_result(self, result):
         config_update = result.get("config", {}).copy()
         log = {}
+        flat_result = flatten_dict(result.copy(), delimiter="/")
 
-        for k, v in result.items():
-            if k in self._to_config:
+        for k, v in flat_result.items():
+            if any([k.startswith(item) for item in self._to_config]):
                 config_update[k] = v
-            elif k in self._exclude:
+            elif any([k.startswith(item) for item in self._exclude]):
                 continue
             elif not isinstance(v, Number):
                 continue


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The Weights & Biases logger does not flatten the result dict, therefore nested dicts will not be considered. This PR flattens the result dict, similar to most other loggers.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
