### PR TITLE
[tune] remove callbacks from config in wandb logger initialization

### DIFF
--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -2,11 +2,13 @@ import os
 
 from multiprocessing import Process, Queue
 from numbers import Number
+from typing import Dict
 
 from ray import logger
 from ray.tune import Trainable
 from ray.tune.function_runner import FunctionRunner
 from ray.tune.logger import Logger
+from ray.tune.utils import flatten_dict
 
 try:
     import wandb
@@ -253,6 +255,8 @@ class WandbLogger(Logger):
 
     def _init(self):
         config = self.config.copy()
+
+        config.pop("callbacks", None)  # Remove callbacks
 
         try:
             if config.get("logger_config", {}).get("wandb"):

--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -2,13 +2,11 @@ import os
 
 from multiprocessing import Process, Queue
 from numbers import Number
-from typing import Dict
 
 from ray import logger
 from ray.tune import Trainable
 from ray.tune.function_runner import FunctionRunner
 from ray.tune.logger import Logger
-from ray.tune.utils import flatten_dict
 
 try:
     import wandb


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Removes problems with wandb logger initialization with the callbacks API.

## Related issue number

#10426

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
