### PR TITLE
[k8s] Replace k8s service name everywhere in ingress manifest

### DIFF
--- a/python/ray/autoscaler/kubernetes/node_provider.py
+++ b/python/ray/autoscaler/kubernetes/node_provider.py
@@ -177,4 +177,7 @@ def _add_service_name_to_service_port(spec, svc_name):
             _add_service_name_to_service_port(item, svc_name) for item in spec
         ]
 
+    elif isinstance(spec, str):
+        if "${RAY_POD_NAME}" in spec:
+            spec.replace("${RAY_POD_NAME}", svc_name)
     return spec


### PR DESCRIPTION

## Why are these changes needed?
There is a small inconvenience in the cod which replaces the magic variable `${RAY_POD_NAME}` in the ingress manifest.
This fix makes sure the magic variable is replaced everywhere in the manifest.

## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
