### PR TITLE
[tune] Use isinstance instead of type in assert in HyperOptSearch

### DIFF
--- a/python/ray/tune/suggest/hyperopt.py
+++ b/python/ray/tune/suggest/hyperopt.py
@@ -121,7 +121,7 @@ class HyperOptSearch(Searcher):
             self._hpopt_trials = hpo.Trials()
             self._points_to_evaluate = 0
         else:
-            assert type(points_to_evaluate) == list
+            assert isinstance(points_to_evaluate, (list, tuple))
             self._hpopt_trials = generate_trials_to_calculate(
                 points_to_evaluate)
             self._hpopt_trials.refresh()


### PR DESCRIPTION
## Why are these changes needed?

`isinstance` should be used instead of `type` in the assert when type-checking `points_to_evaluate` in `ray.tune.suggest.hyperopt.HyperOptSearch`


the goal of this PR isn't really to change any behavior; however, this enables users to subclass list and tuple (which is unlikely, but not too unreasonable)

https://stackoverflow.com/questions/1549801/what-are-the-differences-between-type-and-isinstance

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
