### PR TITLE
[tune] SigOpt multi-objective search + experiments

### DIFF
--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -547,14 +547,24 @@ py_test(
 #     tags = ["exclusive", "example"],
 #     args = ["--smoke-test"]
 # )
-#
-#
+
+
 # Needs SigOpt API key.
 # py_test(
 #     name = "sigopt_multi_objective_example",
 #     size = "medium",
 #     srcs = ["examples/sigopt_multi_objective_example.py"],
 #     deps = [":tune_lib"],                 s
+#     tags = ["exclusive", "example"],
+#     args = ["--smoke-test"]
+# )
+
+# Needs SigOpt API key.
+# py_test(
+#     name = "sigopt_prior_beliefs_example",
+#     size = "medium",
+#     srcs = ["examples/sigopt_prior_beliefs_example.py"],
+#     deps = [":tune_lib"],
 #     tags = ["exclusive", "example"],
 #     args = ["--smoke-test"]
 # )

--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -547,6 +547,17 @@ py_test(
 #     tags = ["exclusive", "example"],
 #     args = ["--smoke-test"]
 # )
+#
+#
+# Needs SigOpt API key.
+# py_test(
+#     name = "sigopt_multi_objective_example",
+#     size = "medium",
+#     srcs = ["examples/sigopt_multi_objective_example.py"],
+#     deps = [":tune_lib"],                 s
+#     tags = ["exclusive", "example"],
+#     args = ["--smoke-test"]
+# )
 
 py_test(
     name = "skopt_example",

--- a/python/ray/tune/examples/sigopt_multi_objective_example.py
+++ b/python/ray/tune/examples/sigopt_multi_objective_example.py
@@ -1,0 +1,79 @@
+"""This test checks that SigOpt is functional.
+
+It also checks that it is usable with a separate scheduler.
+"""
+import time
+
+import ray
+import numpy as np
+from ray import tune
+from ray.tune.schedulers import AsyncHyperBandScheduler
+from ray.tune.suggest.sigopt import SigOptSearch,
+
+np.random.seed(0)
+vector1 = np.random.normal(0, 0.1, 100)
+vector2 = np.random.normal(0, 0.1, 100)
+
+def evaluate(w1, w2):
+    total = w1 * vector1 + w2 * vector2
+    return total.mean(), total.std()
+
+
+def easy_objective(config):
+    # Hyperparameters
+    w1 = config["w1"]
+    w2 = config["total_weight"] - w1
+
+    average, std = evaluate(w1, w2)
+    tune.report(average=average, std=std)
+    time.sleep(0.1)
+
+
+if __name__ == "__main__":
+    import argparse
+    import os
+
+    assert "SIGOPT_KEY" in os.environ, \
+        "SigOpt API key must be stored as environment variable at SIGOPT_KEY"
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--smoke-test", action="store_true", help="Finish quickly for testing")
+    args, _ = parser.parse_known_args()
+    ray.init()
+
+    space = [
+        {
+            "name": "w1",
+            "type": "float",
+            "bounds": {
+                "min": 0,
+                "max": 1
+            },
+        },
+    ]
+
+    config = {
+        "num_samples": 10 if args.smoke_test else 1000,
+        "config": {
+            "total_weight": 1
+        }
+    }
+
+    metric = [
+
+    ]
+
+    algo = SigOptSearch(
+        space,
+        name="SigOpt Example Experiment",
+        max_concurrent=1,
+        metric="mean_loss",
+        mode="min")
+    scheduler = AsyncHyperBandScheduler(metric="mean_loss", mode="min")
+    tune.run(
+        easy_objective,
+        name="my_exp",
+        search_alg=algo,
+        scheduler=scheduler,
+        **config)

--- a/python/ray/tune/examples/sigopt_multi_objective_example.py
+++ b/python/ray/tune/examples/sigopt_multi_objective_example.py
@@ -8,7 +8,7 @@ import ray
 import numpy as np
 from ray import tune
 from ray.tune.schedulers import AsyncHyperBandScheduler
-from ray.tune.suggest.sigopt import SigOptSearch,
+from ray.tune.suggest.sigopt import SigOptSearch
 
 np.random.seed(0)
 vector1 = np.random.normal(0, 0.1, 100)
@@ -45,7 +45,7 @@ if __name__ == "__main__":
     space = [
         {
             "name": "w1",
-            "type": "float",
+            "type": "double",
             "bounds": {
                 "min": 0,
                 "max": 1
@@ -60,16 +60,13 @@ if __name__ == "__main__":
         }
     }
 
-    metric = [
-
-    ]
-
     algo = SigOptSearch(
         space,
-        name="SigOpt Example Experiment",
+        name="SigOpt Example Multi Objective Experiment",
+        observation_budget=10 if args.smoke_test else 1000,
         max_concurrent=1,
-        metric="mean_loss",
-        mode="min")
+        metric=["average", "std"],
+        mode=["max", "min"])
     scheduler = AsyncHyperBandScheduler(metric="mean_loss", mode="min")
     tune.run(
         easy_objective,

--- a/python/ray/tune/examples/sigopt_prior_beliefs_example.py
+++ b/python/ray/tune/examples/sigopt_prior_beliefs_example.py
@@ -1,0 +1,110 @@
+"""This test checks that SigOpt is functional.
+
+It also checks that it is usable with a separate scheduler.
+"""
+import time
+
+import ray
+import numpy as np
+from ray import tune
+
+from ray.tune.schedulers import FIFOScheduler
+from ray.tune.suggest.sigopt import SigOptSearch
+
+np.random.seed(0)
+vector1 = np.random.normal(0.0, 0.1, 100)
+vector2 = np.random.normal(0.0, 0.1, 100)
+vector3 = np.random.normal(0.0, 0.1, 100)
+
+
+def evaluate(w1, w2, w3):
+    total = w1 * vector1 + w2 * vector2 + w3 * vector3
+    return total.mean(), total.std()
+
+
+def easy_objective(config):
+    # Hyperparameters
+    w1 = config["w1"]
+    w2 = config["w2"]
+    total = (w1 + w2)
+    if total > 1:
+        w3 = 0
+        w1 /= total
+        w2 /= total
+    else:
+        w3 = 1 - total
+
+    average, std = evaluate(w1, w2, w3)
+    tune.report(average=average, std=std)
+    time.sleep(0.1)
+
+
+if __name__ == "__main__":
+    import argparse
+    import os
+    from sigopt import Connection
+
+    assert "SIGOPT_KEY" in os.environ, \
+        "SigOpt API key must be stored as environment variable at SIGOPT_KEY"
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--smoke-test", action="store_true", help="Finish quickly for testing")
+    args, _ = parser.parse_known_args()
+    ray.init()
+
+    samples = 10 if args.smoke_test else 1000
+
+    conn = Connection(client_token=os.environ["SIGOPT_KEY"])
+    experiment = conn.experiments().create(
+        name="prior experiment example",
+        parameters=[{
+            "name": "w1",
+            "bounds": {
+                "max": 1,
+                "min": 0
+            },
+            "prior": {
+                "mean": 1 / 3,
+                "name": "normal",
+                "scale": 0.2
+            },
+            "type": "double"
+        }, {
+            "name": "w2",
+            "bounds": {
+                "max": 1,
+                "min": 0
+            },
+            "prior": {
+                "mean": 1 / 3,
+                "name": "normal",
+                "scale": 0.2
+            },
+            "type": "double"
+        }],
+        metrics=[
+            dict(name="std", objective="minimize", strategy="optimize"),
+            dict(name="average", strategy="store")
+        ],
+        observation_budget=samples,
+        parallel_bandwidth=1)
+
+    config = {"num_samples": samples, "config": {}}
+
+    algo = SigOptSearch(
+        connection=conn,
+        experiment_id=experiment.id,
+        name="SigOpt Example Existing Experiment",
+        max_concurrent=1,
+        metric=["average", "std"],
+        mode=["obs", "min"])
+
+    scheduler = FIFOScheduler()
+
+    tune.run(
+        easy_objective,
+        name="my_exp",
+        search_alg=algo,
+        scheduler=scheduler,
+        **config)

--- a/python/ray/tune/suggest/suggestion.py
+++ b/python/ray/tune/suggest/suggestion.py
@@ -21,10 +21,14 @@ class Searcher:
     `suggest` will be passed a trial_id, which will be used in
     subsequent notifications.
 
+    Not all implementations support multi objectives.
+
     Args:
-        metric (str): The training result objective value attribute.
-        mode (str): One of {min, max}. Determines whether objective is
-            minimizing or maximizing the metric attribute.
+        metric (str or list): The training result objective value attribute. If
+            list then list of training result objective value attributes
+        mode (str or list): If string One of {min, max}. If list then list of max and min,
+            Determines whether objective is minimizing or maximizing the metric attribute.
+            match type of metric
 
     .. code-block:: python
 
@@ -65,7 +69,15 @@ class Searcher:
                 "DeprecationWarning: `max_concurrent` is deprecated for this "
                 "search algorithm. Use tune.suggest.ConcurrencyLimiter() "
                 "instead. This will raise an error in future versions of Ray.")
-        assert mode in ["min", "max"], "`mode` must be 'min' or 'max'!"
+
+        # Validate Mode
+        if isinstance(mode, str):
+            assert mode in ["min", "max"], "if `mode` is a str must be 'min' or 'max'!"
+        elif isinstance(mode, list):
+            assert all(mod in ["min", "max"] for mod in mode), "All of mode must be 'min' or 'max'!"
+        else:
+            raise ValueError("Mode most either be a list or string")
+
         self._metric = metric
         self._mode = mode
 

--- a/python/ray/tune/suggest/suggestion.py
+++ b/python/ray/tune/suggest/suggestion.py
@@ -26,9 +26,9 @@ class Searcher:
     Args:
         metric (str or list): The training result objective value attribute. If
             list then list of training result objective value attributes
-        mode (str or list): If string One of {min, max}. If list then list of max and min,
-            Determines whether objective is minimizing or maximizing the metric attribute.
-            match type of metric
+        mode (str or list): If string One of {min, max}. If list then
+            list of max and min, determines whether objective is minimizing
+            or maximizing the metric attribute. Must match type of metric.
 
     .. code-block:: python
 
@@ -70,11 +70,16 @@ class Searcher:
                 "search algorithm. Use tune.suggest.ConcurrencyLimiter() "
                 "instead. This will raise an error in future versions of Ray.")
 
-        # Validate Mode
+        assert isinstance(
+            metric, type(mode)), "metric and mode must be of the same type"
         if isinstance(mode, str):
-            assert mode in ["min", "max"], "if `mode` is a str must be 'min' or 'max'!"
+            assert mode in ["min", "max"
+                            ], "if `mode` is a str must be 'min' or 'max'!"
         elif isinstance(mode, list):
-            assert all(mod in ["min", "max"] for mod in mode), "All of mode must be 'min' or 'max'!"
+            assert len(mode) == len(
+                metric), "Metric and mode must be the same length"
+            assert all(mod in ["min", "max", "obs"] for mod in
+                       mode), "All of mode must be 'min' or 'max' or 'obs'!"
         else:
             raise ValueError("Mode most either be a list or string")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Sigopt allows for multi-objective hyperparameter searches (any many more features). Many of these are very useful! The change I am proposing is backwards compatible and allows for multi-objective hyperparameter searches using SigOpt as well as using existing experiments which fully opens up the original SigOpt API.

Extending the API to allow for existing experiments help us avoid having to make changes around the SigOptSearcher wrapper around SigOpt. This opens up a world of possibilities including prior beliefs and thresholding. (prior beliefs are shown in the added example code)

As a free bonus from this existing experiments will have the correct metric name on the SigOpt dashboard (before features were being called value in SigOpt's dashboard).

Result of running new multi objective example code (non-smoke test):
![image](https://user-images.githubusercontent.com/69156393/91777485-f5003800-ebbd-11ea-859b-bfdc39a02396.png)

Result of running new existing experiment example code:
![image](https://user-images.githubusercontent.com/69156393/91902430-b4f98d80-ec6f-11ea-968e-ca880ac4a3d7.png)


- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Added example that passes testing suite, but is deactivated due to the need for SigOpt API key.
