### PR TITLE
[Java] remove native binary from ray_dist.jar

### DIFF
--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -264,6 +264,12 @@ genrule(
         WORK_DIR="$$(pwd)"
         rm -rf "$$WORK_DIR/python/ray/jars" && mkdir -p "$$WORK_DIR/python/ray/jars"
         cp -f $(location //java:ray_dist_deploy.jar) "$$WORK_DIR/python/ray/jars/ray_dist.jar"
+        chmod +w "$$WORK_DIR/python/ray/jars/ray_dist.jar"
+        zip -d "$$WORK_DIR/python/ray/jars/ray_dist.jar" native/*/gcs_server
+        zip -d "$$WORK_DIR/python/ray/jars/ray_dist.jar" native/*/libray_redis_module.so
+        zip -d "$$WORK_DIR/python/ray/jars/ray_dist.jar" native/*/plasma_store_server
+        zip -d "$$WORK_DIR/python/ray/jars/ray_dist.jar" native/*/raylet
+        zip -d "$$WORK_DIR/python/ray/jars/ray_dist.jar" native/*/redis-server
         date > $@
     """,
     local = 1,

--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -265,11 +265,12 @@ genrule(
         rm -rf "$$WORK_DIR/python/ray/jars" && mkdir -p "$$WORK_DIR/python/ray/jars"
         cp -f $(location //java:ray_dist_deploy.jar) "$$WORK_DIR/python/ray/jars/ray_dist.jar"
         chmod +w "$$WORK_DIR/python/ray/jars/ray_dist.jar"
-        zip -d "$$WORK_DIR/python/ray/jars/ray_dist.jar" native/*/gcs_server
-        zip -d "$$WORK_DIR/python/ray/jars/ray_dist.jar" native/*/libray_redis_module.so
-        zip -d "$$WORK_DIR/python/ray/jars/ray_dist.jar" native/*/plasma_store_server
-        zip -d "$$WORK_DIR/python/ray/jars/ray_dist.jar" native/*/raylet
-        zip -d "$$WORK_DIR/python/ray/jars/ray_dist.jar" native/*/redis-server
+        zip -d "$$WORK_DIR/python/ray/jars/ray_dist.jar" \
+            native/*/gcs_server \
+            native/*/libray_redis_module.so \
+            native/*/plasma_store_server \
+            native/*/raylet \
+            native/*/redis-server
         date > $@
     """,
     local = 1,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Remove following native binaries from ray_dist.jar:
* gcs_server
* libray_redis_module.so
* plasma_store_server
* raylet
* redis-server

`ray_dist.jar` size change from 32M to 20M now.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
