### PR TITLE
[Autoscaler] Change poll interval to 5 sec when checking VMs status

### DIFF
--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -49,6 +49,7 @@ RUN_ENV_TYPES = ["auto", "host", "docker"]
 
 POLL_INTERVAL = 5
 
+
 def _redis():
     global redis_client
     if redis_client is None:
@@ -380,11 +381,11 @@ def teardown_cluster(config_file: str, yes: bool, workers_only: bool,
                     cf.bold(len(A)),
                     _tags=dict(interval="1s"))
 
-                time.sleep(POLL_INTERVAL)  # todo: interval should be a variable
+                time.sleep(
+                    POLL_INTERVAL)  # todo: interval should be a variable
                 A = remaining_nodes()
                 cli_logger.print("{} nodes remaining after {} second(s).",
-                                 cf.bold(len(A)),
-                                 POLL_INTERVAL)
+                                 cf.bold(len(A)), POLL_INTERVAL)
             cli_logger.success("No nodes remaining.")
     finally:
         provider.cleanup()

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -47,6 +47,7 @@ redis_client = None
 
 RUN_ENV_TYPES = ["auto", "host", "docker"]
 
+POLL_INTERVAL = 5
 
 def _redis():
     global redis_client
@@ -379,7 +380,7 @@ def teardown_cluster(config_file: str, yes: bool, workers_only: bool,
                     cf.bold(len(A)),
                     _tags=dict(interval="1s"))
 
-                time.sleep(1)  # todo: interval should be a variable
+                time.sleep(POLL_INTERVAL)  # todo: interval should be a variable
                 A = remaining_nodes()
                 cli_logger.print("{} nodes remaining after 1 second.",
                                  cf.bold(len(A)))
@@ -427,7 +428,7 @@ def kill_node(config_file, yes, hard, override_cluster_name):
 
             _exec(updater, "ray stop", False, False)
 
-        time.sleep(5)
+        time.sleep(POLL_INTERVAL)
 
         if config.get("provider", {}).get("use_internal_ips", False) is True:
             node_ip = provider.internal_ip(node)
@@ -594,7 +595,7 @@ def get_or_create_head_node(config,
                         if len(nodes) == 1:
                             head_node = nodes[0]
                             break
-                        time.sleep(1)
+                        time.sleep(POLL_INTERVAL)
                 cli_logger.newline()
 
         with cli_logger.group(

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -382,8 +382,9 @@ def teardown_cluster(config_file: str, yes: bool, workers_only: bool,
 
                 time.sleep(POLL_INTERVAL)  # todo: interval should be a variable
                 A = remaining_nodes()
-                cli_logger.print("{} nodes remaining after 1 second.",
-                                 cf.bold(len(A)))
+                cli_logger.print("{} nodes remaining after {} second(s).",
+                                 cf.bold(len(A)),
+                                 POLL_INTERVAL)
             cli_logger.success("No nodes remaining.")
     finally:
         provider.cleanup()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently autoscaler polls cloud provider every second to see if instances are up, which results in spikes of DescribeInstance call when creating many nodes.
Changing the default to 5 would improve the situation. It's unlikely to slow down cluster launch time by much, and later in the cluster creation steps, autoscaler will be sleeping with interval of 5 sec to wait for ssh (see usage of READY_CHECK_INTERVAL in [wait_ready](https://github.com/ray-project/ray/blob/dc378a80b77685cc45c2b53e2f484ed9c6d8c44c/python/ray/autoscaler/updater.py#L212).), so 5 sec should be an good interval value.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
