### PR TITLE
[TEST]make retry counts

### DIFF
--- a/python/ray/tests/test_advanced_2.py
+++ b/python/ray/tests/test_advanced_2.py
@@ -580,30 +580,29 @@ def test_many_custom_resources(shutdown_only):
     ray.get(results)
 
 
-def __delete_miscellaneous_item__(resources):
-    del resources["memory"]
-    del resources["object_store_memory"]
-    for key in list(resources.keys()):
-        if key.startswith("node:"):
-            del resources[key]
-
-
 # TODO: 5 retry attempts may be too little for Travis and we may need to
 # increase it if this test begins to be flaky on Travis.
 def test_zero_capacity_deletion_semantics(shutdown_only):
     ray.init(num_cpus=2, num_gpus=1, resources={"test_resource": 1})
+
+    def delete_miscellaneous_item(resources):
+        del resources["memory"]
+        del resources["object_store_memory"]
+        for key in list(resources.keys()):
+            if key.startswith("node:"):
+                del resources[key]
 
     def test():
         resources = ray.available_resources()
         MAX_RETRY_ATTEMPTS = 5
         retry_count = 0
 
-        __delete_miscellaneous_item__(resources)
+        delete_miscellaneous_item(resources)
 
         while resources and retry_count < MAX_RETRY_ATTEMPTS:
             time.sleep(0.1)
             resources = ray.available_resources()
-            __delete_miscellaneous_item__(resources)
+            delete_miscellaneous_item(resources)
             retry_count += 1
 
         if retry_count >= MAX_RETRY_ATTEMPTS:

--- a/python/ray/tests/test_advanced_2.py
+++ b/python/ray/tests/test_advanced_2.py
@@ -580,6 +580,14 @@ def test_many_custom_resources(shutdown_only):
     ray.get(results)
 
 
+def __delete_miscellaneous_item__(resources):
+    del resources["memory"]
+    del resources["object_store_memory"]
+    for key in list(resources.keys()):
+        if key.startswith("node:"):
+            del resources[key]
+
+
 # TODO: 5 retry attempts may be too little for Travis and we may need to
 # increase it if this test begins to be flaky on Travis.
 def test_zero_capacity_deletion_semantics(shutdown_only):
@@ -590,20 +598,12 @@ def test_zero_capacity_deletion_semantics(shutdown_only):
         MAX_RETRY_ATTEMPTS = 5
         retry_count = 0
 
-        del resources["memory"]
-        del resources["object_store_memory"]
-        for key in list(resources.keys()):
-            if key.startswith("node:"):
-                del resources[key]
+        __delete_miscellaneous_item__(resources)
 
         while resources and retry_count < MAX_RETRY_ATTEMPTS:
             time.sleep(0.1)
             resources = ray.available_resources()
-            del resources["memory"]
-            del resources["object_store_memory"]
-            for key in list(resources.keys()):
-                if key.startswith("node:"):
-                    del resources[key]
+            __delete_miscellaneous_item__(resources)
             retry_count += 1
 
         if retry_count >= MAX_RETRY_ATTEMPTS:

--- a/python/ray/tests/test_advanced_2.py
+++ b/python/ray/tests/test_advanced_2.py
@@ -599,11 +599,15 @@ def test_zero_capacity_deletion_semantics(shutdown_only):
         while resources and retry_count < MAX_RETRY_ATTEMPTS:
             time.sleep(0.1)
             resources = ray.available_resources()
+            del resources["memory"]
+            del resources["object_store_memory"]
+            for key in list(resources.keys()):
+                if key.startswith("node:"):
+                    del resources[key]
             retry_count += 1
 
         if retry_count >= MAX_RETRY_ATTEMPTS:
-            raise RuntimeError(
-                "Resources were available even after five retries.", resources)
+            raise RuntimeError("Resources were available even after {} retries.".format(MAX_RETRY_ATTEMPTS), resources)
 
         return resources
 

--- a/python/ray/tests/test_advanced_2.py
+++ b/python/ray/tests/test_advanced_2.py
@@ -607,7 +607,9 @@ def test_zero_capacity_deletion_semantics(shutdown_only):
             retry_count += 1
 
         if retry_count >= MAX_RETRY_ATTEMPTS:
-            raise RuntimeError("Resources were available even after {} retries.".format(MAX_RETRY_ATTEMPTS), resources)
+            raise RuntimeError(
+                "Resources were available even after {} retries.".format(
+                    MAX_RETRY_ATTEMPTS), resources)
 
         return resources
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

in test_advanced_2.py we retry 5 times to wait the resource becoming empty but after first deleing mem/node info we didn't do it again, which makes retries nothing.

We should delete them everty time.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
