### PR TITLE
Atomic Placement Group Part 1, Basic Structure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,8 +159,7 @@ matrix:
         - . ./ci/travis/ci.sh lint
         - . ./ci/travis/ci.sh build
       script:
-        - true  # we still need this block to exist, otherwise it will fall back to the global one
-        - sleep 20
+        - sleep 30  # we still need this block to exist, otherwise it will fall back to the global one
 
     # Build MacOS wheels and MacOS jars
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -160,6 +160,7 @@ matrix:
         - . ./ci/travis/ci.sh build
       script:
         - true  # we still need this block to exist, otherwise it will fall back to the global one
+        - sleep 20
 
     # Build MacOS wheels and MacOS jars
     - os: osx

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -666,8 +666,9 @@ def test_atomic_creation(ray_start_cluster):
     # Destroy one of nodes to fail placement group creation.
     cluster.remove_node(get_other_nodes(cluster, exclude_head=True)[0])
 
-    # Wait on the placement group now. It should be unready because normal actor
-    # takes resources that are required for one of bundle creation.
+    # Wait on the placement group now. It should be unready
+    # because normal actor takes resources that are required
+    # for one of bundle creation.
     ready, unready = ray.wait([pg.ready()], timeout=0)
     assert len(ready) == 0
     assert len(unready) == 1
@@ -682,7 +683,8 @@ def test_atomic_creation(ray_start_cluster):
     # Confirm that the placement group actor is created. It will
     # raise an exception if actor was scheduled before placement group was
     # created.
-    ray.get(pg_actor.ping.remote(), timeout=0.1)
+    # TODO(sang): Turn this on after atomic creation is implemented.
+    # ray.get(pg_actor.ping.remote(), timeout=0.1)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -632,6 +632,7 @@ def test_schedule_placement_group_when_node_add(ray_start_cluster):
     wait_for_condition(is_placement_group_created)
 
 
+@pytest.mark.skip(reason="Not working yet")
 def test_atomic_creation(ray_start_cluster):
     # Setup cluster.
     cluster = ray_start_cluster

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -632,5 +632,58 @@ def test_schedule_placement_group_when_node_add(ray_start_cluster):
     wait_for_condition(is_placement_group_created)
 
 
+def test_atomic_creation(ray_start_cluster):
+    # Setup cluster.
+    cluster = ray_start_cluster
+    bundle_cpu_size = 2
+    bundle_per_node = 2
+    num_nodes = 3
+
+    nodes = [
+        cluster.add_node(num_cpus=bundle_cpu_size * bundle_per_node)
+        for _ in range(num_nodes)
+    ]
+    ray.init(address=cluster.address)
+
+    @ray.remote(num_cpus=1)
+    class NormalActor:
+        def ping(self):
+            pass
+
+    # Create an actor that will fail bundle scheduling.
+    pg = ray.experimental.placement_group(
+        name="name",
+        strategy="SPREAD",
+        bundles=[{
+            "CPU": bundle_cpu_size
+        } for _ in range(num_nodes * bundle_per_node)])
+
+    # Create a placement group actor.
+    # This shouldn't be scheduled until placement group creation is done.
+    pg_actor = NormalActor.options(
+        placement_group=pg,
+        placement_group_bundle_index=num_nodes * bundle_per_node - 1).remote()
+    # Destroy one of nodes to fail placement group creation.
+    cluster.remove_node(get_other_nodes(cluster, exclude_head=True)[0])
+
+    # Wait on the placement group now. It should be unready because normal actor
+    # takes resources that are required for one of bundle creation.
+    ready, unready = ray.wait([pg.ready()], timeout=0)
+    assert len(ready) == 0
+    assert len(unready) == 1
+
+    # Add a node to make bundles to be scheduled.
+    nodes.append(cluster.add_node(num_cpus=bundle_cpu_size * bundle_per_node))
+    # Wait on the placement group creation.
+    ready, unready = ray.wait([pg.ready()])
+    assert len(ready) == 1
+    assert len(unready) == 0
+
+    # Confirm that the placement group actor is created. It will
+    # raise an exception if actor was scheduled before placement group was
+    # created.
+    ray.get(pg_actor.ping.remote(), timeout=0.1)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -168,22 +168,28 @@ class LeaseStatusTracker {
   /// \param leasing_state The state to update.
   /// \return True if succeeds to update. False otherwise.
   bool UpdateLeasingState(LeasingState leasing_state);
+
   /// Placement group of which this leasing context is associated with.
   std::shared_ptr<GcsPlacementGroup> placement_group_;
+
   /// Location of bundles that lease requests were sent.
   /// If schedule success, the decision will be set as schedule_map[bundles[pos]]
   /// else will be set ClientID::Nil().
   std::shared_ptr<BundleLocations> bundle_locations_;
+
   /// Number of lease requests that are returned.
   size_t returned_count_ = 0;
+
   /// The leasing stage. This is used to know the state of current leasing context.
   LeasingState leasing_state_ = LeasingState::SCHEDULING;
+
   /// Map from node ID to the set of bundles for whom we are trying to acquire a lease
   /// from that node. This is needed so that we can retry lease requests from the node
   /// until we receive a reply or the node is removed.
   /// TODO(sang): We don't currently handle retry.
   absl::flat_hash_map<ClientID, absl::flat_hash_set<BundleID>>
       node_to_bundles_when_leasing_;
+
   /// Unplaced bundle specification for this leasing context.
   std::vector<std::shared_ptr<BundleSpecification>> unplaced_bundles_;
 };

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -66,7 +66,12 @@ class GcsPlacementGroupSchedulerInterface {
   virtual void DestroyPlacementGroupBundleResourcesIfExists(
       const PlacementGroupID &placement_group_id) = 0;
 
-  /// Mark the placement group schedule as cancelled. Cancelled bundles will be destroyed.
+  /// Mark the placement group scheduling is cancelled.
+  /// This method will incur check failure if scheduling
+  /// is not actually going on to guarantee strong consistency.
+  ///
+  /// \param placement_group_id The placement group id scheduling is in progress.
+  /// \return void
   virtual void MarkScheduleCancelled(const PlacementGroupID &placement_group_id) = 0;
 
   virtual ~GcsPlacementGroupSchedulerInterface() {}
@@ -132,11 +137,11 @@ class GcsStrictSpreadStrategy : public GcsScheduleStrategy {
 };
 
 enum class LeasingState {
-  // TODO(sang): Use prepare and commit instead for 2PC.
-  /// The phase where lease requests haven't been returned.
-  SCHEDULING,
-  /// The phase where lease requests have returned
-  ALL_RETURNED,
+  /// The first phase of 2PC. It means requests to nodes are sent to prepare resources.
+  PREPARING,
+  /// The second phase of 2PC. It means that all prepare requests succeed, and GCS is
+  /// commiting resources to each node.
+  COMMITING,
   /// Placement group has been removed, and this leasing is not valid.
   CANCELLED
 };
@@ -149,18 +154,63 @@ class LeaseStatusTracker {
                      std::vector<std::shared_ptr<BundleSpecification>> &unplaced_bundles);
   ~LeaseStatusTracker() = default;
 
-  bool MarkLeaseStarted(const ClientID &node_id,
-                        std::shared_ptr<BundleSpecification> bundle);
-  void MarkLeaseReturned(const ClientID &node_id,
-                         std::shared_ptr<BundleSpecification> bundle,
-                         const Status &status);
-  bool IsAllLeaseRequestReturned() const;
-  bool IsLeasingSucceed() const;
+  /// Indicate the tracker that prepare requests are sent to a specific node.
+  ///
+  /// \param node_id Id of a node where prepare request is sent.
+  /// \param bundle Bundle specification the node is supposed to prepare.
+  /// \return False if the prepare phase was already started. True otherwise.
+  bool MarkPreparePhaseStarted(const ClientID &node_id,
+                               std::shared_ptr<BundleSpecification> bundle);
+
+  /// Indicate the tracker that all prepare requests are returned.
+  /// This will update the state to commiting if all prepare requests succeed.
+  /// \param node_id Id of a node where prepare request is returned.
+  /// \param bundle Bundle specification the node was supposed to schedule.
+  /// \param status Status of the prepare response.
+  /// \param void
+  void MarkPreparePhaseDone(const ClientID &node_id,
+                            std::shared_ptr<BundleSpecification> bundle,
+                            const Status &status);
+
+  /// Used to know if all prepare requests are returend.
+  ///
+  /// \return True if all prepare requests are returned
+  bool IsAllPrepareRequestReturned() const;
+
+  /// Used to know if the prepare phase succeed.
+  ///
+  /// \return True if all prepare requests succeed.
+  bool IsPreparePhaseSucceed() const;
+
+  /// Return a placement group this status tracker is associated with.
+  ///
+  /// \return The placement group of this lease status tracker is tracking.
   const std::shared_ptr<GcsPlacementGroup> &GetPlacementGroup() const;
-  const std::vector<std::shared_ptr<BundleSpecification>> &GetUnplacedBundles() const;
-  const std::shared_ptr<BundleLocations> &GetBundleLocations() const;
+
+  /// Return bundles that should be scheduled.
+  ///
+  /// \return List of bundle specification that are supposed to be scheduled.
+  const std::vector<std::shared_ptr<BundleSpecification>> &GetBundlesToSchedule() const;
+
+  /// This method returns bundle locations that succeed to prepare resources.
+  ///
+  /// \return Location of bundles that succeed to prepare resources on a node.
+  const std::shared_ptr<BundleLocations> &GetPreparedBundleLocations() const;
+
+  /// Return the leasing state.
+  ///
+  /// \return Leasing state.
   const LeasingState GetLeasingState() const;
+
+  /// Mark that this leasing is cancelled.
+  ///
+  /// \return void.
   void MarkPlacementGroupScheduleCancelled();
+
+  /// Mark that the commit phase is started.
+  /// There's no need to mark commit phase is done because in that case, we won't need the
+  /// status tracker anymore.
+  void MarkCommitPhaseStarted();
 
  private:
   /// Method to update leasing states.
@@ -172,26 +222,26 @@ class LeaseStatusTracker {
   /// Placement group of which this leasing context is associated with.
   std::shared_ptr<GcsPlacementGroup> placement_group_;
 
-  /// Location of bundles that lease requests were sent.
-  /// If schedule success, the decision will be set as schedule_map[bundles[pos]]
+  /// Location of bundles that prepare requests were sent.
+  /// If prepare succeeds, the decision will be set as schedule_map[bundles[pos]]
   /// else will be set ClientID::Nil().
-  std::shared_ptr<BundleLocations> bundle_locations_;
+  std::shared_ptr<BundleLocations> preparing_bundle_locations_;
 
   /// Number of lease requests that are returned.
-  size_t returned_count_ = 0;
+  size_t prepare_request_returned_count_ = 0;
 
   /// The leasing stage. This is used to know the state of current leasing context.
-  LeasingState leasing_state_ = LeasingState::SCHEDULING;
+  LeasingState leasing_state_ = LeasingState::PREPARING;
 
   /// Map from node ID to the set of bundles for whom we are trying to acquire a lease
   /// from that node. This is needed so that we can retry lease requests from the node
   /// until we receive a reply or the node is removed.
   /// TODO(sang): We don't currently handle retry.
   absl::flat_hash_map<ClientID, absl::flat_hash_set<BundleID>>
-      node_to_bundles_when_leasing_;
+      node_to_bundles_when_preparing_;
 
-  /// Unplaced bundle specification for this leasing context.
-  std::vector<std::shared_ptr<BundleSpecification>> unplaced_bundles_;
+  /// Bundles to schedule.
+  std::vector<std::shared_ptr<BundleSpecification>> bundles_to_schedule_;
 };
 
 /// A data structure that helps fast bundle location lookup.
@@ -272,8 +322,8 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
 
   /// Schedule unplaced bundles of the specified placement group.
   /// If there is no available nodes then the `schedule_failed_handler` will be
-  /// triggered, otherwise the bundle in placement_group will be add into a queue and
-  /// schedule all bundle by calling ReserveResourceFromNode().
+  /// triggered, otherwise the bundle in placement_group will be added into a queue and
+  /// scheduled to all nodes.
   ///
   /// \param placement_group to be scheduled.
   /// \param failure_callback This function is called if the schedule is failed.
@@ -283,18 +333,22 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
       std::function<void(std::shared_ptr<GcsPlacementGroup>)> failure_handler,
       std::function<void(std::shared_ptr<GcsPlacementGroup>)> success_handler) override;
 
-  /// Destroy bundle resources from all nodes in the placement group.
-  /// This doesn't do anything if bundles are already destroyed.
+  /// Destroy the actual bundle resources or locked resources (for 2PC)
+  /// on all nodes associated with this placement group.
+  /// The method is idempotent, meaning if all bundles are already cancelled,
+  /// this method won't do anything.
   ///
   /// \param placement_group_id The id of a placement group to destroy all bundle
-  /// resources.
+  /// or locked resources.
   void DestroyPlacementGroupBundleResourcesIfExists(
       const PlacementGroupID &placement_group_id) override;
 
-  /// Mark the placement group schedule as cancelled.
-  /// Cancelled bundles will be destroyed.
-  /// \param placement_group_id The id of a placement group to mark that scheduling is
-  /// cancelled.
+  /// Mark the placement group scheduling is cancelled.
+  /// This method will incur check failure if scheduling
+  /// is not actually going on to guarantee strong consistency.
+  ///
+  /// \param placement_group_id The placement group id scheduling is in progress.
+  /// \return void
   void MarkScheduleCancelled(const PlacementGroupID &placement_group_id) override;
 
   /// Get bundles belong to the specified node.
@@ -305,15 +359,35 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
       const ClientID &node_id) override;
 
  protected:
-  /// Lease resource from the specified node for the specified bundle.
-  void ReserveResourceFromNode(const std::shared_ptr<BundleSpecification> &bundle,
-                               const std::shared_ptr<ray::rpc::GcsNodeInfo> &node,
-                               const StatusCallback &callback);
+  /// Send a bundle PREPARE request to a node. PREPARE requests will lock resources
+  /// on a node until COMMIT or CANCEL requests are sent to a node.
+  ///
+  /// \param bundle A bundle to schedule on a node.
+  /// \param node A node to prepare resources for a given bundle.
+  /// \param callback
+  /// \return void
+  void PrepareResources(const std::shared_ptr<BundleSpecification> &bundle,
+                        const std::shared_ptr<ray::rpc::GcsNodeInfo> &node,
+                        const StatusCallback &callback);
 
-  /// return resource for the specified node for the specified bundle.
+  /// Send a bundle COMMIT request to a node. This means the placement group creation
+  /// is ready and GCS will commit resources on a given node.
+  ///
+  /// \param bundle A bundle to schedule on a node.
+  /// \param node A node to commit resources for a given bundle.
+  /// \param callback
+  /// \return void
+  void CommitResources(const std::shared_ptr<BundleSpecification> &bundle,
+                       const std::shared_ptr<ray::rpc::GcsNodeInfo> &node,
+                       const StatusCallback callback);
+
+  /// Cacnel prepared or committed resources from a node.
+  /// Nodes will be in charge of tracking state of a bundle.
+  /// This method is supposed to be idempotent.
   ///
   /// \param bundle A description of the bundle to return.
   /// \param node The node that the worker will be returned for.
+  /// \return void
   void CancelResourceReserve(const std::shared_ptr<BundleSpecification> &bundle_spec,
                              const std::shared_ptr<ray::rpc::GcsNodeInfo> &node);
 
@@ -321,12 +395,18 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   std::shared_ptr<ResourceReserveInterface> GetOrConnectLeaseClient(
       const rpc::Address &raylet_address);
 
-  void OnAllBundleSchedulingRequestReturned(
+  /// Get an existing lease client for a given node.
+  std::shared_ptr<ResourceReserveInterface> GetLeaseClientFromNode(
+      const std::shared_ptr<ray::rpc::GcsNodeInfo> &node);
+
+  void OnAllBundlePrepareRequestReturned(
       const std::shared_ptr<LeaseStatusTracker> &lease_status_tracker,
       const std::function<void(std::shared_ptr<GcsPlacementGroup>)>
           &schedule_failure_handler,
       const std::function<void(std::shared_ptr<GcsPlacementGroup>)>
           &schedule_success_handler);
+
+  void CommitAllBundles(const std::shared_ptr<LeaseStatusTracker> &lease_status_tracker);
 
   /// Generate schedule context.
   std::unique_ptr<ScheduleContext> GetScheduleContext(
@@ -351,8 +431,8 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// A vector to store all the schedule strategy.
   std::vector<std::shared_ptr<GcsScheduleStrategy>> scheduler_strategies_;
 
-  /// Index to lookup bundle locations of node or placement group.
-  BundleLocationIndex bundle_location_index_;
+  /// Index to lookup committed bundle locations of node or placement group.
+  BundleLocationIndex committed_bundle_location_index_;
 
   /// Set of placement group that have lease requests in flight to nodes.
   /// It is required to know if placement group has been removed or not.

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -71,7 +71,6 @@ class GcsPlacementGroupSchedulerInterface {
   /// is not actually going on to guarantee strong consistency.
   ///
   /// \param placement_group_id The placement group id scheduling is in progress.
-  /// \return void
   virtual void MarkScheduleCancelled(const PlacementGroupID &placement_group_id) = 0;
 
   virtual ~GcsPlacementGroupSchedulerInterface() {}
@@ -140,8 +139,8 @@ enum class LeasingState {
   /// The first phase of 2PC. It means requests to nodes are sent to prepare resources.
   PREPARING,
   /// The second phase of 2PC. It means that all prepare requests succeed, and GCS is
-  /// commiting resources to each node.
-  COMMITING,
+  /// committing resources to each node.
+  COMMITTING,
   /// Placement group has been removed, and this leasing is not valid.
   CANCELLED
 };
@@ -163,24 +162,43 @@ class LeaseStatusTracker {
                                std::shared_ptr<BundleSpecification> bundle);
 
   /// Indicate the tracker that all prepare requests are returned.
-  /// This will update the state to commiting if all prepare requests succeed.
+  ///
   /// \param node_id Id of a node where prepare request is returned.
   /// \param bundle Bundle specification the node was supposed to schedule.
   /// \param status Status of the prepare response.
   /// \param void
-  void MarkPreparePhaseDone(const ClientID &node_id,
-                            std::shared_ptr<BundleSpecification> bundle,
-                            const Status &status);
+  void MarkPrepareRequestReturned(const ClientID &node_id,
+                                  std::shared_ptr<BundleSpecification> bundle,
+                                  const Status &status);
 
-  /// Used to know if all prepare requests are returend.
+  /// Used to know if all prepare requests are returned.
   ///
-  /// \return True if all prepare requests are returned
-  bool IsAllPrepareRequestReturned() const;
+  /// \return True if all prepare requests are returned. False otherwise.
+  bool AllPrepareRequestsReturned() const;
 
   /// Used to know if the prepare phase succeed.
   ///
-  /// \return True if all prepare requests succeed.
-  bool IsPreparePhaseSucceed() const;
+  /// \return True if all prepare requests were successful.
+  bool AllPrepareRequestsSuccessful() const;
+
+  /// Indicate the tracker that the commit request of a bundle from a node has returned.
+  ///
+  /// \param node_id Id of a node where commit request is returned.
+  /// \param bundle Bundle specification the node was supposed to schedule.
+  /// \param status Status of the returned commit request.
+  void MarkCommitRequestReturned(const ClientID &node_id,
+                                 const std::shared_ptr<BundleSpecification> bundle,
+                                 const Status &status);
+
+  /// Used to know if all commit requests are returend.
+  ///
+  /// \return True if all commit requests are returned. False otherwise.
+  bool AllCommitRequestReturned() const;
+
+  /// Used to know if the commit phase succeed.
+  ///
+  /// \return True if all commit requests were successful..
+  bool AllCommitRequestsSuccessful() const;
 
   /// Return a placement group this status tracker is associated with.
   ///
@@ -197,14 +215,17 @@ class LeaseStatusTracker {
   /// \return Location of bundles that succeed to prepare resources on a node.
   const std::shared_ptr<BundleLocations> &GetPreparedBundleLocations() const;
 
+  /// This method returns bundle locations that succeed to commit resources.
+  ///
+  /// \return Location of bundles that succeed to commit resources on a node.
+  const std::shared_ptr<BundleLocations> &GetUnCommittedBundleLocations() const;
+
   /// Return the leasing state.
   ///
   /// \return Leasing state.
   const LeasingState GetLeasingState() const;
 
   /// Mark that this leasing is cancelled.
-  ///
-  /// \return void.
   void MarkPlacementGroupScheduleCancelled();
 
   /// Mark that the commit phase is started.
@@ -227,8 +248,14 @@ class LeaseStatusTracker {
   /// else will be set ClientID::Nil().
   std::shared_ptr<BundleLocations> preparing_bundle_locations_;
 
-  /// Number of lease requests that are returned.
+  /// Number of prepare requests that are returned.
   size_t prepare_request_returned_count_ = 0;
+
+  /// Number of commit requests that are returned.
+  size_t commit_request_returned_count_ = 0;
+
+  /// Location of bundles that commit requests failed.
+  std::shared_ptr<BundleLocations> uncommitted_bundle_locations_;
 
   /// The leasing stage. This is used to know the state of current leasing context.
   LeasingState leasing_state_ = LeasingState::PREPARING;
@@ -348,7 +375,6 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// is not actually going on to guarantee strong consistency.
   ///
   /// \param placement_group_id The placement group id scheduling is in progress.
-  /// \return void
   void MarkScheduleCancelled(const PlacementGroupID &placement_group_id) override;
 
   /// Get bundles belong to the specified node.
@@ -359,13 +385,12 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
       const ClientID &node_id) override;
 
  protected:
-  /// Send a bundle PREPARE request to a node. PREPARE requests will lock resources
+  /// Send a bundle PREPARE request to a node. The PREPARE request will lock resources
   /// on a node until COMMIT or CANCEL requests are sent to a node.
   ///
   /// \param bundle A bundle to schedule on a node.
   /// \param node A node to prepare resources for a given bundle.
   /// \param callback
-  /// \return void
   void PrepareResources(const std::shared_ptr<BundleSpecification> &bundle,
                         const std::shared_ptr<ray::rpc::GcsNodeInfo> &node,
                         const StatusCallback &callback);
@@ -376,7 +401,6 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// \param bundle A bundle to schedule on a node.
   /// \param node A node to commit resources for a given bundle.
   /// \param callback
-  /// \return void
   void CommitResources(const std::shared_ptr<BundleSpecification> &bundle,
                        const std::shared_ptr<ray::rpc::GcsNodeInfo> &node,
                        const StatusCallback callback);
@@ -387,11 +411,10 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   ///
   /// \param bundle A description of the bundle to return.
   /// \param node The node that the worker will be returned for.
-  /// \return void
   void CancelResourceReserve(const std::shared_ptr<BundleSpecification> &bundle_spec,
                              const std::shared_ptr<ray::rpc::GcsNodeInfo> &node);
 
-  /// Get an existing lease client or connect a new one.
+  /// Get an existing lease client or connect a new one or connect a new one.
   std::shared_ptr<ResourceReserveInterface> GetOrConnectLeaseClient(
       const rpc::Address &raylet_address);
 
@@ -399,6 +422,7 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   std::shared_ptr<ResourceReserveInterface> GetLeaseClientFromNode(
       const std::shared_ptr<ray::rpc::GcsNodeInfo> &node);
 
+  /// Called when all prepare requests are returned from nodes.
   void OnAllBundlePrepareRequestReturned(
       const std::shared_ptr<LeaseStatusTracker> &lease_status_tracker,
       const std::function<void(std::shared_ptr<GcsPlacementGroup>)>
@@ -406,7 +430,20 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
       const std::function<void(std::shared_ptr<GcsPlacementGroup>)>
           &schedule_success_handler);
 
-  void CommitAllBundles(const std::shared_ptr<LeaseStatusTracker> &lease_status_tracker);
+  /// Called when all commit requests are returned from nodes.
+  void OnAllBundleCommitRequestReturned(
+      const std::shared_ptr<LeaseStatusTracker> &lease_status_tracker,
+      const std::function<void(std::shared_ptr<GcsPlacementGroup>)>
+          &schedule_failure_handler,
+      const std::function<void(std::shared_ptr<GcsPlacementGroup>)>
+          &schedule_success_handler);
+
+  /// Commit all bundles recorded in lease status tracker.
+  void CommitAllBundles(const std::shared_ptr<LeaseStatusTracker> &lease_status_tracker,
+                        const std::function<void(std::shared_ptr<GcsPlacementGroup>)>
+                            &schedule_failure_handler,
+                        const std::function<void(std::shared_ptr<GcsPlacementGroup>)>
+                            &schedule_success_handler);
 
   /// Generate schedule context.
   std::unique_ptr<ScheduleContext> GetScheduleContext(

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -120,8 +120,8 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
 
     ASSERT_EQ(2, raylet_client_->num_lease_requested);
     ASSERT_EQ(2, raylet_client_->lease_callbacks.size());
-    ASSERT_TRUE(raylet_client_->GrantResourceReserve());
-    ASSERT_TRUE(raylet_client_->GrantResourceReserve());
+    ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources());
+    ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources());
     WaitPendingDone(failure_placement_groups_, 0);
     WaitPendingDone(success_placement_groups_, 1);
     ASSERT_EQ(placement_group, success_placement_groups_.front());
@@ -152,8 +152,8 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     AddNode(Mocker::GenNodeInfo(0), 2);
     scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler,
                                         success_handler);
-    ASSERT_TRUE(raylet_client_->GrantResourceReserve());
-    ASSERT_TRUE(raylet_client_->GrantResourceReserve());
+    ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources());
+    ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources());
     WaitPendingDone(success_placement_groups_, 1);
   }
 
@@ -229,8 +229,8 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestSchedulePlacementGroupReplyFailure) {
   ASSERT_EQ(2, raylet_client_->lease_callbacks.size());
 
   // Reply failure, so the placement group scheduling failed.
-  ASSERT_TRUE(raylet_client_->GrantResourceReserve(false));
-  ASSERT_TRUE(raylet_client_->GrantResourceReserve(false));
+  ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources(false));
+  ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources(false));
   WaitPendingDone(failure_placement_groups_, 1);
   WaitPendingDone(success_placement_groups_, 0);
   ASSERT_EQ(placement_group, failure_placement_groups_.front());
@@ -285,8 +285,8 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestSchedulePlacementGroupReturnResource)
   ASSERT_EQ(2, raylet_client_->num_lease_requested);
   ASSERT_EQ(2, raylet_client_->lease_callbacks.size());
   // One bundle success and the other failed.
-  ASSERT_TRUE(raylet_client_->GrantResourceReserve());
-  ASSERT_TRUE(raylet_client_->GrantResourceReserve(false));
+  ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources());
+  ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources(false));
   ASSERT_EQ(1, raylet_client_->num_return_requested);
   // Reply the placement_group creation request, then the placement_group should be
   // scheduled successfully.
@@ -318,12 +318,12 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestStrictPackStrategyBalancedScheduling)
                                         success_handler);
 
     if (!raylet_client_->lease_callbacks.empty()) {
-      ASSERT_TRUE(raylet_client_->GrantResourceReserve());
-      ASSERT_TRUE(raylet_client_->GrantResourceReserve());
+      ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources());
+      ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources());
       ++select_node0_count;
     } else {
-      ASSERT_TRUE(raylet_client1_->GrantResourceReserve());
-      ASSERT_TRUE(raylet_client1_->GrantResourceReserve());
+      ASSERT_TRUE(raylet_client1_->GrantPrepareBundleResources());
+      ASSERT_TRUE(raylet_client1_->GrantPrepareBundleResources());
       ++select_node1_count;
     }
   }
@@ -351,8 +351,8 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestStrictPackStrategyResourceCheck) {
       Mocker::GenCreatePlacementGroupRequest("", rpc::PlacementStrategy::STRICT_PACK);
   auto placement_group = std::make_shared<gcs::GcsPlacementGroup>(request);
   scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler, success_handler);
-  ASSERT_TRUE(raylet_client_->GrantResourceReserve());
-  ASSERT_TRUE(raylet_client_->GrantResourceReserve());
+  ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources());
+  ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources());
   WaitPendingDone(success_placement_groups_, 1);
 
   // Node1 has less number of bundles, but it doesn't satisfy the resource
@@ -364,8 +364,8 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestStrictPackStrategyResourceCheck) {
   auto placement_group2 =
       std::make_shared<gcs::GcsPlacementGroup>(create_placement_group_request2);
   scheduler_->ScheduleUnplacedBundles(placement_group2, failure_handler, success_handler);
-  ASSERT_TRUE(raylet_client_->GrantResourceReserve());
-  ASSERT_TRUE(raylet_client_->GrantResourceReserve());
+  ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources());
+  ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources());
   WaitPendingDone(success_placement_groups_, 2);
 }
 
@@ -390,8 +390,8 @@ TEST_F(GcsPlacementGroupSchedulerTest, DestroyPlacementGroup) {
         absl::MutexLock lock(&vector_mutex_);
         success_placement_groups_.emplace_back(std::move(placement_group));
       });
-  ASSERT_TRUE(raylet_client_->GrantResourceReserve());
-  ASSERT_TRUE(raylet_client_->GrantResourceReserve());
+  ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources());
+  ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources());
   WaitPendingDone(failure_placement_groups_, 0);
   WaitPendingDone(success_placement_groups_, 1);
   const auto &placement_group_id = placement_group->GetPlacementGroupID();
@@ -429,9 +429,9 @@ TEST_F(GcsPlacementGroupSchedulerTest, DestroyCancelledPlacementGroup) {
       });
 
   // Now, cancel the schedule request.
-  ASSERT_TRUE(raylet_client_->GrantResourceReserve());
+  ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources());
   scheduler_->MarkScheduleCancelled(placement_group_id);
-  ASSERT_TRUE(raylet_client_->GrantResourceReserve());
+  ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources());
   ASSERT_TRUE(raylet_client_->GrantCancelResourceReserve());
   ASSERT_TRUE(raylet_client_->GrantCancelResourceReserve());
   WaitPendingDone(failure_placement_groups_, 1);
@@ -462,10 +462,10 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestPackStrategyLargeBundlesScheduling) {
   RAY_CHECK(raylet_client_->num_lease_requested > 0);
   RAY_CHECK(raylet_client1_->num_lease_requested > 0);
   for (int index = 0; index < raylet_client_->num_lease_requested; ++index) {
-    ASSERT_TRUE(raylet_client_->GrantResourceReserve());
+    ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources());
   }
   for (int index = 0; index < raylet_client1_->num_lease_requested; ++index) {
-    ASSERT_TRUE(raylet_client1_->GrantResourceReserve());
+    ASSERT_TRUE(raylet_client1_->GrantPrepareBundleResources());
   }
   WaitPendingDone(success_placement_groups_, 1);
 }
@@ -492,8 +492,8 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestRescheduleWhenNodeDead) {
   };
 
   scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler, success_handler);
-  ASSERT_TRUE(raylet_client_->GrantResourceReserve());
-  ASSERT_TRUE(raylet_client1_->GrantResourceReserve());
+  ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources());
+  ASSERT_TRUE(raylet_client1_->GrantPrepareBundleResources());
   WaitPendingDone(success_placement_groups_, 1);
 
   auto bundles_on_node0 =
@@ -509,8 +509,8 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestRescheduleWhenNodeDead) {
   // TODO(ffbin): We need to see which node the other bundles that have been placed are
   // deployed on, and spread them as far as possible. It will be implemented in the next
   // pr.
-  raylet_client_->GrantResourceReserve();
-  raylet_client1_->GrantResourceReserve();
+  raylet_client_->GrantPrepareBundleResources();
+  raylet_client1_->GrantPrepareBundleResources();
   WaitPendingDone(success_placement_groups_, 2);
 }
 
@@ -543,8 +543,8 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestStrictSpreadStrategyResourceCheck) {
   auto node2 = Mocker::GenNodeInfo(2);
   AddNode(node2);
   scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler, success_handler);
-  ASSERT_TRUE(raylet_client_->GrantResourceReserve());
-  ASSERT_TRUE(raylet_client2_->GrantResourceReserve());
+  ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources());
+  ASSERT_TRUE(raylet_client2_->GrantPrepareBundleResources());
   WaitPendingDone(success_placement_groups_, 1);
 }
 

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -394,11 +394,11 @@ TEST_F(GcsPlacementGroupSchedulerTest, DestroyPlacementGroup) {
   ASSERT_TRUE(raylet_client_->GrantPrepareBundleResources());
   WaitPendingDone(failure_placement_groups_, 0);
   WaitPendingDone(success_placement_groups_, 1);
+  RAY_LOG(ERROR) << "sanngbin1";
   const auto &placement_group_id = placement_group->GetPlacementGroupID();
   scheduler_->DestroyPlacementGroupBundleResourcesIfExists(placement_group_id);
   ASSERT_TRUE(raylet_client_->GrantCancelResourceReserve());
   ASSERT_TRUE(raylet_client_->GrantCancelResourceReserve());
-
   // Subsequent destroy request should not do anything.
   scheduler_->DestroyPlacementGroupBundleResourcesIfExists(placement_group_id);
   ASSERT_FALSE(raylet_client_->GrantCancelResourceReserve());

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -158,12 +158,20 @@ struct GcsServerMocker {
 
   class MockRayletResourceClient : public ResourceReserveInterface {
    public:
-    void RequestResourceReserve(
+    void PrepareBundleResources(
         const BundleSpecification &bundle_spec,
-        const ray::rpc::ClientCallback<ray::rpc::RequestResourceReserveReply> &callback)
+        const ray::rpc::ClientCallback<ray::rpc::PrepareBundleResourcesReply> &callback)
         override {
       num_lease_requested += 1;
       lease_callbacks.push_back(callback);
+    }
+
+    void CommitBundleResources(
+        const BundleSpecification &bundle_spec,
+        const ray::rpc::ClientCallback<ray::rpc::CommitBundleResourcesReply> &callback)
+        override {
+      rpc::CommitBundleResourcesReply reply;
+      callback(Status::OK(), reply);
     }
 
     void CancelResourceReserve(
@@ -175,9 +183,9 @@ struct GcsServerMocker {
     }
 
     // Trigger reply to RequestWorkerLease.
-    bool GrantResourceReserve(bool success = true) {
+    bool GrantPrepareBundleResources(bool success = true) {
       Status status = Status::OK();
-      rpc::RequestResourceReserveReply reply;
+      rpc::PrepareBundleResourcesReply reply;
       reply.set_success(success);
       if (lease_callbacks.size() == 0) {
         return false;
@@ -208,7 +216,7 @@ struct GcsServerMocker {
     int num_lease_requested = 0;
     int num_return_requested = 0;
     ClientID node_id = ClientID::FromRandom();
-    std::list<rpc::ClientCallback<rpc::RequestResourceReserveReply>> lease_callbacks = {};
+    std::list<rpc::ClientCallback<rpc::PrepareBundleResourcesReply>> lease_callbacks = {};
     std::list<rpc::ClientCallback<rpc::CancelResourceReserveReply>> return_callbacks = {};
   };
   class MockedGcsActorScheduler : public gcs::GcsActorScheduler {

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -174,7 +174,7 @@ service NodeManagerService {
   // are still needed. And Raylet will release other leased workers.
   rpc ReleaseUnusedWorkers(ReleaseUnusedWorkersRequest)
       returns (ReleaseUnusedWorkersReply);
-  // Request a raylet to lock resources for a bundle. 
+  // Request a raylet to lock resources for a bundle.
   // This is the first phase of 2PC protocol for atomic placement group creation.
   rpc PrepareBundleResources(PrepareBundleResourcesRequest)
       returns (PrepareBundleResourcesReply);

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -43,11 +43,11 @@ message PrepareBundleResourcesRequest {
 }
 
 message PrepareBundleResourcesReply {
-  // The status if resource reserve success.
+  // The status if prepare request was successful.
   bool success = 1;
 }
 
-message CommitBundleResourcesRequest {  
+message CommitBundleResourcesRequest {
   // Bundle containing the requested resources.
   Bundle bundle_spec = 1;
 }

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -37,14 +37,22 @@ message RequestWorkerLeaseReply {
   bool canceled = 4;
 }
 
-message RequestResourceReserveRequest {
+message PrepareBundleResourcesRequest {
   // Bundle containing the requested resources.
   Bundle bundle_spec = 1;
 }
 
-message RequestResourceReserveReply {
+message PrepareBundleResourcesReply {
   // The status if resource reserve success.
   bool success = 1;
+}
+
+message CommitBundleResourcesRequest {  
+  // Bundle containing the requested resources.
+  Bundle bundle_spec = 1;
+}
+
+message CommitBundleResourcesReply {
 }
 
 message CancelResourceReserveRequest {
@@ -166,9 +174,14 @@ service NodeManagerService {
   // are still needed. And Raylet will release other leased workers.
   rpc ReleaseUnusedWorkers(ReleaseUnusedWorkersRequest)
       returns (ReleaseUnusedWorkersReply);
-  // Request resource from the raylet for a bundle.
-  rpc RequestResourceReserve(RequestResourceReserveRequest)
-      returns (RequestResourceReserveReply);
+  // Request a raylet to lock resources for a bundle. 
+  // This is the first phase of 2PC protocol for atomic placement group creation.
+  rpc PrepareBundleResources(PrepareBundleResourcesRequest)
+      returns (PrepareBundleResourcesReply);
+  // Commit bundle resources to a raylet.
+  // This is the second phase of 2PC protocol for atomic placement group creation.
+  rpc CommitBundleResources(CommitBundleResourcesRequest)
+      returns (CommitBundleResourcesReply);
   // Return resource for the raylet.
   rpc CancelResourceReserve(CancelResourceReserveRequest)
       returns (CancelResourceReserveReply);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1819,6 +1819,7 @@ void NodeManager::HandlePrepareBundleResources(
 void NodeManager::HandleCommitBundleResources(
     const rpc::CommitBundleResourcesRequest &request,
     rpc::CommitBundleResourcesReply *reply, rpc::SendReplyCallback send_reply_callback) {
+  send_reply_callback(Status::OK(), nullptr, nullptr);
   // TODO(sang): Implement this in the next PR.
 }
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1795,12 +1795,13 @@ void NodeManager::HandleRequestWorkerLease(const rpc::RequestWorkerLeaseRequest 
   SubmitTask(task);
 }
 
-void NodeManager::HandleRequestResourceReserve(
-    const rpc::RequestResourceReserveRequest &request,
-    rpc::RequestResourceReserveReply *reply, rpc::SendReplyCallback send_reply_callback) {
-  RAY_CHECK(!new_scheduler_enabled_) << "Not implemented";
+void NodeManager::HandlePrepareBundleResources(
+    const rpc::PrepareBundleResourcesRequest &request,
+    rpc::PrepareBundleResourcesReply *reply, rpc::SendReplyCallback send_reply_callback) {
+  // TODO(sang): Port this onto the new scheduler.
+  RAY_CHECK(!new_scheduler_enabled_) << "Not implemented yet.";
   auto bundle_spec = BundleSpecification(request.bundle_spec());
-  RAY_LOG(DEBUG) << "bundle lease request " << bundle_spec.BundleId().first
+  RAY_LOG(DEBUG) << "bundle prepare request " << bundle_spec.BundleId().first
                  << bundle_spec.BundleId().second;
   auto resource_ids = ScheduleBundle(cluster_resource_map_, bundle_spec);
   if (resource_ids.AvailableResources().size() == 0) {
@@ -1813,6 +1814,12 @@ void NodeManager::HandleRequestResourceReserve(
   // Call task dispatch to assign work to the new group.
   TryLocalInfeasibleTaskScheduling();
   DispatchTasks(local_queues_.GetReadyTasksByClass());
+}
+
+void NodeManager::HandleCommitBundleResources(
+    const rpc::CommitBundleResourcesRequest &request,
+    rpc::CommitBundleResourcesReply *reply, rpc::SendReplyCallback send_reply_callback) {
+  // TODO(sang): Implement this in the next PR.
 }
 
 void NodeManager::HandleCancelResourceReserve(

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -552,10 +552,15 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// \return Status indicating whether setup was successful.
   ray::Status SetupPlasmaSubscription();
 
-  /// Handle a `ResourcesLease` request.
-  void HandleRequestResourceReserve(const rpc::RequestResourceReserveRequest &request,
-                                    rpc::RequestResourceReserveReply *reply,
+  /// Handle a `PrepareBundleResources` request.
+  void HandlePrepareBundleResources(const rpc::PrepareBundleResourcesRequest &request,
+                                    rpc::PrepareBundleResourcesReply *reply,
                                     rpc::SendReplyCallback send_reply_callback) override;
+
+  /// Handle a `CommitBundleResources` request.
+  void HandleCommitBundleResources(const rpc::CommitBundleResourcesRequest &request,
+                                   rpc::CommitBundleResourcesReply *reply,
+                                   rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle a `ResourcesReturn` request.
   void HandleCancelResourceReserve(const rpc::CancelResourceReserveRequest &request,

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -378,12 +378,20 @@ void raylet::RayletClient::CancelWorkerLease(
   grpc_client_->CancelWorkerLease(request, callback);
 }
 
-void raylet::RayletClient::RequestResourceReserve(
+void raylet::RayletClient::PrepareBundleResources(
     const BundleSpecification &bundle_spec,
-    const ray::rpc::ClientCallback<ray::rpc::RequestResourceReserveReply> &callback) {
-  rpc::RequestResourceReserveRequest request;
+    const ray::rpc::ClientCallback<ray::rpc::PrepareBundleResourcesReply> &callback) {
+  rpc::PrepareBundleResourcesRequest request;
   request.mutable_bundle_spec()->CopyFrom(bundle_spec.GetMessage());
-  grpc_client_->RequestResourceReserve(request, callback);
+  grpc_client_->PrepareBundleResources(request, callback);
+}
+
+void raylet::RayletClient::CommitBundleResources(
+    const BundleSpecification &bundle_spec,
+    const ray::rpc::ClientCallback<ray::rpc::CommitBundleResourcesReply> &callback) {
+  rpc::CommitBundleResourcesRequest request;
+  request.mutable_bundle_spec()->CopyFrom(bundle_spec.GetMessage());
+  grpc_client_->CommitBundleResources(request, callback);
 }
 
 void raylet::RayletClient::CancelResourceReserve(

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -93,8 +93,10 @@ class ResourceReserveInterface {
  public:
   /// Request a raylet to prepare resources of a given bundle for atomic placement group
   /// creation. This is used for the first phase of atomic placement group creation. The
-  /// callback will be sent via gRPC. \param resource_spec Resources that should be
-  /// allocated for the worker. \return ray::Status
+  /// callback will be sent via gRPC.
+  /// \param resource_spec Resources that should be
+  /// allocated for the worker.
+  /// \return ray::Status
   virtual void PrepareBundleResources(
       const BundleSpecification &bundle_spec,
       const ray::rpc::ClientCallback<ray::rpc::PrepareBundleResourcesReply>
@@ -102,8 +104,10 @@ class ResourceReserveInterface {
 
   /// Request a raylet to commit resources of a given bundle for atomic placement group
   /// creation. This is used for the first phase of atomic placement group creation. The
-  /// callback will be sent via gRPC. \param resource_spec Resources that should be
-  /// allocated for the worker. \return ray::Status
+  /// callback will be sent via gRPC.
+  /// \param resource_spec Resources that should be
+  /// allocated for the worker.
+  /// \return ray::Status
   virtual void CommitBundleResources(
       const BundleSpecification &bundle_spec,
       const ray::rpc::ClientCallback<ray::rpc::CommitBundleResourcesReply> &callback) = 0;
@@ -360,7 +364,7 @@ class RayletClient : public PinObjectsInterface,
       const TaskID &task_id,
       const rpc::ClientCallback<rpc::CancelWorkerLeaseReply> &callback) override;
 
-  /// Implements ResourceReserveInterface.
+  /// Implements PrepareBundleResourcesInterface.
   void PrepareBundleResources(
       const BundleSpecification &bundle_spec,
       const ray::rpc::ClientCallback<ray::rpc::PrepareBundleResourcesReply> &callback)
@@ -372,7 +376,7 @@ class RayletClient : public PinObjectsInterface,
       const ray::rpc::ClientCallback<ray::rpc::CommitBundleResourcesReply> &callback)
       override;
 
-  /// Implements ResourceReserveInterface.
+  /// Implements CancelResourceReserveInterface.
   void CancelResourceReserve(
       BundleSpecification &bundle_spec,
       const ray::rpc::ClientCallback<ray::rpc::CancelResourceReserveReply> &callback)

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -91,13 +91,22 @@ class WorkerLeaseInterface {
 /// Interface for leasing resource.
 class ResourceReserveInterface {
  public:
-  /// Requests a resource from the raylet. The callback will be sent via gRPC.
-  /// \param resource_spec Resources that should be allocated for the worker.
-  /// \return ray::Status
-  virtual void RequestResourceReserve(
+  /// Request a raylet to prepare resources of a given bundle for atomic placement group
+  /// creation. This is used for the first phase of atomic placement group creation. The
+  /// callback will be sent via gRPC. \param resource_spec Resources that should be
+  /// allocated for the worker. \return ray::Status
+  virtual void PrepareBundleResources(
       const BundleSpecification &bundle_spec,
-      const ray::rpc::ClientCallback<ray::rpc::RequestResourceReserveReply>
+      const ray::rpc::ClientCallback<ray::rpc::PrepareBundleResourcesReply>
           &callback) = 0;
+
+  /// Request a raylet to commit resources of a given bundle for atomic placement group
+  /// creation. This is used for the first phase of atomic placement group creation. The
+  /// callback will be sent via gRPC. \param resource_spec Resources that should be
+  /// allocated for the worker. \return ray::Status
+  virtual void CommitBundleResources(
+      const BundleSpecification &bundle_spec,
+      const ray::rpc::ClientCallback<ray::rpc::CommitBundleResourcesReply> &callback) = 0;
 
   virtual void CancelResourceReserve(
       BundleSpecification &bundle_spec,
@@ -352,9 +361,15 @@ class RayletClient : public PinObjectsInterface,
       const rpc::ClientCallback<rpc::CancelWorkerLeaseReply> &callback) override;
 
   /// Implements ResourceReserveInterface.
-  void RequestResourceReserve(
+  void PrepareBundleResources(
       const BundleSpecification &bundle_spec,
-      const ray::rpc::ClientCallback<ray::rpc::RequestResourceReserveReply> &callback)
+      const ray::rpc::ClientCallback<ray::rpc::PrepareBundleResourcesReply> &callback)
+      override;
+
+  /// Implements CommitBundleResourcesInterface.
+  void CommitBundleResources(
+      const BundleSpecification &bundle_spec,
+      const ray::rpc::ClientCallback<ray::rpc::CommitBundleResourcesReply> &callback)
       override;
 
   /// Implements ResourceReserveInterface.

--- a/src/ray/rpc/node_manager/node_manager_client.h
+++ b/src/ray/rpc/node_manager/node_manager_client.h
@@ -82,8 +82,11 @@ class NodeManagerWorkerClient
   /// Cancel a pending worker lease request.
   VOID_RPC_CLIENT_METHOD(NodeManagerService, CancelWorkerLease, grpc_client_, )
 
-  /// Request resource lease.
-  VOID_RPC_CLIENT_METHOD(NodeManagerService, RequestResourceReserve, grpc_client_, )
+  /// Request prepare resources for an atomic placement group creation.
+  VOID_RPC_CLIENT_METHOD(NodeManagerService, PrepareBundleResources, grpc_client_, )
+
+  /// Request prepare resources for an atomic placement group creation.
+  VOID_RPC_CLIENT_METHOD(NodeManagerService, CommitBundleResources, grpc_client_, )
 
   /// Return resource lease.
   VOID_RPC_CLIENT_METHOD(NodeManagerService, CancelResourceReserve, grpc_client_, )

--- a/src/ray/rpc/node_manager/node_manager_client.h
+++ b/src/ray/rpc/node_manager/node_manager_client.h
@@ -85,7 +85,7 @@ class NodeManagerWorkerClient
   /// Request prepare resources for an atomic placement group creation.
   VOID_RPC_CLIENT_METHOD(NodeManagerService, PrepareBundleResources, grpc_client_, )
 
-  /// Request prepare resources for an atomic placement group creation.
+  /// Request commit resources for an atomic placement group creation.
   VOID_RPC_CLIENT_METHOD(NodeManagerService, CommitBundleResources, grpc_client_, )
 
   /// Return resource lease.

--- a/src/ray/rpc/node_manager/node_manager_server.h
+++ b/src/ray/rpc/node_manager/node_manager_server.h
@@ -32,7 +32,8 @@ namespace rpc {
   RPC_SERVICE_HANDLER(NodeManagerService, GetNodeStats)           \
   RPC_SERVICE_HANDLER(NodeManagerService, GlobalGC)               \
   RPC_SERVICE_HANDLER(NodeManagerService, FormatGlobalMemoryInfo) \
-  RPC_SERVICE_HANDLER(NodeManagerService, RequestResourceReserve) \
+  RPC_SERVICE_HANDLER(NodeManagerService, PrepareBundleResources) \
+  RPC_SERVICE_HANDLER(NodeManagerService, CommitBundleResources)  \
   RPC_SERVICE_HANDLER(NodeManagerService, CancelResourceReserve)  \
   RPC_SERVICE_HANDLER(NodeManagerService, RequestObjectSpillage)
 
@@ -66,9 +67,14 @@ class NodeManagerServiceHandler {
                                        rpc::CancelWorkerLeaseReply *reply,
                                        rpc::SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleRequestResourceReserve(
-      const rpc::RequestResourceReserveRequest &request,
-      rpc::RequestResourceReserveReply *reply,
+  virtual void HandlePrepareBundleResources(
+      const rpc::PrepareBundleResourcesRequest &request,
+      rpc::PrepareBundleResourcesReply *reply,
+      rpc::SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleCommitBundleResources(
+      const rpc::CommitBundleResourcesRequest &request,
+      rpc::CommitBundleResourcesReply *reply,
       rpc::SendReplyCallback send_reply_callback) = 0;
 
   virtual void HandleCancelResourceReserve(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Design Doc: https://docs.google.com/document/d/1tPMs2W-557hPmln5xnycK85vKTxJujZIsjq9Rsw9OzY/edit#

This PR restructure the current placement group scheduler to take into account of atomic placement group creation. This includes making the current creation into 2 phases (but only the first phase matters after this refactoring). Without this the whole PR could be really large. If you'd prefer the whole PR at once, please comment. I will close this and make another PR that contains all information.

After this PR, the placement group works in the exact same way as before, but it will send one unnecessary IPC (CommitResources). The actual commit and prepare logic will be implemented in the next PR. 

## Related issue number

https://github.com/ray-project/ray/issues/9807

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
