### PR TITLE
[Java] add exitActor API for java

### DIFF
--- a/java/api/src/main/java/io/ray/api/Ray.java
+++ b/java/api/src/main/java/io/ray/api/Ray.java
@@ -241,4 +241,16 @@ public final class Ray extends RayCall {
       PlacementStrategy strategy) {
     return runtime.createPlacementGroup(bundles, strategy);
   }
+
+  /**
+   * Intentionally exit the current actor.
+   * <p>
+   * This method is used to disconnect an actor and exit the worker.
+   *
+   * @throws RuntimeException An exception is raised if this is a driver or this  worker is not
+   *                          an actor.
+   */
+  public static void exitActor() {
+    runtime.exitActor();
+  }
 }

--- a/java/api/src/main/java/io/ray/api/runtime/RayRuntime.java
+++ b/java/api/src/main/java/io/ray/api/runtime/RayRuntime.java
@@ -193,4 +193,9 @@ public interface RayRuntime {
    * @return The wrapped callable.
    */
   <T> Callable<T> wrapCallable(Callable<T> callable);
+
+  /**
+   * Intentionally exit the current actor.
+   */
+  void exitActor();
 }

--- a/java/runtime/src/main/java/io/ray/runtime/RayDevRuntime.java
+++ b/java/runtime/src/main/java/io/ray/runtime/RayDevRuntime.java
@@ -84,6 +84,11 @@ public class RayDevRuntime extends AbstractRayRuntime {
     super.setAsyncContext(asyncContext);
   }
 
+  @Override
+  public void exitActor() {
+
+  }
+
   private JobId nextJobId() {
     return JobId.fromInt(jobCounter.getAndIncrement());
   }

--- a/java/runtime/src/main/java/io/ray/runtime/exception/RayIntentionalSystemExitException.java
+++ b/java/runtime/src/main/java/io/ray/runtime/exception/RayIntentionalSystemExitException.java
@@ -1,0 +1,15 @@
+package io.ray.runtime.exception;
+
+/**
+ * The exception represents that there is an intentional system exit.
+ */
+public class RayIntentionalSystemExitException extends RuntimeException {
+
+  public RayIntentionalSystemExitException(String message) {
+    super(message);
+  }
+
+  public RayIntentionalSystemExitException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/java/runtime/src/main/java/io/ray/runtime/util/SystemUtil.java
+++ b/java/runtime/src/main/java/io/ray/runtime/util/SystemUtil.java
@@ -1,5 +1,6 @@
 package io.ray.runtime.util;
 
+import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.util.concurrent.locks.ReentrantLock;
@@ -33,5 +34,16 @@ public class SystemUtil {
     }
     return pid;
 
+  }
+
+  public static boolean isProcessAlive(int pid) {
+    Process process;
+    try {
+      process = Runtime.getRuntime().exec(new String[]{"ps", "-p", String.valueOf(pid)});
+      process.waitFor();
+    } catch (InterruptedException | IOException e) {
+      throw new RuntimeException(e);
+    }
+    return process.exitValue() == 0;
   }
 }

--- a/java/test/src/main/java/io/ray/test/ExitActorTest.java
+++ b/java/test/src/main/java/io/ray/test/ExitActorTest.java
@@ -73,7 +73,6 @@ public class ExitActorTest extends BaseTest {
   }
 
   public void testExitActorInMultiWorker() {
-    // TODO (Kai Yang): do we really need to skip it?
     Assert.assertTrue(TestUtils.getRuntime().getRayConfig().numWorkersPerProcess > 1);
     ActorHandle<ExitingActor> actor1 = Ray.actor(ExitingActor::new)
         .setMaxRestarts(10000).remote();

--- a/java/test/src/main/java/io/ray/test/ExitActorTest.java
+++ b/java/test/src/main/java/io/ray/test/ExitActorTest.java
@@ -1,0 +1,115 @@
+package io.ray.test;
+
+import static io.ray.runtime.util.SystemUtil.pid;
+
+import io.ray.api.ActorHandle;
+import io.ray.api.Checkpointable;
+import io.ray.api.ObjectRef;
+import io.ray.api.Ray;
+import io.ray.api.id.ActorId;
+import io.ray.api.id.UniqueId;
+import io.ray.runtime.exception.RayActorException;
+import io.ray.runtime.util.SystemUtil;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@Test(groups = {"cluster"})
+public class ExitActorTest extends BaseTest {
+
+  private static class ExitingActor implements Checkpointable {
+
+    int counter = 0;
+
+    public Integer incr() {
+      return ++counter;
+    }
+
+    public int getPid() {
+      return pid();
+    }
+
+    @Override
+    public boolean shouldCheckpoint(CheckpointContext checkpointContext) {
+      return true;
+    }
+
+    @Override
+    public void saveCheckpoint(ActorId actorId, UniqueId checkpointId) {
+    }
+
+    @Override
+    public UniqueId loadCheckpoint(ActorId actorId, List<Checkpoint> availableCheckpoints) {
+      // Dummy load checkpoint.
+      this.counter = 1;
+      return availableCheckpoints.get(availableCheckpoints.size() - 1).checkpointId;
+    }
+
+    @Override
+    public void checkpointExpired(ActorId actorId, UniqueId checkpointId) {
+    }
+
+    public boolean exit() {
+      Ray.exitActor();
+      return false;
+    }
+  }
+
+  public void testExitActor() throws IOException, InterruptedException {
+    ActorHandle<ExitingActor> actor = Ray.actor(ExitingActor::new)
+        .setMaxRestarts(10000).remote();
+    Assert.assertEquals(1, (int) (actor.task(ExitingActor::incr).remote().get()));
+    int pid = actor.task(ExitingActor::getPid).remote().get();
+    Runtime.getRuntime().exec("kill -9 " + pid);
+    TimeUnit.SECONDS.sleep(1);
+    // Make sure this actor can be reconstructed.
+    Assert.assertEquals(2, (int) actor.task(ExitingActor::incr).remote().get());
+
+    // `exitActor` will exit the actor without reconstructing.
+    ObjectRef<Boolean> obj = actor.task(ExitingActor::exit).remote();
+    Assert.assertThrows(RayActorException.class, obj::get);
+  }
+
+  public void testExitActorInMultiWorker() {
+    // TODO (Kai Yang): do we really need to skip it?
+    Assert.assertTrue(TestUtils.getRuntime().getRayConfig().numWorkersPerProcess > 1);
+    ActorHandle<ExitingActor> actor1 = Ray.actor(ExitingActor::new)
+        .setMaxRestarts(10000).remote();
+    int pid = actor1.task(ExitingActor::getPid).remote().get();
+    ActorHandle<ExitingActor> actor2;
+    while (true) {
+      // Create another actor which share the same process of actor 1.
+      actor2 = Ray.actor(ExitingActor::new).setMaxRestarts(0).remote();
+      int actor2Pid = actor2.task(ExitingActor::getPid).remote().get();
+      if (actor2Pid == pid) {
+        break;
+      }
+    }
+    ObjectRef<Boolean> obj1 = actor1.task(ExitingActor::exit).remote();
+    Assert.assertThrows(RayActorException.class, obj1::get);
+    Assert.assertTrue(SystemUtil.isProcessAlive(pid));
+    // Actor 2 shouldn't exit or be reconstructed.
+    Assert.assertEquals(1, (int) actor2.task(ExitingActor::incr).remote().get());
+    Assert.assertEquals(pid, (int) actor2.task(ExitingActor::getPid).remote().get());
+    Assert.assertTrue(SystemUtil.isProcessAlive(pid));
+  }
+
+  public void testExitActorWithDynamicOptions() {
+    ActorHandle<ExitingActor> actor = Ray.actor(ExitingActor::new)
+        .setMaxRestarts(10000)
+        // Set dummy JVM options to start a worker process with only one worker.
+        .setJvmOptions(" ")
+        .remote();
+    int pid = actor.task(ExitingActor::getPid).remote().get();
+    Assert.assertTrue(SystemUtil.isProcessAlive(pid));
+    ObjectRef<Boolean> obj1 = actor.task(ExitingActor::exit).remote();
+    Assert.assertThrows(RayActorException.class, obj1::get);
+    // Now the actor shouldn't be reconstructed anymore.
+    Assert.assertThrows(RayActorException.class,
+        () -> actor.task(ExitingActor::getPid).remote().get());
+    // Now the worker process should be dead.
+    Assert.assertTrue(TestUtils.waitForCondition(() -> !SystemUtil.isProcessAlive(pid), 5000));
+  }
+}

--- a/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
@@ -144,6 +144,13 @@ JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeInitialize(
         jobject java_return_objects =
             env->CallObjectMethod(java_task_executor, java_task_executor_execute,
                                   ray_function_array_list, args_array_list);
+        // Check whether the exception is `IntentionalSystemExit`.
+        jthrowable throwable = env->ExceptionOccurred();
+        if (throwable &&
+            env->IsInstanceOf(throwable,
+                              java_ray_intentional_system_exit_exception_class)) {
+          return ray::Status::IntentionalSystemExit();
+        }
         RAY_CHECK_JAVA_EXCEPTION(env);
 
         // Process return objects.

--- a/src/ray/core_worker/lib/java/jni_init.cc
+++ b/src/ray/core_worker/lib/java/jni_init.cc
@@ -54,6 +54,7 @@ jclass java_system_class;
 jmethodID java_system_gc;
 
 jclass java_ray_exception_class;
+jclass java_ray_intentional_system_exit_exception_class;
 
 jclass java_jni_exception_util_class;
 jmethodID java_jni_exception_util_get_stack_trace;
@@ -168,6 +169,8 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved) {
   java_system_gc = env->GetStaticMethodID(java_system_class, "gc", "()V");
 
   java_ray_exception_class = LoadClass(env, "io/ray/runtime/exception/RayException");
+  java_ray_intentional_system_exit_exception_class =
+      LoadClass(env, "io/ray/runtime/exception/RayIntentionalSystemExitException");
 
   java_jni_exception_util_class = LoadClass(env, "io/ray/runtime/util/JniExceptionUtil");
   java_jni_exception_util_get_stack_trace = env->GetStaticMethodID(
@@ -265,6 +268,7 @@ void JNI_OnUnload(JavaVM *vm, void *reserved) {
   env->DeleteGlobalRef(java_map_entry_class);
   env->DeleteGlobalRef(java_system_class);
   env->DeleteGlobalRef(java_ray_exception_class);
+  env->DeleteGlobalRef(java_ray_intentional_system_exit_exception_class);
   env->DeleteGlobalRef(java_jni_exception_util_class);
   env->DeleteGlobalRef(java_base_id_class);
   env->DeleteGlobalRef(java_function_descriptor_class);

--- a/src/ray/core_worker/lib/java/jni_utils.h
+++ b/src/ray/core_worker/lib/java/jni_utils.h
@@ -94,6 +94,9 @@ extern jmethodID java_system_gc;
 /// RayException class
 extern jclass java_ray_exception_class;
 
+/// RayIntentionalSystemExitException class
+extern jclass java_ray_intentional_system_exit_exception_class;
+
 /// JniExceptionUtil class
 extern jclass java_jni_exception_util_class;
 /// getStackTrace method of JniExceptionUtil class


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
Add exitActor API for java to exit the current actor
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#10442 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
