### PR TITLE
[tune] Refactored Keras integration callbacks

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -55,6 +55,7 @@ MOCK_MODULES = [
     "tensorflow.contrib.slim",
     "tensorflow.core",
     "tensorflow.core.util",
+    "tensorflow.keras",
     "tensorflow.python",
     "tensorflow.python.client",
     "tensorflow.python.util",
@@ -75,7 +76,9 @@ for mod_name in MOCK_MODULES:
 # ray.rllib.models.action_dist.py and
 # ray.rllib.models.lstm.py will use tf.VERSION
 sys.modules["tensorflow"].VERSION = "9.9.9"
+sys.modules["tensorflow.keras.callbacks"] = ChildClassMock()
 sys.modules["pytorch_lightning"] = ChildClassMock()
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/doc/source/tune/api_docs/integration.rst
+++ b/doc/source/tune/api_docs/integration.rst
@@ -7,8 +7,6 @@ External library integrations (tune.integration)
     :local:
     :depth: 1
 
-.. _tune-integration-kubernetes:
-
 .. _tune-integration-keras:
 
 Keras (tune.integration.keras)
@@ -18,6 +16,7 @@ Keras (tune.integration.keras)
 
 .. autoclass:: ray.tune.integration.keras.TuneReportCheckpointCallback
 
+.. _tune-integration-kubernetes:
 
 Kubernetes (tune.integration.kubernetes)
 ----------------------------------------

--- a/doc/source/tune/api_docs/integration.rst
+++ b/doc/source/tune/api_docs/integration.rst
@@ -9,6 +9,16 @@ External library integrations (tune.integration)
 
 .. _tune-integration-kubernetes:
 
+.. _tune-integration-keras:
+
+Keras (tune.integration.keras)
+------------------------------------------------------
+
+.. autoclass:: ray.tune.integration.keras.TuneReportCallback
+
+.. autoclass:: ray.tune.integration.keras.TuneReportCheckpointCallback
+
+
 Kubernetes (tune.integration.kubernetes)
 ----------------------------------------
 

--- a/python/ray/tune/examples/tune_mnist_keras.py
+++ b/python/ray/tune/examples/tune_mnist_keras.py
@@ -2,7 +2,7 @@ import argparse
 import numpy as np
 from tensorflow.keras.datasets import mnist
 
-from ray.tune.integration.keras import TuneReporterCallback
+from ray.tune.integration.keras import TuneReportCallback
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -39,7 +39,9 @@ def train_mnist(config):
         epochs=epochs,
         verbose=0,
         validation_data=(x_test, y_test),
-        callbacks=[TuneReporterCallback()])
+        callbacks=[TuneReportCallback({
+            "mean_accuracy": "accuracy"
+        })])
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/integration/keras.py
+++ b/python/ray/tune/integration/keras.py
@@ -1,47 +1,264 @@
-from tensorflow import keras
+from typing import Dict, List, Union
+
+from tensorflow.keras.callbacks import Callback
+from ray import tune
+
+import os
 
 
-class TuneReporterCallback(keras.callbacks.Callback):
-    """Tune Callback for Keras."""
+class TuneCallback(Callback):
+    """Base class for Tune's Keras callbacks."""
+    _allowed = [
+        "batch_begin",
+        "batch_end",
+        "epoch_begin",
+        "epoch_end",
+        "train_batch_begin",
+        "train_batch_end",
+        "test_batch_begin",
+        "test_batch_end",
+        "predict_batch_begin",
+        "predict_batch_end",
+        "train_begin",
+        "train_end",
+        "test_begin",
+        "test_end",
+        "predict_begin",
+        "predict_end",
+    ]
 
-    def __init__(self, reporter=None, freq="batch", logs=None):
-        """Initializer.
+    def __init__(self, on: Union[str, List[str]] = "validation_end"):
+        super(TuneCallback, self).__init__()
 
-        Args:
-            freq (str): Sets the frequency of reporting intermediate results.
-                One of ["batch", "epoch"].
-        """
-        self.iteration = 0
-        logs = logs or {}
-        if freq not in ["batch", "epoch"]:
-            raise ValueError("{} not supported as a frequency.".format(freq))
-        self.freq = freq
-        super(TuneReporterCallback, self).__init__()
+        if not isinstance(on, list):
+            on = [on]
+        if any(w not in self._allowed for w in on):
+            raise ValueError(
+                "Invalid trigger time selected: {}. Must be one of {}".format(
+                    on, self._allowed))
+        self._on = on
+
+    def _handle(self, logs: Dict):
+        raise NotImplementedError
+
+    def on_batch_begin(self, batch, logs=None):
+        if "batch_begin" in self._on:
+            self._handle(logs)
 
     def on_batch_end(self, batch, logs=None):
-        from ray import tune
-        logs = logs or {}
-        if not self.freq == "batch":
-            return
-        self.iteration += 1
-        for metric in list(logs):
-            if "loss" in metric and "neg_" not in metric:
-                logs["neg_" + metric] = -logs[metric]
-        if "acc" in logs:
-            tune.report(keras_info=logs, mean_accuracy=logs["acc"])
-        else:
-            tune.report(keras_info=logs, mean_accuracy=logs.get("accuracy"))
+        if "batch_end" in self._on:
+            self._handle(logs)
 
-    def on_epoch_end(self, batch, logs=None):
-        from ray import tune
-        logs = logs or {}
-        if not self.freq == "epoch":
-            return
-        self.iteration += 1
-        for metric in list(logs):
-            if "loss" in metric and "neg_" not in metric:
-                logs["neg_" + metric] = -logs[metric]
-        if "acc" in logs:
-            tune.report(keras_info=logs, mean_accuracy=logs["acc"])
+    def on_epoch_begin(self, epoch, logs=None):
+        if "epoch_begin" in self._on:
+            self._handle(logs)
+
+    def on_epoch_end(self, epoch, logs=None):
+        if "epoch_end" in self._on:
+            self._handle(logs)
+
+    def on_train_batch_begin(self, batch, logs=None):
+        if "train_batch_begin" in self._on:
+            self._handle(logs)
+
+    def on_train_batch_end(self, batch, logs=None):
+        if "train_batch_end" in self._on:
+            self._handle(logs)
+
+    def on_test_batch_begin(self, batch, logs=None):
+        if "test_batch_begin" in self._on:
+            self._handle(logs)
+
+    def on_test_batch_end(self, batch, logs=None):
+        if "test_batch_end" in self._on:
+            self._handle(logs)
+
+    def on_predict_batch_begin(self, batch, logs=None):
+        if "predict_batch_begin" in self._on:
+            self._handle(logs)
+
+    def on_predict_batch_end(self, batch, logs=None):
+        if "predict_batch_end" in self._on:
+            self._handle(logs)
+
+    def on_train_begin(self, logs=None):
+        if "train_begin" in self._on:
+            self._handle(logs)
+
+    def on_train_end(self, logs=None):
+        if "train_end" in self._on:
+            self._handle(logs)
+
+    def on_test_begin(self, logs=None):
+        if "test_begin" in self._on:
+            self._handle(logs)
+
+    def on_test_end(self, logs=None):
+        if "test_end" in self._on:
+            self._handle(logs)
+
+    def on_predict_begin(self, logs=None):
+        if "predict_begin" in self._on:
+            self._handle(logs)
+
+    def on_predict_end(self, logs=None):
+        if "predict_end" in self._on:
+            self._handle(logs)
+
+
+class TuneReportCallback(TuneCallback):
+    """Keras to Ray Tune reporting callback
+
+    Reports metrics to Ray Tune.
+
+    Args:
+        metrics (str|list|dict): Metrics to report to Tune. If this is a list,
+            each item describes the metric key reported to Keras,
+            and it will reported under the same name to Tune. If this is a
+            dict, each key will be the name reported to Tune and the respective
+            value will be the metric key reported to Keras. If this is None,
+            all Keras logs will be reported.
+        on (str|list): When to trigger checkpoint creations. Must be one of
+            the Keras event hooks (less the ``on_``), e.g.
+            "train_start", or "predict_end". Defaults to "epoch_end".
+
+    Example:
+
+    .. code-block:: python
+
+        from ray.tune.integration.keras import TuneReportCallback
+
+        # Report accuracy to Tune after each epoch:
+        model.fit(
+            x_train,
+            y_train,
+            batch_size=batch_size,
+            epochs=epochs,
+            verbose=0,
+            validation_data=(x_test, y_test),
+            callbacks=[TuneReportCallback(
+                {"mean_accuracy": "accuracy"}, on="epoch_end")])
+
+    """
+
+    def __init__(self,
+                 metrics: Union[None, str, List[str], Dict[str, str]] = None,
+                 on: Union[str, List[str]] = "epoch_end"):
+        super(TuneReportCallback, self).__init__(on)
+        if isinstance(metrics, str):
+            metrics = [metrics]
+        self._metrics = metrics
+
+    def _handle(self, logs: Dict):
+        if not self._metrics:
+            report_dict = logs
         else:
-            tune.report(keras_info=logs, mean_accuracy=logs.get("accuracy"))
+            report_dict = {}
+            for key in self._metrics:
+                if isinstance(self._metrics, dict):
+                    metric = self._metrics[key]
+                else:
+                    metric = key
+                report_dict[key] = logs[metric]
+        tune.report(**report_dict)
+
+
+class _TuneCheckpointCallback(TuneCallback):
+    """Keras checkpoint callback
+
+    Saves checkpoints after each validation step.
+
+    Checkpoint are currently not registered if no ``tune.report()`` call
+    is made afterwards. Consider using ``TuneReportCheckpointCallback``
+    instead.
+
+    Args:
+        filename (str): Filename of the checkpoint within the checkpoint
+            directory. Defaults to "checkpoint".
+        on (str|list): When to trigger checkpoint creations. Must be one of
+            the Keras event hooks (less the ``on_``), e.g.
+            "train_start", or "predict_end". Defaults to "epoch_end".
+
+
+    """
+
+    def __init__(self,
+                 filename: str = "checkpoint",
+                 on: Union[str, List[str]] = "epoch_end"):
+        super(_TuneCheckpointCallback, self).__init__(on)
+        self._filename = filename
+        self._epoch = 0
+
+    def _handle(self, logs: Dict):
+        with tune.checkpoint_dir(step=self._epoch) as checkpoint_dir:
+            self.model.save(
+                os.path.join(checkpoint_dir, self._filename), overwrite=True)
+
+    def on_epoch_begin(self, epoch, logs=None):
+        self._epoch = epoch
+        super(_TuneCheckpointCallback, self).on_epoch_begin(epoch, logs)
+
+
+class TuneReportCheckpointCallback(TuneCallback):
+    """Keras report and checkpoint callback
+
+    Saves checkpoints after each validation step. Also reports metrics to Tune,
+    which is needed for checkpoint registration.
+
+    Args:
+        metrics (str|list|dict): Metrics to report to Tune. If this is a list,
+            each item describes the metric key reported to Keras,
+            and it will reported under the same name to Tune. If this is a
+            dict, each key will be the name reported to Tune and the respective
+            value will be the metric key reported to Keras. If this is None,
+            all Keras logs will be reported.
+        filename (str): Filename of the checkpoint within the checkpoint
+            directory. Defaults to "checkpoint".
+        on (str|list): When to trigger checkpoint creations. Must be one of
+            the Keras event hooks (less the ``on_``), e.g.
+            "train_start", or "predict_end". Defaults to "epoch_end".
+
+
+    Example:
+
+    .. code-block:: python
+
+        from ray.tune.integration.keras import TuneReportCheckpointCallback
+
+        # Save checkpoint and report accuracy to Tune after each epoch:
+        model.fit(
+            x_train,
+            y_train,
+            batch_size=batch_size,
+            epochs=epochs,
+            verbose=0,
+            validation_data=(x_test, y_test),
+            callbacks=[TuneReportCheckpointCallback(
+                metrics={"mean_accuracy": "accuracy"},
+                filename="model",
+                on="epoch_end")])
+
+
+    """
+
+    def __init__(self,
+                 metrics: Union[None, str, List[str], Dict[str, str]] = None,
+                 filename: str = "checkpoint",
+                 on: Union[str, List[str]] = "epoch_end"):
+        super(TuneReportCheckpointCallback, self).__init__(on)
+        self._checkpoint = _TuneCheckpointCallback(filename, on)
+        self._report = TuneReportCallback(metrics, on)
+
+    def _handle(self, logs: Dict):
+        self._checkpoint._handle(logs)
+        self._report._handle(logs)
+
+    def on_epoch_begin(self, epoch, logs=None):
+        # Pass through for the checkpoint callback to register epoch
+        self._checkpoint.on_epoch_begin(epoch, logs)
+        self._report.on_epoch_begin(epoch, logs)
+
+    def set_model(self, model):
+        # Pass through for the checkpoint callback to set model
+        self._checkpoint.set_model(model)
+        self._report.set_model(model)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This refactors the existing Keras reporter callback to the API of the PyTorch Lightning/XGBoost callbacks and adds a Tune checkpoint callback.

## Related issue number

Alternative to #10505

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
