### PR TITLE
Remove unnecessary output when connecting to a cluster.

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -622,6 +622,7 @@ def init(
 
     if address:
         redis_address, _, _ = services.validate_redis_address(address)
+        print("Connecting to existing Ray cluster at address:", redis_address)
     else:
         redis_address = None
 

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -22,8 +22,8 @@ namespace gcs {
 GlobalStateAccessor::GlobalStateAccessor(const std::string &redis_address,
                                          const std::string &redis_password,
                                          bool is_test) {
-  RAY_LOG(INFO) << "Redis server address = " << redis_address
-                << ", is test flag = " << is_test;
+  RAY_LOG(DEBUG) << "Redis server address = " << redis_address
+                 << ", is test flag = " << is_test;
   std::vector<std::string> address;
   boost::split(address, redis_address, boost::is_any_of(":"));
   RAY_CHECK(address.size() == 2);

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -89,7 +89,7 @@ Status ServiceBasedJobInfoAccessor::AsyncSubscribeAll(
 }
 
 void ServiceBasedJobInfoAccessor::AsyncResubscribe(bool is_pubsub_server_restarted) {
-  RAY_LOG(INFO) << "Reestablishing subscription for job info.";
+  RAY_LOG(DEBUG) << "Reestablishing subscription for job info.";
   // If only the GCS sever has restarted, we only need to fetch data from the GCS server.
   // If the pub-sub server has also restarted, we need to resubscribe to the pub-sub
   // server first, then fetch data from the GCS server.
@@ -419,7 +419,7 @@ Status ServiceBasedActorInfoAccessor::AsyncGetCheckpointID(
 }
 
 void ServiceBasedActorInfoAccessor::AsyncResubscribe(bool is_pubsub_server_restarted) {
-  RAY_LOG(INFO) << "Reestablishing subscription for actor info.";
+  RAY_LOG(DEBUG) << "Reestablishing subscription for actor info.";
   // If only the GCS sever has restarted, we only need to fetch data from the GCS server.
   // If the pub-sub server has also restarted, we need to resubscribe to the pub-sub
   // server first, then fetch data from the GCS server.
@@ -805,7 +805,7 @@ void ServiceBasedNodeInfoAccessor::HandleNotification(const GcsNodeInfo &node_in
 }
 
 void ServiceBasedNodeInfoAccessor::AsyncResubscribe(bool is_pubsub_server_restarted) {
-  RAY_LOG(INFO) << "Reestablishing subscription for node info.";
+  RAY_LOG(DEBUG) << "Reestablishing subscription for node info.";
   // If only the GCS sever has restarted, we only need to fetch data from the GCS server.
   // If the pub-sub server has also restarted, we need to resubscribe to the pub-sub
   // server first, then fetch data from the GCS server.
@@ -1081,7 +1081,7 @@ Status ServiceBasedTaskInfoAccessor::AttemptTaskReconstruction(
 }
 
 void ServiceBasedTaskInfoAccessor::AsyncResubscribe(bool is_pubsub_server_restarted) {
-  RAY_LOG(INFO) << "Reestablishing subscription for task info.";
+  RAY_LOG(DEBUG) << "Reestablishing subscription for task info.";
   // If only the GCS sever has restarted, we only need to fetch data from the GCS server.
   // If the pub-sub server has also restarted, we need to resubscribe to the pub-sub
   // server first, then fetch data from the GCS server.
@@ -1256,7 +1256,7 @@ Status ServiceBasedObjectInfoAccessor::AsyncSubscribeToLocations(
 }
 
 void ServiceBasedObjectInfoAccessor::AsyncResubscribe(bool is_pubsub_server_restarted) {
-  RAY_LOG(INFO) << "Reestablishing subscription for object locations.";
+  RAY_LOG(DEBUG) << "Reestablishing subscription for object locations.";
   // If only the GCS sever has restarted, we only need to fetch data from the GCS server.
   // If the pub-sub server has also restarted, we need to resubscribe to the pub-sub
   // server first, then fetch data from the GCS server.
@@ -1367,7 +1367,7 @@ Status ServiceBasedWorkerInfoAccessor::AsyncSubscribeToWorkerFailures(
 }
 
 void ServiceBasedWorkerInfoAccessor::AsyncResubscribe(bool is_pubsub_server_restarted) {
-  RAY_LOG(INFO) << "Reestablishing subscription for worker failures.";
+  RAY_LOG(DEBUG) << "Reestablishing subscription for worker failures.";
   // If the pub-sub server has restarted, we need to resubscribe to the pub-sub server.
   if (subscribe_operation_ != nullptr && is_pubsub_server_restarted) {
     RAY_CHECK_OK(subscribe_operation_(nullptr));

--- a/src/ray/gcs/gcs_client/service_based_gcs_client.cc
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.cc
@@ -83,7 +83,7 @@ Status ServiceBasedGcsClient::Connect(boost::asio::io_service &io_service) {
 
   is_connected_ = true;
 
-  RAY_LOG(INFO) << "ServiceBasedGcsClient Connected.";
+  RAY_LOG(DEBUG) << "ServiceBasedGcsClient connected.";
   return Status::OK();
 }
 
@@ -192,8 +192,8 @@ void ServiceBasedGcsClient::ReconnectGcsServer() {
       RAY_LOG(DEBUG) << "Attemptting to reconnect to GCS server: " << address.first << ":"
                      << address.second;
       if (Ping(address.first, address.second, 100)) {
-        RAY_LOG(INFO) << "Reconnected to GCS server: " << address.first << ":"
-                      << address.second;
+        RAY_LOG(DEBUG) << "Reconnected to GCS server: " << address.first << ":"
+                       << address.second;
         break;
       }
     }

--- a/src/ray/gcs/redis_client.cc
+++ b/src/ray/gcs/redis_client.cc
@@ -143,7 +143,7 @@ Status RedisClient::Connect(std::vector<boost::asio::io_service *> io_services) 
   Attach();
 
   is_connected_ = true;
-  RAY_LOG(INFO) << "RedisClient connected.";
+  RAY_LOG(DEBUG) << "RedisClient connected.";
 
   return Status::OK();
 }

--- a/src/ray/gcs/redis_gcs_client.cc
+++ b/src/ray/gcs/redis_gcs_client.cc
@@ -81,7 +81,7 @@ Status RedisGcsClient::Connect(boost::asio::io_service &io_service) {
 
   is_connected_ = true;
 
-  RAY_LOG(INFO) << "RedisGcsClient Connected.";
+  RAY_LOG(DEBUG) << "RedisGcsClient connected.";
 
   return Status::OK();
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Removes a bunch of unnecessary output from RAY_LOG statements when connecting to a running cluster. Unfortunately I couldn't think of a quick way to log these to the proper glog files so instead I just made them debug for now.

Also adds a useful print statement that an existing cluster is being connected to:
```
In [1]: import ray
In [2]: ray.init(address="auto")
Connecting to existing Ray cluster at address: 192.168.0.174:6379
Out[2]: 
{'metrics_export_port': 64686,
 'node_ip_address': '192.168.0.174',
 'object_store_address': '/tmp/ray/session_2020-09-02_16-45-06_231021_65338/sockets/plasma_store',
 'raylet_ip_address': '192.168.0.174',
 'raylet_socket_name': '/tmp/ray/session_2020-09-02_16-45-06_231021_65338/sockets/raylet',
 'redis_address': '192.168.0.174:6379',
 'session_dir': '/tmp/ray/session_2020-09-02_16-45-06_231021_65338',
 'webui_url': 'localhost:8265'}
```

 Could remove this but I think it would be helpful to catch cases where the user doesn't expect a cluster to be running and good to make things more explicit/clear.

## Related issue number

Closes https://github.com/ray-project/ray/issues/10511

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
