### PR TITLE
Fix passing system-config parameter to ray start

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -506,8 +506,7 @@ def start(node_ip_address, redis_address, address, redis_port, port,
         dashboard_port=dashboard_port,
         java_worker_options=java_worker_options,
         load_code_from_local=load_code_from_local,
-        _system_config=json.loads(system_config)
-        if system_config else system_config,
+        _system_config=system_config,
         lru_evict=lru_evict,
         enable_object_reconstruction=enable_object_reconstruction,
         metrics_export_port=metrics_export_port)

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -371,6 +371,13 @@ def test_calling_start_ray_head(call_ray_stop_only):
     check_call_ray(["start", "--head", "--node-ip-address", "127.0.0.1"])
     check_call_ray(["stop"])
 
+    # Test starting Ray with a system config parameter set.
+    check_call_ray([
+        "start", "--head", "--system-config",
+        "{\"metrics_report_interval_ms\":100}"
+    ])
+    check_call_ray(["stop"])
+
     # Test starting Ray with the object manager and node manager ports
     # specified.
     check_call_ray([


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes a bug introduced in https://github.com/ray-project/ray/pull/10333 where passing a valid json dict to `--system-config` threw the following error because we `json.loads`'ed it twice:
```
code/ray % ray start --head --system-config="{\"1\": \"2\"}"                                                   
Traceback (most recent call last):                                                                             
  File "/Users/eoakes/anaconda3/bin/ray", line 11, in <module>                                                 
    load_entry_point('ray', 'console_scripts', 'ray')()                                                        
  File "/Users/eoakes/code/ray/python/ray/scripts/scripts.py", line 1599, in main                              
    return cli()                                                                                               
  File "/Users/eoakes/anaconda3/lib/python3.6/site-packages/click/core.py", line 764, in __call__              
    return self.main(*args, **kwargs)                                                                          
  File "/Users/eoakes/anaconda3/lib/python3.6/site-packages/click/core.py", line 717, in main                  
    rv = self.invoke(ctx)                                                                                      
  File "/Users/eoakes/anaconda3/lib/python3.6/site-packages/click/core.py", line 1137, in invoke               
    return _process_result(sub_ctx.command.invoke(sub_ctx))                                                    
  File "/Users/eoakes/anaconda3/lib/python3.6/site-packages/click/core.py", line 956, in invoke                
    return ctx.invoke(self.callback, **ctx.params)                                                             
  File "/Users/eoakes/anaconda3/lib/python3.6/site-packages/click/core.py", line 555, in invoke                
    return callback(*args, **kwargs)                                                                           
  File "/Users/eoakes/code/ray/python/ray/scripts/scripts.py", line 510, in start
    if system_config else system_config,
  File "/Users/eoakes/anaconda3/lib/python3.6/json/__init__.py", line 348, in loads
    'not {!r}'.format(s.__class__.__name__))
TypeError: the JSON object must be str, bytes or bytearray, not 'dict'
```

Also adds a test.

## Related issue number

Closes https://github.com/ray-project/ray/issues/10515

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
