### PR TITLE
[Streaming]Fix streaming py test for 1.0 APIs

### DIFF
--- a/streaming/python/examples/wordcount.py
+++ b/streaming/python/examples/wordcount.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     titles_file = str(args.titles_file)
 
-    ray.init(load_code_from_local=True, include_java=True)
+    ray.init(_load_code_from_local=True, _include_java=True)
 
     ctx = StreamingContext.Builder() \
         .option(Config.CHANNEL_TYPE, Config.NATIVE_CHANNEL) \

--- a/streaming/python/tests/test_stream.py
+++ b/streaming/python/tests/test_stream.py
@@ -3,7 +3,7 @@ from ray.streaming import StreamingContext
 
 
 def test_data_stream():
-    ray.init(load_code_from_local=True, include_java=True)
+    ray.init(_load_code_from_local=True, _include_java=True)
     ctx = StreamingContext.Builder().build()
     stream = ctx.from_values(1, 2, 3)
     java_stream = stream.as_java_stream()
@@ -17,7 +17,7 @@ def test_data_stream():
 
 
 def test_key_data_stream():
-    ray.init(load_code_from_local=True, include_java=True)
+    ray.init(_load_code_from_local=True, _include_java=True)
     ctx = StreamingContext.Builder().build()
     key_stream = ctx.from_values(
         "a", "b", "c").map(lambda x: (x, 1)).key_by(lambda x: x[0])
@@ -32,7 +32,7 @@ def test_key_data_stream():
 
 
 def test_stream_config():
-    ray.init(load_code_from_local=True, include_java=True)
+    ray.init(_load_code_from_local=True, _include_java=True)
     ctx = StreamingContext.Builder().build()
     stream = ctx.from_values(1, 2, 3)
     stream.with_config("k1", "v1")

--- a/streaming/python/tests/test_union_stream.py
+++ b/streaming/python/tests/test_union_stream.py
@@ -5,7 +5,7 @@ from ray.streaming import StreamingContext
 
 
 def test_union_stream():
-    ray.init(load_code_from_local=True, include_java=True)
+    ray.init(_load_code_from_local=True, _include_java=True)
     ctx = StreamingContext.Builder() \
         .option("streaming.metrics.reporters", "") \
         .build()

--- a/streaming/python/tests/test_word_count.py
+++ b/streaming/python/tests/test_word_count.py
@@ -4,7 +4,7 @@ from ray.streaming import StreamingContext
 
 
 def test_word_count():
-    ray.init(load_code_from_local=True, include_java=True)
+    ray.init(_load_code_from_local=True, _include_java=True)
     ctx = StreamingContext.Builder() \
         .build()
     ctx.read_text_file(__file__) \
@@ -23,7 +23,7 @@ def test_word_count():
 
 
 def test_simple_word_count():
-    ray.init(load_code_from_local=True, include_java=True)
+    ray.init(_load_code_from_local=True, _include_java=True)
     ctx = StreamingContext.Builder() \
         .build()
     sink_file = "/tmp/ray_streaming_test_simple_word_count.txt"


### PR DESCRIPTION
## Why are these changes needed?

Fix streaming py test for 1.0 APIs

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
