### PR TITLE
[Streaming] Remove is_direct_call param

### DIFF
--- a/streaming/python/tests/test_direct_transfer.py
+++ b/streaming/python/tests/test_direct_transfer.py
@@ -101,8 +101,8 @@ class Worker:
 
 def test_queue():
     ray.init()
-    writer = Worker._remote(is_direct_call=True)
-    reader = Worker._remote(is_direct_call=True)
+    writer = Worker._remote()
+    reader = Worker._remote()
     channel_id_str = transfer.ChannelID.gen_random_id()
     inits = [
         writer.init_writer.remote(channel_id_str, pickle.dumps(reader)),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

remove is_direct_call param in python tests. this param is removed in new API.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
