### PR TITLE
object_manager: Implement Chunk Batching on Push

### DIFF
--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -51,6 +51,8 @@ cdef extern from "ray/common/ray_config.h" nogil:
 
         uint64_t object_manager_default_chunk_size() const
 
+        uint64_t object_manager_default_batch_size() const
+
         int num_workers_per_process_python() const
 
         int num_workers_per_process_java() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -89,6 +89,10 @@ cdef class Config:
         return RayConfig.instance().object_manager_default_chunk_size()
 
     @staticmethod
+    def object_manager_default_batch_size():
+        return RayConfig.instance().object_manager_default_batch_size()
+
+    @staticmethod
     def num_workers_per_process_python():
         return RayConfig.instance().num_workers_per_process_python()
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -193,6 +193,11 @@ RAY_CONFIG(int, object_manager_repeated_push_delay_ms, 60000)
 /// chunks exceeds the number of available sending threads.
 RAY_CONFIG(uint64_t, object_manager_default_chunk_size, 1000000)
 
+/// The number of chunks to send at once before waiting for confirmation.
+/// More chunks means less latency, fewer chunks means better multiplexing of
+/// RPC calls.
+RAY_CONFIG(uint64_t, object_manager_default_batch_size, 100)
+
 /// Number of workers per Python worker process
 RAY_CONFIG(int, num_workers_per_process_python, 1)
 

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -462,7 +462,6 @@ void ObjectManager::Push(const ObjectID &object_id, const ClientID &client_id) {
     UniqueID push_id = UniqueID::FromRandom();
     SendChunkBatch(push_id, object_id, owner_address, client_id, data_size, metadata_size,
                    0 /* from_chunk_index */, num_chunks, rpc_client);
-    }
   } else {
     // Push is best effort, so do nothing here.
     RAY_LOG(ERROR)
@@ -470,21 +469,41 @@ void ObjectManager::Push(const ObjectID &object_id, const ClientID &client_id) {
   }
 }
 
-ray::Status ObjectManager::SendChunkBatch(
+void ObjectManager::SendChunkBatch(
     const UniqueID &push_id, const ObjectID &object_id, const rpc::Address &owner_address,
     const ClientID &client_id, uint64_t data_size, uint64_t metadata_size,
     uint64_t from_chunk_index, uint64_t num_chunks, std::shared_ptr<rpc::ObjectManagerClient> rpc_client) {
 
-    for (uint64_t chunk_index = 0; chunk_index < num_chunks; ++chunk_index) {
+    uint64_t max_batch = RayConfig::instance().object_manager_default_batch_size();
+    uint64_t n = 1;
+
+    uint64_t index = from_chunk_index;
+
+    while (true) {
+      if (n > max_batch) {
+        break;
+      }
+      if (index >= num_chunks) {
+        break;
+      }
+      uint64_t send_num_chunks = 0;
+      if (n == max_batch && index != num_chunks - 1) {
+        send_num_chunks = num_chunks;
+      }
+
       rpc_service_.post([this, push_id, object_id, owner_address, client_id, data_size,
-                         metadata_size, chunk_index, rpc_client]() {
+                         metadata_size, index, send_num_chunks, rpc_client]() {
         auto st = SendObjectChunk(push_id, object_id, owner_address, client_id, data_size,
-                                  metadata_size, chunk_index, rpc_client);
+                                  metadata_size, index, send_num_chunks,  rpc_client);
         if (!st.ok()) {
           RAY_LOG(WARNING) << "Send object " << object_id << " chunk failed due to "
-                           << st.message() << ", chunk index " << chunk_index;
+                           << st.message() << ", chunk index " << index;
         }
       });
+
+      index++;
+      n++;
+    }
 }
 
 ray::Status ObjectManager::SendObjectChunk(
@@ -520,10 +539,10 @@ ray::Status ObjectManager::SendObjectChunk(
   push_request.set_data(chunk_info.data, chunk_info.buffer_length);
 
   // record the time cost between send chunk and receive reply
-  rpc::ClientCallback<rpc::PushReply> callback = [this, start_time, object_id, client_id,
-                                                  chunk_index](
-                                                     const Status &status,
-                                                     const rpc::PushReply &reply) {
+  rpc::ClientCallback<rpc::PushReply> callback =
+      [this, start_time, object_id, client_id, chunk_index,
+      push_id, data_size, owner_address, metadata_size, rpc_client, continuation_num_chunks]
+          ( const Status &status, const rpc::PushReply &reply) {
     // TODO: Just print warning here, should we try to resend this chunk?
     if (!status.ok()) {
       RAY_LOG(WARNING) << "Send object " << object_id << " chunk to client " << client_id
@@ -532,6 +551,14 @@ ray::Status ObjectManager::SendObjectChunk(
     }
     double end_time = absl::GetCurrentTimeNanos() / 1e9;
     HandleSendFinished(object_id, client_id, chunk_index, start_time, end_time, status);
+
+    // If there are more chunks to send, sent the next batch.
+    if (continuation_num_chunks != 0) {
+      SendChunkBatch(
+          push_id, object_id, owner_address,
+          client_id, data_size, metadata_size,
+          chunk_index + 1, continuation_num_chunks, rpc_client);
+    }
   };
   rpc_client->Push(push_request, callback);
 

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -147,10 +147,9 @@ class ObjectManager : public ObjectManagerInterface,
   /// \param num_chunks Total number of chunks in the object
   /// \param rpc_client Rpc client used to send message to remote object manager
   void SendChunkBatch(const UniqueID &push_id, const ObjectID &object_id,
-                      const rpc::Address &owner_address,
-                      const ClientID &client_id, uint64_t data_size,
-                      uint64_t metadata_size, uint64_t from_chunk_index,
-                      uint64_t num_chunks,
+                      const rpc::Address &owner_address, const ClientID &client_id,
+                      uint64_t data_size, uint64_t metadata_size,
+                      uint64_t from_chunk_index, uint64_t num_chunks,
                       std::shared_ptr<rpc::ObjectManagerClient> rpc_client);
 
   /// Send object to remote object manager

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -146,12 +146,12 @@ class ObjectManager : public ObjectManagerInterface,
   /// \param from_chunk_index Starting chunk index of the batch
   /// \param num_chunks Total number of chunks in the object
   /// \param rpc_client Rpc client used to send message to remote object manager
-  ray::Status SendChunkBatch(const UniqueID &push_id, const ObjectID &object_id,
-                             const rpc::Address &owner_address,
-                             const ClientID &client_id, uint64_t data_size,
-                             uint64_t metadata_size, uint64_t from_chunk_index,
-                             uint64_t num_chunks,
-                             std::shared_ptr<rpc::ObjectManagerClient> rpc_client);
+  void SendChunkBatch(const UniqueID &push_id, const ObjectID &object_id,
+                      const rpc::Address &owner_address,
+                      const ClientID &client_id, uint64_t data_size,
+                      uint64_t metadata_size, uint64_t from_chunk_index,
+                      uint64_t num_chunks,
+                      std::shared_ptr<rpc::ObjectManagerClient> rpc_client);
 
   /// Send object to remote object manager
   ///

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -134,6 +134,25 @@ class ObjectManager : public ObjectManagerInterface,
                          rpc::FreeObjectsReply *reply,
                          rpc::SendReplyCallback send_reply_callback) override;
 
+  /// Enqueue a limited number of object chunks to send to remote object manager
+  ///
+  /// Object will be transfered as a sequence of chunks, small object(defined in config)
+  /// contains only one chunk
+  /// \param push_id Unique push id to indicate this push request
+  /// \param object_id Object id
+  /// \param owner_address The address of the object's owner
+  /// \param data_size Data size
+  /// \param metadata_size Metadata size
+  /// \param from_chunk_index Starting chunk index of the batch
+  /// \param num_chunks Total number of chunks in the object
+  /// \param rpc_client Rpc client used to send message to remote object manager
+  ray::Status SendChunkBatch(const UniqueID &push_id, const ObjectID &object_id,
+                             const rpc::Address &owner_address,
+                             const ClientID &client_id, uint64_t data_size,
+                             uint64_t metadata_size, uint64_t from_chunk_index,
+                             uint64_t num_chunks,
+                             std::shared_ptr<rpc::ObjectManagerClient> rpc_client);
+
   /// Send object to remote object manager
   ///
   /// Object will be transfered as a sequence of chunks, small object(defined in config)
@@ -144,11 +163,15 @@ class ObjectManager : public ObjectManagerInterface,
   /// \param data_size Data size
   /// \param metadata_size Metadata size
   /// \param chunk_index Chunk index of this object chunk, start with 0
+  /// \param continuation_num_chunks If non-zero, this request will
+  /// trigger the next batch of chunks on completion, and the value is the total
+  /// number of chunks in the object.
   /// \param rpc_client Rpc client used to send message to remote object manager
   ray::Status SendObjectChunk(const UniqueID &push_id, const ObjectID &object_id,
                               const rpc::Address &owner_address,
                               const ClientID &client_id, uint64_t data_size,
                               uint64_t metadata_size, uint64_t chunk_index,
+                              uint64_t continuation_num_chunks,
                               std::shared_ptr<rpc::ObjectManagerClient> rpc_client);
 
   /// Receive object chunk from remote object manager, small object may contain one chunk


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, the object manager queues up every chunk (and copies its data into the appropriate outgoing message) whenever a push happens. For large objects, this can use a lot of memory and can block the io_service with lots of outgoing requests.

This change sets a maximum number of chunks to send at once, at which time the Push will wait for a response from the last chunk and then kick off the next batch.

## Related issue number

Related to #9432 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
