### PR TITLE
[tune] Fix learning rate typo in FAQ

### DIFF
--- a/doc/source/tune/_tutorials/_faq.rst
+++ b/doc/source/tune/_tutorials/_faq.rst
@@ -57,7 +57,7 @@ reports to use ``max_depth=6`` for the maximum decision tree depth. Here, anythi
 between 2 and 10 might make sense (though that naturally depends on your problem).
 
 For **learning rates**, we suggest using a **loguniform distribution** between
-**1e-1** and **1e-5**: ``tune.loguniform(1e-1, 1e05)``.
+**1e-1** and **1e-5**: ``tune.loguniform(1e-1, 1e-5)``.
 
 For **batch sizes**, we suggest trying **powers of 2**, for instance, 2, 4, 8,
 16, 32, 64, 128, 256, etc. The magnitude depends on your problem. For easy


### PR DESCRIPTION
## Why are these changes needed?

The current code sample isn't copy-pasteable because the domain is from `1e-1` to `1e-5` (the typo makes the upper bound far too high)

## Related issue number

related: #10222

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)


CC @richardliaw 