### PR TITLE
[docker] Print "install docker" only when docker is not installed

### DIFF
--- a/python/ray/autoscaler/command_runner.py
+++ b/python/ray/autoscaler/command_runner.py
@@ -659,10 +659,11 @@ class DockerCommandRunner(CommandRunnerInterface):
             self.container_name)
 
     def _check_docker_installed(self):
-        try:
-            self.ssh_command_runner.run("command -v docker")
-            return
-        except Exception:
+        no_exist = "NoExist"
+        output = self.ssh_command_runner.run(
+            f"command -v docker || echo '{no_exist}'", with_output=True)
+        cleaned_output = output.decode().strip()
+        if no_exist in cleaned_output or "docker" not in cleaned_output:
             install_commands = [
                 "curl -fsSL https://get.docker.com -o get-docker.sh",
                 "sudo sh get-docker.sh", "sudo usermod -aG docker $USER",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The generic `try except` block caught **WAY TOO MANY ERRORS**. Literally any error would be caught and printed as "Docker Not installed".  This  old behavior hid numerous SSH and setup errors.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
