### PR TITLE
Properly clean up non-detached, named actor entries from GCS service

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -569,6 +569,15 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
     RemoveActorFromOwner(actor);
   }
 
+  // Remove actor from `named_actors_` if its name is not empty.
+  if (!actor->GetName().empty()) {
+    auto it = named_actors_.find(actor->GetName());
+    if (it != named_actors_.end()) {
+      RAY_CHECK(it->second == actor->GetActorID());
+      named_actors_.erase(it);
+    }
+  }
+
   // The actor is already dead, most likely due to process or node failure.
   if (actor->GetState() == rpc::ActorTableData::DEAD) {
     return;

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -92,7 +92,7 @@ class GcsActor {
   ActorID GetActorID() const;
   /// Returns whether or not this is a detached actor.
   bool IsDetached() const;
-  /// Get the name of this actor (only set if it's a detached actor).
+  /// Get the name of this actor.
   std::string GetName() const;
   /// Get the task specification of this actor.
   TaskSpecification GetCreationTaskSpecification() const;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Actor names weren't deleted from the GCS when non-detached actors went out of scope, so actor names couldn't be reused. This fixes it by cleaning up actor names in `DestroyActor` as well as in `ReconstructActor`. Ideally we would refactor this so that it only happens in one place.

## Related issue number

Closes https://github.com/ray-project/ray/issues/10545

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
