### PR TITLE
[GCS]Add gcs_service_restart_detector_enabled config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
         - RAY_DEFAULT_BUILD=1
         - RAY_CYTHON_EXAMPLES=1
         - RAY_USE_RANDOM_PORTS=1
+        - RAY_GCS_SERVICE_RESTART_DETECTOR_ENABLED=true
       install:
         - . ./ci/travis/ci.sh init RAY_CI_SERVE_AFFECTED,RAY_CI_TUNE_AFFECTED,RAY_CI_PYTHON_AFFECTED
       before_script:
@@ -54,6 +55,7 @@ matrix:
         - RAY_DEFAULT_BUILD=1
         - RAY_CYTHON_EXAMPLES=1
         - RAY_USE_RANDOM_PORTS=1
+        - RAY_GCS_SERVICE_RESTART_DETECTOR_ENABLED=true
       install:
         - . ./ci/travis/ci.sh init RAY_CI_SERVE_AFFECTED,RAY_CI_TUNE_AFFECTED,RAY_CI_PYTHON_AFFECTED
       before_script:
@@ -96,6 +98,7 @@ matrix:
         - RAY_DEFAULT_BUILD=1
         - RAY_CYTHON_EXAMPLES=1
         - RAY_USE_RANDOM_PORTS=1
+        - RAY_GCS_SERVICE_RESTART_DETECTOR_ENABLED=true
       install:
         - . ./ci/travis/ci.sh init RAY_CI_SERVE_AFFECTED,RAY_CI_TUNE_AFFECTED,RAY_CI_PYTHON_AFFECTED
       before_script:
@@ -112,6 +115,7 @@ matrix:
         - RAY_DEFAULT_BUILD=1
         - RAY_CYTHON_EXAMPLES=1
         - RAY_USE_RANDOM_PORTS=1
+        - RAY_GCS_SERVICE_RESTART_DETECTOR_ENABLED=true
       install:
         - . ./ci/travis/ci.sh init RAY_CI_SERVE_AFFECTED,RAY_CI_TUNE_AFFECTED,RAY_CI_PYTHON_AFFECTED
       before_script:

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -298,3 +298,14 @@ RAY_CONFIG(int, max_io_workers, 1)
 /// Enable the task timeline. If this is enabled, certain events such as task
 /// execution are profiled and sent to the GCS.
 RAY_CONFIG(bool, enable_timeline, true)
+
+/// Whether to enable gcs service restart detector.
+/// RAY_GCS_SERVICE_RESTART_DETECTOR_ENABLED is an env variable which only set in ci job
+/// and test case. If the value of RAY_GCS_SERVICE_RESTART_DETECTOR_ENABLED is false, we
+/// will disable gcs service restart detector, otherwise gcs service restart detector is
+/// enabled.
+/// TODO(ffbin): we will remove it after
+/// https://github.com/ray-project/ray/issues/10343#issuecomment-686828226 is fixed.
+RAY_CONFIG(bool, gcs_service_restart_detector_enabled,
+           getenv("RAY_GCS_SERVICE_RESTART_DETECTOR_ENABLED") != nullptr &&
+               getenv("RAY_GCS_SERVICE_RESTART_DETECTOR_ENABLED") == std::string("true"))

--- a/src/ray/gcs/gcs_client/service_based_gcs_client.cc
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.cc
@@ -147,6 +147,14 @@ void ServiceBasedGcsClient::PeriodicallyCheckGcsServerAddress() {
     }
   }
 
+  // If gcs service restart detector is not enabled, we will stop periodic check after
+  // the connection with gcs service is established.
+  if (!current_gcs_server_address_.first.empty() &&
+      !RayConfig::instance().gcs_service_restart_detector_enabled()) {
+    RAY_LOG(INFO) << "GCS service restart detector is not enabled, return directly.";
+    return;
+  }
+
   auto check_period = boost::posix_time::milliseconds(
       RayConfig::instance().gcs_service_address_check_interval_milliseconds());
   detect_timer_->expires_from_now(check_period);

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -31,6 +31,7 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
 
  protected:
   void SetUp() override {
+    setenv("RAY_GCS_SERVICE_RESTART_DETECTOR_ENABLED", "true", 1);
     config_.grpc_server_port = 0;
     config_.grpc_server_name = "MockedGcsServer";
     config_.grpc_server_thread_num = 1;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
GCS service restart detector may cause problem(https://github.com/ray-project/ray/issues/10343#issuecomment-686828226), so we add a configuration to turn it off by default.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
