### PR TITLE
Print "Connecting to existing cluster" message to stderr instead of stdout

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -622,12 +622,15 @@ def init(
 
     if address:
         redis_address, _, _ = services.validate_redis_address(address)
-        print("Connecting to existing Ray cluster at address:", redis_address)
     else:
         redis_address = None
 
     if configure_logging:
         setup_logger(logging_level, logging_format)
+
+    if redis_address is not None:
+        logger.info(
+            f"Connecting to existing Ray cluster at address: {redis_address}")
 
     if local_mode:
         driver_mode = LOCAL_MODE


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

test_multi_driver_logging is failing and this is what we do with other messages.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
