### PR TITLE
[Java] Fix duplicated isInitialized methods

### DIFF
--- a/java/api/src/main/java/io/ray/api/Ray.java
+++ b/java/api/src/main/java/io/ray/api/Ray.java
@@ -203,10 +203,6 @@ public final class Ray extends RayCall {
     return internal().wrapCallable(callable);
   }
 
-  public static boolean isInitialized() {
-    return runtime != null;
-  }
-
   /**
    * Get the underlying runtime instance.
    */


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This issue was introduced by 2 conflicting PRs.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
