### PR TITLE
[Autoscaler] Fix resource demand vector calculation 

### DIFF
--- a/python/ray/autoscaler/load_metrics.py
+++ b/python/ray/autoscaler/load_metrics.py
@@ -23,8 +23,8 @@ class LoadMetrics:
         self.dynamic_resources_by_ip = {}
         self.resource_load_by_ip = {}
         self.local_ip = services.get_node_ip_address()
-        self.waiting_bundles = []
-        self.infeasible_bundles = []
+        self.waiting_bundles_by_ip = {}
+        self.infeasible_bundles_by_ip = {}
 
     def update(self,
                ip,
@@ -51,8 +51,8 @@ class LoadMetrics:
                 static_resources != dynamic_resources:
             self.last_used_time_by_ip[ip] = now
         self.last_heartbeat_time_by_ip[ip] = now
-        self.waiting_bundles = waiting_bundles
-        self.infeasible_bundles = infeasible_bundles
+        self.waiting_bundles_by_ip[ip] = waiting_bundles
+        self.infeasible_bundles_by_ip[ip] = infeasible_bundles
 
     def mark_active(self, ip):
         assert ip is not None, "IP should be known at this time"
@@ -138,7 +138,13 @@ class LoadMetrics:
         return nodes_used, resources_used, resources_total
 
     def get_resource_demand_vector(self):
-        return self.waiting_bundles + self.infeasible_bundles
+        combined = []
+        for vector in self.waiting_bundles_by_ip.values():
+            combined += vector
+        for vector in self.infeasible_bundles_by_ip.values():
+            combined += vector
+
+        return combined
 
     def info_string(self):
         return " - " + "\n - ".join(

--- a/python/ray/test_utils.py
+++ b/python/ray/test_utils.py
@@ -334,13 +334,28 @@ def dicts_equal(dict1, dict2, abs_tol=1e-4):
     return True
 
 
+def counts(iterable):
+    freqs = []
+    for elem in iterable:
+        found = False
+        for i in range(len(freqs)):
+            key, count = freqs[i]
+            if key == elem:
+                found = True
+                freqs[i][1] += 1
+        if not found:
+            freqs.append([elem, 1])
+    return freqs
+
+
 def same_elements(elems_a, elems_b):
     """Checks if two iterables (such as lists) contain the same elements. Elements
         do not have to be hashable (this allows us to compare sets of dicts for
         example). This comparison is not necessarily efficient.
     """
-    a = list(elems_a)
-    b = list(elems_b)
+
+    a = counts(elems_a)
+    b = counts(elems_b)
 
     for x in a:
         if x not in b:

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -180,6 +180,35 @@ class LoadMetricsTest(unittest.TestCase):
             "GPU": 1
         }])
 
+    def testMultiNodeResourceDemanVector(self):
+        lm = LoadMetrics()
+        lm.update(
+            "1.1.1.1", {"CPU": 2}, {"CPU": 1}, {},
+            waiting_bundles=[{
+                "GPU": 1
+            }],
+            infeasible_bundles=[{
+                "CPU": 16
+            }])
+        lm.update(
+            "1.1.1.2", {"CPU": 2}, {"GPU": 1}, {},
+            waiting_bundles=[{
+                "GPU": 1
+            }],
+            infeasible_bundles=[{
+                "CPU": 64
+            }])
+        print(lm.get_resource_demand_vector())
+        assert same_elements(lm.get_resource_demand_vector(), [{
+            "CPU": 16
+        }, {
+            "GPU": 1
+        }, {
+            "GPU": 1
+        }, {
+            "CPU": 64
+        }])
+
 
 class AutoscalingTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Resource demands were not being saved per IP address and now they are. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
