### PR TITLE
[Serve] Fix handle args data type issue

### DIFF
--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -10,6 +10,7 @@ from typing import List
 import io
 import os
 from ray.serve.exceptions import RayServeException
+from collections import UserDict
 
 import requests
 import numpy as np
@@ -23,6 +24,14 @@ from ray.serve.http_util import build_flask_request
 ACTOR_FAILURE_RETRY_TIMEOUT_S = 60
 
 
+class ServeMultiDict(UserDict):
+    """Compatible data structure to simulate Flask.Request.args API."""
+
+    def getlist(self, key):
+        """Return the list of items for a given key."""
+        return self.data.get(key, [])
+
+
 class ServeRequest:
     """The request object used in Python context.
 
@@ -33,7 +42,7 @@ class ServeRequest:
 
     def __init__(self, data, kwargs, headers, method):
         self._data = data
-        self._kwargs = kwargs
+        self._kwargs = ServeMultiDict(kwargs)
         self._headers = headers
         self._method = method
 

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -14,7 +14,6 @@ from ray.serve.exceptions import RayServeException
 import requests
 import numpy as np
 import pydantic
-from werkzeug.datastructures import ImmutableMultiDict
 
 import ray
 from ray.serve.constants import HTTP_PROXY_TIMEOUT
@@ -51,7 +50,7 @@ class ServeRequest:
     @property
     def args(self):
         """The keyword arguments from ``handle.remote(**kwargs)``."""
-        return ImmutableMultiDict(self._kwargs)
+        return self._kwargs
 
     @property
     def json(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
It turns out there is a semantic difference between ImmutableMultiDict and regular dictionary that can cause a lot of confusion down the line.

MultiDict's `get(key, default)` method returns a single item if the value is a list. This is unintuitive for the ServeRequest case.

Imagine the following scenario:
```python
# client
requests.get(".../model?arg=1&arg=2")
handle.remote(arg=[1,2])

# model: before
request.args.get("arg")
  -> http: 1 # user can use requests.args.getlist("arg") to get the list
  -> handle: 1  # BAD: this is un-intuitive!

# model: after this PR
request.args.get("arg")
  -> http: 1 # user can still use getlist("arg") to retrieve the full list, following flask semantics.
  -> handle: [1,2] # GOOD: fit user's mental model
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
