### PR TITLE
[docker] No Docker CP if File Mount

### DIFF
--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -958,7 +958,7 @@ def rsync(config_file: str,
     config = _bootstrap_config(config, no_config_cache=no_config_cache)
 
     is_file_mount = False
-    for remote_mount in config.get("file_mounts").keys():
+    for remote_mount in config.get("file_mounts", {}).keys():
         if remote_mount in (source if down else target):
             is_file_mount = True
             break

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -957,6 +957,12 @@ def rsync(config_file: str,
         config["cluster_name"] = override_cluster_name
     config = _bootstrap_config(config, no_config_cache=no_config_cache)
 
+    is_file_mount = False
+    for remote_mount in config.get("file_mounts").keys():
+        if remote_mount in (source if down else target):
+            is_file_mount = True
+            break
+
     provider = get_node_provider(config["provider"], config["cluster_name"])
     try:
         nodes = []
@@ -996,7 +1002,7 @@ def rsync(config_file: str,
                 cmd_output_util.set_output_redirected(False)
                 set_rsync_silent(False)
 
-                rsync(source, target)
+                rsync(source, target, is_file_mount)
             else:
                 updater.sync_file_mounts(rsync)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
If a user has the file_mount `{ "/root/path" : "/local/path"} and tries to `rsync` the file `/root/path/single_file` to `/local/path/single_file`, this ensures that there is no additional `docker cp` for an already mounted location. The reason the additional `docker cp` is not necessary is that`/root/path` is already mounted into the container. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
