### PR TITLE
[RLlib] fix done value assignment in n_step return

### DIFF
--- a/rllib/agents/dqn/dqn_tf_policy.py
+++ b/rllib/agents/dqn/dqn_tf_policy.py
@@ -352,7 +352,7 @@ def _adjust_nstep(n_step, gamma, obs, actions, rewards, new_obs, dones):
         for j in range(1, n_step):
             if i + j < traj_length:
                 new_obs[i] = new_obs[i + j]
-                dones[i] = dones[i + j]
+                dones[i] = dones[i + j if i + j + 1 == traj_length else i + j + 1]
                 rewards[i] += gamma**j * rewards[i + j]
 
 


### PR DESCRIPTION
In A3C paper, the dones are assgned to `s_{t+n}`, the code in ray is s_{t+n-1}, which is I think may not correct.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In found the `_adjust_nstep` may not correct after reading [A3C](http://proceedings.mlr.press/v48/mniha16.pdf) paper. 

According to n-step return defined in A3C and pseudo-code of one-step A3C. Accordingly, the `dones` should be assigned to `s_{t+n}`. However, in the original design, the `dones` are assigned to `s_{t+n-1}`

![image](https://user-images.githubusercontent.com/9346460/92448226-e41d7b00-f1ea-11ea-80a0-e553058c64e6.png)


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)

Here is my unit test code

```python
def adjust_nstep(args, episode_batch):
    """
    >>> from adjust_nstep import adjust_nstep
    >>> import numpy as np
    >>> from types import SimpleNamespace as SN
    >>> obs = np.array([ [1, 2, 0, 0, 0, 0, 0, 0] ])
    >>> terminated = np.array([ [0, 0, 0, 0, 1, 0, 0, 0], ])
    >>> reward = np.array([ [0, 1, 0, 1, 0, 1, 0, 0], ])
    >>> episode_batch = {'obs': obs, 'terminated': terminated, 'reward': reward }
    >>> args = SN()
    >>> args.n_step = 3
    >>> args.gamma = 1
    >>> adjust_nstep(args, episode_batch)

    args: args of the experiments
    episode_batch: one episode data, aka one trajectory
    """
    assert args.n_step >= 1, 'n_step should be >= 1'
    assert episode_batch['obs'].shape[0] == 1, 'only receives one trajectory data'

    traj_length = episode_batch['obs'].shape[1]
    for i in range(traj_length):
        for j in range(1, args.n_step):
            if i + j < traj_length:
                t_idex = i+j if i+j+1 == traj_length else i+j+1
                episode_batch['terminated'][:, i, ...] = episode_batch['terminated'][:, t_idex, ...]
                episode_batch['reward'][:, i, ...] += args.gamma**j * episode_batch['reward'][:, i+j, ...]
```