### PR TITLE
[tune] Added `timeout` parameter to `tune.run()`,

### DIFF
--- a/python/ray/tune/experiment.py
+++ b/python/ray/tune/experiment.py
@@ -9,7 +9,8 @@ from ray.tune.function_runner import detect_checkpoint_function
 from ray.tune.registry import register_trainable, get_trainable_cls
 from ray.tune.result import DEFAULT_RESULTS_DIR
 from ray.tune.sample import Domain
-from ray.tune.stopper import FunctionStopper, Stopper
+from ray.tune.stopper import CombinedStopper, FunctionStopper, Stopper, \
+    TimeoutStopper
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +103,7 @@ class Experiment:
                  name,
                  run,
                  stop=None,
+                 timeout=None,
                  config=None,
                  resources_per_trial=None,
                  num_samples=1,
@@ -158,6 +160,13 @@ class Experiment:
         else:
             raise ValueError("Invalid stop criteria: {}. Must be a "
                              "callable or dict".format(stop))
+
+        if timeout:
+            if self._stopper:
+                self._stopper = CombinedStopper(self._stopper,
+                                                TimeoutStopper(timeout))
+            else:
+                self._stopper = TimeoutStopper(timeout)
 
         _raise_on_durable(self._run_identifier, sync_to_driver, upload_dir)
 

--- a/python/ray/tune/experiment.py
+++ b/python/ray/tune/experiment.py
@@ -103,7 +103,7 @@ class Experiment:
                  name,
                  run,
                  stop=None,
-                 timeout=None,
+                 time_budget_s=None,
                  config=None,
                  resources_per_trial=None,
                  num_samples=1,
@@ -161,12 +161,12 @@ class Experiment:
             raise ValueError("Invalid stop criteria: {}. Must be a "
                              "callable or dict".format(stop))
 
-        if timeout:
+        if time_budget_s:
             if self._stopper:
                 self._stopper = CombinedStopper(self._stopper,
-                                                TimeoutStopper(timeout))
+                                                TimeoutStopper(time_budget_s))
             else:
-                self._stopper = TimeoutStopper(timeout)
+                self._stopper = TimeoutStopper(time_budget_s)
 
         _raise_on_durable(self._run_identifier, sync_to_driver, upload_dir)
 

--- a/python/ray/tune/stopper.py
+++ b/python/ray/tune/stopper.py
@@ -174,8 +174,7 @@ class TimeoutStopper(Stopper):
         else:
             raise ValueError(
                 "`timeout` parameter has to be either a number or a "
-                "`datetime.timedelta` object. Found: {}".format(
-                    type(timeout)))
+                "`datetime.timedelta` object. Found: {}".format(type(timeout)))
 
         # To account for setup overhead, set the start time only after
         # the first call to `stop_all()`.

--- a/python/ray/tune/stopper.py
+++ b/python/ray/tune/stopper.py
@@ -174,7 +174,8 @@ class TimeoutStopper(Stopper):
         else:
             raise ValueError(
                 "`timeout` parameter has to be either a number or a "
-                "`datetime.timedelta` object.")
+                "`datetime.timedelta` object. Found: {}".format(
+                    type(timeout)))
 
         # To account for setup overhead, set the start time only after
         # the first call to `stop_all()`.

--- a/python/ray/tune/stopper.py
+++ b/python/ray/tune/stopper.py
@@ -1,4 +1,8 @@
+import time
+
 import numpy as np
+
+from ray import logger
 
 
 class Stopper:
@@ -36,6 +40,17 @@ class Stopper:
     def stop_all(self):
         """Returns true if the experiment should be terminated."""
         raise NotImplementedError
+
+
+class CombinedStopper(Stopper):
+    def __init__(self, *stoppers: Stopper):
+        self._stoppers = stoppers
+
+    def __call__(self, trial_id, result):
+        return any(s(trial_id, result) for s in self._stoppers)
+
+    def stop_all(self):
+        return any(s.stop_all() for s in self._stoppers)
 
 
 class NoopStopper(Stopper):
@@ -140,3 +155,42 @@ class EarlyStopping(Stopper):
     def stop_all(self):
         """Return whether to stop and prevent trials from starting."""
         return self.has_plateaued() and self._iterations >= self._patience
+
+
+class TimeoutStopper(Stopper):
+    """Stops all trials after a certain timeout.
+
+    Args:
+        timeout (int|float|datetime.timedelta): Either a number specifying
+            the timeout in seconds, or a `datetime.timedelta` object.
+    """
+
+    def __init__(self, timeout):
+        from datetime import timedelta
+        if isinstance(timeout, timedelta):
+            self._timeout_seconds = timeout.total_seconds()
+        elif isinstance(timeout, (int, float)):
+            self._timeout_seconds = timeout
+        else:
+            raise ValueError(
+                "`timeout` parameter has to be either a number or a "
+                "`datetime.timedelta` object.")
+
+        # To account for setup overhead, set the start time only after
+        # the first call to `stop_all()`.
+        self._start = None
+
+    def __call__(self, trial_id, result):
+        return False
+
+    def stop_all(self):
+        if not self._start:
+            self._start = time.time()
+            return False
+
+        now = time.time()
+        if now - self._start >= self._timeout_seconds:
+            logger.info(f"Reached timeout of {self._timeout_seconds} seconds. "
+                        f"Stopping all trials.")
+            return True
+        return False

--- a/python/ray/tune/tests/test_api.py
+++ b/python/ray/tune/tests/test_api.py
@@ -1109,6 +1109,9 @@ class TrainableFunctionApiTest(unittest.TestCase):
             self.assertIn("LOG_STDERR", content)
 
     def testTimeout(self):
+        from ray.tune.stopper import TimeoutStopper
+        import datetime
+
         def train(config):
             for i in range(20):
                 tune.report(metric=i)
@@ -1135,8 +1138,10 @@ class TrainableFunctionApiTest(unittest.TestCase):
 
         # Combined stopper. Shorter timeout should win.
         start = time.time()
-        from ray.tune.stopper import TimeoutStopper
-        tune.run("f1", stop=TimeoutStopper(10), timeout=3)
+        tune.run(
+            "f1",
+            stop=TimeoutStopper(10),
+            timeout=datetime.timedelta(seconds=3))
         diff = time.time() - start
         self.assertLess(diff, 9)
 

--- a/python/ray/tune/tests/test_api.py
+++ b/python/ray/tune/tests/test_api.py
@@ -1120,19 +1120,19 @@ class TrainableFunctionApiTest(unittest.TestCase):
         register_trainable("f1", train)
 
         start = time.time()
-        tune.run("f1", timeout=5)
+        tune.run("f1", time_budget_s=5)
         diff = time.time() - start
         self.assertLess(diff, 10)
 
         # Metric should fire first
         start = time.time()
-        tune.run("f1", stop={"metric": 3}, timeout=7)
+        tune.run("f1", stop={"metric": 3}, time_budget_s=7)
         diff = time.time() - start
         self.assertLess(diff, 7)
 
         # Timeout should fire first
         start = time.time()
-        tune.run("f1", stop={"metric": 10}, timeout=5)
+        tune.run("f1", stop={"metric": 10}, time_budget_s=5)
         diff = time.time() - start
         self.assertLess(diff, 10)
 
@@ -1141,7 +1141,7 @@ class TrainableFunctionApiTest(unittest.TestCase):
         tune.run(
             "f1",
             stop=TimeoutStopper(10),
-            timeout=datetime.timedelta(seconds=3))
+            time_budget_s=datetime.timedelta(seconds=3))
         diff = time.time() - start
         self.assertLess(diff, 9)
 

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -69,6 +69,7 @@ def run(
         run_or_experiment,
         name=None,
         stop=None,
+        timeout=None,
         config=None,
         resources_per_trial=None,
         num_samples=1,
@@ -155,6 +156,8 @@ def run(
             ``ray.tune.Stopper``, which allows users to implement
             custom experiment-wide stopping (i.e., stopping an entire Tune
             run based on some time constraint).
+        timeout (int|float|datetime.timedelta): Global timeout in seconds
+            after which all trials are stopped.
         config (dict): Algorithm-specific configuration for Tune variant
             generation (e.g. env, hyperparams). Defaults to empty dict.
             Custom search algorithms may ignore this.
@@ -289,6 +292,7 @@ def run(
                 name=name,
                 run=exp,
                 stop=stop,
+                timeout=timeout,
                 config=config,
                 resources_per_trial=resources_per_trial,
                 num_samples=num_samples,

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -69,7 +69,7 @@ def run(
         run_or_experiment,
         name=None,
         stop=None,
-        timeout=None,
+        time_budget_s=None,
         config=None,
         resources_per_trial=None,
         num_samples=1,
@@ -156,8 +156,9 @@ def run(
             ``ray.tune.Stopper``, which allows users to implement
             custom experiment-wide stopping (i.e., stopping an entire Tune
             run based on some time constraint).
-        timeout (int|float|datetime.timedelta): Global timeout in seconds
-            after which all trials are stopped.
+        time_budget_s (int|float|datetime.timedelta): Global time budget in
+            seconds after which all trials are stopped. Can also be a
+            ``datetime.timedelta`` object.
         config (dict): Algorithm-specific configuration for Tune variant
             generation (e.g. env, hyperparams). Defaults to empty dict.
             Custom search algorithms may ignore this.
@@ -292,7 +293,7 @@ def run(
                 name=name,
                 run=exp,
                 stop=stop,
-                timeout=timeout,
+                time_budget_s=time_budget_s,
                 config=config,
                 resources_per_trial=resources_per_trial,
                 num_samples=num_samples,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This enables setting of a global timeout for a tune run. After this timeout, all trials are stopped.

Please note that this currently does not kill trials after this timeout. I.e. if the timeout is at 10 seconds, but a trial does `sleep(100)`, it will not kill the trial after 10 seconds. The trial will finish after 100 seconds.

## Related issue number

#10590

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
