### PR TITLE
[Java] remove resetLibraryPath

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/RayNativeRuntime.java
+++ b/java/runtime/src/main/java/io/ray/runtime/RayNativeRuntime.java
@@ -69,19 +69,11 @@ public final class RayNativeRuntime extends AbstractRayRuntime {
 
     JniUtils.loadLibrary(BinaryFileUtil.CORE_WORKER_JAVA_LIBRARY, true);
     LOGGER.debug("Native libraries loaded.");
-    // Reset library path at runtime.
-    resetLibraryPath(rayConfig);
     try {
       FileUtils.forceMkdir(new File(rayConfig.logDir));
     } catch (IOException e) {
       throw new RuntimeException("Failed to create the log directory.", e);
     }
-  }
-
-  private static void resetLibraryPath(RayConfig rayConfig) {
-    String separator = System.getProperty("path.separator");
-    String libraryPath = String.join(separator, rayConfig.libraryPath);
-    JniUtils.resetLibraryPath(libraryPath);
   }
 
   public RayNativeRuntime(RayConfig rayConfig) {

--- a/java/runtime/src/main/java/io/ray/runtime/util/JniUtils.java
+++ b/java/runtime/src/main/java/io/ray/runtime/util/JniUtils.java
@@ -1,11 +1,9 @@
 package io.ray.runtime.util;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 import com.sun.jna.NativeLibrary;
 import io.ray.runtime.config.RayConfig;
 import java.io.File;
-import java.lang.reflect.Field;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,38 +46,8 @@ public class JniUtils {
       }
       System.load(file.getAbsolutePath());
       LOGGER.debug("Native library loaded.");
-      resetLibraryPath(file.getAbsolutePath());
       loadedLibs.add(libraryName);
     }
   }
 
-  /**
-   * This is a hack to reset library path at runtime. Please don't use it outside of ray
-   */
-  public static synchronized void resetLibraryPath(String libPath) {
-    if (Strings.isNullOrEmpty(libPath)) {
-      return;
-    }
-    String path = System.getProperty("java.library.path");
-    String separator = System.getProperty("path.separator");
-    if (Strings.isNullOrEmpty(path)) {
-      path = "";
-    } else {
-      path += separator;
-    }
-    path += String.join(separator, libPath);
-
-    // This is a hack to reset library path at runtime,
-    // see https://stackoverflow.com/questions/15409223/.
-    System.setProperty("java.library.path", path);
-    // Set sys_paths to null so that java.library.path will be re-evaluated next time it is needed.
-    final Field sysPathsField;
-    try {
-      sysPathsField = ClassLoader.class.getDeclaredField("sys_paths");
-      sysPathsField.setAccessible(true);
-      sysPathsField.set(null, null);
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      LOGGER.error("Failed to set library path.", e);
-    }
-  }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`resetLibraryPath` is useless and doesn't work in higher version jdk. This PR remove resetLibraryPath code
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#10673
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
