### PR TITLE
[tune] wrapper function to pass arbitrary objects through the object store to trainables

### DIFF
--- a/doc/source/tune/_tutorials/_faq.rst
+++ b/doc/source/tune/_tutorials/_faq.rst
@@ -220,18 +220,17 @@ of 4 machines with 1 GPU each, the trial will never be scheduled.
 In other words, you will have to make sure that your Ray cluster
 has machines that can actually fulfill your resource requests.
 
-How can I pass further values to my trainable function?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+How can I pass further parameter values to my trainable function?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Ray Tune expects your trainable functions to accept only up to two parameters,
 ``config`` and ``checkpoint_dir``. But sometimes there are cases where
 you want to pass constant arguments, like the number of epochs to run,
 or a dataset to train on. Ray Tune offers a wrapper function to achieve
-just that, called ``with_parameters``:
+just that, called ``tune.with_parameters()``:
 
 .. code-block:: python
 
     from ray import tune
-    from ray.tune.function_runner import with_parameters
 
     import numpy as np
 
@@ -244,7 +243,7 @@ just that, called ``with_parameters``:
     data = np.random.random(size=100000000)
 
     tune.run(
-        with_parameters(train, num_epochs=10, data=data))
+        tune.with_parameters(train, num_epochs=10, data=data))
 
 
 This function works similarly to ``functools.partial``, but it stores

--- a/doc/source/tune/_tutorials/_faq.rst
+++ b/doc/source/tune/_tutorials/_faq.rst
@@ -220,6 +220,38 @@ of 4 machines with 1 GPU each, the trial will never be scheduled.
 In other words, you will have to make sure that your Ray cluster
 has machines that can actually fulfill your resource requests.
 
+How can I pass further values to my trainable function?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Ray Tune expects your trainable functions to accept only up to two parameters,
+``config`` and ``checkpoint_dir``. But sometimes there are cases where
+you want to pass constant arguments, like the number of epochs to run,
+or a dataset to train on. Ray Tune offers a wrapper function to achieve
+just that, called ``with_parameters``:
+
+.. code-block:: python
+
+    from ray import tune
+    from ray.tune.function_runner import with_parameters
+
+    import numpy as np
+
+    def train(config, checkpoint_dir=None, num_epochs=10, data=None):
+        for i in range(num_epochs):
+            for sample in data:
+                # ... train on sample
+
+    # Some huge dataset
+    data = np.random.random(size=100000000)
+
+    tune.run(
+        with_parameters(train, num_epochs=10, data=data))
+
+
+This function works similarly to ``functools.partial``, but it stores
+the parameters directly in the Ray object store. This means that you
+can pass even huge objects like datasets, and Ray makes sure that these
+are efficiently stored and retrieved on your cluster machines.
+
 
 Further Questions or Issues?
 ----------------------------

--- a/doc/source/tune/api_docs/execution.rst
+++ b/doc/source/tune/api_docs/execution.rst
@@ -18,6 +18,11 @@ tune.Experiment
 
 .. autofunction:: ray.tune.Experiment
 
+tune.with_parameters
+--------------------
+
+.. autofunction:: ray.tune.with_parameters
+
 .. _tune-stop-ref:
 
 Stopper (tune.Stopper)

--- a/doc/source/tune/user-guide.rst
+++ b/doc/source/tune/user-guide.rst
@@ -209,26 +209,26 @@ disable cross-node syncing:
 Handling Large Datasets
 -----------------------
 
-You often will want to compute a large object (e.g., training data, model weights) on the driver and use that object within each trial. Tune provides a ``pin_in_object_store`` utility function that can be used to broadcast such large objects. Objects pinned in this way will never be evicted from the Ray object store while the driver process is running, and can be efficiently retrieved from any task via ``get_pinned_object``.
+You often will want to compute a large object (e.g., training data, model weights) on the driver and use that object within each trial.
+
+Tune provides a wrapper function ``with_parameters`` that allows you to broadcast large objects to your trainable.
+Objects passed with this wrapper will be stored on the Ray object store and will be automatically fetched
+and passed to your trainable as a parameter.
 
 .. code-block:: python
 
-    import ray
     from ray import tune
-    from ray.tune.utils import pin_in_object_store, get_pinned_object
+    from ray.tune.function_runner import with_parameters
 
     import numpy as np
 
-    ray.init()
+    def f(config, data=None):
+        pass
+        # use data
 
-    # X_id can be referenced in closures
-    X_id = pin_in_object_store(np.random.random(size=100000000))
+    data = np.random.random(size=100000000)
 
-    def f(config):
-        X = get_pinned_object(X_id)
-        # use X
-
-    tune.run(f)
+    tune.run(with_parameters(f, data=data))
 
 .. _tune-stopping:
 

--- a/doc/source/tune/user-guide.rst
+++ b/doc/source/tune/user-guide.rst
@@ -211,14 +211,13 @@ Handling Large Datasets
 
 You often will want to compute a large object (e.g., training data, model weights) on the driver and use that object within each trial.
 
-Tune provides a wrapper function ``with_parameters`` that allows you to broadcast large objects to your trainable.
+Tune provides a wrapper function ``tune.with_parameters()`` that allows you to broadcast large objects to your trainable.
 Objects passed with this wrapper will be stored on the Ray object store and will be automatically fetched
 and passed to your trainable as a parameter.
 
 .. code-block:: python
 
     from ray import tune
-    from ray.tune.function_runner import with_parameters
 
     import numpy as np
 
@@ -228,7 +227,7 @@ and passed to your trainable as a parameter.
 
     data = np.random.random(size=100000000)
 
-    tune.run(with_parameters(f, data=data))
+    tune.run(tune.with_parameters(f, data=data))
 
 .. _tune-stopping:
 

--- a/python/ray/tune/__init__.py
+++ b/python/ray/tune/__init__.py
@@ -1,5 +1,6 @@
 from ray.tune.error import TuneError
 from ray.tune.tune import run_experiments, run
+from ray.tune.function_runner import with_parameters
 from ray.tune.syncer import SyncConfig
 from ray.tune.experiment import Experiment
 from ray.tune.analysis import ExperimentAnalysis, Analysis
@@ -21,12 +22,12 @@ from ray.tune.schedulers import create_scheduler
 
 __all__ = [
     "Trainable", "DurableTrainable", "TuneError", "grid_search",
-    "register_env", "register_trainable", "run", "run_experiments", "Stopper",
-    "EarlyStopping", "Experiment", "function", "sample_from", "track",
-    "uniform", "quniform", "choice", "randint", "qrandint", "randn", "qrandn",
-    "loguniform", "qloguniform", "ExperimentAnalysis", "Analysis",
-    "CLIReporter", "JupyterNotebookReporter", "ProgressReporter", "report",
-    "get_trial_dir", "get_trial_name", "get_trial_id", "make_checkpoint_dir",
-    "save_checkpoint", "checkpoint_dir", "SyncConfig", "create_searcher",
-    "create_scheduler"
+    "register_env", "register_trainable", "run", "run_experiments",
+    "with_parameters", "Stopper", "EarlyStopping", "Experiment", "function",
+    "sample_from", "track", "uniform", "quniform", "choice", "randint",
+    "qrandint", "randn", "qrandn", "loguniform", "qloguniform",
+    "ExperimentAnalysis", "Analysis", "CLIReporter", "JupyterNotebookReporter",
+    "ProgressReporter", "report", "get_trial_dir", "get_trial_name",
+    "get_trial_id", "make_checkpoint_dir", "save_checkpoint", "checkpoint_dir",
+    "SyncConfig", "create_searcher", "create_scheduler"
 ]

--- a/python/ray/tune/function_runner.py
+++ b/python/ray/tune/function_runner.py
@@ -7,6 +7,7 @@ import threading
 import traceback
 import uuid
 
+from ray.tune.registry import get_user_parameter, put_user_parameter
 from six.moves import queue
 
 from ray.util.debug import log_once
@@ -507,3 +508,66 @@ def wrap_function(train_func, warn=True):
             return output
 
     return ImplicitFunc
+
+
+def with_parameters(fn, **kwargs):
+    """Wrapper for function trainables to pass arbitrary large data objects.
+
+    This wrapper function will store all passed parameters in the Ray
+    object store and retrieve them when calling the function. It can thus
+    be used to pass arbitrary data, even datasets, to Tune trainable functions.
+
+    This can also be used as an alternative to `functools.partial` to pass
+    default arguments to trainables.
+
+    Args:
+        fn: function to wrap
+        **kwargs: parameters to store in object store.
+
+
+    .. code-block:: python
+
+    from ray.tune.function_runner import with_parameters
+
+    def train(config, data=None):
+        for sample in data:
+            # ...
+            tune.report(loss=loss)
+
+    data = HugeDataset(download=True)
+
+    tune.run(
+        with_parameters(train, data=data),
+        #...
+    )
+
+    """
+    prefix = f"{str(fn)}_"
+    for k, v in kwargs.items():
+        put_user_parameter(prefix + k, v)
+
+    use_checkpoint = detect_checkpoint_function(fn)
+
+    def inner(config, checkpoint_dir=None):
+        fn_kwargs = {}
+        if use_checkpoint:
+            default = checkpoint_dir
+            sig = inspect.signature(fn)
+            if "checkpoint_dir" in sig.parameters:
+                default = sig.parameters["checkpoint_dir"].default \
+                          or default
+            fn_kwargs["checkpoint_dir"] = default
+
+        for k in kwargs:
+            fn_kwargs[k] = get_user_parameter(prefix + k)
+        fn(config, **fn_kwargs)
+
+    # Use correct function signature if no `checkpoint_dir` parameter is set
+    if not use_checkpoint:
+
+        def _inner(config):
+            inner(config, checkpoint_dir=None)
+
+        return _inner
+
+    return inner

--- a/python/ray/tune/function_runner.py
+++ b/python/ray/tune/function_runner.py
@@ -7,9 +7,9 @@ import threading
 import traceback
 import uuid
 
-from ray.tune.registry import get_user_parameter, put_user_parameter
 from six.moves import queue
 
+import ray
 from ray.util.debug import log_once
 from ray.tune import TuneError, session
 from ray.tune.trainable import Trainable, TrainableUtil
@@ -510,6 +510,9 @@ def wrap_function(train_func, warn=True):
     return ImplicitFunc
 
 
+_parameter_registry = {}
+
+
 def with_parameters(fn, **kwargs):
     """Wrapper for function trainables to pass arbitrary large data objects.
 
@@ -542,9 +545,14 @@ def with_parameters(fn, **kwargs):
         )
 
     """
+    if not ray.is_initialized():
+        raise ValueError(
+            "`tune.with_parameters()` requires Ray to be initialized. Please "
+            "call `ray.init()` before invoking this function.")
+
     prefix = f"{str(fn)}_"
     for k, v in kwargs.items():
-        put_user_parameter(prefix + k, v)
+        _parameter_registry[prefix + k] = ray.put(v)
 
     use_checkpoint = detect_checkpoint_function(fn)
 
@@ -559,7 +567,7 @@ def with_parameters(fn, **kwargs):
             fn_kwargs["checkpoint_dir"] = default
 
         for k in kwargs:
-            fn_kwargs[k] = get_user_parameter(prefix + k)
+            fn_kwargs[k] = ray.get(_parameter_registry[prefix + k])
         fn(config, **fn_kwargs)
 
     # Use correct function signature if no `checkpoint_dir` parameter is set

--- a/python/ray/tune/function_runner.py
+++ b/python/ray/tune/function_runner.py
@@ -527,19 +527,19 @@ def with_parameters(fn, **kwargs):
 
     .. code-block:: python
 
-    from ray.tune.function_runner import with_parameters
+        from ray import tune
 
-    def train(config, data=None):
-        for sample in data:
-            # ...
-            tune.report(loss=loss)
+        def train(config, data=None):
+            for sample in data:
+                # ...
+                tune.report(loss=loss)
 
-    data = HugeDataset(download=True)
+        data = HugeDataset(download=True)
 
-    tune.run(
-        with_parameters(train, data=data),
-        #...
-    )
+        tune.run(
+            tune.with_parameters(train, data=data),
+            #...
+        )
 
     """
     prefix = f"{str(fn)}_"

--- a/python/ray/tune/registry.py
+++ b/python/ray/tune/registry.py
@@ -8,14 +8,15 @@ from ray.experimental.internal_kv import _internal_kv_initialized, \
 from ray.tune.error import TuneError
 
 TRAINABLE_CLASS = "trainable_class"
+USER_PARAMETER = "user_parameter"
 ENV_CREATOR = "env_creator"
 RLLIB_MODEL = "rllib_model"
 RLLIB_PREPROCESSOR = "rllib_preprocessor"
 RLLIB_ACTION_DIST = "rllib_action_dist"
 TEST = "__test__"
 KNOWN_CATEGORIES = [
-    TRAINABLE_CLASS, ENV_CREATOR, RLLIB_MODEL, RLLIB_PREPROCESSOR,
-    RLLIB_ACTION_DIST, TEST
+    TRAINABLE_CLASS, USER_PARAMETER, ENV_CREATOR, RLLIB_MODEL,
+    RLLIB_PREPROCESSOR, RLLIB_ACTION_DIST, TEST
 ]
 
 logger = logging.getLogger(__name__)
@@ -69,6 +70,18 @@ def register_trainable(name, trainable, warn=True):
         raise TypeError("Second argument must be convertable to Trainable",
                         trainable)
     _global_registry.register(TRAINABLE_CLASS, name, trainable)
+
+
+def has_user_parameter(parameter_name):
+    return _global_registry.contains(USER_PARAMETER, parameter_name)
+
+
+def get_user_parameter(parameter_name):
+    return _global_registry.get(USER_PARAMETER, parameter_name)
+
+
+def put_user_parameter(parameter_name, obj):
+    _global_registry.register(USER_PARAMETER, parameter_name, obj)
 
 
 def register_env(name, env_creator):

--- a/python/ray/tune/registry.py
+++ b/python/ray/tune/registry.py
@@ -8,15 +8,14 @@ from ray.experimental.internal_kv import _internal_kv_initialized, \
 from ray.tune.error import TuneError
 
 TRAINABLE_CLASS = "trainable_class"
-USER_PARAMETER = "user_parameter"
 ENV_CREATOR = "env_creator"
 RLLIB_MODEL = "rllib_model"
 RLLIB_PREPROCESSOR = "rllib_preprocessor"
 RLLIB_ACTION_DIST = "rllib_action_dist"
 TEST = "__test__"
 KNOWN_CATEGORIES = [
-    TRAINABLE_CLASS, USER_PARAMETER, ENV_CREATOR, RLLIB_MODEL,
-    RLLIB_PREPROCESSOR, RLLIB_ACTION_DIST, TEST
+    TRAINABLE_CLASS, ENV_CREATOR, RLLIB_MODEL, RLLIB_PREPROCESSOR,
+    RLLIB_ACTION_DIST, TEST
 ]
 
 logger = logging.getLogger(__name__)
@@ -70,18 +69,6 @@ def register_trainable(name, trainable, warn=True):
         raise TypeError("Second argument must be convertable to Trainable",
                         trainable)
     _global_registry.register(TRAINABLE_CLASS, name, trainable)
-
-
-def has_user_parameter(parameter_name):
-    return _global_registry.contains(USER_PARAMETER, parameter_name)
-
-
-def get_user_parameter(parameter_name):
-    return _global_registry.get(USER_PARAMETER, parameter_name)
-
-
-def put_user_parameter(parameter_name, obj):
-    _global_registry.register(USER_PARAMETER, parameter_name, obj)
 
 
 def register_env(name, env_creator):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds a `with_parameters` wrapper function to pass arbitrary parameters to Tune trainables. It works similar to `functools.partial`, but it stores parameters in the Ray object store and automatically retrieves and passes them to the trainable.

## Related issue number

#10305
Also answers numerous requests on Slack on how to pass parameters to trainables.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
