### PR TITLE
[tune] wandb log cleaning to use yaml representer

### DIFF
--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -38,8 +38,7 @@ def _clean_log(obj):
             allow_unicode=True,
             encoding="utf-8")
         return obj
-    except Exception as e:
-        print(f"EXCEPTION {e}")
+    except Exception:
         # give up, similar to _SafeFallBackEncoder
         return str(obj)
 

--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -9,6 +9,8 @@ from ray.tune.function_runner import FunctionRunner
 from ray.tune.logger import Logger
 from ray.tune.utils import flatten_dict
 
+from yaml.representer import BaseRepresenter
+
 try:
     import wandb
 except ImportError:
@@ -17,6 +19,8 @@ except ImportError:
 
 WANDB_ENV_VAR = "WANDB_API_KEY"
 _WANDB_QUEUE_END = (None, )
+
+_yaml_representer = BaseRepresenter()
 
 
 def _clean_log(obj):
@@ -29,6 +33,7 @@ def _clean_log(obj):
     # Else
     try:
         pickle.dumps(obj)
+        _yaml_representer.represent(obj)
         return obj
     except Exception:
         # give up, similar to _SafeFallBackEncoder

--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -9,7 +9,7 @@ from ray.tune.function_runner import FunctionRunner
 from ray.tune.logger import Logger
 from ray.tune.utils import flatten_dict
 
-from yaml.representer import BaseRepresenter
+import yaml
 
 try:
     import wandb
@@ -19,8 +19,6 @@ except ImportError:
 
 WANDB_ENV_VAR = "WANDB_API_KEY"
 _WANDB_QUEUE_END = (None, )
-
-_yaml_representer = BaseRepresenter()
 
 
 def _clean_log(obj):
@@ -33,9 +31,15 @@ def _clean_log(obj):
     # Else
     try:
         pickle.dumps(obj)
-        _yaml_representer.represent(obj)
+        yaml.dump(
+            obj,
+            Dumper=yaml.SafeDumper,
+            default_flow_style=False,
+            allow_unicode=True,
+            encoding="utf-8")
         return obj
-    except Exception:
+    except Exception as e:
+        print(f"EXCEPTION {e}")
         # give up, similar to _SafeFallBackEncoder
         return str(obj)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

APPO didn't work with the WandbLogger because the objects were pickable, but not representable in yamls, which seems to be a requirement for passing it to wandb. This PR catches these unrepresentable values.

## Related issue number

Closes #10426

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
