### PR TITLE
[autoscaler] make commands very explicit on logs

### DIFF
--- a/python/ray/autoscaler/cli_logger.py
+++ b/python/ray/autoscaler/cli_logger.py
@@ -219,13 +219,13 @@ class _CliLogger():
 
     def __init__(self):
         self.old_style = os.environ.get("RAY_LOG_NEWSTYLE", "1") == "0"
-        self.pretty = True
-        self.interactive = _isatty()
         self.indent_level = 0
 
         self._verbosity = 0
         self._color_mode = "auto"
-        self._log_style = "auto"
+        self._log_style = "record"
+        self.pretty = False
+        self.interactive = False
 
         # store whatever colorful has detected for future use if
         # the color ouput is toggled (colorful detects # of supported colors,
@@ -239,13 +239,27 @@ class _CliLogger():
             format_tmpl = ray_constants.LOGGER_FORMAT
         self._formatter = logging.Formatter(format_tmpl)
 
+    def configure(self, log_style=None, color_mode=None, verbosity=None):
+        """Configures the logger according to values."""
+        if log_style is not None:
+            self._set_log_style(log_style)
+
+        if color_mode is not None:
+            self._set_color_mode(color_mode)
+
+        if verbosity is not None:
+            self._set_verbosity(verbosity)
+
+        self.detect_colors()
+
     @property
     def log_style(self):
         return self._log_style
 
-    @log_style.setter
-    def log_style(self, x):
+    def _set_log_style(self, x):
+        """Configures interactivity and formatting."""
         self._log_style = x.lower()
+        self.interactive = _isatty()
 
         if self._log_style == "auto":
             self.pretty = _isatty()
@@ -259,8 +273,7 @@ class _CliLogger():
     def color_mode(self):
         return self._color_mode
 
-    @color_mode.setter
-    def color_mode(self, x):
+    def _set_color_mode(self, x):
         self._color_mode = x.lower()
         self.detect_colors()
 
@@ -270,8 +283,7 @@ class _CliLogger():
             return 999
         return self._verbosity
 
-    @verbosity.setter
-    def verbosity(self, x):
+    def _set_verbosity(self, x):
         self._verbosity = x
 
     def detect_colors(self):

--- a/python/ray/autoscaler/cli_logger.py
+++ b/python/ray/autoscaler/cli_logger.py
@@ -187,6 +187,9 @@ def _isatty():
 class _CliLogger():
     """Singleton class for CLI logging.
 
+    Without calling 'cli_logger.configure', the CLILogger will default
+    to 'record' style logging.
+
     Attributes:
         old_style (bool):
             If `old_style` is `True`, the old logging calls are used instead

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -397,10 +397,7 @@ def start(node_ip_address, redis_address, address, redis_port, port,
           system_config, lru_evict, enable_object_reconstruction,
           metrics_export_port, log_style, log_color, verbose):
     """Start Ray processes manually on the local machine."""
-    cli_logger.log_style = log_style
-    cli_logger.color_mode = log_color
-    cli_logger.verbosity = verbose
-    cli_logger.detect_colors()
+    cli_logger.configure(log_style, log_color, verbose)
 
     if gcs_server_port and not head:
         raise ValueError(
@@ -755,10 +752,7 @@ def start(node_ip_address, redis_address, address, redis_port, port,
 def stop(force, verbose, log_style, log_color):
     """Stop Ray processes manually on the local machine."""
 
-    cli_logger.log_style = log_style
-    cli_logger.color_mode = log_color
-    cli_logger.verbosity = verbose
-    cli_logger.detect_colors()
+    cli_logger.configure(log_style, log_color, verbose)
 
     # Note that raylet needs to exit before object store, otherwise
     # it cannot exit gracefully.
@@ -923,10 +917,7 @@ def up(cluster_config_file, min_workers, max_workers, no_restart, restart_only,
        yes, cluster_name, no_config_cache, redirect_command_output,
        use_login_shells, log_style, log_color, verbose):
     """Create or update a Ray cluster."""
-    cli_logger.log_style = log_style
-    cli_logger.color_mode = log_color
-    cli_logger.verbosity = verbose
-    cli_logger.detect_colors()
+    cli_logger.configure(log_style, log_color, verbose)
 
     if restart_only or no_restart:
         cli_logger.doassert(restart_only != no_restart,
@@ -989,10 +980,7 @@ def up(cluster_config_file, min_workers, max_workers, no_restart, restart_only,
 def down(cluster_config_file, yes, workers_only, cluster_name,
          keep_min_workers, log_style, log_color, verbose):
     """Tear down a Ray cluster."""
-    cli_logger.log_style = log_style
-    cli_logger.color_mode = log_color
-    cli_logger.verbosity = verbose
-    cli_logger.detect_colors()
+    cli_logger.configure(log_style, log_color, verbose)
 
     teardown_cluster(cluster_config_file, yes, workers_only, cluster_name,
                      keep_min_workers)
@@ -1042,10 +1030,7 @@ def kill_random_node(cluster_config_file, yes, hard, cluster_name):
 def monitor(cluster_config_file, lines, cluster_name, log_style, log_color,
             verbose):
     """Tails the autoscaler logs of a Ray cluster."""
-    cli_logger.log_style = log_style
-    cli_logger.color_mode = log_color
-    cli_logger.verbosity = verbose
-    cli_logger.detect_colors()
+    cli_logger.configure(log_style, log_color, verbose)
 
     monitor_cluster(cluster_config_file, lines, cluster_name)
 
@@ -1085,10 +1070,7 @@ def monitor(cluster_config_file, lines, cluster_name, log_style, log_color,
 def attach(cluster_config_file, start, screen, tmux, cluster_name,
            no_config_cache, new, port_forward, log_style, log_color, verbose):
     """Create or attach to a SSH session to a Ray cluster."""
-    cli_logger.log_style = log_style
-    cli_logger.color_mode = log_color
-    cli_logger.verbosity = verbose
-    cli_logger.detect_colors()
+    cli_logger.configure(log_style, log_color, verbose)
 
     port_forward = [(port, port) for port in list(port_forward)]
     attach_cluster(
@@ -1116,10 +1098,7 @@ def attach(cluster_config_file, start, screen, tmux, cluster_name,
 def rsync_down(cluster_config_file, source, target, cluster_name, log_style,
                log_color, verbose):
     """Download specific files from a Ray cluster."""
-    cli_logger.log_style = log_style
-    cli_logger.color_mode = log_color
-    cli_logger.verbosity = verbose
-    cli_logger.detect_colors()
+    cli_logger.configure(log_style, log_color, verbose)
 
     rsync(cluster_config_file, source, target, cluster_name, down=True)
 
@@ -1144,10 +1123,7 @@ def rsync_down(cluster_config_file, source, target, cluster_name, log_style,
 def rsync_up(cluster_config_file, source, target, cluster_name, all_nodes,
              log_style, log_color, verbose):
     """Upload specific files to a Ray cluster."""
-    cli_logger.log_style = log_style
-    cli_logger.color_mode = log_color
-    cli_logger.verbosity = verbose
-    cli_logger.detect_colors()
+    cli_logger.configure(log_style, log_color, verbose)
 
     rsync(
         cluster_config_file,
@@ -1215,10 +1191,7 @@ def submit(cluster_config_file, screen, tmux, stop, start, cluster_name,
     Example:
         >>> ray submit [CLUSTER.YAML] experiment.py -- --smoke-test
     """
-    cli_logger.log_style = log_style
-    cli_logger.color_mode = log_color
-    cli_logger.verbosity = verbose
-    cli_logger.detect_colors()
+    cli_logger.configure(log_style, log_color, verbose)
 
     cli_logger.doassert(not (screen and tmux),
                         "`{}` and `{}` are incompatible.", cf.bold("--screen"),
@@ -1339,10 +1312,7 @@ def exec(cluster_config_file, cmd, run_env, screen, tmux, stop, start,
          cluster_name, no_config_cache, port_forward, log_style, log_color,
          verbose):
     """Execute a command via SSH on a Ray cluster."""
-    cli_logger.log_style = log_style
-    cli_logger.color_mode = log_color
-    cli_logger.verbosity = verbose
-    cli_logger.detect_colors()
+    cli_logger.configure(log_style, log_color, verbose)
 
     port_forward = [(port, port) for port in list(port_forward)]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Monitor logs were being reduced in verbosity.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)