### PR TITLE
[Java] fix download jars

### DIFF
--- a/java/build-jar-multiplatform.sh
+++ b/java/build-jar-multiplatform.sh
@@ -90,9 +90,9 @@ download_jars() {
   local sleep_time_units=60
 
   for f in "$@"; do
-    for os in 'darwin' 'windows'; do
+    for os in 'darwin' 'linux' 'windows'; do
       if [[ "$os" == "windows" ]]; then
-        break
+        continue
       fi
       local url="https://ray-wheels.s3-us-west-2.amazonaws.com/jars/$TRAVIS_BRANCH/$TRAVIS_COMMIT/$os/$f"
       mkdir -p "$JAR_BASE_DIR/$os"
@@ -115,6 +115,7 @@ download_jars() {
       done
     done
   done
+  echo "Download jars took $wait_time seconds"
 }
 
 # prepare native binaries and libraries.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fix  download linux jars for multi-platform jars build and deploy
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#10701
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
