### PR TITLE
[Java] Skip gpg sign for deploy snapshot jars

### DIFF
--- a/java/build-jar-multiplatform.sh
+++ b/java/build-jar-multiplatform.sh
@@ -167,11 +167,11 @@ deploy_jars() {
   if native_files_exist; then
     (
       cd "$WORKSPACE_DIR/java"
-      mvn -T16 install deploy -Dmaven.test.skip=true -Dcheckstyle.skip -Prelease -Dgpg.skip=true
+      mvn -T16 install deploy -Dmaven.test.skip=true -Dcheckstyle.skip -Prelease -Dgpg.skip="${GPG_SKIP:-true}"
     )
     (
       cd "$WORKSPACE_DIR/streaming/java"
-      mvn -T16 deploy -Dmaven.test.skip=true -Dcheckstyle.skip -Prelease -Dgpg.skip=true
+      mvn -T16 deploy -Dmaven.test.skip=true -Dcheckstyle.skip -Prelease -Dgpg.skip="${GPG_SKIP:-true}"
     )
     echo "Finished deploying jars"
   else

--- a/java/build-jar-multiplatform.sh
+++ b/java/build-jar-multiplatform.sh
@@ -167,11 +167,11 @@ deploy_jars() {
   if native_files_exist; then
     (
       cd "$WORKSPACE_DIR/java"
-      mvn -T16 deploy -Dmaven.test.skip=true -Dcheckstyle.skip -Prelease
+      mvn -T16 install deploy -Dmaven.test.skip=true -Dcheckstyle.skip -Prelease -Dgpg.skip=true
     )
     (
       cd "$WORKSPACE_DIR/streaming/java"
-      mvn -T16 deploy -Dmaven.test.skip=true -Dcheckstyle.skip -Prelease
+      mvn -T16 deploy -Dmaven.test.skip=true -Dcheckstyle.skip -Prelease -Dgpg.skip=true
     )
     echo "Finished deploying jars"
   else


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Skip gpg sign for deploy snapshot jars. GPG sing will be enabled when `GPG_SKIP` environment variable is set to `false`
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#10701 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
