### PR TITLE
[Dashboard] Change key for hosts from hostname to (hostname, ip)

### DIFF
--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -212,11 +212,11 @@ class DashboardController(BaseDashboardController):
     def kill_actor(self, actor_id, ip_address, port):
         return self.raylet_stats.kill_actor(actor_id, ip_address, port)
 
-    def get_logs(self, hostname, pid):
-        return self.node_stats.get_logs(hostname, pid)
+    def get_logs(self, ip, pid):
+        return self.node_stats.get_logs(ip, pid)
 
-    def get_errors(self, hostname, pid):
-        return self.node_stats.get_errors(hostname, pid)
+    def get_errors(self, ip, pid):
+        return self.node_stats.get_errors(ip, pid)
 
     def start_collecting_metrics(self):
         self.node_stats.start()
@@ -333,15 +333,15 @@ class DashboardRouteHandler(BaseDashboardRouteHandler):
             self.dashboard_controller.kill_actor(actor_id, ip_address, port))
 
     async def logs(self, req) -> aiohttp.web.Response:
-        hostname = req.query.get("hostname")
+        ip = req.query.get("ip_address")
         pid = req.query.get("pid")
-        result = self.dashboard_controller.get_logs(hostname, pid)
+        result = self.dashboard_controller.get_logs(ip, pid)
         return await json_response(self.is_dev, result=result)
 
     async def errors(self, req) -> aiohttp.web.Response:
-        hostname = req.query.get("hostname")
+        ip = req.query.get("ip_address")
         pid = req.query.get("pid")
-        result = self.dashboard_controller.get_errors(hostname, pid)
+        result = self.dashboard_controller.get_errors(ip, pid)
         return await json_response(self.is_dev, result=result)
 
 

--- a/python/ray/dashboard/interface.py
+++ b/python/ray/dashboard/interface.py
@@ -47,11 +47,11 @@ class BaseDashboardController(ABC):
         raise NotImplementedError("Please implement this method.")
 
     @abstractmethod
-    def get_logs(self, hostname, pid):
+    def get_logs(self, ip, pid):
         raise NotImplementedError("Please implement this method.")
 
     @abstractmethod
-    def get_errors(self, hostname, pid):
+    def get_errors(self, ip, pid):
         raise NotImplementedError("Please implement this method.")
 
     @abstractmethod

--- a/python/ray/dashboard/tests/test_node_stats.py
+++ b/python/ray/dashboard/tests/test_node_stats.py
@@ -61,10 +61,10 @@ def test_log_and_error_messages(ray_start_with_dashboard):
     stats = node_stats.get_node_stats()
     client_stats = stats and stats.get("clients")
     assert len(client_stats) == 1, "Client stats is not available."
-    hostname = client_stats[0]["hostname"]
+    ip = client_stats[0]["ip"]
 
     wait_for_condition(
-        lambda: len(node_stats.get_logs(hostname, pid)[pid]) == 3)
+        lambda: len(node_stats.get_logs(ip, pid)[pid]) == 3)
 
     @ray.remote
     class Actor:
@@ -78,4 +78,4 @@ def test_log_and_error_messages(ray_start_with_dashboard):
     pid = str(ray.get(actor.get_pid.remote()))
     actor.generate_error.remote()
     wait_for_condition(
-        lambda: len(node_stats.get_errors(hostname, pid)[pid]) == 1)
+        lambda: len(node_stats.get_errors(ip, pid)[pid]) == 1)

--- a/python/ray/dashboard/tests/test_node_stats.py
+++ b/python/ray/dashboard/tests/test_node_stats.py
@@ -63,8 +63,7 @@ def test_log_and_error_messages(ray_start_with_dashboard):
     assert len(client_stats) == 1, "Client stats is not available."
     ip = client_stats[0]["ip"]
 
-    wait_for_condition(
-        lambda: len(node_stats.get_logs(ip, pid)[pid]) == 3)
+    wait_for_condition(lambda: len(node_stats.get_logs(ip, pid)[pid]) == 3)
 
     @ray.remote
     class Actor:
@@ -77,5 +76,4 @@ def test_log_and_error_messages(ray_start_with_dashboard):
     actor = Actor.remote()
     pid = str(ray.get(actor.get_pid.remote()))
     actor.generate_error.remote()
-    wait_for_condition(
-        lambda: len(node_stats.get_errors(ip, pid)[pid]) == 1)
+    wait_for_condition(lambda: len(node_stats.get_errors(ip, pid)[pid]) == 1)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Multiple nodes may have the same IP address and different hostnames, and in addition nodes may have the same hostname and different IP addresses.  In our `node_stats` dictionary, then, we should use the tuple `(hostname, ip)` as the key instead of just `hostname`.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/9157.
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)
I don't know how to automatically start up a cluster with specified hostnames and IP addresses.  However, we tested this on an AWS cluster and manually changed the hostname of one of the worker nodes to match the head node, and the dashboard successfully displayed each one in its own row, rather than flickering between them as before.