### PR TITLE
[core] Fix segfault in network utils

### DIFF
--- a/src/ray/common/network_util.cc
+++ b/src/ray/common/network_util.cc
@@ -97,7 +97,7 @@ std::vector<boost::asio::ip::address> GetValidLocalIpCandidates() {
 
   struct ifaddrs *if_info = nullptr;
   for (if_info = ifs_info; if_info != nullptr; if_info = if_info->ifa_next) {
-    if (if_info->ifa_addr->sa_family == AF_INET) {
+    if (if_info->ifa_addr && if_info->ifa_addr->sa_family == AF_INET) {
       void *addr = &((struct sockaddr_in *)if_info->ifa_addr)->sin_addr;
 
       char ip[INET_ADDRSTRLEN];
@@ -115,7 +115,8 @@ std::vector<boost::asio::ip::address> GetValidLocalIpCandidates() {
 
   // Filter out interfaces with small possibility of being desired to be used to serve
   std::sort(ifnames_and_ips.begin(), ifnames_and_ips.end(), CompNamesAndIps);
-  while (GetPriority(ifnames_and_ips.back().first) == Priority::kExclude) {
+  while (!ifnames_and_ips.empty() &&
+         GetPriority(ifnames_and_ips.back().first) == Priority::kExclude) {
     ifnames_and_ips.pop_back();
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes some bad memory accesses in C++ network utils.

## Related issue number

Closes #10722.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)

I wasn't able to trigger the issue naturally again, but was able to trigger segfaults in the same method by disabling my laptop's network interfaces and hacking the code a bit. I hope but am not sure that these were the same issues.
