### PR TITLE
[Java] Fix java doc building error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -172,10 +172,11 @@ matrix:
         - PYTHONWARNINGS=ignore
         - RAY_INSTALL_JAVA=1
       install:
-        - brew tap adoptopenjdk/openjdk
-        - brew cask install adoptopenjdk8
         - . ./ci/travis/ci.sh init RAY_CI_MACOS_WHEELS_AFFECTED,RAY_CI_JAVA_AFFECTED,RAY_CI_STREAMING_JAVA_AFFECTED
       before_script:
+        - brew tap adoptopenjdk/openjdk
+        - brew cask install adoptopenjdk8
+        - java -version
         - . ./ci/travis/ci.sh build
       script:
         - . ./ci/travis/ci.sh test_wheels

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ before_install:
     git fetch -q -- origin "${to_fetch[@]}"
     git checkout -qf "${TRAVIS_COMMIT}" --
     python -u ci/remote-watch.py --skip_repo=ray-project/ray &
-  - wget https://github.com/michaelklishin/jdk_switcher/blob/master/jdk_switcher.sh
-  - sh jdk_switcher.sh use openjdk8
+  - export JAVA_HOME=$HOME/openjdk8
+  - $TRAVIS_BUILD_DIR/install-jdk.sh --install openjdk8 --target $JAVA_HOME
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,6 +123,7 @@ matrix:
 
     - os: linux
       env:
+        - JAVA_TESTS=1
         - PYTHON=3.6 PYTHONWARNINGS=ignore
         - RAY_INSTALL_JAVA=1
       install:
@@ -134,7 +135,7 @@ matrix:
 
     - os: linux
       env:
-        - TESTSUITE=streaming
+        - STREAMING_TESTS=1
         - RAY_INSTALL_JAVA=1
         - PYTHON=3.6 PYTHONWARNINGS=ignore
         - RAY_USE_RANDOM_PORTS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ git:
   depth: false  # Shallow clones can prevent diff against base branch
   quiet: true
 
-jdk:
-  - openjdk8
-
 before_install:
   - unset -f cd  # Travis defines this on Mac for RVM, but it breaks the Mac build
   - |
@@ -20,6 +17,8 @@ before_install:
     git fetch -q -- origin "${to_fetch[@]}"
     git checkout -qf "${TRAVIS_COMMIT}" --
     python -u ci/remote-watch.py --skip_repo=ray-project/ray &
+  - wget https://github.com/michaelklishin/jdk_switcher/blob/master/jdk_switcher.sh
+  - sh jdk_switcher.sh use openjdk8
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ git:
   depth: false  # Shallow clones can prevent diff against base branch
   quiet: true
 
+jdk:
+  - openjdk8
+
 before_install:
   - unset -f cd  # Travis defines this on Mac for RVM, but it breaks the Mac build
   - |
@@ -17,7 +20,6 @@ before_install:
     git fetch -q -- origin "${to_fetch[@]}"
     git checkout -qf "${TRAVIS_COMMIT}" --
     python -u ci/remote-watch.py --skip_repo=ray-project/ray &
-  - jdk_switcher use openjdk8
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
     git fetch -q -- origin "${to_fetch[@]}"
     git checkout -qf "${TRAVIS_COMMIT}" --
     python -u ci/remote-watch.py --skip_repo=ray-project/ray &
+  - jdk_switcher use openjdk8
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -171,9 +171,9 @@ matrix:
         - MAC_WHEELS=1 MAC_JARS=1
         - PYTHONWARNINGS=ignore
         - RAY_INSTALL_JAVA=1
-      language: java
-      jdk: openjdk8
       install:
+        - brew tap adoptopenjdk/openjdk
+        - brew cask install adoptopenjdk8
         - . ./ci/travis/ci.sh init RAY_CI_MACOS_WHEELS_AFFECTED,RAY_CI_JAVA_AFFECTED,RAY_CI_STREAMING_JAVA_AFFECTED
       before_script:
         - . ./ci/travis/ci.sh build

--- a/.travis.yml
+++ b/.travis.yml
@@ -176,6 +176,7 @@ matrix:
       before_script:
         - brew tap adoptopenjdk/openjdk
         - brew cask install adoptopenjdk8
+        - export JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
         - java -version
         - . ./ci/travis/ci.sh build
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ before_install:
     git fetch -q -- origin "${to_fetch[@]}"
     git checkout -qf "${TRAVIS_COMMIT}" --
     python -u ci/remote-watch.py --skip_repo=ray-project/ray &
-  - export JAVA_HOME=$HOME/openjdk8
-  - $TRAVIS_BUILD_DIR/install-jdk.sh --install openjdk8 --target $JAVA_HOME
 
 matrix:
   include:
@@ -124,7 +122,7 @@ matrix:
 
     - os: linux
       env:
-        - JAVA_TESTS=1
+        - JDK='Oracle JDK 8'
         - PYTHON=3.6 PYTHONWARNINGS=ignore
         - RAY_INSTALL_JAVA=1
       install:
@@ -136,7 +134,8 @@ matrix:
 
     - os: linux
       env:
-        - STREAMING_TESTS=1
+        - TESTSUITE=streaming
+        - JDK='Oracle JDK 8'
         - RAY_INSTALL_JAVA=1
         - PYTHON=3.6 PYTHONWARNINGS=ignore
         - RAY_USE_RANDOM_PORTS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,9 +122,11 @@ matrix:
 
     - os: linux
       env:
-        - JDK='Oracle JDK 8'
+        - JAVA_TESTS=1
         - PYTHON=3.6 PYTHONWARNINGS=ignore
         - RAY_INSTALL_JAVA=1
+      language: java
+      jdk: openjdk8
       install:
         - . ./ci/travis/ci.sh init RAY_CI_JAVA_AFFECTED
       before_script:
@@ -134,11 +136,12 @@ matrix:
 
     - os: linux
       env:
-        - TESTSUITE=streaming
-        - JDK='Oracle JDK 8'
+        - STREAMING_TESTS=1
         - RAY_INSTALL_JAVA=1
         - PYTHON=3.6 PYTHONWARNINGS=ignore
         - RAY_USE_RANDOM_PORTS=1
+      language: java
+      jdk: openjdk8
       install:
         - . ./ci/travis/ci.sh init RAY_CI_STREAMING_PYTHON_AFFECTED,RAY_CI_STREAMING_JAVA_AFFECTED
       before_script:
@@ -168,6 +171,8 @@ matrix:
         - MAC_WHEELS=1 MAC_JARS=1
         - PYTHONWARNINGS=ignore
         - RAY_INSTALL_JAVA=1
+      language: java
+      jdk: openjdk8
       install:
         - . ./ci/travis/ci.sh init RAY_CI_MACOS_WHEELS_AFFECTED,RAY_CI_JAVA_AFFECTED,RAY_CI_STREAMING_JAVA_AFFECTED
       before_script:
@@ -176,12 +181,14 @@ matrix:
         - . ./ci/travis/ci.sh test_wheels
         - bash ./java/build-jar-multiplatform.sh darwin
 
-    # Build Linux wheels and  jars.
+    # Build Linux wheels and jars.
     - os: linux
       env:
         - LINUX_WHEELS=1 LINUX_JARS=1
         - PYTHONWARNINGS=ignore
         - RAY_INSTALL_JAVA=1
+      language: java
+      jdk: openjdk8
       install:
         - . ./ci/travis/ci.sh init RAY_CI_LINUX_WHEELS_AFFECTED,RAY_CI_JAVA_AFFECTED,RAY_CI_STREAMING_JAVA_AFFECTED
       before_script:
@@ -200,6 +207,8 @@ matrix:
         - RAY_INSTALL_JAVA=1
         - secure: "Un2SGOCdD/RiqbO47vtkwn5dPbGbwHi/TKunyNJLKcGILwJc0sZL9uf8pkffyYGbt7ejnYwV9tPgoAlFxcuJYgbmkt84AxDF8oskJmFKYjkxOtEFkqskhTb0u9/usjq23OXrmGN4NqvzLEdbf7Z3wyMxXpzgDKPUgDAFUfB2Ya8OapXuPdt/5KDlDBS0Bj9sKqI+0keYovfRY8dO2/Vd0Ojqkmz1PWHTQP0TrC1X+juciDdoRnU1rO8mxhQW4HKICexwAr1rsAqALpuDlfyhG7I+aicVjK3uiQuviGJOoI813f00YlTOAoXW2YPpblExp0uoTQN2zaYvpp1zUx7V/rVaAoXmFI7ELQ+nr8oAJbImWe1bCNO3UsxpzGamGlTIx7hAiJ0CwFU6qW/+NKWIlhH1iBxUZHw/F8Ixsqtdwx3yhR/rj86sdItAM9CkK6URVdWk2U4VimyDzzJpUWWFsjUZ2V8jNxYPrWg52ciC4k7tp32qrKYrBa+mJduE68/xjFeeZdYUxzg1AT3Lh3rA0ebMIELT7OBz6DRjUmRgO6+VJIRfbPszHEG2X+aPHtSj+Fsc4AacVtiIUUpXMeUx9nxM7oD1lXr8I59vq5+6EhohKBmc4DkpkWLnsCMTnJ1HQ37zKxRSE5jDwyNTJ8x2l8bbK/pqTRZPWUeKL3Is8NE="
         - secure: "IrNncc7RpiSnU/3fB72bG/Vyt/w50uTIVMIdgy64eNw0TgDf15/0IuwzCZDrjTAwq2meGAYFq1KNb7W538UDn+zJs6YIrcEF+2c53alCRASrafFEgAQmbvTpFtxAcHfTFK3c3neVXGiCeOSn64ymV5vQKjLCGvlEpmA10EUmdIE3wIgYRYMTzpzV9A4HmJbAgkBslhIw17BottFbfrL9Z4LlBJjOSP/t9cbGn8QVuM7V4dR+lo5j1Ns8XaVCkNvVqQdJEsp8xeMMn3pvFDxBBEn4zQ2xEGN4QvKquiACaVZLTnNCTkan5pRbswy25hOTnt/zNovJK8TBNuyWTBJNJo+f6vkuQXNR9iRkOQ+FAInjvEVYUWstuc6+opp8yV9cMdOsOMQRX/V6qo5pE2uERU0Fr6WtAhSvZDcGinpfoYkbMXxPdI8E7gmCJKrQ91hVU1ExokztbNesy7YWic/GZPzoBGMSPnNJ8chaydvmeq74P6F0cGI1LU/Tea7Ewf9MbJjWiVZ2C9G1Po3a6vu0ElE1NSIotBZFfpp2P8IeqP5/pZ84E93yRpT4Pt2kBsEjUqiNqLduXDPJnoBHHRzuNovT7sHJoZZAaBipuiNdj4ZQLgA+1WVysaHIDlzlcOMAxNNRMuT6+GATEvtsK8llh0qEzKShbOST54DDp1jST4w="
+      language: java
+      jdk: openjdk8
       install:
         - . ./ci/travis/ci.sh init RAY_CI_JAVA_AFFECTED,RAY_CI_STREAMING_JAVA_AFFECTED
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,6 @@ matrix:
 
     - os: linux
       env:
-        - JDK='Oracle JDK 8'
         - PYTHON=3.6 PYTHONWARNINGS=ignore
         - RAY_INSTALL_JAVA=1
       install:
@@ -136,7 +135,6 @@ matrix:
     - os: linux
       env:
         - TESTSUITE=streaming
-        - JDK='Oracle JDK 8'
         - RAY_INSTALL_JAVA=1
         - PYTHON=3.6 PYTHONWARNINGS=ignore
         - RAY_USE_RANDOM_PORTS=1

--- a/java/api/src/main/java/io/ray/api/call/BaseActorCreator.java
+++ b/java/api/src/main/java/io/ray/api/call/BaseActorCreator.java
@@ -89,7 +89,7 @@ public class BaseActorCreator<T extends BaseActorCreator> {
    * Set the max number of concurrent calls to allow for this actor.
    * <p>
    * The max concurrency defaults to 1 for threaded execution.
-   * Note that the execution order is not guaranteed when max_concurrency > 1.
+   * Note that the execution order is not guaranteed when {@code max_concurrency > 1}.
    *
    * @param maxConcurrency The max number of concurrent calls to allow for this actor.
    * @return self

--- a/java/api/src/main/java/io/ray/api/options/ActorCreationOptions.java
+++ b/java/api/src/main/java/io/ray/api/options/ActorCreationOptions.java
@@ -129,7 +129,7 @@ public class ActorCreationOptions extends BaseTaskOptions {
      * Set the max number of concurrent calls to allow for this actor.
      * <p>
      * The max concurrency defaults to 1 for threaded execution.
-     * Note that the execution order is not guaranteed when max_concurrency > 1.
+     * Note that the execution order is not guaranteed when {@code max_concurrency > 1}.
      *
      * @param maxConcurrency The max number of concurrent calls to allow for this actor.
      * @return self

--- a/java/build-jar-multiplatform.sh
+++ b/java/build-jar-multiplatform.sh
@@ -17,6 +17,15 @@ cd "$WORKSPACE_DIR/java"
 version=$(python -c "import xml.etree.ElementTree as ET;  r = ET.parse('pom.xml').getroot(); print(r.find(r.tag.replace('project', 'version')).text);" | tail -n 1)
 cd -
 
+check_java_version() {
+  local VERSION
+  VERSION=$(java  -version 2>&1 | awk -F '"' '/version/ {print $2}')
+  if [[ ! $VERSION =~ 1.8 ]]; then
+    echo "Java version is $VERSION. Please install jkd8."
+    exit 1
+  fi
+}
+
 build_jars() {
   local platform="$1"
   local bazel_build="${2:-true}"
@@ -179,6 +188,8 @@ deploy_jars() {
     echo "Native bianries/libraries are not ready, skip deploying jars."
   fi
 }
+
+check_java_version
 
 case "$1" in
 linux) # build jars that only contains Linux binaries.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -124,7 +124,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.4</version>
+          <version>3.1.0</version>
           <executions>
             <execution>
               <id>attach-javadocs</id>

--- a/java/test.sh
+++ b/java/test.sh
@@ -6,6 +6,7 @@ set -e
 set -x
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
+java -version
 
 run_testng() {
     local exit_code

--- a/streaming/java/pom.xml
+++ b/streaming/java/pom.xml
@@ -153,7 +153,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.4</version>
+          <version>3.1.0</version>
           <executions>
             <execution>
               <id>attach-javadocs</id>


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When build java doc with jdk11, we got `the code being documented uses modules` error. This PR fix it by using jdk8 and upgrade java doc plugin version. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
