### PR TITLE
[cli] make test failure less verbose + print ssh

### DIFF
--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -730,9 +730,13 @@ def get_or_create_head_node(config,
                 cf.bold("  ray exec {}{} {}"), config_file, modifiers,
                 quote(monitor_str))
 
-            cli_logger.print("Connect to a terminal on the cluster head")
+            cli_logger.print("Connect to a terminal on the cluster head:")
             cli_logger.print(
                 cf.bold("  ray attach {}{}"), config_file, modifiers)
+
+            remote_shell_str = updater.cmd_runner.remote_shell_command_str()
+            cli_logger.print("Get a remote shell to the cluster manually:")
+            cli_logger.print("  {}", remote_shell_str.strip())
     finally:
         provider.cleanup()
 

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -94,7 +94,7 @@ def _debug_check_line_by_line(result, expected_lines):
         if i >= len(expected_lines):
             i += 1
             print("!!!!!! Expected fewer lines")
-            context = [f"CONTEXT: {line}" for line in output_lines[i-3:i]]
+            context = [f"CONTEXT: {line}" for line in output_lines[i - 3:i]]
             print("\n".join(context))
             extra = [f"-- {line}" for line in output_lines[i:]]
             print("\n".join(extra))

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -91,21 +91,23 @@ def _debug_check_line_by_line(result, expected_lines):
     i = 0
 
     for out in output_lines:
-        print(out)
-
         if i >= len(expected_lines):
             i += 1
             print("!!!!!! Expected fewer lines")
-            print("\n".join(output_lines[i:]))
+            context = [f"CONTEXT: {line}" for line in output_lines[i-3:i]]
+            print("\n".join(context))
+            extra = [f"-- {line}" for line in output_lines[i:]]
+            print("\n".join(extra))
             break
 
         exp = expected_lines[i]
         matched = re.fullmatch(exp + r" *", out) is not None
         if not matched:
-            print(f"!!!!!!! Expected (regex): {repr(exp)}")
+            print(f"!!! ERROR: Expected (regex): {repr(exp)}")
+            print(f"Got: {out}")
         i += 1
     if i < len(expected_lines):
-        print("!!!!!!! Expected (regex):")
+        print("!!! ERROR: Expected extra lines (regex):")
         for line in expected_lines[i:]:
 
             print(repr(line))

--- a/python/ray/tests/test_cli_patterns/test_ray_up.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_up.txt
@@ -42,5 +42,7 @@ Acquiring an up-to-date head node
 Useful commands
   Monitor autoscaling with
     ray exec .+ 'tail -n 100 -f /tmp/ray/session_latest/logs/monitor\*'
-  Connect to a terminal on the cluster head
+  Connect to a terminal on the cluster head:
     ray attach .+
+  Get a remote shell to the cluster manually:
+    ssh .+

--- a/python/ray/tests/test_cli_patterns/test_ray_up_record.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_up_record.txt
@@ -71,5 +71,7 @@
 .+\.py.*Useful commands
 .+\.py.*Monitor autoscaling with
 .+\.py.*  ray exec .+ 'tail -n 100 -f .+
-.+\.py.*Connect to a terminal on the cluster head
+.+\.py.*Connect to a terminal on the cluster head:
 .+\.py.*  ray attach .+
+.+\.py.*Get a remote shell to the cluster manually:
+.+\.py.*  ssh.+\.pem.+


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A ssh command is now printed to avoid being too magical.

Closes #10763 

@ericl
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(