### PR TITLE
[Java] rename config ray.redis.address to ray.address

### DIFF
--- a/doc/source/starting-ray.rst
+++ b/doc/source/starting-ray.rst
@@ -152,17 +152,17 @@ There are two steps needed to use Ray in a distributed setting:
 
         .. group-tab:: Java
 
-          You need to add the ``ray.redis.address`` parameter to your command line (like ``-Dray.redis.address=...``).
+          You need to add the ``ray.address`` parameter to your command line (like ``-Dray.address=...``).
 
           To connect your program to the Ray cluster, run it like this:
 
               .. code-block:: bash
 
                   java -classpath /path/to/jars/ \
-                    -Dray.redis.address=<address> \
+                    -Dray.address=<address> \
                     <classname> <args>
 
-          .. note:: Specifying ``auto`` as the Redis address hasn't been implemented in Java yet. You need to provide the actual Redis address. You can find the address of the Redis server from the output of the ``ray up`` command.
+          .. note:: Specifying ``auto`` as the address hasn't been implemented in Java yet. You need to provide the actual address. You can find the address of the server from the output of the ``ray up`` command.
 
       Your driver code **only** needs to execute on one machine in the cluster (usually the head node).
 

--- a/doc/source/walkthrough.rst
+++ b/doc/source/walkthrough.rst
@@ -48,7 +48,7 @@ You can start Ray on a single machine by adding this to your code.
 
       public static void main(String[] args) {
         // Start Ray runtime. If you're connecting to an existing cluster, you can set
-        // the `-Dray.redis.address=<cluster-address>` java system property.
+        // the `-Dray.address=<cluster-address>` java system property.
         Ray.init();
         ...
       }

--- a/java/runtime/src/main/java/io/ray/runtime/config/RayConfig.java
+++ b/java/runtime/src/main/java/io/ray/runtime/config/RayConfig.java
@@ -190,7 +190,7 @@ public class RayConfig {
     }
 
     // Redis configurations.
-    String redisAddress = config.getString("ray.redis.address");
+    String redisAddress = config.getString("ray.address");
     if (StringUtils.isNotBlank(redisAddress)) {
       setRedisAddress(redisAddress);
     } else {
@@ -313,7 +313,7 @@ public class RayConfig {
     dynamic.put("ray.raylet.socket-name", rayletSocketName);
     dynamic.put("ray.object-store.socket-name", objectStoreSocketName);
     dynamic.put("ray.raylet.node-manager-port", nodeManagerPort);
-    dynamic.put("ray.redis.address", redisAddress);
+    dynamic.put("ray.address", redisAddress);
     dynamic.put("ray.job.code-search-path", codeSearchPath);
     Config toRender = ConfigFactory.parseMap(dynamic).withFallback(config);
     return toRender.root().render(ConfigRenderOptions.concise());

--- a/java/runtime/src/main/resources/ray.default.conf
+++ b/java/runtime/src/main/resources/ray.default.conf
@@ -7,6 +7,10 @@ ray {
   // Basic configurations
   // ----------------------
 
+  // Address of the Ray cluster to connect to.
+  // If not provided, a new Ray cluster will be created.
+  address: ""
+
   // Run mode, available options are:
   //
   // `SINGLE_PROCESS`: Ray is running in one single Java process, without Raylet backend,
@@ -67,10 +71,6 @@ ray {
   // Redis configurations
   // ----------------------
   redis {
-    // The address of the redis server to connect, in format `ip:port`.
-    // If not provided, Ray processes will be started locally, including
-    // Redis server, Raylet and object store.
-    address: ""
     // If `redis.server` isn't provided, which port we should use to start redis server.
     // If `head-port` is not provided, it will be generated randomly.
     // head-port: 6379

--- a/java/test.sh
+++ b/java/test.sh
@@ -58,7 +58,7 @@ case "${OSTYPE}" in
   *) echo "Can't get ip address for ${OSTYPE}"; exit 1;;
 esac
 RAY_BACKEND_LOG_LEVEL=debug ray start --head --redis-port=6379 --redis-password=123456 --code-search-path="$PWD/bazel-bin/java/all_tests_deploy.jar"
-RAY_BACKEND_LOG_LEVEL=debug java -cp bazel-bin/java/all_tests_deploy.jar -Dray.redis.address="$ip:6379"\
+RAY_BACKEND_LOG_LEVEL=debug java -cp bazel-bin/java/all_tests_deploy.jar -Dray.address="$ip:6379"\
  -Dray.redis.password='123456' -Dray.job.code-search-path="$PWD/bazel-bin/java/all_tests_deploy.jar" io.ray.test.MultiDriverTest
 ray stop
 

--- a/java/test/src/main/java/io/ray/docdemo/WalkthroughDemo.java
+++ b/java/test/src/main/java/io/ray/docdemo/WalkthroughDemo.java
@@ -136,7 +136,7 @@ public class WalkthroughDemo {
 
   public static void main(String[] args) {
     // Start Ray runtime. If you're connecting to an existing cluster, you can set
-    // the `-Dray.redis.address=<cluster-address>` java system property.
+    // the `-Dray.address=<cluster-address>` java system property.
     Ray.init();
 
     demoTasks();

--- a/java/test/src/main/java/io/ray/test/BaseMultiLanguageTest.java
+++ b/java/test/src/main/java/io/ray/test/BaseMultiLanguageTest.java
@@ -92,7 +92,7 @@ public abstract class BaseMultiLanguageTest {
 
     // Connect to the cluster.
     Assert.assertFalse(Ray.isInitialized());
-    System.setProperty("ray.redis.address", "127.0.0.1:6379");
+    System.setProperty("ray.address", "127.0.0.1:6379");
     System.setProperty("ray.object-store.socket-name", PLASMA_STORE_SOCKET_NAME);
     System.setProperty("ray.raylet.socket-name", RAYLET_SOCKET_NAME);
     System.setProperty("ray.raylet.node-manager-port", nodeManagerPort);
@@ -110,7 +110,7 @@ public abstract class BaseMultiLanguageTest {
   public void tearDown() {
     // Disconnect to the cluster.
     Ray.shutdown();
-    System.clearProperty("ray.redis.address");
+    System.clearProperty("ray.address");
     System.clearProperty("ray.object-store.socket-name");
     System.clearProperty("ray.raylet.socket-name");
     System.clearProperty("ray.raylet.node-manager-port");

--- a/java/test/src/main/java/io/ray/test/MultiDriverTest.java
+++ b/java/test/src/main/java/io/ray/test/MultiDriverTest.java
@@ -119,7 +119,7 @@ public class MultiDriverTest extends BaseTest {
         "java",
         "-cp",
         System.getProperty("java.class.path"),
-        "-Dray.redis.address=" + rayConfig.getRedisAddress(),
+        "-Dray.address=" + rayConfig.getRedisAddress(),
         "-Dray.object-store.socket-name=" + rayConfig.objectStoreSocketName,
         "-Dray.raylet.socket-name=" + rayConfig.rayletSocketName,
         "-Dray.raylet.node-manager-port=" + String.valueOf(rayConfig.getNodeManagerPort()),

--- a/java/test/src/main/java/io/ray/test/NamedActorTest.java
+++ b/java/test/src/main/java/io/ray/test/NamedActorTest.java
@@ -59,7 +59,7 @@ public class NamedActorTest extends BaseTest {
           "java",
           "-cp",
           System.getProperty("java.class.path"),
-          "-Dray.redis.address=" + rayConfig.getRedisAddress(),
+          "-Dray.address=" + rayConfig.getRedisAddress(),
           "-Dray.object-store.socket-name=" + rayConfig.objectStoreSocketName,
           "-Dray.raylet.socket-name=" + rayConfig.rayletSocketName,
           "-Dray.raylet.node-manager-port=" + rayConfig.getNodeManagerPort(),

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1495,7 +1495,7 @@ def build_java_worker_command(java_worker_options, redis_address,
     """
     pairs = []
     if redis_address is not None:
-        pairs.append(("ray.redis.address", redis_address))
+        pairs.append(("ray.address", redis_address))
     pairs.append(("ray.raylet.node-manager-port", node_manager_port))
 
     if plasma_store_name is not None:

--- a/streaming/java/streaming-api/src/main/java/io/ray/streaming/api/context/ClusterStarter.java
+++ b/streaming/java/streaming-api/src/main/java/io/ray/streaming/api/context/ClusterStarter.java
@@ -76,7 +76,7 @@ class ClusterStarter {
     }
 
     // Connect to the cluster.
-    System.setProperty("ray.redis.address", "127.0.0.1:6379");
+    System.setProperty("ray.address", "127.0.0.1:6379");
     System.setProperty("ray.object-store.socket-name", PLASMA_STORE_SOCKET_NAME);
     System.setProperty("ray.raylet.socket-name", RAYLET_SOCKET_NAME);
     System.setProperty("ray.raylet.node-manager-port", nodeManagerPort);
@@ -86,7 +86,7 @@ class ClusterStarter {
   public static synchronized void stopCluster(boolean isCrossLanguage) {
     // Disconnect to the cluster.
     Ray.shutdown();
-    System.clearProperty("ray.redis.address");
+    System.clearProperty("ray.address");
     System.clearProperty("ray.object-store.socket-name");
     System.clearProperty("ray.raylet.socket-name");
     System.clearProperty("ray.raylet.node-manager-port");

--- a/streaming/java/streaming-api/src/main/resources/ray.conf
+++ b/streaming/java/streaming-api/src/main/resources/ray.conf
@@ -1,5 +1,5 @@
 ray {
   run-mode = SINGLE_PROCESS
   resources = "CPU:4"
-  redis.address = ""
+  address = ""
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray is now decoupled with Redis. Avoid exposing redis in configuration.

## Related issue number


## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
