### PR TITLE
[tune] convert fallback representation to numbers in wandb integration

### DIFF
--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -2,6 +2,7 @@ import os
 import pickle
 from multiprocessing import Process, Queue
 from numbers import Number
+import numpy as np
 
 from ray import logger
 from ray.tune import Trainable
@@ -21,12 +22,21 @@ WANDB_ENV_VAR = "WANDB_API_KEY"
 _WANDB_QUEUE_END = (None, )
 
 
+def _is_allowed_type(obj):
+    """Return True if type is allowed for logging to wandb"""
+    if isinstance(obj, np.ndarray) and obj.size == 1:
+        return np.isscalar(obj.item())
+    return isinstance(obj, Number) or np.isscalar(obj)
+
+
 def _clean_log(obj):
     # Fixes https://github.com/ray-project/ray/issues/10631
     if isinstance(obj, dict):
         return {k: _clean_log(v) for k, v in obj.items()}
     elif isinstance(obj, list):
         return [_clean_log(v) for v in obj]
+    elif _is_allowed_type(obj):
+        return obj
 
     # Else
     try:
@@ -199,7 +209,7 @@ class _WandbLoggingProcess(Process):
                     k.startswith(item + "/") or k == item
                     for item in self._exclude):
                 continue
-            elif not isinstance(v, Number):
+            elif not _is_allowed_type(v):
                 continue
             else:
                 log[k] = v

--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -25,8 +25,8 @@ _WANDB_QUEUE_END = (None, )
 def _is_allowed_type(obj):
     """Return True if type is allowed for logging to wandb"""
     if isinstance(obj, np.ndarray) and obj.size == 1:
-        return np.isscalar(obj.item())
-    return isinstance(obj, Number) or np.isscalar(obj)
+        return isinstance(obj.item(), Number)
+    return isinstance(obj, Number)
 
 
 def _clean_log(obj):

--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -40,7 +40,24 @@ def _clean_log(obj):
         return obj
     except Exception:
         # give up, similar to _SafeFallBackEncoder
-        return str(obj)
+        fallback = str(obj)
+
+        # Try to convert to int
+        try:
+            fallback = int(fallback)
+            return fallback
+        except ValueError:
+            pass
+
+        # Try to convert to float
+        try:
+            fallback = float(fallback)
+            return fallback
+        except ValueError:
+            pass
+
+        # Else, return string
+        return fallback
 
 
 def wandb_mixin(func):

--- a/python/ray/tune/tests/test_integration_wandb.py
+++ b/python/ray/tune/tests/test_integration_wandb.py
@@ -4,6 +4,8 @@ from collections import namedtuple
 from multiprocessing import Queue
 import unittest
 
+import numpy as np
+
 from ray.tune import Trainable
 from ray.tune.function_runner import wrap_function
 from ray.tune.integration.wandb import _WandbLoggingProcess, \
@@ -156,6 +158,8 @@ class WandbIntegrationTest(unittest.TestCase):
         r1 = {
             "metric1": 0.8,
             "metric2": 1.4,
+            "metric3": np.asarray(32.0),
+            "metric4": np.float32(32.0),
             "const": "text",
             "config": trial_config
         }
@@ -165,6 +169,8 @@ class WandbIntegrationTest(unittest.TestCase):
         logged = logger._wandb.logs.get(timeout=10)
         self.assertIn("metric1", logged)
         self.assertNotIn("metric2", logged)
+        self.assertIn("metric3", logged)
+        self.assertIn("metric4", logged)
         self.assertNotIn("const", logged)
         self.assertNotIn("config", logged)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The wandb logger filters out non-numbers before logging. However, in log cleaning, number types like num,py floats, integers, and arrays were converted to strings. Metrics like episode rewards were thus not logged anymore.

## Related issue number

Closes extension of #10426

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
