### PR TITLE
[cli][ray] update ray cli message

### DIFF
--- a/doc/source/cluster/slurm.rst
+++ b/doc/source/cluster/slurm.rst
@@ -79,7 +79,7 @@ Starter SLURM script
   redis_password = sys.argv[1]
   num_cpus = int(sys.argv[2])
 
-  ray.init(address=os.environ["ip_head"], redis_password=redis_password)
+  ray.init(address=os.environ["ip_head"], _redis_password=redis_password)
 
   print("Nodes in the Ray cluster:")
   print(ray.nodes())

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -584,7 +584,7 @@ def start(node_ip_address, redis_address, address, redis_port, port,
                     cli_logger.print(
                         "ray{}init(address{}{}{})", c.magenta("."),
                         c.magenta("="), c.yellow("'auto'"),
-                        ", redis_password{}{}".format(
+                        ", _redis_password{}{}".format(
                             c.magenta("="),
                             c.yellow("'" + redis_password + "'"))
                         if redis_password else "")

--- a/python/ray/tests/test_cli_patterns/test_ray_start.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_start.txt
@@ -10,7 +10,7 @@ Next steps
 
   Alternatively, use the following Python code:
     import ray
-    ray\.init\(address='auto', redis_password='.+'\)
+    ray\.init\(address='auto', _redis_password='.+'\)
 
   If connection fails, check your firewall settings and network configuration.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The instructions from `ray start --head` has a typo:

```
> ray start --head
Local node IP: 192.168.86.36
2020-09-15 21:36:33,184	INFO services.py:1164 -- View the Ray dashboard at http://192.168.86.36:8265

--------------------
Ray runtime started.
--------------------

Next steps
  To connect to this Ray runtime from another node, run
    ray start --address='192.168.86.36:6379' --redis-password='5241590000000000'

  Alternatively, use the following Python code:
    import ray
    ray.init(address='auto', redis_password='5241590000000000') <<------ THIS LINE -----
```

It should be:
```
    ray.init(address='auto', _redis_password='5241590000000000') 
```

Also updated a similar typo in doc.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
