### PR TITLE
[cli][ray] fix `ray start` should error by default if there`s already…

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -471,7 +471,6 @@ def start(node_ip_address, address, port, redis_password, redis_shard_ports,
             autoscaling_config=autoscaling_config,
         )
 
-        print(f"port {port}")
         # Fail early when starting a new cluster when one is already running
         if address is None:
             default_address = f"{node_ip_address}:{port}"

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -430,6 +430,15 @@ def start(node_ip_address, address, port, redis_password, redis_shard_ports,
         enable_object_reconstruction=enable_object_reconstruction,
         metrics_export_port=metrics_export_port)
     if head:
+        # Use default if port is none, allocate an available port if port is 0
+        if port is None:
+            port = ray_constants.DEFAULT_PORT
+
+        if port == 0:
+            with socket() as s:
+                s.bind(("", 0))
+                port = s.getsockname()[1]
+
         num_redis_shards = None
         # Start Ray on the head node.
         if redis_shard_ports is not None:
@@ -463,15 +472,7 @@ def start(node_ip_address, address, port, redis_password, redis_shard_ports,
             autoscaling_config=autoscaling_config,
         )
 
-        # Use default if port is none, allocate an available port if port is 0
-        if port is None:
-            port = ray_constants.DEFAULT_PORT
-
-        if port == 0:
-            with socket() as s:
-                s.bind(("", 0))
-                port = s.getsockname()[1]
-
+        print(f"port {port}")
         # Fail early when starting a new cluster when one is already running
         if address is None:
             default_address = f"{node_ip_address}:{port}"

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -447,8 +447,7 @@ def start(node_ip_address, address, port, redis_password, redis_shard_ports,
         node_ip_address = services.get_node_ip_address()
 
         # Get the node IP address if one is not provided.
-        ray_params.update_if_absent(
-            node_ip_address=node_ip_address)
+        ray_params.update_if_absent(node_ip_address=node_ip_address)
         cli_logger.labeled_value("Local node IP", ray_params.node_ip_address)
         cli_logger.old_info(logger, "Using IP address {} for this node.",
                             ray_params.node_ip_address)

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -467,7 +467,8 @@ def start(node_ip_address, address, port, redis_password, redis_shard_ports,
             if len(redis_addresses) > 0:
                 raise ConnectionError(
                     f"Ray is already running at {default_address}. "
-                    f" Please specify a different port using the `--port` command to `ray start`."
+                    f" Please specify a different port using the `--port`"
+                    f" command to `ray start`.")
 
         node = ray.node.Node(
             ray_params, head=True, shutdown_at_exit=block, spawn_reaper=block)

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -466,8 +466,7 @@ def start(node_ip_address, address, port, redis_password, redis_shard_ports,
             redis_addresses = services.find_redis_address(default_address)
             if len(redis_addresses) > 0:
                 raise ConnectionError(
-                    f"There is already a Ray head running "
-                    f"at: {default_address}."
+                    f"Ray is already running at {default_address}. "
                     f" Please specify a different address to start.")
 
         node = ray.node.Node(

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -467,7 +467,7 @@ def start(node_ip_address, address, port, redis_password, redis_shard_ports,
             if len(redis_addresses) > 0:
                 raise ConnectionError(
                     f"Ray is already running at {default_address}. "
-                    f" Please specify a different address to start.")
+                    f" Please specify a different port using the `--port` command to `ray start`."
 
         node = ray.node.Node(
             ray_params, head=True, shutdown_at_exit=block, spawn_reaper=block)

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -467,7 +467,7 @@ def start(node_ip_address, address, port, redis_password, redis_shard_ports,
             if len(redis_addresses) > 0:
                 raise ConnectionError(
                     f"Ray is already running at {default_address}. "
-                    f" Please specify a different port using the `--port`"
+                    f"Please specify a different port using the `--port`"
                     f" command to `ray start`.")
 
         node = ray.node.Node(

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -163,7 +163,6 @@ def dashboard(cluster_config_file, cluster_name, port, remote_port):
     "--port",
     type=int,
     required=False,
-
     help=f"the port of the head ray process. If not provided, defaults to "
     f"{ray_constants.DEFAULT_PORT}; if port is set to 0, we will"
     f" allocate an available port.")

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -178,9 +178,8 @@ def ray_start_object_store_memory(request):
 @pytest.fixture
 def call_ray_start(request):
     parameter = getattr(
-        request, "param",
-        "ray start --head --num-cpus=1 --min-worker-port=0 --max-worker-port=0 --port 0"
-    )
+        request, "param", "ray start --head --num-cpus=1 --min-worker-port=0 "
+        "--max-worker-port=0 --port 0")
     command_args = parameter.split(" ")
     out = ray.utils.decode(
         subprocess.check_output(command_args, stderr=subprocess.STDOUT))

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -179,7 +179,7 @@ def ray_start_object_store_memory(request):
 def call_ray_start(request):
     parameter = getattr(
         request, "param",
-        "ray start --head --num-cpus=1 --min-worker-port=0 --max-worker-port=0"
+        "ray start --head --num-cpus=1 --min-worker-port=0 --max-worker-port=0 --port 0"
     )
     command_args = parameter.split(" ")
     out = ray.utils.decode(

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -158,9 +158,9 @@ DEFAULT_TEST_CONFIG_PATH = str(
     reason=("Mac builds don't provide proper locale support"))
 def test_ray_start(configure_lang):
     runner = CliRunner()
-    result = runner.invoke(
-        scripts.start,
-        ["--head", "--log-style=pretty", "--log-color", "False"])
+    result = runner.invoke(scripts.start, [
+        "--head", "--log-style=pretty", "--log-color", "False", "--port", "0"
+    ])
     _die_on_error(runner.invoke(scripts.stop))
 
     _check_output_via_pattern("test_ray_start.txt", result)

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -382,7 +382,7 @@ def test_calling_start_ray_head(call_ray_stop_only):
     with socket() as s:
         s.bind(('',0))
         port = s.getsockname()[1]
-        check_call_ray(["start", "--head", "--port", port])
+        check_call_ray(["start", "--head", "--port", str(port)])
         check_call_ray(["stop"])
 
     # Test starting Ray with a node IP address specified.

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -459,7 +459,7 @@ def test_calling_start_ray_head(call_ray_stop_only):
 
 @pytest.mark.parametrize(
     "call_ray_start",
-    ["ray start --head --num-cpus=1 " + "--node-ip-address=localhost" + " --port 0"],
+    ["ray start --head --num-cpus=1 " + "--node-ip-address=localhost " + "--port 0"],
     indirect=True)
 def test_using_hostnames(call_ray_start):
     ray.init(_node_ip_address="localhost", address="localhost:6379")

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -381,7 +381,7 @@ def test_calling_start_ray_head(call_ray_stop_only):
     # Test starting Ray with a redis port specified.
     port = 0
     with socket() as s:
-        s.bind(('',0))
+        s.bind(("", 0))
         port = s.getsockname()[1]
     check_call_ray(["start", "--head", "--port", str(port)])
     check_call_ray(["stop"])

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -3,6 +3,7 @@ import pytest
 import subprocess
 import sys
 import time
+from socket import socket
 
 import ray
 from ray.test_utils import (
@@ -378,8 +379,11 @@ def test_calling_start_ray_head(call_ray_stop_only):
     check_call_ray(["stop"])
 
     # Test starting Ray with a redis port specified.
-    check_call_ray(["start", "--head"])
-    check_call_ray(["stop"])
+    with socket() as s:
+        s.bind(('',0))
+        port = s.getsockname()[1]
+        check_call_ray(["start", "--head", "--port", port])
+        check_call_ray(["stop"])
 
     # Test starting Ray with a node IP address specified.
     check_call_ray(["start", "--head", "--node-ip-address", "127.0.0.1"])

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -3,7 +3,6 @@ import pytest
 import subprocess
 import sys
 import time
-from socket import socket
 
 import ray
 from ray.test_utils import (
@@ -380,7 +379,8 @@ def test_calling_start_ray_head(call_ray_stop_only):
     check_call_ray(["stop"])
 
     # Test starting Ray with a node IP address specified.
-    check_call_ray(["start", "--head", "--node-ip-address", "127.0.0.1", "--port", "0"])
+    check_call_ray(
+        ["start", "--head", "--node-ip-address", "127.0.0.1", "--port", "0"])
     check_call_ray(["stop"])
 
     # Test starting Ray with a system config parameter set.
@@ -414,8 +414,10 @@ def test_calling_start_ray_head(call_ray_stop_only):
     check_call_ray(["stop"])
 
     # Test starting Ray with redis shard ports specified.
-    check_call_ray(
-        ["start", "--head", "--redis-shard-ports", "6380,6381,6382", "--port", "0"])
+    check_call_ray([
+        "start", "--head", "--redis-shard-ports", "6380,6381,6382", "--port",
+        "0"
+    ])
     check_call_ray(["stop"])
 
     # Test starting Ray with all arguments specified.
@@ -428,11 +430,13 @@ def test_calling_start_ray_head(call_ray_stop_only):
 
     # Test starting Ray with invalid arguments.
     with pytest.raises(subprocess.CalledProcessError):
-        check_call_ray(["start", "--head", "--address", "127.0.0.1:6379", "--port", "0"])
+        check_call_ray(
+            ["start", "--head", "--address", "127.0.0.1:6379", "--port", "0"])
     check_call_ray(["stop"])
 
     # Test --block. Killing a child process should cause the command to exit.
-    blocked = subprocess.Popen(["ray", "start", "--head", "--block", "--port", "0"])
+    blocked = subprocess.Popen(
+        ["ray", "start", "--head", "--block", "--port", "0"])
 
     wait_for_children_of_pid(blocked.pid, num_children=7, timeout=30)
 
@@ -445,7 +449,8 @@ def test_calling_start_ray_head(call_ray_stop_only):
     assert blocked.returncode != 0, "ray start shouldn't return 0 on bad exit"
 
     # Test --block. Killing the command should clean up all child processes.
-    blocked = subprocess.Popen(["ray", "start", "--head", "--block", "--port", "0"])
+    blocked = subprocess.Popen(
+        ["ray", "start", "--head", "--block", "--port", "0"])
     blocked.poll()
     assert blocked.returncode is None
 

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -302,7 +302,7 @@ ray.get([a.log.remote(), f.remote()])
 @pytest.mark.parametrize(
     "call_ray_start", [
         "ray start --head --num-cpus=1 --num-gpus=1 " +
-        "--min-worker-port=0 --max-worker-port=0"
+        "--min-worker-port=0 --max-worker-port=0 --port 0"
     ],
     indirect=True)
 def test_drivers_release_resources(call_ray_start):
@@ -371,90 +371,68 @@ print("success")
 
 def test_calling_start_ray_head(call_ray_stop_only):
 
-    def get_available_port():
-        port = 0
-        with socket() as s:
-            s.bind(("", 0))
-            port = s.getsockname()[1]
-        return port
-
     # Test that we can call ray start with various command line
     # parameters. TODO(rkn): This test only tests the --head code path. We
     # should also test the non-head node code path.
 
-    # Test starting Ray with no arguments.
-    check_call_ray(["start", "--head"])
-    check_call_ray(["stop"])
-
     # Test starting Ray with a redis port specified.
-    port = get_available_port()
-    check_call_ray(["start", "--head", "--port", str(port)])
+    check_call_ray(["start", "--head", "--port", "0"])
     check_call_ray(["stop"])
 
     # Test starting Ray with a node IP address specified.
-    port = get_available_port()
-    check_call_ray(["start", "--head", "--node-ip-address", "127.0.0.1", "--port", str(port)])
+    check_call_ray(["start", "--head", "--node-ip-address", "127.0.0.1", "--port", "0"])
     check_call_ray(["stop"])
 
     # Test starting Ray with a system config parameter set.
-    port = get_available_port()
     check_call_ray([
         "start", "--head", "--system-config",
-        "{\"metrics_report_interval_ms\":100}", "--port", str(port)
+        "{\"metrics_report_interval_ms\":100}", "--port", "0"
     ])
     check_call_ray(["stop"])
 
     # Test starting Ray with the object manager and node manager ports
     # specified.
-    port = get_available_port()
     check_call_ray([
         "start", "--head", "--object-manager-port", "12345",
-        "--node-manager-port", "54321", "--port", str(port)
+        "--node-manager-port", "54321", "--port", "0"
     ])
     check_call_ray(["stop"])
 
     # Test starting Ray with the worker port range specified.
-    port = get_available_port()
     check_call_ray([
         "start", "--head", "--min-worker-port", "50000", "--max-worker-port",
-        "51000", "--port", str(port)
+        "51000", "--port", "0"
     ])
     check_call_ray(["stop"])
 
     # Test starting Ray with the number of CPUs specified.
-    port = get_available_port()
-    check_call_ray(["start", "--head", "--num-cpus", "2", "--port", str(port)])
+    check_call_ray(["start", "--head", "--num-cpus", "2", "--port", "0"])
     check_call_ray(["stop"])
 
     # Test starting Ray with the number of GPUs specified.
-    port = get_available_port()
-    check_call_ray(["start", "--head", "--num-gpus", "100", "--port", str(port)])
+    check_call_ray(["start", "--head", "--num-gpus", "100", "--port", "0"])
     check_call_ray(["stop"])
 
     # Test starting Ray with redis shard ports specified.
-    port = get_available_port()
     check_call_ray(
-        ["start", "--head", "--redis-shard-ports", "6380,6381,6382", "--port", str(port)])
+        ["start", "--head", "--redis-shard-ports", "6380,6381,6382", "--port", "0"])
     check_call_ray(["stop"])
 
     # Test starting Ray with all arguments specified.
-    port = get_available_port()
     check_call_ray([
         "start", "--head", "--redis-shard-ports", "6380,6381,6382",
         "--object-manager-port", "12345", "--num-cpus", "2", "--num-gpus", "0",
-        "--resources", "{\"Custom\": 1}", "--port", str(port)
+        "--resources", "{\"Custom\": 1}", "--port", "0"
     ])
     check_call_ray(["stop"])
 
     # Test starting Ray with invalid arguments.
     with pytest.raises(subprocess.CalledProcessError):
-        port = get_available_port()
-        check_call_ray(["start", "--head", "--address", "127.0.0.1:6379", "--port", str(port)])
+        check_call_ray(["start", "--head", "--address", "127.0.0.1:6379", "--port", "0"])
     check_call_ray(["stop"])
 
     # Test --block. Killing a child process should cause the command to exit.
-    port = get_available_port()
-    blocked = subprocess.Popen(["ray", "start", "--head", "--block", "--port", str(port)])
+    blocked = subprocess.Popen(["ray", "start", "--head", "--block", "--port", "0"])
 
     wait_for_children_of_pid(blocked.pid, num_children=7, timeout=30)
 
@@ -467,8 +445,7 @@ def test_calling_start_ray_head(call_ray_stop_only):
     assert blocked.returncode != 0, "ray start shouldn't return 0 on bad exit"
 
     # Test --block. Killing the command should clean up all child processes.
-    port = get_available_port()
-    blocked = subprocess.Popen(["ray", "start", "--head", "--block", "--port", str(port)])
+    blocked = subprocess.Popen(["ray", "start", "--head", "--block", "--port", "0"])
     blocked.poll()
     assert blocked.returncode is None
 
@@ -482,7 +459,7 @@ def test_calling_start_ray_head(call_ray_stop_only):
 
 @pytest.mark.parametrize(
     "call_ray_start",
-    ["ray start --head --num-cpus=1 " + "--node-ip-address=localhost"],
+    ["ray start --head --num-cpus=1 " + "--node-ip-address=localhost" + " --port 0"],
     indirect=True)
 def test_using_hostnames(call_ray_start):
     ray.init(_node_ip_address="localhost", address="localhost:6379")

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -379,11 +379,12 @@ def test_calling_start_ray_head(call_ray_stop_only):
     check_call_ray(["stop"])
 
     # Test starting Ray with a redis port specified.
+    port = 0
     with socket() as s:
         s.bind(('',0))
         port = s.getsockname()[1]
-        check_call_ray(["start", "--head", "--port", str(port)])
-        check_call_ray(["stop"])
+    check_call_ray(["start", "--head", "--port", str(port)])
+    check_call_ray(["stop"])
 
     # Test starting Ray with a node IP address specified.
     check_call_ray(["start", "--head", "--node-ip-address", "127.0.0.1"])

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -459,7 +459,7 @@ def test_calling_start_ray_head(call_ray_stop_only):
 
 @pytest.mark.parametrize(
     "call_ray_start",
-    ["ray start --head --num-cpus=1 " + "--node-ip-address=localhost " + "--port 0"],
+    ["ray start --head --num-cpus=1 " + "--node-ip-address=localhost"],
     indirect=True)
 def test_using_hostnames(call_ray_start):
     ray.init(_node_ip_address="localhost", address="localhost:6379")

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -42,7 +42,7 @@ def test_tempdir_commandline():
     shutil.rmtree(ray.utils.get_ray_temp_dir(), ignore_errors=True)
     check_call_ray([
         "start", "--head", "--temp-dir=" + os.path.join(
-            ray.utils.get_user_temp_dir(), "i_am_a_temp_dir2")
+            ray.utils.get_user_temp_dir(), "i_am_a_temp_dir2", "--port", "0")
     ])
     assert os.path.exists(
         os.path.join(ray.utils.get_user_temp_dir(),

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -42,7 +42,7 @@ def test_tempdir_commandline():
     shutil.rmtree(ray.utils.get_ray_temp_dir(), ignore_errors=True)
     check_call_ray([
         "start", "--head", "--temp-dir=" + os.path.join(
-            ray.utils.get_user_temp_dir(), "i_am_a_temp_dir2", "--port", "0")
+            ray.utils.get_user_temp_dir(), "i_am_a_temp_dir2"), "--port", "0"
     ])
     assert os.path.exists(
         os.path.join(ray.utils.get_user_temp_dir(),


### PR DESCRIPTION
… a ray cluster running #10717

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Refer to #10717, 
> I often run into issues by accidentally starting a new cluster when one is already running. Then, this later causes problems when I try to connect and there are two running clusters. I'm then forced to ray stop both clusters and ray start my new one again. My workflow would be improved if I just got an error when trying to start the second cluster and knew to immediately tear down the existing one. This behavior may be useful in some cases (e.g., for testing), so we could introduce a flag to permit multiple clusters, e.g., ray start --allow-existing.

Before:
You can run multiple clusters on the same host, after:
```
> ray start --head
Local node IP: 192.168.86.36
2020-09-19 22:46:58,457	INFO services.py:1174 -- View the Ray dashboard at http://localhost:8265

--------------------
Ray runtime started.
--------------------

Next steps
  To connect to this Ray runtime from another node, run
    ray start --address='192.168.86.36:6379' --redis-password='5241590000000000'

  Alternatively, use the following Python code:
    import ray
    ray.init(address='auto', _redis_password='5241590000000000')

  If connection fails, check your firewall settings and network configuration.

  To terminate the Ray runtime, run
    ray stop
> ray start --head
Local node IP: 192.168.86.36
Traceback (most recent call last):
  File "/Users/khu/opt/anaconda3/bin/ray", line 33, in <module>
    sys.exit(load_entry_point('ray', 'console_scripts', 'ray')())
  File "/Users/khu/ray/ray/python/ray/scripts/scripts.py", line 1568, in main
    return cli()
  File "/Users/khu/opt/anaconda3/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/khu/opt/anaconda3/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/khu/opt/anaconda3/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/khu/opt/anaconda3/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/khu/opt/anaconda3/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/khu/ray/ray/python/ray/scripts/scripts.py", line 564, in start
    raise ConnectionError(
ConnectionError: There is already a Ray head running at: 192.168.86.36:6379. Please specify a different address to start.

> ray start --head --port 9999
Local node IP: 192.168.86.36
2020-09-19 22:47:31,986	INFO services.py:1174 -- View the Ray dashboard at http://localhost:8265

--------------------
Ray runtime started.
--------------------

Next steps
  To connect to this Ray runtime from another node, run
    ray start --address='192.168.86.36:9999' --redis-password='5241590000000000'

  Alternatively, use the following Python code:
    import ray
    ray.init(address='auto', _redis_password='5241590000000000')

  If connection fails, check your firewall settings and network configuration.

  To terminate the Ray runtime, run
    ray stop
> ray start --head --port 9999
Local node IP: 192.168.86.36
Traceback (most recent call last):
  File "/Users/khu/opt/anaconda3/bin/ray", line 33, in <module>
    sys.exit(load_entry_point('ray', 'console_scripts', 'ray')())
  File "/Users/khu/ray/ray/python/ray/scripts/scripts.py", line 1568, in main
    return cli()
  File "/Users/khu/opt/anaconda3/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/khu/opt/anaconda3/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/khu/opt/anaconda3/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/khu/opt/anaconda3/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/khu/opt/anaconda3/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/khu/ray/ray/python/ray/scripts/scripts.py", line 564, in start
    raise ConnectionError(
ConnectionError: There is already a Ray head running at: 192.168.86.36:9999. Please specify a different address to start.
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#10717
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
