### PR TITLE
[docs] fix book icon in version flyout menu

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -52,3 +52,10 @@ img.inline-figure {
   /* Make version warning clickable */
   z-index: 1;
 }
+
+span.rst-current-version > span.fa.fa-book {
+  /* Move the book icon away from the top right
+   * corner of the version flyout menu */
+  margin: 10px 0px 0px 5px;
+}
+


### PR DESCRIPTION
## Why are these changes needed?

the book icon in the top left corner of the version flyout menu is a little too close to the border of the menu

## Related issue number

didn't create one

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
