### PR TITLE
[Serve] Unwrap Flask Request from ServeHandle

### DIFF
--- a/doc/source/serve/advanced.rst
+++ b/doc/source/serve/advanced.rst
@@ -411,3 +411,14 @@ you would with HTTP request. Here are some examples how ServeRequest mirrors Fla
             print("Request coming from web!")
         elif isinstance(request, ServeRequest):
             print("Request coming from Python!")
+
+.. note::
+
+    Once special case is when you pass a web request to a handle.
+
+    .. code-block:: python
+
+        handle.remote(flask_request)
+
+    In this case, Serve will `not` wrap it in ServeRequest. You can directly
+    process the request as a ``flask.Request``.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When user just pass in `handle.remote(flask_request)`, instead of wrapping the data into a ServeRequest, we will now inject it as Flask request.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
