### PR TITLE
[Core] Fix `maximum_startup_concurrency` caused by `AnnounceWorkerPort`

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1330,6 +1330,7 @@ void NodeManager::ProcessAnnounceWorkerPortMessage(
   int port = message->port();
   worker->Connect(port);
   if (is_worker) {
+    worker_pool_.OnWorkerStarted(worker);
     HandleWorkerAvailable(worker->Connection());
   }
 }

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -447,14 +447,16 @@ Status WorkerPool::RegisterWorker(const std::shared_ptr<WorkerInterface> &worker
   RAY_CHECK(worker);
 
   auto &state = GetStateForLanguage(worker->GetLanguage());
+  auto process = Process::FromPid(pid);
 
-  auto it = state.starting_worker_processes.find(Process::FromPid(pid));
-  if (it == state.starting_worker_processes.end()) {
-    RAY_LOG(WARNING) << "Received a register request from an unknown worker " << pid;
+  if (state.starting_worker_processes.count(process) == 0) {
+    RAY_LOG(WARNING) << "Received a register request from an unknown worker "
+                     << process.GetId();
     Status status = Status::Invalid("Unknown worker");
     send_reply_callback(status, /*port=*/0);
     return status;
   }
+  worker->SetProcess(process);
 
   // The port that this worker's gRPC server should listen on. 0 if the worker
   // should bind on a random port.
@@ -467,20 +469,8 @@ Status WorkerPool::RegisterWorker(const std::shared_ptr<WorkerInterface> &worker
   RAY_LOG(DEBUG) << "Registering worker with pid " << pid << ", port: " << port
                  << ", worker_type: " << rpc::WorkerType_Name(worker->GetWorkerType());
   worker->SetAssignedPort(port);
-  worker->SetProcess(it->first);
-  it->second--;
-  if (it->second == 0) {
-    state.starting_worker_processes.erase(it);
-    // We may have slots to start more workers now.
-    TryStartIOWorkers(worker->GetLanguage(), state);
-  }
 
-  RAY_CHECK(worker->GetProcess().GetId() == pid);
   state.registered_workers.insert(worker);
-  if (worker->GetWorkerType() == rpc::WorkerType::IO_WORKER) {
-    state.registered_io_workers.insert(worker);
-    state.num_starting_io_workers--;
-  }
 
   if (RayConfig::instance().enable_multi_tenancy()) {
     auto dedicated_workers_it = state.worker_pids_to_assigned_jobs.find(pid);
@@ -500,11 +490,38 @@ Status WorkerPool::RegisterWorker(const std::shared_ptr<WorkerInterface> &worker
     worker->AssignJobId(job_id);
     // We don't call state.worker_pids_to_assigned_jobs.erase(job_id) here
     // because we allow multi-workers per worker process.
+  }
 
+  // Send the reply immediately for worker registrations.
+  send_reply_callback(Status::OK(), port);
+  return Status::OK();
+}
+
+void WorkerPool::OnWorkerStarted(const std::shared_ptr<WorkerInterface> &worker) {
+  auto &state = GetStateForLanguage(worker->GetLanguage());
+  auto process = worker->GetProcess();
+  RAY_CHECK(process.IsValid());
+
+  auto it = state.starting_worker_processes.find(process);
+  if (it != state.starting_worker_processes.end()) {
+    it->second--;
+    if (it->second == 0) {
+      state.starting_worker_processes.erase(it);
+      // We may have slots to start more workers now.
+      TryStartIOWorkers(worker->GetLanguage(), state);
+    }
+  }
+  if (worker->GetWorkerType() == rpc::WorkerType::IO_WORKER) {
+    state.registered_io_workers.insert(worker);
+    state.num_starting_io_workers--;
+  }
+
+  if (RayConfig::instance().enable_multi_tenancy()) {
     // This is a workaround to finish driver registration after all initial workers are
     // registered to Raylet if and only if Raylet is started by a Python driver and the
     // job config is not set in `ray.init(...)`.
-    if (first_job_ == job_id && worker->GetLanguage() == Language::PYTHON) {
+    if (first_job_ == worker->GetAssignedJobId() &&
+        worker->GetLanguage() == Language::PYTHON) {
       if (++first_job_registered_python_worker_count_ ==
           first_job_driver_wait_num_python_workers_) {
         if (first_job_send_register_client_reply_to_driver_) {
@@ -514,10 +531,6 @@ Status WorkerPool::RegisterWorker(const std::shared_ptr<WorkerInterface> &worker
       }
     }
   }
-
-  // Send the reply immediately for worker registrations.
-  send_reply_callback(Status::OK(), port);
-  return Status::OK();
 }
 
 Status WorkerPool::RegisterDriver(const std::shared_ptr<WorkerInterface> &driver,

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -499,7 +499,7 @@ Status WorkerPool::RegisterWorker(const std::shared_ptr<WorkerInterface> &worker
 
 void WorkerPool::OnWorkerStarted(const std::shared_ptr<WorkerInterface> &worker) {
   auto &state = GetStateForLanguage(worker->GetLanguage());
-  auto process = worker->GetProcess();
+  const auto &process = worker->GetProcess();
   RAY_CHECK(process.IsValid());
 
   auto it = state.starting_worker_processes.find(process);

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -125,7 +125,7 @@ class WorkerPool : public WorkerPoolInterface {
                         std::function<void(Status, int)> send_reply_callback);
 
   /// To be invoked when a worker is started. This method should be called when the worker
-  /// announcces its port.
+  /// announces its port.
   ///
   /// \param[in] worker The worker which is started.
   void OnWorkerStarted(const std::shared_ptr<WorkerInterface> &worker);

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -124,6 +124,12 @@ class WorkerPool : public WorkerPoolInterface {
   Status RegisterWorker(const std::shared_ptr<WorkerInterface> &worker, pid_t pid,
                         std::function<void(Status, int)> send_reply_callback);
 
+  /// To be invoked when a worker is started. This method should be called when the worker
+  /// announcces its port.
+  ///
+  /// \param[in] worker The worker which is started.
+  void OnWorkerStarted(const std::shared_ptr<WorkerInterface> &worker);
+
   /// Register a new driver.
   ///
   /// \param[in] worker The driver to be registered.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The calculation of `starting_workers` is inaccurate because `starting_worker_processes` is deducted when receiving the `RegisterClientRequest` message but not the `AnnounceWorkerPort` message. But a worker can only be popped from the worker pool after `HandleAnnounceWorkerPort` is executed.

https://github.com/ray-project/ray/blob/5c7b35d6948ed9f9840c3e45ae9cdef4562e02de/src/ray/raylet/worker_pool.cc#L195-L203

If `DispatchTasks` is triggered after Raylet has received the `RegisterClientRequest` message but right before receiving the `AnnounceWorkerPort` message, the worker pool may spawn more workers than we expect.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
