### PR TITLE
[Doc] Broken doc build fix.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -43,6 +43,7 @@ MOCK_MODULES = [
     "mxnet",
     "mxnet.model",
     "psutil",
+    "ray._raylet",
     "ray.core.generated",
     "ray.core.generated.common_pb2",
     "ray.core.generated.gcs_pb2",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

this temporariliy fix the doc build. But placement group doc will still see the Mocked objects. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
