### PR TITLE
add log-dir to new dashboard

### DIFF
--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -634,6 +634,7 @@ class Node:
             self._ray_params.dashboard_host,
             self.redis_address,
             self._temp_dir,
+            self._logs_dir,
             stdout_file=stdout_file,
             stderr_file=stderr_file,
             redis_password=self._ray_params.redis_password,

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1038,12 +1038,11 @@ def start_dashboard(require_dashboard,
             raise ValueError(
                 f"The given dashboard port {port} is already in use")
 
-    append_log_dir = None
     if "RAY_USE_NEW_DASHBOARD" in os.environ:
         dashboard_dir = "new_dashboard"
-        append_log_dir = log_dir
     else:
         dashboard_dir = "dashboard"
+        log_dir = None
 
     dashboard_filepath = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), dashboard_dir,
@@ -1057,8 +1056,8 @@ def start_dashboard(require_dashboard,
         f"--redis-address={redis_address}",
         f"--temp-dir={temp_dir}",
     ]
-    if append_log_dir:
-        command += [f"--log-dir={append_log_dir}"]
+    if log_dir:
+        command += [f"--log-dir={log_dir}"]
     if redis_password:
         command += ["--redis-password", redis_password]
 

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -992,6 +992,7 @@ def start_dashboard(require_dashboard,
                     host,
                     redis_address,
                     temp_dir,
+                    log_dir,
                     port=ray_constants.DEFAULT_DASHBOARD_PORT,
                     stdout_file=None,
                     stderr_file=None,
@@ -1009,6 +1010,7 @@ def start_dashboard(require_dashboard,
         redis_address (str): The address of the Redis instance.
         temp_dir (str): The temporary directory used for log files and
             information for this Ray session.
+        log_dir (str): The log directory used to generate dashboard log.
         stdout_file: A file handle opened for writing to redirect stdout to. If
             no redirection should happen, then this should be None.
         stderr_file: A file handle opened for writing to redirect stderr to. If
@@ -1036,8 +1038,10 @@ def start_dashboard(require_dashboard,
             raise ValueError(
                 f"The given dashboard port {port} is already in use")
 
+    append_log_dir = None
     if "RAY_USE_NEW_DASHBOARD" in os.environ:
         dashboard_dir = "new_dashboard"
+        append_log_dir = log_dir
     else:
         dashboard_dir = "dashboard"
 
@@ -1053,6 +1057,8 @@ def start_dashboard(require_dashboard,
         f"--redis-address={redis_address}",
         f"--temp-dir={temp_dir}",
     ]
+    if append_log_dir:
+        command += [f"--log-dir={append_log_dir}"]
     if redis_password:
         command += ["--redis-password", redis_password]
 

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -992,7 +992,7 @@ def start_dashboard(require_dashboard,
                     host,
                     redis_address,
                     temp_dir,
-                    log_dir,
+                    logdir,
                     port=ray_constants.DEFAULT_DASHBOARD_PORT,
                     stdout_file=None,
                     stderr_file=None,
@@ -1010,7 +1010,7 @@ def start_dashboard(require_dashboard,
         redis_address (str): The address of the Redis instance.
         temp_dir (str): The temporary directory used for log files and
             information for this Ray session.
-        log_dir (str): The log directory used to generate dashboard log.
+        logdir (str): The log directory used to generate dashboard log.
         stdout_file: A file handle opened for writing to redirect stdout to. If
             no redirection should happen, then this should be None.
         stderr_file: A file handle opened for writing to redirect stderr to. If
@@ -1042,7 +1042,7 @@ def start_dashboard(require_dashboard,
         dashboard_dir = "new_dashboard"
     else:
         dashboard_dir = "dashboard"
-        log_dir = None
+        logdir = None
 
     dashboard_filepath = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), dashboard_dir,
@@ -1056,8 +1056,8 @@ def start_dashboard(require_dashboard,
         f"--redis-address={redis_address}",
         f"--temp-dir={temp_dir}",
     ]
-    if log_dir:
-        command += [f"--log-dir={log_dir}"]
+    if logdir:
+        command += [f"--log-dir={logdir}"]
     if redis_password:
         command += ["--redis-password", redis_password]
 


### PR DESCRIPTION
## Why are these changes needed?

Add log-dir to new dashboard command to guarantee `dashboard.log` located together with other logs.

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
