### PR TITLE
[docs] fix version flyout menu z-index

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -61,5 +61,5 @@ span.rst-current-version > span.fa.fa-book {
 
 /* Adjustment to Version block */
 .rst-versions {
-  z-index: 1200;
+  z-index: 1200 !important;
 }


### PR DESCRIPTION
## Why are these changes needed?

the z-index hasn't been applied because RTD's `badge_only.css` applies `z-index:400` to `.rst-versions`

## Related issue number

fixes #10841 v2

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
