### PR TITLE
Fix examples Dockerfile

### DIFF
--- a/docker/examples/Dockerfile
+++ b/docker/examples/Dockerfile
@@ -3,7 +3,7 @@
 FROM rayproject/ray:latest
 
 # Needed to run Tune example with a 'plot' call - which does not actually render a plot, but throws an error.
-RUN apt-get update && install -y zlib1g-dev libgl1-mesa-dev libgtk2.0-dev && apt-get clean
+RUN apt-get update && apt-get install -y zlib1g-dev libgl1-mesa-dev libgtk2.0-dev && apt-get clean
 RUN pip install --no-cache-dir -U pip \
     gym[atari] \
     opencv-python-headless==4.3.0.36 \


### PR DESCRIPTION
## Why are these changes needed?

Missing apt-get when trying to install packages causes docker build to fail. Image builds successfully with the patch.

## Related issue number

Closes #10907

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
