### PR TITLE
[docker] Add $GPU to image tag name

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -59,10 +59,10 @@ for IMAGE in "base-deps" "ray-deps" "ray"
 do
     cp "$WHEEL" "docker/$IMAGE/$(basename "$WHEEL")"
     if [ $OUTPUT_SHA ]; then
-        IMAGE_SHA=$(docker build $NO_CACHE --build-arg GPU="$GPU" --build-arg BASE_IMAGE="$BASE_IMAGE" --build-arg WHEEL_PATH="$(basename "$WHEEL")" -q -t rayproject/$IMAGE:latest docker/$IMAGE)
-        echo "rayproject/$IMAGE:latest SHA:$IMAGE_SHA"
+        IMAGE_SHA=$(docker build $NO_CACHE --build-arg GPU="$GPU" --build-arg BASE_IMAGE="$BASE_IMAGE" --build-arg WHEEL_PATH="$(basename "$WHEEL")" -q -t rayproject/$IMAGE:latest$GPU docker/$IMAGE)
+        echo "rayproject/$IMAGE:latest$GPU SHA:$IMAGE_SHA"
     else
-        docker build $NO_CACHE  --build-arg GPU="$GPU" --build-arg BASE_IMAGE="$BASE_IMAGE" --build-arg WHEEL_PATH="$(basename "$WHEEL")" --build-arg PYTHON_VERSION="$PYTHON_VERSION" -t rayproject/$IMAGE:latest docker/$IMAGE
+        docker build $NO_CACHE  --build-arg GPU="$GPU" --build-arg BASE_IMAGE="$BASE_IMAGE" --build-arg WHEEL_PATH="$(basename "$WHEEL")" --build-arg PYTHON_VERSION="$PYTHON_VERSION" -t rayproject/$IMAGE:latest$GPU docker/$IMAGE
     fi
     rm "docker/$IMAGE/$(basename "$WHEEL")"
 done 


### PR DESCRIPTION
## Why are these changes needed?

`build-docker.sh` command has a `--gpu` option. When this option is enabled, [ray-deps/Dockerfile](https://github.com/ray-project/ray/blob/master/docker/ray-deps/Dockerfile#L2), [ray-ml/Dockerfile](https://github.com/ray-project/ray/blob/master/docker/ray-ml/Dockerfile#L2) , [ray/Dockerfile](https://github.com/ray-project/ray/blob/master/docker/ray/Dockerfile#L2) expects docker image `rayproject/ray-***:latest-gpu` instead of `rayproject/ray-***:latest`.

However, docker image tag created by `build-docker.sh` does not add `-gpu` even if `--gpu` option is enabled.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
