### PR TITLE
[GCS]Add light heartbeat flag in python and use it in load metrics

### DIFF
--- a/python/ray/autoscaler/_private/load_metrics.py
+++ b/python/ray/autoscaler/_private/load_metrics.py
@@ -1,9 +1,13 @@
 import logging
 import time
 
+import ray
 import numpy as np
 import ray.services as services
-from ray.ray_constants import MEMORY_RESOURCE_UNIT_BYTES
+from ray.ray_constants import (
+    MEMORY_RESOURCE_UNIT_BYTES,
+    NODE_RESOURCES_TURNING_EMPTY,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -34,22 +38,51 @@ class LoadMetrics:
                resource_load,
                waiting_bundles=[],
                infeasible_bundles=[]):
-        self.resource_load_by_ip[ip] = resource_load
-        self.static_resources_by_ip[ip] = static_resources
-
-        # We are not guaranteed to have a corresponding dynamic resource for
-        # every static resource because dynamic resources are based on the
-        # available resources in the heartbeat, which does not exist if it is
-        # zero. Thus, we have to update dynamic resources here.
-        dynamic_resources_update = dynamic_resources.copy()
-        for resource_name, capacity in static_resources.items():
-            if resource_name not in dynamic_resources_update:
-                dynamic_resources_update[resource_name] = 0.0
-        self.dynamic_resources_by_ip[ip] = dynamic_resources_update
+        # If light heartbeat enabled, only resources changed will be received.
+        # We should update the changed part and compare static_resources with
+        # dynamic_resources using those updated.
+        if ray._config.light_heartbeat_enabled():
+            if ip not in self.static_resources_by_ip or \
+                    len(static_resources) > 0:
+                self.static_resources_by_ip[ip] = static_resources
+            if ip not in self.dynamic_resources_by_ip or \
+                    len(dynamic_resources) > 0:
+                if NODE_RESOURCES_TURNING_EMPTY in dynamic_resources:
+                    self.dynamic_resources_by_ip[ip] = {}
+                else:
+                    self.dynamic_resources_by_ip[ip] = dynamic_resources
+            if ip not in self.resource_load_by_ip or len(resource_load) > 0:
+                if NODE_RESOURCES_TURNING_EMPTY in resource_load:
+                    self.resource_load_by_ip[ip] = {}
+                else:
+                    self.resource_load_by_ip[ip] = resource_load
+            # We are not guaranteed to have a corresponding dynamic resource
+            # for every static resource because dynamic resources are based on
+            # the available resources in the heartbeat, which does not exist
+            # if it is zero. Thus, we have to update dynamic resources here.
+            dynamic_resources_update = self.dynamic_resources_by_ip[ip].copy()
+            for resource_name, capacity in \
+                    self.static_resources_by_ip[ip].items():
+                if resource_name not in dynamic_resources_update:
+                    dynamic_resources_update[resource_name] = 0.0
+            self.dynamic_resources_by_ip[ip] = dynamic_resources_update
+        else:
+            self.resource_load_by_ip[ip] = resource_load
+            self.static_resources_by_ip[ip] = static_resources
+            # We are not guaranteed to have a corresponding dynamic resource
+            # for every static resource because dynamic resources are based on
+            # the available resources in the heartbeat, which does not exist
+            # if it is zero. Thus, we have to update dynamic resources here.
+            dynamic_resources_update = dynamic_resources.copy()
+            for resource_name, capacity in static_resources.items():
+                if resource_name not in dynamic_resources_update:
+                    dynamic_resources_update[resource_name] = 0.0
+            self.dynamic_resources_by_ip[ip] = dynamic_resources_update
 
         now = time.time()
         if ip not in self.last_used_time_by_ip or \
-                static_resources != dynamic_resources:
+                self.static_resources_by_ip[ip] != \
+                self.dynamic_resources_by_ip[ip]:
             self.last_used_time_by_ip[ip] = now
         self.last_heartbeat_time_by_ip[ip] = now
         self.waiting_bundles = waiting_bundles

--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -15,6 +15,8 @@ cdef extern from "ray/common/ray_config.h" nogil:
 
         int64_t raylet_heartbeat_timeout_milliseconds() const
 
+        c_bool light_heartbeat_enabled() const
+
         int64_t debug_dump_period_milliseconds() const
 
         int64_t num_heartbeats_timeout() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -14,6 +14,10 @@ cdef class Config:
         return RayConfig.instance().raylet_heartbeat_timeout_milliseconds()
 
     @staticmethod
+    def light_heartbeat_enabled():
+        return RayConfig.instance().light_heartbeat_enabled()
+
+    @staticmethod
     def debug_dump_period_milliseconds():
         return RayConfig.instance().debug_dump_period_milliseconds()
 

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -215,3 +215,5 @@ MACH_PAGE_SIZE_BYTES = 4096
 # Max 64 bit integer value, which is needed to ensure against overflow
 # in C++ when passing integer values cross-language.
 MAX_INT64_VALUE = 9223372036854775807
+
+NODE_RESOURCES_TURNING_EMPTY = "_TURNING_EMPTY_"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We add light heartbeat enable flag in python code, which read the config value from cpp.
Then use the flag to update resources in load_metric.py, in case the flag is set to true.

## Related issue number

part of https://github.com/ray-project/ray/issues/10355

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
