### PR TITLE
[tune] sort running trials to top in status table

### DIFF
--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -465,7 +465,7 @@ def trial_progress_str(trials,
                 continue
             trials += trials_by_state[state]
 
-    if total_samples >= sys.maxsize:
+    if total_samples and total_samples >= sys.maxsize:
         total_samples = "infinite"
 
     messages.append("Number of trials: {}{} ({})".format(

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -435,7 +435,7 @@ def trial_progress_str(trials,
         for state in sorted(trials_by_state)
     ]
 
-    state_tbl_oder = [
+    state_tbl_order = [
         Trial.RUNNING, Trial.PAUSED, Trial.PENDING, Trial.TERMINATED,
         Trial.ERROR
     ]

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -554,7 +554,7 @@ def best_trial_str(trial, metric, parameter_columns=None):
         parameter_columns = parameter_columns.keys()
     params = {p: config.get(p) for p in parameter_columns}
     return f"Current best trial: {trial.trial_id} with {metric}={val} and " \
-           f"parameters = {params}"
+           f"parameters={params}"
 
 
 def _fair_filter_trials(trials_by_state, max_trials):

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -459,6 +459,11 @@ def trial_progress_str(trials,
         overflow_str = ", ".join(overflow_strs)
     else:
         overflow = False
+        trials = []
+        for state in state_tbl_oder:
+            if state not in trials_by_state:
+                continue
+            trials += trials_by_state[state]
 
     if total_samples >= sys.maxsize:
         total_samples = "infinite"

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -9,6 +9,7 @@ import time
 from ray.tune.result import (EPISODE_REWARD_MEAN, MEAN_ACCURACY, MEAN_LOSS,
                              TRAINING_ITERATION, TIME_TOTAL_S, TIMESTEPS_TOTAL,
                              AUTO_RESULT_KEYS)
+from ray.tune.trial import Trial
 from ray.tune.utils import unflattened_lookup
 
 try:
@@ -376,13 +377,20 @@ def trial_progress_str(trials,
         for state in sorted(trials_by_state)
     ]
 
+    state_tbl_oder = [
+        Trial.RUNNING, Trial.PAUSED, Trial.PENDING, Trial.TERMINATED,
+        Trial.ERROR
+    ]
+
     max_rows = max_rows or float("inf")
     if num_trials > max_rows:
         # TODO(ujvl): suggestion for users to view more rows.
         trials_by_state_trunc = _fair_filter_trials(trials_by_state, max_rows)
         trials = []
         overflow_strs = []
-        for state in sorted(trials_by_state):
+        for state in state_tbl_oder:
+            if state not in trials_by_state:
+                continue
             trials += trials_by_state_trunc[state]
             num = len(trials_by_state[state]) - len(
                 trials_by_state_trunc[state])

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -155,10 +155,10 @@ EXPECTED_END_TO_END_AC = """Number of trials: 30/30 (30 TERMINATED)
 +---------------+------------+-------+-----+-----+-----+"""
 
 EXPECTED_BEST_1 = "Current best trial: 00001 with metric_1=0.5 and " \
-                  "parameters = {'a': 1, 'b': 2, 'n': {'k': [1, 2]}}"
+                  "parameters={'a': 1, 'b': 2, 'n': {'k': [1, 2]}}"
 
 EXPECTED_BEST_2 = "Current best trial: 00004 with metric_1=2.0 and " \
-                  "parameters = {'a': 4}"
+                  "parameters={'a': 4}"
 
 
 class ProgressReporterTest(unittest.TestCase):

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -8,7 +8,7 @@ from ray.test_utils import run_string_as_driver
 from ray.tune.trial import Trial
 from ray.tune.result import AUTO_RESULT_KEYS
 from ray.tune.progress_reporter import (CLIReporter, _fair_filter_trials,
-                                        trial_progress_str)
+                                        best_trial_str, trial_progress_str)
 
 EXPECTED_RESULT_1 = """Result logdir: /foo
 Number of trials: 5 (1 PENDING, 3 RUNNING, 1 TERMINATED)
@@ -153,6 +153,9 @@ EXPECTED_END_TO_END_AC = """Number of trials: 30/30 (30 TERMINATED)
 | f_xxxxx_00028 | TERMINATED |       |     |     |   8 |
 | f_xxxxx_00029 | TERMINATED |       |     |     |   9 |
 +---------------+------------+-------+-----+-----+-----+"""
+
+EXPECTED_BEST_1 = "Current best trial: 00001 with metric_1=0.5 and " \
+                  "parameters = {'a': 1, 'b': 2, 'n': {'k': [1, 2]}}"
 
 
 class ProgressReporterTest(unittest.TestCase):
@@ -307,6 +310,10 @@ class ProgressReporterTest(unittest.TestCase):
             max_rows=3)
         print(prog3)
         assert prog3 == EXPECTED_RESULT_3
+
+        # Current best trial
+        best1 = best_trial_str(trials[1], "metric_1")
+        assert best1 == EXPECTED_BEST_1
 
     def testEndToEndReporting(self):
         try:

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -15,8 +15,8 @@ Number of trials: 5 (1 PENDING, 3 RUNNING, 1 TERMINATED)
 +--------------+------------+-------+-----+-----+------------+
 |   Trial name | status     | loc   |   a |   b |   metric_1 |
 |--------------+------------+-------+-----+-----+------------|
-|        00001 | PENDING    | here  |   1 |   2 |        0.5 |
 |        00002 | RUNNING    | here  |   2 |   4 |        1   |
+|        00001 | PENDING    | here  |   1 |   2 |        0.5 |
 |        00000 | TERMINATED | here  |   0 |   0 |        0   |
 +--------------+------------+-------+-----+-----+------------+
 ... 2 more trials not shown (2 RUNNING)"""
@@ -26,11 +26,11 @@ Number of trials: 5 (1 PENDING, 3 RUNNING, 1 TERMINATED)
 +--------------+------------+-------+-----+-----+---------+---------+
 |   Trial name | status     | loc   |   a |   b |   n/k/0 |   n/k/1 |
 |--------------+------------+-------+-----+-----+---------+---------|
-|        00000 | TERMINATED | here  |   0 |   0 |       0 |       0 |
-|        00001 | PENDING    | here  |   1 |   2 |       1 |       2 |
 |        00002 | RUNNING    | here  |   2 |   4 |       2 |       4 |
 |        00003 | RUNNING    | here  |   3 |   6 |       3 |       6 |
 |        00004 | RUNNING    | here  |   4 |   8 |       4 |       8 |
+|        00001 | PENDING    | here  |   1 |   2 |       1 |       2 |
+|        00000 | TERMINATED | here  |   0 |   0 |       0 |       0 |
 +--------------+------------+-------+-----+-----+---------+---------+"""
 
 EXPECTED_RESULT_3 = """Result logdir: /foo
@@ -38,8 +38,8 @@ Number of trials: 5 (1 PENDING, 3 RUNNING, 1 TERMINATED)
 +--------------+------------+-------+-----+------------+------------+
 |   Trial name | status     | loc   |   A |   Metric 1 |   Metric 2 |
 |--------------+------------+-------+-----+------------+------------|
-|        00001 | PENDING    | here  |   1 |        0.5 |       0.25 |
 |        00002 | RUNNING    | here  |   2 |        1   |       0.5  |
+|        00001 | PENDING    | here  |   1 |        0.5 |       0.25 |
 |        00000 | TERMINATED | here  |   0 |        0   |       0    |
 +--------------+------------+-------+-----+------------+------------+
 ... 2 more trials not shown (2 RUNNING)"""
@@ -305,6 +305,7 @@ class ProgressReporterTest(unittest.TestCase):
             }, {"a": "A"},
             fmt="psql",
             max_rows=3)
+        print(prog3)
         assert prog3 == EXPECTED_RESULT_3
 
     def testEndToEndReporting(self):

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -343,7 +343,7 @@ class ProgressReporterTest(unittest.TestCase):
                 progress_str = self._progress_str(*args, **kwargs)
                 self._output.append(progress_str)
 
-        reporter = TestReporter()
+        reporter = TestReporter(mode="max")
         reporter.report(trials, done=False)
 
         assert EXPECTED_BEST_2 in reporter._output[0]

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -388,6 +388,12 @@ def run(
         else:
             progress_reporter = CLIReporter()
 
+    if not progress_reporter.set_search_properties(metric, mode):
+        raise ValueError(
+            "You passed a `metric` or `mode` argument to `tune.run()`, but "
+            "the reporter you are using was already instantiated with their "
+            "own `metric` and `mode` parameters. Either remove the arguments "
+            "from your reporter or from your call to `tune.run()`")
     progress_reporter.set_total_samples(search_alg.total_samples)
 
     # User Warning for GPUs


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This will sort running trials to the top of the table. Also, the current best trial is detected using a `metric` and `mode` parameter, usually passed to `tune.run()`.

Metric is auto-detected if not passed.

```
Number of trials: 30/30 (14 PENDING, 16 RUNNING)
+-------------------+----------+-------------------+---------+--------+------------------+-----------+
| Trial name        | status   | loc               | Alpha   |   iter |   total time (s) |   _metric |
|-------------------+----------+-------------------+---------+--------+------------------+-----------|
| train_3798b_00000 | RUNNING  | 192.168.1.145:982 | b       |      1 |      0.000114202 |         4 |
| train_3798b_00001 | RUNNING  | 192.168.1.145:984 | d       |      1 |      0.000112772 |         4 |
| train_3798b_00002 | RUNNING  | 192.168.1.145:981 | b       |      1 |      0.00012207  |         4 |
| train_3798b_00016 | PENDING  |                   | c       |        |                  |           |
| train_3798b_00017 | PENDING  |                   | c       |        |                  |           |
| train_3798b_00018 | PENDING  |                   | b       |        |                  |           |
+-------------------+----------+-------------------+---------+--------+------------------+-----------+
... 25 more trials not shown (13 RUNNING, 11 PENDING)

Current best trial: 3798b_00005 with _metric=8 and parameters={'a': 'c'}
```

## Related issue number


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
