### PR TITLE
[Serve] Only install dataclasses on Python 3.6

### DIFF
--- a/ci/asan_tests/ray-project/requirements.txt
+++ b/ci/asan_tests/ray-project/requirements.txt
@@ -2,7 +2,7 @@ aiohttp
 blist
 boto3
 cython==0.29.0
-dataclasses
+dataclasses; python_version < '3.7'
 dm-tree
 feather-format
 flask

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -38,13 +38,13 @@ tabulate
 tensorboardX
 uvicorn
 pydantic
-dataclasses
+dataclasses; python_version < '3.7'
 
 # Requirements for running tests
 blist; platform_system != "Windows"
 boto3
 cython==0.29.0
-dataclasses
+dataclasses; python_version < '3.7'
 dask[complete]
 feather-format
 gym

--- a/python/setup.py
+++ b/python/setup.py
@@ -103,8 +103,8 @@ optional_ray_files += ray_dashboard_files
 # in this directory
 extras = {
     "debug": [],
-    "serve": ["uvicorn", "flask", "requests", "pydantic", "dataclasses"],
-    "tune": ["tabulate", "tensorboardX", "pandas", "dataclasses"]
+    "serve": ["uvicorn", "flask", "requests", "pydantic", "dataclasses; python_version < '3.7'"],
+    "tune": ["tabulate", "tensorboardX", "pandas", "dataclasses; python_version < '3.7'"]
 }
 
 extras["rllib"] = extras["tune"] + [

--- a/python/setup.py
+++ b/python/setup.py
@@ -103,8 +103,14 @@ optional_ray_files += ray_dashboard_files
 # in this directory
 extras = {
     "debug": [],
-    "serve": ["uvicorn", "flask", "requests", "pydantic", "dataclasses; python_version < '3.7'"],
-    "tune": ["tabulate", "tensorboardX", "pandas", "dataclasses; python_version < '3.7'"]
+    "serve": [
+        "uvicorn", "flask", "requests", "pydantic",
+        "dataclasses; python_version < '3.7'"
+    ],
+    "tune": [
+        "tabulate", "tensorboardX", "pandas",
+        "dataclasses; python_version < '3.7'"
+    ]
 }
 
 extras["rllib"] = extras["tune"] + [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Before this PR, running the following script
```python
import ray
from ray import serve
ray.init()
client = serve.start() 
```
on the product (a linux machine running python 3.7) would cause the following error:

```python-traceback
2020-09-21 14:07:19,632	WARNING worker.py:1070 -- Failed to unpickle actor class 'ServeController' for actor ID d327fad408000000. Traceback:
Traceback (most recent call last):
  File "/root/anaconda3/lib/python3.7/site-packages/ray/function_manager.py", line 493, in _load_actor_class_from_gcs
    actor_class = pickle.loads(pickled_class)
  File "/root/anaconda3/lib/python3.7/site-packages/ray/serve/__init__.py", line 1, in <module>
    from ray.serve.api import (accept_batch, Client, connect, start)  # noqa: F401
  File "/root/anaconda3/lib/python3.7/site-packages/ray/serve/api.py", line 7, in <module>
    from ray.serve.controller import ServeController
  File "/root/anaconda3/lib/python3.7/site-packages/ray/serve/controller.py", line 12, in <module>
    from ray.serve.backend_worker import create_backend_worker
  File "/root/anaconda3/lib/python3.7/site-packages/ray/serve/backend_worker.py", line 16, in <module>
    from ray.serve.config import BackendConfig
  File "/root/anaconda3/lib/python3.7/site-packages/ray/serve/config.py", line 23, in <module>
    @dataclass
  File "/root/anaconda3/lib/python3.7/site-packages/dataclasses.py", line 958, in dataclass
    return wrap(_cls)
  File "/root/anaconda3/lib/python3.7/site-packages/dataclasses.py", line 950, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash, frozen)
  File "/root/anaconda3/lib/python3.7/site-packages/dataclasses.py", line 801, in _process_class
    for name, type in cls_annotations.items()]
  File "/root/anaconda3/lib/python3.7/site-packages/dataclasses.py", line 801, in <listcomp>
    for name, type in cls_annotations.items()]
  File "/root/anaconda3/lib/python3.7/site-packages/dataclasses.py", line 659, in _get_field
    if (_is_classvar(a_type, typing)
  File "/root/anaconda3/lib/python3.7/site-packages/dataclasses.py", line 550, in _is_classvar
    return type(a_type) is typing._ClassVar
AttributeError: module 'typing' has no attribute '_ClassVar'
```
<!-- Please give a short summary of the change and the problem this solves. -->

A couple sources (https://github.com/HumanCellAtlas/metadata-api/issues/95, https://github.com/konradhalas/dacite/issues/48) suggest this error comes from having the `dataclasses` package (which is a backport for python 3.6) installed alongside python 3.7 (or presumably 3.8).  Indeed, running `pip uninstall dataclasses` fixes the error, and reinstalling `dataclasses` reintroduces the error.
 
The solution is to only include `dataclasses` as a dependency if the python version is less than 3.7.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
