### PR TITLE
[Tests] Fix flaky test_failures by using semaphore instead of sleep

### DIFF
--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -756,7 +756,7 @@ def test_warning_for_too_many_nested_tasks(shutdown_only):
         ray.get(remote_waits)
         ray.get(h.remote(nested_waits))
 
-    num_root_tasks = num_cpus * 6
+    num_root_tasks = num_cpus * 4
     # Lock remote task until everything is scheduled.
     remote_waits = []
     nested_waits = []


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This guarantees that all h is scheduled after every g is scheduled, and same for g -> f.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
