### PR TITLE
[Java Worker]Add a resource checker for java worker creation

### DIFF
--- a/java/api/src/main/java/io/ray/api/options/BaseTaskOptions.java
+++ b/java/api/src/main/java/io/ray/api/options/BaseTaskOptions.java
@@ -20,8 +20,8 @@ public abstract class BaseTaskOptions {
         throw new IllegalArgumentException(String.format("Resource capacity should be "
             + "positive, but got resource %s = %s.", entry.getKey(), entry.getValue()));
       }
-      // Note: resource value should be an integer if it is greater than 1.0, like 3.0 is legal,
-      // but 3.5 is illegal.
+      // Note: A resource value should be an integer if it is greater than 1.0. e.g. 3.0 is a valid resource value,
+      // but 3.5 is not.
       if (entry.getValue().compareTo(1.0) >= 0
           && entry.getValue().compareTo(Math.floor(entry.getValue())) != 0) {
         throw new IllegalArgumentException(String.format("Resource capacity should be "

--- a/java/api/src/main/java/io/ray/api/options/BaseTaskOptions.java
+++ b/java/api/src/main/java/io/ray/api/options/BaseTaskOptions.java
@@ -20,8 +20,8 @@ public abstract class BaseTaskOptions {
         throw new IllegalArgumentException(String.format("Resource values should be "
             + "positive. Specified resource: %s = %s.", entry.getKey(), entry.getValue()));
       }
-      // Note: A resource value should be an integer if it is greater than 1.0. e.g. 3.0 is a valid resource value,
-      // but 3.5 is not.
+      // Note: A resource value should be an integer if it is greater than 1.0.
+      // e.g. 3.0 is a valid resource value, but 3.5 is not.
       if (entry.getValue().compareTo(1.0) >= 0
           && entry.getValue().compareTo(Math.floor(entry.getValue())) != 0) {
         throw new IllegalArgumentException(String.format("A resource value should be "

--- a/java/api/src/main/java/io/ray/api/options/BaseTaskOptions.java
+++ b/java/api/src/main/java/io/ray/api/options/BaseTaskOptions.java
@@ -17,15 +17,15 @@ public abstract class BaseTaskOptions {
   public BaseTaskOptions(Map<String, Double> resources) {
     for (Map.Entry<String, Double> entry : resources.entrySet()) {
       if (entry.getValue() == null || entry.getValue().compareTo(0.0) <= 0) {
-        throw new IllegalArgumentException(String.format("Resource capacity should be "
-            + "positive, but got resource %s = %s.", entry.getKey(), entry.getValue()));
+        throw new IllegalArgumentException(String.format("Resource values should be "
+            + "positive. Specified resource: %s = %s.", entry.getKey(), entry.getValue()));
       }
       // Note: A resource value should be an integer if it is greater than 1.0. e.g. 3.0 is a valid resource value,
       // but 3.5 is not.
       if (entry.getValue().compareTo(1.0) >= 0
           && entry.getValue().compareTo(Math.floor(entry.getValue())) != 0) {
-        throw new IllegalArgumentException(String.format("Resource capacity should be "
-                + "a positive integer if it is greater than 1.0, but got resource %s = %s.",
+        throw new IllegalArgumentException(String.format("A resource value should be "
+                + "an integer if it is greater than 1.0. Specified resource: %s = %s.",
             entry.getKey(), entry.getValue()));
       }
     }

--- a/java/api/src/main/java/io/ray/api/options/BaseTaskOptions.java
+++ b/java/api/src/main/java/io/ray/api/options/BaseTaskOptions.java
@@ -16,9 +16,17 @@ public abstract class BaseTaskOptions {
 
   public BaseTaskOptions(Map<String, Double> resources) {
     for (Map.Entry<String, Double> entry : resources.entrySet()) {
-      if (entry.getValue().compareTo(0.0) <= 0) {
-        throw new IllegalArgumentException(String.format("Resource capacity should be " +
-            "positive, but got resource %s = %f.", entry.getKey(), entry.getValue()));
+      if (entry.getValue() == null || entry.getValue().compareTo(0.0) <= 0) {
+        throw new IllegalArgumentException(String.format("Resource capacity should be "
+            + "positive, but got resource %s = %s.", entry.getKey(), entry.getValue()));
+      }
+      // Note: resource value should be an integer if it is greater than 1.0, like 3.0 is legal,
+      // but 3.5 is illegal.
+      if (entry.getValue().compareTo(1.0) >= 0
+          && entry.getValue().compareTo(Math.floor(entry.getValue())) != 0) {
+        throw new IllegalArgumentException(String.format("Resource capacity should be "
+                + "a positive integer if it is greater than 1.0, but got resource %s = %s.",
+            entry.getKey(), entry.getValue()));
       }
     }
     this.resources = resources;

--- a/java/test/src/main/java/io/ray/test/BaseTaskOptionsTest.java
+++ b/java/test/src/main/java/io/ray/test/BaseTaskOptionsTest.java
@@ -1,0 +1,49 @@
+package io.ray.test;
+
+import com.google.common.collect.ImmutableMap;
+import io.ray.api.options.BaseTaskOptions;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+public class BaseTaskOptionsTest {
+
+  public static class MockActorCreationOptions extends BaseTaskOptions {
+    public MockActorCreationOptions(Map<String, Double> resources) {
+      super(resources);
+    }
+  }
+
+  @Test
+  public void testLegalResources() {
+    Map<String, Double> resources = ImmutableMap.of(
+        "CPU", 0.5, "GPU", 3.0, "memory", 1024.0, "A", 4294967296.0);
+    new MockActorCreationOptions(resources);
+  }
+
+  @Test(expectedExceptions = {IllegalArgumentException.class})
+  public void testIllegalResourcesWithNullValue() {
+    Map<String, Double> resources = new HashMap<>();
+    resources.put("CPU", null);
+    new MockActorCreationOptions(resources);
+  }
+
+  @Test(expectedExceptions = {IllegalArgumentException.class})
+  public void testIllegalResourcesWithZeroValue() {
+    Map<String, Double> resources = ImmutableMap.of("CPU", 0.0);
+    new MockActorCreationOptions(resources);
+  }
+
+  @Test(expectedExceptions = {IllegalArgumentException.class})
+  public void testIllegalResourcesWithNegativeValue() {
+    Map<String, Double> resources = ImmutableMap.of("CPU", -1.0);
+    new MockActorCreationOptions(resources);
+  }
+
+  @Test(expectedExceptions = {IllegalArgumentException.class})
+  public void testIllegalResourcesWithNonIntegerValue() {
+    Map<String, Double> resources = ImmutableMap.of("CPU", 3.5);
+    new MockActorCreationOptions(resources);
+  }
+
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Resource value should be an integer if it is greater than 1.0, like 3.0 is legal, but 3.5 is illegal. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
