### PR TITLE
[docs][tune] update max_failures kwarg default in tune.run docstring

### DIFF
--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -230,7 +230,7 @@ def run(
         max_failures (int): Try to recover a trial at least this many times.
             Ray will recover from the latest checkpoint if present.
             Setting to -1 will lead to infinite recovery retries.
-            Setting to 0 will disable retries. Defaults to 3.
+            Setting to 0 will disable retries. Defaults to 0.
         fail_fast (bool | str): Whether to fail upon the first error.
             If fail_fast='raise' provided, Tune will automatically
             raise the exception received by the Trainable. fail_fast='raise'


### PR DESCRIPTION
## Why are these changes needed?

the docstring on both latest and master says `max_failures` defaults to 3 but the signature says the kwarg defaults to 0

## Related issue number

closes #10923

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
