### PR TITLE
[Autoscaler] Fix k8s command runner when command fails

### DIFF
--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -241,7 +241,6 @@ class KubernetesCommandRunner(CommandRunnerInterface):
             # side-effects.
             final_cmd = " ".join(final_cmd)
             logger.info(self.log_prefix + "Running {}".format(final_cmd))
-
             try:
                 if with_output:
                     return self.process_runner.check_output(

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -241,6 +241,7 @@ class KubernetesCommandRunner(CommandRunnerInterface):
             # side-effects.
             final_cmd = " ".join(final_cmd)
             logger.info(self.log_prefix + "Running {}".format(final_cmd))
+
             try:
                 if with_output:
                     return self.process_runner.check_output(

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -235,6 +235,7 @@ class KubernetesCommandRunner(CommandRunnerInterface):
             if environment_variables:
                 cmd = _with_environment_variables(cmd, environment_variables)
             cmd = _with_interactive(cmd)
+            cmd_prefix = " ".join(final_cmd)
             final_cmd += cmd
             # `kubectl exec` + subprocess w/ list of args has unexpected
             # side-effects.
@@ -248,8 +249,7 @@ class KubernetesCommandRunner(CommandRunnerInterface):
                     self.process_runner.check_call(final_cmd, shell=True)
             except subprocess.CalledProcessError:
                 if exit_on_fail:
-                    quoted_cmd = " ".join(final_cmd[:-1] +
-                                          [quote(final_cmd[-1])])
+                    quoted_cmd = cmd_prefix + quote(" ".join(cmd))
                     logger.error(
                         self.log_prefix +
                         "Command failed: \n\n  {}\n".format(quoted_cmd))

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from subprocess import CalledProcessError
 import tempfile
 import threading
 import time
@@ -48,7 +49,8 @@ class MockProcessRunner:
     def check_call(self, cmd, *args, **kwargs):
         for token in self.fail_cmds:
             if token in str(cmd):
-                raise Exception("Failing command on purpose")
+                raise CalledProcessError(1, token,
+                                         "Failing command on purpose")
         self.calls.append(cmd)
 
     def check_output(self, cmd):

--- a/python/ray/tests/test_command_runner.py
+++ b/python/ray/tests/test_command_runner.py
@@ -160,7 +160,7 @@ def test_kubernetes_command_runner():
 
     logger = logging.getLogger("ray.autoscaler._private.command_runner")
     with pytest.raises(SystemExit) as pytest_wrapped_e, patch.object(
-            logger, 'error') as mock_logger_error:
+            logger, "error") as mock_logger_error:
         cmd_runner.run(fail_cmd, exit_on_fail=True)
 
     failed_cmd_expected = f'prefixCommand failed: \n\n  kubectl -n namespace exec -it 0 --\'bash --login -c -i \'"\'"\'true && source ~/.bashrc && export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore && ({fail_cmd})\'"\'"\'\'\n'  # noqa: E501

--- a/python/ray/tests/test_command_runner.py
+++ b/python/ray/tests/test_command_runner.py
@@ -1,4 +1,6 @@
+import logging
 import pytest
+from unittest.mock import patch
 from ray.tests.test_autoscaler import MockProvider, MockProcessRunner
 from ray.autoscaler._private.command_runner import CommandRunnerInterface, \
     SSHCommandRunner, _with_environment_variables, DockerCommandRunner, \
@@ -123,7 +125,8 @@ def test_ssh_command_runner():
 
 
 def test_kubernetes_command_runner():
-    process_runner = MockProcessRunner()
+    fail_cmd = "fail command"
+    process_runner = MockProcessRunner([fail_cmd])
     provider = MockProvider()
     provider.create_node({}, {}, 1)
     args = {
@@ -154,6 +157,16 @@ def test_kubernetes_command_runner():
     ]
 
     assert process_runner.calls[0] == " ".join(expected)
+
+    logger = logging.getLogger("ray.autoscaler._private.command_runner")
+    with pytest.raises(SystemExit) as pytest_wrapped_e, patch.object(
+            logger, 'error') as mock_logger_error:
+        cmd_runner.run(fail_cmd, exit_on_fail=True)
+
+    failed_cmd_expected = f'prefixCommand failed: \n\n  kubectl -n namespace exec -it 0 --\'bash --login -c -i \'"\'"\'true && source ~/.bashrc && export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore && ({fail_cmd})\'"\'"\'\'\n'  # noqa: E501
+    mock_logger_error.assert_called_once_with(failed_cmd_expected)
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 1
 
 
 def test_docker_command_runner():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fix the exception that is raised when the command exits on failure (instead of exiting) when using the k8s command runner. 

For example, when executing 
```bash
ray exec cluster.yaml 'command -v foo >/dev/null 2>&1'
``` 
The following exception is raised

```
TypeError: can only concatenate str (not "list") to str
```
Likely related to https://github.com/ray-project/ray/pull/10766.

Tested manually on minikube.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
