### PR TITLE
[Placement Group]Fix raylet handle CommitBundle request crash bug

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -378,6 +378,14 @@ void GcsPlacementGroupScheduler::CommitAllBundles(
         &schedule_failure_handler,
     const std::function<void(std::shared_ptr<GcsPlacementGroup>)>
         &schedule_success_handler) {
+  if (lease_status_tracker->GetLeasingState() == LeasingState::CANCELLED) {
+    auto const &placement_group = lease_status_tracker->GetPlacementGroup();
+    RAY_LOG(INFO) << "Placement group " << placement_group->GetPlacementGroupID()
+                  << " is cancelled, so skip directly.";
+    schedule_failure_handler(placement_group);
+    return;
+  }
+
   const std::shared_ptr<BundleLocations> &prepared_bundle_locations =
       lease_status_tracker->GetPreparedBundleLocations();
   lease_status_tracker->MarkCommitPhaseStarted();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
![image](https://user-images.githubusercontent.com/13081808/94022723-fbae5380-fde7-11ea-9500-9fa0353eb8cf.png)
![image](https://user-images.githubusercontent.com/13081808/94022801-0bc63300-fde8-11ea-996f-aa95c900cb2a.png)
Remove placement group may cause raylet crash because GCS maybe send CommitBundle requests to raylet after placement group bundles is removed.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
