### PR TITLE
[Ray SGD] TorchTrainable pre 0.8.7 deprecation warning

### DIFF
--- a/python/ray/util/sgd/torch/torch_trainer.py
+++ b/python/ray/util/sgd/torch/torch_trainer.py
@@ -672,14 +672,10 @@ class BaseTorchTrainable(Trainable):
         """
         # Maintain Trainable backwards compatibility with pre v0.8.7.
         if self._is_overriden("_train"):
-            result = self._train()
-            if log_once("torch_train"):
-                logger.warning(
-                    "Trainable._train is deprecated and will be "
-                    "removed in "
-                    "a future version of Ray. Override Trainable.step instead."
-                )
-            return result
+            raise DeprecationWarning(
+                "Trainable._train is deprecated and will be "
+                "removed in "
+                "a future version of Ray. Override Trainable.step instead.")
 
         train_stats = self.trainer.train(max_retries=10, profile=True)
         validation_stats = self.trainer.validate(profile=True)

--- a/python/ray/util/sgd/torch/torch_trainer.py
+++ b/python/ray/util/sgd/torch/torch_trainer.py
@@ -670,7 +670,6 @@ class BaseTorchTrainable(Trainable):
 
         You may want to override this if using a custom LR scheduler.
         """
-        # Maintain Trainable backwards compatibility with pre v0.8.7.
         if self._is_overriden("_train"):
             raise DeprecationWarning(
                 "Trainable._train is deprecated and will be "

--- a/python/ray/util/sgd/torch/torch_trainer.py
+++ b/python/ray/util/sgd/torch/torch_trainer.py
@@ -670,6 +670,17 @@ class BaseTorchTrainable(Trainable):
 
         You may want to override this if using a custom LR scheduler.
         """
+        # Maintain Trainable backwards compatibility with pre v0.8.7.
+        if self._is_overriden("_train"):
+            result = self._train()
+            if log_once("torch_train"):
+                logger.warning(
+                    "Trainable._train is deprecated and will be "
+                    "removed in "
+                    "a future version of Ray. Override Trainable.step instead."
+                )
+            return result
+
         train_stats = self.trainer.train(max_retries=10, profile=True)
         validation_stats = self.trainer.validate(profile=True)
         stats = merge_dicts(train_stats, validation_stats)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
TorchTrainable should notify users that _train method is deprecated and to override step instead.

Thanks to @crypdick for bringing this up!

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
