### PR TITLE
[Log] make glog flush and RAY_LOG thread-safe

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -177,6 +177,7 @@ def ray_deps_setup():
         patches = [
             "//thirdparty/patches:glog-log-pid-tid.patch",
             "//thirdparty/patches:glog-stack-trace.patch",
+            "//thirdparty/patches:glog-suffix-log.patch",
         ],
     )
 

--- a/python/ray/tests/test_raylet_output.py
+++ b/python/ray/tests/test_raylet_output.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import time
+
+import pytest
+import ray
+
+
+def test_ray_log_redirected(shutdown_only):
+    ray.init(num_cpus=1)
+    session_dir = ray.worker._global_node.get_session_dir_path()
+    time.sleep(1.0)
+    assert os.path.exists(session_dir), "Specified socket path not found."
+    raylet_out_path = "{}/logs/raylet.out".format(session_dir)
+    raylet_err_path = "{}/logs/raylet.err".format(session_dir)
+    assert os.path.exists(raylet_out_path), "Raylet out not found"
+    assert os.path.exists(raylet_err_path), "Raylet err not found"
+    assert os.path.getsize(raylet_out_path) > 0
+    assert os.path.getsize(raylet_err_path) > 0
+
+
+if __name__ == "__main__":
+    # Make subprocess happy in bazel.
+    os.environ["LC_ALL"] = "en_US.UTF-8"
+    os.environ["LANG"] = "en_US.UTF-8"
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_raylet_output.py
+++ b/python/ray/tests/test_raylet_output.py
@@ -30,7 +30,7 @@ def test_ray_log_redirected(ray_start_regular):
     local_pid = os.getpid()
 
     wait_for_condition(lambda: all(map(file_exists_and_not_empty,
-     [raylet_out_path, raylet_err_path])))
+        [raylet_out_path, raylet_err_path])))
 
     core_worker_logs = glob.glob("{}/logs/python-core-worker*{}.log".format(
         session_dir, remote_pid))

--- a/python/ray/tests/test_raylet_output.py
+++ b/python/ray/tests/test_raylet_output.py
@@ -11,7 +11,7 @@ from ray.test_utils import (
 
 def test_ray_log_redirected(ray_start_regular):
     session_dir = ray.worker._global_node.get_session_dir_path()
-    assert os.path.exists(session_dir), "Specified socket path not found."
+    assert os.path.exists(session_dir), "Session dir not found."
     raylet_out_path = "{}/logs/raylet.out".format(session_dir)
     raylet_err_path = "{}/logs/raylet.err".format(session_dir)
 

--- a/python/ray/tests/test_raylet_output.py
+++ b/python/ray/tests/test_raylet_output.py
@@ -29,8 +29,8 @@ def test_ray_log_redirected(ray_start_regular):
     remote_pid = ray.get(actor.get_pid.remote())
     local_pid = os.getpid()
 
-    wait_for_condition(lambda: all(map(file_exists_and_not_empty,
-        [raylet_out_path, raylet_err_path])))
+    wait_for_condition(lambda: all(
+        map(file_exists_and_not_empty, [raylet_out_path, raylet_err_path])))
 
     core_worker_logs = glob.glob("{}/logs/python-core-worker*{}.log".format(
         session_dir, remote_pid))

--- a/python/ray/tests/test_raylet_output.py
+++ b/python/ray/tests/test_raylet_output.py
@@ -8,6 +8,15 @@ from ray.test_utils import (
     wait_for_condition, )
 
 
+def enable_export_loglevel(func):
+    # For running in both python and pytest, this decorator makes sure
+    # log level env parameter will be changed.
+    # Make raylet emit a log to raylet.err.
+    os.environ["RAY_BACKEND_LOG_LEVEL"] = "info"
+    return func
+
+
+@enable_export_loglevel
 def test_ray_log_redirected(ray_start_regular):
     session_dir = ray.worker._global_node.get_session_dir_path()
     assert os.path.exists(session_dir), "Session dir not found."

--- a/python/ray/tests/test_raylet_output.py
+++ b/python/ray/tests/test_raylet_output.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import time
 import glob
 
 import pytest
@@ -30,7 +29,8 @@ def test_ray_log_redirected(ray_start_regular):
     remote_pid = ray.get(actor.get_pid.remote())
     local_pid = os.getpid()
 
-    wait_for_condition(lambda : all(map(file_exists_and_not_empty, [raylet_out_path, raylet_err_path])))
+    wait_for_condition(lambda: all(map(file_exists_and_not_empty,
+     [raylet_out_path, raylet_err_path])))
 
     core_worker_logs = glob.glob("{}/logs/python-core-worker*{}.log".format(
         session_dir, remote_pid))

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -197,7 +197,7 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
     // we use stdout by default.
     google::base::SetLogger(level, &stdout_logger_singleton);
   }
-  for (int i = static_cast<int>(RayLogLevel::DEBUG);
+  for (int i = static_cast<int>(RayLogLevel::INFO);
        i <= static_cast<int>(RayLogLevel::FATAL); ++i) {
     if (i != level) {
       // NOTE(lingxuan.zlx): It means nothing can be printed or sinked to pass

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -173,9 +173,11 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
     google::SetLogFilenameExtension(app_name_without_path.c_str());
     int level = GetMappedSeverity(static_cast<RayLogLevel>(severity_threshold_));
     google::SetLogDestination(level, dir_ends_with_slash.c_str());
-    for (int i = static_cast<int>(severity_threshold_) + 1;
+    for (int i = static_cast<int>(RayLogLevel::DEBUG);
          i <= static_cast<int>(RayLogLevel::FATAL); ++i) {
-      google::SetLogDestination(i, "");
+      if (i != level) {
+        google::SetLogDestination(i, "");
+      }
     }
     FLAGS_stop_logging_if_full_disk = true;
   }

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -202,6 +202,8 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
     if (i != level) {
       // NOTE(lingxuan.zlx): It means nothing can be printed or sinked to pass
       // an empty destination.
+      // Reference from glog:
+      // https://github.com/google/glog/blob/0a2e5931bd5ff22fd3bf8999eb8ce776f159cda6/src/logging.cc#L1110
       google::SetLogDestination(i, "");
     }
   }

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -197,8 +197,7 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
     // we use stdout by default.
     google::base::SetLogger(level, &stdout_logger_singleton);
   }
-  for (int i = static_cast<int>(RayLogLevel::INFO);
-       i <= static_cast<int>(RayLogLevel::FATAL); ++i) {
+  for (int i = GLOG_INFO; i <= GLOG_FATAL; ++i) {
     if (i != level) {
       // NOTE(lingxuan.zlx): It means nothing can be printed or sinked to pass
       // an empty destination.

--- a/thirdparty/patches/glog-suffix-log.patch
+++ b/thirdparty/patches/glog-suffix-log.patch
@@ -1,0 +1,13 @@
+diff --git src/logging.cc src/logging.cc
+--- src/logging.cc
++++ src/logging.cc
+@@ -1135,7 +1135,8 @@ void LogFileObject::Write(bool force_flush,
+                     << setw(2) << tm_time.tm_min
+                     << setw(2) << tm_time.tm_sec
+                     << '.'
+-                    << GetMainThreadPid();
++                    << GetMainThreadPid()
++                    << ".log";
+     const string& time_pid_string = time_pid_stream.str();
+ 
+     if (base_filename_selected_) {

--- a/thirdparty/patches/glog-suffix-log.patch
+++ b/thirdparty/patches/glog-suffix-log.patch
@@ -11,3 +11,17 @@ diff --git src/logging.cc src/logging.cc
      const string& time_pid_string = time_pid_stream.str();
  
      if (base_filename_selected_) {
+@@ -1146,6 +1147,10 @@ void LogFileObject::Write(bool force_flush,
+         return;
+       }
+     } else {
++      // NOTE(lingxuan.zlx): Why we need do this? Raylet process will never call
++      // StartRayLog, so all log items created by RayLog was erroneously rewritten
++      // to a special file in the tmp directory. To avoid this, we need to output
++      // the log directly to standard output so that the log is redirected to
++      // either raylet.out or raylet.err.
++      std::cout << std::string(message, message_len) << std::flush;
++      return;
+       // If no base filename for logs of this severity has been set, use a
+       // default base filename of
+       // "<program name>.<hostname>.<user name>.log.<severity level>.".  So

--- a/thirdparty/patches/glog-suffix-log.patch
+++ b/thirdparty/patches/glog-suffix-log.patch
@@ -11,18 +11,3 @@ diff --git src/logging.cc src/logging.cc
      const string& time_pid_string = time_pid_stream.str();
  
      if (base_filename_selected_) {
-@@ -1146,6 +1147,14 @@ void LogFileObject::Write(bool force_flush,
-         return;
-       }
-     } else {
-+      // NOTE(lingxuan.zlx): Why we need do this? Raylet process will never
-+                       // call StartRayLog, so all log items created by RayLog was
-+      // erroneously rewritten to a special file in the tmp directory.
-+      // To avoid this, we need to output the log directly to standard
-+                       // output so that the log is redirected to either raylet.out or
-+                       // raylet.err.
-+      std::cout << std::string(message, message_len) << std::flush;
-+      return;
-       // If no base filename for logs of this severity has been set, use a
-       // default base filename of
-       // "<program name>.<hostname>.<user name>.log.<severity level>.".  So

--- a/thirdparty/patches/glog-suffix-log.patch
+++ b/thirdparty/patches/glog-suffix-log.patch
@@ -11,15 +11,16 @@ diff --git src/logging.cc src/logging.cc
      const string& time_pid_string = time_pid_stream.str();
  
      if (base_filename_selected_) {
-@@ -1146,6 +1147,10 @@ void LogFileObject::Write(bool force_flush,
+@@ -1146,6 +1147,14 @@ void LogFileObject::Write(bool force_flush,
          return;
        }
      } else {
-+      // NOTE(lingxuan.zlx): Why we need do this? Raylet process will never call
-+      // StartRayLog, so all log items created by RayLog was erroneously rewritten
-+      // to a special file in the tmp directory. To avoid this, we need to output
-+      // the log directly to standard output so that the log is redirected to
-+      // either raylet.out or raylet.err.
++      // NOTE(lingxuan.zlx): Why we need do this? Raylet process will never
++                       // call StartRayLog, so all log items created by RayLog was
++      // erroneously rewritten to a special file in the tmp directory.
++      // To avoid this, we need to output the log directly to standard
++                       // output so that the log is redirected to either raylet.out or
++                       // raylet.err.
 +      std::cout << std::string(message, message_len) << std::flush;
 +      return;
        // If no base filename for logs of this severity has been set, use a


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Current RAY_LOG will make duplicated output in log files.
For example, all logs of RAY_LOG(ERROR) will be flushed three times to destination file since we use a same sink file for INFO, WARN and ERROR level.

More important thing is this implementation is not thread-safe, so we'd better use glog default logobject.
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
