### PR TITLE
[GCS]Fix GCS actor manager idempotent bug

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -387,6 +387,9 @@ void GcsActorManager::HandleGetActorCheckpointID(
 
 Status GcsActorManager::RegisterActor(const ray::rpc::RegisterActorRequest &request,
                                       RegisterActorCallback success_callback) {
+  // NOTE: After the abnormal recovery of the network between GCS client and GCS server or
+  // the GCS server is restarted, it is required to continue to register actor
+  // successfully.
   RAY_CHECK(success_callback);
   const auto &actor_creation_task_spec = request.task_spec().actor_creation_task_spec();
   auto actor_id = ActorID::FromBinary(actor_creation_task_spec.actor_id());
@@ -469,6 +472,9 @@ Status GcsActorManager::RegisterActor(const ray::rpc::RegisterActorRequest &requ
 
 Status GcsActorManager::CreateActor(const ray::rpc::CreateActorRequest &request,
                                     CreateActorCallback callback) {
+  // NOTE: After the abnormal recovery of the network between GCS client and GCS server or
+  // the GCS server is restarted, it is required to continue to create actor
+  // successfully.
   RAY_CHECK(callback);
   const auto &actor_creation_task_spec = request.task_spec().actor_creation_task_spec();
   auto actor_id = ActorID::FromBinary(actor_creation_task_spec.actor_id());
@@ -502,7 +508,8 @@ Status GcsActorManager::CreateActor(const ray::rpc::CreateActorRequest &request,
   // `CreateActor` request.
   // After GCS restarts, the state of the actor may not be `DEPENDENCIES_UNREADY`.
   if (iter->second->GetState() != rpc::ActorTableData::DEPENDENCIES_UNREADY) {
-    RAY_LOG(INFO) << "Actor is already in the process of creation. Skip it directly.";
+    RAY_LOG(INFO) << "Actor " << actor_id
+                  << " is already in the process of creation. Skip it directly.";
     return Status::OK();
   }
 

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -395,14 +395,15 @@ Status GcsActorManager::RegisterActor(const ray::rpc::RegisterActorRequest &requ
   if (iter != registered_actors_.end()) {
     auto pending_register_iter = actor_to_register_callbacks_.find(actor_id);
     if (pending_register_iter != actor_to_register_callbacks_.end()) {
-      // 1. Worker send RegisterActor request to GCS server.
-      // 2. Worker receives some network errors.
-      // 3. Worker re-send the RegisterActor request to GCS server.
+      // 1. The GCS client sends the `RegisterActor` request to the GCS server.
+      // 2. The GCS client receives some network errors.
+      // 3. The GCS client resends the `RegisterActor` request to the GCS server.
       pending_register_iter->second.emplace_back(std::move(success_callback));
     } else {
-      // 1. Worker send RegisterActor request to GCS server.
-      // 2. GCS server flushed the actor and restarted before replied to the worker.
-      // 3. Worker re-send RegisterActor request to GCS server.
+      // 1. The GCS client sends the `RegisterActor` request to the GCS server.
+      // 2. The GCS server flushes the actor to the storage and restarts before replying
+      // to the GCS client.
+      // 3. The GCS client resends the `RegisterActor` request to the GCS server.
       success_callback(iter->second);
     }
     return Status::OK();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In this pr, we implement idempotent of `RegisterActor` and `CreateActor`. After the abnormal recovery of the network between GCS client and GCS server or the GCS server is restarted, it is required to continue to register/create actor successfully.
We checked the code and fixed three problems:
1) If GCS restarts while processing `CreateActor` request, GCS client will resend the `CreateActor` request, which will cause the actor to schedule twice (because GCS will schedule the unfinished actors by itself after the GCS restarts).     
2) If GCS restarts while processing `CreateActor` request, GCS client will resend the `CreateActor` request. After GCS restarts, the state of the actor may not be `DEPENDENCIES_UNREADY`, so erase actor from unresolved_actors_ will failed.
![image](https://user-images.githubusercontent.com/13081808/94157143-755f4380-feb3-11ea-8f24-ede0a94f9880.png)
3) If GCS restarts while processing `RegisterActor` request, GCS client will resend the `RegisterActor` request, which will cause the failure of `RAY_CHECK(unresolved_actors_[node_id][worker_id].emplace(actor->GetActorID()).second);`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
