### PR TITLE
Add a new _available_resources_per_node for state API

### DIFF
--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -758,20 +758,8 @@ class GlobalState:
             for client in self.node_table() if (client["Alive"])
         }
 
-    def available_resources(self):
-        """Get the current available cluster resources.
-
-        This is different from `cluster_resources` in that this will return
-        idle (available) resources rather than total resources.
-
-        Note that this information can grow stale as tasks start and finish.
-
-        Returns:
-            A dictionary mapping resource name to the total quantity of that
-                resource in the cluster.
-        """
-        self._check_connected()
-
+    def _available_resources_per_node(self):
+        """Returns a dictionary mapping node id to avaiable resources."""
         available_resources_by_id = {}
 
         subscribe_client = self.redis_client.pubsub(
@@ -807,14 +795,32 @@ class GlobalState:
                 if client_id not in client_ids:
                     del available_resources_by_id[client_id]
 
+        # Close the pubsub clients to avoid leaking file descriptors.
+        subscribe_client.close()
+
+        return available_resources_by_id
+
+    def available_resources(self):
+        """Get the current available cluster resources.
+
+        This is different from `cluster_resources` in that this will return
+        idle (available) resources rather than total resources.
+
+        Note that this information can grow stale as tasks start and finish.
+
+        Returns:
+            A dictionary mapping resource name to the total quantity of that
+                resource in the cluster.
+        """
+        self._check_connected()
+
+        available_resources_by_id = self._available_resources_per_node()
+
         # Calculate total available resources
         total_available_resources = defaultdict(int)
         for available_resources in available_resources_by_id.values():
             for resource_id, num_available in available_resources.items():
                 total_available_resources[resource_id] += num_available
-
-        # Close the pubsub clients to avoid leaking file descriptors.
-        subscribe_client.close()
 
         return dict(total_available_resources)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR moves a portion of `available_resources` API to a private method. The intention here is such that libraries like Serve and Tune and access this information. I would like to defer the discussion of making this API public (or promote to the `ray` namespace) until there is a strong ask for it. 

```
>>> ray.state.state._available_resources_per_node()
Out[11]:
{'d0d80b899c203994a3b685ef5c01d0e9f744b376': {'CPU': 14.0,
  'memory': 434.0,
  'object_store_memory': 149.0,
  'node:192.168.31.141': 1.0},
 '47b8f5c92aaa39cb52ee7a8da95bc7fba3c110fc': {'object_store_memory': 147.0,
  'node:192.168.31.141': 1.0,
  'CPU': 16.0,
  'memory': 498.0}}
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
