### PR TITLE
[Placement Group] Remove warning msg for placement groups.

### DIFF
--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -847,7 +847,7 @@ def test_capture_child_tasks(ray_start_cluster):
     assert len(node_id_set) == 1
 
 
-def test_ready_warning_surpressed(ray_start_regular, error_pubsub):
+def test_ready_warning_suppressed(ray_start_regular, error_pubsub):
     p = error_pubsub
     # Create an infeasible pg.
     pg = ray.util.placement_group([{"CPU": 2}] * 2, strategy="STRICT_PACK")

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -81,10 +81,10 @@ class PlacementGroup:
         # This number shouldn't be changed.
         # When it is specified, node manager won't warn about infeasible
         # tasks.
-        INFEASIBLE_TASK_SURPRESS_MAGIC_NUMBER = 0.0101
+        INFEASIBLE_TASK_SUPPRESS_MAGIC_NUMBER = 0.0101
         for key, value in bundle.items():
             if value > 0:
-                value = INFEASIBLE_TASK_SURPRESS_MAGIC_NUMBER
+                value = INFEASIBLE_TASK_SUPPRESS_MAGIC_NUMBER
                 return key, value
         assert False, "This code should be unreachable."
 

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -81,14 +81,9 @@ class PlacementGroup:
         # This number shouldn't be changed.
         # When it is specified, node manager won't warn about infeasible
         # tasks.
-        INFEASIBLE_TASK_SURPRESS_MAGIC_NUMBER = 0.0007
+        INFEASIBLE_TASK_SURPRESS_MAGIC_NUMBER = 0.0101
         for key, value in bundle.items():
             if value > 0:
-                if value < INFEASIBLE_TASK_SURPRESS_MAGIC_NUMBER:
-                    raise ValueError(
-                        "placement_group.ready() API cannot be used if there "
-                        "is resource quantity less than or equal to "
-                        f"{INFEASIBLE_TASK_SURPRESS_MAGIC_NUMBER}")
                 value = INFEASIBLE_TASK_SURPRESS_MAGIC_NUMBER
                 return key, value
         assert False, "This code should be unreachable."

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -78,9 +78,18 @@ class PlacementGroup:
         return len(self.bundle_cache)
 
     def _get_none_zero_resource(self, bundle: List[Dict]):
+        # This number shouldn't be changed.
+        # When it is specified, node manager won't warn about infeasible
+        # tasks.
+        INFEASIBLE_TASK_SURPRESS_MAGIC_NUMBER = 0.0007
         for key, value in bundle.items():
             if value > 0:
-                value = min(value, 0.001)
+                if value < INFEASIBLE_TASK_SURPRESS_MAGIC_NUMBER:
+                    raise ValueError(
+                        "placement_group.ready() API cannot be used if there "
+                        "is resource quantity less than or equal to "
+                        f"{INFEASIBLE_TASK_SURPRESS_MAGIC_NUMBER}")
+                value = INFEASIBLE_TASK_SURPRESS_MAGIC_NUMBER
                 return key, value
         assert False, "This code should be unreachable."
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2165,9 +2165,9 @@ void NodeManager::ScheduleTasks(
     const auto &required_resources = task.GetTaskSpecification().GetRequiredResources();
     const auto &resources_map = required_resources.GetResourceMap();
     const auto &it = resources_map.begin();
-    // It is a hack to surpress infeasible task warning.
+    // It is a hack to suppress infeasible task warning.
     // If the first resource of a task requires this magic number, infeasible warning is
-    // surpressed. It is currently only used by placement group ready API. We don't want
+    // suppressed. It is currently only used by placement group ready API. We don't want
     // to have this in ray_config_def.h because the use case is very narrow, and we don't
     // want to expose this anywhere.
     double INFEASIBLE_TASK_SURPRESS_MAGIC_NUMBER = 0.0101;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2160,7 +2160,7 @@ void NodeManager::ScheduleTasks(
     task_dependency_manager_.TaskPending(task);
     move_task_set.insert(task.GetTaskSpecification().TaskId());
 
-    // This block is used to surpress infeasible task warning.
+    // This block is used to suppress infeasible task warning.
     bool suppress_warning = false;
     const auto &required_resources = task.GetTaskSpecification().GetRequiredResources();
     const auto &resources_map = required_resources.GetResourceMap();
@@ -2170,9 +2170,9 @@ void NodeManager::ScheduleTasks(
     // suppressed. It is currently only used by placement group ready API. We don't want
     // to have this in ray_config_def.h because the use case is very narrow, and we don't
     // want to expose this anywhere.
-    double INFEASIBLE_TASK_SURPRESS_MAGIC_NUMBER = 0.0101;
+    double INFEASIBLE_TASK_SUPPRESS_MAGIC_NUMBER = 0.0101;
     if (it != resources_map.end() &&
-        it->second == INFEASIBLE_TASK_SURPRESS_MAGIC_NUMBER) {
+        it->second == INFEASIBLE_TASK_SUPPRESS_MAGIC_NUMBER) {
       suppress_warning = true;
     }
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2161,7 +2161,7 @@ void NodeManager::ScheduleTasks(
     move_task_set.insert(task.GetTaskSpecification().TaskId());
 
     // This block is used to surpress infeasible task warning.
-    bool surpress_warning = false;
+    bool suppress_warning = false;
     const auto &required_resources = task.GetTaskSpecification().GetRequiredResources();
     const auto &resources_map = required_resources.GetResourceMap();
     const auto &it = resources_map.begin();
@@ -2170,14 +2170,14 @@ void NodeManager::ScheduleTasks(
     // surpressed. It is currently only used by placement group ready API. We don't want
     // to have this in ray_config_def.h because the use case is very narrow, and we don't
     // want to expose this anywhere.
-    double INFEASIBLE_TASK_SURPRESS_MAGIC_NUMBER = 0.0007;
+    double INFEASIBLE_TASK_SURPRESS_MAGIC_NUMBER = 0.0101;
     if (it != resources_map.end() &&
         it->second == INFEASIBLE_TASK_SURPRESS_MAGIC_NUMBER) {
-      surpress_warning = true;
+      suppress_warning = true;
     }
 
     // Push a warning to the task's driver that this task is currently infeasible.
-    if (!surpress_warning) {
+    if (!suppress_warning) {
       // TODO(rkn): Define this constant somewhere else.
       std::string type = "infeasible_task";
       std::ostringstream error_message;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, every time `pg.ready()` is called, it creates an infeasible task warning msg. This is annoying. This PR fixes this issue by introducing "infeasible_task_surpress_magic_number".

Open question:
- Should we include this to ray_config_def? I didn't do that because the use case of this functionality is extremely narrow (only for the placement group for now).

## Related issue number

https://github.com/ray-project/ray/issues/10506

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
