### PR TITLE
[GCS]Fix miss `PollOwnerForActorOutOfScope` after gcs restarts bug

### DIFF
--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -140,8 +140,9 @@ def test_del_actor_after_gcs_server_restart(ray_start_regular):
     ray.worker._global_node.kill_gcs_server()
     ray.worker._global_node.start_gcs_server()
 
-    actor_id=actor._actor_id.hex()
+    actor_id = actor._actor_id.hex()
     del actor
+    
     def condition():
         actor_status = ray.actors(actor_id=actor_id)
         if actor_status["State"] == ray.gcs_utils.ActorTableData.DEAD:

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -133,14 +133,14 @@ def test_node_failure_detector_when_gcs_server_restart(ray_start_cluster_head):
     ],
     indirect=True)
 def test_kill_actor_after_gcs_server_restart(ray_start_regular):
-    actor1 = Increase.remote()
-    result = ray.get(actor1.method.remote(1))
+    actor = Increase.remote()
+    result = ray.get(actor.method.remote(1))
     assert result == 3
 
     ray.worker._global_node.kill_gcs_server()
     ray.worker._global_node.start_gcs_server()
 
-    ray.kill(actor1)
+    ray.kill(actor)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -142,7 +142,7 @@ def test_del_actor_after_gcs_server_restart(ray_start_regular):
 
     actor_id = actor._actor_id.hex()
     del actor
-    
+
     def condition():
         actor_status = ray.actors(actor_id=actor_id)
         if actor_status["State"] == ray.gcs_utils.ActorTableData.DEAD:

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -126,23 +126,6 @@ def test_node_failure_detector_when_gcs_server_restart(ray_start_cluster_head):
     wait_for_condition(condition, timeout=10)
 
 
-@pytest.mark.parametrize(
-    "ray_start_regular", [
-        generate_system_config_map(
-            num_heartbeats_timeout=20, ping_gcs_rpc_server_max_retries=60)
-    ],
-    indirect=True)
-def test_kill_actor_after_gcs_server_restart(ray_start_regular):
-    actor = Increase.remote()
-    result = ray.get(actor.method.remote(1))
-    assert result == 3
-
-    ray.worker._global_node.kill_gcs_server()
-    ray.worker._global_node.start_gcs_server()
-
-    ray.kill(actor)
-
-
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -1,5 +1,4 @@
 import sys
-import time
 
 import ray
 import pytest

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -917,22 +917,23 @@ TEST_F(ServiceBasedGcsClientTest, TestActorTableResubscribe) {
   RestartGcsServer();
 
   // When GCS client detects that GCS server has restarted, but the pub-sub server
-  // didn't restart, it will fetch data again from the GCS server. So we'll receive
-  // another notification of ALIVE state.
+  // didn't restart, it will fetch data again from the GCS server. The GCS will destroy
+  // the actor because it finds that the actor is out of scope, so we'll receive another
+  // notification of DEAD state.
   WaitForExpectedCount(num_subscribe_all_notifications, 2);
   WaitForExpectedCount(num_subscribe_one_notifications, 2);
-  CheckActorData(subscribe_all_notifications[1], rpc::ActorTableData::ALIVE);
-  CheckActorData(subscribe_one_notifications[1], rpc::ActorTableData::ALIVE);
+  CheckActorData(subscribe_all_notifications[1], rpc::ActorTableData::DEAD);
+  CheckActorData(subscribe_one_notifications[1], rpc::ActorTableData::DEAD);
 
-  // Update the actor state to DEAD.
-  actor_table_data->set_state(rpc::ActorTableData::DEAD);
+  // Update the actor state to ALIVE.
+  actor_table_data->set_state(rpc::ActorTableData::ALIVE);
   ASSERT_TRUE(UpdateActor(actor_id, actor_table_data));
 
-  // We should receive a new DEAD notification from the subscribe channel.
+  // We should receive a new ALIVE notification from the subscribe channel.
   WaitForExpectedCount(num_subscribe_all_notifications, 3);
   WaitForExpectedCount(num_subscribe_one_notifications, 3);
-  CheckActorData(subscribe_all_notifications[2], rpc::ActorTableData::DEAD);
-  CheckActorData(subscribe_one_notifications[2], rpc::ActorTableData::DEAD);
+  CheckActorData(subscribe_all_notifications[2], rpc::ActorTableData::ALIVE);
+  CheckActorData(subscribe_one_notifications[2], rpc::ActorTableData::ALIVE);
 }
 
 TEST_F(ServiceBasedGcsClientTest, TestObjectTableResubscribe) {

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -935,7 +935,7 @@ void GcsActorManager::LoadInitialData(const EmptyCallback &done) {
                                                       actor->GetActorID());
         }
 
-        if (!actor->IsDetached() && worker_client_factory_) {
+        if (!actor->IsDetached()) {
           // This actor is owned. Send a long polling request to the actor's
           // owner to determine when the actor should be removed.
           PollOwnerForActorOutOfScope(actor);

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -930,14 +930,15 @@ void GcsActorManager::LoadInitialData(const EmptyCallback &done) {
           RAY_CHECK(unresolved_actors_[owner_node][owner_worker]
                         .emplace(actor->GetActorID())
                         .second);
-          if (!actor->IsDetached() && worker_client_factory_) {
-            // This actor is owned. Send a long polling request to the actor's
-            // owner to determine when the actor should be removed.
-            PollOwnerForActorOutOfScope(actor);
-          }
         } else if (item.second.state() == ray::rpc::ActorTableData::ALIVE) {
           created_actors_[actor->GetNodeID()].emplace(actor->GetWorkerID(),
                                                       actor->GetActorID());
+        }
+
+        if (!actor->IsDetached() && worker_client_factory_) {
+          // This actor is owned. Send a long polling request to the actor's
+          // owner to determine when the actor should be removed.
+          PollOwnerForActorOutOfScope(actor);
         }
 
         auto &workers = owners_[actor->GetNodeID()];


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
After GCS restarts, `PollOwnerForActorOutOfScope` is not called correctly. If we kill actor after GCS restarts, it will not call `DestroyActor`.
I have add a test `test_kill_actor_after_gcs_server_restart` and it was verified manually.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
