### PR TITLE
[Java]Fix testSetResource bug

### DIFF
--- a/java/test/src/main/java/io/ray/test/DynamicResourceTest.java
+++ b/java/test/src/main/java/io/ray/test/DynamicResourceTest.java
@@ -20,19 +20,23 @@ public class DynamicResourceTest extends BaseTest {
     // Call a task in advance to warm up the cluster to avoid being too slow to start workers.
     TestUtils.warmUpCluster();
 
+    String resourceName = "A";
     ObjectRef<String> obj = Ray.task(DynamicResourceTest::sayHi)
-        .setResource("A", 10.0)
+        .setResource(resourceName, 10.0)
         .remote();
     WaitResult<String> result = Ray.wait(ImmutableList.of(obj), 1, 1000);
     Assert.assertEquals(result.getReady().size(), 0);
 
-    Ray.setResource("A", 10.0);
+    Ray.setResource(resourceName, 10.0);
     boolean resourceReady = TestUtils.waitForCondition(() -> {
       List<NodeInfo> nodes = Ray.getRuntimeContext().getAllNodeInfo();
-      if (nodes.size() != 1) {
+      // NOTE: GCS updates node resources asynchronously.
+      // If we directly get the value of "A" for comparison without check whether "A" exists or not,
+      // it maybe lead to NPE.
+      if (nodes.size() != 1 || !nodes.get(0).resources.containsKey(resourceName)) {
         return false;
       }
-      return (0 == Double.compare(10.0, nodes.get(0).resources.get("A")));
+      return (0 == Double.compare(10.0, nodes.get(0).resources.get(resourceName)));
     }, 2000);
 
     Assert.assertTrue(resourceReady);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
![image](https://user-images.githubusercontent.com/13081808/94405207-ca94a100-01a2-11eb-921a-59c936d1681e.png)
https://travis-ci.com/github/ray-project/ray/jobs/391608751
GCS updates node resources asynchronously. If we directly get the value of "A" for comparison without check whether "A" exists or not, it maybe lead to NPE.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
