### PR TITLE
[GCS]Optimizing actor info query interface

### DIFF
--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1016,26 +1016,6 @@ def test_kill(ray_start_regular_shared):
         ray.kill("not_an_actor_handle")
 
 
-def test_get_actor_info(ray_start_regular_shared):
-    @ray.remote
-    class Actor:
-        def hang(self):
-            while True:
-                time.sleep(1)
-
-    actor = Actor.remote()
-    result = actor.hang.remote()
-    ready, _ = ray.wait([result], timeout=0.5)
-    assert len(ready) == 0
-    ray.kill(actor, no_restart=False)
-
-    with pytest.raises(ray.exceptions.RayActorError):
-        ray.get(result)
-
-    with pytest.raises(ValueError):
-        ray.kill("not_an_actor_handle")
-
-
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1016,6 +1016,26 @@ def test_kill(ray_start_regular_shared):
         ray.kill("not_an_actor_handle")
 
 
+def test_get_actor_info(ray_start_regular_shared):
+    @ray.remote
+    class Actor:
+        def hang(self):
+            while True:
+                time.sleep(1)
+
+    actor = Actor.remote()
+    result = actor.hang.remote()
+    ready, _ = ray.wait([result], timeout=0.5)
+    assert len(ready) == 0
+    ray.kill(actor, no_restart=False)
+
+    with pytest.raises(ray.exceptions.RayActorError):
+        ray.get(result)
+
+    with pytest.raises(ValueError):
+        ray.kill("not_an_actor_handle")
+
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main(["-v", __file__]))

--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -229,27 +229,6 @@ TEST_F(GlobalStateAccessorTest, TestObjectTable) {
   }
 }
 
-TEST_F(GlobalStateAccessorTest, TestActorTable) {
-  int actor_count = 1;
-  ASSERT_EQ(global_state_->GetAllActorInfo().size(), 0);
-  auto job_id = JobID::FromInt(1);
-  std::vector<ActorID> actor_ids;
-  actor_ids.reserve(actor_count);
-  for (int index = 0; index < actor_count; ++index) {
-    auto actor_table_data = Mocker::GenActorTableData(job_id);
-    actor_ids.emplace_back(ActorID::FromBinary(actor_table_data->actor_id()));
-    std::promise<bool> promise;
-    RAY_CHECK_OK(gcs_client_->Actors().AsyncRegister(
-        actor_table_data, [&promise](Status status) { promise.set_value(status.ok()); }));
-    WaitReady(promise.get_future(), timeout_ms_);
-  }
-  ASSERT_EQ(global_state_->GetAllActorInfo().size(), actor_count);
-
-  for (auto &actor_id : actor_ids) {
-    ASSERT_TRUE(global_state_->GetActorInfo(actor_id));
-  }
-}
-
 TEST_F(GlobalStateAccessorTest, TestWorkerTable) {
   ASSERT_EQ(global_state_->GetAllWorkerInfo().size(), 0);
   // Add worker info

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -916,8 +916,8 @@ void GcsActorManager::LoadInitialData(const EmptyCallback &done) {
                    done](const std::unordered_map<ActorID, ActorTableData> &result) {
     std::unordered_map<NodeID, std::vector<WorkerID>> node_to_workers;
     for (auto &item : result) {
+      auto actor = std::make_shared<GcsActor>(item.second);
       if (item.second.state() != ray::rpc::ActorTableData::DEAD) {
-        auto actor = std::make_shared<GcsActor>(item.second);
         registered_actors_.emplace(item.first, actor);
 
         if (!actor->GetName().empty()) {
@@ -954,6 +954,8 @@ void GcsActorManager::LoadInitialData(const EmptyCallback &done) {
           RAY_CHECK(!actor->GetNodeID().IsNil());
           node_to_workers[actor->GetNodeID()].emplace_back(actor->GetWorkerID());
         }
+      } else {
+        destroyed_actors_.emplace(item.first, actor);
       }
     }
 

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -561,9 +561,9 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
   auto it = registered_actors_.find(actor_id);
   RAY_CHECK(it != registered_actors_.end())
       << "Tried to destroy actor that does not exist " << actor_id;
+  destroyed_actors_.emplace(it->first, it->second);
+  const auto actor = std::move(it->second);
   registered_actors_.erase(it);
-  destroyed_actors_[it->first] = it->second;
-  const auto actor = it->second;
 
   // Clean up the client to the actor's owner, if necessary.
   if (!actor->IsDetached()) {

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -998,6 +998,14 @@ void GcsActorManager::OnJobFinished(const JobID &job_id) {
       RAY_CHECK_OK(
           gcs_table_storage_->ActorTable().BatchDelete(non_detached_actors, nullptr));
 
+      for (auto iter = destroyed_actors_.begin(); iter != destroyed_actors_.end();) {
+        if (iter->first.JobId() == job_id && !iter->second->IsDetached()) {
+          destroyed_actors_.erase(iter++);
+        } else {
+          iter++;
+        }
+      }
+
       // Get checkpoint id first from checkpoint id table and delete all checkpoints
       // related to this job
       RAY_CHECK_OK(gcs_table_storage_->ActorCheckpointIdTable().GetByJobId(

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -562,7 +562,7 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
   RAY_CHECK(it != registered_actors_.end())
       << "Tried to destroy actor that does not exist " << actor_id;
   registered_actors_.erase(it);
-  destroyed_actors_.emplace(it->first, it->second);
+  destroyed_actors_[it->first] = it->second;
   const auto actor = it->second;
 
   // Clean up the client to the actor's owner, if necessary.

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -561,9 +561,9 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
   auto it = registered_actors_.find(actor_id);
   RAY_CHECK(it != registered_actors_.end())
       << "Tried to destroy actor that does not exist " << actor_id;
-  const auto actor = std::move(it->second);
   registered_actors_.erase(it);
   destroyed_actors_.emplace(it->first, it->second);
+  const auto actor = it->second;
 
   // Clean up the client to the actor's owner, if necessary.
   if (!actor->IsDetached()) {

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -366,6 +366,8 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// All registered actors (unresoved and pending actors are also included).
   /// TODO(swang): Use unique_ptr instead of shared_ptr.
   absl::flat_hash_map<ActorID, std::shared_ptr<GcsActor>> registered_actors_;
+  /// All destroyed actors.
+  absl::flat_hash_map<ActorID, std::shared_ptr<GcsActor>> destroyed_actors_;
   /// Maps actor names to their actor ID for lookups by name.
   absl::flat_hash_map<std::string, ActorID> named_actors_;
   /// The actors which dependencies have not been resolved.

--- a/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
@@ -503,10 +503,8 @@ TEST_F(GcsServerTest, TestJobGarbageCollection) {
   add_job_request.mutable_data()->CopyFrom(*job_table_data);
   ASSERT_TRUE(AddJob(add_job_request));
 
-  // Register actor for job
-  auto actor_table_data = Mocker::GenActorTableData(job_id);
-
   // Add actor checkpoint
+  auto actor_table_data = Mocker::GenActorTableData(job_id);
   ActorCheckpointID checkpoint_id = ActorCheckpointID::FromRandom();
   rpc::ActorCheckpointData checkpoint;
   checkpoint.set_actor_id(actor_table_data->actor_id());


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Optimizing actor info query interface:
Internal tests found that the get actor info interface RT is high because it is asynchronous. If GCS is busy, it will take longer to queue. So we optimize this, get actor info directly from memory, and the interface becomes synchronous return.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
