### PR TITLE
[tune] Create dated subdirectories in tune experiment dirs

### DIFF
--- a/doc/source/tune/user-guide.rst
+++ b/doc/source/tune/user-guide.rst
@@ -579,6 +579,9 @@ These are the environment variables Ray Tune currently considers:
   ``~/ray_bootstrap_key.pem`` will be used.
 * **TUNE_DISABLE_AUTO_INIT**: Disable automatically calling ``ray.init()`` if
   not attached to a Ray session.
+* **TUNE_DISABLE_DATED_SUBDIR**: Tune automatically creates dated subdirectories in the
+  experiment directory (a subdir of ``local_dir`` passed to ``tune.run()``). Setting
+  this environment variable to ``1`` disables creating these subdirectories.
 * **TUNE_DISABLE_STRICT_METRIC_CHECKING**: When you report metrics to Tune via
   ``tune.report()`` and passed a ``metric`` parameter to ``tune.run()``, a scheduler,
   or a search algorithm, Tune will error

--- a/python/ray/tune/tests/test_tune_restore.py
+++ b/python/ray/tune/tests/test_tune_restore.py
@@ -124,11 +124,7 @@ class TuneExampleTest(unittest.TestCase):
 class AutoInitTest(unittest.TestCase):
     def testTuneRestore(self):
         self.assertFalse(ray.is_initialized())
-        tune.run(
-            "__fake",
-            name="TestAutoInit",
-            stop={"training_iteration": 1},
-            ray_auto_init=True)
+        tune.run("__fake", name="TestAutoInit", stop={"training_iteration": 1})
         self.assertTrue(ray.is_initialized())
 
     def tearDown(self):
@@ -139,6 +135,7 @@ class AutoInitTest(unittest.TestCase):
 class AbstractWarmStartTest:
     def setUp(self):
         ray.init(num_cpus=1, local_mode=True)
+        os.environ["TUNE_DISABLE_DATED_SUBDIR"] = "1"
         self.tmpdir = tempfile.mkdtemp()
         self.experiment_name = "results"
 

--- a/python/ray/tune/tests/test_tune_save_restore.py
+++ b/python/ray/tune/tests/test_tune_save_restore.py
@@ -39,6 +39,9 @@ class SerialTuneRelativeLocalDirTest(unittest.TestCase):
 
     def setUp(self):
         self.absolute_local_dir = None
+        # Disable dated logdir creation. This test suite should only test
+        # train/restore.
+        os.environ["TUNE_DISABLE_DATED_SUBDIR"] = "1"
         ray.init(num_cpus=1, num_gpus=0, local_mode=self.local_mode)
 
     def tearDown(self):

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -136,13 +136,15 @@ class TrialInfo:
 
 def create_logdir(dirname, local_dir):
     local_dir = os.path.expanduser(local_dir)
-    logdir = os.path.join(local_dir, dirname)
+    subdir = "" if int(os.environ.get("TUNE_DISABLE_DATED_SUBDIR",
+                                      0)) == 1 else date_str()
+    logdir = os.path.join(local_dir, subdir, dirname)
     if os.path.exists(logdir):
         old_dirname = dirname
         dirname += "_" + uuid.uuid4().hex[:4]
         logger.info(f"Creating a new dirname {dirname} because "
                     f"trial dirname '{old_dirname}' already exists.")
-        logdir = os.path.join(local_dir, dirname)
+        logdir = os.path.join(local_dir, subdir, dirname)
     os.makedirs(logdir, exist_ok=True)
     return logdir
 

--- a/rllib/tests/test_rollout.py
+++ b/rllib/tests/test_rollout.py
@@ -227,6 +227,9 @@ def learn_test_multi_agent_plus_rollout(algo):
 
 
 class TestRolloutSimple(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ["TUNE_DISABLE_DATED_SUBDIR"] = "1"
+
     def test_a3c(self):
         rollout_test("A3C")
 
@@ -250,6 +253,9 @@ class TestRolloutSimple(unittest.TestCase):
 
 
 class TestRolloutLearntPolicy(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ["TUNE_DISABLE_DATED_SUBDIR"] = "1"
+
     def test_ppo_train_then_rollout(self):
         learn_test_plus_rollout("PPO")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

With this PR, dated subdirectories are created for each run in the experiment dir, so that multiple runs of the same experiment will be stored in different directories. The behavior can be disabled setting  the `TUNE_DISABLE_DATED_SUBDIR` environment variable.

WIP for tests.

## Related issue number

Closes #6391

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
