### PR TITLE
[tune] fix flaky callback test

### DIFF
--- a/python/ray/tune/tests/test_trial_runner_callbacks.py
+++ b/python/ray/tune/tests/test_trial_runner_callbacks.py
@@ -89,6 +89,7 @@ class TrialRunnerCallbacks(unittest.TestCase):
         for t in trials:
             self.trial_runner.add_trial(t)
 
+        self.executor.next_trial = trials[0]
         self.trial_runner.step()
 
         # Trial 1 has been started
@@ -103,6 +104,7 @@ class TrialRunnerCallbacks(unittest.TestCase):
                 "trial_complete", "trial_fail"
             ]))
 
+        self.executor.next_trial = trials[1]
         self.trial_runner.step()
 
         # Iteration not increased yet
@@ -120,6 +122,7 @@ class TrialRunnerCallbacks(unittest.TestCase):
                         {TRAINING_ITERATION: 0})
 
         # Let the first trial save a checkpoint
+        self.executor.next_trial = trials[0]
         trials[0].saving_to = cp
         self.trial_runner.step()
         self.assertEqual(self.callback.state["trial_save"]["iteration"], 2)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`trial_runner.step()` is non-deterministic in deciding which trial to process next. This leads to flaky tests.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
