### PR TITLE
[tune] use dated experiment dir per default

### DIFF
--- a/doc/source/tune/user-guide.rst
+++ b/doc/source/tune/user-guide.rst
@@ -579,6 +579,9 @@ These are the environment variables Ray Tune currently considers:
   ``~/ray_bootstrap_key.pem`` will be used.
 * **TUNE_DISABLE_AUTO_INIT**: Disable automatically calling ``ray.init()`` if
   not attached to a Ray session.
+* **TUNE_DISABLE_DATED_SUBDIR**: Tune automatically adds a date string to experiment
+  directories when the name is not specified explicitly. Setting
+  this environment variable to ``1`` disables adding these date strings.
 * **TUNE_DISABLE_STRICT_METRIC_CHECKING**: When you report metrics to Tune via
   ``tune.report()`` and passed a ``metric`` parameter to ``tune.run()``, a scheduler,
   or a search algorithm, Tune will error

--- a/doc/source/tune/user-guide.rst
+++ b/doc/source/tune/user-guide.rst
@@ -580,8 +580,8 @@ These are the environment variables Ray Tune currently considers:
 * **TUNE_DISABLE_AUTO_INIT**: Disable automatically calling ``ray.init()`` if
   not attached to a Ray session.
 * **TUNE_DISABLE_DATED_SUBDIR**: Tune automatically adds a date string to experiment
-  directories when the name is not specified explicitly. Setting
-  this environment variable to ``1`` disables adding these date strings.
+  directories when the name is not specified explicitly or the trainable isn't passed
+  as a string. Setting this environment variable to ``1`` disables adding these date strings.
 * **TUNE_DISABLE_STRICT_METRIC_CHECKING**: When you report metrics to Tune via
   ``tune.report()`` and passed a ``metric`` parameter to ``tune.run()``, a scheduler,
   or a search algorithm, Tune will error

--- a/python/ray/tune/automl/search_policy.py
+++ b/python/ray/tune/automl/search_policy.py
@@ -106,7 +106,7 @@ class AutoMLSearcher(SearchAlgorithm):
                     deep_insert(path.split("."), value, new_spec["config"])
 
                 trial = create_trial_from_spec(
-                    new_spec, exp.name, self._parser, experiment_tag=tag)
+                    new_spec, exp.dir_name, self._parser, experiment_tag=tag)
 
                 # AutoML specific fields set in Trial
                 trial.results = []

--- a/python/ray/tune/experiment.py
+++ b/python/ray/tune/experiment.py
@@ -260,7 +260,13 @@ class Experiment:
         elif isinstance(run_object, type) or callable(run_object):
             name = "DEFAULT"
             if hasattr(run_object, "__name__"):
-                name = run_object.__name__
+                fn_name = run_object.__name__
+                if fn_name == "<lambda>":
+                    name = "lambda"
+                elif fn_name.startswith("<"):
+                    name = "DEFAULT"
+                else:
+                    name = fn_name
             else:
                 logger.warning(
                     "No name detected on trainable. Using {}.".format(name))

--- a/python/ray/tune/experiment.py
+++ b/python/ray/tune/experiment.py
@@ -259,7 +259,9 @@ class Experiment:
             return run_object
         elif isinstance(run_object, type) or callable(run_object):
             name = "DEFAULT"
-            if hasattr(run_object, "__name__"):
+            if hasattr(run_object, "_name"):
+                name = run_object._name
+            elif hasattr(run_object, "__name__"):
                 fn_name = run_object.__name__
                 if fn_name == "<lambda>":
                     name = "lambda"

--- a/python/ray/tune/experiment.py
+++ b/python/ray/tune/experiment.py
@@ -139,8 +139,9 @@ class Experiment:
         self.name = name or self._run_identifier
 
         # If the name has been set explicitly, we don't want to create
-        # dated directories.
-        if int(os.environ.get("TUNE_DISABLE_DATED_SUBDIR", 0)) == 1 or name:
+        # dated directories. The same is true for string run identifiers.
+        if int(os.environ.get("TUNE_DISABLE_DATED_SUBDIR", 0)) == 1 or name \
+           or isinstance(run, str):
             self.dir_name = self.name
         else:
             self.dir_name = "{}_{}".format(self.name, date_str())

--- a/python/ray/tune/suggest/basic_variant.py
+++ b/python/ray/tune/suggest/basic_variant.py
@@ -77,7 +77,7 @@ class BasicVariantGenerator(SearchAlgorithm):
                 self._trial_generator,
                 self._generate_trials(
                     experiment.spec.get("num_samples", 1), experiment.spec,
-                    experiment.name))
+                    experiment.dir_name))
 
     def next_trial(self):
         """Provides one Trial object to be queued into the TrialRunner.

--- a/python/ray/tune/suggest/search_generator.py
+++ b/python/ray/tune/suggest/search_generator.py
@@ -111,7 +111,7 @@ class SearchGenerator(SearchAlgorithm):
         """
         if not self.is_finished():
             return self.create_trial_if_possible(self._experiment.spec,
-                                                 self._experiment.name)
+                                                 self._experiment.dir_name)
         return None
 
     def create_trial_if_possible(self, experiment_spec: Dict,

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -3,7 +3,6 @@ from typing import Sequence
 import ray.cloudpickle as cloudpickle
 from collections import deque
 import copy
-from datetime import datetime
 import logging
 import platform
 import shutil
@@ -22,7 +21,7 @@ from ray.tune.registry import get_trainable_cls, validate_trainable
 from ray.tune.result import DEFAULT_RESULTS_DIR, DONE, TRAINING_ITERATION
 from ray.tune.resources import Resources, json_to_resources, resources_to_json
 from ray.tune.trainable import TrainableUtil
-from ray.tune.utils import flatten_dict
+from ray.tune.utils import date_str, flatten_dict
 from ray.utils import binary_to_hex, hex_to_binary
 
 DEBUG_PRINT_INTERVAL = 5
@@ -34,10 +33,6 @@ if "MAX_LEN_IDENTIFIER" in os.environ:
 MAX_LEN_IDENTIFIER = int(
     os.environ.get("TUNE_MAX_LEN_IDENTIFIER",
                    os.environ.get("MAX_LEN_IDENTIFIER", 130)))
-
-
-def date_str():
-    return datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
 
 
 class Location:

--- a/python/ray/tune/utils/__init__.py
+++ b/python/ray/tune/utils/__init__.py
@@ -1,13 +1,13 @@
 from ray.tune.utils.util import (
-    deep_update, flatten_dict, get_pinned_object, merge_dicts,
+    deep_update, date_str, flatten_dict, get_pinned_object, merge_dicts,
     pin_in_object_store, unflattened_lookup, UtilMonitor,
     validate_save_restore, warn_if_slow, diagnose_serialization,
     detect_checkpoint_function, detect_reporter, detect_config_single,
     env_integer)
 
 __all__ = [
-    "deep_update", "flatten_dict", "get_pinned_object", "merge_dicts",
-    "pin_in_object_store", "unflattened_lookup", "UtilMonitor",
+    "deep_update", "date_str", "flatten_dict", "get_pinned_object",
+    "merge_dicts", "pin_in_object_store", "unflattened_lookup", "UtilMonitor",
     "validate_save_restore", "warn_if_slow", "diagnose_serialization",
     "detect_checkpoint_function", "detect_reporter", "detect_config_single",
     "env_integer"

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -5,6 +5,7 @@ import inspect
 import threading
 import time
 from collections import defaultdict, deque, Mapping, Sequence
+from datetime import datetime
 from threading import Thread
 
 import numpy as np
@@ -151,6 +152,10 @@ class Tee(object):
     def flush(self, *args, **kwargs):
         self.stream1.flush(*args, **kwargs)
         self.stream2.flush(*args, **kwargs)
+
+
+def date_str():
+    return datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
 
 
 def env_integer(key, default):

--- a/rllib/tests/test_rollout.py
+++ b/rllib/tests/test_rollout.py
@@ -178,7 +178,8 @@ def learn_test_multi_agent_plus_rollout(algo):
             checkpoint_freq=1,
             checkpoint_at_end=True,
             local_dir=tmp_dir,
-            verbose=1)
+            verbose=1,
+            name="PPO")
 
         # Find last checkpoint and use that for the rollout.
         checkpoint_path = os.popen("ls {}/PPO/*/checkpoint_*/"

--- a/rllib/tests/test_rollout.py
+++ b/rllib/tests/test_rollout.py
@@ -178,8 +178,7 @@ def learn_test_multi_agent_plus_rollout(algo):
             checkpoint_freq=1,
             checkpoint_at_end=True,
             local_dir=tmp_dir,
-            verbose=1,
-            name="PPO")
+            verbose=1)
 
         # Find last checkpoint and use that for the rollout.
         checkpoint_path = os.popen("ls {}/PPO/*/checkpoint_*/"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When no specific name is set for a trainable, the name will now be appended with a date string suffix. The behavior can be disabled by setting an environment variable or by passing an explicit experiment name (e.g. through `tune.run(name="name")`).

## Related issue number

Replaces and closes #11076

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
