### PR TITLE
auto-update copyright year in docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -19,6 +19,7 @@ import os
 import urllib
 sys.path.insert(0, os.path.abspath('.'))
 from custom_directives import CustomGalleryItemDirective
+from datetime import datetime
 
 # These lines added to enable Sphinx to work without installing Ray.
 import mock
@@ -174,9 +175,9 @@ source_parsers = {
 master_doc = 'index'
 
 # General information about the project.
-project = u'Ray'
-copyright = u'2019, The Ray Team'
-author = u'The Ray Team'
+project = 'Ray'
+copyright = str(datetime.now().year) + ', The Ray Team'
+author = 'The Ray Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The copyright year appearing in the footer of the Ray documentation should always be the year the documentation was created or updated.  Previously the copyright year was hard-coded as "2019".  To fix this, this PR automatically sets the year to the current year whenever the docs are compiled.

Looks like this now: 
<img width="275" alt="Screen Shot 2020-09-29 at 10 46 31 AM" src="https://user-images.githubusercontent.com/5459654/94596501-0ed67e80-0241-11eb-98bc-0a3d67366162.png">
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] Manually tested
