### PR TITLE
Dmitri/add mypy to ci

### DIFF
--- a/python/requirements_linters.txt
+++ b/python/requirements_linters.txt
@@ -1,4 +1,5 @@
 flake8==3.7.7 
 flake8-comprehensions
 flake8-quotes==2.0.0
+mypy==0.782
 yapf==0.23.0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR adds python type checking to the CI pipeline. Specifically, I added some mypy commands to `ci/travis/format.sh`.   
At the moment, mypy does a very coarse check: it's configured to run with flag `--follow-imports=skip`. This should be changed later on when more of the code base has proper type annotations.

I also made a small edit to the line that checks flake8 version to account for the fact that the output of `flake8 --version` could have multiple lines.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

I ran `ci/travis/format.sh` with no flags. I also ran it with flag `--files` on a python file. In both cases, the script correctly errors out when passed an incorrectly typed file and reports success when the types are correct.