### PR TITLE
[Doc] Use different pygments_style

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -24,8 +24,7 @@ sphinx-gallery
 sphinx-jsonschema
 sphinx-tabs
 sphinx-version-warning
-# TODO(simon): Use sphinx book theme released version
-git+https://github.com/executablebooks/sphinx-book-theme.git@0a87d26e214c419d2e6efcadddab4be8ae7b2c21
+sphinx-book-theme
 tabulate
 uvicorn
 werkzeug

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -222,7 +222,7 @@ exclude_patterns += sphinx_gallery_conf['examples_dirs']
 #show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = 'pastie'
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
User complained the doc theme makes it hard differentiate comments and variables.

https://ray-distributed.slack.com/archives/CMVUQ1KMX/p1601489043076900

![image](https://user-images.githubusercontent.com/21118851/94741915-bd55ee80-0329-11eb-8c1c-6a351b48eb57.png)


I just chose one theme for our code highlighting that I see fit. You can see all available theme here: https://help.farbox.com/pygments.html

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
