### PR TITLE
[rllib] Test broken due to gym.Space disallow setattr

### DIFF
--- a/rllib/utils/spaces/repeated.py
+++ b/rllib/utils/spaces/repeated.py
@@ -17,14 +17,9 @@ class Repeated(gym.Space):
     """
 
     def __init__(self, child_space: gym.Space, max_len: int):
-        self.np_random = np.random.RandomState()
         self.child_space = child_space
         self.max_len = max_len
         super().__init__()
-
-    def seed(self, seed=None):
-        self.np_random = np.random.RandomState()
-        self.np_random.seed(seed)
 
     def sample(self):
         return [


### PR DESCRIPTION
Remove setattr in spaces.Repeated. This doesn't seem to be needed any more (not sure why it was there in the first place).

This fixes broken tests in https://flakey-tests.ray.io/