### PR TITLE
[GCS]Optimization: Clear task_spec of destroyed actors 

### DIFF
--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -1291,7 +1291,9 @@ TEST_F(ServiceBasedGcsClientTest, DISABLED_TestGetActorPerf) {
   }
 
   // Get all actors.
-  auto condition = [this, actor_count]() { return GetAllActors().size() == actor_count; };
+  auto condition = [this, actor_count]() {
+    return (int)GetAllActors().size() == actor_count;
+  };
   EXPECT_TRUE(WaitForCondition(condition, timeout_ms_.count()));
 
   int64_t start_time = current_time_ms();

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -1272,7 +1272,9 @@ TEST_F(ServiceBasedGcsClientTest, TestMultiThreadSubAndUnsub) {
   }
 }
 
-TEST_F(ServiceBasedGcsClientTest, TestGetActorPerf) {
+// This UT is only used to test the query actor info performance.
+// We disable it by default.
+TEST_F(ServiceBasedGcsClientTest, DISABLED_TestGetActorPerf) {
   // Register actors.
   JobID job_id = JobID::FromInt(1);
   const int actor_count = 5000;

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -1273,7 +1273,7 @@ TEST_F(ServiceBasedGcsClientTest, TestMultiThreadSubAndUnsub) {
 }
 
 TEST_F(ServiceBasedGcsClientTest, TestGetActorPerf) {
-  // Create actor table data.
+  // Register actors.
   JobID job_id = JobID::FromInt(1);
   const int actor_count = 5000;
   rpc::TaskSpec task_spec;
@@ -1288,6 +1288,7 @@ TEST_F(ServiceBasedGcsClientTest, TestGetActorPerf) {
     RegisterActor(actor_table_data, false, true);
   }
 
+  // Get all actors.
   auto condition = [this]() { return GetAllActors().size() == actor_count; };
   EXPECT_TRUE(WaitForCondition(condition, timeout_ms_.count()));
 

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -1277,7 +1277,7 @@ TEST_F(ServiceBasedGcsClientTest, TestMultiThreadSubAndUnsub) {
 TEST_F(ServiceBasedGcsClientTest, DISABLED_TestGetActorPerf) {
   // Register actors.
   JobID job_id = JobID::FromInt(1);
-  const int actor_count = 5000;
+  int actor_count = 5000;
   rpc::TaskSpec task_spec;
   rpc::TaskArg task_arg;
   task_arg.set_data("0123456789");
@@ -1291,7 +1291,7 @@ TEST_F(ServiceBasedGcsClientTest, DISABLED_TestGetActorPerf) {
   }
 
   // Get all actors.
-  auto condition = [this]() { return GetAllActors().size() == actor_count; };
+  auto condition = [this, actor_count]() { return GetAllActors().size() == actor_count; };
   EXPECT_TRUE(WaitForCondition(condition, timeout_ms_.count()));
 
   int64_t start_time = current_time_ms();

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -20,6 +20,7 @@
 #include "ray/gcs/gcs_server/gcs_server.h"
 #include "ray/gcs/test/gcs_test_util.h"
 #include "ray/rpc/gcs_server/gcs_rpc_client.h"
+#include "ray/util/util.h"
 
 namespace ray {
 
@@ -158,8 +159,7 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
   }
 
   bool RegisterActor(const std::shared_ptr<rpc::ActorTableData> &actor_table_data,
-                     bool is_detached = true) {
-    std::promise<bool> promise;
+                     bool is_detached = true, bool skip_wait = false) {
     rpc::TaskSpec message;
     auto actor_id = ActorID::FromBinary(actor_table_data->actor_id());
     message.set_job_id(actor_id.JobId().Binary());
@@ -173,6 +173,12 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     message.mutable_actor_creation_task_spec()->set_is_detached(is_detached);
     TaskSpecification task_spec(message);
 
+    if (skip_wait) {
+      return gcs_client_->Actors()
+          .AsyncRegisterActor(task_spec, [](Status status) {})
+          .ok();
+    }
+    std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Actors().AsyncRegisterActor(
         task_spec, [&promise](Status status) { promise.set_value(status.ok()); }));
     return WaitReady(promise.get_future(), timeout_ms_);
@@ -190,6 +196,21 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
         }));
     EXPECT_TRUE(WaitReady(promise.get_future(), timeout_ms_));
     return actor_table_data;
+  }
+
+  std::vector<rpc::ActorTableData> GetAllActors() {
+    std::promise<bool> promise;
+    std::vector<rpc::ActorTableData> actors;
+    RAY_CHECK_OK(gcs_client_->Actors().AsyncGetAll(
+        [&actors, &promise](Status status,
+                            const std::vector<rpc::ActorTableData> &result) {
+          if (!result.empty()) {
+            actors.assign(result.begin(), result.end());
+          }
+          promise.set_value(true);
+        }));
+    EXPECT_TRUE(WaitReady(promise.get_future(), timeout_ms_));
+    return actors;
   }
 
   bool AddCheckpoint(
@@ -1249,6 +1270,31 @@ TEST_F(ServiceBasedGcsClientTest, TestMultiThreadSubAndUnsub) {
     thread->join();
     thread.reset();
   }
+}
+
+TEST_F(ServiceBasedGcsClientTest, TestGetActorPerf) {
+  // Create actor table data.
+  JobID job_id = JobID::FromInt(1);
+  const int actor_count = 5000;
+  rpc::TaskSpec task_spec;
+  rpc::TaskArg task_arg;
+  task_arg.set_data("0123456789");
+  for (int index = 0; index < 10000; ++index) {
+    task_spec.add_args()->CopyFrom(task_arg);
+  }
+  for (int index = 0; index < actor_count; ++index) {
+    auto actor_table_data = Mocker::GenActorTableData(job_id);
+    actor_table_data->mutable_task_spec()->CopyFrom(task_spec);
+    RegisterActor(actor_table_data, false, true);
+  }
+
+  auto condition = [this]() { return GetAllActors().size() == actor_count; };
+  EXPECT_TRUE(WaitForCondition(condition, timeout_ms_.count()));
+
+  int64_t start_time = current_time_ms();
+  auto actors = GetAllActors();
+  RAY_LOG(INFO) << "It takes " << current_time_ms() - start_time << "ms to query "
+                << actor_count << " actors.";
 }
 
 // TODO(sang): Add tests after adding asyncAdd

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -561,6 +561,7 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
   auto it = registered_actors_.find(actor_id);
   RAY_CHECK(it != registered_actors_.end())
       << "Tried to destroy actor that does not exist " << actor_id;
+  it->second->GetMutableActorTableData()->mutable_task_spec()->Clear();
   destroyed_actors_.emplace(it->first, it->second);
   const auto actor = std::move(it->second);
   registered_actors_.erase(it);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Clear task_spec of destroyed actors.
Before optimization: It takes 73ms to query 5000 actors.
After optimization: It takes 40ms to query 5000 actors.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
