### PR TITLE
[GCS]Periodically clean up expired data(actors&nodes)

### DIFF
--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -698,6 +698,7 @@ def test_clear_up_expired_actors(ray_start_cluster):
     @ray.remote(num_cpus=1, max_restarts=0)
     class Actor:
         """An actor that won't restart."""
+
         def ready(self):
             return True
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -234,6 +234,10 @@ RAY_CONFIG(uint32_t, gcs_create_actor_retry_interval_ms, 200)
 RAY_CONFIG(uint32_t, gcs_create_placement_group_retry_interval_ms, 200)
 /// Maximum number of destroyed actors in GCS server memory cache.
 RAY_CONFIG(uint32_t, maximum_gcs_destroyed_actor_cached_count, 10000)
+/// The interval at which the gcs server will clear up expired actors.
+RAY_CONFIG(int64_t, gcs_clear_expired_actors_interval_seconds, 600)
+/// The ttl of dead actor.
+RAY_CONFIG(int64_t, gcs_ttl_of_dead_actor_seconds, 3 * 24 * 60 * 60)
 
 /// Maximum number of times to retry putting an object when the plasma store is full.
 /// Can be set to -1 to enable unlimited retries.

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -235,7 +235,7 @@ RAY_CONFIG(uint32_t, gcs_create_placement_group_retry_interval_ms, 200)
 /// Maximum number of destroyed actors in GCS server memory cache.
 RAY_CONFIG(uint32_t, maximum_gcs_destroyed_actor_cached_count, 10000)
 /// Maximum number of dead nodes in GCS server memory cache.
-RAY_CONFIG(uint32_t, maximum_gcs_dead_node_cached_count, 10000)
+RAY_CONFIG(uint32_t, maximum_gcs_dead_node_cached_count, 1000)
 /// The interval at which the gcs server will clear up expired data.
 RAY_CONFIG(int64_t, gcs_clear_up_expired_data_interval_seconds, 600)
 /// The ttl of dead actor.

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -234,10 +234,14 @@ RAY_CONFIG(uint32_t, gcs_create_actor_retry_interval_ms, 200)
 RAY_CONFIG(uint32_t, gcs_create_placement_group_retry_interval_ms, 200)
 /// Maximum number of destroyed actors in GCS server memory cache.
 RAY_CONFIG(uint32_t, maximum_gcs_destroyed_actor_cached_count, 10000)
-/// The interval at which the gcs server will clear up expired actors.
-RAY_CONFIG(int64_t, gcs_clear_expired_actors_interval_seconds, 600)
+/// Maximum number of dead nodes in GCS server memory cache.
+RAY_CONFIG(uint32_t, maximum_gcs_dead_node_cached_count, 10000)
+/// The interval at which the gcs server will clear up expired data.
+RAY_CONFIG(int64_t, gcs_clear_up_expired_data_interval_seconds, 600)
 /// The ttl of dead actor.
 RAY_CONFIG(int64_t, gcs_ttl_of_dead_actor_seconds, 3 * 24 * 60 * 60)
+/// The ttl of dead node.
+RAY_CONFIG(int64_t, gcs_ttl_of_dead_node_seconds, 3 * 24 * 60 * 60)
 
 /// Maximum number of times to retry putting an object when the plasma store is full.
 /// Can be set to -1 to enable unlimited retries.

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -236,7 +236,7 @@ RAY_CONFIG(uint32_t, gcs_create_placement_group_retry_interval_ms, 200)
 RAY_CONFIG(uint32_t, maximum_gcs_destroyed_actor_cached_count, 10000)
 /// Maximum number of dead nodes in GCS server memory cache.
 RAY_CONFIG(uint32_t, maximum_gcs_dead_node_cached_count, 1000)
-/// The interval at which the gcs server will clear up expired data.
+/// The interval at which the gcs server will clean up expired data.
 RAY_CONFIG(int64_t, gcs_clear_up_expired_data_interval_seconds, 600)
 /// The ttl of dead actor.
 RAY_CONFIG(int64_t, gcs_ttl_of_dead_actor_seconds, 3 * 24 * 60 * 60)

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -1111,7 +1111,7 @@ void GcsActorManager::AddDestroyedActorToCache(const std::shared_ptr<GcsActor> &
 void GcsActorManager::ClearUpExpiredActors() {
   for (auto iter = destroyed_actors_.begin(); iter != destroyed_actors_.end();) {
     if (current_sys_time_ms() - iter->second->GetActorTableData().timestamp() >
-        RayConfig::instance().gcs_ttl_of_dead_actor_seconds()) {
+        RayConfig::instance().gcs_ttl_of_dead_actor_seconds() * 1000 /*ms*/) {
       RAY_CHECK_OK(gcs_table_storage_->ActorTable().Delete(iter->first, nullptr));
       destroyed_actors_.erase(iter++);
     } else {

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -1108,7 +1108,7 @@ void GcsActorManager::AddDestroyedActorToCache(const std::shared_ptr<GcsActor> &
   destroyed_actors_.emplace(actor->GetActorID(), actor);
 }
 
-void GcsActorManager::ClearUpExpiredActors() {
+void GcsActorManager::CleanUpExpiredActors() {
   for (auto iter = destroyed_actors_.begin(); iter != destroyed_actors_.end();) {
     if (current_sys_time_ms() - iter->second->GetActorTableData().timestamp() >
         RayConfig::instance().gcs_ttl_of_dead_actor_seconds() * 1000 /*ms*/) {

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -297,8 +297,8 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   const absl::flat_hash_map<ActorID, std::vector<RegisterActorCallback>>
       &GetActorRegisterCallbacks() const;
 
-  /// Clear up expired actors.
-  void ClearUpExpiredActors();
+  /// Clean up expired actors.
+  void CleanUpExpiredActors();
 
  private:
   /// A data structure representing an actor's owner.

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -158,12 +158,10 @@ class GcsActorManager : public rpc::ActorInfoHandler {
  public:
   /// Create a GcsActorManager
   ///
-  /// \param io_context The main event loop.
   /// \param scheduler Used to schedule actor creation tasks.
   /// \param gcs_table_storage Used to flush actor data to storage.
   /// \param gcs_pub_sub Used to publish gcs message.
-  GcsActorManager(boost::asio::io_service &io_service,
-                  std::shared_ptr<GcsActorSchedulerInterface> scheduler,
+  GcsActorManager(std::shared_ptr<GcsActorSchedulerInterface> scheduler,
                   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
                   std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub,
                   const rpc::ClientFactoryFn &worker_client_factory = nullptr);
@@ -299,6 +297,9 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   const absl::flat_hash_map<ActorID, std::vector<RegisterActorCallback>>
       &GetActorRegisterCallbacks() const;
 
+  /// Clear up expired actors.
+  void ClearUpExpiredActors();
+
  private:
   /// A data structure representing an actor's owner.
   struct Owner {
@@ -361,9 +362,6 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// \param actor The actor to be killed.
   void AddDestroyedActorToCache(const std::shared_ptr<GcsActor> &actor);
 
-  /// Fire a periodic timer to clear up expired actors.
-  void PeriodicallyClearExpiredActors();
-
   /// Callbacks of pending `RegisterActor` requests.
   /// Maps actor ID to actor registration callbacks, which is used to filter duplicated
   /// messages from a driver/worker caused by some network problems.
@@ -379,9 +377,6 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   absl::flat_hash_map<ActorID, std::shared_ptr<GcsActor>> registered_actors_;
   /// All destroyed actors.
   absl::flat_hash_map<ActorID, std::shared_ptr<GcsActor>> destroyed_actors_;
-  // A timer used to clear up expired actors.
-  // It includes: dead actors in `destroyed_actors_` and gcs storage.
-  boost::asio::deadline_timer clear_expired_actors_timer_;
   /// Maps actor names to their actor ID for lookups by name.
   absl::flat_hash_map<std::string, ActorID> named_actors_;
   /// The actors which dependencies have not been resolved.

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -168,7 +168,8 @@ GcsNodeManager::GcsNodeManager(boost::asio::io_service &main_io_service,
             main_io_service_.post([this, node_id] {
               if (auto node = RemoveNode(node_id, /* is_intended = */ false)) {
                 node->set_state(rpc::GcsNodeInfo::DEAD);
-                RAY_CHECK(dead_nodes_.emplace(node_id, node).second);
+                node->set_timestamp(current_sys_time_ms());
+                AddDeadNodeToCache(node);
                 auto on_done = [this, node_id, node](const Status &status) {
                   auto on_done = [this, node_id, node](const Status &status) {
                     RAY_CHECK_OK(gcs_pub_sub_->Publish(
@@ -213,7 +214,8 @@ void GcsNodeManager::HandleUnregisterNode(const rpc::UnregisterNodeRequest &requ
   RAY_LOG(INFO) << "Unregistering node info, node id = " << node_id;
   if (auto node = RemoveNode(node_id, /* is_intended = */ true)) {
     node->set_state(rpc::GcsNodeInfo::DEAD);
-    RAY_CHECK(dead_nodes_.emplace(node_id, node).second);
+    node->set_timestamp(current_sys_time_ms());
+    AddDeadNodeToCache(node);
 
     auto on_done = [this, node_id, node, reply,
                     send_reply_callback](const Status &status) {
@@ -347,7 +349,7 @@ void GcsNodeManager::HandleDeleteResources(const rpc::DeleteResourcesRequest &re
 void GcsNodeManager::HandleSetInternalConfig(const rpc::SetInternalConfigRequest &request,
                                              rpc::SetInternalConfigReply *reply,
                                              rpc::SendReplyCallback send_reply_callback) {
-  auto on_done = [reply, send_reply_callback, request](const Status status) {
+  auto on_done = [reply, send_reply_callback, request](const Status &status) {
     RAY_LOG(DEBUG) << "Set internal config: " << request.config().DebugString();
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
   };
@@ -359,7 +361,7 @@ void GcsNodeManager::HandleGetInternalConfig(const rpc::GetInternalConfigRequest
                                              rpc::GetInternalConfigReply *reply,
                                              rpc::SendReplyCallback send_reply_callback) {
   auto get_system_config = [reply, send_reply_callback](
-                               ray::Status status,
+                               const ray::Status &status,
                                const boost::optional<rpc::StoredConfig> &config) {
     if (config.has_value()) {
       reply->mutable_config()->CopyFrom(config.get());
@@ -377,7 +379,7 @@ void GcsNodeManager::HandleGetAllAvailableResources(
   for (const auto &iter : GetClusterRealtimeResources()) {
     rpc::AvailableResources resource;
     resource.set_node_id(iter.first.Binary());
-    for (auto res : iter.second->GetResourceAmountMap()) {
+    for (const auto &res : iter.second->GetResourceAmountMap()) {
       (*resource.mutable_resources_available())[res.first] = res.second.ToDouble();
     }
     reply->add_resources_list()->CopyFrom(resource);
@@ -463,7 +465,7 @@ void GcsNodeManager::LoadInitialData(const EmptyCallback &done) {
         // detector.
         AddNode(std::make_shared<rpc::GcsNodeInfo>(item.second));
       } else if (item.second.state() == rpc::GcsNodeInfo::DEAD) {
-        dead_nodes_.emplace(item.first, std::make_shared<rpc::GcsNodeInfo>(item.second));
+        AddDeadNodeToCache(std::make_shared<rpc::GcsNodeInfo>(item.second));
       }
     }
 
@@ -511,6 +513,25 @@ void GcsNodeManager::UpdatePlacementGroupLoad(
   node_failure_detector_service_.post([this, placement_group_load] {
     node_failure_detector_->UpdatePlacementGroupLoad(move(placement_group_load));
   });
+}
+
+void GcsNodeManager::AddDeadNodeToCache(std::shared_ptr<rpc::GcsNodeInfo> node) {
+  if (dead_nodes_.size() >= RayConfig::instance().maximum_gcs_dead_node_cached_count()) {
+    dead_nodes_.erase(dead_nodes_.begin());
+  }
+  dead_nodes_.emplace(NodeID::FromBinary(node->node_id()), node);
+}
+
+void GcsNodeManager::ClearUpExpiredNodes() {
+  for (auto iter = dead_nodes_.begin(); iter != dead_nodes_.end();) {
+    if (current_sys_time_ms() - iter->second->timestamp() >
+        RayConfig::instance().gcs_ttl_of_dead_node_seconds()) {
+      RAY_CHECK_OK(gcs_table_storage_->NodeTable().Delete(iter->first, nullptr));
+      dead_nodes_.erase(iter++);
+    } else {
+      iter++;
+    }
+  }
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -525,7 +525,7 @@ void GcsNodeManager::AddDeadNodeToCache(std::shared_ptr<rpc::GcsNodeInfo> node) 
 void GcsNodeManager::ClearUpExpiredNodes() {
   for (auto iter = dead_nodes_.begin(); iter != dead_nodes_.end();) {
     if (current_sys_time_ms() - iter->second->timestamp() >
-        RayConfig::instance().gcs_ttl_of_dead_node_seconds()) {
+        RayConfig::instance().gcs_ttl_of_dead_node_seconds() * 1000 /*ms*/) {
       RAY_CHECK_OK(gcs_table_storage_->NodeTable().Delete(iter->first, nullptr));
       dead_nodes_.erase(iter++);
     } else {

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -469,11 +469,10 @@ void GcsNodeManager::LoadInitialData(const EmptyCallback &done) {
         sorted_dead_node_list_.emplace_back(item.first, item.second.timestamp());
       }
     }
-    std::sort(std::begin(sorted_dead_node_list_), std::end(sorted_dead_node_list_),
-              [](const std::pair<NodeID, int64_t> &left,
-                 const std::pair<NodeID, int64_t> &right) {
-                return left.second < right.second;
-              });
+    sorted_dead_node_list_.sort([](const std::pair<NodeID, int64_t> &left,
+                                   const std::pair<NodeID, int64_t> &right) {
+      return left.second < right.second;
+    });
 
     auto get_node_resource_callback =
         [this, done](const std::unordered_map<NodeID, ResourceMap> &result) {

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -164,6 +164,9 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   void UpdatePlacementGroupLoad(
       std::shared_ptr<rpc::PlacementGroupLoad> placement_group_load) const;
 
+  /// Clear up expired nodes.
+  void ClearUpExpiredNodes();
+
  protected:
   class NodeFailureDetector {
    public:
@@ -246,6 +249,12 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   };
 
  private:
+  /// Add the dead node to the cache. If the cache is full, one node is randomly
+  /// evicted.
+  ///
+  /// \param actor The node which is dead.
+  void AddDeadNodeToCache(std::shared_ptr<rpc::GcsNodeInfo> node);
+
   /// The main event loop for node failure detector.
   boost::asio::io_service &main_io_service_;
   /// Detector to detect the failure of node.

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -164,8 +164,8 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   void UpdatePlacementGroupLoad(
       std::shared_ptr<rpc::PlacementGroupLoad> placement_group_load) const;
 
-  /// Clear up expired nodes.
-  void ClearUpExpiredNodes();
+  /// Clean up expired nodes.
+  void CleanUpExpiredNodes();
 
  protected:
   class NodeFailureDetector {
@@ -265,6 +265,9 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>> alive_nodes_;
   /// Dead nodes.
   absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>> dead_nodes_;
+  /// The nodes are sorted according to the timestamp, and the oldest is at the head of
+  /// the list.
+  std::list<std::pair<NodeID, int64_t>> sorted_dead_node_list_;
   /// Cluster resources.
   absl::flat_hash_map<NodeID, rpc::ResourceMap> cluster_resources_;
   /// Listeners which monitors the addition of nodes.

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -252,7 +252,7 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// Add the dead node to the cache. If the cache is full, one node is randomly
   /// evicted.
   ///
-  /// \param actor The node which is dead.
+  /// \param node The node which is dead.
   void AddDeadNodeToCache(std::shared_ptr<rpc::GcsNodeInfo> node);
 
   /// The main event loop for node failure detector.

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -191,7 +191,8 @@ void GcsServer::InitGcsActorManager() {
         return std::make_shared<rpc::CoreWorkerClient>(address, client_call_manager_);
       });
   gcs_actor_manager_ = std::make_shared<GcsActorManager>(
-      scheduler, gcs_table_storage_, gcs_pub_sub_, [this](const rpc::Address &address) {
+      main_service_, scheduler, gcs_table_storage_, gcs_pub_sub_,
+      [this](const rpc::Address &address) {
         return std::make_shared<rpc::CoreWorkerClient>(address, client_call_manager_);
       });
   gcs_node_manager_->AddNodeAddedListener(

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -100,8 +100,8 @@ void GcsServer::Start() {
       new rpc::WorkerInfoGrpcService(main_service_, *gcs_worker_manager_));
   rpc_server_.RegisterService(*worker_info_service_);
 
-  // Clear up expired data.
-  PeriodicallyClearUpExpiredData();
+  // Clean up expired data.
+  PeriodicallyCleanUpExpiredData();
 
   auto load_completed_count = std::make_shared<int>(0);
   int load_count = 2;
@@ -285,12 +285,12 @@ std::unique_ptr<GcsWorkerManager> GcsServer::InitGcsWorkerManager() {
       new GcsWorkerManager(gcs_table_storage_, gcs_pub_sub_));
 }
 
-void GcsServer::PeriodicallyClearUpExpiredData() {
-  // Clear up expired actors.
-  gcs_actor_manager_->ClearUpExpiredActors();
+void GcsServer::PeriodicallyCleanUpExpiredData() {
+  // Clean up expired actors.
+  gcs_actor_manager_->CleanUpExpiredActors();
 
-  // Clear up expired nodes.
-  gcs_node_manager_->ClearUpExpiredNodes();
+  // Clean up expired nodes.
+  gcs_node_manager_->CleanUpExpiredNodes();
 
   auto clear_period = boost::posix_time::seconds(
       RayConfig::instance().gcs_clear_up_expired_data_interval_seconds());
@@ -300,7 +300,7 @@ void GcsServer::PeriodicallyClearUpExpiredData() {
       return;
     }
     RAY_CHECK(!error) << "Clearing expired actors failed with error: " << error.message();
-    PeriodicallyClearUpExpiredData();
+    PeriodicallyCleanUpExpiredData();
   });
 }
 

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -90,6 +90,9 @@ class GcsServer {
   /// Initialize the gcs placement group manager.
   virtual void InitGcsPlacementGroupManager();
 
+  /// Fire a periodic timer to clear up expired data.
+  virtual void PeriodicallyClearUpExpiredData();
+
   /// The object manager
   virtual std::unique_ptr<GcsObjectManager> InitObjectManager();
 
@@ -161,6 +164,9 @@ class GcsServer {
   /// Gcs service state flag, which is used for ut.
   bool is_started_ = false;
   bool is_stopped_ = false;
+  /// A timer used to clear up expired data.
+  // It includes: dead actors and dead nodes in gcs storage.
+  boost::asio::deadline_timer clear_expired_data_timer_;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -90,8 +90,8 @@ class GcsServer {
   /// Initialize the gcs placement group manager.
   virtual void InitGcsPlacementGroupManager();
 
-  /// Fire a periodic timer to clear up expired data.
-  virtual void PeriodicallyClearUpExpiredData();
+  /// Fire a periodic timer to clean up expired data.
+  virtual void PeriodicallyCleanUpExpiredData();
 
   /// The object manager
   virtual std::unique_ptr<GcsObjectManager> InitObjectManager();
@@ -164,7 +164,7 @@ class GcsServer {
   /// Gcs service state flag, which is used for ut.
   bool is_started_ = false;
   bool is_stopped_ = false;
-  /// A timer used to clear up expired data.
+  /// A timer used to clean up expired data.
   // It includes: dead actors and dead nodes in gcs storage.
   boost::asio::deadline_timer clear_expired_data_timer_;
 };

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -86,7 +86,7 @@ class GcsActorManagerTest : public ::testing::Test {
     store_client_ = std::make_shared<gcs::InMemoryStoreClient>(io_service_);
     gcs_table_storage_ = std::make_shared<gcs::InMemoryGcsTableStorage>(io_service_);
     gcs_actor_manager_.reset(new gcs::GcsActorManager(
-        io_service_, mock_actor_scheduler_, gcs_table_storage_, gcs_pub_sub_,
+        mock_actor_scheduler_, gcs_table_storage_, gcs_pub_sub_,
         [this](const rpc::Address &addr) { return worker_client_; }));
   }
 

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -86,7 +86,7 @@ class GcsActorManagerTest : public ::testing::Test {
     store_client_ = std::make_shared<gcs::InMemoryStoreClient>(io_service_);
     gcs_table_storage_ = std::make_shared<gcs::InMemoryGcsTableStorage>(io_service_);
     gcs_actor_manager_.reset(new gcs::GcsActorManager(
-        mock_actor_scheduler_, gcs_table_storage_, gcs_pub_sub_,
+        io_service_, mock_actor_scheduler_, gcs_table_storage_, gcs_pub_sub_,
         [this](const rpc::Address &addr) { return worker_client_; }));
   }
 

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -259,6 +259,8 @@ message GcsNodeInfo {
 
   // The port at which the node will expose metrics to.
   int32 metrics_export_port = 9;
+  // Timestamp that the node is dead.
+  int64 timestamp = 10;
 }
 
 // Represents the demand for a particular resource shape.

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -138,7 +138,7 @@ message ActorTableData {
   bool is_detached = 11;
   // Name of the actor. Only populated if is_detached is true.
   string name = 12;
-  // Timestamp that the actor is created or reconstructed.
+  // Timestamp that the actor is created or reconstructed or dead.
   double timestamp = 13;
   // The task specification of this actor's creation task.
   TaskSpec task_spec = 14;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
For a long running job, it will have some resident actors and some temporarily pulled up actors. For temporarily pulled up actors, it will exit after running, which will cause `destroyed_actors_` and gcs storage to cache a large number of dead actor information. Therefore, we add a cleaning mechanism to clean up expired actors and nodes regularly.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
