### PR TITLE
Remove the stale directory (pyarrow_files)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # The build output should clearly not be checked in
 /bazel-*
 /python/ray/core
-/python/ray/pyarrow_files/
 /python/ray/pickle5_files/
 /python/ray/thirdparty_files/
 /python/ray/jars/

--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -261,12 +261,12 @@ else
 fi
 
 # Ensure import ordering
-# Make sure that for every import psutil; import setpproctitle
+# Make sure that for every import psutil; import setproctitle
 # There's a import ray above it.
 
 PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE:-python}
 
-$PYTHON_EXECUTABLE ci/travis/check_import_order.py . -s ci -s python/ray/pyarrow_files -s python/ray/thirdparty_files -s python/build -s lib
+$PYTHON_EXECUTABLE ci/travis/check_import_order.py . -s ci -s python/ray/thirdparty_files -s python/build -s lib
 
 if ! git diff --quiet &>/dev/null; then
     echo 'Reformatted changed files. Please review and stage the changes.'


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This directory is no longer used in Ray.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
