### PR TITLE
[tune] use isinstance instead of type in PBT

### DIFF
--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -77,7 +77,7 @@ def explore(config: Dict, mutations: Dict, resample_probability: float,
                 new_config[key] = config[key] * 1.2
             else:
                 new_config[key] = config[key] * 0.8
-            if type(config[key]) is int:
+            if isinstance(config[key], int):
                 new_config[key] = int(new_config[key])
     if custom_explore_fn:
         new_config = custom_explore_fn(new_config)


### PR DESCRIPTION
## Why are these changes needed?

isinstance should be used instead of type

## Related issue number

n/a

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
