### PR TITLE
[Serve] Disable serialization for client and print helpful msg

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -54,13 +54,14 @@ class Client:
     def __del__(self):
         if not self._detached:
             logger.info("Shutting down Ray Serve because client went out of "
-                        "scope.")
+                        "scope. To prevent this, either keep a reference to "
+                        "the client object or use serve.start(detached=True).")
             self.shutdown()
 
     def __reduce__(self):
         raise RayServeException(
-            ("Ray Serve client cannot be serialized. "
-             "Please use serve.connect() to create a new client."))
+            ("Ray Serve client cannot be serialized. Please use "
+             "serve.connect() to get a client from within a backend."))
 
     def shutdown(self) -> None:
         """Completely shut down the connected Serve instance.

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -7,7 +7,7 @@ from ray.serve.constants import (DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT,
 from ray.serve.controller import ServeController
 from ray.serve.handle import RayServeHandle
 from ray.serve.utils import (block_until_http_ready, format_actor_name,
-                             get_random_letters)
+                             get_random_letters, logger)
 from ray.serve.exceptions import RayServeException
 from ray.serve.config import BackendConfig, ReplicaConfig, BackendMetadata
 from ray.actor import ActorHandle
@@ -53,7 +53,13 @@ class Client:
 
     def __del__(self):
         if not self._detached:
+            logger.info("Calling shutdown because client went out of scope.")
             self.shutdown()
+
+    def __reduce__(self):
+        raise RayServeException(
+            ("Ray Serve client cannot be serialized. "
+             "Please use serve.connect() to create a new client."))
 
     def shutdown(self) -> None:
         """Completely shut down the connected Serve instance.

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -53,7 +53,8 @@ class Client:
 
     def __del__(self):
         if not self._detached:
-            logger.info("Calling shutdown because client went out of scope.")
+            logger.info("Shutting down Ray Serve because client went out of "
+                        "scope.")
             self.shutdown()
 
     def __reduce__(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fix #11178

Now the script will loudly error:
```
2020-10-02 12:49:46,183	INFO services.py:1088 -- View the Ray dashboard at http://127.0.0.1:8265
(pid=27643) 2020-10-02 12:49:48,818	INFO controller.py:194 -- Starting router with name 'uGogrD:SERVE_CONTROLLER_ACTOR:SERVE_PROXY_ACTOR-node:192.168.31.141-0' on node 'node:192.168.31.141-0' listening on '127.0.0.1:8000'
(pid=27657) 2020-10-02 12:49:48,978	WARNING worker.py:1425 -- Using blocking ray.get inside async actor. This blocks the event loop. Please use `await` on object ref with asyncio.gather if you want to yield execution to the event loop instead.
(pid=27657) INFO:     Started server process [27657]
Traceback (most recent call last):
  File "a.py", line 9, in <module>
    client.create_backend("ForwardActor", ForwardActor, config={"num_replicas": 2})
  File "/Users/simonmo/Desktop/ray/ray/python/ray/serve/api.py", line 29, in check
    return f(self, *args, **kwargs)
  File "/Users/simonmo/Desktop/ray/ray/python/ray/serve/api.py", line 253, in create_backend
    replica_config))
  File "/Users/simonmo/Desktop/ray/ray/python/ray/actor.py", line 101, in remote
    return self._remote(args, kwargs)
  File "/Users/simonmo/Desktop/ray/ray/python/ray/actor.py", line 142, in _remote
    return invocation(args, kwargs)
  File "/Users/simonmo/Desktop/ray/ray/python/ray/actor.py", line 136, in invocation
    num_returns=num_returns)
  File "/Users/simonmo/Desktop/ray/ray/python/ray/actor.py", line 809, in _actor_method_call
    list_args, name, num_returns, self._ray_actor_method_cpus)
  File "python/ray/_raylet.pyx", line 1147, in ray._raylet.CoreWorker.submit_actor_task
  File "python/ray/_raylet.pyx", line 1153, in ray._raylet.CoreWorker.submit_actor_task
  File "python/ray/_raylet.pyx", line 293, in ray._raylet.prepare_args
  File "/Users/simonmo/Desktop/ray/ray/python/ray/serialization.py", line 404, in serialize
    return self._serialize_to_msgpack(value)
  File "/Users/simonmo/Desktop/ray/ray/python/ray/serialization.py", line 384, in _serialize_to_msgpack
    self._serialize_to_pickle5(metadata, python_objects)
  File "/Users/simonmo/Desktop/ray/ray/python/ray/serialization.py", line 344, in _serialize_to_pickle5
    raise e
  File "/Users/simonmo/Desktop/ray/ray/python/ray/serialization.py", line 341, in _serialize_to_pickle5
    value, protocol=5, buffer_callback=writer.buffer_callback)
  File "/Users/simonmo/Desktop/ray/ray/python/ray/cloudpickle/cloudpickle_fast.py", line 70, in dumps
    cp.dump(obj)
  File "/Users/simonmo/Desktop/ray/ray/python/ray/cloudpickle/cloudpickle_fast.py", line 656, in dump
    return Pickler.dump(self, obj)
  File "/Users/simonmo/Desktop/ray/ray/python/ray/serve/api.py", line 62, in __reduce__
    ("Ray Serve client cannot be serialized. "
ray.serve.exceptions.RayServeException: Ray Serve client cannot be serialized. Please use serve.connect() to create a new client.
2020-10-02 12:49:53,475	INFO api.py:56 -- Shutting down Ray Serve because client went out of scope.
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :( Just adding error msg
