### PR TITLE
[GCS]Random eviction of destroyed actors cached in GCS

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -232,6 +232,8 @@ RAY_CONFIG(uint32_t, gcs_lease_worker_retry_interval_ms, 200)
 RAY_CONFIG(uint32_t, gcs_create_actor_retry_interval_ms, 200)
 /// Duration to wait between retries for creating placement group in gcs server.
 RAY_CONFIG(uint32_t, gcs_create_placement_group_retry_interval_ms, 200)
+/// Maximum number of destroyed actors in GCS server memory cache.
+RAY_CONFIG(uint32_t, maximum_gcs_destroyed_actor_cached_count, 10000)
 
 /// Maximum number of times to retry putting an object when the plasma store is full.
 /// Can be set to -1 to enable unlimited retries.

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -1293,7 +1293,7 @@ TEST_F(ServiceBasedGcsClientTest, DISABLED_TestGetActorPerf) {
 
   // Get all actors.
   auto condition = [this, actor_count]() {
-    return (int) GetAllActors().size() == actor_count;
+    return (int)GetAllActors().size() == actor_count;
   };
   EXPECT_TRUE(WaitForCondition(condition, timeout_ms_.count()));
 

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -562,7 +562,7 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
   RAY_CHECK(it != registered_actors_.end())
       << "Tried to destroy actor that does not exist " << actor_id;
   it->second->GetMutableActorTableData()->mutable_task_spec()->Clear();
-  destroyed_actors_.emplace(it->first, it->second);
+  AddDestroyedActorToCache(it->second);
   const auto actor = std::move(it->second);
   registered_actors_.erase(it);
 
@@ -954,7 +954,7 @@ void GcsActorManager::LoadInitialData(const EmptyCallback &done) {
           node_to_workers[actor->GetNodeID()].emplace_back(actor->GetWorkerID());
         }
       } else {
-        destroyed_actors_.emplace(item.first, actor);
+        AddDestroyedActorToCache(actor);
       }
     }
 
@@ -1096,6 +1096,14 @@ void GcsActorManager::KillActor(const std::shared_ptr<GcsActor> &actor) {
   request.set_force_kill(true);
   request.set_no_restart(true);
   RAY_UNUSED(actor_client->KillActor(request, nullptr));
+}
+
+void GcsActorManager::AddDestroyedActorToCache(const std::shared_ptr<GcsActor> &actor) {
+  if (destroyed_actors_.size() >=
+      RayConfig::instance().maximum_gcs_destroyed_actor_cached_count()) {
+    destroyed_actors_.erase(destroyed_actors_.begin());
+  }
+  destroyed_actors_.emplace(actor->GetActorID(), actor);
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -353,6 +353,12 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// \param actor The actor to be killed.
   void KillActor(const std::shared_ptr<GcsActor> &actor);
 
+  /// Add the destroyed actor to the cache. If the cache is full, one actor is randomly
+  /// evicted.
+  ///
+  /// \param actor The actor to be killed.
+  void AddDestroyedActorToCache(const std::shared_ptr<GcsActor> &actor);
+
   /// Callbacks of pending `RegisterActor` requests.
   /// Maps actor ID to actor registration callbacks, which is used to filter duplicated
   /// messages from a driver/worker caused by some network problems.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Random eviction of destroyed actors cached in GCS to prevent memory explosion.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
