### PR TITLE
[autoscaler] include staroid/example-full.yaml in whl package

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -79,6 +79,7 @@ ray_autoscaler_files = [
     "ray/autoscaler/local/example-full.yaml",
     "ray/autoscaler/kubernetes/example-full.yaml",
     "ray/autoscaler/kubernetes/kubectl-rsync.sh",
+    "ray/autoscaler/staroid/example-full.yaml",
     "ray/autoscaler/ray-schema.json"
 ]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

staroid/example-full.yaml is missing in whl package.

How to reproduce

```bash
$ # whl built from master branch
$ pip install ray-1.1.0.dev0-cp37-cp37m-manylinux1_x86_64.whl
$ git clone https://github.com/ray-project/ray
$ ray up ray/python/ray/autoscaler/staroid/example-full.yaml
```
will throw exception

```
2020-10-03 09:28:30,099 INFO commands.py:195 -- Cluster: staroid
Traceback (most recent call last):
  File "/home/ray/anaconda3/bin/ray", line 8, in <module>
    sys.exit(main())
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/scripts/scripts.py", line 1462, in main
    return cli()
  File "/home/ray/anaconda3/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/ray/anaconda3/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ray/anaconda3/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ray/anaconda3/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/scripts/scripts.py", line 855, in up
    use_login_shells=use_login_shells)
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/autoscaler/_private/commands.py", line 202, in create_or_update_cluster
    config = _bootstrap_config(config, no_config_cache=no_config_cache)
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/autoscaler/_private/commands.py", line 214, in _bootstrap_config
    config = prepare_config(config)
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/autoscaler/_private/util.py", line 91, in prepare_config
    with_defaults = fillout_defaults(config)
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/autoscaler/_private/util.py", line 98, in fillout_defaults
    defaults = _get_default_config(config["provider"])
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/autoscaler/_private/providers.py", line 175, in _get_default_config
    with open(path_to_default) as f:
FileNotFoundError: [Errno 2] No such file or directory: '/home/ray/anaconda3/lib/python3.7/site-packages/ray/autoscaler/staroid/example-full.yaml'
```


## Related issue number

https://github.com/ray-project/ray/pull/10956

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
