### PR TITLE
Use isinstance for type-checking keys of tags for metrics

### DIFF
--- a/python/ray/util/metrics.py
+++ b/python/ray/util/metrics.py
@@ -38,9 +38,8 @@ class Metric:
         self._metric = None
 
         if not isinstance(self._tag_keys, tuple):
-            raise ValueError(
-                "tag_keys should be a tuple type, got: "
-                f"{type(self._tag_keys)}")
+            raise ValueError("tag_keys should be a tuple type, got: "
+                             f"{type(self._tag_keys)}")
 
     def set_default_tags(self, default_tags: Dict[str, str]):
         """Set default tags of metrics.

--- a/python/ray/util/metrics.py
+++ b/python/ray/util/metrics.py
@@ -37,10 +37,10 @@ class Metric:
         # The Cython metric class. This should be set in the child class.
         self._metric = None
 
-        if type(self._tag_keys) != tuple:
+        if not isinstance(self._tag_keys, tuple):
             raise ValueError(
-                "tag_keys should be a tuple type, "
-                f"but {type(self._tag_keys)} type was specified instead.")
+                "tag_keys should be a tuple type, got: "
+                f"{type(self._tag_keys)}")
 
     def set_default_tags(self, default_tags: Dict[str, str]):
         """Set default tags of metrics.


### PR DESCRIPTION
## Why are these changes needed?

isinstance should be used instead of type. also changes the error message to be consistent with other errors ("got: ")

## Related issue number

n/a

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
