### PR TITLE
[tune] move _SCHEDULERS to tune.schedulers and add all available schedulers

### DIFF
--- a/python/ray/tune/schedulers/__init__.py
+++ b/python/ray/tune/schedulers/__init__.py
@@ -33,32 +33,12 @@ def create_scheduler(
         >>> scheduler = tune.create_scheduler('pbt')
     """
 
-    def _import_async_hyperband_scheduler():
-        from ray.tune.schedulers import AsyncHyperBandScheduler
-        return AsyncHyperBandScheduler
-
-    def _import_median_stopping_rule_scheduler():
-        from ray.tune.schedulers import MedianStoppingRule
-        return MedianStoppingRule
-
-    def _import_hyperband_scheduler():
-        from ray.tune.schedulers import HyperBandScheduler
-        return HyperBandScheduler
-
-    def _import_hb_bohb_scheduler():
-        from ray.tune.schedulers import HyperBandForBOHB
-        return HyperBandForBOHB
-
-    def _import_pbt_search():
-        from ray.tune.schedulers import PopulationBasedTraining
-        return PopulationBasedTraining
-
     SCHEDULER_IMPORT = {
-        "async_hyperband": _import_async_hyperband_scheduler,
-        "median_stopping_rule": _import_median_stopping_rule_scheduler,
-        "hyperband": _import_hyperband_scheduler,
-        "hb_bohb": _import_hb_bohb_scheduler,
-        "pbt": _import_pbt_search,
+        "async_hyperband": AsyncHyperBandScheduler,
+        "median_stopping_rule": MedianStoppingRule,
+        "hyperband": HyperBandScheduler,
+        "hb_bohb": HyperBandForBOHB,
+        "pbt": PopulationBasedTraining,
     }
     scheduler = scheduler.lower()
     if scheduler not in SCHEDULER_IMPORT:
@@ -66,7 +46,7 @@ def create_scheduler(
             f"Search alg must be one of {list(SCHEDULER_IMPORT)}. "
             f"Got: {scheduler}")
 
-    SchedulerClass = SCHEDULER_IMPORT[scheduler]()
+    SchedulerClass = SCHEDULER_IMPORT[scheduler]
     return SchedulerClass(metric=metric, mode=mode, **kwargs)
 
 
@@ -76,12 +56,3 @@ __all__ = [
     "PopulationBasedTraining", "PopulationBasedTrainingReplay",
     "HyperBandForBOHB"
 ]
-
-_SCHEDULERS = {name: globals()[name] for name in __all__}
-_SCHEDULERS.update({
-    "FIFO": FIFOScheduler,
-    "MedianStopping": MedianStoppingRule,
-    "HyperBand": HyperBandScheduler,
-    "AsyncHyperBand": AsyncHyperBandScheduler,
-    "PBT": PopulationBasedTraining,
-})

--- a/python/ray/tune/schedulers/__init__.py
+++ b/python/ray/tune/schedulers/__init__.py
@@ -28,11 +28,15 @@ def create_scheduler(
     """
 
     SCHEDULER_IMPORT = {
+        "fifo": FIFOScheduler,
         "async_hyperband": AsyncHyperBandScheduler,
+        "asynchyperband": AsyncHyperBandScheduler,
         "median_stopping_rule": MedianStoppingRule,
+        "medianstopping": MedianStoppingRule,
         "hyperband": HyperBandScheduler,
         "hb_bohb": HyperBandForBOHB,
         "pbt": PopulationBasedTraining,
+        "pbt_replay": PopulationBasedTrainingReplay,
     }
     scheduler = scheduler.lower()
     if scheduler not in SCHEDULER_IMPORT:

--- a/python/ray/tune/schedulers/__init__.py
+++ b/python/ray/tune/schedulers/__init__.py
@@ -76,3 +76,12 @@ __all__ = [
     "PopulationBasedTraining", "PopulationBasedTrainingReplay",
     "HyperBandForBOHB"
 ]
+
+_SCHEDULERS = {name: globals()[name] for name in __all__}
+_SCHEDULERS.update({
+    "FIFO": FIFOScheduler,
+    "MedianStopping": MedianStoppingRule,
+    "HyperBand": HyperBandScheduler,
+    "AsyncHyperBand": AsyncHyperBandScheduler,
+    "PBT": PopulationBasedTraining,
+})

--- a/python/ray/tune/schedulers/__init__.py
+++ b/python/ray/tune/schedulers/__init__.py
@@ -10,8 +10,6 @@ from ray.tune.schedulers.pbt import (PopulationBasedTraining,
 
 def create_scheduler(
         scheduler,
-        metric=None,
-        mode=None,
         **kwargs,
 ):
     """Instantiate a scheduler based on the given string.
@@ -20,17 +18,13 @@ def create_scheduler(
 
     Args:
         scheduler (str): The scheduler to use.
-        metric (str): The training result objective value attribute. Stopping
-            procedures will use this attribute.
-        mode (str): One of {min, max}. Determines whether objective is
-            minimizing or maximizing the metric attribute.
-        **kwargs: Additional parameters.
+        **kwargs: Scheduler parameters.
             These keyword arguments will be passed to the initialization
-            function of the chosen class.
+            function of the chosen scheduler.
     Returns:
         ray.tune.schedulers.trial_scheduler.TrialScheduler: The scheduler.
     Example:
-        >>> scheduler = tune.create_scheduler('pbt')
+        >>> scheduler = tune.create_scheduler('pbt', **pbt_kwargs)
     """
 
     SCHEDULER_IMPORT = {
@@ -47,7 +41,7 @@ def create_scheduler(
             f"Got: {scheduler}")
 
     SchedulerClass = SCHEDULER_IMPORT[scheduler]
-    return SchedulerClass(metric=metric, mode=mode, **kwargs)
+    return SchedulerClass(**kwargs)
 
 
 __all__ = [

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -14,7 +14,6 @@ from ray.tune.registry import get_trainable_cls
 from ray.tune.syncer import wait_for_sync, set_sync_periods, SyncConfig
 from ray.tune.trial_runner import TrialRunner
 from ray.tune.progress_reporter import CLIReporter, JupyterNotebookReporter
-from ray.tune.schedulers import _SCHEDULERS
 
 logger = logging.getLogger(__name__)
 
@@ -23,14 +22,6 @@ try:
     IS_NOTEBOOK = True if "Terminal" not in class_name else False
 except NameError:
     IS_NOTEBOOK = False
-
-
-def _make_scheduler(args):
-    if args.scheduler in _SCHEDULERS:
-        return _SCHEDULERS[args.scheduler](**args.scheduler_config)
-    else:
-        raise TuneError("Unknown scheduler: {}, should be one of {}".format(
-            args.scheduler, _SCHEDULERS.keys()))
 
 
 def _check_default_resources_override(run_identifier):

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -18,7 +18,6 @@ from ray.tune.schedulers import _SCHEDULERS
 
 logger = logging.getLogger(__name__)
 
-
 try:
     class_name = get_ipython().__class__.__name__
     IS_NOTEBOOK = True if "Terminal" not in class_name else False

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -14,6 +14,7 @@ from ray.tune.registry import get_trainable_cls
 from ray.tune.syncer import wait_for_sync, set_sync_periods, SyncConfig
 from ray.tune.trial_runner import TrialRunner
 from ray.tune.progress_reporter import CLIReporter, JupyterNotebookReporter
+from ray.tune.schedulers import FIFOScheduler
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -14,17 +14,10 @@ from ray.tune.registry import get_trainable_cls
 from ray.tune.syncer import wait_for_sync, set_sync_periods, SyncConfig
 from ray.tune.trial_runner import TrialRunner
 from ray.tune.progress_reporter import CLIReporter, JupyterNotebookReporter
-from ray.tune.schedulers import (HyperBandScheduler, AsyncHyperBandScheduler,
-                                 FIFOScheduler, MedianStoppingRule)
+from ray.tune.schedulers import _SCHEDULERS
 
 logger = logging.getLogger(__name__)
 
-_SCHEDULERS = {
-    "FIFO": FIFOScheduler,
-    "MedianStopping": MedianStoppingRule,
-    "HyperBand": HyperBandScheduler,
-    "AsyncHyperBand": AsyncHyperBandScheduler,
-}
 
 try:
     class_name = get_ipython().__class__.__name__

--- a/rllib/train.py
+++ b/rllib/train.py
@@ -10,7 +10,8 @@ from ray.cluster_utils import Cluster
 from ray.tune.config_parser import make_parser
 from ray.tune.result import DEFAULT_RESULTS_DIR
 from ray.tune.resources import resources_to_json
-from ray.tune.tune import _make_scheduler, run_experiments
+from ray.tune.tune import run_experiments
+from ray.tune.schedulers import create_scheduler
 from ray.rllib.utils.framework import try_import_tf, try_import_torch
 
 # Try to import both backends for flag checking/warnings.
@@ -207,7 +208,7 @@ def run(args, parser):
 
     run_experiments(
         experiments,
-        scheduler=_make_scheduler(args),
+        scheduler=create_scheduler(args.scheduler, **args.scheduler_config),
         resume=args.resume,
         queue_trials=args.queue_trials,
         verbose=verbose,


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The train.py script in RLLib only allows a few of the available schedulers. This fix allows all schedulers.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #11212

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
