### PR TITLE
fix spelling of overridden

### DIFF
--- a/doc/source/tune/api_docs/reporters.rst
+++ b/doc/source/tune/api_docs/reporters.rst
@@ -58,7 +58,7 @@ Extending ``CLIReporter`` lets you control reporting frequency. For example:
 
     tune.run(my_trainable, progress_reporter=TrialTerminationReporter())
 
-The default reporting style can also be overriden more broadly by extending the ``ProgressReporter`` interface directly. Note that you can print to any output stream, file etc.
+The default reporting style can also be overridden more broadly by extending the ``ProgressReporter`` interface directly. Note that you can print to any output stream, file etc.
 
 .. code-block:: python
 

--- a/python/ray/autoscaler/staroid/example-full.yaml
+++ b/python/ray/autoscaler/staroid/example-full.yaml
@@ -143,7 +143,7 @@ head_node:
           #   - rsync (used for `ray rsync` commands and file mounts)
           #   - screen (used for `ray attach`)
           #   - kubectl (used by the autoscaler to manage worker pods)
-          # Image will be overriden when 'image_from_project' is true.
+          # Image will be overridden when 'image_from_project' is true.
           image: rayproject/autoscaler
           # Do not change this command - it keeps the pod alive until it is
           # explicitly killed.

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -56,7 +56,7 @@ class ProgressReporter:
 class TuneReporterBase(ProgressReporter):
     """Abstract base class for the default Tune reporters.
 
-    If metric_columns is not overriden, Tune will attempt to automatically
+    If metric_columns is not overridden, Tune will attempt to automatically
     infer the metrics being outputted, up to 'infer_limit' number of
     metrics.
 

--- a/python/ray/tune/result.py
+++ b/python/ray/tune/result.py
@@ -48,7 +48,7 @@ TIMESTEPS_THIS_ITER = "timesteps_this_iter"
 TIMESTEPS_TOTAL = "timesteps_total"
 
 # (Auto-filled) Time in seconds this iteration took to run.
-# This may be overriden to override the system-computed time difference.
+# This may be overridden to override the system-computed time difference.
 TIME_THIS_ITER_S = "time_this_iter_s"
 
 # (Auto-filled) Accumulated time in seconds for this entire trial.

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -302,7 +302,7 @@ class Trainable:
             `done` (bool): training is terminated. Filled only if not provided.
 
             `time_this_iter_s` (float): Time in seconds this iteration
-            took to run. This may be overriden in order to override the
+            took to run. This may be overridden in order to override the
             system-computed time difference.
 
             `time_total_s` (float): Accumulated time in seconds for this
@@ -727,7 +727,7 @@ class Trainable:
         """
         result = self._train()
 
-        if self._is_overriden("_train") and log_once("_train"):
+        if self._is_overridden("_train") and log_once("_train"):
             logger.warning(
                 "Trainable._train is deprecated and will be removed in "
                 "a future version of Ray. Override Trainable.step instead.")
@@ -778,7 +778,7 @@ class Trainable:
         """
         checkpoint = self._save(tmp_checkpoint_dir)
 
-        if self._is_overriden("_save") and log_once("_save"):
+        if self._is_overridden("_save") and log_once("_save"):
             logger.warning(
                 "Trainable._save is deprecated and will be removed in a "
                 "future version of Ray. Override "
@@ -836,7 +836,7 @@ class Trainable:
                 underneath the `checkpoint_dir` `save_checkpoint` is preserved.
         """
         self._restore(checkpoint)
-        if self._is_overriden("_restore") and log_once("_restore"):
+        if self._is_overridden("_restore") and log_once("_restore"):
             logger.warning(
                 "Trainable._restore is deprecated and will be removed in a "
                 "future version of Ray. Override Trainable.load_checkpoint "
@@ -859,7 +859,7 @@ class Trainable:
                 Copy of `self.config`.
         """
         self._setup(config)
-        if self._is_overriden("_setup") and log_once("_setup"):
+        if self._is_overridden("_setup") and log_once("_setup"):
             logger.warning(
                 "Trainable._setup is deprecated and will be removed in "
                 "a future version of Ray. Override Trainable.setup instead.")
@@ -884,7 +884,7 @@ class Trainable:
             result (dict): Training result returned by step().
         """
         self._log_result(result)
-        if self._is_overriden("_log_result") and log_once("_log_result"):
+        if self._is_overridden("_log_result") and log_once("_log_result"):
             logger.warning(
                 "Trainable._log_result is deprecated and will be removed in "
                 "a future version of Ray. Override "
@@ -909,7 +909,7 @@ class Trainable:
         .. versionadded:: 0.8.7
         """
         self._stop()
-        if self._is_overriden("_stop") and log_once("trainable.cleanup"):
+        if self._is_overridden("_stop") and log_once("trainable.cleanup"):
             logger.warning(
                 "Trainable._stop is deprecated and will be removed in "
                 "a future version of Ray. Override Trainable.cleanup instead.")
@@ -933,5 +933,5 @@ class Trainable:
         """
         return {}
 
-    def _is_overriden(self, key):
+    def _is_overridden(self, key):
         return getattr(self, key).__code__ != getattr(Trainable, key).__code__

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -43,7 +43,7 @@ def _make_scheduler(args):
 
 def _check_default_resources_override(run_identifier):
     if not isinstance(run_identifier, str):
-        # If obscure dtype, assume it is overriden.
+        # If obscure dtype, assume it is overridden.
         return True
     trainable_cls = get_trainable_cls(run_identifier)
     return hasattr(trainable_cls, "default_resource_request") and (
@@ -409,7 +409,7 @@ def run(
             # "gpu" is manually set.
             pass
         elif _check_default_resources_override(experiments[0].run_identifier):
-            # "default_resources" is manually overriden.
+            # "default_resources" is manually overridden.
             pass
         else:
             logger.warning("Tune detects GPUs, but no trials are using GPUs. "

--- a/python/ray/util/sgd/torch/torch_trainer.py
+++ b/python/ray/util/sgd/torch/torch_trainer.py
@@ -574,7 +574,7 @@ class TorchTrainer:
     def as_trainable(cls, *args, **kwargs):
         """Creates a BaseTorchTrainable class compatible with Tune.
 
-        Any configuration parameters will be overriden by the Tune
+        Any configuration parameters will be overridden by the Tune
         Trial configuration. You can also subclass the provided Trainable
         to implement your own iterative optimization routine.
 
@@ -669,7 +669,7 @@ class BaseTorchTrainable(Trainable):
 
         You may want to override this if using a custom LR scheduler.
         """
-        if self._is_overriden("_train"):
+        if self._is_overridden("_train"):
             raise DeprecationWarning(
                 "Trainable._train is deprecated and will be "
                 "removed in "

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1365,7 +1365,7 @@ def show_in_dashboard(message, key="", dtype="text"):
         message (str): Message to be displayed.
         key (str): The key name for the message. Multiple message under
             different keys will be displayed at the same time. Messages
-            under the same key will be overriden.
+            under the same key will be overridden.
         data_type (str): The type of message for rendering. One of the
             following: text, html.
     """

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -224,7 +224,7 @@ COMMON_CONFIG: TrainerConfigDict = {
     "synchronize_filters": True,
     # Configures TF for single-process operation by default.
     "tf_session_args": {
-        # note: overriden by `local_tf_session_args`
+        # note: overridden by `local_tf_session_args`
         "intra_op_parallelism_threads": 2,
         "inter_op_parallelism_threads": 2,
         "gpu_options": {

--- a/rllib/models/catalog.py
+++ b/rllib/models/catalog.py
@@ -287,7 +287,7 @@ class ModelCatalog:
 
         if model_config.get("custom_model"):
 
-            # Allow model kwargs to be overriden / augmented by
+            # Allow model kwargs to be overridden / augmented by
             # custom_model_config.
             customized_model_kwargs = dict(
                 model_kwargs, **model_config.get("custom_model_config", {}))

--- a/rllib/utils/annotations.py
+++ b/rllib/utils/annotations.py
@@ -2,7 +2,7 @@ def override(cls):
     """Annotation for documenting method overrides.
 
     Args:
-        cls (type): The superclass that provides the overriden method. If this
+        cls (type): The superclass that provides the overridden method. If this
             cls does not actually have the method, an error is raised.
     """
 

--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -349,9 +349,9 @@ void TaskDependencyManager::TaskPending(const Task &task) {
   // For direct actor creation task:
   //   - when it's submitted by core worker, we guarantee that
   //     we always request a new worker lease, in that case
-  //     `OnDispatch` is overriden to an actual callback.
+  //     `OnDispatch` is overridden to an actual callback.
   //   - when it's resubmitted by raylet because of reconstruction,
-  //     `OnDispatch` will not be overriden and thus is nullptr.
+  //     `OnDispatch` will not be overridden and thus is nullptr.
   if (task.GetTaskSpecification().IsActorCreationTask() && task.OnDispatch() == nullptr) {
     // This is an actor creation task, and it's being restarted,
     // in this case we still need the task lease. Note that we don't


### PR DESCRIPTION
## Why are these changes needed?

overriden should be spelled as overridden

~WIP because this will probably break some tests~

## Related issue number

n/a

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
