### PR TITLE
[tune] reuse actors for function API

### DIFF
--- a/doc/source/tune/user-guide.rst
+++ b/doc/source/tune/user-guide.rst
@@ -609,7 +609,7 @@ These are the environment variables Ray Tune currently considers:
   if the metric was not reported in the result. Setting this environment variable
   to ``1`` will disable this check.
 * **TUNE_FUNCTION_THREAD_TIMEOUT_S**: Time in seconds the function API waits
-  for threads to finish after instructing them to comlplete. Defaults to ``2``.
+  for threads to finish after instructing them to complete. Defaults to ``2``.
 * **TUNE_GLOBAL_CHECKPOINT_S**: Time in seconds that limits how often Tune's
   experiment state is checkpointed. If not set this will default to ``10``.
 * **TUNE_MAX_LEN_IDENTIFIER**: Maximum length of trial subdirectory names (those

--- a/doc/source/tune/user-guide.rst
+++ b/doc/source/tune/user-guide.rst
@@ -608,6 +608,8 @@ These are the environment variables Ray Tune currently considers:
   or a search algorithm, Tune will error
   if the metric was not reported in the result. Setting this environment variable
   to ``1`` will disable this check.
+* **TUNE_FUNCTION_THREAD_TIMEOUT_S**: Time in seconds the function API waits
+  for threads to finish after instructing them to comlplete. Defaults to ``2``.
 * **TUNE_GLOBAL_CHECKPOINT_S**: Time in seconds that limits how often Tune's
   experiment state is checkpointed. If not set this will default to ``10``.
 * **TUNE_MAX_LEN_IDENTIFIER**: Maximum length of trial subdirectory names (those

--- a/python/ray/tune/function_runner.py
+++ b/python/ray/tune/function_runner.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 import time
 import inspect
 import shutil
@@ -120,12 +121,14 @@ class StatusReporter:
     def __init__(self,
                  result_queue,
                  continue_semaphore,
+                 continue_event,
                  trial_name=None,
                  trial_id=None,
                  logdir=None):
         self._queue = result_queue
         self._last_report_time = None
         self._continue_semaphore = continue_semaphore
+        self._continue_event = continue_event
         self._trial_name = trial_name
         self._trial_id = trial_id
         self._logdir = logdir
@@ -170,6 +173,12 @@ class StatusReporter:
         # result has been returned to Tune and that the function is safe to
         # resume training.
         self._continue_semaphore.acquire()
+
+        # If the trial should be terminated, exit gracefully.
+        if not self._continue_event.is_set():
+            # Set the continue switch so the function runner can wait for it.
+            self._continue_event.set()
+            sys.exit(0)
 
     def make_checkpoint_dir(self, step):
         checkpoint_dir = TrainableUtil.make_checkpoint_dir(
@@ -264,6 +273,12 @@ class FunctionRunner(Trainable):
         # and to generate the next result.
         self._continue_semaphore = threading.Semaphore(0)
 
+        # Event for notifying the reporter to exit gracefully, terminating
+        # the thread. This is set per default, meaning the thread should
+        # continue. Clearing the evnt will lead to shutdown.
+        self._continue_event = threading.Event()
+        self._continue_event.set()
+
         # Queue for passing results between threads
         self._results_queue = queue.Queue(1)
 
@@ -275,6 +290,7 @@ class FunctionRunner(Trainable):
         self._status_reporter = StatusReporter(
             self._results_queue,
             self._continue_semaphore,
+            self._continue_event,
             trial_name=self.trial_name,
             trial_id=self.trial_id,
             logdir=self.logdir)
@@ -340,7 +356,7 @@ class FunctionRunner(Trainable):
             except queue.Empty:
                 pass
 
-        # check if error occured inside the thread runner
+        # check if error occurred inside the thread runner
         if result is None:
             # only raise an error from the runner if all results are consumed
             self._report_thread_runner_error(block=True)
@@ -441,6 +457,11 @@ class FunctionRunner(Trainable):
         self.restore(checkpoint_path)
 
     def cleanup(self):
+        # Trigger thread termination
+        self._continue_event.clear()
+        self._continue_semaphore.release()
+        # Do not wait for thread termination here.
+
         # If everything stayed in synch properly, this should never happen.
         if not self._results_queue.empty():
             logger.warning(
@@ -456,6 +477,18 @@ class FunctionRunner(Trainable):
             shutil.rmtree(self.temp_checkpoint_dir)
             logger.debug("Clearing temporary checkpoint: %s",
                          self.temp_checkpoint_dir)
+
+    def reset_config(self, new_config):
+        self._last_result = None
+        if self._runner and self._runner.is_alive():
+            self._continue_event.clear()
+            self._continue_semaphore.release()
+            # Wait for thread termination so it is save to re-use the same
+            # actor.
+            self._continue_event.wait()
+            self._runner = None
+            self._error_queue.empty()
+        return True
 
     def _report_thread_runner_error(self, block=False):
         try:

--- a/python/ray/tune/function_runner.py
+++ b/python/ray/tune/function_runner.py
@@ -496,17 +496,6 @@ class FunctionRunner(Trainable):
                 return False
 
         self._runner = None
-
-        # Reset Trainable attributes
-        self._iteration = 0
-        self._time_total = 0.0
-        self._timesteps_total = None
-        self._episodes_total = None
-        self._time_since_restore = 0.0
-        self._timesteps_since_restore = 0
-        self._iterations_since_restore = 0
-        self._restored = False
-
         self._last_result = {}
 
         self._status_reporter.reset(

--- a/python/ray/tune/function_runner.py
+++ b/python/ray/tune/function_runner.py
@@ -488,7 +488,9 @@ class FunctionRunner(Trainable):
             self._continue_semaphore.release()
             # Wait for thread termination so it is save to re-use the same
             # actor.
-            self._runner.join(timeout=1)
+            thread_timeout = int(
+                os.environ.get("TUNE_FUNCTION_THREAD_TIMEOUT_S", 2))
+            self._runner.join(timeout=thread_timeout)
             if self._runner.is_alive():
                 # Did not finish within timeout, reset unsuccessful.
                 return False

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -14,6 +14,7 @@ from ray import ray_constants
 from ray.resource_spec import ResourceSpec
 from ray.tune.durable_trainable import DurableTrainable
 from ray.tune.error import AbortTrialExecution, TuneError
+from ray.tune.function_runner import FunctionRunner
 from ray.tune.logger import NoopLogger
 from ray.tune.result import TRIAL_INFO, STDOUT_FILE, STDERR_FILE
 from ray.tune.resources import Resources
@@ -276,13 +277,13 @@ class RayTrialExecutor(TrialExecutor):
         """
         prior_status = trial.status
         if runner is None:
-            # TODO: Right now, we only support reuse if there has been
-            # previously instantiated state on the worker. However,
-            # we should consider the case where function evaluations
-            # can be very fast - thereby extending the need to support
-            # reuse to cases where there has not been previously
-            # instantiated state before.
-            reuse_allowed = checkpoint is not None or trial.has_checkpoint()
+            # We reuse actors when there is previously instantiated state on
+            # the actor. Function API calls are also supported when there is
+            # no checkpoint to continue from.
+            # TODO: Check preconditions - why is previous state needed?
+            reuse_allowed = checkpoint is not None or trial.has_checkpoint() \
+                            or issubclass(trial.get_trainable_cls(),
+                                          FunctionRunner)
             runner = self._setup_remote_runner(trial, reuse_allowed)
         trial.set_runner(runner)
         self.restore(trial, checkpoint)

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -552,7 +552,22 @@ class Trainable:
         self._close_logfiles()
         self._open_logfiles(stdout_file, stderr_file)
 
-        return self.reset_config(new_config)
+        success = self.reset_config(new_config)
+        if not success:
+            return False
+
+        # Reset attributes. Will be overwritten by `restore` if a checkpoint
+        # is provided.
+        self._iteration = 0
+        self._time_total = 0.0
+        self._timesteps_total = None
+        self._episodes_total = None
+        self._time_since_restore = 0.0
+        self._timesteps_since_restore = 0
+        self._iterations_since_restore = 0
+        self._restored = False
+
+        return True
 
     def reset_config(self, new_config):
         """Resets configuration without restarting the trial.

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -724,7 +724,6 @@ class TrialRunner:
         """
         try:
             result = self.trial_executor.fetch_result(trial)
-
             is_duplicate = RESULT_DUPLICATE in result
             force_checkpoint = result.get(SHOULD_CHECKPOINT, False)
             # TrialScheduler and SearchAlgorithm still receive a

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -453,7 +453,7 @@ def run(
 
     all_taken = time.time() - all_start
     logger.info(f"Total run time: {all_taken:.2f} seconds "
-                f"({tune_taken:.2f} seconds after initialization).")
+                f"({tune_taken:.2f} seconds for the tuning loop).")
 
     trials = runner.get_trials()
     return ExperimentAnalysis(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray actor instantiation (or rather cleanup) is a major bottleneck when executing cheap functions. This PR enables `reuse_actors` for function trainables, avoiding actor re-instantiation and enabling fast function execution.

Performance improvement can be seen with this code snippet:

```
import time
import ray
from ray import tune


def objective(config):
    x = config["x"]
    return (x - 2) ** 2

ray.init()

start = time.time()
analysis = tune.run(
    objective,
    metric="_metric",
    mode="min",
    config={"x": tune.uniform(-10, 10)},
    num_samples=100,
    reuse_actors=False
)

print(analysis.best_config)
print(f"Took {time.time() - start:.2f} seconds to run.")
```

Result with `reuse_actors=False`:
```
{'x': 2.011610390348743}
Took 19.81 seconds to run.
```

Result with `reuse_actors=True`:
```
{'x': 1.8925283623744775}
Took 3.12 seconds to run.
```

## Related issue number

Improves #11004

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
