### PR TITLE
[tune/dashboard] Fix Tune dashboard to work with all trainables

### DIFF
--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -811,7 +811,7 @@ class TuneCollector(threading.Thread):
 
         # search through all the sub_directories in log directory
         analysis = Analysis(str(self._logdir))
-        df = analysis.dataframe(metric="episode_reward_mean", mode="max")
+        df = analysis.dataframe(metric=None, mode=None)
 
         if len(df) == 0 or "trial_id" not in df.columns:
             return

--- a/python/ray/tune/analysis/experiment_analysis.py
+++ b/python/ray/tune/analysis/experiment_analysis.py
@@ -91,8 +91,11 @@ class Analysis:
         Returns:
             pd.DataFrame: Constructed from a result dict of each trial.
         """
-        metric = self._validate_metric(metric)
-        mode = self._validate_mode(mode)
+        # Allow None values here.
+        if metric or self.default_metric:
+            metric = self._validate_metric(metric)
+        if mode or self.default_mode:
+            mode = self._validate_mode(mode)
 
         rows = self._retrieve_rows(metric=metric, mode=mode)
         all_configs = self.get_all_configs(prefix=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The Tune dashboard currently does not work for trainables that do not report a `episode_reward_mean` metric. This is due to two bugs:

1. In the `Analysis.dataframe()` method, the `metric` and `mode` should be optional, but they weren't strictly optional.
2. In the `collect()` method of the dashboard, a dataframe was requested explicitly sorted by `episode_reward_mean`. This excludes all but RLLib trainables.

A follow-up PR might deal with error reporting - right now setting the Tune dir works, but fetching the trials lead to a silent internal error.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
