### PR TITLE
[Placement Group] Fix placement group bugs that happen when rescheduling.

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -125,7 +125,7 @@ PlacementGroupID GcsPlacementGroupManager::GetPlacementGroupIDByName(
 void GcsPlacementGroupManager::OnPlacementGroupCreationFailed(
     std::shared_ptr<GcsPlacementGroup> placement_group) {
   RAY_LOG(INFO) << "Failed to create placement group " << placement_group->GetName()
-                << ", try again.";
+                << ", id: " << placement_group->GetPlacementGroupID() << ", try again.";
   // We will attempt to schedule this placement_group once an eligible node is
   // registered.
   auto state = placement_group->GetState();
@@ -148,7 +148,8 @@ void GcsPlacementGroupManager::OnPlacementGroupCreationFailed(
 
 void GcsPlacementGroupManager::OnPlacementGroupCreationSuccess(
     const std::shared_ptr<GcsPlacementGroup> &placement_group) {
-  RAY_LOG(INFO) << "Successfully created placement group " << placement_group->GetName();
+  RAY_LOG(INFO) << "Successfully created placement group " << placement_group->GetName()
+                << ", id: " << placement_group->GetPlacementGroupID();
   placement_group->UpdateState(rpc::PlacementGroupTableData::CREATED);
   auto placement_group_id = placement_group->GetPlacementGroupID();
   RAY_CHECK_OK(gcs_table_storage_->PlacementGroupTable().Put(

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -475,7 +475,6 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   BundleLocationIndex committed_bundle_location_index_;
 
   /// Set of placement group that have lease requests in flight to nodes.
-  /// It is required to know if placement group has been removed or not.
   absl::flat_hash_map<PlacementGroupID, std::shared_ptr<LeaseStatusTracker>>
       placement_group_leasing_in_progress_;
 };

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -963,7 +963,7 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestPGCancelledDuringReschedulingCommitPr
   auto bundles_on_node1 =
       scheduler_->GetBundlesOnNode(NodeID::FromBinary(node1->node_id()));
   ASSERT_EQ(1, bundles_on_node1.size());
-  // all nodes are dead, reschedule the placement group.
+  // All nodes are dead, reschedule the placement group.
   placement_group->GetMutableBundle(0)->clear_node_id();
   placement_group->GetMutableBundle(1)->clear_node_id();
   scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler, success_handler);

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -59,6 +59,15 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     EXPECT_TRUE(WaitForCondition(condition, timeout_ms_.count()));
   }
 
+  template <typename Data>
+  void WaitPendingDone(const std::list<Data> &data, int expected_count) {
+    auto condition = [this, &data, expected_count]() {
+      absl::MutexLock lock(&vector_mutex_);
+      return (int)data.size() == expected_count;
+    };
+    EXPECT_TRUE(WaitForCondition(condition, timeout_ms_.count()));
+  }
+
   void AddNode(const std::shared_ptr<rpc::GcsNodeInfo> &node, int cpu_num = 10) {
     gcs_node_manager_->AddNode(node);
     rpc::HeartbeatTableData heartbeat;
@@ -115,6 +124,9 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     ASSERT_EQ(2, raylet_clients_[0]->lease_callbacks.size());
     ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
     ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+    WaitPendingDone(raylet_clients_[0]->commit_callbacks, 2);
+    ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+    ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
     WaitPendingDone(failure_placement_groups_, 0);
     WaitPendingDone(success_placement_groups_, 1);
     ASSERT_EQ(placement_group, success_placement_groups_.front());
@@ -147,6 +159,9 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
                                         success_handler);
     ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
     ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+    WaitPendingDone(raylet_clients_[0]->commit_callbacks, 2);
+    ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+    ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
     WaitPendingDone(success_placement_groups_, 1);
   }
 
@@ -314,6 +329,9 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestStrictPackStrategyBalancedScheduling)
     node_commit_count[node_index] += 2;
     ASSERT_TRUE(raylet_clients_[node_index]->GrantPrepareBundleResources());
     ASSERT_TRUE(raylet_clients_[node_index]->GrantPrepareBundleResources());
+    WaitPendingDone(raylet_clients_[node_index]->commit_callbacks, 2);
+    ASSERT_TRUE(raylet_clients_[node_index]->GrantCommitBundleResources());
+    ASSERT_TRUE(raylet_clients_[node_index]->GrantCommitBundleResources());
     auto condition = [this, node_index, node_commit_count]() {
       return raylet_clients_[node_index]->num_commit_requested ==
              node_commit_count[node_index];
@@ -346,6 +364,9 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestStrictPackStrategyResourceCheck) {
   scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler, success_handler);
   ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
   ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 2);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
   WaitPendingDone(success_placement_groups_, 1);
 
   // Node1 has less number of bundles, but it doesn't satisfy the resource
@@ -359,6 +380,9 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestStrictPackStrategyResourceCheck) {
   scheduler_->ScheduleUnplacedBundles(placement_group2, failure_handler, success_handler);
   ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
   ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 2);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
   WaitPendingDone(success_placement_groups_, 2);
 }
 
@@ -385,6 +409,9 @@ TEST_F(GcsPlacementGroupSchedulerTest, DestroyPlacementGroup) {
       });
   ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
   ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 2);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
   WaitPendingDone(failure_placement_groups_, 0);
   WaitPendingDone(success_placement_groups_, 1);
   const auto &placement_group_id = placement_group->GetPlacementGroupID();
@@ -429,6 +456,41 @@ TEST_F(GcsPlacementGroupSchedulerTest, DestroyCancelledPlacementGroup) {
   WaitPendingDone(failure_placement_groups_, 1);
 }
 
+TEST_F(GcsPlacementGroupSchedulerTest, PlacementGroupCancelledDuringCommit) {
+  auto node = Mocker::GenNodeInfo();
+  AddNode(node);
+  ASSERT_EQ(1, gcs_node_manager_->GetAllAliveNodes().size());
+
+  auto create_placement_group_request = Mocker::GenCreatePlacementGroupRequest();
+  auto placement_group =
+      std::make_shared<gcs::GcsPlacementGroup>(create_placement_group_request);
+  const auto &placement_group_id = placement_group->GetPlacementGroupID();
+
+  // Schedule the placement_group with 1 available node, and the lease request should be
+  // send to the node.
+  scheduler_->ScheduleUnplacedBundles(
+      placement_group,
+      [this](std::shared_ptr<gcs::GcsPlacementGroup> placement_group) {
+        absl::MutexLock lock(&vector_mutex_);
+        failure_placement_groups_.emplace_back(std::move(placement_group));
+      },
+      [this](std::shared_ptr<gcs::GcsPlacementGroup> placement_group) {
+        absl::MutexLock lock(&vector_mutex_);
+        success_placement_groups_.emplace_back(std::move(placement_group));
+      });
+
+  // Now, cancel the schedule request.
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  scheduler_->MarkScheduleCancelled(placement_group_id);
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 2);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  ASSERT_TRUE(raylet_clients_[0]->GrantCancelResourceReserve());
+  ASSERT_TRUE(raylet_clients_[0]->GrantCancelResourceReserve());
+  WaitPendingDone(failure_placement_groups_, 1);
+}
+
 TEST_F(GcsPlacementGroupSchedulerTest, TestPackStrategyReschedulingWhenNodeAdd) {
   ReschedulingWhenNodeAddTest(rpc::PlacementStrategy::PACK);
 }
@@ -459,6 +521,17 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestPackStrategyLargeBundlesScheduling) {
   for (int index = 0; index < raylet_clients_[1]->num_lease_requested; ++index) {
     ASSERT_TRUE(raylet_clients_[1]->GrantPrepareBundleResources());
   }
+  // Wait until all resources are prepared.
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks,
+                  raylet_clients_[0]->num_lease_requested);
+  WaitPendingDone(raylet_clients_[1]->commit_callbacks,
+                  raylet_clients_[1]->num_lease_requested);
+  for (int index = 0; index < raylet_clients_[0]->num_commit_requested; ++index) {
+    ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  }
+  for (int index = 0; index < raylet_clients_[1]->num_commit_requested; ++index) {
+    ASSERT_TRUE(raylet_clients_[1]->GrantCommitBundleResources());
+  }
   WaitPendingDone(success_placement_groups_, 1);
 }
 
@@ -486,6 +559,10 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestRescheduleWhenNodeDead) {
   scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler, success_handler);
   ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
   ASSERT_TRUE(raylet_clients_[1]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  WaitPendingDone(raylet_clients_[1]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  ASSERT_TRUE(raylet_clients_[1]->GrantCommitBundleResources());
   WaitPendingDone(success_placement_groups_, 1);
 
   auto bundles_on_node0 =
@@ -501,8 +578,17 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestRescheduleWhenNodeDead) {
   // TODO(ffbin): We need to see which node the other bundles that have been placed are
   // deployed on, and spread them as far as possible. It will be implemented in the next
   // pr.
+
+  auto commit_ready = [this]() {
+    absl::MutexLock lock(&vector_mutex_);
+    return raylet_clients_[0]->commit_callbacks.size() == 1 ||
+           raylet_clients_[1]->commit_callbacks.size() == 1;
+  };
   raylet_clients_[0]->GrantPrepareBundleResources();
   raylet_clients_[1]->GrantPrepareBundleResources();
+  EXPECT_TRUE(WaitForCondition(commit_ready, timeout_ms_.count()));
+  raylet_clients_[0]->GrantCommitBundleResources();
+  raylet_clients_[1]->GrantCommitBundleResources();
   WaitPendingDone(success_placement_groups_, 2);
 }
 
@@ -537,6 +623,10 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestStrictSpreadStrategyResourceCheck) {
   scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler, success_handler);
   ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
   ASSERT_TRUE(raylet_clients_[2]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  WaitPendingDone(raylet_clients_[2]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  ASSERT_TRUE(raylet_clients_[2]->GrantCommitBundleResources());
   WaitPendingDone(success_placement_groups_, 1);
 }
 
@@ -616,7 +706,43 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestBundleLocationIndex) {
   ASSERT_TRUE(bundle_location_index.GetBundleLocationsOnNode(node2).value()->size() == 1);
 }
 
-TEST_F(GcsPlacementGroupSchedulerTest, TestNodeDeadDuringCommitResources) {
+TEST_F(GcsPlacementGroupSchedulerTest, TestNodeDeadDuringPreparingResources) {
+  auto node0 = Mocker::GenNodeInfo(0);
+  auto node1 = Mocker::GenNodeInfo(1);
+  AddNode(node0);
+  AddNode(node1);
+  ASSERT_EQ(2, gcs_node_manager_->GetAllAliveNodes().size());
+
+  auto create_placement_group_request = Mocker::GenCreatePlacementGroupRequest();
+  auto placement_group =
+      std::make_shared<gcs::GcsPlacementGroup>(create_placement_group_request);
+
+  // Schedule the placement group.
+  // One node is dead, so one bundle failed to schedule.
+  auto failure_handler = [this](std::shared_ptr<gcs::GcsPlacementGroup> placement_group) {
+    absl::MutexLock lock(&vector_mutex_);
+    ASSERT_TRUE(placement_group->GetUnplacedBundles().size() == 2);
+    failure_placement_groups_.emplace_back(std::move(placement_group));
+  };
+  auto success_handler = [this](std::shared_ptr<gcs::GcsPlacementGroup> placement_group) {
+    absl::MutexLock lock(&vector_mutex_);
+    success_placement_groups_.emplace_back(std::move(placement_group));
+  };
+
+  scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler, success_handler);
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  gcs_node_manager_->RemoveNode(NodeID::FromBinary(node1->node_id()));
+  // This should fail because the node is dead.
+  ASSERT_TRUE(raylet_clients_[1]->GrantPrepareBundleResources(false));
+  ASSERT_TRUE(raylet_clients_[0]->commit_callbacks.size() == 0);
+  ASSERT_TRUE(raylet_clients_[1]->commit_callbacks.size() == 0);
+  WaitPendingDone(failure_placement_groups_, 1);
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest,
+       TestNodeDeadDuringPreparingResourcesRaceCondition) {
+  // This covers the scnario where the node is dead right after raylet sends a success
+  // response.
   auto node0 = Mocker::GenNodeInfo(0);
   auto node1 = Mocker::GenNodeInfo(1);
   AddNode(node0);
@@ -642,7 +768,216 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestNodeDeadDuringCommitResources) {
   scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler, success_handler);
   ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
   gcs_node_manager_->RemoveNode(NodeID::FromBinary(node1->node_id()));
+  // If node is dead right after raylet succeds to create a bundle, it will reply that
+  // the request has been succeed. In this case, we should just treating like a committed
+  // bundle that is just removed.
   ASSERT_TRUE(raylet_clients_[1]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  // This won't send a commit request because a node is dead.
+  WaitPendingDone(raylet_clients_[1]->commit_callbacks, 0);
+  ASSERT_FALSE(raylet_clients_[1]->GrantCommitBundleResources());
+  // In this case, we treated the placement group creation successful. Instead,
+  // we will reschedule them.
+  WaitPendingDone(failure_placement_groups_, 1);
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest, TestNodeDeadDuringCommittingResources) {
+  auto node0 = Mocker::GenNodeInfo(0);
+  auto node1 = Mocker::GenNodeInfo(1);
+  AddNode(node0);
+  AddNode(node1);
+  ASSERT_EQ(2, gcs_node_manager_->GetAllAliveNodes().size());
+
+  auto create_placement_group_request = Mocker::GenCreatePlacementGroupRequest();
+  auto placement_group =
+      std::make_shared<gcs::GcsPlacementGroup>(create_placement_group_request);
+
+  // Schedule the placement group.
+  // One node is dead, so one bundle failed to schedule.
+  auto failure_handler = [this](std::shared_ptr<gcs::GcsPlacementGroup> placement_group) {
+    absl::MutexLock lock(&vector_mutex_);
+    ASSERT_TRUE(placement_group->GetUnplacedBundles().size() == 2);
+    failure_placement_groups_.emplace_back(std::move(placement_group));
+  };
+  auto success_handler = [this](std::shared_ptr<gcs::GcsPlacementGroup> placement_group) {
+    absl::MutexLock lock(&vector_mutex_);
+    success_placement_groups_.emplace_back(std::move(placement_group));
+  };
+
+  scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler, success_handler);
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  ASSERT_TRUE(raylet_clients_[1]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  WaitPendingDone(raylet_clients_[1]->commit_callbacks, 1);
+  gcs_node_manager_->RemoveNode(NodeID::FromBinary(node1->node_id()));
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  // Commit will fail because the node is dead.
+  ASSERT_TRUE(raylet_clients_[1]->GrantCommitBundleResources(false));
+  WaitPendingDone(success_placement_groups_, 1);
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest, TestNodeDeadDuringRescheduling) {
+  auto node0 = Mocker::GenNodeInfo(0);
+  auto node1 = Mocker::GenNodeInfo(1);
+  AddNode(node0);
+  AddNode(node1);
+  ASSERT_EQ(2, gcs_node_manager_->GetAllAliveNodes().size());
+
+  auto create_placement_group_request = Mocker::GenCreatePlacementGroupRequest();
+  auto placement_group =
+      std::make_shared<gcs::GcsPlacementGroup>(create_placement_group_request);
+
+  // Schedule the placement group successfully.
+  auto failure_handler = [this](std::shared_ptr<gcs::GcsPlacementGroup> placement_group) {
+    absl::MutexLock lock(&vector_mutex_);
+    failure_placement_groups_.emplace_back(std::move(placement_group));
+  };
+  auto success_handler = [this](std::shared_ptr<gcs::GcsPlacementGroup> placement_group) {
+    absl::MutexLock lock(&vector_mutex_);
+    success_placement_groups_.emplace_back(std::move(placement_group));
+  };
+
+  scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler, success_handler);
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  ASSERT_TRUE(raylet_clients_[1]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  WaitPendingDone(raylet_clients_[1]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  ASSERT_TRUE(raylet_clients_[1]->GrantCommitBundleResources());
+  WaitPendingDone(success_placement_groups_, 1);
+
+  auto bundles_on_node0 =
+      scheduler_->GetBundlesOnNode(NodeID::FromBinary(node0->node_id()));
+  ASSERT_EQ(1, bundles_on_node0.size());
+  auto bundles_on_node1 =
+      scheduler_->GetBundlesOnNode(NodeID::FromBinary(node1->node_id()));
+  ASSERT_EQ(1, bundles_on_node1.size());
+  // all nodes are dead, reschedule the placement group.
+  placement_group->GetMutableBundle(0)->clear_node_id();
+  placement_group->GetMutableBundle(1)->clear_node_id();
+  scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler, success_handler);
+
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  // Before prepare requests are done, suppose a node is dead.
+  gcs_node_manager_->RemoveNode(NodeID::FromBinary(node1->node_id()));
+  // This should fail since the node is dead.
+  ASSERT_TRUE(raylet_clients_[1]->GrantPrepareBundleResources(false));
+  // Make sure the commit requests are not sent.
+  ASSERT_TRUE(raylet_clients_[0]->commit_callbacks.size() == 0);
+  ASSERT_TRUE(raylet_clients_[1]->commit_callbacks.size() == 0);
+
+  WaitPendingDone(success_placement_groups_, 1);
+  WaitPendingDone(failure_placement_groups_, 1);
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest, TestPGCancelledDuringReschedulingCommit) {
+  auto node0 = Mocker::GenNodeInfo(0);
+  auto node1 = Mocker::GenNodeInfo(1);
+  AddNode(node0);
+  AddNode(node1);
+  ASSERT_EQ(2, gcs_node_manager_->GetAllAliveNodes().size());
+
+  auto create_placement_group_request = Mocker::GenCreatePlacementGroupRequest();
+  auto placement_group =
+      std::make_shared<gcs::GcsPlacementGroup>(create_placement_group_request);
+
+  // Schedule the placement group successfully.
+  auto failure_handler = [this](std::shared_ptr<gcs::GcsPlacementGroup> placement_group) {
+    absl::MutexLock lock(&vector_mutex_);
+    failure_placement_groups_.emplace_back(std::move(placement_group));
+  };
+  auto success_handler = [this](std::shared_ptr<gcs::GcsPlacementGroup> placement_group) {
+    absl::MutexLock lock(&vector_mutex_);
+    success_placement_groups_.emplace_back(std::move(placement_group));
+  };
+
+  scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler, success_handler);
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  ASSERT_TRUE(raylet_clients_[1]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  WaitPendingDone(raylet_clients_[1]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  ASSERT_TRUE(raylet_clients_[1]->GrantCommitBundleResources());
+  WaitPendingDone(success_placement_groups_, 1);
+
+  auto bundles_on_node0 =
+      scheduler_->GetBundlesOnNode(NodeID::FromBinary(node0->node_id()));
+  ASSERT_EQ(1, bundles_on_node0.size());
+  auto bundles_on_node1 =
+      scheduler_->GetBundlesOnNode(NodeID::FromBinary(node1->node_id()));
+  ASSERT_EQ(1, bundles_on_node1.size());
+  // all nodes are dead, reschedule the placement group.
+  placement_group->GetMutableBundle(0)->clear_node_id();
+  placement_group->GetMutableBundle(1)->clear_node_id();
+  scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler, success_handler);
+
+  // Rescheduling happening.
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  ASSERT_TRUE(raylet_clients_[1]->GrantPrepareBundleResources());
+  // Make sure the commit requests are not sent.
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  WaitPendingDone(raylet_clients_[1]->commit_callbacks, 1);
+  // Cancel the placement group scheduling before commit requests are granted.
+  scheduler_->MarkScheduleCancelled(placement_group->GetPlacementGroupID());
+  // After commits are granted the placement group will be removed.
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  ASSERT_TRUE(raylet_clients_[1]->GrantCommitBundleResources());
+  WaitPendingDone(success_placement_groups_, 1);
+  WaitPendingDone(failure_placement_groups_, 1);
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest, TestPGCancelledDuringReschedulingCommitPrepare) {
+  auto node0 = Mocker::GenNodeInfo(0);
+  auto node1 = Mocker::GenNodeInfo(1);
+  AddNode(node0);
+  AddNode(node1);
+  ASSERT_EQ(2, gcs_node_manager_->GetAllAliveNodes().size());
+
+  auto create_placement_group_request = Mocker::GenCreatePlacementGroupRequest();
+  auto placement_group =
+      std::make_shared<gcs::GcsPlacementGroup>(create_placement_group_request);
+
+  // Schedule the placement group successfully.
+  auto failure_handler = [this](std::shared_ptr<gcs::GcsPlacementGroup> placement_group) {
+    absl::MutexLock lock(&vector_mutex_);
+    failure_placement_groups_.emplace_back(std::move(placement_group));
+  };
+  auto success_handler = [this](std::shared_ptr<gcs::GcsPlacementGroup> placement_group) {
+    absl::MutexLock lock(&vector_mutex_);
+    success_placement_groups_.emplace_back(std::move(placement_group));
+  };
+
+  scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler, success_handler);
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  ASSERT_TRUE(raylet_clients_[1]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  WaitPendingDone(raylet_clients_[1]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  ASSERT_TRUE(raylet_clients_[1]->GrantCommitBundleResources());
+  WaitPendingDone(success_placement_groups_, 1);
+
+  auto bundles_on_node0 =
+      scheduler_->GetBundlesOnNode(NodeID::FromBinary(node0->node_id()));
+  ASSERT_EQ(1, bundles_on_node0.size());
+  auto bundles_on_node1 =
+      scheduler_->GetBundlesOnNode(NodeID::FromBinary(node1->node_id()));
+  ASSERT_EQ(1, bundles_on_node1.size());
+  // all nodes are dead, reschedule the placement group.
+  placement_group->GetMutableBundle(0)->clear_node_id();
+  placement_group->GetMutableBundle(1)->clear_node_id();
+  scheduler_->ScheduleUnplacedBundles(placement_group, failure_handler, success_handler);
+
+  // Rescheduling happening.
+  // Cancel the placement group scheduling before prepare requests are granted.
+  scheduler_->MarkScheduleCancelled(placement_group->GetPlacementGroupID());
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  ASSERT_TRUE(raylet_clients_[1]->GrantPrepareBundleResources());
+  // Make sure the commit requests are not sent.
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 0);
+  WaitPendingDone(raylet_clients_[1]->commit_callbacks, 0);
+  // Make sure the placement group creation has failed.
+  WaitPendingDone(success_placement_groups_, 1);
   WaitPendingDone(failure_placement_groups_, 1);
 }
 

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -183,7 +183,7 @@ struct GcsServerMocker {
       return_callbacks.push_back(callback);
     }
 
-    // Trigger reply to PrepareBundleResources
+    // Trigger reply to PrepareBundleResources.
     bool GrantPrepareBundleResources(bool success = true) {
       Status status = Status::OK();
       rpc::PrepareBundleResourcesReply reply;
@@ -198,7 +198,7 @@ struct GcsServerMocker {
       }
     }
 
-    // Trigger reply to CommitBundleResources
+    // Trigger reply to CommitBundleResources.
     bool GrantCommitBundleResources(bool success = true) {
       Status status = Status::OK();
       rpc::CommitBundleResourcesReply reply;

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -172,8 +172,7 @@ struct GcsServerMocker {
         const ray::rpc::ClientCallback<ray::rpc::CommitBundleResourcesReply> &callback)
         override {
       num_commit_requested += 1;
-      rpc::CommitBundleResourcesReply reply;
-      callback(Status::OK(), reply);
+      commit_callbacks.push_back(callback);
     }
 
     void CancelResourceReserve(
@@ -184,7 +183,7 @@ struct GcsServerMocker {
       return_callbacks.push_back(callback);
     }
 
-    // Trigger reply to RequestWorkerLease.
+    // Trigger reply to PrepareBundleResources
     bool GrantPrepareBundleResources(bool success = true) {
       Status status = Status::OK();
       rpc::PrepareBundleResourcesReply reply;
@@ -195,6 +194,20 @@ struct GcsServerMocker {
         auto callback = lease_callbacks.front();
         callback(status, reply);
         lease_callbacks.pop_front();
+        return true;
+      }
+    }
+
+    // Trigger reply to CommitBundleResources
+    bool GrantCommitBundleResources(bool success = true) {
+      Status status = Status::OK();
+      rpc::CommitBundleResourcesReply reply;
+      if (commit_callbacks.size() == 0) {
+        return false;
+      } else {
+        auto callback = commit_callbacks.front();
+        callback(status, reply);
+        commit_callbacks.pop_front();
         return true;
       }
     }
@@ -220,6 +233,7 @@ struct GcsServerMocker {
     int num_commit_requested = 0;
     NodeID node_id = NodeID::FromRandom();
     std::list<rpc::ClientCallback<rpc::PrepareBundleResourcesReply>> lease_callbacks = {};
+    std::list<rpc::ClientCallback<rpc::CommitBundleResourcesReply>> commit_callbacks = {};
     std::list<rpc::ClientCallback<rpc::CancelResourceReserveReply>> return_callbacks = {};
   };
   class MockedGcsActorScheduler : public gcs::GcsActorScheduler {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Richard discovered that placement group APIs sometimes failed the GCS server because the check error (is_committed and is_prepared cannot be true at the same time). This is not true because when the placement group is re-created, those two flags can be true at the same time.

This PR fixes the issue and also improve unit test to cover lots of scenarios that can happen when placement groups are scheduled in the autoscaler.

Summary
- Improve unit tests to test cases that happen between PrepareResources and CommitResources.
- Create a unit test that can reproduce Richard's issue and fix it.
- Add lots of other unit tests to cover more edge cases.
- Change the log level to DEBUG for logs that expose implementation details (this will be new logging policy).
- Find bugs that I discovered while adding more unit tests.

## Related issue number

https://github.com/ray-project/ray/issues/11150 => Not exactly fixing this issue, but related.

cc @richard4912 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
