### PR TITLE
[autoscaler/k8s] namespace permissions problem

### DIFF
--- a/python/ray/autoscaler/_private/kubernetes/config.py
+++ b/python/ray/autoscaler/_private/kubernetes/config.py
@@ -32,7 +32,7 @@ def not_found_msg(resource_type, name):
 
 
 def not_checking_msg(resource_type, name):
-    return "Ray is not checking if {} '{}' exists.".format(resource_type, name)
+    return "not checking if {} '{}' exists".format(resource_type, name)
 
 
 def created_msg(resource_type, name):
@@ -67,7 +67,8 @@ def _configure_namespace(provider_config):
         namespaces = core_api().list_namespace(
             field_selector=field_selector).items
     except ApiException:
-        logger.warning(not_checking_msg(namespace_field, namespace))
+        logger.warning(log_prefix +
+                       not_checking_msg(namespace_field, namespace))
         return namespace
 
     if len(namespaces) > 0:

--- a/python/ray/autoscaler/_private/kubernetes/config.py
+++ b/python/ray/autoscaler/_private/kubernetes/config.py
@@ -1,6 +1,7 @@
 import logging
 
 from kubernetes import client
+from kubernetes.client.rest import ApiException
 
 from ray.autoscaler._private.kubernetes import auth_api, core_api, log_prefix
 
@@ -28,6 +29,10 @@ def updating_existing_msg(resource_type, name):
 def not_found_msg(resource_type, name):
     return "{} '{}' not found, attempting to create it".format(
         resource_type, name)
+
+
+def not_checking_msg(resource_type, name):
+    return "Ray is not checking if {} '{}' exists.".format(resource_type, name)
 
 
 def created_msg(resource_type, name):
@@ -58,7 +63,13 @@ def _configure_namespace(provider_config):
 
     namespace = provider_config[namespace_field]
     field_selector = "metadata.name={}".format(namespace)
-    namespaces = core_api().list_namespace(field_selector=field_selector).items
+    try:
+        namespaces = core_api().list_namespace(
+            field_selector=field_selector).items
+    except ApiException:
+        logger.warning(not_checking_msg(namespace_field, namespace))
+        return namespace
+
     if len(namespaces) > 0:
         assert len(namespaces) == 1
         logger.info(log_prefix +


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Currently, it is not possible to use the Ray cluster launcher on Kubernetes if the Kubernetes user does not have permission to list namespaces in their Kubernetes cluster. 
This PR resolves that problem -- if the user does not have permission to list namespaces, the user is warned that Ray isn't checking if the namespace they gave in their Ray cluster config exists. If the namespace exists and the user has sufficient permissions in that namespace, everything goes as normal. Otherwise, the cluster launcher will fail with an ApiException from Kubernetes.

## Related issue number
Resolves #10928
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

I tested the changes in a local minikube cluster. Namely, I set up users with the relevant permissions and checked that the outcomes are as described above. In particular, a user with the following characteristics can launch a Ray cluster: 
(1) does not have permission to list namespaces in their k8s cluster
(2) has admin privileges in the namespace in which they are trying to launch a Ray cluster