### PR TITLE
[autoscaler/k8s] Replace read_namespaced_pod_status with read_namespaced_pod

### DIFF
--- a/python/ray/autoscaler/_private/kubernetes/node_provider.py
+++ b/python/ray/autoscaler/_private/kubernetes/node_provider.py
@@ -48,22 +48,22 @@ class KubernetesNodeProvider(NodeProvider):
         return [pod.metadata.name for pod in pod_list.items]
 
     def is_running(self, node_id):
-        pod = core_api().read_namespaced_pod_status(node_id, self.namespace)
+        pod = core_api().read_namespaced_pod(node_id, self.namespace)
         return pod.status.phase == "Running"
 
     def is_terminated(self, node_id):
-        pod = core_api().read_namespaced_pod_status(node_id, self.namespace)
+        pod = core_api().read_namespaced_pod(node_id, self.namespace)
         return pod.status.phase not in ["Running", "Pending"]
 
     def node_tags(self, node_id):
-        pod = core_api().read_namespaced_pod_status(node_id, self.namespace)
+        pod = core_api().read_namespaced_pod(node_id, self.namespace)
         return pod.metadata.labels
 
     def external_ip(self, node_id):
         raise NotImplementedError("Must use internal IPs with Kubernetes.")
 
     def internal_ip(self, node_id):
-        pod = core_api().read_namespaced_pod_status(node_id, self.namespace)
+        pod = core_api().read_namespaced_pod(node_id, self.namespace)
         return pod.status.pod_ip
 
     def get_node_id(self, ip_address, use_internal_ip=True) -> str:
@@ -72,7 +72,7 @@ class KubernetesNodeProvider(NodeProvider):
         return super().get_node_id(ip_address, use_internal_ip=use_internal_ip)
 
     def set_node_tags(self, node_id, tags):
-        pod = core_api().read_namespaced_pod_status(node_id, self.namespace)
+        pod = core_api().read_namespaced_pod(node_id, self.namespace)
         pod.metadata.labels.update(tags)
         core_api().patch_namespaced_pod(node_id, self.namespace, pod)
 

--- a/python/ray/autoscaler/_private/staroid/node_provider.py
+++ b/python/ray/autoscaler/_private/staroid/node_provider.py
@@ -190,21 +190,21 @@ class StaroidNodeProvider(NodeProvider):
         kube_client = self.__cached[self.cluster_name]["kube_client"]
         core_api = client.CoreV1Api(kube_client)
 
-        pod = core_api.read_namespaced_pod_status(node_id, self.namespace)
+        pod = core_api.read_namespaced_pod(node_id, self.namespace)
         return pod.status.phase == "Running"
 
     def is_terminated(self, node_id):
         kube_client = self.__cached[self.cluster_name]["kube_client"]
         core_api = client.CoreV1Api(kube_client)
 
-        pod = core_api.read_namespaced_pod_status(node_id, self.namespace)
+        pod = core_api.read_namespaced_pod(node_id, self.namespace)
         return pod.status.phase not in ["Running", "Pending"]
 
     def node_tags(self, node_id):
         kube_client = self.__cached[self.cluster_name]["kube_client"]
         core_api = client.CoreV1Api(kube_client)
 
-        pod = core_api.read_namespaced_pod_status(node_id, self.namespace)
+        pod = core_api.read_namespaced_pod(node_id, self.namespace)
         return pod.metadata.labels
 
     def external_ip(self, node_id):
@@ -214,7 +214,7 @@ class StaroidNodeProvider(NodeProvider):
         kube_client = self.__cached[self.cluster_name]["kube_client"]
         core_api = client.CoreV1Api(kube_client)
 
-        pod = core_api.read_namespaced_pod_status(node_id, self.namespace)
+        pod = core_api.read_namespaced_pod(node_id, self.namespace)
         return pod.status.pod_ip
 
     def get_node_id(self, ip_address, use_internal_ip=True) -> str:
@@ -226,7 +226,7 @@ class StaroidNodeProvider(NodeProvider):
         kube_client = self.__cached[self.cluster_name]["kube_client"]
         core_api = client.CoreV1Api(kube_client)
 
-        pod = core_api.read_namespaced_pod_status(node_id, self.namespace)
+        pod = core_api.read_namespaced_pod(node_id, self.namespace)
         pod.metadata.labels.update(tags)
         core_api.patch_namespaced_pod(node_id, self.namespace, pod)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Replaced all instances of `core_api().read_namespaced_pod_status()` with  `core_api().read_namespaced_pod()`.
These do pretty much the same thing, but the latter plays better with most users' permissions. (See https://github.com/kubernetes-client/python/issues/993.)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Resolves #10932


## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
