### PR TITLE
[docs] fix version warning banner location

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -51,6 +51,8 @@ img.inline-figure {
 #version-warning-banner {
   /* Make version warning clickable */
   z-index: 1;
+  margin-left: 0;
+  width: calc(100% - 20% - 2 * 1.5625em);
 }
 
 span.rst-current-version > span.fa.fa-book {

--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -52,6 +52,8 @@ img.inline-figure {
   /* Make version warning clickable */
   z-index: 1;
   margin-left: 0;
+  /* 20% is for ToC rightbar */
+  /* 2 * 1.5625em is for horizontal margins */
   width: calc(100% - 20% - 2 * 1.5625em);
 }
 


### PR DESCRIPTION
CC @richardliaw @simon-mo 

## Why are these changes needed?

after:
![Screen Shot 2020-10-08 at 17 14 49](https://user-images.githubusercontent.com/31281983/95515189-35a45b80-098b-11eb-8b35-97ff42e4004a.png)


## Related issue number

n/a

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
