### PR TITLE
[Test] Try to deflake test_failure.

### DIFF
--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -459,9 +459,18 @@ def test_actor_scope_or_intentionally_killed_message(ray_start_regular,
 
     @ray.remote
     class Actor:
-        pass
+        def __init__(self):
+            # This log is added to debug a flaky test issue.
+            print(os.getpid())
+
+        def ping(self):
+            pass
 
     a = Actor.remote()
+    # Without this waiting, there seems to be race condition happening
+    # in the CI. This is not a fundamental fix for that, but it at least
+    # makes the test less flaky.
+    ray.get(a.ping.remote())
     a = Actor.remote()
     a.__ray_terminate__.remote()
     time.sleep(1)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Try two things. 

1. Try waiting for the first action creation to avoid race condition.
2. But we should at least figure out the race condition. So, I added better logs. I will see if 1 will make tests deflaky, and after that I will remove 1 and see if I can figure out the root cause. 

cc @wuisawesome 
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
