### PR TITLE
[Test]Fix TestActorSubscribeAll bug

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -542,7 +542,7 @@ void GcsActorManager::PollOwnerForActorOutOfScope(
           RAY_LOG(INFO) << "Worker " << owner_id << " failed, destroying actor child.";
         } else {
           RAY_LOG(INFO) << "Actor " << actor_id
-                        << " is out of scope,, destroying actor child.";
+                        << " is out of scope, destroying actor child.";
         }
 
         auto node_it = owners_.find(owner_node_id);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
![image](https://user-images.githubusercontent.com/13081808/95551380-431a1e00-0a3d-11eb-87af-bd7e5813ddff.png)
https://travis-ci.com/github/ray-project/ray/jobs/396514347#L2112
The caller address is not set, resulting in an unknown value. Therefore, there is a probability of successful registration of actor. In order to simulate the scenario of registration failure, we set the address to an illegal value.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
