### PR TITLE
Restore uptime timeout to 5 seconds

### DIFF
--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -246,7 +246,8 @@ class NodeUpdater:
                                              self.log_prefix)
 
                         # Run outside of the container
-                        self.cmd_runner.run("uptime", timeout=5, run_env="host")
+                        self.cmd_runner.run(
+                            "uptime", timeout=5, run_env="host")
                         cli_logger.old_debug(logger, "Uptime succeeded.")
                         cli_logger.success("Success.")
                         return True

--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -246,7 +246,7 @@ class NodeUpdater:
                                              self.log_prefix)
 
                         # Run outside of the container
-                        self.cmd_runner.run("uptime", run_env="host")
+                        self.cmd_runner.run("uptime", timeout=5, run_env="host")
                         cli_logger.old_debug(logger, "Uptime succeeded.")
                         cli_logger.success("Success.")
                         return True


### PR DESCRIPTION
Fixes https://github.com/ray-project/ray/issues/11273

## Why are these changes needed?

Speed up boot of worker nodes.  See the above issue for more details.

## Related issue number

Closes #11273 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
