### PR TITLE
[GCS]Eviction of dead nodes cached in GCS

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -234,6 +234,8 @@ RAY_CONFIG(uint32_t, gcs_create_actor_retry_interval_ms, 200)
 RAY_CONFIG(uint32_t, gcs_create_placement_group_retry_interval_ms, 200)
 /// Maximum number of destroyed actors in GCS server memory cache.
 RAY_CONFIG(uint32_t, maximum_gcs_destroyed_actor_cached_count, 10000)
+/// Maximum number of dead nodes in GCS server memory cache.
+RAY_CONFIG(uint32_t, maximum_gcs_dead_node_cached_count, 1000)
 
 /// Maximum number of times to retry putting an object when the plasma store is full.
 /// Can be set to -1 to enable unlimited retries.

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -1341,7 +1341,7 @@ TEST_F(ServiceBasedGcsClientTest, TestRandomEvictDestroyedActors) {
   EXPECT_TRUE(WaitForCondition(condition, timeout_ms_.count()));
 }
 
-TEST_F(ServiceBasedGcsClientTest, TestRandomEvictDeadNodes) {
+TEST_F(ServiceBasedGcsClientTest, TestEvictExpiredDeadNodes) {
   // Simulate the scenario of node dead.
   int node_count = RayConfig::instance().maximum_gcs_dead_node_cached_count();
   RegisterNodeAndMarkDead(node_count);

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -168,6 +168,7 @@ GcsNodeManager::GcsNodeManager(boost::asio::io_service &main_io_service,
             main_io_service_.post([this, node_id] {
               if (auto node = RemoveNode(node_id, /* is_intended = */ false)) {
                 node->set_state(rpc::GcsNodeInfo::DEAD);
+                node->set_timestamp(current_sys_time_ms());
                 AddDeadNodeToCache(node);
                 auto on_done = [this, node_id, node](const Status &status) {
                   auto on_done = [this, node_id, node](const Status &status) {
@@ -213,6 +214,7 @@ void GcsNodeManager::HandleUnregisterNode(const rpc::UnregisterNodeRequest &requ
   RAY_LOG(INFO) << "Unregistering node info, node id = " << node_id;
   if (auto node = RemoveNode(node_id, /* is_intended = */ true)) {
     node->set_state(rpc::GcsNodeInfo::DEAD);
+    node->set_timestamp(current_sys_time_ms());
     AddDeadNodeToCache(node);
 
     auto on_done = [this, node_id, node, reply,
@@ -463,9 +465,14 @@ void GcsNodeManager::LoadInitialData(const EmptyCallback &done) {
         // detector.
         AddNode(std::make_shared<rpc::GcsNodeInfo>(item.second));
       } else if (item.second.state() == rpc::GcsNodeInfo::DEAD) {
-        AddDeadNodeToCache(std::make_shared<rpc::GcsNodeInfo>(item.second));
+        dead_nodes_.emplace(item.first, std::make_shared<rpc::GcsNodeInfo>(item.second));
+        sorted_dead_node_list_.emplace_back(item.first, item.second.timestamp());
       }
     }
+    sorted_dead_node_list_.sort([](const std::pair<NodeID, int64_t> &left,
+                                   const std::pair<NodeID, int64_t> &right) {
+      return left.second < right.second;
+    });
 
     auto get_node_resource_callback =
         [this, done](const std::unordered_map<NodeID, ResourceMap> &result) {
@@ -515,9 +522,12 @@ void GcsNodeManager::UpdatePlacementGroupLoad(
 
 void GcsNodeManager::AddDeadNodeToCache(std::shared_ptr<rpc::GcsNodeInfo> node) {
   if (dead_nodes_.size() >= RayConfig::instance().maximum_gcs_dead_node_cached_count()) {
-    dead_nodes_.erase(dead_nodes_.begin());
+    dead_nodes_.erase(sorted_dead_node_list_.begin()->first);
+    sorted_dead_node_list_.erase(sorted_dead_node_list_.begin());
   }
-  dead_nodes_.emplace(NodeID::FromBinary(node->node_id()), node);
+  auto node_id = NodeID::FromBinary(node->node_id());
+  dead_nodes_.emplace(node_id, node);
+  sorted_dead_node_list_.emplace_back(node_id, node->timestamp());
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -246,7 +246,7 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   };
 
  private:
-  /// Add the dead node to the cache. If the cache is full, one node is randomly
+  /// Add the dead node to the cache. If the cache is full, the earliest dead node is
   /// evicted.
   ///
   /// \param node The node which is dead.

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -246,6 +246,12 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   };
 
  private:
+  /// Add the dead node to the cache. If the cache is full, one node is randomly
+  /// evicted.
+  ///
+  /// \param node The node which is dead.
+  void AddDeadNodeToCache(std::shared_ptr<rpc::GcsNodeInfo> node);
+
   /// The main event loop for node failure detector.
   boost::asio::io_service &main_io_service_;
   /// Detector to detect the failure of node.

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -262,6 +262,9 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>> alive_nodes_;
   /// Dead nodes.
   absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>> dead_nodes_;
+  /// The nodes are sorted according to the timestamp, and the oldest is at the head of
+  /// the list.
+  std::list<std::pair<NodeID, int64_t>> sorted_dead_node_list_;
   /// Cluster resources.
   absl::flat_hash_map<NodeID, rpc::ResourceMap> cluster_resources_;
   /// Listeners which monitors the addition of nodes.

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -259,6 +259,8 @@ message GcsNodeInfo {
 
   // The port at which the node will expose metrics to.
   int32 metrics_export_port = 9;
+  // Timestamp that the node is dead.
+  int64 timestamp = 10;
 }
 
 // Represents the demand for a particular resource shape.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Eviction of dead nodes cached in GCS to prevent memory explosion. If the cache is full, the earliest dead node is evicted.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
