### PR TITLE
[RLlib] Fix crash in vision_net.py (tf) iff len(filters) == 1.

### DIFF
--- a/rllib/models/tf/visionnet.py
+++ b/rllib/models/tf/visionnet.py
@@ -20,6 +20,8 @@ class VisionNetwork(TFModelV2):
         activation = get_activation_fn(
             self.model_config.get("conv_activation"), framework="tf")
         filters = self.model_config["conv_filters"]
+        assert len(filters) > 0,\
+            "Must provide at least 1 entry in `conv_filters`!"
         no_final_linear = self.model_config.get("no_final_linear")
         vf_share_layers = self.model_config.get("vf_share_layers")
 
@@ -64,7 +66,7 @@ class VisionNetwork(TFModelV2):
                 activation=activation,
                 padding="valid",
                 data_format="channels_last",
-                name="conv{}".format(i + 1))(last_layer)
+                name="conv{}".format(len(filters)))(last_layer)
 
             # num_outputs defined. Use that to create an exact
             # `num_output`-sized (1,1)-Conv2D.
@@ -122,7 +124,7 @@ class VisionNetwork(TFModelV2):
                 activation=activation,
                 padding="valid",
                 data_format="channels_last",
-                name="conv_value_{}".format(i + 1))(last_layer)
+                name="conv_value_{}".format(len(filters)))(last_layer)
             last_layer = tf.keras.layers.Conv2D(
                 1, [1, 1],
                 activation=None,

--- a/rllib/models/torch/visionnet.py
+++ b/rllib/models/torch/visionnet.py
@@ -24,6 +24,8 @@ class VisionNetwork(TorchModelV2, nn.Module):
 
         activation = self.model_config.get("conv_activation")
         filters = self.model_config["conv_filters"]
+        assert len(filters) > 0,\
+            "Must provide at least 1 entry in `conv_filters`!"
         no_final_linear = self.model_config.get("no_final_linear")
         vf_share_layers = self.model_config.get("vf_share_layers")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

If the length of `conv2d_filters` is <= 1, the tf version of VisionNet (ray/rllib/model/tf/vision_net.py) will crash.
This PR fixes the problem.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Closes #11038 
<!-- Please give a short summary of the change and the problem this solves. -->

Closes #11038 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
