### PR TITLE
[tune] Add Basic Variant Generator to search algorithm shim function

### DIFF
--- a/python/ray/tune/suggest/__init__.py
+++ b/python/ray/tune/suggest/__init__.py
@@ -76,6 +76,7 @@ def create_searcher(
 
     SEARCH_ALG_IMPORT = {
         "variant_generator": _import_variant_generator,
+        "random": _import_variant_generator,
         "ax": _import_ax_search,
         "dragonfly": _import_dragonfly_search,
         "skopt": _import_skopt_search,

--- a/python/ray/tune/suggest/__init__.py
+++ b/python/ray/tune/suggest/__init__.py
@@ -31,6 +31,9 @@ def create_searcher(
         >>> search_alg = tune.create_searcher('ax')
     """
 
+    def _import_variant_generator():
+        return BasicVariantGenerator
+
     def _import_ax_search():
         from ray.tune.suggest.ax import AxSearch
         return AxSearch
@@ -72,6 +75,7 @@ def create_searcher(
         return SigOptSearch
 
     SEARCH_ALG_IMPORT = {
+        "variant_generator": _import_variant_generator,
         "ax": _import_ax_search,
         "dragonfly": _import_dragonfly_search,
         "skopt": _import_skopt_search,


### PR DESCRIPTION
CC @richardliaw 

## Why are these changes needed?

In #11218 we added "fifo" (the default scheduler for `tune.run`) to the schedulers dict so we should add the basic variant generator (the default search alg for `tune.run`) to the search alg dict.

## Related issue number

n/a

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
