### PR TITLE
[tune] Remove metric and mode kwargs from search algorithm shim function

### DIFF
--- a/python/ray/tune/suggest/__init__.py
+++ b/python/ray/tune/suggest/__init__.py
@@ -8,8 +8,6 @@ from ray.tune.suggest.repeater import Repeater
 
 def create_searcher(
         search_alg,
-        metric=None,
-        mode=None,
         **kwargs,
 ):
     """Instantiate a search algorithm based on the given string.
@@ -90,7 +88,7 @@ def create_searcher(
             f"Got: {search_alg}")
 
     SearcherClass = SEARCH_ALG_IMPORT[search_alg]()
-    return SearcherClass(metric=metric, mode=mode, **kwargs)
+    return SearcherClass(**kwargs)
 
 
 __all__ = [


### PR DESCRIPTION
## Why are these changes needed?

In #11218 we removed the metric and mode kwargs from `create_scheduler` so we should remove these kwargs from `create_searcher` for consistency. This shouldn't change any functionality.

## Related issue number

n/a

(@richardliaw I don't know your opinion on this so feel free to close)

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
