### PR TITLE
[tune][docs] Fix learning rate bounds in FAQ

### DIFF
--- a/doc/source/tune/_tutorials/_faq.rst
+++ b/doc/source/tune/_tutorials/_faq.rst
@@ -57,7 +57,7 @@ reports to use ``max_depth=6`` for the maximum decision tree depth. Here, anythi
 between 2 and 10 might make sense (though that naturally depends on your problem).
 
 For **learning rates**, we suggest using a **loguniform distribution** between
-**1e-1** and **1e-5**: ``tune.loguniform(1e-1, 1e-5)``.
+**1e-5** and **1e-1**: ``tune.loguniform(1e-5, 1e-1)``.
 
 For **batch sizes**, we suggest trying **powers of 2**, for instance, 2, 4, 8,
 16, 32, 64, 128, 256, etc. The magnitude depends on your problem. For easy


### PR DESCRIPTION
CC @richardliaw 

## Why are these changes needed?

`tune.loguniform`'s args are `(low, high)`, not `(high, low)`, so the current snippet for the learning rate in the FAQ isn't copy-pasteable

## Related issue number

n/a

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
