### PR TITLE
[docker] Script for quickly fixing all Latest images

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script is for users to build docker images locally. It is most useful for users wishing to edit the
 # base-deps, ray-deps, or ray images. This script is *not* tested, so please look at the 
-# scripts/build-docker-images.sh if there are problems with using this script.
+# scripts/build-docker-images.py if there are problems with using this script.
 
 set -x
 

--- a/docker/fix-docker-latest.sh
+++ b/docker/fix-docker-latest.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+IMAGE="1.0.0"
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+case $key in
+    --latest-tag)
+    shift
+    IMAGE=$1
+    ;;
+    *)
+    echo "Usage: fix-docker-latest.sh --latest-tag <TAG>"
+    exit 1
+esac
+shift
+done
+
+echo "You must be logged into a user with push priviledges to do this."
+
+docker pull rayproject/ray:"$IMAGE"
+docker tag rayproject/ray:"$IMAGE" rayproject/ray:latest
+docker tag rayproject/ray:"$IMAGE" rayproject/ray:latest-cpu
+docker pull rayproject/ray:"$IMAGE"-gpu
+docker tag rayproject/ray:"$IMAGE"-gpu rayproject/ray:latest-gpu
+docker push rayproject/ray:latest
+docker push rayproject/ray:latest-cpu
+docker push rayproject/ray:latest-gpu
+
+docker pull rayproject/ray-deps:"$IMAGE"
+docker tag rayproject/ray-deps:"$IMAGE" rayproject/ray-deps:latest
+docker tag rayproject/ray-deps:"$IMAGE" rayproject/ray-deps:latest-cpu
+docker pull rayproject/ray-deps:"$IMAGE"-gpu
+docker tag rayproject/ray-deps:"$IMAGE"-gpu rayproject/ray-deps:latest-gpu
+docker push rayproject/ray-deps:latest
+docker push rayproject/ray-deps:latest-cpu
+docker push rayproject/ray-deps:latest-gpu
+
+docker pull rayproject/base-deps:"$IMAGE"
+docker tag rayproject/base-deps:"$IMAGE" rayproject/base-deps:latest
+docker tag rayproject/base-deps:"$IMAGE" rayproject/base-deps:latest-cpu
+docker pull rayproject/base-deps:"$IMAGE"-gpu
+docker tag rayproject/base-deps:"$IMAGE"-gpu rayproject/base-deps:latest-gpu
+docker push rayproject/base-deps:latest
+docker push rayproject/base-deps:latest-cpu
+docker push rayproject/base-deps:latest-gpu
+
+docker pull rayproject/ray-ml:"$IMAGE"
+docker tag rayproject/ray-ml:"$IMAGE" rayproject/ray-ml:latest
+docker tag rayproject/ray-ml:"$IMAGE" rayproject/ray-ml:latest-cpu
+docker pull rayproject/ray-ml:"$IMAGE"-gpu
+docker tag rayproject/ray-ml:"$IMAGE"-gpu rayproject/ray-ml:latest-gpu
+docker push rayproject/ray-ml:latest
+docker push rayproject/ray-ml:latest-cpu
+docker push rayproject/ray-ml:latest-gpu
+
+docker pull rayproject/autoscaler:"$IMAGE"
+docker tag rayproject/autoscaler:"$IMAGE" rayproject/autoscaler:latest
+docker tag rayproject/autoscaler:"$IMAGE" rayproject/autoscaler:latest-cpu
+docker pull rayproject/autoscaler:"$IMAGE"-gpu
+docker tag rayproject/autoscaler:"$IMAGE"-gpu rayproject/autoscaler:latest-gpu
+docker push rayproject/autoscaler:latest
+docker push rayproject/autoscaler:latest-cpu
+docker push rayproject/autoscaler:latest-gpu

--- a/docker/fix-docker-latest.sh
+++ b/docker/fix-docker-latest.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# This script is not for normal use and is used in the event that CI (or a user) overwrites the latest tag.
 
 IMAGE="1.0.0"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

With our previous CI infrastructure various branches would **overwrite** our release images 😱 . This _should be fixed with the python version_. This script is here for emergency use to quickly retag images to the latest.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
