### PR TITLE
Update microbenchmark script to use Python 3.8 wheel

### DIFF
--- a/ci/microbenchmark/run.sh
+++ b/ci/microbenchmark/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ray_version="" 
+ray_version=""
 commit=""
 ray_branch=""
 
@@ -42,11 +42,11 @@ echo "version: $ray_version"
 echo "commit: $commit"
 echo "branch: $ray_branch"
 
-rm "ray-$ray_version-cp36-cp36m-manylinux1_x86_64.whl" || true
-wget "https://s3-us-west-2.amazonaws.com/ray-wheels/$ray_branch/$commit/ray-$ray_version-cp36-cp36m-manylinux1_x86_64.whl"
-      
+rm "ray-$ray_version-cp38-cp38-manylinux1_x86_64.whl" || true
+wget "https://s3-us-west-2.amazonaws.com/ray-wheels/$ray_branch/$commit/ray-$ray_version-cp38-cp38-manylinux1_x86_64.whl"
+
 pip uninstall -y -q ray
-pip install -U "ray-$ray_version-cp36-cp36m-manylinux1_x86_64.whl"
+pip install -U "ray-$ray_version-cp38-cp38-manylinux1_x86_64.whl"
 
 unset RAY_ADDRESS
 OMP_NUM_THREADS=64 ray microbenchmark


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Update the Python version as our periodic CI infra will use Python 3.8 from the default ray/anyscale docker images.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
