### PR TITLE
[Log] dump stacktrace from glog lib

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -185,6 +185,7 @@ def ray_deps_setup():
             "//thirdparty/patches:glog-log-pid-tid.patch",
             "//thirdparty/patches:glog-stack-trace.patch",
             "//thirdparty/patches:glog-suffix-log.patch",
+            "//thirdparty/patches:glog-dump-stacktrack.patch",
         ],
     )
 

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -47,6 +47,14 @@
 
 namespace ray {
 
+std::string GetCallTrace() {
+  std::string return_message = "Cannot get callstack information.";
+#ifdef RAY_USE_GLOG
+  return google::GetStackTraceToString();
+#endif
+  return return_message;
+}
+
 #ifdef RAY_USE_GLOG
 struct StdoutLogger : public google::base::Logger {
   std::ostream &out() { return std::cout; }

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -43,7 +43,10 @@ enum { ERROR = 0 };
 #endif
 
 namespace ray {
-
+/// In order to use the get stacktrace method in other non-glog scenarios, we
+/// have added a patch to allow glog to return the current call stack information
+/// through the internal interface. This function `GetCallTrace` is a wrapper
+/// providing a new detection function for debug or something like that.
 std::string GetCallTrace();
 
 enum class RayLogLevel { DEBUG = -1, INFO = 0, WARNING = 1, ERROR = 2, FATAL = 3 };

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -44,6 +44,8 @@ enum { ERROR = 0 };
 
 namespace ray {
 
+std::string GetCallTrace();
+
 enum class RayLogLevel { DEBUG = -1, INFO = 0, WARNING = 1, ERROR = 2, FATAL = 3 };
 
 #define RAY_LOG_INTERNAL(level) ::ray::RayLog(__FILE__, __LINE__, level)

--- a/src/ray/util/logging_test.cc
+++ b/src/ray/util/logging_test.cc
@@ -64,7 +64,6 @@ TEST(PrintLogTest, LogTestWithInit) {
 
 // This test will output large amount of logs to stderr, should be disabled in travis.
 TEST(LogPerfTest, PerfTest) {
-  RAY_LOG(INFO) << ray::GetUserTempDir() + ray::GetDirSep();
   RayLog::StartRayLog("/fake/path/to/appdire/LogPerfTest", RayLogLevel::ERROR,
                       ray::GetUserTempDir() + ray::GetDirSep());
   int rounds = 100000;
@@ -79,12 +78,10 @@ TEST(LogPerfTest, PerfTest) {
             << std::endl;
 
   start_time = current_time_ms();
-  RAY_LOG(ERROR) << "Start";
   for (int i = 0; i < rounds; ++i) {
     RAY_LOG(ERROR) << "This is the "
                    << "RAY_ERROR message";
   }
-  RAY_LOG(ERROR) << "End";
   elapsed = current_time_ms() - start_time;
   std::cout << "Testing RAY_ERROR log for " << rounds << " rounds takes " << elapsed
             << " ms." << std::endl;

--- a/thirdparty/patches/glog-dump-stacktrack.patch
+++ b/thirdparty/patches/glog-dump-stacktrack.patch
@@ -56,3 +56,17 @@ index c66f914..39c48e8 100644
  
  struct CrashReason {
    CrashReason() : filename(0), line_number(0), message(0), depth(0) {}
+diff --git src/windows/glog/logging.h src/windows/glog/logging.h
+index 2a739f9..4ff2a79 100755
+--- src/windows/glog/logging.h
++++ src/windows/glog/logging.h
+@@ -1677,6 +1677,9 @@ class GOOGLE_GLOG_DLL_DECL NullStreamFatal : public NullStream {
+ // words, stack traces of other threads won't be shown.
+ GOOGLE_GLOG_DLL_DECL void InstallFailureSignalHandler();
+
++// Providing stack trace function for upper level.
++GOOGLE_GLOG_DLL_DECL std::string GetStackTraceToString();
++
+ // Installs a function that is used for writing the failure dump.  "data"
+ // is the pointer to the beginning of a message to be written, and "size"
+ // is the size of the message.  You should not expect the data is

--- a/thirdparty/patches/glog-dump-stacktrack.patch
+++ b/thirdparty/patches/glog-dump-stacktrack.patch
@@ -1,0 +1,58 @@
+diff --git src/glog/logging.h.in src/glog/logging.h.in
+index 64bed1a..0ff073f 100644
+--- src/glog/logging.h.in
++++ src/glog/logging.h.in
+@@ -1676,6 +1676,9 @@ class GOOGLE_GLOG_DLL_DECL NullStreamFatal : public NullStream {
+ // words, stack traces of other threads won't be shown.
+ GOOGLE_GLOG_DLL_DECL void InstallFailureSignalHandler();
+ 
++// Providing stack trace function for upper level.
++GOOGLE_GLOG_DLL_DECL std::string GetStackTraceToString();
++
+ // Installs a function that is used for writing the failure dump.  "data"
+ // is the pointer to the beginning of a message to be written, and "size"
+ // is the size of the message.  You should not expect the data is
+diff --git src/logging.cc src/logging.cc
+index 733ce8c..e988eb9 100644
+--- src/logging.cc
++++ src/logging.cc
+@@ -2336,4 +2336,11 @@ void DisableLogCleaner() {
+   log_cleaner_enabled_ = false;
+ }
+ 
++std::string GetStackTraceToString() {
++  // Collect stacktrace from utilities.
++  std::string stacktrace;
++  DumpStackTraceToString(&stacktrace, 0);
++  return stacktrace;
++}
++
+ _END_GOOGLE_NAMESPACE_
+diff --git src/utilities.cc src/utilities.cc
+index 9a1e35d..3808162 100644
+--- src/utilities.cc
++++ src/utilities.cc
+@@ -318,8 +318,8 @@ static void MyUserNameInitializer() {
+ REGISTER_MODULE_INITIALIZER(utilities, MyUserNameInitializer());
+ 
+ #ifdef HAVE_STACKTRACE
+-void DumpStackTraceToString(string* stacktrace) {
+-  DumpStackTrace(1, DebugWriteToString, stacktrace);
++void DumpStackTraceToString(string* stacktrace, int depth) {
++  DumpStackTrace(depth, DebugWriteToString, stacktrace);
+ }
+ #endif
+ 
+diff --git src/utilities.h src/utilities.h
+index c66f914..39c48e8 100644
+--- src/utilities.h
++++ src/utilities.h
+@@ -209,7 +209,7 @@ inline T sync_val_compare_and_swap(T* ptr, T oldval, T newval) {
+ #endif
+ }
+ 
+-void DumpStackTraceToString(std::string* stacktrace);
++void DumpStackTraceToString(std::string* stacktrace, int depth = 1);
+ 
+ struct CrashReason {
+   CrashReason() : filename(0), line_number(0), message(0), depth(0) {}

--- a/thirdparty/patches/glog-dump-stacktrack.patch
+++ b/thirdparty/patches/glog-dump-stacktrack.patch
@@ -16,13 +16,15 @@ diff --git src/logging.cc src/logging.cc
 index 733ce8c..e988eb9 100644
 --- src/logging.cc
 +++ src/logging.cc
-@@ -2336,4 +2336,11 @@ void DisableLogCleaner() {
+@@ -2336,4 +2336,13 @@ void DisableLogCleaner() {
    log_cleaner_enabled_ = false;
  }
  
 +std::string GetStackTraceToString() {
 +  // Collect stacktrace from utilities.
 +  std::string stacktrace;
++  // The second parameter stands for skip count. The top stack frames will be
++  // skipped to dump from stack if it's non-zero.
 +  DumpStackTraceToString(&stacktrace, 0);
 +  return stacktrace;
 +}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Export a new dump stacktrace interface from glog, which will be helpful to spdlog or collecting call stack manually.

We make a comparison between glog and spdlog and find that only stacktrace is unsupported in spdlog, so this PR will reuse glog stacktrace and symbols for any module in ray.

Reference doc: https://docs.google.com/document/d/1pEXTLOhTFu5-va14Wj-tGoJD9tt_M_-JRMtxqd1JCyI/edit?usp=sharing 
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
