### PR TITLE
WIP: Update to support the Food Collector environment

### DIFF
--- a/rllib/env/unity3d_env.py
+++ b/rllib/env/unity3d_env.py
@@ -223,6 +223,11 @@ class Unity3DEnv(MultiAgentEnv):
             "VisualHallway": Box(float("-inf"), float("inf"), (84, 84, 3)),
             # Walker.
             "Walker": Box(float("-inf"), float("inf"), (212, )),
+            # FoodCollector.
+             "FoodCollector": TupleSpace([
+                Box(float("-inf"), float("inf"), (49, )),
+                Box(float("-inf"), float("inf"), (4, )),
+            ]),
         }
         action_spaces = {
             # 3DBall.
@@ -242,6 +247,8 @@ class Unity3DEnv(MultiAgentEnv):
             "VisualHallway": MultiDiscrete([5]),
             # Walker.
             "Walker": Box(float("-inf"), float("inf"), (39, )),
+            # FoodCollector.
+            "FoodCollector": MultiDiscrete([3, 3, 3, 2]),
         }
 
         # Policies (Unity: "behaviors") and agent-to-policy mapping fns.

--- a/rllib/env/unity3d_env.py
+++ b/rllib/env/unity3d_env.py
@@ -224,7 +224,7 @@ class Unity3DEnv(MultiAgentEnv):
             # Walker.
             "Walker": Box(float("-inf"), float("inf"), (212, )),
             # FoodCollector.
-             "FoodCollector": TupleSpace([
+            "FoodCollector": TupleSpace([
                 Box(float("-inf"), float("inf"), (49, )),
                 Box(float("-inf"), float("inf"), (4, )),
             ]),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Recently, I am trying out ML Agent with Ray, and trying to use the food collector environment. Since the observation space and action space haven't defined in the unity3d_env.py. I propose to make this changes to add the support for Food Collector. I have tried to use this env in the [unity3d_env_local example](https://github.com/ray-project/ray/blob/master/rllib/examples/unity3d_env_local.py). Please let me know if this the proper adjustment. Even these are just few line of code, please let me know how can I made a proper contribution.

In addition, I am seeing the following messages when I try to train with the [GTrXLNet](https://github.com/ray-project/ray/blob/master/rllib/models/tf/attention_net.py#L136) or with a simple 512 x 512 fully connected network.

```
...
(pid=12938) Unknown side channel data received. Channel type: a1d8f7b7-cec8-50f9-b78b-d3e165a78520.
(pid=12938) Unknown side channel data received. Channel type: a1d8f7b7-cec8-50f9-b78b-d3e165a78520.
(pid=12938) 2020-10-13 14:38:26,774     WARNING sampler.py:746 -- More than 2020 observations for 102 env steps are buffered in the sampler. If this is more than you expected, check that that you set a horizon on your environment correctly and that it terminates at some point. Note: In multi-agent environments, `rollout_fragment_length` sets the batch size based on environment steps, not the steps of individual agents, which can result in unexpectedly large batches. Also, you may be in evaluation waiting for your Env to terminate (batch_mode=`complete_episodes`). Make sure it does at some point.
(pid=12938) Unknown side channel data received. Channel type: a1d8f7b7-cec8-50f9-b78b-d3e165a78520.
...
```

<!-- Please give a short summary of the change and the problem this solves. -->
This will add the support for using the Food Collector env from Unity3D with Ray

## Related issue number
Will create if needed.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
