### PR TITLE
[tune] Make `metrics` parameter optional in pytorch lightning integration

### DIFF
--- a/python/ray/tune/integration/pytorch_lightning.py
+++ b/python/ray/tune/integration/pytorch_lightning.py
@@ -162,7 +162,7 @@ class TuneReportCallback(TuneCallback):
     """
 
     def __init__(self,
-                 metrics: Union[str, List[str], Dict[str, str]],
+                 metrics: Union[None, str, List[str], Dict[str, str]] = None,
                  on: Union[str, List[str]] = "validation_end"):
         super(TuneReportCallback, self).__init__(on)
         if isinstance(metrics, str):
@@ -173,13 +173,19 @@ class TuneReportCallback(TuneCallback):
         # Don't report if just doing initial validation sanity checks.
         if trainer.running_sanity_check:
             return
-        report_dict = {}
-        for key in self._metrics:
-            if isinstance(self._metrics, dict):
-                metric = self._metrics[key]
-            else:
-                metric = key
-            report_dict[key] = trainer.callback_metrics[metric].item()
+        if not self._metrics:
+            report_dict = {
+                k: v.item()
+                for k, v in trainer.callback_metrics.items()
+            }
+        else:
+            report_dict = {}
+            for key in self._metrics:
+                if isinstance(self._metrics, dict):
+                    metric = self._metrics[key]
+                else:
+                    metric = key
+                report_dict[key] = trainer.callback_metrics[metric].item()
         tune.report(**report_dict)
 
 
@@ -253,7 +259,7 @@ class TuneReportCheckpointCallback(TuneCallback):
     """
 
     def __init__(self,
-                 metrics: Union[str, List[str], Dict[str, str]],
+                 metrics: Union[None, str, List[str], Dict[str, str]] = None,
                  filename: str = "checkpoint",
                  on: Union[str, List[str]] = "validation_end"):
         super(TuneReportCheckpointCallback, self).__init__(on)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

PyTorch Lightning callbacks should also work without explicitly specifying metrics. Our other callback integrations already support this mode.

## Related issue number

Closes #11344

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
