### PR TITLE
[docker] latest -> nightly on docker image tag on build-docker.sh script

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -59,10 +59,10 @@ for IMAGE in "base-deps" "ray-deps" "ray"
 do
     cp "$WHEEL" "docker/$IMAGE/$(basename "$WHEEL")"
     if [ $OUTPUT_SHA ]; then
-        IMAGE_SHA=$(docker build $NO_CACHE --build-arg GPU="$GPU" --build-arg BASE_IMAGE="$BASE_IMAGE" --build-arg WHEEL_PATH="$(basename "$WHEEL")" -q -t rayproject/$IMAGE:latest$GPU docker/$IMAGE)
-        echo "rayproject/$IMAGE:latest$GPU SHA:$IMAGE_SHA"
+        IMAGE_SHA=$(docker build $NO_CACHE --build-arg GPU="$GPU" --build-arg BASE_IMAGE="$BASE_IMAGE" --build-arg WHEEL_PATH="$(basename "$WHEEL")" -q -t rayproject/$IMAGE:nightly$GPU docker/$IMAGE)
+        echo "rayproject/$IMAGE:nightly$GPU SHA:$IMAGE_SHA"
     else
-        docker build $NO_CACHE  --build-arg GPU="$GPU" --build-arg BASE_IMAGE="$BASE_IMAGE" --build-arg WHEEL_PATH="$(basename "$WHEEL")" --build-arg PYTHON_VERSION="$PYTHON_VERSION" -t rayproject/$IMAGE:latest$GPU docker/$IMAGE
+        docker build $NO_CACHE  --build-arg GPU="$GPU" --build-arg BASE_IMAGE="$BASE_IMAGE" --build-arg WHEEL_PATH="$(basename "$WHEEL")" --build-arg PYTHON_VERSION="$PYTHON_VERSION" -t rayproject/$IMAGE:nightly$GPU docker/$IMAGE
     fi
     rm "docker/$IMAGE/$(basename "$WHEEL")"
 done 


### PR DESCRIPTION
## Why are these changes needed?

https://github.com/ray-project/ray/pull/11139 changed Dockerfiles to start from `***:nightly` instead of `***:latest`. [ray-deps](https://github.com/ray-project/ray/pull/11139/files#diff-5fd73a4e10d1c9fdad007ce763da4309939e72cfcd0e796e5309b29c652190beR2), [ray-ml](https://github.com/ray-project/ray/pull/11139/files#diff-73757a7f97f0cfe4d1aa4d0101bd82536acde3cde9d812954b3c587096edcb27R2) and [ray](https://github.com/ray-project/ray/pull/11139/files#diff-5cd4c77ee5d06fabf676bbb69585f330e332bc3bc3913a0b53eef8e61ec871f6R2) Dockerfiles.

So, I think it makes more sense to make build-docker.sh generates `***:nightly` tag instead of `***:latest`.


## Related issue number

https://github.com/ray-project/ray/pull/11139

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
