### PR TITLE
[docker] Support non-root container

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -41,7 +41,7 @@ RUN sudo apt-get update -y && sudo apt-get upgrade -y \
         -O /tmp/miniconda.sh \
     && /bin/bash /tmp/miniconda.sh -b -u -p $HOME/anaconda3 \
     && $HOME/anaconda3/bin/conda init \ 
-    && echo 'export PATH=$HOME/anaconda3/bin:$PATH' >> /home/ray/.bash_profile \
+    && echo 'export PATH=$HOME/anaconda3/bin:$PATH' >> /home/ray/.bashrc \
     && rm /tmp/miniconda.sh \
     && $HOME/anaconda3/bin/conda install -y \
         libgcc python=$PYTHON_VERSION \

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -10,8 +10,23 @@ ENV TZ=America/Los_Angeles
 ENV PATH "/root/anaconda3/bin:$PATH"
 ARG DEBIAN_FRONTEND=noninteractive
 ARG PYTHON_VERSION=3.7.7
-RUN apt-get update -y && apt-get upgrade -y \
-    && apt-get install -y \
+
+ARG RAY_UID=1000
+ARG RAY_GID=100
+
+RUN apt-get update -y \
+    && apt-get install -y sudo tzdata \
+    && useradd -ms /bin/bash -d /home/ray ray --uid $RAY_UID --gid $RAY_GID \
+    && usermod -aG sudo ray \
+    && echo 'ray ALL=NOPASSWD: ALL' >> /etc/sudoers \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+USER $RAY_UID
+ENV HOME=/home/ray
+
+RUN sudo apt-get update -y && sudo apt-get upgrade -y \
+    && sudo apt-get install -y \
         git \
         wget \
         cmake \
@@ -26,7 +41,7 @@ RUN apt-get update -y && apt-get upgrade -y \
         -O /tmp/miniconda.sh \
     && /bin/bash /tmp/miniconda.sh -b -u -p $HOME/anaconda3 \
     && $HOME/anaconda3/bin/conda init \ 
-    && echo 'export PATH=$HOME/anaconda3/bin:$PATH' > /etc/profile.d/conda.sh \
+    && echo 'export PATH=$HOME/anaconda3/bin:$PATH' >> /home/ray/.bash_profile \
     && rm /tmp/miniconda.sh \
     && $HOME/anaconda3/bin/conda install -y \
         libgcc python=$PYTHON_VERSION \
@@ -42,15 +57,15 @@ RUN apt-get update -y && apt-get upgrade -y \
     # AttributeError: 'numpy.ufunc' object has no attribute '__module__'
     && $HOME/anaconda3/bin/pip uninstall -y dask \ 
     # We install cmake temporarily to get psutil
-    && apt-get autoremove -y cmake \
+    && sudo apt-get autoremove -y cmake \
     # Either install kubectl or remove wget 
     && (if [ "$AUTOSCALER" = "autoscaler" ]; \
-        then wget -O - -q https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
-        && touch /etc/apt/sources.list.d/kubernetes.list \
-        && echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list \
-        && apt-get update \
-        && apt-get install kubectl; \
-    else apt-get autoremove -y wget; \
+        then wget -O - -q https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add - \
+        && sudo touch /etc/apt/sources.list.d/kubernetes.list \
+        && echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list \
+        && sudo apt-get update \
+        && sudo apt-get install kubectl; \
+    else sudo apt-get autoremove -y wget; \
     fi;) \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean 
+    && sudo rm -rf /var/lib/apt/lists/* \
+    && sudo apt-get clean

--- a/docker/ray-deps/Dockerfile
+++ b/docker/ray-deps/Dockerfile
@@ -17,4 +17,4 @@ RUN $HOME/anaconda3/bin/pip --no-cache-dir install $(basename $WHEEL_PATH)[all] 
         "azure-mgmt-compute==12.0.0" \
         "azure-mgmt-msi==1.0.0" \
         "azure-mgmt-network==10.1.0"; fi) \
-    && $HOME/anaconda3/bin/pip uninstall ray -y && rm $(basename $WHEEL_PATH)
+    && $HOME/anaconda3/bin/pip uninstall ray -y && sudo rm $(basename $WHEEL_PATH)

--- a/docker/ray-ml/Dockerfile
+++ b/docker/ray-ml/Dockerfile
@@ -7,15 +7,15 @@ COPY requirements_ml_docker.txt ./
 COPY requirements_rllib.txt ./
 COPY requirements_tune.txt ./
 
-RUN apt-get update \
-    && apt-get install -y gcc \
+RUN sudo apt-get update \
+    && sudo apt-get install -y gcc \
         cmake \
         libgtk2.0-dev \
         zlib1g-dev \
         libgl1-mesa-dev \
     && $HOME/anaconda3/bin/pip --no-cache-dir install -r requirements.txt \ 
     && $HOME/anaconda3/bin/pip --no-cache-dir install -r requirements_ml_docker.txt \
-    && rm requirements.txt && rm requirements_ml_docker.txt \
-    && apt-get remove cmake gcc -y \
-    && apt-get clean 
+    && sudo rm requirements.txt && sudo rm requirements_ml_docker.txt \
+    && sudo apt-get remove cmake gcc -y \
+    && sudo apt-get clean
 

--- a/docker/ray/Dockerfile
+++ b/docker/ray/Dockerfile
@@ -6,4 +6,4 @@ ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 COPY $WHEEL_PATH .
 RUN $HOME/anaconda3/bin/pip --no-cache-dir install `basename $WHEEL_PATH`[all] \
-&& rm `basename $WHEEL_PATH`
+&& sudo rm `basename $WHEEL_PATH`

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -25,6 +25,8 @@ from ray.autoscaler._private.subprocess_output_util import (
 from ray.autoscaler._private.cli_logger import cli_logger, cf
 from ray.util.debug import log_once
 
+from ray.autoscaler._private.constants import RAY_HOME
+
 logger = logging.getLogger(__name__)
 
 # How long to wait for a node to start, in seconds
@@ -32,7 +34,6 @@ NODE_START_WAIT_S = 300
 HASH_MAX_LENGTH = 10
 KUBECTL_RSYNC = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "kubernetes/kubectl-rsync.sh")
-RAY_HOME = "/home/ray"  # ray home path in the container image
 
 _config = {"use_login_shells": True, "silent_rsync": True}
 

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -32,6 +32,7 @@ NODE_START_WAIT_S = 300
 HASH_MAX_LENGTH = 10
 KUBECTL_RSYNC = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "kubernetes/kubectl-rsync.sh")
+RAY_HOME = "/home/ray"  # ray home path in the container image
 
 _config = {"use_login_shells": True, "silent_rsync": True}
 
@@ -190,7 +191,7 @@ class KubernetesCommandRunner(CommandRunnerInterface):
                 logger.warning("'rsync_filter' detected but is currently "
                                "unsupported for k8s.")
         if target.startswith("~"):
-            target = "/root" + target[1:]
+            target = RAY_HOME + target[1:]
 
         try:
             flags = "-aqz" if is_rsync_silent() else "-avz"
@@ -206,7 +207,7 @@ class KubernetesCommandRunner(CommandRunnerInterface):
                 "rsync failed: '{}'. Falling back to 'kubectl cp'".format(e),
                 UserWarning)
             if target.startswith("~"):
-                target = "/root" + target[1:]
+                target = RAY_HOME + target[1:]
 
             self.process_runner.check_call(self.kubectl + [
                 "cp", source, "{}/{}:{}".format(self.namespace, self.node_id,
@@ -215,7 +216,7 @@ class KubernetesCommandRunner(CommandRunnerInterface):
 
     def run_rsync_down(self, source, target, options=None):
         if target.startswith("~"):
-            target = "/root" + target[1:]
+            target = RAY_HOME + target[1:]
 
         try:
             flags = "-aqz" if is_rsync_silent() else "-avz"
@@ -231,7 +232,7 @@ class KubernetesCommandRunner(CommandRunnerInterface):
                 "rsync failed: '{}'. Falling back to 'kubectl cp'".format(e),
                 UserWarning)
             if target.startswith("~"):
-                target = "/root" + target[1:]
+                target = RAY_HOME + target[1:]
 
             self.process_runner.check_call(self.kubectl + [
                 "cp", "{}/{}:{}".format(self.namespace, self.node_id, source),

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -718,8 +718,7 @@ class DockerCommandRunner(CommandRunnerInterface):
                     "run_options", []) + self.docker_config.get(
                         f"{'head' if as_head else 'worker'}_run_options",
                         []) + self._configure_runtime(),
-                self.ssh_command_runner.cluster_name,
-		home_directory)
+                self.ssh_command_runner.cluster_name, home_directory)
             self.run(start_command, run_env="host")
         else:
             running_image = self.run(

--- a/python/ray/autoscaler/_private/constants.py
+++ b/python/ray/autoscaler/_private/constants.py
@@ -41,3 +41,6 @@ AUTOSCALER_MAX_RESOURCE_DEMAND_VECTOR_SIZE = 1000
 BOTO_MAX_RETRIES = env_integer("BOTO_MAX_RETRIES", 12)
 # Max number of retries to create an EC2 node (retry different subnet)
 BOTO_CREATE_MAX_RETRIES = env_integer("BOTO_CREATE_MAX_RETRIES", 5)
+
+# ray home path in the container image
+RAY_HOME = "/home/ray"

--- a/python/ray/autoscaler/_private/docker.py
+++ b/python/ray/autoscaler/_private/docker.py
@@ -65,15 +65,15 @@ def check_docker_image(cname):
 
 
 def docker_start_cmds(user, image, mount_dict, container_name, user_options,
-                      cluster_name):
+                      cluster_name, home_directory):
     # Imported here due to circular dependency.
     from ray.autoscaler.sdk import get_docker_host_mount_location
     docker_mount_prefix = get_docker_host_mount_location(cluster_name)
     mount = {f"{docker_mount_prefix}/{dst}": dst for dst in mount_dict}
 
-    # TODO(ilr) Move away from defaulting to /root/
     mount_flags = " ".join([
-        "-v {src}:{dest}".format(src=k, dest=v.replace("~/", "/root/"))
+        "-v {src}:{dest}".format(
+            src=k, dest=v.replace("~/", home_directory + "/"))
         for k, v in mount.items()
     ])
 

--- a/python/ray/autoscaler/_private/staroid/command_runner.py
+++ b/python/ray/autoscaler/_private/staroid/command_runner.py
@@ -17,21 +17,3 @@ class StaroidCommandRunner(KubernetesCommandRunner):
         if kube_api_server is not None:
             self.kubectl.extend(["--server", kube_api_server])
             os.environ["KUBE_API_SERVER"] = kube_api_server
-
-    def _rewrite_target_home_dir(self, target):
-        # Staroid forces containers to run non-root permission. Ray docker
-        # image does not have a support for non-root user at the moment.
-        # Use /tmp/ray as a home directory until docker image supports
-        # non-root user.
-
-        if target.startswith("~/"):
-            return "/home/ray" + target[1:]
-        return target
-
-    def run_rsync_up(self, source, target, options=None):
-        target = self._rewrite_target_home_dir(target)
-        super().run_rsync_up(source, target, options)
-
-    def run_rsync_down(self, source, target, options=None):
-        target = self._rewrite_target_home_dir(target)
-        super().run_rsync_down(source, target, options)

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -441,6 +441,7 @@ class AutoscalingTest(unittest.TestCase):
         # Two initial calls to docker cp, one before run, two final calls to cp
         runner.respond_to_call(".State.Running",
                                ["false", "false", "false", "true", "true"])
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
         commands.get_or_create_head_node(
             SMALL_CLUSTER,
             config_path,
@@ -1037,6 +1038,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(SMALL_CLUSTER)
         self.provider = MockProvider()
         runner = MockProcessRunner()
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
         autoscaler = StandardAutoscaler(
             config_path,
             LoadMetrics(),
@@ -1075,6 +1077,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(SMALL_CLUSTER)
         self.provider = MockProvider()
         runner = MockProcessRunner()
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
         autoscaler = StandardAutoscaler(
             config_path,
             LoadMetrics(),
@@ -1190,6 +1193,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(SMALL_CLUSTER)
         self.provider = MockProvider()
         runner = MockProcessRunner()
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
         lm = LoadMetrics()
         autoscaler = StandardAutoscaler(
             config_path,
@@ -1255,6 +1259,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(config)
         self.provider = MockProvider(cache_stopped=False)
         runner = MockProcessRunner()
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
         lm = LoadMetrics()
         autoscaler = StandardAutoscaler(
             config_path,
@@ -1297,6 +1302,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(config)
         self.provider = MockProvider(cache_stopped=True)
         runner = MockProcessRunner()
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
         lm = LoadMetrics()
         autoscaler = StandardAutoscaler(
             config_path,
@@ -1363,6 +1369,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(config)
         self.provider = MockProvider(cache_stopped=True)
         runner = MockProcessRunner()
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
         lm = LoadMetrics()
         autoscaler = StandardAutoscaler(
             config_path,
@@ -1413,6 +1420,7 @@ class AutoscalingTest(unittest.TestCase):
         config["max_workers"] = 2
         config_path = self.write_config(config)
         runner = MockProcessRunner()
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
         lm = LoadMetrics()
         autoscaler = StandardAutoscaler(
             config_path,
@@ -1466,6 +1474,7 @@ class AutoscalingTest(unittest.TestCase):
         config["max_workers"] = 2
         config_path = self.write_config(config)
         runner = MockProcessRunner()
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
         lm = LoadMetrics()
         autoscaler = StandardAutoscaler(
             config_path,
@@ -1512,6 +1521,7 @@ class AutoscalingTest(unittest.TestCase):
         from ray.autoscaler._private import util
         util._hash_cache = {}
         runner = MockProcessRunner()
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
         lm = LoadMetrics()
         autoscaler = StandardAutoscaler(
             config_path,

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -441,7 +441,7 @@ class AutoscalingTest(unittest.TestCase):
         # Two initial calls to docker cp, one before run, two final calls to cp
         runner.respond_to_call(".State.Running",
                                ["false", "false", "false", "true", "true"])
-        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
+        runner.respond_to_call("json .Config.Env", ["[]"])
         commands.get_or_create_head_node(
             SMALL_CLUSTER,
             config_path,
@@ -1038,7 +1038,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(SMALL_CLUSTER)
         self.provider = MockProvider()
         runner = MockProcessRunner()
-        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(2)])
         autoscaler = StandardAutoscaler(
             config_path,
             LoadMetrics(),
@@ -1077,7 +1077,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(SMALL_CLUSTER)
         self.provider = MockProvider()
         runner = MockProcessRunner()
-        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(2)])
         autoscaler = StandardAutoscaler(
             config_path,
             LoadMetrics(),
@@ -1193,7 +1193,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(SMALL_CLUSTER)
         self.provider = MockProvider()
         runner = MockProcessRunner()
-        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(2)])
         lm = LoadMetrics()
         autoscaler = StandardAutoscaler(
             config_path,
@@ -1259,7 +1259,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(config)
         self.provider = MockProvider(cache_stopped=False)
         runner = MockProcessRunner()
-        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(2)])
         lm = LoadMetrics()
         autoscaler = StandardAutoscaler(
             config_path,
@@ -1302,7 +1302,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(config)
         self.provider = MockProvider(cache_stopped=True)
         runner = MockProcessRunner()
-        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(3)])
         lm = LoadMetrics()
         autoscaler = StandardAutoscaler(
             config_path,
@@ -1369,7 +1369,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(config)
         self.provider = MockProvider(cache_stopped=True)
         runner = MockProcessRunner()
-        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(13)])
         lm = LoadMetrics()
         autoscaler = StandardAutoscaler(
             config_path,
@@ -1420,7 +1420,7 @@ class AutoscalingTest(unittest.TestCase):
         config["max_workers"] = 2
         config_path = self.write_config(config)
         runner = MockProcessRunner()
-        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(4)])
         lm = LoadMetrics()
         autoscaler = StandardAutoscaler(
             config_path,
@@ -1474,7 +1474,7 @@ class AutoscalingTest(unittest.TestCase):
         config["max_workers"] = 2
         config_path = self.write_config(config)
         runner = MockProcessRunner()
-        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(2)])
         lm = LoadMetrics()
         autoscaler = StandardAutoscaler(
             config_path,
@@ -1521,7 +1521,7 @@ class AutoscalingTest(unittest.TestCase):
         from ray.autoscaler._private import util
         util._hash_cache = {}
         runner = MockProcessRunner()
-        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(2)])
         lm = LoadMetrics()
         autoscaler = StandardAutoscaler(
             config_path,

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -927,7 +927,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(MULTI_WORKER_CLUSTER)
         self.provider = MockProvider()
         runner = MockProcessRunner()
-        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
+        runner.respond_to_call("json .Config.Env", ["[]"])
         get_or_create_head_node(
             MULTI_WORKER_CLUSTER,
             config_path,
@@ -1167,7 +1167,6 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(config)
         self.provider = MockProvider()
         runner = MockProcessRunner()
-        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
         autoscaler = StandardAutoscaler(
             config_path,
             LoadMetrics(),
@@ -1198,7 +1197,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(config)
         self.provider = MockProvider()
         runner = MockProcessRunner()
-        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(2)])
         autoscaler = StandardAutoscaler(
             config_path,
             LoadMetrics(),
@@ -1280,7 +1279,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(config)
         self.provider = MockProvider()
         runner = MockProcessRunner()
-        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(2)])
         autoscaler = StandardAutoscaler(
             config_path,
             LoadMetrics(),

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -1332,6 +1332,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(config)
         self.provider = MockProvider()
         runner = MockProcessRunner()
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(4)])
         autoscaler = StandardAutoscaler(
             config_path,
             LoadMetrics(),

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -927,6 +927,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(MULTI_WORKER_CLUSTER)
         self.provider = MockProvider()
         runner = MockProcessRunner()
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
         get_or_create_head_node(
             MULTI_WORKER_CLUSTER,
             config_path,
@@ -1166,6 +1167,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(config)
         self.provider = MockProvider()
         runner = MockProcessRunner()
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
         autoscaler = StandardAutoscaler(
             config_path,
             LoadMetrics(),
@@ -1196,6 +1198,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(config)
         self.provider = MockProvider()
         runner = MockProcessRunner()
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
         autoscaler = StandardAutoscaler(
             config_path,
             LoadMetrics(),
@@ -1277,6 +1280,7 @@ class AutoscalingTest(unittest.TestCase):
         config_path = self.write_config(config)
         self.provider = MockProvider()
         runner = MockProcessRunner()
+        runner.respond_to_call("json .Config.Env", ["[]" for i in range(100)])
         autoscaler = StandardAutoscaler(
             config_path,
             LoadMetrics(),


### PR DESCRIPTION
## Why are these changes needed?

This change makes non-root container images to be created.

Summary of changes

 - `docker/base-deps/Dockerfile` - create 'ray' user and install 'sudo' command
 - `docker/base-deps|ray-deps|ray|ray-ml/Dockerfile` - Dockerfile switches user to ray and use 'sudo' when command need to run with root permission
 - update python source codes that references `/root` dir (to `/home/ray` dir)

## Related issue number

Closes https://github.com/ray-project/ray/issues/10786

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
