### PR TITLE
[docker] Check for GPUs before setting runtime-nvidia

### DIFF
--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -730,6 +730,7 @@ class DockerCommandRunner(CommandRunnerInterface):
             except Exception as e:
                 logger.warning(
                     "Nvidia Container Runtime is present, but no GPUs found.")
+                logger.debug(f"nvidia-smi error: {e}")
                 return []
 
         return []

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -667,14 +667,14 @@ class DockerCommandRunner(CommandRunnerInterface):
         for mnt in BOOTSTRAP_MOUNTS:
             cleaned_bind_mounts.pop(mnt, None)
 
-        start_command = docker_start_cmds(
-            self.ssh_command_runner.ssh_user, image, cleaned_bind_mounts,
-            self.container_name,
-            self.docker_config.get("run_options", []) + self.docker_config.get(
-                f"{'head' if as_head else 'worker'}_run_options",
-                []) + self._configure_runtime())
-
         if not self._check_container_status():
+            start_command = docker_start_cmds(
+                self.ssh_command_runner.ssh_user, image, cleaned_bind_mounts,
+                self.container_name,
+                self.docker_config.get(
+                    "run_options", []) + self.docker_config.get(
+                        f"{'head' if as_head else 'worker'}_run_options",
+                        []) + self._configure_runtime())
             self.run(start_command, run_env="host")
         else:
             running_image = self.run(
@@ -724,5 +724,12 @@ class DockerCommandRunner(CommandRunnerInterface):
             "docker info -f '{{.Runtimes}}' ",
             with_output=True).decode().strip()
         if "nvidia-container-runtime" in runtime_output:
-            return ["--runtime=nvidia"]
+            try:
+                self.ssh_command_runner.run("nvidia-smi", with_output=False)
+                return ["--runtime=nvidia"]
+            except Exception as e:
+                logger.warning(
+                    "Nvidia Container Runtime is present, but no GPUs found.")
+                return []
+
         return []


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Ray up fails under the following conditions:
* `nvidia-container-runtime` is installed on the host
* **No** GPUs are present on the hsot
* A CUDA based image is being used for running
The output is 
```
docker: Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "process_linux.go:449: container init caused \"process_linux.go:432: running prestart hook 0 caused \\\"error running hook: exit status 1, stdout: , stderr: nvidia-container-cli: initialization error: nvml error: driver not loaded\\\\n\\\"\"": unknown.
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
