### PR TITLE
[autoscaler/AWS] Updated AWS Node Provider threading logic

### DIFF
--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -23,6 +23,8 @@ from ray.autoscaler._private.cli_logger import cli_logger, cf
 
 logger = logging.getLogger(__name__)
 
+TAG_BATCH_DELAY = 1
+
 
 def to_aws_format(tags):
     """Convert the Ray node name tag to the AWS-specific 'Name' tag."""
@@ -165,7 +167,7 @@ class AWSNodeProvider(NodeProvider):
             self.tag_cache_pending[node_id].update(tags)
 
         if is_batching_thread:
-            time.sleep(1)
+            time.sleep(TAG_BATCH_DELAY)
             with self.tag_cache_lock:
                 self._update_node_tags()
                 self.batch_update_done.set()

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -168,14 +168,13 @@ class AWSNodeProvider(NodeProvider):
             with self.tag_cache_lock:
                 self._update_node_tags()
                 self.batch_update_done.set()
-        else:
-            with self.count_lock:
-                self.batch_thread_count += 1
-            self.batch_update_done.wait()
-            with self.count_lock:
-                self.batch_thread_count -= 1
-                if self.batch_thread_count == 0:
-                    self.ready_for_new_batch.set()
+        with self.count_lock:
+            self.batch_thread_count += 1
+        self.batch_update_done.wait()
+        with self.count_lock:
+            self.batch_thread_count -= 1
+            if self.batch_thread_count == 0:
+                self.ready_for_new_batch.set()
 
     def _update_node_tags(self):
         batch_updates = defaultdict(list)

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -123,7 +123,7 @@ py_test(
 )
 
 py_test(
-    name = "test_aws_batch_tag_update.py",
+    name = "test_aws_batch_tag_update",
     size = "small",
     srcs = SRCS + ["aws/test_aws_batch_tag_update.py"],
     deps = ["//:ray_lib"],

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -122,6 +122,13 @@ py_test(
     deps = ["//:ray_lib"],
 )
 
+py_test(
+    name = "test_aws_batch_tag_update.py",
+    size = "small",
+    srcs = SRCS + ["aws/test_aws_batch_tag_update.py"],
+    deps = ["//:ray_lib"],
+)
+
 # Note(simon): typing tests are not included in module list
 #    because they requires globs and it might be refactored in the future.
 py_test(

--- a/python/ray/tests/aws/test_aws_batch_tag_update.py
+++ b/python/ray/tests/aws/test_aws_batch_tag_update.py
@@ -1,0 +1,70 @@
+import threading
+import time
+import unittest
+from unittest import mock
+
+import pytest
+
+from ray.autoscaler._private.aws.node_provider import AWSNodeProvider
+from ray.autoscaler._private.aws.node_provider import TAG_BATCH_DELAY
+
+
+def mock_create_tags(provider, batch_updates):
+    # Increment batches sent.
+    provider.batch_counter += 1
+    # Increment tags updated.
+    provider.tag_update_counter += sum(
+        len(batch_updates[x]) for x in batch_updates)
+
+
+def batch_test(num_threads, delay):
+    """Run AWSNodeProvider.set_node_tags in several threads, with a
+    specified delay between thread launches.
+
+    Return the number of batches of tag updates and the number of tags
+    updated.
+    """
+    with mock.patch("ray.autoscaler._private.aws.node_provider.make_ec2_client"
+                    ), mock.patch.object(AWSNodeProvider, "_create_tags",
+                                         mock_create_tags):
+        provider = AWSNodeProvider(
+            provider_config={"region": "nowhere"}, cluster_name="default")
+        provider.batch_counter = 0
+        provider.tag_update_counter = 0
+        provider.tag_cache = {str(x): {} for x in range(num_threads)}
+
+        threads = []
+        for x in range(num_threads):
+            thread = threading.Thread(
+                target=provider.set_node_tags, args=(str(x), {
+                    "foo": "bar"
+                }))
+            threads.append(thread)
+
+        for thread in threads:
+            thread.start()
+            time.sleep(delay)
+        for thread in threads:
+            thread.join()
+
+        return provider.batch_counter, provider.tag_update_counter
+
+
+class TagBatchTest(unittest.TestCase):
+    def test_concurrent(self):
+        num_threads = 100
+        batches_sent, tags_updated = batch_test(num_threads, delay=0)
+        self.assertLess(batches_sent, num_threads / 10)
+        self.assertEqual(tags_updated, num_threads)
+
+    def test_serial(self):
+        num_threads = 5
+        long_delay = TAG_BATCH_DELAY * 1.2
+        batches_sent, tags_updated = batch_test(num_threads, delay=long_delay)
+        self.assertEqual(batches_sent, num_threads)
+        self.assertEqual(tags_updated, num_threads)
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?


<!-- Please give a short summary of the change and the problem this solves. -->
This PR reworks the threading logic in `AWSNodeProvider` responsible for batching requests to update AWS cluster tags. These changes ensure that when the `AWSNodeProvider.set_node_tags()` method is called, the tags are set before the method returns. 

This PR also obviates the need for the `cleanup` method in the NodeProvider interface — the`tag_update_thread` now ends on its own and does not require external cleanup. I'll remove `cleanup` from the `NodeProvider` interface in a subsequent PR.  

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
Two unit tests: The first runs `set_node_tags` in 100 threads, with no delay between thread starts. The second runs `set_node_tags` in 5 threads, with long delays between thread starts. 