### PR TITLE
[GCS]Fix node info idempotent bug

### DIFF
--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -753,13 +753,17 @@ void ServiceBasedNodeInfoAccessor::HandleNotification(const GcsNodeInfo &node_in
     // was alive and is now dead or resources have been updated.
     bool was_alive = (entry->second.state() == GcsNodeInfo::ALIVE);
     is_notif_new = was_alive && !is_alive;
-    
-    // When a new node(node-B) registers with GCS, it subscribes to all node information.
-    // It will subscribe to redis and then get all node information from GCS through RPC.
-    // If node-A fails after GCS replies to node-B, GCS will send another message(node-A
-    // is dead) to node-B through redis publish. Because RPC and redis subscribe are two
-    // different sessions, node-B may process node-A dead message first and then node-A
-    // alive message.
+
+    // Once a node with a given ID has been removed, it should never be added
+    // again. If the entry was in the cache and the node was deleted, we should check
+    // that this new notification is not an insertion.
+    // However, when a new node(node-B) registers with GCS, it subscribes to all node
+    // information. It will subscribe to redis and then get all node information from GCS
+    // through RPC. If node-A fails after GCS replies to node-B, GCS will send another
+    // message(node-A is dead) to node-B through redis publish. Because RPC and redis
+    // subscribe are two different sessions, node-B may process node-A dead message first
+    // and then node-A alive message. So we use `RAY_LOG` instead of `RAY_CHECK ` as a
+    // workaround.
     if (!was_alive && is_alive) {
       RAY_LOG(INFO) << "Notification for addition of a node that was already removed:"
                     << node_id;

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -753,12 +753,17 @@ void ServiceBasedNodeInfoAccessor::HandleNotification(const GcsNodeInfo &node_in
     // was alive and is now dead or resources have been updated.
     bool was_alive = (entry->second.state() == GcsNodeInfo::ALIVE);
     is_notif_new = was_alive && !is_alive;
-    // Once a node with a given ID has been removed, it should never be added
-    // again. If the entry was in the cache and the node was deleted, check
-    // that this new notification is not an insertion.
-    if (!was_alive) {
-      RAY_CHECK(!is_alive)
-          << "Notification for addition of a node that was already removed:" << node_id;
+    
+    // When a new node(node-B) registers with GCS, it subscribes to all node information.
+    // It will subscribe to redis and then get all node information from GCS through RPC.
+    // If node-A fails after GCS replies to node-B, GCS will send another message(node-A
+    // is dead) to node-B through redis publish. Because RPC and redis subscribe are two
+    // different sessions, node-B may process node-A dead message first and then node-A
+    // alive message.
+    if (!was_alive && is_alive) {
+      RAY_LOG(INFO) << "Notification for addition of a node that was already removed:"
+                    << node_id;
+      return;
     }
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fix node info idempotent bug:
```
2020-10-15 16:24:59,256 F 743 743 service_based_accessor.cc:892:] Check failed: !is_alive Notification for addition of a node that was already removed:3b4865715de695c9a31e5c488608ec91a4a720b9
```
Reason:
When a new node(node-B) registers with GCS, it subscribes to all node information.
It will subscribe to redis and then get all node information from GCS through RPC.
If node-A fails after GCS replies to node-B, GCS will send another message(node-A is dead) to node-B through redis publish. Because RPC and redis subscribe are two different sessions, node-B may process node-A dead message first and then node-A alive message.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
