### PR TITLE
[tune] support hierarchical search spaces for hyperopt

### DIFF
--- a/python/ray/tune/suggest/hyperopt.py
+++ b/python/ray/tune/suggest/hyperopt.py
@@ -366,9 +366,9 @@ class HyperOptSearch(Searcher):
                             category, prefix=par)
                         if isinstance(category, dict) else
                         HyperOptSearch.convert_search_space(
-                            dict(enumerate(category)), prefix=f"par/{i}")
+                            dict(enumerate(category)), prefix=f"{par}/{i}")
                         if isinstance(category, list) else resolve_value(
-                            f"par/{i}", category)
+                            f"{par}/{i}", category)
                         if isinstance(category, Domain) else category
                         for i, category in enumerate(domain.categories)
                     ])

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -438,7 +438,7 @@ class SearchSpaceTest(unittest.TestCase):
             _mock_objective,
             config=config,
             search_alg=searcher,
-            num_samples=100)
+            num_samples=10)
 
         for trial in analysis.trials:
             config = trial.config

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -251,7 +251,7 @@ def flatten_dict(dt, delimiter="/", prevent_delimiter=False):
                             "Found delimiter `{}` in key when trying to "
                             "flatten array. Please avoid using the delimiter "
                             "in your specification.")
-                    add[delimiter.join([key, subkey])] = v
+                    add[delimiter.join([key, str(subkey)])] = v
                 remove.append(key)
         dt.update(add)
         for k in remove:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds support for hierarchical search spaces using hyperopt.

This will now work with HyperOpt:

```
config = {
    "a": 1,
    "dict_nested": tune.choice([{
        "a": tune.choice(["M", "N"]),
        "b": tune.choice(["O", "P"])
    }]),
    "list_nested": tune.choice([
        [
            tune.choice(["M", "N"]),
            tune.choice(["O", "P"])
        ],
        [
            tune.choice(["Q", "R"]),
            tune.choice(["S", "T"])
        ],
    ]),
    "domain_nested": tune.choice([
        tune.choice(["M", "N"]),
        tune.choice(["O", "P"])
    ]),
}
```

and result in configs like this:

```
{'a': 1, 'dict_nested': {'a': 'M', 'b': 'P'}, 'list_nested': {0: 'N', 1: 'O'}, 'domain_nested': 'P'}
{'a': 1, 'dict_nested': {'a': 'N', 'b': 'O'}, 'list_nested': {0: 'R', 1: 'T'}, 'domain_nested': 'M'}
{'a': 1, 'dict_nested': {'a': 'N', 'b': 'P'}, 'list_nested': {0: 'Q', 1: 'T'}, 'domain_nested': 'M'}
{'a': 1, 'dict_nested': {'a': 'M', 'b': 'O'}, 'list_nested': {0: 'Q', 1: 'T'}, 'domain_nested': 'O'}
{'a': 1, 'dict_nested': {'a': 'N', 'b': 'P'}, 'list_nested': {0: 'M', 1: 'O'}, 'domain_nested': 'N'}
{'a': 1, 'dict_nested': {'a': 'N', 'b': 'P'}, 'list_nested': {0: 'R', 1: 'T'}, 'domain_nested': 'M'}
{'a': 1, 'dict_nested': {'a': 'M', 'b': 'P'}, 'list_nested': {0: 'R', 1: 'S'}, 'domain_nested': 'O'}

```

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #11216

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
