### PR TITLE
[RLlib] Fix PyTorch A3C / A2C loss function using mixed reduced sum / mean

### DIFF
--- a/rllib/agents/a3c/a3c_torch_policy.py
+++ b/rllib/agents/a3c/a3c_torch_policy.py
@@ -18,11 +18,13 @@ def actor_critic_loss(policy, model, dist_class, train_batch):
     values = model.value_function()
     dist = dist_class(logits, model)
     log_probs = dist.logp(train_batch[SampleBatch.ACTIONS])
-    policy.entropy = dist.entropy().mean()
+    policy.entropy = dist.entropy().sum()
     policy.pi_err = -train_batch[Postprocessing.ADVANTAGES].dot(
         log_probs.reshape(-1))
-    policy.value_err = nn.functional.mse_loss(
-        values.reshape(-1), train_batch[Postprocessing.VALUE_TARGETS])
+    policy.value_err = torch.sum(
+        torch.pow(
+            values.reshape(-1) - train_batch[Postprocessing.VALUE_TARGETS],
+            2.0))
     overall_err = sum([
         policy.pi_err,
         policy.config["vf_loss_coeff"] * policy.value_err,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
<!-- Please give a short summary of the change and the problem this solves. -->

Currently, the PyTorch implementation of A3C / A2C fails to converge (tested on BreakoutNoFrameskip-v4). I've isolated the cause to the loss function which reduces the loss across batches differently for different losses.

```
# rllib/agents/a3c/a3c_torch_policy.py

# Entropy Loss uses Reduce Mean
policy.entropy = dist.entropy().mean()

# Policy Loss uses Reduce Sum
policy.pi_err = -train_batch[Postprocessing.ADVANTAGES].dot(
    log_probs.reshape(-1))

# Value Loss uses Reduce Mean
policy.value_err = nn.functional.mse_loss(
    values.reshape(-1), train_batch[Postprocessing.VALUE_TARGETS])
```

This pull request changes all losses to use reduce sum to match the TensorFlow implementation. Below is the average reward when training A2C on BreakoutNoFrameskip-v4 using hyperparameters from the tuned examples.

- Orange: TensorFlow
- Blue: PyTorch (Unmodified)
- Red: PyTorch (Fixed)

![a2c-breakout-average-reward](https://user-images.githubusercontent.com/17900636/96351660-994b2900-10ef-11eb-8df1-cf141d5f56a2.png)

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
