### PR TITLE
[tune] Update ZOOpt to better support the latest Ray

### DIFF
--- a/python/ray/tune/examples/zoopt_example.py
+++ b/python/ray/tune/examples/zoopt_example.py
@@ -51,14 +51,22 @@ if __name__ == "__main__":
     #     "height": (ValueType.CONTINUOUS, [-10, 10], 1e-2),
     #     # for discrete dimensions: (discrete, search_range, has_order)
     #     "width": (ValueType.DISCRETE, [0, 10], True)
+    #     # for grid dimensions: (grid, grid_list)
+    #     "layers": (ValueType.GRID, [4, 8, 16])
     # }
+
+    zoopt_search_config = {
+        "parallel_num": 8,
+    }
 
     zoopt_search = ZOOptSearch(
         algo="Asracos",  # only support ASRacos currently
         budget=tune_kwargs["num_samples"],
         # dim_dict=space,  # If you want to set the space yourself
         metric="mean_loss",
-        mode="min")
+        mode="min",
+        **zoopt_search_config
+    )
 
     scheduler = AsyncHyperBandScheduler(metric="mean_loss", mode="min")
 
@@ -68,3 +76,4 @@ if __name__ == "__main__":
         name="zoopt_search",
         scheduler=scheduler,
         **tune_kwargs)
+

--- a/python/ray/tune/examples/zoopt_example.py
+++ b/python/ray/tune/examples/zoopt_example.py
@@ -65,8 +65,7 @@ if __name__ == "__main__":
         # dim_dict=space,  # If you want to set the space yourself
         metric="mean_loss",
         mode="min",
-        **zoopt_search_config
-    )
+        **zoopt_search_config)
 
     scheduler = AsyncHyperBandScheduler(metric="mean_loss", mode="min")
 
@@ -76,4 +75,3 @@ if __name__ == "__main__":
         name="zoopt_search",
         scheduler=scheduler,
         **tune_kwargs)
-

--- a/python/ray/tune/suggest/zoopt.py
+++ b/python/ray/tune/suggest/zoopt.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional, Tuple
 import ray
 import ray.cloudpickle as pickle
 from ray.tune.sample import Categorical, Domain, Float, Integer, Quantized, \
-        Uniform
+    Uniform
 from ray.tune.suggest.variant_generator import parse_spec_vars
 from ray.tune.utils.util import unflatten_dict
 from zoopt import ValueType
@@ -124,7 +124,8 @@ class ZOOptSearch(Searcher):
                  metric: Optional[str] = None,
                  mode: Optional[str] = None,
                  **kwargs):
-        assert zoopt is not None, "ZOOpt not found - please install zoopt by `pip install -U zoopt`."
+        assert zoopt is not None, "ZOOpt not found - please install zoopt " \
+                                  "by `pip install -U zoopt`."
         assert budget is not None, "`budget` should not be None!"
         if mode:
             assert mode in ["min", "max"], "`mode` must be 'min' or 'max'."
@@ -150,8 +151,7 @@ class ZOOptSearch(Searcher):
 
         self.kwargs = kwargs
 
-        super(ZOOptSearch, self).__init__(
-            metric=self._metric, mode=mode)
+        super(ZOOptSearch, self).__init__(metric=self._metric, mode=mode)
 
         if self._dim_dict:
             self.setup_zoopt()
@@ -166,7 +166,8 @@ class ZOOptSearch(Searcher):
         par = zoopt.Parameter(budget=self._budget)
         if self._algo == "sracos" or self._algo == "asracos":
             from zoopt.algos.opt_algorithms.racos.sracos import SRacosTune
-            self.optimizer = SRacosTune(dimension=dim, parameter=par, **self.kwargs)
+            self.optimizer = SRacosTune(
+                dimension=dim, parameter=par, **self.kwargs)
 
     def set_search_properties(self, metric: Optional[str], mode: Optional[str],
                               config: Dict) -> bool:
@@ -200,7 +201,7 @@ class ZOOptSearch(Searcher):
 
         if _solution == "FINISHED":
             if ray.__version__ >= "0.8.7":
-                return Searcher.FINISHED  # return Searcher.FINISHED when Ray >= 0.8.7
+                return Searcher.FINISHED
             else:
                 return None
 
@@ -212,8 +213,8 @@ class ZOOptSearch(Searcher):
             return unflatten_dict(new_trial)
 
     def on_trial_complete(self,
-                          trial_id: str,	
-                          result: Optional[Dict] = None,	
+                          trial_id: str,
+                          result: Optional[Dict] = None,
                           error: bool = False):
         """Notification for the completion of trial."""
         if result:
@@ -286,4 +287,3 @@ class ZOOptSearch(Searcher):
         }
 
         return spec
-

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -556,12 +556,12 @@ class SearchSpaceTest(unittest.TestCase):
             "b/z": (ValueType.CONTINUOUS, [-3, 7], 1e-4),
         }
 
-        zoopt_search_config = {
-            "parallel_num": 4
-        }
+        zoopt_search_config = {"parallel_num": 4}
 
-        searcher1 = ZOOptSearch(dim_dict=converted_config, budget=5,  **zoopt_search_config)
-        searcher2 = ZOOptSearch(dim_dict=zoopt_config, budget=5, **zoopt_search_config)
+        searcher1 = ZOOptSearch(
+            dim_dict=converted_config, budget=5, **zoopt_search_config)
+        searcher2 = ZOOptSearch(
+            dim_dict=zoopt_config, budget=5, **zoopt_search_config)
 
         np.random.seed(1234)
         config1 = searcher1.suggest("0")
@@ -574,11 +574,13 @@ class SearchSpaceTest(unittest.TestCase):
         self.assertLess(-3, config1["b"]["z"])
         self.assertLess(config1["b"]["z"], 7)
 
-        searcher = ZOOptSearch(budget=5, metric="a", mode="max", **zoopt_search_config)
+        searcher = ZOOptSearch(
+            budget=5, metric="a", mode="max", **zoopt_search_config)
         analysis = tune.run(
             _mock_objective, config=config, search_alg=searcher, num_samples=1)
         trial = analysis.trials[0]
         self.assertIn(trial.config["b"]["y"], [2, 4, 6, 8])
+
 
 if __name__ == "__main__":
     import pytest

--- a/python/requirements_tune.txt
+++ b/python/requirements_tune.txt
@@ -30,4 +30,4 @@ git+git://github.com/huggingface/transformers.git@bdcc4b78a27775d1ec8f3fd297cb67
 git+git://github.com/ray-project/tune-sklearn@master#tune-sklearn
 wandb
 xgboost
-zoopt>=0.4.0
+zoopt>=0.4.1


### PR DESCRIPTION
## Why are these changes needed?
Add a `parallel_num` argument that allows users to specify the num of workers to parallel in zoopt.
ZOOpt package supports grid type as of v0.4.1.

This PR fixes some known bugs and supports the latest Ray and zoopt.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
