### PR TITLE
[GCS]Fix TestActorTableResubscribe bug

### DIFF
--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -1043,10 +1043,13 @@ TEST_F(ServiceBasedGcsClientTest, TestActorTableResubscribe) {
   // notification of DEAD state.
   WaitForExpectedCount(num_subscribe_all_notifications, 3);
   WaitForExpectedCount(num_subscribe_one_notifications, 3);
-  CheckActorData(subscribe_all_notifications[1], rpc::ActorTableData::DEAD);
-  CheckActorData(subscribe_one_notifications[1], rpc::ActorTableData::DEAD);
-  CheckActorData(subscribe_all_notifications[2], rpc::ActorTableData::DEAD);
-  CheckActorData(subscribe_one_notifications[2], rpc::ActorTableData::DEAD);
+  /// NOTE: GCS will not reply when actor registration fails, so when GCS restarts, gcs
+  /// client will register the actor again. When an actor is registered, the status in GCS
+  /// is `DEPENDENCIES_UNREADY`. When GCS finds that the owner of an actor is nil, it will
+  /// destroy the actor and the status of the actor will change to `DEAD`. The GCS client
+  /// fetch actor info from the GCS server, and the status of the actor may be
+  /// `DEPENDENCIES_UNREADY` or `DEAD`, so we do not assert the actor status here any
+  /// more.
 }
 
 TEST_F(ServiceBasedGcsClientTest, TestObjectTableResubscribe) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
GCS will not reply when actor registration fails, so when GCS restarts, gcs client will register the actor again. When an actor is registered, the status in GCS is `DEPENDENCIES_UNREADY`. When GCS finds that the owner of an actor is nil, it will destroy the actor and the status of the actor will change to `DEAD`. The GCS client fetch actor info from the GCS server, and the status of the actor may be `DEPENDENCIES_UNREADY` or `DEAD`, so we do not assert the actor status here any more.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
