### PR TITLE
[Serve] Get ServeHandle on the same node

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1,5 +1,6 @@
 import atexit
 from functools import wraps
+import random
 
 import ray
 from ray.serve.constants import (DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT,
@@ -7,7 +8,7 @@ from ray.serve.constants import (DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT,
 from ray.serve.controller import ServeController
 from ray.serve.handle import RayServeHandle
 from ray.serve.utils import (block_until_http_ready, format_actor_name,
-                             get_random_letters, logger)
+                             get_random_letters, logger, get_node_id_for_actor)
 from ray.serve.exceptions import RayServeException
 from ray.serve.config import BackendConfig, ReplicaConfig, BackendMetadata
 from ray.actor import ActorHandle
@@ -317,23 +318,38 @@ class Client:
                                                    proportion))
 
     @_ensure_connected
-    def get_handle(self, endpoint_name: str) -> RayServeHandle:
+    def get_handle(self,
+                   endpoint_name: str,
+                   missing_ok: Optional[bool] = False) -> RayServeHandle:
         """Retrieve RayServeHandle for service endpoint to invoke it from Python.
 
         Args:
             endpoint_name (str): A registered service endpoint.
+            missing_ok (bool): If true, then Serve won't check the endpoint is
+                registered. False by default.
 
         Returns:
             RayServeHandle
         """
-        if endpoint_name not in ray.get(
+        if not missing_ok and endpoint_name not in ray.get(
                 self._controller.get_all_endpoints.remote()):
             raise KeyError(f"Endpoint '{endpoint_name}' does not exist.")
 
-        # TODO(edoakes): we should choose the router on the same node.
-        routers = ray.get(self._controller.get_routers.remote())
+        routers = list(ray.get(self._controller.get_routers.remote()).values())
+        current_node_id = ray.get_runtime_context().node_id.hex()
+
+        try:
+            router_chosen = next(
+                filter(lambda r: get_node_id_for_actor(r) == current_node_id,
+                       routers))
+        except StopIteration:
+            logger.warning(
+                f"When getting a handle for {endpoint_name}, Serve can't find "
+                "a router on the same node. Serve will use a random router.")
+            router_chosen = random.choice(routers)
+
         return RayServeHandle(
-            list(routers.values())[0],
+            router_chosen,
             endpoint_name,
         )
 

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -140,17 +140,17 @@ def test_cluster_handle_affinity():
 
     ray.init(head_node.address)
 
-    # Make sure we have two nodes
+    # Make sure we have two nodes.
     node_ids = [n["NodeID"] for n in ray.nodes()]
     assert len(node_ids) == 2
 
-    # Start the backend
+    # Start the backend.
     client = serve.start(http_port=randint(10000, 30000), detached=True)
     client.create_backend("hi:v0", lambda _: "hi")
     client.create_endpoint("hi", backend="hi:v0")
 
     # Try to retrieve the handle from both head and worker node, check the
-    # router's node id
+    # router's node id.
     @ray.remote
     def check_handle_router_id():
         client = serve.connect()

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -135,6 +135,8 @@ def test_middleware():
             "This test can only be ran when port sharing is supported."))
 def test_cluster_handle_affinity():
     cluster = Cluster()
+    # HACK: using two different ip address so the placement constraint for
+    # resource check later will work.
     head_node = cluster.add_node(node_ip_address="127.0.0.1", num_cpus=4)
     cluster.add_node(node_ip_address="0.0.0.0", num_cpus=4)
 

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -302,6 +302,6 @@ def get_all_node_ids():
 
 
 def get_node_id_for_actor(actor_handle):
-    "Given an actor handle, return the node id it's placed on"
+    """Given an actor handle, return the node id it's placed on."""
 
     return ray.actors()[actor_handle._actor_id.hex()]["Address"]["NodeID"]

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -299,3 +299,9 @@ def get_all_node_ids():
             node_ids.append(("{}-{}".format(node_id, index), node_id))
 
     return node_ids
+
+
+def get_node_id_for_actor(actor_handle):
+    "Given an actor handle, return the node id it's placed on"
+
+    return ray.actors()[actor_handle._actor_id.hex()]["Address"]["NodeID"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
@crypdick ran into this issue running Serve on 20+ machines. This PR resolves a tech debt we had in the past. It will now retrieve the router from the same node, if we can't find a node, it will use a random node. This behavior should be better than offloading all requests to a single node.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
