### PR TITLE
[tune] validate function callable in `tune.with_parameters()`

### DIFF
--- a/python/ray/tune/function_runner.py
+++ b/python/ray/tune/function_runner.py
@@ -616,6 +616,12 @@ def with_parameters(fn, **kwargs):
         )
 
     """
+    if not callable(fn):
+        raise ValueError(
+            "`tune.with_parameters()` only works with the function API. "
+            "If you want to pass parameters to Trainable _classes_, consider "
+            "passing them via the `config` parameter.")
+
     prefix = f"{str(fn)}_"
     for k, v in kwargs.items():
         parameter_registry.put(prefix + k, v)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently `tune.with_parameters()` does not validate that the trainable is indeed a callable. This PR fixes that.

## Related issue number

Closes #11047

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
