### PR TITLE
[autoscaler] Fix race condition for up + rsync

### DIFF
--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -262,8 +262,9 @@ class SSHOptions:
             })
         self.arg_dict.update(kwargs)
 
-    def to_ssh_options_list(self, *, timeout=60):
+    def to_ssh_options_list(self, *, timeout=60, attempts=60):
         self.arg_dict["ConnectTimeout"] = "{}s".format(timeout)
+        self.arg_dict["ConnectionAttempts"] = "{}".format(attempts)
         ssh_key_option = ["-i", self.ssh_key] if self.ssh_key else []
         return ssh_key_option + [
             x for y in (["-o", "{}={}".format(k, v)]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This behavior has only been noticed on GCP so far:
If the autoscaler rsync is called immediately after ray up, the worker nodes might be in the process of initializing the ssh daemon (the IP address is already known) and rsync might not work yet, failing with exit code 255. This PR makes it so the rsync is retried for up to 60s.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR was tested manually since we do not have the necessary testing infrastructure to test it 
