### PR TITLE
Try to raise ulimit for file descriptors to max allowed; warn if ulimit is still too low

### DIFF
--- a/python/ray/resource_spec.py
+++ b/python/ray/resource_spec.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 import logging
 import os
 import re
-import resource
 import subprocess
 import sys
 
@@ -151,20 +150,6 @@ class ResourceSpec(
         num_cpus = self.num_cpus
         if num_cpus is None:
             num_cpus = ray.utils.get_num_cpus()
-
-        # Try to increase the file descriptor limit, which is too low by
-        # default for Ray: https://github.com/ray-project/ray/issues/11239
-        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
-        if soft < hard:
-            logger.debug("Automatically increasing RLIMIT_NOFILE to max "
-                         "value of {}".format(hard))
-            resource.setrlimit(resource.RLIMIT_NOFILE, (hard, hard))
-        if hard < 4096:
-            logger.warning(
-                "File descriptor limit {} is too low for production "
-                "servers and may result in connection errors. "
-                "At least 8192 is recommended. --- "
-                "Fix with 'ulimit -n 8192'".format(soft))
 
         num_gpus = self.num_gpus
         gpu_ids = ray.utils.get_cuda_visible_devices()

--- a/python/ray/resource_spec.py
+++ b/python/ray/resource_spec.py
@@ -156,16 +156,15 @@ class ResourceSpec(
         # default for Ray: https://github.com/ray-project/ray/issues/11239
         soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
         if soft < hard:
-            logger.debug(
-                "Automatically increasing RLIMIT_NOFILE to max "
-                "value of {}".format(hard))
+            logger.debug("Automatically increasing RLIMIT_NOFILE to max "
+                         "value of {}".format(hard))
             resource.setrlimit(resource.RLIMIT_NOFILE, (hard, hard))
         if hard < 4096:
             logger.warning(
-                'File descriptor limit {} is too low for production '
-                'servers and may result in connection errors. '
-                'At least 8192 is recommended. --- '
-                'Fix with "ulimit -n 8192"'.format(soft))
+                "File descriptor limit {} is too low for production "
+                "servers and may result in connection errors. "
+                "At least 8192 is recommended. --- "
+                "Fix with 'ulimit -n 8192'".format(soft))
 
         num_gpus = self.num_gpus
         gpu_ids = ray.utils.get_cuda_visible_devices()

--- a/python/ray/resource_spec.py
+++ b/python/ray/resource_spec.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 import logging
 import os
 import re
+import resource
 import subprocess
 import sys
 
@@ -150,6 +151,21 @@ class ResourceSpec(
         num_cpus = self.num_cpus
         if num_cpus is None:
             num_cpus = ray.utils.get_num_cpus()
+
+        # Try to increase the file descriptor limit, which is too low by
+        # default for Ray: https://github.com/ray-project/ray/issues/11239
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        if soft < hard:
+            logger.debug(
+                "Automatically increasing RLIMIT_NOFILE to max "
+                "value of {}".format(hard))
+            resource.setrlimit(resource.RLIMIT_NOFILE, (hard, hard))
+        if hard < 4096:
+            logger.warning(
+                'File descriptor limit {} is too low for production '
+                'servers and may result in connection errors. '
+                'At least 8192 is recommended. --- '
+                'Fix with "ulimit -n 8192"'.format(soft))
 
         num_gpus = self.num_gpus
         gpu_ids = ray.utils.get_cuda_visible_devices()

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import redis
+import resource
 from six.moves import queue
 import sys
 import threading
@@ -621,6 +622,19 @@ def init(
         Exception: An exception is raised if an inappropriate combination of
             arguments is passed in.
     """
+
+    # Try to increase the file descriptor limit, which is too low by
+    # default for Ray: https://github.com/ray-project/ray/issues/11239
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    if soft < hard:
+        logger.debug("Automatically increasing RLIMIT_NOFILE to max "
+                     "value of {}".format(hard))
+        resource.setrlimit(resource.RLIMIT_NOFILE, (hard, hard))
+    if hard < 4096:
+        logger.warning("File descriptor limit {} is too low for production "
+                       "servers and may result in connection errors. "
+                       "At least 8192 is recommended. --- "
+                       "Fix with 'ulimit -n 8192'".format(soft))
 
     if "RAY_ADDRESS" in os.environ:
         if address is None or address == "auto":

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -630,8 +630,12 @@ def init(
         if soft < hard:
             logger.debug("Automatically increasing RLIMIT_NOFILE to max "
                          "value of {}".format(hard))
-            resource.setrlimit(resource.RLIMIT_NOFILE, (hard, hard))
-        if hard < 4096:
+            try:
+                resource.setrlimit(resource.RLIMIT_NOFILE, (hard, hard))
+            except ValueError:
+                logger.debug("Failed to raise limit.")
+        soft, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+        if soft < 4096:
             logger.warning(
                 "File descriptor limit {} is too low for production "
                 "servers and may result in connection errors. "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Since 0.8.7, Ray now uses 2-3x the number of gRPC connections it used to. This can cause issues on systems configured with low soft file descriptor limits. As a short term solution,
- try to raise the soft limit to the max allowed by default
- print a warning if it still is too low

## Related issue number

Closes https://github.com/ray-project/ray/issues/11309

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
