### PR TITLE
[hotfix] Pin node version (fix linux wheel build)

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -290,12 +290,12 @@ build_wheels() {
 
       # This command should be kept in sync with ray/python/README-building-wheels.md,
       # except the "${MOUNT_BAZEL_CACHE[@]}" part.
-      keep_alive suppress_output docker run --rm -w /ray -v "${PWD}":/ray "${MOUNT_BAZEL_CACHE[@]}" \
+      keep_alive docker run --rm -w /ray -v "${PWD}":/ray "${MOUNT_BAZEL_CACHE[@]}" \
         rayproject/arrow_linux_x86_64_base:python-3.8.0 /ray/python/build-wheel-manylinux1.sh
       ;;
     darwin*)
       # This command should be kept in sync with ray/python/README-building-wheels.md.
-      keep_alive suppress_output "${WORKSPACE_DIR}"/python/build-wheel-macos.sh
+      keep_alive "${WORKSPACE_DIR}"/python/build-wheel-macos.sh
       ;;
     msys*)
       keep_alive "${WORKSPACE_DIR}"/python/build-wheel-windows.sh

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -290,12 +290,12 @@ build_wheels() {
 
       # This command should be kept in sync with ray/python/README-building-wheels.md,
       # except the "${MOUNT_BAZEL_CACHE[@]}" part.
-      keep_alive docker run --rm -w /ray -v "${PWD}":/ray "${MOUNT_BAZEL_CACHE[@]}" \
+      suppress_output docker run --rm -w /ray -v "${PWD}":/ray "${MOUNT_BAZEL_CACHE[@]}" \
         rayproject/arrow_linux_x86_64_base:python-3.8.0 /ray/python/build-wheel-manylinux1.sh
       ;;
     darwin*)
       # This command should be kept in sync with ray/python/README-building-wheels.md.
-      keep_alive "${WORKSPACE_DIR}"/python/build-wheel-macos.sh
+      suppress_output "${WORKSPACE_DIR}"/python/build-wheel-macos.sh
       ;;
     msys*)
       keep_alive "${WORKSPACE_DIR}"/python/build-wheel-windows.sh

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -290,12 +290,12 @@ build_wheels() {
 
       # This command should be kept in sync with ray/python/README-building-wheels.md,
       # except the "${MOUNT_BAZEL_CACHE[@]}" part.
-      suppress_output docker run --rm -w /ray -v "${PWD}":/ray "${MOUNT_BAZEL_CACHE[@]}" \
+      keep_alive suppress_output docker run --rm -w /ray -v "${PWD}":/ray "${MOUNT_BAZEL_CACHE[@]}" \
         rayproject/arrow_linux_x86_64_base:python-3.8.0 /ray/python/build-wheel-manylinux1.sh
       ;;
     darwin*)
       # This command should be kept in sync with ray/python/README-building-wheels.md.
-      suppress_output "${WORKSPACE_DIR}"/python/build-wheel-macos.sh
+      keep_alive suppress_output "${WORKSPACE_DIR}"/python/build-wheel-macos.sh
       ;;
     msys*)
       keep_alive "${WORKSPACE_DIR}"/python/build-wheel-windows.sh

--- a/python/build-wheel-manylinux1.sh
+++ b/python/build-wheel-manylinux1.sh
@@ -36,8 +36,10 @@ nvm use node
 
 # Build the dashboard so its static assets can be included in the wheel.
 pushd python/ray/dashboard/client
-  npm ci
-  npm run build
+  echo "Running npm ci"
+  npm ci --verbose
+  echo "Running npm build"
+  npm run build --verbose
 popd
 set -x
 

--- a/python/build-wheel-manylinux1.sh
+++ b/python/build-wheel-manylinux1.sh
@@ -11,6 +11,7 @@ echo 10
 EOF
 chmod +x /usr/bin/nproc
 
+NODE_VERSION="14"
 PYTHONS=("cp36-cp36m"
          "cp37-cp37m"
          "cp38-cp38")
@@ -31,15 +32,13 @@ export PATH=$PATH:/root/bin
 set +x
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
 source "$HOME"/.nvm/nvm.sh
-nvm install node
+nvm install $NODE_VERSION
 nvm use node
 
 # Build the dashboard so its static assets can be included in the wheel.
 pushd python/ray/dashboard/client
-  echo "Running npm ci"
-  npm ci --verbose
-  echo "Running npm build"
-  npm run build --verbose
+  npm ci
+  npm run build
 popd
 set -x
 


### PR DESCRIPTION
Try to fix failing linux wheel builds by adding keep_alive before the command to fetch a docker image that is timing out (I think)

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
