### PR TITLE
[serve] Split out metadata for checkpointing

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -226,7 +226,7 @@ class Client:
                 will be sent to a replica of this backend without receiving a
                 response.
         """
-        if backend_tag in self.list_backends():
+        if backend_tag in self.list_backends().keys():
             raise ValueError(
                 "Cannot create backend. "
                 "Backend '{}' is already registered.".format(backend_tag))
@@ -255,10 +255,10 @@ class Client:
                                                    replica_config))
 
     @_ensure_connected
-    def list_backends(self) -> Dict[str, Dict[str, Any]]:
+    def list_backends(self) -> Dict[str, BackendConfig]:
         """Returns a dictionary of all registered backends.
 
-        Dictionary maps backend tags to backend configs.
+        Dictionary maps backend tags to backend config objects.
         """
         return ray.get(self._controller.get_all_backends.remote())
 

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -85,9 +85,9 @@ class BackendInfo(BaseModel):
 
 @dataclass
 class ConfigurationStore:
-    backends: Dict[BackendTag, BackendInfo]
-    traffic_policies: Dict[EndpointTag, TrafficPolicy]
-    routes: Dict[BackendTag, Tuple[EndpointTag, Any]]
+    backends: Dict[BackendTag, BackendInfo] = field(default_factory=dict)
+    traffic_policies: Dict[EndpointTag, TrafficPolicy] = field(default_factory=dict)
+    routes: Dict[BackendTag, Tuple[EndpointTag, Any]]= field(default_factory=dict)
 
     def __init__(self):
         self.backends = dict()
@@ -95,14 +95,10 @@ class ConfigurationStore:
         self.routes = dict()
 
     def get_backend_configs(self) -> Dict[BackendTag, BackendConfig]:
-        result = {}
-        for tag, info in self.backends.items():
-            config = info.backend_config
-            result[tag] = config
-        return result
+        return {tag: info.backend_config for tag,info in self.backends.items()}
 
     def get_backend(self, backend_tag: BackendTag) -> Optional[BackendInfo]:
-        return self.backends.get(backend_tag, None)
+        return self.backends.get(backend_tag)
 
     def add_backend(self, backend_tag: BackendTag,
                     backend_info: BackendInfo) -> None:
@@ -137,10 +133,7 @@ class ActorStateReconciler:
         return self.routers_cache.values()
 
     def worker_handles(self) -> List[ActorHandle]:
-        lst = []
-        for replica_dict in self.workers.values():
-            lst.extend(replica_dict.values())
-        return lst
+        return list(itertools.chain.from_iterable([replica_dict.values() for replica_dict in self.workers.values()])
 
     def get_replica_actors(self, backend_tag: BackendTag) -> List[ActorHandle]:
         return_list = []

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -709,7 +709,7 @@ class ServeController:
                 ) for router in self.routers.values()
             ])
 
-    # TODO(architkulkarni): add optional type hints after upgrading cloudpickle
+    # TODO(architkulkarni): add Optional[str] for route after upgrading cloudpickle
     async def create_endpoint(self, endpoint: str,
                               traffic_dict: Dict[str, float], route,
                               methods) -> None:

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -440,7 +440,7 @@ class ActorStateReconciler:
         ])
 
         # Start/stop any pending backend replicas.
-        await self._start_pending_replicas(self)
+        await self._start_pending_replicas(controller)
         await self._stop_pending_replicas()
 
         # Remove any pending backends and endpoints.
@@ -580,7 +580,7 @@ class ServeController:
         self.configuration_store = restored_checkpoint.config
 
         # Restore ActorStateReconciler
-        self.actor_reconciler = restored_checkpoint.nursery
+        self.actor_reconciler = restored_checkpoint.reconciler
 
         await self.actor_reconciler._recover_from_checkpoint(
             self.configuration_store, self)

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -855,7 +855,8 @@ class ServeController:
             # or pushing the updated config to avoid inconsistent state if we
             # crash while making the change.
             self._checkpoint()
-            await self.actor_reconciler._start_pending_replicas(self)
+            await self.actor_reconciler._start_pending_replicas(
+                self.configuration_store)
 
             # Set the backend config inside the router
             # (particularly for max-batch-size).
@@ -942,7 +943,8 @@ class ServeController:
                 for router in self.actor_reconciler.router_handles()
             ])
 
-            await self.actor_reconciler._start_pending_replicas(self)
+            await self.actor_reconciler._start_pending_replicas(
+                self.configuration_store)
             await self.actor_reconciler._stop_pending_replicas()
 
             await self.broadcast_backend_config(backend_tag)

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -580,7 +580,7 @@ class ServeController:
         self.configuration_store = restored_checkpoint.config
 
         # Restore ActorStateReconciler
-        self.actor_reconciler = restored_checkpoint.nursery
+        self.actor_reconciler = restored_checkpoint.reconciler
 
         await self.actor_reconciler._recover_from_checkpoint(
             self.configuration_store, self)

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -863,7 +863,7 @@ class ServeController:
         async with self.write_lock:
             # This method must be idempotent. We should validate that the
             # specified backend exists on the client.
-            if self.configuration_store.get_backend(backend_tag) is not None:
+            if self.configuration_store.get_backend(backend_tag) is None:
                 return
 
             # Check that the specified backend isn't used by any endpoints.
@@ -945,8 +945,8 @@ class ServeController:
         backend_config = self.configuration_store.get_backend(
             backend_tag).backend_config
         broadcast_futures = [
-            replica.update_config.remote(backend_config).as_future()
-            for replica in self.actor_reconciler.get_replica_actors()
+            replica.update_config.remote(backend_config).as_future() for
+            replica in self.actor_reconciler.get_replica_actors(backend_tag)
         ]
         await asyncio.gather(*broadcast_futures)
 

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -502,8 +502,8 @@ class ServeController:
                 router_name)
         # Fetch actor handles for all of the backend replicas in the system.
         # All of these workers are guaranteed to already exist because they
-        # would not be written to a checkpoint in self.actor_nursery.workers until they
-        # were created.
+        # would not be written to a checkpoint in self.actor_nursery.workers
+        # until they were created.
         for backend_tag, replica_tags in self.actor_nursery.replicas.items():
             for replica_tag in replica_tags:
                 replica_name = format_actor_name(replica_tag,
@@ -574,8 +574,8 @@ class ServeController:
             await self.do_autoscale()
             async with self.write_lock:
                 self.actor_nursery._start_routers_if_needed(self)
-                checkpoint_required = self.actor_nursery._stop_routers_if_needed(
-                )
+                checkpoint_required = self.actor_nursery.\
+                    _stop_routers_if_needed()
                 if checkpoint_required:
                     self._checkpoint()
 
@@ -855,7 +855,8 @@ class ServeController:
                                      "again.".format(backend_tag, endpoint))
 
             # Scale its replicas down to 0. This will also remove the backend
-            # from self.configuration_store.backends and self.actor_nursery.replicas.
+            # from self.configuration_store.backends and
+            # self.actor_nursery.replicas.
             self.actor_nursery._scale_replicas(
                 self.configuration_store.backends, backend_tag, 0)
 

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -97,7 +97,8 @@ class MetadataInfo:
     ) -> Dict[BackendTag, Union[BackendConfig, Dict[str, Any]]]:
         result = {}
         for tag, info in self.backends.items():
-            result[tag] = info.__dict__ if as_dict else info
+            config = info.backend_config
+            result[tag] = config.__dict__ if as_dict else config
         return result
 
 

--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -27,5 +27,5 @@ def serve_instance(_shared_serve_instance):
     # Clear all state between tests to avoid naming collisions.
     for endpoint in ray.get(controller.get_all_endpoints.remote()):
         _shared_serve_instance.delete_endpoint(endpoint)
-    for backend in ray.get(controller.get_all_backends.remote()):
+    for backend in ray.get(controller.get_all_backends.remote()).keys():
         _shared_serve_instance.delete_backend(backend)

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -567,7 +567,7 @@ def test_list_backends(serve_instance, use_legacy_config):
     backends = client.list_backends()
     assert len(backends) == 1
     assert "backend" in backends
-    assert backends["backend"]["max_batch_size"] == 10
+    assert backends["backend"].max_batch_size == 10
 
     config2 = {
         "num_replicas": 10
@@ -575,7 +575,7 @@ def test_list_backends(serve_instance, use_legacy_config):
     client.create_backend("backend2", f, config=config2)
     backends = client.list_backends()
     assert len(backends) == 2
-    assert backends["backend2"]["num_replicas"] == 10
+    assert backends["backend2"].num_replicas == 10
 
     client.delete_backend("backend")
     backends = client.list_backends()
@@ -751,13 +751,13 @@ def test_connect(serve_instance):
     client.create_endpoint("endpoint", backend="connect_in_backend")
     handle = client.get_handle("endpoint")
     assert ray.get(handle.remote()) == client._controller_name
-    assert "backend-ception" in client.list_backends()
+    assert "backend-ception" in client.list_backends().keys()
 
     client3.create_backend("connect_in_backend", connect_in_backend)
     client3.create_endpoint("endpoint", backend="connect_in_backend")
     handle = client3.get_handle("endpoint")
     assert ray.get(handle.remote()) == client3._controller_name
-    assert "backend-ception" in client3.list_backends()
+    assert "backend-ception" in client3.list_backends().keys()
 
 
 def test_serve_metrics(serve_instance):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR splits out the data stored in the `Controller` by whether it is more 'stored metadata' or 'lifetime management data'

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
