### PR TITLE
[autoscaler] Removed .cleanup() from NodeProvider and commands.py

### DIFF
--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -129,10 +129,6 @@ class NodeProvider:
                         "{}: Terminating node".format(node_id))
             self.terminate_node(node_id)
 
-    def cleanup(self) -> None:
-        """Clean-up when a Provider is no longer required."""
-        pass
-
     @staticmethod
     def bootstrap_config(cluster_config: Dict[str, Any]) -> Dict[str, Any]:
         """Bootstraps the cluster config by adding env defaults if needed."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

As of #11422, `NodeProvider.cleanup()` doesn't do anything.
As a quick follow-up to that PR, I've removed `cleanup` from the `NodeProvider` interface and have removed all calls to `provider.cleanup()` from `autoscaler/_private/commands.py`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
Changes are cosmetic. Existing tests should be sufficient.
