### PR TITLE
[RLlib] SAC Custom Model Fix

### DIFF
--- a/rllib/models/catalog.py
+++ b/rllib/models/catalog.py
@@ -87,6 +87,9 @@ MODEL_DEFAULTS: ModelConfigDict = {
     # Custom preprocessors are deprecated. Please use a wrapper class around
     # your environment instead to preprocess observations.
     "custom_preprocessor": None,
+    # Overrides model interface; Custom model does not inherit from model
+    # interface.
+    "custom_model_override": False,
 }
 # __sphinx_doc_end__
 # yapf: enable
@@ -303,9 +306,11 @@ class ModelCatalog:
                     "`model_cls` must be a ModelV2 sub-class, but is"
                     " {}!".format(model_cls))
 
-            logger.info("Wrapping {} as {}".format(model_cls, model_interface))
-            model_cls = ModelCatalog._wrap_if_needed(model_cls,
-                                                     model_interface)
+            if not model_config.get("custom_model_override"):
+                logger.info("Wrapping {} as {}".format(model_cls,
+                                                       model_interface))
+                model_cls = ModelCatalog._wrap_if_needed(
+                    model_cls, model_interface)
 
             if framework in ["tf2", "tf", "tfe"]:
                 # Track and warn if vars were created but not registered.


### PR DESCRIPTION
There was originally a bug where custom models calls the forward method of the `model_interface` argument in `get_model_v2` in `catalog.py`. This can be fixed by adding an option that allows the model to not inherit the `model_interface`, since in SAC, the `model_interface` is hardcoded to `SACTFModel`.


## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
