### PR TITLE
[docs] Changing the documentation to reference _temp_dir.

### DIFF
--- a/doc/source/configure.rst
+++ b/doc/source/configure.rst
@@ -78,10 +78,9 @@ For each session, Ray will place all its temporary files under the
 so the default session directory is ``/tmp/ray/{ray_session_name}``.
 You can sort by their names to find the latest session.
 
-Change the *root temporary directory* in one of these ways:
+Change the *root temporary directory* by passing ``--temp-dir={your temp path}`` to ``ray start``.
 
-* Pass ``--temp-dir={your temp path}`` to ``ray start``
-* Specify ``temp_dir`` when call ``ray.init()``
+(There is not currently a stable way to change the root temporary directory when calling ``ray.init()``, but if you need to, you can provide the ``_temp_dir`` argument to ``ray.init()``.)
 
 You can also use ``default_worker.py --temp-dir={your temp path}`` to
 start a new worker with the given *root temporary directory*.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
@sumanthratna is this what you had in mind?
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
doc/source/configure.rst references a keyword argument that no longer exists. See https://github.com/ray-project/ray/blob/master/python/ray/worker.py#L499.
## Related issue number

<!-- For example: "Closes #1234" -->
Closes #11556.
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
