### PR TITLE
[serve] Make fractional resource usage more obvious in docs

### DIFF
--- a/doc/source/serve/advanced.rst
+++ b/doc/source/serve/advanced.rst
@@ -50,13 +50,14 @@ Fractional Resources
 
 The resources specified in ``ray_actor_options`` can also be *fractional*.
 This allows you to flexibly share resources between workers.
-For example, if you have two models and each doesn't fully saturate a GPU, you might want to have them share a GPU by allocating 0.5 GPUs each:
+For example, if you have two models and each doesn't fully saturate a GPU, you might want to have them share a GPU by allocating 0.5 GPUs each.
+The same could be done to multiplex over CPUs.
 
 .. code-block:: python
 
   half_gpu_config = {"num_gpus": 0.5}
-  client.create_backend("my_gpu_backend_1", handle_request, ray_actor_options=config)
-  client.create_backend("my_gpu_backend_2", handle_request, ray_actor_options=config)
+  client.create_backend("my_gpu_backend_1", handle_request, ray_actor_options=half_gpu_config)
+  client.create_backend("my_gpu_backend_2", handle_request, ray_actor_options=half_gpu_config)
 
 Configuring Parallelism with OMP_NUM_THREADS
 --------------------------------------------

--- a/doc/source/serve/advanced.rst
+++ b/doc/source/serve/advanced.rst
@@ -33,8 +33,9 @@ Using Resources (CPUs, GPUs)
 ============================
 
 To assign hardware resources per worker, you can pass resource requirements to
-``ray_actor_options``. To learn about options to pass in, take a look at
-:ref:`Resources with Actor<actor-resource-guide>` guide.
+``ray_actor_options``.
+By default, each worker requires one CPU.
+To learn about options to pass in, take a look at :ref:`Resources with Actor<actor-resource-guide>` guide.
 
 For example, to create a backend where each replica uses a single GPU, you can do the
 following:
@@ -43,6 +44,19 @@ following:
 
   config = {"num_gpus": 1}
   client.create_backend("my_gpu_backend", handle_request, ray_actor_options=config)
+
+Fractional Resources
+--------------------
+
+The resources specified in ``ray_actor_options`` can also be *fractional*.
+This allows you to flexibly share resources between workers.
+For example, if you have two models and each doesn't fully saturate a GPU, you might want to have them share a GPU by allocating 0.5 GPUs each:
+
+.. code-block:: python
+
+  half_gpu_config = {"num_gpus": 0.5}
+  client.create_backend("my_gpu_backend_1", handle_request, ray_actor_options=config)
+  client.create_backend("my_gpu_backend_2", handle_request, ray_actor_options=config)
 
 Configuring Parallelism with OMP_NUM_THREADS
 --------------------------------------------


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Users aren't clear on how they can split resources across backend replicas.

## Related issue number

Closes https://github.com/ray-project/ray/issues/11574

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
