### PR TITLE
[dask-on-ray] Convert tuple of object refs to list before ray.get() call.

### DIFF
--- a/python/ray/tests/test_dask_scheduler.py
+++ b/python/ray/tests/test_dask_scheduler.py
@@ -1,4 +1,6 @@
 import dask
+import numpy as np
+import dask.array as da
 import pytest
 
 import ray
@@ -30,6 +32,13 @@ def test_ray_dask_basic(ray_start_regular_shared):
     assert ans == "The answer is 6", ans
 
 
+def test_ray_dask_persist(ray_start_regular_shared):
+    arr = da.ones(5) + 2
+    result = arr.persist(scheduler=ray_dask_get)
+    np.testing.assert_array_equal(result.dask.values()[0], np.ones(5) + 2)
+
+
 if __name__ == "__main__":
     import sys
+
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/util/dask/scheduler.py
+++ b/python/ray/util/dask/scheduler.py
@@ -346,9 +346,11 @@ def ray_get_unpack(object_refs):
         The input Python object with all contained Ray object references
         resolved with their concrete values.
     """
-    if isinstance(object_refs,
-                  (tuple, list)) and any(not isinstance(x, ray.ObjectRef)
-                                         for x in object_refs):
+    if isinstance(object_refs, tuple):
+        object_refs = list(object_refs)
+
+    if isinstance(object_refs, list) and any(not isinstance(x, ray.ObjectRef)
+                                             for x in object_refs):
         # We flatten the object references before calling ray.get(), since Dask
         # loves to nest collections in nested tuples and Ray expects a flat
         # list of object references. We repack the results after ray.get()


### PR DESCRIPTION
In the Dask-on-Ray scheduler, before calling `ray.get()` on the sink object references, we need to convert any tuples of object refs that may arise to lists of object refs, since `ray.get()` [doesn't like tuples](https://github.com/ray-project/ray/blob/e7aa6441b78e5fb3bbf8a08226048ed89cc38f4c/python/ray/worker.py#L1460-L1462).

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #11558

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
