### PR TITLE
[tune] fixed validation for search metrics

### DIFF
--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -821,7 +821,9 @@ class TrialRunner:
                     search_metric not in result
                     for search_metric in search_metrics
             ]):
-                report_metric = search_metrics
+                report_metric = list(
+                    filter(lambda search_metric: search_metric not in result,
+                           search_metrics))
                 location = type(self._search_alg).__name__
             else:
                 report_metric = None
@@ -830,7 +832,7 @@ class TrialRunner:
             if report_metric:
                 raise ValueError(
                     "Trial returned a result which did not include the "
-                    "specified metric `{}` that `{}` expects. "
+                    "specified metric(s) `{}` that `{}` expects. "
                     "Make sure your calls to `tune.report()` include the "
                     "metric, or set the "
                     "TUNE_DISABLE_STRICT_METRIC_CHECKING "

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -817,7 +817,10 @@ class TrialRunner:
             elif scheduler_metric and scheduler_metric not in result:
                 report_metric = scheduler_metric
                 location = type(self._scheduler_alg).__name__
-            elif search_metrics and any([search_metric not in result for search_metric in search_metrics]):
+            elif search_metrics and any([
+                    search_metric not in result
+                    for search_metric in search_metrics
+            ]):
                 report_metric = search_metrics
                 location = type(self._search_alg).__name__
             else:

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -824,6 +824,8 @@ class TrialRunner:
                 report_metric = list(
                     filter(lambda search_metric: search_metric not in result,
                            search_metrics))
+                if len(report_metric) == 1:
+                    report_metric = report_metric[0]
                 location = type(self._search_alg).__name__
             else:
                 report_metric = None

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -807,7 +807,9 @@ class TrialRunner:
                                             or "done" not in result):
             base_metric = self._metric
             scheduler_metric = self._scheduler_alg.metric
-            search_metric = self._search_alg.metric
+            search_metrics = self._search_alg.metric
+            if isinstance(search_metrics, str):
+                search_metrics = [search_metrics]
 
             if base_metric and base_metric not in result:
                 report_metric = base_metric
@@ -815,8 +817,8 @@ class TrialRunner:
             elif scheduler_metric and scheduler_metric not in result:
                 report_metric = scheduler_metric
                 location = type(self._scheduler_alg).__name__
-            elif search_metric and search_metric not in result:
-                report_metric = search_metric
+            elif search_metrics and any([search_metric not in result for search_metric in search_metrics]):
+                report_metric = search_metrics
                 location = type(self._search_alg).__name__
             else:
                 report_metric = None

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -817,10 +817,8 @@ class TrialRunner:
             elif scheduler_metric and scheduler_metric not in result:
                 report_metric = scheduler_metric
                 location = type(self._scheduler_alg).__name__
-            elif search_metrics and any([
-                    search_metric not in result
-                    for search_metric in search_metrics
-            ]):
+            elif search_metrics and any(search_metric not in result
+                                        for search_metric in search_metrics):
                 report_metric = list(
                     filter(lambda search_metric: search_metric not in result,
                            search_metrics))


### PR DESCRIPTION
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Since advanced search algorithms allow for multiple search metrics we should accommodate for that. Unfortunately, validate result currently only assumes that the search algorithm metric is a string; however, if using sigopt it will be a list. This change was introduced recently and broke some of our stuff, I know that the test is hard to run since you guys might not have the API keys for sigopt... 

https://github.com/ray-project/ray/issues/11581


<!-- Please give a short summary of the change and the problem this solves. -->

https://github.com/ray-project/ray/issues/11581


- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at 
