### PR TITLE
Remove outdated serializer for python <= 3.5

### DIFF
--- a/python/ray/cloudpickle/cloudpickle_fast.py
+++ b/python/ray/cloudpickle/cloudpickle_fast.py
@@ -439,51 +439,6 @@ def _class_setstate(obj, state):
     return obj
 
 
-def _numpy_frombuffer(buffer, dtype, shape, order):
-    # Get the _frombuffer() function for reconstruction
-    from numpy.core.numeric import _frombuffer
-    array = _frombuffer(buffer, dtype, shape, order)
-    # Unfortunately, numpy does not follow the standard, so we still
-    # have to set the readonly flag for it here.
-    array.setflags(write=isinstance(buffer, bytearray) or not buffer.readonly)
-    return array
-
-
-def _numpy_ndarray_reduce(array):
-    # This function is implemented according to 'array_reduce_ex_picklebuffer'
-    # in numpy C backend. This is a workaround for python3.5 pickling support.
-    if sys.version_info >= (3, 8):
-        import pickle
-        picklebuf_class = pickle.PickleBuffer
-    elif sys.version_info >= (3, 5):
-        try:
-            import pickle5
-            picklebuf_class = pickle5.PickleBuffer
-        except Exception:
-            raise ImportError("Using pickle protocol 5 requires the pickle5 "
-                              "module for Python >=3.5 and <3.8")
-    else:
-        raise ValueError("pickle protocol 5 is not available for Python < 3.5")
-    # if the array if Fortran-contiguous and not C-contiguous,
-    # the PickleBuffer instance will hold a view on the transpose
-    # of the initial array, that is C-contiguous.
-    if not array.flags.c_contiguous and array.flags.f_contiguous:
-        order = "F"
-        picklebuf_args = array.transpose()
-    else:
-        order = "C"
-        picklebuf_args = array
-    try:
-        buffer = picklebuf_class(picklebuf_args)
-    except Exception:
-        # Some arrays may refuse to export a buffer, in which case
-        # just fall back on regular __reduce_ex__ implementation
-        # (gh-12745).
-        return array.__reduce__()
-
-    return _numpy_frombuffer, (buffer, array.dtype, array.shape, order)
-
-
 class CloudPickler(Pickler):
     """Fast C Pickler extension with additional reducing routines.
 
@@ -564,16 +519,6 @@ class CloudPickler(Pickler):
           for other types that suffered from type-specific reducers, such as
           Exceptions. See https://github.com/cloudpipe/cloudpickle/issues/248
         """
-
-        # This is a patch for python3.5
-        if isinstance(obj, numpy.ndarray):
-            if (self.proto < 5 or
-                    (not obj.flags.c_contiguous and not obj.flags.f_contiguous) or
-                    (issubclass(type(obj), numpy.ndarray) and type(obj) is not numpy.ndarray) or
-                    obj.dtype == "O" or obj.itemsize == 0):
-                return NotImplemented
-            return _numpy_ndarray_reduce(obj)
-
         t = type(obj)
         try:
             is_anyclass = issubclass(t, type)

--- a/python/ray/includes/serialization.pxi
+++ b/python/ray/includes/serialization.pxi
@@ -1,6 +1,5 @@
 from libc.string cimport memcpy
 from libc.stdint cimport uintptr_t, uint64_t, INT32_MAX
-from libcpp cimport nullptr
 import cython
 
 DEF MEMCOPY_THREADS = 6
@@ -116,6 +115,9 @@ cdef class SubBuffer:
             <const char*> self.buf, self.len)
 
     def __getbuffer__(self, Py_buffer* buffer, int flags):
+        if flags & cpython.PyBUF_WRITABLE:
+            # Ray ensures all buffers are immutable.
+            raise BufferError
         buffer.readonly = self.readonly
         buffer.buf = self.buf
         buffer.format = <char *>self._format.c_str()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Cleanup legacy serialization code. This helps us upgrade cloudpickle later.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
