### PR TITLE
Bump flake8 to fix the AttributeError: 'QuoteChecker' on py3.8

### DIFF
--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -114,7 +114,7 @@ GIT_LS_EXCLUDES=(
 # of these arguments to this location, but the long-term answer is to actually
 # make a flake8 config file
 FLAKE8_EXCLUDE="--exclude=python/ray/core/generated/,streaming/python/generated,doc/source/conf.py,python/ray/cloudpickle/,python/ray/thirdparty_files/,python/build/,python/.eggs/"
-FLAKE8_IGNORES="--ignore=C408,E121,E123,E126,E226,E24,E704,W503,W504,W605"
+FLAKE8_IGNORES="--ignore=C408,E121,E123,E126,E226,E24,E704,E741,W503,W504,W605"
 FLAKE8_PYX_IGNORES="--ignore=C408,E121,E123,E126,E211,E225,E226,E227,E24,E704,E999,W503,W504,W605"
 
 shellcheck_scripts() {

--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -5,7 +5,7 @@
 # Cause the script to exit if a single command fails
 set -euo pipefail
 
-FLAKE8_VERSION_REQUIRED="3.7.7"
+FLAKE8_VERSION_REQUIRED="3.8.4"
 YAPF_VERSION_REQUIRED="0.23.0"
 SHELLCHECK_VERSION_REQUIRED="0.7.1"
 MYPY_VERSION_REQUIRED="0.782"

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -62,39 +62,29 @@ if os.path.exists(so_path):
 
 import ray._raylet  # noqa: E402
 
-from ray._raylet import (
-    ActorCheckpointID,
-    ActorClassID,
-    ActorID,
-    NodeID,
-    Config as _Config,
-    JobID,
-    WorkerID,
-    FunctionID,
-    ObjectID,
-    ObjectRef,
-    TaskID,
-    UniqueID,
-    Language,
+from ray._raylet import (  # noqa: E402
+    ActorCheckpointID, ActorClassID, ActorID, NodeID, Config as _Config, JobID,
+    WorkerID, FunctionID, ObjectID, ObjectRef, TaskID, UniqueID, Language,
     PlacementGroupID,
-)  # noqa: E402
+)
 
 _config = _Config()
 
 from ray.profiling import profile  # noqa: E402
-from ray.state import (jobs, nodes, actors, objects, timeline,
-                       object_transfer_timeline, cluster_resources,
-                       available_resources)  # noqa: E402
-from ray.worker import (  # noqa: F401
+from ray.state import (  # noqa: E402
+    jobs, nodes, actors, objects, timeline, object_transfer_timeline,
+    cluster_resources, available_resources,
+)
+from ray.worker import (  # noqa: F401,E402
     LOCAL_MODE, SCRIPT_MODE, WORKER_MODE, IO_WORKER_MODE, cancel, connect,
     disconnect, get, get_actor, get_gpu_ids, get_resource_ids,
     get_dashboard_url, init, is_initialized, put, kill, remote, shutdown,
     show_in_dashboard, wait,
-)  # noqa: E402
+)
 import ray.internal  # noqa: E402
 # We import ray.actor because some code is run in actor.py which initializes
 # some functions in the worker.
-import ray.actor  # noqa: F401
+import ray.actor  # noqa: F401,E402
 from ray.actor import method  # noqa: E402
 from ray.cross_language import java_function, java_actor_class  # noqa: E402
 from ray.runtime_context import get_runtime_context  # noqa: E402

--- a/python/ray/serve/http_proxy.py
+++ b/python/ray/serve/http_proxy.py
@@ -2,6 +2,7 @@ import asyncio
 import socket
 from typing import List
 
+import starlette.middleware
 import uvicorn
 
 import ray
@@ -133,7 +134,7 @@ class HTTPProxyActor:
             host,
             port,
             controller_name,
-            http_middlewares: List["starlette.middleware.Middleware"] = []):
+            http_middlewares: List[starlette.middleware.Middleware] = []):
         self.app = HTTPProxy()
         self.host = host
         self.port = port

--- a/python/ray/tests/test_command_runner.py
+++ b/python/ray/tests/test_command_runner.py
@@ -259,7 +259,7 @@ def test_docker_rsync():
     process_runner.assert_not_has_call(
         "1.2.3.4", pattern=f"mkdir -p {remote_mount}")
     # No docker cp for file_mounts
-    process_runner.assert_not_has_call("1.2.3.4", pattern=f"docker cp")
+    process_runner.assert_not_has_call("1.2.3.4", pattern="docker cp")
     process_runner.assert_has_call(
         "1.2.3.4",
         pattern=f"-avz {local_mount} ray@1.2.3.4:{remote_host_mount}")
@@ -276,7 +276,7 @@ def test_docker_rsync():
     process_runner.assert_not_has_call(
         "1.2.3.4", pattern=f"mkdir -p {remote_file}")
 
-    process_runner.assert_has_call("1.2.3.4", pattern=f"docker cp")
+    process_runner.assert_has_call("1.2.3.4", pattern="docker cp")
     process_runner.assert_has_call(
         "1.2.3.4", pattern=f"-avz {local_file} ray@1.2.3.4:{remote_host_file}")
     process_runner.clear_history()
@@ -285,7 +285,7 @@ def test_docker_rsync():
     cmd_runner.run_rsync_down(
         remote_mount, local_mount, options={"docker_mount_if_possible": True})
 
-    process_runner.assert_not_has_call("1.2.3.4", pattern=f"docker cp")
+    process_runner.assert_not_has_call("1.2.3.4", pattern="docker cp")
     process_runner.assert_not_has_call(
         "1.2.3.4", pattern=f"-avz ray@1.2.3.4:{remote_mount} {local_mount}")
     process_runner.assert_has_call(
@@ -298,7 +298,7 @@ def test_docker_rsync():
     cmd_runner.run_rsync_down(
         remote_file, local_file, options={"docker_mount_if_possible": False})
 
-    process_runner.assert_has_call("1.2.3.4", pattern=f"docker cp")
+    process_runner.assert_has_call("1.2.3.4", pattern="docker cp")
     process_runner.assert_not_has_call(
         "1.2.3.4", pattern=f"-avz ray@1.2.3.4:{remote_file} {local_file}")
     process_runner.assert_has_call(
@@ -335,7 +335,7 @@ def test_rsync_exclude_and_filter():
         })
 
     process_runner.assert_has_call(
-        "1.2.3.4", pattern=f"--exclude test --filter dir-merge,- .ignore")
+        "1.2.3.4", pattern="--exclude test --filter dir-merge,- .ignore")
 
 
 def test_rsync_without_exclude_and_filter():
@@ -365,9 +365,9 @@ def test_rsync_without_exclude_and_filter():
             "docker_mount_if_possible": True,
         })
 
-    process_runner.assert_not_has_call("1.2.3.4", pattern=f"--exclude test")
+    process_runner.assert_not_has_call("1.2.3.4", pattern="--exclude test")
     process_runner.assert_not_has_call(
-        "1.2.3.4", pattern=f"--filter dir-merge,- .ignore")
+        "1.2.3.4", pattern="--filter dir-merge,- .ignore")
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -367,6 +367,7 @@ def test_remove_pending_placement_group(ray_start_cluster):
     # Create a placement group that cannot be scheduled now.
     placement_group = ray.util.placement_group([{"GPU": 2}, {"CPU": 2}])
     ray.util.remove_placement_group(placement_group)
+
     # TODO(sang): Add state check here.
     @ray.remote(num_cpus=4)
     def f():

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -301,8 +301,8 @@ class Trial:
         if trial_dirname_creator:
             self.custom_dirname = trial_dirname_creator(self)
             if os.path.sep in self.custom_dirname:
-                raise ValueError(f"Trial dirname must not contain '/'. "
-                                 "Got {self.custom_dirname}")
+                raise ValueError("Trial dirname must not contain '/'. "
+                                 f"Got {self.custom_dirname}")
 
     @property
     def node_ip(self):

--- a/python/ray/util/iter.py
+++ b/python/ray/util/iter.py
@@ -1122,8 +1122,8 @@ class ParallelIteratorWorker(object):
                     it = iter(make_iterator())
                     if it is item_generator:
                         raise ValueError(
-                            "Cannot iterate over {} multiple times." +
-                            "Please pass in the base iterable or" +
+                            "Cannot iterate over {} multiple times."
+                            "Please pass in the base iterable or"
                             "lambda: {} instead.".format(
                                 item_generator, item_generator))
                     for item in it:

--- a/python/ray/util/sgd/torch/worker_group.py
+++ b/python/ray/util/sgd/torch/worker_group.py
@@ -206,7 +206,7 @@ class RemoteWorkerGroup(WorkerGroupInterface):
         return futures
 
     def start_workers(self, num_workers):
-        logger.debug(f"start_workers: Setting %d workers." % num_workers)
+        logger.debug("start_workers: Setting %d workers.", num_workers)
         if num_workers == 1:
             RemoteRunner = ray.remote(
                 num_cpus=self._num_cpus_per_worker,
@@ -436,7 +436,7 @@ class LocalWorkerGroup(WorkerGroupInterface):
             use_gpu=use_gpu)
 
     def start_workers(self, num_workers):
-        logger.debug(f"start_workers: Setting %d workers." % num_workers)
+        logger.debug("start_workers: Setting %d workers.", num_workers)
 
         if num_workers == 1:
             self.local_worker = TorchRunner(**self._params)

--- a/python/requirements_linters.txt
+++ b/python/requirements_linters.txt
@@ -1,5 +1,5 @@
-flake8==3.7.7 
+flake8==3.8.4
 flake8-comprehensions
-flake8-quotes==2.0.0
+flake8-quotes==3.2.0
 mypy==0.782
 yapf==0.23.0

--- a/release/stress_tests/workloads/test_many_tasks.py
+++ b/release/stress_tests/workloads/test_many_tasks.py
@@ -120,7 +120,7 @@ logger.info("Finished stage 3 in %s seconds.", stage_3_time)
 # requests, we will run into head of line blocking and we should be able to
 # measure this timing.
 num_tasks = int(ray.cluster_resources()["GPU"])
-logger.info(f"Scheduling many tasks for spillback.")
+logger.info("Scheduling many tasks for spillback.")
 
 
 @ray.remote(num_gpus=1)

--- a/rllib/agents/dqn/apex.py
+++ b/rllib/agents/dqn/apex.py
@@ -17,6 +17,7 @@ import copy
 from typing import Tuple
 
 import ray
+from ray.actor import ActorHandle
 from ray.rllib.agents.dqn.dqn import DEFAULT_CONFIG as DQN_CONFIG
 from ray.rllib.agents.dqn.dqn import DQNTrainer, calculate_rr_weights
 from ray.rllib.agents.dqn.learner_thread import LearnerThread
@@ -77,7 +78,7 @@ class UpdateWorkerWeights:
         self.max_weight_sync_delay = max_weight_sync_delay
         self.weights = None
 
-    def __call__(self, item: Tuple["ActorHandle", SampleBatchType]):
+    def __call__(self, item: Tuple[ActorHandle, SampleBatchType]):
         actor, batch = item
         self.steps_since_update[actor] += batch.count
         if self.steps_since_update[actor] >= self.max_weight_sync_delay:
@@ -115,7 +116,7 @@ def apex_execution_plan(workers: WorkerSet,
     learner_thread.start()
 
     # Update experience priorities post learning.
-    def update_prio_and_stats(item: Tuple["ActorHandle", dict, int]) -> None:
+    def update_prio_and_stats(item: Tuple[ActorHandle, dict, int]) -> None:
         actor, prio_dict, count = item
         actor.update_priorities.remote(prio_dict)
         metrics = _get_shared_metrics()

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -10,6 +10,7 @@ import tempfile
 from typing import Callable, Dict, List, Optional, Type, Union
 
 import ray
+from ray.actor import ActorHandle
 from ray.exceptions import RayError
 from ray.rllib.agents.callbacks import DefaultCallbacks
 from ray.rllib.env.normalize_actions import NormalizeActionWrapper
@@ -1006,7 +1007,7 @@ class Trainer(Trainable):
 
     @DeveloperAPI
     def collect_metrics(self,
-                        selected_workers: List["ActorHandle"] = None) -> dict:
+                        selected_workers: List[ActorHandle] = None) -> dict:
         """Collects metrics from the remote workers of this agent.
 
         This is the same data as returned by a call to train().

--- a/rllib/env/group_agents_wrapper.py
+++ b/rllib/env/group_agents_wrapper.py
@@ -34,7 +34,7 @@ class _GroupAgentsWrapper(MultiAgentEnv):
             for agent_id in agent_ids:
                 if agent_id in self.agent_id_to_group:
                     raise ValueError(
-                        "Agent id {} is in multiple groups".format(
+                        "Agent id {} is in multiple groups: {}".format(
                             agent_id, groups))
                 self.agent_id_to_group[agent_id] = group_id
         if obs_space is not None:

--- a/rllib/evaluation/metrics.py
+++ b/rllib/evaluation/metrics.py
@@ -4,7 +4,9 @@ import collections
 from typing import List, Optional, Tuple, Union
 
 import ray
+from ray.actor import ActorHandle
 from ray.rllib.evaluation.rollout_metrics import RolloutMetrics
+from ray.rllib.evaluation.rollout_worker import RolloutWorker
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
 from ray.rllib.offline.off_policy_estimator import OffPolicyEstimate
 from ray.rllib.policy.policy import LEARNER_STATS_KEY
@@ -38,9 +40,9 @@ def get_learner_stats(grad_info: GradInfoDict) -> LearnerStatsDict:
 
 
 @DeveloperAPI
-def collect_metrics(local_worker: Optional["RolloutWorker"] = None,
-                    remote_workers: List["ActorHandle"] = [],
-                    to_be_collected: List["ObjectRef"] = [],
+def collect_metrics(local_worker: Optional[RolloutWorker] = None,
+                    remote_workers: List[ActorHandle] = [],
+                    to_be_collected: List[ray.ObjectRef] = [],
                     timeout_seconds: int = 180) -> ResultDict:
     """Gathers episode metrics from RolloutWorker instances."""
 
@@ -55,11 +57,11 @@ def collect_metrics(local_worker: Optional["RolloutWorker"] = None,
 
 @DeveloperAPI
 def collect_episodes(
-        local_worker: Optional["RolloutWorker"] = None,
-        remote_workers: List["ActorHandle"] = [],
-        to_be_collected: List["ObjectRef"] = [],
-        timeout_seconds: int = 180
-) -> Tuple[List[Union[RolloutMetrics, OffPolicyEstimate]], List["ObjectRef"]]:
+        local_worker: Optional[RolloutWorker] = None,
+        remote_workers: List[ActorHandle] = [],
+        to_be_collected: List[ray.ObjectRef] = [],
+        timeout_seconds: int = 180) -> Tuple[List[Union[
+            RolloutMetrics, OffPolicyEstimate]], List[ray.ObjectRef]]:
     """Gathers new episodes metrics tuples from the given evaluators."""
 
     if remote_workers:

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -9,6 +9,7 @@ from typing import Callable, Any, List, Dict, Tuple, Union, Optional, \
     TYPE_CHECKING, Type, TypeVar
 
 import ray
+from ray.rllib.agents.callbacks import DefaultCallbacks
 from ray.rllib.env.atari_wrappers import wrap_deepmind, is_atari
 from ray.rllib.env.base_env import BaseEnv
 from ray.rllib.env.env_context import EnvContext
@@ -161,7 +162,7 @@ class RolloutWorker(ParallelIteratorWorker):
             monitor_path: str = None,
             log_dir: str = None,
             log_level: str = None,
-            callbacks: Type["DefaultCallbacks"] = None,
+            callbacks: Type[DefaultCallbacks] = None,
             input_creator: Callable[[
                 IOContext
             ], InputReader] = lambda ioctx: ioctx.default_sampler_input(),
@@ -337,10 +338,9 @@ class RolloutWorker(ParallelIteratorWorker):
         self.env_context = env_context
         self.policy_config: TrainerConfigDict = policy_config
         if callbacks:
-            self.callbacks: "DefaultCallbacks" = callbacks()
+            self.callbacks: DefaultCallbacks = callbacks()
         else:
-            from ray.rllib.agents.callbacks import DefaultCallbacks
-            self.callbacks: "DefaultCallbacks" = DefaultCallbacks()
+            self.callbacks: DefaultCallbacks = DefaultCallbacks()
         self.worker_index: int = worker_index
         self.num_workers: int = num_workers
         model_config: ModelConfigDict = model_config or {}

--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -423,7 +423,7 @@ def _env_runner(
         clip_actions: bool,
         multiple_episodes_in_batch: bool,
         callbacks: "DefaultCallbacks",
-        tf_sess: Optional["tf.Session"],
+        tf_sess: Optional["tf.Session"],  # noqa: F821
         perf_stats: _PerfStats,
         soft_horizon: bool,
         no_done_at_end: bool,

--- a/rllib/evaluation/worker_set.py
+++ b/rllib/evaluation/worker_set.py
@@ -4,6 +4,7 @@ from types import FunctionType
 from typing import Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 import ray
+from ray.actor import ActorHandle
 from ray.rllib.utils.annotations import DeveloperAPI
 from ray.rllib.evaluation.rollout_worker import RolloutWorker, \
     _validate_multiagent_config
@@ -99,7 +100,7 @@ class WorkerSet:
         """Return the local rollout worker."""
         return self._local_worker
 
-    def remote_workers(self) -> List["ActorHandle"]:
+    def remote_workers(self) -> List[ActorHandle]:
         """Return a list of remote rollout workers."""
         return self._remote_workers
 
@@ -138,7 +139,7 @@ class WorkerSet:
                 config=self._remote_config) for i in range(num_workers)
         ])
 
-    def reset(self, new_remote_workers: List["ActorHandle"]) -> None:
+    def reset(self, new_remote_workers: List[ActorHandle]) -> None:
         """Called to change the set of remote workers."""
         self._remote_workers = new_remote_workers
 
@@ -226,7 +227,7 @@ class WorkerSet:
 
     @staticmethod
     def _from_existing(local_worker: RolloutWorker,
-                       remote_workers: List["ActorHandle"] = None):
+                       remote_workers: List[ActorHandle] = None):
         workers = WorkerSet(
             env_creator=None,
             policy_class=None,
@@ -248,7 +249,7 @@ class WorkerSet:
             config: TrainerConfigDict,
             spaces: Optional[Dict[PolicyID, Tuple[gym.spaces.Space,
                                                   gym.spaces.Space]]] = None,
-    ) -> Union[RolloutWorker, "ActorHandle"]:
+    ) -> Union[RolloutWorker, ActorHandle]:
         def session_creator():
             logger.debug("Creating TF session {}".format(
                 config["tf_session_args"]))

--- a/rllib/examples/env/windy_maze_env.py
+++ b/rllib/examples/env/windy_maze_env.py
@@ -99,7 +99,7 @@ class HierarchicalWindyMazeEnv(MultiAgentEnv):
             return self._low_level_step(list(action_dict.values())[0])
 
     def _high_level_step(self, action):
-        logger.debug("High level agent sets goal".format(action))
+        logger.debug("High level agent sets goal: %s", action)
         self.current_goal = action
         self.steps_remaining_at_level = 25
         self.num_high_level_steps += 1

--- a/rllib/execution/metric_ops.py
+++ b/rllib/execution/metric_ops.py
@@ -1,6 +1,7 @@
 from typing import Any, List
 import time
 
+from ray.actor import ActorHandle
 from ray.util.iter import LocalIterator
 from ray.rllib.evaluation.metrics import collect_episodes, summarize_episodes
 from ray.rllib.execution.common import STEPS_SAMPLED_COUNTER, \
@@ -12,7 +13,7 @@ def StandardMetricsReporting(
         train_op: LocalIterator[Any],
         workers: WorkerSet,
         config: dict,
-        selected_workers: List["ActorHandle"] = None) -> LocalIterator[dict]:
+        selected_workers: List[ActorHandle] = None) -> LocalIterator[dict]:
     """Operator to periodically collect and report metrics.
 
     Args:
@@ -62,7 +63,7 @@ class CollectMetrics:
                  workers,
                  min_history=100,
                  timeout_seconds=180,
-                 selected_workers: List["ActorHandle"] = None):
+                 selected_workers: List[ActorHandle] = None):
         self.workers = workers
         self.episode_history = []
         self.to_be_collected = []

--- a/rllib/execution/replay_ops.py
+++ b/rllib/execution/replay_ops.py
@@ -1,6 +1,7 @@
 from typing import List
 import random
 
+from ray.actor import ActorHandle
 from ray.util.iter import from_actors, LocalIterator, _NextValueNotReady
 from ray.util.iter_metrics import SharedMetrics
 from ray.rllib.execution.replay_buffer import LocalReplayBuffer, \
@@ -31,7 +32,7 @@ class StoreToReplayBuffer:
     def __init__(self,
                  *,
                  local_buffer: LocalReplayBuffer = None,
-                 actors: List["ActorHandle"] = None):
+                 actors: List[ActorHandle] = None):
         if bool(local_buffer) == bool(actors):
             raise ValueError(
                 "Exactly one of local_buffer and replay_actors must be given.")
@@ -54,7 +55,7 @@ class StoreToReplayBuffer:
 
 def Replay(*,
            local_buffer: LocalReplayBuffer = None,
-           actors: List["ActorHandle"] = None,
+           actors: List[ActorHandle] = None,
            num_async=4):
     """Replay experiences from the given buffer or actors.
 

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -4,6 +4,7 @@ import numpy as np
 import tree
 from typing import Dict, List, Optional
 
+from ray.rllib.evaluation.episode import MultiAgentEpisode
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.policy.view_requirement import ViewRequirement
 from ray.rllib.utils.annotations import DeveloperAPI
@@ -93,7 +94,7 @@ class Policy(metaclass=ABCMeta):
             prev_action_batch: Union[List[TensorType], TensorType] = None,
             prev_reward_batch: Union[List[TensorType], TensorType] = None,
             info_batch: Optional[Dict[str, list]] = None,
-            episodes: Optional[List["MultiAgentEpisode"]] = None,
+            episodes: Optional[List[MultiAgentEpisode]] = None,
             explore: Optional[bool] = None,
             timestep: Optional[int] = None,
             **kwargs) -> \
@@ -142,7 +143,7 @@ class Policy(metaclass=ABCMeta):
             prev_action: Optional[TensorType] = None,
             prev_reward: Optional[TensorType] = None,
             info: dict = None,
-            episode: Optional["MultiAgentEpisode"] = None,
+            episode: Optional[MultiAgentEpisode] = None,
             clip_actions: bool = False,
             explore: Optional[bool] = None,
             timestep: Optional[int] = None,
@@ -318,7 +319,7 @@ class Policy(metaclass=ABCMeta):
             sample_batch: SampleBatch,
             other_agent_batches: Optional[Dict[AgentID, Tuple[
                 "Policy", SampleBatch]]] = None,
-            episode: Optional["MultiAgentEpisode"] = None) -> SampleBatch:
+            episode: Optional[MultiAgentEpisode] = None) -> SampleBatch:
         """Implements algorithm-specific trajectory postprocessing.
 
         This will be called on each trajectory fragment computed during policy

--- a/rllib/policy/tf_policy.py
+++ b/rllib/policy/tf_policy.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import ray
 import ray.experimental.tf_utils
 from ray.util.debug import log_once
+from ray.rllib.evaluation.episode import MultiAgentEpisode
 from ray.rllib.policy.policy import Policy, LEARNER_STATS_KEY
 from ray.rllib.policy.rnn_sequencing import pad_batch_to_sequences_of_same_size
 from ray.rllib.policy.sample_batch import SampleBatch
@@ -310,7 +311,7 @@ class TFPolicy(Policy):
             prev_action_batch: Union[List[TensorType], TensorType] = None,
             prev_reward_batch: Union[List[TensorType], TensorType] = None,
             info_batch: Optional[Dict[str, list]] = None,
-            episodes: Optional[List["MultiAgentEpisode"]] = None,
+            episodes: Optional[List[MultiAgentEpisode]] = None,
             explore: Optional[bool] = None,
             timestep: Optional[int] = None,
             **kwargs):

--- a/rllib/policy/tf_policy_template.py
+++ b/rllib/policy/tf_policy_template.py
@@ -1,6 +1,7 @@
 import gym
 from typing import Callable, Dict, List, Optional, Tuple, Type, Union
 
+from ray.rllib.evaluation.episode import MultiAgentEpisode
 from ray.rllib.models.tf.tf_action_dist import TFActionDistribution
 from ray.rllib.models.modelv2 import ModelV2
 from ray.rllib.policy.dynamic_tf_policy import DynamicTFPolicy
@@ -25,19 +26,23 @@ def build_tf_policy(
                                               TrainerConfigDict]] = None,
         postprocess_fn: Optional[Callable[[
             Policy, SampleBatch, Optional[Dict[AgentID, SampleBatch]],
-            Optional["MultiAgentEpisode"]
+            Optional[MultiAgentEpisode]
         ], SampleBatch]] = None,
         stats_fn: Optional[Callable[[Policy, SampleBatch], Dict[
             str, TensorType]]] = None,
         optimizer_fn: Optional[Callable[[
             Policy, TrainerConfigDict
-        ], "tf.keras.optimizers.Optimizer"]] = None,
+        ], "tf.keras.optimizers.Optimizer"]] = None,  # noqa: F821
         gradients_fn: Optional[Callable[[
-            Policy, "tf.keras.optimizers.Optimizer", TensorType
+            Policy,
+            "tf.keras.optimizers.Optimizer",  # noqa: F821
+            TensorType
         ], ModelGradients]] = None,
         apply_gradients_fn: Optional[Callable[[
-            Policy, "tf.keras.optimizers.Optimizer", ModelGradients
-        ], "tf.Operation"]] = None,
+            Policy,
+            "tf.keras.optimizers.Optimizer",  # noqa: F821
+            ModelGradients
+        ], "tf.Operation"]] = None,  # noqa: F821
         grad_stats_fn: Optional[Callable[[Policy, SampleBatch, ModelGradients],
                                          Dict[str, TensorType]]] = None,
         extra_action_fetches_fn: Optional[Callable[[Policy], Dict[

--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -5,6 +5,7 @@ import numpy as np
 import time
 from typing import Callable, Dict, List, Optional, Tuple, Type, Union
 
+from ray.rllib.evaluation.episode import MultiAgentEpisode
 from ray.rllib.models.modelv2 import ModelV2
 from ray.rllib.models.torch.torch_modelv2 import TorchModelV2
 from ray.rllib.models.torch.torch_action_dist import TorchDistributionWrapper
@@ -139,7 +140,7 @@ class TorchPolicy(Policy):
             prev_action_batch: Union[List[TensorType], TensorType] = None,
             prev_reward_batch: Union[List[TensorType], TensorType] = None,
             info_batch: Optional[Dict[str, list]] = None,
-            episodes: Optional[List["MultiAgentEpisode"]] = None,
+            episodes: Optional[List[MultiAgentEpisode]] = None,
             explore: Optional[bool] = None,
             timestep: Optional[int] = None,
             **kwargs) -> \

--- a/rllib/policy/torch_policy_template.py
+++ b/rllib/policy/torch_policy_template.py
@@ -1,6 +1,7 @@
 import gym
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
+from ray.rllib.evaluation.episode import MultiAgentEpisode
 from ray.rllib.models.catalog import ModelCatalog
 from ray.rllib.models.modelv2 import ModelV2
 from ray.rllib.models.torch.torch_action_dist import TorchDistributionWrapper
@@ -30,7 +31,7 @@ def build_torch_policy(
             str, TensorType]]] = None,
         postprocess_fn: Optional[Callable[[
             Policy, SampleBatch, Optional[Dict[Any, SampleBatch]], Optional[
-                "MultiAgentEpisode"]
+                MultiAgentEpisode]
         ], SampleBatch]] = None,
         extra_action_out_fn: Optional[Callable[[
             Policy, Dict[str, TensorType], List[TensorType], ModelV2,
@@ -80,7 +81,7 @@ def build_torch_policy(
             overrides. If None, uses only(!) the user-provided
             PartialTrainerConfigDict as dict for this Policy.
         postprocess_fn (Optional[Callable[[Policy, SampleBatch,
-            Optional[Dict[Any, SampleBatch]], Optional["MultiAgentEpisode"]],
+            Optional[Dict[Any, SampleBatch]], Optional[MultiAgentEpisode]],
             SampleBatch]]): Optional callable for post-processing experience
             batches (called after the super's `postprocess_trajectory` method).
         stats_fn (Optional[Callable[[Policy, SampleBatch],

--- a/rllib/tests/test_rollout.py
+++ b/rllib/tests/test_rollout.py
@@ -52,7 +52,7 @@ def rollout_test(algo, env="CartPole-v0", test_episode_rollout=False):
                      rllib_dir, algo, checkpoint_path, tmp_dir)).read()
         if not os.path.exists(tmp_dir + "/rollouts_10steps.pkl"):
             sys.exit(1)
-        print("rollout output (10 steps) exists!".format(checkpoint_path))
+        print("rollout output (10 steps) exists!")
 
         # Test rolling out 1 episode.
         if test_episode_rollout:
@@ -61,7 +61,7 @@ def rollout_test(algo, env="CartPole-v0", test_episode_rollout=False):
                          rllib_dir, algo, checkpoint_path, tmp_dir)).read()
             if not os.path.exists(tmp_dir + "/rollouts_1episode.pkl"):
                 sys.exit(1)
-            print("rollout output (1 ep) exists!".format(checkpoint_path))
+            print("rollout output (1 ep) exists!")
 
         # Cleanup.
         os.popen("rm -rf \"{}\"".format(tmp_dir)).read()
@@ -115,8 +115,7 @@ def learn_test_plus_rollout(algo, env="CartPole-v0"):
                 rllib_dir, algo, tmp_dir, last_checkpoint)).read()[:-1]
         if not os.path.exists(tmp_dir + "/rollouts_n_steps.pkl"):
             sys.exit(1)
-        print("Rollout output exists -> Checking reward ...".format(
-            checkpoint_path))
+        print("Rollout output exists -> Checking reward ...")
         episodes = result.split("\n")
         mean_reward = 0.0
         num_episodes = 0
@@ -208,8 +207,7 @@ def learn_test_multi_agent_plus_rollout(algo):
                 rllib_dir, algo, tmp_dir, last_checkpoint)).read()[:-1]
         if not os.path.exists(tmp_dir + "/rollouts_n_steps.pkl"):
             sys.exit(1)
-        print("Rollout output exists -> Checking reward ...".format(
-            checkpoint_path))
+        print("Rollout output exists -> Checking reward ...")
         episodes = result.split("\n")
         mean_reward = 0.0
         num_episodes = 0

--- a/rllib/utils/exploration/exploration.py
+++ b/rllib/utils/exploration/exploration.py
@@ -56,7 +56,7 @@ class Exploration:
             *,
             timestep: Optional[Union[TensorType, int]] = None,
             explore: Optional[Union[TensorType, bool]] = None,
-            tf_sess: Optional["tf.Session"] = None,
+            tf_sess: Optional["tf.Session"] = None,  # noqa: F821
             **kwargs):
         """Hook for preparations before policy.compute_actions() is called.
 
@@ -111,7 +111,7 @@ class Exploration:
                          *,
                          environment: BaseEnv = None,
                          episode: int = None,
-                         tf_sess: Optional["tf.Session"] = None):
+                         tf_sess: Optional["tf.Session"] = None):  # noqa: F821
         """Handles necessary exploration logic at the beginning of an episode.
 
         Args:
@@ -128,7 +128,7 @@ class Exploration:
                        *,
                        environment: BaseEnv = None,
                        episode: int = None,
-                       tf_sess: Optional["tf.Session"] = None):
+                       tf_sess: Optional["tf.Session"] = None):  # noqa: F821
         """Handles necessary exploration logic at the end of an episode.
 
         Args:
@@ -140,10 +140,11 @@ class Exploration:
         pass
 
     @DeveloperAPI
-    def postprocess_trajectory(self,
-                               policy: "Policy",
-                               sample_batch: SampleBatch,
-                               tf_sess: Optional["tf.Session"] = None):
+    def postprocess_trajectory(
+            self,
+            policy: "Policy",
+            sample_batch: SampleBatch,
+            tf_sess: Optional["tf.Session"] = None):  # noqa: F821
         """Handles post-processing of done episode trajectories.
 
         Changes the given batch in place. This callback is invoked by the
@@ -194,7 +195,7 @@ class Exploration:
         return policy_loss
 
     @DeveloperAPI
-    def get_info(self, sess: Optional["tf.Session"] = None):
+    def get_info(self, sess: Optional["tf.Session"] = None):  # noqa: F821
         """Returns a description of the current exploration state.
 
         This is not necessarily the state itself (and cannot be used in

--- a/rllib/utils/typing.py
+++ b/rllib/utils/typing.py
@@ -69,8 +69,8 @@ FileType = Any
 ResultDict = dict
 
 # A tf or torch local optimizer object.
-LocalOptimizer = Union["tf.keras.optimizers.Optimizer",
-                       "torch.optim.Optimizer"]
+LocalOptimizer = Union["tf.keras.optimizers.Optimizer",  # noqa: F821
+                       "torch.optim.Optimizer"]  # noqa: F821
 
 # Dict of tensors returned by compute gradients on the policy, e.g.,
 # {"td_error": [...], "learner_stats": {"vf_loss": ..., ...}}, for multi-agent,
@@ -95,7 +95,7 @@ ModelGradients = Union[List[Tuple[TensorType, TensorType]], List[TensorType]]
 ModelWeights = dict
 
 # Some kind of sample batch.
-SampleBatchType = Union["SampleBatch", "MultiAgentBatch"]
+SampleBatchType = Union["SampleBatch", "MultiAgentBatch"]  # noqa: F821
 
 # Either a plain tensor, or a dict or tuple of tensors (or StructTensors).
 TensorStructType = Union[TensorType, dict, tuple]

--- a/streaming/python/function.py
+++ b/streaming/python/function.py
@@ -347,4 +347,4 @@ def _get_simple_function_class(function_interface):
                     "Simple"):
                 return obj
     raise Exception(
-        "SimpleFunction for %s doesn't exist".format(function_interface))
+        "SimpleFunction for {} doesn't exist".format(function_interface))

--- a/streaming/python/message.py
+++ b/streaming/python/message.py
@@ -6,7 +6,7 @@ class Record:
         self.stream = None
 
     def __repr__(self):
-        return "Record(%s)".format(self.value)
+        return "Record({})".format(self.value)
 
     def __eq__(self, other):
         if type(self) is type(other):

--- a/streaming/python/runtime/graph.py
+++ b/streaming/python/runtime/graph.py
@@ -145,11 +145,11 @@ class ExecutionVertexContext:
             if execution_vertex.execution_vertex_id == execution_vertex_id:
                 return execution_vertex.worker_actor
         raise Exception(
-            "Vertex %s does not exist!".format(execution_vertex_id))
+            "Vertex {} does not exist!".format(execution_vertex_id))
 
     def get_target_actor_by_execution_vertex_id(self, execution_vertex_id):
         for execution_vertex in self.downstream_execution_vertices:
             if execution_vertex.execution_vertex_id == execution_vertex_id:
                 return execution_vertex.worker_actor
         raise Exception(
-            "Vertex %s does not exist!".format(execution_vertex_id))
+            "Vertex {} does not exist!".format(execution_vertex_id))


### PR DESCRIPTION
## Why are these changes needed?

Bump `flake8(-quotes)?` to latest in order to stop it from having a sad when it is run with more than one file as input. This mostly happens when you run `./scripts/ci/format.sh` after having modified more than one file.

## Related issue number

n/a

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] Manually verified that things don't explode horribly on 3.8 & 3.6