### PR TITLE
[tune] use isinstance instead of type for TBXLogger

### DIFF
--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -219,17 +219,16 @@ class TBXLogger(Logger):
 
         for attr, value in flat_result.items():
             full_attr = "/".join(path + [attr])
-            if type(value) in VALID_SUMMARY_TYPES and not np.isnan(value):
+            if isinstance(value, VALID_SUMMARY_TYPES) and not np.isnan(value):
                 valid_result[full_attr] = value
                 self._file_writer.add_scalar(
                     full_attr, value, global_step=step)
-            elif (type(value) == list
-                  and len(value) > 0) or (type(value) == np.ndarray
-                                          and value.size > 0):
+            elif (isinstance(value, list) and len(value) > 0) or
+                 (isinstance(value, np.ndarray) and value.size > 0):
                 valid_result[full_attr] = value
 
                 # Must be video
-                if type(value) == np.ndarray and value.ndim == 5:
+                if isinstance(value, np.ndarray) and value.ndim == 5:
                     self._file_writer.add_video(
                         full_attr, value, global_step=step, fps=20)
                     continue
@@ -260,7 +259,7 @@ class TBXLogger(Logger):
                 scrubbed_result = {
                     k: value
                     for k, value in flat_result.items()
-                    if type(value) in VALID_SUMMARY_TYPES
+                    if isinstance(value, VALID_SUMMARY_TYPES)
                 }
                 self._try_log_hparams(scrubbed_result)
             self._file_writer.close()

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -223,8 +223,8 @@ class TBXLogger(Logger):
                 valid_result[full_attr] = value
                 self._file_writer.add_scalar(
                     full_attr, value, global_step=step)
-            elif (isinstance(value, list) and len(value) > 0) or
-                 (isinstance(value, np.ndarray) and value.size > 0):
+            elif ((isinstance(value, list) and len(value) > 0) or
+                  (isinstance(value, np.ndarray) and value.size > 0)):
                 valid_result[full_attr] = value
 
                 # Must be video

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -220,7 +220,7 @@ class TBXLogger(Logger):
         for attr, value in flat_result.items():
             full_attr = "/".join(path + [attr])
             if (isinstance(value, tuple(VALID_SUMMARY_TYPES))
-                and not np.isnan(value)):
+                    and not np.isnan(value)):
                 valid_result[full_attr] = value
                 self._file_writer.add_scalar(
                     full_attr, value, global_step=step)

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -223,8 +223,8 @@ class TBXLogger(Logger):
                 valid_result[full_attr] = value
                 self._file_writer.add_scalar(
                     full_attr, value, global_step=step)
-            elif ((isinstance(value, list) and len(value) > 0) or
-                  (isinstance(value, np.ndarray) and value.size > 0)):
+            elif ((isinstance(value, list) and len(value) > 0)
+                  or (isinstance(value, np.ndarray) and value.size > 0)):
                 valid_result[full_attr] = value
 
                 # Must be video

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -260,7 +260,7 @@ class TBXLogger(Logger):
                 scrubbed_result = {
                     k: value
                     for k, value in flat_result.items()
-                    if isinstance(value, VALID_SUMMARY_TYPES)
+                    if isinstance(value, tuple(VALID_SUMMARY_TYPES))
                 }
                 self._try_log_hparams(scrubbed_result)
             self._file_writer.close()

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -219,7 +219,8 @@ class TBXLogger(Logger):
 
         for attr, value in flat_result.items():
             full_attr = "/".join(path + [attr])
-            if isinstance(value, VALID_SUMMARY_TYPES) and not np.isnan(value):
+            if (isinstance(value, tuple(VALID_SUMMARY_TYPES))
+                and not np.isnan(value)):
                 valid_result[full_attr] = value
                 self._file_writer.add_scalar(
                     full_attr, value, global_step=step)


### PR DESCRIPTION
## Why are these changes needed?

isinstance instead of type

## Related issue number

n/a

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
