### PR TITLE
[new scheduler] Pass test_basic and add CI builds with flag on

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -105,7 +105,7 @@ build:ci --ui_actions_shown=1024
 build:ci-travis --show_timestamps  # Travis doesn't have an option to show timestamps, but GitHub Actions does
 # GitHub Actions has low disk space, so prefer hardlinks there.
 build:ci-github --experimental_repository_cache_hardlinks
-test:ci --flaky_test_attempts=1
+test:ci --flaky_test_attempts=3
 test:ci --nocache_test_results
 test:ci --spawn_strategy=local
 test:ci --test_output=errors

--- a/.bazelrc
+++ b/.bazelrc
@@ -105,7 +105,7 @@ build:ci --ui_actions_shown=1024
 build:ci-travis --show_timestamps  # Travis doesn't have an option to show timestamps, but GitHub Actions does
 # GitHub Actions has low disk space, so prefer hardlinks there.
 build:ci-github --experimental_repository_cache_hardlinks
-test:ci --flaky_test_attempts=3
+test:ci --flaky_test_attempts=1
 test:ci --nocache_test_results
 test:ci --spawn_strategy=local
 test:ci --test_output=errors

--- a/.bazelrc
+++ b/.bazelrc
@@ -21,6 +21,7 @@ test --action_env=VIRTUAL_ENV
 test --action_env=PYENV_VIRTUAL_ENV
 test --action_env=PYENV_VERSION
 test --action_env=PYENV_SHELL
+test --action_env=RAY_ENABLE_NEW_SCHEDULER
 # This is needed for some core tests to run correctly
 test:windows --enable_runfiles
 # TODO(mehrdadn): Revert the "-\\.(asm|S)$" exclusion when this Bazel bug

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ matrix:
         - . ./ci/travis/ci.sh init RAY_CI_SERVE_AFFECTED,RAY_CI_TUNE_AFFECTED,RAY_CI_PYTHON_AFFECTED,RAY_CI_DASHBOARD_AFFECTED
       before_script:
         - . ./ci/travis/ci.sh build
+      script:
+      # bazel python tests. This should be run last to keep its logs at the end of travis logs.
+      - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then ./ci/keep_alive bazel test --config=ci $(./scripts/bazel_export_options) --test_tag_filters=-jenkins_only,-medium_size_python_tests_a_to_j,-medium_size_python_tests_k_to_z,-new_scheduler_broken python/ray/tests/...; fi
 
     - os: linux
       env:
@@ -45,7 +48,7 @@ matrix:
         - . ./ci/travis/ci.sh build
       script:
         # bazel python tests for medium size tests. Used for parallelization.
-        - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then ./ci/keep_alive bazel test --config=ci $(./scripts/bazel_export_options) --test_tag_filters=-jenkins_only,medium_size_python_tests_a_to_j python/ray/tests/...; fi
+        - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then ./ci/keep_alive bazel test --config=ci $(./scripts/bazel_export_options) --test_tag_filters=-jenkins_only,medium_size_python_tests_a_to_j,-new_scheduler_broken python/ray/tests/...; fi
 
     - os: linux
       env:
@@ -60,7 +63,7 @@ matrix:
         - . ./ci/travis/ci.sh build
       script:
         # bazel python tests for medium size tests. Used for parallelization.
-        - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then ./ci/keep_alive bazel test --config=ci $(./scripts/bazel_export_options) --test_tag_filters=-jenkins_only,medium_size_python_tests_k_to_z python/ray/tests/...; fi
+        - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then ./ci/keep_alive bazel test --config=ci $(./scripts/bazel_export_options) --test_tag_filters=-jenkins_only,medium_size_python_tests_k_to_z,-new_scheduler_broken python/ray/tests/...; fi
     - os: linux
       env:
         - PYTHON=3.6 SMALL_AND_LARGE_TESTS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,47 @@ matrix:
   include:
     - os: linux
       env:
+        - PYTHON=3.6 SMALL_AND_LARGE_TESTS=1 RAY_ENABLE_NEW_SCHEDULER=1
+        - PYTHONWARNINGS=ignore
+        - RAY_DEFAULT_BUILD=1
+        - RAY_CYTHON_EXAMPLES=1
+        - RAY_USE_RANDOM_PORTS=1
+      install:
+        - . ./ci/travis/ci.sh init RAY_CI_SERVE_AFFECTED,RAY_CI_TUNE_AFFECTED,RAY_CI_PYTHON_AFFECTED,RAY_CI_DASHBOARD_AFFECTED
+      before_script:
+        - . ./ci/travis/ci.sh build
+
+    - os: linux
+      env:
+        - PYTHON=3.6 MEDIUM_TESTS_A_TO_J=1 RAY_ENABLE_NEW_SCHEDULER=1
+        - PYTHONWARNINGS=ignore
+        - RAY_DEFAULT_BUILD=1
+        - RAY_CYTHON_EXAMPLES=1
+        - RAY_USE_RANDOM_PORTS=1
+      install:
+        - . ./ci/travis/ci.sh init RAY_CI_SERVE_AFFECTED,RAY_CI_TUNE_AFFECTED,RAY_CI_PYTHON_AFFECTED,RAY_CI_DASHBOARD_AFFECTED
+      before_script:
+        - . ./ci/travis/ci.sh build
+      script:
+        # bazel python tests for medium size tests. Used for parallelization.
+        - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then ./ci/keep_alive bazel test --config=ci $(./scripts/bazel_export_options) --test_tag_filters=-jenkins_only,medium_size_python_tests_a_to_j python/ray/tests/...; fi
+
+    - os: linux
+      env:
+        - PYTHON=3.6 MEDIUM_TESTS_K_TO_Z=1 RAY_ENABLE_NEW_SCHEDULER=1
+        - PYTHONWARNINGS=ignore
+        - RAY_DEFAULT_BUILD=1
+        - RAY_CYTHON_EXAMPLES=1
+        - RAY_USE_RANDOM_PORTS=1
+      install:
+        - . ./ci/travis/ci.sh init RAY_CI_SERVE_AFFECTED,RAY_CI_TUNE_AFFECTED,RAY_CI_PYTHON_AFFECTED,RAY_CI_DASHBOARD_AFFECTED
+      before_script:
+        - . ./ci/travis/ci.sh build
+      script:
+        # bazel python tests for medium size tests. Used for parallelization.
+        - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then ./ci/keep_alive bazel test --config=ci $(./scripts/bazel_export_options) --test_tag_filters=-jenkins_only,medium_size_python_tests_k_to_z python/ray/tests/...; fi
+    - os: linux
+      env:
         - PYTHON=3.6 SMALL_AND_LARGE_TESTS=1
         - PYTHONWARNINGS=ignore
         - RAY_DEFAULT_BUILD=1

--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -52,9 +52,7 @@ class RayOutOfMemoryError(Exception):
                 f"The top 10 memory consumers are:\n\n{proc_str}" +
                 "\n\nIn addition, up to {} GiB of shared memory is ".format(
                     round(get_shared(psutil.virtual_memory()) / (1024**3), 2))
-                + "currently being used by the Ray object store. You can set "
-                "the object store size with the `object_store_memory` "
-                "parameter when starting Ray.\n---\n"
+                + "currently being used by the Ray object store.\n---\n"
                 "--- Tip: Use the `ray memory` command to list active "
                 "objects in the cluster.\n---\n")
 

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -10,28 +10,13 @@ SRCS = [] + select({
 
 py_test_module_list(
   files = [
-    "test_actor_advanced.py",
-    "test_actor_failures.py",
-    "test_actor.py",
-    "test_actor_resources.py",
-    "test_advanced_2.py",
-    "test_advanced_3.py",
-    "test_advanced.py",
-    "test_array.py",
     "test_async.py",
-    "test_basic_2.py",
     "test_basic.py",
-    "test_cancel.py",
     "test_cli.py",
-    "test_component_failures_2.py",
     "test_component_failures_3.py",
-    "test_dynres.py",
     "test_error_ray_not_initialized.py",
     "test_gcs_fault_tolerance.py",
-    "test_global_gc.py",
-    "test_global_state.py",
     "test_iter.py",
-    "test_joblib.py",
     "test_resource_demand_scheduler.py",
   ],
   size = "medium",
@@ -42,23 +27,38 @@ py_test_module_list(
 
 py_test_module_list(
   files = [
+    "test_actor_advanced.py",
+    "test_actor_failures.py",
+    "test_actor.py",
+    "test_actor_resources.py",
+    "test_advanced_2.py",
+    "test_advanced_3.py",
+    "test_advanced.py",
+    "test_array.py",
+    "test_basic_2.py",
+    "test_cancel.py",
+    "test_component_failures_2.py",
+    "test_dynres.py",
+    "test_global_gc.py",
+    "test_global_state.py",
+    "test_joblib.py",
+  ],
+  size = "medium",
+  extra_srcs = SRCS,
+  tags = ["exclusive", "medium_size_python_tests_a_to_j", "new_scheduler_broken"],
+  deps = ["//:ray_lib"],
+)
+
+py_test_module_list(
+  files = [
     "test_memory_limits.py",
     "test_memory_scheduling.py",
     "test_metrics.py",
     "test_multi_node_2.py",
-    "test_multi_tenancy.py",
     "test_multinode_failures_2.py",
-    "test_multinode_failures.py",
-    "test_multi_node.py",
     "test_multiprocessing.py",
-    "test_object_manager.py",
     "test_output.py",
-    "test_reconstruction.py",
     "test_reference_counting_2.py",
-    "test_reference_counting.py",
-    "test_serialization.py",
-    "test_stress.py",
-    "test_stress_sharded.py",
     "test_unreconstructable_errors.py",
     "test_tensorflow.py",
     "test_object_spilling.py",
@@ -71,7 +71,24 @@ py_test_module_list(
 
 py_test_module_list(
   files = [
-    "test_actor_pool.py",
+    "test_multinode_failures.py",
+    "test_multi_node.py",
+    "test_object_manager.py",
+    "test_reconstruction.py",
+    "test_reference_counting.py",
+    "test_serialization.py",
+    "test_stress.py",
+    "test_stress_sharded.py",
+    "test_multi_tenancy.py",
+  ],
+  size = "medium",
+  extra_srcs = SRCS,
+  tags = ["exclusive", "medium_size_python_tests_k_to_z", "new_scheduler_broken"],
+  deps = ["//:ray_lib"],
+)
+
+py_test_module_list(
+  files = [
     "test_args.py",
     "test_asyncio.py",
     "test_autoscaler.py",
@@ -83,9 +100,7 @@ py_test_module_list(
     "test_dask_callback.py",
     "test_debug_tools.py",
     "test_job.py",
-    "test_memstat.py",
     "test_metrics_agent.py",
-    "test_microbenchmarks.py",
     "test_mini.py",
     "test_monitor.py",
     "test_node_manager.py",
@@ -102,13 +117,34 @@ py_test_module_list(
 
 py_test_module_list(
   files = [
+    "test_actor_pool.py",
+    "test_memstat.py",
+    "test_microbenchmarks.py",
+  ],
+  size = "small",
+  extra_srcs = SRCS,
+  tags = ["exclusive", "new_scheduler_broken"],
+  deps = ["//:ray_lib"],
+)
+
+py_test_module_list(
+  files = [
     "test_stress_failure.py",
+  ],
+  size = "large",
+  extra_srcs = SRCS,
+  tags = ["exclusive"],
+  deps = ["//:ray_lib"],
+)
+
+py_test_module_list(
+  files = [
     "test_failure.py",
     "test_placement_group.py",
   ],
   size = "large",
   extra_srcs = SRCS,
-  tags = ["exclusive"],
+  tags = ["exclusive", "new_scheduler_broken"],
   deps = ["//:ray_lib"],
 )
 

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -166,35 +166,68 @@ def test_invalid_arguments(shutdown_only):
 
 
 def test_many_fractional_resources(shutdown_only):
-    ray.init(num_cpus=2,num_gpus=2,resources={"Custom2": 2})
+    ray.init(num_cpus=2, num_gpus=2, resources={"Custom": 2})
 
     @ray.remote
     def g():
         return 1
 
     @ray.remote
-    def f():
-        ray.get(g.remote())
+    def f(block, accepted_resources):
+        true_resources = {
+            resource: value[0][1]
+            for resource, value in ray.get_resource_ids().items()
+        }
+        if block:
+            ray.get(g.remote())
+        return ray.test_utils.dicts_equal(true_resources, accepted_resources)
 
+    # Check that the resource are assigned correctly.
     result_ids = []
-#    np.random.seed(0)
     for rand1, rand2, rand3 in np.random.uniform(size=(100, 3)):
+        resource_set = {"CPU": int(rand1 * 10000) / 10000}
+        result_ids.append(f._remote([False, resource_set], num_cpus=rand1))
+
+        resource_set = {"CPU": 1, "GPU": int(rand1 * 10000) / 10000}
+        result_ids.append(f._remote([False, resource_set], num_gpus=rand1))
+
+        resource_set = {"CPU": 1, "Custom": int(rand1 * 10000) / 10000}
         result_ids.append(
-            f._remote([], num_cpus=rand1))
-    ray.get(result_ids)
+            f._remote([False, resource_set], resources={"Custom": rand1}))
+
+        resource_set = {
+            "CPU": int(rand1 * 10000) / 10000,
+            "GPU": int(rand2 * 10000) / 10000,
+            "Custom": int(rand3 * 10000) / 10000
+        }
+        result_ids.append(
+            f._remote(
+                [False, resource_set],
+                num_cpus=rand1,
+                num_gpus=rand2,
+                resources={"Custom": rand3}))
+        result_ids.append(
+            f._remote(
+                [True, resource_set],
+                num_cpus=rand1,
+                num_gpus=rand2,
+                resources={"Custom": rand3}))
+    assert all(ray.get(result_ids))
 
     # Check that the available resources at the end are the same as the
     # beginning.
-    stop_time = time.time() + 2
+    stop_time = time.time() + 10
     correct_available_resources = False
     while time.time() < stop_time:
         available_resources = ray.available_resources()
         if ("CPU" in available_resources
-                and ray.available_resources()["CPU"] == 2.0):
+                and ray.available_resources()["CPU"] == 2.0
+                and "GPU" in available_resources
+                and ray.available_resources()["GPU"] == 2.0
+                and "Custom" in available_resources
+                and ray.available_resources()["Custom"] == 2.0):
             correct_available_resources = True
             break
-    print("end avail resources", ray.available_resources())
-    time.sleep(.1)
     if not correct_available_resources:
         assert False, "Did not get correct available resources."
 

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -166,68 +166,35 @@ def test_invalid_arguments(shutdown_only):
 
 
 def test_many_fractional_resources(shutdown_only):
-    ray.init(num_cpus=2, num_gpus=2, resources={"Custom": 2})
+    ray.init(num_cpus=2,num_gpus=2,resources={"Custom2": 2})
 
     @ray.remote
     def g():
         return 1
 
     @ray.remote
-    def f(block, accepted_resources):
-        true_resources = {
-            resource: value[0][1]
-            for resource, value in ray.get_resource_ids().items()
-        }
-        if block:
-            ray.get(g.remote())
-        return ray.test_utils.dicts_equal(true_resources, accepted_resources)
+    def f():
+        ray.get(g.remote())
 
-    # Check that the resource are assigned correctly.
     result_ids = []
+#    np.random.seed(0)
     for rand1, rand2, rand3 in np.random.uniform(size=(100, 3)):
-        resource_set = {"CPU": int(rand1 * 10000) / 10000}
-        result_ids.append(f._remote([False, resource_set], num_cpus=rand1))
-
-        resource_set = {"CPU": 1, "GPU": int(rand1 * 10000) / 10000}
-        result_ids.append(f._remote([False, resource_set], num_gpus=rand1))
-
-        resource_set = {"CPU": 1, "Custom": int(rand1 * 10000) / 10000}
         result_ids.append(
-            f._remote([False, resource_set], resources={"Custom": rand1}))
-
-        resource_set = {
-            "CPU": int(rand1 * 10000) / 10000,
-            "GPU": int(rand2 * 10000) / 10000,
-            "Custom": int(rand3 * 10000) / 10000
-        }
-        result_ids.append(
-            f._remote(
-                [False, resource_set],
-                num_cpus=rand1,
-                num_gpus=rand2,
-                resources={"Custom": rand3}))
-        result_ids.append(
-            f._remote(
-                [True, resource_set],
-                num_cpus=rand1,
-                num_gpus=rand2,
-                resources={"Custom": rand3}))
-    assert all(ray.get(result_ids))
+            f._remote([], num_cpus=rand1))
+    ray.get(result_ids)
 
     # Check that the available resources at the end are the same as the
     # beginning.
-    stop_time = time.time() + 10
+    stop_time = time.time() + 2
     correct_available_resources = False
     while time.time() < stop_time:
         available_resources = ray.available_resources()
         if ("CPU" in available_resources
-                and ray.available_resources()["CPU"] == 2.0
-                and "GPU" in available_resources
-                and ray.available_resources()["GPU"] == 2.0
-                and "Custom" in available_resources
-                and ray.available_resources()["Custom"] == 2.0):
+                and ray.available_resources()["CPU"] == 2.0):
             correct_available_resources = True
             break
+    print("end avail resources", ray.available_resources())
+    time.sleep(.1)
     if not correct_available_resources:
         assert False, "Did not get correct available resources."
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -108,9 +108,11 @@ RAY_CONFIG(size_t, free_objects_batch_size, 100)
 RAY_CONFIG(bool, lineage_pinning_enabled, false)
 
 /// Whether to enable the new scheduler. The new scheduler is designed
-/// only to work with  direct calls. Once direct calls afre becoming
+/// only to work with direct calls. Once direct calls are becoming
 /// the default, this scheduler will also become the default.
-RAY_CONFIG(bool, new_scheduler_enabled, false)
+RAY_CONFIG(bool, new_scheduler_enabled,
+           getenv("RAY_ENABLE_NEW_SCHEDULER") != nullptr &&
+               getenv("RAY_ENABLE_NEW_SCHEDULER") == std::string("1"))
 
 // The max allowed size in bytes of a return object from direct actor calls.
 // Objects larger than this size will be spilled/promoted to plasma.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2312,6 +2312,7 @@ void NodeManager::HandleDirectCallTaskBlocked(
 void NodeManager::HandleDirectCallTaskUnblocked(
     const std::shared_ptr<WorkerInterface> &worker) {
   if (new_scheduler_enabled_) {
+    // Important: avoid double unblocking if the unblock RPC finishes after task end.
     if (!worker || !worker->IsBlocked()) {
       return;
     }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2572,8 +2572,6 @@ bool NodeManager::FinishAssignedTask(WorkerInterface &worker) {
     task = worker.GetAssignedTask();
     // leased_workers_.erase(worker.WorkerId()); // Maybe RAY_CHECK ?
     if (worker.GetAllocatedInstances() != nullptr) {
-      new_resource_scheduler_->SubtractCPUResourceInstances(
-          worker.GetBorrowedCPUInstances());
       new_resource_scheduler_->FreeLocalTaskResources(worker.GetAllocatedInstances());
       worker.ClearAllocatedInstances();
     }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1435,8 +1435,6 @@ void NodeManager::ProcessDisconnectClientMessage(
 
     // Return the resources that were being used by this worker.
     if (new_scheduler_enabled_) {
-      new_resource_scheduler_->SubtractCPUResourceInstances(
-          worker->GetBorrowedCPUInstances());
       new_resource_scheduler_->FreeLocalTaskResources(worker->GetAllocatedInstances());
       worker->ClearAllocatedInstances();
       new_resource_scheduler_->FreeLocalTaskResources(
@@ -2324,6 +2322,7 @@ void NodeManager::HandleDirectCallTaskUnblocked(
     if (cpu_instances.size() > 0) {
       new_resource_scheduler_->SubtractCPUResourceInstances(cpu_instances);
       new_resource_scheduler_->AddCPUResourceInstances(worker->GetBorrowedCPUInstances());
+      worker->ClearBorrowedCPUInstances();
       worker->MarkUnblocked();
     }
     ScheduleAndDispatch();

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2284,7 +2284,7 @@ void NodeManager::SubmitTask(const Task &task) {
 void NodeManager::HandleDirectCallTaskBlocked(
     const std::shared_ptr<WorkerInterface> &worker) {
   if (new_scheduler_enabled_) {
-    if (!worker) {
+    if (!worker || worker->IsBlocked()) {
       return;
     }
     std::vector<double> cpu_instances;
@@ -2314,7 +2314,7 @@ void NodeManager::HandleDirectCallTaskBlocked(
 void NodeManager::HandleDirectCallTaskUnblocked(
     const std::shared_ptr<WorkerInterface> &worker) {
   if (new_scheduler_enabled_) {
-    if (!worker) {
+    if (!worker || !worker->IsBlocked()) {
       return;
     }
     std::vector<double> cpu_instances;

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -171,7 +171,6 @@ void ClusterTaskManager::TasksUnblocked(const std::vector<TaskID> ready_ids) {
       waiting_tasks_.erase(it);
     }
   }
-  RAY_LOG(ERROR) << "unblock " << DebugString();
 }
 
 void ClusterTaskManager::HandleTaskFinished(std::shared_ptr<WorkerInterface> worker) {

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -171,11 +171,10 @@ void ClusterTaskManager::TasksUnblocked(const std::vector<TaskID> ready_ids) {
       waiting_tasks_.erase(it);
     }
   }
+  RAY_LOG(ERROR) << "unblock " << DebugString();
 }
 
 void ClusterTaskManager::HandleTaskFinished(std::shared_ptr<WorkerInterface> worker) {
-  cluster_resource_scheduler_->SubtractCPUResourceInstances(
-      worker->GetBorrowedCPUInstances());
   cluster_resource_scheduler_->FreeLocalTaskResources(worker->GetAllocatedInstances());
   worker->ClearAllocatedInstances();
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- Make the feature flag toggleable with the env var `RAY_ENABLE_NEW_SCHEDULER=1`
- Fix the race conditions in worker block/unblocking that cause test hangs in test_many_fractional_resources due to double un-blocks (lost CPUs).
- Add CI builds with the env var set to avoid future regressions.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
