### PR TITLE
[docker] Synchronize Torch for Tune & RLlib

### DIFF
--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
                 RAY_CI_STREAMING_PYTHON_AFFECTED = 1
                 RAY_CI_DOC_AFFECTED = 1
                 if changed_file.startswith("python/setup.py") or re.match(
-                        "requirements.*\.txt", changed_file):
+                        ".*requirements.*\.txt", changed_file):
                     RAY_CI_PYTHON_DEPENDENCIES_AFFECTED = 1
             elif changed_file.startswith("java/"):
                 RAY_CI_JAVA_AFFECTED = 1

--- a/python/requirements_rllib.txt
+++ b/python/requirements_rllib.txt
@@ -1,7 +1,7 @@
 tensorflow-probability
 gast
 # Version requirement to match Tune
-torch>=1.5.0
+torch>=1.6.0
 # Version requirement to match Tune
 torchvision>=0.6.0
 smart_open


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* The `ray-ml` image requires installs both `Tune` and `RLlib` requirements. If they are mismatched, pip throws the following error
```
ERROR: Double requirement given: torch>=1.6.0 (from -r requirements_tune.txt (line 27)) (already in torch>=1.5.0 (from -r requirements_rllib.txt (line 4)), name='torch')
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #11634

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
