### PR TITLE
[Dashboard] Fix null gpu utilization

### DIFF
--- a/dashboard/client/src/api.ts
+++ b/dashboard/client/src/api.ts
@@ -96,7 +96,7 @@ export type GPUStats = {
   name: string;
   temperatureGpu: number;
   fanSpeed: number;
-  utilizationGpu: number;
+  utilizationGpu?: number;
   powerDraw: number;
   enforcedPowerLimit: number;
   memoryUsed: number;

--- a/dashboard/client/src/pages/dashboard/logical-view/ActorDetailsPane.tsx
+++ b/dashboard/client/src/pages/dashboard/logical-view/ActorDetailsPane.tsx
@@ -144,20 +144,26 @@ const ActorDetailsPane: React.FC<ActorDetailsPaneProps> = ({ actor }) => {
               <Grid item xs={12}>
                 <Typography>GPU Usage</Typography>
               </Grid>
-              {actor.gpus.map((gpu) => (
-                <React.Fragment key={gpu.uuid}>
+              {actor.gpus.map((gpu) => {
+                const gpuUtilization = gpu.utilizationGpu ?
+                  <UsageBar
+                    percent={gpu.utilizationGpu * 100}
+                    text={`${gpu.utilizationGpu * 100}%`}
+                  /> :
+                  <Typography color="textSecondary" component="span" variant="inherit">
+                    N/A
+                  </Typography>;
+                return <React.Fragment key={gpu.uuid}>
                   <Grid item xs={4}>
                     {`[${gpu.name}]`}
                   </Grid>
                   <Grid item xs={4}>
-                    <UsageBar
-                      percent={gpu.utilizationGpu * 100}
-                      text={`${gpu.utilizationGpu * 100}%`}
-                    />
+                    {gpuUtilization}
                   </Grid>
                   <Grid item xs={4} />
                 </React.Fragment>
-              ))}
+              }
+              )}
             </Grid>
           )}
         </Grid>

--- a/dashboard/client/src/pages/dashboard/logical-view/ActorDetailsPane.tsx
+++ b/dashboard/client/src/pages/dashboard/logical-view/ActorDetailsPane.tsx
@@ -145,25 +145,32 @@ const ActorDetailsPane: React.FC<ActorDetailsPaneProps> = ({ actor }) => {
                 <Typography>GPU Usage</Typography>
               </Grid>
               {actor.gpus.map((gpu) => {
-                const gpuUtilization = gpu.utilizationGpu ?
+                const gpuUtilization = gpu.utilizationGpu ? (
                   <UsageBar
                     percent={gpu.utilizationGpu * 100}
                     text={`${gpu.utilizationGpu * 100}%`}
-                  /> :
-                  <Typography color="textSecondary" component="span" variant="inherit">
+                  />
+                ) : (
+                  <Typography
+                    color="textSecondary"
+                    component="span"
+                    variant="inherit"
+                  >
                     N/A
-                  </Typography>;
-                return <React.Fragment key={gpu.uuid}>
-                  <Grid item xs={4}>
-                    {`[${gpu.name}]`}
-                  </Grid>
-                  <Grid item xs={4}>
-                    {gpuUtilization}
-                  </Grid>
-                  <Grid item xs={4} />
-                </React.Fragment>
-              }
-              )}
+                  </Typography>
+                );
+                return (
+                  <React.Fragment key={gpu.uuid}>
+                    <Grid item xs={4}>
+                      {`[${gpu.name}]`}
+                    </Grid>
+                    <Grid item xs={4}>
+                      {gpuUtilization}
+                    </Grid>
+                    <Grid item xs={4} />
+                  </React.Fragment>
+                );
+              })}
             </Grid>
           )}
         </Grid>

--- a/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
@@ -32,11 +32,17 @@ const clusterGPUUtilization = (nodes: Array<Node>): number => {
 };
 
 const nodeGPUUtilization = (node: Node): number => {
-  if (node.gpus === null) return NaN;
-  const gpusWithUtilInfo = node.gpus.filter(gpu => gpu.utilizationGpu);
-  if (gpusWithUtilInfo.length === 0) return NaN;
+  if (node.gpus === null) {
+    return NaN;
+  }
+  const gpusWithUtilInfo = node.gpus.filter((gpu) => gpu.utilizationGpu);
+  if (gpusWithUtilInfo.length === 0) {
+    return NaN;
+  }
 
-  const utilizationSum = sum(gpusWithUtilInfo.map((gpu) => gpu.utilizationGpu ?? 0));
+  const utilizationSum = sum(
+    gpusWithUtilInfo.map((gpu) => gpu.utilizationGpu ?? 0),
+  );
   const avgUtilization = utilizationSum / gpusWithUtilInfo.length;
   return avgUtilization;
 };
@@ -88,15 +94,16 @@ const NodeGPUEntry: React.FC<NodeGPUEntryProps> = ({ gpu, slot }) => {
       <Tooltip title={gpu.name}>
         <RightPaddedTypography variant="body1">[{slot}]:</RightPaddedTypography>
       </Tooltip>
-      {gpu.utilizationGpu ?
+      {gpu.utilizationGpu ? (
         <UsageBar
           percent={gpu.utilizationGpu}
           text={`${gpu.utilizationGpu.toFixed(1)}%`}
-        /> :
+        />
+      ) : (
         <Typography color="textSecondary" component="span" variant="inherit">
           N/A
         </Typography>
-      }
+      )}
     </Box>
   );
 };

--- a/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
@@ -32,11 +32,12 @@ const clusterGPUUtilization = (nodes: Array<Node>): number => {
 };
 
 const nodeGPUUtilization = (node: Node): number => {
-  if (!node.gpus || node.gpus.length === 0) {
-    return NaN;
-  }
-  const utilizationSum = sum(node.gpus.map((gpu) => gpu.utilizationGpu));
-  const avgUtilization = utilizationSum / node.gpus.length;
+  if (node.gpus === null) return NaN;
+  const gpusWithUtilInfo = node.gpus.filter(gpu => gpu.utilizationGpu);
+  if (gpusWithUtilInfo.length === 0) return NaN;
+
+  const utilizationSum = sum(gpusWithUtilInfo.map((gpu) => gpu.utilizationGpu ?? 0));
+  const avgUtilization = utilizationSum / gpusWithUtilInfo.length;
   return avgUtilization;
 };
 
@@ -87,10 +88,15 @@ const NodeGPUEntry: React.FC<NodeGPUEntryProps> = ({ gpu, slot }) => {
       <Tooltip title={gpu.name}>
         <RightPaddedTypography variant="body1">[{slot}]:</RightPaddedTypography>
       </Tooltip>
-      <UsageBar
-        percent={gpu.utilizationGpu}
-        text={`${gpu.utilizationGpu.toFixed(1)}%`}
-      />
+      {gpu.utilizationGpu ?
+        <UsageBar
+          percent={gpu.utilizationGpu}
+          text={`${gpu.utilizationGpu.toFixed(1)}%`}
+        /> :
+        <Typography color="textSecondary" component="span" variant="inherit">
+          N/A
+        </Typography>
+      }
     </Box>
   );
 };

--- a/dashboard/client/src/pages/dashboard/node-info/features/GRAM.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/features/GRAM.tsx
@@ -6,7 +6,6 @@ import { MiBRatioNoPercent } from "../../../../common/formatUtils";
 import { Accessor } from "../../../../common/tableUtils";
 import UsageBar from "../../../../common/UsageBar";
 import { getWeightedAverage, sum } from "../../../../common/util";
-import { util } from '../../../../../../../bazel-ray/external/arrow/js/src/Arrow';
 import {
   ClusterFeatureRenderFn,
   Node,
@@ -21,10 +20,12 @@ const GRAM_COL_WIDTH = 120;
 
 const nodeGRAMUtilization = (node: Node) => {
   const utilization = (gpu: GPUStats) => {
-    if (!gpu.memoryUsed || !gpu.memoryTotal) return NaN;
+    if (!gpu.memoryUsed || !gpu.memoryTotal) {
+      return NaN;
+    }
     return gpu.memoryUsed / gpu.memoryTotal;
-  }
-  const gramUtils = node.gpus.map(utilization).filter(util => !!util);
+  };
+  const gramUtils = node.gpus.map(utilization).filter((util) => !!util);
   if (gramUtils.length === 0) {
     return NaN;
   }

--- a/dashboard/client/src/pages/dashboard/node-info/features/GRAM.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/features/GRAM.tsx
@@ -6,6 +6,7 @@ import { MiBRatioNoPercent } from "../../../../common/formatUtils";
 import { Accessor } from "../../../../common/tableUtils";
 import UsageBar from "../../../../common/UsageBar";
 import { getWeightedAverage, sum } from "../../../../common/util";
+import { util } from '../../../../../../../bazel-ray/external/arrow/js/src/Arrow';
 import {
   ClusterFeatureRenderFn,
   Node,
@@ -19,8 +20,12 @@ import {
 const GRAM_COL_WIDTH = 120;
 
 const nodeGRAMUtilization = (node: Node) => {
-  const utilization = (gpu: GPUStats) => gpu.memoryUsed / gpu.memoryTotal;
-  if (node.gpus.length === 0) {
+  const utilization = (gpu: GPUStats) => {
+    if (!gpu.memoryUsed || !gpu.memoryTotal) return NaN;
+    return gpu.memoryUsed / gpu.memoryTotal;
+  }
+  const gramUtils = node.gpus.map(utilization).filter(util => !!util);
+  if (gramUtils.length === 0) {
     return NaN;
   }
   const utilizationSum = sum(node.gpus.map((gpu) => utilization(gpu)));


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There are several fields that are actually nullable from the `gpustat` library that the dashboard front-end had as non-nullable types. This led to the page crashing in scenarios where gpu utilization or memory utilization was not available.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #11313 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(

Manually QA'd but not tested, like much of the front-end...