### PR TITLE
[Dashboard] Make Infeasible Actor UX Less Scary

### DIFF
--- a/dashboard/client/src/common/LabeledDatum.tsx
+++ b/dashboard/client/src/common/LabeledDatum.tsx
@@ -24,7 +24,7 @@ const LabeledDatum: React.FC<LabeledDatumProps> = ({
 }) => {
   const classes = useLabeledDatumStyles();
   const innerHtml = (
-    <Grid container item xs={6}>
+    <Grid container item xs={12}>
       <Grid item xs={6}>
         <Box className={tooltip && classes.tooltipLabel}>{label}</Box>
       </Grid>

--- a/dashboard/client/src/pages/dashboard/logical-view/ActorClassGroup.tsx
+++ b/dashboard/client/src/pages/dashboard/logical-view/ActorClassGroup.tsx
@@ -63,56 +63,59 @@ const ActorClassGroup: React.FC<ActorClassGroupProps> = ({
       <Box display="block" className={classes.title}>
         <Typography variant="h5">{title}</Typography>
       </Box>
-      <Grid container className={classes.title}>
-        <LabeledDatum
-          label={
-            <ActorStateRepr state={Alive} variant="body1" showTooltip={true} />
-          }
-          datum={
-            Alive in summary.stateToCount ? summary.stateToCount[Alive] : 0
-          }
-        />
-        <LabeledDatum
-          label={
-            <ActorStateRepr
-              state={Infeasible}
-              variant="body1"
-              showTooltip={true}
-            />
-          }
-          datum={
-            Infeasible in summary.stateToCount
-              ? summary.stateToCount[Infeasible]
-              : 0
-          }
-        />
-        <LabeledDatum
-          label={
-            <ActorStateRepr
-              state={PendingResources}
-              variant="body1"
-              showTooltip={true}
-            />
-          }
-          datum={
-            PendingResources in summary.stateToCount
-              ? summary.stateToCount[PendingResources]
-              : 0
-          }
-        />
-        <LabeledDatum
-          label={"Mean Lifetime"}
-          datum={asSeconds(summary.avgLifetime)}
-        />
-        <LabeledDatum
-          label={"Max Lifetime"}
-          datum={asSeconds(summary.maxLifetime)}
-        />
-        <LabeledDatum
-          label={"Executed Tasks"}
-          datum={summary.numExecutedTasks}
-        />
+      <Grid container xs={12} spacing={2}>
+        <Grid container item xs={5} className={classes.title}>
+          {Infeasible in summary.stateToCount && (<LabeledDatum
+            label={
+              <ActorStateRepr
+                state={Infeasible}
+                variant="body1"
+                showTooltip={true}
+              />
+            }
+            datum={summary.stateToCount[Infeasible]}
+          />)}
+          <LabeledDatum
+            label={
+              <ActorStateRepr state={Alive} variant="body1" showTooltip={true} />
+            }
+            datum={
+              Alive in summary.stateToCount ? summary.stateToCount[Alive] : 0
+            }
+          />
+
+          <LabeledDatum
+            label={
+              <ActorStateRepr
+                state={PendingResources}
+                variant="body1"
+                showTooltip={true}
+              />
+            }
+            datum={
+              PendingResources in summary.stateToCount
+                ? summary.stateToCount[PendingResources]
+                : 0
+            }
+          />
+        </Grid>
+        <Grid container item xs={5} className={classes.title}>
+          <LabeledDatum
+            label={"Mean Lifetime"}
+            datum={asSeconds(summary.avgLifetime)}
+          />
+          <LabeledDatum
+            label={"Max Lifetime"}
+            datum={asSeconds(summary.maxLifetime)}
+          />
+          <LabeledDatum
+            label={"Executed Tasks"}
+            datum={summary.numExecutedTasks}
+          />
+        </Grid>
       </Grid>
+
+
       {expanded ? (
         <React.Fragment>
           <Box>{entries}</Box>
@@ -121,10 +124,10 @@ const ActorClassGroup: React.FC<ActorClassGroupProps> = ({
           </CenteredBox>
         </React.Fragment>
       ) : (
-        <CenteredBox>
-          <Expander onClick={toggleExpanded} />
-        </CenteredBox>
-      )}
+          <CenteredBox>
+            <Expander onClick={toggleExpanded} />
+          </CenteredBox>
+        )}
     </Paper>
   );
 };

--- a/dashboard/client/src/pages/dashboard/logical-view/ActorClassGroup.tsx
+++ b/dashboard/client/src/pages/dashboard/logical-view/ActorClassGroup.tsx
@@ -65,19 +65,25 @@ const ActorClassGroup: React.FC<ActorClassGroupProps> = ({
       </Box>
       <Grid container xs={12} spacing={2}>
         <Grid container item xs={5} className={classes.title}>
-          {Infeasible in summary.stateToCount && (<LabeledDatum
+          {Infeasible in summary.stateToCount && (
+            <LabeledDatum
+              label={
+                <ActorStateRepr
+                  state={Infeasible}
+                  variant="body1"
+                  showTooltip={true}
+                />
+              }
+              datum={summary.stateToCount[Infeasible]}
+            />
+          )}
+          <LabeledDatum
             label={
               <ActorStateRepr
-                state={Infeasible}
+                state={Alive}
                 variant="body1"
                 showTooltip={true}
               />
-            }
-            datum={summary.stateToCount[Infeasible]}
-          />)}
-          <LabeledDatum
-            label={
-              <ActorStateRepr state={Alive} variant="body1" showTooltip={true} />
             }
             datum={
               Alive in summary.stateToCount ? summary.stateToCount[Alive] : 0
@@ -115,7 +121,6 @@ const ActorClassGroup: React.FC<ActorClassGroupProps> = ({
         </Grid>
       </Grid>
 
-
       {expanded ? (
         <React.Fragment>
           <Box>{entries}</Box>
@@ -124,10 +129,10 @@ const ActorClassGroup: React.FC<ActorClassGroupProps> = ({
           </CenteredBox>
         </React.Fragment>
       ) : (
-          <CenteredBox>
-            <Expander onClick={toggleExpanded} />
-          </CenteredBox>
-        )}
+        <CenteredBox>
+          <Expander onClick={toggleExpanded} />
+        </CenteredBox>
+      )}
     </Paper>
   );
 };

--- a/dashboard/client/src/pages/dashboard/logical-view/ActorDetailsPane.tsx
+++ b/dashboard/client/src/pages/dashboard/logical-view/ActorDetailsPane.tsx
@@ -125,7 +125,7 @@ const ActorDetailsPane: React.FC<ActorDetailsPaneProps> = ({ actor }) => {
         <div>{actor.actorClass}</div>
         <ActorStateRepr state={actor.state} />
       </div>
-      {isFullActorInfo(actor) &&
+      {isFullActorInfo(actor) && (
         <Grid container spacing={3} className={classes.detailsPane}>
           <Grid container item xs={6}>
             <Grid item xs={4}>
@@ -161,7 +161,7 @@ const ActorDetailsPane: React.FC<ActorDetailsPaneProps> = ({ actor }) => {
             </Grid>
           )}
         </Grid>
-      }
+      )}
       <Divider className={classes.divider} />
       <Grid container className={classes.detailsPane}>
         {actorData.map(

--- a/dashboard/client/src/pages/dashboard/logical-view/ActorDetailsPane.tsx
+++ b/dashboard/client/src/pages/dashboard/logical-view/ActorDetailsPane.tsx
@@ -125,8 +125,8 @@ const ActorDetailsPane: React.FC<ActorDetailsPaneProps> = ({ actor }) => {
         <div>{actor.actorClass}</div>
         <ActorStateRepr state={actor.state} />
       </div>
-      {isFullActorInfo(actor) && (
-        <Grid container className={classes.detailsPane}>
+      {isFullActorInfo(actor) &&
+        <Grid container spacing={3} className={classes.detailsPane}>
           <Grid container item xs={6}>
             <Grid item xs={4}>
               <Typography>CPU Usage</Typography>
@@ -161,7 +161,7 @@ const ActorDetailsPane: React.FC<ActorDetailsPaneProps> = ({ actor }) => {
             </Grid>
           )}
         </Grid>
-      )}
+      }
       <Divider className={classes.divider} />
       <Grid container className={classes.detailsPane}>
         {actorData.map(


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This updates the infeasible actor UI in the logical view so that the "Infeasible" data point for a given actor class will only be displayed if there is at least one actor of that class which is infeasible. It used to be always displayed.

![Screen Shot 2020-10-27 at 10 49 22 AM](https://user-images.githubusercontent.com/3156716/97343315-91ecf380-1844-11eb-9ac0-37831d388c7e.png)

## Related issue number
None.



## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
Manually QA'd like other dashboard front-end changes :/ 