### PR TITLE
[autoscaler/k8s] ray up 409 error fix

### DIFF
--- a/python/ray/autoscaler/_private/kubernetes/node_provider.py
+++ b/python/ray/autoscaler/_private/kubernetes/node_provider.py
@@ -76,7 +76,7 @@ class KubernetesNodeProvider(NodeProvider):
         return super().get_node_id(ip_address, use_internal_ip=use_internal_ip)
 
     def set_node_tags(self, node_ids, tags):
-        for _ in range(MAX_TAG_RETRIES):
+        for _ in range(MAX_TAG_RETRIES - 1):
             try:
                 self._set_node_tags(node_ids, tags)
                 return
@@ -88,7 +88,8 @@ class KubernetesNodeProvider(NodeProvider):
                     continue
                 else:
                     raise
-        raise Exception("Reached max retries for setting node tags.")
+        # One more try
+        self._set_node_tags(node_ids, tags)
 
     def _set_node_tags(self, node_id, tags):
         pod = core_api().read_namespaced_pod(node_id, self.namespace)

--- a/python/ray/autoscaler/_private/kubernetes/node_provider.py
+++ b/python/ray/autoscaler/_private/kubernetes/node_provider.py
@@ -12,6 +12,9 @@ from ray.autoscaler.tags import TAG_RAY_CLUSTER_NAME
 
 logger = logging.getLogger(__name__)
 
+MAX_TAG_RETRIES = 3
+DELAY_BEFORE_TAG_RETRY = .5
+
 
 def to_label_selector(tags):
     label_selector = ""
@@ -73,18 +76,19 @@ class KubernetesNodeProvider(NodeProvider):
         return super().get_node_id(ip_address, use_internal_ip=use_internal_ip)
 
     def set_node_tags(self, node_ids, tags):
-        while 1:
+        for _ in range(MAX_TAG_RETRIES):
             try:
                 self._set_node_tags(node_ids, tags)
-                break
+                return
             except ApiException as e:
                 if e.status == 409:
                     logger.info(log_prefix + "Caught a 409 error while setting"
                                 " node tags. Retrying...")
-                    time.sleep(.5)
+                    time.sleep(DELAY_BEFORE_TAG_RETRY)
                     continue
                 else:
                     raise
+        raise Exception("Reached max retries for setting node tags.")
 
     def _set_node_tags(self, node_id, tags):
         pod = core_api().read_namespaced_pod(node_id, self.namespace)

--- a/python/ray/autoscaler/_private/kubernetes/node_provider.py
+++ b/python/ray/autoscaler/_private/kubernetes/node_provider.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from uuid import uuid4
 from kubernetes.client.rest import ApiException
 
@@ -71,7 +72,21 @@ class KubernetesNodeProvider(NodeProvider):
             raise ValueError("Must use internal IPs with Kubernetes.")
         return super().get_node_id(ip_address, use_internal_ip=use_internal_ip)
 
-    def set_node_tags(self, node_id, tags):
+    def set_node_tags(self, node_ids, tags):
+        while 1:
+            try:
+                self._set_node_tags(node_ids, tags)
+                break
+            except ApiException as e:
+                if e.status == 409:
+                    logger.info(log_prefix + "Caught a 409 error while setting"
+                                " node tags. Retrying...")
+                    time.sleep(.5)
+                    continue
+                else:
+                    raise
+
+    def _set_node_tags(self, node_id, tags):
         pod = core_api().read_namespaced_pod(node_id, self.namespace)
         pod.metadata.labels.update(tags)
         core_api().patch_namespaced_pod(node_id, self.namespace, pod)

--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -75,7 +75,6 @@ class NodeUpdater:
             process_runner, use_internal_ip, docker_config)
 
         self.daemon = True
-        self.process_runner = process_runner
         self.node_id = node_id
         self.provider = provider
         # Some node providers don't specify empty structures as

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -224,7 +224,7 @@ class Node:
         ray.utils.set_sigterm_handler(sigterm_handler)
 
     def _init_temp(self, redis_client):
-        # Create an dictionary to store temp file index.
+        # Create a dictionary to store temp file index.
         self._incremental_dict = collections.defaultdict(lambda: 0)
 
         if self.head:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?



<!-- Please give a short summary of the change and the problem this solves. -->

Running `ray up` with a Kubernetes cluster config sporadically fails with a 409 error. The user then has to run `ray up` again to get a working ray cluster.

The 409 error arises from a call to `KubernetesNodeProvider.set_node_tags` in the process of setting up files on the head node pod. This happens because the pod is still starting up and the pod's version number changes during the call to `set_node_tags`.

The solution, implemented in this PR, is to catch the exception, wait a fraction of a second, and try setting the node tags again. 

While I was at it, I removed an unused attribute of `NodeUpdater` and fixed a typo in a comment in `ray/node.py`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(

Tested locally by starting a fresh minikube cluster and running 
`ray up python/ray/autoscaler/kubernetes/example-minimal.yaml --no-config-cache`.
The logger prints a message indicating that the 409 error was caught, and the cluster starts as normal.
