### PR TITLE
[GCS]Optimize subscription perf

### DIFF
--- a/src/ray/gcs/pubsub/gcs_pub_sub.h
+++ b/src/ray/gcs/pubsub/gcs_pub_sub.h
@@ -99,12 +99,14 @@ class GcsPubSub {
   /// channel.
   struct Command {
     /// SUBSCRIBE constructor.
-    Command(const Callback &subscribe_callback, const StatusCallback &done_callback)
+    Command(const Callback &subscribe_callback, const StatusCallback &done_callback,
+            bool is_sub_or_unsub_all)
         : is_subscribe(true),
           subscribe_callback(subscribe_callback),
-          done_callback(done_callback) {}
+          done_callback(done_callback),
+          is_sub_or_unsub_all(is_sub_or_unsub_all) {}
     /// UNSUBSCRIBE constructor.
-    Command() : is_subscribe(false) {}
+    Command() : is_subscribe(false), is_sub_or_unsub_all(false) {}
     /// True if this is a SUBSCRIBE command and false if UNSUBSCRIBE.
     const bool is_subscribe;
     /// Callback that is called whenever a new pubsub message is received from
@@ -113,6 +115,8 @@ class GcsPubSub {
     /// Callback that is called once we have successfully subscribed to a
     /// channel. This should only be set if is_subscribe is true.
     const StatusCallback done_callback;
+    /// True if this is a SUBSCRIBE all or UNSUBSCRIBE all command else false.
+    const bool is_sub_or_unsub_all;
   };
 
   struct Channel {
@@ -147,7 +151,7 @@ class GcsPubSub {
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   Status SubscribeInternal(const std::string &channel_name, const Callback &subscribe,
-                           const StatusCallback &done,
+                           const StatusCallback &done, bool is_sub_or_unsub_all,
                            const boost::optional<std::string> &id = boost::none);
 
   std::string GenChannelPattern(const std::string &channel,

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -241,6 +241,23 @@ class RedisContext {
 
   /// Subscribes the client to the given pattern.
   ///
+  /// \param channel The subscription channel.
+  /// \param redisCallback The callback function that the notification calls.
+  /// \param callback_index The index at which to add the callback. This index
+  /// must already be allocated in the callback manager via
+  /// RedisCallbackManager::AllocateCallbackIndex.
+  /// \return Status.
+  Status SubscribeAsync(const std::string &channel, const RedisCallback &redisCallback,
+                        int64_t callback_index);
+
+  /// Unsubscribes the client from the given channel.
+  ///
+  /// \param channel The unsubscription channel.
+  /// \return Status.
+  Status UnsubscribeAsync(const std::string &channel);
+
+  /// Subscribes the client to the given pattern.
+  ///
   /// \param pattern The pattern of subscription channel.
   /// \param redisCallback The callback function that the notification calls.
   /// \param callback_index The index at which to add the callback. This index

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -239,7 +239,7 @@ class RedisContext {
   Status SubscribeAsync(const NodeID &client_id, const TablePubsub pubsub_channel,
                         const RedisCallback &redisCallback, int64_t *out_callback_index);
 
-  /// Subscribes the client to the given pattern.
+  /// Subscribes the client to the given channel.
   ///
   /// \param channel The subscription channel.
   /// \param redisCallback The callback function that the notification calls.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We test the performance of gcs client `psubscribe` on a 200 node cluster (5000 psubscribes at the same time), which leads to redis block. We change the subscription of a single channel to subscribe, and there is no block in redis. The redis community has also optimized the performance of psubscribe(https://github.com/redis/redis/pull/4721/files), so we changed the subscription of a single channel to subscribe.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
