### PR TITLE
Disable validation of cluster config on the cluster to allow for cluster configs with new properties.

### DIFF
--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -326,19 +326,18 @@ class StandardAutoscaler:
         try:
             with open(self.config_path) as f:
                 new_config = yaml.safe_load(f.read())
-            try:
-                validate_config(new_config)
-            except Exception as e:
-                if not new_config.get(
-                        "no_config_validation_warning",
-                        False) and log_once("cluster_validate_config_fail"):
-                    logger.warning(
-                        "Cluster config validation failed. The version of the "
-                        "ray CLI you launched this cluster with may be higher "
-                        "than the version of ray being run on the cluster. "
-                        "Some new features may not be available until you "
-                        "upgrade ray on your cluster.",
-                        exc_info=e)
+            if not new_config.get("no_config_validation_warning", False):
+                try:
+                    validate_config(new_config)
+                except Exception as e:
+                    if log_once("cluster_validate_config_fail"):
+                        logger.warning(
+                            "Cluster config validation failed. The version of "
+                            "the ray CLI you launched this cluster with may "
+                            "be higher than the version of ray being run on "
+                            "the cluster. Some new features may not be "
+                            "available until you upgrade ray on your cluster.",
+                            exc_info=e)
             (new_runtime_hash,
              new_file_mounts_contents_hash) = hash_runtime_conf(
                  new_config["file_mounts"],

--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -325,7 +325,7 @@ class StandardAutoscaler:
         try:
             with open(self.config_path) as f:
                 new_config = yaml.safe_load(f.read())
-            if new_config != getattr(self, 'config', None):
+            if new_config != getattr(self, "config", None):
                 try:
                     validate_config(new_config)
                 except Exception as e:

--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -327,7 +327,7 @@ class StandardAutoscaler:
                 new_config = yaml.safe_load(f.read())
             if not new_config.get(
                     "no_config_validation_warning",
-                    False) and new_config != getattr(self, 'config'):
+                    False) and new_config != getattr(self, 'config', None):
                 try:
                     validate_config(new_config)
                 except Exception as e:

--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -329,7 +329,9 @@ class StandardAutoscaler:
             try:
                 validate_config(new_config)
             except Exception as e:
-                if log_once("cluster_validate_config_fail"):
+                if not new_config.get(
+                        "no_config_validation_warning",
+                        False) and log_once("cluster_validate_config_fail"):
                     logger.warning(
                         "Cluster config validation failed. The version of the ray CLI "
                         "you launched this cluster with may be higher than the version "

--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -333,10 +333,11 @@ class StandardAutoscaler:
                         "no_config_validation_warning",
                         False) and log_once("cluster_validate_config_fail"):
                     logger.warning(
-                        "Cluster config validation failed. The version of the ray CLI "
-                        "you launched this cluster with may be higher than the version "
-                        "of ray being run on the cluster. Some new features may not be "
-                        "available until you upgrade ray on your cluster.",
+                        "Cluster config validation failed. The version of the "
+                        "ray CLI you launched this cluster with may be higher "
+                        "than the version of ray being run on the cluster. "
+                        "Some new features may not be available until you "
+                        "upgrade ray on your cluster.",
                         exc_info=e)
             (new_runtime_hash,
              new_file_mounts_contents_hash) = hash_runtime_conf(

--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -325,7 +325,9 @@ class StandardAutoscaler:
         try:
             with open(self.config_path) as f:
                 new_config = yaml.safe_load(f.read())
-            if not new_config.get("no_config_validation_warning", False):
+            if not new_config.get(
+                    "no_config_validation_warning",
+                    False) and new_config != getattr(self, 'config'):
                 try:
                     validate_config(new_config)
                 except Exception as e:

--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -30,7 +30,6 @@ from ray.autoscaler._private.constants import \
     AUTOSCALER_MAX_NUM_FAILURES, AUTOSCALER_MAX_LAUNCH_BATCH, \
     AUTOSCALER_MAX_CONCURRENT_LAUNCHES, AUTOSCALER_UPDATE_INTERVAL_S, \
     AUTOSCALER_HEARTBEAT_TIMEOUT_S
-from ray.util.debug import log_once
 from six.moves import queue
 
 logger = logging.getLogger(__name__)
@@ -330,14 +329,13 @@ class StandardAutoscaler:
                 try:
                     validate_config(new_config)
                 except Exception as e:
-                    if log_once("cluster_validate_config_fail"):
-                        logger.warning(
-                            "Cluster config validation failed. The version of "
-                            "the ray CLI you launched this cluster with may "
-                            "be higher than the version of ray being run on "
-                            "the cluster. Some new features may not be "
-                            "available until you upgrade ray on your cluster.",
-                            exc_info=e)
+                    logger.warning(
+                        "Cluster config validation failed. The version of "
+                        "the ray CLI you launched this cluster with may "
+                        "be higher than the version of ray being run on "
+                        "the cluster. Some new features may not be "
+                        "available until you upgrade ray on your cluster.",
+                        exc_info=e)
             (new_runtime_hash,
              new_file_mounts_contents_hash) = hash_runtime_conf(
                  new_config["file_mounts"],

--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -325,13 +325,11 @@ class StandardAutoscaler:
         try:
             with open(self.config_path) as f:
                 new_config = yaml.safe_load(f.read())
-            if not new_config.get(
-                    "no_config_validation_warning",
-                    False) and new_config != getattr(self, 'config', None):
+            if new_config != getattr(self, 'config', None):
                 try:
                     validate_config(new_config)
                 except Exception as e:
-                    logger.warning(
+                    logger.debug(
                         "Cluster config validation failed. The version of "
                         "the ray CLI you launched this cluster with may "
                         "be higher than the version of ray being run on "

--- a/python/ray/autoscaler/ray-schema.json
+++ b/python/ray/autoscaler/ray-schema.json
@@ -307,10 +307,6 @@
         "no_restart": {
             "description": "Whether to avoid restarting the cluster during updates. This field is controlled by the ray --no-restart flag and cannot be set by the user."
         },
-        "no_config_validation_warning": {
-            "type": "boolean",
-            "description": "Disables the warning when the config on the cluster fails validation."
-        },
         "available_node_types": {
             "type": "object",
             "description": "A list of node types for multi-node-type autoscaling.",

--- a/python/ray/autoscaler/ray-schema.json
+++ b/python/ray/autoscaler/ray-schema.json
@@ -307,6 +307,10 @@
         "no_restart": {
             "description": "Whether to avoid restarting the cluster during updates. This field is controlled by the ray --no-restart flag and cannot be set by the user."
         },
+        "no_config_validation_warning": {
+            "type": "boolean",
+            "description": "Disables the warning when the config on the cluster fails validation."
+        },
         "available_node_types": {
             "type": "object",
             "description": "A list of node types for multi-node-type autoscaling.",

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -381,11 +381,26 @@ class AutoscalingTest(unittest.TestCase):
             f.write(yaml.dump(config))
         return path
 
-    def testInvalidConfig(self):
-        invalid_config = os.devnull
-        with pytest.raises(ValueError):
-            StandardAutoscaler(
-                invalid_config, LoadMetrics(), update_interval_s=0)
+    def testAutoscalerConfigValidationFailNotFatal(self):
+        invalid_config = {**SMALL_CLUSTER, "invalid_property_12345": "test"}
+        # First check that this config is actually invalid
+        with pytest.raises(ValidationError):
+            validate_config(invalid_config)
+
+        config_path = self.write_config(invalid_config)
+        self.provider = MockProvider()
+        runner = MockProcessRunner()
+        autoscaler = StandardAutoscaler(
+            config_path,
+            LoadMetrics(),
+            max_failures=0,
+            process_runner=runner,
+            update_interval_s=0)
+        assert len(self.provider.non_terminated_nodes({})) == 0
+        autoscaler.update()
+        self.waitForNodes(2)
+        autoscaler.update()
+        self.waitForNodes(2)
 
     def testValidation(self):
         """Ensures that schema validation is working."""


### PR DESCRIPTION
The autoscaler no longer errors if cluster config validations fail. Instead it will log a warning or ignore the validation error if the warning is disabled.
Validation of the cluster config still happens on the CLI side.


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This will allow older versions of ray to be launched by the autoscaler CLI.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
