### PR TITLE
[Dashboard] Don't show GPU columns if no GPU in cluster

### DIFF
--- a/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
@@ -200,14 +200,24 @@ const NodeInfo: React.FC<{}> = () => {
   )?.workerAccessor;
   const sortWorkerComparator =
     sortWorkerAccessor && getFnComparator(order, sortWorkerAccessor);
+
+  // Show GPU features only if there is at least one GPU in cluster.
+  const showGPUs =
+    nodes.map((n) => n.gpus).filter((gpus) => gpus.length !== 0).length !== 0;
+  const filterPredicate = (
+    feature: NodeInfoFeature | HeaderInfo<nodeInfoColumnId>,
+  ) => showGPUs || (feature.id !== "gpu" && feature.id !== "gram");
+  const filteredFeatures = nodeInfoFeatures.filter(filterPredicate);
+  const filteredHeaders = nodeInfoHeaders.filter(filterPredicate);
+
   const tableContents = isGrouped
     ? makeGroupedTableContents(
         nodes,
         sortWorkerComparator,
         sortNodeComparator,
-        nodeInfoFeatures,
+        filteredFeatures,
       )
-    : makeUngroupedTableContents(nodes, sortWorkerComparator, nodeInfoFeatures);
+    : makeUngroupedTableContents(nodes, sortWorkerComparator, filteredFeatures);
   return (
     <React.Fragment>
       <FormControlLabel
@@ -230,7 +240,7 @@ const NodeInfo: React.FC<{}> = () => {
               setOrder("asc");
             }
           }}
-          headerInfo={nodeInfoHeaders}
+          headerInfo={filteredHeaders}
           order={order}
           orderBy={orderBy}
           firstColumnEmpty={true}
@@ -240,7 +250,7 @@ const NodeInfo: React.FC<{}> = () => {
           <TotalRow
             clusterTotalWorkers={clusterTotalWorkers}
             nodes={nodes}
-            features={nodeInfoFeatures.map(
+            features={filteredFeatures.map(
               (feature) => feature.ClusterFeatureRenderFn,
             )}
           />

--- a/dashboard/client/src/pages/dashboard/node-info/features/ObjectStoreMemory.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/features/ObjectStoreMemory.tsx
@@ -31,7 +31,7 @@ export const ClusterObjectStoreMemory: ClusterFeatureRenderFn = ({ nodes }) => {
 export const NodeObjectStoreMemory: NodeFeatureRenderFn = ({ node }) => {
   const total = node.raylet.objectStoreAvailableMemory;
   const used = node.raylet.objectStoreUsedMemory;
-  if (!used || !total) {
+  if (used === undefined || total === undefined || total === 0) {
     return (
       <Typography color="textSecondary" component="span" variant="inherit">
         N/A


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
No need to show GPU information for a cluster that has no GPUs
![Screen Shot 2020-10-29 at 11 26 44 AM](https://user-images.githubusercontent.com/3156716/97617543-20937900-19db-11eb-97ee-5d18fcf05836.png)
## Related issue number
Closes #10295

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
