### PR TITLE
[RLLIB] Convert torch state arrays to tensors during compute log like…

### DIFF
--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -306,6 +306,10 @@ class TorchPolicy(Policy):
             if prev_reward_batch is not None:
                 input_dict[SampleBatch.PREV_REWARDS] = prev_reward_batch
             seq_lens = torch.ones(len(obs_batch), dtype=torch.int32)
+            state_batches = [
+                convert_to_torch_tensor(s, self.device)
+                for s in (state_batches or [])
+            ]
 
             # Exploration hook before each forward pass.
             self.exploration.before_compute_actions(explore=False)


### PR DESCRIPTION
## Why are these changes needed?

pytorch policy does not convert state batches to a tensor in compute_log_likelihoods. As a result, a numpy array is passed to the torch model and leads to an error. This error only occurs when training a model with an LSTM layer using marwil and sampling from an offline dataset.

This PR converts the state_batches to a torch_tensor in the same way as it is done in compute_actions. 

I did not add a marwil unit test but I could if you desire. It will not work with the current cartpole offline datasets in rllib/tests/data/cartpole because they do not have state information in them so I would need to generate a new one.

This only works with config["framework"] = tf and torch. The lstm does not work for tfe or tf2 but the error appears unrelated to this issue. It fails to even compile the model.

## Related issue number

Closes #10068

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/. (N/A)
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
