### PR TITLE
[autoscaler/k8s] [minor] Kubernetes rsync verbosity fixed

### DIFF
--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -193,9 +193,10 @@ class KubernetesCommandRunner(CommandRunnerInterface):
             target = "/root" + target[1:]
 
         try:
+            flags = "-aqz" if is_rsync_silent() else "-avz"
             self.process_runner.check_call([
                 KUBECTL_RSYNC,
-                "-avz",
+                flags,
                 source,
                 "{}@{}:{}".format(self.node_id, self.namespace, target),
             ])
@@ -217,9 +218,10 @@ class KubernetesCommandRunner(CommandRunnerInterface):
             target = "/root" + target[1:]
 
         try:
+            flags = "-aqz" if is_rsync_silent() else "-avz"
             self.process_runner.check_call([
                 KUBECTL_RSYNC,
-                "-avz",
+                flags,
                 "{}@{}:{}".format(self.node_id, self.namespace, source),
                 target,
             ])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, `ray rsync` always produces verbose output on a Kubernetes cluster. This PR changes the behavior to be more consistent with the other providers -- the output is verbose when copying files specified on the command line but quiet when syncing file mounts. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Resolves #11685. 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

Kubernetes syncer looks not too spammy when run on local minikube cluster.  