### PR TITLE
[docs] Show expected terminal output for manual cluster setup

### DIFF
--- a/doc/source/cluster/index.rst
+++ b/doc/source/cluster/index.rst
@@ -87,18 +87,35 @@ random port.
 
 .. code-block:: bash
 
-  ray start --head --port=6379
+  $ ray start --head --port=6379
+  ...
+  Next steps
+    To connect to this Ray runtime from another node, run
+      ray start --address='<ip address>:6379' --redis-password='<password>'
+
+  If connection fails, check your firewall settings and network configuration.
 
 The command will print out the address of the Redis server that was started
-(and some other address information).
+(the local node IP address plus the port number you specified).
 
-**Then on all of the other nodes**, run the following. Make sure to replace
+**Then on each of the other nodes**, run the following. Make sure to replace
 ``<address>`` with the value printed by the command on the head node (it
 should look something like ``123.45.67.89:6379``).
 
 .. code-block:: bash
 
-  ray start --address=<address>
+  $ ray start --address=<address> --redis-password='<password>'
+  --------------------
+  Ray runtime started.
+  --------------------
+
+  To terminate the Ray runtime, run
+    ray stop
+
+If you see ``Ray runtime started.``, then the node successfully connected to
+the ``<address>``. If the ``<address>`` is inaccessible (because, for example,
+the head node is not actually running), you will get an error such as
+``Unable to connect to Redis. If the Redis instance is on a different machine, check that your firewall is configured properly.``
 
 If you wish to specify that a machine has 10 CPUs and 1 GPU, you can do this
 with the flags ``--num-cpus=10`` and ``--num-gpus=1``. See the :ref:`Configuration <configuring-ray>` page for more information.

--- a/doc/source/cluster/index.rst
+++ b/doc/source/cluster/index.rst
@@ -112,15 +112,14 @@ should look something like ``123.45.67.89:6379``).
   To terminate the Ray runtime, run
     ray stop
 
-If you see ``Ray runtime started.``, then the node successfully connected to
-the ``<address>``. If the ``<address>`` is inaccessible (because, for example,
-the head node is not actually running), you will get an error such as
-``Unable to connect to Redis. If the Redis instance is on a different machine, check that your firewall is configured properly.``
-
 If you wish to specify that a machine has 10 CPUs and 1 GPU, you can do this
 with the flags ``--num-cpus=10`` and ``--num-gpus=1``. See the :ref:`Configuration <configuring-ray>` page for more information.
 
-Now we've started the Ray runtime.
+If you see ``Ray runtime started.``, then the node successfully connected to
+the ``<address>``. If the ``<address>`` is inaccessible (because, for example,
+the head node is not actually running), you will get an error such as
+``Unable to connect to Redis. If the Redis instance is on a different machine,
+check that your firewall is configured properly.``
 
 Stopping Ray
 ~~~~~~~~~~~~

--- a/doc/source/cluster/index.rst
+++ b/doc/source/cluster/index.rst
@@ -117,7 +117,7 @@ with the flags ``--num-cpus=10`` and ``--num-gpus=1``. See the :ref:`Configurati
 
 If you see ``Ray runtime started.``, then the node successfully connected to
 the ``<address>``. If the ``<address>`` is inaccessible (because, for example,
-the head node is not actually running), you will get an error such as
+the head node is not actually running), then you will get an error such as
 ``Unable to connect to Redis. If the Redis instance is on a different machine,
 check that your firewall is configured properly.``
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Currently, https://docs.ray.io/en/master/cluster/index.html#starting-ray-on-each-machine has gotten out of date with the actual command you will need to run, so that the user must be some on-the-fly 'translation' based on the terminal output they see.

Simultaneously, it isn't immediately obvious that a secondary node has successfully connected (or whether ``ray start`` merely waits for ``ray.init()`` and the address has not yet necessarily been successfully reached).

The two combine to create uncertainty whether the user is doing the correct thing.
## Related issue number

<!-- For example: "Closes #1234" -->
(I skipped creating an issue because I figured unless this was presented along with a positive change to make, people would just be annoyed by chatter about the minor issue.)
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
