### PR TITLE
Fix the linter failure in rllib/utils/exploration/epsilon_greedy.py.

### DIFF
--- a/rllib/utils/exploration/epsilon_greedy.py
+++ b/rllib/utils/exploration/epsilon_greedy.py
@@ -167,8 +167,7 @@ class EpsilonGreedy(Exploration):
                             exploit_action[j][i] = torch.tensor(
                                 random_action[j])
                 exploit_action = tree.unflatten_as(
-                    action_distribution.action_space_struct,
-                    exploit_action)
+                    action_distribution.action_space_struct, exploit_action)
 
                 return exploit_action, action_logp
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The linter is currently failing.
<!-- Please give a short summary of the change and the problem this solves. -->
This changes the code the way the linter wants.
## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/11756
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
