### PR TITLE
[redis-py] relax redis-py dep and update redis-py h{m}set calls

### DIFF
--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -139,8 +139,9 @@ class FunctionActorManager:
                                "remote function", self._worker)
         key = (b"RemoteFunction:" + self._worker.current_job_id.binary() + b":"
                + remote_function._function_descriptor.function_id.binary())
-        self._worker.redis_client.hmset(
-            key, {
+        self._worker.redis_client.hset(
+            key,
+            mapping={
                 "job_id": self._worker.current_job_id.binary(),
                 "function_id": remote_function._function_descriptor.
                 function_id.binary(),
@@ -333,7 +334,7 @@ class FunctionActorManager:
         """
         # We set the driver ID here because it may not have been available when
         # the actor class was defined.
-        self._worker.redis_client.hmset(key, actor_class_info)
+        self._worker.redis_client.hset(key, mapping=actor_class_info)
         self._worker.redis_client.rpush("Exports", key)
 
     def export_actor_class(self, Class, actor_creation_function_descriptor,

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -643,7 +643,7 @@ class Node:
                 process_info,
             ]
             redis_client = self.create_redis_client()
-            redis_client.hmset("webui", {"url": self._webui_url})
+            redis_client.hset("webui", mapping={"url": self._webui_url})
 
     def start_plasma_store(self, plasma_directory, object_store_memory):
         """Start the plasma store."""

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -359,8 +359,9 @@ class Worker:
                                    "function", self)
 
             # Run the function on all workers.
-            self.redis_client.hmset(
-                key, {
+            self.redis_client.hset(
+                key,
+                mapping={
                     "job_id": self.current_job_id.binary(),
                     "function_id": function_to_run_id,
                     "function": pickled_function,
@@ -368,7 +369,7 @@ class Worker:
                 })
             self.redis_client.rpush("Exports", key)
             # TODO(rkn): If the worker fails after it calls setnx and before it
-            # successfully completes the hmset and rpush, then the program will
+            # successfully completes the hset and rpush, then the program will
             # most likely hang. This could be fixed by making these three
             # operations into a transaction (or by implementing a custom
             # command that does all three things).

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -22,7 +22,7 @@ prometheus_client >= 0.7.1
 protobuf >= 3.8.0
 py-spy >= 0.2.0
 pyyaml
-redis >= 3.3.2, < 3.5.0
+redis >= 3.5.0
 requests
 
 ## setup.py extras

--- a/python/setup.py
+++ b/python/setup.py
@@ -154,7 +154,7 @@ install_requires = [
     "py-spy >= 0.2.0",
     "pyyaml",
     "requests",
-    "redis >= 3.3.2, < 3.5.0",
+    "redis >= 3.5.0",
     "opencensus",
     "prometheus_client >= 0.7.1",
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Relaxing the `redis` dep is needed as the Arch Linux package is already on `redis==3.5.3` and `ray` will not run otherwise. This PR updates redis api so that we can safely unpin the dep.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #8257
Closes #9069
Closes #11632
Downstream issue: https://github.com/acxz/pkgbuilds/issues/80

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
N/A as this is a build PR.