### PR TITLE
[hotfix] Bazel candidates not found due to raising too early

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -192,7 +192,6 @@ def bazel_invoke(invoker, cmdline, *args, **kwargs):
             result = invoker([cmd] + cmdline, *args, **kwargs)
             break
         except IOError:
-            raise
             if i >= len(candidates) - 1:
                 raise
     return result


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This fixes `setup.py` failure on Linux introduced by https://github.com/ray-project/ray/pull/11621/files