### PR TITLE
[doc] Troubleshooting --dashboard-port

### DIFF
--- a/doc/source/configure.rst
+++ b/doc/source/configure.rst
@@ -135,6 +135,7 @@ Head Node
 In addition to ports specified above, the head node needs to open several more ports.
 
 - ``--port``: Port of GCS. Default: 6379.
+- ``--redis-shard-ports``: Comma-separated list of ports for non-primary Redis shards. Default: Random values.
 - ``--dashboard-port``: Port for accessing the dashboard. Default: 8265
 - ``--gcs-server-port``: GCS Server port. GCS server is a stateless service that is in charge of communicating with the GCS. Default: Random value.
 

--- a/doc/source/configure.rst
+++ b/doc/source/configure.rst
@@ -136,8 +136,25 @@ In addition to ports specified above, the head node needs to open several more p
 
 - ``--port``: Port of GCS. Default: 6379.
 - ``--redis-shard-ports``: Comma-separated list of ports for non-primary Redis shards. Default: Random values.
-- ``--dashboard-port``: Port for accessing the dashboard. Default: 8265
 - ``--gcs-server-port``: GCS Server port. GCS server is a stateless service that is in charge of communicating with the GCS. Default: Random value.
+
+- If ``--include-dashboard`` is true (the default), then the head node must open ``--dashboard-port``. Default: 8265.
+
+If ``--include-dashboard`` is true but the ``--dashboard-port`` is not open on
+the head node, you will repeatedly get
+
+.. code-block:: bash
+
+  WARNING worker.py:1114 -- The agent on node runner-psehzuf-project-12345-concurrent-0 failed with the following error:
+  Traceback (most recent call last):
+    File "/usr/local/lib/python3.8/dist-packages/grpc/aio/_call.py", line 285, in __await__
+      raise _create_rpc_error(self._cython_call._initial_metadata,
+  grpc.aio._call.AioRpcError: <AioRpcError of RPC that terminated with:
+    status = StatusCode.UNAVAILABLE
+    details = "failed to connect to all addresses"
+    debug_error_string = "{"description":"Failed to pick subchannel","file":"src/core/ext/filters/client_channel/client_channel.cc","file_line":4165,"referenced_errors":[{"description":"failed to connect to all addresses","file":"src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc","file_line":397,"grpc_status":14}]}"
+
+(Also, you will not be able to access the dashboard.)
 
 Redis Port Authentication
 -------------------------

--- a/doc/source/configure.rst
+++ b/doc/source/configure.rst
@@ -172,7 +172,8 @@ with ``nc`` or ``nmap`` (or your browser).
 Note that the dashboard runs as a separate subprocess which can crash invisibly
 in the background, so even if you checked port 8265 earlier, the port might be
 closed *now* (for the prosaic reason that there is no longer a service running
-on it).
+on it). On the other side, if that port is unreachable, if you ``ray stop`` and
+``ray start``, it may become reachable again due to the dashboard restarting.
 
 If you don't want the dashboard, set ``--include-dashboard=false``.
 

--- a/doc/source/configure.rst
+++ b/doc/source/configure.rst
@@ -157,8 +157,19 @@ the head node, you will repeatedly get
 (Also, you will not be able to access the dashboard.)
 
 If you see that error, check whether the ``--dashboard-port`` is accessible
-with ``nc`` or ``nmap`` (or your browser). If you don't want the dashboard, set
-``--include-dashboard=false``.
+with ``nc`` or ``nmap`` (or your browser).
+
+.. code-block:: bash
+
+  $ nmap -sV --reason -p 8265 $HEAD_ADDRESS
+  Nmap scan report for compute04.berkeley.edu (123.456.78.910)
+  Host is up, received reset ttl 60 (0.00065s latency).
+  rDNS record for 123.456.78.910: compute04.berkeley.edu
+  PORT     STATE SERVICE REASON         VERSION
+  8265/tcp open  http    syn-ack ttl 60 aiohttp 3.7.2 (Python 3.8)
+  Service detection performed. Please report any incorrect results at https://nmap.org/submit/ .
+
+If you don't want the dashboard, set ``--include-dashboard=false``.
 
 Redis Port Authentication
 -------------------------

--- a/doc/source/configure.rst
+++ b/doc/source/configure.rst
@@ -169,6 +169,11 @@ with ``nc`` or ``nmap`` (or your browser).
   8265/tcp open  http    syn-ack ttl 60 aiohttp 3.7.2 (Python 3.8)
   Service detection performed. Please report any incorrect results at https://nmap.org/submit/ .
 
+Note that the dashboard runs as a separate subprocess which can crash invisibly
+in the background, so even if you checked port 8265 earlier, the port might be
+closed *now* (for the prosaic reason that there is no longer a service running
+on it).
+
 If you don't want the dashboard, set ``--include-dashboard=false``.
 
 Redis Port Authentication

--- a/doc/source/configure.rst
+++ b/doc/source/configure.rst
@@ -156,6 +156,10 @@ the head node, you will repeatedly get
 
 (Also, you will not be able to access the dashboard.)
 
+If you see that error, check whether the ``--dashboard-port`` is accessible
+with ``nc`` or ``nmap`` (or your browser). If you don't want the dashboard, set
+``--include-dashboard=false``.
+
 Redis Port Authentication
 -------------------------
 

--- a/doc/source/configure.rst
+++ b/doc/source/configure.rst
@@ -172,8 +172,9 @@ with ``nc`` or ``nmap`` (or your browser).
 Note that the dashboard runs as a separate subprocess which can crash invisibly
 in the background, so even if you checked port 8265 earlier, the port might be
 closed *now* (for the prosaic reason that there is no longer a service running
-on it). On the other side, if that port is unreachable, if you ``ray stop`` and
-``ray start``, it may become reachable again due to the dashboard restarting.
+on it). This also means that if that port is unreachable, if you ``ray stop``
+and ``ray start``, it may become reachable again due to the dashboard
+restarting.
 
 If you don't want the dashboard, set ``--include-dashboard=false``.
 

--- a/doc/source/configure.rst
+++ b/doc/source/configure.rst
@@ -145,7 +145,7 @@ the head node, you will repeatedly get
 
 .. code-block:: bash
 
-  WARNING worker.py:1114 -- The agent on node runner-psehzuf-project-12345-concurrent-0 failed with the following error:
+  WARNING worker.py:1114 -- The agent on node <hostname of node that tried to run a task> failed with the following error:
   Traceback (most recent call last):
     File "/usr/local/lib/python3.8/dist-packages/grpc/aio/_call.py", line 285, in __await__
       raise _create_rpc_error(self._cython_call._initial_metadata,


### PR DESCRIPTION
See https://github.com/ray-project/ray/pull/11808 first.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Currently, https://docs.ray.io/en/master/configure.html#head-node says that `--dashboard-port` is required to be open, but doesn't say exactly when it is required to be open or what problem you will see if it *isn't* open.
## Related issue number

<!-- For example: "Closes #1234" -->
It seemed more fruitful to open with the suggested change rather than complain about what wasn't there, but there is a related *pull request*: because https://github.com/ray-project/ray/pull/11808 was going to have merge conflicts with this, this actually incorporates https://github.com/ray-project/ray/pull/11808 so that this won't get tripped up by merge conflicts if https://github.com/ray-project/ray/pull/11808 is merged.

So there's actually an unrelated addition of `--redis-shard-ports` sitting in this branch, which is why https://github.com/ray-project/ray/pull/11808 should be looked at first. (It's much shorter and simpler than this.)
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
