### PR TITLE
[autoscaler] Fix semantics of request_resources

### DIFF
--- a/doc/source/cluster/autoscaling.rst
+++ b/doc/source/cluster/autoscaling.rst
@@ -41,7 +41,7 @@ The basic autoscaling config settings are as follows:
 Programmatically Scaling a Cluster
 ----------------------------------
 
-You can from within a Ray program command the autoscaler to scale the cluster up to a desired size with ``request_resources()`` call. Note that this is a hint to the autoscaler only.
+You can from within a Ray program command the autoscaler to scale the cluster up to a desired size with ``request_resources()`` call. The cluster will immediately attempt to scale to accomodate the requested resources, bypassing normal upscaling delay.
 
 .. autofunction:: ray.autoscaler.sdk.request_resources
 

--- a/doc/source/cluster/autoscaling.rst
+++ b/doc/source/cluster/autoscaling.rst
@@ -38,6 +38,12 @@ The basic autoscaling config settings are as follows:
     # considered idle if there are no tasks or actors running on it.
     idle_timeout_minutes: 5
 
+Programmatically Scaling a Cluster
+----------------------------------
+
+You can from within a Ray program command the autoscaler to scale the cluster up to a desired size with ``request_resources()`` call. Note that this is a hint to the autoscaler only.
+
+.. autofunction:: ray.autoscaler.sdk.request_resources
 
 Manually Adding Nodes without Resources (Unmanaged Nodes)
 ---------------------------------------------------------

--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -560,7 +560,11 @@ class StandardAutoscaler:
             "StandardAutoscaler: Queue {} new nodes for launch".format(count))
         self.pending_launches.inc(node_type, count)
         config = copy.deepcopy(self.config)
-        self.launch_queue.put((config, count, node_type))
+        # Split into individual launch requests of the max batch size.
+        while count > 0:
+            self.launch_queue.put((config, min(count, self.max_launch_batch),
+                                   node_type))
+            count -= self.max_launch_batch
 
     def all_workers(self):
         return self.workers() + self.unmanaged_workers()

--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -209,17 +209,14 @@ class StandardAutoscaler:
 
         # First let the resource demand scheduler launch nodes, if enabled.
         if self.resource_demand_scheduler:
-            resource_demand_vector = self.resource_demand_vector + \
-                self.load_metrics.get_resource_demand_vector()
-            pending_placement_groups = \
-                self.load_metrics.get_pending_placement_groups()
             to_launch = self.resource_demand_scheduler.get_nodes_to_launch(
                 self.provider.non_terminated_nodes(tag_filters={}),
                 self.pending_launches.breakdown(),
-                resource_demand_vector,
+                self.load_metrics.get_resource_demand_vector(),
                 self.load_metrics.get_resource_utilization(),
-                pending_placement_groups,
-                self.load_metrics.get_static_node_resources_by_ip())
+                self.load_metrics.get_pending_placement_groups(),
+                self.load_metrics.get_static_node_resources_by_ip(),
+                ensure_min_cluster_size=self.resource_demand_vector)
             for node_type, count in to_launch.items():
                 self.launch_new_node(count, node_type=node_type)
 

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -104,22 +104,29 @@ def request_resources(num_cpus: Optional[int] = None,
     This function is to be called e.g. on a node before submitting a bunch of
     ray.remote calls to ensure that resources rapidly become available.
 
-    This function is EXPERIMENTAL.
-
     Args:
-        num_cpus: int -- the number of CPU cores to request
-        bundles: List[dict] -- list of resource dicts (e.g., {"CPU": 1}). This
-            only has an effect if you've configured `available_node_types`
-            if your cluster config.
+        num_cpus (int): Scale the cluster to ensure this number of CPUs are
+            available. This request is persistent until another call to
+            request_resources() is made.
+        bundles (List[ResourceDict]): Scale the cluster to ensure this set of
+            resource shapes can fit. This request is persistent until another
+            call to request_resources() is made.
+
+    Examples:
+        >>> # Request 1000 CPUs.
+        >>> request_resources(num_cpus=1000)
+        >>> # Request 64 CPUs and also fit a 1-GPU/4-CPU task.
+        >>> request_resources(num_cpus=64, bundles=[{"GPU": 1, "CPU": 4}])
+        >>> # Same as requesting 3 CPUs.
+        >>> request_resources(bundles=[{"CPU": 1}, {"CPU": 1}, {"CPU": 1}])
     """
     r = _redis()
-    if num_cpus is not None and num_cpus > 0:
-        r.publish(AUTOSCALER_RESOURCE_REQUEST_CHANNEL,
-                  json.dumps({
-                      "CPU": num_cpus
-                  }))
+    to_request = []
+    if num_cpus:
+        to_request += [{"CPU": 1}] * num_cpus
     if bundles:
-        r.publish(AUTOSCALER_RESOURCE_REQUEST_CHANNEL, json.dumps(bundles))
+        to_request += bundles
+    r.publish(AUTOSCALER_RESOURCE_REQUEST_CHANNEL, json.dumps(to_request))
 
 
 def create_or_update_cluster(config_file: str,

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -19,6 +19,7 @@ try:  # py3
 except ImportError:  # py2
     from pipes import quote
 
+import ray
 from ray.experimental.internal_kv import _internal_kv_get
 import ray._private.services as services
 from ray.autoscaler.node_provider import NodeProvider
@@ -120,6 +121,8 @@ def request_resources(num_cpus: Optional[int] = None,
         >>> # Same as requesting 3 CPUs.
         >>> request_resources(bundles=[{"CPU": 1}, {"CPU": 1}, {"CPU": 1}])
     """
+    if not ray.is_initialized():
+        raise RuntimeError("Ray is not initialized yet")
     r = _redis()
     to_request = []
     if num_cpus:

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -112,14 +112,6 @@ def request_resources(num_cpus: Optional[int] = None,
         bundles (List[ResourceDict]): Scale the cluster to ensure this set of
             resource shapes can fit. This request is persistent until another
             call to request_resources() is made.
-
-    Examples:
-        >>> # Request 1000 CPUs.
-        >>> request_resources(num_cpus=1000)
-        >>> # Request 64 CPUs and also fit a 1-GPU/4-CPU task.
-        >>> request_resources(num_cpus=64, bundles=[{"GPU": 1, "CPU": 4}])
-        >>> # Same as requesting 3 CPUs.
-        >>> request_resources(bundles=[{"CPU": 1}, {"CPU": 1}, {"CPU": 1}])
     """
     if not ray.is_initialized():
         raise RuntimeError("Ray is not initialized yet")

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -85,14 +85,17 @@ class ResourceDemandScheduler:
                 that we don't take into account existing usage.
         """
 
-        # Calculate any extra requests we need to make that don't already fit
-        # into the cluster.
+        # If the user is using request_resources() API, calculate the remaining
+        # delta resources required to meet their requested cluster size.
         if ensure_min_cluster_size is not None:
             used_resources = []
             for ip, max_res in max_resources_by_ip.items():
                 res = copy.deepcopy(max_res)
                 _inplace_subtract(res, unused_resources_by_ip.get(ip, {}))
                 used_resources.append(res)
+            # Example: user requests 1000 CPUs, but the cluster is currently
+            # 500 CPUs in size with 250 used. Then, the delta is 750 CPUs that
+            # we need to fit to get the cluster to scale to 1000.
             resource_requests, _ = get_bin_pack_residual(
                 used_resources, ensure_min_cluster_size)
             resource_demands += resource_requests

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -277,17 +277,20 @@ class ResourceDemandScheduler:
             total_pending_nodes = pending_launches_nodes.get(
                 node_type, 0) + pending_nodes[node_type]
 
-            # Allow more nodes if this is to respect min_workers constraint.
             nodes_to_add = max(
                 max_allowed_pending_nodes - total_pending_nodes,
+
+                # Allow more nodes if this is to respect min_workers.
                 self.node_types[node_type].get("min_workers", 0) -
-                total_pending_nodes - running_nodes[node_type])
+                total_pending_nodes - running_nodes[node_type],
+
+                # Allow more nodes from request_resources API.
+                nodes_to_add_based_on_requests.get(node_type,
+                                                   0) - total_pending_nodes)
 
             if nodes_to_add > 0:
                 updated_nodes_to_launch[node_type] = min(
-                    max(nodes_to_add,
-                        nodes_to_add_based_on_requests.get(node_type, 0)),
-                    to_launch[node_type])
+                    nodes_to_add, to_launch[node_type])
 
         return updated_nodes_to_launch
 

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -277,7 +277,7 @@ class ResourceDemandScheduler:
             total_pending_nodes = pending_launches_nodes.get(
                 node_type, 0) + pending_nodes[node_type]
 
-            nodes_to_add = max(
+            upper_bound = max(
                 max_allowed_pending_nodes - total_pending_nodes,
 
                 # Allow more nodes if this is to respect min_workers.
@@ -288,9 +288,9 @@ class ResourceDemandScheduler:
                 nodes_to_add_based_on_requests.get(node_type,
                                                    0) - total_pending_nodes)
 
-            if nodes_to_add > 0:
+            if upper_bound > 0:
                 updated_nodes_to_launch[node_type] = min(
-                    nodes_to_add, to_launch[node_type])
+                    upper_bound, to_launch[node_type])
 
         return updated_nodes_to_launch
 

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -86,7 +86,8 @@ class ResourceDemandScheduler:
         """
 
         # Calculate any extra requests we need to make that don't already fit
-        # into the cluster.
+        # into the cluster. TODO(ekl) consider bypassing the instance launch
+        # rate limits when using request_resources.
         if ensure_min_cluster_size is not None:
             used_resources = []
             for ip, max_res in max_resources_by_ip.items():

--- a/python/ray/autoscaler/sdk.py
+++ b/python/ray/autoscaler/sdk.py
@@ -193,7 +193,7 @@ def request_resources(num_cpus: Optional[int] = None,
         >>> request_resources(num_cpus=1000)
         >>> # Request 64 CPUs and also fit a 1-GPU/4-CPU task.
         >>> request_resources(num_cpus=64, bundles=[{"GPU": 1, "CPU": 4}])
-        >>> # Same as requesting 3 CPUs.
+        >>> # Same as requesting num_cpus=3.
         >>> request_resources(bundles=[{"CPU": 1}, {"CPU": 1}, {"CPU": 1}])
     """
     return commands.request_resources(num_cpus, bundles)

--- a/python/ray/autoscaler/sdk.py
+++ b/python/ray/autoscaler/sdk.py
@@ -180,13 +180,21 @@ def request_resources(num_cpus: Optional[int] = None,
     This function is to be called e.g. on a node before submitting a bunch of
     ray.remote calls to ensure that resources rapidly become available.
 
-    This function is EXPERIMENTAL.
-
     Args:
-        num_cpus: int -- the number of CPU cores to request
-        bundles: List[dict] -- list of resource dicts (e.g., {"CPU": 1}). This
-            only has an effect if you've configured `available_node_types`
-            if your cluster config.
+        num_cpus (int): Scale the cluster to ensure this number of CPUs are
+            available. This request is persistent until another call to
+            request_resources() is made.
+        bundles (List[ResourceDict]): Scale the cluster to ensure this set of
+            resource shapes can fit. This request is persistent until another
+            call to request_resources() is made.
+
+    Examples:
+        >>> # Request 1000 CPUs.
+        >>> request_resources(num_cpus=1000)
+        >>> # Request 64 CPUs and also fit a 1-GPU/4-CPU task.
+        >>> request_resources(num_cpus=64, bundles=[{"GPU": 1, "CPU": 4}])
+        >>> # Same as requesting 3 CPUs.
+        >>> request_resources(bundles=[{"CPU": 1}, {"CPU": 1}, {"CPU": 1}])
     """
     return commands.request_resources(num_cpus, bundles)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The semantics of request_resources was broken in the multi node autoscaler, since we did not take into account existing resource usage.
- Fix it so the cluster will be scaled up to fit the requested bundles, as if the cluster was unutilized.
- Allow request_resources() to bypass the launch rate limit.
- Chunk node launches into 5 nodes launched per API request.

## Related issue number

Closes https://github.com/ray-project/ray/issues/11417
Closes https://github.com/ray-project/ray/issues/10836