### PR TITLE
[Tune] Better warnings/exceptions for fail_fast='raise'

### DIFF
--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -6,6 +6,7 @@ import os
 import time
 import traceback
 import types
+import warnings
 
 import ray.cloudpickle as cloudpickle
 from ray.services import get_node_ip_address
@@ -157,7 +158,7 @@ class TrialRunner:
         if isinstance(self._fail_fast, str):
             self._fail_fast = self._fail_fast.upper()
             if self._fail_fast == TrialRunner.RAISE:
-                logger.warning(
+                warnings.warn(
                     "fail_fast='raise' detected. Be careful when using this "
                     "mode as resources (such as Ray processes, "
                     "file descriptors, and temporary files) may not be "
@@ -474,7 +475,7 @@ class TrialRunner:
         wait_for_trial = trials_done and not self._search_alg.is_finished()
         # Only fetch a new trial if we have no pending trial
         if not any(trial.status == Trial.PENDING for trial in self._trials) \
-           or wait_for_trial:
+                or wait_for_trial:
             self._update_trial_queue(blocking=wait_for_trial)
         with warn_if_slow("choose_trial_to_run"):
             trial = self._scheduler_alg.choose_trial_to_run(self)
@@ -625,9 +626,12 @@ class TrialRunner:
             else:
                 self._execute_action(trial, decision)
         except Exception:
-            logger.exception("Trial %s: Error processing event.", trial)
+            error_msg = "Trial %s: Error processing event." % trial
             if self._fail_fast == TrialRunner.RAISE:
+                logger.error(error_msg)
                 raise
+            else:
+                logger.exception(error_msg)
             self._process_trial_failure(trial, traceback.format_exc())
 
     def _validate_result_metrics(self, result):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Better warnings & exception messages when fail_fast is set to "raise". This is needed for better errors for tune-sklearn.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
