### PR TITLE
[core] Add retry for reading session name

### DIFF
--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -26,8 +26,23 @@ from ray.utils import try_to_create_directory, try_to_symlink, open_log
 logger = logging.getLogger(__name__)
 
 SESSION_LATEST = "session_latest"
-NUMBER_OF_PORT_RETRIES = 40
-NUMBER_OF_NAME_READ_RETRIES = 10
+NUM_PORT_RETRIES = 40
+NUM_REDIS_GET_RETRIES = 20
+
+
+def _get_with_retry(redis_client, key, num_retries=NUM_REDIS_GET_RETRIES):
+    result = None
+    for i in range(num_retries):
+        result = redis_client.get(key)
+        if result is not None:
+            break
+        else:
+            logger.debug(f"Fetched {key}=None from redis. Retrying.")
+            time.sleep(2)
+    if not result:
+        raise RuntimeError(f"Could not read '{key}' from GCS (redis). "
+                           "Has redis started correctly on the head node?")
+    return result
 
 
 class Node:
@@ -140,19 +155,7 @@ class Node:
             self.session_name = f"session_{date_str}_{os.getpid()}"
         else:
             redis_client = self.create_redis_client()
-            session_name = None
-            for i in range(NUMBER_OF_NAME_READ_RETRIES):
-                session_name = redis_client.get("session_name")
-                if session_name:
-                    break
-                else:
-                    logger.debug(
-                        "Fetched session_name=None from redis. Retrying.")
-                    time.sleep(1)
-            if not session_name:
-                raise RuntimeError(
-                    "Could not read 'session_name' from GCS (redis). "
-                    "Has redis started correctly on the head node?")
+            session_name = _get_with_retry(redis_client, "session_name")
             self.session_name = ray.utils.decode(session_name)
 
         self._init_temp(redis_client)
@@ -243,15 +246,16 @@ class Node:
         if self.head:
             self._temp_dir = self._ray_params.temp_dir
         else:
-            self._temp_dir = ray.utils.decode(redis_client.get("temp_dir"))
+            temp_dir = _get_with_retry(redis_client, "temp_dir")
+            self._temp_dir = ray.utils.decode(temp_dir)
 
         try_to_create_directory(self._temp_dir)
 
         if self.head:
             self._session_dir = os.path.join(self._temp_dir, self.session_name)
         else:
-            self._session_dir = ray.utils.decode(
-                redis_client.get("session_dir"))
+            session_dir = _get_with_retry(redis_client, "session_dir")
+            self._session_dir = ray.utils.decode(session_dir)
         session_symlink = os.path.join(self._temp_dir, SESSION_LATEST)
 
         # Send a warning message if the session exists.
@@ -507,7 +511,7 @@ class Node:
         # Try to generate a port that is far above the 'next available' one.
         # This solves issue #8254 where GRPC fails because the port assigned
         # from this method has been used by a different process.
-        for _ in range(NUMBER_OF_PORT_RETRIES):
+        for _ in range(NUM_PORT_RETRIES):
             new_port = random.randint(port, 65535)
             new_s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Seems like redis client doesn't set this fast enough on the head sometimes. This adds a 40 second retry to try to obtain certain keys from redis.

From https://github.com/ray-project/ray/issues/5119#issuecomment-508966913: 

```
I think what happens is:

Worker node starts
Head node starts
Worker node connect to head node
Worker tries to get session_name from the head node, resulting in the error above (line)
Head node sets session_name (line)
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/5119.
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(