### PR TITLE
Fix prometheus configuration doc

### DIFF
--- a/doc/source/ray-metrics.rst
+++ b/doc/source/ray-metrics.rst
@@ -37,11 +37,11 @@ Let's modify Prometheus's config file to scrape metrics from Prometheus endpoint
 
     # prometheus.yml
     global:
-    scrape_interval:     5s
-    evaluation_interval: 5s
+      scrape_interval:     5s
+      evaluation_interval: 5s
 
     scrape_configs:
-    - job_name: prometheus
+      - job_name: prometheus
         static_configs:
         - targets: ['localhost:8080'] # This must be same as metrics_export_port
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There is an error when starting prometheus according to the Ray Monitoring doc configurations.
```
level=info ts=2020-11-06T10:06:55.071Z caller=main.go:296 msg="no time or size retention was set so using the default time retention" duration=15d
level=info ts=2020-11-06T10:06:55.071Z caller=main.go:332 msg="Starting Prometheus" version="(version=2.13.1, branch=non-git, revision=non-git)"
level=info ts=2020-11-06T10:06:55.071Z caller=main.go:333 build_context="(go=go1.13.1, user=brew@Mojave.local, date=20191018-01:13:04)"
level=info ts=2020-11-06T10:06:55.071Z caller=main.go:334 host_details=(darwin)
level=info ts=2020-11-06T10:06:55.071Z caller=main.go:335 fd_limits="(soft=256, hard=unlimited)"
level=info ts=2020-11-06T10:06:55.071Z caller=main.go:336 vm_limits="(soft=unlimited, hard=unlimited)"
level=info ts=2020-11-06T10:06:55.075Z caller=main.go:657 msg="Starting TSDB ..."
level=info ts=2020-11-06T10:06:55.075Z caller=web.go:450 component=web msg="Start listening for connections" address=0.0.0.0:9090
level=info ts=2020-11-06T10:06:55.083Z caller=head.go:514 component=tsdb msg="replaying WAL, this may take awhile"
level=info ts=2020-11-06T10:06:55.085Z caller=head.go:562 component=tsdb msg="WAL segment loaded" segment=0 maxSegment=13
level=info ts=2020-11-06T10:06:55.085Z caller=head.go:562 component=tsdb msg="WAL segment loaded" segment=1 maxSegment=13
level=info ts=2020-11-06T10:06:55.086Z caller=head.go:562 component=tsdb msg="WAL segment loaded" segment=2 maxSegment=13
level=info ts=2020-11-06T10:06:55.086Z caller=head.go:562 component=tsdb msg="WAL segment loaded" segment=3 maxSegment=13
level=info ts=2020-11-06T10:06:55.086Z caller=head.go:562 component=tsdb msg="WAL segment loaded" segment=4 maxSegment=13
level=info ts=2020-11-06T10:06:55.086Z caller=head.go:562 component=tsdb msg="WAL segment loaded" segment=5 maxSegment=13
level=info ts=2020-11-06T10:06:55.091Z caller=head.go:562 component=tsdb msg="WAL segment loaded" segment=6 maxSegment=13
level=info ts=2020-11-06T10:06:55.092Z caller=head.go:562 component=tsdb msg="WAL segment loaded" segment=7 maxSegment=13
level=info ts=2020-11-06T10:06:55.092Z caller=head.go:562 component=tsdb msg="WAL segment loaded" segment=8 maxSegment=13
level=info ts=2020-11-06T10:06:55.092Z caller=head.go:562 component=tsdb msg="WAL segment loaded" segment=9 maxSegment=13
level=info ts=2020-11-06T10:06:55.094Z caller=head.go:562 component=tsdb msg="WAL segment loaded" segment=10 maxSegment=13
level=info ts=2020-11-06T10:06:55.095Z caller=head.go:562 component=tsdb msg="WAL segment loaded" segment=11 maxSegment=13
level=info ts=2020-11-06T10:06:55.096Z caller=head.go:562 component=tsdb msg="WAL segment loaded" segment=12 maxSegment=13
level=info ts=2020-11-06T10:06:55.097Z caller=head.go:562 component=tsdb msg="WAL segment loaded" segment=13 maxSegment=13
level=info ts=2020-11-06T10:06:55.098Z caller=main.go:672 fs_type=19
level=info ts=2020-11-06T10:06:55.098Z caller=main.go:673 msg="TSDB started"
level=info ts=2020-11-06T10:06:55.098Z caller=main.go:743 msg="Loading configuration file" filename=promconfig_ray.yml
level=info ts=2020-11-06T10:06:55.100Z caller=main.go:526 msg="Stopping scrape discovery manager..."
level=info ts=2020-11-06T10:06:55.100Z caller=main.go:540 msg="Stopping notify discovery manager..."
level=info ts=2020-11-06T10:06:55.100Z caller=main.go:522 msg="Scrape discovery manager stopped"
level=info ts=2020-11-06T10:06:55.100Z caller=main.go:536 msg="Notify discovery manager stopped"
level=info ts=2020-11-06T10:06:55.100Z caller=main.go:562 msg="Stopping scrape manager..."
level=info ts=2020-11-06T10:06:55.101Z caller=manager.go:814 component="rule manager" msg="Stopping rule manager..."
level=info ts=2020-11-06T10:06:55.101Z caller=main.go:556 msg="Scrape manager stopped"
level=info ts=2020-11-06T10:06:55.101Z caller=manager.go:820 component="rule manager" msg="Rule manager stopped"
level=info ts=2020-11-06T10:06:55.113Z caller=notifier.go:602 component=notifier msg="Stopping notification manager..."
level=info ts=2020-11-06T10:06:55.113Z caller=main.go:727 msg="Notifier manager stopped"
level=error ts=2020-11-06T10:06:55.115Z caller=main.go:736 err="error loading config from \"promconfig_ray.yml\": couldn't load configuration (--config.file=\"promconfig.yml\"): parsing YAML file promconfig.yml: yaml: line 8: mapping values are not allowed in this context"
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
