### PR TITLE
[examples] comment out `rsync_` settings for K8S

### DIFF
--- a/python/ray/autoscaler/kubernetes/defaults.yaml
+++ b/python/ray/autoscaler/kubernetes/defaults.yaml
@@ -277,13 +277,13 @@ file_mounts_sync_continuously: False
 
 # Patterns for files to exclude when running rsync up or rsync down.
 # This is not supported on kubernetes.
-rsync_exclude: []
+# rsync_exclude: []
 
 # Pattern files to use for filtering out files when running rsync up or rsync down. The file is searched for
 # in the source directory and recursively through all subdirectories. For example, if .gitignore is provided
 # as a value, the behavior will match git's behavior for finding and using .gitignore files.
 # This is not supported on kubernetes.
-rsync_filter: []
+# rsync_filter: []
 
 
 # List of commands that will be run before `setup_commands`. If docker is

--- a/python/ray/autoscaler/kubernetes/example-full.yaml
+++ b/python/ray/autoscaler/kubernetes/example-full.yaml
@@ -277,13 +277,13 @@ file_mounts_sync_continuously: False
 
 # Patterns for files to exclude when running rsync up or rsync down.
 # This is not supported on kubernetes.
-rsync_exclude: []
+# rsync_exclude: []
 
 # Pattern files to use for filtering out files when running rsync up or rsync down. The file is searched for
 # in the source directory and recursively through all subdirectories. For example, if .gitignore is provided
 # as a value, the behavior will match git's behavior for finding and using .gitignore files.
 # This is not supported on kubernetes.
-rsync_filter: []
+# rsync_filter: []
 
 # List of commands that will be run before `setup_commands`. If docker is
 # enabled, these commands will run outside the container and before docker


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When running a ray cluster in K8S, the rsync_ options will break. This comments them out so the defaults.yaml and example-full.yaml run cleaning the first time.

## Related issue number
Addresses #11850

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
it ran w/o error, but didn't see an explicit confirmation
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
no doc updates required. in fact, this commit makes the doc work
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
