### PR TITLE
[Dashboard][Bugfix] Fix Error when Actor has no Core Worker

### DIFF
--- a/dashboard/datacenter.py
+++ b/dashboard/datacenter.py
@@ -229,23 +229,24 @@ class DataOrganizer:
         # TODO(fyrestone): remove this, give a link from actor
         # info to worker info in front-end.
         node_id = actor["address"]["rayletId"]
-        pid = core_worker_stats["pid"]
+        pid = core_worker_stats.get("pid")
         node_physical_stats = DataSource.node_physical_stats.get(node_id, {})
-
         actor_process_stats = None
-        for process_stats in node_physical_stats.get("workers"):
-            if process_stats["pid"] == pid:
-                actor_process_stats = process_stats
-                break
-
         actor_process_gpu_stats = None
-        for gpu_stats in node_physical_stats.get("gpus"):
-            for process in gpu_stats.get("processes", []):
-                if process["pid"] == pid:
-                    actor_process_gpu_stats = gpu_stats
+        if pid:
+            for process_stats in node_physical_stats.get("workers"):
+                if process_stats["pid"] == pid:
+                    actor_process_stats = process_stats
                     break
-            if actor_process_gpu_stats is not None:
-                break
+
+            for gpu_stats in node_physical_stats.get("gpus"):
+                for process in gpu_stats.get("processes", []):
+                    if process["pid"] == pid:
+                        actor_process_gpu_stats = gpu_stats
+                        break
+                if actor_process_gpu_stats is not None:
+                    break
+
         actor["gpus"] = actor_process_gpu_stats
         actor["processStats"] = actor_process_stats
 


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When, for whatever reason, the dashboard doesn't have the current mapping between actor and core worker, the `pid` lookup would cause an error, as opposed to simply failing to pull process data for the actor. This is a defensive coding change to prevent that error.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
