### PR TITLE
find_redis_address docstring

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -126,7 +126,30 @@ def find_redis_address(address=None):
     Currently, this extracts the --redis-address from the command that launched
     the raylet running on this node, if any. For context, these commands look
     like, for example:
-    /usr/local/lib/python3.8/dist-packages/ray/core/src/ray/raylet/raylet --raylet_socket_name=... --store_socket_name=... --object_manager_port=0 --min_worker_port=10000 --max_worker_port=10999 --node_manager_port=58578 --node_ip_address=123.456.78.910 --redis_address=123.456.78.910 --redis_port=6379 --num_initial_workers=8 --maximum_startup_concurrency=8 --static_resource_list=node:123.456.78.910,1.0,CPU,8,memory,224,object_store_memory,66 --config_list=plasma_store_as_thread,True --python_worker_command=/usr/bin/python /usr/local/lib/python3.8/dist-packages/ray/workers/default_worker.py --node-ip-address=123.456.78.910 --node-manager-port=58578 --object-store-name=... --raylet-name=... --redis-address=123.456.78.910:6379 --config-list=plasma_store_as_thread,True --temp-dir=/tmp/ray --metrics-agent-port=41856 --redis-password=[MASKED] --java_worker_command= --cpp_worker_command= --redis_password=[MASKED] --temp_dir=/tmp/ray --session_dir=... --metrics-agent-port=41856 --metrics_export_port=64229 --agent_command=/usr/bin/python -u /usr/local/lib/python3.8/dist-packages/ray/new_dashboard/agent.py --redis-address=123.456.78.910:6379 --metrics-export-port=64229 --dashboard-agent-port=41856 --node-manager-port=58578 --object-store-name=... --raylet-name=... --temp-dir=/tmp/ray --log-dir=/tmp/ray/session_2020-11-08_14-29-07_199128_278000/logs --redis-password=[MASKED] --object_store_memory=5037192806 --plasma_directory=/tmp
+    /usr/local/lib/python3.8/dist-packages/ray/core/src/ray/raylet/raylet
+    --raylet_socket_name=... --store_socket_name=... --object_manager_port=0
+    --min_worker_port=10000 --max_worker_port=10999 --node_manager_port=58578
+    --node_ip_address=123.456.78.910 --redis_address=123.456.78.910
+    --redis_port=6379 --num_initial_workers=8 --maximum_startup_concurrency=8
+    --static_resource_list=node:123.456.78.910,1.0,object_store_memory,66
+    --config_list=plasma_store_as_thread,True
+    --python_worker_command=/usr/bin/python
+        /usr/local/lib/python3.8/dist-packages/ray/workers/default_worker.py
+        --node-ip-address=123.456.78.910 --node-manager-port=58578
+        --object-store-name=... --raylet-name=...
+        --redis-address=123.456.78.910:6379
+        --config-list=plasma_store_as_thread,True --temp-dir=/tmp/ray
+        --metrics-agent-port=41856 --redis-password=[MASKED]
+        --java_worker_command= --cpp_worker_command= --redis_password=[MASKED]
+        --temp_dir=/tmp/ray --session_dir=... --metrics-agent-port=41856
+        --metrics_export_port=64229 --agent_command=/usr/bin/python
+        -u /usr/local/lib/python3.8/dist-packages/ray/new_dashboard/agent.py
+            --redis-address=123.456.78.910:6379 --metrics-export-port=64229
+            --dashboard-agent-port=41856 --node-manager-port=58578
+            --object-store-name=... --raylet-name=... --temp-dir=/tmp/ray
+            --log-dir=/tmp/ray/session_2020-11-08_14-29-07_199128_278000/logs
+            --redis-password=[MASKED] --object_store_memory=5037192806
+            --plasma_directory=/tmp
     Longer arguments are elided with ... but all arguments from this instance
     are included, to provide a sense of what is in these.
     Notice that --redis-address appears twice. This is not a copy-paste error;

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -122,6 +122,17 @@ def new_port():
 
 
 def find_redis_address(address=None):
+    """
+    Currently, this extracts the --redis-address from the command that launched
+    the raylet running on this node, if any. For context, these commands look
+    like, for example:
+    /usr/local/lib/python3.8/dist-packages/ray/core/src/ray/raylet/raylet --raylet_socket_name=... --store_socket_name=... --object_manager_port=0 --min_worker_port=10000 --max_worker_port=10999 --node_manager_port=58578 --node_ip_address=123.456.78.910 --redis_address=123.456.78.910 --redis_port=6379 --num_initial_workers=8 --maximum_startup_concurrency=8 --static_resource_list=node:123.456.78.910,1.0,CPU,8,memory,224,object_store_memory,66 --config_list=plasma_store_as_thread,True --python_worker_command=/usr/bin/python /usr/local/lib/python3.8/dist-packages/ray/workers/default_worker.py --node-ip-address=123.456.78.910 --node-manager-port=58578 --object-store-name=... --raylet-name=... --redis-address=123.456.78.910:6379 --config-list=plasma_store_as_thread,True --temp-dir=/tmp/ray --metrics-agent-port=41856 --redis-password=[MASKED] --java_worker_command= --cpp_worker_command= --redis_password=[MASKED] --temp_dir=/tmp/ray --session_dir=... --metrics-agent-port=41856 --metrics_export_port=64229 --agent_command=/usr/bin/python -u /usr/local/lib/python3.8/dist-packages/ray/new_dashboard/agent.py --redis-address=123.456.78.910:6379 --metrics-export-port=64229 --dashboard-agent-port=41856 --node-manager-port=58578 --object-store-name=... --raylet-name=... --temp-dir=/tmp/ray --log-dir=/tmp/ray/session_2020-11-08_14-29-07_199128_278000/logs --redis-password=[MASKED] --object_store_memory=5037192806 --plasma_directory=/tmp
+    Longer arguments are elided with ... but all arguments from this instance
+    are included, to provide a sense of what is in these.
+    Notice that --redis-address appears twice. This is not a copy-paste error;
+    this is the reason why the for loop below attempts to pick out every
+    appearance of --redis-address.
+    """
     pids = psutil.pids()
     redis_addresses = set()
     for pid in pids:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Currently, `find_redis_address()` lacks a docstring, and is somewhat complicated and counter-intuitive when reading the code. This adds a specific example of a string `find_redis_address()` might process.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
