### PR TITLE
[GCS]Only pass node id to node failure detector

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -45,8 +45,7 @@ void GcsNodeManager::NodeFailureDetector::AddNode(const ray::NodeID &node_id) {
   heartbeats_.emplace(node_id, num_heartbeats_timeout_);
 }
 
-void GcsNodeManager::NodeFailureDetector::HandleHeartbeat(
-    const NodeID &node_id, const rpc::HeartbeatTableData &heartbeat_data) {
+void GcsNodeManager::NodeFailureDetector::HandleHeartbeat(const NodeID &node_id) {
   auto iter = heartbeats_.find(node_id);
   if (iter == heartbeats_.end()) {
     // Ignore this heartbeat as the node is not registered.
@@ -208,9 +207,8 @@ void GcsNodeManager::HandleReportHeartbeat(const rpc::ReportHeartbeatRequest &re
 
   // Note: To avoid heartbeats being delayed by main thread, make sure heartbeat is always
   // handled by its own IO service.
-  node_failure_detector_service_.post([this, node_id, heartbeat_data] {
-    node_failure_detector_->HandleHeartbeat(node_id, *heartbeat_data);
-  });
+  node_failure_detector_service_.post(
+      [this, node_id] { node_failure_detector_->HandleHeartbeat(node_id); });
   GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
 }
 

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -206,7 +206,7 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
 
     /// Handle a heartbeat from a Raylet.
     ///
-    /// \param node_id The client ID of the Raylet that sent the heartbeat.
+    /// \param node_id The node ID of the Raylet that sent the heartbeat.
     void HandleHeartbeat(const NodeID &node_id);
 
    protected:

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -207,9 +207,7 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
     /// Handle a heartbeat from a Raylet.
     ///
     /// \param node_id The client ID of the Raylet that sent the heartbeat.
-    /// \param heartbeat_data The heartbeat sent by the client.
-    void HandleHeartbeat(const NodeID &node_id,
-                         const rpc::HeartbeatTableData &heartbeat_data);
+    void HandleHeartbeat(const NodeID &node_id);
 
    protected:
     /// A periodic timer that fires on every heartbeat period. Raylets that have


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Since we moved "SendBatchedResources" out of node failure detector(https://github.com/ray-project/ray/pull/11465), heartbeat data is no longer needed. We should not pass that data into it but only node id.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
