### PR TITLE
[Serialization] Fix buffer alignment issues

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1355,6 +1355,7 @@ cc_library(
     strip_include_prefix = "src",
     visibility = ["//visibility:public"],
     deps = [
+        ":aligned_alloc",
         ":sha256",
         "//src/ray/protobuf:event_cc_proto",
         "@boost//:asio",
@@ -1408,6 +1409,18 @@ cc_library(
     ],
     hdrs = [
         "src/ray/thirdparty/sha256.h",
+    ],
+    copts = COPTS,
+    strip_include_prefix = "src",
+)
+
+cc_library(
+    name = "aligned_alloc",
+    srcs = [
+        "src/ray/thirdparty/aligned_alloc.c",
+    ],
+    hdrs = [
+        "src/ray/thirdparty/aligned_alloc.h",
     ],
     copts = COPTS,
     strip_include_prefix = "src",

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -54,7 +54,6 @@ from ray.includes.common cimport (
     CTaskType,
     CPlacementStrategy,
     CRayFunction,
-    LocalMemoryBuffer,
     move,
     LANGUAGE_CPP,
     LANGUAGE_JAVA,

--- a/python/ray/includes/serialization.pxi
+++ b/python/ray/includes/serialization.pxi
@@ -68,6 +68,9 @@ cdef extern from "src/ray/protobuf/serialization.pb.h" nogil:
 cdef int64_t padded_length(int64_t offset, int64_t alignment):
     return ((offset + alignment - 1) // alignment) * alignment
 
+cdef uint8_t* aligned_address(uint8_t* addr, uint64_t alignment) nogil:
+    cdef uintptr_t u_addr = <uintptr_t>addr
+    return <uint8_t*>(((u_addr + alignment - 1) // alignment) * alignment)
 
 cdef int64_t padded_length_u64(uint64_t offset, uint64_t alignment):
     return ((offset + alignment - 1) // alignment) * alignment
@@ -203,37 +206,39 @@ def split_buffer(Buffer buf):
                        kMessagePackOffset + msgpack_bytes_length],
             bufferview[kMessagePackOffset + msgpack_bytes_length:])
 
+# Note [Pickle5 serialization layout & alignment]
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# To ensure efficient data access, our serialize enforces alignment
+# when writing data to a buffer. See 'serialization.proto' for
+# the detail memory layout and alignment.
 
-# See 'serialization.proto' for the memory layout in the Plasma buffer.
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def unpack_pickle5_buffers(uint8_t[:] bufferview):
     cdef:
         const uint8_t *data = &bufferview[0]
-        size_t size = len(bufferview)
         CPythonObject python_object
         CPythonBuffer *buffer_meta
-        int64_t protobuf_offset
+        int inband_offset = sizeof(int64_t) * 2
+        int64_t inband_size
         int64_t protobuf_size
         int32_t i
         const uint8_t *buffers_segment
-    protobuf_offset = (<int64_t*>data)[0]
-    if protobuf_offset < 0:
-        raise ValueError("The protobuf data offset should be positive."
+    inband_size = (<int64_t*>data)[0]
+    if inband_size < 0:
+        raise ValueError("The inband data size should be positive."
                          "Got negative instead. "
                          "Maybe the buffer has been corrupted.")
     protobuf_size = (<int64_t*>data)[1]
     if protobuf_size > INT32_MAX or protobuf_size < 0:
         raise ValueError("Incorrect protobuf size. "
                          "Maybe the buffer has been corrupted.")
+    inband_data = bufferview[inband_offset:inband_offset + inband_size]
     if not python_object.ParseFromArray(
-            data + protobuf_offset, <int32_t>protobuf_size):
+            data + inband_offset + inband_size, <int32_t>protobuf_size):
         raise ValueError("Protobuf object is corrupted.")
-    inband_data_offset = python_object.inband_data_offset()
-    inband_data = bufferview[
-        inband_data_offset:
-        inband_data_offset + python_object.inband_data_size()]
-    buffers_segment = data + python_object.raw_buffers_offset()
+    buffers_segment = aligned_address(
+        <uint8_t*>data + inband_size + protobuf_size, kMajorBufferAlign)
     pickled_buffers = []
     # Now read buffer meta
     for i in range(python_object.buffer_size()):
@@ -321,43 +326,48 @@ cdef class Pickle5Writer:
         self.python_object.set_raw_buffers_size(self._curr_buffer_addr)
         # Since calculating the output size is expensive, we will
         # reuse the cached size.
-        # So we MUST NOT change 'python_object' afterwards.
-        # This is because protobuf could change the output size
-        # according to different values.
+        # However, protobuf could change the output size according to
+        # different values, so we MUST NOT change 'python_object' afterwards.
         protobuf_bytes = self.python_object.ByteSizeLong()
         if protobuf_bytes > INT32_MAX:
             raise ValueError("Total buffer metadata size is bigger than %d. "
                              "Consider reduce the number of buffers "
                              "(number of numpy arrays, etc)." % INT32_MAX)
-        self._protobuf_offset = padded_length_u64(
-            raw_buffers_offset + self._curr_buffer_addr, kMinorBufferAlign)
+        self._protobuf_offset = inband_data_offset + len(inband)
         self._total_bytes = self._protobuf_offset + protobuf_bytes
+        if self._curr_buffer_addr > 0:
+            # reserve 'kMajorBufferAlign' bytes for possible buffer alignment
+            self._total_bytes += kMajorBufferAlign + self._curr_buffer_addr
         return self._total_bytes
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     cdef void write_to(self, const uint8_t[:] inband, uint8_t[:] data,
                        int memcopy_threads) nogil:
-        cdef uint8_t *ptr = &data[0]
-        cdef int32_t protobuf_size
-        cdef uint64_t buffer_addr
-        cdef uint64_t buffer_len
-        cdef int i
+        cdef:
+            uint8_t *ptr = &data[0]
+            uint64_t buffer_addr
+            uint64_t buffer_len
+            int i
+            int64_t protobuf_size = self.python_object.GetCachedSize()
         if self._total_bytes < 0:
             raise ValueError("Must call 'get_total_bytes()' first "
                              "to get the actual size")
-        # Write protobuf size for deserialization.
-        protobuf_size = self.python_object.GetCachedSize()
-        (<int64_t*>ptr)[0] = self._protobuf_offset
+        # Write inband data & protobuf size for deserialization.
+        (<int64_t*>ptr)[0] = len(inband)
         (<int64_t*>ptr)[1] = protobuf_size
-        # Write protobuf data.
-        self.python_object.SerializeWithCachedSizesToArray(
-            ptr + self._protobuf_offset)
         # Write inband data.
-        memcpy(ptr + self.python_object.inband_data_offset(),
-               &inband[0], len(inband))
-        # Write buffer data.
-        ptr += self.python_object.raw_buffers_offset()
+        ptr += sizeof(int64_t) * 2
+        memcpy(ptr, &inband[0], len(inband))
+        # Write protobuf data.
+        ptr += len(inband)
+        self.python_object.SerializeWithCachedSizesToArray(ptr)
+        ptr += protobuf_size
+        if self._curr_buffer_addr <= 0:
+            # End of serialization. Writing more stuff will corrupt the memory.
+            return
+        # aligned to 64 bytes
+        ptr = aligned_address(ptr, kMajorBufferAlign)
         for i in range(self.python_object.buffer_size()):
             buffer_addr = self.python_object.buffer(i).address()
             buffer_len = self.python_object.buffer(i).length()

--- a/python/ray/includes/serialization.pxi
+++ b/python/ray/includes/serialization.pxi
@@ -232,7 +232,8 @@ def unpack_pickle5_buffers(uint8_t[:] bufferview):
             data + inband_offset + inband_size, <int32_t>protobuf_size):
         raise ValueError("Protobuf object is corrupted.")
     buffers_segment = aligned_address(
-        <uint8_t*>data + inband_size + protobuf_size, kMajorBufferAlign)
+        <uint8_t*>data + inband_offset + inband_size + protobuf_size,
+        kMajorBufferAlign)
     pickled_buffers = []
     # Now read buffer meta
     for i in range(python_object.buffer_size()):

--- a/python/ray/includes/serialization.pxi
+++ b/python/ray/includes/serialization.pxi
@@ -200,11 +200,13 @@ def split_buffer(Buffer buf):
                        kMessagePackOffset + msgpack_bytes_length],
             bufferview[kMessagePackOffset + msgpack_bytes_length:])
 
+
 # Note [Pickle5 serialization layout & alignment]
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # To ensure efficient data access, our serialize enforces alignment
 # when writing data to a buffer. See 'serialization.proto' for
 # the detail memory layout and alignment.
+
 
 @cython.boundscheck(False)
 @cython.wraparound(False)

--- a/python/ray/includes/serialization.pxi
+++ b/python/ray/includes/serialization.pxi
@@ -48,12 +48,8 @@ cdef extern from "src/ray/protobuf/serialization.pb.h" nogil:
         int strides_size()
 
     cdef cppclass CPythonObject "ray::serialization::PythonObject":
-        uint64_t inband_data_offset() const
-        void set_inband_data_offset(uint64_t value)
         uint64_t inband_data_size() const
         void set_inband_data_size(uint64_t value)
-        uint64_t raw_buffers_offset() const
-        void set_raw_buffers_offset(uint64_t value)
         uint64_t raw_buffers_size() const
         void set_raw_buffers_size(uint64_t value)
         CPythonBuffer* add_buffer()
@@ -68,12 +64,10 @@ cdef extern from "src/ray/protobuf/serialization.pb.h" nogil:
 cdef int64_t padded_length(int64_t offset, int64_t alignment):
     return ((offset + alignment - 1) // alignment) * alignment
 
+
 cdef uint8_t* aligned_address(uint8_t* addr, uint64_t alignment) nogil:
     cdef uintptr_t u_addr = <uintptr_t>addr
     return <uint8_t*>(((u_addr + alignment - 1) // alignment) * alignment)
-
-cdef int64_t padded_length_u64(uint64_t offset, uint64_t alignment):
-    return ((offset + alignment - 1) // alignment) * alignment
 
 
 cdef class SubBuffer:
@@ -318,11 +312,7 @@ cdef class Pickle5Writer:
         cdef:
             size_t protobuf_bytes = 0
             uint64_t inband_data_offset = sizeof(int64_t) * 2
-            uint64_t raw_buffers_offset = padded_length_u64(
-                inband_data_offset + len(inband), kMajorBufferAlign)
-        self.python_object.set_inband_data_offset(inband_data_offset)
         self.python_object.set_inband_data_size(len(inband))
-        self.python_object.set_raw_buffers_offset(raw_buffers_offset)
         self.python_object.set_raw_buffers_size(self._curr_buffer_addr)
         # Since calculating the output size is expensive, we will
         # reuse the cached size.

--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -543,6 +543,31 @@ def test_reducer_override_no_reference_cycle(ray_start_shared_local_modes):
     assert new_obj() is None
 
 
+def test_buffer_alignment():
+    # Deserialized large numpy arrays should be 64-byte aligned.
+    x = np.random.normal(size=(10, 20, 30))
+    y = ray.get(ray.put(x))
+    assert y.ctypes.data % 64 == 0
+
+    # Unlike PyArrow, Ray aligns small numpy arrays to 8
+    # bytes to be memory efficient.
+    xs = [np.random.normal(size=i) for i in range(100)]
+    ys = ray.get(ray.put(xs))
+    for y in ys:
+        assert y.ctypes.data % 8 == 0
+
+    xs = [np.random.normal(size=i * (1,)) for i in range(20)]
+    ys = ray.get(ray.put(xs))
+    for y in ys:
+        assert y.ctypes.data % 8 == 0
+
+    xs = [np.random.normal(size=i * (5,)) for i in range(1, 8)]
+    xs = [xs[i][(i + 1) * (slice(1, 3),)] for i in range(len(xs))]
+    ys = ray.get(ray.put(xs))
+    for y in ys:
+        assert y.ctypes.data % 8 == 0
+
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -556,13 +556,13 @@ def test_buffer_alignment():
     for y in ys:
         assert y.ctypes.data % 8 == 0
 
-    xs = [np.random.normal(size=i * (1,)) for i in range(20)]
+    xs = [np.random.normal(size=i * (1, )) for i in range(20)]
     ys = ray.get(ray.put(xs))
     for y in ys:
         assert y.ctypes.data % 8 == 0
 
-    xs = [np.random.normal(size=i * (5,)) for i in range(1, 8)]
-    xs = [xs[i][(i + 1) * (slice(1, 3),)] for i in range(len(xs))]
+    xs = [np.random.normal(size=i * (5, )) for i in range(1, 8)]
+    xs = [xs[i][(i + 1) * (slice(1, 3), )] for i in range(len(xs))]
     ys = ray.get(ray.put(xs))
     for y in ys:
         assert y.ctypes.data % 8 == 0

--- a/src/ray/common/buffer.h
+++ b/src/ray/common/buffer.h
@@ -69,7 +69,7 @@ class LocalMemoryBuffer : public Buffer {
       : has_data_copy_(copy_data) {
     if (copy_data) {
       RAY_CHECK(data != nullptr);
-      buffer_ = (uint8_t *)aligned_malloc(size, BUFFER_ALIGNMENT);
+      buffer_ = reinterpret_cast<uint8_t *>(aligned_malloc(size, BUFFER_ALIGNMENT));
       std::copy(data, data + size, buffer_);
       data_ = buffer_;
       size_ = size;
@@ -81,7 +81,7 @@ class LocalMemoryBuffer : public Buffer {
 
   /// Construct a LocalMemoryBuffer of all zeros of the given size.
   LocalMemoryBuffer(size_t size) : has_data_copy_(true) {
-    buffer_ = (uint8_t *)aligned_malloc(size, BUFFER_ALIGNMENT);
+    buffer_ = reinterpret_cast<uint8_t *>(aligned_malloc(size, BUFFER_ALIGNMENT));
     data_ = buffer_;
     size_ = size;
   }

--- a/src/ray/common/buffer.h
+++ b/src/ray/common/buffer.h
@@ -69,7 +69,7 @@ class LocalMemoryBuffer : public Buffer {
       : has_data_copy_(copy_data) {
     if (copy_data) {
       RAY_CHECK(data != nullptr);
-      buffer_ = (uint8_t*)aligned_malloc(size, BUFFER_ALIGNMENT);
+      buffer_ = (uint8_t *)aligned_malloc(size, BUFFER_ALIGNMENT);
       std::copy(data, data + size, buffer_);
       data_ = buffer_;
       size_ = size;
@@ -81,7 +81,7 @@ class LocalMemoryBuffer : public Buffer {
 
   /// Construct a LocalMemoryBuffer of all zeros of the given size.
   LocalMemoryBuffer(size_t size) : has_data_copy_(true) {
-    buffer_ = (uint8_t*)aligned_malloc(size, BUFFER_ALIGNMENT);
+    buffer_ = (uint8_t *)aligned_malloc(size, BUFFER_ALIGNMENT);
     data_ = buffer_;
     size_ = size;
   }
@@ -114,7 +114,7 @@ class LocalMemoryBuffer : public Buffer {
   /// Whether this buffer holds a copy of data.
   bool has_data_copy_;
   /// This is only valid when `should_copy` is true.
-  uint8_t* buffer_ = NULL;
+  uint8_t *buffer_ = NULL;
 };
 
 /// Represents a byte buffer for plasma object. This can be used to hold the

--- a/src/ray/protobuf/serialization.proto
+++ b/src/ray/protobuf/serialization.proto
@@ -21,9 +21,9 @@ package ray.serialization;
 // ## About Pickle 5 Protocol
 // Pickle5 will create two things during serialization:
 //   1. Inband data. This is the framed pickle data for most objects.
-//   2. Buffers. They are python buffers referring internal data of objects.
-//       They contain metadata of the buffer and a native pointer.
-//       Thus they provide interface for zero-copy serialization.
+//   2. Buffers. They are python buffers wrapping internal data chunks of objects.
+//       They contain metadata of the buffer and a native pointer, which is
+//       intended for zero-copy serialization.
 //
 // ## Protobuf object
 // A PythonObject protobuf object will be created for each python object.
@@ -34,19 +34,20 @@ package ray.serialization;
 //
 // ## Python object serialization memory layout
 // This section describes the memory layout in the Plasma store buffer.
-// Unfortunately, no frame info is included in protobuf data, so we have to specify
-// the length and offset of PythonObject.
 // ---------------------
-// i64 offset(PythonObject):
+// i64 len(inband_data):
 //     Offset of the PythonObject relative to the start of this buffer.
 // i64 len(PythonObject):
 //     Length of the PythonObject.
-// inband_data | pad(64)
+// inband_data
 //     Inband data, padded with 64 bytes for the alignment of buffers.
-// buffers | pad(8)
-//     Raw data of buffers, padded with 8 bytes for the alignment of PythonObject.
 // PythonObject
-//     PythonObject is stored at the end because its size will be variable.
+//     PythonObject protobuf defined as below.
+// buffers | aligned(64)
+//     Raw data of buffers, this section is 64-byte aligned.
+//     Inside the section, large buffers (>=2048 bytes) are aligned to 64 bytes for faster SIMD,
+//     small buffers (<2048 bytes) are aligned to 8 bytes.
+
 // ---------------------
 
 // The message for metadata of python buffer objects.

--- a/src/ray/protobuf/serialization.proto
+++ b/src/ray/protobuf/serialization.proto
@@ -45,8 +45,9 @@ package ray.serialization;
 //     PythonObject protobuf defined as below.
 // buffers | aligned(64)
 //     Raw data of buffers, this section is 64-byte aligned.
-//     Inside the section, large buffers (>=2048 bytes) are aligned to 64 bytes for faster SIMD,
-//     small buffers (<2048 bytes) are aligned to 8 bytes.
+//     Inside the section, large buffers (>=2048 bytes) are aligned
+//     to 64 bytes for faster SIMD, small buffers (<2048 bytes) are
+//     aligned to 8 bytes.
 
 // ---------------------
 

--- a/src/ray/protobuf/serialization.proto
+++ b/src/ray/protobuf/serialization.proto
@@ -36,7 +36,7 @@ package ray.serialization;
 // This section describes the memory layout in the Plasma store buffer.
 // ---------------------
 // i64 len(inband_data):
-//     Offset of the PythonObject relative to the start of this buffer.
+//     Length of the inband data.
 // i64 len(PythonObject):
 //     Length of the PythonObject.
 // inband_data
@@ -82,16 +82,12 @@ message PythonBuffer {
 
 // The message for pickle5 serialized python object.
 message PythonObject {
-  // The offset of the inband data section relative to the beginning of the Plasma buffer.
-  uint64 inband_data_offset = 1;
   // The size of the inband data section.
-  uint64 inband_data_size = 2;
-  // The offset of the raw buffers section relative to the beginning of the Plasma buffer.
-  uint64 raw_buffers_offset = 3;
+  uint64 inband_data_size = 1;
   // The size of the buffers section. It is not used in deserialization
   // because we already have the length and address of every buffer. However, it could
   // be useful for debugging or future adjustment, so we just keep it.
-  uint64 raw_buffers_size = 4;
+  uint64 raw_buffers_size = 2;
   // The metadata of python buffer objects.
-  repeated PythonBuffer buffer = 5;
+  repeated PythonBuffer buffer = 3;
 }

--- a/src/ray/thirdparty/aligned_alloc.c
+++ b/src/ray/thirdparty/aligned_alloc.c
@@ -1,0 +1,49 @@
+#include "ray/thirdparty/aligned_alloc.h"
+
+#if defined(__APPLE__) || defined(__linux__)
+
+#include <stdlib.h>
+
+void *aligned_malloc(size_t size, size_t alignment) {
+	void *pointer;
+	posix_memalign(&pointer, alignment, size);
+	return pointer;
+}
+
+void aligned_free(void *pointer) {
+	free(pointer);
+}
+
+#elif defined(_WIN32)
+
+#include <crtdbg.h>
+
+void *aligned_malloc(size_t size, size_t alignment) {
+	return _aligned_malloc_dbg(size, alignment, __FILE__, __LINE__); // This is reduced to a call to `_aligned_malloc` when _DEBUG is not defined
+}
+
+void aligned_free(void *pointer) {
+	_aligned_free_dbg(pointer); // This is reduced to a call to `_aligned_free` when _DEBUG is not defined
+}
+
+#else
+
+// https://sites.google.com/site/ruslancray/lab/bookshelf/interview/ci/low-level/write-an-aligned-malloc-free-function
+#include <stdlib.h>
+
+void *aligned_malloc(size_t size, size_t alignment) {
+	void *p1; // original block
+	void **p2; // aligned block
+	int offset = alignment - 1 + sizeof(void *);
+	if ((p1 = (void *)malloc(size + offset)) == NULL)
+		return NULL;
+	p2 = (void **)(((size_t)(p1) + offset) & ~(alignment - 1));
+	p2[-1] = p1;
+	return p2;
+}
+
+void aligned_free(void *pointer) {
+	free(((void **)pointer)[-1]);
+}
+
+#endif

--- a/src/ray/thirdparty/aligned_alloc.c
+++ b/src/ray/thirdparty/aligned_alloc.c
@@ -1,3 +1,29 @@
+/*
+Adopted from https://github.com/NickStrupat/AlignedMalloc
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Nick Strupat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 #include "ray/thirdparty/aligned_alloc.h"
 
 #if defined(__APPLE__) || defined(__linux__)
@@ -6,7 +32,7 @@
 
 void *aligned_malloc(size_t size, size_t alignment) {
 	void *pointer;
-	posix_memalign(&pointer, alignment, size);
+	(void)posix_memalign(&pointer, alignment, size);
 	return pointer;
 }
 

--- a/src/ray/thirdparty/aligned_alloc.c
+++ b/src/ray/thirdparty/aligned_alloc.c
@@ -16,14 +16,14 @@ void aligned_free(void *pointer) {
 
 #elif defined(_WIN32)
 
-#include <crtdbg.h>
+#include <malloc.h>
 
 void *aligned_malloc(size_t size, size_t alignment) {
-	return _aligned_malloc_dbg(size, alignment, __FILE__, __LINE__); // This is reduced to a call to `_aligned_malloc` when _DEBUG is not defined
+	return _aligned_malloc(size, alignment);
 }
 
 void aligned_free(void *pointer) {
-	_aligned_free_dbg(pointer); // This is reduced to a call to `_aligned_free` when _DEBUG is not defined
+	_aligned_free(pointer);
 }
 
 #else

--- a/src/ray/thirdparty/aligned_alloc.c
+++ b/src/ray/thirdparty/aligned_alloc.c
@@ -31,8 +31,11 @@ SOFTWARE.
 #include <stdlib.h>
 
 void *aligned_malloc(size_t size, size_t alignment) {
-	void *pointer;
-	(void)posix_memalign(&pointer, alignment, size);
+	void *pointer = NULL;
+	int rv = posix_memalign(&pointer, alignment, size);
+	if (rv != 0) {
+	  pointer = NULL;
+	}
 	return pointer;
 }
 

--- a/src/ray/thirdparty/aligned_alloc.h
+++ b/src/ray/thirdparty/aligned_alloc.h
@@ -1,0 +1,19 @@
+// Adopted from https://github.com/NickStrupat/AlignedMalloc
+
+#ifndef ALIGNED_ALLOC_H_INCLUDED
+#define ALIGNED_ALLOC_H_INCLUDED
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+
+void * aligned_malloc(size_t size, size_t alignment);
+void aligned_free(void * pointer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/ray/thirdparty/aligned_alloc.h
+++ b/src/ray/thirdparty/aligned_alloc.h
@@ -1,4 +1,28 @@
-// Adopted from https://github.com/NickStrupat/AlignedMalloc
+/*
+Adopted from https://github.com/NickStrupat/AlignedMalloc
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Nick Strupat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
 
 #ifndef ALIGNED_ALLOC_H_INCLUDED
 #define ALIGNED_ALLOC_H_INCLUDED


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The plasma allocated buffers are 64-byte aligned. However, recently we append a msgpack header before our serialization context, so the serialized content are not aligned to 64 bytes in the plasma allocated buffers. This PR fixes the issue.

## Related issue number

Closes #11760

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
