### PR TITLE
Distinguish a bad --redis-password from any other Redis error

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -570,7 +570,7 @@ def wait_for_redis_to_start(redis_ip_address, redis_port, password=None):
         # redis.AuthenticationError isn't trapped here.
         except redis.AuthenticationError as authEx:
             raise RuntimeError("Unable to connect to Redis at {}:{}.".format(
-                                   redis_ip_address, redis_port)) from authEx
+                redis_ip_address, redis_port)) from authEx
         except redis.ConnectionError:
             # Wait a little bit.
             time.sleep(delay)

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -560,6 +560,17 @@ def wait_for_redis_to_start(redis_ip_address, redis_port, password=None):
                 "Waiting for redis server at {}:{} to respond...".format(
                     redis_ip_address, redis_port))
             redis_client.client_list()
+        # If the Redis service is delayed getting set up for any reason, we may
+        # get a redis.ConnectionError: Error 111 connecting to host:port.
+        # Connection refused.
+        # Unfortunately, redis.ConnectionError is also the base class of
+        # redis.AuthenticationError. We *don't* want to obscure a
+        # redis.AuthenticationError, because that indicates the user provided a
+        # bad password. Thus a double except clause to ensure a
+        # redis.AuthenticationError isn't trapped here.
+        except redis.AuthenticationError as authEx:
+            raise RuntimeError("Unable to connect to Redis at {}:{}.".format(
+                                   redis_ip_address, redis_port)) from authEx
         except redis.ConnectionError:
             # Wait a little bit.
             time.sleep(delay)

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -37,7 +37,7 @@ class TestRedisPassword:
         # We want to simulate how this is called by ray.scripts.start().
         try:
             ray._private.services.wait_for_redis_to_start(
-                redis_ip, redis_port, password='wrong password')
+                redis_ip, redis_port, password="wrong password")
         except RuntimeError as runtimeEx:
             if not isinstance(runtimeEx.__cause__, redis.AuthenticationError):
                 raise

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -39,7 +39,7 @@ class TestRedisPassword:
             ray._private.services.wait_for_redis_to_start(
                 redis_ip, redis_port, password='wrong password')
         except RuntimeError as runtimeError:
-            if not isinstance(ex.__cause__, redis.AuthenticationError):
+            if not isinstance(runtimeError.__cause__, redis.AuthenticationError):
                 raise
 
         # Check that we can connect to Redis using the provided password

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -38,8 +38,8 @@ class TestRedisPassword:
         try:
             ray._private.services.wait_for_redis_to_start(
                 redis_ip, redis_port, password='wrong password')
-        except RuntimeError as runtimeError:
-            if not isinstance(runtimeError.__cause__, redis.AuthenticationError):
+        except RuntimeError as runtimeEx:
+            if not isinstance(runtimeEx.__cause__, redis.AuthenticationError):
                 raise
 
         # Check that we can connect to Redis using the provided password

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -20,6 +20,11 @@ class TestRedisPassword:
         def f():
             return 1
 
+        # Check that AuthenticationError is raised if the wrong password is
+        # provided.
+        with pytest.raises(redis.exceptions.AuthenticationError):
+            ray.init(_redis_password='wrong password')
+
         info = ray.init(_redis_password=password)
         address = info["redis_address"]
         redis_ip, redis_port = address.split(":")

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -23,7 +23,7 @@ class TestRedisPassword:
         # Check that AuthenticationError is raised if the wrong password is
         # provided.
         with pytest.raises(redis.exceptions.AuthenticationError):
-            ray.init(_redis_password='wrong password')
+            ray.init(_redis_password='wrongpassword')
 
         info = ray.init(_redis_password=password)
         address = info["redis_address"]

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -20,11 +20,6 @@ class TestRedisPassword:
         def f():
             return 1
 
-        # Check that AuthenticationError is raised if the wrong password is
-        # provided.
-        with pytest.raises(redis.exceptions.AuthenticationError):
-            ray.init(_redis_password='wrongpassword')
-
         info = ray.init(_redis_password=password)
         address = info["redis_address"]
         redis_ip, redis_port = address.split(":")

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -48,7 +48,7 @@ class TestRedisPassword:
             # the exact error from the Redis library.
             # https://github.com/andymccurdy/redis-py/blob/master/
             # redis/connection.py#L132
-            if 'invalid password' not in str(ex.__cause__):
+            if "invalid password" not in str(ex.__cause__):
                 raise
 
         # Check that we can connect to Redis using the provided password


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
<!-- Please give a short summary of the change and the problem this solves. -->
Currently, any failure to connect to Redis is obscured behind a generic error message.
This checks specifically for the case of a redis.AuthenticationError and attaches it to alert the user they supplied a bad `--redis-password`.

Technically, this is orthogonal to https://github.com/ray-project/ray/pull/11880, but it's also obviously an attempt to walk back https://github.com/ray-project/ray/pull/11880 a bit, making a more specific change.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
