### PR TITLE
[RLlib] rollout batch, handle unknown rewards (#11858)

### DIFF
--- a/rllib/rollout.py
+++ b/rllib/rollout.py
@@ -440,7 +440,7 @@ def rollout(agent,
 
             if multiagent:
                 done = done["__all__"]
-                reward_total += sum(reward.values())
+                reward_total += sum(r for r in reward.values() if r is not None)
             else:
                 reward_total += reward
             if not no_render:

--- a/rllib/rollout.py
+++ b/rllib/rollout.py
@@ -440,7 +440,8 @@ def rollout(agent,
 
             if multiagent:
                 done = done["__all__"]
-                reward_total += sum(r for r in reward.values() if r is not None)
+                reward_total += sum(
+                    r for r in reward.values() if r is not None)
             else:
                 reward_total += reward
             if not no_render:


### PR DESCRIPTION
rollout batch, handle unknown rewards returned by environment step 

In rare cases the reward can be None. That's the case when running a multi agent environment, one agent acting per step and an episode consists of one step only. It also better complies to the environment interfaces allowing None reward values. 

Closes #11858 
