### PR TITLE
Closes #11913 observation of type list support for ES and ARS

### DIFF
--- a/rllib/agents/ars/ars_tf_policy.py
+++ b/rllib/agents/ars/ars_tf_policy.py
@@ -71,6 +71,8 @@ class ARSTFPolicy(Policy):
         # Batch is given as list of one.
         if isinstance(observation, list) and len(observation) == 1:
             observation = observation[0]
+        if type(observation) in [float, int]:
+            observation = np.array([observation])
         observation = self.preprocessor.transform(observation)
         observation = self.observation_filter(observation[None], update=update)
 

--- a/rllib/agents/es/es.py
+++ b/rllib/agents/es/es.py
@@ -356,6 +356,8 @@ class ESTrainer(Trainer):
             ]
             # Get the results of the rollouts.
             for result in ray.get(rollout_ids):
+                if type(result) in [float, int]:
+                    result = np.array([result])
                 results.append(result)
                 # Update the number of episodes and the number of timesteps
                 # keeping in mind that result.noisy_lengths is a list of lists,

--- a/rllib/agents/es/es_tf_policy.py
+++ b/rllib/agents/es/es_tf_policy.py
@@ -121,6 +121,8 @@ class ESTFPolicy(Policy):
         # Batch is given as list of one.
         if isinstance(observation, list) and len(observation) == 1:
             observation = observation[0]
+        if type(observation) in [float, int]:
+            observation = np.array([observation])
         observation = self.preprocessor.transform(observation)
         observation = self.observation_filter(observation[None], update=update)
         # `actions` is a list of (component) batches.

--- a/rllib/models/preprocessors.py
+++ b/rllib/models/preprocessors.py
@@ -53,6 +53,8 @@ class Preprocessor:
     def check_shape(self, observation: Any) -> None:
         """Checks the shape of the given observation."""
         if self._i % VALIDATION_INTERVAL == 0:
+            if type(observation) in [float, int]:
+                observation = [observation]
             if type(observation) is list and isinstance(
                     self._obs_space, gym.spaces.Box):
                 observation = np.array(observation)


### PR DESCRIPTION
Make it possible to run ES and ARS agents with observation of type list and len(list)=1

## Why are these changes needed?
For ES and ARS agents, this PR converts scalar observations (int or float) internally into np.array, so that the training does not crash.

## Related issue number
Closes #11913

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
