### PR TITLE
If failed to connect to redis, try to say why.

### DIFF
--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -301,7 +301,14 @@ Status ConnectWithRetries(const std::string &address, int port,
       }
       break;
     }
-    RAY_LOG(WARNING) << "Failed to connect to Redis, retrying.";
+    if (*context == nullptr) {
+      RAY_LOG(WARNING) << "Could not allocate Redis context, retrying.";
+    }
+    if ((*context)->err) {
+      RAY_LOG(WARNING) << "Could not establish connection to Redis " << address << ":"
+                       << port << " (context.err = " << (*context)->err << ")"
+                       << ", retrying.";
+    }
     // Sleep for a little.
     std::this_thread::sleep_for(std::chrono::milliseconds(
         RayConfig::instance().redis_db_connect_wait_milliseconds()));


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Currently, if the Redis connection is bad (or just flaky, taking many attempts to connect), the log dutifully reports that it's not getting through, but doesn't say why.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
