### PR TITLE
Closes #11924 Add support for custom/ray environments in rollouts.py for agents without workers

### DIFF
--- a/rllib/rollout.py
+++ b/rllib/rollout.py
@@ -372,8 +372,10 @@ def rollout(agent,
             env = gym.make(agent.config["env"])
         else:
             # if environment registered ray environment, load from ray
-            env_creator = _global_registry.get(ENV_CREATOR, agent.config["env"])
-            env_context = EnvContext(agent.config["env_config"] or {}, worker_index=0)
+            env_creator = _global_registry.get(ENV_CREATOR,
+                                               agent.config["env"])
+            env_context = EnvContext(
+                agent.config["env_config"] or {}, worker_index=0)
             env = env_creator(env_context)
         multiagent = False
         try:


### PR DESCRIPTION
## Why are these changes needed?
Formerly, rollout.py would only load environments from gym (with `gym.make()` ) , if an agent without workers is employed (such as ES or ARS). This will result in an error, if a custom environment is used. This PR adds the possibility to load environments from the ray registry, while maintaining the support for gym environments. For code example, see issue: https://github.com/ray-project/ray/issues/11924

## Related issue number
Closes #11924 

## Checks
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
