### PR TITLE
[RLlib] Issue with pickle versions (breaks rollout test cases in RLlib).

### DIFF
--- a/rllib/rollout.py
+++ b/rllib/rollout.py
@@ -8,7 +8,10 @@ from gym import wrappers as gym_wrappers
 import json
 import os
 from pathlib import Path
-import pickle
+try:
+    import pickle5 as pickle
+except (ModuleNotFoundError, ImportError):
+    import pickle
 import shelve
 
 import ray

--- a/rllib/rollout.py
+++ b/rllib/rollout.py
@@ -8,13 +8,10 @@ from gym import wrappers as gym_wrappers
 import json
 import os
 from pathlib import Path
-try:
-    import pickle5 as pickle
-except (ModuleNotFoundError, ImportError):
-    import pickle
 import shelve
 
 import ray
+import ray.cloudpickle as cloudpickle
 from ray.rllib.env import MultiAgentEnv
 from ray.rllib.env.base_env import _DUMMY_AGENT_ID
 from ray.rllib.evaluation.worker_set import WorkerSet
@@ -121,7 +118,7 @@ class RolloutSaver:
             self._shelf.close()
         elif self._outfile and not self._use_shelve:
             # Dump everything as one big pickle:
-            pickle.dump(self._rollouts, open(self._outfile, "wb"))
+            cloudpickle.dump(self._rollouts, open(self._outfile, "wb"))
         if self._update_file:
             # Remove the temp progress file:
             self._get_tmp_progress_filename().unlink()
@@ -264,7 +261,7 @@ def run(args, parser):
     # Load the config from pickled.
     else:
         with open(config_path, "rb") as f:
-            config = pickle.load(f)
+            config = cloudpickle.load(f)
 
     # Set num_workers to be at least 2.
     if "num_workers" in config:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Issue with pickle versions (breaks rollout.py test cases in RLlib).
- Use ray.cloudpickle instead.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
