### PR TITLE
[C++ API] Add RAY_CI_CPP_AFFECTED flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -477,7 +477,7 @@ matrix:
         - PYTHON=3.6
         - PYTHONWARNINGS=ignore
       install:
-        - . ./ci/travis/ci.sh init
+        - . ./ci/travis/ci.sh init RAY_CI_CPP_AFFECTED
       before_script:
         - . ./ci/travis/ci.sh build
       script:

--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -40,6 +40,7 @@ if __name__ == "__main__":
     RAY_CI_SERVE_AFFECTED = 0
     RAY_CI_JAVA_AFFECTED = 0
     RAY_CI_PYTHON_AFFECTED = 0
+    RAY_CI_CPP_AFFECTED = 0
     RAY_CI_LINUX_WHEELS_AFFECTED = 0
     RAY_CI_MACOS_WHEELS_AFFECTED = 0
     RAY_CI_STREAMING_CPP_AFFECTED = 0
@@ -112,6 +113,8 @@ if __name__ == "__main__":
             elif changed_file.startswith("java/"):
                 RAY_CI_JAVA_AFFECTED = 1
                 RAY_CI_STREAMING_JAVA_AFFECTED = 1
+            elif changed_file.startswith("cpp/"):
+                RAY_CI_CPP_AFFECTED = 1
             elif changed_file.startswith("docker/"):
                 RAY_CI_DOCKER_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1
@@ -130,6 +133,7 @@ if __name__ == "__main__":
                 RAY_CI_SERVE_AFFECTED = 1
                 RAY_CI_JAVA_AFFECTED = 1
                 RAY_CI_PYTHON_AFFECTED = 1
+                RAY_CI_CPP_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1
                 RAY_CI_MACOS_WHEELS_AFFECTED = 1
                 RAY_CI_STREAMING_CPP_AFFECTED = 1
@@ -152,6 +156,7 @@ if __name__ == "__main__":
                 RAY_CI_SERVE_AFFECTED = 1
                 RAY_CI_JAVA_AFFECTED = 1
                 RAY_CI_PYTHON_AFFECTED = 1
+                RAY_CI_CPP_AFFECTED = 1
                 RAY_CI_DOC_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1
                 RAY_CI_MACOS_WHEELS_AFFECTED = 1
@@ -166,6 +171,7 @@ if __name__ == "__main__":
         RAY_CI_SERVE_AFFECTED = 1
         RAY_CI_JAVA_AFFECTED = 1
         RAY_CI_PYTHON_AFFECTED = 1
+        RAY_CI_CPP_AFFECTED = 1
         RAY_CI_DOC_AFFECTED = 1
         RAY_CI_LINUX_WHEELS_AFFECTED = 1
         RAY_CI_MACOS_WHEELS_AFFECTED = 1
@@ -175,7 +181,7 @@ if __name__ == "__main__":
 
     if not RAY_CI_TUNE_AFFECTED and not RAY_CI_SERVE_AFFECTED and \
             not RAY_CI_JAVA_AFFECTED and not RAY_CI_PYTHON_AFFECTED and not \
-            RAY_CI_STREAMING_CPP_AFFECTED and \
+            RAY_CI_CPP_AFFECTED and not RAY_CI_STREAMING_CPP_AFFECTED and \
             not RAY_CI_STREAMING_PYTHON_AFFECTED and \
             not RAY_CI_STREAMING_JAVA_AFFECTED and \
             not RAY_CI_SGD_AFFECTED:
@@ -193,6 +199,7 @@ if __name__ == "__main__":
         "RAY_CI_DOC_AFFECTED={}".format(RAY_CI_DOC_AFFECTED),
         "RAY_CI_JAVA_AFFECTED={}".format(RAY_CI_JAVA_AFFECTED),
         "RAY_CI_PYTHON_AFFECTED={}".format(RAY_CI_PYTHON_AFFECTED),
+        "RAY_CI_CPP_AFFECTED={}".format(RAY_CI_CPP_AFFECTED),
         "RAY_CI_LINUX_WHEELS_AFFECTED={}".format(RAY_CI_LINUX_WHEELS_AFFECTED),
         "RAY_CI_MACOS_WHEELS_AFFECTED={}".format(RAY_CI_MACOS_WHEELS_AFFECTED),
         "RAY_CI_STREAMING_CPP_AFFECTED={}".format(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If only C++ worker code is changed, Travis can skip other CI jobs except for the C++ worker one. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
