### PR TITLE
[tune] Fix hpo randint limits

### DIFF
--- a/python/ray/tune/suggest/hyperopt.py
+++ b/python/ray/tune/suggest/hyperopt.py
@@ -361,17 +361,7 @@ class HyperOptSearch(Searcher):
                         logger.warning(
                             "HyperOpt does not support quantization for "
                             "integer values. Reverting back to 'randint'.")
-                    if domain.lower != 0:
-                        raise ValueError(
-                            "HyperOpt only allows integer sampling with "
-                            f"lower bound 0. Got: {domain.lower}.")
-                    if domain.upper < 1:
-                        raise ValueError(
-                            "HyperOpt does not support integer sampling "
-                            "of values lower than 0. Set your maximum range "
-                            "to something above 0 (currently {})".format(
-                                domain.upper))
-                    return hpo.hp.randint(par, domain.upper)
+                    return hpo.hp.randint(par, domain.lower, domain.upper)
             elif isinstance(domain, Categorical):
                 if isinstance(sampler, Uniform):
                     return hpo.hp.choice(par, [

--- a/python/ray/tune/suggest/hyperopt.py
+++ b/python/ray/tune/suggest/hyperopt.py
@@ -222,7 +222,7 @@ class HyperOptSearch(Searcher):
 
             # Get new suggestion from Hyperopt
             new_trials = self.algo(new_ids, self.domain, self._hpopt_trials,
-                                   self.rstate.randint(0, 2**31 - 1))
+                                   self.rstate.randint(2**31 - 1))
             self._hpopt_trials.insert_trial_docs(new_trials)
             self._hpopt_trials.refresh()
             new_trial = new_trials[0]
@@ -361,7 +361,7 @@ class HyperOptSearch(Searcher):
                         logger.warning(
                             "HyperOpt does not support quantization for "
                             "integer values. Reverting back to 'randint'.")
-                    return hpo.hp.randint(par, domain.lower, domain.upper)
+                    return hpo.hp.randint(par, domain.lower, high=domain.upper)
             elif isinstance(domain, Categorical):
                 if isinstance(sampler, Uniform):
                     return hpo.hp.choice(par, [

--- a/python/ray/tune/suggest/hyperopt.py
+++ b/python/ray/tune/suggest/hyperopt.py
@@ -222,7 +222,7 @@ class HyperOptSearch(Searcher):
 
             # Get new suggestion from Hyperopt
             new_trials = self.algo(new_ids, self.domain, self._hpopt_trials,
-                                   self.rstate.randint(2**31 - 1))
+                                   self.rstate.randint(0, 2**31 - 1))
             self._hpopt_trials.insert_trial_docs(new_trials)
             self._hpopt_trials.refresh()
             new_trial = new_trials[0]

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -412,7 +412,7 @@ class SearchSpaceTest(unittest.TestCase):
         config = {
             "a": tune.sample.Categorical([2, 3, 4]).uniform(),
             "b": {
-                "x": tune.sample.Integer(0, 5).quantized(2),
+                "x": tune.sample.Integer(-15, -10).quantized(2),
                 "y": 4,
                 "z": tune.sample.Float(1e-4, 1e-2).loguniform()
             }
@@ -421,7 +421,7 @@ class SearchSpaceTest(unittest.TestCase):
         hyperopt_config = {
             "a": hp.choice("a", [2, 3, 4]),
             "b": {
-                "x": hp.randint("x", 5),
+                "x": hp.randint("x", -15, -10),
                 "y": 4,
                 "z": hp.loguniform("z", np.log(1e-4), np.log(1e-2))
             }
@@ -443,7 +443,7 @@ class SearchSpaceTest(unittest.TestCase):
 
         self.assertEqual(config1, config2)
         self.assertIn(config1["a"], [2, 3, 4])
-        self.assertIn(config1["b"]["x"], list(range(5)))
+        self.assertIn(config1["b"]["x"], list(range(-15, -10)))
         self.assertEqual(config1["b"]["y"], 4)
         self.assertLess(1e-4, config1["b"]["z"])
         self.assertLess(config1["b"]["z"], 1e-2)

--- a/python/requirements_tune.txt
+++ b/python/requirements_tune.txt
@@ -7,7 +7,7 @@ gym[atari]
 GPy
 h5py
 hpbandster
-hyperopt==0.1.2
+hyperopt>=0.2.5
 jupyter
 keras
 kubernetes


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

HyperOpt actually supports broader limits for randint.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
