### PR TITLE
[tune] Fix unflatten dict

### DIFF
--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -268,12 +268,13 @@ def flatten_dict(dt, delimiter="/", prevent_delimiter=False):
 
 def unflatten_dict(dt, delimiter="/"):
     """Unflatten dict. Does not support unflattening lists."""
-    out = defaultdict(dict)
+    dict_type = type(dt)
+    out = dict_type()
     for key, val in dt.items():
         path = key.split(delimiter)
         item = out
         for k in path[:-1]:
-            item = item[k]
+            item = item.setdefault(k, dict_type())
         item[path[-1]] = val
     return dict(out)
 

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -276,7 +276,7 @@ def unflatten_dict(dt, delimiter="/"):
         for k in path[:-1]:
             item = item.setdefault(k, dict_type())
         item[path[-1]] = val
-    return dict(out)
+    return out
 
 
 def unflattened_lookup(flat_key, lookup, delimiter="/", **kwargs):

--- a/python/ray/tune/utils/util_test.py
+++ b/python/ray/tune/utils/util_test.py
@@ -7,33 +7,33 @@ from .util import unflatten_dict
 
 class UnflattenDictTest(unittest.TestCase):
     def test_output_type(self):
-        in_ = OrderedDict({'a/b': 1, 'c/d': 2, 'e': 3})
+        in_ = OrderedDict({"a/b": 1, "c/d": 2, "e": 3})
         out = unflatten_dict(in_)
         assert type(in_) is type(out)
 
     def test_one_level_nested(self):
-        result = unflatten_dict({'a/b': 1, 'c/d': 2, 'e': 3})
-        assert result == {'a': {'b': 1}, 'c': {'d': 2}, 'e': 3}
+        result = unflatten_dict({"a/b": 1, "c/d": 2, "e": 3})
+        assert result == {"a": {"b": 1}, "c": {"d": 2}, "e": 3}
 
     def test_multi_level_nested(self):
-        result = unflatten_dict({'a/b/c/d': 1, 'b/c/d': 2, 'c/d': 3, 'e': 4})
+        result = unflatten_dict({"a/b/c/d": 1, "b/c/d": 2, "c/d": 3, "e": 4})
         assert result == {
-            'a': {
-                'b': {
-                    'c': {
-                        'd': 1,
+            "a": {
+                "b": {
+                    "c": {
+                        "d": 1,
                     },
                 },
             },
-            'b': {
-                'c': {
-                    'd': 2,
+            "b": {
+                "c": {
+                    "d": 2,
                 },
             },
-            'c': {
-                'd': 3,
+            "c": {
+                "d": 3,
             },
-            'e': 4,
+            "e": 4,
         }
 
 

--- a/python/ray/tune/utils/util_test.py
+++ b/python/ray/tune/utils/util_test.py
@@ -1,0 +1,15 @@
+import unittest
+
+from .util import unflatten_dict
+
+
+class UnflattenDictTest(unittest.TestCase):
+    def test_one_level_nested(self):
+        result = unflatten_dict({'a/b': 1, 'c/d': 2, 'e': 3})
+        assert result == {'a': {'b': 1}, 'c': {'d': 2}, 'e': 3}
+
+
+if __name__ == "__main__":
+    import pytest
+    import sys
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tune/utils/util_test.py
+++ b/python/ray/tune/utils/util_test.py
@@ -16,7 +16,7 @@ class UnflattenDictTest(unittest.TestCase):
         assert result == {'a': {'b': 1}, 'c': {'d': 2}, 'e': 3}
 
     def test_multi_level_nested(self):
-        result = unflatten_dict({'a/b/c/d': 1, 'a/b/c': 2, 'c/d': 3, 'e': 4})
+        result = unflatten_dict({'a/b/c/d': 1, 'b/c/d': 2, 'c/d': 3, 'e': 4})
         assert result == {
             'a': {
                 'b': {
@@ -25,9 +25,9 @@ class UnflattenDictTest(unittest.TestCase):
                     },
                 },
             },
-            'a': {
-                'b': {
-                    'c': 2,
+            'b': {
+                'c': {
+                    'd': 2,
                 },
             },
             'c': {

--- a/python/ray/tune/utils/util_test.py
+++ b/python/ray/tune/utils/util_test.py
@@ -1,9 +1,16 @@
+from collections import OrderedDict
+
 import unittest
 
 from .util import unflatten_dict
 
 
 class UnflattenDictTest(unittest.TestCase):
+    def test_output_type(self):
+        in_ = OrderedDict({'a/b': 1, 'c/d': 2, 'e': 3})
+        out = unflatten_dict(in_)
+        assert type(in_) is type(out)
+
     def test_one_level_nested(self):
         result = unflatten_dict({'a/b': 1, 'c/d': 2, 'e': 3})
         assert result == {'a': {'b': 1}, 'c': {'d': 2}, 'e': 3}

--- a/python/ray/tune/utils/util_test.py
+++ b/python/ray/tune/utils/util_test.py
@@ -8,6 +8,27 @@ class UnflattenDictTest(unittest.TestCase):
         result = unflatten_dict({'a/b': 1, 'c/d': 2, 'e': 3})
         assert result == {'a': {'b': 1}, 'c': {'d': 2}, 'e': 3}
 
+    def test_multi_level_nested(self):
+        result = unflatten_dict({'a/b/c/d': 1, 'a/b/c': 2, 'c/d': 3, 'e': 4})
+        assert result == {
+            'a': {
+                'b': {
+                    'c': {
+                        'd': 1,
+                    },
+                },
+            },
+            'a': {
+                'b': {
+                    'c': 2,
+                },
+            },
+            'c': {
+                'd': 3,
+            },
+            'e': 4,
+        }
+
 
 if __name__ == "__main__":
     import pytest


### PR DESCRIPTION
## Why are these changes needed?
To support deeply-nested configs for tune.

## Related issue number
Fixes #11947.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
