### PR TITLE
State which IP addresses are failing to match.

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -191,11 +191,13 @@ def get_address_info_from_redis_helper(redis_address,
             break
     if relevant_client is None:
         raise RuntimeError(
-            f"Connected to Redis at {redis_address} and found raylets at "
+            f"This node has an IP address of {node_ip_address}, and Ray "
+            "expects this IP address to be either the Redis address or one of"
+            " the Raylet addresses. Connected to Redis at {redis_address} and"
+            " found raylets at "
             "{', '.join(c['NodeManagerAddress'] for c in client_table)} but "
             "none of these match this node's IP {node_ip_address}. Are any of"
-            " these actually just the same node being accessed from a "
-            "different interface?")
+            " these actually a different IP address for the same node?")
 
     return {
         "object_store_address": relevant_client["ObjectStoreSocketName"],

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -193,7 +193,7 @@ def get_address_info_from_redis_helper(redis_address,
         raise RuntimeError(
             f"This node has an IP address of {node_ip_address}, and Ray "
             "expects this IP address to be either the Redis address or one of"
-            " the Raylet addresses. Connected to Redis at {redis_address} and"
+            f" the Raylet addresses. Connected to Redis at {redis_address} and"
             " found raylets at "
             f"{', '.join(c['NodeManagerAddress'] for c in client_table)} but "
             f"none of these match this node's IP {node_ip_address}. Are any of"

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -193,8 +193,8 @@ def get_address_info_from_redis_helper(redis_address,
         raise RuntimeError(
             f"Connected to Redis at {redis_address} and found raylets at "
              "{', '.join(c['NodeManagerAddress'] for c in client_table)} but "
-             "none of these match this node's IP {node_ip_address}. Are any of"
-             "these actually just the same node being accessed from a "
+             "none of these match this node's IP {node_ip_address}. Are any "
+             "of these actually just the same node being accessed from a "
              "different interface?")
 
     return {

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -197,7 +197,9 @@ def get_address_info_from_redis_helper(redis_address,
             " found raylets at "
             "{', '.join(c['NodeManagerAddress'] for c in client_table)} but "
             "none of these match this node's IP {node_ip_address}. Are any of"
-            " these actually a different IP address for the same node?")
+            " these actually a different IP address for the same node?"
+            "You might need to provide --node-ip-address to specify the IP "
+            "address that the head should use when sending to this node.")
 
     return {
         "object_store_address": relevant_client["ObjectStoreSocketName"],

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -191,10 +191,9 @@ def get_address_info_from_redis_helper(redis_address,
             break
     if relevant_client is None:
         raise RuntimeError(
-            "Connected to Redis at {} and found raylets at {} but none of these"
-            " match this node's IP {}.".format(redis_address,
-                ", ".join(c["NodeManagerAddress"] for c in client_table),
-                node_ip_address))
+            f"Connected to Redis at {redis_address} and found raylets at "
+             "{', '.join(c['NodeManagerAddress'] for c in client_table)} but "
+             "none of these match this node's IP {node_ip_address}.")
 
     return {
         "object_store_address": relevant_client["ObjectStoreSocketName"],

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -193,7 +193,9 @@ def get_address_info_from_redis_helper(redis_address,
         raise RuntimeError(
             f"Connected to Redis at {redis_address} and found raylets at "
              "{', '.join(c['NodeManagerAddress'] for c in client_table)} but "
-             "none of these match this node's IP {node_ip_address}.")
+             "none of these match this node's IP {node_ip_address}. Are any of"
+             "these actually just the same node being accessed from a "
+             "different interface?")
 
     return {
         "object_store_address": relevant_client["ObjectStoreSocketName"],

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -196,7 +196,7 @@ def get_address_info_from_redis_helper(redis_address,
             " the Raylet addresses. Connected to Redis at {redis_address} and"
             " found raylets at "
             f"{', '.join(c['NodeManagerAddress'] for c in client_table)} but "
-            "none of these match this node's IP {node_ip_address}. Are any of"
+            f"none of these match this node's IP {node_ip_address}. Are any of"
             " these actually a different IP address for the same node?"
             "You might need to provide --node-ip-address to specify the IP "
             "address that the head should use when sending to this node.")

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -191,7 +191,10 @@ def get_address_info_from_redis_helper(redis_address,
             break
     if relevant_client is None:
         raise RuntimeError(
-            "Redis has started but no raylets have registered yet.")
+            "Connected to Redis at {} and found raylets at {} but none of these"
+            " match this node's IP {}.".format(redis_address,
+                ", ".join(c["NodeManagerAddress"] for c in client_table),
+                node_ip_address))
 
     return {
         "object_store_address": relevant_client["ObjectStoreSocketName"],

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -192,10 +192,10 @@ def get_address_info_from_redis_helper(redis_address,
     if relevant_client is None:
         raise RuntimeError(
             f"Connected to Redis at {redis_address} and found raylets at "
-             "{', '.join(c['NodeManagerAddress'] for c in client_table)} but "
-             "none of these match this node's IP {node_ip_address}. Are any "
-             "of these actually just the same node being accessed from a "
-             "different interface?")
+            "{', '.join(c['NodeManagerAddress'] for c in client_table)} but "
+            "none of these match this node's IP {node_ip_address}. Are any of"
+            " these actually just the same node being accessed from a "
+            "different interface?")
 
     return {
         "object_store_address": relevant_client["ObjectStoreSocketName"],

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -195,7 +195,7 @@ def get_address_info_from_redis_helper(redis_address,
             "expects this IP address to be either the Redis address or one of"
             " the Raylet addresses. Connected to Redis at {redis_address} and"
             " found raylets at "
-            "{', '.join(c['NodeManagerAddress'] for c in client_table)} but "
+            f"{', '.join(c['NodeManagerAddress'] for c in client_table)} but "
             "none of these match this node's IP {node_ip_address}. Are any of"
             " these actually a different IP address for the same node?"
             "You might need to provide --node-ip-address to specify the IP "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Currently, if `get_address_info_from_redis_helper` finds clients but none of them match, it reports that it found no clients at all, even though this may be merely a question of an unusual network configuration.
https://github.com/ray-project/ray/pull/11944 fixes things for now by making `get_address_info_from_redis_helper` match; this provides help going forward by reporting if something still fails to match.
## Related issue number

<!-- For example: "Closes #1234" -->
This should make issues like https://github.com/ray-project/ray/issues/11943 easier to diagnose in the future.
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
