### PR TITLE
make some private rsync, and exec_cluster arguments public

### DIFF
--- a/python/ray/autoscaler/sdk.py
+++ b/python/ray/autoscaler/sdk.py
@@ -130,7 +130,8 @@ def rsync(cluster_config: Union[dict, str],
             public or private.
         no_config_cache (bool): Whether to disable the config cache and fully
             resolve all environment settings from the Cloud provider again.
-        all_nodes (bool): whether to sync worker nodes in addition to the head node
+        all_nodes (bool): whether to sync worker nodes in addition to the head
+            node
 
     Raises:
         RuntimeError if the cluster head node is not found.

--- a/python/ray/autoscaler/sdk.py
+++ b/python/ray/autoscaler/sdk.py
@@ -70,6 +70,8 @@ def run_on_cluster(cluster_config: Union[dict, str],
                    *,
                    cmd: Optional[str] = None,
                    run_env: str = "auto",
+                   tmux: bool = False,
+                   stop: bool = False,
                    no_config_cache: bool = False,
                    port_forward: Optional[commands.Port_forward] = None,
                    with_output: bool = False) -> Optional[str]:
@@ -81,6 +83,8 @@ def run_on_cluster(cluster_config: Union[dict, str],
         cmd (str): the command to run, or None for a no-op command.
         run_env (str): whether to run the command on the host or in a
             container. Select between "auto", "host" and "docker".
+        tmux (bool): whether to run in a tmux session
+        stop (bool): whether to stop the cluster after command run
         no_config_cache (bool): Whether to disable the config cache and fully
             resolve all environment settings from the Cloud provider again.
         port_forward ( (int,int) or list[(int,int)]): port(s) to forward.
@@ -95,8 +99,8 @@ def run_on_cluster(cluster_config: Union[dict, str],
             cmd=cmd,
             run_env=run_env,
             screen=False,
-            tmux=False,
-            stop=False,
+            tmux=tmux,
+            stop=stop,
             start=False,
             override_cluster_name=None,
             no_config_cache=no_config_cache,
@@ -106,12 +110,13 @@ def run_on_cluster(cluster_config: Union[dict, str],
 
 def rsync(cluster_config: Union[dict, str],
           *,
-          source: str,
-          target: str,
+          source: Optional[str],
+          target: Optional[str],
           down: bool,
           ip_address: str = None,
           use_internal_ip: bool = False,
-          no_config_cache: bool = False):
+          no_config_cache: bool = False,
+          all_nodes: bool = False):
     """Rsyncs files to or from the cluster.
 
     Args:
@@ -125,6 +130,7 @@ def rsync(cluster_config: Union[dict, str],
             public or private.
         no_config_cache (bool): Whether to disable the config cache and fully
             resolve all environment settings from the Cloud provider again.
+        all_nodes (bool): whether to sync worker nodes in addition to the head node
 
     Raises:
         RuntimeError if the cluster head node is not found.
@@ -139,7 +145,7 @@ def rsync(cluster_config: Union[dict, str],
             ip_address=ip_address,
             use_internal_ip=use_internal_ip,
             no_config_cache=no_config_cache,
-            all_nodes=False)
+            all_nodes=all_nodes)
 
 
 def get_head_node_ip(cluster_config: Union[dict, str]) -> str:

--- a/python/ray/autoscaler/sdk.py
+++ b/python/ray/autoscaler/sdk.py
@@ -115,8 +115,7 @@ def rsync(cluster_config: Union[dict, str],
           down: bool,
           ip_address: str = None,
           use_internal_ip: bool = False,
-          no_config_cache: bool = False,
-          all_nodes: bool = False):
+          no_config_cache: bool = False):
     """Rsyncs files to or from the cluster.
 
     Args:
@@ -130,8 +129,6 @@ def rsync(cluster_config: Union[dict, str],
             public or private.
         no_config_cache (bool): Whether to disable the config cache and fully
             resolve all environment settings from the Cloud provider again.
-        all_nodes (bool): whether to sync worker nodes in addition to the head
-            node
 
     Raises:
         RuntimeError if the cluster head node is not found.
@@ -146,7 +143,7 @@ def rsync(cluster_config: Union[dict, str],
             ip_address=ip_address,
             use_internal_ip=use_internal_ip,
             no_config_cache=no_config_cache,
-            all_nodes=all_nodes)
+            all_nodes=False)
 
 
 def get_head_node_ip(cluster_config: Union[dict, str]) -> str:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
These arguments unlock customizations for rsync and run_on_cluster for anyone using the autoscaler public api.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
