### PR TITLE
[autoscaler] Interpret autoscaling_speed as 1/x-1 of previous target util fraction

### DIFF
--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -361,11 +361,12 @@ class StandardAutoscaler:
                     "detected. Replacing it by setting upscaling_speed to "
                     "99999.")
             elif target_utilization_fraction:
-                upscaling_speed = 1 / max(target_utilization_fraction, 0.001)
+                upscaling_speed = (
+                    1 / max(target_utilization_fraction, 0.001) - 1)
                 logger.warning(
                     "Legacy target_utilization_fraction config "
                     "detected. Replacing it by setting upscaling_speed to " +
-                    "1 / target_utilization_fraction.")
+                    "1 / target_utilization_fraction - 1.")
             else:
                 upscaling_speed = 1.0
             if self.resource_demand_scheduler:

--- a/python/ray/tests/test_autoscaling_policy.py
+++ b/python/ray/tests/test_autoscaling_policy.py
@@ -415,17 +415,16 @@ class Simulator:
         num_connected_nodes = len(
             [node for node in self.ip_to_nodes.values() if node.in_cluster])
         num_pending_nodes = len(self.ip_to_nodes) - num_connected_nodes
-        return f"""[t={self.virtual_time}]
-    Connected nodes: {num_connected_nodes}
-    Pending nodes: {num_pending_nodes}
-    Remaining requests: {len(self.work_queue)}
-        """
+        return (f"[t={self.virtual_time}] "
+                f"Connected: {num_connected_nodes}, "
+                f"Pending: {num_pending_nodes}, "
+                f"Remaining: {len(self.work_queue)}")
 
 
 SAMPLE_CLUSTER_CONFIG = copy.deepcopy(MULTI_WORKER_CLUSTER)
 SAMPLE_CLUSTER_CONFIG["min_workers"] = 0
 SAMPLE_CLUSTER_CONFIG["max_workers"] = 9999
-SAMPLE_CLUSTER_CONFIG["target_utilization_fraction"] = 1.0
+SAMPLE_CLUSTER_CONFIG["target_utilization_fraction"] = 0.5
 SAMPLE_CLUSTER_CONFIG["available_node_types"]["m4.16xlarge"][
     "max_workers"] = 100
 SAMPLE_CLUSTER_CONFIG["available_node_types"]["m4.4xlarge"][


### PR DESCRIPTION
If target_util_fraction = 0.8; currently autoscaling speed will be set to 1.25, whereas it should really be more like 0.25.