### PR TITLE
[CLI] Fix ray commands when RAY_ADDRESS used

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -203,7 +203,9 @@ def find_redis_address(address=None):
     return redis_addresses
 
 
-def find_redis_address_or_die():
+def find_redis_address_or_die(check_environ=True):
+    if check_environ and "RAY_ADDRESS" in os.environ:
+        return None
     redis_addresses = find_redis_address()
     if len(redis_addresses) > 1:
         raise ConnectionError(
@@ -305,7 +307,7 @@ def validate_redis_address(address):
     """
 
     if address == "auto":
-        address = find_redis_address_or_die()
+        address = find_redis_address_or_die(check_environ=False)
     redis_address = address_to_ip(address)
 
     redis_address_parts = redis_address.split(":")

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -170,6 +170,10 @@ def find_redis_address(address=None):
     The --redis-address here is what is now called the --address, but it
     appears in the default_worker.py and agent.py calls as --redis-address.
     """
+
+    if "RAY_ADDRESS" in os.environ:
+        return os.environ["RAY_ADDRESS"]
+
     pids = psutil.pids()
     redis_addresses = set()
     for pid in pids:
@@ -203,9 +207,7 @@ def find_redis_address(address=None):
     return redis_addresses
 
 
-def find_redis_address_or_die(check_environ=True):
-    if check_environ and "RAY_ADDRESS" in os.environ:
-        return None
+def find_redis_address_or_die():
     redis_addresses = find_redis_address()
     if len(redis_addresses) > 1:
         raise ConnectionError(
@@ -307,7 +309,7 @@ def validate_redis_address(address):
     """
 
     if address == "auto":
-        address = find_redis_address_or_die(check_environ=False)
+        address = find_redis_address_or_die()
     redis_address = address_to_ip(address)
 
     redis_address_parts = redis_address.split(":")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* When `RAY_ADDRESS` is set, I cannot make calls like `ray status` because `ray.init()` is called with `address='auto'` and `RAY_ADDRESS=...`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
