### PR TITLE
Log the Redis shard addresses as originally received from the head GCS.

### DIFF
--- a/src/ray/gcs/redis_client.cc
+++ b/src/ray/gcs/redis_client.cc
@@ -86,9 +86,8 @@ static void GetRedisShards(redisContext *context, std::vector<std::string> *addr
     int port;
     ss >> port;
     ports->emplace_back(port);
-    RAY_LOG(DEBUG)
-        << "Received Redis shard address " << addr << ":" << port
-        << " from head GCS.";
+    RAY_LOG(DEBUG) << "Received Redis shard address " << addr << ":" << port
+                   << " from head GCS.";
   }
   freeReplyObject(reply);
 }

--- a/src/ray/gcs/redis_client.cc
+++ b/src/ray/gcs/redis_client.cc
@@ -86,6 +86,8 @@ static void GetRedisShards(redisContext *context, std::vector<std::string> *addr
     int port;
     ss >> port;
     ports->emplace_back(port);
+    RAY_LOG(DEBUG) << "Received Redis shard address " << addr << ":" << port
+        << " from head GCS.";
   }
   freeReplyObject(reply);
 }

--- a/src/ray/gcs/redis_client.cc
+++ b/src/ray/gcs/redis_client.cc
@@ -86,7 +86,8 @@ static void GetRedisShards(redisContext *context, std::vector<std::string> *addr
     int port;
     ss >> port;
     ports->emplace_back(port);
-    RAY_LOG(DEBUG) << "Received Redis shard address " << addr << ":" << port
+    RAY_LOG(DEBUG)
+        << "Received Redis shard address " << addr << ":" << port
         << " from head GCS.";
   }
   freeReplyObject(reply);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Currently, if Redis shards are failing to connect, it can be tricky to know you're checking the right addresses with `nc` or `nmap`. This logs the original shard addresses exactly as they are received from the head GCS.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
