### PR TITLE
Allow setting the RAY_BACKEND_LOG_LEVEL to trace.

### DIFF
--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -254,7 +254,9 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
   if (var_value != nullptr) {
     std::string data = var_value;
     std::transform(data.begin(), data.end(), data.begin(), ::tolower);
-    if (data == "debug") {
+    if (data == "trace") {
+      severity_threshold = RayLogLevel::TRACE;
+    } else if (data == "debug") {
       severity_threshold = RayLogLevel::DEBUG;
     } else if (data == "info") {
       severity_threshold = RayLogLevel::INFO;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, RAY_BACKEND_LOG_LEVEL can set RayLogLevel::DEBUG, RayLogLevel::INFO, RayLogLevel::WARNING, RayLogLevel::ERROR, or RayLogLevel::FATAL, but not RayLogLevel::TRACE.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
