### PR TITLE
Clarify that Ray is not yet retrying to connect.

### DIFF
--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -307,8 +307,8 @@ Status ConnectWithRetries(const std::string &address, int port,
                        << " milliseconds.";
     }
     if ((*context)->err) {
-      RAY_LOG(WARNING) << "Could not establish connection to Redis " << address
-                       << ":" << port << " (context.err = " << (*context)->err
+      RAY_LOG(WARNING) << "Could not establish connection to Redis " << address << ":"
+                       << port << " (context.err = " << (*context)->err
                        << "), will retry in "
                        << RayConfig::instance().redis_db_connect_wait_milliseconds()
                        << " milliseconds.";

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -302,18 +302,16 @@ Status ConnectWithRetries(const std::string &address, int port,
       break;
     }
     if (*context == nullptr) {
-      RAY_LOG(WARNING)
-          << "Could not allocate Redis context, will retry in "
-          << RayConfig::instance().redis_db_connect_wait_milliseconds()
-          << " milliseconds.";
+      RAY_LOG(WARNING) << "Could not allocate Redis context, will retry in "
+                       << RayConfig::instance().redis_db_connect_wait_milliseconds()
+                       << " milliseconds.";
     }
     if ((*context)->err) {
-      RAY_LOG(WARNING)
-          << "Could not establish connection to Redis " << address << ":"
-          << port << " (context.err = " << (*context)->err << "), will retry "
-          << "in "
-          << RayConfig::instance().redis_db_connect_wait_milliseconds()
-          << " milliseconds.";
+      RAY_LOG(WARNING) << "Could not establish connection to Redis " << address
+                       << ":" << port << " (context.err = " << (*context)->err
+                       << "), will retry in "
+                       << RayConfig::instance().redis_db_connect_wait_milliseconds()
+                       << " milliseconds.";
     }
     // Sleep for a little.
     std::this_thread::sleep_for(std::chrono::milliseconds(

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -302,12 +302,18 @@ Status ConnectWithRetries(const std::string &address, int port,
       break;
     }
     if (*context == nullptr) {
-      RAY_LOG(WARNING) << "Could not allocate Redis context, retrying.";
+      RAY_LOG(WARNING)
+          << "Could not allocate Redis context, will retry in "
+          << RayConfig::instance().redis_db_connect_wait_milliseconds()
+          << " milliseconds.";
     }
     if ((*context)->err) {
-      RAY_LOG(WARNING) << "Could not establish connection to Redis " << address << ":"
-                       << port << " (context.err = " << (*context)->err << ")"
-                       << ", retrying.";
+      RAY_LOG(WARNING)
+          << "Could not establish connection to Redis " << address << ":"
+          << port << " (context.err = " << (*context)->err << "), will retry "
+          << "in "
+          << RayConfig::instance().redis_db_connect_wait_milliseconds()
+          << " milliseconds.";
     }
     // Sleep for a little.
     std::this_thread::sleep_for(std::chrono::milliseconds(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Now that the warning specifies where Ray is trying to connect to (https://github.com/ray-project/ray/pull/11916), it is possible to check on the connection, but since `RayConfig::instance().redis_db_connect_wait_milliseconds()` can be nontrivial, this also makes it worth clarifying that Ray is actually going to sleep for a bit before retrying.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
