### PR TITLE
Extract the connection logic to reduce duplication.

### DIFF
--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -291,14 +291,14 @@ Status ConnectWithoutRetries(const std::string &address, int port,
                              std::string &errorMessage) {
   *context = connect_function(address.c_str(), port);
   if (*context == nullptr || (*context)->err) {
-    ostringstream oss(errorMessage);
+    std::ostringstream oss(errorMessage);
     if (*context == nullptr) {
       oss << "Could not allocate Redis context.";
     } else if ((*context)->err) {
       oss << "Could not establish connection to Redis " << address << ":"
           << port << " (context.err = " << (*context)->err << ")";
     }
-    return Status::RedisError();
+    return Status::RedisError(errorMessage);
   }
   return Status::OK();
 }

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -285,20 +285,34 @@ void SetDisconnectCallback(RedisAsyncContext *redis_async_context) {
 }
 
 template <typename RedisContext, typename RedisConnectFunction>
+Status ConnectWithoutRetries(const std::string &address, int port,
+                             const RedisConnectFunction &connect_function,
+                             RedisContext **context,
+                             std::string &errorMessage) {
+  *context = connect_function(address.c_str(), port);
+  if (*context == nullptr || (*context)->err) {
+    ostringstream oss(errorMessage);
+    if (*context == nullptr) {
+      oss << "Could not allocate Redis context."
+    } else if ((*context)->err) {
+      oss << "Could not establish connection to Redis " << address << ":"
+          << port << " (context.err = " << (*context)->err << ")";
+    }
+    return Status::RedisError();
+  }
+  return Status::OK();
+}
+
+template <typename RedisContext, typename RedisConnectFunction>
 Status ConnectWithRetries(const std::string &address, int port,
                           const RedisConnectFunction &connect_function,
                           RedisContext **context) {
   int connection_attempts = 0;
-  *context = connect_function(address.c_str(), port);
-  while (*context == nullptr || (*context)->err) {
+  std::string errorMessage = "";
+  Status status = ConnectWithoutRetries(address, port, connect_function, context, errorMessage);
+  while (status != Status::OK()) {
     if (connection_attempts >= RayConfig::instance().redis_db_connect_retries()) {
-      if (*context == nullptr) {
-        RAY_LOG(FATAL) << "Could not allocate redis context.";
-      }
-      if ((*context)->err) {
-        RAY_LOG(FATAL) << "Could not establish connection to redis " << address << ":"
-                       << port << " (context.err = " << (*context)->err << ")";
-      }
+      RAY_LOG(FATAL) << errorMessage;
       break;
     }
     if (*context == nullptr) {
@@ -312,7 +326,7 @@ Status ConnectWithRetries(const std::string &address, int port,
     // Sleep for a little.
     std::this_thread::sleep_for(std::chrono::milliseconds(
         RayConfig::instance().redis_db_connect_wait_milliseconds()));
-    *context = connect_function(address.c_str(), port);
+    status = ConnectWithoutRetries(address, port, connect_function, context, errorMessage);
     connection_attempts += 1;
   }
   return Status::OK();

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -310,7 +310,7 @@ Status ConnectWithRetries(const std::string &address, int port,
   int connection_attempts = 0;
   std::string errorMessage = "";
   Status status = ConnectWithoutRetries(address, port, connect_function, context, errorMessage);
-  while (status != Status::OK()) {
+  while (!status.ok()) {
     if (connection_attempts >= RayConfig::instance().redis_db_connect_retries()) {
       RAY_LOG(FATAL) << errorMessage;
       break;

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -309,7 +309,8 @@ Status ConnectWithRetries(const std::string &address, int port,
                           RedisContext **context) {
   int connection_attempts = 0;
   std::string errorMessage = "";
-  Status status = ConnectWithoutRetries(address, port, connect_function, context, errorMessage);
+  Status status = ConnectWithoutRetries(address, port, connect_function, context,
+                                        errorMessage);
   while (!status.ok()) {
     if (connection_attempts >= RayConfig::instance().redis_db_connect_retries()) {
       RAY_LOG(FATAL) << errorMessage;
@@ -326,7 +327,8 @@ Status ConnectWithRetries(const std::string &address, int port,
     // Sleep for a little.
     std::this_thread::sleep_for(std::chrono::milliseconds(
         RayConfig::instance().redis_db_connect_wait_milliseconds()));
-    status = ConnectWithoutRetries(address, port, connect_function, context, errorMessage);
+    status = ConnectWithoutRetries(address, port, connect_function, context,
+                                   errorMessage);
     connection_attempts += 1;
   }
   return Status::OK();

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -293,7 +293,7 @@ Status ConnectWithoutRetries(const std::string &address, int port,
   if (*context == nullptr || (*context)->err) {
     ostringstream oss(errorMessage);
     if (*context == nullptr) {
-      oss << "Could not allocate Redis context."
+      oss << "Could not allocate Redis context.";
     } else if ((*context)->err) {
       oss << "Could not establish connection to Redis " << address << ":"
           << port << " (context.err = " << (*context)->err << ")";

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -287,16 +287,15 @@ void SetDisconnectCallback(RedisAsyncContext *redis_async_context) {
 template <typename RedisContext, typename RedisConnectFunction>
 Status ConnectWithoutRetries(const std::string &address, int port,
                              const RedisConnectFunction &connect_function,
-                             RedisContext **context,
-                             std::string &errorMessage) {
+                             RedisContext **context, std::string &errorMessage) {
   *context = connect_function(address.c_str(), port);
   if (*context == nullptr || (*context)->err) {
     std::ostringstream oss(errorMessage);
     if (*context == nullptr) {
       oss << "Could not allocate Redis context.";
     } else if ((*context)->err) {
-      oss << "Could not establish connection to Redis " << address << ":"
-          << port << " (context.err = " << (*context)->err << ")";
+      oss << "Could not establish connection to Redis " << address << ":" << port
+          << " (context.err = " << (*context)->err << ")";
     }
     return Status::RedisError(errorMessage);
   }
@@ -309,8 +308,8 @@ Status ConnectWithRetries(const std::string &address, int port,
                           RedisContext **context) {
   int connection_attempts = 0;
   std::string errorMessage = "";
-  Status status = ConnectWithoutRetries(address, port, connect_function, context,
-                                        errorMessage);
+  Status status =
+      ConnectWithoutRetries(address, port, connect_function, context, errorMessage);
   while (!status.ok()) {
     if (connection_attempts >= RayConfig::instance().redis_db_connect_retries()) {
       RAY_LOG(FATAL) << errorMessage;
@@ -327,8 +326,8 @@ Status ConnectWithRetries(const std::string &address, int port,
     // Sleep for a little.
     std::this_thread::sleep_for(std::chrono::milliseconds(
         RayConfig::instance().redis_db_connect_wait_milliseconds()));
-    status = ConnectWithoutRetries(address, port, connect_function, context,
-                                   errorMessage);
+    status =
+        ConnectWithoutRetries(address, port, connect_function, context, errorMessage);
     connection_attempts += 1;
   }
   return Status::OK();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Currently, the logic of connecting to Redis is commingled with the logic of how often to retry. This splits out a separate function the only tries to connect once.

Obviously the idea is to use the single source for the error message and just append a "retrying" message in the retrying case, but for the moment this only actually changes the fatal case, to avoid merge conflicts.

Since I just picked Status::RedisError out of a hat and I'm not sure whether we might ultimately want to return something else (I'm not familiar with how these Status objects are intended to be used), currently this passes back the error message with a separate output parameter.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
