### PR TITLE
Instructions to run clang-format

### DIFF
--- a/doc/source/getting-involved.rst
+++ b/doc/source/getting-involved.rst
@@ -37,7 +37,7 @@ Setting up your development environment
 
 To edit the Ray source code, you'll want to checkout the repository and also build Ray from source. Follow :ref:`these instructions for building <building-ray>` a local copy of Ray to easily make changes.
 
-When editing C++ code, if you're not very familiar with Google style, you may find it useful to repeatedly run clang-format as you go. Note however that ``clang-format`` will only pick up the ``.clang-format`` if you run from the top-level directory with ``-style=file``.
+When editing C++ code, if you're not very familiar with Google style, you may find it useful to repeatedly run clang-format as you go. Note however that ``clang-format`` will only pick up the ``.clang-format`` file if you run from the top-level directory with ``-style=file``.
 On systems with a precompiled wheel available, the easiest way to use clang-format might be to ``pip install clang-format`` into your regular Python environment.
 
 .. code:: bash

--- a/doc/source/getting-involved.rst
+++ b/doc/source/getting-involved.rst
@@ -44,6 +44,8 @@ On systems with a precompiled wheel available, the easiest way to use clang-form
 
   path/to/your/env/bin/clang-format --style=file -i src/ray/path/name_of_file.cc
 
+A normal ``git diff`` will then show the changes clang-format made.
+
 
 Submitting and Merging a Contribution
 -------------------------------------

--- a/doc/source/getting-involved.rst
+++ b/doc/source/getting-involved.rst
@@ -37,6 +37,13 @@ Setting up your development environment
 
 To edit the Ray source code, you'll want to checkout the repository and also build Ray from source. Follow :ref:`these instructions for building <building-ray>` a local copy of Ray to easily make changes.
 
+When editing C++ code, if you're not very familiar with Google style, you may find it useful to repeatedly run clang-format as you go. Note however that ``clang-format`` will only pick up the ``.clang-format`` if you run from the top-level directory with ``-style=file``.
+On systems with a precompiled wheel available, the easiest way to use clang-format might be to ``pip install clang-format`` into your regular Python environment.
+
+.. code:: bash
+
+  path/to/your/env/bin/clang-format --style=file -i src/ray/path/name_of_file.cc
+
 
 Submitting and Merging a Contribution
 -------------------------------------


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
clang-format can spit out some unexpected errors, but it turns out it's fairly easy to use if you know how.

In the interest of saving page space, this never quite comes out and says the basics like "By the way, we use a custom .clang-format configuration file", but the fact that *a file named .clang-format exists and you can look at it if you want* is implicit in the paragraph. This provides a minimal "run this command to solve your problem", and anyone interested in knowing more can look at the `.clang-format` themselves.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
