### PR TITLE
Allow redis.ResponseError instead of redis.AuthenticationError

### DIFF
--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -43,9 +43,8 @@ class TestRedisPassword:
         except Exception as ex:
             if not (isinstance(ex.__cause__, redis.AuthenticationError)
                     and "invalid password" in str(ex.__cause__)) and not (
-                    isinstance(ex, redis.ResponseError)
-                    and "WRONGPASS invalid username-password pair" in str(ex)
-                    ):
+                        isinstance(ex, redis.ResponseError) and
+                        "WRONGPASS invalid username-password pair" in str(ex)):
                 raise
             # By contrast, we may be fairly confident the exact string
             # 'invalid password' won't go away, because redis-py simply wraps


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
https://github.com/ray-project/ray/pull/11893 added a clause to test_ray_init that gave a bad password. This passed at the time (https://travis-ci.com/github/ray-project/ray/jobs/434064778). However, now builds are failing.

It appears that the failure is caused by the change to the test, not the change to `wait_for_redis_to_start()`. The error that is appearing is a redis.ResponseError, which is not derived from redis.ConnectionError, so it would not have been caught in any event. The cause of the failing builds is that the test was not previously trying to give a bad password, and now it is.

redis.AuthenticationErrors are caught. It appears that sometimes redis-py raises a redis.AuthenticationError in response to a bad password and sometimes it raises a redis.ResponseError --- it's unclear what causes it to raise one or the other. The test sometimes passes (with a redis.AuthenticationError), e.g. on https://github.com/ray-project/ray/pull/12012. But sometimes it fails with a redis.ResponseError.

This changes the test to allow either a redis.AuthenticationError or a redis.ResponseError. Not sure what the best way to handle this is.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
