### PR TITLE
Pin aiohttp to the 3.7.x version

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,7 +5,7 @@
 # In short, if you change it here, PLEASE also change it in setup.py.
 #
 # setup.py install_requires
-aiohttp
+aiohttp==3.7
 aioredis
 click >= 7.0
 colorama


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
aiohttp has released a 4.0 build that changes some APIs and led to the dashboard breaking in the nightly. This pins the version so that we maintain a consistent API.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #12049.

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
