### PR TITLE
Lazily initialize the global state accessor in Python workers

### DIFF
--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -63,6 +63,8 @@ class GlobalState:
         """Disconnect global state from GCS."""
         self.redis_client = None
         self.redis_clients = None
+        self.redis_address = None
+        self.redis_password = None
         if self.global_state_accessor is not None:
             self.global_state_accessor.disconnect()
             self.global_state_accessor = None

--- a/python/ray/tests/test_error_ray_not_initialized.py
+++ b/python/ray/tests/test_error_ray_not_initialized.py
@@ -17,14 +17,14 @@ def test_errors_before_initializing_ray():
     api_methods = [
         f.remote,
         Foo.remote,
-        ray.actors,
+#        ray.actors,
         lambda: ray.cancel(None),  # Not valid API usage.
         lambda: ray.get([]),
         lambda: ray.get_actor("name"),
         ray.get_gpu_ids,
         ray.get_resource_ids,
         ray.get_dashboard_url,
-        ray.jobs,
+#        ray.jobs,
         lambda: ray.kill(None),  # Not valid API usage.
         ray.nodes,
         ray.objects,

--- a/python/ray/tests/test_error_ray_not_initialized.py
+++ b/python/ray/tests/test_error_ray_not_initialized.py
@@ -17,14 +17,14 @@ def test_errors_before_initializing_ray():
     api_methods = [
         f.remote,
         Foo.remote,
-#        ray.actors,
+        ray.actors,
         lambda: ray.cancel(None),  # Not valid API usage.
         lambda: ray.get([]),
         lambda: ray.get_actor("name"),
         ray.get_gpu_ids,
         ray.get_resource_ids,
         ray.get_dashboard_url,
-#        ray.jobs,
+        ray.jobs,
         lambda: ray.kill(None),  # Not valid API usage.
         ray.nodes,
         ray.objects,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR changes the global state accessor API to be lazily initialized (e.g., for `ray.nodes()` calls). This reduces the number of redis connections used by about half (more for clusters with many redis shards).

Empirically, this reduces the rate of fd leak by half as well (https://github.com/ray-project/ray/issues/11713), suggesting that the fd leaks may be redis related.