### PR TITLE
[Dashboard] Patch issue in 1.0.1 release where worker stats are not present for a node

### DIFF
--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -696,7 +696,8 @@ class RayletStats(threading.Thread):
                         node_manager_pb2.GetNodeStatsRequest(
                             include_memory_info=self.include_memory_info),
                         timeout=2)
-                    reply_dict = MessageToDict(reply, including_default_value_fields=True)
+                    reply_dict = MessageToDict(
+                        reply, including_default_value_fields=True)
                     reply_dict["nodeId"] = node_id
                     replies[node["NodeManagerAddress"]] = reply_dict
                 with self._raylet_stats_lock:

--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -81,7 +81,7 @@ class DashboardController(BaseDashboardController):
     def _construct_raylet_info(self):
         D = self.raylet_stats.get_raylet_stats()
         workers_info_by_node = {
-            data["nodeId"]: data.get("workersStats")
+            data["nodeId"]: data.get("workersStats", [])
             for data in D.values()
         }
 
@@ -165,7 +165,7 @@ class DashboardController(BaseDashboardController):
         self.raylet_stats.include_memory_info = True
         D = self.raylet_stats.get_raylet_stats()
         workers_info_by_node = {
-            data["nodeId"]: data.get("workersStats")
+            data["nodeId"]: data.get("workersStats", [])
             for data in D.values()
         }
         self.memory_table = construct_memory_table(
@@ -696,7 +696,7 @@ class RayletStats(threading.Thread):
                         node_manager_pb2.GetNodeStatsRequest(
                             include_memory_info=self.include_memory_info),
                         timeout=2)
-                    reply_dict = MessageToDict(reply)
+                    reply_dict = MessageToDict(reply, including_default_value_fields=True)
                     reply_dict["nodeId"] = node_id
                     replies[node["NodeManagerAddress"]] = reply_dict
                 with self._raylet_stats_lock:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Hot fixes the issue that causes the dashboard not to render when there are no workers on a node.
I tested this running locally on a node, starting out with 0 workers running, then adding actors and tasks, making sure logging/errors worked. I also made sure the memory view and logical view were looking correctly.

I haven't tested it running on a cluster. I was trying to, but ran into various issues with my config yaml files and installing over the 1.0.1 release.

## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
