### PR TITLE
[Metrics] Add stats to measure process startup time + scheduling stats.

### DIFF
--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -20,7 +20,7 @@ import ray.new_dashboard.utils as dashboard_utils
 import ray.ray_constants as ray_constants
 import ray._private.services
 import ray.utils
-
+from ray.metrics_agent import PrometheusServiceDiscoveryWriter
 # Logger for this module. It should be configured at the entry point
 # into the program using Ray. Ray provides a default configuration at
 # entry/init points.
@@ -194,6 +194,9 @@ if __name__ == "__main__":
             args.redis_address,
             redis_password=args.redis_password,
             log_dir=args.log_dir)
+        service_discovery = PrometheusServiceDiscoveryWriter(
+            args.redis_address, args.redis_password, args.temp_dir)
+        service_discovery.start()
         loop = asyncio.get_event_loop()
         loop.run_until_complete(dashboard.run())
     except Exception as e:

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -219,6 +219,8 @@ int main(int argc, char *argv[]) {
             RayConfig::instance().raylet_heartbeat_timeout_milliseconds();
         node_manager_config.debug_dump_period_ms =
             RayConfig::instance().debug_dump_period_milliseconds();
+        node_manager_config.record_metrics_period_ms =
+            RayConfig::instance().metrics_report_interval_ms() / 2;
         node_manager_config.fair_queueing_enabled =
             RayConfig::instance().fair_queueing_enabled();
         node_manager_config.object_pinning_enabled =

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -3356,7 +3356,6 @@ void NodeManager::RecordMetrics() {
   // Last recorded time will be reset in the caller side.
   uint64_t current_time = current_time_ms();
   uint64_t duration_ms = current_time - metrics_last_recorded_time_ms_;
-  RAY_LOG(ERROR) << "sangbin duration" << duration_ms;
 
   // Record available resources of this node.
   const auto &available_resources =

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -99,6 +99,8 @@ struct NodeManagerConfig {
   std::string session_dir;
   /// The raylet config list of this node.
   std::unordered_map<std::string, std::string> raylet_config;
+  // The time between record metrics in milliseconds, or -1 to disable.
+  uint64_t record_metrics_period_ms;
 };
 
 typedef std::pair<PlacementGroupID, int64_t> BundleID;
@@ -816,6 +818,22 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// creation.
   absl::flat_hash_map<BundleID, std::shared_ptr<BundleState>, pair_hash>
       bundle_state_map_;
+
+  /// Fields that are used to report metrics.
+  /// The period between debug state dumps.
+  int64_t record_metrics_period_;
+
+  /// Last time metrics are recorded.
+  uint64_t metrics_last_recorded_time_ms_;
+
+  /// Number of tasks that are received and scheduled.
+  uint64_t metrics_num_task_scheduled_;
+
+  /// Number of tasks that are executed at this node.
+  uint64_t metrics_num_task_executed_;
+
+  /// Number of tasks that are spilled back to other nodes.
+  uint64_t metrics_num_task_spilled_back_;
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -339,8 +339,13 @@ Process WorkerPool::StartWorkerProcess(
   for (const auto &pair : override_environment_variables) {
     env[pair.first] = pair.second;
   }
-
+  // Start a process and measure the startup time.
+  auto start = std::chrono::high_resolution_clock::now();
   Process proc = StartProcess(worker_command_args, env);
+  auto end = std::chrono::high_resolution_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  stats::ProcessStartupTimeMs.Record(duration.count());
+
   RAY_LOG(DEBUG) << "Started worker process of " << workers_to_start
                  << " worker(s) with pid " << proc.GetId();
   MonitorStartingWorkerProcess(proc, language, worker_type);

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -75,6 +75,25 @@ static Histogram HeartbeatReportMs(
     "heartbeats.",
     "ms", {100, 200, 400, 800, 1600, 3200, 6400, 15000, 30000});
 
+static Histogram ProcessStartupTimeMs("process_startup_time_ms",
+                                      "Time to start up a worker process.", "ms",
+                                      {1, 10, 100, 1000, 10000});
+
+static Gauge AvgNumScheduledTasks(
+    "avg_num_scheduled_tasks",
+    "Number of tasks that are queued on this node per second. It doesn't guarantee "
+    "that the task will be executed in this node. If the task is executed, it is "
+    "recorded as avg_num_executed_tasks. If the task is not executed and needs to be "
+    "scheduled in other nodes, it will be recorded as avg_num_spilled_back_tasks",
+    "tasks");
+
+static Gauge AvgNumExecutedTasks("avg_num_executed_tasks",
+                                 "Number of executed tasks on this node per second.",
+                                 "tasks");
+
+static Gauge AvgNumSpilledBackTasks("avg_num_spilled_back_tasks",
+                                    "Number of spilled back tasks per second.", "tasks");
+
 ///
 /// GCS Server Metrics
 ///


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR is doing several things.

- I found the regression that Prometheus service discovery wasn't running in the new dashboard. It fixes the issue.
- Added 4 new metrics. One to measure process startup time. Other 3 to measure average task scheduling / executing / spillback counts per second.

Would love to hear more suggestion about metrics to measure scheduling stats.

<img width="1639" alt="Screen Shot 2020-11-17 at 9 55 06 PM" src="https://user-images.githubusercontent.com/18510752/99490878-8f4f5c80-291f-11eb-8ab9-56724b612072.png">

## Related issue number

Hopefully helpful to figure out the root cause this issue https://github.com/ray-project/ray/issues/12052

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
