### PR TITLE
Revert "[CLI] Fix ray commands when RAY_ADDRESS used (#11989)"

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -170,10 +170,6 @@ def find_redis_address(address=None):
     The --redis-address here is what is now called the --address, but it
     appears in the default_worker.py and agent.py calls as --redis-address.
     """
-
-    if "RAY_ADDRESS" in os.environ:
-        return os.environ["RAY_ADDRESS"]
-
     pids = psutil.pids()
     redis_addresses = set()
     for pid in pids:

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -125,9 +125,6 @@ def find_redis_address(address=None):
     """
     Attempts to find all valid Ray redis addresses on this node.
 
-    Args:
-        address: The ...
-
     Returns:
         Set of detected Redis instances.
     """

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -211,9 +211,16 @@ def find_redis_address(address=None):
     return redis_addresses
 
 
-def find_redis_address_or_die_respect_environment():
+def get_ray_address_to_use_or_die():
+    """
+    Attempts to find an address for an existing Ray cluster if it is not
+    already specified as an environment variable.
+    Returns:
+        A string to pass into `ray.init(address=...)`
+    """
     if "RAY_ADDRESS" in os.environ:
-        return None
+        return "auto"
+
     return find_redis_address_or_die()
 
 

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -123,53 +123,61 @@ def new_port():
 
 def find_redis_address(address=None):
     """
-    Currently, this extracts the deprecated --redis-address from the command
-    that launched the raylet running on this node, if any. Anyone looking to
-    edit this function should be warned that these commands look like, for
-    example:
-    /usr/local/lib/python3.8/dist-packages/ray/core/src/ray/raylet/raylet
-    --redis_address=123.456.78.910 --node_ip_address=123.456.78.910
-    --raylet_socket_name=... --store_socket_name=... --object_manager_port=0
-    --min_worker_port=10000 --max_worker_port=10999 --node_manager_port=58578
-    --redis_port=6379 --num_initial_workers=8 --maximum_startup_concurrency=8
-    --static_resource_list=node:123.456.78.910,1.0,object_store_memory,66
-    --config_list=plasma_store_as_thread,True
-    --python_worker_command=/usr/bin/python
-        /usr/local/lib/python3.8/dist-packages/ray/workers/default_worker.py
-        --redis-address=123.456.78.910:6379
-        --node-ip-address=123.456.78.910 --node-manager-port=58578
-        --object-store-name=... --raylet-name=...
-        --config-list=plasma_store_as_thread,True --temp-dir=/tmp/ray
-        --metrics-agent-port=41856 --redis-password=[MASKED]
-        --java_worker_command= --cpp_worker_command= --redis_password=[MASKED]
-        --temp_dir=/tmp/ray --session_dir=... --metrics-agent-port=41856
-        --metrics_export_port=64229
-        --agent_command=/usr/bin/python
-        -u /usr/local/lib/python3.8/dist-packages/ray/new_dashboard/agent.py
-            --redis-address=123.456.78.910:6379 --metrics-export-port=64229
-            --dashboard-agent-port=41856 --node-manager-port=58578
-            --object-store-name=... --raylet-name=... --temp-dir=/tmp/ray
-            --log-dir=/tmp/ray/session_2020-11-08_14-29-07_199128_278000/logs
-            --redis-password=[MASKED] --object_store_memory=5037192806
-            --plasma_directory=/tmp
-    Longer arguments are elided with ... but all arguments from this instance
-    are included, to provide a sense of what is in these.
-    Indeed, we had to pull --redis-address to the front of each call to make
-    this readable.
-    As you can see, this is very long and complex, which is why we can't simply
-    extract all the the arguments using regular expressions and present a dict
-    as if we never lost track of these arguments, for example.
-    Picking out --redis-address below looks like it might grab the wrong thing,
-    but double-checking that we're finding the correct process by checking that
-    the contents look like we expect would probably be prone to choking in
-    unexpected ways.
-    Notice that --redis-address appears twice. This is not a copy-paste error;
-    this is the reason why the for loop below attempts to pick out every
-    appearance of --redis-address.
+    Attempts to find all valid Ray redis addresses on this node.
 
-    The --redis-address here is what is now called the --address, but it
-    appears in the default_worker.py and agent.py calls as --redis-address.
+    Args:
+        address: The ...
+
+    Returns:
+        Set of detected Redis instances.
     """
+    # Currently, this extracts the deprecated --redis-address from the command
+    # that launched the raylet running on this node, if any. Anyone looking to
+    # edit this function should be warned that these commands look like, for
+    # example:
+    # /usr/local/lib/python3.8/dist-packages/ray/core/src/ray/raylet/raylet
+    # --redis_address=123.456.78.910 --node_ip_address=123.456.78.910
+    # --raylet_socket_name=... --store_socket_name=... --object_manager_port=0
+    # --min_worker_port=10000 --max_worker_port=10999
+    # --node_manager_port=58578 --redis_port=6379 --num_initial_workers=8
+    # --maximum_startup_concurrency=8
+    # --static_resource_list=node:123.456.78.910,1.0,object_store_memory,66
+    # --config_list=plasma_store_as_thread,True
+    # --python_worker_command=/usr/bin/python
+    #     /usr/local/lib/python3.8/dist-packages/ray/workers/default_worker.py
+    #     --redis-address=123.456.78.910:6379
+    #     --node-ip-address=123.456.78.910 --node-manager-port=58578
+    #     --object-store-name=... --raylet-name=...
+    #     --config-list=plasma_store_as_thread,True --temp-dir=/tmp/ray
+    #     --metrics-agent-port=41856 --redis-password=[MASKED]
+    #     --java_worker_command= --cpp_worker_command=
+    #     --redis_password=[MASKED] --temp_dir=/tmp/ray --session_dir=...
+    #     --metrics-agent-port=41856 --metrics_export_port=64229
+    #     --agent_command=/usr/bin/python
+    #     -u /usr/local/lib/python3.8/dist-packages/ray/new_dashboard/agent.py
+    #         --redis-address=123.456.78.910:6379 --metrics-export-port=64229
+    #         --dashboard-agent-port=41856 --node-manager-port=58578
+    #         --object-store-name=... --raylet-name=... --temp-dir=/tmp/ray
+    #         --log-dir=/tmp/ray/session_2020-11-08_14-29-07_199128_278000/logs
+    #         --redis-password=[MASKED] --object_store_memory=5037192806
+    #         --plasma_directory=/tmp
+    # Longer arguments are elided with ... but all arguments from this instance
+    # are included, to provide a sense of what is in these.
+    # Indeed, we had to pull --redis-address to the front of each call to make
+    # this readable.
+    # As you can see, this is very long and complex, which is why we can't
+    # simply extract all the the arguments using regular expressions and
+    # present a dict as if we never lost track of these arguments, for
+    # example. Picking out --redis-address below looks like it might grab the
+    # wrong thing, but double-checking that we're finding the correct process
+    # by checking that the contents look like we expect would probably be prone
+    # to choking in unexpected ways.
+    # Notice that --redis-address appears twice. This is not a copy-paste
+    # error; this is the reason why the for loop below attempts to pick out
+    # every appearance of --redis-address.
+
+    # The --redis-address here is what is now called the --address, but it
+    # appears in the default_worker.py and agent.py calls as --redis-address.
     pids = psutil.pids()
     redis_addresses = set()
     for pid in pids:

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -216,7 +216,7 @@ def get_ray_address_to_use_or_die():
         A string to pass into `ray.init(address=...)`
     """
     if "RAY_ADDRESS" in os.environ:
-        return "auto"   # Avoid conflict with RAY_ADDRESS env var
+        return "auto"  # Avoid conflict with RAY_ADDRESS env var
 
     return find_redis_address_or_die()
 

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -219,7 +219,7 @@ def get_ray_address_to_use_or_die():
         A string to pass into `ray.init(address=...)`
     """
     if "RAY_ADDRESS" in os.environ:
-        return "auto"
+        return "auto"   # Avoid conflict with RAY_ADDRESS env var
 
     return find_redis_address_or_die()
 

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -203,7 +203,10 @@ def find_redis_address(address=None):
     return redis_addresses
 
 
-def find_redis_address_or_die():
+def find_redis_address_or_die(check_environ=False):
+    if check_environ and "RAY_ADDRESS" in os.environ:
+        return None
+
     redis_addresses = find_redis_address()
     if len(redis_addresses) > 1:
         raise ConnectionError(

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -203,9 +203,13 @@ def find_redis_address(address=None):
     return redis_addresses
 
 
-def find_redis_address_or_die(check_environ=False):
-    if check_environ and "RAY_ADDRESS" in os.environ:
+def find_redis_address_or_die_respect_environment():
+    if "RAY_ADDRESS" in os.environ:
         return None
+    return find_redis_address_or_die()
+
+
+def find_redis_address_or_die():
 
     redis_addresses = find_redis_address()
     if len(redis_addresses) > 1:

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -160,7 +160,7 @@ def debug(address):
     """Show all active breakpoints and exceptions in the Ray debugger."""
     from telnetlib import Telnet
     if not address:
-        address = services.find_redis_address_or_die(check_environ=True)
+        address = services.find_redis_address_or_die_respect_environment()
     logger.info(f"Connecting to Ray instance at {address}.")
     ray.init(address=address)
     while True:
@@ -1309,7 +1309,7 @@ def microbenchmark():
 def timeline(address):
     """Take a Chrome tracing timeline for a Ray cluster."""
     if not address:
-        address = services.find_redis_address_or_die(check_environ=True)
+        address = services.find_redis_address_or_die_respect_environment()
     logger.info(f"Connecting to Ray instance at {address}.")
     ray.init(address=address)
     time = datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
@@ -1337,7 +1337,7 @@ def timeline(address):
 def memory(address, redis_password):
     """Print object references held in a Ray cluster."""
     if not address:
-        address = services.find_redis_address_or_die(check_environ=True)
+        address = services.find_redis_address_or_die_respect_environment()
     logger.info(f"Connecting to Ray instance at {address}.")
     ray.init(address=address, _redis_password=redis_password)
     print(ray.internal.internal_api.memory_summary())
@@ -1352,7 +1352,7 @@ def memory(address, redis_password):
 def status(address):
     """Print cluster status, including autoscaling info."""
     if not address:
-        address = services.find_redis_address_or_die(check_environ=True)
+        address = services.find_redis_address_or_die_respect_environment()
     logger.info(f"Connecting to Ray instance at {address}.")
     ray.init(address=address)
     print(debug_status())
@@ -1367,7 +1367,7 @@ def status(address):
 def global_gc(address):
     """Trigger Python garbage collection on all cluster workers."""
     if not address:
-        address = services.find_redis_address_or_die(check_environ=True)
+        address = services.find_redis_address_or_die_respect_environment()
     logger.info(f"Connecting to Ray instance at {address}.")
     ray.init(address=address)
     ray.internal.internal_api.global_gc()

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -160,7 +160,7 @@ def debug(address):
     """Show all active breakpoints and exceptions in the Ray debugger."""
     from telnetlib import Telnet
     if not address:
-        address = services.find_redis_address_or_die_respect_environment()
+        address = services.get_ray_address_to_use_or_die()
     logger.info(f"Connecting to Ray instance at {address}.")
     ray.init(address=address)
     while True:
@@ -1309,7 +1309,7 @@ def microbenchmark():
 def timeline(address):
     """Take a Chrome tracing timeline for a Ray cluster."""
     if not address:
-        address = services.find_redis_address_or_die_respect_environment()
+        address = services.get_ray_address_to_use_or_die()
     logger.info(f"Connecting to Ray instance at {address}.")
     ray.init(address=address)
     time = datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
@@ -1337,7 +1337,7 @@ def timeline(address):
 def memory(address, redis_password):
     """Print object references held in a Ray cluster."""
     if not address:
-        address = services.find_redis_address_or_die_respect_environment()
+        address = services.get_ray_address_to_use_or_die()
     logger.info(f"Connecting to Ray instance at {address}.")
     ray.init(address=address, _redis_password=redis_password)
     print(ray.internal.internal_api.memory_summary())
@@ -1352,7 +1352,7 @@ def memory(address, redis_password):
 def status(address):
     """Print cluster status, including autoscaling info."""
     if not address:
-        address = services.find_redis_address_or_die_respect_environment()
+        address = services.get_ray_address_to_use_or_die()
     logger.info(f"Connecting to Ray instance at {address}.")
     ray.init(address=address)
     print(debug_status())
@@ -1367,7 +1367,7 @@ def status(address):
 def global_gc(address):
     """Trigger Python garbage collection on all cluster workers."""
     if not address:
-        address = services.find_redis_address_or_die_respect_environment()
+        address = services.get_ray_address_to_use_or_die()
     logger.info(f"Connecting to Ray instance at {address}.")
     ray.init(address=address)
     ray.internal.internal_api.global_gc()

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -160,7 +160,7 @@ def debug(address):
     """Show all active breakpoints and exceptions in the Ray debugger."""
     from telnetlib import Telnet
     if not address:
-        address = services.find_redis_address_or_die()
+        address = services.find_redis_address_or_die(check_environ=True)
     logger.info(f"Connecting to Ray instance at {address}.")
     ray.init(address=address)
     while True:
@@ -1309,7 +1309,7 @@ def microbenchmark():
 def timeline(address):
     """Take a Chrome tracing timeline for a Ray cluster."""
     if not address:
-        address = services.find_redis_address_or_die()
+        address = services.find_redis_address_or_die(check_environ=True)
     logger.info(f"Connecting to Ray instance at {address}.")
     ray.init(address=address)
     time = datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
@@ -1337,7 +1337,7 @@ def timeline(address):
 def memory(address, redis_password):
     """Print object references held in a Ray cluster."""
     if not address:
-        address = services.find_redis_address_or_die()
+        address = services.find_redis_address_or_die(check_environ=True)
     logger.info(f"Connecting to Ray instance at {address}.")
     ray.init(address=address, _redis_password=redis_password)
     print(ray.internal.internal_api.memory_summary())
@@ -1352,7 +1352,7 @@ def memory(address, redis_password):
 def status(address):
     """Print cluster status, including autoscaling info."""
     if not address:
-        address = services.find_redis_address_or_die()
+        address = services.find_redis_address_or_die(check_environ=True)
     logger.info(f"Connecting to Ray instance at {address}.")
     ray.init(address=address)
     print(debug_status())
@@ -1367,7 +1367,7 @@ def status(address):
 def global_gc(address):
     """Trigger Python garbage collection on all cluster workers."""
     if not address:
-        address = services.find_redis_address_or_die()
+        address = services.find_redis_address_or_die(check_environ=True)
     logger.info(f"Connecting to Ray instance at {address}.")
     ray.init(address=address)
     ray.internal.internal_api.global_gc()


### PR DESCRIPTION
This reverts commit d23d326560a49e9f59941a0686a10753c66f4581.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Fixes `ray start`

<img width="867" alt="Screen Shot 2020-11-18 at 1 19 35 PM" src="https://user-images.githubusercontent.com/21353794/99589408-ce71c200-29a0-11eb-9886-6198899ad2c6.png">

* Keeps fix for `ray status` (and similar CLI commands)
<img width="957" alt="Screen Shot 2020-11-18 at 1 20 46 PM" src="https://user-images.githubusercontent.com/21353794/99589467-dfbace80-29a0-11eb-8c80-401f5a10b1f4.png">


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
