### PR TITLE
[core] Clean up google package from requirements.txt

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -11,7 +11,6 @@ click >= 7.0
 colorama
 colorful
 filelock
-google
 gpustat
 grpcio >= 1.28.1
 jsonschema


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is a leftover from https://github.com/ray-project/ray/pull/12085 that I came across today

It seems that there are some more differences between setup.py and requirements.txt (e.g. aiohttp is pinned in requirements.txt but not in setup.py). We should remove these differences and also add a test in the CI that checks that the two lists are the same @barakmich 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
