### PR TITLE
Revert "[Core] Async API should raise on all RayError"

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1525,7 +1525,7 @@ cdef void async_set_result(shared_ptr[CRayObject] obj,
             cpython.Py_DECREF(py_future)
             return
 
-        if isinstance(result, RayError):
+        if isinstance(result, RayTaskError):
             ray.worker.last_task_error_raise_time = time.time()
             py_future.set_exception(result.as_instanceof_cause())
         else:


### PR DESCRIPTION
Reverts ray-project/ray#12043

Seems like it's causing serve:test_router to fail deterministically? 