### PR TITLE
[CI] Use Docker image for microbenchmarks

### DIFF
--- a/release/microbenchmark/cluster.yaml
+++ b/release/microbenchmark/cluster.yaml
@@ -1,7 +1,7 @@
 cluster_name: ray-release-microbenchmark
 
 docker:
-    image: anyscale/ray-ml:latest
+    image: anyscale/ray:latest
     container_name: ray_container
     pull_before_run: False
 

--- a/release/microbenchmark/cluster.yaml
+++ b/release/microbenchmark/cluster.yaml
@@ -1,57 +1,17 @@
 cluster_name: ray-release-microbenchmark
-min_workers: 0
-max_workers: 0
-target_utilization_fraction: 0.8
-idle_timeout_minutes: 5
 
-# Cloud-provider specific configuration.
+docker:
+    image: anyscale/ray-ml:latest
+    container_name: ray_container
+    pull_before_run: False
+
 provider:
     type: aws
     region: us-west-2
-    availability_zone: us-west-2a
+    availability_zone: us-west-2a, us-west-2b, us-west-2c
+
 auth:
     ssh_user: ubuntu
 
 head_node:
-    InstanceType: m4.16xlarge
-    ImageId: ami-06d51e91cea0dac8d  # Ubuntu 18.04
-    BlockDeviceMappings:
-        - DeviceName: /dev/sda1
-          Ebs:
-              VolumeSize: 150
-
-worker_nodes:
-    InstanceType: m5.large
-    ImageId: ami-06d51e91cea0dac8d  # Ubuntu 18.04
-    BlockDeviceMappings:
-        - DeviceName: /dev/sda1
-          Ebs:
-              VolumeSize: 150
-
-    # Run workers on spot by default. Comment this out to use on-demand.
-    InstanceMarketOptions:
-        MarketType: spot
-
-# List of shell commands to run to set up nodes.
-setup_commands:
-    # Install latest TensorFlow
-    - echo set-window-option -g mouse on > ~/.tmux.conf
-    - echo 'termcapinfo xterm* ti@:te@' > ~/.screenrc
-
-# Custom commands that will be run on the head node after common setup.
-head_setup_commands: 
-    # Install Anaconda.
-    - wget --quiet https://repo.continuum.io/archive/Anaconda3-5.0.1-Linux-x86_64.sh || true
-    - bash Anaconda3-5.0.1-Linux-x86_64.sh -b -p $HOME/anaconda3 || true
-    - echo 'export PATH="$HOME/anaconda3/bin:$PATH"' >> ~/.bashrc
-    - pip install -U pip 
-    - conda uninstall -y terminado
-
-# Custom commands that will be run on worker nodes after common setup.
-worker_setup_commands: []
-
-# Command to start ray on the head node. You don't need to change this.
-head_start_ray_commands: []
-
-# Command to start ray on worker nodes. You don't need to change this.
-worker_start_ray_commands: []
+    InstanceType: m5.16xlarge

--- a/release/microbenchmark/run.sh
+++ b/release/microbenchmark/run.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -xe
+
 ray_version=""
 commit=""
 ray_branch=""
@@ -47,14 +49,12 @@ echo "commit: $commit"
 echo "branch: $ray_branch"
 echo "workload: $workload"
 
-wheel="https://s3-us-west-2.amazonaws.com/ray-wheels/$ray_branch/$commit/ray-$ray_version-cp38-cp38-manylinux2014_x86_64.whl"
+wheel="https://s3-us-west-2.amazonaws.com/ray-wheels/$ray_branch/$commit/ray-$ray_version-cp37-cp37m-manylinux2014_x86_64.whl"
 
-
-echo set-window-option -g mouse on > ~/.tmux.conf
-echo 'termcapinfo xterm* ti@:te@' > ~/.screenrc
 pip uninstall -y -q ray
 pip install --upgrade pip
 pip install -U "$wheel"
 
 unset RAY_ADDRESS
+ray stop --force
 OMP_NUM_THREADS=64 ray microbenchmark


### PR DESCRIPTION
This PR updates the microbenchmark YAML to be useful by ray-project/releaser tool.

No need to test this because these are all scripts used by release process only.