### PR TITLE
Fix lint crash (title underline too short)

### DIFF
--- a/doc/source/profiling.rst
+++ b/doc/source/profiling.rst
@@ -4,7 +4,7 @@ Profiling for Ray Developers
 This document details, for Ray developers, how to analyze Ray performance.
 
 Getting a stack trace of Ray C++ processes
-----------------------------------------
+------------------------------------------
 
 You can use the following GDB command to view the current stack trace of any
 running Ray process (e.g., raylet). This can be useful for debugging 100% CPU


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The linter is crashing on Travis.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
