### PR TITLE
[Serve] Wait for actor name to be cleaned up

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1,4 +1,5 @@
 import atexit
+import time
 from functools import wraps
 import os
 from uuid import UUID
@@ -79,22 +80,22 @@ class Client:
         Shuts down all processes and deletes all state associated with the
         instance.
         """
-        if not self._shutdown:
+        if (not self._shutdown) and ray.is_initialized():
             ray.get(self._controller.shutdown.remote())
             ray.kill(self._controller, no_restart=True)
 
             # Wait for the named actor entry gets removed as well.
-            num_tries = 0
+            started = time.time()
             while True:
                 try:
                     ray.get_actor(self._controller_name)
-                    num_tries += 1
-                    if num_tries > 10:
-                        logger.info(
-                            "Waiting for controller actor be to removed "
-                            "from Ray actor registry. If this message "
-                            "occur too many times, please file a bug "
-                            "report.")
+                    if time.time() - started > 5:
+                        logger.warning(
+                            "Waited 5s for Serve to shutdown gracefully but "
+                            "the controller is still not cleaned up. "
+                            "You can ignore this warning if you are shutting "
+                            "down the Ray cluster.")
+                        break
                 except ValueError:  # actor name is removed
                     break
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Add a check in `client.shutdown()` to wait for the named actor handle is gone. This is because ray.kill will not wait for the actor name to be cleaned up. One alternative is to do this in CoreWorker side but I just chose this approach for simplicity.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Fixes #12214

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
