### PR TITLE
[Core] Force get actor has val

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/RayNativeRuntime.java
+++ b/java/runtime/src/main/java/io/ray/runtime/RayNativeRuntime.java
@@ -216,6 +216,9 @@ public final class RayNativeRuntime extends AbstractRayRuntime {
   @SuppressWarnings("unchecked")
   @Override
   public <T extends BaseActorHandle> Optional<T> getActor(String name, boolean global) {
+    if (name.isEmpty()) {
+      return Optional.empty();
+    }
     byte[] actorIdBytes = nativeGetActorIdOfNamedActor(name, global);
     ActorId actorId = ActorId.fromBytes(actorIdBytes);
     if (actorId.isNil()) {

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1032,6 +1032,12 @@ def test_kill(ray_start_regular_shared):
         ray.kill("not_an_actor_handle")
 
 
+def test_get_actor_no_input(ray_start_regular_shared):
+    for bad_name in [None, "", "    "]:
+        with pytest.raises(ValueError):
+            ray.get_actor(bad_name)
+
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1543,6 +1543,8 @@ def get_actor(name):
     Raises:
         ValueError if the named actor does not exist.
     """
+    if not name:
+        raise ValueError("Please supply a non-empty value to get_actor")
     worker = global_worker
     worker.check_connected()
     handle = worker.core_worker.get_named_actor_handle(name)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* If I call `ray.get_actor(None)` or `ray.get_actor("")` Ray explodes :'( because of [`RAY_CHECK(!name.empty());` ](https://github.com/ray-project/ray/blob/f6b84cb2f76188d0e77bc293d8662379609edd0e/src/ray/core_worker/core_worker.cc#L1616)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
