### PR TITLE
[docs] Point out debugger is currently only available in Ray nightly

### DIFF
--- a/doc/source/ray-debugging.rst
+++ b/doc/source/ray-debugging.rst
@@ -10,8 +10,11 @@ drop into a PDB session that you can then use to:
 - Move up or down the stack
 
 .. note::
+    To use this feature, you need to install a **nightly Ray wheel**.
+    See :ref:`install-nightlies` for instructions.
 
-    It is currently an experimental feature and under active development. Interfaces are subject to change.
+    The Ray debugger is currently experimental and under active development.
+    Interfaces are subject to change.
 
 Getting Started
 ---------------


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

fixes https://github.com/ray-project/ray/issues/12238

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
