### PR TITLE
[PlacementGroup] Introduce GcsResourceManager and avoid copying resources when scheduling placement groups

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1189,6 +1189,20 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "gcs_resource_manager_test",
+    srcs = [
+        "src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc",
+    ],
+    copts = COPTS,
+    deps = [
+        ":gcs_table_storage_lib",
+        ":gcs_test_util_lib",
+        ":store_client_test_lib",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "service_based_gcs_client_lib",
     srcs = glob(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1196,9 +1196,9 @@ cc_test(
     ],
     copts = COPTS,
     deps = [
-        ":gcs_table_storage_lib",
+        ":gcs_server_lib",
         ":gcs_test_util_lib",
-        ":store_client_test_lib",
+        ":gcs_server_test_util",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1197,8 +1197,8 @@ cc_test(
     copts = COPTS,
     deps = [
         ":gcs_server_lib",
-        ":gcs_test_util_lib",
         ":gcs_server_test_util",
+        ":gcs_test_util_lib",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1197,7 +1197,6 @@ cc_test(
     copts = COPTS,
     deps = [
         ":gcs_server_lib",
-        ":gcs_server_test_util",
         ":gcs_test_util_lib",
         "@com_google_googletest//:gtest_main",
     ],

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -534,8 +534,8 @@ void GcsNodeManager::UpdateNodeRealtimeResources(
   }
 }
 
-std::shared_ptr<absl::flat_hash_map<NodeID, ResourceSet>>
-GcsNodeManager::GetClusterRealtimeResources() {
+const std::shared_ptr<absl::flat_hash_map<NodeID, ResourceSet>>
+GcsNodeManager::GetClusterRealtimeResources() const {
   return cluster_realtime_resources_;
 }
 

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -94,10 +94,12 @@ void GcsNodeManager::NodeFailureDetector::ScheduleTick() {
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-GcsNodeManager::GcsNodeManager(boost::asio::io_service &main_io_service,
-                               boost::asio::io_service &node_failure_detector_io_service,
-                               std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub,
-                               std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage)
+GcsNodeManager::GcsNodeManager(
+    boost::asio::io_service &main_io_service,
+    boost::asio::io_service &node_failure_detector_io_service,
+    std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub,
+    std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
+    std::shared_ptr<gcs::GcsResourceManager> gcs_resource_manager)
     : main_io_service_(main_io_service),
       node_failure_detector_(new NodeFailureDetector(
           node_failure_detector_io_service, gcs_table_storage, gcs_pub_sub,
@@ -124,7 +126,8 @@ GcsNodeManager::GcsNodeManager(boost::asio::io_service &main_io_service,
       node_failure_detector_service_(node_failure_detector_io_service),
       heartbeat_timer_(main_io_service),
       gcs_pub_sub_(gcs_pub_sub),
-      gcs_table_storage_(gcs_table_storage) {
+      gcs_table_storage_(gcs_table_storage),
+      gcs_resource_manager_(gcs_resource_manager) {
   SendBatchedHeartbeat();
 }
 
@@ -334,7 +337,7 @@ void GcsNodeManager::HandleGetAllAvailableResources(
     const rpc::GetAllAvailableResourcesRequest &request,
     rpc::GetAllAvailableResourcesReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  for (const auto &iter : cluster_realtime_resources_) {
+  for (const auto &iter : gcs_resource_manager_->GetClusterResources()) {
     rpc::AvailableResources resource;
     resource.set_node_id(iter.first.Binary());
     for (const auto &res : iter.second.GetResourceAmountMap()) {
@@ -462,8 +465,6 @@ std::shared_ptr<rpc::GcsNodeInfo> GcsNodeManager::RemoveNode(
     alive_nodes_.erase(iter);
     // Remove from cluster resources.
     cluster_resources_.erase(node_id);
-    // Remove from cluster realtime resources.
-    cluster_realtime_resources_.erase(node_id);
     heartbeat_buffer_.erase(node_id);
     if (!is_intended) {
       // Broadcast a warning to all of the drivers indicating that the node
@@ -520,15 +521,10 @@ void GcsNodeManager::StartNodeFailureDetector() {
 void GcsNodeManager::UpdateNodeRealtimeResources(
     const NodeID &node_id, const rpc::HeartbeatTableData &heartbeat) {
   if (!RayConfig::instance().light_heartbeat_enabled() ||
-      cluster_realtime_resources_.count(node_id) == 0 ||
+      gcs_resource_manager_->GetClusterResources().count(node_id) == 0 ||
       heartbeat.resources_available_changed()) {
-    cluster_realtime_resources_[node_id] =
-        ResourceSet(MapFromProtobuf(heartbeat.resources_available()));
-
-    // Notify all listeners.
-    for (auto &listener : node_resource_change_listeners_) {
-      listener(heartbeat);
-    }
+    gcs_resource_manager_->UpdateResources(
+        node_id, ResourceSet(MapFromProtobuf(heartbeat.resources_available())));
   }
 }
 

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -124,7 +124,9 @@ GcsNodeManager::GcsNodeManager(boost::asio::io_service &main_io_service,
       node_failure_detector_service_(node_failure_detector_io_service),
       heartbeat_timer_(main_io_service),
       gcs_pub_sub_(gcs_pub_sub),
-      gcs_table_storage_(gcs_table_storage) {
+      gcs_table_storage_(gcs_table_storage),
+      cluster_realtime_resources_(
+          std::make_shared<absl::flat_hash_map<NodeID, ResourceSet>>()) {
   SendBatchedHeartbeat();
 }
 
@@ -334,7 +336,7 @@ void GcsNodeManager::HandleGetAllAvailableResources(
     const rpc::GetAllAvailableResourcesRequest &request,
     rpc::GetAllAvailableResourcesReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  for (const auto &iter : GetClusterRealtimeResources()) {
+  for (const auto &iter : *GetClusterRealtimeResources()) {
     rpc::AvailableResources resource;
     resource.set_node_id(iter.first.Binary());
     for (const auto &res : iter.second.GetResourceAmountMap()) {
@@ -463,7 +465,7 @@ std::shared_ptr<rpc::GcsNodeInfo> GcsNodeManager::RemoveNode(
     // Remove from cluster resources.
     cluster_resources_.erase(node_id);
     // Remove from cluster realtime resources.
-    cluster_realtime_resources_.erase(node_id);
+    cluster_realtime_resources_->erase(node_id);
     heartbeat_buffer_.erase(node_id);
     if (!is_intended) {
       // Broadcast a warning to all of the drivers indicating that the node
@@ -520,9 +522,9 @@ void GcsNodeManager::StartNodeFailureDetector() {
 void GcsNodeManager::UpdateNodeRealtimeResources(
     const NodeID &node_id, const rpc::HeartbeatTableData &heartbeat) {
   if (!RayConfig::instance().light_heartbeat_enabled() ||
-      cluster_realtime_resources_.count(node_id) == 0 ||
+      cluster_realtime_resources_->count(node_id) == 0 ||
       heartbeat.resources_available_changed()) {
-    cluster_realtime_resources_[node_id] =
+    (*cluster_realtime_resources_)[node_id] =
         ResourceSet(MapFromProtobuf(heartbeat.resources_available()));
 
     // Notify all listeners.
@@ -532,8 +534,8 @@ void GcsNodeManager::UpdateNodeRealtimeResources(
   }
 }
 
-const absl::flat_hash_map<NodeID, ResourceSet>
-    &GcsNodeManager::GetClusterRealtimeResources() const {
+std::shared_ptr<absl::flat_hash_map<NodeID, ResourceSet>>
+GcsNodeManager::GetClusterRealtimeResources() {
   return cluster_realtime_resources_;
 }
 

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -524,6 +524,11 @@ void GcsNodeManager::UpdateNodeRealtimeResources(
       heartbeat.resources_available_changed()) {
     cluster_realtime_resources_[node_id] =
         ResourceSet(MapFromProtobuf(heartbeat.resources_available()));
+
+    // Notify all listeners.
+    for (auto &listener : node_resource_change_listeners_) {
+      listener(heartbeat);
+    }
   }
 }
 

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -535,7 +535,7 @@ void GcsNodeManager::UpdateNodeRealtimeResources(
 }
 
 const std::shared_ptr<absl::flat_hash_map<NodeID, ResourceSet>>
-GcsNodeManager::GetClusterRealtimeResources() const {
+    &GcsNodeManager::GetClusterRealtimeResources() const {
   return cluster_realtime_resources_;
 }
 

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -175,10 +175,6 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   void UpdateNodeRealtimeResources(const NodeID &node_id,
                                    const rpc::HeartbeatTableData &heartbeat);
 
-  /// Get cluster realtime resources.
-  const std::shared_ptr<absl::flat_hash_map<NodeID, ResourceSet>>
-      &GetClusterRealtimeResources() const;
-
   /// Update the placement group load information so that it will be reported through
   /// heartbeat.
   ///
@@ -299,7 +295,7 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// Storage for GCS tables.
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
   /// Cluster realtime resources.
-  std::shared_ptr<absl::flat_hash_map<NodeID, ResourceSet>> cluster_realtime_resources_;
+  absl::flat_hash_map<NodeID, ResourceSet> cluster_realtime_resources_;
   /// Placement group load information that is used for autoscaler.
   absl::optional<std::shared_ptr<rpc::PlacementGroupLoad>> placement_group_load_;
 

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -176,7 +176,8 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
                                    const rpc::HeartbeatTableData &heartbeat);
 
   /// Get cluster realtime resources.
-  std::shared_ptr<absl::flat_hash_map<NodeID, ResourceSet>> GetClusterRealtimeResources();
+  const std::shared_ptr<absl::flat_hash_map<NodeID, ResourceSet>>
+  GetClusterRealtimeResources() const;
 
   /// Update the placement group load information so that it will be reported through
   /// heartbeat.

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -153,6 +153,15 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
     node_added_listeners_.emplace_back(std::move(listener));
   }
 
+  /// Add listener to monitor the resource change of nodes.
+  ///
+  /// \param listener The handler which process the resource change of nodes.
+  void AddNodeResourceChangeListener(
+      std::function<void(const rpc::HeartbeatTableData &)> listener) {
+    RAY_CHECK(listener);
+    node_resource_change_listeners_.emplace_back(std::move(listener));
+  }
+
   /// Initialize with the gcs tables data synchronously.
   /// This should be called when GCS server restarts after a failure.
   ///
@@ -281,6 +290,9 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// Listeners which monitors the removal of nodes.
   std::vector<std::function<void(std::shared_ptr<rpc::GcsNodeInfo>)>>
       node_removed_listeners_;
+  /// Listeners which monitors the resource change of nodes.
+  std::vector<std::function<void(const rpc::HeartbeatTableData &)>>
+      node_resource_change_listeners_;
   /// A publisher for publishing gcs messages.
   std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub_;
   /// Storage for GCS tables.

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -177,7 +177,7 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
 
   /// Get cluster realtime resources.
   const std::shared_ptr<absl::flat_hash_map<NodeID, ResourceSet>>
-  GetClusterRealtimeResources() const;
+      &GetClusterRealtimeResources() const;
 
   /// Update the placement group load information so that it will be reported through
   /// heartbeat.

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -176,7 +176,7 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
                                    const rpc::HeartbeatTableData &heartbeat);
 
   /// Get cluster realtime resources.
-  const absl::flat_hash_map<NodeID, ResourceSet> &GetClusterRealtimeResources() const;
+  std::shared_ptr<absl::flat_hash_map<NodeID, ResourceSet>> GetClusterRealtimeResources();
 
   /// Update the placement group load information so that it will be reported through
   /// heartbeat.
@@ -298,7 +298,7 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// Storage for GCS tables.
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
   /// Cluster realtime resources.
-  absl::flat_hash_map<NodeID, ResourceSet> cluster_realtime_resources_;
+  std::shared_ptr<absl::flat_hash_map<NodeID, ResourceSet>> cluster_realtime_resources_;
   /// Placement group load information that is used for autoscaler.
   absl::optional<std::shared_ptr<rpc::PlacementGroupLoad>> placement_group_load_;
 

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -30,7 +30,6 @@ GcsPlacementGroupScheduler::GcsPlacementGroupScheduler(
       gcs_node_manager_(gcs_node_manager),
       gcs_resource_manager_(gcs_resource_manager),
       lease_client_factory_(std::move(lease_client_factory)) {
-  auto cluster_resources = gcs_node_manager.GetClusterRealtimeResources();
   scheduler_strategies_.push_back(
       std::make_shared<GcsPackStrategy>(gcs_resource_manager));
   scheduler_strategies_.push_back(
@@ -644,12 +643,10 @@ void GcsPlacementGroupScheduler::DestroyPlacementGroupCommittedBundleResources(
 
 void GcsPlacementGroupScheduler::ReturnBundleResources(
     const std::shared_ptr<BundleLocations> bundle_locations) {
-  auto cluster_resources = gcs_node_manager_.GetClusterRealtimeResources();
   for (auto &bundle_location : *bundle_locations) {
-    auto iter = cluster_resources->find(bundle_location.second.first);
-    if (iter != cluster_resources->end()) {
-      iter->second.AddResources(bundle_location.second.second->GetRequiredResources());
-    }
+    gcs_resource_manager_.ReleaseResource(
+        bundle_location.second.first,
+        bundle_location.second.second->GetRequiredResources());
   }
 }
 

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -41,14 +41,13 @@ bool GcsScheduleStrategy::IsAvailableResourceSufficient(
     const ResourceSet &to_allocate_resources) const {
   const auto &to_allocate_resource_capacity =
       to_allocate_resources.GetResourceAmountMap();
-  // Check to make sure all keys of this are in other.
   for (const auto &resource_pair : to_allocate_resource_capacity) {
     const auto &resource_name = resource_pair.first;
     const auto &lhs_quantity = resource_pair.second;
     const auto &rhs_quantity = available_resources.GetResource(resource_name) -
                                allocated_resources.GetResource(resource_name);
     if (lhs_quantity > rhs_quantity) {
-      // Resource found in rhs, but lhs capacity exceeds rhs capacity.
+      // lhs capacity exceeds rhs capacity.
       return false;
     }
   }
@@ -86,7 +85,6 @@ ScheduleMap GcsStrictPackStrategy::Schedule(
   for (auto &bundle : bundles) {
     schedule_map[bundle->BundleId()] = candidate_nodes.front().second;
   }
-
   return schedule_map;
 }
 

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -23,16 +23,59 @@ namespace gcs {
 GcsPlacementGroupScheduler::GcsPlacementGroupScheduler(
     boost::asio::io_context &io_context,
     std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
-    const gcs::GcsNodeManager &gcs_node_manager,
+    gcs::GcsNodeManager &gcs_node_manager,
     ReserveResourceClientFactoryFn lease_client_factory)
     : return_timer_(io_context),
       gcs_table_storage_(std::move(gcs_table_storage)),
       gcs_node_manager_(gcs_node_manager),
       lease_client_factory_(std::move(lease_client_factory)) {
-  scheduler_strategies_.push_back(std::make_shared<GcsPackStrategy>());
-  scheduler_strategies_.push_back(std::make_shared<GcsSpreadStrategy>());
-  scheduler_strategies_.push_back(std::make_shared<GcsStrictPackStrategy>());
-  scheduler_strategies_.push_back(std::make_shared<GcsStrictSpreadStrategy>());
+  auto cluster_resources = gcs_node_manager.GetClusterRealtimeResources();
+  scheduler_strategies_.push_back(std::make_shared<GcsPackStrategy>(cluster_resources));
+  scheduler_strategies_.push_back(std::make_shared<GcsSpreadStrategy>(cluster_resources));
+  scheduler_strategies_.push_back(
+      std::make_shared<GcsStrictPackStrategy>(cluster_resources));
+  scheduler_strategies_.push_back(
+      std::make_shared<GcsStrictSpreadStrategy>(cluster_resources));
+}
+
+void GcsScheduleStrategy::OnPlacementGroupCreationFailed() {
+  RollbackAcquireResourceTransaction();
+}
+
+void GcsScheduleStrategy::OnPlacementGroupCreationSuccess() {
+  CommitAcquireResourceTransaction();
+}
+
+std::shared_ptr<absl::flat_hash_map<NodeID, ResourceSet>>
+GcsScheduleStrategy::GetClusterResources() {
+  return cluster_resources_;
+}
+
+void GcsScheduleStrategy::StartAcquireResourceTransaction() {
+  RAY_CHECK(!is_transaction_in_progress_);
+  is_transaction_in_progress_ = true;
+}
+
+void GcsScheduleStrategy::CommitAcquireResourceTransaction() {
+  RAY_CHECK(is_transaction_in_progress_);
+  resource_changes_during_transaction_.clear();
+  is_transaction_in_progress_ = false;
+}
+
+void GcsScheduleStrategy::RollbackAcquireResourceTransaction() {
+  RAY_CHECK(is_transaction_in_progress_);
+  for (auto &resource_changes : resource_changes_during_transaction_) {
+    for (auto &resource : resource_changes.second) {
+      (*cluster_resources_)[resource_changes.first].AddResources(resource);
+    }
+  }
+  resource_changes_during_transaction_.clear();
+  is_transaction_in_progress_ = false;
+}
+
+void GcsScheduleStrategy::RecordResourceAcquisition(
+    const NodeID &node_id, const ResourceSet &required_resources) {
+  resource_changes_during_transaction_[node_id].push_back(required_resources);
 }
 
 ScheduleMap GcsStrictPackStrategy::Schedule(
@@ -45,9 +88,9 @@ ScheduleMap GcsStrictPackStrategy::Schedule(
   }
 
   // Filter candidate nodes.
-  const auto &alive_nodes = context->node_manager_.GetClusterRealtimeResources();
+  const auto &alive_nodes = GetClusterResources();
   std::vector<std::pair<int64_t, NodeID>> candidate_nodes;
-  for (auto &node : alive_nodes) {
+  for (auto &node : *alive_nodes) {
     if (required_resources.IsSubset(node.second)) {
       candidate_nodes.emplace_back((*context->node_to_bundles_)[node.first], node.first);
     }
@@ -67,25 +110,29 @@ ScheduleMap GcsStrictPackStrategy::Schedule(
   for (auto &bundle : bundles) {
     schedule_map[bundle->BundleId()] = candidate_nodes.front().second;
   }
+
+  StartAcquireResourceTransaction();
+  RecordResourceAcquisition(candidate_nodes.front().second, required_resources);
   return schedule_map;
 }
 
 ScheduleMap GcsPackStrategy::Schedule(
     std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
     const std::unique_ptr<ScheduleContext> &context) {
+  // Start the transaction to acquire resources.
+  StartAcquireResourceTransaction();
+
   // The current algorithm is to select a node and deploy as many bundles as possible.
   // First fill up a node. If the node resource is insufficient, select a new node.
   // TODO(ffbin): We will speed this up in next PR. Currently it is a double for loop.
   ScheduleMap schedule_map;
-  // TODO(WangTao): This copy might take too much space once cluster grows very large.
-  // Would find better solution.
-  absl::flat_hash_map<NodeID, ResourceSet> alive_nodes(
-      context->node_manager_.GetClusterRealtimeResources());
+  auto alive_nodes = GetClusterResources();
   for (const auto &bundle : bundles) {
     const auto &required_resources = bundle->GetRequiredResources();
-    for (auto &node : alive_nodes) {
+    for (auto &node : *alive_nodes) {
       if (required_resources.IsSubset(node.second)) {
         node.second.SubtractResourcesStrict(required_resources);
+        RecordResourceAcquisition(node.first, required_resources);
         schedule_map[bundle->BundleId()] = node.first;
         break;
       }
@@ -94,6 +141,7 @@ ScheduleMap GcsPackStrategy::Schedule(
 
   if (schedule_map.size() != bundles.size()) {
     schedule_map.clear();
+    RollbackAcquireResourceTransaction();
   }
   return schedule_map;
 }
@@ -105,41 +153,43 @@ ScheduleMap GcsSpreadStrategy::Schedule(
   // bundles will be deployed to the previous nodes. So we start with the next node of the
   // last selected node.
   ScheduleMap schedule_map;
-  // TODO(WangTao): This copy might take too much space once cluster grows very large.
-  // Would find better solution.
-  absl::flat_hash_map<NodeID, ResourceSet> candidate_nodes(
-      context->node_manager_.GetClusterRealtimeResources());
-  if (candidate_nodes.empty()) {
+  auto candidate_nodes = GetClusterResources();
+  if (candidate_nodes->empty()) {
     return schedule_map;
   }
 
-  auto iter = candidate_nodes.begin();
+  // Start the transaction to acquire resources.
+  StartAcquireResourceTransaction();
+
+  auto iter = candidate_nodes->begin();
   auto iter_begin = iter;
   for (const auto &bundle : bundles) {
     const auto &required_resources = bundle->GetRequiredResources();
-    // Traverse all nodes from `iter_begin` to `candidate_nodes.end()` to find a node that
-    // meets the resource requirements. `iter_begin` is the next node of the last selected
-    // node.
-    for (; iter != candidate_nodes.end(); ++iter) {
+    // Traverse all nodes from `iter_begin` to `candidate_nodes->end()` to find a node
+    // that meets the resource requirements. `iter_begin` is the next node of the last
+    // selected node.
+    for (; iter != candidate_nodes->end(); ++iter) {
       if (required_resources.IsSubset(iter->second)) {
         iter->second.SubtractResourcesStrict(required_resources);
+        RecordResourceAcquisition(iter->first, required_resources);
         schedule_map[bundle->BundleId()] = iter->first;
         break;
       }
     }
 
-    // We've traversed all the nodes from `iter_begin` to `candidate_nodes.end()`, but we
+    // We've traversed all the nodes from `iter_begin` to `candidate_nodes->end()`, but we
     // haven't found one that meets the requirements.
-    // If `iter_begin` is `candidate_nodes.begin()`, it means that all nodes are not
+    // If `iter_begin` is `candidate_nodes->begin()`, it means that all nodes are not
     // satisfied, we will return directly. Otherwise, we will traverse the nodes from
-    // `candidate_nodes.begin()` to `iter_begin` to find the nodes that meet the
+    // `candidate_nodes->begin()` to `iter_begin` to find the nodes that meet the
     // requirements.
-    if (iter == candidate_nodes.end()) {
-      if (iter_begin != candidate_nodes.begin()) {
-        // Traverse all the nodes from `candidate_nodes.begin()` to `iter_begin`.
-        for (iter = candidate_nodes.begin(); iter != iter_begin; ++iter) {
+    if (iter == candidate_nodes->end()) {
+      if (iter_begin != candidate_nodes->begin()) {
+        // Traverse all the nodes from `candidate_nodes->begin()` to `iter_begin`.
+        for (iter = candidate_nodes->begin(); iter != iter_begin; ++iter) {
           if (required_resources.IsSubset(iter->second)) {
             iter->second.SubtractResourcesStrict(required_resources);
+            RecordResourceAcquisition(iter->first, required_resources);
             schedule_map[bundle->BundleId()] = iter->first;
             break;
           }
@@ -153,12 +203,13 @@ ScheduleMap GcsSpreadStrategy::Schedule(
         break;
       }
     }
-    // NOTE: If `iter == candidate_nodes.end()`, ++iter causes crash.
+    // NOTE: If `iter == candidate_nodes->end()`, ++iter causes crash.
     iter_begin = ++iter;
   }
 
   if (schedule_map.size() != bundles.size()) {
     schedule_map.clear();
+    RollbackAcquireResourceTransaction();
   }
   return schedule_map;
 }
@@ -170,32 +221,37 @@ ScheduleMap GcsStrictSpreadStrategy::Schedule(
   // schedule bundles with special resource requirements first, which will be implemented
   // in the next pr.
   ScheduleMap schedule_map;
-  auto candidate_nodes = context->node_manager_.GetClusterRealtimeResources();
+  auto candidate_nodes = GetClusterResources();
 
   // The number of bundles is more than the number of nodes, scheduling fails.
-  if (bundles.size() > candidate_nodes.size()) {
+  if (bundles.size() > candidate_nodes->size()) {
     return schedule_map;
   }
 
+  // Start the transaction to acquire resources.
+  StartAcquireResourceTransaction();
+
   for (const auto &bundle : bundles) {
     const auto &required_resources = bundle->GetRequiredResources();
-    auto iter = candidate_nodes.begin();
-    for (; iter != candidate_nodes.end(); ++iter) {
+    auto iter = candidate_nodes->begin();
+    for (; iter != candidate_nodes->end(); ++iter) {
       if (required_resources.IsSubset(iter->second)) {
         schedule_map[bundle->BundleId()] = iter->first;
-        candidate_nodes.erase(iter);
+        candidate_nodes->erase(iter);
+        RecordResourceAcquisition(iter->first, required_resources);
         break;
       }
     }
 
     // Node resource is not satisfied, scheduling failed.
-    if (iter == candidate_nodes.end()) {
+    if (iter == candidate_nodes->end()) {
       break;
     }
   }
 
   if (schedule_map.size() != bundles.size()) {
     schedule_map.clear();
+    RollbackAcquireResourceTransaction();
   }
   return schedule_map;
 }
@@ -246,16 +302,28 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
     lease_status_tracker->MarkPreparePhaseStarted(node_id, bundle);
     // TODO(sang): The callback might not be called at all if nodes are dead. We should
     // handle this case properly.
-    PrepareResources(bundle, gcs_node_manager_.GetNode(node_id),
-                     [this, bundle, node_id, lease_status_tracker, failure_callback,
-                      success_callback](const Status &status) {
-                       lease_status_tracker->MarkPrepareRequestReturned(node_id, bundle,
-                                                                        status);
-                       if (lease_status_tracker->AllPrepareRequestsReturned()) {
-                         OnAllBundlePrepareRequestReturned(
-                             lease_status_tracker, failure_callback, success_callback);
-                       }
-                     });
+    PrepareResources(
+        bundle, gcs_node_manager_.GetNode(node_id),
+        [this, bundle, node_id, lease_status_tracker, failure_callback,
+         success_callback](const Status &status) {
+          lease_status_tracker->MarkPrepareRequestReturned(node_id, bundle, status);
+          if (lease_status_tracker->AllPrepareRequestsReturned()) {
+            auto on_failure = [this, failure_callback](
+                                  std::shared_ptr<GcsPlacementGroup> placement_group) {
+              scheduler_strategies_[placement_group->GetStrategy()]
+                  ->OnPlacementGroupCreationFailed();
+              failure_callback(placement_group);
+            };
+            auto on_success = [this, success_callback](
+                                  std::shared_ptr<GcsPlacementGroup> placement_group) {
+              scheduler_strategies_[placement_group->GetStrategy()]
+                  ->OnPlacementGroupCreationSuccess();
+              success_callback(placement_group);
+            };
+            OnAllBundlePrepareRequestReturned(lease_status_tracker, on_failure,
+                                              on_success);
+          }
+        });
   }
 }
 
@@ -518,8 +586,8 @@ std::unique_ptr<ScheduleContext> GcsPlacementGroupScheduler::GetScheduleContext(
 
   auto &bundle_locations =
       committed_bundle_location_index_.GetBundleLocations(placement_group_id);
-  return std::unique_ptr<ScheduleContext>(new ScheduleContext(
-      std::move(node_to_bundles), bundle_locations, gcs_node_manager_));
+  return std::unique_ptr<ScheduleContext>(
+      new ScheduleContext(std::move(node_to_bundles), bundle_locations));
 }
 
 absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>>

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -653,7 +653,17 @@ void GcsPlacementGroupScheduler::ReturnBundleResources(
 void BundleLocationIndex::AddBundleLocations(
     const PlacementGroupID &placement_group_id,
     std::shared_ptr<BundleLocations> bundle_locations) {
-  placement_group_to_bundle_locations_.emplace(placement_group_id, bundle_locations);
+  // Update `placement_group_to_bundle_locations_`.
+  // The placement group may be scheduled several times to succeed, so we need to merge
+  // `bundle_locations` instead of covering it directly.
+  auto iter = placement_group_to_bundle_locations_.find(placement_group_id);
+  if (iter == placement_group_to_bundle_locations_.end()) {
+    placement_group_to_bundle_locations_.emplace(placement_group_id, bundle_locations);
+  } else {
+    iter->second->insert(bundle_locations->begin(), bundle_locations->end());
+  }
+
+  // Update `node_to_leased_bundles_`.
   for (auto iter : *bundle_locations) {
     const auto &node_id = iter.second.first;
     if (!node_to_leased_bundles_.contains(node_id)) {

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -23,7 +23,7 @@ namespace gcs {
 GcsPlacementGroupScheduler::GcsPlacementGroupScheduler(
     boost::asio::io_context &io_context,
     std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
-    gcs::GcsNodeManager &gcs_node_manager,
+    const gcs::GcsNodeManager &gcs_node_manager,
     ReserveResourceClientFactoryFn lease_client_factory)
     : return_timer_(io_context),
       gcs_table_storage_(std::move(gcs_table_storage)),
@@ -45,7 +45,7 @@ GcsScheduleStrategy::GetClusterResources() {
 
 void GcsScheduleStrategy::ResetAcquiredResources() { acquired_resources_.clear(); }
 
-void GcsScheduleStrategy::RecordResourceAcquisition(
+void GcsScheduleStrategy::RecordResourceAcquirement(
     const NodeID &node_id, const ResourceSet &required_resources) {
   acquired_resources_[node_id].push_back(required_resources);
 }
@@ -114,7 +114,7 @@ ScheduleMap GcsPackStrategy::Schedule(
     for (auto &node : *alive_nodes) {
       if (required_resources.IsSubset(node.second)) {
         node.second.SubtractResourcesStrict(required_resources);
-        RecordResourceAcquisition(node.first, required_resources);
+        RecordResourceAcquirement(node.first, required_resources);
         schedule_map[bundle->BundleId()] = node.first;
         break;
       }
@@ -151,7 +151,7 @@ ScheduleMap GcsSpreadStrategy::Schedule(
     for (; iter != candidate_nodes->end(); ++iter) {
       if (required_resources.IsSubset(iter->second)) {
         iter->second.SubtractResourcesStrict(required_resources);
-        RecordResourceAcquisition(iter->first, required_resources);
+        RecordResourceAcquirement(iter->first, required_resources);
         schedule_map[bundle->BundleId()] = iter->first;
         break;
       }
@@ -169,7 +169,7 @@ ScheduleMap GcsSpreadStrategy::Schedule(
         for (iter = candidate_nodes->begin(); iter != iter_begin; ++iter) {
           if (required_resources.IsSubset(iter->second)) {
             iter->second.SubtractResourcesStrict(required_resources);
-            RecordResourceAcquisition(iter->first, required_resources);
+            RecordResourceAcquirement(iter->first, required_resources);
             schedule_map[bundle->BundleId()] = iter->first;
             break;
           }
@@ -216,7 +216,7 @@ ScheduleMap GcsStrictSpreadStrategy::Schedule(
       if (required_resources.IsSubset(iter->second)) {
         schedule_map[bundle->BundleId()] = iter->first;
         candidate_nodes->erase(iter);
-        RecordResourceAcquisition(iter->first, required_resources);
+        RecordResourceAcquirement(iter->first, required_resources);
         break;
       }
     }

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -107,6 +107,8 @@ class GcsScheduleStrategy {
   virtual ScheduleMap Schedule(
       std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
       const std::unique_ptr<ScheduleContext> &context) = 0;
+
+ protected:
   /// Judge whether the remaining resources are sufficient for allocate.
   ///
   /// \param available_resources Total available resources.

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -141,9 +141,7 @@ class GcsScheduleStrategy {
 /// nodes.
 class GcsPackStrategy : public GcsScheduleStrategy {
  public:
-  GcsPackStrategy(
-      std::shared_ptr<absl::flat_hash_map<NodeID, ResourceSet>> cluster_resources)
-      : GcsScheduleStrategy(cluster_resources) {}
+  using GcsScheduleStrategy::GcsScheduleStrategy;
   ScheduleMap Schedule(std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
                        const std::unique_ptr<ScheduleContext> &context) override;
 };
@@ -151,9 +149,7 @@ class GcsPackStrategy : public GcsScheduleStrategy {
 /// The `GcsSpreadStrategy` is that spread all bundles in different nodes.
 class GcsSpreadStrategy : public GcsScheduleStrategy {
  public:
-  GcsSpreadStrategy(
-      std::shared_ptr<absl::flat_hash_map<NodeID, ResourceSet>> cluster_resources)
-      : GcsScheduleStrategy(cluster_resources) {}
+  using GcsScheduleStrategy::GcsScheduleStrategy;
   ScheduleMap Schedule(std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
                        const std::unique_ptr<ScheduleContext> &context) override;
 };
@@ -162,9 +158,7 @@ class GcsSpreadStrategy : public GcsScheduleStrategy {
 /// node does not have enough resources, it will fail to schedule.
 class GcsStrictPackStrategy : public GcsScheduleStrategy {
  public:
-  GcsStrictPackStrategy(
-      std::shared_ptr<absl::flat_hash_map<NodeID, ResourceSet>> cluster_resources)
-      : GcsScheduleStrategy(cluster_resources) {}
+  using GcsScheduleStrategy::GcsScheduleStrategy;
   ScheduleMap Schedule(std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
                        const std::unique_ptr<ScheduleContext> &context) override;
 };
@@ -174,9 +168,7 @@ class GcsStrictPackStrategy : public GcsScheduleStrategy {
 /// If the node resource is insufficient, it will fail to schedule.
 class GcsStrictSpreadStrategy : public GcsScheduleStrategy {
  public:
-  GcsStrictSpreadStrategy(
-      std::shared_ptr<absl::flat_hash_map<NodeID, ResourceSet>> cluster_resources)
-      : GcsScheduleStrategy(cluster_resources) {}
+  using GcsScheduleStrategy::GcsScheduleStrategy;
   ScheduleMap Schedule(std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
                        const std::unique_ptr<ScheduleContext> &context) override;
 };

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -139,7 +139,7 @@ class GcsScheduleStrategy {
   /// \return Void.
   void RollbackAcquireResourceTransaction();
 
-  /// Acquire resources from the specified node.
+  /// Records the acquisition of resources from the specified node.
   ///
   /// \param node_id Id of a node.
   /// \param required_resources Resources to apply for.

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -106,6 +106,46 @@ class GcsScheduleStrategy {
   virtual ScheduleMap Schedule(
       std::vector<std::shared_ptr<ray::BundleSpecification>> &bundles,
       const std::unique_ptr<ScheduleContext> &context) = 0;
+
+  void OnPlacementGroupCreationSuccess();
+
+  /// Handle actor creation task failure. This should be called when scheduling
+  /// an actor creation task is infeasible.
+  ///
+  /// \param actor The actor whose creation task is infeasible.
+  void OnPlacementGroupCreationFailed(std::shared_ptr<GcsActor> actor);
+
+  /// Handle actor creation task success. This should be called when the actor
+  /// creation task has been scheduled successfully.
+  ///
+  /// \param actor The actor that has been created.
+  void OnPlacementGroupCreationSuccess(const std::shared_ptr<GcsActor> &actor);
+
+ protected:
+
+  void StartTransaction();
+
+  void CommitTransaction();
+
+  void RollbackTransaction();
+
+  /// Acquire resources from the specified node. It will deduct directly from the node
+  /// resource.
+  ///
+  /// \param node_id Id of a node.
+  /// \param required_resources Resources to apply for.
+  /// \return True if acquire resources successfully. False otherwise.
+  void AcquireResource(const NodeID &node_id,
+                       const ResourceSet &required_resources);
+
+  /// Release the resource of the specified node. It will be added directly to the node
+  /// resource.
+  ///
+  /// \param node_id Id of a node.
+  /// \param acquired_resources Resources to release.
+  /// \return True if release resources successfully. False otherwise.
+  void ReleaseResource(const NodeID &node_id,
+                       const ResourceSet &acquired_resources);
 };
 
 /// The `GcsPackStrategy` is that pack all bundles in one node as much as possible.

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -117,12 +117,12 @@ class GcsScheduleStrategy {
   /// \return Void.
   void ResetAcquiredResources();
 
-  /// Records the acquisition of resources from the specified node.
+  /// Records the acquirement of resources from the specified node.
   ///
   /// \param node_id Id of a node.
   /// \param required_resources Resources to apply for.
   /// \return Void.
-  void RecordResourceAcquisition(const NodeID &node_id,
+  void RecordResourceAcquirement(const NodeID &node_id,
                                  const ResourceSet &required_resources);
 
   /// Return acquired resources.
@@ -397,7 +397,7 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   GcsPlacementGroupScheduler(
       boost::asio::io_context &io_context,
       std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
-      GcsNodeManager &gcs_node_manager,
+      const GcsNodeManager &gcs_node_manager,
       ReserveResourceClientFactoryFn lease_client_factory = nullptr);
 
   virtual ~GcsPlacementGroupScheduler() = default;
@@ -540,7 +540,7 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
 
   /// Reference of GcsNodeManager.
-  GcsNodeManager &gcs_node_manager_;
+  const GcsNodeManager &gcs_node_manager_;
 
   /// The cached node clients which are used to communicate with raylet to lease workers.
   absl::flat_hash_map<NodeID, std::shared_ptr<ResourceReserveInterface>>

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -1,0 +1,37 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/gcs/gcs_server/gcs_resource_manager.h"
+#include "src/ray/protobuf/gcs.pb.h"
+
+namespace ray {
+namespace gcs {
+
+const absl::flat_hash_map<NodeID, SchedulingResources>
+    &GcsResourceManager::GetClusterResources() const {
+  return cluster_scheduling_resources_;
+}
+
+bool GcsResourceManager::AcquireResource(const NodeID &node_id,
+                                         const ResourceSet &required_resources) {
+  return true;
+}
+
+bool GcsResourceManager::ReleaseResource(const NodeID &node_id,
+                                         const ResourceSet &acquired_resources) {
+  return true;
+}
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -24,6 +24,10 @@ GcsResourceManager::GcsResourceManager(GcsNodeManager &gcs_node_manager) {
         cluster_resources_[node_id] =
             ResourceSet(MapFromProtobuf(heartbeat.resources_available()));
       });
+  gcs_node_manager.AddNodeRemovedListener(
+      [this](std::shared_ptr<rpc::GcsNodeInfo> node_info) {
+        cluster_resources_.erase(NodeID::FromBinary(node_info->node_id()));
+      });
 }
 
 const absl::flat_hash_map<NodeID, ResourceSet> &GcsResourceManager::GetClusterResources()

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "ray/gcs/gcs_server/gcs_resource_manager.h"
-#include "src/ray/protobuf/gcs.pb.h"
 
 namespace ray {
 namespace gcs {

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -18,7 +18,7 @@
 namespace ray {
 namespace gcs {
 
-GcsResourceManager::GcsResourceManager(const GcsNodeManager &gcs_node_manager) {
+GcsResourceManager::GcsResourceManager(GcsNodeManager &gcs_node_manager) {
   gcs_node_manager.AddNodeResourceChangeListener(
       [this](const rpc::HeartbeatTableData &heartbeat) {
         auto node_id = NodeID::FromBinary(heartbeat.client_id());
@@ -45,9 +45,9 @@ void GcsResourceManager::CommitTransaction() {
 
 void GcsResourceManager::RollbackTransaction() {
   RAY_CHECK(is_transaction_in_progress_);
-  for (const auto &resource_changes : resource_changes_during_transaction_) {
-    for (const auto &resource : resource_changes) {
-      cluster_resources_[node_id].AddResources(resource);
+  for (auto &resource_changes : resource_changes_during_transaction_) {
+    for (auto &resource : resource_changes.second) {
+      cluster_resources_[resource_changes.first].AddResources(resource);
     }
   }
   resource_changes_during_transaction_.clear();
@@ -64,7 +64,7 @@ void GcsResourceManager::AcquireResource(const NodeID &node_id,
 
 void GcsResourceManager::ReleaseResource(const NodeID &node_id,
                                          const ResourceSet &acquired_resources) {
-  cluster_resources_[node_id].AddResources(required_resources);
+  cluster_resources_[node_id].AddResources(acquired_resources);
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -1,0 +1,55 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "ray/gcs/gcs_server/gcs_node_manager.h"
+
+namespace ray {
+namespace gcs {
+
+class GcsResourceManagerInterface {
+ public:
+  virtual ~GcsResourceManagerInterface() {}
+
+  virtual const absl::flat_hash_map<NodeID, SchedulingResources> &GetClusterResources()
+      const = 0;
+
+  virtual bool AcquireResource(const NodeID &node_id,
+                               const ResourceSet &required_resources) = 0;
+
+  virtual bool ReleaseResource(const NodeID &node_id,
+                               const ResourceSet &acquired_resources) = 0;
+};
+
+class GcsResourceManager : public GcsResourceManagerInterface {
+ public:
+  GcsResourceManager(const GcsNodeManager &gcs_node_manager);
+
+  virtual ~GcsResourceManager() = default;
+
+  const absl::flat_hash_map<NodeID, SchedulingResources> &GetClusterResources() const;
+
+  bool AcquireResource(const NodeID &node_id, const ResourceSet &required_resources);
+
+  bool ReleaseResource(const NodeID &node_id, const ResourceSet &acquired_resources);
+
+ private:
+  /// Map from node id to the scheduling resources of the node.
+  absl::flat_hash_map<NodeID, SchedulingResources> cluster_scheduling_resources_;
+};
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -24,18 +24,12 @@ class GcsResourceManagerInterface {
  public:
   virtual ~GcsResourceManagerInterface() {}
 
-  virtual void StartTransaction() = 0;
-
-  virtual void CommitTransaction() = 0;
-
-  virtual void RollbackTransaction() = 0;
-
   virtual const absl::flat_hash_map<NodeID, ResourceSet> &GetClusterResources() const = 0;
 
-  virtual void AcquireResource(const NodeID &node_id,
+  virtual bool AcquireResource(const NodeID &node_id,
                                const ResourceSet &required_resources) = 0;
 
-  virtual void ReleaseResource(const NodeID &node_id,
+  virtual bool ReleaseResource(const NodeID &node_id,
                                const ResourceSet &acquired_resources) = 0;
 };
 
@@ -45,29 +39,15 @@ class GcsResourceManager : public GcsResourceManagerInterface {
 
   virtual ~GcsResourceManager() = default;
 
-  void StartTransaction();
-
-  void CommitTransaction();
-
-  void RollbackTransaction();
-
   const absl::flat_hash_map<NodeID, ResourceSet> &GetClusterResources() const;
 
-  void AcquireResource(const NodeID &node_id, const ResourceSet &required_resources);
+  bool AcquireResource(const NodeID &node_id, const ResourceSet &required_resources);
 
-  void ReleaseResource(const NodeID &node_id, const ResourceSet &acquired_resources);
+  bool ReleaseResource(const NodeID &node_id, const ResourceSet &acquired_resources);
 
  private:
-  /// Check if there's any transaction going on.
-  bool IsTransactionInProgress() const { return is_transaction_in_progress_; }
-
-  bool is_transaction_in_progress_;
-
   /// Map from node id to the resources of the node.
   absl::flat_hash_map<NodeID, ResourceSet> cluster_resources_;
-
-  absl::flat_hash_map<NodeID, std::list<ResourceSet>>
-      resource_changes_during_transaction_;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -20,19 +20,39 @@
 namespace ray {
 namespace gcs {
 
+/// Gcs resource manager interface.
+/// It is used for actor and placement group scheduling.
+/// Non-thread safe.
 class GcsResourceManagerInterface {
  public:
   virtual ~GcsResourceManagerInterface() {}
 
+  /// Get the resources of all nodes in the cluster.
+  ///
+  /// \return The resources of all nodes in the cluster.
   virtual const absl::flat_hash_map<NodeID, ResourceSet> &GetClusterResources() const = 0;
 
+  /// Acquire resources from the specified node. It will deduct directly from the node
+  /// resource.
+  ///
+  /// \param node_id Id of a node.
+  /// \param required_resources Resources to apply for.
+  /// \return True if acquire resources successfully. False otherwise.
   virtual bool AcquireResource(const NodeID &node_id,
                                const ResourceSet &required_resources) = 0;
 
+  /// Release the resource of the specified node. It will be added directly to the node
+  /// resource.
+  ///
+  /// \param node_id Id of a node.
+  /// \param acquired_resources Resources to release.
+  /// \return True if release resources successfully. False otherwise.
   virtual bool ReleaseResource(const NodeID &node_id,
                                const ResourceSet &acquired_resources) = 0;
 };
 
+/// Gcs resource manager implementation. It obtains the available resources of nodes
+/// through heartbeat reporting. Non-thread safe.
 class GcsResourceManager : public GcsResourceManagerInterface {
  public:
   GcsResourceManager(GcsNodeManager &gcs_node_manager);

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -41,7 +41,7 @@ class GcsResourceManagerInterface {
 
 class GcsResourceManager : public GcsResourceManagerInterface {
  public:
-  GcsResourceManager(const GcsNodeManager &gcs_node_manager);
+  GcsResourceManager(GcsNodeManager &gcs_node_manager);
 
   virtual ~GcsResourceManager() = default;
 

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -14,7 +14,6 @@
 #pragma once
 
 #include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
 #include "ray/gcs/gcs_server/gcs_node_manager.h"
 
 namespace ray {

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -65,11 +65,11 @@ void GcsServer::Start() {
 }
 
 void GcsServer::DoStart(const GcsInitData &gcs_init_data) {
-  // Init gcs node manager.
-  InitGcsNodeManager(gcs_init_data);
-
   // Init gcs resource manager.
   InitGcsResourceManager();
+
+  // Init gcs node manager.
+  InitGcsNodeManager(gcs_init_data);
 
   // Init gcs job manager.
   InitGcsJobManager();
@@ -137,7 +137,8 @@ void GcsServer::InitGcsNodeManager(const GcsInitData &gcs_init_data) {
     node_manager_io_service_.run();
   }));
   gcs_node_manager_ = std::make_shared<GcsNodeManager>(
-      main_service_, node_manager_io_service_, gcs_pub_sub_, gcs_table_storage_);
+      main_service_, node_manager_io_service_, gcs_pub_sub_, gcs_table_storage_,
+      gcs_resource_manager_);
   // Initialize by gcs tables data.
   gcs_node_manager_->Initialize(gcs_init_data);
   // Register service.
@@ -147,7 +148,7 @@ void GcsServer::InitGcsNodeManager(const GcsInitData &gcs_init_data) {
 }
 
 void GcsServer::InitGcsResourceManager() {
-  gcs_resource_manager_ = std::make_shared<GcsResourceManager>(*gcs_node_manager_);
+  gcs_resource_manager_ = std::make_shared<GcsResourceManager>();
 }
 
 void GcsServer::InitGcsJobManager() {
@@ -292,6 +293,7 @@ void GcsServer::InstallEventListeners() {
         // node is removed from the GCS.
         gcs_placement_group_manager_->OnNodeDead(node_id);
         gcs_actor_manager_->OnNodeDead(node_id);
+        gcs_resource_manager_->RemoveResources(node_id);
       });
 
   // Install worker event listener.

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -131,10 +131,10 @@ class GcsServer {
   rpc::GrpcServer rpc_server_;
   /// The `ClientCallManager` object that is shared by all `NodeManagerWorkerClient`s.
   rpc::ClientCallManager client_call_manager_;
-  /// The gcs node manager.
-  std::shared_ptr<GcsNodeManager> gcs_node_manager_;
   /// The gcs resource manager.
   std::shared_ptr<GcsResourceManager> gcs_resource_manager_;
+  /// The gcs node manager.
+  std::shared_ptr<GcsNodeManager> gcs_node_manager_;
   /// The gcs redis failure detector.
   std::shared_ptr<GcsRedisFailureDetector> gcs_redis_failure_detector_;
   /// The gcs actor manager

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -17,6 +17,7 @@
 #include "ray/gcs/gcs_server/gcs_init_data.h"
 #include "ray/gcs/gcs_server/gcs_object_manager.h"
 #include "ray/gcs/gcs_server/gcs_redis_failure_detector.h"
+#include "ray/gcs/gcs_server/gcs_resource_manager.h"
 #include "ray/gcs/gcs_server/gcs_table_storage.h"
 #include "ray/gcs/pubsub/gcs_pub_sub.h"
 #include "ray/gcs/redis_gcs_client.h"
@@ -77,6 +78,9 @@ class GcsServer {
   /// Initialize gcs node manager.
   void InitGcsNodeManager(const GcsInitData &gcs_init_data);
 
+  /// Initialize gcs resource manager.
+  void InitGcsResourceManager();
+
   /// Initialize gcs job manager.
   void InitGcsJobManager();
 
@@ -129,6 +133,8 @@ class GcsServer {
   rpc::ClientCallManager client_call_manager_;
   /// The gcs node manager.
   std::shared_ptr<GcsNodeManager> gcs_node_manager_;
+  /// The gcs resource manager.
+  std::shared_ptr<GcsResourceManager> gcs_resource_manager_;
   /// The gcs redis failure detector.
   std::shared_ptr<GcsRedisFailureDetector> gcs_redis_failure_detector_;
   /// The gcs actor manager

--- a/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_test.cc
@@ -27,8 +27,10 @@ class GcsActorSchedulerTest : public ::testing::Test {
     worker_client_ = std::make_shared<GcsServerMocker::MockWorkerClient>();
     gcs_pub_sub_ = std::make_shared<GcsServerMocker::MockGcsPubSub>(redis_client_);
     gcs_table_storage_ = std::make_shared<gcs::RedisGcsTableStorage>(redis_client_);
-    gcs_node_manager_ = std::make_shared<gcs::GcsNodeManager>(
-        io_service_, io_service_, gcs_pub_sub_, gcs_table_storage_);
+    gcs_resource_manager_ = std::make_shared<gcs::GcsResourceManager>();
+    gcs_node_manager_ =
+        std::make_shared<gcs::GcsNodeManager>(io_service_, io_service_, gcs_pub_sub_,
+                                              gcs_table_storage_, gcs_resource_manager_);
     store_client_ = std::make_shared<gcs::InMemoryStoreClient>(io_service_);
     gcs_actor_table_ =
         std::make_shared<GcsServerMocker::MockedGcsActorTable>(store_client_);
@@ -54,6 +56,7 @@ class GcsActorSchedulerTest : public ::testing::Test {
   std::shared_ptr<GcsServerMocker::MockedGcsActorTable> gcs_actor_table_;
   std::shared_ptr<GcsServerMocker::MockRayletClient> raylet_client_;
   std::shared_ptr<GcsServerMocker::MockWorkerClient> worker_client_;
+  std::shared_ptr<gcs::GcsResourceManager> gcs_resource_manager_;
   std::shared_ptr<gcs::GcsNodeManager> gcs_node_manager_;
   std::shared_ptr<GcsServerMocker::MockedGcsActorScheduler> gcs_actor_scheduler_;
   std::vector<std::shared_ptr<gcs::GcsActor>> success_actors_;

--- a/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
@@ -29,12 +29,13 @@ class GcsNodeManagerTest : public ::testing::Test {
   std::shared_ptr<GcsServerMocker::MockGcsPubSub> gcs_pub_sub_;
   std::shared_ptr<gcs::RedisClient> redis_client_;
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
+  std::shared_ptr<gcs::GcsResourceManager> gcs_resource_manager_;
 };
 
 TEST_F(GcsNodeManagerTest, TestManagement) {
   boost::asio::io_service io_service;
   gcs::GcsNodeManager node_manager(io_service, io_service, gcs_pub_sub_,
-                                   gcs_table_storage_);
+                                   gcs_table_storage_, gcs_resource_manager_);
   // Test Add/Get/Remove functionality.
   auto node = Mocker::GenNodeInfo();
   auto node_id = NodeID::FromBinary(node->node_id());
@@ -49,7 +50,7 @@ TEST_F(GcsNodeManagerTest, TestManagement) {
 TEST_F(GcsNodeManagerTest, TestListener) {
   boost::asio::io_service io_service;
   gcs::GcsNodeManager node_manager(io_service, io_service, gcs_pub_sub_,
-                                   gcs_table_storage_);
+                                   gcs_table_storage_, gcs_resource_manager_);
   // Test AddNodeAddedListener.
   int node_count = 1000;
   std::vector<std::shared_ptr<rpc::GcsNodeInfo>> added_nodes;

--- a/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
@@ -86,30 +86,6 @@ TEST_F(GcsNodeManagerTest, TestListener) {
   }
 }
 
-TEST_F(GcsNodeManagerTest, TestGetClusterRealtimeResources) {
-  boost::asio::io_service io_service;
-  gcs::GcsNodeManager node_manager(io_service, io_service, gcs_pub_sub_,
-                                   gcs_table_storage_);
-
-  auto node_id = NodeID::FromRandom();
-  rpc::HeartbeatTableData heartbeat;
-  const std::string cpu_resource = "CPU";
-  (*heartbeat.mutable_resources_available())[cpu_resource] = 10;
-  node_manager.UpdateNodeRealtimeResources(node_id, heartbeat);
-  auto node_resources = node_manager.GetClusterRealtimeResources();
-
-  ResourceSet required_resources;
-  required_resources.AddOrUpdateResource(cpu_resource, 9);
-  ASSERT_TRUE(required_resources.IsSubset((*node_resources)[node_id]));
-  required_resources.AddOrUpdateResource(cpu_resource, 10);
-  ASSERT_TRUE(required_resources.IsSubset((*node_resources)[node_id]));
-  required_resources.AddOrUpdateResource(cpu_resource, 10.1);
-  ASSERT_FALSE(required_resources.IsSubset((*node_resources)[node_id]));
-  required_resources.DeleteResource(cpu_resource);
-  required_resources.AddOrUpdateResource("GPU", 9);
-  ASSERT_FALSE(required_resources.IsSubset((*node_resources)[node_id]));
-}
-
 }  // namespace ray
 
 int main(int argc, char **argv) {

--- a/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
@@ -100,14 +100,14 @@ TEST_F(GcsNodeManagerTest, TestGetClusterRealtimeResources) {
 
   ResourceSet required_resources;
   required_resources.AddOrUpdateResource(cpu_resource, 9);
-  ASSERT_TRUE(required_resources.IsSubset(node_resources[node_id]));
+  ASSERT_TRUE(required_resources.IsSubset((*node_resources)[node_id]));
   required_resources.AddOrUpdateResource(cpu_resource, 10);
-  ASSERT_TRUE(required_resources.IsSubset(node_resources[node_id]));
+  ASSERT_TRUE(required_resources.IsSubset((*node_resources)[node_id]));
   required_resources.AddOrUpdateResource(cpu_resource, 10.1);
-  ASSERT_FALSE(required_resources.IsSubset(node_resources[node_id]));
+  ASSERT_FALSE(required_resources.IsSubset((*node_resources)[node_id]));
   required_resources.DeleteResource(cpu_resource);
   required_resources.AddOrUpdateResource("GPU", 9);
-  ASSERT_FALSE(required_resources.IsSubset(node_resources[node_id]));
+  ASSERT_FALSE(required_resources.IsSubset((*node_resources)[node_id]));
 }
 
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/test/gcs_object_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_object_manager_test.cc
@@ -54,8 +54,10 @@ class GcsObjectManagerTest : public ::testing::Test {
  public:
   void SetUp() override {
     gcs_table_storage_ = std::make_shared<gcs::InMemoryGcsTableStorage>(io_service_);
-    gcs_node_manager_ = std::make_shared<gcs::GcsNodeManager>(
-        io_service_, io_service_, gcs_pub_sub_, gcs_table_storage_);
+    gcs_resource_manager_ = std::make_shared<gcs::GcsResourceManager>();
+    gcs_node_manager_ =
+        std::make_shared<gcs::GcsNodeManager>(io_service_, io_service_, gcs_pub_sub_,
+                                              gcs_table_storage_, gcs_resource_manager_);
     gcs_object_manager_ = std::make_shared<MockedGcsObjectManager>(
         gcs_table_storage_, gcs_pub_sub_, *gcs_node_manager_);
     GenTestData();
@@ -83,6 +85,7 @@ class GcsObjectManagerTest : public ::testing::Test {
 
  protected:
   boost::asio::io_service io_service_;
+  std::shared_ptr<gcs::GcsResourceManager> gcs_resource_manager_;
   std::shared_ptr<gcs::GcsNodeManager> gcs_node_manager_;
   std::shared_ptr<gcs::RedisGcsClient> gcs_client_;
   std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub_;

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
@@ -68,8 +68,10 @@ class GcsPlacementGroupManagerTest : public ::testing::Test {
       : mock_placement_group_scheduler_(new MockPlacementGroupScheduler()) {
     gcs_pub_sub_ = std::make_shared<GcsServerMocker::MockGcsPubSub>(redis_client_);
     gcs_table_storage_ = std::make_shared<gcs::InMemoryGcsTableStorage>(io_service_);
-    gcs_node_manager_ = std::make_shared<gcs::GcsNodeManager>(
-        io_service_, io_service_, gcs_pub_sub_, gcs_table_storage_);
+    gcs_resource_manager_ = std::make_shared<gcs::GcsResourceManager>();
+    gcs_node_manager_ =
+        std::make_shared<gcs::GcsNodeManager>(io_service_, io_service_, gcs_pub_sub_,
+                                              gcs_table_storage_, gcs_resource_manager_);
     gcs_placement_group_manager_.reset(
         new gcs::GcsPlacementGroupManager(io_service_, mock_placement_group_scheduler_,
                                           gcs_table_storage_, *gcs_node_manager_));
@@ -103,6 +105,7 @@ class GcsPlacementGroupManagerTest : public ::testing::Test {
   std::unique_ptr<std::thread> thread_io_service_;
   boost::asio::io_service io_service_;
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
+  std::shared_ptr<gcs::GcsResourceManager> gcs_resource_manager_;
   std::shared_ptr<gcs::GcsNodeManager> gcs_node_manager_;
   std::shared_ptr<GcsServerMocker::MockGcsPubSub> gcs_pub_sub_;
   std::shared_ptr<gcs::RedisClient> redis_client_;

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -40,9 +40,10 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     }
     gcs_table_storage_ = std::make_shared<gcs::InMemoryGcsTableStorage>(io_service_);
     gcs_pub_sub_ = std::make_shared<GcsServerMocker::MockGcsPubSub>(redis_client_);
-    gcs_node_manager_ = std::make_shared<gcs::GcsNodeManager>(
-        io_service_, io_service_, gcs_pub_sub_, gcs_table_storage_);
-    gcs_resource_manager_ = std::make_shared<gcs::GcsResourceManager>(*gcs_node_manager_);
+    gcs_resource_manager_ = std::make_shared<gcs::GcsResourceManager>();
+    gcs_node_manager_ =
+        std::make_shared<gcs::GcsNodeManager>(io_service_, io_service_, gcs_pub_sub_,
+                                              gcs_table_storage_, gcs_resource_manager_);
     gcs_table_storage_ = std::make_shared<gcs::InMemoryGcsTableStorage>(io_service_);
     store_client_ = std::make_shared<gcs::InMemoryStoreClient>(io_service_);
     scheduler_ = std::make_shared<GcsServerMocker::MockedGcsPlacementGroupScheduler>(
@@ -204,8 +205,8 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
   std::shared_ptr<gcs::StoreClient> store_client_;
 
   std::vector<std::shared_ptr<GcsServerMocker::MockRayletResourceClient>> raylet_clients_;
-  std::shared_ptr<gcs::GcsNodeManager> gcs_node_manager_;
   std::shared_ptr<gcs::GcsResourceManager> gcs_resource_manager_;
+  std::shared_ptr<gcs::GcsNodeManager> gcs_node_manager_;
   std::shared_ptr<GcsServerMocker::MockedGcsPlacementGroupScheduler> scheduler_;
   std::vector<std::shared_ptr<gcs::GcsPlacementGroup>> success_placement_groups_
       GUARDED_BY(placement_group_requests_mutex_);

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -42,10 +42,11 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     gcs_pub_sub_ = std::make_shared<GcsServerMocker::MockGcsPubSub>(redis_client_);
     gcs_node_manager_ = std::make_shared<gcs::GcsNodeManager>(
         io_service_, io_service_, gcs_pub_sub_, gcs_table_storage_);
+    gcs_resource_manager_ = std::make_shared<gcs::GcsResourceManager>(*gcs_node_manager_);
     gcs_table_storage_ = std::make_shared<gcs::InMemoryGcsTableStorage>(io_service_);
     store_client_ = std::make_shared<gcs::InMemoryStoreClient>(io_service_);
     scheduler_ = std::make_shared<GcsServerMocker::MockedGcsPlacementGroupScheduler>(
-        io_service_, gcs_table_storage_, *gcs_node_manager_,
+        io_service_, gcs_table_storage_, *gcs_node_manager_, *gcs_resource_manager_,
         /*lease_client_fplacement_groupy=*/
         [this](const rpc::Address &address) { return raylet_clients_[address.port()]; });
   }
@@ -98,6 +99,7 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
   void AddNode(const std::shared_ptr<rpc::GcsNodeInfo> &node, int cpu_num = 10) {
     gcs_node_manager_->AddNode(node);
     rpc::HeartbeatTableData heartbeat;
+    heartbeat.set_client_id(node->node_id());
     (*heartbeat.mutable_resources_available())["CPU"] = cpu_num;
     gcs_node_manager_->UpdateNodeRealtimeResources(NodeID::FromBinary(node->node_id()),
                                                    heartbeat);
@@ -203,6 +205,7 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
 
   std::vector<std::shared_ptr<GcsServerMocker::MockRayletResourceClient>> raylet_clients_;
   std::shared_ptr<gcs::GcsNodeManager> gcs_node_manager_;
+  std::shared_ptr<gcs::GcsResourceManager> gcs_resource_manager_;
   std::shared_ptr<GcsServerMocker::MockedGcsPlacementGroupScheduler> scheduler_;
   std::vector<std::shared_ptr<gcs::GcsPlacementGroup>> success_placement_groups_
       GUARDED_BY(placement_group_requests_mutex_);

--- a/src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc
@@ -80,14 +80,11 @@ TEST_F(GcsResourceManagerTest, TestBasic) {
   std::unordered_map<std::string, double> resource_map;
   resource_map[cpu_resource] = 10;
   ResourceSet resource_set(resource_map);
-  ASSERT_FALSE(
-      gcs_resource_manager_->AcquireResource(NodeID::FromRandom(), resource_set));
   ASSERT_TRUE(gcs_resource_manager_->AcquireResource(node_id, resource_set));
   ASSERT_FALSE(gcs_resource_manager_->AcquireResource(node_id, resource_set));
 
   // Test `ReleaseResource`.
-  ASSERT_FALSE(
-      gcs_resource_manager_->ReleaseResource(NodeID::FromRandom(), resource_set));
+  ASSERT_TRUE(gcs_resource_manager_->ReleaseResource(NodeID::FromRandom(), resource_set));
   ASSERT_TRUE(gcs_resource_manager_->ReleaseResource(node_id, resource_set));
   ASSERT_TRUE(gcs_resource_manager_->AcquireResource(node_id, resource_set));
 }

--- a/src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc
@@ -15,10 +15,7 @@
 #include <memory>
 
 #include "gtest/gtest.h"
-#include "ray/common/test_util.h"
-#include "ray/gcs/gcs_server/gcs_node_manager.h"
 #include "ray/gcs/gcs_server/gcs_resource_manager.h"
-#include "ray/gcs/gcs_server/test/gcs_server_test_util.h"
 #include "ray/gcs/test/gcs_test_util.h"
 
 namespace ray {
@@ -28,65 +25,34 @@ using ::testing::_;
 class GcsResourceManagerTest : public ::testing::Test {
  public:
   GcsResourceManagerTest() {
-    std::promise<bool> promise;
-    thread_io_service_.reset(new std::thread([this, &promise] {
-      std::unique_ptr<boost::asio::io_service::work> work(
-          new boost::asio::io_service::work(io_service_));
-      promise.set_value(true);
-      io_service_.run();
-    }));
-    promise.get_future().get();
-
-    gcs_pub_sub_ = std::make_shared<GcsServerMocker::MockGcsPubSub>(redis_client_);
-    gcs_table_storage_ = std::make_shared<gcs::RedisGcsTableStorage>(redis_client_);
-    gcs_node_manager_ = std::make_shared<gcs::GcsNodeManager>(
-        io_service_, io_service_, gcs_pub_sub_, gcs_table_storage_);
-    gcs_resource_manager_ = std::make_shared<gcs::GcsResourceManager>(*gcs_node_manager_);
+    gcs_resource_manager_ = std::make_shared<gcs::GcsResourceManager>();
   }
 
-  virtual ~GcsResourceManagerTest() {
-    io_service_.stop();
-    thread_io_service_->join();
-    gcs_node_manager_.reset();
-  }
-
-  std::shared_ptr<gcs::GcsNodeManager> gcs_node_manager_;
   std::shared_ptr<gcs::GcsResourceManagerInterface> gcs_resource_manager_;
-
- private:
-  boost::asio::io_service io_service_;
-  std::unique_ptr<std::thread> thread_io_service_;
-  std::shared_ptr<gcs::RedisClient> redis_client_;
-  std::shared_ptr<GcsServerMocker::MockGcsPubSub> gcs_pub_sub_;
-  std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
-
-  const std::chrono::milliseconds timeout_ms_{2000};
 };
 
 TEST_F(GcsResourceManagerTest, TestBasic) {
   // Add node resources.
   auto node_id = NodeID::FromRandom();
-  rpc::HeartbeatTableData heartbeat;
   const std::string cpu_resource = "CPU";
-  heartbeat.set_client_id(node_id.Binary());
-  (*heartbeat.mutable_resources_available())[cpu_resource] = 10;
-  gcs_node_manager_->UpdateNodeRealtimeResources(node_id, heartbeat);
+  std::unordered_map<std::string, double> resource_map;
+  resource_map[cpu_resource] = 10;
+  ResourceSet resource_set(resource_map);
+  gcs_resource_manager_->UpdateResources(node_id, resource_set);
 
   // Get and check cluster resources.
   const auto &cluster_resource = gcs_resource_manager_->GetClusterResources();
   ASSERT_EQ(1, cluster_resource.size());
 
-  // Test `AcquireResource`.
-  std::unordered_map<std::string, double> resource_map;
-  resource_map[cpu_resource] = 10;
-  ResourceSet resource_set(resource_map);
-  ASSERT_TRUE(gcs_resource_manager_->AcquireResource(node_id, resource_set));
-  ASSERT_FALSE(gcs_resource_manager_->AcquireResource(node_id, resource_set));
+  // Test `AcquireResources`.
+  ASSERT_TRUE(gcs_resource_manager_->AcquireResources(node_id, resource_set));
+  ASSERT_FALSE(gcs_resource_manager_->AcquireResources(node_id, resource_set));
 
-  // Test `ReleaseResource`.
-  ASSERT_TRUE(gcs_resource_manager_->ReleaseResource(NodeID::FromRandom(), resource_set));
-  ASSERT_TRUE(gcs_resource_manager_->ReleaseResource(node_id, resource_set));
-  ASSERT_TRUE(gcs_resource_manager_->AcquireResource(node_id, resource_set));
+  // Test `ReleaseResources`.
+  ASSERT_TRUE(
+      gcs_resource_manager_->ReleaseResources(NodeID::FromRandom(), resource_set));
+  ASSERT_TRUE(gcs_resource_manager_->ReleaseResources(node_id, resource_set));
+  ASSERT_TRUE(gcs_resource_manager_->AcquireResources(node_id, resource_set));
 }
 
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc
@@ -16,6 +16,9 @@
 
 #include "gtest/gtest.h"
 #include "ray/common/test_util.h"
+#include "ray/gcs/gcs_server/gcs_node_manager.h"
+#include "ray/gcs/gcs_server/gcs_resource_manager.h"
+#include "ray/gcs/gcs_server/test/gcs_server_test_util.h"
 #include "ray/gcs/test/gcs_test_util.h"
 
 namespace ray {
@@ -34,22 +37,60 @@ class GcsResourceManagerTest : public ::testing::Test {
     }));
     promise.get_future().get();
 
-    gcs_table_storage_ = std::make_shared<gcs::InMemoryGcsTableStorage>(io_service_);
+    gcs_pub_sub_ = std::make_shared<GcsServerMocker::MockGcsPubSub>(redis_client_);
+    gcs_table_storage_ = std::make_shared<gcs::RedisGcsTableStorage>(redis_client_);
+    gcs_node_manager_ = std::make_shared<gcs::GcsNodeManager>(
+        io_service_, io_service_, gcs_pub_sub_, gcs_table_storage_);
+    gcs_resource_manager_ = std::make_shared<gcs::GcsResourceManager>(*gcs_node_manager_);
   }
 
   virtual ~GcsResourceManagerTest() {
     io_service_.stop();
     thread_io_service_->join();
+    gcs_node_manager_.reset();
   }
 
+  std::shared_ptr<gcs::GcsNodeManager> gcs_node_manager_;
+  std::shared_ptr<gcs::GcsResourceManagerInterface> gcs_resource_manager_;
+
+ private:
   boost::asio::io_service io_service_;
   std::unique_ptr<std::thread> thread_io_service_;
+  std::shared_ptr<gcs::RedisClient> redis_client_;
+  std::shared_ptr<GcsServerMocker::MockGcsPubSub> gcs_pub_sub_;
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
 
   const std::chrono::milliseconds timeout_ms_{2000};
 };
 
-TEST_F(GcsResourceManagerTest, TestBasic) {}
+TEST_F(GcsResourceManagerTest, TestBasic) {
+  // Add node resources.
+  auto node_id = NodeID::FromRandom();
+  rpc::HeartbeatTableData heartbeat;
+  const std::string cpu_resource = "CPU";
+  heartbeat.set_client_id(node_id.Binary());
+  (*heartbeat.mutable_resources_available())[cpu_resource] = 10;
+  gcs_node_manager_->UpdateNodeRealtimeResources(node_id, heartbeat);
+
+  // Get and check cluster resources.
+  const auto &cluster_resource = gcs_resource_manager_->GetClusterResources();
+  ASSERT_EQ(1, cluster_resource.size());
+
+  // Test `AcquireResource`.
+  std::unordered_map<std::string, double> resource_map;
+  resource_map[cpu_resource] = 10;
+  ResourceSet resource_set(resource_map);
+  ASSERT_FALSE(
+      gcs_resource_manager_->AcquireResource(NodeID::FromRandom(), resource_set));
+  ASSERT_TRUE(gcs_resource_manager_->AcquireResource(node_id, resource_set));
+  ASSERT_FALSE(gcs_resource_manager_->AcquireResource(node_id, resource_set));
+
+  // Test `ReleaseResource`.
+  ASSERT_FALSE(
+      gcs_resource_manager_->ReleaseResource(NodeID::FromRandom(), resource_set));
+  ASSERT_TRUE(gcs_resource_manager_->ReleaseResource(node_id, resource_set));
+  ASSERT_TRUE(gcs_resource_manager_->AcquireResource(node_id, resource_set));
+}
 
 }  // namespace ray
 

--- a/src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc
@@ -1,0 +1,59 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "ray/common/test_util.h"
+#include "ray/gcs/test/gcs_test_util.h"
+
+namespace ray {
+
+using ::testing::_;
+
+class GcsResourceManagerTest : public ::testing::Test {
+ public:
+  GcsResourceManagerTest() {
+    std::promise<bool> promise;
+    thread_io_service_.reset(new std::thread([this, &promise] {
+      std::unique_ptr<boost::asio::io_service::work> work(
+          new boost::asio::io_service::work(io_service_));
+      promise.set_value(true);
+      io_service_.run();
+    }));
+    promise.get_future().get();
+
+    gcs_table_storage_ = std::make_shared<gcs::InMemoryGcsTableStorage>(io_service_);
+  }
+
+  virtual ~GcsResourceManagerTest() {
+    io_service_.stop();
+    thread_io_service_->join();
+  }
+
+  boost::asio::io_service io_service_;
+  std::unique_ptr<std::thread> thread_io_service_;
+  std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
+
+  const std::chrono::milliseconds timeout_ms_{2000};
+};
+
+TEST_F(GcsResourceManagerTest, TestBasic) {}
+
+}  // namespace ray
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -25,6 +25,7 @@
 #include "ray/gcs/gcs_server/gcs_node_manager.h"
 #include "ray/gcs/gcs_server/gcs_placement_group_manager.h"
 #include "ray/gcs/gcs_server/gcs_placement_group_scheduler.h"
+#include "ray/gcs/gcs_server/gcs_resource_manager.h"
 #include "ray/util/asio_util.h"
 
 namespace ray {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When the placement group is scheduling, we will copy the cluster resources. If there are many nodes, the performance will be affected. In this PR, we no longer copy and directly repair the cluster resources. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
