### PR TITLE
Fix dashboard agent check ppid is raylet pid

### DIFF
--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -90,9 +90,7 @@ class DashboardAgent(object):
         async def _check_parent():
             """Check if raylet is dead."""
             curr_proc = psutil.Process()
-            ppid = os.environ.get("RAY_NODE_PID")
-            if ppid is not None:
-                ppid = int(ppid)
+            ppid = int(os.environ["RAY_NODE_PID"])
             logger.info("Parent pid is %s", ppid)
             while True:
                 parent = curr_proc.parent()

--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -87,17 +87,15 @@ class DashboardAgent(object):
         return modules
 
     async def run(self):
-        ppid = os.environ.get("RAY_NODE_PID")
-        if ppid is not None:
-            ppid = int(ppid)
-        logger.info("Parent pid is %s", ppid)
-
         async def _check_parent():
             """Check if raylet is dead."""
             curr_proc = psutil.Process()
+            ppid = os.environ.get("RAY_NODE_PID")
+            if ppid is not None:
+                ppid = int(ppid)
+            logger.info("Parent pid is %s", ppid)
             while True:
                 parent = curr_proc.parent()
-                nonlocal ppid
                 if parent is None or parent.pid == 1 or (ppid and
                                                          ppid != parent.pid):
                     logger.error("raylet is dead, agent will die because "

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -142,6 +142,11 @@ def test_basic(ray_start_with_dashboard):
         assert agent_proc.pid == agent_pid
         time.sleep(1)
 
+    # The agent should be dead if raylet exits.
+    raylet_proc.kill()
+    raylet_proc.wait()
+    agent_proc.wait(5)
+
     # Check redis keys are set.
     logger.info("Check redis keys are set.")
     dashboard_address = client.get(dashboard_consts.REDIS_KEY_DASHBOARD)

--- a/src/ray/protobuf/agent_manager.proto
+++ b/src/ray/protobuf/agent_manager.proto
@@ -31,6 +31,7 @@ message RegisterAgentRequest {
 
 message RegisterAgentReply {
   AgentRpcStatus status = 1;
+  int32 ppid = 2;
 }
 
 service AgentManagerService {

--- a/src/ray/protobuf/agent_manager.proto
+++ b/src/ray/protobuf/agent_manager.proto
@@ -31,7 +31,6 @@ message RegisterAgentRequest {
 
 message RegisterAgentReply {
   AgentRpcStatus status = 1;
-  int32 ppid = 2;
 }
 
 service AgentManagerService {

--- a/src/ray/raylet/agent_manager.cc
+++ b/src/ray/raylet/agent_manager.cc
@@ -32,6 +32,7 @@ void AgentManager::HandleRegisterAgent(const rpc::RegisterAgentRequest &request,
   RAY_LOG(INFO) << "HandleRegisterAgent, ip: " << agent_ip_address_
                 << ", port: " << agent_port_ << ", pid: " << agent_pid_;
   reply->set_status(rpc::AGENT_RPC_STATUS_OK);
+  reply->set_ppid(getpid());
   send_reply_callback(ray::Status::OK(), nullptr, nullptr);
 }
 

--- a/src/ray/raylet/agent_manager.cc
+++ b/src/ray/raylet/agent_manager.cc
@@ -32,7 +32,6 @@ void AgentManager::HandleRegisterAgent(const rpc::RegisterAgentRequest &request,
   RAY_LOG(INFO) << "HandleRegisterAgent, ip: " << agent_ip_address_
                 << ", port: " << agent_port_ << ", pid: " << agent_pid_;
   reply->set_status(rpc::AGENT_RPC_STATUS_OK);
-  reply->set_ppid(getpid());
   send_reply_callback(ray::Status::OK(), nullptr, nullptr);
 }
 
@@ -59,8 +58,10 @@ void AgentManager::StartAgent() {
   }
   argv.push_back(NULL);
   // Set node id to agent.
+  static std::string pid_string = std::to_string(getpid());
   ProcessEnvironment env;
   env.insert({"RAY_NODE_ID", options_.node_id.Hex()});
+  env.insert({"RAY_NODE_PID", pid_string});
   Process child(argv.data(), nullptr, ec, false, env);
   if (!child.IsValid() || ec) {
     // The worker failed to start. This is a fatal error.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
The ppid of dashboard agent may not be 1 if the raylet process has exit.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/12176

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
