### PR TITLE
[docs] Fix dead links to cluster docs by making dashes slashes

### DIFF
--- a/doc/source/joblib.rst
+++ b/doc/source/joblib.rst
@@ -55,7 +55,7 @@ Run on a Cluster
 ----------------
 
 This section assumes that you have a running Ray cluster. To start a Ray cluster,
-please refer to the `cluster setup <cluster-index.html>`__ instructions.
+please refer to the `cluster setup <cluster/index.html>`__ instructions.
 
 To connect a scikit-learn to a running Ray cluster, you have to specify the address of the
 head node by setting the ``RAY_ADDRESS`` environment variable.

--- a/doc/source/multiprocessing.rst
+++ b/doc/source/multiprocessing.rst
@@ -49,7 +49,7 @@ Run on a Cluster
 ----------------
 
 This section assumes that you have a running Ray cluster. To start a Ray cluster,
-please refer to the `cluster setup <cluster-index.html>`__ instructions.
+please refer to the `cluster setup <cluster/index.html>`__ instructions.
 
 To connect a ``Pool`` to a running Ray cluster, you can specify the address of the
 head node in one of two ways:

--- a/doc/source/starting-ray.rst
+++ b/doc/source/starting-ray.rst
@@ -197,4 +197,4 @@ Note that there are some known issues with local mode. Please read :ref:`these t
 What's next?
 ------------
 
-Check out our `Deployment section <cluster-index.html>`_ for more information on deploying Ray in different settings, including Kubernetes, YARN, and SLURM.
+Check out our `Deployment section <cluster/index.html>`_ for more information on deploying Ray in different settings, including Kubernetes, YARN, and SLURM.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
