### PR TITLE
Removed double "install" statement

### DIFF
--- a/ci/travis/install-toolchains.sh
+++ b/ci/travis/install-toolchains.sh
@@ -30,7 +30,7 @@ install_clang() {
   if ! command -v "${cc}"; then
     case "${osversion}" in
       linux-gnu-ubuntu*)
-        sudo apt-get install -qq -o=Dpkg::Use-Pty=0 install clang clang-format clang-tidy
+        sudo apt-get install -qq -o=Dpkg::Use-Pty=0 clang clang-format clang-tidy
         ;;
       *)  # Fallback for all platforms is to download from LLVM's site, but avoided until necessary
         local target="./${url##*/}"


### PR DESCRIPTION
## Why are these changes needed?

Fixed a double "install" statement in `install_toolchains.sh`. I guess this is a bug, and not a desire to install `install` package. :) At least my package manager doesn't know about such package.

## Related issue number

None.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [X] This PR is not tested :(
