### PR TITLE
[tune] Allow None values in TBX logger

### DIFF
--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -189,8 +189,8 @@ class TBXLogger(Logger):
         {"a": {"b": 1, "c": 2}} -> {"a/b": 1, "a/c": 2}
     """
 
-    # NoneType is not supported on the last TBX release yet.
-    VALID_HPARAMS = (str, bool, np.bool8, int, np.integer, float, list)
+    VALID_HPARAMS = (str, bool, np.bool8, int, np.integer, float, list,
+                     NoneType)
 
     def _init(self):
         try:

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -190,7 +190,7 @@ class TBXLogger(Logger):
     """
 
     VALID_HPARAMS = (str, bool, np.bool8, int, np.integer, float, list,
-                     NoneType)
+                     type(None))
 
     def _init(self):
         try:

--- a/python/ray/tune/tests/test_logger.py
+++ b/python/ray/tune/tests/test_logger.py
@@ -56,7 +56,8 @@ class LoggerSuite(unittest.TestCase):
                 }
             },
             "d": np.int64(1),
-            "e": np.bool8(True)
+            "e": np.bool8(True),
+            "f": None,
         }
         t = Trial(evaluated_params=config, trial_id="tbx")
         logger = TBXLogger(config=config, logdir=self.test_dir, trial=t)


### PR DESCRIPTION
## Why are these changes needed?

```python
from tensorboardX.summary import hparams
from tensorboardX import SummaryWriter


writer = SummaryWriter()
experiment_tag, session_start_tag, session_end_tag = hparams(hparam_dict={'a': None}, metric_dict={'loss': 3.9})
writer.file_writer.add_summary(experiment_tag)
writer.file_writer.add_summary(session_start_tag)
writer.file_writer.add_summary(session_end_tag)
# no errors! None doesn't raise any exceptions anymore
```

## Related issue number

n/a, see https://github.com/lanpa/tensorboardX/issues/544

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
