### PR TITLE
[serve] Only use typed BackendConfig in controller

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -192,10 +192,10 @@ class Client:
             raise TypeError(
                 "config_options must be a BackendConfig or dictionary.")
         if isinstance(config_options, dict):
-            config_options = BackendConfig.parse_obj(config)
+            config_options = BackendConfig.parse_obj(config_options)
         ray.get(
             self._controller.update_backend_config.remote(
-                backend_tag, backend_config))
+                backend_tag, config_options))
 
     @_ensure_connected
     def get_backend_config(self, backend_tag: str) -> BackendConfig:

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -193,7 +193,6 @@ class Client:
                 "config_options must be a BackendConfig or dictionary.")
         if isinstance(config_options, dict):
             config_options = BackendConfig.parse_obj(config)
-        config_options._validate_complete()
         ray.get(
             self._controller.update_backend_config.remote(
                 backend_tag, backend_config))

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -192,9 +192,7 @@ class Client:
             raise TypeError(
                 "config_options must be a BackendConfig or dictionary.")
         if isinstance(config_options, dict):
-            config_options = BackendConfig.parse_obj({
-                **config, "internal_metadata": metadata
-            })
+            config_options = BackendConfig.parse_obj(config)
         config_options._validate_complete()
         ray.get(
             self._controller.update_backend_config.remote(

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -191,9 +191,14 @@ class Client:
         if not isinstance(config_options, (BackendConfig, dict)):
             raise TypeError(
                 "config_options must be a BackendConfig or dictionary.")
+        if isinstance(config_options, dict):
+            config_options = BackendConfig.parse_obj({
+                **config, "internal_metadata": metadata
+            })
+        config_options._validate_complete()
         ray.get(
             self._controller.update_backend_config.remote(
-                backend_tag, config_options))
+                backend_tag, backend_config))
 
     @_ensure_connected
     def get_backend_config(self, backend_tag: str) -> BackendConfig:

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -5,7 +5,7 @@ import os
 import random
 import time
 from dataclasses import dataclass, field
-from typing import Union, Dict, Any, List, Optional, Tuple
+from typing import Dict, Any, List, Optional, Tuple
 from pydantic import BaseModel
 
 import ray

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -871,17 +871,17 @@ class ServeController:
             self.notify_replica_handles_changed()
 
     async def update_backend_config(self, backend_tag: BackendTag,
-                                    config_update: BackendConfig) -> None:
+                                    config_options: BackendConfig) -> None:
         """Set the config for the specified backend."""
         async with self.write_lock:
             assert (self.configuration_store.get_backend(backend_tag)
                     ), "Backend {} is not registered.".format(backend_tag)
-            assert isinstance(config, BackendConfig)
+            assert isinstance(config_options, BackendConfig)
 
             stored_backend_config = self.configuration_store.get_backend(
                 backend_tag).backend_config
             backend_config = stored_backend_config.copy(
-                update=config_update.dict(exclude_unset=True))
+                update=config_options.dict(exclude_unset=True))
             backend_config._validate_complete()
             self.configuration_store.get_backend(
                 backend_tag).backend_config = backend_config

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -578,7 +578,7 @@ class ServeController:
                 self.backend_stats[backend], info.backend_config.num_replicas)
             if new_num_replicas > 0:
                 await self.update_backend_config(
-                    backend, {"num_replicas": new_num_replicas})
+                    backend, BackendConfig(num_replicas=new_num_replicas))
 
     async def run_control_loop(self) -> None:
         while True:
@@ -870,24 +870,18 @@ class ServeController:
 
             self.notify_replica_handles_changed()
 
-    async def update_backend_config(
-            self, backend_tag: BackendTag,
-            config_options: "Union[BackendConfig, Dict[str, Any]]") -> None:
+    async def update_backend_config(self, backend_tag: BackendTag,
+                                    config_update: BackendConfig) -> None:
         """Set the config for the specified backend."""
         async with self.write_lock:
             assert (self.configuration_store.get_backend(backend_tag)
                     ), "Backend {} is not registered.".format(backend_tag)
-            assert isinstance(config_options, BackendConfig) or isinstance(
-                config_options, dict)
-
-            if isinstance(config_options, BackendConfig):
-                update_data = config_options.dict(exclude_unset=True)
-            elif isinstance(config_options, dict):
-                update_data = config_options
+            assert isinstance(config, BackendConfig)
 
             stored_backend_config = self.configuration_store.get_backend(
                 backend_tag).backend_config
-            backend_config = stored_backend_config.copy(update=update_data)
+            backend_config = stored_backend_config.copy(
+                update=config_update.dict(exclude_unset=True))
             backend_config._validate_complete()
             self.configuration_store.get_backend(
                 backend_tag).backend_config = backend_config


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Makes it so that only the API layer handles the conversion from dict -> `BackendConfig`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
