### PR TITLE
[Serve] Remove route argument for create_endpoint

### DIFF
--- a/doc/source/serve/advanced.rst
+++ b/doc/source/serve/advanced.rst
@@ -106,7 +106,7 @@ You can also have Ray Serve batch requests for performance. In order to do use t
 
   config = {"max_batch_size": 5}
   client.create_backend("counter1", BatchingExample, config=config)
-  client.create_endpoint("counter1", backend="counter1", route="/increment")
+  client.create_endpoint("increment", backend="counter1")
 
 Please take a look at :ref:`Batching Tutorial<serve-batch-tutorial>` for a deep
 dive.
@@ -126,7 +126,7 @@ For example, here we split traffic 50/50 between two backends:
   client.create_backend("backend1", MyClass1)
   client.create_backend("backend2", MyClass2)
 
-  client.create_endpoint("fifty-fifty", backend="backend1", route="/fifty")
+  client.create_endpoint("fifty-fifty", backend="backend1")
   client.set_traffic("fifty-fifty", {"backend1": 0.5, "backend2": 0.5})
 
 Each request is routed randomly between the backends in the traffic dictionary according to the provided weights.
@@ -142,21 +142,21 @@ Canary Deployments
   client.create_backend("default_backend", MyClass)
 
   # Initially, set all traffic to be served by the "default" backend.
-  client.create_endpoint("canary_endpoint", backend="default_backend", route="/canary-test")
+  client.create_endpoint("canary-test", backend="default_backend")
 
   # Add a second backend and route 1% of the traffic to it.
   client.create_backend("new_backend", MyNewClass)
-  client.set_traffic("canary_endpoint", {"default_backend": 0.99, "new_backend": 0.01})
+  client.set_traffic("canary-test", {"default_backend": 0.99, "new_backend": 0.01})
 
   # Add a third backend that serves another 1% of the traffic.
   client.create_backend("new_backend2", MyNewClass2)
-  client.set_traffic("canary_endpoint", {"default_backend": 0.98, "new_backend": 0.01, "new_backend2": 0.01})
+  client.set_traffic("canary-test", {"default_backend": 0.98, "new_backend": 0.01, "new_backend2": 0.01})
 
   # Route all traffic to the new, better backend.
-  client.set_traffic("canary_endpoint", {"new_backend": 1.0})
+  client.set_traffic("canary-test", {"new_backend": 1.0})
 
   # Or, if not so succesful, revert to the "default" backend for all traffic.
-  client.set_traffic("canary_endpoint", {"default_backend": 1.0})
+  client.set_traffic("canary-test", {"default_backend": 1.0})
 
 Incremental Rollout
 -------------------
@@ -170,17 +170,17 @@ In the example below, we do this repeatedly in one script, but in practice this 
   client.create_backend("existing_backend", MyClass)
 
   # Initially, all traffic is served by the existing backend.
-  client.create_endpoint("incremental_endpoint", backend="existing_backend", route="/incremental")
+  client.create_endpoint("incremental", backend="existing_backend")
 
   # Then we can slowly increase the proportion of traffic served by the new backend.
   client.create_backend("new_backend", MyNewClass)
-  client.set_traffic("incremental_endpoint", {"existing_backend": 0.9, "new_backend": 0.1})
-  client.set_traffic("incremental_endpoint", {"existing_backend": 0.8, "new_backend": 0.2})
-  client.set_traffic("incremental_endpoint", {"existing_backend": 0.5, "new_backend": 0.5})
-  client.set_traffic("incremental_endpoint", {"new_backend": 1.0})
+  client.set_traffic("incremental", {"existing_backend": 0.9, "new_backend": 0.1})
+  client.set_traffic("incremental", {"existing_backend": 0.8, "new_backend": 0.2})
+  client.set_traffic("incremental", {"existing_backend": 0.5, "new_backend": 0.5})
+  client.set_traffic("incremental", {"new_backend": 1.0})
 
   # At any time, we can roll back to the existing backend.
-  client.set_traffic("incremental_endpoint", {"existing_backend": 1.0})
+  client.set_traffic("incremental", {"existing_backend": 1.0})
 
 .. _session-affinity:
 
@@ -200,7 +200,7 @@ The shard key can either be specified via the X-SERVE-SHARD-KEY HTTP header or :
   requests.get("127.0.0.1:8000/api", headers={"X-SERVE-SHARD-KEY": session_id})
 
   # Specifying the shard key in a call made via serve handle.
-  handle = client.get_handle("api_endpoint")
+  handle = client.get_handle("api")
   handler.options(shard_key=session_id).remote(args)
 
 .. _serve-shadow-testing:
@@ -218,7 +218,7 @@ This is demonstrated in the example below, where we create an endpoint serviced 
   client.create_backend("existing_backend", MyClass)
 
   # All traffic is served by the existing backend.
-  client.create_endpoint("shadowed_endpoint", backend="existing_backend", route="/shadow")
+  client.create_endpoint("shadow", backend="existing_backend")
 
   # Create two new backends that we want to test.
   client.create_backend("new_backend_1", MyNewClass)
@@ -229,13 +229,13 @@ This is demonstrated in the example below, where we create an endpoint serviced 
   # *additionally* sent to these backends.
 
   # Send 50% of all queries to the endpoint new_backend_1.
-  client.shadow_traffic("shadowed_endpoint", "new_backend_1", 0.5)
+  client.shadow_traffic("shadow", "new_backend_1", 0.5)
   # Send 10% of all queries to the endpoint new_backend_2.
-  client.shadow_traffic("shadowed_endpoint", "new_backend_2", 0.1)
+  client.shadow_traffic("shadow", "new_backend_2", 0.1)
 
   # Stop shadowing traffic to the backends.
-  client.shadow_traffic("shadowed_endpoint", "new_backend_1", 0)
-  client.shadow_traffic("shadowed_endpoint", "new_backend_2", 0)
+  client.shadow_traffic("shadow", "new_backend_1", 0)
+  client.shadow_traffic("shadow", "new_backend_2", 0)
 
 .. _serve-model-composition:
 

--- a/doc/source/serve/deployment.rst
+++ b/doc/source/serve/deployment.rst
@@ -105,7 +105,7 @@ these two models.
 
 .. code::
 
-    client.set_traffic("iris_classifier", {"lr:v2": 0.25, "lr:v1": 0.75})
+    client.set_traffic("iris-classifier", {"lr:v2": 0.25, "lr:v1": 0.75})
 
 While this is a simple operation, you may want to see :ref:`serve-split-traffic` for more information.
 One thing you may want to consider as well is

--- a/doc/source/serve/index.rst
+++ b/doc/source/serve/index.rst
@@ -18,7 +18,7 @@ For users, Ray Serve is:
 - **Framework Agnostic**: Use the same toolkit to serve everything from deep learning models
   built with frameworks like :ref:`PyTorch <serve-pytorch-tutorial>`,
   :ref:`Tensorflow, and Keras <serve-tensorflow-tutorial>`, to :ref:`Scikit-Learn <serve-sklearn-tutorial>` models, to arbitrary business logic.
-- **Python First**: Configure your model serving with pure Python code--no more YAML or
+- **Python First**: Configure your model serving with pure Python code---no more YAML or
   JSON configs.
 
 As a library, Ray Serve enables:
@@ -64,7 +64,7 @@ Why Ray Serve?
 ==============
 
 There are generally two ways of serving machine learning applications, both with serious limitations:
-you can build using a **traditional webserver** - your own Flask app or you can use a cloud hosted solution.
+you can build using a **traditional webserver**---your own Flask app---or you can use a cloud-hosted solution.
 
 The first approach is easy to get started with, but it's hard to scale each component. The second approach
 requires vendor lock-in (SageMaker), framework specific tooling (TFServing), and a general
@@ -80,7 +80,7 @@ When should I use Ray Serve?
 ----------------------------
 
 Ray Serve is a simple (but flexible) tool for deploying, operating, and monitoring Python based machine learning models.
-Ray Serve excels when scaling out to serve models in production is a necessity. This might be because of large scale batch processing
+Ray Serve excels when scaling out to serve models in production is a necessity. This might be because of large-scale batch processing
 requirements or because you're going to serve a number of models behind different endpoints and may need to run A/B tests or control
 traffic between different models.
 

--- a/doc/source/serve/index.rst
+++ b/doc/source/serve/index.rst
@@ -18,7 +18,7 @@ For users, Ray Serve is:
 - **Framework Agnostic**: Use the same toolkit to serve everything from deep learning models
   built with frameworks like :ref:`PyTorch <serve-pytorch-tutorial>`,
   :ref:`Tensorflow, and Keras <serve-tensorflow-tutorial>`, to :ref:`Scikit-Learn <serve-sklearn-tutorial>` models, to arbitrary business logic.
-- **Python First**: Configure your model serving with pure Python code - no more YAML or
+- **Python First**: Configure your model serving with pure Python code--no more YAML or
   JSON configs.
 
 As a library, Ray Serve enables:

--- a/doc/source/serve/key-concepts.rst
+++ b/doc/source/serve/key-concepts.rst
@@ -54,10 +54,10 @@ Note that a backend cannot be deleted while it is in use by an endpoint because 
       'simple_backend': {'accepts_batches': False, 'num_replicas': 1, 'max_batch_size': None},
       'simple_backend_class': {'accepts_batches': False, 'num_replicas': 1, 'max_batch_size': None},
   }
-  >> client.delete_backend("simple_backend")
+  >> client.delete_backend("simple_backend_class")
   >> client.list_backends()
   {
-      'simple_backend_class': {'accepts_batches': False, 'num_replicas': 1, 'max_batch_size': None},
+      'simple_backend': {'accepts_batches': False, 'num_replicas': 1, 'max_batch_size': None},
   }
 
 .. _`serve-endpoint`:
@@ -73,7 +73,7 @@ For information on how to do this, please see :ref:`serve-split-traffic`.
 
 .. code-block:: python
 
-  client.create_endpoint("simple_endpoint", backend="simple_backend", route="/simple", methods=["GET"])
+  client.create_endpoint("simple-endpoint", backend="simple_backend", methods=["GET"])
 
 After creating the endpoint, it is now exposed by the HTTP server and handles requests using the specified backend.
 We can query the model to verify that it's working.
@@ -81,14 +81,16 @@ We can query the model to verify that it's working.
 .. code-block:: python
 
   import requests
-  print(requests.get("http://127.0.0.1:8000/simple").text)
+  print(requests.get("http://127.0.0.1:8000/simple-endpoint").text)
 
 To view all of the existing endpoints that have created, use :mod:`client.list_endpoints <ray.serve.api.Client.list_endpoints>`.
 
 .. code-block:: python
 
   >>> client.list_endpoints()
-  {'simple_endpoint': {'route': '/simple', 'methods': ['GET'], 'traffic': {}}}
+  {'simple-endpoint': {'methods': ['GET'],
+    'traffic': {'simple_backend': 1.0},
+    'shadows': {}}}
 
 You can also delete an endpoint using :mod:`client.delete_endpoint <ray.serve.api.Client.delete_endpoint>`.
 Endpoints and backends are independent, so deleting an endpoint will not delete its backends.
@@ -96,4 +98,4 @@ However, an endpoint must be deleted in order to delete the backends that serve 
 
 .. code-block:: python
 
-  client.delete_endpoint("simple_endpoint")
+  client.delete_endpoint("simple-endpoint")

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -985,7 +985,8 @@ def _start_redis_instance(executable,
         # 10000 - redis_client_buffer.
         redis_client_buffer = 32
         if current_max_clients < ulimit_n - redis_client_buffer:
-            redis_client.config_set("maxclients", 10000)
+            redis_client.config_set("maxclients",
+                                    ulimit_n - redis_client_buffer)
 
     # Increase the hard and soft limits for the redis client pubsub buffer to
     # 128MB. This is a hack to make it less likely for pubsub messages to be

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -986,7 +986,7 @@ def _start_redis_instance(executable,
         redis_client_buffer = 32
         if current_max_clients < ulimit_n - redis_client_buffer:
             redis_client.config_set("maxclients",
-                                    ulimit_n - redis_client_buffer)
+                                    10000)
 
     # Increase the hard and soft limits for the redis client pubsub buffer to
     # 128MB. This is a hack to make it less likely for pubsub messages to be

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -985,8 +985,7 @@ def _start_redis_instance(executable,
         # 10000 - redis_client_buffer.
         redis_client_buffer = 32
         if current_max_clients < ulimit_n - redis_client_buffer:
-            redis_client.config_set("maxclients",
-                                    10000)
+            redis_client.config_set("maxclients", 10000)
 
     # Increase the hard and soft limits for the redis client pubsub buffer to
     # 128MB. This is a hack to make it less likely for pubsub messages to be

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -102,10 +102,10 @@ class Client:
         """
         if route is not None:
             raise ValueError(
-                "The 'route' keyword argument for create_endpoint is deprecated "
-                " as of Ray 1.0.2. Please call create_endpoint without 'route'. "
-                "The endpoint name will be used as the route; i.e. '/endpoint_name.'"
-            )
+                "The 'route' keyword argument for create_endpoint is "
+                "deprecated as of Ray 1.0.2. Please call create_endpoint "
+                "without 'route'. The endpoint name will be used as the "
+                "route; i.e. '/endpoint_name.'")
         if backend is None:
             raise TypeError("backend must be specified when creating "
                             "an endpoint.")

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -5,7 +5,7 @@ import os
 import random
 import time
 from dataclasses import dataclass, field
-from typing import Union, Dict, Any, List, Optional, Tuple
+from typing import Union, Dict, Any, List, Optional
 from pydantic import BaseModel
 
 import ray
@@ -94,8 +94,7 @@ class ConfigurationStore:
     traffic_policies: Dict[EndpointTag, TrafficPolicy] = field(
         default_factory=dict)
     # Maps endpoint to list of methods
-    endpoints: Dict[EndpointTag, Any] = field(
-        default_factory=dict)
+    endpoints: Dict[EndpointTag, Any] = field(default_factory=dict)
 
     def get_backend_configs(self) -> Dict[BackendTag, BackendConfig]:
         return {
@@ -522,8 +521,8 @@ class ServeController:
 
         # Set route for each endpoint to '/endpoint_name'.
         endpoints = self.configuration_store.endpoints
-        return {'/' + k : v for k, v in endpoints.items()}
-                
+        return {"/" + k: v for k, v in endpoints.items()}
+
     def _checkpoint(self) -> None:
         """Checkpoint internal state and write it to the KV store."""
         assert self.write_lock.locked()
@@ -698,8 +697,7 @@ class ServeController:
             self.notify_traffic_policies_changed()
 
     async def create_endpoint(self, endpoint: EndpointTag,
-                              traffic_dict: Dict[str, float],
-                              methods) -> None:
+                              traffic_dict: Dict[str, float], methods) -> None:
         """Create a new endpoint with the specified methods."""
         async with self.write_lock:
             # TODO(edoakes): move this to client side.
@@ -720,9 +718,8 @@ class ServeController:
                     "{} Endpoint '{}' is already registered.".format(
                         err_prefix, endpoint))
 
-            logger.info(
-                "Registering endpoint '{}' with methods '{}'.".
-                format(endpoint, methods))
+            logger.info("Registering endpoint '{}' with methods '{}'.".format(
+                endpoint, methods))
 
             self.configuration_store.endpoints[endpoint] = methods
 

--- a/python/ray/serve/examples/doc/conda_env.py
+++ b/python/ray/serve/examples/doc/conda_env.py
@@ -13,9 +13,9 @@ def tf_version(request):
 
 
 client.create_backend("tf1", tf_version, env=CondaEnv("ray-tf1"))
-client.create_endpoint("tf1", backend="tf1", route="/tf1")
+client.create_endpoint("tf1", backend="tf1")
 client.create_backend("tf2", tf_version, env=CondaEnv("ray-tf2"))
-client.create_endpoint("tf2", backend="tf2", route="/tf2")
+client.create_endpoint("tf2", backend="tf2")
 
 print(requests.get("http://127.0.0.1:8000/tf1").text)  # Tensorflow 1.15.0
 print(requests.get("http://127.0.0.1:8000/tf2").text)  # Tensorflow 2.3.0

--- a/python/ray/serve/examples/doc/quickstart_class.py
+++ b/python/ray/serve/examples/doc/quickstart_class.py
@@ -15,8 +15,8 @@ class Counter:
         return {"current_counter": self.count}
 
 
-client.create_backend("counter", Counter)
-client.create_endpoint("counter", backend="counter", route="/counter")
+client.create_backend("simple_counter", Counter)
+client.create_endpoint("counter", backend="simple_counter")
 
 print(requests.get("http://127.0.0.1:8000/counter").json())
 # > {"current_counter": 1}

--- a/python/ray/serve/examples/doc/quickstart_function.py
+++ b/python/ray/serve/examples/doc/quickstart_function.py
@@ -11,7 +11,7 @@ def echo(flask_request):
 
 
 client.create_backend("hello", echo)
-client.create_endpoint("hello", backend="hello", route="/hello")
+client.create_endpoint("greet", backend="hello")
 
-print(requests.get("http://127.0.0.1:8000/hello").text)
+print(requests.get("http://127.0.0.1:8000/greet").text)
 # > hello serve!

--- a/python/ray/serve/examples/doc/snippet_model_composition.py
+++ b/python/ray/serve/examples/doc/snippet_model_composition.py
@@ -55,8 +55,7 @@ client.create_endpoint("model_two", backend="model_two")
 # function, Ray Serve sets the limit to a high number.
 client.create_backend(
     "composed_backend", ComposedModel, config={"max_concurrent_queries": 10})
-client.create_endpoint(
-    "composed", backend="composed_backend", route="/composed")
+client.create_endpoint("composed", backend="composed_backend")
 
 for _ in range(5):
     resp = requests.get("http://127.0.0.1:8000/composed", data="hey!")

--- a/python/ray/serve/examples/doc/snippet_reconfigure.py
+++ b/python/ray/serve/examples/doc/snippet_reconfigure.py
@@ -25,9 +25,9 @@ class Threshold:
 
 backend_config = BackendConfig(user_config={"threshold": 0.01})
 client.create_backend("threshold", Threshold, config=backend_config)
-client.create_endpoint("threshold", backend="threshold", route="/threshold")
-print(requests.get("http://127.0.0.1:8000/threshold").text)  # true, probably
+client.create_endpoint("threshold", backend="threshold")
+print(requests.get("http://127.0.0.1:8000/threshold").text)  # likely True
 
 backend_config = BackendConfig(user_config={"threshold": 0.99})
 client.update_backend_config("threshold", backend_config)
-print(requests.get("http://127.0.0.1:8000/threshold").text)  # false, probably
+print(requests.get("http://127.0.0.1:8000/threshold").text)  # likely False

--- a/python/ray/serve/examples/doc/tutorial_batch.py
+++ b/python/ray/serve/examples/doc/tutorial_batch.py
@@ -32,8 +32,7 @@ ray.init(num_cpus=8)
 # __doc_deploy_begin__
 client = serve.start()
 client.create_backend("adder:v0", batch_adder_v0, config={"max_batch_size": 4})
-client.create_endpoint(
-    "adder", backend="adder:v0", route="/adder", methods=["GET"])
+client.create_endpoint("adder", backend="adder:v0", methods=["GET"])
 # __doc_deploy_end__
 
 

--- a/python/ray/serve/examples/doc/tutorial_deploy.py
+++ b/python/ray/serve/examples/doc/tutorial_deploy.py
@@ -71,7 +71,7 @@ ray.init(address="auto")
 # listen on 0.0.0.0 to make the HTTP server accessible from other machines.
 client = serve.start(http_host="0.0.0.0")
 client.create_backend("lr:v1", BoostingModel)
-client.create_endpoint("iris_classifier", backend="lr:v1", route="/regressor")
+client.create_endpoint("iris-classifier", backend="lr:v1")
 # __doc_create_deploy_end__
 
 # __doc_query_begin__
@@ -84,15 +84,15 @@ sample_request_input = {
     "petal width": 0.9,
 }
 response = requests.get(
-    "http://localhost:8000/regressor", json=sample_request_input)
+    "http://localhost:8000/iris-classifier", json=sample_request_input)
 print(response.text)
 # Result:
 # {
 #  "result": "setosa",
 #  "version": "v1"
 # }
-# this result may vary, since the training parameters may change.
-# as we update this model, this result will also change over time.
+# This result may vary, since the training parameters may change.
+# As we update this model, this result will also change over time.
 # __doc_query_end__
 
 
@@ -165,5 +165,5 @@ class BoostingModelv2:
 
 client = serve.connect()
 client.create_backend("lr:v2", BoostingModelv2)
-client.set_traffic("iris_classifier", {"lr:v2": 0.25, "lr:v1": 0.75})
+client.set_traffic("iris-classifier", {"lr:v2": 0.25, "lr:v1": 0.75})
 # __doc_create_deploy_2_end__

--- a/python/ray/serve/examples/doc/tutorial_pytorch.py
+++ b/python/ray/serve/examples/doc/tutorial_pytorch.py
@@ -51,10 +51,7 @@ ray.init(num_cpus=8)
 client = serve.start()
 client.create_backend("resnet18:v0", ImageModel)
 client.create_endpoint(
-    "predictor",
-    backend="resnet18:v0",
-    route="/image_predict",
-    methods=["POST"])
+    "image-predict", backend="resnet18:v0", methods=["POST"])
 # __doc_deploy_end__
 
 # __doc_query_begin__
@@ -63,7 +60,7 @@ ray_logo_bytes = requests.get(
     "master/doc/source/images/ray_header_logo.png").content
 
 resp = requests.post(
-    "http://localhost:8000/image_predict", data=ray_logo_bytes)
+    "http://localhost:8000/image-predict", data=ray_logo_bytes)
 print(resp.json())
 # Output
 # {'class_index': 463}

--- a/python/ray/serve/examples/doc/tutorial_sklearn.py
+++ b/python/ray/serve/examples/doc/tutorial_sklearn.py
@@ -75,7 +75,7 @@ ray.init(num_cpus=8)
 # __doc_deploy_begin__
 client = serve.start()
 client.create_backend("lr:v1", BoostingModel)
-client.create_endpoint("iris_classifier", backend="lr:v1", route="/regressor")
+client.create_endpoint("iris-classifier", backend="lr:v1")
 # __doc_deploy_end__
 
 # __doc_query_begin__
@@ -86,7 +86,7 @@ sample_request_input = {
     "petal width": 0.9,
 }
 response = requests.get(
-    "http://localhost:8000/regressor", json=sample_request_input)
+    "http://localhost:8000/iris-classifier", json=sample_request_input)
 print(response.text)
 # Result:
 # {

--- a/python/ray/serve/examples/doc/tutorial_tensorflow.py
+++ b/python/ray/serve/examples/doc/tutorial_tensorflow.py
@@ -73,12 +73,12 @@ ray.init(num_cpus=8)
 # __doc_deploy_begin__
 client = serve.start()
 client.create_backend("tf:v1", TFMnistModel, TRAINED_MODEL_PATH)
-client.create_endpoint("tf_classifier", backend="tf:v1", route="/mnist")
+client.create_endpoint("tf-classifier", backend="tf:v1")
 # __doc_deploy_end__
 
 # __doc_query_begin__
 resp = requests.get(
-    "http://localhost:8000/mnist",
+    "http://localhost:8000/tf-classifier",
     json={"array": np.random.randn(28 * 28).tolist()})
 print(resp.json())
 # {

--- a/python/ray/serve/http_proxy.py
+++ b/python/ray/serve/http_proxy.py
@@ -109,7 +109,7 @@ class HTTPProxy:
 
         http_body_bytes = await self.receive_http_body(scope, receive, send)
 
-        endpoint_name = current_path[1:] # Strip initial '/' from route.
+        endpoint_name = current_path[1:]  # Strip initial '/' from route.
         headers = {k.decode(): v.decode() for k, v in scope["headers"]}
         request_metadata = RequestMetadata(
             get_random_letters(10),  # Used for debugging.

--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -11,7 +11,7 @@ if os.environ.get("RAY_SERVE_INTENTIONALLY_CRASH", False) == 1:
 
 @pytest.fixture(scope="session")
 def _shared_serve_instance():
-    os.environ["SERVE_LOG_DEBUG"] = "1"  # Turns on debug log for tests
+    # os.environ["SERVE_LOG_DEBUG"] = "1"  # Turns on debug log for tests
     # Overriding task_retry_delay_ms to relaunch actors more quickly
     ray.init(
         num_cpus=36,

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -22,8 +22,7 @@ def test_e2e(serve_instance):
         return {"method": flask_request.method}
 
     client.create_backend("echo:v1", function)
-    client.create_endpoint(
-        "api", backend="echo:v1", methods=["GET", "POST"])
+    client.create_endpoint("api", backend="echo:v1", methods=["GET", "POST"])
 
     retry_count = 5
     timeout_sleep = 0.5
@@ -149,7 +148,6 @@ def test_reject_duplicate_endpoint(serve_instance):
         client.create_endpoint(endpoint_name, backend="backend2")
 
 
-
 def test_set_traffic_missing_data(serve_instance):
     client = serve_instance
 
@@ -230,8 +228,7 @@ def test_batching(serve_instance, use_legacy_config):
     } if use_legacy_config else BackendConfig(
         max_batch_size=5, batch_wait_timeout=1)
     client.create_backend("counter:v11", BatchingExample, config=config)
-    client.create_endpoint(
-        "increment2", backend="counter:v11")
+    client.create_endpoint("increment2", backend="counter:v11")
 
     # Keep checking the routing table until /increment is populated
     while "/increment2" not in requests.get(
@@ -268,8 +265,7 @@ def test_batching_exception(serve_instance, use_legacy_config):
         "max_batch_size": 5
     } if use_legacy_config else BackendConfig(max_batch_size=5)
     client.create_backend("exception:v1", NoListReturned, config=config)
-    client.create_endpoint(
-        "exception-test", backend="exception:v1")
+    client.create_endpoint("exception-test", backend="exception:v1")
 
     handle = client.get_handle("exception-test")
     with pytest.raises(ray.exceptions.RayTaskError):
@@ -324,8 +320,7 @@ def test_delete_backend(serve_instance):
         return "hello"
 
     client.create_backend("delete:v1", function)
-    client.create_endpoint(
-        "delete_backend", backend="delete:v1")
+    client.create_endpoint("delete_backend", backend="delete:v1")
 
     assert requests.get("http://127.0.0.1:8000/delete_backend").text == "hello"
 
@@ -382,7 +377,6 @@ def test_delete_endpoint(serve_instance):
     client.delete_endpoint(endpoint_name)
     client.create_endpoint(endpoint_name, backend=backend_name)
 
-
     assert requests.get(
         "http://127.0.0.1:8000/delete_endpoint").text == "hello"
     handle = client.get_handle(endpoint_name)
@@ -404,8 +398,7 @@ def test_shard_key(serve_instance):
         traffic_dict[backend_name] = 1.0 / num_backends
         client.create_backend(backend_name, function)
 
-    client.create_endpoint(
-        "shard", backend=list(traffic_dict.keys())[0])
+    client.create_endpoint("shard", backend=list(traffic_dict.keys())[0])
     client.set_traffic("shard", traffic_dict)
 
     def do_request(shard_key):

--- a/python/ray/serve/tests/test_failure.py
+++ b/python/ray/serve/tests/test_failure.py
@@ -29,8 +29,7 @@ def test_controller_failure(serve_instance):
     client.create_backend("controller_failure:v1", function)
     client.create_endpoint(
         "controller_failure",
-        backend="controller_failure:v1",
-        route="/controller_failure")
+        backend="controller_failure:v1")
 
     assert request_with_retries(
         "/controller_failure", timeout=1).text == "hello1"
@@ -65,8 +64,7 @@ def test_controller_failure(serve_instance):
     ray.kill(client._controller, no_restart=False)
     client.create_endpoint(
         "controller_failure_2",
-        backend="controller_failure_2",
-        route="/controller_failure_2")
+        backend="controller_failure_2")
     ray.kill(client._controller, no_restart=False)
 
     for _ in range(10):
@@ -90,7 +88,7 @@ def test_http_proxy_failure(serve_instance):
 
     client.create_backend("proxy_failure:v1", function)
     client.create_endpoint(
-        "proxy_failure", backend="proxy_failure:v1", route="/proxy_failure")
+        "proxy_failure", backend="proxy_failure:v1")
 
     assert request_with_retries("/proxy_failure", timeout=1.0).text == "hello1"
 
@@ -129,7 +127,7 @@ def test_worker_restart(serve_instance):
 
     client.create_backend("worker_failure:v1", Worker1)
     client.create_endpoint(
-        "worker_failure", backend="worker_failure:v1", route="/worker_failure")
+        "worker_failure", backend="worker_failure:v1")
 
     # Get the PID of the worker.
     old_pid = request_with_retries("/worker_failure", timeout=1).text
@@ -185,7 +183,7 @@ def test_worker_replica_failure(serve_instance):
     client.update_backend_config(
         "replica_failure", BackendConfig(num_replicas=2))
     client.create_endpoint(
-        "replica_failure", backend="replica_failure", route="/replica_failure")
+        "replica_failure", backend="replica_failure")
 
     # Wait until both replicas have been started.
     responses = set()
@@ -228,9 +226,9 @@ def test_create_backend_idempotent(serve_instance):
 
     assert len(ray.get(controller.get_all_backends.remote())) == 1
     client.create_endpoint(
-        "my_endpoint", backend="my_backend", route="/my_route")
+        "my_endpoint", backend="my_backend")
 
-    assert requests.get("http://127.0.0.1:8000/my_route").text == "hello"
+    assert requests.get("http://127.0.0.1:8000/my_endpoint").text == "hello"
 
 
 def test_create_endpoint_idempotent(serve_instance):
@@ -246,12 +244,12 @@ def test_create_endpoint_idempotent(serve_instance):
     for i in range(10):
         ray.get(
             controller.create_endpoint.remote(
-                "my_endpoint", {"my_backend": 1.0}, "/my_route", ["GET"]))
+                "my_endpoint", {"my_backend": 1.0}, ["GET"]))
 
     assert len(ray.get(controller.get_all_endpoints.remote())) == 1
-    assert requests.get("http://127.0.0.1:8000/my_route").text == "hello"
+    assert requests.get("http://127.0.0.1:8000/my_endpoint").text == "hello"
     resp = requests.get("http://127.0.0.1:8000/-/routes", timeout=0.5).json()
-    assert resp == {"/my_route": ["my_endpoint", ["GET"]]}
+    assert resp == {"/my_endpoint": ["GET"]}
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_failure.py
+++ b/python/ray/serve/tests/test_failure.py
@@ -28,8 +28,7 @@ def test_controller_failure(serve_instance):
 
     client.create_backend("controller_failure:v1", function)
     client.create_endpoint(
-        "controller_failure",
-        backend="controller_failure:v1")
+        "controller_failure", backend="controller_failure:v1")
 
     assert request_with_retries(
         "/controller_failure", timeout=1).text == "hello1"
@@ -63,8 +62,7 @@ def test_controller_failure(serve_instance):
     client.create_backend("controller_failure_2", function)
     ray.kill(client._controller, no_restart=False)
     client.create_endpoint(
-        "controller_failure_2",
-        backend="controller_failure_2")
+        "controller_failure_2", backend="controller_failure_2")
     ray.kill(client._controller, no_restart=False)
 
     for _ in range(10):
@@ -87,8 +85,7 @@ def test_http_proxy_failure(serve_instance):
         return "hello1"
 
     client.create_backend("proxy_failure:v1", function)
-    client.create_endpoint(
-        "proxy_failure", backend="proxy_failure:v1")
+    client.create_endpoint("proxy_failure", backend="proxy_failure:v1")
 
     assert request_with_retries("/proxy_failure", timeout=1.0).text == "hello1"
 
@@ -126,8 +123,7 @@ def test_worker_restart(serve_instance):
             return os.getpid()
 
     client.create_backend("worker_failure:v1", Worker1)
-    client.create_endpoint(
-        "worker_failure", backend="worker_failure:v1")
+    client.create_endpoint("worker_failure", backend="worker_failure:v1")
 
     # Get the PID of the worker.
     old_pid = request_with_retries("/worker_failure", timeout=1).text
@@ -182,8 +178,7 @@ def test_worker_replica_failure(serve_instance):
     client.create_backend("replica_failure", Worker, temp_path)
     client.update_backend_config(
         "replica_failure", BackendConfig(num_replicas=2))
-    client.create_endpoint(
-        "replica_failure", backend="replica_failure")
+    client.create_endpoint("replica_failure", backend="replica_failure")
 
     # Wait until both replicas have been started.
     responses = set()
@@ -225,8 +220,7 @@ def test_create_backend_idempotent(serve_instance):
                                              replica_config))
 
     assert len(ray.get(controller.get_all_backends.remote())) == 1
-    client.create_endpoint(
-        "my_endpoint", backend="my_backend")
+    client.create_endpoint("my_endpoint", backend="my_backend")
 
     assert requests.get("http://127.0.0.1:8000/my_endpoint").text == "hello"
 
@@ -243,8 +237,8 @@ def test_create_endpoint_idempotent(serve_instance):
 
     for i in range(10):
         ray.get(
-            controller.create_endpoint.remote(
-                "my_endpoint", {"my_backend": 1.0}, ["GET"]))
+            controller.create_endpoint.remote("my_endpoint",
+                                              {"my_backend": 1.0}, ["GET"]))
 
     assert len(ray.get(controller.get_all_endpoints.remote())) == 1
     assert requests.get("http://127.0.0.1:8000/my_endpoint").text == "hello"

--- a/python/ray/serve/tests/test_handle.py
+++ b/python/ray/serve/tests/test_handle.py
@@ -23,14 +23,12 @@ def test_handle_in_endpoint(serve_instance):
     client.create_endpoint(
         "endpoint1",
         backend="endpoint1:v0",
-        route="/endpoint1",
         methods=["GET", "POST"])
 
     client.create_backend("endpoint2:v0", Endpoint2)
     client.create_endpoint(
         "endpoint2",
         backend="endpoint2:v0",
-        route="/endpoint2",
         methods=["GET", "POST"])
 
     assert requests.get("http://127.0.0.1:8000/endpoint2").text == "hello"
@@ -50,7 +48,7 @@ def test_handle_http_args(serve_instance):
 
     client.create_backend("backend", Endpoint)
     client.create_endpoint(
-        "endpoint", backend="backend", route="/endpoint", methods=["POST"])
+        "endpoint", backend="backend", methods=["POST"])
 
     ground_truth = {
         "args": {
@@ -91,14 +89,14 @@ def test_handle_inject_flask_request(serve_instance):
         return str(type(request))
 
     client.create_backend("echo:v0", echo_request_type)
-    client.create_endpoint("echo", backend="echo:v0", route="/echo")
+    client.create_endpoint("echo", backend="echo:v0")
 
     def wrapper_model(web_request):
         handle = serve.connect().get_handle("echo")
         return ray.get(handle.remote(web_request))
 
     client.create_backend("wrapper:v0", wrapper_model)
-    client.create_endpoint("wrapper", backend="wrapper:v0", route="/wrapper")
+    client.create_endpoint("wrapper", backend="wrapper:v0")
 
     for route in ["/echo", "/wrapper"]:
         resp = requests.get(f"http://127.0.0.1:8000{route}")

--- a/python/ray/serve/tests/test_handle.py
+++ b/python/ray/serve/tests/test_handle.py
@@ -21,15 +21,11 @@ def test_handle_in_endpoint(serve_instance):
 
     client.create_backend("endpoint1:v0", Endpoint1)
     client.create_endpoint(
-        "endpoint1",
-        backend="endpoint1:v0",
-        methods=["GET", "POST"])
+        "endpoint1", backend="endpoint1:v0", methods=["GET", "POST"])
 
     client.create_backend("endpoint2:v0", Endpoint2)
     client.create_endpoint(
-        "endpoint2",
-        backend="endpoint2:v0",
-        methods=["GET", "POST"])
+        "endpoint2", backend="endpoint2:v0", methods=["GET", "POST"])
 
     assert requests.get("http://127.0.0.1:8000/endpoint2").text == "hello"
 
@@ -47,8 +43,7 @@ def test_handle_http_args(serve_instance):
             }
 
     client.create_backend("backend", Endpoint)
-    client.create_endpoint(
-        "endpoint", backend="backend", methods=["POST"])
+    client.create_endpoint("endpoint", backend="backend", methods=["POST"])
 
     ground_truth = {
         "args": {

--- a/python/ray/serve/tests/test_persistence.py
+++ b/python/ray/serve/tests/test_persistence.py
@@ -16,7 +16,7 @@ def driver(flask_request):
     return "OK!"
 
 client.create_backend("driver", driver)
-client.create_endpoint("driver", backend="driver", route="/driver")
+client.create_endpoint("driver", backend="driver")
 """.format(ray.worker._global_node._redis_address)
     ray.test_utils.run_string_as_driver(script)
 

--- a/python/ray/serve/tests/test_regression.py
+++ b/python/ray/serve/tests/test_regression.py
@@ -27,8 +27,7 @@ def test_np_in_composed_model(serve_instance):
     client.create_backend("sum_model", sum_model)
     client.create_endpoint("sum_model", backend="sum_model")
     client.create_backend("model", ComposedModel)
-    client.create_endpoint(
-        "model", backend="model", methods=["GET"])
+    client.create_endpoint("model", backend="model", methods=["GET"])
 
     result = requests.get("http://127.0.0.1:8000/model")
     assert result.status_code == 200

--- a/python/ray/serve/tests/test_regression.py
+++ b/python/ray/serve/tests/test_regression.py
@@ -28,7 +28,7 @@ def test_np_in_composed_model(serve_instance):
     client.create_endpoint("sum_model", backend="sum_model")
     client.create_backend("model", ComposedModel)
     client.create_endpoint(
-        "model", backend="model", route="/model", methods=["GET"])
+        "model", backend="model", methods=["GET"])
 
     result = requests.get("http://127.0.0.1:8000/model")
     assert result.status_code == 200


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR removes the `route` keyword argument for `create_endpoint()`.  The HTTP route for an endpoint will now be the name of the endpoint.  

This simplifies common code such as `client.create_endpoint("counter", backend="counter", route="/counter")` to just `client.create_endpoint("counter", backend="counter")`.  

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
