### PR TITLE
[autoscaler/k8s] Handle unavailable k8s API

### DIFF
--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -131,6 +131,8 @@ class StandardAutoscaler:
             if _internal_kv_initialized():
                 _internal_kv_put(
                     DEBUG_AUTOSCALING_ERROR, str(e), overwrite=True)
+            # Don't abort the autoscaler if the K8s API server is down.
+            # https://github.com/ray-project/ray/issues/12255
             is_k8s_connection_error = (
                 self.config["provider"]["type"] == "kubernetes"
                 and isinstance(e, MaxRetryError))

--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -1,5 +1,6 @@
 from collections import defaultdict, namedtuple
 from typing import Any, Optional, Dict, List
+from urllib3.exceptions import MaxRetryError
 import copy
 import logging
 import math
@@ -130,7 +131,11 @@ class StandardAutoscaler:
             if _internal_kv_initialized():
                 _internal_kv_put(
                     DEBUG_AUTOSCALING_ERROR, str(e), overwrite=True)
-            self.num_failures += 1
+            is_k8s_connection_error = (
+                self.config["provider"]["type"] == "kubernetes"
+                and isinstance(e, MaxRetryError))
+            if not is_k8s_connection_error:
+                self.num_failures += 1
             if self.num_failures > self.max_failures:
                 logger.critical("StandardAutoscaler: "
                                 "Too many errors, abort.")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Addresses #12255. The `except` clause of autoscaler's update checks if (a) we have a connection error (b) if the provider being used is Kubernetes. If so, we don't increment `num_failures`.
This check is perhaps too coarse, but I think it'll do for now. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #12255
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

I tested the changes on minikube locally, just to make sure I didn't break anything. Couldn't figure out how to simulate apiserver downtime in a minikube environment.
As @simon-mo suggested, we should test this on a GKE cluster. 