### PR TITLE
[Core] zero-copy serializer for pytorch

### DIFF
--- a/python/ray/serialization.py
+++ b/python/ray/serialization.py
@@ -26,6 +26,7 @@ from ray._raylet import (
     MessagePackSerializedObject,
     RawSerializedObject,
 )
+from ray import serialization_addons
 
 logger = logging.getLogger(__name__)
 
@@ -155,6 +156,7 @@ class SerializationContext:
         # Because objects have default __reduce__ method, we only need to
         # treat ObjectRef specifically.
         self._register_cloudpickle_reducer(ray.ObjectRef, object_ref_reducer)
+        serialization_addons.apply(self)
 
     def _register_cloudpickle_reducer(self, cls, reducer):
         pickle.CloudPickler.dispatch[cls] = reducer

--- a/python/ray/serialization_addons.py
+++ b/python/ray/serialization_addons.py
@@ -10,7 +10,6 @@ try:
 
     _TORCH_WARNING_FILTER_ACTIVATE = True
 
-
     class _TorchTensorReducingHelper:
         def __init__(self, tensor):
             self.tensor = tensor
@@ -23,8 +22,10 @@ try:
             # we would only deal with it for the first time.
             if _TORCH_WARNING_FILTER_ACTIVATE:
                 with warnings.catch_warnings():
-                    warnings.filterwarnings("ignore", category=UserWarning,
-                                            message="The given NumPy array is not writeable")
+                    warnings.filterwarnings(
+                        "ignore",
+                        category=UserWarning,
+                        message="The given NumPy array is not writeable")
                     storage = torch.from_numpy(ndarray).storage()
                 _TORCH_WARNING_FILTER_ACTIVATE = False
             else:
@@ -36,19 +37,19 @@ try:
             if self.tensor.is_sparse:
                 # Torch will help us reduce the sparse tensor into
                 # several continuous tensors.
-                return _TorchTensorReducingHelper, (self.tensor,)
+                return _TorchTensorReducingHelper, (self.tensor, )
             # By only replacing the storage with a numpy array, we can reuse
-            # zero-copy serialization while keeping all other params of the torch tensor.
+            # zero-copy serialization while keeping all other params of the
+            # torch tensor.
             _rebuild_func, content = self.tensor.__reduce_ex__(protocol)
-            return self.rebuild_tensor, (_rebuild_func, self.tensor.numpy(), content[1:])
-
+            return self.rebuild_tensor, (_rebuild_func, self.tensor.numpy(),
+                                         content[1:])
 
     def _unwrap_tensor(s):
         return s.tensor
 
-
     def torch_tensor_reducer(tensor):
-        return _unwrap_tensor, (_TorchTensorReducingHelper(tensor),)
+        return _unwrap_tensor, (_TorchTensorReducingHelper(tensor), )
 
 except ImportError:
     pass

--- a/python/ray/serialization_addons.py
+++ b/python/ray/serialization_addons.py
@@ -30,7 +30,7 @@ try:
                 _TORCH_WARNING_FILTER_ACTIVATE = False
             else:
                 _tensor = torch.from_numpy(ndarray)
-            if device != torch.device('cpu'):
+            if device != torch.device("cpu"):
                 _tensor = _tensor.to(device)
             tensor = rebuild_func(_tensor.storage(), *params)
             return cls(tensor)

--- a/python/ray/serialization_addons.py
+++ b/python/ray/serialization_addons.py
@@ -1,0 +1,53 @@
+"""
+This module is intended for implementing internal serializers for some
+site packages.
+"""
+
+import warnings
+
+try:
+    import torch
+
+
+    class _TorchTensorReducingHelper:
+        def __init__(self, tensor):
+            self.tensor = tensor
+
+        @classmethod
+        def rebuild_tensor(cls, _rebuild_func, ndarray, params):
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=UserWarning,
+                                        message="The given NumPy array is not writeable")
+                storage = torch.from_numpy(ndarray).storage()
+            tensor = _rebuild_func(storage, *params)
+            return cls(tensor)
+
+        def __reduce_ex__(self, protocol):
+            if self.tensor.is_sparse:
+                # Torch will help us reduce the sparse tensor into
+                # several continuous tensors.
+                return _TorchTensorReducingHelper, (self.tensor,)
+            # By only replacing the storage with a numpy array, we can reuse
+            # zero-copy serialization while keeping all other params of the torch tensor.
+            _rebuild_func, content = self.tensor.__reduce_ex__(protocol)
+            return self.rebuild_tensor, (_rebuild_func, self.tensor.numpy(), content[1:])
+
+
+    def _unwrap_tensor(s):
+        return s.tensor
+
+
+    def torch_tensor_reducer(tensor):
+        return _unwrap_tensor, (_TorchTensorReducingHelper(tensor),)
+
+except ImportError:
+    pass
+
+
+def apply(serialization_context):
+    try:
+        import torch
+        serialization_context._register_cloudpickle_reducer(
+            torch.Tensor, torch_tensor_reducer)
+    except ImportError:
+        pass

--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -543,7 +543,7 @@ def test_reducer_override_no_reference_cycle(ray_start_shared_local_modes):
     assert new_obj() is None
 
 
-def test_buffer_alignment():
+def test_buffer_alignment(ray_start_shared_local_modes):
     # Deserialized large numpy arrays should be 64-byte aligned.
     x = np.random.normal(size=(10, 20, 30))
     y = ray.get(ray.put(x))
@@ -566,6 +566,22 @@ def test_buffer_alignment():
     ys = ray.get(ray.put(xs))
     for y in ys:
         assert y.ctypes.data % 8 == 0
+
+
+def test_pytorch_tensor_zerocopy_serialization(ray_start_shared_local_modes):
+    import torch
+    tensor = torch.rand(32, 3, 64, 64)
+    ref = ray.put(tensor)
+    tensor_1, tensor_2 = ray.get([ref] * 2)
+    assert tensor_1.data_ptr() == tensor_2.data_ptr()
+
+    i = torch.arange(0, 1024 * 1024, 4).view(1, -1)
+    v = torch.rand(1024 * 1024 // 4)
+    k = torch.sparse_coo_tensor(i, v, size=(1024 * 1024, ))
+    ref = ray.put(k)
+    tensor_1, tensor_2 = ray.get([ref] * 2)
+    assert tensor_1._indices().data_ptr() == tensor_2._indices().data_ptr()
+    assert tensor_1._values().data_ptr() == tensor_2._values().data_ptr()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When shifted from PyArrow, we lost zero-copy serialization for torch tensors. This PR not only recovers the zero-copy serialization, it also fixes several bugs in the original serializer.

## Related issue number

Closes #4855
Closes #12317 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
