### PR TITLE
[Streaming] export aligned_ symbols from raylet.so

### DIFF
--- a/src/ray/ray_exported_symbols.lds
+++ b/src/ray/ray_exported_symbols.lds
@@ -29,3 +29,5 @@
 *Java*
 *JNI_*
 *ray*streaming*
+*aligned_free*
+*aligned_malloc*

--- a/src/ray/ray_version_script.lds
+++ b/src/ray/ray_version_script.lds
@@ -31,5 +31,7 @@ VERSION_1.0 {
         *Java*;
         *JNI_*;
         *ray*streaming*;
+        *aligned_free*;
+        *aligned_malloc*;
     local: *;
 };


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

fix crashing in CI. which caused by the lack of `aligned_free` and `aligned_malloc` symbols in raylet.so.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
