### PR TITLE
[PlacementGroup]Fix node manager release unused bundles bug

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -577,18 +577,26 @@ void NodeManager::HandleReleaseUnusedBundles(
   }
 
   // Kill all workers that are currently associated with the unused bundles.
+  // NOTE: We can't traverse directly with `leased_workers_`, because `DestroyWorker` will
+  // delete the element of `leased_workers_`. So we need to filter out
+  // `workers_associated_with_unused_bundles` separately.
+  std::vector<std::shared_ptr<WorkerInterface>> workers_associated_with_unused_bundles;
   for (const auto &worker_it : leased_workers_) {
     auto &worker = worker_it.second;
     if (0 == in_use_bundles.count(worker->GetBundleId())) {
-      RAY_LOG(DEBUG)
-          << "Destroying worker since its bundle was unused. Placement group id: "
-          << worker->GetBundleId().first
-          << ", bundle index: " << worker->GetBundleId().second
-          << ", task id: " << worker->GetAssignedTaskId()
-          << ", actor id: " << worker->GetActorId()
-          << ", worker id: " << worker->WorkerId();
-      DestroyWorker(worker);
+      workers_associated_with_unused_bundles.push_back(worker);
     }
+  }
+
+  for (const auto &worker_it : workers_associated_with_unused_bundles) {
+    RAY_LOG(DEBUG)
+        << "Destroying worker since its bundle was unused. Placement group id: "
+        << worker->GetBundleId().first
+        << ", bundle index: " << worker->GetBundleId().second
+        << ", task id: " << worker->GetAssignedTaskId()
+        << ", actor id: " << worker->GetActorId()
+        << ", worker id: " << worker->WorkerId();
+    DestroyWorker(worker);
   }
 
   // Return unused bundle resources.
@@ -1819,6 +1827,9 @@ void NodeManager::HandleCancelResourceReserve(
                 << bundle_spec.DebugString();
 
   // Kill all workers that are currently associated with the placement group.
+  // NOTE: We can't traverse directly with `leased_workers_`, because `DestroyWorker` will
+  // delete the element of `leased_workers_`. So we need to filter out
+  // `workers_associated_with_pg` separately.
   std::vector<std::shared_ptr<WorkerInterface>> workers_associated_with_pg;
   for (const auto &worker_it : leased_workers_) {
     auto &worker = worker_it.second;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -584,11 +584,11 @@ void NodeManager::HandleReleaseUnusedBundles(
   for (const auto &worker_it : leased_workers_) {
     auto &worker = worker_it.second;
     if (0 == in_use_bundles.count(worker->GetBundleId())) {
-      workers_associated_with_unused_bundles.push_back(worker);
+      workers_associated_with_unused_bundles.emplace_back(worker);
     }
   }
 
-  for (const auto &worker_it : workers_associated_with_unused_bundles) {
+  for (const auto &worker : workers_associated_with_unused_bundles) {
     RAY_LOG(DEBUG)
         << "Destroying worker since its bundle was unused. Placement group id: "
         << worker->GetBundleId().first
@@ -1834,7 +1834,7 @@ void NodeManager::HandleCancelResourceReserve(
   for (const auto &worker_it : leased_workers_) {
     auto &worker = worker_it.second;
     if (worker->GetBundleId().first == bundle_spec.PlacementGroupId()) {
-      workers_associated_with_pg.push_back(worker);
+      workers_associated_with_pg.emplace_back(worker);
     }
   }
   for (const auto &worker : workers_associated_with_pg) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We can't traverse directly with `leased_workers_`, because `DestroyWorker` will delete the element of `leased_workers_`. So we need to filter out `workers_associated_with_unused_bundles` separately.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
