### PR TITLE
[rllib] A wrapper to silently reset an environment on an exception

### DIFF
--- a/rllib/env/wrappers/exception_wrapper.py
+++ b/rllib/env/wrappers/exception_wrapper.py
@@ -1,0 +1,37 @@
+import logging
+import traceback
+
+import gym
+
+logger = logging.getLogger(__name__)
+
+
+class TooManyResetAttemptsException(Exception):
+    def __init__(self, max_attempts: int):
+        super().__init__(
+            f"Reached the maximum number of attempts ({max_attempts}) "
+            f"to reset an environment.")
+
+
+class ResetOnExceptionWrapper(gym.Wrapper):
+    def __init__(self, env: gym.Env, max_reset_attempts: int = 5):
+        super().__init__(env)
+        self.max_reset_attempts = max_reset_attempts
+
+    def reset(self, **kwargs):
+        attempt = 0
+        while attempt < self.max_reset_attempts:
+            try:
+                return self.env.reset(**kwargs)
+            except Exception:
+                logger.error(traceback.format_exc())
+                attempt += 1
+        else:
+            raise TooManyResetAttemptsException(self.max_reset_attempts)
+
+    def step(self, action):
+        try:
+            return self.env.step(action)
+        except Exception:
+            logger.error(traceback.format_exc())
+            return self.reset(), 0.0, False, {"__terminated__": True}

--- a/rllib/env/wrappers/tests/test_exception_wrapper.py
+++ b/rllib/env/wrappers/tests/test_exception_wrapper.py
@@ -1,0 +1,57 @@
+import random
+import unittest
+
+import gym
+from ray.rllib.env.wrappers.exception_wrapper import ResetOnExceptionWrapper, \
+    TooManyResetAttemptsException
+
+
+class TestResetOnExceptionWrapper(unittest.TestCase):
+    def test_unstable_env(self):
+        class UnstableEnv(gym.Env):
+            observation_space = gym.spaces.Discrete(2)
+            action_space = gym.spaces.Discrete(2)
+
+            def step(self, action):
+                if random.choice([True, False]):
+                    raise ValueError("An error from a unstable environment.")
+                return self.observation_space.sample(), 0.0, False, {}
+
+            def reset(self):
+                return self.observation_space.sample()
+
+        env = UnstableEnv()
+        env = ResetOnExceptionWrapper(env)
+
+        try:
+            self._run_for_100_steps(env)
+        except Exception:
+            self.fail()
+
+    def test_very_unstable_env(self):
+        class VeryUnstableEnv(gym.Env):
+            observation_space = gym.spaces.Discrete(2)
+            action_space = gym.spaces.Discrete(2)
+
+            def step(self, action):
+                return self.observation_space.sample(), 0.0, False, {}
+
+            def reset(self):
+                raise ValueError("An error from a very unstable environment.")
+
+        env = VeryUnstableEnv()
+        env = ResetOnExceptionWrapper(env)
+        self.assertRaises(TooManyResetAttemptsException,
+                          lambda: self._run_for_100_steps(env))
+
+    @staticmethod
+    def _run_for_100_steps(env):
+        env.reset()
+        for _ in range(100):
+            env.step(env.action_space.sample())
+
+
+if __name__ == "__main__":
+    import sys
+    import pytest
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Sometimes there are environments, which are naturally unstable (e.g. due to bugs in their non-editable code (e.g. 3rd party binaries)). To solve this, we often use this `ResetOnExceptionWrapper` which hides all exceptions raised by an environment and silently resets it. This, of course, might become problematic (e.g. in GAE), but when applied to environments, which raise from time to time only, we found this very useful.

## Related issue number

None.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
