### PR TITLE
[docker] Docker stop on each node

### DIFF
--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -364,17 +364,21 @@ def teardown_cluster(config_file: str, yes: bool, workers_only: bool,
 
     def run_docker_stop(node, container_name):
         try:
-            exec_cluster(
-                config_file,
-                cmd=f"docker stop {container_name}",
-                run_env="host",
-                screen=False,
-                tmux=False,
-                stop=False,
-                start=False,
-                override_cluster_name=override_cluster_name,
-                port_forward=None,
-                with_output=False)
+            updater = NodeUpdaterThread(
+                node_id=node,
+                provider_config=config["provider"],
+                provider=provider,
+                auth_config=config["auth"],
+                cluster_name=config["cluster_name"],
+                file_mounts=config["file_mounts"],
+                initialization_commands=[],
+                setup_commands=[],
+                ray_start_commands=[],
+                runtime_hash="",
+                file_mounts_contents_hash="",
+                is_head_node=False,
+                docker_config=config.get("docker"))
+            _exec(updater, cmd=f"docker stop {container_name}", run_env="host")
         except Exception:
             cli_logger.warning(f"Docker stop failed on {node}")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* Fixes a bug where we run `ray stop` on the head node **many times**.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #12326

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
** Manually Tested **: Started a cluster with `ray up my.yaml` then edited the `teardown` path to exit before calling the `node_provider` to shutdown the instances. After this I ran `ray down my.yaml` and then manually inspected each node to check that the container was no longer running!
