### PR TITLE
[Bugfix][Dashboard] Make sure not to iterate over "None" when worker payload not present

### DIFF
--- a/dashboard/datacenter.py
+++ b/dashboard/datacenter.py
@@ -240,12 +240,12 @@ class DataOrganizer:
         actor_process_stats = None
         actor_process_gpu_stats = None
         if pid:
-            for process_stats in node_physical_stats.get("workers"):
+            for process_stats in node_physical_stats.get("workers", []):
                 if process_stats["pid"] == pid:
                     actor_process_stats = process_stats
                     break
 
-            for gpu_stats in node_physical_stats.get("gpus"):
+            for gpu_stats in node_physical_stats.get("gpus", []):
                 for process in gpu_stats.get("processes", []):
                     if process["pid"] == pid:
                         actor_process_gpu_stats = gpu_stats


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
These changes are needed because in the case where we do not yet have data from the reporter module for a given node's workers, the code tries to iterate over "None"
This is fixed by changing the default value of the `.get` call to return `[]` instead of `None`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #11631

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
