### PR TITLE
Don't allow 'optional' files in setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -68,9 +68,10 @@ generated_python_directories = [
     "ray/streaming/generated",
 ]
 
-optional_ray_files = ["ray/nightly-wheels.yaml"]
+ray_files.append("ray/nightly-wheels.yaml")
 
-ray_autoscaler_files = [
+# Autoscaler files.
+ray_files += [
     "ray/autoscaler/aws/defaults.yaml",
     "ray/autoscaler/azure/defaults.yaml",
     "ray/autoscaler/_private/azure/azure-vm-template.json",
@@ -83,21 +84,11 @@ ray_autoscaler_files = [
     "ray/autoscaler/ray-schema.json",
 ]
 
-ray_project_files = [
-    "ray/projects/schema.json",
-    "ray/projects/templates/cluster_template.yaml",
-    "ray/projects/templates/project_template.yaml",
-    "ray/projects/templates/requirements.txt",
-]
-
-ray_dashboard_files = [
+# Dashboard files.
+ray_files += [
     os.path.join(dirpath, filename) for dirpath, dirnames, filenames in
     os.walk("ray/new_dashboard/client/build") for filename in filenames
 ]
-
-optional_ray_files += ray_autoscaler_files
-optional_ray_files += ray_project_files
-optional_ray_files += ray_dashboard_files
 
 # If you're adding dependencies for ray extras, please
 # also update the matching section of requirements.txt
@@ -364,14 +355,6 @@ def pip_run(build_ext):
 
     for filename in files_to_include:
         move_file(build_ext.build_lib, filename)
-
-    # Try to copy over the optional files.
-    for filename in optional_ray_files:
-        try:
-            move_file(build_ext.build_lib, filename)
-        except Exception:
-            print("Failed to copy optional file {}. This is ok."
-                  .format(filename))
 
 
 def api_main(program, *args):

--- a/python/setup.py
+++ b/python/setup.py
@@ -79,7 +79,7 @@ ray_files += [
     "ray/autoscaler/gcp/defaults.yaml",
     "ray/autoscaler/local/defaults.yaml",
     "ray/autoscaler/kubernetes/defaults.yaml",
-    "ray/autoscaler/kubernetes/kubectl-rsync.sh",
+    "ray/autoscaler/_private/kubernetes/kubectl-rsync.sh",
     "ray/autoscaler/staroid/defaults.yaml",
     "ray/autoscaler/ray-schema.json",
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The wheels were successfully building even though provided files were missing. If we failed the build when these files weren't present, we would not run into issues like https://github.com/ray-project/ray/issues/12355.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
