### PR TITLE
[docker] Use cuDNN7, not 8

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -16,7 +16,7 @@ key="$1"
 case $key in
     --gpu)
     GPU="-gpu"
-    BASE_IMAGE="nvidia/cuda:10.1-cudnn8-runtime-ubuntu18.04"
+    BASE_IMAGE="nvidia/cuda:10.1-cudnn7d-runtime-ubuntu18.04"
     ;;
     --no-cache-build)
     NO_CACHE="--no-cache"

--- a/ci/travis/build-docker-images.py
+++ b/ci/travis/build-docker-images.py
@@ -84,7 +84,7 @@ def _build_cpu_gpu_images(image_name, no_cache=True) -> List[str]:
         build_args = {}
         if image_name == "base-deps":
             build_args["BASE_IMAGE"] = (
-                "nvidia/cuda:10.1-cudnn8-runtime-ubuntu18.04"
+                "nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04"
                 if gpu == "-gpu" else "ubuntu:focal")
         else:
             build_args["GPU"] = gpu

--- a/ci/travis/build-docker-images.sh
+++ b/ci/travis/build-docker-images.sh
@@ -22,7 +22,7 @@ build_and_push_tags() {
     # $2 tag for image (e.g. hash of commit)
     for GPU in "" "-gpu" 
     do 
-        BASE_IMAGE=$(if [ "$GPU" ]; then echo "nvidia/cuda:10.1-cudnn8-runtime-ubuntu18.04"; else echo "ubuntu:focal"; fi;)
+        BASE_IMAGE=$(if [ "$GPU" ]; then echo "nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04"; else echo "ubuntu:focal"; fi;)
         FULL_NAME_WITH_TAG="rayproject/$1:$2$GPU"
         NIGHTLY_FULL_NAME_WITH_TAG="rayproject/$1:nightly$GPU"
         docker build --no-cache --build-arg GPU="$GPU" --build-arg BASE_IMAGE="$BASE_IMAGE" --build-arg WHEEL_PATH=".whl/$WHEEL" --label "SHA=$2" -t "$FULL_NAME_WITH_TAG" /"$ROOT_DIR"/docker/"$1"

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -1,6 +1,6 @@
 # The base-deps Docker image installs main libraries needed to run Ray
 
-# The GPU option is nvidia/cuda:10.1-cudnn8-runtime-ubuntu18.04
+# The GPU option is nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04
 ARG BASE_IMAGE="ubuntu:focal"
 FROM ${BASE_IMAGE}
 # If this arg is not "autoscaler" then no autoscaler requirements will be included


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* Tensorflow only works on CUDA 10.1 & cuDNN 7.6 right [now](https://www.tensorflow.org/install/source#gpu). It will support CUDA 11 & cuDNN 8 soon, but we'd rather maintain backwards compatibility.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks
#12201

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
