### PR TITLE
[RLlib] Move pettingzoo into rllib's requirements file (from ray's requirements.txt file).

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -55,7 +55,6 @@ mypy
 networkx
 numba
 openpyxl
-pettingzoo>=1.4.0
 Pillow; platform_system != "Windows"
 pygments
 pytest==5.4.3

--- a/python/requirements_rllib.txt
+++ b/python/requirements_rllib.txt
@@ -5,3 +5,5 @@ torch>=1.6.0
 # Version requirement to match Tune
 torchvision>=0.6.0
 smart_open
+# For tests on PettingZoo's multi-agent envs.
+pettingzoo>=1.4.0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

The pettingzoo module should only be installed for RLlib's tests. It should therefor be located in ray/python/requirements_rllib.txt. Moved there from ray/python/requirements.txt.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
