### PR TITLE
[Dashboard][Bug] Fix duplicate node total rows in dashboard

### DIFF
--- a/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
@@ -88,7 +88,7 @@ const makeGroupedTableContents = (
     );
     return (
       <NodeRowGroup
-        key={node.ip}
+        key={node.raylet.nodeId}
         node={node}
         workerFeatureData={sortedClusterWorkers}
         features={nodeInfoFeatures}

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -21,6 +21,7 @@ from ray.test_utils import (
     wait_for_condition,
     wait_until_server_available,
     run_string_as_driver,
+    wait_until_succeeded_without_exception
 )
 from ray.autoscaler._private.util import (DEBUG_AUTOSCALING_STATUS,
                                           DEBUG_AUTOSCALING_ERROR)
@@ -455,22 +456,16 @@ def test_get_cluster_status(ray_start_with_dashboard):
 
     # Check that the cluster_status endpoint works without the underlying data
     # from the GCS, but returns nothing.
-    last_exception = None
-    for _ in range(5):
-        try:
-            response = requests.get(f"{webui_url}/api/cluster_status")
-            response.raise_for_status()
-            assert response.json()["result"]
-            assert "autoscalingStatus" in response.json()["data"]
-            assert response.json()["data"]["autoscalingStatus"] is None
-            assert "autoscalingError" in response.json()["data"]
-            assert response.json()["data"]["autoscalingError"] is None
-            break
-        except requests.RequestException as e:
-            last_exception = e
-            time.sleep(1)
-    else:
-        raise last_exception
+    def get_cluster_status():
+        response = requests.get(f"{webui_url}/api/cluster_status")
+        response.raise_for_status()
+        assert response.json()["result"]
+        assert "autoscalingStatus" in response.json()["data"]
+        assert response.json()["data"]["autoscalingStatus"] is None
+        assert "autoscalingError" in response.json()["data"]
+        assert response.json()["data"]["autoscalingError"] is None
+
+    wait_until_succeeded_without_exception(get_cluster_status, (requests.RequestException,))
 
     # Populate the GCS field, check that the data is returned from the
     # endpoint.

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -16,13 +16,9 @@ import redis
 import requests
 
 from ray import ray_constants
-from ray.test_utils import (
-    format_web_url,
-    wait_for_condition,
-    wait_until_server_available,
-    run_string_as_driver,
-    wait_until_succeeded_without_exception
-)
+from ray.test_utils import (format_web_url, wait_for_condition,
+                            wait_until_server_available, run_string_as_driver,
+                            wait_until_succeeded_without_exception)
 from ray.autoscaler._private.util import (DEBUG_AUTOSCALING_STATUS,
                                           DEBUG_AUTOSCALING_ERROR)
 import ray.new_dashboard.consts as dashboard_consts
@@ -465,7 +461,8 @@ def test_get_cluster_status(ray_start_with_dashboard):
         assert "autoscalingError" in response.json()["data"]
         assert response.json()["data"]["autoscalingError"] is None
 
-    wait_until_succeeded_without_exception(get_cluster_status, (requests.RequestException,))
+    wait_until_succeeded_without_exception(get_cluster_status,
+                                           (requests.RequestException, ))
 
     # Populate the GCS field, check that the data is returned from the
     # endpoint.


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fix duplicate node total rows in dashboard by changing the react key of the NodeTotalRow component from the node IP to the node ID (node IP can be duplicated in the case of docker containers running on the same node).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #12363 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
