### PR TITLE
[RLLib] Fix HyperOptSearch tuple to list conversion

### DIFF
--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -1053,9 +1053,9 @@ class Trainer(Trainable):
             raise ValueError("`model._time_major` only supported "
                              "iff `_use_trajectory_view_api` is True!")
 
-        if type(config["input_evaluation"]) == tuple:
+        if isinstance(config["input_evaluation"], tuple):
             config["input_evaluation"] = list(config["input_evaluation"])
-        elif type(config["input_evaluation"]) != list:
+        elif not isinstance(config["input_evaluation"], list):
             raise ValueError(
                 "`input_evaluation` must be a list of strings, got {}!".format(
                     config["input_evaluation"]))

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -1053,7 +1053,9 @@ class Trainer(Trainable):
             raise ValueError("`model._time_major` only supported "
                              "iff `_use_trajectory_view_api` is True!")
 
-        if type(config["input_evaluation"]) != list:
+        if type(config["input_evaluation"]) == tuple:
+            config["input_evaluation"] = list(config["input_evaluation"])
+        elif type(config["input_evaluation"]) != list:
             raise ValueError(
                 "`input_evaluation` must be a list of strings, got {}!".format(
                     config["input_evaluation"]))


### PR DESCRIPTION
## Why are these changes needed?

To fix HyperOptSearch usage with RLLib.
See the linked issue for further explanations.
My small fix is a simple tuple to list conversion.

## Related issue number

Closes #12461

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR. -----> rllirllib/agents/trainer.py:1010:48: F821 undefined name 'ActorHandle'
b/agents/trainer.py:1010:48: F821 undefined name 'ActorHandle'
**Not linked to my change**

- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :( ---------> This is a simple tuple to list conversion, it doesn't need a test.
