### PR TITLE
[tune] remove some bottlenecks in trialrunner

### DIFF
--- a/doc/source/tune/user-guide.rst
+++ b/doc/source/tune/user-guide.rst
@@ -687,6 +687,8 @@ These are the environment variables Ray Tune currently considers:
 * **TUNE_RESULT_DIR**: Directory where Tune trial results are stored. If this
   is not set, ``~/ray_results`` will be used.
 * **TUNE_SYNCER_VERBOSITY**: Amount of command output when using Tune with Docker Syncer. Defaults to 0.
+* **TUNE_WARN_THRESHOLD_S**: Threshold for logging if an Tune event loop operation takes too long. Defaults to 0.5 (seconds).
+* **TUNE_STATE_REFRESH_PERIOD**: Frequency of updating the resource tracking from Ray. Defaults to 10 (seconds).
 
 
 There are some environment variables that are mostly relevant for integrated libraries:

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -25,7 +25,7 @@ from ray.tune.utils import warn_if_slow
 
 logger = logging.getLogger(__name__)
 
-RAY_STATE_REFRESH_PERIOD = 10  # Refresh resources every 1 s
+RAY_STATE_REFRESH_PERIOD = 10  # Refresh resources every 10 s
 BOTTLENECK_WARN_PERIOD_S = 60
 NONTRIVIAL_WAIT_TIME_THRESHOLD_S = 1e-3
 DEFAULT_GET_TIMEOUT = 60.0  # seconds

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -25,7 +25,7 @@ from ray.tune.utils import warn_if_slow
 
 logger = logging.getLogger(__name__)
 
-RAY_STATE_REFRESH_PERIOD = 10  # Refresh resources every 10 s
+TUNE_STATE_REFRESH_PERIOD = 10  # Refresh resources every 10 s
 BOTTLENECK_WARN_PERIOD_S = 60
 NONTRIVIAL_WAIT_TIME_THRESHOLD_S = 1e-3
 DEFAULT_GET_TIMEOUT = 60.0  # seconds
@@ -139,7 +139,7 @@ class RayTrialExecutor(TrialExecutor):
                  queue_trials=False,
                  reuse_actors=False,
                  ray_auto_init=None,
-                 refresh_period=RAY_STATE_REFRESH_PERIOD):
+                 refresh_period=None):
         if ray_auto_init is None:
             if os.environ.get("TUNE_DISABLE_AUTO_INIT") == "1":
                 logger.info("'TUNE_DISABLE_AUTO_INIT=1' detected.")
@@ -164,6 +164,11 @@ class RayTrialExecutor(TrialExecutor):
         self._avail_resources = Resources(cpu=0, gpu=0)
         self._committed_resources = Resources(cpu=0, gpu=0)
         self._resources_initialized = False
+
+        if refresh_period is None:
+            refresh_period = float(
+                os.environ.get("TUNE_STATE_REFRESH_PERIOD",
+                               TUNE_STATE_REFRESH_PERIOD))
         self._refresh_period = refresh_period
         self._last_resource_refresh = float("-inf")
         self._last_ip_refresh = float("-inf")

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -25,7 +25,7 @@ from ray.tune.utils import warn_if_slow
 
 logger = logging.getLogger(__name__)
 
-RESOURCE_REFRESH_PERIOD = 0.5  # Refresh resources every 500 ms
+RAY_STATE_REFRESH_PERIOD = 10  # Refresh resources every 1 s
 BOTTLENECK_WARN_PERIOD_S = 60
 NONTRIVIAL_WAIT_TIME_THRESHOLD_S = 1e-3
 DEFAULT_GET_TIMEOUT = 60.0  # seconds
@@ -139,7 +139,7 @@ class RayTrialExecutor(TrialExecutor):
                  queue_trials=False,
                  reuse_actors=False,
                  ray_auto_init=None,
-                 refresh_period=RESOURCE_REFRESH_PERIOD):
+                 refresh_period=RAY_STATE_REFRESH_PERIOD):
         if ray_auto_init is None:
             if os.environ.get("TUNE_DISABLE_AUTO_INIT") == "1":
                 logger.info("'TUNE_DISABLE_AUTO_INIT=1' detected.")
@@ -166,6 +166,8 @@ class RayTrialExecutor(TrialExecutor):
         self._resources_initialized = False
         self._refresh_period = refresh_period
         self._last_resource_refresh = float("-inf")
+        self._last_ip_refresh = float("-inf")
+        self._last_ip_addresses = set()
         self._last_nontrivial_wait = time.time()
         if not ray.is_initialized() and ray_auto_init:
             logger.info("Initializing Ray automatically."
@@ -423,11 +425,17 @@ class RayTrialExecutor(TrialExecutor):
         return list(self._running.values())
 
     def get_alive_node_ips(self):
+        now = time.time()
+        if now - self._last_ip_refresh < self._refresh_period:
+            return self._last_ip_addresses
+        logger.info("Checking ips from Ray state.")
+        self._last_ip_refresh = now
         nodes = ray.state.nodes()
         ip_addresses = set()
         for node in nodes:
             if node["alive"]:
                 ip_addresses.add(node["NodeManagerAddress"])
+        self._last_ip_addresses = ip_addresses
         return ip_addresses
 
     def get_current_trial_ips(self):
@@ -525,6 +533,9 @@ class RayTrialExecutor(TrialExecutor):
             "Resource invalid: {}".format(resources))
 
     def _update_avail_resources(self, num_retries=5):
+        if time.time() - self._last_resource_refresh < self._refresh_period:
+            return
+        logger.info("Checking resources.")
         resources = None
         for i in range(num_retries):
             if i > 0:
@@ -534,10 +545,10 @@ class RayTrialExecutor(TrialExecutor):
                 time.sleep(0.5)
             try:
                 resources = ray.cluster_resources()
-            except Exception:
+            except Exception as exc:
                 # TODO(rliaw): Remove this when local mode is fixed.
                 # https://github.com/ray-project/ray/issues/4147
-                logger.debug("Using resources for local machine.")
+                logger.debug(f"{exc}: Using resources for local machine.")
                 resources = ResourceSpec().resolve(True).to_resource_dict()
             if resources:
                 break
@@ -575,9 +586,7 @@ class RayTrialExecutor(TrialExecutor):
         has exceeded self._refresh_period. This also assumes that the
         cluster is not resizing very frequently.
         """
-        if time.time() - self._last_resource_refresh > self._refresh_period:
-            self._update_avail_resources()
-
+        self._update_avail_resources()
         currently_available = Resources.subtract(self._avail_resources,
                                                  self._committed_resources)
 

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -433,7 +433,7 @@ class RayTrialExecutor(TrialExecutor):
         now = time.time()
         if now - self._last_ip_refresh < self._refresh_period:
             return self._last_ip_addresses
-        logger.info("Checking ips from Ray state.")
+        logger.debug("Checking ips from Ray state.")
         self._last_ip_refresh = now
         nodes = ray.state.nodes()
         ip_addresses = set()
@@ -540,7 +540,7 @@ class RayTrialExecutor(TrialExecutor):
     def _update_avail_resources(self, num_retries=5):
         if time.time() - self._last_resource_refresh < self._refresh_period:
             return
-        logger.info("Checking resources.")
+        logger.debug("Checking Ray cluster resources.")
         resources = None
         for i in range(num_retries):
             if i > 0:

--- a/python/ray/tune/tests/test_actor_reuse.py
+++ b/python/ray/tune/tests/test_actor_reuse.py
@@ -87,6 +87,7 @@ def create_resettable_function(num_resets: defaultdict):
 class ActorReuseTest(unittest.TestCase):
     def setUp(self):
         ray.init(num_cpus=1, num_gpus=0)
+        os.environ["TUNE_STATE_REFRESH_PERIOD"] = "0.1"
 
     def tearDown(self):
         ray.shutdown()

--- a/python/ray/tune/tests/test_cluster.py
+++ b/python/ray/tune/tests/test_cluster.py
@@ -76,6 +76,7 @@ class _PerTrialSyncerCallback(SyncerCallback):
 def start_connected_cluster():
     # Start the Ray processes.
     cluster = _start_new_cluster()
+    os.environ["TUNE_STATE_REFRESH_PERIOD"] = "0.1"
     yield cluster
     # The code after the yield will run as teardown code.
     ray.shutdown()
@@ -98,6 +99,7 @@ def start_connected_emptyhead_cluster():
     _register_all()
     register_trainable("__fake_remote", MockRemoteTrainer)
     register_trainable("__fake_durable", MockDurableTrainer)
+    os.environ["TUNE_STATE_REFRESH_PERIOD"] = "0.1"
     yield cluster
     # The code after the yield will run as teardown code.
     ray.shutdown()

--- a/python/ray/tune/tests/test_run_experiment.py
+++ b/python/ray/tune/tests/test_run_experiment.py
@@ -13,6 +13,9 @@ from ray.tune.trial import Trial, ExportFormat
 
 
 class RunExperimentTest(unittest.TestCase):
+    def setUp(self):
+        os.environ["TUNE_STATE_REFRESH_PERIOD"] = "0.1"
+
     def tearDown(self):
         ray.shutdown()
         _register_all()  # re-register the evicted objects

--- a/python/ray/tune/tests/test_trial_runner_2.py
+++ b/python/ray/tune/tests/test_trial_runner_2.py
@@ -36,6 +36,9 @@ def create_mock_components():
 
 
 class TrialRunnerTest2(unittest.TestCase):
+    def setUp(self):
+        os.environ["TUNE_STATE_REFRESH_PERIOD"] = "0.1"
+
     def tearDown(self):
         ray.shutdown()
         _register_all()  # re-register the evicted objects

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -19,7 +19,6 @@ from ray.tune.trial import Checkpoint, Trial
 from ray.tune.schedulers import FIFOScheduler, TrialScheduler
 from ray.tune.suggest import BasicVariantGenerator
 from ray.tune.utils import warn_if_slow, flatten_dict, env_integer
-from ray.tune.utils.util import profile
 from ray.tune.utils.serialization import TuneFunctionDecoder, \
     TuneFunctionEncoder
 from ray.tune.web_server import TuneServer
@@ -361,7 +360,7 @@ class TrialRunner:
                     trials=self._trials,
                     trial=next_trial)
         elif self.trial_executor.get_running_trials():
-            with warn_if_slow("process_events", threshold=1.0):
+            with warn_if_slow("process_events"):
                 self._process_events()  # blocking
         else:
             self.trial_executor.on_no_available_trials(self)

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -19,6 +19,7 @@ from ray.tune.trial import Checkpoint, Trial
 from ray.tune.schedulers import FIFOScheduler, TrialScheduler
 from ray.tune.suggest import BasicVariantGenerator
 from ray.tune.utils import warn_if_slow, flatten_dict, env_integer
+from ray.tune.utils.util import profile
 from ray.tune.utils.serialization import TuneFunctionDecoder, \
     TuneFunctionEncoder
 from ray.tune.web_server import TuneServer
@@ -360,7 +361,12 @@ class TrialRunner:
                     trials=self._trials,
                     trial=next_trial)
         elif self.trial_executor.get_running_trials():
-            self._process_events()  # blocking
+            with warn_if_slow(
+                    "_process_events", threshold=2.0) as events_timer:
+                with profile() as events_trace:
+                    self._process_events()  # blocking
+            if events_timer.too_slow:
+                events_trace.print_summary()
         else:
             self.trial_executor.on_no_available_trials(self)
 
@@ -453,11 +459,13 @@ class TrialRunner:
             self._update_trial_queue(blocking=wait_for_trial)
         with warn_if_slow("choose_trial_to_run"):
             trial = self._scheduler_alg.choose_trial_to_run(self)
-            logger.debug("Running trial {}".format(trial))
+            if trial:
+                logger.debug("Running trial {}".format(trial))
         return trial
 
     def _process_events(self):
-        failed_trial = self.trial_executor.get_next_failed_trial()
+        with warn_if_slow("get_next_failed_trial"):
+            failed_trial = self.trial_executor.get_next_failed_trial()
         if failed_trial:
             error_msg = (
                 "{} (IP: {}) detected as stale. This is likely because the "
@@ -478,14 +486,14 @@ class TrialRunner:
                         trials=self._trials,
                         trial=trial)
             elif trial.is_saving:
-                with warn_if_slow("process_trial_save") as profile:
+                with warn_if_slow("process_trial_save") as _profile:
                     self._process_trial_save(trial)
                 with warn_if_slow("callbacks.on_trial_save"):
                     self._callbacks.on_trial_save(
                         iteration=self._iteration,
                         trials=self._trials,
                         trial=trial)
-                if profile.too_slow and trial.sync_on_checkpoint:
+                if _profile.too_slow and trial.sync_on_checkpoint:
                     # TODO(ujvl): Suggest using DurableTrainable once
                     #  API has converged.
 

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -361,12 +361,8 @@ class TrialRunner:
                     trials=self._trials,
                     trial=next_trial)
         elif self.trial_executor.get_running_trials():
-            with warn_if_slow(
-                    "_process_events", threshold=2.0) as events_timer:
-                with profile() as events_trace:
-                    self._process_events()  # blocking
-            if events_timer.too_slow:
-                events_trace.print_summary()
+            with warn_if_slow("process_events", threshold=1.0):
+                self._process_events()  # blocking
         else:
             self.trial_executor.on_no_available_trials(self)
 

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -114,37 +114,15 @@ def get_pinned_object(pinned_id):
     return ray.get(pinned_id)
 
 
-class profile:
-    def __init__(self):
-        import cProfile
-        self.pr = cProfile.Profile()
-
-    def __enter__(self):
-        self.pr.enable()
-        return self
-
-    def __exit__(self, type, value, traceback):
-        import pstats, io
-        self.pr.disable()
-        s = io.StringIO()
-        ps = pstats.Stats(self.pr, stream=s)
-        self.stats = ps
-
-    def print_summary(self):
-        self.stats.sort_stats("cumtime").print_stats(0.1)
-        print(self.stats.stream.getvalue())
-        self.stats.stream.truncate(0)
-
-
 class warn_if_slow:
-    """Prints a warning if a given operation is slower than 100ms.
+    """Prints a warning if a given operation is slower than 500ms.
 
     Example:
         >>> with warn_if_slow("some_operation"):
         ...    ray.get(something)
     """
 
-    DEFAULT_THRESHOLD = float(os.environ.get("TUNE_WARN_THRESHOLD_S", 0.3))
+    DEFAULT_THRESHOLD = float(os.environ.get("TUNE_WARN_THRESHOLD_S", 0.5))
 
     def __init__(self, name, threshold=None):
         self.name = name


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

With this change, we no longer see 'Tune results backlogged' with:

```
rllib train --run=A3C --env=CartPole-v0 --config='{"num_workers": 8}' --num-samples=100 --ray-address=auto -vv
```
up to 50 nodes (m5.4xlarge).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(