### PR TITLE
[Docker] Uninstall Typing

### DIFF
--- a/docker/ray-ml/Dockerfile
+++ b/docker/ray-ml/Dockerfile
@@ -15,7 +15,7 @@ RUN sudo apt-get update \
         libgl1-mesa-dev \
     && $HOME/anaconda3/bin/pip --no-cache-dir install -r requirements.txt \ 
     && $HOME/anaconda3/bin/pip --no-cache-dir install -r requirements_ml_docker.txt \
-    && $HOME/anaconda3/bin/pip uninstall dataclasses -y  \ 
+    && $HOME/anaconda3/bin/pip uninstall dataclasses typing -y  \ 
     && sudo rm requirements.txt && sudo rm requirements_ml_docker.txt \
     && sudo apt-get remove cmake gcc -y \
     && sudo apt-get clean

--- a/docker/ray-ml/Dockerfile
+++ b/docker/ray-ml/Dockerfile
@@ -15,6 +15,7 @@ RUN sudo apt-get update \
         libgl1-mesa-dev \
     && $HOME/anaconda3/bin/pip --no-cache-dir install -r requirements.txt \ 
     && $HOME/anaconda3/bin/pip --no-cache-dir install -r requirements_ml_docker.txt \
+    # Remove dataclasses & typing because they are included in Py3.7
     && $HOME/anaconda3/bin/pip uninstall dataclasses typing -y  \ 
     && sudo rm requirements.txt && sudo rm requirements_ml_docker.txt \
     && sudo apt-get remove cmake gcc -y \


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Having `typing` `pip`-installed on `Python > 3.5` can cause problems.
* It appears some libraries do this :'( so we need to manually uninstall 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
