### PR TITLE
[serve] Fix typo in long poll logs

### DIFF
--- a/python/ray/serve/long_poll.py
+++ b/python/ray/serve/long_poll.py
@@ -65,7 +65,7 @@ class LongPollerAsyncClient:
         while True:
             updates: Dict[str, UpdatedObject] = await self._poll_once()
             self._update(updates)
-            logger.debug(f"LongPollerClient received udpates: {updates}")
+            logger.debug(f"LongPollerClient received updates: {updates}")
             for key, updated_object in updates.items():
                 # NOTE(simon): This blocks the loop from doing another poll.
                 # Consider use loop.create_task here or poll first then call


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Was bothering me in the test logs and I don't have another PR to piggyback it onto right now...

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
