### PR TITLE
[Serve] Deflake Serve tests

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -139,6 +139,7 @@ test_python() {
     args+=(
       python/ray/serve/...
       python/ray/tests/...
+      -python/ray/serve:test_api # segfault on windows? https://github.com/ray-project/ray/issues/12541
       -python/ray/tests:test_advanced_2
       -python/ray/tests:test_advanced_3  # test_invalid_unicode_in_worker_log() fails on Windows
       -python/ray/tests:test_autoscaler_aws

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -364,7 +364,16 @@ def test_delete_backend(serve_instance):
     client.create_backend("delete:v1", function2)
     client.set_traffic("delete_backend", {"delete:v1": 1.0})
 
-    assert requests.get("http://127.0.0.1:8000/delete-backend").text == "olleh"
+    for _ in range(10):
+        try:
+            assert requests.get(
+                "http://127.0.0.1:8000/delete-backend").text == "olleh"
+            break
+        except AssertionError:
+            time.sleep(0.5)  # wait for the traffic policy to propogate
+    else:
+        assert requests.get(
+            "http://127.0.0.1:8000/delete-backend").text == "olleh"
 
 
 @pytest.mark.parametrize("route", [None, "/delete-endpoint"])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- Skip windows test https://github.com/ray-project/ray/issues/12541
- Deflake linux test:https://travis-ci.com/github/ray-project/ray/jobs/451299748#L4680-L4727
```
=================================== FAILURES ===================================
_____________________________ test_delete_backend ______________________________
serve_instance = <ray.serve.api.Client object at 0x1122e6ef0>
    def test_delete_backend(serve_instance):
        client = serve_instance
    
        def function(_):
            return "hello"
    
        client.create_backend("delete:v1", function)
        client.create_endpoint(
            "delete_backend", backend="delete:v1", route="/delete-backend")
    
        assert requests.get("http://127.0.0.1:8000/delete-backend").text == "hello"
    
        # Check that we can't delete the backend while it's in use.
        with pytest.raises(ValueError):
            client.delete_backend("delete:v1")
    
        client.create_backend("delete:v2", function)
        client.set_traffic("delete_backend", {"delete:v1": 0.5, "delete:v2": 0.5})
    
        with pytest.raises(ValueError):
            client.delete_backend("delete:v1")
    
        # Check that the backend can be deleted once it's no longer in use.
        client.set_traffic("delete_backend", {"delete:v2": 1.0})
        client.delete_backend("delete:v1")
    
        # Check that we can no longer use the previously deleted backend.
        with pytest.raises(ValueError):
            client.set_traffic("delete_backend", {"delete:v1": 1.0})
    
        def function2(_):
            return "olleh"
    
        # Check that we can now reuse the previously delete backend's tag.
        client.create_backend("delete:v1", function2)
        client.set_traffic("delete_backend", {"delete:v1": 1.0})
    
>       assert requests.get("http://127.0.0.1:8000/delete-backend").text == "olleh"
E       AssertionError: assert 'hello' == 'olleh'
E         - olleh
E         + hello
/Users/travis/build/ray-project/ray/python/ray/serve/tests/test_api.py:367: AssertionError
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
