### PR TITLE
[tune] trim kwargs in shim instantiation functions

### DIFF
--- a/python/ray/tune/schedulers/__init__.py
+++ b/python/ray/tune/schedulers/__init__.py
@@ -1,3 +1,4 @@
+from ray.utils import get_function_args
 from ray.tune.schedulers.trial_scheduler import TrialScheduler, FIFOScheduler
 from ray.tune.schedulers.hyperband import HyperBandScheduler
 from ray.tune.schedulers.hb_bohb import HyperBandForBOHB
@@ -53,7 +54,11 @@ def create_scheduler(
             f"Got: {scheduler}")
 
     SchedulerClass = SCHEDULER_IMPORT[scheduler]
-    return SchedulerClass(**kwargs)
+
+    scheduler_args = get_function_args(SchedulerClass)
+    trimmed_kwargs = {k: v for k, v in kwargs.items() if k in scheduler_args}
+
+    return SchedulerClass(**trimmed_kwargs)
 
 
 __all__ = [

--- a/python/ray/tune/suggest/__init__.py
+++ b/python/ray/tune/suggest/__init__.py
@@ -1,5 +1,3 @@
-import inspect
-
 from ray.utils import get_function_args
 from ray.tune.suggest.search import SearchAlgorithm
 from ray.tune.suggest.basic_variant import BasicVariantGenerator

--- a/python/ray/tune/suggest/__init__.py
+++ b/python/ray/tune/suggest/__init__.py
@@ -1,3 +1,4 @@
+import inspect
 from ray.tune.suggest.search import SearchAlgorithm
 from ray.tune.suggest.basic_variant import BasicVariantGenerator
 from ray.tune.suggest.suggestion import Searcher, ConcurrencyLimiter
@@ -93,7 +94,15 @@ def create_searcher(
             f"Got: {search_alg}")
 
     SearcherClass = SEARCH_ALG_IMPORT[search_alg]()
-    return SearcherClass(**kwargs)
+
+    search_alg_defined_args = inspect.getfullargspec(SearcherClass).args
+    search_alg_input_args = {}
+
+    for arg, value in kwargs.items():
+        if arg in search_alg_defined_args:
+            search_alg_input_args[arg] = value
+
+    return SearcherClass(**search_alg_input_args)
 
 
 __all__ = [

--- a/python/ray/tune/suggest/__init__.py
+++ b/python/ray/tune/suggest/__init__.py
@@ -1,4 +1,6 @@
 import inspect
+
+from ray.utils import get_function_args
 from ray.tune.suggest.search import SearchAlgorithm
 from ray.tune.suggest.basic_variant import BasicVariantGenerator
 from ray.tune.suggest.suggestion import Searcher, ConcurrencyLimiter
@@ -95,14 +97,10 @@ def create_searcher(
 
     SearcherClass = SEARCH_ALG_IMPORT[search_alg]()
 
-    search_alg_defined_args = inspect.getfullargspec(SearcherClass).args
-    search_alg_input_args = {}
+    search_alg_args = get_function_args(SearcherClass)
+    trimmed_kwargs = {k: v for k, v in kwargs.items() if k in search_alg_args}
 
-    for arg, value in kwargs.items():
-        if arg in search_alg_defined_args:
-            search_alg_input_args[arg] = value
-
-    return SearcherClass(**search_alg_input_args)
+    return SearcherClass(**trimmed_kwargs)
 
 
 __all__ = [

--- a/python/ray/tune/tests/test_api.py
+++ b/python/ray/tune/tests/test_api.py
@@ -1153,6 +1153,15 @@ class ShimCreationTest(unittest.TestCase):
         real_searcher_hyperopt = HyperOptSearch({}, **kwargs)
         assert type(shim_searcher_hyperopt) is type(real_searcher_hyperopt)
 
+    def testExtraParams(self):
+        kwargs = {"metric": "metric_foo", "mode": "min", "extra_param": "test"}
+
+        scheduler = "async_hyperband"
+        tune.create_scheduler(scheduler, **kwargs)
+
+        searcher_ax = "ax"
+        tune.create_searcher(searcher_ax, **kwargs)
+
 
 class ApiTestFast(unittest.TestCase):
     @classmethod

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -4,7 +4,6 @@ import hashlib
 import inspect
 import logging
 import multiprocessing
-import numpy as np
 import os
 import signal
 import subprocess
@@ -13,11 +12,13 @@ import tempfile
 import threading
 import time
 import uuid
+from inspect import signature
 
+import numpy as np
+import psutil
 import ray
 import ray.gcs_utils
 import ray.ray_constants as ray_constants
-import psutil
 
 pwd = None
 if sys.platform != "win32":
@@ -854,3 +855,8 @@ def get_user():
         return pwd.getpwuid(os.getuid()).pw_name
     except Exception:
         return ""
+
+
+def get_function_args(callable):
+    all_parameters = frozenset(signature(callable).parameters)
+    return list(all_parameters)


### PR DESCRIPTION
Resolves Issue #12351 

The motivation is if the User passes extra params to `tune.create_searcher` in kwargs for the search algs' `__init__` methods, it shouldn't raise an error and ignore the unexpected keyword arguments.