### PR TITLE
[Windows] Fix windows build

### DIFF
--- a/ci/remote-watch.py
+++ b/ci/remote-watch.py
@@ -249,7 +249,6 @@ def main(program, *args):
     skipped_repos = parsed_args.skip_repo or []
     repo_slug = get_repo_slug()
     event_name = get_ci_event_name()
-    result = None
     if repo_slug not in skipped_repos or event_name == "pull_request":
         result = monitor()
     else:

--- a/ci/remote-watch.py
+++ b/ci/remote-watch.py
@@ -249,6 +249,7 @@ def main(program, *args):
     skipped_repos = parsed_args.skip_repo or []
     repo_slug = get_repo_slug()
     event_name = get_ci_event_name()
+    result = None
     if repo_slug not in skipped_repos or event_name == "pull_request":
         result = monitor()
     else:

--- a/src/ray/raylet/test/local_object_manager_test.cc
+++ b/src/ray/raylet/test/local_object_manager_test.cc
@@ -232,17 +232,16 @@ class LocalObjectManagerTest : public ::testing::Test {
   LocalObjectManagerTest()
       : owner_client(std::make_shared<MockWorkerClient>()),
         client_pool([&](const rpc::Address &addr) { return owner_client; }),
-        manager(
-            io_service_, free_objects_batch_size,
-            /*free_objects_period_ms=*/1000, worker_pool, object_table, client_pool,
-            /*object_pinning_enabled=*/true,
-            /*automatic_object_delete_enabled=*/true,
-            [&](const std::vector<ObjectID> &object_ids) {
-              for (const auto &object_id : object_ids) {
-                freed.insert(object_id);
-              }
-            },
-            [&]() { num_callbacks_fired++; }),
+        manager(io_service_, free_objects_batch_size,
+                /*free_objects_period_ms=*/1000, worker_pool, object_table, client_pool,
+                /*object_pinning_enabled=*/true,
+                /*automatic_object_delete_enabled=*/true,
+                [&](const std::vector<ObjectID> &object_ids) {
+                  for (const auto &object_id : object_ids) {
+                    freed.insert(object_id);
+                  }
+                },
+                [&]() { num_callbacks_fired++; }),
         unpins(std::make_shared<std::unordered_map<ObjectID, int>>()) {
     RayConfig::instance().initialize({{"object_spilling_config", "mock_config"}});
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

The windows build has been broken since #12341 
The error is [here](https://github.com/ray-project/ray/runs/1482605583#step:7:630) and is basically the following for the `src/ray/raylet/test/local_object_manager_test.cc`:
```
error C2338: The C++ Standard forbids containers of const elements because allocator<const T> is ill-formed.
note: see reference to class template instantiation 'std::_Default_allocator_traits<_Alloc>' being compiled
        with
        [
            _Alloc=std::allocator<const ray::rpc::DeleteSpilledObjectsRequest>
        ]
```

NOTE: This is _separate_ from the Serve test failure :'( 

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number



<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
