### PR TITLE
[Hotfix] Pin llvmlite for windows build

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -54,6 +54,8 @@ moto
 mypy
 networkx
 numba
+# higher version of llvmlite breaks windows
+llvmlite==0.34.0
 openpyxl
 Pillow; platform_system != "Windows"
 pygments


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
https://github.com/ray-project/ray/runs/1483531169#step:7:200
```
  ERROR: Command errored out with exit status 1:
     command: '\''c:\hostedtoolcache\windows\python\3.7.9\x64\python.exe'\'' -u -c '\''import sys, setuptools, tokenize; sys.argv[0] = '\''"'\''"'\''C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\pip-install-uupr7nyj\\llvmlite_51e85716ab2d4ee7a3d9388cf90710a6\\setup.py'\''"'\''"'\''; __file__='\''"'\''"'\''C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\pip-install-uupr7nyj\\llvmlite_51e85716ab2d4ee7a3d9388cf90710a6\\setup.py'\''"'\''"'\'';f=getattr(tokenize, '\''"'\''"'\''open'\''"'\''"'\'', open)(__file__);code=f.read().replace('\''"'\''"'\''\r\n'\''"'\''"'\'', '\''"'\''"'\''\n'\''"'\''"'\'');f.close();exec(compile(code, __file__, '\''"'\''"'\''exec'\''"'\''"'\''))'\'' install --record '\''C:\Users\RUNNER~1\AppData\Local\Temp\pip-record-g4huwcso\install-record.txt'\'' --single-version-externally-managed --compile --install-headers '\''c:\hostedtoolcache\windows\python\3.7.9\x64\Include\llvmlite'\''
         cwd: C:\Users\RUNNER~1\AppData\Local\Temp\pip-install-uupr7nyj\llvmlite_51e85716ab2d4ee7a3d9388cf90710a6\
    Complete output (28 lines):
    running install
    running build
    got version from file C:\Users\RUNNER~1\AppData\Local\Temp\pip-install-uupr7nyj\llvmlite_51e85716ab2d4ee7a3d9388cf90710a6\llvmlite/_version.py {'\''version'\'': '\''0.35.0'\'', '\''full'\'': '\''ea23b026930cc00824c907172383f54c9d438e6b'\''}
    running build_ext
    c:\hostedtoolcache\windows\python\3.7.9\x64\python.exe C:\Users\RUNNER~1\AppData\Local\Temp\pip-install-uupr7nyj\llvmlite_51e85716ab2d4ee7a3d9388cf90710a6\ffi\build.py
    CMake Error at CMakeLists.txt:3 (project):
      Generator
    
        Visual Studio 15 2017 Win64
    
      could not find any instance of Visual Studio.
    
    
    
    -- Configuring incomplete, errors occurred!
    See also "C:/Users/runneradmin/AppData/Local/Temp/tmp8w_se5rm/CMakeFiles/CMakeOutput.log".
    Trying generator '\''Visual Studio 15 2017 Win64'\''
    Traceback (most recent call last):
      File "C:\Users\RUNNER~1\AppData\Local\Temp\pip-install-uupr7nyj\llvmlite_51e85716ab2d4ee7a3d9388cf90710a6\ffi\build.py", line 191, in <module>
        main()
      File "C:\Users\RUNNER~1\AppData\Local\Temp\pip-install-uupr7nyj\llvmlite_51e85716ab2d4ee7a3d9388cf90710a6\ffi\build.py", line 179, in main
        main_win32()
      File "C:\Users\RUNNER~1\AppData\Local\Temp\pip-install-uupr7nyj\llvmlite_51e85716ab2d4ee7a3d9388cf90710a6\ffi\build.py", line 88, in main_win32
        generator = find_win32_generator()
      File "C:\Users\RUNNER~1\AppData\Local\Temp\pip-install-uupr7nyj\llvmlite_51e85716ab2d4ee7a3d9388cf90710a6\ffi\build.py", line 84, in find_win32_generator
        raise RuntimeError("No compatible cmake generator installed on this machine")
    RuntimeError: No compatible cmake generator installed on this machine
    error: command '\''c:\\hostedtoolcache\\windows\\python\\3.7.9\\x64\\python.exe'\'' failed with exit status 1
    ----------------------------------------
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
