### PR TITLE
[PlacementGroup]Fix bug that kill workers mistakenly when gcs restarts

### DIFF
--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -36,15 +36,18 @@ def test_gcs_server_restart(ray_start_regular):
     ray.worker._global_node.kill_gcs_server()
     ray.worker._global_node.start_gcs_server()
 
-    result = ray.get(actor1.method.remote(7))
-    assert result == 9
-
     actor2 = Increase.remote()
     result = ray.get(actor2.method.remote(2))
     assert result == 4
 
     result = ray.get(increase.remote(1))
     assert result == 2
+
+    # Check whether actor1 is alive or not.
+    # NOTE: We can't execute it immediately after gcs restarts
+    # because it takes time for the worker to exit.
+    result = ray.get(actor1.method.remote(7))
+    assert result == 9
 
 
 @pytest.mark.parametrize(

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -1249,7 +1249,7 @@ def test_create_placement_group_during_gcs_server_restart(
     cluster.head_node.kill_gcs_server()
     cluster.head_node.start_gcs_server()
 
-    for i in range(0, 10):
+    for i in range(0, 100):
         ray.get(placement_groups[i].ready())
 
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -578,7 +578,7 @@ void NodeManager::HandleReleaseUnusedBundles(
     auto &worker = worker_it.second;
     const auto &bundle_id = worker->GetBundleId();
     // We need to filter out the workers used by placement group.
-    if (!bundle_id.first.IsNil() && 0 == in_use_bundles.count(worker->GetBundleId())) {
+    if (!bundle_id.first.IsNil() && 0 == in_use_bundles.count(bundle_id)) {
       workers_associated_with_unused_bundles.emplace_back(worker);
     }
   }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -576,7 +576,9 @@ void NodeManager::HandleReleaseUnusedBundles(
   std::vector<std::shared_ptr<WorkerInterface>> workers_associated_with_unused_bundles;
   for (const auto &worker_it : leased_workers_) {
     auto &worker = worker_it.second;
-    if (0 == in_use_bundles.count(worker->GetBundleId())) {
+    const auto &bundle_id = worker->GetBundleId();
+    // We need to filter out the workers used by placement group.
+    if (!bundle_id.first.IsNil() && 0 == in_use_bundles.count(worker->GetBundleId())) {
       workers_associated_with_unused_bundles.emplace_back(worker);
     }
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When gcs restarts, it will notify raylet to release unused bundles. We need to filter out the workers used by placement group, otherwise we will kill workers mistakenly which do not belong to placement group.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
