### PR TITLE
[Utils] Add Queue async and batch methods

### DIFF
--- a/python/ray/tests/test_queue.py
+++ b/python/ray/tests/test_queue.py
@@ -160,8 +160,8 @@ def test_batch(ray_start_regular_shared):
         q.get_nowait_batch(1)
 
     big_q = Queue(100)
-    big_q.put_nowait_batch([i for i in range(100)])
-    assert big_q.get_nowait_batch(100) == [i for i in range(100)]
+    big_q.put_nowait_batch(range(100))
+    assert big_q.get_nowait_batch(100) == range(100)
 
 
 def test_qsize(ray_start_regular_shared):

--- a/python/ray/tests/test_queue.py
+++ b/python/ray/tests/test_queue.py
@@ -4,6 +4,7 @@ import ray
 from ray.exceptions import GetTimeoutError
 from ray.util.queue import Queue, Empty, Full
 
+
 # Remote helper functions for testing concurrency
 @ray.remote
 def async_get(queue):
@@ -49,6 +50,7 @@ def test_get(ray_start_regular_shared):
     with pytest.raises(Empty):
         q.get(timeout=0.2)
 
+
 @pytest.mark.asyncio
 async def test_get_async(ray_start_regular_shared):
 
@@ -69,7 +71,8 @@ async def test_get_async(ray_start_regular_shared):
         await q.get_async(block=False)
 
     with pytest.raises(Empty):
-        await q.get_async(timeout=0.2)    
+        await q.get_async(timeout=0.2)
+
 
 def test_put(ray_start_regular_shared):
 
@@ -93,6 +96,7 @@ def test_put(ray_start_regular_shared):
     with pytest.raises(Full):
         q.put(1, timeout=0.2)
 
+
 @pytest.mark.asyncio
 async def test_put_async(ray_start_regular_shared):
 
@@ -115,6 +119,7 @@ async def test_put_async(ray_start_regular_shared):
 
     with pytest.raises(Full):
         await q.put_async(1, timeout=0.2)
+
 
 def test_concurrent_get(ray_start_regular_shared):
     q = Queue()
@@ -144,18 +149,20 @@ def test_concurrent_put(ray_start_regular_shared):
     assert q.get() == 1
     assert q.get() == 2
 
+
 def test_batch(ray_start_regular_shared):
     q = Queue(1)
 
     with pytest.raises(Full):
-        q.put_nowait_batch([1,2])
-    
+        q.put_nowait_batch([1, 2])
+
     with pytest.raises(Empty):
         q.get_nowait_batch(1)
 
     big_q = Queue(100)
     big_q.put_nowait_batch([i for i in range(100)])
     assert big_q.get_nowait_batch(100) == [i for i in range(100)]
+
 
 def test_qsize(ray_start_regular_shared):
 

--- a/python/ray/tests/test_queue.py
+++ b/python/ray/tests/test_queue.py
@@ -160,8 +160,8 @@ def test_batch(ray_start_regular_shared):
         q.get_nowait_batch(1)
 
     big_q = Queue(100)
-    big_q.put_nowait_batch(range(100))
-    assert big_q.get_nowait_batch(100) == range(100)
+    big_q.put_nowait_batch(list(range(100)))
+    assert big_q.get_nowait_batch(100) == list(range(100))
 
 
 def test_qsize(ray_start_regular_shared):

--- a/python/ray/tests/test_queue.py
+++ b/python/ray/tests/test_queue.py
@@ -4,7 +4,7 @@ import ray
 from ray.exceptions import GetTimeoutError
 from ray.util.queue import Queue, Empty, Full
 
-
+# Remote helper functions for testing concurrency
 @ray.remote
 def async_get(queue):
     return queue.get(block=True)
@@ -49,6 +49,27 @@ def test_get(ray_start_regular_shared):
     with pytest.raises(Empty):
         q.get(timeout=0.2)
 
+@pytest.mark.asyncio
+async def test_get_async(ray_start_regular_shared):
+
+    q = Queue()
+
+    item = 0
+    await q.put_async(item)
+    assert await q.get_async(block=False) == item
+
+    item = 1
+    await q.put_async(item)
+    assert await q.get_async(timeout=0.2) == item
+
+    with pytest.raises(ValueError):
+        await q.get_async(timeout=-1)
+
+    with pytest.raises(Empty):
+        await q.get_async(block=False)
+
+    with pytest.raises(Empty):
+        await q.get_async(timeout=0.2)    
 
 def test_put(ray_start_regular_shared):
 
@@ -72,8 +93,30 @@ def test_put(ray_start_regular_shared):
     with pytest.raises(Full):
         q.put(1, timeout=0.2)
 
+@pytest.mark.asyncio
+async def test_put_async(ray_start_regular_shared):
 
-def test_async_get(ray_start_regular_shared):
+    q = Queue(1)
+
+    item = 0
+    await q.put_async(item, block=False)
+    assert await q.get_async() == item
+
+    item = 1
+    await q.put_async(item, timeout=0.2)
+    assert await q.get_async() == item
+
+    with pytest.raises(ValueError):
+        await q.put_async(0, timeout=-1)
+
+    await q.put_async(0)
+    with pytest.raises(Full):
+        await q.put_async(1, block=False)
+
+    with pytest.raises(Full):
+        await q.put_async(1, timeout=0.2)
+
+def test_concurrent_get(ray_start_regular_shared):
     q = Queue()
     future = async_get.remote(q)
 
@@ -87,7 +130,7 @@ def test_async_get(ray_start_regular_shared):
     assert ray.get(future) == 1
 
 
-def test_async_put(ray_start_regular_shared):
+def test_concurrent_put(ray_start_regular_shared):
     q = Queue(1)
     q.put(1)
     future = async_put.remote(q, 2)
@@ -101,6 +144,18 @@ def test_async_put(ray_start_regular_shared):
     assert q.get() == 1
     assert q.get() == 2
 
+def test_batch(ray_start_regular_shared):
+    q = Queue(1)
+
+    with pytest.raises(Full):
+        q.put_nowait_batch([1,2])
+    
+    with pytest.raises(Empty):
+        q.get_nowait_batch(1)
+
+    big_q = Queue(100)
+    big_q.put_nowait_batch([i for i in range(100)])
+    assert big_q.get_nowait_batch(100) == [i for i in range(100)]
 
 def test_qsize(ray_start_regular_shared):
 

--- a/python/ray/util/queue.py
+++ b/python/ray/util/queue.py
@@ -197,8 +197,10 @@ class Queue:
             raise ValueError("'num_items' must be nonnegative")
         if num_items > self.qsize():
             raise Empty("Cannot get " + str(num_items) +
-                       " items from queue of size " + str(self.qsize()))
+                        " items from queue of size " + str(self.qsize()))
         return ray.get(self.actor.get_nowait_batch.remote(num_items))
+
+
 @ray.remote
 class _QueueActor:
     def __init__(self, maxsize):

--- a/python/ray/util/queue.py
+++ b/python/ray/util/queue.py
@@ -12,8 +12,9 @@ class Full(Exception):
 
 
 class Queue:
-    """A first-in, first-out queue implementation on Ray.  The behavior and use
-    cases are similar to those of the asyncio.Queue class.
+    """A first-in, first-out queue implementation on Ray. 
+    
+    The behavior and use cases are similar to those of the asyncio.Queue class.
 
     Features both sync and async put and get methods.  Provides the option to
     block until space is available when calling put on a full queue,

--- a/python/ray/util/queue.py
+++ b/python/ray/util/queue.py
@@ -38,33 +38,33 @@ class Queue:
         >>>     assert item == q.get()
     """
 
-    def __init__(self, maxsize: int = 0):
+    def __init__(self, maxsize: int = 0) -> None:
         self.maxsize = maxsize
         self.actor = _QueueActor.remote(self.maxsize)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self.size()
 
-    def size(self):
+    def size(self) -> int:
         """The size of the queue."""
         return ray.get(self.actor.qsize.remote())
 
-    def qsize(self):
+    def qsize(self) -> int:
         """The size of the queue."""
         return self.size()
 
-    def empty(self):
+    def empty(self) -> bool:
         """Whether the queue is empty."""
         return ray.get(self.actor.empty.remote())
 
-    def full(self):
+    def full(self) -> bool:
         """Whether the queue is full."""
         return ray.get(self.actor.full.remote())
 
     def put(self,
             item: Any,
             block: bool = True,
-            timeout: Optional[float] = None):
+            timeout: Optional[float] = None) -> None:
         """Adds an item to the queue.
 
         If block is True and the queue is full, blocks until the queue is no
@@ -92,7 +92,7 @@ class Queue:
     async def put_async(self,
                         item: Any,
                         block: bool = True,
-                        timeout: Optional[float] = None):
+                        timeout: Optional[float] = None) -> None:
         """Adds an item to the queue.
 
         If block is True and the queue is full,
@@ -117,7 +117,7 @@ class Queue:
             else:
                 await self.actor.put.remote(item, timeout)
 
-    def get(self, block: bool = True, timeout: Optional[float] = None):
+    def get(self, block: bool = True, timeout: Optional[float] = None) -> Any:
         """Gets an item from the queue.
 
         If block is True and the queue is empty, blocks until the queue is no
@@ -147,7 +147,7 @@ class Queue:
 
     async def get_async(self,
                         block: bool = True,
-                        timeout: Optional[float] = None):
+                        timeout: Optional[float] = None) -> Any:
         """Gets an item from the queue.
 
         There is no guarantee of order if multiple consumers get from the
@@ -171,7 +171,7 @@ class Queue:
             else:
                 return await self.actor.get.remote(timeout)
 
-    def put_nowait(self, item: Any):
+    def put_nowait(self, item: Any) -> None:
         """Equivalent to put(item, block=False).
 
         Raises:
@@ -179,7 +179,7 @@ class Queue:
         """
         return self.put(item, block=False)
 
-    def put_nowait_batch(self, items: Iterable):
+    def put_nowait_batch(self, items: Iterable) -> None:
         """Takes in a list of items and puts them into the queue in order.
 
         Raises:
@@ -190,7 +190,7 @@ class Queue:
 
         ray.get(self.actor.put_nowait_batch.remote(items))
 
-    def get_nowait(self):
+    def get_nowait(self) -> Any:
         """Equivalent to get(block=False).
 
         Raises:
@@ -198,7 +198,7 @@ class Queue:
         """
         return self.get(block=False)
 
-    def get_nowait_batch(self, num_items: int):
+    def get_nowait_batch(self, num_items: int) -> List[Any]:
         """Gets items from the queue and returns them in a
         list in order.
 

--- a/python/ray/util/queue.py
+++ b/python/ray/util/queue.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Optional, Any
+from typing import Optional, Any, List
 from collections.abc import Iterable
 
 import ray

--- a/python/ray/util/queue.py
+++ b/python/ray/util/queue.py
@@ -37,6 +37,7 @@ class Queue:
         >>> for item in items:
         >>>     assert item == q.get()
     """
+
     def __init__(self, maxsize: int = 0) -> None:
         self.maxsize = maxsize
         self.actor = _QueueActor.remote(self.maxsize)

--- a/python/ray/util/queue.py
+++ b/python/ray/util/queue.py
@@ -246,9 +246,8 @@ class _QueueActor:
     def put_nowait_batch(self, items):
         # If maxsize is 0, queue is unbounded, so no need to check size.
         if self.maxsize > 0 and len(items) + self.qsize() > self.maxsize:
-            raise Full("Cannot add " + str(len(items)) +
-                       " items to queue of size " + str(self.qsize()) +
-                       " and maxsize " + str(self.maxsize))
+            raise Full(f"Cannot add {len(items)} items to queue of size "
+                       f"{self.qsize()} and maxsize {self.maxsize}.")
         for item in items:
             self.queue.put_nowait(item)
 
@@ -257,6 +256,6 @@ class _QueueActor:
 
     def get_nowait_batch(self, num_items):
         if num_items > self.qsize():
-            raise Empty("Cannot get " + str(num_items) +
-                        " items from queue of size " + str(self.qsize()))
+            raise Empty(f"Cannot get {num_items} items from queue of size "
+                        f"{self.qsize()}.")
         return [self.queue.get_nowait() for _ in range(num_items)]

--- a/python/ray/util/queue.py
+++ b/python/ray/util/queue.py
@@ -12,7 +12,11 @@ class Full(Exception):
 
 
 class Queue:
-    """Queue implementation on Ray.
+    """A first-in, first-out queue implementation on Ray.  The behavior and use
+    cases are similar to those of the asyncio.Queue class.
+
+    Features both sync and async put and get methods, optional blocking, and
+    batching.
 
     Args:
         maxsize (int): maximum size of the queue. If zero, size is unbounded.

--- a/python/ray/util/queue.py
+++ b/python/ray/util/queue.py
@@ -37,7 +37,6 @@ class Queue:
         >>> for item in items:
         >>>     assert item == q.get()
     """
-
     def __init__(self, maxsize: int = 0) -> None:
         self.maxsize = maxsize
         self.actor = _QueueActor.remote(self.maxsize)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->


## Why are these changes needed?


When `Queue.get` is called on an empty queue, previously we would block until something was put into the queue, and similarly when calling `Queue.put` on a full queue we would block until space was created.  This PR provides `async` get and put methods so that other computations can be done during this blocking situation.

When putting or getting large numbers of small items into the queue, serialization overhead becomes significant.  Previously, there would be a remote call for each item.  This PR provides batched put and get methods, so there is only one remote call for each batch.

This PR also cleans up and adds more details to the documentation.

The batched put and get methods are `sync` and don't support blocking as described above.  This seems appropriate for the use case of, say, quickly grabbing or dumping 10000 strings from the queue.  A future PR could provide `async` versions of the batched put and get, and an option for blocking for batched put and get.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/11162.
Closes https://github.com/ray-project/ray/issues/11443.
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
