### PR TITLE
[Dashboard][Bugfix] Filter dead nodes from Machine View (fixes duplicate node issue)

### DIFF
--- a/dashboard/client/src/api.ts
+++ b/dashboard/client/src/api.ts
@@ -112,7 +112,7 @@ export type NodeDetails = {
 } & BaseNodeInfo;
 
 export type RayletData = {
-  // Merger of GCSNodeStats and GetNodeStatsReply
+  // Merger of GCSNodeInfo and GetNodeStatsReply
   // GetNodeStatsReply fields.
   // Note workers are in an array in NodeDetails
   objectStoreUsedMemory: number;

--- a/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
@@ -139,7 +139,10 @@ const useNodeInfoStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-const nodesSelector = (state: StoreState) => state.dashboard?.nodeInfo?.clients;
+// Dead node payloads don't contain the full information needed to render
+// so we filter them out here.
+const liveNodesSelector = (state: StoreState) =>
+  state.dashboard?.nodeInfo?.clients.filter(node => node.raylet.state === "ALIVE");
 
 type DialogState = {
   nodeIp: string;
@@ -170,7 +173,7 @@ const NodeInfo: React.FC<{}> = () => {
   const toggleOrder = () => setOrder(order === "asc" ? "desc" : "asc");
   const [orderBy, setOrderBy] = React.useState<nodeInfoColumnId | null>(null);
   const classes = useNodeInfoStyles();
-  const nodes = useSelector(nodesSelector);
+  const nodes = useSelector(liveNodesSelector);
   if (!nodes) {
     return <Typography color="textSecondary">Loading...</Typography>;
   }

--- a/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
@@ -142,7 +142,9 @@ const useNodeInfoStyles = makeStyles((theme: Theme) =>
 // Dead node payloads don't contain the full information needed to render
 // so we filter them out here.
 const liveNodesSelector = (state: StoreState) =>
-  state.dashboard?.nodeInfo?.clients.filter(node => node.raylet.state === "ALIVE");
+  state.dashboard?.nodeInfo?.clients.filter(
+    (node) => node.raylet.state === "ALIVE",
+  );
 
 type DialogState = {
   nodeIp: string;


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We were displaying duplicate entries for various nodes on the Machine View when the raylet process would be killed or die/crash, and a new one begun. This is because each time a raylet process is started, this counts as a new "Node" data structure that gets stored in the dashboard's memory store. 

This data may be useful later, but currently it is confusing when it gets displayed as it looks the same as a live node. Further, it can cause the page to crash because the full data structure is not present when the node is in a DEAD state, leading to the issue here: https://github.com/ray-project/ray/issues/12554

I was able to locally repro the issue with the following script, as well as verify that the issue was gone with the change in-place.
```
def main():
    max_nodes = 4
    cluster = start_ray_cluster(max_nodes)
    nodes = ray.nodes()
    print(f"There are {len(nodes)} nodes")
    print(f"Their payload looks like: ")
    pprint.pprint(nodes)
    while True:
        cluster_nodes = get_other_nodes(cluster)
        if len(cluster_nodes) > 1:
            cluster.remove_node(cluster_nodes[-1])
            cluster.wait_for_nodes()
        time.sleep(10)
        nodes = ray.nodes()
        print(f"There are {len(nodes)} nodes")
        print(f"Their payload looks like: ")
        pprint.pprint(nodes)


def start_ray_cluster(num_nodes):
    num_redis_shards = 2
    redis_max_memory = 10**8

    cluster = Cluster()
    for i in range(num_nodes):
        cluster.add_node(
            redis_port=6379 if i == 0 else None,
            num_redis_shards=num_redis_shards if i == 0 else None,
            num_cpus=2 if i == 0 else 1,
            num_gpus=0,
            resources={str(i): 500},
            object_store_memory = 10**8,
            redis_max_memory=redis_max_memory)
    ray.init(address=cluster.address)

    return cluster

if __name__ == '__main__':
    main()
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #12363

Also related is the GPU issue I linked above. This is a bandage for it, but at some point I'll want to make a broader fix around what data is guaranteed to be present in the node payload vs not, as I think the current type script API definition is not perfect.

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
