### PR TITLE
[Metrics] Fix the invalid metrics name issue

### DIFF
--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -36,11 +36,11 @@ static Histogram GcsLatency("gcs_latency",
 /// Raylet Metrics
 ///
 static Gauge LocalAvailableResource("local_available_resource",
-                                    "The available resources on this node.", "pcs",
+                                    "The available resources on this node.", "",
                                     {ResourceNameKey});
 
 static Gauge LocalTotalResource("local_total_resource",
-                                "The total resources on this node.", "pcs",
+                                "The total resources on this node.", "",
                                 {ResourceNameKey});
 
 static Gauge LiveActors("live_actors", "Number of live actors.", "actors");
@@ -101,11 +101,11 @@ static Count UnintentionalWorkerFailures(
     "unintentional_worker_failures_total",
     "Number of worker failures that are not intentional. For example, worker failures "
     "due to system related errors.",
-    "worker_failures");
+    "");
 
 static Count NodeFailureTotal(
     "node_failure_total", "Number of node failures that have happened in the cluster.",
-    "node_failures.");
+    "");
 
 static Gauge PendingActors("pending_actors", "Number of pending actors in GCS server.",
                            "actors");


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Prometheus exporter always tries to append the units at the end of the name. I had a metric with unit `node_failures.`, and this caused the failure.

I also removed units or tried to match with the appendix of every string.

```python3
class Metric(object):
    """A single metric family and its samples.

    This is intended only for internal use by the instrumentation client.

    Custom collectors should use GaugeMetricFamily, CounterMetricFamily
    and SummaryMetricFamily instead.
    """

    def __init__(self, name, documentation, typ, unit=''):
        if unit and not name.endswith("_" + unit):
            name += "_" + unit
        if not METRIC_NAME_RE.match(name):
            raise ValueError('Invalid metric name: ' + name)
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
