### PR TITLE
[tune] Callable accepted for register_env

### DIFF
--- a/python/ray/tune/registry.py
+++ b/python/ray/tune/registry.py
@@ -79,11 +79,11 @@ def register_env(name, env_creator):
 
     Args:
         name (str): Name to register.
-        env_creator (obj): Function that creates an env.
+        env_creator (obj): Callable that creates an env.
     """
 
-    if not isinstance(env_creator, FunctionType):
-        raise TypeError("Second argument must be a function.", env_creator)
+    if not callable(env_creator):
+        raise TypeError("Second argument must be callable.", env_creator)
     _global_registry.register(ENV_CREATOR, name, env_creator)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In tune, register_env should accept any `callable` like `functools.partial`. This PR only modifies the checks for `FunctionType` and related docstrings.

## Related issue number

Closes #12575 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
