### PR TITLE
Including last step in OPE

### DIFF
--- a/rllib/offline/is_estimator.py
+++ b/rllib/offline/is_estimator.py
@@ -18,7 +18,7 @@ class ImportanceSamplingEstimator(OffPolicyEstimator):
 
         # calculate importance ratios
         p = []
-        for t in range(batch.count - 1):
+        for t in range(batch.count):
             if t == 0:
                 pt_prev = 1.0
             else:

--- a/rllib/offline/is_estimator.py
+++ b/rllib/offline/is_estimator.py
@@ -27,7 +27,7 @@ class ImportanceSamplingEstimator(OffPolicyEstimator):
 
         # calculate stepwise IS estimate
         V_prev, V_step_IS = 0.0, 0.0
-        for t in range(batch.count - 1):
+        for t in range(batch.count):
             V_prev += rewards[t] * self.gamma**t
             V_step_IS += p[t] * rewards[t] * self.gamma**t
 

--- a/rllib/offline/wis_estimator.py
+++ b/rllib/offline/wis_estimator.py
@@ -40,7 +40,7 @@ class WeightedImportanceSamplingEstimator(OffPolicyEstimator):
 
         # calculate stepwise weighted IS estimate
         V_prev, V_step_WIS = 0.0, 0.0
-        for t in range(batch.count - 1):
+        for t in range(batch.count):
             V_prev += rewards[t] * self.gamma**t
             w_t = self.filter_values[t] / self.filter_counts[t]
             V_step_WIS += p[t] / w_t * rewards[t] * self.gamma**t

--- a/rllib/offline/wis_estimator.py
+++ b/rllib/offline/wis_estimator.py
@@ -24,7 +24,7 @@ class WeightedImportanceSamplingEstimator(OffPolicyEstimator):
 
         # calculate importance ratios
         p = []
-        for t in range(batch.count - 1):
+        for t in range(batch.count):
             if t == 0:
                 pt_prev = 1.0
             else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The problem was cited in [this discussion topic](https://discuss.ray.io/t/last-step-not-counted-in-off-policy-estimation/134/2) and also discussed with Sven in a private Slack channel:

> We noticed that the code discards the last transition when calculating the WIS metrics since it uses range(batch.count - 1) in the for loop (lines 27 and 43 of this file).
We were already discarding the last state in our batch training because the new_obs variable would be a list of NAs. When we are at the last state we simply cannot observe the new_obs variable. This would probably not happen if we were using a traditional simulator for the environment like in the Cartpole example, as even the last state has a new_obs provided by the environment. 
It seems that the code was considering a scenario with only episodic trajectories. If this is the case, should we consider adjusting our batches to make sure they include the last state (even with the new_obs being a list of NAs)? 

Sven response was:

> Each row should have: o1, a1, r1, d1, o2: Where o1=initial obs; a1=action taken in o1; r1=reward received after taking a1 in o1; d1=[is o2 a terminal state?]; o2=next obs after taking a1 in o1 and receiving r1.
Yes, you should always be able to set o2 to 0.0 (better than NaNs), and then make sure done=True (so DQN will ignore the last state). Would that work for you?
Now that I'm seeing this, though, I'm not sure either, why we cut off the last item in the batch. If the SampleBatch contains the new_obs field, this should not be necessary and we would lose the last transition.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
