### PR TITLE
[docker] fix typo in gpu base image name, in build-docker.sh script

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -16,7 +16,7 @@ key="$1"
 case $key in
     --gpu)
     GPU="-gpu"
-    BASE_IMAGE="nvidia/cuda:10.1-cudnn7d-runtime-ubuntu18.04"
+    BASE_IMAGE="nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04"
     ;;
     --no-cache-build)
     NO_CACHE="--no-cache"


### PR DESCRIPTION
## Why are these changes needed?

Trivial fix for a typo in docker image name tag =)

## Related issue number

https://github.com/ray-project/ray/pull/12375

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
