### PR TITLE
[Fix-Err-msg] Fix that add_worker fails when driver exits.

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -853,6 +853,7 @@ def custom_excepthook(type, value, tb):
         worker_type = ray.gcs_utils.DRIVER
         worker_info = {"exception": error_message}
 
+        ray.state.state._check_connected()
         ray.state.state.add_worker(worker_id, worker_type, worker_info)
     # Call the normal excepthook.
     normal_excepthook(type, value, tb)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Related: https://github.com/ray-project/ray/pull/12054

After we lazily initialize the global state (to reduce the number of connection), we cannot guarantee that global state is connected before we add driver failure information to GCS. We should ensure the state is connected.

Since exception hook is executed for a short time, it will unlikely cause the num connection issues.

cc @ericl 

## Related issue number

https://github.com/ray-project/ray/issues/12643

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
