### PR TITLE
[docs] Add troubleshooting section to installation page

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -304,3 +304,32 @@ that you've cloned the git repository.
 .. code-block:: bash
 
   python -m pytest -v python/ray/tests/test_mini.py
+
+Troubleshooting
+---------------
+
+If importing Ray (``python3 -c "import ray"``) in your development clone results
+in this error:
+
+.. code-block
+
+  Traceback (most recent call last):
+    File "<string>", line 1, in <module>
+    File ".../ray/python/ray/__init__.py", line 63, in <module>
+      import ray._raylet  # noqa: E402
+    File "python/ray/_raylet.pyx", line 98, in init ray._raylet
+      import ray.memory_monitor as memory_monitor
+    File ".../ray/python/ray/memory_monitor.py", line 9, in <module>
+      import psutil  # noqa E402
+    File ".../ray/python/ray/thirdparty_files/psutil/__init__.py", line 159, in <module>
+      from . import _psosx as _psplatform
+    File ".../ray/python/ray/thirdparty_files/psutil/_psosx.py", line 15, in <module>
+      from . import _psutil_osx as cext
+  ImportError: cannot import name '_psutil_osx' from partially initialized module 'psutil' (most likely due to a circular import) (.../ray/python/ray/thirdparty_files/psutil/__init__.py)
+
+Then you should run the following commands:
+
+.. code-block
+
+  rm -rf python/ray/thirdparty_files/
+  python3 -m pip install setproctitle

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -311,7 +311,7 @@ Troubleshooting
 If importing Ray (``python3 -c "import ray"``) in your development clone results
 in this error:
 
-.. code-block
+.. code-block:: python
 
   Traceback (most recent call last):
     File "<string>", line 1, in <module>

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -329,7 +329,7 @@ in this error:
 
 Then you should run the following commands:
 
-.. code-block
+.. code-block:: bash
 
   rm -rf python/ray/thirdparty_files/
   python3 -m pip install setproctitle


### PR DESCRIPTION
## Why are these changes needed?

adds a "Troubleshooting" section to the bottom of the Installation page. (currently only has a note on the `psutil` error on import)

## Related issue number

closes #12623

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
