### PR TITLE
[Dashboard][Bugfix] Fix object store memory display.

### DIFF
--- a/dashboard/client/src/pages/dashboard/node-info/features/ObjectStoreMemory.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/features/ObjectStoreMemory.tsx
@@ -18,20 +18,22 @@ export const ClusterObjectStoreMemory: ClusterFeatureRenderFn = ({ nodes }) => {
     nodes.map((n) => n.raylet.objectStoreAvailableMemory),
   );
   const totalUsed = sum(nodes.map((n) => n.raylet.objectStoreUsedMemory));
+  const total = totalUsed + totalAvailable;
   return (
     <div style={{ minWidth: 60 }}>
       <UsageBar
-        percent={100 * (totalUsed / totalAvailable)}
-        text={formatUsage(totalUsed, totalAvailable, "mebibyte", false)}
+        percent={100 * (totalUsed / total)}
+        text={formatUsage(totalUsed, total, "mebibyte", false)}
       />
     </div>
   );
 };
 
 export const NodeObjectStoreMemory: NodeFeatureRenderFn = ({ node }) => {
-  const total = node.raylet.objectStoreAvailableMemory;
+  const totalAvailable = node.raylet.objectStoreAvailableMemory;
   const used = node.raylet.objectStoreUsedMemory;
-  if (used === undefined || total === undefined || total === 0) {
+  const total = totalAvailable + used;
+  if (used === undefined || totalAvailable === undefined || total === 0) {
     return (
       <Typography color="textSecondary" component="span" variant="inherit">
         N/A


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
These changes are needed because the old code used objectStoreAvailableMemory as though it were the total object store memory allocated for the node; however, objectStoreAvailableMemory is actually a gauge that changes depending on how much is currently available. This code makes the necessary change.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
