### PR TITLE
[doc] update lint script location

### DIFF
--- a/doc/source/getting-involved.rst
+++ b/doc/source/getting-involved.rst
@@ -139,7 +139,7 @@ You can run the following locally:
 
 .. code-block:: shell
 
-    ray/scripts/format.sh
+    ./ci/travis/format.sh
 
 An output like the following indicates failure:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The location of the Python & C++ lint file is not correct.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
