### PR TITLE
[Dashboard]Add GPU/GRAM status bar support for Nvidia Jetson machines

### DIFF
--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -30,6 +30,13 @@ except ImportError:
     logger.warning(
         "Install gpustat with 'pip install gpustat' to enable GPU monitoring.")
 
+if os.uname()[4] == 'aarch64':
+    try:
+        from jtop import jtop
+    except ImportError:
+        jtop = None
+        logger.warning(
+            "Install jetson_stats with 'pip install -U jetson-stats' to enable GPU monitoring on jetson machine.")
 
 def recursive_asdict(o):
     if isinstance(o, tuple) and hasattr(o, "_asdict"):
@@ -108,25 +115,45 @@ class ReporterAgent(dashboard_utils.DashboardAgentModule,
     def _get_cpu_percent():
         return psutil.cpu_percent()
 
-    @staticmethod
-    def _get_gpu_usage():
-        if gpustat is None:
-            return []
+    def _get_gpu_usage(self):
         gpu_utilizations = []
-        gpus = []
-        try:
-            gpus = gpustat.new_query().gpus
-        except Exception as e:
-            logger.debug(f"gpustat failed to retrieve GPU information: {e}")
-        for gpu in gpus:
-            # Note the keys in this dict have periods which throws
-            # off javascript so we change .s to _s
-            gpu_data = {
-                "_".join(key.split(".")): val
-                for key, val in gpu.entry.items()
-            }
-            gpu_utilizations.append(gpu_data)
+        if os.uname()[4] != 'aarch64':
+            if gpustat is None:
+                return []
+            gpus = []
+            try:
+                gpus = gpustat.new_query().gpus
+            except Exception as e:
+                logger.debug(f"gpustat failed to retrieve GPU information: {e}")
+            for gpu in gpus:
+                # Note the keys in this dict have periods which throws
+                # off javascript so we change .s to _s
+                gpu_data = {
+                    "_".join(key.split(".")): val
+                    for key, val in gpu.entry.items()
+                }
+                gpu_utilizations.append(gpu_data)
+        else:
+            if jtop is None:
+                return []
+            gpu_utilizations = self._get_gpu_usage_jetson()
+            
         return gpu_utilizations
+ 
+    @staticmethod
+    def _get_gpu_usage_jetson():
+        gpu_utilizations_jetson = []
+        gpu_data = {}
+        with jtop() as jetson:
+            gpu_data['index'] = 0
+            #This is a bit of dirty hack. For some reason, Jetson's gpu
+            # can't be recognized when utilization is 0.
+            gpu_data['utilization_gpu'] = jetson.gpu['val'] + 1
+            gpu_data['memory_used'] = jetson.ram['use'] /1000
+            gpu_data['memory_total'] = jetson.ram['tot'] /1000
+        
+        gpu_utilizations_jetson.append(gpu_data)
+        return gpu_utilizations_jetson
 
     @staticmethod
     def _get_boot_time():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
GPU/GRAM information can't show up correctly on Ray dashboard for arm64 machines like Nvidia Jetson [Xavier NX, Nano, AGX Xavier, TX1, TX2]. This is due to `gpustat` is not supported on these platforms. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
