### PR TITLE
[grpc]'ray memory' fails if there are many objects in scope #8502

### DIFF
--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -68,3 +68,5 @@ cdef extern from "ray/common/ray_config.h" nogil:
         c_bool enable_timeline() const
 
         c_bool automatic_object_deletion_enabled() const
+
+        uint32_t max_grpc_message_size() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -119,3 +119,7 @@ cdef class Config:
     @staticmethod
     def automatic_object_deletion_enabled():
         return RayConfig.instance().automatic_object_deletion_enabled()
+
+    @staticmethod
+    def max_grpc_message_size():
+        return RayConfig.instance().max_grpc_message_size()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fix https://github.com/ray-project/ray/issues/8502. Address @ericl 's comment to set Python GRPC message size the same as C++ grpc size.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/8502
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
