### PR TITLE
Fix exit_actor in asyncio mode

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -351,7 +351,12 @@ cdef execute_task(
     # Automatically restrict the GPUs available to this task.
     ray.utils.set_cuda_visible_devices(ray.get_gpu_ids())
 
-    # Helper method used to exit current asyncio actor
+    # Helper method used to exit current asyncio actor.
+    # This is called when a KeyBoardInterrupt is received by the main thread.
+    # Upon receiving a KeyBoardInterrupt signal, Ray will exit the current
+    # worker. If the worker is processing normal tasks, Ray treat it as task
+    # cancellation from ray.cancel(object_ref). If the worker is an asyncio
+    # actor, Ray will exit the actor.
     def exit_current_actor_if_asyncio():
         if core_worker.current_actor_is_asyncio():
             error = SystemExit(0)

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -352,8 +352,8 @@ cdef execute_task(
     ray.utils.set_cuda_visible_devices(ray.get_gpu_ids())
 
     # Helper method used to exit current asyncio actor.
-    # This is called when a KeyBoardInterrupt is received by the main thread.
-    # Upon receiving a KeyBoardInterrupt signal, Ray will exit the current
+    # This is called when a KeyboardInterrupt is received by the main thread.
+    # Upon receiving a KeyboardInterrupt signal, Ray will exit the current
     # worker. If the worker is processing normal tasks, Ray treat it as task
     # cancellation from ray.cancel(object_ref). If the worker is an asyncio
     # actor, Ray will exit the actor.

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1,6 +1,7 @@
 import inspect
 import logging
 import weakref
+import _thread
 
 import ray.ray_constants as ray_constants
 import ray._raylet
@@ -1018,6 +1019,14 @@ def exit_actor():
         ray.disconnect()
         # Disconnect global state from GCS.
         ray.state.state.disconnect()
+
+        # In asyncio actor mode, we can't raise SystemExit because it will just
+        # quit the asycnio event loop thread, not the main thread. Instead, we
+        # raise an interrupt signal to the main thread to tell it to exit.
+        if worker.core_worker.current_actor_is_asyncio():
+            _thread.interrupt_main()
+            return
+
         # Set a flag to indicate this is an intentional actor exit. This
         # reduces log verbosity.
         exit = SystemExit(0)

--- a/python/ray/tests/test_asyncio.py
+++ b/python/ray/tests/test_asyncio.py
@@ -198,6 +198,25 @@ async def test_asyncio_double_await(ray_start_regular_shared):
     await waiting
 
 
+@pytest.mark.asyncio
+async def test_asyncio_exit_actor(ray_start_regular_shared):
+    # https://github.com/ray-project/ray/issues/12649
+
+    @ray.remote
+    class Actor:
+        async def exit(self):
+            ray.actor.exit_actor()
+
+        async def ping(self):
+            return "pong"
+
+    a = Actor.remote()
+    ray.get(a.exit.remote())
+
+    with pytest.raises(ray.exceptions.RayActorError):
+        ray.get(a.ping.remote())
+
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_asyncio.py
+++ b/python/ray/tests/test_asyncio.py
@@ -201,6 +201,7 @@ async def test_asyncio_double_await(ray_start_regular_shared):
 @pytest.mark.asyncio
 async def test_asyncio_exit_actor(ray_start_regular_shared):
     # https://github.com/ray-project/ray/issues/12649
+    # The test should just hang without the fix.
 
     @ray.remote
     class Actor:

--- a/python/ray/tests/test_asyncio.py
+++ b/python/ray/tests/test_asyncio.py
@@ -211,7 +211,13 @@ async def test_asyncio_exit_actor(ray_start_regular_shared):
         async def ping(self):
             return "pong"
 
-    a = Actor.remote()
+        async def loop_forever(self):
+            while True:
+                await asyncio.sleep(5)
+
+    a = Actor.options(max_task_retries=0).remote()
+    a.loop_forever.remote()
+    # Make sure exit_actor exits immediately, not once all tasks completed.
     ray.get(a.exit.remote())
 
     with pytest.raises(ray.exceptions.RayActorError):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fixes #12649

The issue was that `SystemExit` was raised in async thread instead of the main thread. This PR share the task cancellation code path to tell main thread to exit properly.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
