### PR TITLE
[xgboost][hotfix] fix readthedocs

### DIFF
--- a/doc/source/xgboost-ray.rst
+++ b/doc/source/xgboost-ray.rst
@@ -143,21 +143,3 @@ the `examples folder <https://github.com/ray-project/xgboost_ray/tree/master/exa
   * `[download dataset (2.6 GB)] <https://archive.ics.uci.edu/ml/machine-learning-databases/00280/HIGGS.csv.gz>`__
 * `HIGGS classification example with Parquet <https://github.com/ray-project/xgboost_ray/tree/master/examples/higgs_parquet.py>`__ (uses the same dataset)
 * `Test data classification <https://github.com/ray-project/xgboost_ray/tree/master/examples/train_on_test_data.py>`__ (uses a self-generated dataset)
-
-Package Reference
------------------
-
-
-Training/Validation
-~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: ray.util.xgboost.RayParams
-
-.. autofunction:: ray.util.xgboost.train
-
-.. autofunction:: ray.util.xgboost.predict
-
-RayDMatrix
-~~~~~~~~~~
-
-.. autoclass:: ray.util.xgboost.RayDMatrix


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For some reason, xgboost causes readthedocs to fail building. Seems related to https://github.com/readthedocs/readthedocs.org/issues/4686

@krfricke


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(