### PR TITLE
[RLlib] Issue 12516: Trainer.compute_action() throws error w/ Dict observation space and num_workers > 0.

### DIFF
--- a/rllib/agents/trainer_template.py
+++ b/rllib/agents/trainer_template.py
@@ -65,7 +65,7 @@ def build_trainer(
             Optional callable that takes the config to check for correctness.
             It may mutate the config as needed.
         default_policy (Optional[Type[Policy]]): The default Policy class to
-            use.
+            use if `get_policy_class` returns None.
         get_policy_class (Optional[Callable[
             TrainerConfigDict, Optional[Type[Policy]]]]): Optional callable
             that takes a config and returns the policy class or None. If None

--- a/rllib/evaluation/worker_set.py
+++ b/rllib/evaluation/worker_set.py
@@ -79,7 +79,10 @@ class WorkerSet:
                 remote_spaces = ray.get(self.remote_workers(
                 )[0].foreach_policy.remote(
                     lambda p, pid: (pid, p.observation_space, p.action_space)))
-                spaces = {e[0]: (e[1], e[2]) for e in remote_spaces}
+                spaces = {
+                    e[0]: (getattr(e[1], "original_space", e[1]), e[2])
+                    for e in remote_spaces
+                }
             else:
                 spaces = None
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

This PR fixes issue 12516:
- Trainer.compute_action() throws error w/ Dict observation space and num_workers > 0.

The problem was that the local-worker (driver) was using the already preprocessed space (got it from the remote-worker) to build its own policy/preprocessot stack. That's why the necessary DictFlatteningPreprocessor was never built and your Trainer did not do any preprocessing (on your input dict's observation) prior to sending the data to the Policy.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Closes issue #12516 

<!-- Please give a short summary of the change and the problem this solves. -->


Closes issue #12516 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
