### PR TITLE
[GCS]GCS based Actor Scheduling support actor colocation

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
@@ -47,12 +47,12 @@ void GcsActorScheduler::Schedule(std::shared_ptr<GcsActor> actor) {
   // Select a node to lease worker for the actor.
   std::shared_ptr<rpc::GcsNodeInfo> node;
 
-  // If the actor is non-detached, try to schedule it on the same node as the owner if
-  // possible.
-  if (!actor->IsDetached()) {
+  // If an actor is non-detached and has resource requirements, We will try to schedule it
+  // on the same node as the owner if possible.
+  const auto &task_spec = actor->GetCreationTaskSpecification();
+  if (!actor->IsDetached() && !task_spec.GetRequiredResources().IsEmpty()) {
     auto maybe_node = gcs_node_manager_.GetNode(actor->GetOwnerNodeID());
     node = maybe_node.has_value() ? maybe_node.value() : SelectNodeRandomly();
-    ;
   } else {
     node = SelectNodeRandomly();
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Before we enabled GCS-based-actor-scheduling (< 0.8.7), actors were always tried to be scheduled on the same node as the owner if possible (by our worker lease protocol). But after 0.8.7, actor lease requests are just sent to the random node instead of being sent to the node of the owner. This leads actors to be distributed well across the cluster.
If an actor is non-detached and has resource requirements, we will try to schedule it on the same node as the owner if possible. We implement it in this PR.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/12546
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
