### PR TITLE
[rllib] move evaluation to trainer.step() such that the result is properly logged

### DIFF
--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -535,14 +535,6 @@ class Trainer(Trainable):
         if hasattr(self, "workers") and isinstance(self.workers, WorkerSet):
             self._sync_filters_if_needed(self.workers)
 
-        if self.config["evaluation_interval"] == 1 or (
-                self._iteration > 0 and self.config["evaluation_interval"]
-                and self._iteration % self.config["evaluation_interval"] == 0):
-            evaluation_metrics = self._evaluate()
-            assert isinstance(evaluation_metrics, dict), \
-                "_evaluate() needs to return a dict."
-            result.update(evaluation_metrics)
-
         return result
 
     def _sync_filters_if_needed(self, workers: WorkerSet):

--- a/rllib/agents/trainer_template.py
+++ b/rllib/agents/trainer_template.py
@@ -149,9 +149,9 @@ def build_trainer(
 
             # self._iteration gets incremented after this function returns,
             # meaning that e. g. the first time this function is called,
-            # self._iteration will be 0. We add 1 to self._iteration in the
+            # self._iteration will be 0. We check `self._iteration+1` in the
             # if-statement below to reflect that the first training iteration
-            # is over.
+            # is already over.
             if (self.config["evaluation_interval"] and (self._iteration + 1) %
                     self.config["evaluation_interval"] == 0):
                 evaluation_metrics = self._evaluate()

--- a/rllib/agents/trainer_template.py
+++ b/rllib/agents/trainer_template.py
@@ -146,6 +146,18 @@ def build_trainer(
         @override(Trainer)
         def step(self):
             res = next(self.train_exec_impl)
+
+            # self._iteration gets incremented after this function returns,
+            # meaning that e. g. the first time this function is called,
+            # self._iteration will be 0. We add 1 to self._iteration in the
+            # if-statement below to reflect that the first training iteration
+            # is over.
+            if (self.config["evaluation_interval"] and (self._iteration + 1) %
+                    self.config["evaluation_interval"] == 0):
+                evaluation_metrics = self._evaluate()
+                assert isinstance(evaluation_metrics, dict), \
+                    "_evaluate() needs to return a dict."
+                res.update(evaluation_metrics)
             return res
 
         @override(Trainer)


### PR DESCRIPTION
Move evaluation to ```trainer.step()``` such that the result is properly logged even when training with ```trainer.train()``` instead of ```tune.run()```

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When training with ```trainer.train()``` instead of ```tune.run()```, the results of the evaluation (evaluation metrics) are not written to disk (e. g. to the progress.csv).

<!-- Please give a short summary of the change and the problem this solves. -->
This moves the evaluation code to ```trainer.step()```, which ensures that the evaluation metrics are included in progress.csv and other output files.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR. --> yes but this errors with a flake8 error unrelated to the code
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/. --> no doc changes needed
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(

I only tested this PR in my own experiments.