### PR TITLE
[RLlib] Add DQN softQ learning test case.

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -172,6 +172,7 @@ py_test(
     data = [
         "tuned_examples/dqn/cartpole-simpleq.yaml",
         "tuned_examples/dqn/cartpole-dqn.yaml",
+        "tuned_examples/dqn/cartpole-dqn-softq.yaml",
         "tuned_examples/dqn/cartpole-dqn-param-noise.yaml",
     ],
     args = ["--yaml-dir=tuned_examples/dqn"]
@@ -186,6 +187,7 @@ py_test(
     data = [
         "tuned_examples/dqn/cartpole-simpleq.yaml",
         "tuned_examples/dqn/cartpole-dqn.yaml",
+        "tuned_examples/dqn/cartpole-dqn-softq.yaml",
         "tuned_examples/dqn/cartpole-dqn-param-noise.yaml",
     ],
     args = ["--yaml-dir=tuned_examples/dqn", "--torch"]

--- a/rllib/tuned_examples/dqn/cartpole-dqn-softq.yaml
+++ b/rllib/tuned_examples/dqn/cartpole-dqn-softq.yaml
@@ -1,0 +1,16 @@
+cartpole-dqn:
+    env: CartPole-v0
+    run: DQN
+    stop:
+        episode_reward_mean: 150
+        timesteps_total: 100000
+    config:
+        # Works for both torch and tf.
+        framework: tf
+        model:
+            fcnet_hiddens: [64]
+            fcnet_activation: linear
+        n_step: 3
+        exploration_config:
+            type: SoftQ
+            temperature: 0.5


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

This PR adds a (currently missing) DQN softQ-exploration learning test case for CartPole.


<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
