### PR TITLE
Fix Checkstyle UnusedImports errors in streaming CI tests

### DIFF
--- a/streaming/java/streaming-runtime/src/main/java/io/ray/streaming/runtime/transfer/TransferHandler.java
+++ b/streaming/java/streaming-runtime/src/main/java/io/ray/streaming/runtime/transfer/TransferHandler.java
@@ -1,6 +1,5 @@
 package io.ray.streaming.runtime.transfer;
 
-import io.ray.runtime.RayNativeRuntime;
 import io.ray.runtime.util.BinaryFileUtil;
 import io.ray.runtime.util.JniUtils;
 

--- a/streaming/java/streaming-runtime/src/main/java/io/ray/streaming/runtime/util/EnvUtil.java
+++ b/streaming/java/streaming-runtime/src/main/java/io/ray/streaming/runtime/util/EnvUtil.java
@@ -1,6 +1,5 @@
 package io.ray.streaming.runtime.util;
 
-import io.ray.runtime.RayNativeRuntime;
 import io.ray.runtime.util.BinaryFileUtil;
 import io.ray.runtime.util.JniUtils;
 import java.lang.management.ManagementFactory;


### PR DESCRIPTION
## Why are these changes needed?

CI is failing right now because of unused imports:
```
[WARNING] src/main/java/io/ray/streaming/runtime/util/EnvUtil.java:[3,8] (imports) UnusedImports: Unused import - io.ray.runtime.RayNativeRuntime.
[WARNING] src/main/java/io/ray/streaming/runtime/transfer/TransferHandler.java:[3,8] (imports) UnusedImports: Unused import - io.ray.runtime.RayNativeRuntime.
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.0.0:check (validate) on project streaming-runtime: You have 2 Checkstyle violations. -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :streaming-runtime
```

I have no idea if this:
- will break anything
- is the right way to fix the error
- is missing any other changes

just my attempt at fixing CI

## Related issue number

n/a

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
