### PR TITLE
Remove incorrect warning about process events being slow

### DIFF
--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -357,8 +357,7 @@ class TrialRunner:
                     trials=self._trials,
                     trial=next_trial)
         elif self.trial_executor.get_running_trials():
-            with warn_if_slow("process_events"):
-                self._process_events()  # blocking
+            self._process_events()  # blocking
         else:
             self.trial_executor.on_no_available_trials(self)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Process events contains a blocking ray.wait call to wait for results. This might not have been the case in the past, but is now causing incorrect warnings.

Related to https://github.com/ray-project/ray/issues/12073