### PR TITLE
remove debug extras from setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,7 +158,7 @@ RLlib Quick Start
 .. code-block:: bash
 
   pip install tensorflow  # or tensorflow-gpu
-  pip install "ray[rllib]"  # also recommended: ray[debug]
+  pip install "ray[rllib]"
 
 .. code-block:: python
 

--- a/doc/examples/cython/ray-project/requirements.txt
+++ b/doc/examples/cython/ray-project/requirements.txt
@@ -1,2 +1,2 @@
-ray[debug]
+ray
 scipy

--- a/doc/examples/lbfgs/ray-project/requirements.txt
+++ b/doc/examples/lbfgs/ray-project/requirements.txt
@@ -1,1 +1,1 @@
-ray[debug,rllib]
+ray[rllib]

--- a/doc/examples/newsreader/ray-project/requirements.txt
+++ b/doc/examples/newsreader/ray-project/requirements.txt
@@ -1,3 +1,3 @@
-ray[debug]
+ray
 atoma
 flask

--- a/doc/examples/streaming/ray-project/requirements.txt
+++ b/doc/examples/streaming/ray-project/requirements.txt
@@ -1,2 +1,2 @@
-ray[debug]
+ray
 wikipedia

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -15,7 +15,7 @@ You can install the latest official version of Ray as follows. Official releases
 
 .. code-block:: bash
 
-  pip install -U ray  # also recommended: ray[debug]
+  pip install -U ray
 
 **Note for Windows Users:** To use Ray on Windows, Visual C++ runtime must be installed (see :ref:`Windows Dependencies <windows-dependencies>` section). If you run into any issues, please see the :ref:`Windows Support <windows-support>` section.
 

--- a/doc/source/ray-overview/index.rst
+++ b/doc/source/ray-overview/index.rst
@@ -196,7 +196,7 @@ RLlib Quick Start
 .. code-block:: bash
 
   pip install tensorflow  # or tensorflow-gpu
-  pip install ray[rllib]  # also recommended: ray[debug]
+  pip install ray[rllib]
 
 .. code-block:: python
 

--- a/doc/source/rllib.rst
+++ b/doc/source/rllib.rst
@@ -23,7 +23,7 @@ RLlib has extra dependencies on top of ``ray``. First, you'll need to install ei
 
 .. code-block:: bash
 
-  pip install 'ray[rllib]'  # also recommended: ray[debug]
+  pip install 'ray[rllib]'
 
 Then, you can try out training in the following equivalent ways:
 

--- a/python/ray/autoscaler/aws/example-ml.yaml
+++ b/python/ray/autoscaler/aws/example-ml.yaml
@@ -120,7 +120,7 @@ setup_commands:
     # has your Ray repo pre-cloned. Then, you can replace the pip installs
     # below with a git checkout <your_sha> (and possibly a recompile).
     - source activate pytorch_p36 && pip install -U ray
-    - source activate pytorch_p36 && pip install -U ray[rllib] ray[tune] ray[debug]
+    - source activate pytorch_p36 && pip install -U ray[rllib] ray[tune] ray
     # Consider uncommenting these if you also want to run apt-get commands during setup
     # - sudo pkill -9 apt-get || true
     # - sudo pkill -9 dpkg || true

--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -91,7 +91,7 @@ class MemoryMonitor:
         if not psutil:
             logger.warn("WARNING: Not monitoring node memory since `psutil` "
                         "is not installed. Install this with "
-                        "`pip install psutil` (or ray[debug]) to enable "
+                        "`pip install psutil` to enable "
                         "debugging of memory-related crashes.")
 
     def get_memory_usage(self):

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1290,7 +1290,7 @@ def stack():
     COMMAND = """
 pyspy=`which py-spy`
 if [ ! -e "$pyspy" ]; then
-    echo "ERROR: Please 'pip install py-spy' (or ray[debug]) first"
+    echo "ERROR: Please 'pip install py-spy' first"
     exit 1
 fi
 # Set IFS to iterate over lines instead of over words.

--- a/python/ray/tests/project_files/session-tests/git-repo-pass/ray-project/requirements.txt
+++ b/python/ray/tests/project_files/session-tests/git-repo-pass/ray-project/requirements.txt
@@ -1,1 +1,1 @@
-ray[debug]
+ray

--- a/python/ray/tests/project_files/session-tests/invalid-config-fail/ray-project/requirements.txt
+++ b/python/ray/tests/project_files/session-tests/invalid-config-fail/ray-project/requirements.txt
@@ -1,1 +1,1 @@
-ray[debug]
+ray

--- a/python/ray/tests/project_files/session-tests/project-pass/ray-project/requirements.txt
+++ b/python/ray/tests/project_files/session-tests/project-pass/ray-project/requirements.txt
@@ -1,1 +1,1 @@
-ray[debug]
+ray

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -460,7 +460,7 @@ def memory_debug_str():
             round(used_gb, 1), round(total_gb, 1), warn)
     except ImportError:
         return ("Unknown memory usage. Please run `pip install psutil` "
-                "(or ray[debug]) to resolve)")
+                "to resolve)")
 
 
 def _get_trials_by_state(trials: List[Trial]):

--- a/python/setup.py
+++ b/python/setup.py
@@ -95,7 +95,6 @@ ray_files += [
 # also update the matching section of requirements.txt
 # in this directory
 extras = {
-    "debug": [],
     "serve": [
         "uvicorn", "flask", "requests", "pydantic<1.7",
         "dataclasses; python_version < '3.7'"

--- a/release/rllib_tests/regression_tests/run.sh
+++ b/release/rllib_tests/regression_tests/run.sh
@@ -46,7 +46,7 @@ wheel="https://s3-us-west-2.amazonaws.com/ray-wheels/$ray_branch/$commit/ray-$ra
 conda uninstall -y terminado
 pip install -U pip
 pip install -U "$wheel"
-pip install "ray[rllib]" "ray[debug]"
+pip install "ray[rllib]" "ray"
 pip install terminado
 pip install torch==1.6 torchvision
 pip install boto3==1.4.8 cython==0.29.0

--- a/release/rllib_tests/stress_tests/run.sh
+++ b/release/rllib_tests/stress_tests/run.sh
@@ -47,7 +47,7 @@ wheel="https://s3-us-west-2.amazonaws.com/ray-wheels/$ray_branch/$commit/ray-$ra
 conda uninstall -y terminado
 pip install -U pip
 pip install -U "$wheel"
-pip install "ray[rllib]" "ray[debug]"
+pip install "ray[rllib]" "ray"
 pip install terminado
 pip install boto3==1.4.8 cython==0.29.0
 

--- a/release/rllib_tests/unit_gpu_tests/requirements.txt
+++ b/release/rllib_tests/unit_gpu_tests/requirements.txt
@@ -1,5 +1,5 @@
 ray[rllib]
-ray[debug]
+ray
 torch==1.6+cu101
 torchvision==0.7.0+cu101
 boto3==1.4.8

--- a/release/stress_tests/requirements.txt
+++ b/release/stress_tests/requirements.txt
@@ -1,1 +1,1 @@
-ray[debug]
+ray


### PR DESCRIPTION
pip install 'ray[debug]' ceased installing extra packages in
0826f95e1c744aa25e8aacd1de43562d40ceeb4a

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Documentation indicates `pip install 'ray[debug]'` is recommended but `[debug]` does not install any extra packages.

## Related issue number

#7031

See also the discussion [here](https://discuss.ray.io/t/what-does-pip-install-ray-debug-do/182?u=esquires)

## Checks

- [x ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x ] This PR is not tested :(
