### PR TITLE
add tags.lock and tags.temp to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,8 @@ venv
 .*.swp
 *.swp
 tags
+tags.lock
+tags.temp
 
 # Emacs
 .#*


### PR DESCRIPTION
## Why are these changes needed?

These can be temporarily created by vim. Without this patch `tags.temp` and `tags.lock` may be inadvertently added to the repo. Since they are temporary files they will continually show up in staging as either removed or changed.

The change is two lines to `.gitignore`

## Related issue number

None

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x ] This PR is not tested :(
