### PR TITLE
Expose C NodeID to Python.

### DIFF
--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -132,9 +132,6 @@ cdef extern from "ray/common/status.h" namespace "ray::StatusCode" nogil:
 
 
 cdef extern from "ray/common/id.h" namespace "ray" nogil:
-    cdef cppclass CNodeID "ray::NodeID":
-        pass
-
     const CTaskID GenerateTaskId(const CJobID &job_id,
                                  const CTaskID &parent_task_id,
                                  int parent_task_counter)

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -132,6 +132,9 @@ cdef extern from "ray/common/status.h" namespace "ray::StatusCode" nogil:
 
 
 cdef extern from "ray/common/id.h" namespace "ray" nogil:
+    cdef cppclass CNodeID "ray::NodeID":
+        pass
+
     const CTaskID GenerateTaskId(const CJobID &job_id,
                                  const CTaskID &parent_task_id,
                                  int parent_task_counter)

--- a/python/ray/includes/libcoreworker.pxi
+++ b/python/ray/includes/libcoreworker.pxi
@@ -2,8 +2,8 @@ from libcpp.string cimport string as c_string
 
 from ray.includes.libcoreworker cimport CProfileEvent
 from ray.includes.libcoreworker cimport CCoreWorker
-from ray.includes.unique_ids cimport CNodeID
-from ray.includes.unique_ids cimport NodeID
+
+include "includes/unique_ids.pxi"
 
 import json
 import traceback

--- a/python/ray/includes/libcoreworker.pxi
+++ b/python/ray/includes/libcoreworker.pxi
@@ -1,9 +1,23 @@
 from libcpp.string cimport string as c_string
 
 from ray.includes.libcoreworker cimport CProfileEvent
+from ray.includes.libcoreworker cimport CCoreWorker
+from ray.includes.unique_ids cimport CNodeID
+from ray.includes.unique_ids cimport NodeID
 
 import json
 import traceback
+
+
+cdef class CoreWorker:
+    """Cython wrapper class of C++ `ray::CoreWorker`."""
+    cdef:
+        unique_ptr[CCoreWorker] inner
+
+    def GetCurrentNodeId(self):
+        cdef CNodeID c_nodeID = inner.get().GetCurrentNodeId()
+        return NodeID(c_nodeID.Binary())
+
 
 cdef class ProfileEvent:
     """Cython wrapper class of C++ `ray::worker::ProfileEvent`."""

--- a/python/ray/includes/libcoreworker.pxi
+++ b/python/ray/includes/libcoreworker.pxi
@@ -18,7 +18,7 @@ cdef class CoreWorkerWrapper:
         unique_ptr[CCoreWorker] inner
 
     def GetCurrentNodeId(self):
-        cdef CNodeID c_nodeID = inner.get().GetCurrentNodeId()
+        cdef CNodeID c_nodeID = self.inner.get().GetCurrentNodeId()
         return NodeID(c_nodeID.Binary())
 
 

--- a/python/ray/includes/libcoreworker.pxi
+++ b/python/ray/includes/libcoreworker.pxi
@@ -9,7 +9,10 @@ import json
 import traceback
 
 
-cdef class CoreWorker:
+# We cannot call this CoreWorker because _raylet.pxd defines an unrelated
+# cdef class CoreWorker and _raylet.pyx does
+# include "includes/libcoreworker.pxi"
+cdef class CoreWorkerWrapper:
     """Cython wrapper class of C++ `ray::CoreWorker`."""
     cdef:
         unique_ptr[CCoreWorker] inner


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is a baby step towards allowing Ray to know its own node UUID at the Python level, so that we can avoid using alternative not-quite-UUIDs such as IP addresses.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
