### PR TITLE
Circular-import ray.worker in ray.node

### DIFF
--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -17,6 +17,7 @@ import ray
 import ray.ray_constants as ray_constants
 import ray._private.services
 import ray.utils
+import ray.worker
 from ray.resource_spec import ResourceSpec
 from ray.utils import try_to_create_directory, try_to_symlink, open_log
 


### PR DESCRIPTION
Making a separate PR just for this in case this is preferred to be avoided and we should extract the needed bits from ray.worker into a separate module instead.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
