### PR TITLE
[tune] upgrade gpytorch, bump default pytorch to 1.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -401,7 +401,7 @@ matrix:
         - PYTHON=3.6
         - TF_VERSION=2.2.0
         - TFP_VERSION=0.8
-        - TORCH_VERSION=1.6
+        - TORCH_VERSION=1.7
         - PYTHONWARNINGS=ignore
       install:
         - . ./ci/travis/ci.sh init RAY_CI_TUNE_AFFECTED
@@ -421,7 +421,7 @@ matrix:
         - PYTHON=3.6
         - TF_VERSION=2.1.0
         - TFP_VERSION=0.8
-        - TORCH_VERSION=1.5
+        - TORCH_VERSION=1.7
         - PYTHONWARNINGS=ignore
       install:
         - . ./ci/travis/ci.sh init RAY_CI_SGD_AFFECTED
@@ -441,7 +441,7 @@ matrix:
         - PYTHON=3.6
         - TF_VERSION=2.1.0
         - TFP_VERSION=0.8
-        - TORCH_VERSION=1.5
+        - TORCH_VERSION=1.7
         - PYTHONWARNINGS=ignore
       install:
         - . ./ci/travis/ci.sh init RAY_CI_PYTHON_AFFECTED,RAY_CI_TUNE_AFFECTED,RAY_CI_DOC_AFFECTED
@@ -459,7 +459,7 @@ matrix:
         - INSTALL_HOROVOD=1
         - TF_VERSION=2.1.0
         - TFP_VERSION=0.8
-        - TORCH_VERSION=1.5
+        - TORCH_VERSION=1.7
         - PYTHONWARNINGS=ignore
       install:
         - . ./ci/travis/ci.sh init RAY_CI_TUNE_AFFECTED,RAY_CI_SGD_AFFECTED

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -254,7 +254,7 @@ install_dependencies() {
     local torch_url="https://download.pytorch.org/whl/torch_stable.html"
     case "${OSTYPE}" in
       darwin*) pip install torch torchvision;;
-      *) pip install torch==1.7.0+cpu torchvision==0.8.0+cpu -f "${torch_url}";;
+      *) pip install torch==1.7.0+cpu torchvision==0.8.1+cpu -f "${torch_url}";;
     esac
 
     # Try n times; we often encounter OpenSSL.SSL.WantReadError (or others)
@@ -313,7 +313,7 @@ install_dependencies() {
   # should be installed, then upgrade/downgrade to that specific version.
   if [ -n "${TORCH_VERSION-}" ] || [ -n "${TFP_VERSION-}" ] || [ -n "${TF_VERSION-}" ]; then
     case "${TORCH_VERSION-1.7}" in
-      1.7) TORCHVISION_VERSION=0.8.0;;
+      1.7) TORCHVISION_VERSION=0.8.1;;
       1.5) TORCHVISION_VERSION=0.6.0;;
       *) TORCHVISION_VERSION=0.5.0;;
     esac

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -254,7 +254,7 @@ install_dependencies() {
     local torch_url="https://download.pytorch.org/whl/torch_stable.html"
     case "${OSTYPE}" in
       darwin*) pip install torch torchvision;;
-      *) pip install torch==1.5.0+cpu torchvision==0.6.0+cpu -f "${torch_url}";;
+      *) pip install torch==1.7.0+cpu torchvision==0.8.0+cpu -f "${torch_url}";;
     esac
 
     # Try n times; we often encounter OpenSSL.SSL.WantReadError (or others)
@@ -312,12 +312,13 @@ install_dependencies() {
   # If CI has deemed that a different version of Tensorflow or Torch
   # should be installed, then upgrade/downgrade to that specific version.
   if [ -n "${TORCH_VERSION-}" ] || [ -n "${TFP_VERSION-}" ] || [ -n "${TF_VERSION-}" ]; then
-    case "${TORCH_VERSION-1.6}" in
+    case "${TORCH_VERSION-1.7}" in
+      1.7) TORCHVISION_VERSION=0.8.0;;
       1.5) TORCHVISION_VERSION=0.6.0;;
       *) TORCHVISION_VERSION=0.5.0;;
     esac
     pip install --use-deprecated=legacy-resolver --upgrade tensorflow-probability=="${TFP_VERSION-0.8}" \
-      torch=="${TORCH_VERSION-1.6}" torchvision=="${TORCHVISION_VERSION}" \
+      torch=="${TORCH_VERSION-1.7}" torchvision=="${TORCHVISION_VERSION}" \
       tensorflow=="${TF_VERSION-2.2.0}" gym
   fi
 

--- a/python/ray/util/sgd/torch/examples/dcgan.py
+++ b/python/ray/util/sgd/torch/examples/dcgan.py
@@ -182,8 +182,8 @@ class GANOperator(TrainingOperator):
     @override(TrainingOperator)
     def train_batch(self, batch, batch_info):
         """Trains on one batch of data from the data creator."""
-        real_label = 1
-        fake_label = 0
+        real_label = 1.0
+        fake_label = 0.
         discriminator, generator = self.models
         optimD, optimG = self.optimizers
 

--- a/python/requirements_tune.txt
+++ b/python/requirements_tune.txt
@@ -1,5 +1,4 @@
 ax-platform
-gpytorch==1.2
 bayesian-optimization
 ConfigSpace==0.4.10
 dragonfly-opt


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Moves off the legacy pytorch.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(