### PR TITLE
Ask the head node what IP it uses to reach the joining node and use that as the key in the node table.

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -248,12 +248,13 @@ def get_address_info_from_redis_helper(redis_address,
         raise RuntimeError(
             "Redis has started but no raylets have registered yet.")
 
+    ip_head_uses_to_reach_here = get_node_ip_address(redis_address)
     relevant_client = None
     for client_info in client_table:
         client_node_ip_address = client_info["NodeManagerAddress"]
         if (client_node_ip_address == node_ip_address
                 or (client_node_ip_address == "127.0.0.1"
-                    and redis_ip_address == get_node_ip_address())
+                    and redis_ip_address == ip_head_uses_to_reach_here)
                 or client_node_ip_address == redis_ip_address):
             relevant_client = client_info
             break


### PR DESCRIPTION
Using a proper UUID seems more robust, but that turned out to be a way bigger job than I was expecting. This is a stopgap.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Currently, several pieces of information are stored and retrieved for each node.

(Specifically, the object store address, the raylet socket name, and the node manager port. To be honest I'm shaky on why any of these things need to be stored and retrieved in the GCS, but the specifics are kind of beside the point: there's a general need to store and retrieve metadata about each node.)

Currently, `get_address_info_from_redis_helper()` pulls the `node_table()` from the GCS and looks for a matching IP address. This results in problems such as https://github.com/ray-project/ray/issues/11943. We were able to hack around it by allowing the node to pull the "wrong" row from the node table, but ideally the node would be able to pull its own row from the node table. (Personally I don't understand the node table, but presumably it exists for a reason.)

An IP address is not a UUID, but naturally enough each node must be reached by a different IP:port combination *from the perspective of the head*. The head is currently building the node table using the IP addresses by which the head finds each of the joining nodes.

This by itself obviously isn't an ideal solution. In particular, the head finds the node by an IP:port combination, and this is only using the IP address.

However, I think this will cover a lot of cases, and in fact I think we can replace the entire
```
        if (client_node_ip_address == node_ip_address
                or (client_node_ip_address == "127.0.0.1"
                    and redis_ip_address == get_node_ip_address())
                or client_node_ip_address == redis_ip_address):
```
construction with simply `if client_node_ip_address == ip_head_uses_to_reach_here` and it will work just as well.
Skipping over the `node_ip_address` that the user manually set would make me nervous, but as a practical matter *in this node table* the IP address that was *actually populated* was the IP address that the head saw, because the head was who populated the node table. Still, we probably should keep the `client_node_ip_address == node_ip_address`, just because you never know what might happen and there might be a need for the user to override what IP address matches.
## Related issue number

<!-- For example: "Closes #1234" -->
This might also close https://github.com/ray-project/ray/issues/12665.
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
