### PR TITLE
Split out the part of get_node_ip_address for which the docstring is correct

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -375,7 +375,7 @@ def address_to_ip(address):
     return ":".join([ip_address] + address_parts[1:])
 
 
-def node_ip_address_from_perspective(address="8.8.8.8:53"):
+def node_ip_address_from_perspective(address):
     """IP address by which the local node can be reached *from* the `address`.
 
     Args:

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -375,7 +375,7 @@ def address_to_ip(address):
     return ":".join([ip_address] + address_parts[1:])
 
 
-def get_node_ip_address(address="8.8.8.8:53"):
+def node_ip_address_from_perspective(address="8.8.8.8:53"):
     """IP address by which the local node can be reached *from* the `address`.
 
     Args:
@@ -385,9 +385,6 @@ def get_node_ip_address(address="8.8.8.8:53"):
     Returns:
         The IP address by which the local node can be reached from the address.
     """
-    if ray.worker._global_node is not None:
-        return ray.worker._global_node.node_ip_address
-
     ip_address, port = address.split(":")
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
@@ -409,6 +406,12 @@ def get_node_ip_address(address="8.8.8.8:53"):
         s.close()
 
     return node_ip_address
+
+
+def get_node_ip_address(address="8.8.8.8:53"):
+    if ray.worker._global_node is not None:
+        return ray.worker._global_node.node_ip_address
+    return node_ip_address_from_perspective(address)
 
 
 def create_redis_client(redis_address, password=None):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The docstring for get_node_ip_address isn't *quite* correct. The docstring is only correct if `ray.worker._global_node.node_ip_address` was not manually set from somewhere.

This splits out the part of the function for which the docstring is strictly accurate.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
