### PR TITLE
[tests] disable xgboost tests for now

### DIFF
--- a/python/ray/util/xgboost/BUILD
+++ b/python/ray/util/xgboost/BUILD
@@ -2,25 +2,25 @@
 # Tests from the python/ray/util/sgd/tests directory.
 # Please keep these sorted alphabetically.
 # --------------------------------------------------------------------
-py_test(
-    name = "simple_example",
-    size = "small",
-    srcs = ["simple_example.py"],
-    deps = [":xgb_lib"],
-    tags = ["exclusive"],
-)
+# py_test(
+#     name = "simple_example",
+#     size = "small",
+#     srcs = ["simple_example.py"],
+#     deps = [":xgb_lib"],
+#     tags = ["exclusive"],
+# )
 
-py_test(
-    name = "simple_tune",
-    size="small",
-    srcs = ["simple_tune.py"],
-    deps = [":xgb_lib"],
-    tags = ["exlcusive"]
-)
+# py_test(
+#     name = "simple_tune",
+#     size="small",
+#     srcs = ["simple_tune.py"],
+#     deps = [":xgb_lib"],
+#     tags = ["exlcusive"]
+# )
 
-# This is a dummy test dependency that causes the above tests to be
-# re-run if any of these files changes.
-py_library(
-    name = "xgb_lib",
-    srcs = glob(["**/*.py"], exclude=["tests/*.py"]),
-)
+# # This is a dummy test dependency that causes the above tests to be
+# # re-run if any of these files changes.
+# py_library(
+#     name = "xgb_lib",
+#     srcs = glob(["**/*.py"], exclude=["tests/*.py"]),
+# )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
xgboost is still not "stable" enough to have ray upstream test. 

we should wait until a pip release to actually add tests locally.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(