### PR TITLE
[PlacementGroup]Fix placement group wait api disorder bug

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/placementgroup/PlacementGroupImpl.java
+++ b/java/runtime/src/main/java/io/ray/runtime/placementgroup/PlacementGroupImpl.java
@@ -52,11 +52,11 @@ public class PlacementGroupImpl implements PlacementGroup {
 
   /**
    * Wait for the placement group to be ready within the specified time.
-   * @param timeoutMs Timeout in milliseconds.
+   * @param timeoutSeconds Timeout in seconds.
    * @return True if the placement group is created. False otherwise.
    */
-  public boolean wait(int timeoutMs) {
-    return Ray.internal().waitPlacementGroupReady(id, timeoutMs);
+  public boolean wait(int timeoutSeconds) {
+    return Ray.internal().waitPlacementGroupReady(id, timeoutSeconds);
   }
 
   /**

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1215,6 +1215,9 @@ cdef class CoreWorker:
         with nogil:
             status = CCoreWorkerProcess.GetCoreWorker() \
                 .WaitPlacementGroupReady(cplacement_group_id, ctimeout_ms)
+            if status.IsNotFound():
+                raise Exception("Placement group {} does not exist.".format(
+                    placement_group_id))
         return status.ok()
 
     def submit_actor_task(self,

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1207,14 +1207,14 @@ cdef class CoreWorker:
 
     def wait_placement_group_ready(self,
                                    PlacementGroupID placement_group_id,
-                                   int32_t timeout_ms):
+                                   int32_t timeout_seconds):
         cdef CRayStatus status
         cdef CPlacementGroupID cplacement_group_id = (
             CPlacementGroupID.FromBinary(placement_group_id.binary()))
-        cdef int ctimeout_ms = timeout_ms
+        cdef int ctimeout_seconds = timeout_seconds
         with nogil:
             status = CCoreWorkerProcess.GetCoreWorker() \
-                .WaitPlacementGroupReady(cplacement_group_id, ctimeout_ms)
+                .WaitPlacementGroupReady(cplacement_group_id, ctimeout_seconds)
             if status.IsNotFound():
                 raise Exception("Placement group {} does not exist.".format(
                     placement_group_id))

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -1256,7 +1256,7 @@ def test_create_placement_group_during_gcs_server_restart(
 @pytest.mark.parametrize(
     "ray_start_cluster_head", [
         generate_system_config_map(
-            num_heartbeats_timeout=3, ping_gcs_rpc_server_max_retries=60)
+            num_heartbeats_timeout=20, ping_gcs_rpc_server_max_retries=60)
     ],
     indirect=True)
 def test_placement_group_wait_api(ray_start_cluster_head):

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -1253,5 +1253,30 @@ def test_create_placement_group_during_gcs_server_restart(
         ray.get(placement_groups[i].ready())
 
 
+@pytest.mark.parametrize(
+    "ray_start_cluster_head", [
+        generate_system_config_map(
+            num_heartbeats_timeout=3, ping_gcs_rpc_server_max_retries=60)
+    ],
+    indirect=True)
+def test_placement_group_wait_api(ray_start_cluster_head):
+    cluster = ray_start_cluster_head
+    cluster.add_node(num_cpus=2)
+    cluster.add_node(num_cpus=2)
+    cluster.wait_for_nodes()
+
+    # Create placement group 1 successfully.
+    placement_group1 = ray.util.placement_group([{"CPU": 1}, {"CPU": 1}])
+    assert placement_group1.wait(10000)
+
+    # Restart gcs server.
+    cluster.head_node.kill_gcs_server()
+    cluster.head_node.start_gcs_server()
+
+    # Create placement group 2 successfully.
+    placement_group2 = ray.util.placement_group([{"CPU": 1}, {"CPU": 1}])
+    assert placement_group2.wait(10000)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -1267,7 +1267,7 @@ def test_placement_group_wait_api(ray_start_cluster_head):
 
     # Create placement group 1 successfully.
     placement_group1 = ray.util.placement_group([{"CPU": 1}, {"CPU": 1}])
-    assert placement_group1.wait(10000)
+    assert placement_group1.wait(10)
 
     # Restart gcs server.
     cluster.head_node.kill_gcs_server()
@@ -1275,7 +1275,14 @@ def test_placement_group_wait_api(ray_start_cluster_head):
 
     # Create placement group 2 successfully.
     placement_group2 = ray.util.placement_group([{"CPU": 1}, {"CPU": 1}])
-    assert placement_group2.wait(10000)
+    assert placement_group2.wait(10)
+
+    # Remove placement group 1.
+    ray.util.remove_placement_group(placement_group1)
+
+    # Wait for placement group 1 after it is removed.
+    with pytest.raises(Exception):
+        placement_group1.wait(10)
 
 
 if __name__ == "__main__":

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -83,10 +83,10 @@ class PlacementGroup:
             placement_group_bundle_index=bundle_index,
             resources=resources).remote(self)
 
-    def wait(self, timeout_ms: int) -> bool:
+    def wait(self, timeout_seconds: int) -> bool:
         """Wait for the placement group to be ready within the specified time.
         Args:
-             timeout_ms(str): Timeout in milliseconds.
+             timeout_seconds(str): Timeout in seconds.
         Return:
              True if the placement group is created. False otherwise.
         """
@@ -94,7 +94,7 @@ class PlacementGroup:
         worker.check_connected()
 
         return worker.core_worker.wait_placement_group_ready(
-            self.id, timeout_ms)
+            self.id, timeout_seconds)
 
     @property
     def bundle_specs(self) -> List[Dict]:

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -83,6 +83,19 @@ class PlacementGroup:
             placement_group_bundle_index=bundle_index,
             resources=resources).remote(self)
 
+    def wait(self, timeout_ms: int) -> bool:
+        """Wait for the placement group to be ready within the specified time.
+        Args:
+             timeout_ms(str): Timeout in milliseconds.
+        Return:
+             True if the placement group is created. False otherwise.
+        """
+        worker = ray.worker.global_worker
+        worker.check_connected()
+
+        return worker.core_worker.wait_placement_group_ready(
+            self.id, timeout_ms)
+
     @property
     def bundle_specs(self) -> List[Dict]:
         """List[Dict]: Return bundles belonging to this placement group."""

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1460,14 +1460,14 @@ Status CoreWorker::RemovePlacementGroup(const PlacementGroupID &placement_group_
 }
 
 Status CoreWorker::WaitPlacementGroupReady(const PlacementGroupID &placement_group_id,
-                                           int timeout_ms) {
+                                           int timeout_seconds) {
   std::shared_ptr<std::promise<Status>> status_promise =
       std::make_shared<std::promise<Status>>();
   RAY_CHECK_OK(gcs_client_->PlacementGroups().AsyncWaitUntilReady(
       placement_group_id,
       [status_promise](const Status &status) { status_promise->set_value(status); }));
   auto status_future = status_promise->get_future();
-  if (status_future.wait_for(std::chrono::milliseconds(timeout_ms)) !=
+  if (status_future.wait_for(std::chrono::seconds(timeout_seconds)) !=
       std::future_status::ready) {
     std::ostringstream stream;
     stream << "There was timeout in waiting for placement group " << placement_group_id

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -682,11 +682,11 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// Returns once the placement group is created or the timeout expires.
   ///
   /// \param placement_group The id of a placement group to wait for.
-  /// \param timeout_ms Timeout in milliseconds.
+  /// \param timeout_seconds Timeout in seconds.
   /// \return Status OK if the placement group is created. TimedOut if request to GCS
   /// server times out. NotFound if placement group is already removed or doesn't exist.
   Status WaitPlacementGroupReady(const PlacementGroupID &placement_group_id,
-                                 int timeout_ms);
+                                 int timeout_seconds);
 
   /// Submit an actor task.
   ///

--- a/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskSubmitter.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskSubmitter.cc
@@ -297,11 +297,11 @@ Java_io_ray_runtime_task_NativeTaskSubmitter_nativeRemovePlacementGroup(
 
 JNIEXPORT jboolean JNICALL
 Java_io_ray_runtime_task_NativeTaskSubmitter_nativeWaitPlacementGroupReady(
-    JNIEnv *env, jclass p, jbyteArray placement_group_id_bytes, jint timeout_ms) {
+    JNIEnv *env, jclass p, jbyteArray placement_group_id_bytes, jint timeout_seconds) {
   const auto placement_group_id =
       JavaByteArrayToId<ray::PlacementGroupID>(env, placement_group_id_bytes);
   auto status = ray::CoreWorkerProcess::GetCoreWorker().WaitPlacementGroupReady(
-      placement_group_id, timeout_ms);
+      placement_group_id, timeout_seconds);
   if (status.IsNotFound()) {
     env->ThrowNew(java_ray_exception_class, status.message().c_str());
   }

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -410,28 +410,44 @@ void GcsPlacementGroupManager::HandleWaitPlacementGroupUntilReady(
   RAY_LOG(DEBUG) << "Waiting for placement group until ready, placement group id = "
                  << placement_group_id;
 
-  // If the placement group has been successfully created, return directly.
+  auto callback = [placement_group_id, reply, send_reply_callback](const Status &status) {
+    RAY_LOG(DEBUG)
+        << "Finished waiting for placement group until ready, placement group id = "
+        << placement_group_id;
+    GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
+  };
+
+  // If the placement group does not exist or it has been successfully created, return
+  // directly.
   const auto &iter = registered_placement_groups_.find(placement_group_id);
-  if (iter != registered_placement_groups_.end() &&
-      iter->second->GetState() == rpc::PlacementGroupTableData::CREATED) {
+  if (iter == registered_placement_groups_.end()) {
+    // GCS client does not guarantee the order of placement group creation and
+    // wait, and GCS may call wait placement group first and then create placement group.
+    // So we need to detect whether the placement group does not exist or is removed.
+    auto on_done = [this, placement_group_id, reply, callback, send_reply_callback](
+                       const Status &status,
+                       const boost::optional<PlacementGroupTableData> &result) {
+      if (result) {
+        placement_group_to_create_callbacks_[placement_group_id].emplace_back(
+            std::move(callback));
+      } else {
+        RAY_LOG(DEBUG) << "Placement group is not exist, placement group id = "
+                       << placement_group_id;
+        GCS_RPC_SEND_REPLY(send_reply_callback, reply,
+                           Status::NotFound("Placement group is not exist."));
+      }
+    };
+
+    Status status =
+        gcs_table_storage_->PlacementGroupTable().Get(placement_group_id, on_done);
+    if (!status.ok()) {
+      on_done(status, boost::none);
+    }
+  } else if (iter->second->GetState() == rpc::PlacementGroupTableData::CREATED) {
     RAY_LOG(DEBUG) << "Placement group is created, placement group id = "
                    << placement_group_id;
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
   } else {
-    // NOTE: We don't check if the placement group exist. There are two reasons:
-    // 1.`wait` is a method of placement group object. Placement group object is
-    // obtained by create placement group api, so it can guarantee the existence of
-    // placement group. Currently, we will not call the wait api after deleting placement
-    // group.
-    // 2.GCS client does not guarantee the order of placement group creation and
-    // wait, so GCS may call wait placement group first and then create placement group.
-    auto callback = [placement_group_id, reply,
-                     send_reply_callback](const Status &status) {
-      RAY_LOG(DEBUG)
-          << "Finished waiting for placement group until ready, placement group id = "
-          << placement_group_id;
-      GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
-    };
     placement_group_to_create_callbacks_[placement_group_id].emplace_back(
         std::move(callback));
   }

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -421,20 +421,24 @@ void GcsPlacementGroupManager::HandleWaitPlacementGroupUntilReady(
   // directly.
   const auto &iter = registered_placement_groups_.find(placement_group_id);
   if (iter == registered_placement_groups_.end()) {
-    // GCS client does not guarantee the order of placement group creation and
-    // wait, and GCS may call wait placement group first and then create placement group.
-    // So we need to detect whether the placement group does not exist or is removed.
+    // Check whether the placement group does not exist or is removed.
     auto on_done = [this, placement_group_id, reply, callback, send_reply_callback](
                        const Status &status,
                        const boost::optional<PlacementGroupTableData> &result) {
       if (result) {
-        placement_group_to_create_callbacks_[placement_group_id].emplace_back(
-            std::move(callback));
-      } else {
-        RAY_LOG(DEBUG) << "Placement group is not exist, placement group id = "
+        RAY_LOG(DEBUG) << "Placement group is removed, placement group id = "
                        << placement_group_id;
         GCS_RPC_SEND_REPLY(send_reply_callback, reply,
-                           Status::NotFound("Placement group is not exist."));
+                           Status::NotFound("Placement group is removed."));
+      } else {
+        // `wait` is a method of placement group object. Placement group object is
+        // obtained by create placement group api, so it can guarantee the existence of
+        // placement group.
+        // GCS client does not guarantee the order of placement group creation and
+        // wait, so GCS may call wait placement group first and then create placement
+        // group.
+        placement_group_to_create_callbacks_[placement_group_id].emplace_back(
+            std::move(callback));
       }
     };
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
![image](https://user-images.githubusercontent.com/13081808/102004928-2e654980-3d50-11eb-96b0-f7fecc854a4e.png)
The RPC request of placement group is not in order, this will cause that GCS may deal with wait first and then create placement group.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
