### PR TITLE
[RLlib] Issue 12831: AttributeError: 'NoneType' object has no attribute 'id' when using custom Atari env.

### DIFF
--- a/rllib/env/atari_wrappers.py
+++ b/rllib/env/atari_wrappers.py
@@ -278,7 +278,7 @@ def wrap_deepmind(env, dim=84, framestack=True):
     """
     env = MonitorEnv(env)
     env = NoopResetEnv(env, noop_max=30)
-    if "NoFrameskip" in env.spec.id:
+    if env.spec is not None and "NoFrameskip" in env.spec.id:
         env = MaxAndSkipEnv(env, skip=4)
     env = EpisodicLifeEnv(env)
     if "FIRE" in env.unwrapped.get_action_meanings():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

AttributeError: 'NoneType' object has no attribute 'id' when using custom Atari env.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Closes #12831 

<!-- Please give a short summary of the change and the problem this solves. -->

Closes #12831 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
