### PR TITLE
[Logging] Use file handle instead of log rotation file-like object

### DIFF
--- a/python/ray/workers/default_worker.py
+++ b/python/ray/workers/default_worker.py
@@ -11,8 +11,7 @@ import ray.node
 import ray.ray_constants as ray_constants
 import ray.utils
 from ray.parameter import RayParams
-from ray.ray_logging import (StandardStreamInterceptor,
-                             setup_and_get_worker_interceptor_logger)
+from ray.ray_logging import get_worker_log_file_name, configure_log_file
 
 parser = argparse.ArgumentParser(
     description=("Parse addresses for the worker "
@@ -175,20 +174,10 @@ if __name__ == "__main__":
     ray.worker._global_node = node
     ray.worker.connect(node, mode=mode)
 
-    # Redirect stdout and stderr to the default worker interceptor logger.
-    # NOTE: We deprecated redirect_worker_output arg,
-    # so we don't need to handle here.
-    stdout_interceptor = StandardStreamInterceptor(
-        setup_and_get_worker_interceptor_logger(args, is_for_stdout=True),
-        intercept_stdout=True)
-    stderr_interceptor = StandardStreamInterceptor(
-        setup_and_get_worker_interceptor_logger(args, is_for_stdout=False),
-        intercept_stdout=False)
-    # Although the os level fd is duplicated already, we should overwrite
-    # the python level stdout/stderr object.
-    # Otherwise, buffers won't be flushed.
-    sys.stdout = stdout_interceptor
-    sys.stderr = stderr_interceptor
+    # Setup log file.
+    out_file, err_file = node.get_log_file_handles(
+        get_worker_log_file_name(args.worker_type))
+    configure_log_file(out_file, err_file)
 
     if mode == ray.WORKER_MODE:
         ray.worker.global_worker.main_loop()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is a quick patch.

Since we will cherry-pick this PR for the next release which will happen in a few days, it is safer to just go back to previous behavior (before log rotation support) instead of building the full-file-like object for log rotation. 

I will work on supporting all file methods after this patch (so that I will have enough time to avoid regression).

I verified it works with tf_mnist_example.py which streams cpp logs.

cc @PidgeyBE 

## Related issue number

https://github.com/ray-project/ray/issues/12784

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
