### PR TITLE
Fix bug in ModelCatalog when using custom action distribution

### DIFF
--- a/rllib/models/catalog.py
+++ b/rllib/models/catalog.py
@@ -191,7 +191,7 @@ class ModelCatalog:
                 "Using custom action distribution {}".format(action_dist_name))
             dist_cls = _global_registry.get(RLLIB_ACTION_DIST,
                                             action_dist_name)
-            dist_cls = ModelCatalog._get_multi_action_distribution(
+            return ModelCatalog._get_multi_action_distribution(
                 dist_cls, action_space, {}, framework)
 
         # Dist_type is given directly as a class.

--- a/rllib/models/catalog.py
+++ b/rllib/models/catalog.py
@@ -708,7 +708,8 @@ class ModelCatalog:
                 action_space=action_space,
                 child_distributions=child_dists,
                 input_lens=input_lens), int(sum(input_lens))
-        return dist_class
+        return dist_class, dist_class.required_model_output_shape(
+            action_space, config)
 
     @staticmethod
     def _validate_config(config: ModelConfigDict, framework: str) -> None:

--- a/rllib/models/catalog.py
+++ b/rllib/models/catalog.py
@@ -192,7 +192,7 @@ class ModelCatalog:
             dist_cls = _global_registry.get(RLLIB_ACTION_DIST,
                                             action_dist_name)
             return ModelCatalog._get_multi_action_distribution(
-                dist_cls, action_space, {}, framework)
+                dist_cls, action_space, config, framework)
 
         # Dist_type is given directly as a class.
         elif type(dist_type) is type and \


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously, when a custom action distribution is defined, `ModelCatalog._get_multi_action_distribution` was assigned to `dist_cls`, which later is returned as tuple together with `dist_cls.required_model_output_shape`. This tuple is already returned from `_get_multi_action_distribution` though, so it can directly be returned from `get_action_dist`.

## Related issue number

None

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
