### PR TITLE
Fix continue for debugger

### DIFF
--- a/python/ray/tests/test_ray_debugger.py
+++ b/python/ray/tests/test_ray_debugger.py
@@ -39,6 +39,33 @@ def test_ray_debugger_breakpoint(shutdown_only):
 
 @pytest.mark.skipif(
     platform.system() == "Windows", reason="Failing on Windows.")
+def test_ray_debugger_commands(shutdown_only):
+    ray.init(num_cpus=2)
+
+    @ray.remote
+    def f():
+        ray.util.pdb.set_trace()
+
+    result1 = f.remote()
+    result2 = f.remote()
+
+    # Make sure that calling "continue" in the debugger
+    # gives back control to the debugger loop:
+    p = pexpect.spawn("ray debug")
+    p.expect("Enter breakpoint index or press enter to refresh: ")
+    p.sendline("0")
+    p.expect("-> ray.util.pdb.set_trace()")
+    p.sendline("c")
+    p.expect("Enter breakpoint index or press enter to refresh: ")
+    p.sendline("0")
+    p.expect("-> ray.util.pdb.set_trace()")
+    p.sendline("c")
+
+    ray.get([result1, result2])
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="Failing on Windows.")
 def test_ray_debugger_stepping(shutdown_only):
     ray.init(num_cpus=1)
 

--- a/python/ray/util/rpdb.py
+++ b/python/ray/util/rpdb.py
@@ -125,6 +125,13 @@ class RemotePdb(Pdb):
 
     do_q = do_exit = do_quit
 
+    def do_continue(self, arg):
+        self.__restore()
+        self.handle.connection.close()
+        return Pdb.do_continue(self, arg)
+
+    do_c = do_continue
+
     def set_trace(self, frame=None):
         if frame is None:
             frame = sys._getframe().f_back


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR makes it so the debugger drops back into the main debug loop when the user continues the execution of a task with the "continue" or "c" command.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
