### PR TITLE
[autoscaler][k8s][doc][minor] Fix typo in k8s doc.

### DIFF
--- a/doc/source/cluster/k8s-operator.rst
+++ b/doc/source/cluster/k8s-operator.rst
@@ -22,7 +22,7 @@ The rest of this document explains step-by-step how to use the Ray Kubernetes Op
 .. note::
    The example commands in this document launch six Kubernetes pods, using a total of 6 CPU and 3.5Gi memory.   
    If you are experimenting using a test Kubernetes environment such as `minikube`_, make sure to provision sufficient resources, e.g.
-   :bash:`minikube start --cpu=6 --memory="4G"`.
+   :bash:`minikube start --cpus=6 --memory="4G"`.
    Alternatively, reduce resource usage by editing the ``yaml`` files referenced in this document; for example, reduce ``minWorkers``
    in ``example_cluster.yaml`` and ``example_cluster2.yaml``.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fix typo in docs -- `minikube start` flag should be `--cpus` not `cpu`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
