### PR TITLE
Check for raylet PID as ppid in dashboard agent fate-sharing

### DIFF
--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -104,7 +104,7 @@ class DashboardAgent(object):
                         dashboard_consts.
                         DASHBOARD_AGENT_CHECK_PARENT_INTERVAL_SECONDS)
             except Exception:
-                logger.error("Failed to check parent PID. Exiting.")
+                logger.error("Failed to check parent PID, exiting.")
                 sys.exit(1)
 
         check_parent_task = create_task(_check_parent())

--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -62,7 +62,9 @@ class DashboardAgent(object):
         self.object_store_name = object_store_name
         self.raylet_name = raylet_name
         self.node_id = os.environ["RAY_NODE_ID"]
-        assert self.node_id, "Empty node id (RAY_NODE_ID)."
+        self.ppid = int(os.environ["RAY_RAYLET_PID"])
+        assert self.ppid > 0
+        logger.info("Parent pid is %s", self.ppid)
         self.server = aiogrpc.server(options=(("grpc.so_reuseport", 0), ))
         self.grpc_port = self.server.add_insecure_port(
             f"[::]:{self.dashboard_agent_port}")
@@ -89,20 +91,21 @@ class DashboardAgent(object):
 
     async def run(self):
         async def _check_parent():
-            """Check if raylet is dead."""
-            curr_proc = psutil.Process()
-            ppid = int(os.environ["RAY_NODE_PID"])
-            logger.info("Parent pid is %s", ppid)
-            while True:
-                parent = curr_proc.parent()
-                if parent is None or parent.pid == 1 or (ppid and
-                                                         ppid != parent.pid):
-                    logger.error("raylet is dead, agent will die because "
-                                 "it fate-shares with raylet.")
-                    sys.exit(0)
-                await asyncio.sleep(
-                    dashboard_consts.
-                    DASHBOARD_AGENT_CHECK_PARENT_INTERVAL_SECONDS)
+            """Check if raylet is dead and fate-share if it is."""
+            try:
+                curr_proc = psutil.Process()
+                while True:
+                    parent = curr_proc.parent()
+                    if (parent is None or parent.pid == 1
+                            or self.ppid != parent.pid):
+                        logger.error("Raylet is dead, exiting.")
+                        sys.exit(0)
+                    await asyncio.sleep(
+                        dashboard_consts.
+                        DASHBOARD_AGENT_CHECK_PARENT_INTERVAL_SECONDS)
+            except Exception:
+                logger.error("Failed to check parent PID. Exiting.")
+                sys.exit(1)
 
         check_parent_task = create_task(_check_parent())
 

--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -91,9 +91,12 @@ class DashboardAgent(object):
         async def _check_parent():
             """Check if raylet is dead."""
             curr_proc = psutil.Process()
+            ppid = int(os.environ["RAY_NODE_PID"])
+            logger.info("Parent pid is %s", ppid)
             while True:
                 parent = curr_proc.parent()
-                if parent is None or parent.pid == 1:
+                if parent is None or parent.pid == 1 or (ppid and
+                                                         ppid != parent.pid):
                     logger.error("raylet is dead, agent will die because "
                                  "it fate-shares with raylet.")
                     sys.exit(0)

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -137,6 +137,11 @@ def test_basic(ray_start_with_dashboard):
         assert agent_proc.pid == agent_pid
         time.sleep(1)
 
+    # The agent should be dead if raylet exits.
+    raylet_proc.kill()
+    raylet_proc.wait()
+    agent_proc.wait(5)
+
     # Check redis keys are set.
     logger.info("Check redis keys are set.")
     dashboard_address = client.get(dashboard_consts.REDIS_KEY_DASHBOARD)

--- a/src/ray/raylet/agent_manager.cc
+++ b/src/ray/raylet/agent_manager.cc
@@ -58,8 +58,10 @@ void AgentManager::StartAgent() {
   }
   argv.push_back(NULL);
   // Set node id to agent.
+  static std::string pid_string = std::to_string(getpid());
   ProcessEnvironment env;
   env.insert({"RAY_NODE_ID", options_.node_id.Hex()});
+  env.insert({"RAY_NODE_PID", pid_string});
   Process child(argv.data(), nullptr, ec, false, env);
   if (!child.IsValid() || ec) {
     // The worker failed to start. This is a fatal error.

--- a/src/ray/raylet/agent_manager.cc
+++ b/src/ray/raylet/agent_manager.cc
@@ -58,10 +58,9 @@ void AgentManager::StartAgent() {
   }
   argv.push_back(NULL);
   // Set node id to agent.
-  static std::string pid_string = std::to_string(getpid());
   ProcessEnvironment env;
   env.insert({"RAY_NODE_ID", options_.node_id.Hex()});
-  env.insert({"RAY_NODE_PID", pid_string});
+  env.insert({"RAY_RAYLET_PID", std::to_string(getpid())});
   Process child(argv.data(), nullptr, ec, false, env);
   if (!child.IsValid() || ec) {
     // The worker failed to start. This is a fatal error.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The dashboard agent process sometimes leaks on linux machines. This could be because its parent PID is reassigned to something other than the init process. @ericl confirmed that this fixes the issue for him locally.

Original PR here: https://github.com/ray-project/ray/pull/12256

## Related issue number

Closes https://github.com/ray-project/ray/pull/12867

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
