### PR TITLE
[autoscaler][k8s][minor] Use nightly images in all Kubernetes examples.

### DIFF
--- a/python/ray/autoscaler/kubernetes/defaults.yaml
+++ b/python/ray/autoscaler/kubernetes/defaults.yaml
@@ -142,7 +142,7 @@ head_node:
           #   - rsync (used for `ray rsync` commands and file mounts)
           #   - screen (used for `ray attach`)
           #   - kubectl (used by the autoscaler to manage worker pods)
-          image: rayproject/ray
+          image: rayproject/ray:nightly
           # Do not change this command - it keeps the pod alive until it is
           # explicitly killed.
           command: ["/bin/bash", "-c", "--"]
@@ -215,7 +215,7 @@ worker_nodes:
           # You are free (and encouraged) to use your own container image,
           # but it should have the following installed:
           #   - rsync (used for `ray rsync` commands and file mounts)
-          image: rayproject/ray
+          image: rayproject/ray:nightly
           # Do not change this command - it keeps the pod alive until it is
           # explicitly killed.
           command: ["/bin/bash", "-c", "--"]

--- a/python/ray/autoscaler/kubernetes/example-full.yaml
+++ b/python/ray/autoscaler/kubernetes/example-full.yaml
@@ -142,7 +142,7 @@ head_node:
           #   - rsync (used for `ray rsync` commands and file mounts)
           #   - screen (used for `ray attach`)
           #   - kubectl (used by the autoscaler to manage worker pods)
-          image: rayproject/ray
+          image: rayproject/ray:nightly
           # Do not change this command - it keeps the pod alive until it is
           # explicitly killed.
           command: ["/bin/bash", "-c", "--"]
@@ -215,7 +215,7 @@ worker_nodes:
           # You are free (and encouraged) to use your own container image,
           # but it should have the following installed:
           #   - rsync (used for `ray rsync` commands and file mounts)
-          image: rayproject/ray
+          image: rayproject/ray:nightly
           # Do not change this command - it keeps the pod alive until it is
           # explicitly killed.
           command: ["/bin/bash", "-c", "--"]

--- a/python/ray/autoscaler/kubernetes/example-ingress.yaml
+++ b/python/ray/autoscaler/kubernetes/example-ingress.yaml
@@ -146,7 +146,7 @@ head_node:
               #   - rsync (used for `ray rsync` commands and file mounts)
               #   - screen (used for `ray attach`)
               #   - kubectl (used by the autoscaler to manage worker pods)
-              image: rayproject/ray
+              image: rayproject/ray:nightly
               # Do not change this command - it keeps the pod alive until it is
               # explicitly killed.
               command: ["/bin/bash", "-c", "--"]
@@ -221,7 +221,7 @@ worker_nodes:
               # You are free (and encouraged) to use your own container image,
               # but it should have the following installed:
               #   - rsync (used for `ray rsync` commands and file mounts)
-              image: rayproject/ray
+              image: rayproject/ray:nightly
               # Do not change this command - it keeps the pod alive until it is
               # explicitly killed.
               command: ["/bin/bash", "-c", "--"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Several users have had issues when attempting using the cluster launcher to launch k8s clusters with a version of Ray in the launcher newer than the version in the worker pod container images.
I think it's safer to suggest using the nightly images in the example configs.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
