### PR TITLE
[k8s] avoid bad error messages

### DIFF
--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -256,8 +256,16 @@ class NodeUpdater:
 
                         retry_str = "(" + str(e) + ")"
                         if hasattr(e, "cmd"):
+                            if isinstance(e.cmd, str):
+                                cmd_ = e.cmd
+                            elif isinstance(e.cmd, list):
+                                cmd_ = " ".join(e.cmd)
+                            else:
+                                logger.debug(
+                                    f"e.cmd type ({type(e.cmd)}) not list or str.")
+                                cmd_ = str(e.cmd)
                             retry_str = "(Exit Status {}): {}".format(
-                                e.returncode, " ".join(e.cmd))
+                                e.returncode, cmd_)
 
                         cli_logger.print(
                             "SSH still not available {}, "

--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -261,8 +261,8 @@ class NodeUpdater:
                             elif isinstance(e.cmd, list):
                                 cmd_ = " ".join(e.cmd)
                             else:
-                                logger.debug(
-                                    f"e.cmd type ({type(e.cmd)}) not list or str.")
+                                logger.debug(f"e.cmd type ({type(e.cmd)}) not "
+                                             "list or str.")
                                 cmd_ = str(e.cmd)
                             retry_str = "(Exit Status {}): {}".format(
                                 e.returncode, cmd_)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Error message currently shows up like a meme:

```
2020-12-14 23:36:22,652	INFO updater.py:280 -- SSH still not available (Exit Status 127): k u b e c t l   - n   r a y   e x e c   - i t   r a y - w o r k e r - d f s z 4   - -   b a s h   - - l o g i n   - c   - i   ' t r u e   & &   s o u r c e   ~ / . b a s h r c   & &   e x p o r t   O M P _ N U M _ T H R E A D S = 1   P Y T H O N W A R N I N G S = i g n o r e   & &   ( u p t i m e ) ', retrying in 5 seconds.
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(