### PR TITLE
[core] recover startup logs

### DIFF
--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -737,8 +737,6 @@ class Node:
         process_info = ray._private.services.start_monitor(
             self._redis_address,
             self._logs_dir,
-            stdout_file=subprocess.DEVNULL,
-            stderr_file=subprocess.DEVNULL,
             autoscaling_config=self._ray_params.autoscaling_config,
             redis_password=self._ray_params.redis_password,
             fate_share=self.kernel_fate_share)

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -733,7 +733,12 @@ class Node:
         raise NotImplementedError
 
     def start_monitor(self):
-        """Start the monitor."""
+        """Start the monitor.
+
+        Autoscaling output goes to these monitor.err/out files, and
+        any modification to these files may break existing
+        cluster launching commands.
+        """
         stdout_file, stderr_file = self.get_log_file_handles(
             "monitor", unique=True)
         process_info = ray._private.services.start_monitor(

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -734,9 +734,13 @@ class Node:
 
     def start_monitor(self):
         """Start the monitor."""
+        stdout_file, stderr_file = self.get_log_file_handles(
+            "monitor", unique=True)
         process_info = ray._private.services.start_monitor(
             self._redis_address,
             self._logs_dir,
+            stdout_file=stdout_file,
+            stderr_file=stderr_file,
             autoscaling_config=self._ray_params.autoscaling_config,
             redis_password=self._ray_params.redis_password,
             fate_share=self.kernel_fate_share)


### PR DESCRIPTION
## Why are these changes needed?

Startup logs were going to devnull :) This change reverts the regression, and it now works for me on my cluster.

Note that this also means that `monitor` will have 3 files -- monitor.log, monitor.err, and monitor.out.

This is only a temporary measure to unblock the release

Closes #12771 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(