### PR TITLE
[Release Tests] shm size microbenchmark

### DIFF
--- a/release/microbenchmark/cluster.yaml
+++ b/release/microbenchmark/cluster.yaml
@@ -4,6 +4,8 @@ docker:
     image: anyscale/ray:latest
     container_name: ray_container
     pull_before_run: False
+    run_options:
+        - "--shm-size=100gb"
 
 provider:
     type: aws

--- a/release/microbenchmark/run.sh
+++ b/release/microbenchmark/run.sh
@@ -57,4 +57,4 @@ pip install -U "$wheel"
 
 unset RAY_ADDRESS
 ray stop --force
-OMP_NUM_THREADS=64 ray microbenchmark
+ray microbenchmark


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This does two things to fix a perf regression in the microbenchmark when running on docker.
- set shm-size to 100gb in docker image for microbenchmarks because otherwise client puts/gets run very slowly
- do not prepend OMP_THREAD arg to microbenchmark script. Actors should be functioning with one core each, not 64 each.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #12895 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
