### PR TITLE
[tune] Add `points_to_evaluate` to BasicVariantGenerator

### DIFF
--- a/doc/source/tune/api_docs/search_space.rst
+++ b/doc/source/tune/api_docs/search_space.rst
@@ -263,10 +263,7 @@ Grid Search API
 
 .. autofunction:: ray.tune.grid_search
 
-Internals
----------
+References
+----------
 
-BasicVariantGenerator
-~~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: ray.tune.suggest.BasicVariantGenerator
+See also :ref:`tune-basicvariant`.

--- a/doc/source/tune/api_docs/suggestion.rst
+++ b/doc/source/tune/api_docs/suggestion.rst
@@ -22,6 +22,10 @@ Summary
      - Summary
      - Website
      - Code Example
+   * - :ref:`Random search/grid search <tune-basicvariant>`
+     - Random search/grid search
+     -
+     - :doc:`/tune/examples/tune_basic_example`
    * - :ref:`AxSearch <tune-ax>`
      - Bayesian/Bandit Optimization
      - [`Ax <https://ax.dev/>`__]
@@ -122,6 +126,21 @@ identifier.
       os.path.join("~/my_results", "my-experiment-1"))
 
 .. note:: This is currently not implemented for: AxSearch, TuneBOHB, SigOptSearch, and DragonflySearch.
+
+.. _tune-basicvariant:
+
+Random search and grid search (tune.suggest.basic_variant.BasicVariantGenerator)
+--------------------------------------------------------------------------------
+
+The default and most basic way to do hyperparameter search is via random and grid search.
+Ray Tune does this through the :class:`BasicVariantGenerator <ray.tune.suggest.basic_variant.BasicVariantGenerator>`
+class that generates trial variants given a search space definition.
+
+The :class:`BasicVariantGenerator <ray.tune.suggest.basic_variant.BasicVariantGenerator>` is used per
+default if no search algorithm is passed to
+:func:`tune.run() <ray.tune.run>`.
+
+.. autoclass:: ray.tune.suggest.basic_variant.BasicVariantGenerator
 
 .. _tune-ax:
 

--- a/doc/source/tune/examples/index.rst
+++ b/doc/source/tune/examples/index.rst
@@ -13,7 +13,7 @@ If any example is broken, or if you'd like to add an example to this page, feel 
 General Examples
 ----------------
 
-
+- :doc:`/tune/examples/tune_basic_example`: Simple example for doing a basic random and grid search.
 - :doc:`/tune/examples/async_hyperband_example`: Example of using a simple tuning function with AsyncHyperBandScheduler.
 - :doc:`/tune/examples/hyperband_function_example`: Example of using a Trainable function with HyperBandScheduler.  Also uses the AsyncHyperBandScheduler.
 - :doc:`/tune/examples/pbt_function`: Example of using the function API with a PopulationBasedTraining scheduler.

--- a/doc/source/tune/examples/tune_basic_example.rst
+++ b/doc/source/tune/examples/tune_basic_example.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+tune_basic_example
+~~~~~~~~~~~~~~~~~~
+
+.. literalinclude:: /../../python/ray/tune/examples/tune_basic_example.py

--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -696,6 +696,15 @@ py_test(
     args = ["--smoke-test"]
 )
 
+py_test(
+    name = "tune_basic_example",
+    size = "small",
+    srcs = ["examples/tune_basic_example.py"],
+    deps = [":tune_lib"],
+    tags = ["exclusive", "example"],
+    args = ["--smoke-test"]
+)
+
 # Downloads too much data.
 # py_test(
 #     name = "tune_cifar10_gluon",

--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -157,7 +157,7 @@ py_test(
 
 py_test(
     name = "test_sample",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_sample.py"],
     deps = [":tune_lib"],
     tags = ["exclusive"],

--- a/python/ray/tune/examples/tune_basic_example.py
+++ b/python/ray/tune/examples/tune_basic_example.py
@@ -1,0 +1,51 @@
+"""This example demonstrates basic Ray Tune random search and grid search."""
+import time
+
+import ray
+from ray import tune
+
+
+def evaluation_fn(step, width, height):
+    time.sleep(0.1)
+    return (0.1 + width * step / 100)**(-1) + height * 0.1
+
+
+def easy_objective(config):
+    # Hyperparameters
+    width, height = config["width"], config["height"]
+
+    for step in range(config["steps"]):
+        # Iterative training function - can be any arbitrary training procedure
+        intermediate_score = evaluation_fn(step, width, height)
+        # Feed the score back back to Tune.
+        tune.report(iterations=step, mean_loss=intermediate_score)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--smoke-test", action="store_true", help="Finish quickly for testing")
+    args, _ = parser.parse_known_args()
+    ray.init(configure_logging=False)
+
+    # This will do a grid search over the `activation` parameter. This means
+    # that each of the two values (`relu` and `tanh`) will be sampled once
+    # for each sample (`num_samples`). We end up with 2 * 50 = 100 samples.
+    # The `width` and `height` parameters are sampled randomly.
+    # `steps` is a constant parameter.
+
+    analysis = tune.run(
+        easy_objective,
+        metric="mean_loss",
+        mode="min",
+        num_samples=5 if args.smoke_test else 50,
+        config={
+            "steps": 100,
+            "width": tune.uniform(0, 20),
+            "height": tune.uniform(-100, 100),
+            "activation": tune.grid_search(["relu", "tanh"])
+        })
+
+    print("Best hyperparameters found were: ", analysis.best_config)

--- a/python/ray/tune/examples/tune_basic_example.py
+++ b/python/ray/tune/examples/tune_basic_example.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
         mode="min",
         num_samples=5 if args.smoke_test else 50,
         config={
-            "steps": 100,
+            "steps": 5 if args.smoke_test else 100,
             "width": tune.uniform(0, 20),
             "height": tune.uniform(-100, 100),
             "activation": tune.grid_search(["relu", "tanh"])

--- a/python/ray/tune/sample.py
+++ b/python/ray/tune/sample.py
@@ -53,6 +53,14 @@ class Domain:
     def is_function(self):
         return False
 
+    def is_valid(self, value: Any):
+        """Returns True if `value` is a valid value in this domain."""
+        raise NotImplementedError
+
+    @property
+    def domain_str(self):
+        return "(unknown)"
+
 
 class Sampler:
     def sample(self,
@@ -203,6 +211,13 @@ class Float(Domain):
         new.set_sampler(Quantized(new.get_sampler(), q), allow_override=True)
         return new
 
+    def is_valid(self, value: float):
+        return self.lower <= value <= self.upper
+
+    @property
+    def domain_str(self):
+        return f"({self.lower}, {self.upper})"
+
 
 class Integer(Domain):
     class _Uniform(Uniform):
@@ -231,6 +246,13 @@ class Integer(Domain):
         new = copy(self)
         new.set_sampler(self._Uniform())
         return new
+
+    def is_valid(self, value: int):
+        return self.lower <= value <= self.upper
+
+    @property
+    def domain_str(self):
+        return f"({self.lower}, {self.upper})"
 
 
 class Categorical(Domain):
@@ -264,6 +286,13 @@ class Categorical(Domain):
     def __getitem__(self, item):
         return self.categories[item]
 
+    def is_valid(self, value: Any):
+        return value in self.categories
+
+    @property
+    def domain_str(self):
+        return f"{self.categories}"
+
 
 class Function(Domain):
     class _CallSampler(BaseSampler):
@@ -294,6 +323,13 @@ class Function(Domain):
 
     def is_function(self):
         return True
+
+    def is_valid(self, value: Any):
+        return True  # This is user-defined, so lets not assume anything
+
+    @property
+    def domain_str(self):
+        return f"{self.func}()"
 
 
 class Quantized(Sampler):

--- a/python/ray/tune/suggest/basic_variant.py
+++ b/python/ray/tune/suggest/basic_variant.py
@@ -16,19 +16,9 @@ from ray.tune.suggest.search import SearchAlgorithm
 class BasicVariantGenerator(SearchAlgorithm):
     """Uses Tune's variant generation for resolving variables.
 
-    See also: `ray.tune.suggest.variant_generator`.
+    This is the default search algorithm used if no other search algorithm
+    is specified.
 
-    This generator accepts a pre-set list of points that should be evaluated.
-    The points will replace the first samples of each experiment passed to
-    the ``BasicVariantGenerator``.
-
-    Each point will replace one sample of the specified ``num_samples``. If
-    grid search variables are overwritten with the values specified in the
-    presets, the number of samples will thus be reduced. For example, if
-    a grid search variable ``a`` with values ``[0, 1, 2]`` is passed, and
-    ``num_samples=5``, and if ``a=2`` is passed as the first and only
-    ``points_to_evaluate``, a total number of 13 samples is generated: One
-    for ``a=2``, and then 4 samples for each of the 3 grid search variables.
 
     Args:
         points_to_evaluate (list): Initial parameter suggestions to be run
@@ -37,26 +27,66 @@ class BasicVariantGenerator(SearchAlgorithm):
             for future parameters. Needs to be a list of dicts containing the
             configurations.
 
-    User API:
+
+    Example:
 
     .. code-block:: python
 
         from ray import tune
-        from ray.tune.suggest import BasicVariantGenerator
 
-        searcher = BasicVariantGenerator()
-        tune.run(my_trainable_func, algo=searcher)
+        # This will automatically use the `BasicVariantGenerator`
+        tune.run(
+            lambda config: config["a"] + config["b"],
+            config={
+                "a": tune.grid_search([1, 2]),
+                "b": tune.randint(0, 3)
+            },
+            num_samples=4)
 
-    Internal API:
+    In the example above, 8 trials will be generated: For each sample
+    (``4``), each of the grid search variants for ``a`` will be sampled
+    once. The ``b`` parameter will be sampled randomly.
+
+    The generator accepts a pre-set list of points that should be evaluated.
+    The points will replace the first samples of each experiment passed to
+    the ``BasicVariantGenerator``.
+
+    Each point will replace one sample of the specified ``num_samples``. If
+    grid search variables are overwritten with the values specified in the
+    presets, the number of samples will thus be reduced.
+
+    Example:
 
     .. code-block:: python
 
-        from ray.tune.suggest import BasicVariantGenerator
+        from ray import tune
+        from ray.tune.suggest.basic_variant import BasicVariantGenerator
 
-        searcher = BasicVariantGenerator()
-        searcher.add_configurations({"experiment": { ... }})
-        trial = searcher.next_trial()
-        searcher.is_finished == True
+
+        tune.run(
+            lambda config: config["a"] + config["b"],
+            config={
+                "a": tune.grid_search([1, 2]),
+                "b": tune.randint(0, 3)
+            },
+            search_alg=BasicVariantGenerator(points_to_evaluate=[
+                {"a": 2, "b": 2},
+                {"a": 1},
+                {"b": 2}
+            ]),
+            num_samples=4)
+
+    The example above will produce six trials via four samples:
+
+    - The first sample will produce one trial with ``a=2`` and ``b=2``.
+    - The second sample will produce one trial with ``a=1`` and ``b`` sampled
+      randomly
+    - The third sample will produce two trials, one for each grid search
+      value of ``a``. It will be ``b=2`` for both of these trials.
+    - The fourth sample will produce two trials, one for each grid search
+      value of ``a``. ``b`` will be sampled randomly and independently for
+      both of these trials.
+
     """
 
     def __init__(self, points_to_evaluate: Optional[List[Dict]] = None):

--- a/python/ray/tune/suggest/basic_variant.py
+++ b/python/ray/tune/suggest/basic_variant.py
@@ -32,10 +32,10 @@ class BasicVariantGenerator(SearchAlgorithm):
 
     Args:
         points_to_evaluate (list): Initial parameter suggestions to be run
-        first. This is for when you already have some good parameters
-        you want to run first to help the algorithm make better suggestions
-        for future parameters. Needs to be a list of dicts containing the
-        configurations.
+            first. This is for when you already have some good parameters
+            you want to run first to help the algorithm make better suggestions
+            for future parameters. Needs to be a list of dicts containing the
+            configurations.
 
     User API:
 

--- a/python/ray/tune/suggest/basic_variant.py
+++ b/python/ray/tune/suggest/basic_variant.py
@@ -22,12 +22,12 @@ class BasicVariantGenerator(SearchAlgorithm):
     The points will replace the first samples of each experiment passed to
     the ``BasicVariantGenerator``.
 
-    Each points will replace one sample of the specified ``num_samples``. If
+    Each point will replace one sample of the specified ``num_samples``. If
     grid search variables are overwritten with the values specified in the
     presets, the number of samples will thus be reduced. For example, if
     a grid search variable ``a`` with values ``[0, 1, 2]`` is passed, and
     ``num_samples=5``, and if ``a=2`` is passed as the first and only
-    ``point_to_evaluate``, a total number of 13 samples is generated: One
+    ``points_to_evaluate``, a total number of 13 samples is generated: One
     for ``a=2``, and then 4 samples for each of the 3 grid search variables.
 
     Args:

--- a/python/ray/tune/suggest/basic_variant.py
+++ b/python/ray/tune/suggest/basic_variant.py
@@ -18,6 +18,18 @@ class BasicVariantGenerator(SearchAlgorithm):
 
     See also: `ray.tune.suggest.variant_generator`.
 
+    This generator accepts a pre-set list of points that should be evaluated.
+    The points will replace the first samples of each experiment passed to
+    the ``BasicVariantGenerator``.
+
+    Each points will replace one sample of the specified ``num_samples``. If
+    grid search variables are overwritten with the values specified in the
+    presets, the number of samples will thus be reduced. For example, if
+    a grid search variable ``a`` with values ``[0, 1, 2]`` is passed, and
+    ``num_samples=5``, and if ``a=2`` is passed as the first and only
+    ``point_to_evaluate``, a total number of 13 samples is generated: One
+    for ``a=2``, and then 4 samples for each of the 3 grid search variables.
+
     Args:
         points_to_evaluate (list): Initial parameter suggestions to be run
         first. This is for when you already have some good parameters

--- a/python/ray/tune/suggest/variant_generator.py
+++ b/python/ray/tune/suggest/variant_generator.py
@@ -199,8 +199,14 @@ def _generate_variants(spec: Dict) -> Tuple[Dict, Dict]:
 
 
 def get_preset_variants(spec: Dict, config: Dict):
-    """Get variants according to a spec, but first overwrite spec config
-    variables with values from `config`"""
+    """Get variants according to a spec, initialized with a config.
+
+    Variables from the spec are overwritten by the variables in the config.
+    Thus, we may end up with less sampled parameters.
+
+    This function also checks if values used to overwrite search space
+    parameters are valid, and logs a warning if not.
+    """
     spec = copy.deepcopy(spec)
 
     resolved, _, _ = parse_spec_vars(config)

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -946,7 +946,7 @@ class SearchSpaceTest(unittest.TestCase):
         self.assertEqual(searcher.total_samples, 1 + 5 * 12)
 
         # When initialized with all points, the first three trials are
-        # defined by the logic above. Only 2 trials are grid searched
+        # defined by the logic above. Only 3 trials are grid searched
         # compeletely.
         searcher = BasicVariantGenerator(points_to_evaluate=points)
         exp = Experiment(

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -2,6 +2,7 @@ import numpy as np
 import unittest
 
 from ray import tune
+from ray.tune import Experiment
 from ray.tune.suggest.variant_generator import generate_variants
 
 
@@ -870,6 +871,102 @@ class SearchSpaceTest(unittest.TestCase):
         from ray.tune.suggest.zoopt import ZOOptSearch
         return self._testPointsToEvaluate(
             ZOOptSearch, config, budget=10, parallel_num=8)
+
+    def testPointsToEvaluateBasicVariant(self):
+        config = {
+            "metric": tune.sample.Categorical([1, 2, 3, 4]).uniform(),
+            "a": tune.sample.Categorical(["t1", "t2", "t3", "t4"]).uniform(),
+            "b": tune.sample.Integer(0, 5),
+            "c": tune.sample.Float(1e-4, 1e-1).loguniform()
+        }
+
+        from ray.tune.suggest.basic_variant import BasicVariantGenerator
+        return self._testPointsToEvaluate(BasicVariantGenerator, config)
+
+    def testPointsToEvaluateBasicVariantAdvanced(self):
+        config = {
+            "grid_1": tune.grid_search(["a", "b", "c", "d"]),
+            "grid_2": tune.grid_search(["x", "y", "z"]),
+            "nested": {
+                "random": tune.uniform(2., 10.),
+                "dependent": tune.sample_from(
+                    lambda spec: -1. * spec.config.nested.random)
+            }
+        }
+
+        points = [
+            {
+                "grid_1": "b"
+            },
+            {
+                "grid_2": "z"
+            },
+            {
+                "grid_1": "a",
+                "grid_2": "y"
+            },
+            {
+                "nested": {
+                    "random": 8.0
+                }
+            },
+        ]
+
+        from ray.tune.suggest.basic_variant import BasicVariantGenerator
+
+        # grid_1 * grid_2 are 3 * 4 = 12 variants per complete grid search
+        # However if one grid var is set by preset variables, that run
+        # is excluded from grid search.
+
+        # Point 1 overwrites grid_1, so the first trial only grid searches
+        # over grid_2 (3 trials).
+        # The remaining 5 trials search over the whole space (5 * 12 trials)
+        searcher = BasicVariantGenerator(points_to_evaluate=[points[0]])
+        exp = Experiment(
+            run=_mock_objective, name="test", config=config, num_samples=6)
+        searcher.add_configurations(exp)
+        self.assertEqual(searcher.total_samples, 1 * 3 + 5 * 12)
+
+        # Point 2 overwrites grid_2, so the first trial only grid searches
+        # over grid_1 (4 trials).
+        # The remaining 5 trials search over the whole space (5 * 12 trials)
+        searcher = BasicVariantGenerator(points_to_evaluate=[points[1]])
+        exp = Experiment(
+            run=_mock_objective, name="test", config=config, num_samples=6)
+        searcher.add_configurations(exp)
+        self.assertEqual(searcher.total_samples, 1 * 4 + 5 * 12)
+
+        # Point 3 overwrites grid_1 and grid_2, so the first trial does not
+        # grid search.
+        # The remaining 5 trials search over the whole space (5 * 12 trials)
+        searcher = BasicVariantGenerator(points_to_evaluate=[points[2]])
+        exp = Experiment(
+            run=_mock_objective, name="test", config=config, num_samples=6)
+        searcher.add_configurations(exp)
+        self.assertEqual(searcher.total_samples, 1 + 5 * 12)
+
+        # When initialized with all points, the first three trials are
+        # defined by the logic above. Only 2 trials are grid searched
+        # compeletely.
+        searcher = BasicVariantGenerator(points_to_evaluate=points)
+        exp = Experiment(
+            run=_mock_objective, name="test", config=config, num_samples=6)
+        searcher.add_configurations(exp)
+        self.assertEqual(searcher.total_samples, 1 * 3 + 1 * 4 + 1 + 3 * 12)
+
+        # Run this and confirm results
+        analysis = tune.run(exp, search_alg=searcher)
+        configs = [trial.config for trial in analysis.trials]
+
+        self.assertEqual(len(configs), searcher.total_samples)
+        self.assertTrue(
+            all(config["grid_1"] == "b" for config in configs[0:3]))
+        self.assertTrue(
+            all(config["grid_2"] == "z" for config in configs[3:7]))
+        self.assertTrue(configs[7]["grid_1"] == "a"
+                        and configs[7]["grid_2"] == "y")
+        self.assertTrue(configs[8]["nested"]["random"] == 8.0)
+        self.assertTrue(configs[8]["nested"]["dependent"] == -8.0)
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -171,7 +171,8 @@ def run(
             samples are generated until a stopping condition is met.
         local_dir (str): Local dir to save training results to.
             Defaults to ``~/ray_results``.
-        search_alg (Searcher): Search algorithm for optimization.
+        search_alg (Searcher|SearchAlgorithm): Search algorithm for
+            optimization.
         scheduler (TrialScheduler): Scheduler for executing
             the experiment. Choose among FIFO (default), MedianStopping,
             AsyncHyperBand, HyperBand and PopulationBasedTraining. Refer to


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We support `points_to_evaluate` for all search algorithms except for the basic variant generator (random and grid search). This PR adds support for this.

Notably, the `points_to_evaluate` passed to the `BasicVariantGenerator` can be partially specified. E.g. if we have a config like this:

```
config = {
    "a": tune.uniform(1.0, 4.0),
    "b": tune.grid_search(["Alpha", "Beta"]),
    "c": tune.sample_from(lambda spec: spec.config["a"] * -1),
}
```
we can specify initial points like this:
```
search_alg = tune.suggest.BasicVariantGenerator(points_to_evaluate=[
    {
        "a": 3.0,
        "b": "Alpha"
    },
    {
        "c": -7.0
    }
])
```

And the unspecified values will be sampled as before. This is also true for grid search variables. Generally, each point passed in `points_to_evaluate` will replace exactly one `num_samples` sample. If a grid search variable is overwritten like this, the number of total samples thus reduces to one for this sample (instead of the number of grid search values).

## Related issue number

Closes https://github.com/ray-project/ray/issues/9159

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
