### PR TITLE
Test shard_context on already-created boost::asio::io_service.

### DIFF
--- a/src/ray/gcs/test/asio_test.cc
+++ b/src/ray/gcs/test/asio_test.cc
@@ -70,7 +70,8 @@ TEST_F(RedisAsioTest, TestRedisCommands) {
   std::shared_ptr<RedisContext> shard_context =
       std::make_shared<RedisContext>(io_service);
   shard_context->Connect(std::string("127.0.0.1"), TEST_REDIS_SERVER_PORTS.front(),
-                         /*sharding=*/true);
+                         /*sharding=*/true,
+                         /*password=*/std::string());
 
   io_service.run();
 }

--- a/src/ray/gcs/test/asio_test.cc
+++ b/src/ray/gcs/test/asio_test.cc
@@ -69,10 +69,10 @@ TEST_F(RedisAsioTest, TestRedisCommands) {
 
   std::shared_ptr<RedisContext> shard_context =
       std::make_shared<RedisContext>(io_service);
-  RAY_CHECK_OK(shard_context->Connect(std::string("127.0.0.1"),
-                                      TEST_REDIS_SERVER_PORTS.front(),
-                                      /*sharding=*/true,
-                                      /*password=*/std::string()));
+  ASSERT_TRUE(shard_context->Connect(std::string("127.0.0.1"),
+                                     TEST_REDIS_SERVER_PORTS.front(),
+                                     /*sharding=*/true,
+                                     /*password=*/std::string()));
 
   io_service.run();
 }

--- a/src/ray/gcs/test/asio_test.cc
+++ b/src/ray/gcs/test/asio_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "ray/gcs/asio.h"
+#include "ray/gcs/redis_context.h"
 
 #include <iostream>
 

--- a/src/ray/gcs/test/asio_test.cc
+++ b/src/ray/gcs/test/asio_test.cc
@@ -69,10 +69,11 @@ TEST_F(RedisAsioTest, TestRedisCommands) {
 
   std::shared_ptr<RedisContext> shard_context =
       std::make_shared<RedisContext>(io_service);
-  ASSERT_TRUE(shard_context->Connect(std::string("127.0.0.1"),
-                                     TEST_REDIS_SERVER_PORTS.front(),
-                                     /*sharding=*/true,
-                                     /*password=*/std::string()).ok());
+  ASSERT_TRUE(shard_context
+                  ->Connect(std::string("127.0.0.1"), TEST_REDIS_SERVER_PORTS.front(),
+                            /*sharding=*/true,
+                            /*password=*/std::string())
+                  .ok());
 
   io_service.run();
 }

--- a/src/ray/gcs/test/asio_test.cc
+++ b/src/ray/gcs/test/asio_test.cc
@@ -66,6 +66,11 @@ TEST_F(RedisAsioTest, TestRedisCommands) {
   redisAsyncCommand(ac, NULL, NULL, "SET key test");
   redisAsyncCommand(ac, GetCallback, nullptr, "GET key");
 
+  std::shared_ptr<RedisContext> shard_context =
+      std::make_shared<RedisContext>(io_service);
+  shard_context->Connect("127.0.0.1", TEST_REDIS_SERVER_PORTS.front(),
+                         /*sharding=*/true);
+
   io_service.run();
 }
 

--- a/src/ray/gcs/test/asio_test.cc
+++ b/src/ray/gcs/test/asio_test.cc
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 #include "ray/gcs/asio.h"
-#include "ray/gcs/redis_context.h"
 
 #include <iostream>
 
 #include "gtest/gtest.h"
 #include "ray/common/test_util.h"
+#include "ray/gcs/redis_context.h"
 #include "ray/util/logging.h"
 
 extern "C" {
@@ -69,9 +69,10 @@ TEST_F(RedisAsioTest, TestRedisCommands) {
 
   std::shared_ptr<RedisContext> shard_context =
       std::make_shared<RedisContext>(io_service);
-  shard_context->Connect(std::string("127.0.0.1"), TEST_REDIS_SERVER_PORTS.front(),
-                         /*sharding=*/true,
-                         /*password=*/std::string());
+  RAY_CHECK_OK(shard_context->Connect(std::string("127.0.0.1"),
+                                      TEST_REDIS_SERVER_PORTS.front(),
+                                      /*sharding=*/true,
+                                      /*password=*/std::string()));
 
   io_service.run();
 }

--- a/src/ray/gcs/test/asio_test.cc
+++ b/src/ray/gcs/test/asio_test.cc
@@ -69,7 +69,7 @@ TEST_F(RedisAsioTest, TestRedisCommands) {
 
   std::shared_ptr<RedisContext> shard_context =
       std::make_shared<RedisContext>(io_service);
-  shard_context->Connect("127.0.0.1", TEST_REDIS_SERVER_PORTS.front(),
+  shard_context->Connect(std::string("127.0.0.1"), TEST_REDIS_SERVER_PORTS.front(),
                          /*sharding=*/true);
 
   io_service.run();

--- a/src/ray/gcs/test/asio_test.cc
+++ b/src/ray/gcs/test/asio_test.cc
@@ -72,7 +72,7 @@ TEST_F(RedisAsioTest, TestRedisCommands) {
   ASSERT_TRUE(shard_context->Connect(std::string("127.0.0.1"),
                                      TEST_REDIS_SERVER_PORTS.front(),
                                      /*sharding=*/true,
-                                     /*password=*/std::string()));
+                                     /*password=*/std::string()).ok());
 
   io_service.run();
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
I figured I'd model the test for PingPort() on the test for Connect(). But there doesn't seem to be a test for Connect(), so I'm trying to make one.
## Related issue number

<!-- For example: "Closes #1234" -->
https://github.com/ray-project/ray/pull/12022#issuecomment-732648281
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
