### PR TITLE
[rllib] Disable test_distributions due to failing in CI

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1089,12 +1089,13 @@ py_test(
     srcs = ["models/tests/test_convtranspose2d_stack.py"]
 )
 
-py_test(
-    name = "test_distributions",
-    tags = ["models"],
-    size = "medium",
-    srcs = ["models/tests/test_distributions.py"]
-)
+# Failing after the following PR: https://github.com/ray-project/ray/pull/12760.
+#py_test(
+#    name = "test_distributions",
+#    tags = ["models"],
+#    size = "medium",
+#    srcs = ["models/tests/test_distributions.py"]
+#)
 
 # --------------------------------------------------------------------
 # Evaluation components


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The rllib test_distributions has been failing since https://github.com/ray-project/ray/commit/becca1424d0f9aa4bec927168619b099a63b39bd

Tried reverting with this commit https://github.com/ray-project/ray/commit/cde711aaf14f6445d123665df6cb99ab1e7912b4

But unfortunately it's still failing, probably due to some change between the original and the revert. Disabling the test for now.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
