### PR TITLE
[K8s] Retry getting home directory in command runner.

### DIFF
--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -263,7 +263,7 @@ class KubernetesCommandRunner(CommandRunnerInterface):
                 time.sleep(DELAY_BEFORE_HOME_RETRY)
         # Last try
         self._home_cached = self._try_to_get_home()
-        return self._home_cached()
+        return self._home_cached
 
     def _try_to_get_home(self):
         # TODO (Dmitri): Think about how to use the node's HOME variable

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -35,6 +35,8 @@ logger = logging.getLogger(__name__)
 HASH_MAX_LENGTH = 10
 KUBECTL_RSYNC = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "kubernetes/kubectl-rsync.sh")
+MAX_HOME_RETRIES = 3
+DELAY_BEFORE_HOME_RETRY = 5
 
 _config = {"use_login_shells": True, "silent_rsync": True}
 
@@ -248,16 +250,31 @@ class KubernetesCommandRunner(CommandRunnerInterface):
 
     @property
     def _home(self):
+        if self._home_cached is not None:
+            return self._home_cached
+        for _ in range(MAX_HOME_RETRIES - 1):
+            try:
+                self._home_cached = self._try_to_get_home()
+                return self._home_cached
+            except Exception:
+                # TODO (Dmitri): Identify the exception we're trying to avoid.
+                logger.info("Error reading container's home directory. "
+                            f"Retrying in {DELAY_BEFORE_HOME_RETRY} seconds.")
+                time.sleep(DELAY_BEFORE_HOME_RETRY)
+        # Last try
+        self._home_cached = self._try_to_get_home()
+        return self._home_cached()
+
+    def _try_to_get_home(self):
         # TODO (Dmitri): Think about how to use the node's HOME variable
         # without making an extra kubectl exec call.
-        if self._home_cached is None:
-            cmd = self.kubectl + [
-                "exec", "-it", self.node_id, "--", "printenv", "HOME"
-            ]
-            joined_cmd = " ".join(cmd)
-            raw_out = self.process_runner.check_output(joined_cmd, shell=True)
-            self._home_cached = raw_out.decode().strip("\n\r")
-        return self._home_cached
+        cmd = self.kubectl + [
+            "exec", "-it", self.node_id, "--", "printenv", "HOME"
+        ]
+        joined_cmd = " ".join(cmd)
+        raw_out = self.process_runner.check_output(joined_cmd, shell=True)
+        home = raw_out.decode().strip("\n\r")
+        return home
 
 
 class SSHOptions:

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -36,7 +36,7 @@ HASH_MAX_LENGTH = 10
 KUBECTL_RSYNC = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "kubernetes/kubectl-rsync.sh")
 MAX_HOME_RETRIES = 3
-DELAY_BEFORE_HOME_RETRY = 5
+HOME_RETRY_DELAY_S = 5
 
 _config = {"use_login_shells": True, "silent_rsync": True}
 
@@ -259,8 +259,8 @@ class KubernetesCommandRunner(CommandRunnerInterface):
             except Exception:
                 # TODO (Dmitri): Identify the exception we're trying to avoid.
                 logger.info("Error reading container's home directory. "
-                            f"Retrying in {DELAY_BEFORE_HOME_RETRY} seconds.")
-                time.sleep(DELAY_BEFORE_HOME_RETRY)
+                            f"Retrying in {HOME_RETRY_DELAY_S} seconds.")
+                time.sleep(HOME_RETRY_DELAY_S)
         # Last try
         self._home_cached = self._try_to_get_home()
         return self._home_cached


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/12883

Works towards https://github.com/ray-project/ray/issues/12924

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
  
I've tested locally that these changes don't mess up `ray up` or `ray rsync_` with `~` in the remote path.
Testing that this actually solves the problem will require more work (see https://github.com/ray-project/ray/issues/12924).
