### PR TITLE
[New Scheduler/Old Scheduler] Implement WarnResourceDeadlock

### DIFF
--- a/python/ray/test_utils.py
+++ b/python/ray/test_utils.py
@@ -414,7 +414,7 @@ def init_error_pubsub():
     return p
 
 
-def get_error_message(pub_sub, num, error_type=None, timeout=5):
+def get_error_message(pub_sub, num, error_type=None, timeout=20):
     """Get errors through pub/sub."""
     start_time = time.time()
     msgs = []

--- a/src/ray/raylet/scheduling/cluster_resource_data.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_data.cc
@@ -201,7 +201,9 @@ bool NodeResources::operator!=(const NodeResources &other) { return !(*this == o
 std::string NodeResources::DebugString(StringIdMap string_to_in_map) const {
   std::stringstream buffer;
   buffer << " {\n";
-  for (size_t i = 0; i < this->predefined_resources.size(); i++) {
+  // We only iterate total predefined resources size - 1 because this method will be
+  // displayed to the user console, and we don't want to TPU to users.
+  for (size_t i = 0; i < this->predefined_resources.size() - 1; i++) {
     buffer << "\t";
     switch (i) {
     case CPU:
@@ -213,20 +215,17 @@ std::string NodeResources::DebugString(StringIdMap string_to_in_map) const {
     case GPU:
       buffer << "GPU: ";
       break;
-    case TPU:
-      buffer << "TPU: ";
-      break;
     default:
       RAY_CHECK(false) << "This should never happen.";
       break;
     }
-    buffer << "(" << this->predefined_resources[i].total << ":"
-           << this->predefined_resources[i].available << ")\n";
+    buffer << "(total:" << this->predefined_resources[i].total
+           << ", available:" << this->predefined_resources[i].available << ")\n";
   }
   for (auto it = this->custom_resources.begin(); it != this->custom_resources.end();
        ++it) {
-    buffer << "\t" << string_to_in_map.Get(it->first) << ":(" << it->second.total << ":"
-           << it->second.available << ")\n";
+    buffer << "\t" << string_to_in_map.Get(it->first) << ": (total:" << it->second.total
+           << ", available:" << it->second.available << ")\n";
   }
   buffer << "}" << std::endl;
   return buffer.str();

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -482,6 +482,12 @@ void ClusterResourceScheduler::InitResourceInstances(
   }
 }
 
+std::string ClusterResourceScheduler::GetLocalResourceViewString() const {
+  const auto &node_it = nodes_.find(local_node_id_);
+  RAY_CHECK(node_it != nodes_.end());
+  return node_it->second.GetLocalView().DebugString(string_to_int_map_);
+}
+
 void ClusterResourceScheduler::InitLocalResources(const NodeResources &node_resources) {
   local_resources_.predefined_resources.resize(PredefinedResources_MAX);
 

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -186,6 +186,8 @@ class ClusterResourceScheduler {
   /// Return local resources.
   NodeResourceInstances GetLocalResources() { return local_resources_; };
 
+  std::string GetLocalResourceViewString() const;
+
   /// Create instances for each resource associated with the local node, given
   /// the node's resources.
   ///


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This implements WarnResourceDeadlock in the new scheduler.

It also fixes a bug from the old scheduler and enables skipped tests. There was a new issue I found while I enabled the old test (https://github.com/ray-project/ray/issues/12937). This won't be handled in this PR. 

This also fixed/added a test that was broken according to Robert; https://github.com/ray-project/ray/issues/5790

## Related issue number

https://github.com/ray-project/ray/issues/12695

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
