### PR TITLE
fixed value() without gae to get any argument

### DIFF
--- a/rllib/agents/ppo/ppo_torch_policy.py
+++ b/rllib/agents/ppo/ppo_torch_policy.py
@@ -244,7 +244,7 @@ class ValueNetworkMixin:
         # When not doing GAE, we do not require the value function's output.
         else:
 
-            def value(ob, prev_action, prev_reward, *state):
+            def value(*args, **kwargs):
                 return 0.0
 
         self._value = value


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
So, using PPO/APPO with PyTorch and setting the following config parameters:
```
{
        "framework": "torch",
        "vtrace": False,
        "use_gae": False,
        ...
}
```
fails on `value() got unexpected obs argument`. 

<!-- Please give a short summary of the change and the problem this solves. -->
This just removes named argument from the value() method and replaces them with any arbitrary argument to pass to that method, as this method is a dummy one that always returns 0.

## Related issue number

No issue opened. This is a 1-liner fix.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
