### PR TITLE
[dashboard] Fix RAY_RAYLET_PID KeyError on Windows

### DIFF
--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -65,7 +65,7 @@ class DashboardAgent(object):
         # TODO(edoakes): RAY_RAYLET_PID isn't properly set on Windows. This is
         # only used for fate-sharing with the raylet and we need a different
         # fate-sharing mechanism for Windows anyways.
-        if sys.platform != "win32":
+        if sys.platform not in ["win32", "cygwin"]:
             self.ppid = int(os.environ["RAY_RAYLET_PID"])
             assert self.ppid > 0
             logger.info("Parent pid is %s", self.ppid)
@@ -111,7 +111,7 @@ class DashboardAgent(object):
                 logger.error("Failed to check parent PID, exiting.")
                 sys.exit(1)
 
-        if sys.platform != "win32":
+        if sys.platform not in ["win32", "cygwin"]:
             check_parent_task = create_task(_check_parent())
 
         # Create an aioredis client for all modules.

--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -62,9 +62,13 @@ class DashboardAgent(object):
         self.object_store_name = object_store_name
         self.raylet_name = raylet_name
         self.node_id = os.environ["RAY_NODE_ID"]
-        self.ppid = int(os.environ["RAY_RAYLET_PID"])
-        assert self.ppid > 0
-        logger.info("Parent pid is %s", self.ppid)
+        # TODO(edoakes): RAY_RAYLET_PID isn't properly set on Windows. This is
+        # only used for fate-sharing with the raylet and we need a different
+        # fate-sharing mechanism for Windows anyways.
+        if sys.platform != "win32":
+            self.ppid = int(os.environ["RAY_RAYLET_PID"])
+            assert self.ppid > 0
+            logger.info("Parent pid is %s", self.ppid)
         self.server = aiogrpc.server(options=(("grpc.so_reuseport", 0), ))
         self.grpc_port = self.server.add_insecure_port(
             f"[::]:{self.dashboard_agent_port}")
@@ -107,7 +111,8 @@ class DashboardAgent(object):
                 logger.error("Failed to check parent PID, exiting.")
                 sys.exit(1)
 
-        check_parent_task = create_task(_check_parent())
+        if sys.platform != "win32":
+            check_parent_task = create_task(_check_parent())
 
         # Create an aioredis client for all modules.
         try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

The existing fate-sharing mechanism for the dashboard agent won't work properly on Windows anyways, so this just skips that path on Windows.

Follow-up issue:
https://github.com/ray-project/ray/issues/12949

## Related issue number

Closes https://github.com/ray-project/ray/issues/12947

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
