### PR TITLE
[Autoscaler/Core] Remove autoscaler spam 

### DIFF
--- a/python/ray/autoscaler/_private/load_metrics.py
+++ b/python/ray/autoscaler/_private/load_metrics.py
@@ -79,27 +79,27 @@ class LoadMetrics:
         active_ips = set(active_ips)
         active_ips.add(self.local_ip)
 
-        def prune(mapping):
+        def prune(mapping, should_log):
             unwanted = set(mapping) - active_ips
             for unwanted_key in unwanted:
-                # TODO (Alex): Change this back to info after #12138.
-                logger.debug("LoadMetrics: "
-                             "Removed mapping: {} - {}".format(
-                                 unwanted_key, mapping[unwanted_key]))
+                if should_log:
+                    logger.info("LoadMetrics: "
+                                "Removed mapping: {} - {}".format(
+                                    unwanted_key, mapping[unwanted_key]))
                 del mapping[unwanted_key]
-            if unwanted:
+            if unwanted and should_log:
                 # TODO (Alex): Change this back to info after #12138.
-                logger.debug(
+                logger.info(
                     "LoadMetrics: "
                     "Removed {} stale ip mappings: {} not in {}".format(
                         len(unwanted), unwanted, active_ips))
             assert not (unwanted & set(mapping))
 
-        prune(self.last_used_time_by_ip)
-        prune(self.static_resources_by_ip)
-        prune(self.dynamic_resources_by_ip)
-        prune(self.resource_load_by_ip)
-        prune(self.last_heartbeat_time_by_ip)
+        prune(self.last_used_time_by_ip, should_log=True)
+        prune(self.static_resources_by_ip, should_log=False)
+        prune(self.dynamic_resources_by_ip, should_log=False)
+        prune(self.resource_load_by_ip, should_log=False)
+        prune(self.last_heartbeat_time_by_ip, should_log=False)
 
     def get_node_resources(self):
         """Return a list of node resources (static resource sizes).

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -258,6 +258,7 @@ std::shared_ptr<rpc::GcsNodeInfo> GcsNodeManager::RemoveNode(
     // Remove from cluster resources.
     gcs_resource_manager_->OnNodeDead(node_id);
     resources_buffer_.erase(node_id);
+    node_resource_usages_.erase(node_id);
     if (!is_intended) {
       // Broadcast a warning to all of the drivers indicating that the node
       // has been marked as dead.

--- a/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
@@ -44,7 +44,8 @@ TEST_F(GcsNodeManagerTest, TestManagement) {
   {
     rpc::GetAllResourceUsageRequest request;
     rpc::GetAllResourceUsageReply reply;
-    auto send_reply_callback = [](ray::Status status, std::function<void()> f1, std::function<void()> f2){};
+    auto send_reply_callback = [](ray::Status status, std::function<void()> f1,
+                                  std::function<void()> f2) {};
     node_manager.HandleGetAllResourceUsage(request, &reply, send_reply_callback);
     ASSERT_EQ(reply.resource_usage_data().batch().size(), 0);
   }
@@ -60,7 +61,8 @@ TEST_F(GcsNodeManagerTest, TestManagement) {
   {
     rpc::GetAllResourceUsageRequest request;
     rpc::GetAllResourceUsageReply reply;
-    auto send_reply_callback = [](ray::Status status, std::function<void()> f1, std::function<void()> f2){};
+    auto send_reply_callback = [](ray::Status status, std::function<void()> f1,
+                                  std::function<void()> f2) {};
     node_manager.HandleGetAllResourceUsage(request, &reply, send_reply_callback);
     ASSERT_EQ(reply.resource_usage_data().batch().size(), 1);
   }
@@ -71,7 +73,8 @@ TEST_F(GcsNodeManagerTest, TestManagement) {
   {
     rpc::GetAllResourceUsageRequest request;
     rpc::GetAllResourceUsageReply reply;
-    auto send_reply_callback = [](ray::Status status, std::function<void()> f1, std::function<void()> f2){};
+    auto send_reply_callback = [](ray::Status status, std::function<void()> f1,
+                                  std::function<void()> f2) {};
     node_manager.HandleGetAllResourceUsage(request, &reply, send_reply_callback);
     ASSERT_EQ(reply.resource_usage_data().batch().size(), 0);
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes an autoscaler issue in which the error message

```
2020-11-18 21:58:14,440	INFO load_metrics.py:87 -- LoadMetrics: Removed mapping: 172.30.0.248 - {}
```

is printed many times.

This is caused by 2 issues:

1. GCS was improperly reporting stale heartbeats from removed nodes. Therefore, the autoscaler would consistently re-add the node when it received the heartbeat, then prune the node when it realizes the node is terminated. 
2. The prune function which prints the log is called 5x. This meant the infinite loop in (1) was 5x more annoying.

The fixes for both these issues are straight forward. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

#12138 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
