### PR TITLE
Clean up block/unblock handling of resources in new scheduler

### DIFF
--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -17,8 +17,7 @@ import ray.ray_constants as ray_constants
 from ray.exceptions import RayTaskError
 from ray.cluster_utils import Cluster
 from ray.test_utils import (wait_for_condition, SignalActor, init_error_pubsub,
-                            get_error_message, Semaphore,
-                            new_scheduler_enabled)
+                            get_error_message, Semaphore)
 
 
 def test_failed_task(ray_start_regular, error_pubsub):
@@ -633,8 +632,6 @@ def test_export_large_objects(ray_start_regular, error_pubsub):
     assert errors[0].type == ray_constants.PICKLING_LARGE_OBJECT_PUSH_ERROR
 
 
-@pytest.mark.skipif(
-    new_scheduler_enabled(), reason="Supposed to deadlock, but it doesn't")
 def test_warning_all_tasks_blocked(shutdown_only):
     ray.init(
         num_cpus=1, _system_config={"debug_dump_period_milliseconds": 500})

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -6,7 +6,6 @@ from ray.test_utils import (
     generate_system_config_map,
     wait_for_condition,
     wait_for_pid_to_exit,
-    new_scheduler_enabled,
 )
 
 
@@ -21,7 +20,6 @@ def increase(x):
     return x + 1
 
 
-@pytest.mark.skipif(new_scheduler_enabled(), reason="notimpl")
 @pytest.mark.parametrize(
     "ray_start_regular", [
         generate_system_config_map(

--- a/python/ray/tests/test_global_state.py
+++ b/python/ray/tests/test_global_state.py
@@ -8,7 +8,6 @@ import time
 import ray
 import ray.ray_constants
 import ray.test_utils
-from ray.test_utils import new_scheduler_enabled
 
 from ray._raylet import GlobalStateAccessor
 
@@ -217,8 +216,6 @@ def test_load_report(shutdown_only, max_shapes):
     global_state_accessor.disconnect()
 
 
-@pytest.mark.skipif(
-    new_scheduler_enabled(), reason="requires placement groups")
 def test_placement_group_load_report(ray_start_cluster):
     cluster = ray_start_cluster
     # Add a head node that doesn't have gpu resource.

--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -167,7 +167,7 @@ def test_dependency_refcounts(ray_start_regular):
     check_refcounts({})
 
 
-@pytest.mark.skipif(new_scheduler_enabled(), reason="hangs")
+@pytest.mark.skipif(new_scheduler_enabled(), reason="dynamic res todo")
 def test_actor_creation_task(ray_start_regular):
     @ray.remote
     def large_object():

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2131,7 +2131,9 @@ void NodeManager::HandleDirectCallTaskBlocked(
     if (cpu_instances.size() > 0) {
       std::vector<double> overflow_cpu_instances =
           new_resource_scheduler_->AddCPUResourceInstances(cpu_instances);
-      worker->SetOverflowCPUInstances(overflow_cpu_instances);
+      for (unsigned int i = 0; i < overflow_cpu_instances.size(); i++) {
+        RAY_CHECK(overflow_cpu_instances[i] == 0) << "Should not be overflow";
+      }
       worker->MarkBlocked();
     }
     ScheduleAndDispatch();
@@ -2174,8 +2176,6 @@ void NodeManager::HandleDirectCallTaskUnblocked(
       // negative, at most one task can "borrow" this worker's resources.
       new_resource_scheduler_->SubtractCPUResourceInstances(
           cpu_instances, /*allow_going_negative=*/true);
-      new_resource_scheduler_->AddCPUResourceInstances(worker->GetOverflowCPUInstances());
-      worker->ClearOverflowCPUInstances();
       worker->MarkUnblocked();
     }
     ScheduleAndDispatch();

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -860,7 +860,8 @@ void ClusterResourceScheduler::FillResourceUsage(
     for (int i = 0; i < PredefinedResources_MAX; i++) {
       const auto &label = ResourceEnumToString((PredefinedResources)i);
       const auto &capacity = resources.predefined_resources[i];
-      if (capacity.available != 0) {
+      // Note: available may be negative, but only report positive to GCS.
+      if (capacity.available > 0) {
         (*resources_data->mutable_resources_available())[label] =
             capacity.available.Double();
       }
@@ -873,7 +874,8 @@ void ClusterResourceScheduler::FillResourceUsage(
       uint64_t custom_id = it->first;
       const auto &capacity = it->second;
       const auto &label = string_to_int_map_.Get(custom_id);
-      if (capacity.available != 0) {
+      // Note: available may be negative, but only report positive to GCS.
+      if (capacity.available > 0) {
         (*resources_data->mutable_resources_available())[label] =
             capacity.available.Double();
       }

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -921,11 +921,11 @@ void ClusterResourceScheduler::FillResourceUsage(
       const auto &label = ResourceEnumToString((PredefinedResources)i);
       const auto &capacity = resources.predefined_resources[i];
       const auto &last_capacity = last_report_resources_->predefined_resources[i];
-      if (capacity.available != last_capacity.available) {
+      // Note: available may be negative, but only report positive to GCS.
+      if (capacity.available != last_capacity.available && capacity.available > 0) {
         resources_data->set_resources_available_changed(true);
-        // Note: available may be negative, but only report positive to GCS.
         (*resources_data->mutable_resources_available())[label] =
-            std::max(0.0, capacity.available.Double());
+            capacity.available.Double();
       }
       if (capacity.total != last_capacity.total) {
         (*resources_data->mutable_resources_total())[label] = capacity.total.Double();
@@ -937,11 +937,11 @@ void ClusterResourceScheduler::FillResourceUsage(
       const auto &capacity = it->second;
       const auto &last_capacity = last_report_resources_->custom_resources[custom_id];
       const auto &label = string_to_int_map_.Get(custom_id);
-      if (capacity.available != last_capacity.available) {
+      // Note: available may be negative, but only report positive to GCS.
+      if (capacity.available != last_capacity.available && capacity.available > 0) {
         resources_data->set_resources_available_changed(true);
-        // Note: available may be negative, but only report positive to GCS.
         (*resources_data->mutable_resources_available())[label] =
-            std::max(0.0, capacity.available.Double());
+            capacity.available.Double();
       }
       if (capacity.total != last_capacity.total) {
         (*resources_data->mutable_resources_total())[label] = capacity.total.Double();

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -523,15 +523,25 @@ std::vector<FixedPoint> ClusterResourceScheduler::AddAvailableResourceInstances(
 }
 
 std::vector<FixedPoint> ClusterResourceScheduler::SubtractAvailableResourceInstances(
-    std::vector<FixedPoint> available, ResourceInstanceCapacities *resource_instances) {
+    std::vector<FixedPoint> available, ResourceInstanceCapacities *resource_instances,
+    bool allow_going_negative) {
   RAY_CHECK(available.size() == resource_instances->available.size());
 
   std::vector<FixedPoint> underflow(available.size(), 0.);
   for (size_t i = 0; i < available.size(); i++) {
-    resource_instances->available[i] = resource_instances->available[i] - available[i];
     if (resource_instances->available[i] < 0) {
-      underflow[i] = -resource_instances->available[i];
-      resource_instances->available[i] = 0;
+      if (allow_going_negative) {
+        resource_instances->available[i] =
+            resource_instances->available[i] - available[i];
+      } else {
+        underflow[i] = available[i];  // No change in the value in this case.
+      }
+    } else {
+      resource_instances->available[i] = resource_instances->available[i] - available[i];
+      if (resource_instances->available[i] < 0 && !allow_going_negative) {
+        underflow[i] = -resource_instances->available[i];
+        resource_instances->available[i] = 0;
+      }
     }
   }
   return underflow;
@@ -735,7 +745,7 @@ std::vector<double> ClusterResourceScheduler::AddCPUResourceInstances(
 }
 
 std::vector<double> ClusterResourceScheduler::SubtractCPUResourceInstances(
-    std::vector<double> &cpu_instances) {
+    std::vector<double> &cpu_instances, bool allow_going_negative) {
   std::vector<FixedPoint> cpu_instances_fp =
       VectorDoubleToVectorFixedPoint(cpu_instances);
 
@@ -745,7 +755,8 @@ std::vector<double> ClusterResourceScheduler::SubtractCPUResourceInstances(
   RAY_CHECK(nodes_.find(local_node_id_) != nodes_.end());
 
   auto underflow = SubtractAvailableResourceInstances(
-      cpu_instances_fp, &local_resources_.predefined_resources[CPU]);
+      cpu_instances_fp, &local_resources_.predefined_resources[CPU],
+      allow_going_negative);
   UpdateLocalAvailableResourcesFromResourceInstances();
 
   return VectorFixedPointToVectorDouble(underflow);

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -954,7 +954,8 @@ void ClusterResourceScheduler::FillResourceUsage(
     for (int i = 0; i < PredefinedResources_MAX; i++) {
       const auto &label = ResourceEnumToString((PredefinedResources)i);
       const auto &capacity = resources.predefined_resources[i];
-      if (capacity.available != 0) {
+      // Note: available may be negative, but only report positive to GCS.
+      if (capacity.available > 0) {
         (*resources_data->mutable_resources_available())[label] =
             capacity.available.Double();
       }
@@ -967,7 +968,8 @@ void ClusterResourceScheduler::FillResourceUsage(
       uint64_t custom_id = it->first;
       const auto &capacity = it->second;
       const auto &label = string_to_int_map_.Get(custom_id);
-      if (capacity.available != 0) {
+      // Note: available may be negative, but only report positive to GCS.
+      if (capacity.available > 0) {
         (*resources_data->mutable_resources_available())[label] =
             capacity.available.Double();
       }

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -925,7 +925,7 @@ void ClusterResourceScheduler::FillResourceUsage(
         resources_data->set_resources_available_changed(true);
         // Note: available may be negative, but only report positive to GCS.
         (*resources_data->mutable_resources_available())[label] =
-            std::max(0, capacity.available.Double());
+            std::max(0.0, capacity.available.Double());
       }
       if (capacity.total != last_capacity.total) {
         (*resources_data->mutable_resources_total())[label] = capacity.total.Double();
@@ -941,7 +941,7 @@ void ClusterResourceScheduler::FillResourceUsage(
         resources_data->set_resources_available_changed(true);
         // Note: available may be negative, but only report positive to GCS.
         (*resources_data->mutable_resources_available())[label] =
-            std::max(0, capacity.available.Double());
+            std::max(0.0, capacity.available.Double());
       }
       if (capacity.total != last_capacity.total) {
         (*resources_data->mutable_resources_total())[label] = capacity.total.Double();

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -271,11 +271,13 @@ class ClusterResourceScheduler {
   ///
   /// \param free A list of capacities for resource's instances to be freed.
   /// \param resource_instances List of the resource instances being updated.
+  /// \param allow_going_negative Allow the values to go negative (disable underflow).
   /// \return Underflow of "resource_instances" after subtracting instance
   /// capacities in "available", i.e.,.
   /// max(available - reasource_instances.available, 0)
   std::vector<FixedPoint> SubtractAvailableResourceInstances(
-      std::vector<FixedPoint> available, ResourceInstanceCapacities *resource_instances);
+      std::vector<FixedPoint> available, ResourceInstanceCapacities *resource_instances,
+      bool allow_going_negative = false);
 
   /// Increase the available CPU instances of this node.
   ///
@@ -288,10 +290,12 @@ class ClusterResourceScheduler {
   /// Decrease the available CPU instances of this node.
   ///
   /// \param cpu_instances CPU instances to be removed from available cpus.
+  /// \param allow_going_negative Allow the values to go negative (disable underflow).
   ///
   /// \return Underflow capacities of CPU instances after subtracting CPU
   /// capacities in cpu_instances.
-  std::vector<double> SubtractCPUResourceInstances(std::vector<double> &cpu_instances);
+  std::vector<double> SubtractCPUResourceInstances(std::vector<double> &cpu_instances,
+                                                   bool allow_going_negative = false);
 
   /// Increase the available GPU instances of this node.
   ///

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -1,7 +1,7 @@
 #include "ray/raylet/scheduling/cluster_task_manager.h"
 
-#include <boost/range/join.hpp>
 #include <google/protobuf/map.h>
+#include <boost/range/join.hpp>
 
 #include "ray/util/logging.h"
 

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -1,5 +1,6 @@
 #include "ray/raylet/scheduling/cluster_task_manager.h"
 
+#include <boost/range/join.hpp>
 #include <google/protobuf/map.h>
 
 #include "ray/util/logging.h"
@@ -242,10 +243,7 @@ void ClusterTaskManager::TasksUnblocked(const std::vector<TaskID> ready_ids) {
       const auto &scheduling_key = task.GetTaskSpecification().GetSchedulingClass();
       RAY_LOG(DEBUG) << "Args ready, task can be dispatched "
                      << task.GetTaskSpecification().TaskId();
-      // Note: we transition tasks back to the scheduling queue instead of directly
-      // to dispatch. This allows AnyPendingTasks() to simply check the scheduling
-      // queue to see if any tasks are blocked on resource availability: see #12438
-      tasks_to_schedule_[scheduling_key].push_back(work);
+      tasks_to_dispatch_[scheduling_key].push_back(work);
       waiting_tasks_.erase(it);
     }
   }
@@ -507,9 +505,9 @@ bool ClusterTaskManager::AnyPendingTasks(Task *exemplar, bool *any_pending,
                                          int *num_pending_actor_creation,
                                          int *num_pending_tasks) const {
   // We are guaranteed that these tasks are blocked waiting for resources after a
-  // call to ScheduleAndDispatch(). Note that tasks that transition to waiting
-  // move back to the tasks_to_schedule_ queue after their deps are satisfied.
-  for (const auto &shapes_it : tasks_to_schedule_) {
+  // call to ScheduleAndDispatch(). They may be waiting for workers as well, but
+  // this should be a transient condition only.
+  for (const auto &shapes_it : boost::join(tasks_to_dispatch_, tasks_to_schedule_)) {
     auto &work_queue = shapes_it.second;
     for (const auto &work_it : work_queue) {
       const auto &task = std::get<0>(work_it);

--- a/src/ray/raylet/scheduling/cluster_task_manager.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager.h
@@ -157,11 +157,11 @@ class ClusterTaskManager {
   std::unordered_map<SchedulingClass, std::deque<Work>> tasks_to_schedule_;
 
   /// Queue of lease requests that should be scheduled onto workers.
-  /// Tasks move from scheduled -> dispatch.
+  /// Tasks move from scheduled | waiting -> dispatch.
   std::unordered_map<SchedulingClass, std::deque<Work>> tasks_to_dispatch_;
 
   /// Tasks waiting for arguments to be transferred locally.
-  /// Tasks move (back) from waiting -> scheduled.
+  /// Tasks move from waiting -> dispatch.
   absl::flat_hash_map<TaskID, Work> waiting_tasks_;
 
   /// Queue of lease requests that are infeasible.

--- a/src/ray/raylet/test/util.h
+++ b/src/ray/raylet/test/util.h
@@ -161,20 +161,12 @@ class MockWorker : public WorkerInterface {
 
   void ClearLifetimeAllocatedInstances() { lifetime_allocated_instances_ = nullptr; }
 
-  void SetOverflowCPUInstances(std::vector<double> &cpu_instances) {
-    borrowed_cpu_instances_ = cpu_instances;
-  }
-
   const BundleID &GetBundleId() const {
     RAY_CHECK(false) << "Method unused";
     return bundle_id_;
   }
 
   void SetBundleId(const BundleID &bundle_id) { RAY_CHECK(false) << "Method unused"; }
-
-  std::vector<double> &GetOverflowCPUInstances() { return borrowed_cpu_instances_; }
-
-  void ClearOverflowCPUInstances() { RAY_CHECK(false) << "Method unused"; }
 
   Task &GetAssignedTask() {
     RAY_CHECK(false) << "Method unused";

--- a/src/ray/raylet/test/util.h
+++ b/src/ray/raylet/test/util.h
@@ -161,7 +161,7 @@ class MockWorker : public WorkerInterface {
 
   void ClearLifetimeAllocatedInstances() { lifetime_allocated_instances_ = nullptr; }
 
-  void SetBorrowedCPUInstances(std::vector<double> &cpu_instances) {
+  void SetOverflowCPUInstances(std::vector<double> &cpu_instances) {
     borrowed_cpu_instances_ = cpu_instances;
   }
 
@@ -172,9 +172,9 @@ class MockWorker : public WorkerInterface {
 
   void SetBundleId(const BundleID &bundle_id) { RAY_CHECK(false) << "Method unused"; }
 
-  std::vector<double> &GetBorrowedCPUInstances() { return borrowed_cpu_instances_; }
+  std::vector<double> &GetOverflowCPUInstances() { return borrowed_cpu_instances_; }
 
-  void ClearBorrowedCPUInstances() { RAY_CHECK(false) << "Method unused"; }
+  void ClearOverflowCPUInstances() { RAY_CHECK(false) << "Method unused"; }
 
   Task &GetAssignedTask() {
     RAY_CHECK(false) << "Method unused";

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -259,10 +259,6 @@ class Worker : public WorkerInterface {
   /// The capacity of each resource instance allocated to this worker
   /// when running as an actor.
   std::shared_ptr<TaskResourceInstances> lifetime_allocated_instances_;
-  /// When a worker is blocked, it tries to add its CPU instances to the scheduler.
-  /// If the scheduler cannot accept that many CPUs, those CPUs go here and we give
-  /// them back later during unblock.
-  std::vector<double> overflow_cpu_instances_;
   /// Task being assigned to this worker.
   Task assigned_task_;
 };

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -196,13 +196,13 @@ class Worker : public WorkerInterface {
 
   void ClearLifetimeAllocatedInstances() { lifetime_allocated_instances_ = nullptr; };
 
-  void SetBorrowedCPUInstances(std::vector<double> &cpu_instances) {
-    borrowed_cpu_instances_ = cpu_instances;
+  void SetOverflowCPUInstances(std::vector<double> &cpu_instances) {
+    overflow_cpu_instances_ = cpu_instances;
   };
 
-  std::vector<double> &GetBorrowedCPUInstances() { return borrowed_cpu_instances_; };
+  std::vector<double> &GetOverflowCPUInstances() { return overflow_cpu_instances_; };
 
-  void ClearBorrowedCPUInstances() { return borrowed_cpu_instances_.clear(); };
+  void ClearOverflowCPUInstances() { return overflow_cpu_instances_.clear(); };
 
   Task &GetAssignedTask() { return assigned_task_; };
 
@@ -273,14 +273,10 @@ class Worker : public WorkerInterface {
   /// The capacity of each resource instance allocated to this worker
   /// when running as an actor.
   std::shared_ptr<TaskResourceInstances> lifetime_allocated_instances_;
-  /// CPUs borrowed by the worker. This happens in the following scenario:
-  /// 1) Worker A is blocked, so it donates its CPUs back to the node.
-  /// 2) Other workers are scheduled and are allocated some of the CPUs donated by A.
-  /// 3) Task A is unblocked, but it cannot get all CPUs back. At this point,
-  /// the node is oversubscribed. borrowed_cpu_instances_ represents the number
-  /// of CPUs this node is oversubscribed by.
-  /// TODO (Ion): Investigate a more intuitive alternative to track these Cpus.
-  std::vector<double> borrowed_cpu_instances_;
+  /// When a worker is blocked, it tries to add its CPU instances to the scheduler.
+  /// If the scheduler cannot accept that many CPUs, those CPUs go here and we give
+  /// them back later during unblock.
+  std::vector<double> overflow_cpu_instances_;
   /// Task being assigned to this worker.
   Task assigned_task_;
 };

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -98,12 +98,6 @@ class WorkerInterface {
 
   virtual void ClearLifetimeAllocatedInstances() = 0;
 
-  virtual void SetOverflowCPUInstances(std::vector<double> &cpu_instances) = 0;
-
-  virtual std::vector<double> &GetOverflowCPUInstances() = 0;
-
-  virtual void ClearOverflowCPUInstances() = 0;
-
   virtual Task &GetAssignedTask() = 0;
 
   virtual void SetAssignedTask(const Task &assigned_task) = 0;
@@ -195,14 +189,6 @@ class Worker : public WorkerInterface {
   };
 
   void ClearLifetimeAllocatedInstances() { lifetime_allocated_instances_ = nullptr; };
-
-  void SetOverflowCPUInstances(std::vector<double> &cpu_instances) {
-    overflow_cpu_instances_ = cpu_instances;
-  };
-
-  std::vector<double> &GetOverflowCPUInstances() { return overflow_cpu_instances_; };
-
-  void ClearOverflowCPUInstances() { return overflow_cpu_instances_.clear(); };
 
   Task &GetAssignedTask() { return assigned_task_; };
 

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -98,11 +98,11 @@ class WorkerInterface {
 
   virtual void ClearLifetimeAllocatedInstances() = 0;
 
-  virtual void SetBorrowedCPUInstances(std::vector<double> &cpu_instances) = 0;
+  virtual void SetOverflowCPUInstances(std::vector<double> &cpu_instances) = 0;
 
-  virtual std::vector<double> &GetBorrowedCPUInstances() = 0;
+  virtual std::vector<double> &GetOverflowCPUInstances() = 0;
 
-  virtual void ClearBorrowedCPUInstances() = 0;
+  virtual void ClearOverflowCPUInstances() = 0;
 
   virtual Task &GetAssignedTask() = 0;
 

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -956,8 +956,8 @@ const std::vector<std::shared_ptr<WorkerInterface>> WorkerPool::GetAllRegistered
 }
 
 void WorkerPool::WarnAboutSize() {
-  for (const auto &entry : states_by_lang_) {
-    auto state = entry.second;
+  for (auto &entry : states_by_lang_) {
+    auto &state = entry.second;
     int64_t num_workers_started_or_registered = 0;
     num_workers_started_or_registered +=
         static_cast<int64_t>(state.registered_workers.size());


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This simplifies the block/unblock problem by allow available_resources to go negative in the new scheduler (overcommit). Previously this wasn't allowed, which made it difficult to avoid two edge conditions: (1) infinite cpu acquisition by repeatedly block/unblocking a task, and (2) available_resources sometimes exceeding total_resources, requiring tracking of the overflow.

By allowing available_resources to go negative, we can maintain the invariant that `available_resources <= total_resources`, and trivially prevent infinite resource acquisition.

Closes https://github.com/ray-project/ray/issues/12937