### PR TITLE
[ray_client] Integrate with test_basic, test_basic_2 and test_actor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ matrix:
       script:
         # bazel python tests for medium size tests. Used for parallelization.
         - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then ./ci/keep_alive bazel test --config=ci $(./scripts/bazel_export_options) --test_tag_filters=-jenkins_only,medium_size_python_tests_a_to_j python/ray/tests/...; fi
+        - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then ./ci/keep_alive bazel test --config=ci $(./scripts/bazel_export_options) --test_tag_filters=-jenkins_only,client_tests --test_env=RAY_TEST_CLIENT_MODE=1 python/ray/tests/...; fi
 
     - os: linux
       env:

--- a/bazel/python.bzl
+++ b/bazel/python.bzl
@@ -1,12 +1,14 @@
 # py_test_module_list creates a py_test target for each
 # Python file in `files`
-def py_test_module_list(files, size, deps, extra_srcs, **kwargs):
+def py_test_module_list(files, size, deps, extra_srcs, name_suffix="", **kwargs):
     for file in files:
         # remove .py
-        name = file[:-3]
+        name = file[:-3] + name_suffix
+        main = file
         native.py_test(
             name = name,
             size = size,
+            main = file,
             srcs = extra_srcs + [file],
             **kwargs
         )

--- a/python/ray/experimental/client/__init__.py
+++ b/python/ray/experimental/client/__init__.py
@@ -132,23 +132,23 @@ class RayAPIStub:
             global _test_server
             import ray.experimental.client.server.server as ray_client_server
             _test_server, address_info = ray_client_server.init_and_serve(
-                "localhost:50051",
-                test_mode=True,
-                *args,
-                **kwargs)
+                "localhost:50051", test_mode=True, *args, **kwargs)
             self.connect("localhost:50051")
             return address_info
         else:
-            raise NotImplementedError("Please call ray.connect() in client mode")
+            raise NotImplementedError(
+                "Please call ray.connect() in client mode")
 
 
 ray = RayAPIStub()
 
 _test_server = None
 
+
 def _stop_test_server(*args):
     global _test_server
     _test_server.stop(*args)
+
 
 def _is_client_test_env() -> bool:
     return os.environ.get("RAY_TEST_CLIENT_MODE") == "1"

--- a/python/ray/experimental/client/__init__.py
+++ b/python/ray/experimental/client/__init__.py
@@ -44,9 +44,11 @@ def stash_api_for_tests(in_test: bool):
     is_server = _is_server
     if in_test:
         _is_server = True
-    yield _server_api
-    if in_test:
-        _is_server = is_server
+    try:
+        yield _server_api
+    finally:
+        if in_test:
+            _is_server = is_server
 
 
 def _set_client_api(val: Optional[APIImpl]):

--- a/python/ray/experimental/client/__init__.py
+++ b/python/ray/experimental/client/__init__.py
@@ -4,6 +4,7 @@ from typing import Optional, List, Tuple
 from contextlib import contextmanager
 
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -124,8 +125,32 @@ class RayAPIStub:
         global _client_api
         return _client_api is not None
 
+    def init(self, *args, **kwargs):
+        if _is_client_test_env():
+            global _test_server
+            import ray.experimental.client.server.server as ray_client_server
+            _test_server, address_info = ray_client_server.init_and_serve(
+                "localhost:50051",
+                test_mode=True,
+                *args,
+                **kwargs)
+            self.connect("localhost:50051")
+            return address_info
+        else:
+            raise NotImplementedError("Please call ray.connect() in client mode")
+
 
 ray = RayAPIStub()
+
+_test_server = None
+
+def _stop_test_server(*args):
+    global _test_server
+    _test_server.stop(*args)
+
+def _is_client_test_env() -> bool:
+    return os.environ.get("RAY_TEST_CLIENT_MODE") == "1"
+
 
 # Someday we might add methods in this module so that someone who
 # tries to `import ray_client as ray` -- as a module, instead of

--- a/python/ray/experimental/client/__init__.py
+++ b/python/ray/experimental/client/__init__.py
@@ -80,18 +80,7 @@ def reset_api():
 
 def _get_client_api() -> APIImpl:
     global _client_api
-    global _server_api
-    global _is_server
-    api = None
-    if _is_server:
-        api = _server_api
-    else:
-        api = _client_api
-    if api is None:
-        # We're inside a raylet worker
-        from ray.experimental.client.server.core_ray_api import CoreRayAPI
-        return CoreRayAPI()
-    return api
+    return _client_api
 
 
 def _get_server_instance():

--- a/python/ray/experimental/client/client_pickler.py
+++ b/python/ray/experimental/client/client_pickler.py
@@ -50,13 +50,9 @@ else:
 
 # NOTE(barakmich): These PickleStubs are really close to
 # the data for an exectuion, with no arguments. Combine the two?
-PickleStub = NamedTuple(
-    "PickleStub", [
-        ("type", str),
-        ("client_id", str),
-        ("ref_id", bytes),
-        ("name", Optional[str])
-    ])
+PickleStub = NamedTuple("PickleStub",
+                        [("type", str), ("client_id", str), ("ref_id", bytes),
+                         ("name", Optional[str])])
 
 
 class ClientPickler(cloudpickle.CloudPickler):
@@ -127,7 +123,7 @@ class ClientPickler(cloudpickle.CloudPickler):
             return PickleStub(
                 type="RemoteMethod",
                 client_id=self.client_id,
-                ref_id = obj.actor_handle.actor_ref.id,
+                ref_id=obj.actor_handle.actor_ref.id,
                 name=obj.method_name,
             )
         return None

--- a/python/ray/experimental/client/common.py
+++ b/python/ray/experimental/client/common.py
@@ -1,6 +1,5 @@
 import ray.core.generated.ray_client_pb2 as ray_client_pb2
 from ray.experimental.client import ray
-from typing import Dict
 
 
 class ClientBaseRef:

--- a/python/ray/experimental/client/common.py
+++ b/python/ray/experimental/client/common.py
@@ -62,8 +62,6 @@ class ClientRemoteFunc(ClientStub):
     def remote(self, *args, **kwargs):
         return ClientObjectRef(ray.call_remote(self, *args, **kwargs))
 
-    def _remote(self, *args, **kwargs):
-        return self.remote(*args, **kwargs)
     def __repr__(self):
         return "ClientRemoteFunc(%s, %s)" % (self._name, self._ref)
 

--- a/python/ray/experimental/client/common.py
+++ b/python/ray/experimental/client/common.py
@@ -62,6 +62,8 @@ class ClientRemoteFunc(ClientStub):
     def remote(self, *args, **kwargs):
         return ClientObjectRef(ray.call_remote(self, *args, **kwargs))
 
+    def _remote(self, *args, **kwargs):
+        return self.remote(*args, **kwargs)
     def __repr__(self):
         return "ClientRemoteFunc(%s, %s)" % (self._name, self._ref)
 

--- a/python/ray/experimental/client/common.py
+++ b/python/ray/experimental/client/common.py
@@ -8,17 +8,20 @@ class ClientBaseRef:
         self.id: bytes = id
         ray.call_retain(id)
 
+    def binary(self):
+        return self.id
+
+    def __eq__(self, other):
+        return self.id == other.id
+
     def __repr__(self):
         return "%s(%s)" % (
             type(self).__name__,
             self.id.hex(),
         )
 
-    def __eq__(self, other):
-        return self.id == other.id
-
-    def binary(self):
-        return self.id
+    def __hash__(self):
+        return hash(self.id)
 
     def __del__(self):
         if ray.is_connected():

--- a/python/ray/experimental/client/dataclient.py
+++ b/python/ray/experimental/client/dataclient.py
@@ -67,7 +67,8 @@ class DataClient:
                 # Gracefully shutting down
                 logger.info("Cancelling data channel")
             else:
-                logger.error(f"Got Error from rpc channel -- shutting down: {e}")
+                logger.error(
+                    f"Got Error from rpc channel -- shutting down: {e}")
                 raise e
 
     def close(self, close_channel: bool = False) -> None:

--- a/python/ray/experimental/client/dataclient.py
+++ b/python/ray/experimental/client/dataclient.py
@@ -63,7 +63,12 @@ class DataClient:
                     self.ready_data[response.req_id] = response
                     self.cv.notify_all()
         except grpc.RpcError as e:
-            logger.error(f"Got Error from rpc channel -- shutting down: {e}")
+            if grpc.StatusCode.CANCELLED == e.code():
+                # Gracefully shutting down
+                logger.info("Cancelling data channel")
+            else:
+                logger.error(f"Got Error from rpc channel -- shutting down: {e}")
+                raise e
 
     def close(self, close_channel: bool = False) -> None:
         if self.request_queue is not None:

--- a/python/ray/experimental/client/server/core_ray_api.py
+++ b/python/ray/experimental/client/server/core_ray_api.py
@@ -79,8 +79,3 @@ class RayServerAPI(CoreRayAPI):
 
     def __init__(self, server_instance):
         self.server = server_instance
-
-    def call_remote(self, instance: ClientStub, *args, **kwargs) -> bytes:
-        task = instance._prepare_client_task()
-        ticket = self.server.Schedule(task, prepared_args=args)
-        return ticket.return_id

--- a/python/ray/experimental/client/server/server.py
+++ b/python/ray/experimental/client/server/server.py
@@ -221,10 +221,8 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
                     "Unimplemented Schedule task type: %s" %
                     ray_client_pb2.ClientTask.RemoteExecType.Name(task.type))
 
-    def _schedule_method(
-            self,
-            task: ray_client_pb2.ClientTask,
-            context=None) -> ray_client_pb2.ClientTaskTicket:
+    def _schedule_method(self, task: ray_client_pb2.ClientTask,
+                         context=None) -> ray_client_pb2.ClientTaskTicket:
         actor_handle = self.actor_refs.get(task.payload_id)
         if actor_handle is None:
             raise Exception(
@@ -234,8 +232,7 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
         self.object_refs[task.client_id][output.binary()] = output
         return ray_client_pb2.ClientTaskTicket(return_id=output.binary())
 
-    def _schedule_actor(self,
-                        task: ray_client_pb2.ClientTask,
+    def _schedule_actor(self, task: ray_client_pb2.ClientTask,
                         context=None) -> ray_client_pb2.ClientTaskTicket:
         remote_class = self.lookup_or_register_actor(task.payload_id,
                                                      task.client_id)
@@ -248,10 +245,8 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
         return ray_client_pb2.ClientTaskTicket(
             return_id=actor._actor_id.binary())
 
-    def _schedule_function(
-            self,
-            task: ray_client_pb2.ClientTask,
-            context=None) -> ray_client_pb2.ClientTaskTicket:
+    def _schedule_function(self, task: ray_client_pb2.ClientTask,
+                           context=None) -> ray_client_pb2.ClientTaskTicket:
         remote_func = self.lookup_or_register_func(task.payload_id,
                                                    task.client_id)
         arglist, kwargs = self._convert_args(task.args, task.kwargs)

--- a/python/ray/experimental/client/server/server.py
+++ b/python/ray/experimental/client/server/server.py
@@ -319,6 +319,12 @@ def serve(connection_str, test_mode=False):
     return server
 
 
+def init_and_serve(connection_str, test_mode=False, *args, **kwargs):
+    info = ray.init(*args, **kwargs)
+    server = serve(connection_str, test_mode)
+    return (server, info)
+
+
 if __name__ == "__main__":
     logging.basicConfig(level="INFO")
     # TODO(barakmich): Perhaps wrap ray init

--- a/python/ray/experimental/client/server/server.py
+++ b/python/ray/experimental/client/server/server.py
@@ -220,15 +220,14 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
                 else:
                     raise NotImplementedError(
                         "Unimplemented Schedule task type: %s" %
-                        ray_client_pb2.ClientTask.RemoteExecType.Name(task.type))
+                        ray_client_pb2.ClientTask.RemoteExecType.Name(
+                            task.type))
                 result.valid = True
                 return result
             except Exception as e:
                 logger.error(f"Caught schedule exception {e}")
                 return ray_client_pb2.ClientTaskTicket(
                     valid=False, error=cloudpickle.dumps(e))
-
-
 
     def _schedule_method(self, task: ray_client_pb2.ClientTask,
                          context=None) -> ray_client_pb2.ClientTaskTicket:

--- a/python/ray/experimental/client/server/server.py
+++ b/python/ray/experimental/client/server/server.py
@@ -205,18 +205,17 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
             ready_object_ids=ready_object_ids,
             remaining_object_ids=remaining_object_ids)
 
-    def Schedule(self, task, context=None,
-                 prepared_args=None) -> ray_client_pb2.ClientTaskTicket:
+    def Schedule(self, task, context=None) -> ray_client_pb2.ClientTaskTicket:
         logger.info("schedule: %s %s" %
                     (task.name,
                      ray_client_pb2.ClientTask.RemoteExecType.Name(task.type)))
         with stash_api_for_tests(self._test_mode):
             if task.type == ray_client_pb2.ClientTask.FUNCTION:
-                return self._schedule_function(task, context, prepared_args)
+                return self._schedule_function(task, context)
             elif task.type == ray_client_pb2.ClientTask.ACTOR:
-                return self._schedule_actor(task, context, prepared_args)
+                return self._schedule_actor(task, context)
             elif task.type == ray_client_pb2.ClientTask.METHOD:
-                return self._schedule_method(task, context, prepared_args)
+                return self._schedule_method(task, context)
             else:
                 raise NotImplementedError(
                     "Unimplemented Schedule task type: %s" %
@@ -225,21 +224,19 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
     def _schedule_method(
             self,
             task: ray_client_pb2.ClientTask,
-            context=None,
-            prepared_args=None) -> ray_client_pb2.ClientTaskTicket:
+            context=None) -> ray_client_pb2.ClientTaskTicket:
         actor_handle = self.actor_refs.get(task.payload_id)
         if actor_handle is None:
             raise Exception(
                 "Can't run an actor the server doesn't have a handle for")
-        arglist = self._convert_args(task.args, prepared_args)
-        output = getattr(actor_handle, task.name).remote(*arglist)
+        arglist, kwargs = self._convert_args(task.args, task.kwargs)
+        output = getattr(actor_handle, task.name).remote(*arglist, **kwargs)
         self.object_refs[task.client_id][output.binary()] = output
         return ray_client_pb2.ClientTaskTicket(return_id=output.binary())
 
     def _schedule_actor(self,
                         task: ray_client_pb2.ClientTask,
-                        context=None,
-                        prepared_args=None) -> ray_client_pb2.ClientTaskTicket:
+                        context=None) -> ray_client_pb2.ClientTaskTicket:
         if task.payload_id not in self.registered_actor_classes:
             actor_class_ref = \
                     self.object_refs[task.client_id][task.payload_id]
@@ -250,8 +247,8 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
             reg_class = ray.remote(actor_class)
             self.registered_actor_classes[task.payload_id] = reg_class
         remote_class = self.registered_actor_classes[task.payload_id]
-        arglist = self._convert_args(task.args, prepared_args)
-        actor = remote_class.remote(*arglist)
+        arglist, kwargs = self._convert_args(task.args, task.kwargs)
+        actor = remote_class.remote(*arglist, **kwargs)
         self.actor_refs[actor._actor_id.binary()] = actor
         self.actor_owners[task.client_id].add(actor._actor_id.binary())
         return ray_client_pb2.ClientTaskTicket(
@@ -260,27 +257,27 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
     def _schedule_function(
             self,
             task: ray_client_pb2.ClientTask,
-            context=None,
-            prepared_args=None) -> ray_client_pb2.ClientTaskTicket:
+            context=None) -> ray_client_pb2.ClientTaskTicket:
         remote_func = self.lookup_or_register_func(task.payload_id,
                                                    task.client_id)
-        arglist = self._convert_args(task.args, prepared_args)
+        arglist, kwargs = self._convert_args(task.args, task.kwargs)
         # Prepare call if we're in a test
         with current_func(remote_func):
-            output = remote_func.remote(*arglist)
+            output = remote_func.remote(*arglist, **kwargs)
         if output.binary() in self.object_refs[task.client_id]:
             raise Exception("already found it")
         self.object_refs[task.client_id][output.binary()] = output
         return ray_client_pb2.ClientTaskTicket(return_id=output.binary())
 
-    def _convert_args(self, arg_list, prepared_args=None):
-        if prepared_args is not None:
-            return prepared_args
-        out = []
+    def _convert_args(self, arg_list, kwarg_map):
+        argout = []
         for arg in arg_list:
             t = convert_from_arg(arg, self)
-            out.append(t)
-        return out
+            argout.append(t)
+        kwargout = {}
+        for k in kwarg_map:
+            kwargout[k] = convert_from_arg(kwarg_map[k], self)
+        return argout, kwargout
 
     def lookup_or_register_func(self, id: bytes, client_id: str
                                 ) -> ray.remote_function.RemoteFunction:

--- a/python/ray/experimental/client/server/server_pickler.py
+++ b/python/ray/experimental/client/server/server_pickler.py
@@ -21,7 +21,8 @@ from typing import Any
 from typing import TYPE_CHECKING
 
 from ray.experimental.client.client_pickler import PickleStub
-from ray.experimental.client.server.server_stubs import ServerSelfReferenceSentinel
+from ray.experimental.client.server.server_stubs import (
+    ServerSelfReferenceSentinel)
 
 if TYPE_CHECKING:
     from ray.experimental.client.server.server import RayletServicer
@@ -89,8 +90,8 @@ class ClientUnpickler(pickle.Unpickler):
         elif pid.type == "RemoteActorSelfReference":
             return ServerSelfReferenceSentinel()
         elif pid.type == "RemoteActor":
-            return self.server.lookup_or_register_actor(pid.ref_id,
-                                                        pid.client_id)
+            return self.server.lookup_or_register_actor(
+                pid.ref_id, pid.client_id)
         else:
             raise NotImplementedError("Uncovered client data type")
 

--- a/python/ray/experimental/client/server/server_pickler.py
+++ b/python/ray/experimental/client/server/server_pickler.py
@@ -21,7 +21,7 @@ from typing import Any
 from typing import TYPE_CHECKING
 
 from ray.experimental.client.client_pickler import PickleStub
-from ray.experimental.client.server.server_stubs import ServerFunctionSentinel
+from ray.experimental.client.server.server_stubs import ServerSelfReferenceSentinel
 
 if TYPE_CHECKING:
     from ray.experimental.client.server.server import RayletServicer
@@ -82,10 +82,15 @@ class ClientUnpickler(pickle.Unpickler):
         elif pid.type == "Actor":
             return self.server.actor_refs[pid.ref_id]
         elif pid.type == "RemoteFuncSelfReference":
-            return ServerFunctionSentinel()
+            return ServerSelfReferenceSentinel()
         elif pid.type == "RemoteFunc":
             return self.server.lookup_or_register_func(pid.ref_id,
                                                        pid.client_id)
+        elif pid.type == "RemoteActorSelfReference":
+            return ServerSelfReferenceSentinel()
+        elif pid.type == "RemoteActor":
+            return self.server.lookup_or_register_actor(pid.ref_id,
+                                                        pid.client_id)
         else:
             raise NotImplementedError("Uncovered client data type")
 

--- a/python/ray/experimental/client/server/server_stubs.py
+++ b/python/ray/experimental/client/server/server_stubs.py
@@ -1,28 +1,28 @@
 from contextlib import contextmanager
 
-_current_remote_func = None
+_current_remote_obj = None
 
 
 @contextmanager
-def current_func(f):
-    global _current_remote_func
-    remote_func = _current_remote_func
-    _current_remote_func = f
+def current_remote(r):
+    global _current_remote_obj
+    remote = _current_remote_obj
+    _current_remote_obj = r
     try:
         yield
     finally:
-        _current_remote_func = remote_func
+        _current_remote_obj = remote
 
 
-class ServerFunctionSentinel:
+class ServerSelfReferenceSentinel:
     def __init__(self):
         pass
 
     def __reduce__(self):
-        global _current_remote_func
-        if _current_remote_func is None:
-            return (ServerFunctionSentinel, tuple())
-        return (identity, (_current_remote_func, ))
+        global _current_remote_obj
+        if _current_remote_obj is None:
+            return (ServerSelfReferenceSentinel, tuple())
+        return (identity, (_current_remote_obj, ))
 
 
 def identity(x):

--- a/python/ray/experimental/client/worker.py
+++ b/python/ray/experimental/client/worker.py
@@ -149,6 +149,8 @@ class Worker:
         for arg in args:
             pb_arg = convert_to_arg(arg, self._client_id)
             task.args.append(pb_arg)
+        for k, v in kwargs.items():
+            task.kwargs[k].CopyFrom(convert_to_arg(v, self._client_id))
         task.client_id = self._client_id
         logger.debug("Scheduling %s" % task)
         ticket = self.server.Schedule(task, metadata=self.metadata)

--- a/python/ray/experimental/client/worker.py
+++ b/python/ray/experimental/client/worker.py
@@ -173,10 +173,9 @@ class Worker:
         self.reference_count[id] += 1
 
     def close(self):
-        self.data_client.close()
+        self.data_client.close(close_channel = True)
         self.server = None
         if self.channel:
-            self.channel.close()
             self.channel = None
 
     def terminate_actor(self, actor: ClientActorHandle,

--- a/python/ray/experimental/client/worker.py
+++ b/python/ray/experimental/client/worker.py
@@ -177,7 +177,7 @@ class Worker:
         self.reference_count[id] += 1
 
     def close(self):
-        self.data_client.close(close_channel = True)
+        self.data_client.close(close_channel=True)
         self.server = None
         if self.channel:
             self.channel = None

--- a/python/ray/experimental/client/worker.py
+++ b/python/ray/experimental/client/worker.py
@@ -109,9 +109,13 @@ class Worker:
              num_returns: int = 1,
              timeout: float = None
              ) -> Tuple[List[ClientObjectRef], List[ClientObjectRef]]:
-        assert isinstance(object_refs, list)
+        if not isinstance(object_refs, list):
+            raise TypeError("wait() expected a list of ClientObjectRef, "
+                            f"got {type(object_refs)}")
         for ref in object_refs:
-            assert isinstance(ref, ClientObjectRef)
+            if not isinstance(ref, ClientObjectRef):
+                raise TypeError("wait() expected a list of ClientObjectRef, "
+                                f"got list containing {type(ref)}")
         data = {
             "object_ids": [object_ref.id for object_ref in object_refs],
             "num_returns": num_returns,

--- a/python/ray/test_utils.py
+++ b/python/ray/test_utils.py
@@ -443,3 +443,7 @@ def format_web_url(url):
 
 def new_scheduler_enabled():
     return os.environ.get("RAY_ENABLE_NEW_SCHEDULER", "1") == "1"
+
+
+def client_test_enabled() -> bool:
+    return os.environ.get("RAY_TEST_CLIENT_MODE") == "1"

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -158,6 +158,7 @@ py_test(
 
 py_test_module_list(
   files = [
+    "test_actor.py",
     "test_basic.py",
     "test_basic_2.py",
   ],

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -154,7 +154,6 @@ py_test(
     deps = ["//:ray_lib"],
 )
 
-# TODO(barakmich): py_test will support env in 4.0.0... until then, tags.
 
 py_test_module_list(
   files = [
@@ -165,6 +164,8 @@ py_test_module_list(
   size = "medium",
   extra_srcs = SRCS,
   name_suffix = "_client_mode",
+  # TODO(barakmich): py_test will support env in Bazel 4.0.0... 
+  # Until then, we can use tags.
   #env = {"RAY_TEST_CLIENT_MODE": "true"},
   tags = ["exclusive", "client_tests"],
   deps = ["//:ray_lib"],

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -159,7 +159,7 @@ py_test(
 py_test_module_list(
   files = [
     "test_basic.py",
-    #"test_basic_2.py",
+    "test_basic_2.py",
   ],
   size = "medium",
   extra_srcs = SRCS,

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -153,3 +153,18 @@ py_test(
     tags = ["exclusive"],
     deps = ["//:ray_lib"],
 )
+
+# TODO(barakmich): py_test will support env in 4.0.0... until then, tags.
+
+py_test_module_list(
+  files = [
+    "test_basic.py",
+    #"test_basic_2.py",
+  ],
+  size = "medium",
+  extra_srcs = SRCS,
+  name_suffix = "_client_mode",
+  #env = {"RAY_TEST_CLIENT_MODE": "true"},
+  tags = ["exclusive", "client_tests"],
+  deps = ["//:ray_lib"],
+)

--- a/python/ray/tests/client_test_utils.py
+++ b/python/ray/tests/client_test_utils.py
@@ -1,0 +1,19 @@
+import asyncio
+
+def create_remote_signal_actor(ray):
+    # TODO(barakmich): num_cpus=0
+    @ray.remote
+    class SignalActor:
+        def __init__(self):
+            self.ready_event = asyncio.Event()
+
+        def send(self, clear=False):
+            self.ready_event.set()
+            if clear:
+                self.ready_event.clear()
+
+        async def wait(self, should_wait=True):
+            if should_wait:
+                await self.ready_event.wait()
+
+    return SignalActor

--- a/python/ray/tests/client_test_utils.py
+++ b/python/ray/tests/client_test_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 
+
 def create_remote_signal_actor(ray):
     # TODO(barakmich): num_cpus=0
     @ray.remote

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -144,9 +144,16 @@ def _ray_start_cluster(**kwargs):
         # We assume driver will connect to the head (first node),
         # so ray init will be invoked if do_init is true
         if len(remote_nodes) == 1 and do_init:
-            ray.init(address=cluster.address)
+            if client_test_enabled():
+                ray_client.ray.init(address=cluster.address)
+            else:
+                ray.init(address=cluster.address)
     yield cluster
     # The code after the yield will run as teardown code.
+    if client_test_enabled():
+        ray_client.ray.disconnect()
+        ray_client._stop_test_server(1)
+        ray_client.reset_api()
     ray.shutdown()
     cluster.shutdown()
 

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -9,12 +9,18 @@ import subprocess
 import ray
 from ray.cluster_utils import Cluster
 from ray.test_utils import init_error_pubsub
+from ray.test_utils import client_test_enabled
+import ray.experimental.client as ray_client
 
 
 @pytest.fixture
 def shutdown_only():
     yield None
     # The code after the yield will run as teardown code.
+    if client_test_enabled():
+        ray_client.ray.disconnect()
+        ray_client._stop_test_server(1)
+        ray_client.reset_api()
     ray.shutdown()
 
 
@@ -43,9 +49,17 @@ def _ray_start(**kwargs):
     init_kwargs = get_default_fixture_ray_kwargs()
     init_kwargs.update(kwargs)
     # Start the Ray processes.
-    address_info = ray.init(**init_kwargs)
+    if client_test_enabled():
+        address_info = ray_client.ray.init(**init_kwargs)
+    else:
+        address_info = ray.init(**init_kwargs)
+
     yield address_info
     # The code after the yield will run as teardown code.
+    if client_test_enabled():
+        ray_client.ray.disconnect()
+        ray_client._stop_test_server(1)
+        ray_client.reset_api()
     ray.shutdown()
 
 

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -244,6 +244,7 @@ def test_actor_import_counter(ray_start_10_cpus):
     assert ray.get(g.remote()) == num_remote_functions - 1
 
 
+@pytest.mark.skipif(client_test_enabled(), reason="internal api")
 def test_actor_method_metadata_cache(ray_start_regular):
     class Actor(object):
         pass
@@ -263,6 +264,7 @@ def test_actor_method_metadata_cache(ray_start_regular):
     assert [id(x) for x in list(cache.items())[0]] == cached_data_id
 
 
+@pytest.mark.skipif(client_test_enabled(), reason="internal api")
 def test_actor_class_name(ray_start_regular):
     @ray.remote
     class Foo:
@@ -562,6 +564,7 @@ def test_actor_static_attributes(ray_start_regular_shared):
     assert ray.get(t.g.remote()) == 3
 
 
+@pytest.mark.skipif(client_test_enabled(), reason="remote args")
 def test_decorator_args(ray_start_regular_shared):
     # This is an invalid way of using the actor decorator.
     with pytest.raises(Exception):
@@ -624,6 +627,8 @@ def test_random_id_generation(ray_start_regular_shared):
     assert f1._actor_id != f2._actor_id
 
 
+@pytest.mark.skipif(client_test_enabled(),
+                    reason="differing inheritence structure")
 def test_actor_inheritance(ray_start_regular_shared):
     class NonActorBase:
         def __init__(self):
@@ -637,7 +642,7 @@ def test_actor_inheritance(ray_start_regular_shared):
 
     # Test that you can't instantiate an actor class directly.
     with pytest.raises(
-            Exception, match="Actors cannot be instantiated directly."):
+            Exception, match="cannot be instantiated directly"):
         ActorBase()
 
     # Test that you can't inherit from an actor class.
@@ -651,6 +656,7 @@ def test_actor_inheritance(ray_start_regular_shared):
                 pass
 
 
+@pytest.mark.skipif(client_test_enabled(), reason="remote args")
 def test_multiple_return_values(ray_start_regular_shared):
     @ray.remote
     class Foo:
@@ -684,6 +690,7 @@ def test_multiple_return_values(ray_start_regular_shared):
     assert ray.get([id3a, id3b, id3c]) == [1, 2, 3]
 
 
+@pytest.mark.skipif(client_test_enabled(), reason="remote args")
 def test_options_num_returns(ray_start_regular_shared):
     @ray.remote
     class Foo:
@@ -699,6 +706,7 @@ def test_options_num_returns(ray_start_regular_shared):
     assert ray.get([obj1, obj2]) == [1, 2]
 
 
+@pytest.mark.skipif(client_test_enabled(), reason="remote args")
 def test_options_name(ray_start_regular_shared):
     @ray.remote
     class Foo:
@@ -775,7 +783,7 @@ def test_distributed_actor_handle_deletion(ray_start_regular_shared):
         ray.get(signal.wait.remote())
         return ray.get(actor.method.remote())
 
-    SignalActor = create_remote_signal_actor()
+    SignalActor = create_remote_signal_actor(ray)
     signal = SignalActor.remote()
     a = Actor.remote()
     pid = ray.get(a.getpid.remote())

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -22,7 +22,7 @@ else:
     import ray
 # NOTE: We have to import setproctitle after ray because we bundle setproctitle
 # with ray.
-import setproctitle
+import setproctitle  # noqa
 
 
 @pytest.mark.skipif(client_test_enabled(), reason="test setup order")

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -627,8 +627,8 @@ def test_random_id_generation(ray_start_regular_shared):
     assert f1._actor_id != f2._actor_id
 
 
-@pytest.mark.skipif(client_test_enabled(),
-                    reason="differing inheritence structure")
+@pytest.mark.skipif(
+    client_test_enabled(), reason="differing inheritence structure")
 def test_actor_inheritance(ray_start_regular_shared):
     class NonActorBase:
         def __init__(self):
@@ -641,8 +641,7 @@ def test_actor_inheritance(ray_start_regular_shared):
             pass
 
     # Test that you can't instantiate an actor class directly.
-    with pytest.raises(
-            Exception, match="cannot be instantiated directly"):
+    with pytest.raises(Exception, match="cannot be instantiated directly"):
         ActorBase()
 
     # Test that you can't inherit from an actor class.

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -62,7 +62,7 @@ def test_omp_threads_set(shutdown_only):
     assert os.environ["OMP_NUM_THREADS"] == "1"
 
 
-@pytest.mark.skipif(client_test_enabled(), reason="internal api")
+@pytest.mark.skipif(client_test_enabled(), reason="remote args")
 def test_submit_api(shutdown_only):
     ray.init(num_cpus=2, num_gpus=1, resources={"Custom": 1})
 
@@ -176,7 +176,7 @@ def test_invalid_arguments(shutdown_only):
                 x = 1
 
 
-@pytest.mark.skipif(client_test_enabled(), reason="internal _remote")
+@pytest.mark.skipif(client_test_enabled(), reason="remote args")
 def test_many_fractional_resources(shutdown_only):
     ray.init(num_cpus=2, num_gpus=2, resources={"Custom": 2})
 

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 # https://github.com/ray-project/ray/issues/6662
+@pytest.mark.skipif(client_test_enabled(), reason="not part of client api")
 def test_ignore_http_proxy(shutdown_only):
     ray.init(num_cpus=1)
     os.environ["http_proxy"] = "http://example.com"

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -456,7 +456,8 @@ def test_nested_functions(ray_start_shared_local_modes):
     assert ray.get(factorial.remote(5)) == 120
 
 
-@pytest.mark.skipif(client_test_enabled(), reason="mutual recursion is a known issue")
+@pytest.mark.skipif(
+    client_test_enabled(), reason="mutual recursion is a known issue")
 def test_mutually_recursive_functions(ray_start_shared_local_modes):
     # Test remote functions that recursively call each other.
     @ray.remote

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 # https://github.com/ray-project/ray/issues/6662
-@pytest.mark.skipif(client_test_enabled(), reason="not part of client api")
+@pytest.mark.skipif(client_test_enabled(), reason="internal api")
 def test_ignore_http_proxy(shutdown_only):
     ray.init(num_cpus=1)
     os.environ["http_proxy"] = "http://example.com"
@@ -55,7 +55,7 @@ def test_grpc_message_size(shutdown_only):
 
 
 # https://github.com/ray-project/ray/issues/7287
-@pytest.mark.skipif(client_test_enabled(), reason="not part of client api")
+@pytest.mark.skipif(client_test_enabled(), reason="internal api")
 def test_omp_threads_set(shutdown_only):
     ray.init(num_cpus=1)
     # Should have been auto set by ray init.
@@ -244,7 +244,7 @@ def test_many_fractional_resources(shutdown_only):
         assert False, "Did not get correct available resources."
 
 
-@pytest.mark.skipif(client_test_enabled(), reason="remote options")
+@pytest.mark.skipif(client_test_enabled(), reason="remote args")
 def test_background_tasks_with_max_calls(shutdown_only):
     ray.init(num_cpus=2)
 
@@ -275,7 +275,6 @@ def test_background_tasks_with_max_calls(shutdown_only):
         wait_for_pid_to_exit(pid)
 
 
-@pytest.mark.skipif(client_test_enabled(), reason="passes with pytest, not in bazel")
 def test_fair_queueing(shutdown_only):
     ray.init(num_cpus=1, _system_config={"fair_queueing_enabled": 1})
 
@@ -326,7 +325,6 @@ def test_put_get(shutdown_only):
         assert value_before == value_after
 
 
-@pytest.mark.skipif(client_test_enabled(), reason="passes with pytest, not in bazel")
 @pytest.mark.skipif(sys.platform != "linux", reason="Failing on Windows")
 def test_wait_timing(shutdown_only):
     ray.init(num_cpus=2)
@@ -362,7 +360,7 @@ def test_function_descriptor():
     assert d.get(python_descriptor2) == 123
 
 
-@pytest.mark.skipif(client_test_enabled(), reason="remote options")
+@pytest.mark.skipif(client_test_enabled(), reason="remote args")
 def test_ray_options(shutdown_only):
     @ray.remote(
         num_cpus=2, num_gpus=3, memory=150 * 2**20, resources={"custom1": 1})
@@ -457,8 +455,10 @@ def test_nested_functions(ray_start_shared_local_modes):
     assert ray.get(factorial.remote(4)) == 24
     assert ray.get(factorial.remote(5)) == 120
 
-    # Test remote functions that recursively call each other.
 
+@pytest.mark.skipif(client_test_enabled(), reason="mutual recursion is a known issue")
+def test_mutually_recursive_functions(ray_start_shared_local_modes):
+    # Test remote functions that recursively call each other.
     @ray.remote
     def factorial_even(n):
         assert n % 2 == 0

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -388,6 +388,7 @@ def test_ray_options(shutdown_only):
     assert without_options != with_options
 
 
+@pytest.mark.skipif(client_test_enabled(), reason="message size")
 @pytest.mark.parametrize(
     "ray_start_cluster_head", [{
         "num_cpus": 0,
@@ -730,6 +731,7 @@ def test_args_stars_after(ray_start_shared_local_modes):
     ray.get(remote_test_function.remote(local_method, actor_method))
 
 
+@pytest.mark.skipif(client_test_enabled(), reason="internal api")
 def test_object_id_backward_compatibility(ray_start_shared_local_modes):
     # We've renamed Python's `ObjectID` to `ObjectRef`, and added a type
     # alias for backward compatibility.

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 
 
 # https://github.com/ray-project/ray/issues/6662
-@pytest.mark.skipif(client_test_enabled(), reason="not part of client api")
 def test_ignore_http_proxy(shutdown_only):
     ray.init(num_cpus=1)
     os.environ["http_proxy"] = "http://example.com"

--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -22,6 +22,7 @@ else:
 
 logger = logging.getLogger(__name__)
 
+
 @pytest.mark.parametrize(
     "shutdown_only", [{
         "local_mode": True
@@ -31,6 +32,7 @@ logger = logging.getLogger(__name__)
     indirect=True)
 def test_variable_number_of_args(shutdown_only):
     ray.init(num_cpus=1)
+
     @ray.remote
     def varargs_fct1(*a):
         return " ".join(map(str, a))
@@ -38,7 +40,6 @@ def test_variable_number_of_args(shutdown_only):
     @ray.remote
     def varargs_fct2(a, *b):
         return " ".join(map(str, b))
-
 
     x = varargs_fct1.remote(0, 1, 2)
     assert ray.get(x) == "0 1 2"
@@ -464,8 +465,8 @@ def test_skip_plasma(ray_start_regular_shared):
     assert ray.get(obj_ref) == 2
 
 
-@pytest.mark.skipif(client_test_enabled(),
-                    reason="internal api and message size")
+@pytest.mark.skipif(
+    client_test_enabled(), reason="internal api and message size")
 def test_actor_large_objects(ray_start_regular_shared):
     @ray.remote
     class Actor:

--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -22,7 +22,6 @@ else:
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.skipif(client_test_enabled(), reason="test setup order")
 @pytest.mark.parametrize(
     "shutdown_only", [{
         "local_mode": True
@@ -31,6 +30,7 @@ logger = logging.getLogger(__name__)
     }],
     indirect=True)
 def test_variable_number_of_args(shutdown_only):
+    ray.init(num_cpus=1)
     @ray.remote
     def varargs_fct1(*a):
         return " ".join(map(str, a))
@@ -39,7 +39,6 @@ def test_variable_number_of_args(shutdown_only):
     def varargs_fct2(a, *b):
         return " ".join(map(str, b))
 
-    ray.init(num_cpus=1)
 
     x = varargs_fct1.remote(0, 1, 2)
     assert ray.get(x) == "0 1 2"

--- a/python/ray/tests/test_experimental_client.py
+++ b/python/ray/tests/test_experimental_client.py
@@ -81,11 +81,11 @@ def test_wait(ray_start_regular_shared):
         with pytest.raises(Exception):
             # Reference not in the object store.
             ray.wait([ClientObjectRef("blabla")])
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             ray.wait("blabla")
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             ray.wait(ClientObjectRef("blabla"))
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             ray.wait(["blabla"])
 
 

--- a/python/ray/tests/test_experimental_client_terminate.py
+++ b/python/ray/tests/test_experimental_client_terminate.py
@@ -1,5 +1,4 @@
 import pytest
-import asyncio
 from ray.tests.test_experimental_client import ray_start_client_server
 from ray.tests.client_test_utils import create_remote_signal_actor
 from ray.test_utils import wait_for_condition

--- a/python/ray/tests/test_experimental_client_terminate.py
+++ b/python/ray/tests/test_experimental_client_terminate.py
@@ -1,6 +1,7 @@
 import pytest
 import asyncio
 from ray.tests.test_experimental_client import ray_start_client_server
+from ray.tests.client_test_utils import create_remote_signal_actor
 from ray.test_utils import wait_for_condition
 from ray.exceptions import TaskCancelledError
 from ray.exceptions import RayTaskError
@@ -45,21 +46,7 @@ def test_kill_actor_immediately_after_creation(ray_start_regular):
 @pytest.mark.parametrize("use_force", [True, False])
 def test_cancel_chain(ray_start_regular, use_force):
     with ray_start_client_server() as ray:
-
-        @ray.remote
-        class SignalActor:
-            def __init__(self):
-                self.ready_event = asyncio.Event()
-
-            def send(self, clear=False):
-                self.ready_event.set()
-                if clear:
-                    self.ready_event.clear()
-
-            async def wait(self, should_wait=True):
-                if should_wait:
-                    await self.ready_event.wait()
-
+        SignalActor = create_remote_signal_actor(ray)
         signaler = SignalActor.remote()
 
         @ray.remote

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -50,8 +50,9 @@ message ClientTask {
   string name = 2;
   // A reference to the payload.
   bytes payload_id = 3;
-  // The parameters to pass to this call.
+  // Positional parameters to pass to this call.
   repeated Arg args = 4;
+  // Keyword parameters to pass to this call.
   map<string, Arg> kwargs = 5;
   // The ID of the client namespace associated with the Datapath stream making this
   // request.
@@ -59,9 +60,11 @@ message ClientTask {
 }
 
 message ClientTaskTicket {
+  // Was the task successful?
   bool valid = 1;
   // A reference to the returned value from the execution.
   bytes return_id = 2;
+  // If unsuccessful, an encoding of the error.
   bytes error = 3;
 }
 

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -59,8 +59,10 @@ message ClientTask {
 }
 
 message ClientTaskTicket {
+  bool valid = 1;
   // A reference to the returned value from the execution.
-  bytes return_id = 1;
+  bytes return_id = 2;
+  bytes error = 3;
 }
 
 // Delivers data to the server

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -52,9 +52,10 @@ message ClientTask {
   bytes payload_id = 3;
   // The parameters to pass to this call.
   repeated Arg args = 4;
+  map<string, Arg> kwargs = 5;
   // The ID of the client namespace associated with the Datapath stream making this
   // request.
-  string client_id = 5;
+  string client_id = 6;
 }
 
 message ClientTaskTicket {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
## Why are these changes needed?

Brings the client in line with our usual unit tests. Skips tests if the functionality is internal (not exposed in the ray client API), if the functionality has a ticket in this milestone (mostly regarding passing options like num_cpu), grpc message size issues that datastreaming can relatively easily handle (for a future milestone) or on rare occasion, a completely odd reason altogether.

Current stats:
test_basic: 23 pass, 11 skip
test_basic_2: 16 pass, 8 skip
test_actor: 27 pass, 9 skip


## Related issue number
Depends on #12818 
Closes #12422 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
