### PR TITLE
[GCS]GCS resource manager remove cluster_resources_

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -240,7 +240,7 @@ void GcsNodeManager::AddNode(std::shared_ptr<rpc::GcsNodeInfo> node) {
     for (auto &listener : node_added_listeners_) {
       listener(node);
     }
-    gcs_resource_manager_->OnNodeAdd(node_id);
+    gcs_resource_manager_->OnNodeAdd(*node);
   }
 }
 

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -26,10 +26,13 @@ void GcsResourceManager::HandleGetResources(const rpc::GetResourcesRequest &requ
                                             rpc::GetResourcesReply *reply,
                                             rpc::SendReplyCallback send_reply_callback) {
   NodeID node_id = NodeID::FromBinary(request.node_id());
-  auto iter = cluster_resources_.find(node_id);
-  if (iter != cluster_resources_.end()) {
-    for (const auto &resource : iter->second.items()) {
-      (*reply->mutable_resources())[resource.first] = resource.second;
+  auto iter = cluster_scheduling_resources_.find(node_id);
+  if (iter != cluster_scheduling_resources_.end()) {
+    const auto &resource_map = iter->second.GetTotalResources().GetResourceMap();
+    rpc::ResourceTableData resource_table_data;
+    for (const auto &resource : resource_map) {
+      resource_table_data.set_resource_capacity(resource.second);
+      (*reply->mutable_resources())[resource.first] = resource_table_data;
     }
   }
   GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
@@ -41,29 +44,35 @@ void GcsResourceManager::HandleUpdateResources(
     rpc::SendReplyCallback send_reply_callback) {
   NodeID node_id = NodeID::FromBinary(request.node_id());
   RAY_LOG(DEBUG) << "Updating resources, node id = " << node_id;
-  auto iter = cluster_resources_.find(node_id);
-  std::unordered_map<std::string, double> to_be_updated_resources;
-  for (const auto &entry : request.resources()) {
-    to_be_updated_resources.emplace(entry.first, entry.second.resource_capacity());
+  std::unordered_map<std::string, double> changed_resources;
+  for (auto &entry : request.resources()) {
+    changed_resources.emplace(entry.first, entry.second.resource_capacity());
   }
 
-  if (iter != cluster_resources_.end()) {
-    for (const auto &entry : request.resources()) {
-      (*iter->second.mutable_items())[entry.first] = entry.second;
+  auto iter = cluster_scheduling_resources_.find(node_id);
+  if (iter != cluster_scheduling_resources_.end()) {
+    // Update `cluster_scheduling_resources_`.
+    SchedulingResources &scheduling_resources = iter->second;
+    for (const auto &entry : changed_resources) {
+      scheduling_resources.UpdateResourceCapacity(entry.first, entry.second);
     }
-    UpdateResourceCapacity(node_id, to_be_updated_resources);
-    auto on_done = [this, node_id, to_be_updated_resources, reply,
+
+    // Update gcs storage.
+    rpc::ResourceMap resource_map;
+    for (const auto &entry : iter->second.GetTotalResources().GetResourceMap()) {
+      (*resource_map.mutable_items())[entry.first].set_resource_capacity(entry.second);
+    }
+    for (const auto &entry : changed_resources) {
+      (*resource_map.mutable_items())[entry.first].set_resource_capacity(entry.second);
+    }
+
+    auto on_done = [this, node_id, changed_resources, reply,
                     send_reply_callback](const Status &status) {
       RAY_CHECK_OK(status);
       rpc::NodeResourceChange node_resource_change;
       node_resource_change.set_node_id(node_id.Binary());
-      for (const auto &it : to_be_updated_resources) {
-        const auto &resource_name = it.first;
-        const auto &resource_capacity = it.second;
-        auto &node_updated_resources =
-            (*node_resource_change.mutable_updated_resources());
-        node_updated_resources[resource_name] = resource_capacity;
-      }
+      node_resource_change.mutable_updated_resources()->insert(changed_resources.begin(),
+                                                               changed_resources.end());
       RAY_CHECK_OK(gcs_pub_sub_->Publish(NODE_RESOURCE_CHANNEL, node_id.Hex(),
                                          node_resource_change.SerializeAsString(),
                                          nullptr));
@@ -73,7 +82,7 @@ void GcsResourceManager::HandleUpdateResources(
     };
 
     RAY_CHECK_OK(
-        gcs_table_storage_->NodeResourceTable().Put(node_id, iter->second, on_done));
+        gcs_table_storage_->NodeResourceTable().Put(node_id, resource_map, on_done));
   } else {
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::Invalid("Node is not exist."));
     RAY_LOG(ERROR) << "Failed to update resources as node " << node_id
@@ -88,13 +97,23 @@ void GcsResourceManager::HandleDeleteResources(
   NodeID node_id = NodeID::FromBinary(request.node_id());
   RAY_LOG(DEBUG) << "Deleting node resources, node id = " << node_id;
   auto resource_names = VectorFromProtobuf(request.resource_name_list());
-  auto iter = cluster_resources_.find(node_id);
-  if (iter != cluster_resources_.end()) {
-    DeleteResources(node_id, resource_names);
-
-    for (const auto &resource_name : resource_names) {
-      RAY_IGNORE_EXPR(iter->second.mutable_items()->erase(resource_name));
+  auto iter = cluster_scheduling_resources_.find(node_id);
+  if (iter != cluster_scheduling_resources_.end()) {
+    // Update `cluster_scheduling_resources_`.
+    for (auto &resource_name : resource_names) {
+      iter->second.DeleteResource(resource_name);
     }
+
+    // Update gcs storage.
+    rpc::ResourceMap resource_map;
+    auto resources = iter->second.GetTotalResources().GetResourceMap();
+    for (auto &resource_name : resource_names) {
+      resources.erase(resource_name);
+    }
+    for (const auto &entry : resources) {
+      (*resource_map.mutable_items())[entry.first].set_resource_capacity(entry.second);
+    }
+
     auto on_done = [this, node_id, resource_names, reply,
                     send_reply_callback](const Status &status) {
       RAY_CHECK_OK(status);
@@ -110,7 +129,7 @@ void GcsResourceManager::HandleDeleteResources(
       GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
     };
     RAY_CHECK_OK(
-        gcs_table_storage_->NodeResourceTable().Put(node_id, iter->second, on_done));
+        gcs_table_storage_->NodeResourceTable().Put(node_id, resource_map, on_done));
   } else {
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
     RAY_LOG(DEBUG) << "Finished deleting node resources, node id = " << node_id;
@@ -139,7 +158,7 @@ void GcsResourceManager::Initialize(const GcsInitData &gcs_init_data) {
   for (auto &entry : gcs_init_data.ClusterResources()) {
     const auto &iter = nodes.find(entry.first);
     if (iter->second.state() == rpc::GcsNodeInfo::ALIVE) {
-      cluster_resources_[entry.first] = entry.second;
+//      cluster_resources_[entry.first] = entry.second;
     }
   }
 }
@@ -180,12 +199,10 @@ void GcsResourceManager::DeleteResources(
 }
 
 void GcsResourceManager::OnNodeAdd(const NodeID &node_id) {
-  // Add an empty resources for this node.
-  cluster_resources_.emplace(node_id, rpc::ResourceMap());
+
 }
 
 void GcsResourceManager::OnNodeDead(const NodeID &node_id) {
-  cluster_resources_.erase(node_id);
   cluster_scheduling_resources_.erase(node_id);
 }
 

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -72,8 +72,8 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler {
 
   /// Handle a node registration.
   ///
-  /// \param node_id The specified node id.
-  void OnNodeAdd(const NodeID &node_id);
+  /// \param node The specified node to add.
+  void OnNodeAdd(const rpc::GcsNodeInfo &node);
 
   /// Handle a node death.
   ///
@@ -130,8 +130,6 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler {
   std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub_;
   /// Storage for GCS tables.
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
-  /// Cluster resources.
-  absl::flat_hash_map<NodeID, rpc::ResourceMap> cluster_resources_;
   /// Map from node id to the scheduling resources of the node.
   absl::flat_hash_map<NodeID, SchedulingResources> cluster_scheduling_resources_;
 

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -101,6 +101,7 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     rpc::ResourcesData resource;
     resource.set_node_id(node->node_id());
     (*resource.mutable_resources_available())["CPU"] = cpu_num;
+    resource.set_resources_available_changed(true);
     gcs_node_manager_->UpdateNodeRealtimeResources(NodeID::FromBinary(node->node_id()),
                                                    resource);
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
GCS resource manager code optimization, remove redundant variables `cluster_resources_`.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
