### PR TITLE
[Tune]Add integer loguniform support

### DIFF
--- a/doc/source/tune/api_docs/search_space.rst
+++ b/doc/source/tune/api_docs/search_space.rst
@@ -200,7 +200,7 @@ For a high-level overview, see this example:
         # rounding to increments of 3 (includes 12)
         "qrandint": tune.qrandint(-21, 12, 3),
 
-        # Sample a integer uniformly between 1 (inclusive) and 10 (exclusive),
+        # Sample a integer uniformly between 1 (inclusive) and 10 (inclusive (!)),
         # while sampling in log space and rounding to increments of 2
         "qlograndint": tune.qlograndint(1, 10, 2),
 

--- a/doc/source/tune/api_docs/search_space.rst
+++ b/doc/source/tune/api_docs/search_space.rst
@@ -192,9 +192,17 @@ For a high-level overview, see this example:
         # Sample a integer uniformly between -9 (inclusive) and 15 (exclusive)
         "randint": tune.randint(-9, 15),
 
+        # Sample a integer uniformly between 1 (inclusive) and 10 (exclusive),
+        # while sampling in log space
+        "lograndint": tune.lograndint(1, 10),
+
         # Sample a random uniformly between -21 (inclusive) and 12 (inclusive (!))
         # rounding to increments of 3 (includes 12)
         "qrandint": tune.qrandint(-21, 12, 3),
+
+        # Sample a integer uniformly between 1 (inclusive) and 10 (exclusive),
+        # while sampling in log space and rounding to increments of 2
+        "qlograndint": tune.qlograndint(1, 10, 2),
 
         # Sample an option uniformly from the specified choices
         "choice": tune.choice(["a", "b", "c"]),

--- a/python/ray/tune/__init__.py
+++ b/python/ray/tune/__init__.py
@@ -16,8 +16,8 @@ from ray.tune.session import (
 from ray.tune.progress_reporter import (ProgressReporter, CLIReporter,
                                         JupyterNotebookReporter)
 from ray.tune.sample import (function, sample_from, uniform, quniform, choice,
-                             randint, qrandint, randn, qrandn, loguniform,
-                             qloguniform)
+                             randint, lograndint, qrandint, qlograndint, randn,
+                             qrandn, loguniform, qloguniform)
 from ray.tune.suggest import create_searcher
 from ray.tune.schedulers import create_scheduler
 
@@ -26,10 +26,10 @@ __all__ = [
     "register_env", "register_trainable", "run", "run_experiments",
     "with_parameters", "Stopper", "EarlyStopping", "Experiment", "function",
     "sample_from", "track", "uniform", "quniform", "choice", "randint",
-    "qrandint", "randn", "qrandn", "loguniform", "qloguniform",
-    "ExperimentAnalysis", "Analysis", "CLIReporter", "JupyterNotebookReporter",
-    "ProgressReporter", "report", "get_trial_dir", "get_trial_name",
-    "get_trial_id", "make_checkpoint_dir", "save_checkpoint",
+    "lograndint", "qrandint", "qlograndint", "randn", "qrandn", "loguniform",
+    "qloguniform", "ExperimentAnalysis", "Analysis", "CLIReporter",
+    "JupyterNotebookReporter", "ProgressReporter", "report", "get_trial_dir",
+    "get_trial_name", "get_trial_id", "make_checkpoint_dir", "save_checkpoint",
     "is_session_enabled", "checkpoint_dir", "SyncConfig", "create_searcher",
     "create_scheduler"
 ]

--- a/python/ray/tune/sample.py
+++ b/python/ray/tune/sample.py
@@ -484,9 +484,6 @@ def lograndint(lower: int, upper: int, base: float = 10):
 
     ``lower`` is inclusive, ``upper`` is exclusive.
 
-    Sampling from ``tune.randint(10)`` is equivalent to sampling from
-    ``np.random.randint(10)``
-
     """
     return Integer(lower, upper).loguniform(base)
 
@@ -498,9 +495,6 @@ def qrandint(lower: int, upper: int, q: int = 1):
 
     The value will be quantized, i.e. rounded to an integer increment of ``q``.
     Quantization makes the upper bound inclusive.
-
-    Sampling from ``tune.randint(10)`` is equivalent to sampling from
-    ``np.random.randint(10)``
 
     """
     return Integer(lower, upper).uniform().quantized(q)
@@ -514,9 +508,6 @@ def qlograndint(lower: int, upper: int, q: int, base: float = 10):
 
     The value will be quantized, i.e. rounded to an integer increment of ``q``.
     Quantization makes the upper bound inclusive.
-
-    Sampling from ``tune.randint(10)`` is equivalent to sampling from
-    ``np.random.randint(10)``
 
     """
     return Integer(lower, upper).loguniform(base).quantized(q)

--- a/python/ray/tune/suggest/bohb.py
+++ b/python/ray/tune/suggest/bohb.py
@@ -281,7 +281,15 @@ class TuneBOHB(Searcher):
                         log=False)
 
             elif isinstance(domain, Integer):
-                if isinstance(sampler, Uniform):
+                if isinstance(sampler, LogUniform):
+                    lower = domain.lower
+                    upper = domain.upper
+                    if quantize:
+                        lower = math.ceil(domain.lower / quantize) * quantize
+                        upper = math.floor(domain.upper / quantize) * quantize
+                    return ConfigSpace.UniformIntegerHyperparameter(
+                        par, lower=lower, upper=upper, q=quantize, log=True)
+                elif isinstance(sampler, Uniform):
                     lower = domain.lower
                     upper = domain.upper
                     if quantize:

--- a/python/ray/tune/suggest/hyperopt.py
+++ b/python/ray/tune/suggest/hyperopt.py
@@ -400,8 +400,9 @@ class HyperOptSearch(Searcher):
             if isinstance(domain, Float):
                 if isinstance(sampler, LogUniform):
                     if quantize:
-                        return hpo.hp.qloguniform(par, domain.lower,
-                                                  domain.upper, quantize)
+                        return hpo.hp.qloguniform(par, np.log(domain.lower),
+                                                  np.log(domain.upper),
+                                                  quantize)
                     return hpo.hp.loguniform(par, np.log(domain.lower),
                                              np.log(domain.upper))
                 elif isinstance(sampler, Uniform):

--- a/python/ray/tune/suggest/hyperopt.py
+++ b/python/ray/tune/suggest/hyperopt.py
@@ -416,12 +416,21 @@ class HyperOptSearch(Searcher):
                     return hpo.hp.normal(par, sampler.mean, sampler.sd)
 
             elif isinstance(domain, Integer):
-                if isinstance(sampler, Uniform):
+                if isinstance(sampler, LogUniform):
                     if quantize:
-                        logger.warning(
-                            "HyperOpt does not support quantization for "
-                            "integer values. Reverting back to 'randint'.")
-                    return hpo.hp.randint(par, domain.lower, high=domain.upper)
+                        return hpo.base.pyll.scope.int(
+                            hpo.hp.qloguniform(par, np.log(domain.lower),
+                                               np.log(domain.upper), quantize))
+                    return hpo.base.pyll.scope.int(
+                        hpo.hp.qloguniform(par, np.log(domain.lower),
+                                           np.log(domain.upper), 1.0))
+                elif isinstance(sampler, Uniform):
+                    if quantize:
+                        return hpo.base.pyll.scope.int(
+                            hpo.hp.quniform(par, domain.lower, domain.upper,
+                                            quantize))
+                    return hpo.hp.uniformint(
+                        par, domain.lower, high=domain.upper)
             elif isinstance(domain, Categorical):
                 if isinstance(sampler, Uniform):
                     return hpo.hp.choice(par, [

--- a/python/ray/tune/suggest/nevergrad.py
+++ b/python/ray/tune/suggest/nevergrad.py
@@ -311,6 +311,11 @@ class NevergradSearch(Searcher):
                 return ng.p.Scalar(lower=domain.lower, upper=domain.upper)
 
             if isinstance(domain, Integer):
+                if isinstance(sampler, LogUniform):
+                    return ng.p.Log(
+                        lower=domain.lower,
+                        upper=domain.upper,
+                        exponent=sampler.base).set_integer_casting()
                 return ng.p.Scalar(
                     lower=domain.lower,
                     upper=domain.upper).set_integer_casting()

--- a/python/ray/tune/suggest/nevergrad.py
+++ b/python/ray/tune/suggest/nevergrad.py
@@ -310,7 +310,7 @@ class NevergradSearch(Searcher):
                         exponent=sampler.base)
                 return ng.p.Scalar(lower=domain.lower, upper=domain.upper)
 
-            if isinstance(domain, Integer):
+            elif isinstance(domain, Integer):
                 if isinstance(sampler, LogUniform):
                     return ng.p.Log(
                         lower=domain.lower,
@@ -320,11 +320,13 @@ class NevergradSearch(Searcher):
                     lower=domain.lower,
                     upper=domain.upper).set_integer_casting()
 
-            if isinstance(domain, Categorical):
+            elif isinstance(domain, Categorical):
                 return ng.p.Choice(choices=domain.categories)
 
-            raise ValueError("SkOpt does not support parameters of type "
-                             "`{}`".format(type(domain).__name__))
+            raise ValueError("Nevergrad does not support parameters of type "
+                             "`{}` with samplers of type `{}`".format(
+                                 type(domain).__name__,
+                                 type(domain.sampler).__name__))
 
         # Parameter name is e.g. "a/b/c" for nested dicts
         space = {

--- a/python/ray/tune/suggest/skopt.py
+++ b/python/ray/tune/suggest/skopt.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from ray.tune.result import DEFAULT_METRIC
 from ray.tune.sample import Categorical, Domain, Float, Integer, Quantized, \
-    Uniform, LogUniform
+    LogUniform
 from ray.tune.suggest.suggestion import UNRESOLVED_SEARCH_SPACE, \
     UNDEFINED_METRIC_MODE, UNDEFINED_SEARCH_SPACE
 from ray.tune.suggest.variant_generator import parse_spec_vars

--- a/python/ray/tune/suggest/skopt.py
+++ b/python/ray/tune/suggest/skopt.py
@@ -338,23 +338,23 @@ class SkOptSearch(Searcher):
                 if isinstance(domain.sampler, LogUniform):
                     return sko.space.Real(
                         domain.lower, domain.upper, prior="log-uniform")
-                elif isinstance(domain.sampler, Uniform):
-                    return sko.space.Real(
-                        domain.lower, domain.upper, prior="uniform")
+                return sko.space.Real(
+                    domain.lower, domain.upper, prior="uniform")
 
-            if isinstance(domain, Integer):
+            elif isinstance(domain, Integer):
                 if isinstance(domain.sampler, LogUniform):
                     return sko.space.Integer(
                         domain.lower, domain.upper, prior="log-uniform")
-                elif isinstance(domain.sampler, Uniform):
-                    return sko.space.Integer(
-                        domain.lower, domain.upper, prior="uniform")
+                return sko.space.Integer(
+                    domain.lower, domain.upper, prior="uniform")
 
-            if isinstance(domain, Categorical):
+            elif isinstance(domain, Categorical):
                 return domain.categories
 
             raise ValueError("SkOpt does not support parameters of type "
-                             "`{}`".format(type(domain).__name__))
+                             "`{}` with samplers of type `{}`".format(
+                                 type(domain).__name__,
+                                 type(domain.sampler).__name__))
 
         # Parameter name is e.g. "a/b/c" for nested dicts
         space = {

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -430,7 +430,7 @@ class SearchSpaceTest(unittest.TestCase):
         config = {
             "a": tune.sample.Categorical([2, 3, 4]).uniform(),
             "b": {
-                "x": tune.sample.Integer(-15, -10).quantized(2),
+                "x": tune.sample.Integer(-15, -10),
                 "y": 4,
                 "z": tune.sample.Float(1e-4, 1e-2).loguniform()
             }
@@ -439,7 +439,7 @@ class SearchSpaceTest(unittest.TestCase):
         hyperopt_config = {
             "a": hp.choice("a", [2, 3, 4]),
             "b": {
-                "x": hp.randint("x", -15, -10),
+                "x": hp.uniformint("x", -15, -10),
                 "y": 4,
                 "z": hp.loguniform("z", np.log(1e-4), np.log(1e-2))
             }
@@ -638,17 +638,22 @@ class SearchSpaceTest(unittest.TestCase):
 
     def testConvertSkOpt(self):
         from ray.tune.suggest.skopt import SkOptSearch
+        from skopt.space import Real, Integer
 
         config = {
             "a": tune.sample.Categorical([2, 3, 4]).uniform(),
             "b": {
-                "x": tune.sample.Integer(0, 5).quantized(2),
+                "x": tune.sample.Integer(0, 5),
                 "y": 4,
                 "z": tune.sample.Float(1e-4, 1e-2).loguniform()
             }
         }
         converted_config = SkOptSearch.convert_search_space(config)
-        skopt_config = {"a": [2, 3, 4], "b/x": (0, 5), "b/z": (1e-4, 1e-2)}
+        skopt_config = {
+            "a": [2, 3, 4],
+            "b/x": Integer(0, 5),
+            "b/z": Real(1e-4, 1e-2, prior="log-uniform")
+        }
 
         searcher1 = SkOptSearch(space=converted_config, metric="a", mode="max")
         searcher2 = SkOptSearch(space=skopt_config, metric="a", mode="max")

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -26,7 +26,9 @@ class SearchSpaceTest(unittest.TestCase):
             "qloguniform": tune.qloguniform(1e-4, 1e-1, 5e-5),
             "choice": tune.choice([2, 3, 4]),
             "randint": tune.randint(-9, 15),
+            "lograndint": tune.lograndint(1, 10),
             "qrandint": tune.qrandint(-21, 12, 3),
+            "qlograndint": tune.qlograndint(2, 20, 2),
             "randn": tune.randn(10, 2),
             "qrandn": tune.qrandn(10, 2, 0.2),
         }
@@ -59,9 +61,16 @@ class SearchSpaceTest(unittest.TestCase):
             self.assertGreaterEqual(out["randint"], -9)
             self.assertLess(out["randint"], 15)
 
+            self.assertGreaterEqual(out["lograndint"], 1)
+            self.assertLess(out["lograndint"], 10)
+
             self.assertGreaterEqual(out["qrandint"], -21)
             self.assertLessEqual(out["qrandint"], 12)
             self.assertEqual(out["qrandint"] % 3, 0)
+
+            self.assertGreaterEqual(out["qlograndint"], 2)
+            self.assertLessEqual(out["qlograndint"], 20)
+            self.assertEqual(out["qlograndint"] % 2, 0)
 
             # Very improbable
             self.assertGreater(out["randn"], 0)

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -60,17 +60,21 @@ class SearchSpaceTest(unittest.TestCase):
 
             self.assertGreaterEqual(out["randint"], -9)
             self.assertLess(out["randint"], 15)
+            self.assertTrue(isinstance(out["randint"], int))
 
             self.assertGreaterEqual(out["lograndint"], 1)
             self.assertLess(out["lograndint"], 10)
+            self.assertTrue(isinstance(out["lograndint"], int))
 
             self.assertGreaterEqual(out["qrandint"], -21)
             self.assertLessEqual(out["qrandint"], 12)
             self.assertEqual(out["qrandint"] % 3, 0)
+            self.assertTrue(isinstance(out["qrandint"], int))
 
             self.assertGreaterEqual(out["qlograndint"], 2)
             self.assertLessEqual(out["qlograndint"], 20)
             self.assertEqual(out["qlograndint"] % 2, 0)
+            self.assertTrue(isinstance(out["qlograndint"], int))
 
             # Very improbable
             self.assertGreater(out["randn"], 0)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds loguniform integer search spaces to Tune search spaces, with support for algorithms that can work with them.

Furthermore, it also fixes an oversight where hyperopt's `qloguniform` would not have its bounds transformed with `np.log` first.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
