### PR TITLE
[GCS]Fix redis store client AsyncPutWithIndex unordered bug

### DIFF
--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -45,6 +45,9 @@ Status RedisStoreClient::AsyncPutWithIndex(const std::string &table_name,
   RAY_CHECK_OK(DoPut(index_table_key, key, nullptr));
 
   // Write data to Redis.
+  // The operation of redis client is executed in order, and it can ensure that index is
+  // written first and then data is written. The index and data are decoupled, so we don't
+  // need to write data in the callback function of index writing.
   const auto &status = DoPut(GenRedisKey(table_name, key), data, callback);
   if (!status.ok()) {
     // Run callback if failed.

--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -38,29 +38,21 @@ Status RedisStoreClient::AsyncPutWithIndex(const std::string &table_name,
                                            const std::string &index_key,
                                            const std::string &data,
                                            const StatusCallback &callback) {
-  auto write_callback = [this, table_name, key, data, callback](Status status) {
-    if (!status.ok()) {
-      // Run callback if failed.
-      if (callback != nullptr) {
-        callback(status);
-      }
-      return;
-    }
-
-    // Write data to Redis.
-    status = DoPut(GenRedisKey(table_name, key), data, callback);
-
-    if (!status.ok()) {
-      // Run callback if failed.
-      if (callback != nullptr) {
-        callback(status);
-      }
-    }
-  };
-
+  // NOTE: To ensure the atomicity of `AsyncPutWithIndex`, we can't write data to Redis in
+  // the callback function of index writing.
   // Write index to Redis.
-  std::string index_table_key = GenRedisKey(table_name, key, index_key);
-  return DoPut(index_table_key, key, write_callback);
+  const auto &index_table_key = GenRedisKey(table_name, key, index_key);
+  RAY_CHECK_OK(DoPut(index_table_key, key, nullptr));
+
+  // Write data to Redis.
+  const auto &status = DoPut(GenRedisKey(table_name, key), data, callback);
+  if (!status.ok()) {
+    // Run callback if failed.
+    if (callback != nullptr) {
+      callback(status);
+    }
+  }
+  return status;
 }
 
 Status RedisStoreClient::AsyncGet(const std::string &table_name, const std::string &key,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
To ensure the atomicity of `AsyncPutWithIndex`, we can't write data to Redis in the callback function of index writing.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
