### PR TITLE
Deprecate experimental / dynamic resources

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -190,36 +190,6 @@ appear as the task name in the logs.
 .. image:: images/task_name_dashboard.png
 
 
-Dynamic Custom Resources
-------------------------
-
-Ray enables explicit developer control with respect to the task and actor placement by using custom resources. Further, users are able to dynamically adjust custom resources programmatically with ``ray.experimental.set_resource``. This allows the Ray application to implement virtually any scheduling policy, including task affinity, data locality, anti-affinity,
-load balancing, gang scheduling, and priority-based scheduling.
-
-
-.. code-block:: python
-
-    ray.init()
-    resource_name = "test_resource"
-    resource_capacity = 1.0
-
-    @ray.remote
-    def set_resource(resource_name, resource_capacity):
-        ray.experimental.set_resource(resource_name, resource_capacity)
-
-    ray.get(set_resource.remote(resource_name, resource_capacity))
-
-    available_resources = ray.available_resources()
-    cluster_resources = ray.cluster_resources()
-
-    assert available_resources[resource_name] == resource_capacity
-    assert cluster_resources[resource_name] == resource_capacity
-
-
-.. autofunction:: ray.experimental.set_resource
-    :noindex:
-
-
 Accelerator Types
 ------------------
 

--- a/python/ray/experimental/dynamic_resources.py
+++ b/python/ray/experimental/dynamic_resources.py
@@ -1,6 +1,3 @@
-import ray
-
-
 def set_resource(resource_name, capacity, node_id=None):
     raise DeprecationWarning(
         "Dynamic custom resources are deprecated. Consider using placement "

--- a/python/ray/experimental/dynamic_resources.py
+++ b/python/ray/experimental/dynamic_resources.py
@@ -7,6 +7,9 @@ def set_resource(resource_name, capacity, node_id=None):
     Dynamic custom resources are deprecated and won't work unless
     RAY_ENABLE_NEW_SCHEDULER=0 is set; consider using placement groups
     instead (docs.ray.io/en/master/placement-group.html).
+
+    You can also specify resources at node start time with the "resources"
+    field in the cluster autoscaler.
     """
 
     if node_id is not None:

--- a/python/ray/experimental/dynamic_resources.py
+++ b/python/ray/experimental/dynamic_resources.py
@@ -2,22 +2,8 @@ import ray
 
 
 def set_resource(resource_name, capacity, node_id=None):
-    """Set a resource to a specified capacity.
-
-    Dynamic custom resources are deprecated and won't work unless
-    RAY_ENABLE_NEW_SCHEDULER=0 is set; consider using placement groups
-    instead (docs.ray.io/en/master/placement-group.html).
-
-    You can also specify resources at Ray start time with the "resources"
-    field in the cluster autoscaler.
-    """
-
-    if node_id is not None:
-        node_id_obj = ray.NodeID(ray.utils.hex_to_binary(node_id))
-    else:
-        node_id_obj = ray.NodeID.nil()
-    if (capacity < 0) or (capacity != int(capacity)):
-        raise ValueError(
-            "Capacity {} must be a non-negative integer.".format(capacity))
-    return ray.worker.global_worker.core_worker.set_resource(
-        resource_name, capacity, node_id_obj)
+    raise DeprecationWarning(
+        "Dynamic custom resources are deprecated. Consider using placement "
+        "groups instead (docs.ray.io/en/master/placement-group.html). You "
+        "can also specify resources at Ray start time with the 'resources' "
+        "field in the cluster autoscaler.")

--- a/python/ray/experimental/dynamic_resources.py
+++ b/python/ray/experimental/dynamic_resources.py
@@ -4,7 +4,8 @@ import ray
 def set_resource(resource_name, capacity, node_id=None):
     """Set a resource to a specified capacity.
 
-    Dynamic custom resources are deprecated; consider using placement groups
+    Dynamic custom resources are deprecated and won't work unless
+    RAY_ENABLE_NEW_SCHEDULER=0 is set; consider using placement groups
     instead (docs.ray.io/en/master/placement-group.html).
     """
 

--- a/python/ray/experimental/dynamic_resources.py
+++ b/python/ray/experimental/dynamic_resources.py
@@ -8,7 +8,7 @@ def set_resource(resource_name, capacity, node_id=None):
     RAY_ENABLE_NEW_SCHEDULER=0 is set; consider using placement groups
     instead (docs.ray.io/en/master/placement-group.html).
 
-    You can also specify resources at node start time with the "resources"
+    You can also specify resources at Ray start time with the "resources"
     field in the cluster autoscaler.
     """
 

--- a/python/ray/experimental/dynamic_resources.py
+++ b/python/ray/experimental/dynamic_resources.py
@@ -2,28 +2,12 @@ import ray
 
 
 def set_resource(resource_name, capacity, node_id=None):
-    """ Set a resource to a specified capacity.
+    """Set a resource to a specified capacity.
 
-    This creates, updates or deletes a custom resource for a target NodeID.
-    If the resource already exists, it's capacity is updated to the new value.
-    If the capacity is set to 0, the resource is deleted.
-    If NodeID is not specified or set to None,
-    the resource is created on the local node where the actor is running.
-
-    Args:
-        resource_name (str): Name of the resource to be created
-        capacity (int): Capacity of the new resource. Resource is deleted if
-            capacity is 0.
-        node_id (str): The NodeID of the node where the resource is to be
-            set.
-
-    Returns:
-        None
-
-    Raises:
-          ValueError: This exception is raised when a non-negative capacity is
-            specified.
+    Dynamic custom resources are deprecated; consider using placement groups
+    instead (docs.ray.io/en/master/placement-group.html).
     """
+
     if node_id is not None:
         node_id_obj = ray.NodeID(ray.utils.hex_to_binary(node_id))
     else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Deprecate the dynamic resource experimental API, it was always buggy and isn't supported in the new scheduler.

(please comment about your use case if you are using dynamic resources; and can't use placement groups instead)