### PR TITLE
[core] Pull Manager exponential backoff

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -183,7 +183,7 @@ RAY_CONFIG(int, object_manager_timer_freq_ms, 100)
 
 /// Timeout, in milliseconds, to wait before retrying a failed pull in the
 /// ObjectManager.
-RAY_CONFIG(int, object_manager_pull_timeout_ms, 1000)
+RAY_CONFIG(int, object_manager_pull_timeout_ms, 10000)
 
 /// Timeout, in milliseconds, to wait until the Push request fails.
 /// Special value:

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -183,7 +183,7 @@ RAY_CONFIG(int, object_manager_timer_freq_ms, 100)
 
 /// Timeout, in milliseconds, to wait before retrying a failed pull in the
 /// ObjectManager.
-RAY_CONFIG(int, object_manager_pull_timeout_ms, 10000)
+RAY_CONFIG(int, object_manager_pull_timeout_ms, 1000)
 
 /// Timeout, in milliseconds, to wait until the Push request fails.
 /// Special value:

--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -111,6 +111,9 @@ void PullManager::TryPull(const ObjectID &object_id) {
 
   RAY_LOG(DEBUG) << "Sending pull request from " << self_node_id_ << " to " << node_id
                  << " of object " << object_id;
+  const auto time = get_time_();
+  auto &request = it->second;
+  request.next_pull_time = time + (pull_timeout_ms_ / 1000) * (1 << request.num_retries);
   send_pull_request_(object_id, node_id);
 }
 
@@ -131,7 +134,7 @@ void PullManager::Tick() {
     const auto time = get_time_();
     if (time >= request.next_pull_time) {
       TryPull(object_id);
-      request.next_pull_time = time + pull_timeout_ms_ / 1000;
+      request.num_retries++;
     }
   }
 }

--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -138,11 +138,8 @@ void PullManager::Tick() {
     if (time >= request.next_pull_time) {
       TryPull(object_id);
       request.num_retries++;
-      // Better to fail than have unexpected overflow behavior.
-      RAY_CHECK(request.num_retries < 42) << "Pull manager has retried pull object: " << object_id
-                       << "more than 42 times. There is an exponential backoff between "
-                          "retries so this should never happen. Please file a bug report "
-        "https://github.com/ray-project/ray/issues/new.";
+      // Bound the retry time at 10 * 1024 seconds.
+      request.num_retries = std::min(num_retries + 1, 10);
     }
   }
 }

--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -13,8 +13,7 @@ PullManager::PullManager(
       restore_spilled_object_(restore_spilled_object),
       get_time_(get_time),
       pull_timeout_ms_(pull_timeout_ms),
-      gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {
-}
+      gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {}
 
 bool PullManager::Pull(const ObjectID &object_id, const rpc::Address &owner_address) {
   RAY_LOG(DEBUG) << "Pull "
@@ -115,8 +114,7 @@ void PullManager::TryPull(const ObjectID &object_id) {
   const auto time = get_time_();
   auto &request = it->second;
   auto retry_timeout_len = (pull_timeout_ms_ / 1000.) * (1UL << request.num_retries);
-  request.next_pull_time =
-      time + retry_timeout_len;
+  request.next_pull_time = time + retry_timeout_len;
   send_pull_request_(object_id, node_id);
 }
 
@@ -137,9 +135,8 @@ void PullManager::Tick() {
     const auto time = get_time_();
     if (time >= request.next_pull_time) {
       TryPull(object_id);
-      request.num_retries++;
       // Bound the retry time at 10 * 1024 seconds.
-      request.num_retries = std::min(num_retries + 1, 10);
+      request.num_retries = std::min(request.num_retries + 1, 10);
     }
   }
 }

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -93,7 +93,7 @@ class PullManager {
   const std::function<void(const ObjectID &, const NodeID &)> send_pull_request_;
   const RestoreSpilledObjectCallback restore_spilled_object_;
   const std::function<double()> get_time_;
-  int pull_timeout_ms_;
+  uint8_t pull_timeout_ms_;
 
   /// The objects that this object manager is currently trying to fetch from
   /// remote object managers.

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -84,7 +84,7 @@ class PullManager {
         : client_locations(), next_pull_time(first_retry_time), num_retries(0) {}
     std::vector<NodeID> client_locations;
     double next_pull_time;
-    int num_retries;
+    uint8_t num_retries;
   };
 
   /// See the constructor's arguments.
@@ -93,7 +93,7 @@ class PullManager {
   const std::function<void(const ObjectID &, const NodeID &)> send_pull_request_;
   const RestoreSpilledObjectCallback restore_spilled_object_;
   const std::function<double()> get_time_;
-  uint8_t pull_timeout_ms_;
+  uint64_t pull_timeout_ms_;
 
   /// The objects that this object manager is currently trying to fetch from
   /// remote object managers.

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -81,9 +81,10 @@ class PullManager {
   /// A helper structure for tracking information about each ongoing object pull.
   struct PullRequest {
     PullRequest(double first_retry_time)
-        : client_locations(), next_pull_time(first_retry_time) {}
+        : client_locations(), next_pull_time(first_retry_time), num_retries(0) {}
     std::vector<NodeID> client_locations;
     double next_pull_time;
+    int num_retries;
   };
 
   /// See the constructor's arguments.

--- a/src/ray/object_manager/test/pull_manager_test.cc
+++ b/src/ray/object_manager/test/pull_manager_test.cc
@@ -125,7 +125,7 @@ TEST_F(PullManagerTest, TestRetryTimer) {
   ASSERT_EQ(num_send_pull_request_calls_, 1);
   ASSERT_EQ(num_restore_spilled_object_calls_, 0);
 
-  for (; fake_time_ <= 127 * 10; fake_time_ += 0.1) {
+  for (; fake_time_ <= 127 * 10; fake_time_ += 1.) {
     pull_manager_.Tick();
   }
 

--- a/src/ray/object_manager/test/pull_manager_test.cc
+++ b/src/ray/object_manager/test/pull_manager_test.cc
@@ -140,7 +140,7 @@ TEST_F(PullManagerTest, TestRetryTimer) {
   // OnLocationChange also doesn't count towards the retry timer.
   // To the casual observer, this may seem off-by-one, but this is due to floating point
   // error (0.1 + 0.1 ... 10k times > 10 == True)
-  ASSERT_EQ(num_send_pull_request_calls_, 127 * 2);
+  ASSERT_EQ(num_send_pull_request_calls_, 1 + 7 + 127);
   ASSERT_EQ(num_restore_spilled_object_calls_, 0);
 
   pull_manager_.CancelPull(obj1);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This code in this PR is simple, but the implications may not be. This PR:

1. Retries w.r.t last pull time, regardless of whether that pull was a retry or new object location.
2. Introduces exponential backoff on retries.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
