### PR TITLE
[core][new scheduler] Move tasks from ready to dispatch to waiting on argument eviction

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2631,9 +2631,10 @@ void NodeManager::HandleObjectMissing(const ObjectID &object_id) {
   }
   RAY_LOG(DEBUG) << result.str();
 
-  if (new_scheduler_enabled_) {
-    cluster_task_manager_->TasksBlocked(waiting_task_ids);
-  } else {
+  // We don't need to do anything if the new scheduler is enabled because tasks
+  // will get moved back to waiting once they reach the front of the dispatch
+  // queue.
+  if (!new_scheduler_enabled_) {
     // Transition any tasks that were in the runnable state and are dependent on
     // this object to the waiting state.
     if (!waiting_task_ids.empty()) {

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -259,24 +259,6 @@ void ClusterTaskManager::TasksUnblocked(const std::vector<TaskID> ready_ids) {
   }
 }
 
-void ClusterTaskManager::TasksBlocked(const std::vector<TaskID> ready_ids) {
-  for (const auto &task_id : ready_ids) {
-    auto it = tasks_to_dispatch_index_.find(task_id);
-    if (it != tasks_to_dispatch_index_.end()) {
-      // Move the task from ready for dispatch to waiting.
-      auto &work_it = it->second.second;
-      waiting_tasks_[task_id] = std::move(*work_it);
-
-      auto &work_queue = tasks_to_dispatch_[it->second.first];
-      work_queue.erase(work_it);
-      if (work_queue.empty()) {
-        tasks_to_dispatch_.erase(it->second.first);
-      }
-      tasks_to_dispatch_index_.erase(it);
-    }
-  }
-}
-
 void ClusterTaskManager::HandleTaskFinished(std::shared_ptr<WorkerInterface> worker) {
   cluster_resource_scheduler_->FreeLocalTaskResources(worker->GetAllocatedInstances());
   worker->ClearAllocatedInstances();

--- a/src/ray/raylet/scheduling/cluster_task_manager.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager.h
@@ -166,10 +166,11 @@ class ClusterTaskManager {
 
   /// Queue of lease requests that are waiting for resources to become available.
   /// Tasks move from scheduled -> dispatch | waiting.
-  std::unordered_map<SchedulingClass, std::list<Work>> tasks_to_schedule_;
+  std::unordered_map<SchedulingClass, std::deque<Work>> tasks_to_schedule_;
 
   /// Queue of lease requests that should be scheduled onto workers.
   /// Tasks move from scheduled | waiting -> dispatch.
+<<<<<<< HEAD
   /// Tasks can also move from dispatch -> waiting if one of their arguments is
   /// evicted.
   /// All tasks in this map that have dependencies should be registered with
@@ -180,6 +181,9 @@ class ClusterTaskManager {
   /// An index to speed up looking up a request from the dispatch queue.
   std::unordered_map<TaskID, std::pair<SchedulingClass, std::list<Work>::iterator>>
       tasks_to_dispatch_index_;
+=======
+  std::unordered_map<SchedulingClass, std::deque<Work>> tasks_to_dispatch_;
+>>>>>>> parent of c6ccb9aa3... Add index for tasks to dispatch
 
   /// Tasks waiting for arguments to be transferred locally.
   /// Tasks move from waiting -> dispatch.
@@ -192,7 +196,7 @@ class ClusterTaskManager {
 
   /// Queue of lease requests that are infeasible.
   /// Tasks go between scheduling <-> infeasible.
-  std::unordered_map<SchedulingClass, std::list<Work>> infeasible_tasks_;
+  std::unordered_map<SchedulingClass, std::deque<Work>> infeasible_tasks_;
 
   /// Track the cumulative backlog of all workers requesting a lease to this raylet.
   std::unordered_map<SchedulingClass, int> backlog_tracker_;
@@ -213,8 +217,6 @@ class ClusterTaskManager {
 
   void AddToBacklogTracker(const Task &task);
   void RemoveFromBacklogTracker(const Task &task);
-
-  friend class ClusterTaskManagerTest;
 };
 }  // namespace raylet
 }  // namespace ray

--- a/src/ray/raylet/scheduling/cluster_task_manager.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager.h
@@ -159,11 +159,15 @@ class ClusterTaskManager {
 
   /// Queue of lease requests that are waiting for resources to become available.
   /// Tasks move from scheduled -> dispatch | waiting.
-  std::unordered_map<SchedulingClass, std::deque<Work>> tasks_to_schedule_;
+  std::unordered_map<SchedulingClass, std::list<Work>> tasks_to_schedule_;
 
   /// Queue of lease requests that should be scheduled onto workers.
   /// Tasks move from scheduled | waiting -> dispatch.
-  std::unordered_map<SchedulingClass, std::deque<Work>> tasks_to_dispatch_;
+  std::unordered_map<SchedulingClass, std::list<Work>> tasks_to_dispatch_;
+
+  /// An index to speed up looking up a request from the dispatch queue.
+  std::unordered_map<TaskID, std::pair<SchedulingClass, std::list<Work>::iterator>>
+      tasks_to_dispatch_index_;
 
   /// Tasks waiting for arguments to be transferred locally.
   /// Tasks move from waiting -> dispatch.
@@ -171,7 +175,7 @@ class ClusterTaskManager {
 
   /// Queue of lease requests that are infeasible.
   /// Tasks go between scheduling <-> infeasible.
-  std::unordered_map<SchedulingClass, std::deque<Work>> infeasible_tasks_;
+  std::unordered_map<SchedulingClass, std::list<Work>> infeasible_tasks_;
 
   /// Track the cumulative backlog of all workers requesting a lease to this raylet.
   std::unordered_map<SchedulingClass, int> backlog_tracker_;
@@ -192,6 +196,8 @@ class ClusterTaskManager {
 
   void AddToBacklogTracker(const Task &task);
   void RemoveFromBacklogTracker(const Task &task);
+
+  friend class ClusterTaskManagerTest;
 };
 }  // namespace raylet
 }  // namespace ray

--- a/src/ray/raylet/scheduling/cluster_task_manager.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager.h
@@ -5,6 +5,7 @@
 #include "ray/common/task/task.h"
 #include "ray/common/task/task_common.h"
 #include "ray/raylet/scheduling/cluster_resource_scheduler.h"
+#include "ray/raylet/task_dependency_manager.h"
 #include "ray/raylet/worker.h"
 #include "ray/raylet/worker_pool.h"
 #include "ray/rpc/grpc_client.h"
@@ -46,14 +47,13 @@ class ClusterTaskManager {
   /// \param self_node_id: ID of local node.
   /// \param cluster_resource_scheduler: The resource scheduler which contains
   /// the state of the cluster.
-  /// \param fulfills_dependencies_func: Returns true if all of a task's
-  /// dependencies are fulfilled.
+  /// \param task_dependency_manager_ Used to fetch task's dependencies.
   /// \param is_owner_alive: A callback which returns if the owner process is alive
   /// (according to our ownership model).
   /// \param gcs_client: A gcs client.
   ClusterTaskManager(const NodeID &self_node_id,
                      std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler,
-                     std::function<bool(const Task &)> fulfills_dependencies_func,
+                     TaskDependencyManagerInterface &task_dependency_manager_,
                      std::function<bool(const WorkerID &, const NodeID &)> is_owner_alive,
                      NodeInfoGetter get_node_info,
                      std::function<void(const Task &)> announce_infeasible_task);
@@ -145,8 +145,8 @@ class ClusterTaskManager {
 
   const NodeID &self_node_id_;
   std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler_;
-  /// Function to make task dependencies to be local.
-  std::function<bool(const Task &)> fulfills_dependencies_func_;
+  /// Class to make task dependencies to be local.
+  TaskDependencyManagerInterface &task_dependency_manager_;
   /// Function to check if the owner is alive on a given node.
   std::function<bool(const WorkerID &, const NodeID &)> is_owner_alive_;
   /// Function to get the node information of a given node id.

--- a/src/ray/raylet/scheduling/cluster_task_manager.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager.h
@@ -92,13 +92,6 @@ class ClusterTaskManager {
   /// \param readyIds: The tasks which are now ready to be dispatched.
   void TasksUnblocked(const std::vector<TaskID> ready_ids);
 
-  /// Move tasks from ready for dispatch to waiting. Called
-  /// when a task's dependencies were resolved, but one was
-  /// evicted.
-  ///
-  /// \param ready_ids: The tasks which are now waiting for arguments.
-  void TasksBlocked(const std::vector<TaskID> ready_ids);
-
   /// (Step 5) Call once a task finishes (i.e. a worker is returned).
   ///
   /// \param worker: The worker which was running the task.
@@ -170,20 +163,12 @@ class ClusterTaskManager {
 
   /// Queue of lease requests that should be scheduled onto workers.
   /// Tasks move from scheduled | waiting -> dispatch.
-<<<<<<< HEAD
   /// Tasks can also move from dispatch -> waiting if one of their arguments is
   /// evicted.
   /// All tasks in this map that have dependencies should be registered with
-  /// the dependency manager, so that they can be moved to waiting if one of
-  /// their dependencies is evicted.
-  std::unordered_map<SchedulingClass, std::list<Work>> tasks_to_dispatch_;
-
-  /// An index to speed up looking up a request from the dispatch queue.
-  std::unordered_map<TaskID, std::pair<SchedulingClass, std::list<Work>::iterator>>
-      tasks_to_dispatch_index_;
-=======
+  /// the dependency manager, in case a dependency gets evicted while the task
+  /// is still queued.
   std::unordered_map<SchedulingClass, std::deque<Work>> tasks_to_dispatch_;
->>>>>>> parent of c6ccb9aa3... Add index for tasks to dispatch
 
   /// Tasks waiting for arguments to be transferred locally.
   /// Tasks move from waiting -> dispatch.

--- a/src/ray/raylet/scheduling/cluster_task_manager.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager.h
@@ -202,6 +202,8 @@ class ClusterTaskManager {
 
   void AddToBacklogTracker(const Task &task);
   void RemoveFromBacklogTracker(const Task &task);
+
+  friend class ClusterTaskManagerTest;
 };
 }  // namespace raylet
 }  // namespace ray

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -100,6 +100,12 @@ class MockTaskDependencyManager : public TaskDependencyManagerInterface {
                bool(const TaskID &task_id,
                     const std::vector<rpc::ObjectReference> &required_objects));
   MOCK_METHOD1(UnsubscribeGetDependencies, bool(const TaskID &task_id));
+
+  bool IsTaskReady(const TaskID &task_id) const {
+    return task_ready_;
+  }
+
+  bool task_ready_ = true;
 };
 
 class ClusterTaskManagerTest : public ::testing::Test {

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -136,14 +136,6 @@ class ClusterTaskManagerTest : public ::testing::Test {
     node_info_[id] = info;
   }
 
-  void AssertNoLeaks() {
-    ASSERT_TRUE(task_manager_.tasks_to_schedule_.empty());
-    ASSERT_TRUE(task_manager_.tasks_to_dispatch_.empty());
-    ASSERT_TRUE(task_manager_.tasks_to_dispatch_index_.empty());
-    ASSERT_TRUE(task_manager_.waiting_tasks_.empty());
-    ASSERT_TRUE(task_manager_.infeasible_tasks_.empty());
-  }
-
   NodeID id_;
   std::shared_ptr<ClusterResourceScheduler> scheduler_;
   MockWorkerPool pool_;
@@ -189,8 +181,6 @@ TEST_F(ClusterTaskManagerTest, BasicTest) {
   ASSERT_EQ(leased_workers_.size(), 1);
   ASSERT_EQ(pool_.workers.size(), 0);
   ASSERT_EQ(node_info_calls_, 0);
-
-  AssertNoLeaks();
 }
 
 TEST_F(ClusterTaskManagerTest, NoFeasibleNodeTest) {
@@ -282,7 +272,6 @@ TEST_F(ClusterTaskManagerTest, ResourceTakenWhileResolving) {
   ASSERT_EQ(num_callbacks, 2);
   ASSERT_EQ(leased_workers_.size(), 1);
   ASSERT_EQ(pool_.workers.size(), 0);
-  AssertNoLeaks();
 }
 
 TEST_F(ClusterTaskManagerTest, TestSpillAfterAssigned) {
@@ -332,7 +321,6 @@ TEST_F(ClusterTaskManagerTest, TestSpillAfterAssigned) {
   // The second task was spilled.
   ASSERT_EQ(spillback_reply.retry_at_raylet_address().raylet_id(),
             remote_node_id.Binary());
-  AssertNoLeaks();
 }
 
 TEST_F(ClusterTaskManagerTest, TaskCancellationTest) {
@@ -389,7 +377,6 @@ TEST_F(ClusterTaskManagerTest, TaskCancellationTest) {
   ASSERT_FALSE(callback_called);
   ASSERT_EQ(pool_.workers.size(), 0);
   ASSERT_EQ(leased_workers_.size(), 1);
-  AssertNoLeaks();
 }
 
 TEST_F(ClusterTaskManagerTest, TaskCancelInfeasibleTask) {
@@ -427,7 +414,6 @@ TEST_F(ClusterTaskManagerTest, TaskCancelInfeasibleTask) {
   ASSERT_TRUE(reply.canceled());
   ASSERT_EQ(leased_workers_.size(), 0);
   ASSERT_EQ(pool_.workers.size(), 1);
-  AssertNoLeaks();
 }
 
 TEST_F(ClusterTaskManagerTest, HeartbeatTest) {
@@ -593,7 +579,6 @@ TEST_F(ClusterTaskManagerTest, BacklogReportTest) {
   ASSERT_EQ(shape1.backlog_size(), 0);
   ASSERT_EQ(shape1.num_infeasible_requests_queued(), 0);
   ASSERT_EQ(shape1.num_ready_requests_queued(), 0);
-  AssertNoLeaks();
 }
 
 TEST_F(ClusterTaskManagerTest, OwnerDeadTest) {
@@ -627,7 +612,6 @@ TEST_F(ClusterTaskManagerTest, OwnerDeadTest) {
   ASSERT_FALSE(callback_occurred);
   ASSERT_EQ(leased_workers_.size(), 0);
   ASSERT_EQ(pool_.workers.size(), 1);
-  AssertNoLeaks();
 }
 
 TEST_F(ClusterTaskManagerTest, TestInfeasibleTaskWarning) {
@@ -670,7 +654,6 @@ TEST_F(ClusterTaskManagerTest, TestInfeasibleTaskWarning) {
   ASSERT_EQ(pool_.workers.size(), 1);
   // Make sure the spillback callback is called.
   ASSERT_EQ(reply.retry_at_raylet_address().raylet_id(), remote_node_id.Binary());
-  AssertNoLeaks();
 }
 
 TEST_F(ClusterTaskManagerTest, TestMultipleInfeasibleTasksWarnOnce) {

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -132,6 +132,14 @@ class ClusterTaskManagerTest : public ::testing::Test {
     node_info_[id] = info;
   }
 
+  void AssertNoLeaks() {
+    ASSERT_TRUE(task_manager_.tasks_to_schedule_.empty());
+    ASSERT_TRUE(task_manager_.tasks_to_dispatch_.empty());
+    ASSERT_TRUE(task_manager_.tasks_to_dispatch_index_.empty());
+    ASSERT_TRUE(task_manager_.waiting_tasks_.empty());
+    ASSERT_TRUE(task_manager_.infeasible_tasks_.empty());
+  }
+
   NodeID id_;
   std::shared_ptr<ClusterResourceScheduler> scheduler_;
   MockWorkerPool pool_;
@@ -180,6 +188,8 @@ TEST_F(ClusterTaskManagerTest, BasicTest) {
   ASSERT_EQ(pool_.workers.size(), 0);
   ASSERT_EQ(fulfills_dependencies_calls_, 0);
   ASSERT_EQ(node_info_calls_, 0);
+
+  AssertNoLeaks();
 }
 
 TEST_F(ClusterTaskManagerTest, NoFeasibleNodeTest) {
@@ -270,6 +280,7 @@ TEST_F(ClusterTaskManagerTest, ResourceTakenWhileResolving) {
   ASSERT_EQ(num_callbacks, 2);
   ASSERT_EQ(leased_workers_.size(), 1);
   ASSERT_EQ(pool_.workers.size(), 0);
+  AssertNoLeaks();
 }
 
 TEST_F(ClusterTaskManagerTest, TestSpillAfterAssigned) {
@@ -319,6 +330,7 @@ TEST_F(ClusterTaskManagerTest, TestSpillAfterAssigned) {
   // The second task was spilled.
   ASSERT_EQ(spillback_reply.retry_at_raylet_address().raylet_id(),
             remote_node_id.Binary());
+  AssertNoLeaks();
 }
 
 TEST_F(ClusterTaskManagerTest, TaskCancellationTest) {
@@ -375,6 +387,7 @@ TEST_F(ClusterTaskManagerTest, TaskCancellationTest) {
   ASSERT_FALSE(callback_called);
   ASSERT_EQ(pool_.workers.size(), 0);
   ASSERT_EQ(leased_workers_.size(), 1);
+  AssertNoLeaks();
 }
 
 TEST_F(ClusterTaskManagerTest, TaskCancelInfeasibleTask) {
@@ -412,6 +425,7 @@ TEST_F(ClusterTaskManagerTest, TaskCancelInfeasibleTask) {
   ASSERT_TRUE(reply.canceled());
   ASSERT_EQ(leased_workers_.size(), 0);
   ASSERT_EQ(pool_.workers.size(), 1);
+  AssertNoLeaks();
 }
 
 TEST_F(ClusterTaskManagerTest, HeartbeatTest) {
@@ -578,6 +592,7 @@ TEST_F(ClusterTaskManagerTest, BacklogReportTest) {
   ASSERT_EQ(shape1.backlog_size(), 0);
   ASSERT_EQ(shape1.num_infeasible_requests_queued(), 0);
   ASSERT_EQ(shape1.num_ready_requests_queued(), 0);
+  AssertNoLeaks();
 }
 
 TEST_F(ClusterTaskManagerTest, OwnerDeadTest) {
@@ -611,6 +626,7 @@ TEST_F(ClusterTaskManagerTest, OwnerDeadTest) {
   ASSERT_FALSE(callback_occurred);
   ASSERT_EQ(leased_workers_.size(), 0);
   ASSERT_EQ(pool_.workers.size(), 1);
+  AssertNoLeaks();
 }
 
 TEST_F(ClusterTaskManagerTest, TestInfeasibleTaskWarning) {
@@ -653,6 +669,7 @@ TEST_F(ClusterTaskManagerTest, TestInfeasibleTaskWarning) {
   ASSERT_EQ(pool_.workers.size(), 1);
   // Make sure the spillback callback is called.
   ASSERT_EQ(reply.retry_at_raylet_address().raylet_id(), remote_node_id.Binary());
+  AssertNoLeaks();
 }
 
 TEST_F(ClusterTaskManagerTest, TestMultipleInfeasibleTasksWarnOnce) {

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -758,7 +758,8 @@ TEST_F(ClusterTaskManagerTest, ArgumentEvicted) {
   EXPECT_CALL(dependency_manager_,
               SubscribeGetDependencies(task.GetTaskSpecification().TaskId(), _));
   EXPECT_CALL(dependency_manager_,
-              UnsubscribeGetDependencies(task.GetTaskSpecification().TaskId())).Times(0);
+              UnsubscribeGetDependencies(task.GetTaskSpecification().TaskId()))
+      .Times(0);
   task_manager_.QueueTask(task, &reply, callback);
   task_manager_.SchedulePendingTasks();
   task_manager_.DispatchScheduledTasksToWorkers(pool_, leased_workers_);

--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -211,6 +211,12 @@ bool TaskDependencyManager::SubscribeGetDependencies(
   return (task_entry.num_missing_get_dependencies == 0);
 }
 
+bool TaskDependencyManager::IsTaskReady(const TaskID &task_id) const {
+  auto task_entry = task_dependencies_.find(task_id);
+  RAY_CHECK(task_entry != task_dependencies_.end());
+  return task_entry->second.num_missing_get_dependencies == 0;
+}
+
 void TaskDependencyManager::SubscribeWaitDependencies(
     const WorkerID &worker_id,
     const std::vector<rpc::ObjectReference> &required_objects) {

--- a/src/ray/raylet/task_dependency_manager.h
+++ b/src/ray/raylet/task_dependency_manager.h
@@ -30,6 +30,17 @@ using rpc::TaskLeaseData;
 
 class ReconstructionPolicy;
 
+/// Used for unit-testing the ClusterTaskManager, which calls these methods for
+/// locally queued tasks that have dependencies.
+class TaskDependencyManagerInterface {
+ public:
+  virtual bool SubscribeGetDependencies(
+      const TaskID &task_id,
+      const std::vector<rpc::ObjectReference> &required_objects) = 0;
+  virtual bool UnsubscribeGetDependencies(const TaskID &task_id) = 0;
+  virtual ~TaskDependencyManagerInterface() {}
+};
+
 /// \class TaskDependencyManager
 ///
 /// Responsible for managing object dependencies for tasks.  The caller can
@@ -40,7 +51,7 @@ class ReconstructionPolicy;
 /// made available locally, either by object transfer from a remote node or
 /// reconstruction. The task manager will also cancel these objects if they are
 /// no longer needed by any task.
-class TaskDependencyManager {
+class TaskDependencyManager : public TaskDependencyManagerInterface {
  public:
   /// Create a task dependency manager.
   TaskDependencyManager(ObjectManagerInterface &object_manager,

--- a/src/ray/raylet/task_dependency_manager.h
+++ b/src/ray/raylet/task_dependency_manager.h
@@ -37,6 +37,7 @@ class TaskDependencyManagerInterface {
   virtual bool SubscribeGetDependencies(
       const TaskID &task_id,
       const std::vector<rpc::ObjectReference> &required_objects) = 0;
+  virtual bool IsTaskReady(const TaskID &task_id) const = 0;
   virtual bool UnsubscribeGetDependencies(const TaskID &task_id) = 0;
   virtual ~TaskDependencyManagerInterface() {}
 };
@@ -81,6 +82,14 @@ class TaskDependencyManager : public TaskDependencyManagerInterface {
   /// local.
   bool SubscribeGetDependencies(
       const TaskID &task_id, const std::vector<rpc::ObjectReference> &required_objects);
+
+  /// Check whether a task is ready to run. The task ID must
+  /// have been previously subscribed by the caller.
+  ///
+  /// \param task_id The ID of the task to check.
+  /// \return Whether all of the dependencies for the task are
+  /// local.
+  bool IsTaskReady(const TaskID &task_id) const;
 
   /// Subscribe to object depedencies required by the worker. This should be called for
   /// ray.wait calls during task execution.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Arguments for tasks that are ready to dispatch can get evicted before the task gets dispatched to a worker. This PR moves these tasks back to the waiting queue. It also adds an index for the dispatch tasks to speed up lookup when there are many tasks queued.

This PR modifies the ClusterTaskManager class to call directly into the TaskDependencyManager to wait for/cancel task dependencies. This is so that the ClusterTaskManager can cancel the task dependencies once the task is dispatched (or removed), instead of canceling the first time that the arguments become ready.

## Related issue number

Fixes some new flakiness in test_array. I noticed that the test still fails with a mysterious ObjectLostError, but this other error also seemed to show up when the new scheduler is disabled.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
