### PR TITLE
[Serve] Validate __init__ method

### DIFF
--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -5,6 +5,8 @@ from ray.serve.constants import ASYNC_CONCURRENCY
 from typing import Optional, Dict, Any
 from dataclasses import dataclass
 
+from ray.serve.utils import validate_init_args
+
 
 def _callable_accepts_batch(func_or_class):
     if inspect.isfunction(func_or_class):
@@ -131,7 +133,9 @@ class ReplicaConfig:
             if len(self.actor_init_args) != 0:
                 raise ValueError(
                     "actor_init_args not supported for function backend.")
-        elif not inspect.isclass(self.func_or_class):
+        elif inspect.isclass(self.func_or_class):
+            validate_init_args(self.func_or_class, self.actor_init_args)
+        else:
             raise TypeError(
                 "Backend must be a function or class, it is {}.".format(
                     type(self.func_or_class)))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Add sanity check for `__init__` method
```
In [1]: from ray import serve

In [2]: client = serve.start()
2020-12-22 17:54:05,442	INFO services.py:1171 -- View the Ray dashboard at http://127.0.0.1:8265
(pid=94119) 2020-12-22 17:54:08,093	INFO controller.py:409 -- Starting HTTP proxy with name 'sumQfP:SERVE_CONTROLLER_ACTOR:SERVE_PROXY_ACTOR-node:192.168.31.141-0' on node 'node:192.168.31.141-0' listening on '127.0.0.1:8000'
(pid=94116) INFO:     Started server process [94116]

In [3]: class A:
   ...:     def __init__(self, a, b):
   ...:         pass
   ...:


In [5]: client.create_backend("a", A) # without args
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-5-817d28f639af> in <module>
----> 1 client.create_backend("a", A) # without args

~/Desktop/ray/ray/python/ray/serve/api.py in check(self, *args, **kwargs)
     32         if self._shutdown:
     33             raise RayServeException("Client has already been shut down.")
---> 34         return f(self, *args, **kwargs)
     35
     36     return check

~/Desktop/ray/ray/python/ray/serve/api.py in create_backend(self, backend_tag, func_or_class, ray_actor_options, config, env, *actor_init_args)
    327             func_or_class,
    328             *actor_init_args,
--> 329             ray_actor_options=ray_actor_options)
    330         metadata = BackendMetadata(
    331             accepts_batches=replica_config.accepts_batches,

~/Desktop/ray/ray/python/ray/serve/config.py in __init__(self, func_or_class, ray_actor_options, *actor_init_args)
    126
    127         self.resource_dict = {}
--> 128         self._validate()
    129
    130     def _validate(self):

~/Desktop/ray/ray/python/ray/serve/config.py in _validate(self)
    135                     "actor_init_args not supported for function backend.")
    136         elif inspect.isclass(self.func_or_class):
--> 137             validate_init_args(self.func_or_class, self.actor_init_args)
    138         else:
    139             raise TypeError(

~/Desktop/ray/ray/python/ray/serve/utils.py in validate_init_args(cls, init_args)
    406     if len(init_args) != number_of_args:
    407         raise ValueError(
--> 408             f"{init_method} takes {number_of_args} arguments {arg_names} but "
    409             f"you passed in {len(init_args)} init arguments.")

ValueError: <function A.__init__ at 0x7fc6083ed378> takes 2 arguments ['a', 'b'] but you passed in 0 init arguments.

In [6]: client.create_backend("a", A, 1) # without args
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-6-898f2af0ab03> in <module>
----> 1 client.create_backend("a", A, 1) # without args

~/Desktop/ray/ray/python/ray/serve/api.py in check(self, *args, **kwargs)
     32         if self._shutdown:
     33             raise RayServeException("Client has already been shut down.")
---> 34         return f(self, *args, **kwargs)
     35
     36     return check

~/Desktop/ray/ray/python/ray/serve/api.py in create_backend(self, backend_tag, func_or_class, ray_actor_options, config, env, *actor_init_args)
    327             func_or_class,
    328             *actor_init_args,
--> 329             ray_actor_options=ray_actor_options)
    330         metadata = BackendMetadata(
    331             accepts_batches=replica_config.accepts_batches,

~/Desktop/ray/ray/python/ray/serve/config.py in __init__(self, func_or_class, ray_actor_options, *actor_init_args)
    126
    127         self.resource_dict = {}
--> 128         self._validate()
    129
    130     def _validate(self):

~/Desktop/ray/ray/python/ray/serve/config.py in _validate(self)
    135                     "actor_init_args not supported for function backend.")
    136         elif inspect.isclass(self.func_or_class):
--> 137             validate_init_args(self.func_or_class, self.actor_init_args)
    138         else:
    139             raise TypeError(

~/Desktop/ray/ray/python/ray/serve/utils.py in validate_init_args(cls, init_args)
    406     if len(init_args) != number_of_args:
    407         raise ValueError(
--> 408             f"{init_method} takes {number_of_args} arguments {arg_names} but "
    409             f"you passed in {len(init_args)} init arguments.")

ValueError: <function A.__init__ at 0x7fc6083ed378> takes 2 arguments ['a', 'b'] but you passed in 1 init arguments.

In [7]: client.create_backend("a", A, 1, 2) # without args

```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
