### PR TITLE
speed up local mode object store get

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/object/LocalModeObjectStore.java
+++ b/java/runtime/src/main/java/io/ray/runtime/object/LocalModeObjectStore.java
@@ -21,7 +21,7 @@ public class LocalModeObjectStore extends ObjectStore {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(LocalModeObjectStore.class);
 
-  private static final int GET_CHECK_INTERVAL_MS = 100;
+  private static final int GET_CHECK_INTERVAL_MS = 1;
 
   private final Map<ObjectId, NativeRayObject> pool = new ConcurrentHashMap<>();
   private final List<Consumer<ObjectId>> objectPutCallbacks = new ArrayList<>();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The object wait/get interval `GET_CHECK_INTERVAL_MS` is 100, which is too slow when run unit test with local mode.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
