### PR TITLE
[WIP] Install pickle5 from wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,7 @@
 *test-output.xml
 /bazel-*
 /python/ray/core
-/python/ray/pickle5_files/
 /python/ray/thirdparty_files/
-/python/ray/pyarrow_files/
 /python/ray/jars/
 /python/build
 /python/dist

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -132,9 +132,8 @@ test_core() {
 }
 
 test_python() {
-  local pathsep=":" args=()
+  args=()
   if [ "${OSTYPE}" = msys ]; then
-    pathsep=";"
     args+=(
       python/ray/serve/...
       python/ray/tests/...
@@ -163,13 +162,9 @@ test_python() {
   fi
   if [ 0 -lt "${#args[@]}" ]; then  # Any targets to test?
     install_ray
-    # TODO(mehrdadn): We set PYTHONPATH here to let Python find our pickle5 under pip install -e.
-    # It's unclear to me if this should be necessary, but this is to make tests run for now.
-    # Check why this issue doesn't arise on Linux/Mac.
-    # Ideally importing ray.cloudpickle should import pickle5 automatically.
-    bazel test --config=ci --build_tests_only \
-      --test_env=PYTHONPATH="${PYTHONPATH-}${pathsep}${WORKSPACE_DIR}/python/ray/pickle5_files" -- \
-      "${args[@]}";
+    # pickle5-wheels-helper helps us ensuring pickle5 dependencies
+    pip install  --upgrade --force-reinstall --no-cache-dir pickle5-wheels-helper
+    bazel test --config=ci --build_tests_only -- "${args[@]}"
   fi
 }
 

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -4,10 +4,12 @@ from os.path import dirname
 import platform
 import sys
 
+import pickle5_wheels_helper
+
 logger = logging.getLogger(__name__)
 
-# MUST add pickle5 to the import path because it will be imported by some
-# raylet modules.
+# Check pickle5 status
+pickle5_wheels_helper.try_install_pickle5()
 
 if "pickle5" in sys.modules:
     import pkg_resources
@@ -30,12 +32,6 @@ if "OMP_NUM_THREADS" not in os.environ:
                  "degradation with many workers (issue #6998). You can "
                  "override this by explicitly setting OMP_NUM_THREADS.")
     os.environ["OMP_NUM_THREADS"] = "1"
-
-# Add the directory containing pickle5 to the Python path so that we find the
-# pickle5 version packaged with ray and not a pre-existing pickle5.
-pickle5_path = os.path.join(
-    os.path.abspath(os.path.dirname(__file__)), "pickle5_files")
-sys.path.insert(0, pickle5_path)
 
 # Importing psutil & setproctitle. Must be before ray._raylet is initialized.
 thirdparty_files = os.path.join(

--- a/python/ray/cloudpickle/compat.py
+++ b/python/ray/cloudpickle/compat.py
@@ -5,9 +5,8 @@ if sys.version_info < (3, 8):
     try:
         import pickle5 as pickle  # noqa: F401
         from pickle5 import Pickler  # noqa: F401
-    except ImportError:
-        import pickle  # noqa: F401
-        from pickle import _Pickler as Pickler  # noqa: F401
+    except ImportError as e:
+        raise ImportError("Ray requires pickle5 for serialization.") from e
 else:
     import pickle  # noqa: F401
     from _pickle import Pickler  # noqa: F401

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -23,6 +23,7 @@ py-spy >= 0.2.0
 pyyaml
 redis >= 3.5.0
 requests
+pickle5-wheels-helper
 
 ## setup.py extras
 atari_py


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray vendors pickle5 because there are no existing wheels. However this would fail thirdparty libraries using cloudpickle (joblib, sklearn, etc). This PR tries to build pickle5 wheels from an external repo.

## Related issue number

Closes #11547

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
