### PR TITLE
[docs] Fix Sphinx.add_stylesheet deprecation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -477,6 +477,6 @@ def update_context(app, pagename, templatename, context, doctree):
 
 def setup(app):
     app.connect('html-page-context', update_context)
-    app.add_stylesheet('css/custom.css')
+    app.add_css_file('css/custom.css')
     # Custom directives
     app.add_directive('customgalleryitem', CustomGalleryItemDirective)


### PR DESCRIPTION
## Why are these changes needed?

`app.add_stylesheet()` was renamed to `app.add_css_file()` in version 1.8

## Related issue number

n/a

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
