### PR TITLE
[docs] fix wandb url

### DIFF
--- a/doc/source/tune/_tutorials/tune-wandb.rst
+++ b/doc/source/tune/_tutorials/tune-wandb.rst
@@ -3,7 +3,7 @@
 Using Weights & Biases with Tune
 ================================
 
-`Weights & Biases <https://www.wandb.com/>`_ (Wandb) is a tool for experiment
+`Weights & Biases <https://www.wandb.ai/>`_ (Wandb) is a tool for experiment
 tracking, model optimizaton, and dataset versioning. It is very popular
 in the machine learning and data science community for its superb visualization
 tools.
@@ -12,7 +12,7 @@ tools.
   :height: 80px
   :alt: Weights & Biases
   :align: center
-  :target: https://www.wandb.com/
+  :target: https://www.wandb.ai/
 
 Ray Tune currently offers two lightweight integrations for Weights & Biases.
 One is the :ref:`WandbLoggerCallback <tune-wandb-logger>`, which automatically logs

--- a/doc/source/tune/api_docs/logging.rst
+++ b/doc/source/tune/api_docs/logging.rst
@@ -168,7 +168,7 @@ You can see the :doc:`tutorial here </tune/tutorials/tune-mlflow>`.
 WandbLogger
 -----------
 
-Tune also provides a default logger for `Weights & Biases <https://www.wandb.com/>`_. You can install Wandb via ``pip install wandb``.
+Tune also provides a default logger for `Weights & Biases <https://www.wandb.ai/>`_. You can install Wandb via ``pip install wandb``.
 You can see the :doc:`tutorial here </tune/tutorials/tune-wandb>`
 
 

--- a/doc/source/tune/examples/index.rst
+++ b/doc/source/tune/examples/index.rst
@@ -85,8 +85,8 @@ Pytorch Lightning
 Wandb, MLFlow
 ~~~~~~~~~~~~~
 
-- :ref:`Tutorial <tune-wandb>` for using `wandb <https://www.wandb.com/>`__ with Ray Tune
-- :doc:`/tune/examples/wandb_example`: Example for using `Weights and Biases <https://www.wandb.com/>`__ with Ray Tune.
+- :ref:`Tutorial <tune-wandb>` for using `wandb <https://www.wandb.ai/>`__ with Ray Tune
+- :doc:`/tune/examples/wandb_example`: Example for using `Weights and Biases <https://www.wandb.ai/>`__ with Ray Tune.
 - :doc:`/tune/examples/mlflow_example`: Example for using `MLFlow <https://github.com/mlflow/mlflow/>`__ with Ray Tune.
 - :doc:`/tune/examples/mlflow_ptl_example`: Example for using `MLFlow <https://github.com/mlflow/mlflow/>`__ and `Pytorch Lightning <https://github.com/PyTorchLightning/pytorch-lightning>`_ with Ray Tune.
 

--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -75,7 +75,7 @@ def _clean_log(obj: Any):
 def wandb_mixin(func: Callable):
     """wandb_mixin
 
-    Weights and biases (https://www.wandb.com/) is a tool for experiment
+    Weights and biases (https://www.wandb.ai/) is a tool for experiment
     tracking, model optimization, and dataset versioning. This Ray Tune
     Trainable mixin helps initializing the Wandb API for use with the
     ``Trainable`` class or with `@wandb_mixin` for the function API.
@@ -109,7 +109,7 @@ def wandb_mixin(func: Callable):
     values.
 
     Please see here for all other valid configuration settings:
-    https://docs.wandb.com/library/init
+    https://docs.wandb.ai/library/init
 
     Example:
 
@@ -225,7 +225,7 @@ class _WandbLoggingProcess(Process):
 class WandbLoggerCallback(LoggerCallback):
     """WandbLoggerCallback
 
-    Weights and biases (https://www.wandb.com/) is a tool for experiment
+    Weights and biases (https://www.wandb.ai/) is a tool for experiment
     tracking, model optimization, and dataset versioning. This Ray Tune
     ``LoggerCallback`` sends metrics to Wandb for automatic tracking and
     visualization.
@@ -251,7 +251,7 @@ class WandbLoggerCallback(LoggerCallback):
     values.
 
     Please see here for all other valid configuration settings:
-    https://docs.wandb.com/library/init
+    https://docs.wandb.ai/library/init
 
     Example:
 
@@ -382,7 +382,7 @@ class WandbLogger(Logger):
         This `Logger` class is deprecated. Use the `WandbLoggerCallback`
         callback instead.
 
-    Weights and biases (https://www.wandb.com/) is a tool for experiment
+    Weights and biases (https://www.wandb.ai/) is a tool for experiment
     tracking, model optimization, and dataset versioning. This Ray Tune
     ``Logger`` sends metrics to Wandb for automatic tracking and
     visualization.
@@ -415,7 +415,7 @@ class WandbLogger(Logger):
     values.
 
     Please see here for all other valid configuration settings:
-    https://docs.wandb.com/library/init
+    https://docs.wandb.ai/library/init
 
     Example:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We're switching our domain from wandb.com to wandb.ai. This PR updates wandb.com and docs.wandb.com links to wandb.ai.

## Related issue number

NA

## Checks

- [ yes ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ NA ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ yes ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ NA ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
