### PR TITLE
[RLlib] run_regression_tests.py: --framework flag (instead of --torch).

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -59,7 +59,7 @@ py_test(
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/a3c/cartpole-a2c.yaml"],
-    args = ["--yaml-dir=tuned_examples/a3c", "--torch"]
+    args = ["--yaml-dir=tuned_examples/a3c", "--framework=torch"]
 )
 
 py_test(
@@ -79,7 +79,7 @@ py_test(
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/a3c/cartpole-a3c.yaml"],
-    args = ["--yaml-dir=tuned_examples/a3c", "--torch"]
+    args = ["--yaml-dir=tuned_examples/a3c", "--framework=torch"]
 )
 
 # APPO
@@ -106,7 +106,7 @@ py_test(
         "tuned_examples/ppo/cartpole-appo.yaml",
         "tuned_examples/ppo/cartpole-appo-vtrace.yaml"
     ],
-    args = ["--yaml-dir=tuned_examples/ppo", "--torch"]
+    args = ["--yaml-dir=tuned_examples/ppo", "--framework=torch"]
 )
 
 # ARS
@@ -127,7 +127,7 @@ py_test(
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ars/cartpole-ars.yaml"],
-    args = ["--yaml-dir=tuned_examples/ars", "--torch"]
+    args = ["--yaml-dir=tuned_examples/ars", "--framework=torch"]
 )
 
 # DDPG
@@ -148,7 +148,7 @@ py_test(
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = glob(["tuned_examples/ddpg/pendulum-ddpg.yaml"]),
-    args = ["--torch", "--yaml-dir=tuned_examples/ddpg"]
+    args = ["--yaml-dir=tuned_examples/ddpg", "--framework=torch"]
 )
 
 # DDPPO
@@ -159,7 +159,7 @@ py_test(
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = glob(["tuned_examples/ppo/cartpole-ddppo.yaml"]),
-    args = ["--yaml-dir=tuned_examples/ppo", "--torch"]
+    args = ["--yaml-dir=tuned_examples/ppo", "--framework=torch"]
 )
 
 # DQN/Simple-Q
@@ -190,7 +190,7 @@ py_test(
         "tuned_examples/dqn/cartpole-dqn-softq.yaml",
         "tuned_examples/dqn/cartpole-dqn-param-noise.yaml",
     ],
-    args = ["--yaml-dir=tuned_examples/dqn", "--torch"]
+    args = ["--yaml-dir=tuned_examples/dqn", "--framework=torch"]
 )
 
 # ES
@@ -211,7 +211,7 @@ py_test(
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/es/cartpole-es.yaml"],
-    args = ["--yaml-dir=tuned_examples/es", "--torch"]
+    args = ["--yaml-dir=tuned_examples/es", "--framework=torch"]
 )
 
 # IMPALA
@@ -232,7 +232,7 @@ py_test(
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/impala/cartpole-impala.yaml"],
-    args = ["--yaml-dir=tuned_examples/impala", "--torch"]
+    args = ["--yaml-dir=tuned_examples/impala", "--framework=torch"]
 )
 
 # Working, but takes a long time to learn (>15min).
@@ -266,7 +266,7 @@ py_test(
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/pg/cartpole-pg.yaml"],
-    args = ["--yaml-dir=tuned_examples/pg", "--torch"]
+    args = ["--yaml-dir=tuned_examples/pg", "--framework=torch"]
 )
 
 # PPO
@@ -287,7 +287,7 @@ py_test(
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ppo/cartpole-ppo.yaml"],
-    args = ["--yaml-dir=tuned_examples/ppo", "--torch"]
+    args = ["--yaml-dir=tuned_examples/ppo", "--framework=torch"]
 )
 
 py_test(
@@ -307,7 +307,7 @@ py_test(
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ppo/pendulum-ppo.yaml"],
-    args = ["--torch", "--yaml-dir=tuned_examples/ppo"]
+    args = ["--yaml-dir=tuned_examples/ppo", "--framework=torch"]
 )
 
 py_test(
@@ -327,7 +327,7 @@ py_test(
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ppo/repeatafterme-ppo-lstm.yaml"],
-    args = ["--torch", "--yaml-dir=tuned_examples/ppo"]
+    args = ["--yaml-dir=tuned_examples/ppo", "--framework=torch"]
 )
 
 # SAC
@@ -358,7 +358,7 @@ py_test(
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/sac/cartpole-sac.yaml"],
-    args = ["--yaml-dir=tuned_examples/sac", "--torch"]
+    args = ["--yaml-dir=tuned_examples/sac", "--framework=torch"]
 )
 
 py_test(
@@ -368,7 +368,7 @@ py_test(
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/sac/cartpole-continuous-pybullet-sac.yaml"],
-    args = ["--yaml-dir=tuned_examples/sac", "--torch"]
+    args = ["--yaml-dir=tuned_examples/sac", "--framework=torch"]
 )
 
 py_test(
@@ -388,7 +388,7 @@ py_test(
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/sac/pendulum-sac.yaml"],
-    args = ["--yaml-dir=tuned_examples/sac", "--torch"]
+    args = ["--yaml-dir=tuned_examples/sac", "--framework=torch"]
 )
 
 
@@ -410,7 +410,7 @@ py_test(
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ddpg/pendulum-td3.yaml"],
-    args = ["--yaml-dir=tuned_examples/ddpg", "--torch"]
+    args = ["--yaml-dir=tuned_examples/ddpg", "--framework=torch"]
 )
 
 

--- a/rllib/tests/run_regression_tests.py
+++ b/rllib/tests/run_regression_tests.py
@@ -25,16 +25,24 @@ import yaml
 import ray
 from ray.tune import run_experiments
 from ray.rllib import _register_all
+from ray.rllib.utils.deprecation import deprecation_warning
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
-    "--torch",
-    action="store_true",
-    help="Runs all tests with PyTorch enabled.")
+    "--framework",
+    choices=["jax", "tf2", "tf", "tfe", "torch"],
+    default="tf",
+    help="The deep learning framework to use.")
 parser.add_argument(
     "--yaml-dir",
     type=str,
     help="The directory in which to find all yamls to test.")
+
+# Obsoleted arg, use --framework=torch instead.
+parser.add_argument(
+    "--torch",
+    action="store_true",
+    help="Runs all tests with PyTorch enabled.")
 
 if __name__ == "__main__":
     args = parser.parse_args()
@@ -69,8 +77,11 @@ if __name__ == "__main__":
 
         # Add torch option to exp configs.
         for exp in experiments.values():
+            exp["config"]["framework"] = args.framework
             if args.torch:
+                deprecation_warning(old="--torch", new="--framework=torch")
                 exp["config"]["framework"] = "torch"
+                args.framework = "torch"
 
         # Print out the actual config.
         print("== Test config ==")
@@ -82,7 +93,7 @@ if __name__ == "__main__":
         for i in range(3):
             try:
                 ray.init(num_cpus=5)
-                trials = run_experiments(experiments, resume=False, verbose=1)
+                trials = run_experiments(experiments, resume=False, verbose=2)
             finally:
                 ray.shutdown()
                 _register_all()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

run_regression_tests.py: Add --framework flag (instead of --torch).

- in prep for JAX regression tests.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
