### PR TITLE
[CoreWorker] Cache the named actors in core worker locally.

### DIFF
--- a/src/ray/core_worker/actor_manager.h
+++ b/src/ray/core_worker/actor_manager.h
@@ -149,6 +149,9 @@ class ActorManager {
   /// This is used for debugging purpose.
   std::vector<ObjectID> GetActorHandleIDsFromHandles();
 
+  /// Get actor handle of named actor by the given name.
+  /// Note that if it cached in local, return it immediately,
+  /// otherwise fetch from Gcs and then return it synchronously.
   std::pair<const ActorHandle *, Status> GetNamedActorHandle(
       const std::string &name, const TaskID &caller_id, const std::string &call_site,
       const rpc::Address &rpc_address);
@@ -176,6 +179,7 @@ class ActorManager {
                       const rpc::Address &caller_address, const ActorID &actor_id,
                       const ObjectID &actor_creation_return_id);
 
+  /// Helper to add a new actor handle for named actor.
   void AddNewActorHandleForNamedActor(const std::string &name,
                                       std::unique_ptr<ActorHandle> actor_handle,
                                       const TaskID &caller_id,

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -403,7 +403,6 @@ void ReferenceCounter::DeleteReferenceInternal(ReferenceTable::iterator it,
   const ObjectID id = it->first;
   RAY_LOG(DEBUG) << "Attempting to delete object " << id;
   if (it->second.RefCount() == 0 && it->second.on_ref_removed) {
-    RAY_LOG(DEBUG) << "Calling on_ref_removed for object " << id;
     it->second.on_ref_removed(id);
     it->second.on_ref_removed = nullptr;
   }

--- a/src/ray/core_worker/test/object_recovery_manager_test.cc
+++ b/src/ray/core_worker/test/object_recovery_manager_test.cc
@@ -112,28 +112,29 @@ class ObjectRecoveryManagerTest : public ::testing::Test {
         ref_counter_(std::make_shared<ReferenceCounter>(
             rpc::Address(), /*distributed_ref_counting_enabled=*/true,
             /*lineage_pinning_enabled=*/true)),
-        manager_(rpc::Address(),
-                 [&](const std::string &ip, int port) { return raylet_client_; },
-                 raylet_client_,
-                 [&](const ObjectID &object_id, const ObjectLookupCallback &callback) {
-                   object_directory_->AsyncGetLocations(object_id, callback);
-                   return Status::OK();
-                 },
-                 task_resubmitter_, ref_counter_, memory_store_,
-                 [&](const ObjectID &object_id, bool pin_object) {
-                   RAY_CHECK(failed_reconstructions_.count(object_id) == 0);
-                   failed_reconstructions_[object_id] = pin_object;
+        manager_(
+            rpc::Address(),
+            [&](const std::string &ip, int port) { return raylet_client_; },
+            raylet_client_,
+            [&](const ObjectID &object_id, const ObjectLookupCallback &callback) {
+              object_directory_->AsyncGetLocations(object_id, callback);
+              return Status::OK();
+            },
+            task_resubmitter_, ref_counter_, memory_store_,
+            [&](const ObjectID &object_id, bool pin_object) {
+              RAY_CHECK(failed_reconstructions_.count(object_id) == 0);
+              failed_reconstructions_[object_id] = pin_object;
 
-                   std::string meta =
-                       std::to_string(static_cast<int>(rpc::ErrorType::OBJECT_IN_PLASMA));
-                   auto metadata = const_cast<uint8_t *>(
-                       reinterpret_cast<const uint8_t *>(meta.data()));
-                   auto meta_buffer =
-                       std::make_shared<LocalMemoryBuffer>(metadata, meta.size());
-                   auto data = RayObject(nullptr, meta_buffer, std::vector<ObjectID>());
-                   RAY_CHECK(memory_store_->Put(data, object_id));
-                 },
-                 /*lineage_reconstruction_enabled=*/true) {}
+              std::string meta =
+                  std::to_string(static_cast<int>(rpc::ErrorType::OBJECT_IN_PLASMA));
+              auto metadata =
+                  const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(meta.data()));
+              auto meta_buffer =
+                  std::make_shared<LocalMemoryBuffer>(metadata, meta.size());
+              auto data = RayObject(nullptr, meta_buffer, std::vector<ObjectID>());
+              RAY_CHECK(memory_store_->Put(data, object_id));
+            },
+            /*lineage_reconstruction_enabled=*/true) {}
 
   NodeID local_raylet_id_;
   std::unordered_map<ObjectID, bool> failed_reconstructions_;

--- a/src/ray/core_worker/test/task_manager_test.cc
+++ b/src/ray/core_worker/test/task_manager_test.cc
@@ -41,15 +41,16 @@ class TaskManagerTest : public ::testing::Test {
         reference_counter_(std::shared_ptr<ReferenceCounter>(new ReferenceCounter(
             rpc::Address(),
             /*distributed_ref_counting_enabled=*/true, lineage_pinning_enabled))),
-        manager_(store_, reference_counter_,
-                 [this](TaskSpecification &spec, bool delay) {
-                   num_retries_++;
-                   return Status::OK();
-                 },
-                 [this](const NodeID &node_id) { return all_nodes_alive_; },
-                 [this](const ObjectID &object_id) {
-                   objects_to_recover_.push_back(object_id);
-                 }) {}
+        manager_(
+            store_, reference_counter_,
+            [this](TaskSpecification &spec, bool delay) {
+              num_retries_++;
+              return Status::OK();
+            },
+            [this](const NodeID &node_id) { return all_nodes_alive_; },
+            [this](const ObjectID &object_id) {
+              objects_to_recover_.push_back(object_id);
+            }) {}
 
   std::shared_ptr<CoreWorkerMemoryStore> store_;
   std::shared_ptr<ReferenceCounter> reference_counter_;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
It's inefficient to fetch named actor from GCS every time since there aren't many named actors in most user cases, but every named actor is used frequently.
The bulk of users use the `get_named_actor` API directly(without any storage for the named actors) :
```python
ray.get_actor("xxx")      // every where
```

In Java:
```java
Ray.getActor("xxxx");      // every where
```

- Move the code of fetching actor info to actor manager.
- Add delete callback to remove the cache.
- Add C++ test cases to cover cache and evict.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
