### PR TITLE
[Bugfix][Dashboard] Fix undefined logCount, errorCount UI crash

### DIFF
--- a/dashboard/client/src/api.ts
+++ b/dashboard/client/src/api.ts
@@ -65,8 +65,8 @@ type ProcessStats = {
 export type Worker = {
   pid: number;
   workerId: string;
-  logCount: number;
-  errorCount: number;
+  logCount?: number;
+  errorCount?: number;
   language: string;
   jobId: string;
   coreWorkerStats: CoreWorkerStats[];
@@ -167,8 +167,8 @@ type BaseNodeInfo = {
   };
   loadAvg: [[number, number, number], [number, number, number]];
   net: [number, number]; // Sent and received network traffic in bytes / second
-  logCount: number;
-  errorCount: number;
+  logCount?: number;
+  errorCount?: number;
 };
 
 export type NodeInfoResponse = {

--- a/dashboard/client/src/pages/dashboard/node-info/features/Errors.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/features/Errors.tsx
@@ -13,7 +13,7 @@ import {
 } from "./types";
 
 const ClusterErrors: ClusterFeatureRenderFn = ({ nodes }) => {
-  const totalErrCount = sum(nodes.map((node) => node.errorCount));
+  const totalErrCount = sum(nodes.map((node) => node.errorCount ?? 0));
   return totalErrCount === 0 ? (
     <Typography color="textSecondary" component="span" variant="inherit">
       No errors
@@ -29,26 +29,27 @@ const ClusterErrors: ClusterFeatureRenderFn = ({ nodes }) => {
 const makeNodeErrors = (
   setErrorDialog: (nodeIp: string, pid: number | null) => void,
 ): NodeFeatureRenderFn => ({ node }) => {
-  return node.errorCount === 0 ? (
+  const errorCount = node.errorCount ?? 0;
+  return errorCount === 0 ? (
     <Typography color="textSecondary" component="span" variant="inherit">
       No errors
     </Typography>
   ) : (
     <SpanButton onClick={() => setErrorDialog(node.ip, null)}>
-      View all errors ({node.errorCount.toLocaleString()})
+      View all errors ({errorCount.toLocaleString()})
     </SpanButton>
   );
 };
 
 const nodeErrorsAccessor: Accessor<NodeFeatureData> = ({ node }) =>
-  node.errorCount;
+  node.errorCount ?? 0;
 
 const makeWorkerErrors = (
   setErrorDialog: (nodeIp: string, pid: number | null) => void,
 ): WorkerFeatureRenderFn => ({ node, worker }) => {
   return worker.errorCount !== 0 ? (
     <SpanButton onClick={() => setErrorDialog(node.ip, worker.pid)}>
-      View errors ({worker.errorCount.toLocaleString()})
+      View errors ({worker.errorCount?.toLocaleString()})
     </SpanButton>
   ) : (
     <Typography color="textSecondary" component="span" variant="inherit">
@@ -58,7 +59,7 @@ const makeWorkerErrors = (
 };
 
 const workerErrorsAccessor: Accessor<WorkerFeatureData> = ({ worker }) =>
-  worker.errorCount;
+  worker.errorCount ?? 0;
 
 const makeErrorsFeature = (
   setErrorDialog: (nodeIp: string, pid: number | null) => void,

--- a/dashboard/client/src/pages/dashboard/node-info/features/Logs.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/features/Logs.tsx
@@ -39,8 +39,8 @@ const makeNodeLogs = (
       {node.logCount === 1 ? "line" : "lines"})
     </SpanButton>
   );
-}
-  
+};
+
 const nodeLogsAccessor: Accessor<NodeFeatureData> = ({ node }) =>
   node.logCount ? sum(Object.values(node.logCount)) : 0;
 
@@ -54,11 +54,11 @@ const makeWorkerLogs = (
       {worker.logCount === 1 ? "line" : "lines"})
     </SpanButton>
   ) : (
-      <Typography color="textSecondary" component="span" variant="inherit">
-        No logs
-      </Typography>
-    );
-}
+    <Typography color="textSecondary" component="span" variant="inherit">
+      No logs
+    </Typography>
+  );
+};
 
 const workerLogsAccessor: Accessor<WorkerFeatureData> = ({ worker }) =>
   worker.logCount ?? 0;

--- a/dashboard/client/src/pages/dashboard/node-info/features/Logs.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/features/Logs.tsx
@@ -13,7 +13,7 @@ import {
 } from "./types";
 
 const ClusterLogs: ClusterFeatureRenderFn = ({ nodes }) => {
-  const totalLogCount = sum(nodes.map((n) => n.logCount));
+  const totalLogCount = sum(nodes.map((n) => n.logCount ?? 0));
   return totalLogCount === 0 ? (
     <Typography color="textSecondary" component="span" variant="inherit">
       No logs
@@ -27,37 +27,41 @@ const ClusterLogs: ClusterFeatureRenderFn = ({ nodes }) => {
 
 const makeNodeLogs = (
   setLogDialog: (nodeIp: string, pid: number | null) => void,
-): NodeFeatureRenderFn => ({ node }) =>
-  node.logCount === 0 ? (
+): NodeFeatureRenderFn => ({ node }) => {
+  const logCount = node.logCount ?? 0;
+  return logCount === 0 ? (
     <Typography color="textSecondary" component="span" variant="inherit">
       No logs
     </Typography>
   ) : (
     <SpanButton onClick={() => setLogDialog(node.ip, null)}>
-      View all logs ({node.logCount.toLocaleString()}{" "}
+      View all logs ({logCount.toLocaleString()}{" "}
       {node.logCount === 1 ? "line" : "lines"})
     </SpanButton>
   );
-
+}
+  
 const nodeLogsAccessor: Accessor<NodeFeatureData> = ({ node }) =>
   node.logCount ? sum(Object.values(node.logCount)) : 0;
 
 const makeWorkerLogs = (
   setLogDialog: (nodeIp: string, pid: number | null) => void,
-): WorkerFeatureRenderFn => ({ worker, node }) =>
-  worker.logCount !== 0 ? (
+): WorkerFeatureRenderFn => ({ worker, node }) => {
+  const logCount = worker.logCount ?? 0;
+  return logCount !== 0 ? (
     <SpanButton onClick={() => setLogDialog(node.ip, worker.pid)}>
-      View log ({worker.logCount.toLocaleString()}{" "}
+      View log ({logCount.toLocaleString()}{" "}
       {worker.logCount === 1 ? "line" : "lines"})
     </SpanButton>
   ) : (
-    <Typography color="textSecondary" component="span" variant="inherit">
-      No logs
-    </Typography>
-  );
+      <Typography color="textSecondary" component="span" variant="inherit">
+        No logs
+      </Typography>
+    );
+}
 
 const workerLogsAccessor: Accessor<WorkerFeatureData> = ({ worker }) =>
-  worker.logCount;
+  worker.logCount ?? 0;
 
 const makeLogsFeature = (
   setLogDialog: (nodeIp: string, pid: number | null) => void,


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
On Ubuntu, there is a dashboard error where the error pane and the log pane fail to render, crashing the page, because of a missing worker field in the payload, specifically the "logCount" and "errorCount" fields are coming through as undefined. 

I was unable to figure out why this was occurring from the code paths on the backend (it seems to me these fields should always be set, to a default value if nothing else), so I've patched it on the front end by handling the case where the value is undefined.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #12938
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
Tested via manual QA of the dashboard on a Ubuntu 1-machine cluster. (Tested error repro first).