### PR TITLE
[Java] Avoid failure of serializing a user-defined unserializable exception.

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/exception/RayTaskException.java
+++ b/java/runtime/src/main/java/io/ray/runtime/exception/RayTaskException.java
@@ -5,6 +5,10 @@ import io.ray.runtime.util.SystemUtil;
 
 public class RayTaskException extends RayException {
 
+  public RayTaskException(String message) {
+    super(message);
+  }
+
   public RayTaskException(String message, Throwable cause) {
     super(
         String.format(

--- a/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
@@ -17,6 +17,8 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -159,9 +161,22 @@ public abstract class TaskExecutor<T extends TaskExecutor.ActorContext> {
         boolean hasReturn = rayFunction != null && rayFunction.hasReturn();
         boolean isCrossLanguage = parseFunctionDescriptor(rayFunctionInfo).signature.equals("");
         if (hasReturn || isCrossLanguage) {
-          returnObjects.add(
-              ObjectSerializer.serialize(
-                  new RayTaskException("Error executing task " + taskId, e)));
+          NativeRayObject serializedException;
+          try {
+            serializedException = ObjectSerializer.serialize(new RayTaskException(
+              "Error executing task " + taskId, e));
+          } catch (Exception unserializable) {
+            // We should try-catch `ObjectSerializer.serialize` here. Because otherwise if the
+            // application-level exception is not serializable. `ObjectSerializer.serialize`
+            // will throw an exception and crash the worker.
+            // Refer to the case `TaskExceptionTest.java` for more details.
+            LOGGER.warn("Failed to serialize the exception to a RayObject.", unserializable);
+            serializedException = ObjectSerializer.serialize(new RayTaskException(
+              String.format("Error executing task %s with the exception: %s",
+                taskId, ExceptionUtils.getStackTrace(e))));
+          }
+          Preconditions.checkNotNull(serializedException);
+          returnObjects.add(serializedException);
         }
       } else {
         actorContext.actorCreationException = e;

--- a/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
@@ -17,7 +17,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
-
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -163,17 +162,21 @@ public abstract class TaskExecutor<T extends TaskExecutor.ActorContext> {
         if (hasReturn || isCrossLanguage) {
           NativeRayObject serializedException;
           try {
-            serializedException = ObjectSerializer.serialize(new RayTaskException(
-              "Error executing task " + taskId, e));
+            serializedException =
+                ObjectSerializer.serialize(
+                    new RayTaskException("Error executing task " + taskId, e));
           } catch (Exception unserializable) {
             // We should try-catch `ObjectSerializer.serialize` here. Because otherwise if the
             // application-level exception is not serializable. `ObjectSerializer.serialize`
             // will throw an exception and crash the worker.
             // Refer to the case `TaskExceptionTest.java` for more details.
             LOGGER.warn("Failed to serialize the exception to a RayObject.", unserializable);
-            serializedException = ObjectSerializer.serialize(new RayTaskException(
-              String.format("Error executing task %s with the exception: %s",
-                taskId, ExceptionUtils.getStackTrace(e))));
+            serializedException =
+                ObjectSerializer.serialize(
+                    new RayTaskException(
+                        String.format(
+                            "Error executing task %s with the exception: %s",
+                            taskId, ExceptionUtils.getStackTrace(e))));
           }
           Preconditions.checkNotNull(serializedException);
           returnObjects.add(serializedException);

--- a/java/test/src/main/java/io/ray/test/TaskExceptionTest.java
+++ b/java/test/src/main/java/io/ray/test/TaskExceptionTest.java
@@ -36,8 +36,8 @@ public class TaskExceptionTest extends BaseTest {
   @Test
   public void testThrowUnserializableExceptionInNormalTask() {
     // Test that if a task throws an unserializable exception, the worker won't crash.
-    Assert.assertThrows((() -> Ray.task(
-      TaskExceptionTest::throwUnserializableException).remote().get()));
+    Assert.assertThrows(
+        (() -> Ray.task(TaskExceptionTest::throwUnserializableException).remote().get()));
   }
 
   @Test

--- a/java/test/src/main/java/io/ray/test/TaskExceptionTest.java
+++ b/java/test/src/main/java/io/ray/test/TaskExceptionTest.java
@@ -1,41 +1,49 @@
 package io.ray.test;
+
 import io.ray.api.ActorHandle;
 import io.ray.api.Ray;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
 public class TaskExceptionTest extends BaseTest {
+
   private static class UnserializableClass {}
+
   private static class UnserializableException extends RuntimeException {
+
     public UnserializableException() {
       super();
     }
+
     private UnserializableClass unSerializableClass = new UnserializableClass();
   }
+
   private static class MyActor {
+
     public String sayHi() {
       return "Hi";
     }
+
     public String throwUnserializableException() {
       throw new UnserializableException();
     }
   }
+
   private static String throwUnserializableException() {
     throw new UnserializableException();
   }
+
   @Test
   public void testThrowUnserializableExceptionInNormalTask() {
     // Test that if a task throws an unserializable exception, the worker won't crash.
-    assertThrowingSpecifiedException((() -> Ray.task(TaskExceptionTest::throwUnserializableException).remote().get()));
+    Assert.assertThrows((() -> Ray.task(
+      TaskExceptionTest::throwUnserializableException).remote().get()));
   }
 
   @Test
   public void testThrowUnserializableExceptionInActorTask() {
     ActorHandle<MyActor> myActor = Ray.actor(MyActor::new).remote();
     Assert.assertEquals("Hi", myActor.task(MyActor::sayHi).remote().get());
-    assertThrowingSpecifiedException((() -> myActor.task(MyActor::throwUnserializableException).remote().get()));
-  }
-  private static void assertThrowingSpecifiedException(Assert.ThrowingRunnable func) {
-    Exception throwingException = null;
-    Assert.assertThrows(func);
+    Assert.assertThrows((() -> myActor.task(MyActor::throwUnserializableException).remote().get()));
   }
 }

--- a/java/test/src/main/java/io/ray/test/TaskExceptionTest.java
+++ b/java/test/src/main/java/io/ray/test/TaskExceptionTest.java
@@ -1,0 +1,41 @@
+package io.ray.test;
+import io.ray.api.ActorHandle;
+import io.ray.api.Ray;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+public class TaskExceptionTest extends BaseTest {
+  private static class UnserializableClass {}
+  private static class UnserializableException extends RuntimeException {
+    public UnserializableException() {
+      super();
+    }
+    private UnserializableClass unSerializableClass = new UnserializableClass();
+  }
+  private static class MyActor {
+    public String sayHi() {
+      return "Hi";
+    }
+    public String throwUnserializableException() {
+      throw new UnserializableException();
+    }
+  }
+  private static String throwUnserializableException() {
+    throw new UnserializableException();
+  }
+  @Test
+  public void testThrowUnserializableExceptionInNormalTask() {
+    // Test that if a task throws an unserializable exception, the worker won't crash.
+    assertThrowingSpecifiedException((() -> Ray.task(TaskExceptionTest::throwUnserializableException).remote().get()));
+  }
+
+  @Test
+  public void testThrowUnserializableExceptionInActorTask() {
+    ActorHandle<MyActor> myActor = Ray.actor(MyActor::new).remote();
+    Assert.assertEquals("Hi", myActor.task(MyActor::sayHi).remote().get());
+    assertThrowingSpecifiedException((() -> myActor.task(MyActor::throwUnserializableException).remote().get()));
+  }
+  private static void assertThrowingSpecifiedException(Assert.ThrowingRunnable func) {
+    Exception throwingException = null;
+    Assert.assertThrows(func);
+  }
+}


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If user have a unserializable exception like:
```java
class A {}
class UnserializableException {
    A a;
}

String remoteTask() {
    throw new UnserializableException();
}
```
Before this PR, the worker would be dead caused by the failure of packing the unserializable exception.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
