### PR TITLE
[Java] Support `wasCurrentActorRestarted` in actor task.

### DIFF
--- a/java/api/src/main/java/io/ray/api/runtimecontext/RuntimeContext.java
+++ b/java/api/src/main/java/io/ray/api/runtimecontext/RuntimeContext.java
@@ -18,9 +18,9 @@ public interface RuntimeContext {
   ActorId getCurrentActorId();
 
   /**
-   * Returns true if the current actor was restarted, false if it's created for the first time.
+   * Returns true if the current actor was restarted, otherwise false.
    *
-   * <p>Note, this method should only be called from an actor creation task.
+   * <p>Note, this method can be called from both an actor creation task and an actor task.
    */
   boolean wasCurrentActorRestarted();
 

--- a/java/api/src/main/java/io/ray/api/runtimecontext/RuntimeContext.java
+++ b/java/api/src/main/java/io/ray/api/runtimecontext/RuntimeContext.java
@@ -19,8 +19,6 @@ public interface RuntimeContext {
 
   /**
    * Returns true if the current actor was restarted, otherwise false.
-   *
-   * <p>Note, this method can be called from both an actor creation task and an actor task.
    */
   boolean wasCurrentActorRestarted();
 

--- a/java/api/src/main/java/io/ray/api/runtimecontext/RuntimeContext.java
+++ b/java/api/src/main/java/io/ray/api/runtimecontext/RuntimeContext.java
@@ -17,9 +17,7 @@ public interface RuntimeContext {
    */
   ActorId getCurrentActorId();
 
-  /**
-   * Returns true if the current actor was restarted, otherwise false.
-   */
+  /** Returns true if the current actor was restarted, otherwise false. */
   boolean wasCurrentActorRestarted();
 
   /**

--- a/java/runtime/src/main/java/io/ray/runtime/context/RuntimeContextImpl.java
+++ b/java/runtime/src/main/java/io/ray/runtime/context/RuntimeContextImpl.java
@@ -33,14 +33,9 @@ public class RuntimeContextImpl implements RuntimeContext {
 
   @Override
   public boolean wasCurrentActorRestarted() {
-    TaskType currentTaskType = runtime.getWorkerContext().getCurrentTaskType();
-    Preconditions.checkState(
-        currentTaskType == TaskType.ACTOR_CREATION_TASK,
-        "This method can only be called from an actor creation task.");
     if (isSingleProcess()) {
       return false;
     }
-
     return runtime.getGcsClient().wasCurrentActorRestarted(getCurrentActorId());
   }
 

--- a/java/runtime/src/main/java/io/ray/runtime/context/RuntimeContextImpl.java
+++ b/java/runtime/src/main/java/io/ray/runtime/context/RuntimeContextImpl.java
@@ -7,7 +7,6 @@ import io.ray.api.runtimecontext.NodeInfo;
 import io.ray.api.runtimecontext.RuntimeContext;
 import io.ray.runtime.RayRuntimeInternal;
 import io.ray.runtime.config.RunMode;
-import io.ray.runtime.generated.Common.TaskType;
 import java.util.List;
 
 public class RuntimeContextImpl implements RuntimeContext {

--- a/java/test/src/main/java/io/ray/test/ActorRestartTest.java
+++ b/java/test/src/main/java/io/ray/test/ActorRestartTest.java
@@ -95,7 +95,8 @@ public class ActorRestartTest extends BaseTest {
    * @param actor The counter actor to be killed.
    * @return The pid of the actor.
    */
-  private static void killActorProcess(ActorHandle<Counter> actor) throws IOException, InterruptedException {
+  private static void killActorProcess(ActorHandle<Counter> actor)
+      throws IOException, InterruptedException {
     // Kill the actor process.
     int pid = actor.task(Counter::getPid).remote().get();
     Process p = Runtime.getRuntime().exec("kill -9 " + pid);

--- a/java/test/src/main/java/io/ray/test/ActorRestartTest.java
+++ b/java/test/src/main/java/io/ray/test/ActorRestartTest.java
@@ -48,8 +48,10 @@ public class ActorRestartTest extends BaseTest {
     }
 
     // Check if actor was restarted.
-    Assert.assertFalse(actor.task(Counter::checkWasCurrentActorRestartedInActorCreationTask).remote().get());
-    Assert.assertFalse(actor.task(Counter::checkWasCurrentActorRestartedInActorTask).remote().get());
+    Assert.assertFalse(
+        actor.task(Counter::checkWasCurrentActorRestartedInActorCreationTask).remote().get());
+    Assert.assertFalse(
+        actor.task(Counter::checkWasCurrentActorRestartedInActorTask).remote().get());
 
     // Kill the actor process.
     killActorProcess(actor);
@@ -58,19 +60,19 @@ public class ActorRestartTest extends BaseTest {
     Assert.assertEquals(value, 1);
 
     // Check if actor was restarted again.
-    Assert.assertTrue(actor.task(Counter::checkWasCurrentActorRestartedInActorCreationTask).remote().get());
+    Assert.assertTrue(
+        actor.task(Counter::checkWasCurrentActorRestartedInActorCreationTask).remote().get());
     Assert.assertTrue(actor.task(Counter::checkWasCurrentActorRestartedInActorTask).remote().get());
 
     // Kill the actor process again.
     killActorProcess(actor);
 
     // Try calling increase on this actor again and this should fail.
-    Assert.assertThrows(RayActorException.class, () -> actor.task(Counter::increase).remote().get());
+    Assert.assertThrows(
+        RayActorException.class, () -> actor.task(Counter::increase).remote().get());
   }
 
-  /**
-   * The helper to kill a counter actor.
-   */
+  /** The helper to kill a counter actor. */
   private static void killActorProcess(ActorHandle<Counter> actor)
       throws IOException, InterruptedException {
     // Kill the actor process.

--- a/java/test/src/main/java/io/ray/test/ActorRestartTest.java
+++ b/java/test/src/main/java/io/ray/test/ActorRestartTest.java
@@ -92,6 +92,7 @@ public class ActorRestartTest extends BaseTest {
 
   /**
    * The helper to kill a counter actor.
+   *
    * @param actor The counter actor to be killed.
    * @return The pid of the actor.
    */


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Since `wasCurrentActorRestarted()` can be called in actor task, remove the check expr.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
