### PR TITLE
[Serve] Use a small object to track requests

### DIFF
--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -121,6 +121,7 @@ def create_backend_replica(func_or_class: Union[Callable, Type[Callable]]):
             self.backend = RayServeReplica(_callable, backend_config,
                                            is_function, controller_handle)
 
+        @ray.method(num_returns=2)
         async def handle_request(self, request):
             return await self.backend.handle_request(request)
 
@@ -411,7 +412,10 @@ class RayServeReplica:
             self.replica_tag, request.metadata.request_id, request_time_ms))
 
         self.num_ongoing_requests -= 1
-        return result
+        # Returns a small object for router to track request status.
+        # The self.num_ongoing_requests is chosen because it's small and may
+        # be useful for the router.
+        return self.num_ongoing_requests, result
 
     async def drain_pending_queries(self):
         """Perform graceful shutdown.

--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -413,9 +413,7 @@ class RayServeReplica:
 
         self.num_ongoing_requests -= 1
         # Returns a small object for router to track request status.
-        # The self.num_ongoing_requests is chosen because it's small and may
-        # be useful for the router.
-        return self.num_ongoing_requests, result
+        return b"", result
 
     async def drain_pending_queries(self):
         """Perform graceful shutdown.

--- a/python/ray/serve/router.py
+++ b/python/ray/serve/router.py
@@ -103,9 +103,9 @@ class ReplicaSet:
                 continue
             logger.debug(f"Assigned query {query.metadata.request_id} "
                          f"to replica {replica}.")
-            ref = replica.handle_request.remote(query)
-            self.in_flight_queries[replica].add(ref)
-            return ref
+            tracker_ref, user_ref = replica.handle_request.remote(query)
+            self.in_flight_queries[replica].add(tracker_ref)
+            return user_ref
         return None
 
     @property

--- a/python/ray/serve/tests/test_backend_worker.py
+++ b/python/ray/serve/tests/test_backend_worker.py
@@ -33,6 +33,7 @@ def setup_worker(name,
         def ready(self):
             pass
 
+        @ray.method(num_returns=2)
         async def handle_request(self, *args, **kwargs):
             return await self.worker.handle_request(*args, **kwargs)
 

--- a/python/ray/serve/tests/test_router.py
+++ b/python/ray/serve/tests/test_router.py
@@ -32,12 +32,13 @@ def mock_task_runner():
             self.query = None
             self.queries = []
 
+        @ray.method(num_returns=2)
         async def handle_request(self, request):
             if isinstance(request, bytes):
                 request = Query.ray_deserialize(request)
             self.query = request
             self.queries.append(request)
-            return "DONE"
+            return 0, "DONE"
 
         def get_recent_call(self):
             return self.query
@@ -195,10 +196,11 @@ async def test_replica_set(ray_instance):
     class MockWorker:
         _num_queries = 0
 
+        @ray.method(num_returns=2)
         async def handle_request(self, request):
             self._num_queries += 1
             await signal.wait.remote()
-            return "DONE"
+            return 0, "DONE"
 
         async def num_queries(self):
             return self._num_queries

--- a/python/ray/serve/tests/test_router.py
+++ b/python/ray/serve/tests/test_router.py
@@ -38,7 +38,7 @@ def mock_task_runner():
                 request = Query.ray_deserialize(request)
             self.query = request
             self.queries.append(request)
-            return 0, "DONE"
+            return b"", "DONE"
 
         def get_recent_call(self):
             return self.query
@@ -200,7 +200,7 @@ async def test_replica_set(ray_instance):
         async def handle_request(self, request):
             self._num_queries += 1
             await signal.wait.remote()
-            return 0, "DONE"
+            return b"", "DONE"
 
         async def num_queries(self):
             return self._num_queries


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Use a small object to track ongoing requests, instead using user's object refs. This is preferable because:
- Provide a mechanism to piggyback some information from the replica to the replica set for load balancing
- Avoid holding on to the ref for user's result for too long, which might lead to undesired memory growth.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #12329

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
