### PR TITLE
[core] Make `GlobalState.available_resources_per_node` public

### DIFF
--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -282,7 +282,7 @@ def try_schedule_resources_on_nodes(
         requirements(List[dict]): The list of resource requirements.
         ray_nodes(Optional[Dict[str, Dict]]): The resource dictionary keyed by
             node id. By default it reads from
-            ``ray.state.state._available_resources_per_node()``.
+            ``ray.state.state.available_resources_per_node()``.
     Returns:
         successfully_scheduled(List[bool]): A list with the same length as
             requirements. Each element indicates whether or not the requirement
@@ -290,7 +290,7 @@ def try_schedule_resources_on_nodes(
     """
 
     if ray_resource is None:
-        ray_resource = ray.state.state._available_resources_per_node()
+        ray_resource = ray.state.state.available_resources_per_node()
 
     successfully_scheduled = []
 

--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -781,8 +781,10 @@ class GlobalState:
             for node in self.node_table() if (node["Alive"])
         }
 
-    def _available_resources_per_node(self):
-        """Returns a dictionary mapping node id to avaiable resources."""
+    def available_resources_per_node(self):
+        """Returns a dictionary mapping node id to available resources."""
+        self._check_connected()
+
         available_resources_by_id = {}
 
         all_available_resources = \
@@ -822,7 +824,7 @@ class GlobalState:
         """
         self._check_connected()
 
-        available_resources_by_id = self._available_resources_per_node()
+        available_resources_by_id = self.available_resources_per_node()
 
         # Calculate total available resources.
         total_available_resources = defaultdict(int)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`ray.state.state._available_resources_per_node()` is used by Ray Serve and xgboost_ray (e.g. https://github.com/ray-project/xgboost_ray/pull/36/), so we should consider making it public.

This will also ensure that the global state accessor is initialized when calling this method.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
