### PR TITLE
[kubernetes][docs][minor] Kubernetes version warning

### DIFF
--- a/doc/source/cluster/k8s-operator.rst
+++ b/doc/source/cluster/k8s-operator.rst
@@ -19,6 +19,10 @@ The rest of this document explains step-by-step how to use the Ray Kubernetes Op
 .. role:: bash(code)
    :language: bash
 
+.. warning::
+   The Ray Kubernetes Operator requires Kubernetes version at least ``v1.17.0``. Check Kubernetes version info with the command
+   :bash:`kubectl version`.
+
 .. note::
    The example commands in this document launch six Kubernetes pods, using a total of 6 CPU and 3.5Gi memory.   
    If you are experimenting using a test Kubernetes environment such as `minikube`_, make sure to provision sufficient resources, e.g.

--- a/python/ray/operator/operator.py
+++ b/python/ray/operator/operator.py
@@ -1,23 +1,3 @@
-"""
-Ray operator for Kubernetes.
-
-Reads ray cluster config from a k8s ConfigMap, starts a ray head node pod using
-create_or_update_cluster(), then runs an autoscaling loop in the operator pod
-executing this script. Writes autoscaling logs to the directory
-/root/ray-operator-logs.
-
-In this setup, the ray head node does not run an autoscaler. It is important
-NOT to supply an --autoscaling-config argument to head node's ray start command
-in the cluster config when using this operator.
-
-To run, first create a ConfigMap named ray-operator-configmap from a ray
-cluster config. Then apply the manifest at python/ray/autoscaler/kubernetes/operator_configs/operator_config.yaml
-
-For example:
-kubectl create namespace raytest
-kubectl -n raytest create configmap ray-operator-configmap --from-file=python/ray/autoscaler/kubernetes/operator_configs/test_cluster_config.yaml
-kubectl -n raytest apply -f python/ray/autoscaler/kubernetes/operator_configs/operator_config.yaml
-""" # noqa
 import logging
 import multiprocessing as mp
 import os


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A bug in older versions of Kubernetes makes it impossible to run the operator. 
(Specifically, there was a problem reading CRDs.)

I'm adding a warning to the operator docs to use K8s version at least v1.17.0.  

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
