### PR TITLE
[tune] wandb - WandbLogger now also accepts wandb.data_types.Video

### DIFF
--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -1,6 +1,6 @@
 import os
 import pickle
-from collections import Iterable
+from collections.abc import Iterable
 from multiprocessing import Process, Queue
 from numbers import Number
 from typing import Any, Callable, Dict, List, Optional, Tuple

--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -22,13 +22,17 @@ except ImportError:
 
 WANDB_ENV_VAR = "WANDB_API_KEY"
 _WANDB_QUEUE_END = (None, )
+_VALID_TYPES = (Number, wandb.data_types.Video)
+_VALID_ITERABLE_TYPES = (wandb.data_types.Video)
 
 
 def _is_allowed_type(obj):
     """Return True if type is allowed for logging to wandb"""
     if isinstance(obj, np.ndarray) and obj.size == 1:
         return isinstance(obj.item(), Number)
-    return isinstance(obj, Number)
+    if isinstance(obj, Iterable) and len(obj) > 0:
+        return isinstance(obj[0], _VALID_ITERABLE_TYPES)
+    return isinstance(obj, _VALID_TYPES)
 
 
 def _clean_log(obj: Any):

--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -1,5 +1,6 @@
 import os
 import pickle
+from collections import Iterable
 from multiprocessing import Process, Queue
 from numbers import Number
 from typing import Any, Callable, Dict, List, Optional, Tuple


### PR DESCRIPTION
## Why are these changes needed?

Currently the WandbLogger does not accept `wandb.data_types.Video`'s as they are stripped away by the `_is_allowed_type` method. To fix this I also check for the `wandb.data_types.Video` and let the method return `True` if it finds this data type. I also make sure that Iterables containing this data type are accepted (as `wandb.log` also accepts this). 

More about logging videos using wandb can be read [here](https://docs.wandb.ai/library/log#log-a-video).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
