### PR TITLE
[Core] Remove PlasmaBuffer in buffer header

### DIFF
--- a/src/ray/common/buffer.h
+++ b/src/ray/common/buffer.h
@@ -152,7 +152,7 @@ class SharedMemoryBuffer : public Buffer {
 
   size_t Size() const override { return size_; }
 
-  bool OwnsData() const override { return false; }
+  bool OwnsData() const override { return true; }
 
   bool IsPlasmaBuffer() const override { return true; }
 

--- a/src/ray/common/buffer.h
+++ b/src/ray/common/buffer.h
@@ -172,34 +172,4 @@ class SharedMemoryBuffer : public Buffer {
   std::shared_ptr<Buffer> parent_;
 };
 
-/// Represents a byte buffer for plasma object. This can be used to hold the
-/// reference to a plasma object (via the underlying plasma::PlasmaBuffer).
-class PlasmaBuffer : public Buffer {
- public:
-  PlasmaBuffer(std::shared_ptr<Buffer> buffer,
-               std::function<void(PlasmaBuffer *)> on_delete = nullptr)
-      : buffer_(buffer), on_delete_(on_delete) {}
-
-  uint8_t *Data() const override { return buffer_->Data(); }
-
-  size_t Size() const override { return buffer_->Size(); }
-
-  bool OwnsData() const override { return true; }
-
-  bool IsPlasmaBuffer() const override { return true; }
-
-  ~PlasmaBuffer() {
-    if (on_delete_ != nullptr) {
-      on_delete_(this);
-    }
-  };
-
- private:
-  /// shared_ptr to a buffer which can potentially hold a reference
-  /// for the object (when it's a plasma::PlasmaBuffer).
-  std::shared_ptr<Buffer> buffer_;
-  /// Callback to run on destruction.
-  std::function<void(PlasmaBuffer *)> on_delete_;
-};
-
 }  // namespace ray

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -21,6 +21,35 @@
 
 namespace ray {
 
+void BufferTracker::Record(const ObjectID &object_id, TrackedBuffer *buffer, const std::string &call_site) {
+  absl::MutexLock lock(&active_buffers_mutex_);
+  active_buffers_[std::make_pair(object_id, buffer)] = call_site;
+}
+
+void BufferTracker::Release(const ObjectID &object_id, TrackedBuffer *buffer) {
+  absl::MutexLock lock(&active_buffers_mutex_);
+  auto key = std::make_pair(object_id, buffer);
+  RAY_CHECK(active_buffers_.contains(key));
+  active_buffers_.erase(key);
+}
+
+absl::flat_hash_map<ObjectID, std::pair<int64_t, std::string>>
+BufferTracker::UsedObjects() const {
+  absl::flat_hash_map<ObjectID, std::pair<int64_t, std::string>> used;
+  absl::MutexLock lock(&active_buffers_mutex_);
+  for (const auto &entry : active_buffers_) {
+    auto it = used.find(entry.first.first);
+    if (it != used.end()) {
+      // Prefer to keep entries that have non-empty callsites.
+      if (!it->second.second.empty()) {
+        continue;
+      }
+    }
+    used[entry.first.first] = std::make_pair(entry.first.second->Size(), entry.second);
+  }
+  return used;
+}
+
 CoreWorkerPlasmaStoreProvider::CoreWorkerPlasmaStoreProvider(
     const std::string &store_socket,
     const std::shared_ptr<raylet::RayletClient> raylet_client,
@@ -85,13 +114,12 @@ Status CoreWorkerPlasmaStoreProvider::Create(const std::shared_ptr<Buffer> &meta
                                              const rpc::Address &owner_address,
                                              std::shared_ptr<Buffer> *data) {
   Status status;
-  std::shared_ptr<Buffer> plasma_buffer;
   uint64_t retry_with_request_id = 0;
   {
     std::lock_guard<std::mutex> guard(store_client_mutex_);
     status = store_client_.Create(
         object_id, owner_address, data_size, metadata ? metadata->Data() : nullptr,
-        metadata ? metadata->Size() : 0, &retry_with_request_id, &plasma_buffer,
+        metadata ? metadata->Size() : 0, &retry_with_request_id, data,
         /*device_num=*/0);
   }
 
@@ -104,7 +132,7 @@ Status CoreWorkerPlasmaStoreProvider::Create(const std::shared_ptr<Buffer> &meta
                      << retry_with_request_id;
       status = store_client_.RetryCreate(object_id, retry_with_request_id,
                                          metadata ? metadata->Data() : nullptr,
-                                         &retry_with_request_id, &plasma_buffer);
+                                         &retry_with_request_id, data);
     }
   }
 
@@ -129,7 +157,6 @@ Status CoreWorkerPlasmaStoreProvider::Create(const std::shared_ptr<Buffer> &meta
     status = Status::OK();
   } else {
     RAY_RETURN_NOT_OK(status);
-    *data = std::make_shared<PlasmaBuffer>(PlasmaBuffer(plasma_buffer));
   }
   return status;
 }
@@ -171,27 +198,16 @@ Status CoreWorkerPlasmaStoreProvider::FetchAndGetFromPlasmaStore(
   for (size_t i = 0; i < plasma_results.size(); i++) {
     if (plasma_results[i].data != nullptr || plasma_results[i].metadata != nullptr) {
       const auto &object_id = batch_ids[i];
-      std::shared_ptr<PlasmaBuffer> data = nullptr;
-      std::shared_ptr<PlasmaBuffer> metadata = nullptr;
+      std::shared_ptr<TrackedBuffer> data = nullptr;
+      std::shared_ptr<Buffer> metadata = nullptr;
       if (plasma_results[i].data && plasma_results[i].data->Size()) {
         // We track the set of active data buffers in active_buffers_. On destruction,
         // the buffer entry will be removed from the set via callback.
-        std::shared_ptr<BufferTracker> tracker = buffer_tracker_;
-        data = std::make_shared<PlasmaBuffer>(
-            plasma_results[i].data, [tracker, object_id](PlasmaBuffer *this_buffer) {
-              absl::MutexLock lock(&tracker->active_buffers_mutex_);
-              auto key = std::make_pair(object_id, this_buffer);
-              RAY_CHECK(tracker->active_buffers_.contains(key));
-              tracker->active_buffers_.erase(key);
-            });
-        auto call_site = get_current_call_site_();
-        {
-          absl::MutexLock lock(&tracker->active_buffers_mutex_);
-          tracker->active_buffers_[std::make_pair(object_id, data.get())] = call_site;
-        }
+        data = std::make_shared<TrackedBuffer>(plasma_results[i].data, buffer_tracker_, object_id);
+        buffer_tracker_->Record(object_id, data.get(), get_current_call_site_());
       }
       if (plasma_results[i].metadata && plasma_results[i].metadata->Size()) {
-        metadata = std::make_shared<PlasmaBuffer>(plasma_results[i].metadata);
+        metadata = plasma_results[i].metadata;
       }
       const auto result_object =
           std::make_shared<RayObject>(data, metadata, std::vector<ObjectID>());
@@ -373,19 +389,7 @@ std::string CoreWorkerPlasmaStoreProvider::MemoryUsageString() {
 
 absl::flat_hash_map<ObjectID, std::pair<int64_t, std::string>>
 CoreWorkerPlasmaStoreProvider::UsedObjectsList() const {
-  absl::flat_hash_map<ObjectID, std::pair<int64_t, std::string>> used;
-  absl::MutexLock lock(&buffer_tracker_->active_buffers_mutex_);
-  for (const auto &entry : buffer_tracker_->active_buffers_) {
-    auto it = used.find(entry.first.first);
-    if (it != used.end()) {
-      // Prefer to keep entries that have non-empty callsites.
-      if (!it->second.second.empty()) {
-        continue;
-      }
-    }
-    used[entry.first.first] = std::make_pair(entry.first.second->Size(), entry.second);
-  }
-  return used;
+  return buffer_tracker_->UsedObjects();
 }
 
 void CoreWorkerPlasmaStoreProvider::WarnIfAttemptedTooManyTimes(

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -21,7 +21,8 @@
 
 namespace ray {
 
-void BufferTracker::Record(const ObjectID &object_id, TrackedBuffer *buffer, const std::string &call_site) {
+void BufferTracker::Record(const ObjectID &object_id, TrackedBuffer *buffer,
+                           const std::string &call_site) {
   absl::MutexLock lock(&active_buffers_mutex_);
   active_buffers_[std::make_pair(object_id, buffer)] = call_site;
 }
@@ -203,7 +204,8 @@ Status CoreWorkerPlasmaStoreProvider::FetchAndGetFromPlasmaStore(
       if (plasma_results[i].data && plasma_results[i].data->Size()) {
         // We track the set of active data buffers in active_buffers_. On destruction,
         // the buffer entry will be removed from the set via callback.
-        data = std::make_shared<TrackedBuffer>(plasma_results[i].data, buffer_tracker_, object_id);
+        data = std::make_shared<TrackedBuffer>(plasma_results[i].data, buffer_tracker_,
+                                               object_id);
         buffer_tracker_->Record(object_id, data.get(), get_current_call_site_());
       }
       if (plasma_results[i].metadata && plasma_results[i].metadata->Size()) {

--- a/src/ray/core_worker/store_provider/plasma_store_provider.h
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.h
@@ -27,6 +27,59 @@
 
 namespace ray {
 
+class TrackedBuffer;
+
+// Active buffers tracker. This must be allocated as a separate structure since its
+// lifetime can exceed that of the store provider due to TrackedBuffer.
+class RAY_NO_EXPORT BufferTracker {
+ public:
+  // Track an object.
+  void Record(const ObjectID &object_id, TrackedBuffer *buffer, const std::string &call_site);
+  // Release an object from tracking.
+  void Release(const ObjectID &object_id, TrackedBuffer *buffer);
+  // List tracked objects.
+  absl::flat_hash_map<ObjectID, std::pair<int64_t, std::string>> UsedObjects() const;
+
+ private:
+  // Guards the active buffers map. This mutex may be acquired during TrackedBuffer
+  // destruction.
+  mutable absl::Mutex active_buffers_mutex_;
+  // Mapping of live object buffers to their creation call site. Destroyed buffers are
+  // automatically removed from this list via destructor. The map key uniquely
+  // identifies a buffer. It should not be a shared ptr since that would keep the Buffer
+  // alive forever (i.e., this is a weak ref map).
+  absl::flat_hash_map<std::pair<ObjectID, TrackedBuffer *>, std::string> active_buffers_
+      GUARDED_BY(active_buffers_mutex_);
+};
+
+/// This can be used to hold the reference to a buffer.
+class TrackedBuffer : public Buffer {
+ public:
+  TrackedBuffer(std::shared_ptr<Buffer> buffer,
+                const std::shared_ptr<BufferTracker> &tracker,
+                const ObjectID &object_id)
+      : buffer_(buffer), tracker_(tracker), object_id_(object_id) {}
+
+  uint8_t *Data() const override { return buffer_->Data(); }
+
+  size_t Size() const override { return buffer_->Size(); }
+
+  bool OwnsData() const override { return true; }
+
+  bool IsPlasmaBuffer() const override { return true; }
+
+  ~TrackedBuffer() {
+    tracker_->Release(object_id_, this);
+  }
+
+ private:
+  /// shared_ptr to a buffer which can potentially hold a reference
+  /// for the object (when it's a SharedMemoryBuffer).
+  std::shared_ptr<Buffer> buffer_;
+  std::shared_ptr<BufferTracker> tracker_;
+  ObjectID object_id_;
+};
+
 /// The class provides implementations for accessing plasma store, which includes both
 /// local and remote stores. Local access goes is done via a
 /// CoreWorkerLocalPlasmaStoreProvider and remote access goes through the raylet.
@@ -154,21 +207,6 @@ class CoreWorkerPlasmaStoreProvider {
   std::function<Status()> check_signals_;
   std::function<std::string()> get_current_call_site_;
   uint32_t object_store_full_delay_ms_;
-
-  // Active buffers tracker. This must be allocated as a separate structure since its
-  // lifetime can exceed that of the store provider due to callback references.
-  struct BufferTracker {
-    // Guards the active buffers map. This mutex may be acquired during PlasmaBuffer
-    // destruction.
-    mutable absl::Mutex active_buffers_mutex_;
-    // Mapping of live object buffers to their creation call site. Destroyed buffers are
-    // automatically removed from this list via destructor callback. The map key uniquely
-    // identifies a buffer. It should not be a shared ptr since that would keep the Buffer
-    // alive forever (i.e., this is a weak ref map).
-    absl::flat_hash_map<std::pair<ObjectID, PlasmaBuffer *>, std::string> active_buffers_
-        GUARDED_BY(active_buffers_mutex_);
-  };
-
   // Pointer to the shared buffer tracker.
   std::shared_ptr<BufferTracker> buffer_tracker_;
 };

--- a/src/ray/core_worker/store_provider/plasma_store_provider.h
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.h
@@ -31,7 +31,7 @@ class TrackedBuffer;
 
 // Active buffers tracker. This must be allocated as a separate structure since its
 // lifetime can exceed that of the store provider due to TrackedBuffer.
-class RAY_NO_EXPORT BufferTracker {
+class BufferTracker {
  public:
   // Track an object.
   void Record(const ObjectID &object_id, TrackedBuffer *buffer,

--- a/src/ray/core_worker/store_provider/plasma_store_provider.h
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.h
@@ -34,7 +34,8 @@ class TrackedBuffer;
 class RAY_NO_EXPORT BufferTracker {
  public:
   // Track an object.
-  void Record(const ObjectID &object_id, TrackedBuffer *buffer, const std::string &call_site);
+  void Record(const ObjectID &object_id, TrackedBuffer *buffer,
+              const std::string &call_site);
   // Release an object from tracking.
   void Release(const ObjectID &object_id, TrackedBuffer *buffer);
   // List tracked objects.
@@ -56,8 +57,7 @@ class RAY_NO_EXPORT BufferTracker {
 class TrackedBuffer : public Buffer {
  public:
   TrackedBuffer(std::shared_ptr<Buffer> buffer,
-                const std::shared_ptr<BufferTracker> &tracker,
-                const ObjectID &object_id)
+                const std::shared_ptr<BufferTracker> &tracker, const ObjectID &object_id)
       : buffer_(buffer), tracker_(tracker), object_id_(object_id) {}
 
   uint8_t *Data() const override { return buffer_->Data(); }
@@ -68,9 +68,7 @@ class TrackedBuffer : public Buffer {
 
   bool IsPlasmaBuffer() const override { return true; }
 
-  ~TrackedBuffer() {
-    tracker_->Release(object_id_, this);
-  }
+  ~TrackedBuffer() { tracker_->Release(object_id_, this); }
 
  private:
   /// shared_ptr to a buffer which can potentially hold a reference

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -820,7 +820,7 @@ TEST_F(SingleNodeTest, TestObjectInterface) {
   ASSERT_EQ(wait_results, std::vector<bool>({true, true, false}));
 
   // Test Delete().
-  // clear the reference held by PlasmaBuffer.
+  // clear the reference held by TrackedBuffer.
   results.clear();
   RAY_CHECK_OK(core_worker.Delete(ids, true));
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2861,8 +2861,8 @@ void NodeManager::HandlePinObjectIDs(const rpc::PinObjectIDsRequest &request,
       if (plasma_results[i].data == nullptr) {
         objects.push_back(nullptr);
       } else {
-        objects.emplace_back(std::unique_ptr<RayObject>(new RayObject(
-            plasma_results[i].data, plasma_results[i].metadata, {})));
+        objects.emplace_back(std::unique_ptr<RayObject>(
+            new RayObject(plasma_results[i].data, plasma_results[i].metadata, {})));
       }
     }
     local_object_manager_.PinObjects(object_ids, std::move(objects));

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2862,8 +2862,7 @@ void NodeManager::HandlePinObjectIDs(const rpc::PinObjectIDsRequest &request,
         objects.push_back(nullptr);
       } else {
         objects.emplace_back(std::unique_ptr<RayObject>(new RayObject(
-            std::make_shared<PlasmaBuffer>(plasma_results[i].data),
-            std::make_shared<PlasmaBuffer>(plasma_results[i].metadata), {})));
+            plasma_results[i].data, plasma_results[i].metadata, {})));
       }
     }
     local_object_manager_.PinObjects(object_ids, std::move(objects));


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The `PlasmaBuffer` in `buffer.h` conflicts and shadows the `PlasmaBuffer` definition in the Plasma store. This is confusing. Also it actually only used once globally (other use cases are trivial shared pointers that harm the performance), there is no need to define it in the top-level header file. It is moved and renamed to `TrackedBuffer` with slight refactoring.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
