### PR TITLE
[WIP] Add cluster_resource_scheduler_interface to eliminate `new_scheduler_enabled_`

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -202,10 +202,8 @@ NodeManager::NodeManager(boost::asio::io_service &io_service, const NodeID &self
 
   if (new_scheduler_enabled_) {
     SchedulingResources &local_resources = cluster_resource_map_[self_node_id_];
-    auto new_resource_scheduler =
-        std::make_shared<ClusterResourceScheduler>(
-            self_node_id_.Binary(),
-            local_resources.GetTotalResources().GetResourceMap());
+    auto new_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
+        self_node_id_.Binary(), local_resources.GetTotalResources().GetResourceMap());
     cluster_resource_scheduler_ = new_resource_scheduler;
 
     auto get_node_info_func = [this](const NodeID &node_id) {
@@ -454,7 +452,7 @@ void NodeManager::ReportResourceUsage() {
   cluster_resource_scheduler_->UpdateLastReportResourcesFromGcs(
       gcs_client_->NodeResources().GetLastResourceUsage());
   cluster_resource_scheduler_->FillResourceUsage(light_report_resource_usage_enabled_,
-                                              resources_data);
+                                                 resources_data);
 
   if (new_scheduler_enabled_) {
     cluster_task_manager_->FillResourceUsage(light_report_resource_usage_enabled_,

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -761,7 +761,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// responsible for maintaining a view of the cluster state w.r.t resource
   /// usage. ClusterTaskManager is responsible for queuing, spilling back, and
   /// dispatching tasks.
-  std::shared_ptr<ClusterResourceScheduler> new_resource_scheduler_;
+  std::shared_ptr<ClusterResourceSchedulerInterface> cluster_resource_scheduler_;
   std::shared_ptr<ClusterTaskManager> cluster_task_manager_;
 
   absl::flat_hash_map<ObjectID, std::unique_ptr<RayObject>> pinned_objects_;

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler_interface.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler_interface.h
@@ -1,0 +1,72 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "ray/common/task/scheduling_resources.h"
+#include "src/ray/protobuf/gcs.pb.h"
+
+namespace ray {
+class ClusterResourceSchedulerInterface {
+ public:
+  virtual ~ClusterResourceSchedulerInterface() = default;
+
+  /// Remove node from the cluster data structure. This happens
+  /// when a node fails or it is removed from the cluster.
+  ///
+  /// \param node_id_string ID of the node to be removed.
+  virtual bool RemoveNode(const std::string &node_id_string) = 0;
+
+  /// Update node resources. This hanppens when a node resource usage udpated.
+  ///
+  /// \param node_id_string ID of the node which resoruces need to be udpated.
+  /// \param resource_data The node resource data.
+  virtual bool UpdateNode(const std::string &node_id_string,
+                          const rpc::ResourcesData &resource_data) = 0;
+
+  /// \param node_name: Node whose resource we want to update.
+  /// \param resource_name: Resource which we want to update.
+  /// \param resource_total: New capacity of the resource.
+  virtual void UpdateResourceCapacity(const std::string &node_id_string,
+                                      const std::string &resource_name,
+                                      double resource_total) = 0;
+
+  /// Delete a given resource from a given node.
+  ///
+  /// \param node_name: Node whose resource we want to delete.
+  /// \param resource_name: Resource we want to delete
+  virtual void DeleteResource(const std::string &node_id_string,
+                              const std::string &resource_name) = 0;
+
+  /// Update last report resources local cache from gcs cache,
+  /// this is needed when gcs fo.
+  ///
+  /// \param gcs_resources: The remote cache from gcs.
+  virtual void UpdateLastReportResourcesFromGcs(
+      std::shared_ptr<SchedulingResources> gcs_resources) {}
+
+  /// Populate the relevant parts of the heartbeat table. This is intended for
+  /// sending raylet <-> gcs heartbeats. In particular, this should fill in
+  /// resources_available and resources_total.
+  ///
+  /// \param light_report_resource_usage_enabled Only send changed fields if true.
+  /// \param Output parameter. `resources_available` and `resources_total` are the only
+  /// fields used.
+  virtual void FillResourceUsage(bool light_report_resource_usage_enabled,
+                                 std::shared_ptr<rpc::ResourcesData> data) = 0;
+
+  /// Return local resources in human-readable string form.
+  virtual std::string GetLocalResourceViewString() const = 0;
+};
+}  // namespace ray

--- a/src/ray/raylet/scheduling/cluster_task_manager.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager.h
@@ -141,8 +141,8 @@ class ClusterTaskManager {
   ///
   /// \param worker The worker to be marked as blocked.
   /// \return true if the worker is non-block and release_resources is true, else false.
-  bool ReleaseCpuResourcesAndMarkWorkerAsBlocked(
-      std::shared_ptr<WorkerInterface> worker, bool release_resources);
+  bool ReleaseCpuResourcesAndMarkWorkerAsBlocked(std::shared_ptr<WorkerInterface> worker,
+                                                 bool release_resources);
 
   /// When direct call task is unblocked, the cpu resources that the worker gave up should
   /// be returned to it.

--- a/src/ray/raylet/scheduling/cluster_task_manager.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager.h
@@ -132,6 +132,25 @@ class ClusterTaskManager {
 
   std::string DebugString() const;
 
+  /// Return the resources that were being used by this worker.
+  void FreeLocalTaskResources(std::shared_ptr<WorkerInterface> worker);
+
+  /// When direct call task is blocked, the worker who is executing the task should give
+  /// up the cpu resources allocated for the running task for the time being and the
+  /// worker itself should also be marked as blocked.
+  ///
+  /// \param worker The worker to be marked as blocked.
+  /// \return true if the worker is non-block and release_resources is true, else false.
+  bool ReleaseCpuResourcesAndMarkWorkerAsBlocked(
+      std::shared_ptr<WorkerInterface> worker, bool release_resources);
+
+  /// When direct call task is unblocked, the cpu resources that the worker gave up should
+  /// be returned to it.
+  /// \param worker The blocked worker.
+  /// \return true if the worker is blocking, else false.
+  bool ReturnCpuResourcesAndMarkWorkerAsUnblocked(
+      std::shared_ptr<WorkerInterface> worker);
+
  private:
   /// Helper method to try dispatching a single task from the queue to an
   /// available worker. Returns whether the task should be removed from the

--- a/src/ray/raylet/scheduling/old_cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/old_cluster_resource_scheduler.cc
@@ -1,0 +1,152 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/raylet/scheduling/old_cluster_resource_scheduler.h"
+
+#include "ray/common/grpc_util.h"
+#include "ray/common/ray_config.h"
+
+namespace ray {
+OldClusterResourceScheduler::OldClusterResourceScheduler(
+    const NodeID &self_node_id, ResourceIdSet &local_available_resources,
+    std::unordered_map<NodeID, SchedulingResources> &cluster_resource_map,
+    std::shared_ptr<SchedulingResources> last_heartbeat_resources)
+    : self_node_id_string_(self_node_id.Binary()),
+      local_available_resources_(local_available_resources),
+      cluster_resource_map_(cluster_resource_map),
+      last_heartbeat_resources_(last_heartbeat_resources) {}
+
+bool OldClusterResourceScheduler::RemoveNode(const std::string &node_id_string) {
+  return cluster_resource_map_.erase(NodeID::FromBinary(node_id_string)) != 0;
+}
+
+void OldClusterResourceScheduler::UpdateResourceCapacity(
+    const std::string &node_id_string, const std::string &resource_name,
+    double resource_total) {
+  if (node_id_string == self_node_id_string_) {
+    local_available_resources_.AddOrUpdateResource(resource_name, resource_total);
+  }
+  auto iter = cluster_resource_map_.find(NodeID::FromBinary(node_id_string));
+  if (iter != cluster_resource_map_.end()) {
+    auto &scheduling_resources = iter->second;
+    scheduling_resources.UpdateResourceCapacity(resource_name, resource_total);
+  }
+}
+
+void OldClusterResourceScheduler::DeleteResource(const std::string &node_id_string,
+                                                 const std::string &resource_name) {
+  if (node_id_string == self_node_id_string_) {
+    local_available_resources_.DeleteResource(resource_name);
+  }
+  auto iter = cluster_resource_map_.find(NodeID::FromBinary(node_id_string));
+  if (iter != cluster_resource_map_.end()) {
+    auto &scheduling_resources = iter->second;
+    scheduling_resources.DeleteResource(resource_name);
+  }
+}
+
+void OldClusterResourceScheduler::FillResourceUsage(
+    bool light_report_resource_usage_enabled,
+    std::shared_ptr<rpc::ResourcesData> resources_data) {
+  // TODO(atumanov): modify the heartbeat table protocol to use the ResourceSet
+  // directly.
+  // TODO(atumanov): implement a ResourceSet const_iterator.
+  // If light resource usage report enabled, we only set filed that represent resources
+  // changed.
+  auto &local_resources = cluster_resource_map_[NodeID::FromBinary(self_node_id_string_)];
+  if (light_report_resource_usage_enabled) {
+    if (!last_heartbeat_resources_->GetTotalResources().IsEqual(
+            local_resources.GetTotalResources())) {
+      for (const auto &resource_pair :
+           local_resources.GetTotalResources().GetResourceMap()) {
+        (*resources_data->mutable_resources_total())[resource_pair.first] =
+            resource_pair.second;
+      }
+      last_heartbeat_resources_->SetTotalResources(
+          ResourceSet(local_resources.GetTotalResources()));
+    }
+
+    if (!last_heartbeat_resources_->GetAvailableResources().IsEqual(
+            local_resources.GetAvailableResources())) {
+      resources_data->set_resources_available_changed(true);
+      for (const auto &resource_pair :
+           local_resources.GetAvailableResources().GetResourceMap()) {
+        (*resources_data->mutable_resources_available())[resource_pair.first] =
+            resource_pair.second;
+      }
+      last_heartbeat_resources_->SetAvailableResources(
+          ResourceSet(local_resources.GetAvailableResources()));
+    }
+  } else {
+    // If light resource usage report disabled, we send whole resources information
+    // every time.
+    for (const auto &resource_pair :
+         local_resources.GetTotalResources().GetResourceMap()) {
+      (*resources_data->mutable_resources_total())[resource_pair.first] =
+          resource_pair.second;
+    }
+
+    for (const auto &resource_pair :
+         local_resources.GetAvailableResources().GetResourceMap()) {
+      (*resources_data->mutable_resources_available())[resource_pair.first] =
+          resource_pair.second;
+    }
+  }
+}
+
+bool OldClusterResourceScheduler::UpdateNode(const std::string &node_id_string,
+                                             const rpc::ResourcesData &resource_data) {
+  NodeID node_id = NodeID::FromBinary(node_id_string);
+  auto iter = cluster_resource_map_.find(node_id);
+  if (iter == cluster_resource_map_.end()) {
+    return false;
+  }
+
+  SchedulingResources &remote_resources = iter->second;
+  // If light resource usage report enabled, we update remote resources only when related
+  // resources map in heartbeat is not empty.
+  if (RayConfig::instance().light_report_resource_usage_enabled()) {
+    if (resource_data.resources_total_size() > 0) {
+      ResourceSet remote_total(MapFromProtobuf(resource_data.resources_total()));
+      remote_resources.SetTotalResources(std::move(remote_total));
+    }
+    if (resource_data.resources_available_changed()) {
+      ResourceSet remote_available(MapFromProtobuf(resource_data.resources_available()));
+      remote_resources.SetAvailableResources(std::move(remote_available));
+    }
+    if (resource_data.resource_load_changed()) {
+      ResourceSet remote_load(MapFromProtobuf(resource_data.resource_load()));
+      // Extract the load information and save it locally.
+      remote_resources.SetLoadResources(std::move(remote_load));
+    }
+  } else {
+    // If light resource usage report disabled, we update remote resources every time.
+    ResourceSet remote_total(MapFromProtobuf(resource_data.resources_total()));
+    remote_resources.SetTotalResources(std::move(remote_total));
+    ResourceSet remote_available(MapFromProtobuf(resource_data.resources_available()));
+    remote_resources.SetAvailableResources(std::move(remote_available));
+    ResourceSet remote_load(MapFromProtobuf(resource_data.resource_load()));
+    // Extract the load information and save it locally.
+    remote_resources.SetLoadResources(std::move(remote_load));
+  }
+  return true;
+}
+
+std::string OldClusterResourceScheduler::GetLocalResourceViewString() const {
+  SchedulingResources &local_resources =
+      cluster_resource_map_[NodeID::FromBinary(self_node_id_string_)];
+  return local_resources.GetAvailableResources().ToString();
+}
+
+}  // namespace ray

--- a/src/ray/raylet/scheduling/old_cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/old_cluster_resource_scheduler.h
@@ -1,0 +1,74 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "ray/common/task/scheduling_resources.h"
+#include "ray/raylet/scheduling/cluster_resource_scheduler_interface.h"
+
+namespace ray {
+class OldClusterResourceScheduler : public ClusterResourceSchedulerInterface {
+ public:
+  explicit OldClusterResourceScheduler(
+      const NodeID &self_node_id, ResourceIdSet &local_available_resources,
+      std::unordered_map<NodeID, SchedulingResources> &cluster_resource_map,
+      std::shared_ptr<SchedulingResources> last_heartbeat_resources);
+
+  /// Remove node from the cluster data structure. This happens
+  /// when a node fails or it is removed from the cluster.
+  ///
+  /// \param node_id_string ID of the node to be removed.
+  bool RemoveNode(const std::string &node_id_string) override;
+
+  /// Update node resources. This hanppens when a node resource usage udpated.
+  ///
+  /// \param node_id_string ID of the node which resoruces need to be udpated.
+  /// \param resource_data The node resource data.
+  bool UpdateNode(const std::string &node_id_string,
+                  const rpc::ResourcesData &resource_data) override;
+
+  /// \param node_name: Node whose resource we want to update.
+  /// \param resource_name: Resource which we want to update.
+  /// \param resource_total: New capacity of the resource.
+  void UpdateResourceCapacity(const std::string &node_id_string,
+                              const std::string &resource_name,
+                              double resource_total) override;
+
+  /// Delete a given resource from a given node.
+  ///
+  /// \param node_name: Node whose resource we want to delete.
+  /// \param resource_name: Resource we want to delete
+  void DeleteResource(const std::string &node_id_string,
+                      const std::string &resource_name) override;
+
+  /// Populate the relevant parts of the heartbeat table. This is intended for
+  /// sending raylet <-> gcs heartbeats. In particular, this should fill in
+  /// resources_available and resources_total.
+  ///
+  /// \param light_report_resource_usage_enabled Only send changed fields if true.
+  /// \param Output parameter. `resources_available` and `resources_total` are the only
+  /// fields used.
+  void FillResourceUsage(bool light_report_resource_usage_enabled,
+                         std::shared_ptr<rpc::ResourcesData> data) override;
+
+  /// Return local resources in human-readable string form.
+  std::string GetLocalResourceViewString() const override;
+
+ private:
+  std::string self_node_id_string_;
+  ResourceIdSet &local_available_resources_;
+  std::unordered_map<NodeID, SchedulingResources> &cluster_resource_map_;
+  std::shared_ptr<SchedulingResources> last_heartbeat_resources_;
+};
+}  // namespace ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Now the new_scheduler_enabled_ is everywhere inside node_manager.cc, which leads to poor readability of the code. Meanwhile, one need to be very careful when changing the related logic, because you have to worry about whether the changed code will affect new/old scheduler.

if (new_scheduler_enabled_) {
  ...
} else {
  ...
}
Based on the above considerations, both `ClusterResourceScheduler` and `ClusterTaskManager` should be abstracted. 

This is the first PR to abstract `ClusterResourceScheduler`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
