### PR TITLE
[GCS]Fix gcs table storage `GetAll` and `GetByJobId` api bug

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_table_storage.cc
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.cc
@@ -49,9 +49,11 @@ Status GcsTable<Key, Data>::GetAll(const MapCallback<Key, Data> &callback) {
   auto on_done = [callback](const std::unordered_map<std::string, std::string> &result) {
     std::unordered_map<Key, Data> values;
     for (auto &item : result) {
-      Data data;
-      data.ParseFromString(item.second);
-      values[Key::FromBinary(item.first)] = data;
+      if (!item.second.empty()) {
+        Data data;
+        data.ParseFromString(item.second);
+        values[Key::FromBinary(item.first)] = data;
+      }
     }
     callback(values);
   };
@@ -89,9 +91,11 @@ Status GcsTableWithJobId<Key, Data>::GetByJobId(const JobID &job_id,
   auto on_done = [callback](const std::unordered_map<std::string, std::string> &result) {
     std::unordered_map<Key, Data> values;
     for (auto &item : result) {
-      Data data;
-      data.ParseFromString(item.second);
-      values[Key::FromBinary(item.first)] = std::move(data);
+      if (!item.second.empty()) {
+        Data data;
+        data.ParseFromString(item.second);
+        values[Key::FromBinary(item.first)] = std::move(data);
+      }
     }
     callback(values);
   };


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`GetAll` and `GetByJobId` api are asynchronous. During execution, some keys may be deleted, so that empty data will be read.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
