### PR TITLE
Use wait_for_condition to reduce flakiness in test_queue.py::test_custom_resources

### DIFF
--- a/python/ray/tests/test_queue.py
+++ b/python/ray/tests/test_queue.py
@@ -1,10 +1,9 @@
-import time
-
 import pytest
 
 import ray
 from ray.exceptions import GetTimeoutError, RayActorError
 from ray.util.queue import Queue, Empty, Full
+from ray.test_utils import wait_for_condition
 
 
 # Remote helper functions for testing concurrency
@@ -206,9 +205,11 @@ def test_custom_resources(ray_start_regular_shared):
 
     # Specify resource requirement. The queue should now reserve 1 CPU.
     Queue(actor_options={"num_cpus": 1})
-    time.sleep(1)
-    current_resources = ray.available_resources()
-    assert "CPU" not in current_resources, current_resources
+
+    def no_cpu_in_resources():
+        return "CPU" not in ray.available_resources()
+
+    wait_for_condition(no_cpu_in_resources)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/13200

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
