### PR TITLE
[Core] Ownership-based Object Directory: Consolidate location table and reference table.

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -914,7 +914,7 @@ cdef class CoreWorker:
                             CObjectID *c_object_id, shared_ptr[CBuffer] *data):
         if object_ref is None:
             with nogil:
-                check_status(CCoreWorkerProcess.GetCoreWorker().Create(
+                check_status(CCoreWorkerProcess.GetCoreWorker().CreateOwned(
                              metadata, data_size, contained_ids,
                              c_object_id, data))
         else:
@@ -1008,7 +1008,8 @@ cdef class CoreWorker:
             else:
                 with nogil:
                     if object_ref is None:
-                        check_status(CCoreWorkerProcess.GetCoreWorker().Seal(
+                        check_status(
+                            CCoreWorkerProcess.GetCoreWorker().SealOwned(
                                         c_object_id,
                                         pin_object))
                     else:

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -920,7 +920,7 @@ cdef class CoreWorker:
         else:
             c_object_id[0] = object_ref.native()
             with nogil:
-                check_status(CCoreWorkerProcess.GetCoreWorker().Create(
+                check_status(CCoreWorkerProcess.GetCoreWorker().CreateExisting(
                             metadata, data_size, c_object_id[0],
                             CCoreWorkerProcess.GetCoreWorker().GetRpcAddress(),
                             data))
@@ -932,7 +932,7 @@ cdef class CoreWorker:
         return data.get() == NULL
 
     def put_file_like_object(
-            self, metadata, data_size, file_like, ObjectRef object_ref=None):
+            self, metadata, data_size, file_like, ObjectRef object_ref):
         """Directly create a new Plasma Store object from a file like
         object. This avoids extra memory copy.
 
@@ -970,8 +970,9 @@ cdef class CoreWorker:
             # Using custom object refs is not supported because we
             # can't track their lifecycle, so we don't pin the object
             # in this case.
-            check_status(CCoreWorkerProcess.GetCoreWorker().Seal(
-                         c_object_id, pin_object=False))
+            check_status(
+                CCoreWorkerProcess.GetCoreWorker().SealExisting(
+                            c_object_id, pin_object=False))
 
     def put_serialized_object(self, serialized_object,
                               ObjectRef object_ref=None,
@@ -1006,12 +1007,17 @@ cdef class CoreWorker:
                         c_object_id_vector, c_object_id))
             else:
                 with nogil:
-                    # Using custom object refs is not supported because we
-                    # can't track their lifecycle, so we don't pin the object
-                    # in this case.
-                    check_status(CCoreWorkerProcess.GetCoreWorker().Seal(
-                                    c_object_id,
-                                    pin_object and object_ref is None))
+                    if object_ref is None:
+                        check_status(CCoreWorkerProcess.GetCoreWorker().Seal(
+                                        c_object_id,
+                                        pin_object))
+                    else:
+                        # Using custom object refs is not supported because we
+                        # can't track their lifecycle, so we don't pin the
+                        # object in this case.
+                        check_status(
+                            CCoreWorkerProcess.GetCoreWorker().SealExisting(
+                                        c_object_id, pin_object=False))
 
         return c_object_id.Binary()
 

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -168,12 +168,13 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
                           const size_t data_size,
                           const c_vector[CObjectID] &contained_object_ids,
                           CObjectID *object_id, shared_ptr[CBuffer] *data)
-        CRayStatus Create(const shared_ptr[CBuffer] &metadata,
-                          const size_t data_size,
-                          const CObjectID &object_id,
-                          const CAddress &owner_address,
-                          shared_ptr[CBuffer] *data)
+        CRayStatus CreateExisting(const shared_ptr[CBuffer] &metadata,
+                                  const size_t data_size,
+                                  const CObjectID &object_id,
+                                  const CAddress &owner_address,
+                                  shared_ptr[CBuffer] *data)
         CRayStatus Seal(const CObjectID &object_id, c_bool pin_object)
+        CRayStatus SealExisting(const CObjectID &object_id, c_bool pin_object)
         CRayStatus Get(const c_vector[CObjectID] &ids, int64_t timeout_ms,
                        c_vector[shared_ptr[CRayObject]] *results,
                        c_bool plasma_objects_only)

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -164,16 +164,16 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         CRayStatus Put(const CRayObject &object,
                        const c_vector[CObjectID] &contained_object_ids,
                        const CObjectID &object_id)
-        CRayStatus Create(const shared_ptr[CBuffer] &metadata,
-                          const size_t data_size,
-                          const c_vector[CObjectID] &contained_object_ids,
-                          CObjectID *object_id, shared_ptr[CBuffer] *data)
+        CRayStatus CreateOwned(const shared_ptr[CBuffer] &metadata,
+                               const size_t data_size,
+                               const c_vector[CObjectID] &contained_object_ids,
+                               CObjectID *object_id, shared_ptr[CBuffer] *data)
         CRayStatus CreateExisting(const shared_ptr[CBuffer] &metadata,
                                   const size_t data_size,
                                   const CObjectID &object_id,
                                   const CAddress &owner_address,
                                   shared_ptr[CBuffer] *data)
-        CRayStatus Seal(const CObjectID &object_id, c_bool pin_object)
+        CRayStatus SealOwned(const CObjectID &object_id, c_bool pin_object)
         CRayStatus SealExisting(const CObjectID &object_id, c_bool pin_object)
         CRayStatus Get(const c_vector[CObjectID] &ids, int64_t timeout_ms,
                        c_vector[shared_ptr[CRayObject]] *results,

--- a/python/ray/test_utils.py
+++ b/python/ray/test_utils.py
@@ -370,6 +370,13 @@ def put_object(obj, use_ray_put):
         return _put.remote(obj)
 
 
+def put_unpinned_object(obj):
+    value = ray.worker.global_worker.get_serialization_context().serialize(obj)
+    return ray.ObjectRef(
+        ray.worker.global_worker.core_worker.put_serialized_object(
+            value, pin_object=False))
+
+
 def wait_until_server_available(address,
                                 timeout_ms=5000,
                                 retry_interval_ms=100):

--- a/python/ray/tests/test_memory_limits.py
+++ b/python/ray/tests/test_memory_limits.py
@@ -2,6 +2,7 @@ import numpy as np
 import unittest
 
 import ray
+from ray.test_utils import put_unpinned_object
 
 MB = 1024 * 1024
 
@@ -49,7 +50,7 @@ class TestMemoryLimits(unittest.TestCase):
         try:
             ray.init(num_cpus=1, _driver_object_store_memory=100 * MB)
             ray.worker.global_worker.put_object(
-                np.zeros(50 * MB, dtype=np.uint8), pin_object=False)
+                np.zeros(50 * MB, dtype=np.uint8))
             self.assertRaises(
                 OBJECT_TOO_LARGE,
                 lambda: ray.put(np.zeros(200 * MB, dtype=np.uint8)))
@@ -64,7 +65,7 @@ class TestMemoryLimits(unittest.TestCase):
                 object_store_memory=300 * MB,
                 _driver_object_store_memory=driver_quota)
             obj = np.ones(200 * 1024, dtype=np.uint8)
-            z = ray.worker.global_worker.put_object(obj, pin_object=False)
+            z = put_unpinned_object(obj)
             a = LightActor._remote(object_store_memory=a_quota)
             b = GreedyActor._remote(object_store_memory=b_quota)
             for _ in range(5):

--- a/python/ray/tests/test_unreconstructable_errors.py
+++ b/python/ray/tests/test_unreconstructable_errors.py
@@ -2,6 +2,7 @@ import numpy as np
 import unittest
 
 import ray
+from ray.test_utils import put_unpinned_object
 
 
 class TestObjectLostErrors(unittest.TestCase):
@@ -15,8 +16,7 @@ class TestObjectLostErrors(unittest.TestCase):
         ray.shutdown()
 
     def testDriverPutEvictedCannotReconstruct(self):
-        x_id = ray.worker.global_worker.put_object(
-            np.zeros(1 * 1024 * 1024), pin_object=False)
+        x_id = put_unpinned_object(np.zeros(1 * 1024 * 1024))
         ray.get(x_id)
         for _ in range(20):
             ray.put(np.zeros(10 * 1024 * 1024))

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -228,7 +228,7 @@ class Worker:
     def set_load_code_from_local(self, load_code_from_local):
         self._load_code_from_local = load_code_from_local
 
-    def put_object(self, value, object_ref=None, pin_object=True):
+    def put_object(self, value, object_ref=None):
         """Put value in the local object store with object reference `object_ref`.
 
         This assumes that the value for `object_ref` has not yet been placed in
@@ -242,7 +242,6 @@ class Worker:
             value: The value to put in the object store.
             object_ref (ObjectRef): The object ref of the value to be
                 put. If None, one will be generated.
-            pin_object: If set, the object will be pinned at the raylet.
 
         Returns:
             ObjectRef: The object ref the object was put under.
@@ -274,8 +273,7 @@ class Worker:
         # reference counter.
         return ray.ObjectRef(
             self.core_worker.put_serialized_object(
-                serialized_value, object_ref=object_ref,
-                pin_object=pin_object))
+                serialized_value, object_ref=object_ref))
 
     def deserialize_objects(self, data_metadata_pairs, object_refs):
         context = self.get_serialization_context()
@@ -1423,7 +1421,7 @@ def put(value):
     worker.check_connected()
     with profiling.profile("ray.put"):
         try:
-            object_ref = worker.put_object(value, pin_object=True)
+            object_ref = worker.put_object(value)
         except ObjectStoreFullError:
             logger.info(
                 "Put failed since the value was either too large or the "

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -910,9 +910,10 @@ Status CoreWorker::Put(const RayObject &object,
   return Status::OK();
 }
 
-Status CoreWorker::Create(const std::shared_ptr<Buffer> &metadata, const size_t data_size,
-                          const std::vector<ObjectID> &contained_object_ids,
-                          ObjectID *object_id, std::shared_ptr<Buffer> *data) {
+Status CoreWorker::CreateOwned(const std::shared_ptr<Buffer> &metadata,
+                               const size_t data_size,
+                               const std::vector<ObjectID> &contained_object_ids,
+                               ObjectID *object_id, std::shared_ptr<Buffer> *data) {
   *object_id = ObjectID::FromIndex(worker_context_.GetCurrentTaskID(),
                                    worker_context_.GetNextPutIndex());
   reference_counter_->AddOwnedObject(*object_id, contained_object_ids, rpc_address_,
@@ -949,7 +950,7 @@ Status CoreWorker::CreateExisting(const std::shared_ptr<Buffer> &metadata,
   }
 }
 
-Status CoreWorker::Seal(const ObjectID &object_id, bool pin_object) {
+Status CoreWorker::SealOwned(const ObjectID &object_id, bool pin_object) {
   auto status = SealExisting(object_id, pin_object);
   if (!status.ok()) {
     reference_counter_->RemoveOwnedObject(object_id);

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2182,7 +2182,7 @@ void CoreWorker::HandleGetObjectLocationsOwner(
                            send_reply_callback)) {
     return;
   }
-  auto node_ids =
+  absl::flat_hash_set<NodeID> node_ids =
       reference_counter_->GetObjectLocations(ObjectID::FromBinary(request.object_id()));
   for (const auto &node_id : node_ids) {
     reply->add_node_ids(node_id.Binary());

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -950,7 +950,11 @@ Status CoreWorker::Create(const std::shared_ptr<Buffer> &metadata, const size_t 
 
 Status CoreWorker::Seal(const ObjectID &object_id, bool pin_object,
                         const absl::optional<rpc::Address> &owner_address) {
-  RAY_RETURN_NOT_OK(plasma_store_provider_->Seal(object_id));
+  auto status = plasma_store_provider_->Seal(object_id);
+  if (!status.ok()) {
+    reference_counter_->RemoveOwnedObject(object_id);
+    return status;
+  }
   if (pin_object) {
     // Tell the raylet to pin the object **after** it is created.
     RAY_LOG(DEBUG) << "Pinning sealed object " << object_id;

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2182,7 +2182,7 @@ void CoreWorker::HandleGetObjectLocationsOwner(
                            send_reply_callback)) {
     return;
   }
-  std::unordered_set<NodeID> node_ids =
+  auto node_ids =
       reference_counter_->GetObjectLocations(ObjectID::FromBinary(request.object_id()));
   for (const auto &node_id : node_ids) {
     reply->add_node_ids(node_id.Binary());

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -508,9 +508,10 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
                 std::shared_ptr<Buffer> *data);
 
   /// Create and return a buffer in the object store that can be directly written
-  /// into. After writing to the buffer, the caller must call `Seal()` to finalize
-  /// the object. The `Create()` and `Seal()` combination is an alternative interface
-  /// to `Put()` that allows frontends to avoid an extra copy when possible.
+  /// into, for an object ID that already exists. After writing to the buffer, the
+  /// caller must call `SealExisting()` to finalize the object. The `CreateExisting()`
+  /// and `SealExisting()` combination is an alternative interface to `Put()` that
+  /// allows frontends to avoid an extra copy when possible.
   ///
   /// \param[in] metadata Metadata of the object to be written.
   /// \param[in] data_size Size of the object to be written.
@@ -518,20 +519,28 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] owner_address The address of the object's owner.
   /// \param[out] data Buffer for the user to write the object into.
   /// \return Status.
-  Status Create(const std::shared_ptr<Buffer> &metadata, const size_t data_size,
-                const ObjectID &object_id, const rpc::Address &owner_address,
-                std::shared_ptr<Buffer> *data);
+  Status CreateExisting(const std::shared_ptr<Buffer> &metadata, const size_t data_size,
+                        const ObjectID &object_id, const rpc::Address &owner_address,
+                        std::shared_ptr<Buffer> *data);
 
   /// Finalize placing an object into the object store. This should be called after
   /// a corresponding `Create()` call and then writing into the returned buffer.
   ///
   /// \param[in] object_id Object ID corresponding to the object.
   /// \param[in] pin_object Whether or not to pin the object at the local raylet.
+  /// \return Status.
+  Status Seal(const ObjectID &object_id, bool pin_object);
+
+  /// Finalize placing an object into the object store. This should be called after
+  /// a corresponding `CreateExisting()` call and then writing into the returned buffer.
+  ///
+  /// \param[in] object_id Object ID corresponding to the object.
+  /// \param[in] pin_object Whether or not to pin the object at the local raylet.
   /// \param[in] owner_address Address of the owner of the object who will be contacted by
   /// the raylet if the object is pinned. If not provided, defaults to this worker.
   /// \return Status.
-  Status Seal(const ObjectID &object_id, bool pin_object,
-              const absl::optional<rpc::Address> &owner_address = absl::nullopt);
+  Status SealExisting(const ObjectID &object_id, bool pin_object,
+                      const absl::optional<rpc::Address> &owner_address = absl::nullopt);
 
   /// Get a list of objects from the object store. Objects that failed to be retrieved
   /// will be returned as nullptrs.

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -493,9 +493,10 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
              const ObjectID &object_id, bool pin_object = false);
 
   /// Create and return a buffer in the object store that can be directly written
-  /// into. After writing to the buffer, the caller must call `Seal()` to finalize
-  /// the object. The `Create()` and `Seal()` combination is an alternative interface
-  /// to `Put()` that allows frontends to avoid an extra copy when possible.
+  /// into. After writing to the buffer, the caller must call `SealOwned()` to
+  /// finalize the object. The `CreateOwned()` and `SealOwned()` combination is
+  /// an alternative interface to `Put()` that allows frontends to avoid an extra
+  /// copy when possible.
   ///
   /// \param[in] metadata Metadata of the object to be written.
   /// \param[in] data_size Size of the object to be written.
@@ -503,9 +504,9 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[out] object_id Object ID generated for the put.
   /// \param[out] data Buffer for the user to write the object into.
   /// \return Status.
-  Status Create(const std::shared_ptr<Buffer> &metadata, const size_t data_size,
-                const std::vector<ObjectID> &contained_object_ids, ObjectID *object_id,
-                std::shared_ptr<Buffer> *data);
+  Status CreateOwned(const std::shared_ptr<Buffer> &metadata, const size_t data_size,
+                     const std::vector<ObjectID> &contained_object_ids,
+                     ObjectID *object_id, std::shared_ptr<Buffer> *data);
 
   /// Create and return a buffer in the object store that can be directly written
   /// into, for an object ID that already exists. After writing to the buffer, the
@@ -524,12 +525,12 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
                         std::shared_ptr<Buffer> *data);
 
   /// Finalize placing an object into the object store. This should be called after
-  /// a corresponding `Create()` call and then writing into the returned buffer.
+  /// a corresponding `CreateOwned()` call and then writing into the returned buffer.
   ///
   /// \param[in] object_id Object ID corresponding to the object.
   /// \param[in] pin_object Whether or not to pin the object at the local raylet.
   /// \return Status.
-  Status Seal(const ObjectID &object_id, bool pin_object);
+  Status SealOwned(const ObjectID &object_id, bool pin_object);
 
   /// Finalize placing an object into the object store. This should be called after
   /// a corresponding `CreateExisting()` call and then writing into the returned buffer.

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -172,6 +172,14 @@ class ReferenceCounter : public ReferenceCounterInterface,
       const absl::optional<NodeID> &pinned_at_raylet_id = absl::optional<NodeID>())
       LOCKS_EXCLUDED(mutex_);
 
+  /// Remove reference for an object that we own. The reference will only be
+  /// removed if the object's ref count is 0. This should only be used when
+  /// speculatively adding an owned reference that may need to be rolled back, e.g. if
+  /// the creation of the corresponding Plasma object fails.
+  ///
+  /// \param[in] object_id The ID of the object that we own and wish to remove.
+  void RemoveOwnedObject(const ObjectID &object_id) LOCKS_EXCLUDED(mutex_);
+
   /// Update the size of the object.
   ///
   /// \param[in] object_id The ID of the object.

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -175,7 +175,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// Remove reference for an object that we own. The reference will only be
   /// removed if the object's ref count is 0. This should only be used when
   /// speculatively adding an owned reference that may need to be rolled back, e.g. if
-  /// the creation of the corresponding Plasma object fails.
+  /// the creation of the corresponding Plasma object fails. All other references will
+  /// be cleaned up via the reference counting protocol.
   ///
   /// \param[in] object_id The ID of the object that we own and wish to remove.
   void RemoveOwnedObject(const ObjectID &object_id) LOCKS_EXCLUDED(mutex_);

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -373,22 +373,25 @@ class ReferenceCounter : public ReferenceCounterInterface,
   ///
   /// \param[in] object_id The object to update.
   /// \param[in] node_id The new object location to be added.
-  void AddObjectLocation(const ObjectID &object_id, const NodeID &node_id)
+  /// \return True if the reference exists, false otherwise.
+  bool AddObjectLocation(const ObjectID &object_id, const NodeID &node_id)
       LOCKS_EXCLUDED(mutex_);
 
   /// Remove a location for the given object.
   ///
   /// \param[in] object_id The object to update.
   /// \param[in] node_id The object location to be removed.
-  void RemoveObjectLocation(const ObjectID &object_id, const NodeID &node_id)
+  /// \return True if the reference exists, false otherwise.
+  bool RemoveObjectLocation(const ObjectID &object_id, const NodeID &node_id)
       LOCKS_EXCLUDED(mutex_);
 
   /// Get the locations of the given object.
   ///
   /// \param[in] object_id The object to get locations for.
-  /// \return The nodes that have the object.
-  absl::flat_hash_set<NodeID> GetObjectLocations(const ObjectID &object_id)
-      LOCKS_EXCLUDED(mutex_);
+  /// \return The nodes that have the object if the reference exists, empty optional
+  ///         otherwise.
+  absl::optional<absl::flat_hash_set<NodeID>> GetObjectLocations(
+      const ObjectID &object_id) LOCKS_EXCLUDED(mutex_);
 
   /// Handle an object has been spilled to external storage.
   ///

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -369,7 +369,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
       const absl::flat_hash_map<ObjectID, std::pair<int64_t, std::string>> pinned_objects,
       rpc::CoreWorkerStats *stats) const LOCKS_EXCLUDED(mutex_);
 
-  /// Add a new location for the given object.
+  /// Add a new location for the given object. The owner must have the object ref in
+  /// scope.
   ///
   /// \param[in] object_id The object to update.
   /// \param[in] node_id The new object location to be added.
@@ -377,7 +378,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
   bool AddObjectLocation(const ObjectID &object_id, const NodeID &node_id)
       LOCKS_EXCLUDED(mutex_);
 
-  /// Remove a location for the given object.
+  /// Remove a location for the given object. The owner must have the object ref in
+  /// scope.
   ///
   /// \param[in] object_id The object to update.
   /// \param[in] node_id The object location to be removed.
@@ -385,7 +387,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
   bool RemoveObjectLocation(const ObjectID &object_id, const NodeID &node_id)
       LOCKS_EXCLUDED(mutex_);
 
-  /// Get the locations of the given object.
+  /// Get the locations of the given object. The owner must have the object ref in
+  /// scope.
   ///
   /// \param[in] object_id The object to get locations for.
   /// \return The nodes that have the object if the reference exists, empty optional

--- a/src/ray/core_worker/reference_count_test.cc
+++ b/src/ray/core_worker/reference_count_test.cc
@@ -2108,6 +2108,16 @@ TEST_F(ReferenceCountTest, TestFree) {
   ASSERT_FALSE(rc->IsPlasmaObjectFreed(id));
 }
 
+TEST_F(ReferenceCountTest, TestRemoveOwnedObject) {
+  ObjectID id = ObjectID::FromRandom();
+
+  // Test remove owned object.
+  rc->AddOwnedObject(id, {}, rpc::Address(), "", 0, false);
+  ASSERT_TRUE(rc->HasReference(id));
+  rc->RemoveOwnedObject(id);
+  ASSERT_FALSE(rc->HasReference(id));
+}
+
 }  // namespace ray
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Consolidates the location table and reference table. This was initially blocked by the `Create()` + `Seal()` path, which would put the object into Plasma before adding a reference to the reference counter's reference table; that has been rectified in this PR.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Reduces complexity and table bloat in the reference counter, and makes the reference table the sole source-of-truth for locality data, used for locality-aware scheduling.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #13203 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## TODOs:

- [x] Tests