### PR TITLE
[Cancellation] Make Test Cancel Easier to Debug

### DIFF
--- a/python/ray/tests/test_cancel.py
+++ b/python/ray/tests/test_cancel.py
@@ -185,16 +185,16 @@ def test_stress(shutdown_only, use_force):
 
     for done in cancelled:
         with pytest.raises(valid_exceptions(use_force)):
-            ray.get(done)
+            ray.get(done, timeout=120)
     for indx, t in enumerate(tasks):
         if sleep_or_no[indx]:
             ray.cancel(t, force=use_force)
             cancelled.add(t)
         if t in cancelled:
             with pytest.raises(valid_exceptions(use_force)):
-                ray.get(t)
+                ray.get(t, timeout=120)
         else:
-            ray.get(t)
+            ray.get(t, timeout=120)
 
 
 @pytest.mark.parametrize("use_force", [True, False])
@@ -209,6 +209,12 @@ def test_fast(shutdown_only, use_force):
     ids = list()
     for _ in range(100):
         x = fast.remote("a")
+        # NOTE If a non-force Cancellation is attempted in the time 
+        # between a worker receiving a task and the worker executing
+        # that task (specifically the python execution), Cancellation
+        # can fail.
+        if not use_force:
+            time.sleep(0.1)
         ray.cancel(x, force=use_force)
         ids.append(x)
 
@@ -225,11 +231,11 @@ def test_fast(shutdown_only, use_force):
         if random.random() > 0.95:
             ray.cancel(ids[idx], force=use_force)
     signaler.send.remote()
-    for obj_ref in ids:
+    for i, obj_ref in enumerate(ids):
         try:
-            ray.get(obj_ref)
+            ray.get(obj_ref, timeout=120)
         except Exception as e:
-            assert isinstance(e, valid_exceptions(use_force))
+            assert isinstance(e, valid_exceptions(use_force)), f"Failure on iteration {i}"
 
 
 @pytest.mark.parametrize("use_force", [True, False])

--- a/python/ray/tests/test_cancel.py
+++ b/python/ray/tests/test_cancel.py
@@ -209,7 +209,7 @@ def test_fast(shutdown_only, use_force):
     ids = list()
     for _ in range(100):
         x = fast.remote("a")
-        # NOTE If a non-force Cancellation is attempted in the time 
+        # NOTE If a non-force Cancellation is attempted in the time
         # between a worker receiving a task and the worker executing
         # that task (specifically the python execution), Cancellation
         # can fail.
@@ -235,7 +235,8 @@ def test_fast(shutdown_only, use_force):
         try:
             ray.get(obj_ref, timeout=120)
         except Exception as e:
-            assert isinstance(e, valid_exceptions(use_force)), f"Failure on iteration {i}"
+            assert isinstance(
+                e, valid_exceptions(use_force)), f"Failure on iteration: {i}"
 
 
 @pytest.mark.parametrize("use_force", [True, False])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* Makes it more clear why `test_fast` and `test_stress` fail. The **2 minute** timeout should not introduce any flakiness.
* Adds a sleep in `test_fast` to avoid a potential race condition with rapid cancelling.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
