### PR TITLE
[Serve] Rescale Serve's Long Running Test to Cluster Mode

### DIFF
--- a/release/long_running_tests/workloads/serve.py
+++ b/release/long_running_tests/workloads/serve.py
@@ -11,7 +11,7 @@ from ray.cluster_utils import Cluster
 num_redis_shards = 1
 redis_max_memory = 10**8
 object_store_memory = 10**8
-num_nodes = 1
+num_nodes = 4
 cluster = Cluster()
 for i in range(num_nodes):
     cluster.add_node(

--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -11,7 +11,7 @@ from ray.cluster_utils import Cluster
 num_redis_shards = 1
 redis_max_memory = 10**8
 object_store_memory = 10**8
-num_nodes = 1
+num_nodes = 4
 cpus_per_node = 10
 cluster = Cluster()
 for i in range(num_nodes):
@@ -39,10 +39,9 @@ class RandomKiller:
 
     def _get_all_serve_actors(self):
         controller = self.client._controller
-        routers = list(ray.get(controller.get_routers.remote()).values())
+        routers = list(ray.get(controller.get_http_proxies.remote()).values())
         all_handles = routers + [controller]
-        worker_handle_dict = ray.get(
-            controller.get_all_worker_handles.remote())
+        worker_handle_dict = ray.get(controller._all_replica_handles.remote())
         for _, replica_dict in worker_handle_dict.items():
             all_handles.extend(list(replica_dict.values()))
 


### PR DESCRIPTION
Now that `HeadOnly` becomes the new default HTTP location, we can re-enable the long running tests to use local multi-clusters. (also fixed the controller's API to match up to date, we should have caught these, I will open issues for this.)

Verified by running the releaser tool.

<img width="1259" alt="Screen Shot 2021-01-06 at 3 11 40 PM" src="https://user-images.githubusercontent.com/21118851/103833319-91878a80-5035-11eb-894c-5e1061e86947.png">


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #12779
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
