### PR TITLE
Fix passing env on windows

### DIFF
--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -139,6 +139,15 @@ class ProcessFD {
         STARTUPINFO si = {sizeof(si)};
         RAY_UNUSED(
             new_env_block.c_str());  // Ensure there's a final terminator for Windows
+        // MSDN:
+        // https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa
+        // Note that an ANSI environment block is terminated by two zero bytes:
+        // one for the last string, one more to terminate the block.
+        // A Unicode environment block is terminated by four zero bytes:
+        // two for the last string, two more to terminate the block.
+        if (!new_env_block.empty()) {
+          new_env_block += '\0';
+        }
         char *const envp = &new_env_block[0];
         if (CreateProcessA(NULL, cmdline, NULL, NULL, FALSE, 0, envp, NULL, &si, &pi)) {
           succeeded = true;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

- Problem
  - The environment vars passed by raylet to the child process is incorrect.
- Solution
  - Add an `\0` to the end of `lpEnvironment` in process.cc.

## References
MSDN: https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa

> Note that an ANSI environment block is terminated by two zero bytes: one for the last string, one more to terminate the block. A Unicode environment block is terminated by four zero bytes: two for the last string, two more to terminate the block.

### Example
https://docs.microsoft.com/en-us/windows/win32/procthread/changing-environment-variables

## Why not use Boost.Process?
https://github.com/ray-project/ray/pull/9860#discussion_r466872104

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/13199
Reverts https://github.com/ray-project/ray/pull/12948

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
