### PR TITLE
[Core]Fix ray.kill doesn't cancel pending actor bug

### DIFF
--- a/java/test/src/main/java/io/ray/test/KillActorTest.java
+++ b/java/test/src/main/java/io/ray/test/KillActorTest.java
@@ -59,6 +59,8 @@ public class KillActorTest extends BaseTest {
 
   private void testKillActor(BiConsumer<ActorHandle<?>, Boolean> kill, boolean noRestart) {
     ActorHandle<HangActor> actor = Ray.actor(HangActor::new).setMaxRestarts(1).remote();
+    // Wait for the actor to be created.
+    actor.task(HangActor::ping).remote().get();
     ObjectRef<Boolean> result = actor.task(HangActor::hang).remote();
     // The actor will hang in this task.
     Assert.assertEquals(0, Ray.wait(ImmutableList.of(result), 1, 500).getReady().size());

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1093,6 +1093,42 @@ def test_actor_resource_demand(shutdown_only):
     global_state_accessor.disconnect()
 
 
+def test_kill_pending_actor():
+    cluster = ray.init()
+    global_state_accessor = GlobalStateAccessor(
+        cluster["redis_address"], ray.ray_constants.REDIS_DEFAULT_PASSWORD)
+    global_state_accessor.connect()
+
+    @ray.remote(resources={"WORKER": 1.0})
+    class PendingActor:
+        pass
+
+    # kill actor with `no_restart=True`.
+    actor1 = PendingActor.remote()
+    ray.kill(actor1, no_restart=True) # Do not wait until it starts.
+    def condition1():
+        message = global_state_accessor.get_all_resource_usage()
+        resource_usages = ray.gcs_utils.ResourceUsageBatchData.FromString(message)
+        if len(resource_usages.resource_load_by_shape.resource_demands) == 0:
+            return True
+        return False
+    wait_for_condition(condition1, timeout=10)
+
+    # kill actor with `no_restart=False`.
+    actor2 = PendingActor.remote()
+    ray.kill(actor2, no_restart=False) # Do not wait until it starts.
+    def condition2():
+        message = global_state_accessor.get_all_resource_usage()
+        resource_usages = ray.gcs_utils.ResourceUsageBatchData.FromString(message)
+        if len(resource_usages.resource_load_by_shape.resource_demands) == 1:
+            return True
+        return False
+    wait_for_condition(condition2, timeout=10)
+
+    global_state_accessor.disconnect()
+    ray.shutdown()
+
+
 if __name__ == "__main__":
     import pytest
     # Test suite is timing out. Disable on windows for now.

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1159,7 +1159,8 @@ def test_kill_pending_actor_with_no_restart_false():
     # Actor restarts, so the infeasible task queue length is 1.
     wait_for_condition(condition1, timeout=10)
 
-    # Kill actor again and actor is dead, so the infeasible task queue length is 0.
+    # Kill actor again and actor is dead,
+    # so the infeasible task queue length is 0.
     ray.kill(actor, no_restart=False)
 
     def condition2():

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1105,7 +1105,10 @@ def test_kill_pending_actor_with_no_restart_true():
 
     # Kill actor with `no_restart=True`.
     actor = PendingActor.remote()
-    # TODO(ffbin): The raylet doesn't guarantee the order when dealing with RequestWorkerLease and CancelWorkerLease. If we kill the actor immediately after creating the actor, we may not be able to clean up the request cached by the raylet.
+    # TODO(ffbin): The raylet doesn't guarantee the order when dealing with
+    # RequestWorkerLease and CancelWorkerLease. If we kill the actor
+    # immediately after creating the actor, we may not be able to clean up
+    # the request cached by the raylet.
     # See https://github.com/ray-project/ray/issues/13545 for details.
     time.sleep(1)
     ray.kill(actor, no_restart=True)
@@ -1137,7 +1140,10 @@ def test_kill_pending_actor_with_no_restart_false():
 
     # Kill actor with `no_restart=False`.
     actor = PendingActor.remote()
-    # TODO(ffbin): The raylet doesn't guarantee the order when dealing with RequestWorkerLease and CancelWorkerLease. If we kill the actor immediately after creating the actor, we may not be able to clean up the request cached by the raylet.
+    # TODO(ffbin): The raylet doesn't guarantee the order when dealing with
+    # RequestWorkerLease and CancelWorkerLease. If we kill the actor
+    # immediately after creating the actor, we may not be able to clean up
+    # the request cached by the raylet.
     # See https://github.com/ray-project/ray/issues/13545 for details.
     time.sleep(1)
     ray.kill(actor, no_restart=False)
@@ -1155,6 +1161,7 @@ def test_kill_pending_actor_with_no_restart_false():
 
     # Kill actor again and actor is dead, so the infeasible task queue length is 0.
     ray.kill(actor, no_restart=False)
+
     def condition2():
         message = global_state_accessor.get_all_resource_usage()
         resource_usages = ray.gcs_utils.ResourceUsageBatchData.FromString(

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1105,24 +1105,30 @@ def test_kill_pending_actor():
 
     # kill actor with `no_restart=True`.
     actor1 = PendingActor.remote()
-    ray.kill(actor1, no_restart=True) # Do not wait until it starts.
+    ray.kill(actor1, no_restart=True)  # Do not wait until it starts.
+
     def condition1():
         message = global_state_accessor.get_all_resource_usage()
-        resource_usages = ray.gcs_utils.ResourceUsageBatchData.FromString(message)
+        resource_usages = ray.gcs_utils.ResourceUsageBatchData.FromString(
+            message)
         if len(resource_usages.resource_load_by_shape.resource_demands) == 0:
             return True
         return False
+
     wait_for_condition(condition1, timeout=10)
 
     # kill actor with `no_restart=False`.
     actor2 = PendingActor.remote()
-    ray.kill(actor2, no_restart=False) # Do not wait until it starts.
+    ray.kill(actor2, no_restart=False)  # Do not wait until it starts.
+
     def condition2():
         message = global_state_accessor.get_all_resource_usage()
-        resource_usages = ray.gcs_utils.ResourceUsageBatchData.FromString(message)
+        resource_usages = ray.gcs_utils.ResourceUsageBatchData.FromString(
+            message)
         if len(resource_usages.resource_load_by_shape.resource_demands) == 1:
             return True
         return False
+
     wait_for_condition(condition2, timeout=10)
 
     global_state_accessor.disconnect()

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -1419,8 +1419,10 @@ ray.shutdown()
 
     # Kill an actor and wait until it is killed.
     ray.kill(a)
-    with pytest.raises(ray.exceptions.RayActorError):
+    try:
         ray.get(a.ready.remote())
+    except ray.exceptions.RayActorError:
+        pass
 
     # We should have 2 alive pgs and 4 alive actors.
     assert assert_alive_num_pg(2)

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -901,8 +901,10 @@ def test_capture_child_actors(ray_start_cluster):
 
     # Kill an actor and wait until it is killed.
     ray.kill(a)
-    with pytest.raises(ray.exceptions.RayActorError):
+    try:
         ray.get(a.ready.remote())
+    except ray.exceptions.RayActorError:
+        pass
 
     # Now create an actor, but do not capture the current tasks
     a = Actor.options(
@@ -924,8 +926,10 @@ def test_capture_child_actors(ray_start_cluster):
 
     # Kill an actor and wait until it is killed.
     ray.kill(a)
-    with pytest.raises(ray.exceptions.RayActorError):
+    try:
         ray.get(a.ready.remote())
+    except ray.exceptions.RayActorError:
+        pass
 
     # Lastly, make sure when None is specified, actors are not scheduled
     # on the same placement group.

--- a/python/ray/tests/test_queue.py
+++ b/python/ray/tests/test_queue.py
@@ -199,12 +199,12 @@ def test_custom_resources(ray_start_regular_shared):
     assert current_resources["CPU"] == 1.0
 
     # By default an actor should not reserve any resources.
-    Queue()
+    p1 = Queue()
     current_resources = ray.available_resources()
     assert current_resources["CPU"] == 1.0
 
     # Specify resource requirement. The queue should now reserve 1 CPU.
-    Queue(actor_options={"num_cpus": 1})
+    p2 = Queue(actor_options={"num_cpus": 1})
 
     def no_cpu_in_resources():
         return "CPU" not in ray.available_resources()

--- a/python/ray/tests/test_queue.py
+++ b/python/ray/tests/test_queue.py
@@ -199,17 +199,19 @@ def test_custom_resources(ray_start_regular_shared):
     assert current_resources["CPU"] == 1.0
 
     # By default an actor should not reserve any resources.
-    p1 = Queue()
+    q = Queue()
     current_resources = ray.available_resources()
     assert current_resources["CPU"] == 1.0
+    q.shutdown()
 
     # Specify resource requirement. The queue should now reserve 1 CPU.
-    p2 = Queue(actor_options={"num_cpus": 1})
+    q = Queue(actor_options={"num_cpus": 1})
 
     def no_cpu_in_resources():
         return "CPU" not in ray.available_resources()
 
     wait_for_condition(no_cpu_in_resources)
+    q.shutdown()
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -470,8 +470,10 @@ def test_actor_holding_serialized_reference(one_worker_100MiB, use_ray_put,
         # Test that the actor exiting stops the reference from being pinned.
         ray.kill(actor)
         # Wait for the actor to exit.
-        with pytest.raises(ray.exceptions.RayActorError):
+        try:
             ray.get(actor.delete_ref1.remote())
+        except ray.exceptions.RayActorError:
+            pass
     else:
         # Test that deleting the second reference stops it from being pinned.
         ray.get(actor.delete_ref2.remote())

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1629,11 +1629,8 @@ Status CoreWorker::KillActor(const ActorID &actor_id, bool force_kill, bool no_r
     return Status::Invalid(stream.str());
   }
 
-  if (no_restart) {
-    RAY_CHECK_OK(gcs_client_->Actors().AsyncDestroyActor(actor_id, nullptr));
-  } else {
-    direct_actor_submitter_->KillActor(actor_id, force_kill, no_restart);
-  }
+  RAY_CHECK_OK(
+      gcs_client_->Actors().AsyncKillActor(actor_id, force_kill, no_restart, nullptr));
   return Status::OK();
 }
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1628,7 +1628,12 @@ Status CoreWorker::KillActor(const ActorID &actor_id, bool force_kill, bool no_r
     stream << "Failed to find a corresponding actor handle for " << actor_id;
     return Status::Invalid(stream.str());
   }
-  direct_actor_submitter_->KillActor(actor_id, force_kill, no_restart);
+
+  if (no_restart) {
+    RAY_CHECK_OK(gcs_client_->Actors().AsyncDestroyActor(actor_id, nullptr));
+  } else {
+    direct_actor_submitter_->KillActor(actor_id, force_kill, no_restart);
+  }
   return Status::OK();
 }
 

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -728,6 +728,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// Tell an actor to exit immediately, without completing outstanding work.
   ///
   /// \param[in] actor_id ID of the actor to kill.
+  /// \param[in] force_kill Whether to force kill an actor by killing the worker.
   /// \param[in] no_restart If set to true, the killed actor will not be
   /// restarted anymore.
   /// \param[out] Status

--- a/src/ray/gcs/accessor.h
+++ b/src/ray/gcs/accessor.h
@@ -64,6 +64,14 @@ class ActorInfoAccessor {
   virtual Status AsyncRegisterActor(const TaskSpecification &task_spec,
                                     const StatusCallback &callback) = 0;
 
+  /// Destroy actor via GCS asynchronously.
+  ///
+  /// \param actor_id The ID of actor to destroy.
+  /// \param callback Callback that will be called after the actor is destroyed.
+  /// \return Status
+  virtual Status AsyncDestroyActor(const ActorID &actor_id,
+                                   const StatusCallback &callback) = 0;
+
   /// Asynchronously request GCS to create the actor.
   ///
   /// This should be called after the worker has resolved the actor dependencies.

--- a/src/ray/gcs/accessor.h
+++ b/src/ray/gcs/accessor.h
@@ -64,13 +64,15 @@ class ActorInfoAccessor {
   virtual Status AsyncRegisterActor(const TaskSpecification &task_spec,
                                     const StatusCallback &callback) = 0;
 
-  /// Destroy actor via GCS asynchronously.
+  /// Kill actor via GCS asynchronously.
   ///
   /// \param actor_id The ID of actor to destroy.
+  /// \param force_kill Whether to force kill an actor by killing the worker.
+  /// \param no_restart If set to true, the killed actor will not be restarted anymore.
   /// \param callback Callback that will be called after the actor is destroyed.
   /// \return Status
-  virtual Status AsyncDestroyActor(const ActorID &actor_id,
-                                   const StatusCallback &callback) = 0;
+  virtual Status AsyncKillActor(const ActorID &actor_id, bool force_kill, bool no_restart,
+                                const StatusCallback &callback) = 0;
 
   /// Asynchronously request GCS to create the actor.
   ///

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -200,12 +200,15 @@ Status ServiceBasedActorInfoAccessor::AsyncRegisterActor(
   return Status::OK();
 }
 
-Status ServiceBasedActorInfoAccessor::AsyncDestroyActor(
-    const ActorID &actor_id, const ray::gcs::StatusCallback &callback) {
-  rpc::DestroyActorRequest request;
+Status ServiceBasedActorInfoAccessor::AsyncKillActor(
+    const ActorID &actor_id, bool force_kill, bool no_restart,
+    const ray::gcs::StatusCallback &callback) {
+  rpc::KillActorViaGcsRequest request;
   request.set_actor_id(actor_id.Binary());
-  client_impl_->GetGcsRpcClient().DestroyActor(
-      request, [callback](const Status &, const rpc::DestroyActorReply &reply) {
+  request.set_force_kill(force_kill);
+  request.set_no_restart(no_restart);
+  client_impl_->GetGcsRpcClient().KillActorViaGcs(
+      request, [callback](const Status &, const rpc::KillActorViaGcsReply &reply) {
         if (callback) {
           auto status =
               reply.status().code() == (int)StatusCode::OK

--- a/src/ray/gcs/gcs_client/service_based_accessor.h
+++ b/src/ray/gcs/gcs_client/service_based_accessor.h
@@ -85,6 +85,9 @@ class ServiceBasedActorInfoAccessor : public ActorInfoAccessor {
   Status AsyncCreateActor(const TaskSpecification &task_spec,
                           const StatusCallback &callback) override;
 
+  Status AsyncDestroyActor(const ActorID &actor_id,
+                           const StatusCallback &callback) override;
+
   Status AsyncSubscribeAll(
       const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
       const StatusCallback &done) override;

--- a/src/ray/gcs/gcs_client/service_based_accessor.h
+++ b/src/ray/gcs/gcs_client/service_based_accessor.h
@@ -85,8 +85,8 @@ class ServiceBasedActorInfoAccessor : public ActorInfoAccessor {
   Status AsyncCreateActor(const TaskSpecification &task_spec,
                           const StatusCallback &callback) override;
 
-  Status AsyncDestroyActor(const ActorID &actor_id,
-                           const StatusCallback &callback) override;
+  Status AsyncKillActor(const ActorID &actor_id, bool force_kill, bool no_restart,
+                        const StatusCallback &callback) override;
 
   Status AsyncSubscribeAll(
       const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -214,15 +214,23 @@ void GcsActorManager::HandleGetNamedActorInfo(
   ++counts_[CountType::GET_NAMED_ACTOR_INFO_REQUEST];
 }
 
-void GcsActorManager::HandleDestroyActor(const rpc::DestroyActorRequest &request,
-                                         rpc::DestroyActorReply *reply,
-                                         rpc::SendReplyCallback send_reply_callback) {
+void GcsActorManager::HandleKillActorViaGcs(const rpc::KillActorViaGcsRequest &request,
+                                            rpc::KillActorViaGcsReply *reply,
+                                            rpc::SendReplyCallback send_reply_callback) {
   const auto &actor_id = ActorID::FromBinary(request.actor_id());
-  DestroyActor(actor_id);
+  bool force_kill = request.force_kill();
+  bool no_restart = request.no_restart();
+  if (no_restart) {
+    DestroyActor(actor_id);
+  } else {
+    KillActor(actor_id, force_kill);
+  }
+
   GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
-  RAY_LOG(DEBUG) << "Finished destroying actor, job id = " << actor_id.JobId()
-                 << ", actor id = " << actor_id;
-  ++counts_[CountType::DESTROY_ACTOR_REQUEST];
+  RAY_LOG(DEBUG) << "Finished killing actor, job id = " << actor_id.JobId()
+                 << ", actor id = " << actor_id << ", force_kill = " << force_kill
+                 << ", no_restart = " << no_restart;
+  ++counts_[CountType::KILL_ACTOR_REQUEST];
 }
 
 Status GcsActorManager::RegisterActor(const ray::rpc::RegisterActorRequest &request,
@@ -470,7 +478,7 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
     if (node_it != created_actors_.end() && node_it->second.count(worker_id)) {
       // The actor has already been created. Destroy the process by force-killing
       // it.
-      KillActor(actor);
+      NotifyCoreWorkerToKillActor(actor);
       RAY_CHECK(node_it->second.erase(actor->GetWorkerID()));
       if (node_it->second.empty()) {
         created_actors_.erase(node_it);
@@ -947,13 +955,65 @@ void GcsActorManager::RemoveActorFromOwner(const std::shared_ptr<GcsActor> &acto
   }
 }
 
-void GcsActorManager::KillActor(const std::shared_ptr<GcsActor> &actor) {
+void GcsActorManager::NotifyCoreWorkerToKillActor(const std::shared_ptr<GcsActor> &actor,
+                                                  bool force_kill, bool no_restart) {
   auto actor_client = worker_client_factory_(actor->GetAddress());
   rpc::KillActorRequest request;
   request.set_intended_actor_id(actor->GetActorID().Binary());
-  request.set_force_kill(true);
-  request.set_no_restart(true);
+  request.set_force_kill(force_kill);
+  request.set_no_restart(no_restart);
   RAY_UNUSED(actor_client->KillActor(request, nullptr));
+}
+
+void GcsActorManager::KillActor(const ActorID &actor_id, bool force_kill) {
+  RAY_LOG(DEBUG) << "Killing actor, job id = " << actor_id.JobId()
+                 << ", actor id = " << actor_id << ", force_kill = " << force_kill;
+  auto it = registered_actors_.find(actor_id);
+  if (it == registered_actors_.end()) {
+    RAY_LOG(INFO) << "Tried to kill actor that does not exist " << actor_id;
+    return;
+  }
+
+  const auto &actor = it->second;
+
+  // The actor is already dead, most likely due to process or node failure.
+  if (actor->GetState() == rpc::ActorTableData::DEAD ||
+      actor->GetState() == rpc::ActorTableData::DEPENDENCIES_UNREADY) {
+    return;
+  }
+
+  // The actor is still alive or pending creation. Clean up all remaining
+  // state.
+  const auto &node_id = actor->GetNodeID();
+  const auto &worker_id = actor->GetWorkerID();
+  auto node_it = created_actors_.find(node_id);
+  if (node_it != created_actors_.end() && node_it->second.count(worker_id)) {
+    // The actor has already been created. Destroy the process by force-killing
+    // it.
+    NotifyCoreWorkerToKillActor(actor, force_kill);
+  } else {
+    // The actor has not been created yet. It is either being scheduled or is
+    // pending scheduling.
+    auto canceled_actor_id =
+        gcs_actor_scheduler_->CancelOnWorker(actor->GetNodeID(), actor->GetWorkerID());
+    if (canceled_actor_id.IsNil()) {
+      auto pending_it = std::find_if(pending_actors_.begin(), pending_actors_.end(),
+                                     [actor_id](const std::shared_ptr<GcsActor> &actor) {
+                                       return actor->GetActorID() == actor_id;
+                                     });
+
+      // When actor creation request of this actor id is pending in raylet,
+      // it doesn't responds, and the actor should be still in leasing state.
+      // NOTE: We will cancel outstanding lease request by calling
+      // `raylet_client->CancelWorkerLease`.
+      if (pending_it == pending_actors_.end()) {
+        const auto &task_id = actor->GetCreationTaskSpecification().TaskId();
+        gcs_actor_scheduler_->CancelOnLeasing(node_id, actor_id, task_id);
+      }
+    }
+
+    ReconstructActor(actor_id, /*need_reschedule=*/true);
+  }
 }
 
 void GcsActorManager::AddDestroyedActorToCache(const std::shared_ptr<GcsActor> &actor) {
@@ -977,7 +1037,7 @@ std::string GcsActorManager::DebugString() const {
          << ", GetActorInfo request count: " << counts_[CountType::GET_ACTOR_INFO_REQUEST]
          << ", GetNamedActorInfo request count: "
          << counts_[CountType::GET_NAMED_ACTOR_INFO_REQUEST]
-         << ", DestroyActor request count: " << counts_[CountType::DESTROY_ACTOR_REQUEST]
+         << ", KillActor request count: " << counts_[CountType::KILL_ACTOR_REQUEST]
          << ", Registered actors count: " << registered_actors_.size()
          << ", Destroyed actors count: " << destroyed_actors_.size()
          << ", Named actors count: " << named_actors_.size()

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -214,6 +214,17 @@ void GcsActorManager::HandleGetNamedActorInfo(
   ++counts_[CountType::GET_NAMED_ACTOR_INFO_REQUEST];
 }
 
+void GcsActorManager::HandleDestroyActor(const rpc::DestroyActorRequest &request,
+                                         rpc::DestroyActorReply *reply,
+                                         rpc::SendReplyCallback send_reply_callback) {
+  const auto &actor_id = ActorID::FromBinary(request.actor_id());
+  DestroyActor(actor_id);
+  GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+  RAY_LOG(DEBUG) << "Finished destroying actor, job id = " << actor_id.JobId()
+                 << ", actor id = " << actor_id;
+  ++counts_[CountType::DESTROY_ACTOR_REQUEST];
+}
+
 Status GcsActorManager::RegisterActor(const ray::rpc::RegisterActorRequest &request,
                                       RegisterActorCallback success_callback) {
   // NOTE: After the abnormal recovery of the network between GCS client and GCS server or
@@ -706,7 +717,7 @@ void GcsActorManager::ReconstructActor(const ActorID &actor_id, bool need_resche
     RAY_CHECK_OK(gcs_table_storage_->ActorTable().Put(
         actor_id, *mutable_actor_table_data,
         [this, actor, actor_id, mutable_actor_table_data](Status status) {
-          // if actor was an detached actor, make sure to destroy it.
+          // If actor was an detached actor, make sure to destroy it.
           // We need to do this because detached actors are not destroyed
           // when its owners are dead because it doesn't have owners.
           if (actor->IsDetached()) {
@@ -964,6 +975,7 @@ std::string GcsActorManager::DebugString() const {
          << ", GetActorInfo request count: " << counts_[CountType::GET_ACTOR_INFO_REQUEST]
          << ", GetNamedActorInfo request count: "
          << counts_[CountType::GET_NAMED_ACTOR_INFO_REQUEST]
+         << ", DestroyActor request count: " << counts_[CountType::DESTROY_ACTOR_REQUEST]
          << ", Registered actors count: " << registered_actors_.size()
          << ", Destroyed actors count: " << destroyed_actors_.size()
          << ", Named actors count: " << named_actors_.size()

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -430,6 +430,7 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
   auto it = registered_actors_.find(actor_id);
   RAY_CHECK(it != registered_actors_.end())
       << "Tried to destroy actor that does not exist " << actor_id;
+  const auto &task_id = it->second->GetCreationTaskSpecification().TaskId();
   it->second->GetMutableActorTableData()->mutable_task_spec()->Clear();
   it->second->GetMutableActorTableData()->set_timestamp(current_sys_time_ms());
   AddDestroyedActorToCache(it->second);
@@ -495,8 +496,6 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
           // it doesn't responds, and the actor should be still in leasing state.
           // NOTE: We will cancel outstanding lease request by calling
           // `raylet_client->CancelWorkerLease`.
-          const auto &task_id =
-              TaskID::FromBinary(actor->GetActorTableData().task_spec().task_id());
           gcs_actor_scheduler_->CancelOnLeasing(node_id, actor_id, task_id);
         }
       }

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -428,8 +428,10 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
   actor_to_register_callbacks_.erase(actor_id);
   actor_to_create_callbacks_.erase(actor_id);
   auto it = registered_actors_.find(actor_id);
-  RAY_CHECK(it != registered_actors_.end())
-      << "Tried to destroy actor that does not exist " << actor_id;
+  if (it == registered_actors_.end()) {
+    RAY_LOG(INFO) << "Tried to destroy actor that does not exist " << actor_id;
+    return;
+  }
   const auto &task_id = it->second->GetCreationTaskSpecification().TaskId();
   it->second->GetMutableActorTableData()->mutable_task_spec()->Clear();
   it->second->GetMutableActorTableData()->set_timestamp(current_sys_time_ms());

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -493,10 +493,11 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
         } else {
           // When actor creation request of this actor id is pending in raylet,
           // it doesn't responds, and the actor should be still in leasing state.
-          // NOTE: Raylet will cancel the lease request once it receives the
-          // actor state notification. So this method doesn't have to cancel
-          // outstanding lease request by calling raylet_client->CancelWorkerLease
-          gcs_actor_scheduler_->CancelOnLeasing(node_id, actor_id);
+          // NOTE: We will cancel outstanding lease request by calling
+          // `raylet_client->CancelWorkerLease`.
+          const auto &task_id =
+              TaskID::FromBinary(actor->GetActorTableData().task_spec().task_id());
+          gcs_actor_scheduler_->CancelOnLeasing(node_id, actor_id, task_id);
         }
       }
     }

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -223,7 +223,7 @@ void GcsActorManager::HandleKillActorViaGcs(const rpc::KillActorViaGcsRequest &r
   if (no_restart) {
     DestroyActor(actor_id);
   } else {
-    KillActor(actor_id, force_kill);
+    KillActor(actor_id, force_kill, no_restart);
   }
 
   GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
@@ -941,7 +941,8 @@ void GcsActorManager::NotifyCoreWorkerToKillActor(const std::shared_ptr<GcsActor
   RAY_UNUSED(actor_client->KillActor(request, nullptr));
 }
 
-void GcsActorManager::KillActor(const ActorID &actor_id, bool force_kill) {
+void GcsActorManager::KillActor(const ActorID &actor_id, bool force_kill,
+                                bool no_restart) {
   RAY_LOG(DEBUG) << "Killing actor, job id = " << actor_id.JobId()
                  << ", actor id = " << actor_id << ", force_kill = " << force_kill;
   const auto &it = registered_actors_.find(actor_id);
@@ -963,7 +964,7 @@ void GcsActorManager::KillActor(const ActorID &actor_id, bool force_kill) {
   if (node_it != created_actors_.end() && node_it->second.count(worker_id)) {
     // The actor has already been created. Destroy the process by force-killing
     // it.
-    NotifyCoreWorkerToKillActor(actor, force_kill);
+    NotifyCoreWorkerToKillActor(actor, force_kill, no_restart);
   } else {
     const auto &task_id = actor->GetCreationTaskSpecification().TaskId();
     CancelActorInScheduling(actor, task_id);

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -190,9 +190,9 @@ class GcsActorManager : public rpc::ActorInfoHandler {
                              rpc::GetAllActorInfoReply *reply,
                              rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleDestroyActor(const rpc::DestroyActorRequest &request,
-                          rpc::DestroyActorReply *reply,
-                          rpc::SendReplyCallback send_reply_callback) override;
+  void HandleKillActorViaGcs(const rpc::KillActorViaGcsRequest &request,
+                             rpc::KillActorViaGcsReply *reply,
+                             rpc::SendReplyCallback send_reply_callback) override;
 
   /// Register actor asynchronously.
   ///
@@ -340,8 +340,17 @@ class GcsActorManager : public rpc::ActorInfoHandler {
 
   /// Kill the specified actor.
   ///
+  /// \param actor_id ID of the actor to kill.
+  /// \param force_kill Whether to force kill an actor by killing the worker.
+  void KillActor(const ActorID &actor_id, bool force_kill);
+
+  /// Notify CoreWorker to kill the specified actor.
+  ///
   /// \param actor The actor to be killed.
-  void KillActor(const std::shared_ptr<GcsActor> &actor);
+  /// \param force_kill Whether to force kill an actor by killing the worker.
+  /// \param no_restart If set to true, the killed actor will not be restarted anymore.
+  void NotifyCoreWorkerToKillActor(const std::shared_ptr<GcsActor> &actor,
+                                   bool force_kill = true, bool no_restart = true);
 
   /// Add the destroyed actor to the cache. If the cache is full, one actor is randomly
   /// evicted.
@@ -417,7 +426,7 @@ class GcsActorManager : public rpc::ActorInfoHandler {
     GET_ACTOR_INFO_REQUEST = 2,
     GET_NAMED_ACTOR_INFO_REQUEST = 3,
     GET_ALL_ACTOR_INFO_REQUEST = 4,
-    DESTROY_ACTOR_REQUEST = 5,
+    KILL_ACTOR_REQUEST = 5,
     CountType_MAX = 6,
   };
   uint64_t counts_[CountType::CountType_MAX] = {0};

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -190,6 +190,10 @@ class GcsActorManager : public rpc::ActorInfoHandler {
                              rpc::GetAllActorInfoReply *reply,
                              rpc::SendReplyCallback send_reply_callback) override;
 
+  void HandleDestroyActor(const rpc::DestroyActorRequest &request,
+                          rpc::DestroyActorReply *reply,
+                          rpc::SendReplyCallback send_reply_callback) override;
+
   /// Register actor asynchronously.
   ///
   /// \param request Contains the meta info to create the actor.
@@ -413,7 +417,8 @@ class GcsActorManager : public rpc::ActorInfoHandler {
     GET_ACTOR_INFO_REQUEST = 2,
     GET_NAMED_ACTOR_INFO_REQUEST = 3,
     GET_ALL_ACTOR_INFO_REQUEST = 4,
-    CountType_MAX = 10,
+    DESTROY_ACTOR_REQUEST = 5,
+    CountType_MAX = 6,
   };
   uint64_t counts_[CountType::CountType_MAX] = {0};
 };

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -342,7 +342,8 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   ///
   /// \param actor_id ID of the actor to kill.
   /// \param force_kill Whether to force kill an actor by killing the worker.
-  void KillActor(const ActorID &actor_id, bool force_kill);
+  /// \param no_restart If set to true, the killed actor will not be restarted anymore.
+  void KillActor(const ActorID &actor_id, bool force_kill, bool no_restart);
 
   /// Notify CoreWorker to kill the specified actor.
   ///

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -369,6 +369,13 @@ class GcsActorManager : public rpc::ActorInfoHandler {
     return actor_delta;
   }
 
+  /// Cancel actor which is either being scheduled or is pending scheduling.
+  ///
+  /// \param actor The actor to be cancelled.
+  /// \param task_id The id of actor creation task to be cancelled.
+  void CancelActorInScheduling(const std::shared_ptr<GcsActor> &actor,
+                               const TaskID &task_id);
+
   /// Callbacks of pending `RegisterActor` requests.
   /// Maps actor ID to actor registration callbacks, which is used to filter duplicated
   /// messages from a driver/worker caused by some network problems.

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
@@ -297,13 +297,17 @@ void GcsActorScheduler::HandleWorkerLeasedReply(
   const auto &retry_at_raylet_address = reply.retry_at_raylet_address();
   const auto &worker_address = reply.worker_address();
   if (worker_address.raylet_id().empty()) {
-    // The worker did not succeed in the lease, but the specified node returned a new
-    // node, and then try again on the new node.
+    // Actor creation task has been cancelled. It is triggered by `ray.kill`. If the
+    // number of remaining restarts of the actor is not equal to 0, GCS will reschedule
+    // the actor, so it return directly here.
     if (retry_at_raylet_address.raylet_id().empty()) {
-      RAY_LOG(INFO) << "HandleWorkerLeasedReply empty......";
+      RAY_LOG(DEBUG) << "Actor " << actor->GetActorID()
+                     << " creation task has been cancelled.";
       return;
     }
 
+    // The worker did not succeed in the lease, but the specified node returned a new
+    // node, and then try again on the new node.
     auto spill_back_node_id = NodeID::FromBinary(retry_at_raylet_address.raylet_id());
     auto maybe_spill_back_node = gcs_node_manager_.GetAliveNode(spill_back_node_id);
     if (maybe_spill_back_node.has_value()) {

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
@@ -252,6 +252,16 @@ void GcsActorScheduler::LeaseWorkerFromNode(std::shared_ptr<GcsActor> actor,
           }
 
           if (status.ok()) {
+            if (reply.worker_address().raylet_id().empty() &&
+                reply.retry_at_raylet_address().raylet_id().empty()) {
+              // Actor creation task has been cancelled. It is triggered by `ray.kill`. If
+              // the number of remaining restarts of the actor is not equal to 0, GCS will
+              // reschedule the actor, so it return directly here.
+              RAY_LOG(DEBUG) << "Actor " << actor->GetActorID()
+                             << " creation task has been cancelled.";
+              return;
+            }
+
             // Remove the actor from the leasing map as the reply is returned from the
             // remote node.
             iter->second.erase(actor_iter);
@@ -297,17 +307,9 @@ void GcsActorScheduler::HandleWorkerLeasedReply(
   const auto &retry_at_raylet_address = reply.retry_at_raylet_address();
   const auto &worker_address = reply.worker_address();
   if (worker_address.raylet_id().empty()) {
-    // Actor creation task has been cancelled. It is triggered by `ray.kill`. If the
-    // number of remaining restarts of the actor is not equal to 0, GCS will reschedule
-    // the actor, so it return directly here.
-    if (retry_at_raylet_address.raylet_id().empty()) {
-      RAY_LOG(DEBUG) << "Actor " << actor->GetActorID()
-                     << " creation task has been cancelled.";
-      return;
-    }
-
     // The worker did not succeed in the lease, but the specified node returned a new
     // node, and then try again on the new node.
+    RAY_CHECK(!retry_at_raylet_address.raylet_id().empty());
     auto spill_back_node_id = NodeID::FromBinary(retry_at_raylet_address.raylet_id());
     auto maybe_spill_back_node = gcs_node_manager_.GetAliveNode(spill_back_node_id);
     if (maybe_spill_back_node.has_value()) {

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
@@ -59,7 +59,8 @@ class GcsActorSchedulerInterface {
   ///
   /// \param node_id ID of the node where the actor leasing request has been sent.
   /// \param actor_id ID of an actor.
-  virtual void CancelOnLeasing(const NodeID &node_id, const ActorID &actor_id) = 0;
+  virtual void CancelOnLeasing(const NodeID &node_id, const ActorID &actor_id,
+                               const TaskID &task_id) = 0;
 
   /// Cancel the actor that is being scheduled to the specified worker.
   ///
@@ -130,7 +131,8 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
   ///
   /// \param node_id ID of the node where the actor leasing request has been sent.
   /// \param actor_id ID of an actor.
-  void CancelOnLeasing(const NodeID &node_id, const ActorID &actor_id) override;
+  void CancelOnLeasing(const NodeID &node_id, const ActorID &actor_id,
+                       const TaskID &task_id) override;
 
   /// Cancel the actor that is being scheduled to the specified worker.
   ///

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -35,7 +35,8 @@ class MockActorScheduler : public gcs::GcsActorSchedulerInterface {
 
   MOCK_METHOD1(CancelOnNode, std::vector<ActorID>(const NodeID &node_id));
   MOCK_METHOD2(CancelOnWorker, ActorID(const NodeID &node_id, const WorkerID &worker_id));
-  MOCK_METHOD2(CancelOnLeasing, void(const NodeID &node_id, const ActorID &actor_id));
+  MOCK_METHOD3(CancelOnLeasing, void(const NodeID &node_id, const ActorID &actor_id,
+                                     const TaskID &task_id));
 
   std::vector<std::shared_ptr<gcs::GcsActor>> actors;
 };
@@ -735,8 +736,10 @@ TEST_F(GcsActorManagerTest, TestRaceConditionCancelLease) {
   address.set_raylet_id(node_id.Binary());
   address.set_worker_id(worker_id.Binary());
   actor->UpdateAddress(address);
-  const auto actor_id = actor->GetActorID();
-  EXPECT_CALL(*mock_actor_scheduler_, CancelOnLeasing(node_id, actor_id));
+  const auto &actor_id = actor->GetActorID();
+  const auto &task_id =
+      TaskID::FromBinary(registered_actor->GetActorTableData().task_spec().task_id());
+  EXPECT_CALL(*mock_actor_scheduler_, CancelOnLeasing(node_id, actor_id, task_id));
   gcs_actor_manager_->OnWorkerDead(owner_node_id, owner_worker_id);
 }
 

--- a/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_test.cc
@@ -262,7 +262,8 @@ TEST_F(GcsActorSchedulerTest, TestLeasingCancelledWhenLeasing) {
   ASSERT_EQ(1, raylet_client_->callbacks.size());
 
   // Cancel the lease request.
-  gcs_actor_scheduler_->CancelOnLeasing(node_id, actor->GetActorID());
+  const auto &task_id = TaskID::FromBinary(create_actor_request.task_spec().task_id());
+  gcs_actor_scheduler_->CancelOnLeasing(node_id, actor->GetActorID(), task_id);
   ASSERT_EQ(1, raylet_client_->num_workers_requested);
   ASSERT_EQ(1, raylet_client_->callbacks.size());
 

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -92,6 +92,9 @@ message GetAllActorInfoReply {
   repeated ActorTableData actor_table_data = 2;
 }
 
+// `KillActorViaGcsRequest` is sent to GCS Service to ask to kill an actor.
+// `KillActorViaGcsRequest` is different from `KillActorRequest`.
+// `KillActorRequest` is send to core worker to ask to kill an actor.
 message KillActorViaGcsRequest {
   // ID of this actor.
   bytes actor_id = 1;

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -92,12 +92,16 @@ message GetAllActorInfoReply {
   repeated ActorTableData actor_table_data = 2;
 }
 
-message DestroyActorRequest {
+message KillActorViaGcsRequest {
   // ID of this actor.
   bytes actor_id = 1;
+  // Whether to force kill the actor.
+  bool force_kill = 2;
+  // If set to true, the killed actor will not be restarted anymore.
+  bool no_restart = 3;
 }
 
-message DestroyActorReply {
+message KillActorViaGcsReply {
   GcsStatus status = 1;
 }
 
@@ -113,8 +117,8 @@ service ActorInfoGcsService {
   rpc GetNamedActorInfo(GetNamedActorInfoRequest) returns (GetNamedActorInfoReply);
   // Get information of all actor from GCS Service.
   rpc GetAllActorInfo(GetAllActorInfoRequest) returns (GetAllActorInfoReply);
-  // Destroy actor.
-  rpc DestroyActor(DestroyActorRequest) returns (DestroyActorReply);
+  // Kill actor via GCS Service.
+  rpc KillActorViaGcs(KillActorViaGcsRequest) returns (KillActorViaGcsReply);
 }
 
 message RegisterNodeRequest {

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -92,6 +92,15 @@ message GetAllActorInfoReply {
   repeated ActorTableData actor_table_data = 2;
 }
 
+message DestroyActorRequest {
+  // ID of this actor.
+  bytes actor_id = 1;
+}
+
+message DestroyActorReply {
+  GcsStatus status = 1;
+}
+
 // Service for actor info access.
 service ActorInfoGcsService {
   // Register actor to gcs service.
@@ -104,6 +113,8 @@ service ActorInfoGcsService {
   rpc GetNamedActorInfo(GetNamedActorInfoRequest) returns (GetNamedActorInfoReply);
   // Get information of all actor from GCS Service.
   rpc GetAllActorInfo(GetAllActorInfoRequest) returns (GetAllActorInfoReply);
+  // Destroy actor.
+  rpc DestroyActor(DestroyActorRequest) returns (DestroyActorReply);
 }
 
 message RegisterNodeRequest {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1605,7 +1605,43 @@ void NodeManager::HandleCancelWorkerLease(const rpc::CancelWorkerLeaseRequest &r
                                           rpc::CancelWorkerLeaseReply *reply,
                                           rpc::SendReplyCallback send_reply_callback) {
   const TaskID task_id = TaskID::FromBinary(request.task_id());
+<<<<<<< HEAD
   bool canceled = cluster_task_manager_->CancelTask(task_id);
+=======
+  RAY_LOG(INFO) << "HandleCancelWorkerLease begining........ task id = " << task_id;
+  Task removed_task;
+  TaskState removed_task_state;
+  bool canceled;
+  if (new_scheduler_enabled_) {
+    canceled = cluster_task_manager_->CancelTask(task_id);
+    if (!canceled) {
+      // There are 2 cases here.
+      // 1. We haven't received the lease request yet. It's the caller's job to
+      //    retry the cancellation once we've received the request.
+      // 2. We have already granted the lease. The caller is now responsible
+      //    for returning the lease, not cancelling it.
+    }
+  } else {
+    canceled = local_queues_.RemoveTask(task_id, &removed_task, &removed_task_state);
+    if (!canceled) {
+      // We do not have the task. This could be because we haven't received the
+      // lease request yet, or because we already granted the lease request and
+      // it has already been returned.
+    } else {
+      if (removed_task.OnDispatch()) {
+        // We have not yet granted the worker lease. Cancel it now.
+        removed_task.OnCancellation()();
+        if (removed_task_state == TaskState::WAITING) {
+          dependency_manager_.RemoveTaskDependencies(task_id);
+        }
+      } else {
+        // We already granted the worker lease and sent the reply. Re-queue the
+        // task and wait for the requester to return the leased worker.
+        local_queues_.QueueTasks({removed_task}, removed_task_state);
+      }
+    }
+  }
+>>>>>>> fix review comments
   // The task cancellation failed if we did not have the task queued, since
   // this means that we may not have received the task request yet. It is
   // successful if we did have the task queued, since we have now replied to

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1605,43 +1605,7 @@ void NodeManager::HandleCancelWorkerLease(const rpc::CancelWorkerLeaseRequest &r
                                           rpc::CancelWorkerLeaseReply *reply,
                                           rpc::SendReplyCallback send_reply_callback) {
   const TaskID task_id = TaskID::FromBinary(request.task_id());
-<<<<<<< HEAD
   bool canceled = cluster_task_manager_->CancelTask(task_id);
-=======
-  RAY_LOG(INFO) << "HandleCancelWorkerLease begining........ task id = " << task_id;
-  Task removed_task;
-  TaskState removed_task_state;
-  bool canceled;
-  if (new_scheduler_enabled_) {
-    canceled = cluster_task_manager_->CancelTask(task_id);
-    if (!canceled) {
-      // There are 2 cases here.
-      // 1. We haven't received the lease request yet. It's the caller's job to
-      //    retry the cancellation once we've received the request.
-      // 2. We have already granted the lease. The caller is now responsible
-      //    for returning the lease, not cancelling it.
-    }
-  } else {
-    canceled = local_queues_.RemoveTask(task_id, &removed_task, &removed_task_state);
-    if (!canceled) {
-      // We do not have the task. This could be because we haven't received the
-      // lease request yet, or because we already granted the lease request and
-      // it has already been returned.
-    } else {
-      if (removed_task.OnDispatch()) {
-        // We have not yet granted the worker lease. Cancel it now.
-        removed_task.OnCancellation()();
-        if (removed_task_state == TaskState::WAITING) {
-          dependency_manager_.RemoveTaskDependencies(task_id);
-        }
-      } else {
-        // We already granted the worker lease and sent the reply. Re-queue the
-        // task and wait for the requester to return the leased worker.
-        local_queues_.QueueTasks({removed_task}, removed_task_state);
-      }
-    }
-  }
->>>>>>> fix review comments
   // The task cancellation failed if we did not have the task queued, since
   // this means that we may not have received the task request yet. It is
   // successful if we did have the task queued, since we have now replied to

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -144,8 +144,9 @@ class GcsRpcClient {
   VOID_GCS_RPC_CLIENT_METHOD(ActorInfoGcsService, GetAllActorInfo,
                              actor_info_grpc_client_, )
 
-  /// Destroy actor via GCS Service.
-  VOID_GCS_RPC_CLIENT_METHOD(ActorInfoGcsService, DestroyActor, actor_info_grpc_client_, )
+  /// Kill actor via GCS Service.
+  VOID_GCS_RPC_CLIENT_METHOD(ActorInfoGcsService, KillActorViaGcs,
+                             actor_info_grpc_client_, )
 
   /// Register a node to GCS Service.
   VOID_GCS_RPC_CLIENT_METHOD(NodeInfoGcsService, RegisterNode, node_info_grpc_client_, )

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -144,6 +144,9 @@ class GcsRpcClient {
   VOID_GCS_RPC_CLIENT_METHOD(ActorInfoGcsService, GetAllActorInfo,
                              actor_info_grpc_client_, )
 
+  /// Destroy actor via GCS Service.
+  VOID_GCS_RPC_CLIENT_METHOD(ActorInfoGcsService, DestroyActor, actor_info_grpc_client_, )
+
   /// Register a node to GCS Service.
   VOID_GCS_RPC_CLIENT_METHOD(NodeInfoGcsService, RegisterNode, node_info_grpc_client_, )
 

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -126,9 +126,9 @@ class ActorInfoGcsServiceHandler {
                                      GetAllActorInfoReply *reply,
                                      SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleDestroyActor(const DestroyActorRequest &request,
-                                  DestroyActorReply *reply,
-                                  SendReplyCallback send_reply_callback) = 0;
+  virtual void HandleKillActorViaGcs(const KillActorViaGcsRequest &request,
+                                     KillActorViaGcsReply *reply,
+                                     SendReplyCallback send_reply_callback) = 0;
 };
 
 /// The `GrpcService` for `ActorInfoGcsService`.
@@ -152,7 +152,7 @@ class ActorInfoGrpcService : public GrpcService {
     ACTOR_INFO_SERVICE_RPC_HANDLER(GetActorInfo);
     ACTOR_INFO_SERVICE_RPC_HANDLER(GetNamedActorInfo);
     ACTOR_INFO_SERVICE_RPC_HANDLER(GetAllActorInfo);
-    ACTOR_INFO_SERVICE_RPC_HANDLER(DestroyActor);
+    ACTOR_INFO_SERVICE_RPC_HANDLER(KillActorViaGcs);
   }
 
  private:

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -125,6 +125,10 @@ class ActorInfoGcsServiceHandler {
   virtual void HandleGetAllActorInfo(const GetAllActorInfoRequest &request,
                                      GetAllActorInfoReply *reply,
                                      SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleDestroyActor(const DestroyActorRequest &request,
+                                  DestroyActorReply *reply,
+                                  SendReplyCallback send_reply_callback) = 0;
 };
 
 /// The `GrpcService` for `ActorInfoGcsService`.
@@ -148,6 +152,7 @@ class ActorInfoGrpcService : public GrpcService {
     ACTOR_INFO_SERVICE_RPC_HANDLER(GetActorInfo);
     ACTOR_INFO_SERVICE_RPC_HANDLER(GetNamedActorInfo);
     ACTOR_INFO_SERVICE_RPC_HANDLER(GetAllActorInfo);
+    ACTOR_INFO_SERVICE_RPC_HANDLER(DestroyActor);
   }
 
  private:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, ray.kill doesn't cancel pending actor creation request in raylet. So we add `DestroyActor` api in gcs and call `lease_client->CancelWorkerLease` in gcs actor scheduler to cancel actor creation request.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/13214#issuecomment-755018369
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
