### PR TITLE
Do not give an error if both `RAY_ADDRESS` and `address` is specified on initialization

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -533,8 +533,8 @@ def init(
             is running on a node in a Ray cluster, using `auto` as the value
             tells the driver to detect the the cluster, removing the need to
             specify a specific node address. If the environment variable
-            `RAY_ADDRESS` is defined and the address is None or "auto", Ray will
-            set `address` to `RAY_ADDRESS`.
+            `RAY_ADDRESS` is defined and the address is None or "auto", Ray
+            will set `address` to `RAY_ADDRESS`.
         num_cpus (int): Number of CPUs the user wishes to assign to each
             raylet. By default, this is set based on virtual cores.
         num_gpus (int): Number of GPUs the user wishes to assign to each

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -523,7 +523,7 @@ def init(
 
     You can also define an environment variable called `RAY_ADDRESS` in
     the same format as the `address` parameter to connect to an existing
-    cluster with ray.init().
+    cluster with ray.init() or ray.init(address="auto").
 
     Args:
         address (str): The address of the Ray cluster to connect to. If
@@ -532,7 +532,9 @@ def init(
             It will also kill these processes when Python exits. If the driver
             is running on a node in a Ray cluster, using `auto` as the value
             tells the driver to detect the the cluster, removing the need to
-            specify a specific node address.
+            specify a specific node address. If the environment variable
+            `RAY_ADDRESS` is defined and the address is None or "auto", Ray will
+            set `address` to `RAY_ADDRESS`.
         num_cpus (int): Number of CPUs the user wishes to assign to each
             raylet. By default, this is set based on virtual cores.
         num_gpus (int): Number of GPUs the user wishes to assign to each
@@ -634,13 +636,6 @@ def init(
     if "RAY_ADDRESS" in os.environ:
         if address is None or address == "auto":
             address = os.environ["RAY_ADDRESS"]
-        else:
-            raise RuntimeError(
-                "Cannot use both the RAY_ADDRESS environment variable and "
-                "the address argument of ray.init simultaneously. If you "
-                "use RAY_ADDRESS to connect to a specific Ray cluster, "
-                "please call ray.init() or ray.init(address=\"auto\") on the "
-                "driver.")
 
     # Convert hostnames to numerical IP address.
     if _node_ip_address is not None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When we initially implemented `RAY_ADDRESS`, we didn't know if `address` or `RAY_ADDRESS` should take precedence if both are specified and we gave an error if they are both provided. This PR makes it so the in-code `address` overwrites `RAY_ADDRESS`.

Reasons:

- Ray libraries and components use `address` when connecting to the cluster (e.g. serve, also the Ray client, the CLI). Having `address` overwrite the environment variable is the best way to make sure we are connecting to the right Ray cluster even if there are multiple clusters running.
- Users might want to programmatically set `address` in their scripts and the proposed behavior allows them the most flexibility to control which cluster to connect to programmatically, even if `RAY_ADDRESS` is set.

The downside is obviously that `RAY_ADDRESS` cannot be used to overwrite any setting of `address`, but that seems like a feature. If the cluster to connect to is to be determined at runtime, `address="auto"` should be used.

**Compatibility:** There should be no problem for compatibility, since we raised an error in this situation before.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
