### PR TITLE
[Core] Inline small objects in GetObjectStatus response.

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -898,16 +898,17 @@ cdef class CoreWorker:
 
         return RayObjectsToDataMetadataPairs(results)
 
-    def object_exists(self, ObjectRef object_ref):
+    def object_exists(self, ObjectRef object_ref, memory_store_only=False):
         cdef:
             c_bool has_object
+            c_bool is_in_plasma
             CObjectID c_object_id = object_ref.native()
 
         with nogil:
             check_status(CCoreWorkerProcess.GetCoreWorker().Contains(
-                c_object_id, &has_object))
+                c_object_id, &has_object, &is_in_plasma))
 
-        return has_object
+        return has_object and (not memory_store_only or not is_in_plasma)
 
     cdef _create_put_buffer(self, shared_ptr[CBuffer] &metadata,
                             size_t data_size, ObjectRef object_ref,

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -183,7 +183,8 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         CRayStatus Get(const c_vector[CObjectID] &ids, int64_t timeout_ms,
                        c_vector[shared_ptr[CRayObject]] *results,
                        c_bool plasma_objects_only)
-        CRayStatus Contains(const CObjectID &object_id, c_bool *has_object)
+        CRayStatus Contains(const CObjectID &object_id, c_bool *has_object,
+                            c_bool *is_in_plasma)
         CRayStatus Wait(const c_vector[CObjectID] &object_ids, int num_objects,
                         int64_t timeout_ms, c_vector[c_bool] *results,
                         c_bool fetch_local)

--- a/python/ray/tests/test_advanced.py
+++ b/python/ray/tests/test_advanced.py
@@ -521,6 +521,43 @@ def test_wait_makes_object_local(ray_start_cluster):
     assert ray.worker.global_worker.core_worker.object_exists(x_id)
 
 
+@pytest.mark.skipif(client_test_enabled(), reason="internal api")
+def test_future_resolution_skip_plasma(ray_start_cluster):
+    cluster = ray_start_cluster
+    # Disable worker caching so worker leases are not reused; set object
+    # inlining size threshold and enable storing of small objects in in-memory
+    # object store so the borrowed ref is inlined.
+    cluster.add_node(
+        num_cpus=1,
+        resources={"pin_head": 1},
+        _system_config={
+            "worker_lease_timeout_milliseconds": 0,
+            "max_direct_call_object_size": 100 * 1024,
+            "put_small_object_in_memory_store": True,
+        },
+    )
+    cluster.add_node(num_cpus=1, resources={"pin_worker": 1})
+    ray.init(address=cluster.address)
+
+    @ray.remote(resources={"pin_head": 1})
+    def f(x):
+        return x + 1
+
+    @ray.remote(resources={"pin_worker": 1})
+    def g(x):
+        borrowed_ref = x[0]
+        f_ref = f.remote(borrowed_ref)
+        # borrowed_ref should be inlined on future resolution and shouldn't be
+        # in Plasma.
+        assert ray.worker.global_worker.core_worker.object_exists(
+            borrowed_ref, memory_store_only=True)
+        return ray.get(f_ref) * 2
+
+    one = ray.put(1)
+    g_ref = g.remote([one])
+    assert ray.get(g_ref) == 4
+
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main(["-v", __file__]))

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -559,8 +559,10 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   ///
   /// \param[in] object_id ID of the objects to check for.
   /// \param[out] has_object Whether or not the object is present.
+  /// \param[out] is_in_plasma Whether or not the object is in Plasma.
   /// \return Status.
-  Status Contains(const ObjectID &object_id, bool *has_object);
+  Status Contains(const ObjectID &object_id, bool *has_object,
+                  bool *is_in_plasma = nullptr);
 
   /// Wait for a list of objects to appear in the object store.
   /// Duplicate object ids are supported, and `num_objects` includes duplicate ids in this

--- a/src/ray/core_worker/future_resolver.cc
+++ b/src/ray/core_worker/future_resolver.cc
@@ -28,30 +28,53 @@ void FutureResolver::ResolveFutureAsync(const ObjectID &object_id,
   rpc::GetObjectStatusRequest request;
   request.set_object_id(object_id.Binary());
   request.set_owner_worker_id(owner_address.worker_id());
-  conn->GetObjectStatus(
-      request,
-      [this, object_id](const Status &status, const rpc::GetObjectStatusReply &reply) {
-        if (!status.ok()) {
-          RAY_LOG(WARNING) << "Error retrieving the value of object ID " << object_id
-                           << " that was deserialized: " << status.ToString();
-        }
+  conn->GetObjectStatus(request, [this, object_id](
+                                     const Status &status,
+                                     const rpc::GetObjectStatusReply &reply) {
+    if (!status.ok()) {
+      RAY_LOG(WARNING) << "Error retrieving the value of object ID " << object_id
+                       << " that was deserialized: " << status.ToString();
+    }
 
-        if (!status.ok() || reply.status() == rpc::GetObjectStatusReply::OUT_OF_SCOPE) {
-          // The owner is gone or the owner replied that the object has gone
-          // out of scope (this is an edge case in the distributed ref counting
-          // protocol where a borrower dies before it can notify the owner of
-          // another borrower). Store an error so that an exception will be
-          // thrown immediately when the worker tries to get the value.
-          RAY_UNUSED(in_memory_store_->Put(
-              RayObject(rpc::ErrorType::OBJECT_UNRECONSTRUCTABLE), object_id));
-        } else {
-          // We can now try to fetch the object via plasma. If the owner later
-          // fails or the object is released, the raylet will eventually store
-          // an error in plasma on our behalf.
-          RAY_UNUSED(in_memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_IN_PLASMA),
-                                           object_id));
-        }
-      });
+    if (!status.ok() || reply.status() == rpc::GetObjectStatusReply::OUT_OF_SCOPE) {
+      // The owner is gone or the owner replied that the object has gone
+      // out of scope (this is an edge case in the distributed ref counting
+      // protocol where a borrower dies before it can notify the owner of
+      // another borrower). Store an error so that an exception will be
+      // thrown immediately when the worker tries to get the value.
+      RAY_UNUSED(in_memory_store_->Put(
+          RayObject(rpc::ErrorType::OBJECT_UNRECONSTRUCTABLE), object_id));
+    } else if (reply.status() == rpc::GetObjectStatusReply::CREATED) {
+      // The object is either an indicator that the object is in Plasma, or
+      // the object has been returned directly in the reply. In either
+      // case, we put the corresponding RayObject into the in-memory store.
+      // If the owner later fails or the object is released, the raylet
+      // will eventually store an error in Plasma on our behalf.
+      const auto &data = reply.object().data();
+      std::shared_ptr<LocalMemoryBuffer> data_buffer;
+      if (data.size() > 0) {
+        RAY_LOG(DEBUG) << "Object returned directly in GetObjectStatus reply, putting "
+                       << object_id << " in memory store";
+        data_buffer = std::make_shared<LocalMemoryBuffer>(
+            const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(data.data())),
+            data.size());
+      } else {
+        RAY_LOG(DEBUG) << "Object not returned directly in GetObjectStatus reply, "
+                       << object_id << " will have to be fetched from Plasma";
+      }
+      const auto &metadata = reply.object().metadata();
+      std::shared_ptr<LocalMemoryBuffer> metadata_buffer;
+      if (metadata.size() > 0) {
+        metadata_buffer = std::make_shared<LocalMemoryBuffer>(
+            const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(metadata.data())),
+            metadata.size());
+      }
+      auto inlined_ids =
+          IdVectorFromProtobuf<ObjectID>(reply.object().nested_inlined_ids());
+      RAY_UNUSED(in_memory_store_->Put(
+          RayObject(data_buffer, metadata_buffer, inlined_ids), object_id));
+    }
+  });
 }
 
 }  // namespace ray

--- a/src/ray/core_worker/future_resolver.h
+++ b/src/ray/core_worker/future_resolver.h
@@ -16,6 +16,7 @@
 
 #include <memory>
 
+#include "ray/common/grpc_util.h"
 #include "ray/common/id.h"
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
 #include "ray/rpc/worker/core_worker_client.h"

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -132,6 +132,15 @@ message GetObjectStatusRequest {
   bytes object_id = 2;
 }
 
+message RayObject {
+  // Data of the object.
+  bytes data = 1;
+  // Metadata of the object.
+  bytes metadata = 2;
+  // ObjectIDs that were nested in data. This is only set for inlined objects.
+  repeated bytes nested_inlined_ids = 3;
+}
+
 message GetObjectStatusReply {
   enum ObjectStatus {
     CREATED = 0;
@@ -139,6 +148,9 @@ message GetObjectStatusReply {
     FREED = 2;
   }
   ObjectStatus status = 1;
+  // The Ray object: either a concrete value, an in-Plasma indicator, or an
+  // exception.
+  RayObject object = 2;
 }
 
 message WaitForActorOutOfScopeRequest {


### PR DESCRIPTION
Inlines small objects in the `GetObjectStatus` response, bypassing a Plasma put and object transfer.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This should make future resolution for small objects faster and result in one less RPC.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #13304

## TODOs

- [x] Add tests
- [x] Run benchmarks

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(