### PR TITLE
[PlacementGroup]Fix destroy placement group bug

### DIFF
--- a/doc/source/placement-group.rst
+++ b/doc/source/placement-group.rst
@@ -267,7 +267,7 @@ Lifecycle
 
 **Autoscaling**: Placement groups are pending creation if there are no nodes that can satisfy resource requirements for a given strategy. The Ray Autoscaler will be aware of placement groups, and auto-scale the cluster to ensure pending groups can be placed as needed.
 
-**Cleanup**: Placement groups are automatically removed when the job that created the placement group is finished. The only exception is that it is created by detached actors. In this case, placement groups fate-share with the detached actors.
+**Cleanup**: Placement groups are automatically removed when the job that created the placement group is finished. The only exception is that it is created by detached actors. In this case, placement groups fate-share with the detached actors. If the actor is restarted, the placement group created from it is not removed.
 
 
 Fault Tolerance

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -148,6 +148,8 @@ def placement_group(bundles: List[Dict[str, float]],
                     name: str = "unnamed_group") -> PlacementGroup:
     """Asynchronously creates a PlacementGroup.
 
+    NOTE: We should not create a placement group in a constructor, because the placement group will be created repeatedly during actor restarts.
+
     Args:
         bundles(List[Dict]): A list of bundles which
             represent the resources requirements.

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -148,7 +148,8 @@ def placement_group(bundles: List[Dict[str, float]],
                     name: str = "unnamed_group") -> PlacementGroup:
     """Asynchronously creates a PlacementGroup.
 
-    NOTE: We should not create a placement group in a constructor, because the placement group will be created repeatedly during actor restarts.
+    NOTE: We should not create a placement group in a constructor, because the
+    placement group will be created repeatedly during actor restarts.
 
     Args:
         bundles(List[Dict]): A list of bundles which

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -714,8 +714,7 @@ void GcsActorManager::ReconstructActor(const ActorID &actor_id, bool need_resche
   int64_t max_restarts = mutable_actor_table_data->max_restarts();
   uint64_t num_restarts = mutable_actor_table_data->num_restarts();
   int64_t remaining_restarts;
-  // Destroy placement group owned by this actor.
-  destroy_owned_placement_group_if_needed_(actor_id);
+
   if (!need_reschedule) {
     remaining_restarts = 0;
   } else if (max_restarts == -1) {
@@ -770,6 +769,9 @@ void GcsActorManager::ReconstructActor(const ActorID &actor_id, bool need_resche
           RAY_CHECK_OK(gcs_pub_sub_->Publish(
               ACTOR_CHANNEL, actor_id.Hex(),
               mutable_actor_table_data->SerializeAsString(), nullptr));
+
+          // Destroy placement group owned by this actor.
+          destroy_owned_placement_group_if_needed_(actor_id);
         }));
     // The actor is dead, but we should not remove the entry from the
     // registered actors yet. If the actor is owned, we will destroy the actor

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -399,7 +399,7 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// Factory to produce clients to workers. This is used to communicate with
   /// actors and their owners.
   rpc::ClientFactoryFn worker_client_factory_;
-  /// A callback that is used to destroy placemenet group owned by the actor.
+  /// A callback that is used to destroy placement group owned by the actor.
   /// This method MUST BE IDEMPOTENT because it can be called multiple times during
   /// actor destroy process.
   std::function<void(const ActorID &)> destroy_owned_placement_group_if_needed_;

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -305,7 +305,6 @@ void GcsPlacementGroupManager::RemovePlacementGroup(
     const PlacementGroupID &placement_group_id,
     StatusCallback on_placement_group_removed) {
   RAY_CHECK(on_placement_group_removed);
-  RAY_LOG(INFO) << "Removing placement group " << placement_group_id;
 
   // If the placement group has been already removed, don't do anything.
   auto placement_group_it = registered_placement_groups_.find(placement_group_id);
@@ -318,6 +317,7 @@ void GcsPlacementGroupManager::RemovePlacementGroup(
   placement_group_to_create_callbacks_.erase(placement_group_id);
 
   // Destroy all bundles.
+  RAY_LOG(INFO) << "Removing placement group " << placement_group_id;
   gcs_placement_group_scheduler_->DestroyPlacementGroupBundleResourcesIfExists(
       placement_group_id);
   // Cancel the scheduling request if necessary.
@@ -499,8 +499,8 @@ void GcsPlacementGroupManager::CleanPlacementGroupIfNeededWhenJobDead(
     placement_group->MarkCreatorJobDead();
     if (placement_group->IsPlacementGroupRemovable()) {
       RAY_LOG(INFO) << "Actor " << placement_group->GetCreatorActorId()
-                    << " is dead and job " << job_id
-                    << " is finished, we will remove the placement group "
+                    << " is dead and because job " << job_id
+                    << " is finished, it will remove the placement group "
                     << placement_group->GetPlacementGroupID();
       RemovePlacementGroup(placement_group->GetPlacementGroupID(), [](Status status) {});
     }

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -305,6 +305,8 @@ void GcsPlacementGroupManager::RemovePlacementGroup(
     const PlacementGroupID &placement_group_id,
     StatusCallback on_placement_group_removed) {
   RAY_CHECK(on_placement_group_removed);
+  RAY_LOG(INFO) << "Removing placement group " << placement_group_id;
+
   // If the placement group has been already removed, don't do anything.
   auto placement_group_it = registered_placement_groups_.find(placement_group_id);
   if (placement_group_it == registered_placement_groups_.end()) {
@@ -496,6 +498,10 @@ void GcsPlacementGroupManager::CleanPlacementGroupIfNeededWhenJobDead(
     }
     placement_group->MarkCreatorJobDead();
     if (placement_group->IsPlacementGroupRemovable()) {
+      RAY_LOG(INFO) << "Actor " << placement_group->GetCreatorActorId()
+                    << " is dead and job " << job_id
+                    << " is finished, we will remove the placement group "
+                    << placement_group->GetPlacementGroupID();
       RemovePlacementGroup(placement_group->GetPlacementGroupID(), [](Status status) {});
     }
   }
@@ -510,6 +516,10 @@ void GcsPlacementGroupManager::CleanPlacementGroupIfNeededWhenActorDead(
     }
     placement_group->MarkCreatorActorDead();
     if (placement_group->IsPlacementGroupRemovable()) {
+      RAY_LOG(INFO) << "Actor " << actor_id << " is dead and job "
+                    << placement_group->GetCreatorJobId()
+                    << " is finished, we will remove the placement group "
+                    << placement_group->GetPlacementGroupID();
       RemovePlacementGroup(placement_group->GetPlacementGroupID(), [](Status status) {});
     }
   }

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -498,9 +498,9 @@ void GcsPlacementGroupManager::CleanPlacementGroupIfNeededWhenJobDead(
     }
     placement_group->MarkCreatorJobDead();
     if (placement_group->IsPlacementGroupRemovable()) {
-      RAY_LOG(INFO) << "Actor " << placement_group->GetCreatorActorId()
-                    << " is dead and because job " << job_id
-                    << " is finished, it will remove the placement group "
+      RAY_LOG(INFO) << "Job " << job_id << " is finished and because actor "
+                    << placement_group->GetCreatorActorId()
+                    << " is dead, it will remove the placement group "
                     << placement_group->GetPlacementGroupID();
       RemovePlacementGroup(placement_group->GetPlacementGroupID(), [](Status status) {});
     }
@@ -516,9 +516,9 @@ void GcsPlacementGroupManager::CleanPlacementGroupIfNeededWhenActorDead(
     }
     placement_group->MarkCreatorActorDead();
     if (placement_group->IsPlacementGroupRemovable()) {
-      RAY_LOG(INFO) << "Actor " << actor_id << " is dead and job "
+      RAY_LOG(INFO) << "Actor " << actor_id << " is dead and because job "
                     << placement_group->GetCreatorJobId()
-                    << " is finished, we will remove the placement group "
+                    << " is finished, it will remove the placement group "
                     << placement_group->GetPlacementGroupID();
       RemovePlacementGroup(placement_group->GetPlacementGroupID(), [](Status status) {});
     }

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
@@ -121,7 +121,7 @@ class GcsPlacementGroup {
 /// The placementGroup will be added into queue and set the status as pending first and
 /// use SchedulePendingPlacementGroups(). The SchedulePendingPlacementGroups() will get
 /// the head of the queue and schedule it. If schedule success, using the
-/// SchedulePendingPlacementGroups() Immediately. else wait for a short time beforw using
+/// SchedulePendingPlacementGroups() Immediately. Else wait for a short time before using
 /// SchedulePendingPlacementGroups() next time.
 class GcsPlacementGroupManager : public rpc::PlacementGroupInfoHandler {
  public:
@@ -305,7 +305,7 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoHandler {
 
   /// The placement group id that is in progress of scheduling bundles.
   /// TODO(sang): Currently, only one placement group can be scheduled at a time.
-  /// We should probably support concurrenet creation (or batching).
+  /// We should probably support concurrent creation (or batching).
   PlacementGroupID scheduling_in_progress_id_ = PlacementGroupID::Nil();
 
   /// Reference of GcsResourceManager.

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -215,7 +215,7 @@ class LeaseStatusTracker {
                                  const std::shared_ptr<BundleSpecification> bundle,
                                  const Status &status);
 
-  /// Used to know if all commit requests are returend.
+  /// Used to know if all commit requests are returned.
   ///
   /// \return True if all commit requests are returned. False otherwise.
   bool AllCommitRequestReturned() const;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
At present, if the placement group creator actor restarts, the placement group  will be destroyed. We should destroy placement group only when the placement group creator actor is dead.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
