### PR TITLE
[PlacementGroup]Fix the bug that actor does not restart

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -349,7 +349,10 @@ void NodeManager::DestroyWorker(std::shared_ptr<WorkerInterface> worker) {
   // We should disconnect the client first. Otherwise, we'll remove bundle resources
   // before actual resources are returned. Subsequent disconnect request that comes
   // due to worker dead will be ignored.
-  ProcessDisconnectClientMessage(worker->Connection(), /* intentional exit */ true);
+  // NOTE: If `intentional_disconnect` is true, the actor corresponding to the
+  // worker will not be restarted, so `intentional_disconnect` must be set to false.
+  ProcessDisconnectClientMessage(worker->Connection(),
+                                 /* intentional_disconnect= */ false);
   worker->MarkDead();
   KillWorker(worker);
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
If an actor uses a placeemt group bundle, the actor will not restart when the bundle is cancelled.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
