### PR TITLE
fix removal of task dependencies

### DIFF
--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -354,7 +354,6 @@ bool ClusterTaskManager::CancelTask(const TaskID &task_id) {
     }
     waiting_tasks_.erase(iter);
 
-    task_dependency_manager_.RemoveTaskDependencies(task_id);
     return true;
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
- When running the test of python, I got a lot of fatal log "Can't remove dependencies of tasks that are not queued".
- I found that one `task` may be removed twice inside `ClusterTaskManager::CancelTask`, I think it is a bug.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #13335

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
