### PR TITLE
[Core] Trigger Failover When Error Raised in Creation Task

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
@@ -35,7 +35,6 @@ public abstract class TaskExecutor<T extends TaskExecutor.ActorContext> {
 
     /** The current actor object, if this worker is an actor, otherwise null. */
     Object currentActor = null;
-
   }
 
   TaskExecutor(RayRuntimeInternal runtime) {

--- a/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
@@ -36,8 +36,6 @@ public abstract class TaskExecutor<T extends TaskExecutor.ActorContext> {
     /** The current actor object, if this worker is an actor, otherwise null. */
     Object currentActor = null;
 
-    /** The exception that failed the actor creation task, if any. */
-    Throwable actorCreationException = null;
   }
 
   TaskExecutor(RayRuntimeInternal runtime) {
@@ -116,9 +114,6 @@ public abstract class TaskExecutor<T extends TaskExecutor.ActorContext> {
       // Get local actor object and arguments.
       Object actor = null;
       if (taskType == TaskType.ACTOR_TASK) {
-        if (actorContext.actorCreationException != null) {
-          throw actorContext.actorCreationException;
-        }
         actor = actorContext.currentActor;
       }
       Object[] args =
@@ -164,7 +159,8 @@ public abstract class TaskExecutor<T extends TaskExecutor.ActorContext> {
                   new RayTaskException("Error executing task " + taskId, e)));
         }
       } else {
-        actorContext.actorCreationException = e;
+        LOGGER.error("Error in actor creation task " + taskId, e);
+        throw new RuntimeException(e);
       }
     } finally {
       Thread.currentThread().setContextClassLoader(oldLoader);

--- a/java/test/src/main/java/io/ray/test/FailureTest.java
+++ b/java/test/src/main/java/io/ray/test/FailureTest.java
@@ -84,14 +84,13 @@ public class FailureTest extends BaseTest {
 
   public static class ActorFailedAtFirstTime {
     /**
-     * This actor will raise error at first time.
-     * Then after restarting, it will be created successfully
+     * This actor will raise error at first time. Then after restarting, it will be created
+     * successfully
      */
     public ActorFailedAtFirstTime(String flagFileName) {
       File flagFile = new File(flagFileName);
       if (!flagFile.exists()) {
-        LOGGER.info("flag file not exists, throw exception!, fileName={}",
-          flagFile.toString());
+        LOGGER.info("flag file not exists, throw exception!, fileName={}", flagFile.toString());
         try {
           flagFile.createNewFile();
         } catch (IOException e) {
@@ -131,19 +130,22 @@ public class FailureTest extends BaseTest {
 
   public void testActorCreationFailedAndRestarted() {
     String flagFileName = "/tmp/TEST_ERROR_FLAG_" + new Random().nextInt(9999);
-    ActorHandle<ActorFailedAtFirstTime> actor = Ray.actor(
-      ActorFailedAtFirstTime::new, flagFileName).setMaxRestarts(2).remote();
+    ActorHandle<ActorFailedAtFirstTime> actor =
+        Ray.actor(ActorFailedAtFirstTime::new, flagFileName).setMaxRestarts(2).remote();
     // At first, actor will throw exceptions and restarted.
     // Finally after restarted, actor will be created successfully.
-    boolean ok = TestUtils.waitForCondition(() -> {
-      try {
-        Assert.assertEquals(actor.task(ActorFailedAtFirstTime::ok).remote().get(), "OK");
-        return true;
-      } catch (Exception e) {
-        // ignore it
-      }
-      return false;
-    }, 10000);
+    boolean ok =
+        TestUtils.waitForCondition(
+            () -> {
+              try {
+                Assert.assertEquals(actor.task(ActorFailedAtFirstTime::ok).remote().get(), "OK");
+                return true;
+              } catch (Exception e) {
+                // ignore it
+              }
+              return false;
+            },
+            10000);
     Assert.assertTrue(ok);
   }
 

--- a/java/test/src/main/java/io/ray/test/FailureTest.java
+++ b/java/test/src/main/java/io/ray/test/FailureTest.java
@@ -119,13 +119,22 @@ public class FailureTest extends BaseTest {
     }
   }
 
+  private static void assertTaskFailedWithRayActorException(ObjectRef<?> objectRef) {
+    try {
+      objectRef.get();
+      Assert.fail("Task didn't fail.");
+    } catch (RayActorException e) {
+      // ignored
+    }
+  }
+
   public void testNormalTaskFailure() {
     assertTaskFailedWithRayTaskException(Ray.task(FailureTest::badFunc).remote());
   }
 
   public void testActorCreationFailure() {
     ActorHandle<BadActor> actor = Ray.actor(BadActor::new, true).remote();
-    assertTaskFailedWithRayTaskException(actor.task(BadActor::badMethod).remote());
+    assertTaskFailedWithRayActorException(actor.task(BadActor::badMethod).remote());
   }
 
   public void testActorCreationFailedAndRestarted() {

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -513,8 +513,6 @@ cdef execute_task(
             if "RAY_PDB" in os.environ:
                 ray.util.pdb.post_mortem()
 
-            if (<int>task_type == <int>TASK_TYPE_ACTOR_CREATION_TASK):
-                worker.mark_actor_init_failed(error)
 
             backtrace = ray.utils.format_error_message(
                 traceback.format_exc(), task_exception=task_exception)
@@ -535,6 +533,13 @@ cdef execute_task(
                 ray_constants.TASK_PUSH_ERROR,
                 str(failure_object),
                 job_id=worker.current_job_id)
+            
+            # if error raised in creation task, eixt this actor to make it restarted
+            if (<int>task_type == <int>TASK_TYPE_ACTOR_CREATION_TASK):
+                # worker.mark_actor_init_failed(error)
+                # raise exit
+                error = SystemExit(0)
+                raise error
 
     if execution_info.max_calls != 0:
         # Reset the state of the worker for the next task to execute.

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -435,7 +435,6 @@ cdef execute_task(
             task_exception = False
             if not (<int>task_type == <int>TASK_TYPE_ACTOR_TASK
                     and function_name == "__ray_terminate__"):
-                worker.reraise_actor_init_error()
                 worker.memory_monitor.raise_if_low_memory()
 
             with core_worker.profile_event(b"task:deserialize_arguments"):
@@ -536,8 +535,6 @@ cdef execute_task(
             
             # if error raised in creation task, eixt this actor to make it restarted
             if (<int>task_type == <int>TASK_TYPE_ACTOR_CREATION_TASK):
-                # worker.mark_actor_init_failed(error)
-                # raise exit
                 error = SystemExit(0)
                 raise error
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -512,7 +512,6 @@ cdef execute_task(
             if "RAY_PDB" in os.environ:
                 ray.util.pdb.post_mortem()
 
-
             backtrace = ray.utils.format_error_message(
                 traceback.format_exc(), task_exception=task_exception)
             if isinstance(error, RayTaskError):
@@ -532,8 +531,9 @@ cdef execute_task(
                 ray_constants.TASK_PUSH_ERROR,
                 str(failure_object),
                 job_id=worker.current_job_id)
-            
-            # if error raised in creation task, eixt this actor to make it restarted
+
+            # if error raised in creation task,
+            # eixt this actor to make it restarted
             if (<int>task_type == <int>TASK_TYPE_ACTOR_CREATION_TASK):
                 error = SystemExit(0)
                 raise error

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -296,24 +296,6 @@ def test_actor_exit_from_task(ray_start_regular_shared):
     print(ray.get(x_id))  # This should not hang.
 
 
-def test_actor_init_error_propagated(ray_start_regular_shared):
-    @ray.remote
-    class Actor:
-        def __init__(self, error=False):
-            if error:
-                raise Exception("oops")
-
-        def foo(self):
-            return "OK"
-
-    actor = Actor.remote(error=False)
-    ray.get(actor.foo.remote())
-
-    actor = Actor.remote(error=True)
-    with pytest.raises(Exception, match=".*oops.*"):
-        ray.get(actor.foo.remote())
-
-
 def test_keyword_args(ray_start_regular_shared):
     @ray.remote
     class Actor:

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -9,6 +9,7 @@ import time
 
 import numpy as np
 import pytest
+import random
 import redis
 
 import ray
@@ -293,14 +294,14 @@ def test_failed_actor_init(ray_start_regular, error_pubsub):
 def test_failed_actor_init_and_restart(ray_start_regular, error_pubsub):
     p = error_pubsub
     error_message1 = "actor constructor failed"
-    error_flag = "TEST_ERROR_FLAG_666"
+    error_flag_file_name = "/tmp/TEST_ERROR_FLAG_" + str(random.randint(0, 99999))
 
     @ray.remote(max_restarts=2)
     class FailedActor:
         def __init__(self):
-            print("error_flag =", os.environ.get(error_flag))
-            if not os.environ.get(error_flag):
-                os.environ[error_flag] = "1"
+            if not os.path.isfile(error_flag_file_name):
+                open(error_flag_file_name, 'w').close()
+                print("flag not exits, raise error")
                 raise Exception(error_message1)
 
         def ok(self):

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -266,15 +266,14 @@ def temporary_helper_function():
 def test_failed_actor_init(ray_start_regular, error_pubsub):
     p = error_pubsub
     error_message1 = "actor constructor failed"
-    error_message2 = "actor method failed"
 
     @ray.remote
     class FailedActor:
         def __init__(self):
             raise Exception(error_message1)
 
-        def fail_method(self):
-            raise Exception(error_message2)
+        def test_method(self):
+            return True
 
     a = FailedActor.remote()
 
@@ -284,12 +283,11 @@ def test_failed_actor_init(ray_start_regular, error_pubsub):
     assert errors[0].type == ray_constants.TASK_PUSH_ERROR
     assert error_message1 in errors[0].error_message
 
-    # Make sure that we get errors from a failed method.
-    a.fail_method.remote()
-    errors = get_error_message(p, 1, ray_constants.TASK_PUSH_ERROR)
+    # Make sure that we get errors from later method.
+    a.test_method.remote()
+    errors = get_error_message(p, 1, ray_constants.WORKER_DIED_PUSH_ERROR)
     assert len(errors) == 1
-    assert errors[0].type == ray_constants.TASK_PUSH_ERROR
-    assert error_message1 in errors[0].error_message
+    assert errors[0].type == ray_constants.WORKER_DIED_PUSH_ERROR
 
 
 def test_failed_actor_init_and_restart(ray_start_regular, error_pubsub):

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -254,8 +254,7 @@ def temporary_helper_function():
     errors = get_error_message(p, 1, ray_constants.WORKER_DIED_PUSH_ERROR)
     assert len(errors) == 1
     assert errors[0].type == ray_constants.WORKER_DIED_PUSH_ERROR
-    assert ("A worker died or was killed" in
-            errors[0].error_message)
+    assert ("A worker died or was killed" in errors[0].error_message)
 
     f.close()
 

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -291,10 +291,12 @@ def test_failed_actor_init(ray_start_regular, error_pubsub):
     assert errors[0].type == ray_constants.TASK_PUSH_ERROR
     assert error_message1 in errors[0].error_message
 
+
 def test_failed_actor_init_and_restart(ray_start_regular, error_pubsub):
     p = error_pubsub
     error_message1 = "actor constructor failed"
-    error_flag_file_name = "/tmp/TEST_ERROR_FLAG_" + str(random.randint(0, 99999))
+    error_flag_file_name = "/tmp/TEST_ERROR_FLAG_" + str(
+        random.randint(0, 99999))
 
     @ray.remote(max_restarts=2)
     class FailedActor:
@@ -302,7 +304,7 @@ def test_failed_actor_init_and_restart(ray_start_regular, error_pubsub):
             # This actor will raise error at first time.
             # Then after restarting, it will be created successfully
             if not os.path.isfile(error_flag_file_name):
-                open(error_flag_file_name, 'w').close()
+                open(error_flag_file_name, "w").close()
                 print("flag not exits, raise error")
                 raise Exception(error_message1)
 
@@ -321,7 +323,7 @@ def test_failed_actor_init_and_restart(ray_start_regular, error_pubsub):
     def wait_until_ok():
         try:
             return ray.get(a.ok.remote()) == "OK"
-        except Exception as e:
+        except Exception:
             return False
 
     wait_for_condition(wait_until_ok)

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -9,7 +9,6 @@ import time
 
 import numpy as np
 import pytest
-import random
 import redis
 
 import ray

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -247,14 +247,14 @@ def temporary_helper_function():
 
     # Check that if we try to get the function it throws an exception and
     # does not hang.
-    with pytest.raises(Exception, match="failed to be imported"):
+    with pytest.raises(Exception, match="actor died unexpectedly"):
         ray.get(foo.get_val.remote(1, arg2=2))
 
     # Wait for the error from when the call to get_val.
-    errors = get_error_message(p, 1, ray_constants.TASK_PUSH_ERROR)
+    errors = get_error_message(p, 1, ray_constants.WORKER_DIED_PUSH_ERROR)
     assert len(errors) == 1
-    assert errors[0].type == ray_constants.TASK_PUSH_ERROR
-    assert ("failed to be imported, and so cannot execute this method" in
+    assert errors[0].type == ray_constants.WORKER_DIED_PUSH_ERROR
+    assert ("A worker died or was killed" in
             errors[0].error_message)
 
     f.close()

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -88,7 +88,6 @@ class Worker:
         self.node = None
         self.mode = None
         self.cached_functions_to_run = []
-        self.actor_init_error = None
         self.actors = {}
         # When the worker is constructed. Record the original value of the
         # CUDA_VISIBLE_DEVICES environment variable.

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -162,17 +162,6 @@ class Worker:
         assert isinstance(self.current_job_id, ray.JobID)
         return self._session_index, self.current_job_id
 
-    def mark_actor_init_failed(self, error):
-        """Called to mark this actor as failed during initialization."""
-
-        self.actor_init_error = error
-
-    def reraise_actor_init_error(self):
-        """Raises any previous actor initialization error."""
-
-        if self.actor_init_error is not None:
-            raise self.actor_init_error
-
     def get_serialization_context(self, job_id=None):
         """Get the SerializationContext of the job that this worker is processing.
 

--- a/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
@@ -147,11 +147,14 @@ JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeInitialize(
                                   ray_function_array_list, args_array_list);
         // Check whether the exception is `IntentionalSystemExit`.
         jthrowable throwable = env->ExceptionOccurred();
-        if (throwable &&
-            env->IsInstanceOf(throwable,
-                              java_ray_intentional_system_exit_exception_class)) {
+        if (throwable) {
+          bool is_intentional_exception = env->IsInstanceOf(throwable, java_ray_intentional_system_exit_exception_class);
           env->ExceptionClear();
-          return ray::Status::IntentionalSystemExit();
+          if (is_intentional_exception) {
+            return ray::Status::IntentionalSystemExit();
+          } else {
+            return ray::Status::UnexpectedSystemExit();
+          }
         }
         RAY_CHECK_JAVA_EXCEPTION(env);
 

--- a/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
@@ -148,7 +148,8 @@ JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeInitialize(
         // Check whether the exception is `IntentionalSystemExit`.
         jthrowable throwable = env->ExceptionOccurred();
         if (throwable) {
-          bool is_intentional_exception = env->IsInstanceOf(throwable, java_ray_intentional_system_exit_exception_class);
+          bool is_intentional_exception = env->IsInstanceOf(
+              throwable, java_ray_intentional_system_exit_exception_class);
           env->ExceptionClear();
           if (is_intentional_exception) {
             return ray::Status::IntentionalSystemExit();


### PR DESCRIPTION
## Why are these changes needed?

Now if an error is raised in actor's constructor, actor will remember this error and reraise this error in incoming tasks.

However, this makes the failover behavior of actor to be strange, some user is wondering: "why my actor was created failed but not been restarted? I've set max_restarts. Instead, it hangs there and keeps raising errors when I call it."

These users often write some codes that contain uncertain behaviors in the constructor like establishing a network connection, when a network error occurs, they want the actor to be restarted and try again until max_restarts exceed.


So the main problem is how we define 'when to rigger actor failover'(when max_restarts not exceed).

Now it is: 
1. process exits.

I want to change it to:
1. error raised in the constructor.
2. process exits.

What do you think?

This PR makes actors to be restarted when error raised in the constructor.


**Side effect that might happen after this PR:**
1.  User can't get init error by calling this actor anymore. They can only get this error by events.
2. If user set a huge max_restars and wirte bad codes in the constructor, the scale of chaos will be larger after this PR, because we'll keep restarting this actor. But I think it's ok because it's not our responsibility to deal with this.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
