### PR TITLE
Fix typo in Tune Docs (Checkpointing)

### DIFF
--- a/doc/source/tune/user-guide.rst
+++ b/doc/source/tune/user-guide.rst
@@ -233,7 +233,7 @@ To use Tune's checkpointing features, you must expose a ``checkpoint_dir`` argum
                     state = json.loads(f.read())
                     start = state["step"] + 1
 
-            for iter in range(start, 100):
+            for step in range(start, 100):
                 time.sleep(1)
 
                 # Obtain a checkpoint directory


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
<!-- Please give a short summary of the change and the problem this solves. -->
Identified typo in [Tune Checkpointing documentation](https://docs.ray.io/en/master/tune/user-guide.html#checkpointing) where example code snippet used the wrong iteration index. Edited to improve clarity. 


## Related issue number
Closes #13299
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
