### PR TITLE
[RLlib] add __len__() function to SampleBatch

### DIFF
--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -86,6 +86,11 @@ class SampleBatch:
         # Keeps track of new columns added after initial ones.
         self.new_columns = []
 
+    @PublicAPI
+    def __len__(self):
+        """Returns the amount of samples in the sample batch."""
+        return self.count
+
     @staticmethod
     @PublicAPI
     def concat_samples(samples: List["SampleBatch"]) -> \


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
It's a more typical way to get the length of a sample batch by ```len(batch)``` instead of ```batch.count```. The user does not necessarily know that ```batch.count``` exists at all (in fact I ran into this by blindly trying ```len(batch)``` and it didn't work).

<!-- Please give a short summary of the change and the problem this solves. -->
This adds the `__len__()` function to SampleBatch.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
