### PR TITLE
[ray_client]: Wait for ready and retry on ray.connect()

### DIFF
--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -63,8 +63,7 @@ class Worker:
             except grpc.FutureTimeoutError:
                 if conn_attempts == connection_retries:
                     raise ConnectionError("ray client connection timeout")
-                logger.info(
-                    f"Couldn't connect in {timeout} seconds, retrying")
+                logger.info(f"Couldn't connect in {timeout} seconds, retrying")
                 timeout = timeout + 5
                 if timeout > MAX_TIMEOUT_SEC:
                     timeout = MAX_TIMEOUT_SEC


### PR DESCRIPTION

## Why are these changes needed?

Implements wait and retry logic on ray.connect()

This takes care of the case where the server is not yet ready, but does not yet cover the case where the server drops mid-connection (still to come).

## Related issue number

First half of #13353

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
