### PR TITLE
Fix Serve release test

### DIFF
--- a/python/ray/serve/benchmarks/cluster.yaml
+++ b/python/ray/serve/benchmarks/cluster.yaml
@@ -26,7 +26,7 @@ worker_nodes:
     InstanceType: m5.xlarge
 initialization_commands: []
 setup_commands:
-    - apt-get install build-essential libssl-dev git -y
+    - sudo apt-get install build-essential libssl-dev git -y
     - 'rm -r wrk || true && git clone https://github.com/wg/wrk.git wrk && cd wrk && make -j && cp wrk /usr/local/bin'
     - ray install-nightly
 head_setup_commands: []

--- a/python/ray/serve/benchmarks/single.yaml
+++ b/python/ray/serve/benchmarks/single.yaml
@@ -21,7 +21,7 @@ head_node:
 
 initialization_commands: []
 setup_commands:
-    - apt-get install build-essential libssl-dev git -y
+    - sudo apt-get install build-essential libssl-dev git -y
     - 'rm -r wrk || true && git clone https://github.com/wg/wrk.git wrk && cd wrk && make -j && cp wrk /usr/local/bin'
     - ray install-nightly
 head_setup_commands: []


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Previously error due to docker permission changed in 1.1.0

```
(pid=2908) 2021-01-12 00:37:40,897	VINFO command_runner.py:479 -- Running `docker exec -it  ray_container /bin/bash -c 'bash --login -c -i '"'"'true && source ~/.bashrc && export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore && (apt-get install build-essential libssl-dev git -y)'"'"'' `E: Could not open lock file /var/lib/dpkg/lock-frontend - open (13: Permission denied)
(pid=2908) E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), are you root?
```
