### PR TITLE
[ray_client]: Monitor client stream errors

### DIFF
--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -366,6 +366,7 @@ def test_startup_retry(ray_start_regular_shared):
 
 def test_dataclient_server_drop(ray_start_regular_shared):
     from ray.util.client import ray as ray_client
+    ray_client._inside_client_test = True
 
     @ray_client.remote
     def f(x):
@@ -378,13 +379,14 @@ def test_dataclient_server_drop(ray_start_regular_shared):
 
     server = ray_client_server.serve("localhost:50051")
     ray_client.connect("localhost:50051")
-    thread = threading.Thread(target=stop_server, args=(server,))
+    thread = threading.Thread(target=stop_server, args=(server, ))
     thread.start()
     x = f.remote(2)
     with pytest.raises(ConnectionError):
-        g = ray_client.get(x)
+        _ = ray_client.get(x)
     thread.join()
     ray_client.disconnect()
+    ray_client._inside_client_test = False
     # Wait for f(x) to finish before ray.shutdown() in the fixture
     time.sleep(3)
 

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -364,5 +364,30 @@ def test_startup_retry(ray_start_regular_shared):
     ray_client._inside_client_test = False
 
 
+def test_dataclient_server_drop(ray_start_regular_shared):
+    from ray.util.client import ray as ray_client
+
+    @ray_client.remote
+    def f(x):
+        time.sleep(4)
+        return x
+
+    def stop_server(server):
+        time.sleep(2)
+        server.stop(0)
+
+    server = ray_client_server.serve("localhost:50051")
+    ray_client.connect("localhost:50051")
+    thread = threading.Thread(target=stop_server, args=(server,))
+    thread.start()
+    x = f.remote(2)
+    with pytest.raises(ConnectionError):
+        g = ray_client.get(x)
+    thread.join()
+    ray_client.disconnect()
+    # Wait for f(x) to finish before ray.shutdown() in the fixture
+    time.sleep(3)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -89,7 +89,9 @@ class RayAPIStub:
         return getattr(self.api, key)
 
     def is_connected(self) -> bool:
-        return self.client_worker is not None
+        if self.client_worker is None:
+            return False
+        return self.client_worker.is_connected()
 
     def init(self, *args, **kwargs):
         if self._server is not None:

--- a/python/ray/util/client/dataclient.py
+++ b/python/ray/util/client/dataclient.py
@@ -37,6 +37,7 @@ class DataClient:
         self._req_id = 0
         self._client_id = client_id
         self._metadata = metadata
+        self._in_shutdown = False
         self.data_thread.start()
 
     def _next_id(self) -> int:
@@ -67,9 +68,17 @@ class DataClient:
                     self.ready_data[response.req_id] = response
                     self.cv.notify_all()
         except grpc.RpcError as e:
-            if grpc.StatusCode.CANCELLED == e.code():
+            with self.cv:
+                self._in_shutdown = True
+                self.cv.notify_all()
+            if e.code() == grpc.StatusCode.CANCELLED:
                 # Gracefully shutting down
                 logger.info("Cancelling data channel")
+            elif e.code() == grpc.StatusCode.UNAVAILABLE:
+                # TODO(barakmich): The server may have dropped. In theory, we can retry, as per
+                # https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+                # but in practice we may need to think about the correct semantics here.
+                logger.info("Server disconnected from data channel")
             else:
                 logger.error(
                     f"Got Error from data channel -- shutting down: {e}")
@@ -88,7 +97,11 @@ class DataClient:
         self.request_queue.put(req)
         data = None
         with self.cv:
-            self.cv.wait_for(lambda: req_id in self.ready_data)
+            self.cv.wait_for(
+                lambda: req_id in self.ready_data or self._in_shutdown)
+            if self._in_shutdown:
+                raise ConnectionError(
+                    f"cannot send request {req}: data channel shutting down")
             data = self.ready_data[req_id]
             del self.ready_data[req_id]
         return data

--- a/python/ray/util/client/dataclient.py
+++ b/python/ray/util/client/dataclient.py
@@ -75,9 +75,11 @@ class DataClient:
                 # Gracefully shutting down
                 logger.info("Cancelling data channel")
             elif e.code() == grpc.StatusCode.UNAVAILABLE:
-                # TODO(barakmich): The server may have dropped. In theory, we can retry, as per
-                # https://grpc.github.io/grpc/core/md_doc_statuscodes.html
-                # but in practice we may need to think about the correct semantics here.
+                # TODO(barakmich): The server may have
+                # dropped. In theory, we can retry, as per
+                # https://grpc.github.io/grpc/core/md_doc_statuscodes.html but
+                # in practice we may need to think about the correct semantics
+                # here.
                 logger.info("Server disconnected from data channel")
             else:
                 logger.error(

--- a/python/ray/util/client/logsclient.py
+++ b/python/ray/util/client/logsclient.py
@@ -44,8 +44,16 @@ class LogstreamClient:
                     self.stdstream(level=record.level, msg=record.msg)
                 self.log(level=record.level, msg=record.msg)
         except grpc.RpcError as e:
-            if grpc.StatusCode.CANCELLED != e.code():
-                # Not just shutting down normally
+            if e.code() == grpc.StatusCode.CANCELLED:
+                # Graceful shutdown. We've cancelled our own connection.
+                logger.info("Cancelling logs channel")
+            elif e.code() == grpc.StatusCode.UNAVAILABLE:
+                # TODO(barakmich): The server may have dropped. In theory, we can retry, as per
+                # https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+                # but in practice we may need to think about the correct semantics here.
+                logger.info("Server disconnected from logs channel")
+            else:
+                # Some other, unhandled, gRPC error
                 logger.error(
                     f"Got Error from logger channel -- shutting down: {e}")
                 raise e

--- a/python/ray/util/client/logsclient.py
+++ b/python/ray/util/client/logsclient.py
@@ -48,9 +48,11 @@ class LogstreamClient:
                 # Graceful shutdown. We've cancelled our own connection.
                 logger.info("Cancelling logs channel")
             elif e.code() == grpc.StatusCode.UNAVAILABLE:
-                # TODO(barakmich): The server may have dropped. In theory, we can retry, as per
-                # https://grpc.github.io/grpc/core/md_doc_statuscodes.html
-                # but in practice we may need to think about the correct semantics here.
+                # TODO(barakmich): The server may have
+                # dropped. In theory, we can retry, as per
+                # https://grpc.github.io/grpc/core/md_doc_statuscodes.html but
+                # in practice we may need to think about the correct semantics
+                # here.
                 logger.info("Server disconnected from logs channel")
             else:
                 # Some other, unhandled, gRPC error


### PR DESCRIPTION
## Why are these changes needed?

Fixes the blocking bug for clients that have the server disconnect on them. Adds better connection monitoring in general.

## Related issue number

Parallel to #13376 
Closes #13353. (reopen or new bug if more issues come up)

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
