### PR TITLE
[ray_client]: Fix multiple attempts at checking connection

### DIFF
--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -65,6 +65,7 @@ class Worker:
             conn_attempts += 1
             try:
                 grpc.channel_ready_future(self.channel).result(timeout=timeout)
+                break
             except grpc.FutureTimeoutError:
                 if conn_attempts >= connection_retries:
                     raise ConnectionError("ray client connection timeout")


### PR DESCRIPTION
## Why are these changes needed?

Multiple simultaneous checks on connectivity are spun up, but if one completes the entire process before these return, a crash occurs.
It only needs to check connectivity once -- the loop is wrong.

## Related issue number

Closes #13418 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
