### PR TITLE
[ray_client]: fix exceptions raised while executing on the server on behalf of the client

### DIFF
--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -855,6 +855,11 @@ def test_inherit_actor_from_class(ray_start_regular_shared):
     assert ray.get(actor.g.remote(5)) == 6
 
 
+def test_get_non_existing_named_actor(ray_start_regular_shared):
+    with pytest.raises(ValueError):
+        bad = ray.get_actor("non_existing_actor")
+
+
 @pytest.mark.skip(
     "This test is just used to print the latency of creating 100 actors.")
 def test_actor_creation_latency(ray_start_regular_shared):

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -857,7 +857,7 @@ def test_inherit_actor_from_class(ray_start_regular_shared):
 
 def test_get_non_existing_named_actor(ray_start_regular_shared):
     with pytest.raises(ValueError):
-        bad = ray.get_actor("non_existing_actor")
+        _ = ray.get_actor("non_existing_actor")
 
 
 @pytest.mark.skip(

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -261,8 +261,7 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
                 result.valid = True
                 return result
         except Exception as e:
-            logger.error(f"Caught schedule exception {e}")
-            raise e
+            logger.debug(f"Caught schedule exception, returning: {e}")
             return ray_client_pb2.ClientTaskTicket(
                 valid=False, error=cloudpickle.dumps(e))
 


### PR DESCRIPTION
Adds a test for consistency and then fixes the (probably left as a debug) reraise of exceptions for client tasks.
Instead, delivers the correct exception back in-band.

## Related issue number

Closes #13346

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
