### PR TITLE
[Kubernetes] Unit test for cluster launch and teardown using K8s Operator

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -164,6 +164,7 @@ test_python() {
       -python/ray/tests:test_stress  # timeout
       -python/ray/tests:test_stress_sharded  # timeout
       -python/ray/tests:test_k8s_cluster_launcher
+      -python/ray/tests:test_k8s_operator_examples
     )
   fi
   if [ 0 -lt "${#args[@]}" ]; then  # Any targets to test?

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -111,8 +111,9 @@ py_test_module_list(
 py_test_module_list(
   files = [
     "test_k8s_cluster_launcher.py",
+    "test_k8s_operator_examples.py",
   ],
-  size = "small",
+  size = "medium",
   extra_srcs = SRCS,
   deps = ["//:ray_lib"],
   tags = ["kubernetes"]

--- a/python/ray/tests/test_k8s_operator_examples.py
+++ b/python/ray/tests/test_k8s_operator_examples.py
@@ -17,9 +17,9 @@ NAMESPACE = "test-k8s-operator-examples"
 
 
 def retry_until_true(f):
-    # Retry 30 times with 1 second delay between attempts.
+    # Retry 60 times with 1 second delay between attempts.
     def f_with_retries(*args, **kwargs):
-        for _ in range(30):
+        for _ in range(60):
             if f(*args, **kwargs):
                 return
             else:
@@ -147,4 +147,4 @@ class KubernetesOperatorTest(unittest.TestCase):
 
 if __name__ == "__main__":
     kubernetes.config.load_kube_config()
-    sys.exit(pytest.main(["-vs", __file__]))
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_k8s_operator_examples.py
+++ b/python/ray/tests/test_k8s_operator_examples.py
@@ -9,7 +9,6 @@ import kubernetes
 import pytest
 import yaml
 
-
 IMAGE_ENV = "KUBERNETES_OPERATOR_TEST_IMAGE"
 IMAGE = os.getenv(IMAGE_ENV, "rayproject/ray:nightly")
 NAMESPACE = "test-k8s-operator-examples"
@@ -22,6 +21,7 @@ def retry_until_true(f):
                 break
             else:
                 time.sleep(1)
+
     return f_with_retries
 
 
@@ -43,10 +43,10 @@ def wait_for_logs():
         "| grep ^example-cluster: | tail -n 100"
     log_tail = subprocess.check_output(cmd, shell=True).decode()
     # Normalize log to make this less sensitive to changes in logging output.
-    stripped_log_tail = "".join([ch.lower()
-                                 for ch in log_tail if ch.isalnum()])
-    return ("headnode1" in stripped_log_tail) and ("workernodes2"
-                                                   in stripped_log_tail)
+    stripped_log_tail = "".join(
+        [ch.lower() for ch in log_tail if ch.isalnum()])
+    return ("headnode1" in stripped_log_tail) and (
+        "workernodes2" in stripped_log_tail)
 
 
 def operator_configs_directory():
@@ -83,27 +83,26 @@ class KubernetesOperatorTest(unittest.TestCase):
                 open(example_cluster_config_path).read())
             example_cluster2_config = yaml.safe_load(
                 open(example_cluster2_config_path).read())
-            operator_config = list(yaml.safe_load_all(
-                open(operator_config_path).read()))
+            operator_config = list(
+                yaml.safe_load_all(open(operator_config_path).read()))
 
             # Fill image fields
             podTypes = example_cluster_config["spec"]["podTypes"]
             podTypes2 = example_cluster2_config["spec"]["podTypes"]
 
-            pod_configs = ([operator_config[-1]]
-                           + [podType["podConfig"] for podType in podTypes]
-                           + [podType["podConfig"] for podType in podTypes2])
+            pod_configs = ([operator_config[-1]] + [
+                podType["podConfig"] for podType in podTypes
+            ] + [podType["podConfig"] for podType in podTypes2])
             for pod_config in pod_configs:
                 fill_image_field(pod_config)
 
             # Dump to temporary files
-            yaml.dump(example_cluster_config,
-                      example_cluster_file)
-            yaml.dump(example_cluster2_config,
-                      example_cluster2_file)
+            yaml.dump(example_cluster_config, example_cluster_file)
+            yaml.dump(example_cluster2_config, example_cluster2_file)
             yaml.dump_all(operator_config, operator_file)
-            files = [example_cluster_file,
-                     example_cluster2_file, operator_file]
+            files = [
+                example_cluster_file, example_cluster2_file, operator_file
+            ]
             for file in files:
                 file.flush()
 

--- a/python/ray/tests/test_k8s_operator_examples.py
+++ b/python/ray/tests/test_k8s_operator_examples.py
@@ -1,0 +1,156 @@
+import sys
+import os
+import subprocess
+import tempfile
+import time
+import unittest
+
+import kubernetes
+import pytest
+import yaml
+
+
+IMAGE_ENV = "KUBERNETES_OPERATOR_TEST_IMAGE"
+IMAGE = os.getenv(IMAGE_ENV, "rayproject/ray:nightly")
+NAMESPACE = "test-k8s-operator-examples"
+
+
+def retry_until_true(f):
+    def f_with_retries(*args, **kwargs):
+        while True:
+            if f(*args, **kwargs):
+                break
+            else:
+                time.sleep(1)
+    return f_with_retries
+
+
+@retry_until_true
+def wait_for_pods(n):
+    client = kubernetes.client.CoreV1Api()
+    pods = client.list_namespaced_pod(namespace=NAMESPACE).items
+    # Double-check that the correct image is use.
+    for pod in pods:
+        assert pod.spec.containers[0].image == IMAGE
+    return len(pods) == n
+
+
+@retry_until_true
+def wait_for_logs():
+    """Check if logs indicate presence of 1 node of type "head" and 2 nodes of
+    type "worker"."""
+    cmd = f"kubectl -n {NAMESPACE} logs ray-operator-pod"\
+        "| grep ^example-cluster: | tail -n 100"
+    log_tail = subprocess.check_output(cmd, shell=True).decode()
+    # Normalize log to make this less sensitive to changes in logging output.
+    stripped_log_tail = "".join([ch.lower()
+                                 for ch in log_tail if ch.isalnum()])
+    return ("headnode1" in stripped_log_tail) and ("workernodes2"
+                                                   in stripped_log_tail)
+
+
+def operator_configs_directory():
+    here = os.path.realpath(__file__)
+    ray_python_root = os.path.dirname(os.path.dirname(here))
+    relative_path = "autoscaler/kubernetes/operator_configs"
+    return os.path.join(ray_python_root, relative_path)
+
+
+def get_operator_config_path(file_name):
+    return os.path.join(operator_configs_directory(), file_name)
+
+
+def fill_image_field(pod_config):
+    pod_config["spec"]["containers"][0]["image"] = IMAGE
+
+
+class KubernetesOperatorTest(unittest.TestCase):
+    def test_examples(self):
+        with tempfile.NamedTemporaryFile("w+") as example_cluster_file, \
+                tempfile.NamedTemporaryFile("w+") as example_cluster2_file,\
+                tempfile.NamedTemporaryFile("w+") as operator_file:
+
+            # Get paths to operator configs
+            example_cluster_config_path = get_operator_config_path(
+                "example_cluster.yaml")
+            example_cluster2_config_path = get_operator_config_path(
+                "example_cluster2.yaml")
+            operator_config_path = get_operator_config_path("operator.yaml")
+            self.crd_path = get_operator_config_path("cluster_crd.yaml")
+
+            # Load operator configs
+            example_cluster_config = yaml.safe_load(
+                open(example_cluster_config_path).read())
+            example_cluster2_config = yaml.safe_load(
+                open(example_cluster2_config_path).read())
+            operator_config = list(yaml.safe_load_all(
+                open(operator_config_path).read()))
+
+            # Fill image fields
+            podTypes = example_cluster_config["spec"]["podTypes"]
+            podTypes2 = example_cluster2_config["spec"]["podTypes"]
+
+            pod_configs = ([operator_config[-1]]
+                           + [podType["podConfig"] for podType in podTypes]
+                           + [podType["podConfig"] for podType in podTypes2])
+            for pod_config in pod_configs:
+                fill_image_field(pod_config)
+
+            # Dump to temporary files
+            yaml.dump(example_cluster_config,
+                      example_cluster_file)
+            yaml.dump(example_cluster2_config,
+                      example_cluster2_file)
+            yaml.dump_all(operator_config, operator_file)
+            files = [example_cluster_file,
+                     example_cluster2_file, operator_file]
+            for file in files:
+                file.flush()
+
+            # Apply CR
+            cmd = f"kubectl apply -f {self.crd_path}"
+            subprocess.check_call(cmd, shell=True)
+
+            # Create namespace
+            cmd = f"kubectl create namespace {NAMESPACE}"
+            subprocess.check_call(cmd, shell=True)
+
+            # Start operator and two clusters
+            for file in files:
+                cmd = f"kubectl -n {NAMESPACE} apply -f {file.name}"
+                subprocess.check_call(cmd, shell=True)
+
+            # Check that autoscaling respects minWorkers by waiting for
+            # six pods in the namespace.
+            wait_for_pods(6)
+
+            # Check that logging output looks normal (two workers connected to
+            # ray cluster example-cluster.)
+            wait_for_logs()
+
+            # Delete the second cluster
+            cmd = f"kubectl -n {NAMESPACE} delete -f"\
+                f"{example_cluster2_file.name}"
+            subprocess.check_call(cmd, shell=True)
+
+            # Four pods remain
+            wait_for_pods(4)
+
+            # Delete the first cluster
+            cmd = f"kubectl -n {NAMESPACE} delete -f"\
+                f"{example_cluster_file.name}"
+            subprocess.check_call(cmd, shell=True)
+
+            # Only operator pod remains.
+            wait_for_pods(1)
+
+    def __del__(self):
+        cmd = f"kubectl delete -f {self.crd_path}"
+        subprocess.check_call(cmd, shell=True)
+        cmd = f"kubectl delete namespace {NAMESPACE}"
+        subprocess.check_call(cmd, shell=True)
+
+
+if __name__ == "__main__":
+    kubernetes.config.load_kube_config()
+    sys.exit(pytest.main(["-vs", __file__]))

--- a/python/ray/tests/test_k8s_operator_examples.py
+++ b/python/ray/tests/test_k8s_operator_examples.py
@@ -1,3 +1,5 @@
+"""Tests launch and teardown of multiple Ray clusters using Kubernetes
+operator."""
 import sys
 import os
 import subprocess

--- a/python/ray/tests/test_k8s_operator_examples.py
+++ b/python/ray/tests/test_k8s_operator_examples.py
@@ -154,4 +154,4 @@ class KubernetesOperatorTest(unittest.TestCase):
 
 if __name__ == "__main__":
     kubernetes.config.load_kube_config()
-    sys.exit(pytest.main(["-vs", __file__]))
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Adds a unit test for cluster launch and teardown using the K8s Operator. 

Also, updates the `size` of K8s tests in `tests/BUILD` from `small` to `medium`. 
If I understand correctly, the `size` determines a timeout. These test could potentially take longer than a minute.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
  
Test passes locally using minikube with Kubernetes server version v1.19.0 and 1.20.1.
