### PR TITLE
Fix raylet::MockWorker::GetProcess crashes

### DIFF
--- a/src/ray/raylet/test/util.h
+++ b/src/ray/raylet/test/util.h
@@ -67,7 +67,6 @@ class MockWorker : public WorkerInterface {
   }
 
   Process GetProcess() const {
-    RAY_CHECK(false) << "Method unused";
     return Process::CreateNewDummy();
   }
   void SetProcess(Process proc) { RAY_CHECK(false) << "Method unused"; }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- Fix `raylet::MockWorker::GetProcess` crashes

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://github.com/ray-project/ray/pull/13435
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
