### PR TITLE
Revert "Revert "Enable Ray client server by default (#13350)" (#13429)"

### DIFF
--- a/cpp/src/ray/util/process_helper.cc
+++ b/cpp/src/ray/util/process_helper.cc
@@ -70,7 +70,7 @@ void ProcessHelper::RayStart(std::shared_ptr<RayConfig> config,
   options.store_socket = store_socket;
   options.raylet_socket = raylet_socket;
   if (options.worker_type == WorkerType::DRIVER) {
-    options.job_id = JobID::FromInt(1);
+    options.job_id = JobID::FromInt(0);
   }
   options.gcs_options = gcs_options;
   options.enable_logging = true;

--- a/doc/source/ray-client.rst
+++ b/doc/source/ray-client.rst
@@ -10,11 +10,13 @@ Ray Client
 Basic usage
 ===========
 
-While in beta, the server is available as an executable module. To start the server, run
+The Ray client server is automatically started on port ``10001`` when you use ``ray start --head`` or Ray in an autoscaling cluster. The port can be changed by specifying --ray-client-server-port in the ``ray start`` command.
+
+To start the server manually, you can run:
 
 ``python -m ray.util.client.server [--host host_ip] [--port port] [--redis-address address] [--redis-password password]``
 
-This runs ``ray.init()`` with default options and exposes the client gRPC port at ``host_ip:port`` (by default, ``0.0.0.0:50051``). Providing ``redis-address`` and ``redis-password`` will be passed into ``ray.init()`` when the server starts, allowing connection to an existing Ray cluster, as per the `cluster setup <cluster/index.html>`_ instructions.
+This runs ``ray.init()`` with default options and exposes the client gRPC port at ``host_ip:port`` (by default, ``0.0.0.0:10001``). Providing ``redis-address`` and ``redis-password`` will be passed into ``ray.init()`` when the server starts, allowing connection to an existing Ray cluster, as per the `cluster setup <cluster/index.html>`_ instructions.
 
 From here, another Ray script can access that server from a networked machine with ``ray.util.connect()``
 
@@ -23,7 +25,7 @@ From here, another Ray script can access that server from a networked machine wi
    import ray
    import ray.util
 
-   ray.util.connect("0.0.0.0:50051")  # replace with the appropriate host and port
+   ray.util.connect("<head_node_host>:10001")  # replace with the appropriate host and port
 
    # Normal Ray code follows
    @ray.remote
@@ -32,13 +34,12 @@ From here, another Ray script can access that server from a networked machine wi
 
    do_work.remote(2)
    #....
+  
+When the client disconnects, any object or actor references held by the server on behalf of the client are dropped, as if directly disconnecting from the cluster.
 
-When the client disconnects, any object or actor references held by the server on behalf of the client are dropped, as if directly disconnecting from the cluster
-
-
-===================
-``RAY_CLIENT_MODE``
-===================
+============
+Known issues
+============
 
 Because Ray client mode affects the behavior of the Ray API, larger scripts or libraries imported before ``ray.util.connect()`` may not realize they're in client mode. This feature is being tracked with `issue #13272 <https://github.com/ray-project/ray/issues/13272>`_ but the workaround here is provided for beta users.
 
@@ -49,21 +50,3 @@ Therefore, an environment variable is also available to force a Ray program into
 .. code-block:: bash
 
    RAY_CLIENT_MODE=1 python my_ray_program.py
-
-
-===================================
-Programatically creating the server
-===================================
-
-For larger use-cases, it may be desirable to connect remote Ray clients to an existing Ray environment. The server can be started separately via
-
-.. code-block:: python
-
-   from ray.util.client.server import serve
-
-   server = serve("0.0.0.0:50051")
-   # Server does some work
-   # ...
-   # Time to clean up
-   server.stop(0)
-

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -282,7 +282,7 @@ def debug(address):
     "--ray-client-server-port",
     required=False,
     type=int,
-    default=None,
+    default=10001,
     help="the port number the ray client server will bind on. If not set, "
     "the ray client server will not be started.")
 @click.option(

--- a/python/ray/tests/test_job.py
+++ b/python/ray/tests/test_job.py
@@ -33,7 +33,7 @@ _ = Actor.remote()
     assert len(actor_table) == 1
 
     job_table = ray.jobs()
-    assert len(job_table) == 2
+    assert len(job_table) == 3  # dash, ray client server
 
     # Kill the driver process.
     p.kill()
@@ -79,7 +79,7 @@ ray.get(_.value.remote())
     assert len(actor_table) == 1
 
     job_table = ray.jobs()
-    assert len(job_table) == 2
+    assert len(job_table) == 3  # dash, ray client server
 
     # Kill the driver process.
     p.kill()


### PR DESCRIPTION
This reverts commit 560299972c1527063c98c6c9d17f1316426cfa53.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The ray client server was causing the CPP mode test to fail; since it allocated jobid 1. The fix is to avoid using that job id.