### PR TITLE
Introduced automatic retrieval of metric names for the Keras Calback.

### DIFF
--- a/python/ray/tune/integration/keras.py
+++ b/python/ray/tune/integration/keras.py
@@ -146,6 +146,12 @@ class TuneReportCallback(TuneCallback):
                  metrics: Union[None, str, List[str], Dict[str, str]] = None,
                  on: Union[str, List[str]] = "epoch_end"):
         super(TuneReportCallback, self).__init__(on)
+        if metrics is None:
+            metrics = [
+                "{}{}".format(sub, metric)
+                for metric in self.model.metrics_names
+                for sub in ("", "val_")
+            ]
         if isinstance(metrics, str):
             metrics = [metrics]
         self._metrics = metrics


### PR DESCRIPTION
## Why are these changes needed?
This pull request introduces the automatic retrieval of metric names in Keras models.
The code added is extremely minimal, so it should be relatively trivial to merge this in.

## Related issue number
Closes #13449