### PR TITLE
[Core]Fix raylet scheduling bug

### DIFF
--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -1292,11 +1292,7 @@ def test_placement_group_wait_api(ray_start_cluster_head):
 def test_schedule_placement_groups_at_the_same_time():
     ray.init(num_cpus=4)
 
-    pgs = [
-        placement_group([{
-            "CPU": 2
-        }]) for _ in range(6)
-    ]
+    pgs = [placement_group([{"CPU": 2}]) for _ in range(6)]
 
     wait_pgs = {pg.ready(): pg for pg in pgs}
 

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -14,7 +14,7 @@ from ray.test_utils import (generate_system_config_map, get_other_nodes,
                             get_error_message)
 import ray.cluster_utils
 from ray._raylet import PlacementGroupID
-from ray.util.placement_group import (PlacementGroup,
+from ray.util.placement_group import (PlacementGroup, placement_group, remove_placement_group,
                                       get_current_placement_group)
 
 
@@ -1286,6 +1286,30 @@ def test_placement_group_wait_api(ray_start_cluster_head):
     # Wait for placement group 1 after it is removed.
     with pytest.raises(Exception):
         placement_group1.wait(10)
+
+
+def test_schedule_placement_groups_at_the_same_time():
+    ray.init(num_cpus=4)
+
+    pgs = [
+        placement_group([{"CPU": 2}])
+        for _ in range(6)  # Works for `range(4)`
+    ]
+
+    wait_pgs = {pg.ready(): pg for pg in pgs}
+
+    def is_all_placement_group_removed():
+        ready, _ = ray.wait(list(wait_pgs.keys()), timeout=0.5)
+        if ready:
+            ready_pg = wait_pgs[ready[0]]
+            remove_placement_group(ready_pg)
+            del wait_pgs[ready[0]]
+
+        if len(wait_pgs) == 0:
+            return True
+        return False
+
+    wait_for_condition(is_all_placement_group_removed)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -14,7 +14,8 @@ from ray.test_utils import (generate_system_config_map, get_other_nodes,
                             get_error_message)
 import ray.cluster_utils
 from ray._raylet import PlacementGroupID
-from ray.util.placement_group import (PlacementGroup, placement_group, remove_placement_group,
+from ray.util.placement_group import (PlacementGroup, placement_group,
+                                      remove_placement_group,
                                       get_current_placement_group)
 
 
@@ -1292,8 +1293,9 @@ def test_schedule_placement_groups_at_the_same_time():
     ray.init(num_cpus=4)
 
     pgs = [
-        placement_group([{"CPU": 2}])
-        for _ in range(6)  # Works for `range(4)`
+        placement_group([{
+            "CPU": 2
+        }]) for _ in range(6)
     ]
 
     wait_pgs = {pg.ready(): pg for pg in pgs}

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -174,6 +174,10 @@ int64_t ClusterResourceScheduler::GetBestSchedulableNode(const TaskRequest &task
                                                          bool actor_creation,
                                                          int64_t *total_violations,
                                                          bool *is_infeasible) {
+  // NOTE: We need to set `is_infeasible` to false in advance to avoid `is_infeasible` not
+  // being set.
+  *is_infeasible = false;
+
   // Minimum number of soft violations across all nodes that can schedule the request.
   // We will pick the node with the smallest number of soft violations.
   int64_t min_violations = INT_MAX;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fix raylet scheduling bug:  If `GetBestSchedulableNode` returns directly, `is_infeasible` will not be set.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/13403
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
