### PR TITLE
[RLlib] Deflake 2x remote & local inference tests (external env).

### DIFF
--- a/rllib/env/tests/test_local_inference.sh
+++ b/rllib/env/tests/test_local_inference.sh
@@ -10,7 +10,8 @@ else
     basedir="rllib/examples/serving"  # In bazel.
 fi
 
-(python $basedir/cartpole_server.py --run=PPO 2>&1 | grep -v 200) &
+# Do not attempt to restore from checkpoint; leads to errors on travis.
+(python $basedir/cartpole_server.py --run=PPO --no-restore 2>&1 | grep -v 200) &
 pid=$!
 
 echo "Waiting for server to start"

--- a/rllib/env/tests/test_remote_inference.sh
+++ b/rllib/env/tests/test_remote_inference.sh
@@ -10,7 +10,8 @@ else
     basedir="rllib/examples/serving"  # In bazel.
 fi
 
-(python $basedir/cartpole_server.py --run=DQN 2>&1 | grep -v 200) &
+# Do not attempt to restore from checkpoint; leads to errors on travis.
+(python $basedir/cartpole_server.py --run=DQN --no-restore 2>&1 | grep -v 200) &
 pid=$!
 
 echo "Waiting for server to start"

--- a/rllib/examples/serving/cartpole_server.py
+++ b/rllib/examples/serving/cartpole_server.py
@@ -23,6 +23,11 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--run", type=str, default="DQN")
 parser.add_argument(
     "--framework", type=str, choices=["tf", "torch"], default="tf")
+parser.add_argument(
+    "--no-restore",
+    action="store_true",
+    help="Do not restore from a previously saved checkpoint (location of "
+    "which is saved in `last_checkpoint_[algo-name].out`).")
 
 if __name__ == "__main__":
     args = parser.parse_args()
@@ -65,13 +70,13 @@ if __name__ == "__main__":
 
     checkpoint_path = CHECKPOINT_FILE.format(args.run)
 
-    # Attempt to restore from checkpoint if possible.
-    if os.path.exists(checkpoint_path):
+    # Attempt to restore from checkpoint, if possible.
+    if not args.no_restore and os.path.exists(checkpoint_path):
         checkpoint_path = open(checkpoint_path).read()
         print("Restoring from checkpoint path", checkpoint_path)
         trainer.restore(checkpoint_path)
 
-    # Serving and training loop
+    # Serving and training loop.
     while True:
         print(pretty_print(trainer.train()))
         checkpoint = trainer.save()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Deflake 2x remote/local inference tests (for external env).
These tests sometimes fail because the second test finds the `last_checkpoint...` file from the first one, even though the actual checkpoint (pointed to in that file) is already gone -> tune then fails trying to restore from a non-existing checkpoint.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
