### PR TITLE
[Object Spilling] Dedup restore objects

### DIFF
--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -302,6 +302,10 @@ void LocalObjectManager::AsyncRestoreSpilledObject(
     std::function<void(const ray::Status &)> callback) {
   RAY_LOG(DEBUG) << "Restoring spilled object " << object_id << " from URL "
                  << object_url;
+  if (objects_pending_restore_.count(object_id) > 0) {
+    // If the same object is restoring, we dedup here.
+    return;
+  }
   io_worker_pool_.PopRestoreWorker([this, object_id, object_url, callback](
                                        std::shared_ptr<WorkerInterface> io_worker) {
     auto start_time = absl::GetCurrentTimeNanos();
@@ -309,11 +313,14 @@ void LocalObjectManager::AsyncRestoreSpilledObject(
     rpc::RestoreSpilledObjectsRequest request;
     request.add_spilled_objects_url(std::move(object_url));
     request.add_object_ids_to_restore(object_id.Binary());
+    RAY_CHECK(objects_pending_restore_.emplace(object_id).second)
+        << "Object dedupe wasn't done properly. Please report if you see this issue.";
     io_worker->rpc_client()->RestoreSpilledObjects(
         request,
         [this, start_time, object_id, callback, io_worker](
             const ray::Status &status, const rpc::RestoreSpilledObjectsReply &r) {
           io_worker_pool_.PushRestoreWorker(io_worker);
+          objects_pending_restore_.erase(object_id);
           if (!status.ok()) {
             RAY_LOG(ERROR) << "Failed to send restore spilled object request: "
                            << status.ToString();

--- a/src/ray/raylet/local_object_manager.h
+++ b/src/ray/raylet/local_object_manager.h
@@ -193,6 +193,9 @@ class LocalObjectManager {
   // written to the object directory.
   absl::flat_hash_map<ObjectID, std::unique_ptr<RayObject>> objects_pending_spill_;
 
+  /// Objects that were spilled on this node but that are being restored.
+  /// The field is used to dedup the same restore request while restoration is in
+  /// progress.
   absl::flat_hash_set<ObjectID> objects_pending_restore_;
 
   /// The time that we last sent a FreeObjects request to other nodes for

--- a/src/ray/raylet/local_object_manager.h
+++ b/src/ray/raylet/local_object_manager.h
@@ -193,6 +193,8 @@ class LocalObjectManager {
   // written to the object directory.
   absl::flat_hash_map<ObjectID, std::unique_ptr<RayObject>> objects_pending_spill_;
 
+  absl::flat_hash_set<ObjectID> objects_pending_restore_;
+
   /// The time that we last sent a FreeObjects request to other nodes for
   /// objects that have gone out of scope in the application.
   uint64_t last_free_objects_at_ms_ = 0;

--- a/src/ray/raylet/test/local_object_manager_test.cc
+++ b/src/ray/raylet/test/local_object_manager_test.cc
@@ -81,8 +81,15 @@ class MockIOWorkerClient : public rpc::CoreWorkerClientInterface {
   void RestoreSpilledObjects(
       const rpc::RestoreSpilledObjectsRequest &request,
       const rpc::ClientCallback<rpc::RestoreSpilledObjectsReply> &callback) override {
+    restore_callbacks.push_back(callback);
+  }
+
+  void ReplyRestoreObjects(int64_t bytes_restored, Status status = Status::OK()) {
     rpc::RestoreSpilledObjectsReply reply;
-    callback(Status(), reply);
+    reply.set_bytes_restored_total(bytes_restored);
+    auto callback = restore_callbacks.front();
+    callback(status, reply);
+    restore_callbacks.pop_front();
   }
 
   void DeleteSpilledObjects(
@@ -113,6 +120,7 @@ class MockIOWorkerClient : public rpc::CoreWorkerClientInterface {
 
   std::list<rpc::ClientCallback<rpc::SpillObjectsReply>> callbacks;
   std::list<rpc::ClientCallback<rpc::DeleteSpilledObjectsReply>> delete_callbacks;
+  std::list<rpc::ClientCallback<rpc::RestoreSpilledObjectsReply>> restore_callbacks;
   std::list<rpc::DeleteSpilledObjectsRequest> delete_requests;
 };
 
@@ -307,10 +315,14 @@ TEST_F(LocalObjectManagerTest, TestRestoreSpilledObject) {
   std::string object_url("url");
   int num_times_fired = 0;
   EXPECT_CALL(worker_pool, PushRestoreWorker(_));
-  manager.AsyncRestoreSpilledObject(object_id, object_url, [&](const Status &status) {
-    ASSERT_TRUE(status.ok());
-    num_times_fired++;
-  });
+  // Subsequent calls should be deduped, so that only one callback should be fired.
+  for (int i = 0; i < 10; i++) {
+    manager.AsyncRestoreSpilledObject(object_id, object_url, [&](const Status &status) {
+      ASSERT_TRUE(status.ok());
+      num_times_fired++;
+    });
+  }
+  worker_pool.io_worker_client->ReplyRestoreObjects(10);
   ASSERT_EQ(num_times_fired, 1);
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If we are going with Stephanie's suggestion to support multi node spilling, RestoreObjects are invoked much more often, so we should dedup them properly. We also need feature anyway because we still sometimes have duplicated restore objects if restoring is not done before pull is timedout.

## Related issue number

https://github.com/ray-project/ray/issues/13224

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
