### PR TITLE
[ray_client]: fix wrong reference in server_pickler

### DIFF
--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -860,6 +860,25 @@ def test_get_non_existing_named_actor(ray_start_regular_shared):
         _ = ray.get_actor("non_existing_actor")
 
 
+def test_wrapped_actor_handle(ray_start_regular_shared):
+    @ray.remote
+    class B:
+        def doit(self):
+            return 2
+
+    @ray.remote
+    class A:
+        def __init__(self):
+            self.b = B.remote()
+
+        def get_actor_ref(self):
+            return [self.b]
+
+    a = A.remote()
+    b_list = ray.get(a.get_actor_ref.remote())
+    assert ray.get(b_list[0].doit.remote()) == 2
+
+
 @pytest.mark.skip(
     "This test is just used to print the latency of creating 100 actors.")
 def test_actor_creation_latency(ray_start_regular_shared):

--- a/python/ray/util/client/server/server_pickler.py
+++ b/python/ray/util/client/server/server_pickler.py
@@ -61,9 +61,9 @@ class ServerPickler(cloudpickle.CloudPickler):
             actor_id = obj._actor_id.binary()
             if actor_id not in self.server.actor_refs:
                 # We're passing back a handle, probably inside a reference.
-                self.actor_refs[actor_id] = obj
-            if actor_id not in self.actor_owners[self.client_id]:
-                self.actor_owners[self.client_id].add(actor_id)
+                self.server.actor_refs[actor_id] = obj
+            if actor_id not in self.server.actor_owners[self.client_id]:
+                self.server.actor_owners[self.client_id].add(actor_id)
             return PickleStub(
                 type="Actor",
                 client_id=self.client_id,


### PR DESCRIPTION
## Why are these changes needed?

Simple typo in the server_pickler. My comment on that line was a called shot on the use-case, it was just implemented with the wrong checks.

Added a test anyway.

## Related issue number
Closes #13463

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
