### PR TITLE
[Metric] Fix crashed when register metric view in multithread

### DIFF
--- a/src/ray/stats/metric.cc
+++ b/src/ray/stats/metric.cc
@@ -22,7 +22,7 @@ namespace ray {
 
 namespace stats {
 
-absl::Mutex Metric::mutex_;
+absl::Mutex Metric::registration_mutex_;
 
 static void RegisterAsView(opencensus::stats::ViewDescriptor view_descriptor,
                            const std::vector<opencensus::tags::TagKey> &keys) {
@@ -88,10 +88,10 @@ void Metric::Record(double value, const TagsType &tags) {
   }
 
   // NOTE(lingxuan.zlx): Double check for recording performance while
-  // processing in multithread and avoid race since a metric may invoke
+  // processing in multithread and avoid race since metrics may invoke
   // record in different threads or code pathes.
   if (measure_ == nullptr) {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(&registration_mutex_);
     if (measure_ == nullptr) {
       // Measure could be registered before, so we try to get it first.
       MeasureDouble registered_measure =

--- a/src/ray/stats/metric.cc
+++ b/src/ray/stats/metric.cc
@@ -22,6 +22,8 @@ namespace ray {
 
 namespace stats {
 
+absl::Mutex Metric::mutex_;
+
 static void RegisterAsView(opencensus::stats::ViewDescriptor view_descriptor,
                            const std::vector<opencensus::tags::TagKey> &keys) {
   // Register global keys.
@@ -85,19 +87,24 @@ void Metric::Record(double value, const TagsType &tags) {
     return;
   }
 
+  // NOTE(lingxuan.zlx): Double check for recording performance while
+  // processing in multithread and avoid race since a metric may invoke
+  // record in different threads or code pathes.
   if (measure_ == nullptr) {
-    // Measure could be registered before, so we try to get it first.
-    MeasureDouble registered_measure =
-        opencensus::stats::MeasureRegistry::GetMeasureDoubleByName(name_);
+    absl::MutexLock lock(&mutex_);
+    if (measure_ == nullptr) {
+      // Measure could be registered before, so we try to get it first.
+      MeasureDouble registered_measure =
+          opencensus::stats::MeasureRegistry::GetMeasureDoubleByName(name_);
 
-    if (registered_measure.IsValid()) {
-      measure_.reset(new MeasureDouble(registered_measure));
-    } else {
-      measure_.reset(
-          new MeasureDouble(MeasureDouble::Register(name_, description_, unit_)));
+      if (registered_measure.IsValid()) {
+        measure_.reset(new MeasureDouble(registered_measure));
+      } else {
+        measure_.reset(
+            new MeasureDouble(MeasureDouble::Register(name_, description_, unit_)));
+      }
+      RegisterView();
     }
-
-    RegisterView();
   }
 
   // Do record.

--- a/src/ray/stats/metric.h
+++ b/src/ray/stats/metric.h
@@ -129,6 +129,9 @@ class Metric {
   std::vector<opencensus::tags::TagKey> tag_keys_;
   std::unique_ptr<opencensus::stats::Measure<double>> measure_;
 
+  // For making sure thread-safe to all of metric registrations.
+  static absl::Mutex mutex_;
+
 };  // class Metric
 
 class Gauge : public Metric {

--- a/src/ray/stats/metric.h
+++ b/src/ray/stats/metric.h
@@ -130,7 +130,7 @@ class Metric {
   std::unique_ptr<opencensus::stats::Measure<double>> measure_;
 
   // For making sure thread-safe to all of metric registrations.
-  static absl::Mutex mutex_;
+  static absl::Mutex registration_mutex_;
 
 };  // class Metric
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
We fond there will be race while registering metric in multithread and process crash finally.
According to opencensus source code, it's known issue but not fixed yet.
```cpp
void StatsManager::ViewInformation::AddConsumer() {
  mu_->AssertHeld();
  ++num_consumers_;
}

int StatsManager::ViewInformation::RemoveConsumer() {
  mu_->AssertHeld();
  return --num_consumers_;
}
```
```cpp
  // TODO: PERF: Global synchronization is only needed for adding or
  // removing measures--we can reduce recording contention by claiming a reader
  // lock on mu_ and a writer lock on a measure-specific mutex.
  mutable absl::Mutex mu_;
```

So we'd better add lock for registering metric when first recording.
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/13484
<!-- For example: "Closes #1234" -->

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests
   - [ ] This PR is not tested :(
