### PR TITLE
[Metric] AssertError when ray is not initialized

### DIFF
--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -299,6 +299,14 @@ def test_metrics_override_shouldnt_warn(ray_start_regular, log_pubsub):
             assert "Attempt to register measure" not in line
 
 
+def test_custom_metrics_without_ray_init():
+    with pytest.raises(AssertionError):                      
+        error_counter = Count( 
+                    "c", 
+                    description="", 
+                    tag_keys=("backend", ))
+
+
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -300,11 +300,8 @@ def test_metrics_override_shouldnt_warn(ray_start_regular, log_pubsub):
 
 
 def test_custom_metrics_without_ray_init():
-    with pytest.raises(AssertionError):                      
-        error_counter = Count( 
-                    "c", 
-                    description="", 
-                    tag_keys=("backend", ))
+    with pytest.raises(AssertionError):
+        Count("c", description="", tag_keys=("backend", ))
 
 
 if __name__ == "__main__":

--- a/python/ray/util/metrics.py
+++ b/python/ray/util/metrics.py
@@ -2,6 +2,7 @@ import logging
 
 from typing import Dict, Any, List, Optional, Tuple
 
+import ray
 from ray._raylet import (
     Count as CythonCount,
     Histogram as CythonHistogram,
@@ -22,6 +23,8 @@ class Metric:
                  name: str,
                  description: str = "",
                  tag_keys: Optional[Tuple[str]] = None):
+        assert ray.is_initialized(), (
+            "Ray metric APIs cannot be used when ray is not initialized.")
         if len(name) == 0:
             raise ValueError("Empty name is not allowed. "
                              "Please provide a metric name.")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://github.com/ray-project/ray/issues/13378

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
