### PR TITLE
Add Dashboard Python Test to Buildkite

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -7,6 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 ENV BUILDKITE=true
 ENV CI=true
+ENV PYTHON=3.6
 
 RUN apt-get update -qq
 RUN apt-get install -y -qq \

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -25,4 +25,5 @@ WORKDIR /ray
 
 # Below should be re-run each time
 COPY . .
-RUN ./ci/travis/ci.sh init && ./ci/travis/ci.sh build
+RUN ./ci/travis/ci.sh init
+RUN bash --login ./ci/travis/ci.sh build

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -26,4 +26,4 @@ WORKDIR /ray
 # Below should be re-run each time
 COPY . .
 RUN ./ci/travis/ci.sh init
-RUN bash --login ./ci/travis/ci.sh build
+RUN bash --login -i ./ci/travis/ci.sh build

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -25,5 +25,4 @@ WORKDIR /ray
 
 # Below should be re-run each time
 COPY . .
-RUN ./ci/travis/ci.sh init
-RUN ./ci/travis/ci.sh build
+RUN ./ci/travis/ci.sh init && ./ci/travis/ci.sh build

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,11 @@
 - label: "Ray Core Tests (:buildkite: Experimental)"
   commands:
   - bazel test --config=ci $(./scripts/bazel_export_options) --build_tests_only -- //:all -rllib/...
+- label: "Ray Dashboard Tests"
+  commands:
+  - which python
+  - python --version
+  - conda activate || true
+  - which python
+  - python --version
+  - bazel test --config=ci $(./scripts/bazel_export_options) python/ray/new_dashboard/...

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,9 +3,4 @@
   - bazel test --config=ci $(./scripts/bazel_export_options) --build_tests_only -- //:all -rllib/...
 - label: "Ray Dashboard Tests"
   commands:
-  - which python
-  - python --version
-  - conda activate || true
-  - which python
-  - python --version
   - bazel test --config=ci $(./scripts/bazel_export_options) python/ray/new_dashboard/...

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -281,6 +281,11 @@ install_ray() {
   (
     cd "${WORKSPACE_DIR}"/python
     build_dashboard_front_end
+    which python
+    which pip
+    conda activate base
+    which python
+    which pip
     keep_alive pip install -v -e .
   )
 }

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -281,11 +281,6 @@ install_ray() {
   (
     cd "${WORKSPACE_DIR}"/python
     build_dashboard_front_end
-    which python
-    which pip
-    conda activate base
-    which python
-    which pip
     keep_alive pip install -v -e .
   )
 }

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -216,8 +216,10 @@ install_upgrade_pip() {
 }
 
 install_node() {
-  if [ "${OSTYPE}" = msys ]; then
+  if [ "${OSTYPE}" = msys ] ; then
     { echo "WARNING: Skipping running Node.js due to incompatibilities with Windows"; } 2> /dev/null
+  elif [ -n "${BUILDKITE-}" ] ; then
+    { echo "WARNING: Skipping running Node.js on buildkite because it's already there"; } 2> /dev/null
   else
     # Install the latest version of Node.js in order to build the dashboard.
     (


### PR DESCRIPTION
This PR fixes few issue about Python environment in buildkite and turn on the Ray dashboard tests. 
See the build result here: https://buildkite.com/ray-project/ray-builders-pr/builds/41