### PR TITLE
Pipe monitor.err logs to driver

### DIFF
--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -125,8 +125,8 @@ class LogMonitor:
         log_file_paths = glob.glob(f"{self.logs_dir}/worker*[.out|.err]")
         # segfaults and other serious errors are logged here
         raylet_err_paths = glob.glob(f"{self.logs_dir}/raylet*.err")
-        # monitor logs are needed to report autoscaler events
-        monitor_log_paths = glob.glob(f"{self.logs_dir}/monitor.log")
+        # The .log file contains autoscaler events, the .err file errors.
+        monitor_log_paths = glob.glob(f"{self.logs_dir}/monitor*[.log|.err]")
         # If gcs server restarts, there can be multiple log files.
         gcs_err_path = glob.glob(f"{self.logs_dir}/gcs_server*.err")
         for file_path in (log_file_paths + raylet_err_paths + gcs_err_path +

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -995,7 +995,7 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
         else:
             return colorama.Fore.CYAN
 
-    if data["pid"] == "autoscaler":
+    if data["pid"] == "autoscaler" and not data["is_err"]:
         pid = "{} +{}".format(data["pid"], time_string())
         lines = filter_autoscaler_events(data["lines"])
     else:


### PR DESCRIPTION
This is a partial solution to https://github.com/ray-project/ray/issues/13538

It whitelists the monitor.err file, which contains uncaught exceptions. It isn't a total solution since the monitor can crash prior to the user connecting, in which case the user won't see any errors. However, it's better than nothing and is a trivial change.