### PR TITLE
Fix Docker Permission for Serve release test again

### DIFF
--- a/python/ray/serve/benchmarks/cluster.yaml
+++ b/python/ray/serve/benchmarks/cluster.yaml
@@ -27,7 +27,7 @@ worker_nodes:
 initialization_commands: []
 setup_commands:
     - sudo apt-get install build-essential libssl-dev git -y
-    - 'rm -r wrk || true && git clone https://github.com/wg/wrk.git wrk && cd wrk && make -j && cp wrk /usr/local/bin'
+    - 'rm -r wrk || true && git clone https://github.com/wg/wrk.git /tmp/wrk && cd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin'
     - ray install-nightly
 head_setup_commands: []
 worker_setup_commands: []

--- a/python/ray/serve/benchmarks/single.yaml
+++ b/python/ray/serve/benchmarks/single.yaml
@@ -22,7 +22,7 @@ head_node:
 initialization_commands: []
 setup_commands:
     - sudo apt-get install build-essential libssl-dev git -y
-    - 'rm -r wrk || true && git clone https://github.com/wg/wrk.git wrk && cd wrk && make -j && cp wrk /usr/local/bin'
+    - 'rm -r wrk || true && git clone https://github.com/wg/wrk.git /tmp/wrk && cd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin'
     - ray install-nightly
 head_setup_commands: []
 worker_setup_commands: []

--- a/release/long_running_tests/cluster.yaml
+++ b/release/long_running_tests/cluster.yaml
@@ -15,3 +15,10 @@ auth:
 
 head_node:
     InstanceType: m5.xlarge
+    TagSpecifications:
+        - ResourceType: "instance"
+          Tags:
+            - Key: anyscale-user
+              Value: "release-automation@anyscale.com"
+            - Key: anyscale-custodian
+              Value: "ignore"


### PR DESCRIPTION
Somehow missed in the past.
+ Added a piggyback commit to set expiration="never" for long running tests. we will have a separate process of managing that.