### PR TITLE
Remove PYTHON_MODE from __all__ in __init__.py.

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -130,7 +130,6 @@ __all__ = [
     "util",
     "wait",
     "LOCAL_MODE",
-    "PYTHON_MODE",
     "SCRIPT_MODE",
     "WORKER_MODE",
 ]


### PR DESCRIPTION
PYTHON_MODE is not defined in this version of Ray so including it in __all__ in __init__.py causes a "from ray import *" statement in some other Python file to generate an AttributeError for the non-present PYTHON_MODE identifier.  Fix is simply to remove the identifier from __all__.