### PR TITLE
[tune] Allow actor reuse for new trials

### DIFF
--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -257,7 +257,15 @@ class RayTrialExecutor(TrialExecutor):
             existing_runner = self._cached_actor
             self._cached_actor = None
             trial.set_runner(existing_runner)
-            if not self.reset_trial(trial, trial.config, trial.experiment_tag,
+
+            trial_config = copy.deepcopy(trial.config)
+            trial_config[TRIAL_INFO] = TrialInfo(trial)
+
+            stdout_file, stderr_file = trial.log_to_file
+            trial_config[STDOUT_FILE] = stdout_file
+            trial_config[STDERR_FILE] = stderr_file
+
+            if not self.reset_trial(trial, trial_config, trial.experiment_tag,
                                     logger_creator):
                 raise AbortTrialExecution(
                     "Trainable runner reuse requires reset_config() to be "

--- a/python/ray/tune/tests/test_actor_reuse.py
+++ b/python/ray/tune/tests/test_actor_reuse.py
@@ -49,6 +49,7 @@ def create_resettable_class():
             if "fake_reset_not_supported" in self.config:
                 return False
             self.num_resets += 1
+            self.iter = 0
             self.msg = new_config.get("message", "No message")
             return True
 
@@ -131,7 +132,7 @@ class ActorReuseTest(unittest.TestCase):
         self.assertEqual([t.last_result["id"] for t in trials], [0, 1, 2, 3])
         self.assertEqual([t.last_result["iter"] for t in trials], [2, 2, 2, 2])
         self.assertEqual([t.last_result["num_resets"] for t in trials],
-                         [1, 2, 3, 4])
+                         [4, 5, 6, 7])
 
     def testTrialReuseEnabledFunction(self):
         num_resets = defaultdict(lambda: 0)
@@ -176,7 +177,7 @@ class ActorReuseTest(unittest.TestCase):
             reuse_actors=True).trials
 
         # Check trial 1
-        self.assertEqual(trial1.last_result["num_resets"], 1)
+        self.assertEqual(trial1.last_result["num_resets"], 2)
         self.assertTrue(os.path.exists(os.path.join(trial1.logdir, "stdout")))
         self.assertTrue(os.path.exists(os.path.join(trial1.logdir, "stderr")))
         with open(os.path.join(trial1.logdir, "stdout"), "rt") as fp:
@@ -191,7 +192,7 @@ class ActorReuseTest(unittest.TestCase):
             self.assertNotIn("LOG_STDERR: Second", content)
 
         # Check trial 2
-        self.assertEqual(trial2.last_result["num_resets"], 2)
+        self.assertEqual(trial2.last_result["num_resets"], 3)
         self.assertTrue(os.path.exists(os.path.join(trial2.logdir, "stdout")))
         self.assertTrue(os.path.exists(os.path.join(trial2.logdir, "stderr")))
         with open(os.path.join(trial2.logdir, "stdout"), "rt") as fp:

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -431,6 +431,10 @@ class Trainable:
         reset actor behavior for the new config."""
         self.config = new_config
 
+        trial_info = new_config.pop(TRIAL_INFO, None)
+        if trial_info:
+            self._trial_info = trial_info
+
         self._result_logger.flush()
         self._result_logger.close()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently Tune Trainable class actors are only reused when they are restored from a checkpoint. New trials never reuse existing cached actors.

This behavior is unexpected, as the `reset_config()` method should get rid of any state in trainables, i.e. a checkpoint should not be a strict requirement to reuse actors. Enabling actor reuse for fresh trials also gets rid of performance bottlenecks, e.g. in https://github.com/ray-project/tune-sklearn which uses the class API and currently cannot utilize actor reuse at all.

The change has been originally introduced in this https://github.com/ray-project/ray/pull/4218 (this commit: https://github.com/ray-project/ray/pull/4218/commits/1ba7336f4bdc19d1aa3591235d4c5eba355a05df#diff-d2fec0e96fae75bb29b4e5bea5860dfb6388381b31f6859019e8b2bf984bbb55). 

## Related issue number

Closes #13475

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
