### PR TITLE
[RLLIB] trainer._validate_config idempotentcy correction (issue 13427)

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1493,6 +1493,13 @@ py_test(
     srcs = ["tests/test_timesteps.py"]
 )
 
+py_test(
+    name = "tests/test_trainer",
+    tags = ["tests_dir", "tests_dir_T"],
+    size = "small",
+    srcs = ["tests/test_trainer.py"]
+)
+
 # --------------------------------------------------------------------
 # examples/ directory
 #

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -1102,7 +1102,7 @@ class Trainer(Trainable):
             if model_config.get("_time_major"):
                 raise ValueError("`model._time_major` only supported "
                                  "iff `_use_trajectory_view_api` is True!")
-            elif traj_view_framestacks != "auto":
+            elif traj_view_framestacks not in ["auto", 0]:
                 raise ValueError("`model.num_framestacks` only supported "
                                  "iff `_use_trajectory_view_api` is True!")
             model_config["num_framestacks"] = 0

--- a/rllib/tests/test_trainer.py
+++ b/rllib/tests/test_trainer.py
@@ -5,7 +5,6 @@ from ray.rllib.agents.trainer import Trainer, COMMON_CONFIG
 
 
 class TestTrainer(unittest.TestCase):
-
     def test_validate_config_idempotent(self):
         """
         Asserts that validate_config run multiple

--- a/rllib/tests/test_trainer.py
+++ b/rllib/tests/test_trainer.py
@@ -1,0 +1,31 @@
+"""Testing for trainer class"""
+import copy
+import unittest
+from ray.rllib.agents.trainer import Trainer, COMMON_CONFIG
+
+
+class TestTrainer(unittest.TestCase):
+
+    def test_validate_config_idempotent(self):
+        """
+        Asserts that validate_config run multiple
+        times on COMMON_CONFIG will be idempotent
+        """
+        # Given
+        standard_config = copy.deepcopy(COMMON_CONFIG)
+        standard_config["_use_trajectory_view_api"] = False
+
+        # When (we validate config 2 times)
+        Trainer._validate_config(standard_config)
+        config_v1 = copy.deepcopy(standard_config)
+        Trainer._validate_config(standard_config)
+        config_v2 = copy.deepcopy(standard_config)
+
+        # Then
+        self.assertEqual(config_v1, config_v2)
+
+
+if __name__ == "__main__":
+    import pytest
+    import sys
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Why are these changes needed?

_validate_config was failing if run 2 times on the same config.

## Related issue number
@sven1977 does this look like an acceptable resolution for this?

closes #13556

## Checks

- [x ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
