### PR TITLE
[autoscaler][AWS] Make sure subnets belong to same VPC as user-specified security groups

### DIFF
--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -602,8 +602,8 @@ def _upsert_security_group_rules(conf, security_groups):
     sgids = {sg.id for sg in security_groups.values()}
 
     # Update sgids to include user-specified security groups.
-    # This is necessary if the head node type's security groups are specified
-    # but not the worker's, or vice-versa.
+    # This is necessary if the user specifies the head node type's security
+    # groups but not the worker's, or vice-versa.
     for node_type in NODE_KIND_CONFIG_KEYS.values():
         sgids.update(conf[node_type].get("SecurityGroupIds", []))
 
@@ -624,7 +624,7 @@ def _update_inbound_rules(target_security_group, sgids, config):
 
 
 def _create_default_inbound_rules(sgids, extended_rules=[]):
-    intracluster_rules = _create_default_instracluster_inbound_rules(sgids)
+    intracluster_rules = _create_default_intracluster_inbound_rules(sgids)
     ssh_rules = _create_default_ssh_inbound_rules()
     merged_rules = itertools.chain(
         intracluster_rules,
@@ -634,7 +634,7 @@ def _create_default_inbound_rules(sgids, extended_rules=[]):
     return list(merged_rules)
 
 
-def _create_default_instracluster_inbound_rules(intracluster_sgids):
+def _create_default_intracluster_inbound_rules(intracluster_sgids):
     return [{
         "FromPort": -1,
         "ToPort": -1,

--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -600,6 +600,13 @@ def _create_security_group(config, vpc_id, group_name):
 
 def _upsert_security_group_rules(conf, security_groups):
     sgids = {sg.id for sg in security_groups.values()}
+
+    # Update sgids to include user-specified security groups.
+    # This is necessary if the head node type's security groups are specified
+    # but not the worker's, or vice-versa.
+    for node_type in NODE_KIND_CONFIG_KEYS.values():
+        sgids.update(conf[node_type].get("SecurityGroupIds", []))
+
     # sort security group items for deterministic inbound rule config order
     # (mainly supports more precise stub-based boto3 unit testing)
     for node_type, sg in sorted(security_groups.items()):

--- a/python/ray/autoscaler/aws/example-head-and-worker-security-group.yaml
+++ b/python/ray/autoscaler/aws/example-head-and-worker-security-group.yaml
@@ -1,0 +1,31 @@
+cluster_name: sg
+
+max_workers: 1
+
+provider:
+    type: aws
+    region: us-west-2
+    availability_zone: us-west-2a
+
+auth:
+    ssh_user: ubuntu
+
+# If required, head and worker nodes can exist on subnets in different VPCs and
+# communicate via VPC peering.
+
+# VPC peering overview: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-peering.html.
+# Setup VPC peering: https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html.
+# Configure VPC peering route tables: https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-routing.html.
+
+# To enable external SSH connectivity, you should also ensure that your VPC
+# is configured to assign public IPv4 addresses to every EC2 instance
+# assigned to it.
+head_node:
+    SecurityGroupIds:
+        - sg-1234abcd # Replace with an actual security group id.
+
+worker_nodes:
+    SecurityGroupIds:
+        - sg-1234abcd # Replace with an actual security group id.
+
+

--- a/python/ray/tests/aws/test_autoscaler_aws.py
+++ b/python/ray/tests/aws/test_autoscaler_aws.py
@@ -113,6 +113,38 @@ def test_create_sg_with_custom_inbound_rules_and_name(iam_client_stub,
     ec2_client_stub.assert_no_pending_responses()
 
 
+def test_subnet_given_head_and_worker_sg(iam_client_stub, ec2_client_stub):
+    stubs.configure_iam_role_default(iam_client_stub)
+    stubs.configure_key_pair_default(ec2_client_stub)
+
+    #stuff
+
+    config = helpers.bootstrap_aws_example_config_file(
+        "example-security-group.yaml")
+    # assert
+
+    # expect no pending responses left in IAM or EC2 client stub queues
+    iam_client_stub.assert_no_pending_responses()
+    ec2_client_stub.assert_no_pending_responses()
+    pass
+
+
+def test_subnet_given_only_head_sg(iam_client_stub, ec2_client_stub):
+    stubs.configure_iam_role_default(iam_client_stub)
+    stubs.configure_key_pair_default(ec2_client_stub)
+
+    #stuff
+
+    config = helpers.bootstrap_aws_example_config_file(
+        "example-security-group.yaml")
+    # assert
+
+    # expect no pending responses left in IAM or EC2 client stub queues
+    iam_client_stub.assert_no_pending_responses()
+    ec2_client_stub.assert_no_pending_responses()
+    pass
+
+
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/aws/test_autoscaler_aws.py
+++ b/python/ray/tests/aws/test_autoscaler_aws.py
@@ -113,6 +113,7 @@ def test_create_sg_with_custom_inbound_rules_and_name(iam_client_stub,
     ec2_client_stub.assert_no_pending_responses()
 
 
+"""
 def test_subnet_given_head_and_worker_sg(iam_client_stub, ec2_client_stub):
     stubs.configure_iam_role_default(iam_client_stub)
     stubs.configure_key_pair_default(ec2_client_stub)
@@ -143,7 +144,7 @@ def test_subnet_given_only_head_sg(iam_client_stub, ec2_client_stub):
     iam_client_stub.assert_no_pending_responses()
     ec2_client_stub.assert_no_pending_responses()
     pass
-
+"""
 
 if __name__ == "__main__":
     import sys

--- a/python/ray/tests/aws/test_autoscaler_aws.py
+++ b/python/ray/tests/aws/test_autoscaler_aws.py
@@ -113,38 +113,24 @@ def test_create_sg_with_custom_inbound_rules_and_name(iam_client_stub,
     ec2_client_stub.assert_no_pending_responses()
 
 
-"""
 def test_subnet_given_head_and_worker_sg(iam_client_stub, ec2_client_stub):
     stubs.configure_iam_role_default(iam_client_stub)
     stubs.configure_key_pair_default(ec2_client_stub)
 
-    #stuff
+    # expect to describe an sg and filter subnets based on that sg
+    stubs.configure_subnet_given_sg(ec2_client_stub, DEFAULT_SG)
 
     config = helpers.bootstrap_aws_example_config_file(
-        "example-security-group.yaml")
-    # assert
+        "example-head-and-worker-security-group.yaml")
+
+    # check that subnets are filled
+    assert config["head_node"]["SubnetIds"] == [DEFAULT_SUBNET["SubnetId"]]
+    assert config["worker_nodes"]["SubnetIds"] == [DEFAULT_SUBNET["SubnetId"]]
 
     # expect no pending responses left in IAM or EC2 client stub queues
     iam_client_stub.assert_no_pending_responses()
     ec2_client_stub.assert_no_pending_responses()
-    pass
 
-
-def test_subnet_given_only_head_sg(iam_client_stub, ec2_client_stub):
-    stubs.configure_iam_role_default(iam_client_stub)
-    stubs.configure_key_pair_default(ec2_client_stub)
-
-    #stuff
-
-    config = helpers.bootstrap_aws_example_config_file(
-        "example-security-group.yaml")
-    # assert
-
-    # expect no pending responses left in IAM or EC2 client stub queues
-    iam_client_stub.assert_no_pending_responses()
-    ec2_client_stub.assert_no_pending_responses()
-    pass
-"""
 
 if __name__ == "__main__":
     import sys

--- a/python/ray/tests/aws/test_autoscaler_aws.py
+++ b/python/ray/tests/aws/test_autoscaler_aws.py
@@ -117,13 +117,14 @@ def test_subnet_given_head_and_worker_sg(iam_client_stub, ec2_client_stub):
     stubs.configure_iam_role_default(iam_client_stub)
     stubs.configure_key_pair_default(ec2_client_stub)
 
-    # expect to describe an sg and filter subnets based on that sg
-    stubs.configure_subnet_given_sg(ec2_client_stub, DEFAULT_SG)
+    # list a security group and a thousand subnets in different vpcs
+    stubs.describe_a_security_group(ec2_client_stub, DEFAULT_SG)
+    stubs.describe_a_thousand_subnets_in_different_vpcs(ec2_client_stub)
 
     config = helpers.bootstrap_aws_example_config_file(
         "example-head-and-worker-security-group.yaml")
 
-    # check that subnets are filled
+    # check that just the single subnet in the right vpc is filled
     assert config["head_node"]["SubnetIds"] == [DEFAULT_SUBNET["SubnetId"]]
     assert config["worker_nodes"]["SubnetIds"] == [DEFAULT_SUBNET["SubnetId"]]
 

--- a/python/ray/tests/aws/utils/constants.py
+++ b/python/ray/tests/aws/utils/constants.py
@@ -50,6 +50,23 @@ DEFAULT_SUBNET = {
     "VpcId": "vpc-0000000",
 }
 
+
+def subnet_in_vpc(vpc_num):
+    """Returns a copy of DEFAULT_SUBNET whose VpcId ends with the digits
+    of vpc_num."""
+    subnet = copy.copy(DEFAULT_SUBNET)
+    vpc_id = DEFAULT_SUBNET["VpcId"]
+    vpc_num = str(vpc_num)
+    n = len(vpc_num)
+    new_vpc_id = vpc_id[:-n] + vpc_num
+    subnet["VpcId"] = new_vpc_id
+    return subnet
+
+
+A_THOUSAND_SUBNETS_IN_DIFFERENT_VPCS = [
+    subnet_in_vpc(vpc_num) for vpc_num in range(1, 1000)
+] + [DEFAULT_SUBNET]
+
 # Secondary EC2 subnet to expose to tests as required.
 AUX_SUBNET = {
     "AvailabilityZone": "us-west-2a",

--- a/python/ray/tests/aws/utils/constants.py
+++ b/python/ray/tests/aws/utils/constants.py
@@ -55,11 +55,7 @@ def subnet_in_vpc(vpc_num):
     """Returns a copy of DEFAULT_SUBNET whose VpcId ends with the digits
     of vpc_num."""
     subnet = copy.copy(DEFAULT_SUBNET)
-    vpc_id = DEFAULT_SUBNET["VpcId"]
-    vpc_num = str(vpc_num)
-    n = len(vpc_num)
-    new_vpc_id = vpc_id[:-n] + vpc_num
-    subnet["VpcId"] = new_vpc_id
+    subnet["VpcId"] = f"vpc-{vpc_num:07d}"
     return subnet
 
 

--- a/python/ray/tests/aws/utils/stubs.py
+++ b/python/ray/tests/aws/utils/stubs.py
@@ -35,9 +35,10 @@ def configure_key_pair_default(ec2_client_stub):
 
 
 def configure_subnet_default(ec2_client_stub):
+    describe_no_security_groups(ec2_client_stub)
     ec2_client_stub.add_response(
         "describe_subnets",
-        expected_params={},
+        expected_params={"Filters": ANY},
         service_response={"Subnets": [DEFAULT_SUBNET]})
 
 

--- a/python/ray/tests/aws/utils/stubs.py
+++ b/python/ray/tests/aws/utils/stubs.py
@@ -1,7 +1,7 @@
 import ray
 from ray.tests.aws.utils.mocks import mock_path_exists_key_pair
 from ray.tests.aws.utils.constants import DEFAULT_INSTANCE_PROFILE, \
-    DEFAULT_KEY_PAIR, DEFAULT_SUBNET
+    DEFAULT_KEY_PAIR, DEFAULT_SUBNET, A_THOUSAND_SUBNETS_IN_DIFFERENT_VPCS
 
 from unittest import mock
 
@@ -35,24 +35,17 @@ def configure_key_pair_default(ec2_client_stub):
 
 
 def configure_subnet_default(ec2_client_stub):
-    describe_no_security_groups(ec2_client_stub)
     ec2_client_stub.add_response(
         "describe_subnets",
-        expected_params={"Filters": []},
+        expected_params={},
         service_response={"Subnets": [DEFAULT_SUBNET]})
 
 
-def configure_subnet_given_sg(ec2_client_stub, security_group):
-    describe_a_security_group(ec2_client_stub, security_group)
+def describe_a_thousand_subnets_in_different_vpcs(ec2_client_stub):
     ec2_client_stub.add_response(
         "describe_subnets",
-        expected_params={
-            "Filters": [{
-                "Name": "vpc-id",
-                "Values": [security_group["VpcId"]]
-            }]
-        },
-        service_response={"Subnets": [DEFAULT_SUBNET]})
+        expected_params={},
+        service_response={"Subnets": A_THOUSAND_SUBNETS_IN_DIFFERENT_VPCS})
 
 
 def skip_to_configure_sg(ec2_client_stub, iam_client_stub):

--- a/python/ray/tests/aws/utils/stubs.py
+++ b/python/ray/tests/aws/utils/stubs.py
@@ -38,7 +38,20 @@ def configure_subnet_default(ec2_client_stub):
     describe_no_security_groups(ec2_client_stub)
     ec2_client_stub.add_response(
         "describe_subnets",
-        expected_params={"Filters": ANY},
+        expected_params={"Filters": []},
+        service_response={"Subnets": [DEFAULT_SUBNET]})
+
+
+def configure_subnet_given_sg(ec2_client_stub, security_group):
+    describe_a_security_group(ec2_client_stub, security_group)
+    ec2_client_stub.add_response(
+        "describe_subnets",
+        expected_params={
+            "Filters": [{
+                "Name": "vpc-id",
+                "Values": [security_group["VpcId"]]
+            }]
+        },
         service_response={"Subnets": [DEFAULT_SUBNET]})
 
 
@@ -65,6 +78,18 @@ def describe_no_security_groups(ec2_client_stub):
         "describe_security_groups",
         expected_params={"Filters": ANY},
         service_response={})
+
+
+def describe_a_security_group(ec2_client_stub, security_group):
+    ec2_client_stub.add_response(
+        "describe_security_groups",
+        expected_params={
+            "Filters": [{
+                "Name": "group-id",
+                "Values": [security_group["GroupId"]]
+            }]
+        },
+        service_response={"SecurityGroups": [security_group]})
 
 
 def create_sg_echo(ec2_client_stub, security_group):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR addresses a problem in `autoscaler/_private/aws/config.py`.
Currently `_configure_subnets` does not take into account security groups specified in the `head_node` and `worker_nodes` fields. 
Thus, it's possible that a subnet is chosen that belongs to a different VPC than user-specified security groups. In this situation, a cluster can't be launched.

This PR fixes that problem by detecting the VPC of security groups specified in `head_node` and `worker_nodes` configs and restricting to subnets in that VPC.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
 
I also did some manual tests of `_configure_subnets` and of `ray up` to make sure things were working as expected. 
