### PR TITLE
[Metrics] Make DeltaProducer thread detached

### DIFF
--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -183,7 +183,7 @@ def test_metrics_export_end_to_end(_setup_cluster_for_test):
 
 
 def test_metrics_after_restart(shutdown_only):
-    # Test that metrics infrastructure is correctly cleaned up upon 
+    # Test that metrics infrastructure is correctly cleaned up upon
     # shutting down a Ray cluster.
     ray.init()
     ray.shutdown()

--- a/thirdparty/patches/opencensus-cpp-shutdown-api.patch
+++ b/thirdparty/patches/opencensus-cpp-shutdown-api.patch
@@ -1,12 +1,17 @@
 diff --git opencensus/stats/internal/delta_producer.cc opencensus/stats/internal/delta_producer.cc
-index c61b4d9..b3e4ef2 100644
+index c61b4d9..e38c952 100644
 --- opencensus/stats/internal/delta_producer.cc
 +++ opencensus/stats/internal/delta_producer.cc
-@@ -75,6 +75,20 @@ DeltaProducer* DeltaProducer::Get() {
+@@ -75,6 +75,25 @@ DeltaProducer* DeltaProducer::Get() {
    return global_delta_producer;
  }
  
 +void DeltaProducer::Shutdown() {
++  // NOTE(simon): Shutdown is skipped because the global singleton thread
++  // cannot be restarted after ray.shutdown() followed by ray.init().
++  // See https://github.com/ray-project/ray/issues/13532
++  return;
++
 +  {
 +    absl::MutexLock l(&mu_);
 +    if (!thread_started_) {
@@ -23,19 +28,20 @@ index c61b4d9..b3e4ef2 100644
  void DeltaProducer::AddMeasure() {
    delta_mu_.Lock();
    absl::MutexLock harvester_lock(&harvester_mu_);
-@@ -115,7 +129,10 @@ void DeltaProducer::Flush() {
+@@ -115,7 +134,11 @@ void DeltaProducer::Flush() {
  }
  
  DeltaProducer::DeltaProducer()
 -    : harvester_thread_(&DeltaProducer::RunHarvesterLoop, this) {}
 +    : harvester_thread_(&DeltaProducer::RunHarvesterLoop, this) {
++  harvester_thread_.detach();
 +  absl::MutexLock l(&mu_);
 +  thread_started_ = true;
 +}
  
  void DeltaProducer::SwapDeltas() {
    ABSL_ASSERT(last_delta_.delta().empty() && "Last delta was not consumed.");
-@@ -131,11 +148,19 @@ void DeltaProducer::RunHarvesterLoop() {
+@@ -131,11 +154,19 @@ void DeltaProducer::RunHarvesterLoop() {
    absl::Time next_harvest_time = absl::Now() + harvest_interval_;
    while (true) {
      const absl::Time now = absl::Now();
@@ -82,10 +88,10 @@ index 2cff522..c8e2e95 100644
  
  }  // namespace stats
 diff --git opencensus/stats/internal/stats_exporter.cc opencensus/stats/internal/stats_exporter.cc
-index 43ddbc7..37b4ae1 100644
+index 43ddbc7..685249c 100644
 --- opencensus/stats/internal/stats_exporter.cc
 +++ opencensus/stats/internal/stats_exporter.cc
-@@ -95,25 +95,52 @@ void StatsExporterImpl::ClearHandlersForTesting() {
+@@ -95,25 +95,57 @@ void StatsExporterImpl::ClearHandlersForTesting() {
  }
  
  void StatsExporterImpl::StartExportThread() EXCLUSIVE_LOCKS_REQUIRED(mu_) {
@@ -105,6 +111,11 @@ index 43ddbc7..37b4ae1 100644
 +  // Join loop thread when shutdown.
 +  if (t_.joinable()) {
 +    t_.join();
++  }
++  {
++    absl::MutexLock l(&mu_);
++    handlers_.clear();
++    views_.clear();
 +  }
  }
  


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR fixes a problem with Ray stats not being correctly cleaned up upon `ray.shutdown()`.  This PR resets the global variables `handlers_`and `views_` in `StatsExporter` upon shutdown.  For `DeltaProducer`, shutdown is skipped because the global singleton thread cannot be restarted after `ray.shutdown()` followed by `ray.init()`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/13532.
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
