### PR TITLE
Fix for operator role definition to add raycluster/finalizer

### DIFF
--- a/python/ray/autoscaler/kubernetes/operator_configs/operator.yaml
+++ b/python/ray/autoscaler/kubernetes/operator_configs/operator.yaml
@@ -10,8 +10,8 @@ metadata:
   name: ray-operator-role
 rules:
 - apiGroups: ["", "cluster.ray.io"]
-  resources: ["rayclusters", "pods", "pods/exec"]
-  verbs: ["get", "watch", "list", "create", "delete", "patch"]
+  resources: ["rayclusters", "rayclusters/finalizers", "pods", "pods/exec"]
+  verbs: ["get", "watch", "list", "create", "delete", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Fix to k8s operator role definition
## Related issue number

<!-- For example: "Closes #1234" -->
Fix for #13554 
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
I ran script with the following results:
```
$ scripts/format.sh
WARNING: Ray uses clang-format 7.0.0, You currently are using 11.0.1. This might generate different results.
From github.com:ray-project/ray
 * branch                master     -> FETCH_HEAD
 $
 ```
 From the output provided above, not sure if the script above is successful.


- [N/A] I've included any doc changes needed for https://docs.ray.io/en/master/.

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/

Ran the following tests resulting in 2 failures:
```
$ bazel test --build_tests_only //:all  --test_output=streamed
Extracting Bazel installation...
//:actor_manager_test                                                    PASSED in 9.0s
//:client_connection_test                                                PASSED in 0.4s
//:cluster_resource_scheduler_test                                       PASSED in 0.7s
//:cluster_task_manager_test                                             PASSED in 0.7s
//:core_worker_test                                                      PASSED in 31.6s
//:create_request_queue_test                                             PASSED in 1.1s
//:dependency_manager_test                                               PASSED in 0.4s
//:direct_actor_transport_test                                           PASSED in 30.4s
//:direct_task_transport_test                                            PASSED in 0.4s
//:event_test                                                            PASSED in 3.6s
//:filesystem_test                                                       PASSED in 0.3s
//:gcs_actor_manager_test                                                PASSED in 0.5s
//:gcs_actor_scheduler_test                                              PASSED in 0.3s
//:gcs_node_manager_test                                                 PASSED in 0.4s
//:gcs_object_manager_test                                               PASSED in 0.4s
//:gcs_placement_group_manager_test                                      PASSED in 1.0s
//:gcs_placement_group_scheduler_test                                    PASSED in 0.7s
//:gcs_pub_sub_test                                                      PASSED in 7.2s
//:gcs_resource_manager_test                                             PASSED in 0.3s
//:gcs_resource_scheduler_test                                           PASSED in 0.3s
//:gcs_server_rpc_test                                                   PASSED in 3.6s
//:global_state_accessor_test                                            PASSED in 7.3s
//:id_test                                                               PASSED in 0.4s
//:in_memory_gcs_table_storage_test                                      PASSED in 0.7s
//:in_memory_store_client_test                                           PASSED in 0.8s
//:lease_policy_test                                                     PASSED in 0.4s
//:local_object_manager_test                                             PASSED in 0.4s
//:logging_test                                                          PASSED in 0.3s
//:metric_exporter_client_test                                           PASSED in 0.6s
//:object_recovery_manager_test                                          PASSED in 0.4s
//:placement_group_resource_manager_test                                 PASSED in 0.5s
//:pull_manager_test                                                     PASSED in 0.4s
//:push_manager_test                                                     PASSED in 0.4s
//:reconstruction_policy_test                                            PASSED in 1.5s
//:redis_gcs_table_storage_test                                          PASSED in 0.9s
//:redis_store_client_test                                               PASSED in 2.8s
//:reference_count_test                                                  PASSED in 0.4s
//:sample_test                                                           PASSED in 0.7s
//:scheduling_queue_test                                                 PASSED in 30.3s
//:sequencer_test                                                        PASSED in 0.5s
//:signal_test                                                           PASSED in 1.6s
//:stats_test                                                            PASSED in 3.9s
//:task_manager_test                                                     PASSED in 0.7s
//:util_test                                                             PASSED in 0.8s
//:worker_pool_test                                                      PASSED in 0.5s
//:asio_test                                                             FAILED in 1.4s
  /private/var/tmp/_bazel_darroyo/622e41ccb4a7fed29380a636c729d919/execroot/com_github_ray_project_ray/bazel-out/darwin-opt/testlogs/asio_test/test.log
//:gcs_server_test                                                       FAILED in 94.8s
  /private/var/tmp/_bazel_darroyo/622e41ccb4a7fed29380a636c729d919/execroot/com_github_ray_project_ray/bazel-out/darwin-opt/testlogs/gcs_server_test/test.log

Executed 47 out of 47 tests: 45 tests pass and 2 fail locally.
INFO: Build completed, 2 tests FAILED, 3568 total actions
$
```


- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
