### PR TITLE
[Metrics] Fix serialization for custom metrics

### DIFF
--- a/python/ray/util/metrics.py
+++ b/python/ray/util/metrics.py
@@ -132,6 +132,11 @@ class Count(Metric):
         self._metric = CythonCount(self._name, self._description, self._unit,
                                    self._tag_keys)
 
+    def __reduce__(self):
+        deserializer = Count
+        serialized_data = (self._name, self._description, self._tag_keys)
+        return deserializer, serialized_data
+
 
 class Histogram(Metric):
     """Histogram distribution of metric points.
@@ -162,6 +167,12 @@ class Histogram(Metric):
                                        self._unit, self.boundaries,
                                        self._tag_keys)
 
+    def __reduce__(self):
+        deserializer = Histogram
+        serialized_data = (self._name, self._description, self.boundaries,
+                           self._tag_keys)
+        return deserializer, serialized_data
+
     @property
     def info(self):
         """Return information about histogram metric."""
@@ -188,6 +199,11 @@ class Gauge(Metric):
         super().__init__(name, description, tag_keys)
         self._metric = CythonGauge(self._name, self._description, self._unit,
                                    self._tag_keys)
+
+    def __reduce__(self):
+        deserializer = Count
+        serialized_data = (self._name, self._description, self._tag_keys)
+        return deserializer, serialized_data
 
 
 __all__ = [

--- a/python/ray/util/metrics.py
+++ b/python/ray/util/metrics.py
@@ -201,7 +201,7 @@ class Gauge(Metric):
                                    self._tag_keys)
 
     def __reduce__(self):
-        deserializer = Count
+        deserializer = Gauge
         serialized_data = (self._name, self._description, self._tag_keys)
         return deserializer, serialized_data
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Overrides `__reduce__` methods in custom metrics to make them serializable.  Some serialization has been added to the end-to-end custom metrics test to test this.

## Related issue number

Closes https://github.com/ray-project/ray/issues/10564. 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
