### PR TITLE
Revert "Pipe monitor.err logs to driver"

### DIFF
--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -125,8 +125,8 @@ class LogMonitor:
         log_file_paths = glob.glob(f"{self.logs_dir}/worker*[.out|.err]")
         # segfaults and other serious errors are logged here
         raylet_err_paths = glob.glob(f"{self.logs_dir}/raylet*.err")
-        # The .log file contains autoscaler events, the .err file errors.
-        monitor_log_paths = glob.glob(f"{self.logs_dir}/monitor*[.log|.err]")
+        # monitor logs are needed to report autoscaler events
+        monitor_log_paths = glob.glob(f"{self.logs_dir}/monitor.log")
         # If gcs server restarts, there can be multiple log files.
         gcs_err_path = glob.glob(f"{self.logs_dir}/gcs_server*.err")
         for file_path in (log_file_paths + raylet_err_paths + gcs_err_path +

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -995,7 +995,7 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
         else:
             return colorama.Fore.CYAN
 
-    if data["pid"] == "autoscaler" and not data["is_err"]:
+    if data["pid"] == "autoscaler":
         pid = "{} +{}".format(data["pid"], time_string())
         lines = filter_autoscaler_events(data["lines"])
     else:


### PR DESCRIPTION
This reverts commit a0d08c2cc638c1766a08e2030642c9b434609efa.

It seems the monitor.err logs contain SSH stderr output, which is too verbose ("Shared connection to YYY closed" etc.)