### PR TITLE
Extra new line in Ray client logstream print

### DIFF
--- a/python/ray/util/client/logsclient.py
+++ b/python/ray/util/client/logsclient.py
@@ -69,7 +69,7 @@ class LogstreamClient:
             msg: The content of the message
         """
         print_file = sys.stderr if level == -2 else sys.stdout
-        print(msg, file=print_file)
+        print(msg, file=print_file, end="")
 
     def set_logstream_level(self, level: int):
         logger.setLevel(level)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We add an extra newline to lines piped from the client. This also sometimes results in "phantom newlines" when the logstream contains empty strings.