### PR TITLE
[Autoscaler] Ensure ubuntu is owner of docker host mount folder

### DIFF
--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -634,7 +634,8 @@ class DockerCommandRunner(CommandRunnerInterface):
 
         host_mount_location = os.path.dirname(host_destination.rstrip('/'))
         self.ssh_command_runner.run(
-            f"mkdir -p {host_mount_location} && chown -R ubuntu {host_mount_location}",
+            f"mkdir -p {host_mount_location} && chown -R "
+            f"{self.ssh_command_runner.ssh_user} {host_mount_location}",
             silent=is_rsync_silent())
 
         self.ssh_command_runner.run_rsync_up(
@@ -658,7 +659,8 @@ class DockerCommandRunner(CommandRunnerInterface):
                 self.ssh_command_runner.cluster_name), source.lstrip("/"))
         host_mount_location = os.path.dirname(host_source.rstrip('/'))
         self.ssh_command_runner.run(
-            f"mkdir -p {host_mount_location} && chown -R ubuntu {host_mount_location}",
+            f"mkdir -p {host_mount_location} && chown -R "
+            f"{self.ssh_command_runner.ssh_user} {host_mount_location}",
             silent=is_rsync_silent())
         if source[-1] == "/":
             source += "."

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -632,8 +632,9 @@ class DockerCommandRunner(CommandRunnerInterface):
             self._get_docker_host_mount_location(
                 self.ssh_command_runner.cluster_name), target.lstrip("/"))
 
+        host_mount_location = os.path.dirname(host_destination.rstrip('/'))
         self.ssh_command_runner.run(
-            f"mkdir -p {os.path.dirname(host_destination.rstrip('/'))}",
+            f"mkdir -p {host_mount_location} && chown -R ubuntu {host_mount_location}",
             silent=is_rsync_silent())
 
         self.ssh_command_runner.run_rsync_up(
@@ -655,8 +656,9 @@ class DockerCommandRunner(CommandRunnerInterface):
         host_source = os.path.join(
             self._get_docker_host_mount_location(
                 self.ssh_command_runner.cluster_name), source.lstrip("/"))
+        host_mount_location = os.path.dirname(host_source.rstrip('/'))
         self.ssh_command_runner.run(
-            f"mkdir -p {os.path.dirname(host_source.rstrip('/'))}",
+            f"mkdir -p {host_mount_location} && chown -R ubuntu {host_mount_location}",
             silent=is_rsync_silent())
         if source[-1] == "/":
             source += "."

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -632,7 +632,7 @@ class DockerCommandRunner(CommandRunnerInterface):
             self._get_docker_host_mount_location(
                 self.ssh_command_runner.cluster_name), target.lstrip("/"))
 
-        host_mount_location = os.path.dirname(host_destination.rstrip('/'))
+        host_mount_location = os.path.dirname(host_destination.rstrip("/"))
         self.ssh_command_runner.run(
             f"mkdir -p {host_mount_location} && chown -R "
             f"{self.ssh_command_runner.ssh_user} {host_mount_location}",
@@ -657,7 +657,7 @@ class DockerCommandRunner(CommandRunnerInterface):
         host_source = os.path.join(
             self._get_docker_host_mount_location(
                 self.ssh_command_runner.cluster_name), source.lstrip("/"))
-        host_mount_location = os.path.dirname(host_source.rstrip('/'))
+        host_mount_location = os.path.dirname(host_source.rstrip("/"))
         self.ssh_command_runner.run(
             f"mkdir -p {host_mount_location} && chown -R "
             f"{self.ssh_command_runner.ssh_user} {host_mount_location}",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Problem: The docker host mount folder is sometimes created with `root` as the owner. Later, `rsync_up` is run as part of the session startup with `ubuntu` as the user. This leads to an error because it cannot write to the folder.
```
rsync: failed to set times on "/tmp/ray_tmp_mount/anyscale-dev-prod-ecd59fe03a481195/home/ray/test_anyscale_up_2021-01-20-00-11-47-612669_new_up/.": Operation not permitted (1)
./
.anyscale.yaml
session-default.yaml
rsync: mkstemp "/tmp/ray_tmp_mount/anyscale-dev-prod-ecd59fe03a481195/home/ray/test_anyscale_up_2021-01-20-00-11-47-612669_new_up/.anyscale.yaml.01i2l3" failed: Permission denied (13)
rsync: mkstemp "/tmp/ray_tmp_mount/anyscale-dev-prod-ecd59fe03a481195/home/ray/test_anyscale_up_2021-01-20-00-11-47-612669_new_up/.session-default.yaml.HX8zA0" failed: Permission denied (13)
```

Solution:  It seems this folder is only being created in `run_rsync_up` and `run_rsync_down` so this PR is changing the ownership of the folder to `ubuntu`.

- If the folder already exists and the owner is `ubuntu`, no ownership will be changed and no errors will be raised.
- If the folder already exists and the owner is `root`, this will fail unless the user is also `root`. This may affect clusters that have already been created. However, it should be ok if this fails because `rsync` will likely not work on these clusters unless the user running `rsync` is `root`.
- If the folder doesn't already exist and the user is `ubuntu`, the folder will be created with the owner as `ubuntu`.
- If the folder doesn't already exist and the user is `root`, the folder will be created with the owner as `root`, but the owner will immediately be changed to `ubuntu`. Because `root` is the user, this shouldn't throw an error and would allow `rsync` to work in the future during session startup.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
