### PR TITLE
[Object Spilling] Not deleting objects when restoring.

### DIFF
--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -360,11 +360,12 @@ void LocalObjectManager::ProcessSpilledObjectsDeleteQueue(uint32_t max_batch_siz
   while (!spilled_object_pending_delete_.empty() &&
          object_urls_to_delete.size() < max_batch_size) {
     auto &object_id = spilled_object_pending_delete_.front();
-    // If the object is still spilling, do nothing. This will block other entries to be
-    // processed, but it should be fine because the spilling will be eventually done, and
-    // deleting objects is the low priority tasks.
-    // This will instead enable simpler logic after this block.
-    if (objects_pending_spill_.contains(object_id)) {
+    // If the object is still spilling or restoring, do nothing. This will block other
+    // entries to be processed, but it should be fine because the spilling will be
+    // eventually done, and deleting objects is the low priority tasks. This will instead
+    // enable simpler logic after this block.
+    if (objects_pending_spill_.contains(object_id) ||
+        objects_pending_restore_.count(object_id) > 0) {
       break;
     }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I think this is why you sometimes saw file not found an error. Previously, we could delete the object while it is restored.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
