### PR TITLE
[Ax] Align optimization mode and reported SEM with Ax

### DIFF
--- a/python/ray/tune/suggest/ax.py
+++ b/python/ray/tune/suggest/ax.py
@@ -205,6 +205,7 @@ class AxSearch(Searcher):
         exp = self._ax.experiment
         self._mode = "min" if exp.optimization_config.objective.minimize else "max"
         self._metric = exp.optimization_config.objective.metric.name
+        self._objective_name = exp.optimization_config.objective.metric.name
         self._parameters = list(exp.parameters)
 
         if self._ax._enforce_sequential_optimization:

--- a/python/ray/tune/suggest/ax.py
+++ b/python/ray/tune/suggest/ax.py
@@ -124,9 +124,9 @@ class AxSearch(Searcher):
         assert ax is not None, """Ax must be installed!
             You can install AxSearch with the command:
             `pip install ax-platform sqlalchemy`."""
-        
+
         if mode:
-            assert mode in ["min", "max"], "`mode` must be 'min' or 'max'."                     
+            assert mode in ["min", "max"], "`mode` must be 'min' or 'max'."
 
         super(AxSearch, self).__init__(
             metric=metric,
@@ -172,7 +172,7 @@ class AxSearch(Searcher):
             has_experiment = True
         except ValueError:
             has_experiment = False
-        
+
         if not has_experiment:
             if not self._space:
                 raise ValueError(
@@ -185,8 +185,7 @@ class AxSearch(Searcher):
                 objective_name=self._metric,
                 parameter_constraints=self._parameter_constraints,
                 outcome_constraints=self._outcome_constraints,
-                minimize=self._mode != "max"
-            )
+                minimize=self._mode != "max")
         else:
             if any([
                     self._space, self._parameter_constraints,
@@ -195,15 +194,16 @@ class AxSearch(Searcher):
                 raise ValueError(
                     "If you create the Ax experiment yourself, do not pass "
                     "values for these parameters to `AxSearch`: {}.".format([
-                        "space", 
-                        "parameter_constraints", 
+                        "space",
+                        "parameter_constraints",
                         "outcome_constraints",
                         "mode",
                         "metric",
                     ]))
 
         exp = self._ax.experiment
-        self._mode = "min" if exp.optimization_config.objective.minimize else "max"
+        self._mode = "min" \
+            if exp.optimization_config.objective.minimize else "max"
         self._metric = exp.optimization_config.objective.metric.name
         self._objective_name = exp.optimization_config.objective.metric.name
         self._parameters = list(exp.parameters)

--- a/python/ray/tune/suggest/ax.py
+++ b/python/ray/tune/suggest/ax.py
@@ -12,10 +12,16 @@ from ray.tune.utils.util import flatten_dict, unflatten_dict
 try:
     import ax
     from ax.service.ax_client import AxClient
+except ImportError:
+    ax = AxClient = None
+
+# This exception only exists in newer Ax releases for python 3.7
+try:
     from ax.exceptions.generation_strategy import \
         MaxParallelismReachedException
 except ImportError:
-    ax = AxClient = MaxParallelismReachedException = None
+    MaxParallelismReachedException = Exception
+
 import logging
 
 from ray.tune.suggest import Searcher

--- a/python/ray/tune/suggest/ax.py
+++ b/python/ray/tune/suggest/ax.py
@@ -124,8 +124,14 @@ class AxSearch(Searcher):
         assert ax is not None, """Ax must be installed!
             You can install AxSearch with the command:
             `pip install ax-platform sqlalchemy`."""
+        
+        ax_mode_is_min = ax.experiment.optimization_config.objective.minimize 
+        expected_mode = "min" if ax_mode_is_min else "max"
         if mode:
-            assert mode in ["min", "max"], "`mode` must be 'min' or 'max'."
+            assert mode in ["min", "max"], "`mode` must be 'min' or 'max'."         
+            assert mode == expected_mode, "`mode` does not correspond to the one set in `AxClient`."
+            
+        mode = expected_mode
 
         super(AxSearch, self).__init__(
             metric=metric,
@@ -262,7 +268,7 @@ class AxSearch(Searcher):
             oc.metric.name for oc in
             self._ax.experiment.optimization_config.outcome_constraints
         ]
-        metric_dict.update({on: (result[on], 0.0) for on in outcome_names})
+        metric_dict.update({on: (result[on], None) for on in outcome_names})
         self._ax.complete_trial(
             trial_index=ax_trial_index, raw_data=metric_dict)
 

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -237,12 +237,14 @@ class SearchSpaceTest(unittest.TestCase):
         ]
 
         client1 = AxClient(random_seed=1234)
-        client1.create_experiment(parameters=converted_config)
-        searcher1 = AxSearch(ax_client=client1, metric="a", mode="max")
+        client1.create_experiment(
+            parameters=converted_config, objective_name="a", minimize=False)
+        searcher1 = AxSearch(ax_client=client1)
 
         client2 = AxClient(random_seed=1234)
-        client2.create_experiment(parameters=ax_config)
-        searcher2 = AxSearch(ax_client=client2, metric="a", mode="max")
+        client2.create_experiment(
+            parameters=ax_config, objective_name="a", minimize=False)
+        searcher2 = AxSearch(ax_client=client2)
 
         config1 = searcher1.suggest("0")
         config2 = searcher2.suggest("0")

--- a/python/ray/tune/tests/test_searchers.py
+++ b/python/ray/tune/tests/test_searchers.py
@@ -49,8 +49,10 @@ class InvalidValuesTest(unittest.TestCase):
         # At least one nan, inf, -inf and float
         client = AxClient(random_seed=4321)
         client.create_experiment(
-            parameters=converted_config, objective_name="_metric")
-        searcher = AxSearch(ax_client=client, metric="_metric", mode="max")
+            parameters=converted_config,
+            objective_name="_metric",
+            minimize=False)
+        searcher = AxSearch(ax_client=client)
 
         out = tune.run(
             _invalid_objective,


### PR DESCRIPTION
Ensure that `mode` aligns with the mode set in Ax + report SEM as None rather than as 0.0 to make use of Ax noise inference