### PR TITLE
[kubernetes][operator][minutiae] Backwards compatibility of operator

### DIFF
--- a/python/ray/operator/operator_utils.py
+++ b/python/ray/operator/operator_utils.py
@@ -95,4 +95,4 @@ def get_cluster_owner_reference(
 
 def translate(configuration: Dict[str, Any],
               dictionary: Dict[str, str]) -> Dict[str, Any]:
-    return {dictionary[field]: configuration[field] for field in configuration}
+    return {dictionary[field]: configuration[field] for field in dictionary}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
https://github.com/ray-project/ray/pull/13588 deleted a field from the CRD.

This PR makes a tiny change so that the deletion doesn't create a version compatibility issue
when deploying the operator using the CRD in a version of Ray slightly older than current master.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
  
Ran the operator unit test.