### PR TITLE
[Core] Better error if /dev/shm is too small

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1622,11 +1622,11 @@ def determine_plasma_store_config(object_store_memory,
                     "This will harm performance! You may be able to free up "
                     "space by deleting files in /dev/shm. If you are inside a "
                     "Docker container, you can increase /dev/shm size by "
-                    "passing '--shm-size={}gb' to 'docker run' (or add it to "
-                    "the run_options list in a Ray cluster config). Make sure "
-                    "to set this to more than 30% of available RAM.".format(
-                        ray.utils.get_user_temp_dir(), shm_avail,
-                        object_store_memory * (1.1) / (2**30)))
+                    "passing '--shm-size={:.2f}gb' to 'docker run' (or add it "
+                    "to the run_options list in a Ray cluster config). Make "
+                    "sure to set this to more than 30% of available RAM.".
+                    format(ray.utils.get_user_temp_dir(), shm_avail,
+                           object_store_memory * (1.1) / (2**30)))
         else:
             plasma_directory = ray.utils.get_user_temp_dir()
 

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1622,10 +1622,11 @@ def determine_plasma_store_config(object_store_memory,
                     "This will harm performance! You may be able to free up "
                     "space by deleting files in /dev/shm. If you are inside a "
                     "Docker container, you can increase /dev/shm size by "
-                    "passing '--shm-size=Xgb' to 'docker run' (or add it to "
+                    "passing '--shm-size={}gb' to 'docker run' (or add it to "
                     "the run_options list in a Ray cluster config). Make sure "
-                    "to set this to more than 2gb.".format(
-                        ray.utils.get_user_temp_dir(), shm_avail))
+                    "to set this to more than 30% of available RAM.".format(
+                        ray.utils.get_user_temp_dir(), shm_avail,
+                        object_store_memory * (1.1) / (2**30)))
         else:
             plasma_directory = ray.utils.get_user_temp_dir()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Explicitly state how much memory to pass in.
* Mention that `2Gb` is not enough, and that 30% of Available Memory is!
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Addresses #13619

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
