### PR TITLE
[Object Spilling] Clean up FS storage upon sigint for ray.init().

### DIFF
--- a/python/ray/external_storage.py
+++ b/python/ray/external_storage.py
@@ -2,7 +2,6 @@ import abc
 import logging
 import os
 import shutil
-import traceback
 import urllib
 from collections import namedtuple
 from typing import List, IO, Tuple
@@ -274,9 +273,7 @@ class FileSystemStorage(ExternalStorage):
                 # deleting the file at the same time.
                 pass
             except Exception:
-                logger.exception("Error cleaning up spill files\n"
-                                 f"Directory path: {self.directory_path}\n"
-                                 f"Traceback: {traceback.format_exc()}")
+                logger.exception("Error cleaning up spill files")
                 break
 
 

--- a/python/ray/external_storage.py
+++ b/python/ray/external_storage.py
@@ -1,4 +1,5 @@
 import abc
+import logging
 import os
 import shutil
 import traceback
@@ -11,6 +12,7 @@ from ray.ray_constants import DEFAULT_OBJECT_PREFIX
 from ray._raylet import ObjectRef
 
 ParsedURL = namedtuple("ParsedURL", "base_url, offset, size")
+logger = logging.getLogger(__name__)
 
 
 def create_url_with_offset(*, url: str, offset: int, size: int) -> str:
@@ -268,14 +270,13 @@ class FileSystemStorage(ExternalStorage):
             try:
                 shutil.rmtree(self.directory_path)
             except FileNotFoundError:
-                # It excpetion occurs when other IO workers are
+                # If excpetion occurs when other IO workers are
                 # deleting the file at the same time.
                 pass
             except Exception:
-                print("There were unexpected errors while deleting "
-                      "a directory that Ray objects are spilled.\n"
-                      f"Directory path: {self.directory_path}\n"
-                      f"Traceback: {traceback.format_exc()}")
+                logger.exception("Error cleaning up spill files\n"
+                                 f"Directory path: {self.directory_path}\n"
+                                 f"Traceback: {traceback.format_exc()}")
                 break
 
 

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -1132,9 +1132,6 @@ class Node:
         if object_spilling_config:
             object_spilling_config = json.loads(object_spilling_config)
             from ray import external_storage
-            # Validate external storage usage.
             storage = external_storage.setup_external_storage(
                 object_spilling_config)
-            # For third party library developers who turned off
-            # log monitor wouldn't want to print messages.
             storage.destroy_external_storage()

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -400,6 +400,9 @@ class Node:
             "metrics_export_port": self._metrics_export_port
         }
 
+    def is_head(self):
+        return self.head
+
     def create_redis_client(self):
         """Create a redis client."""
         return ray._private.services.create_redis_client(
@@ -1123,3 +1126,15 @@ class Node:
             True if any process that wasn't explicitly killed is still alive.
         """
         return not any(self.dead_processes())
+
+    def destroy_external_storage(self):
+        object_spilling_config = self._config.get("object_spilling_config", {})
+        if object_spilling_config:
+            object_spilling_config = json.loads(object_spilling_config)
+            from ray import external_storage
+            # Validate external storage usage.
+            storage = external_storage.setup_external_storage(
+                object_spilling_config)
+            # For third party library developers who turned off
+            # log monitor wouldn't want to print messages.
+            storage.destroy_external_storage()

--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -556,6 +556,8 @@ def test_fusion_objects(object_spilling_config, shutdown_only):
         assert np.array_equal(sample, solution)
 
     is_test_passing = False
+    # Since we'd like to see the temp directory that stores the files,
+    # we need to append this directory.
     temp_folder = temp_folder / ray.ray_constants.DEFAULT_OBJECT_PREFIX
     for path in temp_folder.iterdir():
         file_size = path.stat().st_size

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -818,6 +818,8 @@ def shutdown(_exiting_interpreter=False):
     # Shut down the Ray processes.
     global _global_node
     if _global_node is not None:
+        if _global_node.is_head():
+            _global_node.destroy_external_storage()
         _global_node.kill_all_processes(check_alive=False, allow_graceful=True)
         _global_node = None
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This cleans up FS storage upon sigint. It also prints the progress when it is shutting down (so that users won't be confused why their driver is not terminated quickly).

The current output looks like...
```
Removing remaining files that are spilled to /private/var/folders/b8/khqvq5l13d76pjwz49bw76ph0000gn/T/pytest-of-sangbincho/pytest-98/test_file_deleted_when_driver_0/spill.

Total number of files spilled: 21
Path: /private/var/folders/b8/khqvq5l13d76pjwz49bw76ph0000gn/T/pytest-of-sangbincho/pytest-98/test_file_deleted_when_driver_0/spill.
Removed [5 / 21]
Removed [9 / 21]
Removed [13 / 21]
Removed [17 / 21]

Removed: 21
Path: /private/var/folders/b8/khqvq5l13d76pjwz49bw76ph0000gn/T/pytest-of-sangbincho/pytest-98/test_file_deleted_when_driver_0/spill.
```

## Note
- It doesn't work with ray start. Making it work complicates the design, and it is unlikely that anyone who uses ray start will have the issue that their objects are not deleted from their external storage (because we already delete objects when refs are gone out of scope).
- I found Ray doesn't stop upon Sigterm. Not sure if it was intended.
- Didn't implement S3 yet.

## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
