### PR TITLE
[kubernetes][operator][hotfix] Dictionary fix

### DIFF
--- a/python/ray/operator/operator_utils.py
+++ b/python/ray/operator/operator_utils.py
@@ -95,4 +95,7 @@ def get_cluster_owner_reference(
 
 def translate(configuration: Dict[str, Any],
               dictionary: Dict[str, str]) -> Dict[str, Any]:
-    return {dictionary[field]: configuration[field] for field in dictionary}
+    return {
+        dictionary[field]: configuration[field]
+        for field in dictionary if field in configuration
+    }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://github.com/ray-project/ray/pull/13623 causes a key error when launching the operator -- 
Error comes from the fact that the head pod's config doesn't have the optional minWorkers.
(Don't know how I missed this before -- probably screwed up tests when checking https://github.com/ray-project/ray/pull/13623.)

This PR fixes the problem by iterating only over the keys belong to _both_ of the relevant dictionaries.
A key error from the `translate` method is no longer possible.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/13667 .

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

I'm pretty sure I ran the test right this time --
built an image incorporating the changes, 
ran a container based on the image and checked that the code changes were present in the ray installed there, ran the operator unit test, 
checked that the operator pod was using the right image. 