### PR TITLE
fix multiprocessing starmap to allow passing in zip

### DIFF
--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -74,12 +74,13 @@ def test_ray_init(shutdown_only):
     ray.shutdown()
 
 
-@pytest.mark.parametrize("ray_start_cluster", [{
-    "num_cpus": 1,
-    "num_nodes": 1,
-    "do_init": False,
-}],
-                         indirect=True)
+@pytest.mark.parametrize(
+    "ray_start_cluster", [{
+        "num_cpus": 1,
+        "num_nodes": 1,
+        "do_init": False,
+    }],
+    indirect=True)
 def test_connect_to_ray(ray_start_cluster):
     def getpid(args):
         return os.getpid()
@@ -141,9 +142,8 @@ def test_initializer(shutdown_only):
 
     with tempfile.TemporaryDirectory() as dirname:
         num_processes = 4
-        pool = Pool(processes=num_processes,
-                    initializer=init,
-                    initargs=(dirname, ))
+        pool = Pool(
+            processes=num_processes, initializer=init, initargs=(dirname, ))
 
         assert len(os.listdir(dirname)) == 4
         pool.terminate()
@@ -296,8 +296,8 @@ def test_map_async(pool_4_processes):
         return index, os.getpid()
 
     signal = SignalActor.remote()
-    async_result = pool_4_processes.map_async(f, [(i, signal)
-                                                  for i in range(1000)])
+    async_result = pool_4_processes.map_async(
+        f, [(i, signal) for i in range(1000)])
     assert not async_result.ready()
     with pytest.raises(TimeoutError):
         async_result.get(timeout=0.01)
@@ -366,18 +366,18 @@ def test_callbacks(pool_4_processes):
     result.get()
 
     # Will error, check that error_callback is called.
-    result = pool_4_processes.apply_async(f, ((0, [0]), ),
-                                          error_callback=error_callback)
+    result = pool_4_processes.apply_async(
+        f, ((0, [0]), ), error_callback=error_callback)
     assert isinstance(callback_queue.get(), Exception)
     with pytest.raises(Exception, match="intentional failure"):
         result.get()
 
     # Test callbacks for map_async.
     error_indices = [2, 50, 98]
-    result = pool_4_processes.map_async(f, [(index, error_indices)
-                                            for index in range(100)],
-                                        callback=callback,
-                                        error_callback=error_callback)
+    result = pool_4_processes.map_async(
+        f, [(index, error_indices) for index in range(100)],
+        callback=callback,
+        error_callback=error_callback)
     callback_results = []
     while len(callback_results) < 100:
         callback_results.append(callback_queue.get())
@@ -408,9 +408,8 @@ def test_imap(pool_4_processes):
         return index
 
     error_indices = [2, 50, 98]
-    result_iter = pool_4_processes.imap(f, [(index, error_indices)
-                                            for index in range(100)],
-                                        chunksize=11)
+    result_iter = pool_4_processes.imap(
+        f, [(index, error_indices) for index in range(100)], chunksize=11)
     for i in range(100):
         result = result_iter.next()
         if i in error_indices:
@@ -434,9 +433,8 @@ def test_imap_unordered(pool_4_processes):
     error_indices = [2, 50, 98]
     in_order = []
     num_errors = 0
-    result_iter = pool_4_processes.imap_unordered(f, [(index, error_indices)
-                                                      for index in range(100)],
-                                                  chunksize=11)
+    result_iter = pool_4_processes.imap_unordered(
+        f, [(index, error_indices) for index in range(100)], chunksize=11)
     for i in range(100):
         result = result_iter.next()
         if isinstance(result, Exception):
@@ -465,8 +463,8 @@ def test_imap_timeout(pool_4_processes):
 
     wait_index = 23
     signal = SignalActor.remote()
-    result_iter = pool_4_processes.imap(f, [(index, wait_index, signal)
-                                            for index in range(100)])
+    result_iter = pool_4_processes.imap(
+        f, [(index, wait_index, signal) for index in range(100)])
     for i in range(100):
         if i == wait_index:
             with pytest.raises(TimeoutError):
@@ -481,10 +479,8 @@ def test_imap_timeout(pool_4_processes):
 
     wait_index = 23
     signal = SignalActor.remote()
-    result_iter = pool_4_processes.imap_unordered(f,
-                                                  [(index, wait_index, signal)
-                                                   for index in range(100)],
-                                                  chunksize=11)
+    result_iter = pool_4_processes.imap_unordered(
+        f, [(index, wait_index, signal) for index in range(100)], chunksize=11)
     in_order = []
     for i in range(100):
         try:

--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -74,13 +74,12 @@ def test_ray_init(shutdown_only):
     ray.shutdown()
 
 
-@pytest.mark.parametrize(
-    "ray_start_cluster", [{
-        "num_cpus": 1,
-        "num_nodes": 1,
-        "do_init": False,
-    }],
-    indirect=True)
+@pytest.mark.parametrize("ray_start_cluster", [{
+    "num_cpus": 1,
+    "num_nodes": 1,
+    "do_init": False,
+}],
+                         indirect=True)
 def test_connect_to_ray(ray_start_cluster):
     def getpid(args):
         return os.getpid()
@@ -142,8 +141,9 @@ def test_initializer(shutdown_only):
 
     with tempfile.TemporaryDirectory() as dirname:
         num_processes = 4
-        pool = Pool(
-            processes=num_processes, initializer=init, initargs=(dirname, ))
+        pool = Pool(processes=num_processes,
+                    initializer=init,
+                    initargs=(dirname, ))
 
         assert len(os.listdir(dirname)) == 4
         pool.terminate()
@@ -296,8 +296,8 @@ def test_map_async(pool_4_processes):
         return index, os.getpid()
 
     signal = SignalActor.remote()
-    async_result = pool_4_processes.map_async(
-        f, [(i, signal) for i in range(1000)])
+    async_result = pool_4_processes.map_async(f, [(i, signal)
+                                                  for i in range(1000)])
     assert not async_result.ready()
     with pytest.raises(TimeoutError):
         async_result.get(timeout=0.01)
@@ -340,6 +340,7 @@ def test_starmap(pool):
 
     args = [tuple(range(i)) for i in range(100)]
     assert pool.starmap(f, args) == args
+    assert pool.starmap(lambda x, y: x + y, zip([1, 2], [3, 4])) == [4, 6]
 
 
 def test_callbacks(pool_4_processes):
@@ -365,18 +366,18 @@ def test_callbacks(pool_4_processes):
     result.get()
 
     # Will error, check that error_callback is called.
-    result = pool_4_processes.apply_async(
-        f, ((0, [0]), ), error_callback=error_callback)
+    result = pool_4_processes.apply_async(f, ((0, [0]), ),
+                                          error_callback=error_callback)
     assert isinstance(callback_queue.get(), Exception)
     with pytest.raises(Exception, match="intentional failure"):
         result.get()
 
     # Test callbacks for map_async.
     error_indices = [2, 50, 98]
-    result = pool_4_processes.map_async(
-        f, [(index, error_indices) for index in range(100)],
-        callback=callback,
-        error_callback=error_callback)
+    result = pool_4_processes.map_async(f, [(index, error_indices)
+                                            for index in range(100)],
+                                        callback=callback,
+                                        error_callback=error_callback)
     callback_results = []
     while len(callback_results) < 100:
         callback_results.append(callback_queue.get())
@@ -407,8 +408,9 @@ def test_imap(pool_4_processes):
         return index
 
     error_indices = [2, 50, 98]
-    result_iter = pool_4_processes.imap(
-        f, [(index, error_indices) for index in range(100)], chunksize=11)
+    result_iter = pool_4_processes.imap(f, [(index, error_indices)
+                                            for index in range(100)],
+                                        chunksize=11)
     for i in range(100):
         result = result_iter.next()
         if i in error_indices:
@@ -432,8 +434,9 @@ def test_imap_unordered(pool_4_processes):
     error_indices = [2, 50, 98]
     in_order = []
     num_errors = 0
-    result_iter = pool_4_processes.imap_unordered(
-        f, [(index, error_indices) for index in range(100)], chunksize=11)
+    result_iter = pool_4_processes.imap_unordered(f, [(index, error_indices)
+                                                      for index in range(100)],
+                                                  chunksize=11)
     for i in range(100):
         result = result_iter.next()
         if isinstance(result, Exception):
@@ -462,8 +465,8 @@ def test_imap_timeout(pool_4_processes):
 
     wait_index = 23
     signal = SignalActor.remote()
-    result_iter = pool_4_processes.imap(
-        f, [(index, wait_index, signal) for index in range(100)])
+    result_iter = pool_4_processes.imap(f, [(index, wait_index, signal)
+                                            for index in range(100)])
     for i in range(100):
         if i == wait_index:
             with pytest.raises(TimeoutError):
@@ -478,8 +481,10 @@ def test_imap_timeout(pool_4_processes):
 
     wait_index = 23
     signal = SignalActor.remote()
-    result_iter = pool_4_processes.imap_unordered(
-        f, [(index, wait_index, signal) for index in range(100)], chunksize=11)
+    result_iter = pool_4_processes.imap_unordered(f,
+                                                  [(index, wait_index, signal)
+                                                   for index in range(100)],
+                                                  chunksize=11)
     in_order = []
     for i in range(100):
         try:

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -112,7 +112,6 @@ class AsyncResult:
 
     This should not be constructed directly.
     """
-
     def __init__(self,
                  chunk_object_refs,
                  callback=None,
@@ -174,7 +173,6 @@ class AsyncResult:
 
 class IMapIterator:
     """Base class for OrderedIMapIterator and UnorderedIMapIterator."""
-
     def __init__(self, pool, func, iterable, chunksize=None):
         self._pool = pool
         self._func = func
@@ -226,7 +224,6 @@ class OrderedIMapIterator(IMapIterator):
 
     Should not be constructed directly.
     """
-
     def next(self, timeout=None):
         if len(self._ready_objects) == 0:
             if self._next_chunk_index == self._total_chunks:
@@ -244,8 +241,8 @@ class OrderedIMapIterator(IMapIterator):
                     timeout = max(0, timeout - (time.time() - start))
 
             while self._next_chunk_index < len(
-                    self._submitted_chunks
-            ) and self._submitted_chunks[self._next_chunk_index]:
+                    self._submitted_chunks) and self._submitted_chunks[
+                        self._next_chunk_index]:
                 for result in self._result_thread.result(
                         self._next_chunk_index):
                     self._ready_objects.append(result)
@@ -263,7 +260,6 @@ class UnorderedIMapIterator(IMapIterator):
 
     Should not be constructed directly.
     """
-
     def next(self, timeout=None):
         if len(self._ready_objects) == 0:
             if self._next_chunk_index == self._total_chunks:
@@ -282,7 +278,6 @@ class UnorderedIMapIterator(IMapIterator):
 @ray.remote(num_cpus=1)
 class PoolActor:
     """Actor used to process tasks submitted to a Pool."""
-
     def __init__(self, initializer=None, initargs=None):
         if initializer:
             initargs = initargs or ()
@@ -322,7 +317,6 @@ class Pool:
             be passed to `ray.init()` to connect to a running cluster. This may
             also be specified using the `RAY_ADDRESS` environment variable.
     """
-
     def __init__(self,
                  processes=None,
                  initializer=None,
@@ -386,10 +380,9 @@ class Pool:
         if timeout is not None:
             timeout = float(timeout)
 
-        _, deleting = ray.wait(
-            self._actor_deletion_ids,
-            num_returns=len(self._actor_deletion_ids),
-            timeout=timeout)
+        _, deleting = ray.wait(self._actor_deletion_ids,
+                               num_returns=len(self._actor_deletion_ids),
+                               timeout=timeout)
         self._actor_deletion_ids = deleting
 
     def _stop_actor(self, actor):
@@ -461,8 +454,10 @@ class Pool:
         self._check_running()
         object_ref = self._run_batch(self._random_actor_index(), func,
                                      [(args, kwargs)])
-        return AsyncResult(
-            [object_ref], callback, error_callback, single_result=True)
+        return AsyncResult([object_ref],
+                           callback,
+                           error_callback,
+                           single_result=True)
 
     def _calculate_chunksize(self, iterable):
         chunksize, extra = divmod(len(iterable), len(self._actor_pool) * 4)
@@ -491,10 +486,13 @@ class Pool:
 
         return self._run_batch(actor_index, func, chunk)
 
-    def _chunk_and_run(self, func, iterable, chunksize=None,
+    def _chunk_and_run(self,
+                       func,
+                       iterable,
+                       chunksize=None,
                        unpack_args=False):
         if not hasattr(iterable, "__len__"):
-            iterable = [iterable]
+            iterable = list(iterable)
 
         if chunksize is None:
             chunksize = self._calculate_chunksize(iterable)
@@ -504,12 +502,11 @@ class Pool:
         while len(chunk_object_refs) * chunksize < len(iterable):
             actor_index = len(chunk_object_refs) % len(self._actor_pool)
             chunk_object_refs.append(
-                self._submit_chunk(
-                    func,
-                    iterator,
-                    chunksize,
-                    actor_index,
-                    unpack_args=unpack_args))
+                self._submit_chunk(func,
+                                   iterator,
+                                   chunksize,
+                                   actor_index,
+                                   unpack_args=unpack_args))
 
         return chunk_object_refs
 
@@ -521,8 +518,10 @@ class Pool:
                    callback=None,
                    error_callback=None):
         self._check_running()
-        object_refs = self._chunk_and_run(
-            func, iterable, chunksize=chunksize, unpack_args=unpack_args)
+        object_refs = self._chunk_and_run(func,
+                                          iterable,
+                                          chunksize=chunksize,
+                                          unpack_args=unpack_args)
         return AsyncResult(object_refs, callback, error_callback)
 
     def map(self, func, iterable, chunksize=None):
@@ -540,8 +539,10 @@ class Pool:
             A list of results.
         """
 
-        return self._map_async(
-            func, iterable, chunksize=chunksize, unpack_args=False).get()
+        return self._map_async(func,
+                               iterable,
+                               chunksize=chunksize,
+                               unpack_args=False).get()
 
     def map_async(self,
                   func,
@@ -568,34 +569,37 @@ class Pool:
         Returns:
             AsyncResult
         """
-        return self._map_async(
-            func,
-            iterable,
-            chunksize=chunksize,
-            unpack_args=False,
-            callback=callback,
-            error_callback=error_callback)
+        return self._map_async(func,
+                               iterable,
+                               chunksize=chunksize,
+                               unpack_args=False,
+                               callback=callback,
+                               error_callback=error_callback)
 
     def starmap(self, func, iterable, chunksize=None):
         """Same as `map`, but unpacks each element of the iterable as the
         arguments to func like: [func(*args) for args in iterable].
         """
 
-        return self._map_async(
-            func, iterable, chunksize=chunksize, unpack_args=True).get()
+        return self._map_async(func,
+                               iterable,
+                               chunksize=chunksize,
+                               unpack_args=True).get()
 
-    def starmap_async(self, func, iterable, callback=None,
+    def starmap_async(self,
+                      func,
+                      iterable,
+                      callback=None,
                       error_callback=None):
         """Same as `map_async`, but unpacks each element of the iterable as the
         arguments to func like: [func(*args) for args in iterable].
         """
 
-        return self._map_async(
-            func,
-            iterable,
-            unpack_args=True,
-            callback=callback,
-            error_callback=error_callback)
+        return self._map_async(func,
+                               iterable,
+                               unpack_args=True,
+                               callback=callback,
+                               error_callback=error_callback)
 
     def imap(self, func, iterable, chunksize=1):
         """Same as `map`, but only submits one batch of tasks to each actor


### PR DESCRIPTION
## Why are these changes needed?

Fix multiprocessing starmap to allow passing in zip. I also notices Python's multiprocessing convert iterable directly to list (see [here](https://github.com/python/cpython/blob/63298930fb531ba2bb4f23bc3b915dbf1e17e9e1/Lib/multiprocessing/pool.py#L474-L475)) , instead of doing `[iterable]` in Ray currently

## Related issue number

Closes #11451

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
