### PR TITLE
[Core] Don't try to gather check_parent_task on Windows.

### DIFF
--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -185,8 +185,11 @@ class DashboardAgent(object):
                 agent_port=self.grpc_port,
                 agent_ip_address=self.ip))
 
-        await asyncio.gather(check_parent_task,
-                             *(m.run(self.server) for m in modules))
+        tasks = [m.run(self.server) for m in modules]
+        if sys.platform not in ["win32", "cygwin"]:
+            tasks.append(check_parent_task)
+        await asyncio.gather(*tasks)
+
         await self.server.wait_for_termination()
         # Wait for finish signal.
         await runner.cleanup()


### PR DESCRIPTION
Added Windows check to the site of the `check_parent_task` gather.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`check_parent_task` is only defined for non-Windows systems due to [this commit](https://github.com/ray-project/ray/commit/d96a9fa19225b95b51d9d4422ad82324e75ad6d0), but is still gathered in Windows systems [here](https://github.com/ray-project/ray/blob/d96a9fa19225b95b51d9d4422ad82324e75ad6d0/dashboard/agent.py#L188-L189), resulting in an `UnboundLocalError`:
```
Traceback (most recent call last):
  File "d:\a\ray\ray\python\ray\new_dashboard/agent.py", line 311, in <module>
    loop.run_until_complete(agent.run())
  File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\asyncio\base_events.py", line 587, in run_until_complete
    return future.result()
  File "d:\a\ray\ray\python\ray\new_dashboard/agent.py", line 187, in run
    await asyncio.gather(check_parent_task,
UnboundLocalError: local variable 'check_parent_task' referenced before assignment
```

This PR adds that Windows check to the site of the `check_parent_task` gather as well.

## Related issue number

<!-- For example: "Closes #1234" -->

Hotfix, no issue.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
