### PR TITLE
[CI] Remove object_manager_test in Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,5 @@
 - label: ":cpp: Tests"
   commands:
-  - bash src/ray/test/run_object_manager_tests.sh
   - bazel test --config=ci $(./scripts/bazel_export_options)
       --build_tests_only
       -- //:all -rllib/... -core_worker_test


### PR DESCRIPTION
https://github.com/ray-project/ray/commit/0998d69968608012ca6cdd1ee166961df1aa0f0b removed the object_manager_test and we didn't get to remove it in buildkite. This PR fixes it.
