### PR TITLE
[wip] Add setup hooks for python workers to the job config

### DIFF
--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -357,6 +357,21 @@ class GlobalState:
 
         return results
 
+    def job_config(self, job_id):
+        """Fetch the JobConfig for the specified job.
+
+        TODO(edoakes): we should not fetch the whole job table for this.
+        """
+        self._check_connected()
+
+        job_table = self.global_state_accessor.get_job_table()
+        for i in range(len(job_table)):
+            entry = gcs_utils.JobTableData.FromString(job_table[i])
+            if entry.job_id.hex() == job_id:
+                return entry.config
+
+        return None
+
     def profile_table(self):
         self._check_connected()
 

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -353,14 +353,16 @@ message TaskLeaseData {
 message JobConfig {
   // Environment variables to be set on worker processes.
   map<string, string> worker_env = 1;
+  // Serialized Python setup hook to run on worker processes.
+  bytes python_worker_setup_hook = 2;
   // The number of java workers per worker process.
-  uint32 num_java_workers_per_process = 2;
+  uint32 num_java_workers_per_process = 3;
   // The jvm options for java workers of the job.
-  repeated string jvm_options = 3;
+  repeated string jvm_options = 4;
   // A list of directories or jar files that specify the search path for user
   // code. This will be used as `CLASSPATH` in Java, and `PYTHONPATH` in
   // Python.
-  repeated string code_search_path = 4;
+  repeated string code_search_path = 5;
 }
 
 message JobTableData {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Adds the ability to define a startup hook for python workers to run before they start executing tasks.

TODO:
- [P0] Add a new API to the GCS client to fetch a single job's info instead of pulling the whole table.
- [P1] The raylet shouldn't schedule tasks to the worker until after it runs the setup hook.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
