### PR TITLE
[autoscaler][kubernetes] Add ability to not copy cluster config to head node when calling `create_or_update_head_node`.

### DIFF
--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -137,18 +137,18 @@ def request_resources(num_cpus: Optional[int] = None,
         overwrite=True)
 
 
-def create_or_update_cluster(config_file: str,
-                             override_min_workers: Optional[int],
-                             override_max_workers: Optional[int],
-                             no_restart: bool,
-                             restart_only: bool,
-                             yes: bool,
-                             override_cluster_name: Optional[str] = None,
-                             no_config_cache: bool = False,
-                             redirect_command_output: Optional[bool] = False,
-                             use_login_shells: bool = True,
-                             no_monitor_on_head: bool = False) -> Dict[str,
-                                                                       Any]:
+def create_or_update_cluster(
+        config_file: str,
+        override_min_workers: Optional[int],
+        override_max_workers: Optional[int],
+        no_restart: bool,
+        restart_only: bool,
+        yes: bool,
+        override_cluster_name: Optional[str] = None,
+        no_config_cache: bool = False,
+        redirect_command_output: Optional[bool] = False,
+        use_login_shells: bool = True,
+        no_monitor_on_head: bool = False) -> Dict[str, Any]:
     """Create or updates an autoscaling Ray cluster from a config json."""
     set_using_login_shells(use_login_shells)
     if not use_login_shells:
@@ -494,8 +494,8 @@ def warn_about_bad_start_command(start_commands: List[str],
         cli_logger.warning(
             "Ray runtime will not be started because `{}` is not in `{}`.",
             cf.bold("ray start"), cf.bold("head_start_ray_commands"))
-    if not (any("autoscaling-config" in x for x in ray_start_cmd)
-            or no_monitor_on_head):
+    if not (any("autoscaling-config" in x
+                for x in ray_start_cmd) or no_monitor_on_head):
         cli_logger.warning(
             "The head node will not launch any workers because "
             "`{}` does not have `{}` set.\n"
@@ -635,7 +635,8 @@ def get_or_create_head_node(config: Dict[str, Any],
             config["file_mounts"], None, config)
 
         if not no_monitor_on_head:
-            config = _prepare_config_for_head_node(
+            # Return remote_config_file to avoid prematurely closing it.
+            config, remote_config_file = _prepare_config_for_head_node(
                 config, provider, no_restart)
             cli_logger.print("Prepared bootstrap config")
 
@@ -748,7 +749,7 @@ def _prepare_config_for_head_node(config, provider, no_restart):
             remote_key_path: config["auth"]["ssh_private_key"],
         })
 
-    return config
+    return config, remote_config_file
 
 
 def attach_cluster(config_file: str,

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -150,6 +150,9 @@ def create_or_update_cluster(
         use_login_shells: bool = True,
         no_monitor_on_head: bool = False) -> Dict[str, Any]:
     """Create or updates an autoscaling Ray cluster from a config json."""
+    # no_monitor_on_head is an internal flag used by the Ray K8s operator.
+    # If True, prevents autoscaling config sync to the Ray head during cluster
+    # creation. See https://github.com/ray-project/ray/pull/13720.
     set_using_login_shells(use_login_shells)
     if not use_login_shells:
         cmd_output_util.set_allow_interactive(False)

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -713,7 +713,9 @@ def get_or_create_head_node(config: Dict[str, Any],
         cli_logger.print("  {}", remote_shell_str.strip())
 
 
-def _prepare_config_for_head_node(config, provider, no_restart):
+def _prepare_config_for_head_node(config: Dict[str, Any],
+                                  provider: NodeProvider,
+                                  no_restart: bool) -> Tuple[Dict[str, Any], tempfile.NamedTemporaryFile]:
     # Rewrite the auth config so that the head
     # node can update the workers
     remote_config = copy.deepcopy(config)

--- a/python/ray/autoscaler/kubernetes/operator_configs/example_cluster.yaml
+++ b/python/ray/autoscaler/kubernetes/operator_configs/example_cluster.yaml
@@ -119,7 +119,7 @@ spec:
   # Note dashboard-host is set to 0.0.0.0 so that Kubernetes can port forward.
   headStartRayCommands:
       - ray stop
-      - ulimit -n 65536; ray start --head --port=6379 --object-manager-port=8076  --dashboard-host 0.0.0.0
+      - ulimit -n 65536; ray start --head --no-monitor --port=6379 --object-manager-port=8076 --dashboard-host 0.0.0.0
   # Commands to start Ray on worker nodes. You don't need to change this.
   workerStartRayCommands:
       - ray stop

--- a/python/ray/autoscaler/kubernetes/operator_configs/example_cluster2.yaml
+++ b/python/ray/autoscaler/kubernetes/operator_configs/example_cluster2.yaml
@@ -119,7 +119,7 @@ spec:
   # Note dashboard-host is set to 0.0.0.0 so that Kubernetes can port forward.
   headStartRayCommands:
       - ray stop
-      - ulimit -n 65536; ray start --head --port=6379 --object-manager-port=8076  --dashboard-host 0.0.0.0
+      - ulimit -n 65536; ray start --head --no-monitor --port=6379 --object-manager-port=8076  --dashboard-host 0.0.0.0
   # Commands to start Ray on worker nodes. You don't need to change this.
   workerStartRayCommands:
       - ray stop

--- a/python/ray/ray_operator/operator.py
+++ b/python/ray/ray_operator/operator.py
@@ -57,7 +57,8 @@ class RayCluster():
             no_restart=False,
             restart_only=False,
             yes=True,
-            no_config_cache=True)
+            no_config_cache=True,
+            no_monitor_on_head=True)
         self.write_config()
 
     def start_monitor(self) -> None:

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -92,6 +92,7 @@ py_test_module_list(
     "test_dask_scheduler.py",
     "test_debug_tools.py",
     "test_job.py",
+    "test_k8s_operator_mock.py",
     "test_memstat.py",
     "test_metrics_agent.py",
     "test_microbenchmarks.py",

--- a/python/ray/tests/test_k8s_operator_mock.py
+++ b/python/ray/tests/test_k8s_operator_mock.py
@@ -1,0 +1,151 @@
+import copy
+import os
+import unittest
+from unittest.mock import patch
+
+import pytest
+import tempfile
+import yaml
+
+from ray.autoscaler.tags import TAG_RAY_NODE_KIND, NODE_KIND_HEAD
+from ray.autoscaler.node_provider import NodeProvider
+from ray.ray_operator.operator import RayCluster
+from ray.autoscaler._private.kubernetes.node_provider import\
+    KubernetesNodeProvider
+from ray.autoscaler._private.updater import NodeUpdaterThread
+"""
+Tests that, when the K8s operator launches a cluster, no files are mounted onto
+the head node.
+The main idea is to mock the NodeUpdaterThread to report if it received any
+file mounts.
+"""
+
+# NodeUpdaterThread mock methods
+START = "start"
+JOIN = "join"
+
+
+def mock_start(self):
+    # Detects any file mounts passed in NodeUpdaterThread.__init__()
+    if self.file_mounts:
+        raise ValueError("File mounts in operator's code path.")
+
+
+def mock_join(self):
+    # Fake success
+    self.exitcode = 0
+    return
+
+
+# RayCluster mock methods
+SETUP_LOGGING = "setup_logging"
+WRITE_CONFIG = "write_config"
+
+
+def mock_setup_logging(self):
+    return
+
+
+def mock_write_config(self):
+    # Use a named temporary file instead of a real one.
+    self.config_file = tempfile.NamedTemporaryFile("w")
+    self.config_path = self.config_file.name
+    yaml.dump(self.config, self.config_file)
+    self.config_file.flush()
+
+
+# KubernetesNodeProvider mock methods
+INIT = "__init__"
+NON_TERMINATED_NODES = "non_terminated_nodes"
+CREATE_NODE = "create_node"
+BOOTSTRAP_CONFIG = "bootstrap_config"
+
+HEAD_NODE_TAGS = {TAG_RAY_NODE_KIND: NODE_KIND_HEAD}
+
+
+def mock_init(self, provider_config, cluster_name):
+    # Adds an attribute to detect if the provider has created the head.
+    NodeProvider.__init__(self, provider_config, cluster_name)
+    self.cluster_name = cluster_name
+    self.namespace = provider_config["namespace"]
+
+    self._head_created = False
+
+
+def mock_non_terminated_nodes(self, node_tags):
+    # First time this is called, it returns an empty list.
+    # Second time, returns a mock head node id.
+    if HEAD_NODE_TAGS.items() <= node_tags.items() and self._head_created:
+        # Second call.
+        return ["HEAD"]
+    elif node_tags == HEAD_NODE_TAGS:
+        # First call.
+        return []
+    else:
+        # Should not go here.
+        raise ValueError("Test passed invalid parameters.")
+
+
+def mock_create_node(self, node_config, tags, count):
+    # Called during head node creation. Marks that a head node has been
+    # created.
+    if HEAD_NODE_TAGS.items() <= tags.items() and count == 1:
+        self._head_created = True
+    else:
+        raise ValueError(f"Test passed invalid parameter {tags} {count}.")
+
+
+def mock_bootstrap_config(cluster_config):
+    # KubernetesNodeProvider.bootstrap_config has no side effects
+    # on cluster_config -- the method just creates K8s API objects.
+    # Thus it makes sense to dummy out the K8s API calls and return
+    # the config.
+    return cluster_config
+
+
+def config_path():
+    # Config used in test.
+    here = os.path.realpath(__file__)
+    ray_python_root = os.path.dirname(os.path.dirname(here))
+    relative_path = "autoscaler/kubernetes/example-full.yaml"
+    return os.path.join(ray_python_root, relative_path)
+
+
+class OperatorTest(unittest.TestCase):
+    def test_no_file_mounts_k8s_operator_cluster_launch(self):
+        with patch.object(NodeUpdaterThread, START, mock_start),\
+                patch.object(NodeUpdaterThread, JOIN, mock_join),\
+                patch.object(RayCluster, SETUP_LOGGING, mock_setup_logging),\
+                patch.object(RayCluster, WRITE_CONFIG, mock_write_config),\
+                patch.object(KubernetesNodeProvider, INIT, mock_init),\
+                patch.object(KubernetesNodeProvider, NON_TERMINATED_NODES,
+                             mock_non_terminated_nodes),\
+                patch.object(KubernetesNodeProvider, CREATE_NODE,
+                             mock_create_node),\
+                patch.object(KubernetesNodeProvider, BOOTSTRAP_CONFIG,
+                             mock_bootstrap_config):
+
+            config = yaml.safe_load(open(config_path()).read())
+
+            # Ensure that operator does not mount any files during cluster
+            # launch.
+            config1 = copy.deepcopy(config)
+            cluster1 = RayCluster(config1)
+            cluster1.start_head()
+
+            # Check that this test is working correctly by inserting extraneous
+            # file mounts and confirming a ValueError from the mocked
+            # NodeUpdater.
+            config2 = copy.deepcopy(config)
+            # Giving this cluster a different name so that a new
+            # KubernetesNodeProvider is instantiated in cluster2.start_head().
+            config2["cluster_name"] = "another_name"
+            config2["file_mounts"] = {"remote_foo": os.path.abspath(__file__)}
+            cluster2 = RayCluster(config2)
+            with pytest.raises(ValueError):
+                cluster2.start_head()
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In situations where we don't run the monitor on the head node, there's no point in copying the cluster launching config onto the head node. 
The copying operation has lead to issues with the K8s operator (https://github.com/ray-project/ray/issues/13569).
 
This PR makes the following changes:

- Adds a `no_monitor_on_head_node` boolean argument to `commands.create_or_update_or_cluster`. 
When set to True, the cluster launching config is not copied to the head node.  

- Updates the K8s operator is to use the new flag.

- Updates the K8s operator example configs  to use the `--no-monitor` flag (https://github.com/ray-project/ray/pull/13505) in the head ray start commands. 

- To clean up the code a bit, I hid the config-copying logic behind a function call.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
   
  Tested manually by running the unit tests for K8s operator and Ray on K8s cluster launcher.
