### PR TITLE
[CI] Skip test_multi_node_3 on Windows

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -156,6 +156,7 @@ test_python() {
       -python/ray/tests:test_metrics_agent # timeout
       -python/ray/tests:test_multi_node
       -python/ray/tests:test_multi_node_2
+      -python/ray/tests:test_multi_node_3
       -python/ray/tests:test_multiprocessing  # test_connect_to_ray() fails to connect to raylet
       -python/ray/tests:test_node_manager
       -python/ray/tests:test_object_manager


### PR DESCRIPTION
test_multi_node_3 was recently split from test_multi_node, but we forgot to skip it on Windows
