### PR TITLE
Fix high CPU usage in object manager due to O(n^2) iteration over active pulls list

### DIFF
--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -123,7 +123,6 @@ void PullManager::UpdatePullsBasedOnAvailableMemory(size_t num_bytes_available) 
     RAY_LOG(DEBUG) << "Updating pulls based on available memory: " << num_bytes_available;
   }
   num_bytes_available_ = num_bytes_available;
-  uint64_t prev_highest_req_id_being_pulled = highest_req_id_being_pulled_;
 
   // While there is available capacity, activate the next pull request.
   while (num_bytes_being_pulled_ < num_bytes_available_) {

--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -52,7 +52,7 @@ uint64_t PullManager::Pull(const std::vector<rpc::ObjectReference> &object_ref_b
 bool PullManager::ActivateNextPullBundleRequest(
     const std::map<uint64_t, std::vector<rpc::ObjectReference>>::iterator
         &next_request_it,
-      std::vector<ObjectID> *objects_to_pull) {
+    std::vector<ObjectID> *objects_to_pull) {
   // Check that we have sizes for all of the objects in the bundle. If not, we
   // should not activate the bundle, since it may put us over the available
   // capacity.
@@ -93,7 +93,8 @@ bool PullManager::ActivateNextPullBundleRequest(
 }
 
 void PullManager::DeactivatePullBundleRequest(
-    const std::map<uint64_t, std::vector<rpc::ObjectReference>>::iterator &request_it, std::unordered_set<ObjectID> *objects_to_cancel) {
+    const std::map<uint64_t, std::vector<rpc::ObjectReference>>::iterator &request_it,
+    std::unordered_set<ObjectID> *objects_to_cancel) {
   for (const auto &ref : request_it->second) {
     auto obj_id = ObjectRefToId(ref);
     RAY_CHECK(active_object_pull_requests_[obj_id].erase(request_it->first));

--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -51,7 +51,8 @@ uint64_t PullManager::Pull(const std::vector<rpc::ObjectReference> &object_ref_b
 
 bool PullManager::ActivateNextPullBundleRequest(
     const std::map<uint64_t, std::vector<rpc::ObjectReference>>::iterator
-        &next_request_it) {
+        &next_request_it,
+      std::vector<ObjectID> *objects_to_pull) {
   // Check that we have sizes for all of the objects in the bundle. If not, we
   // should not activate the bundle, since it may put us over the available
   // capacity.
@@ -81,9 +82,7 @@ bool PullManager::ActivateNextPullBundleRequest(
       auto it = object_pull_requests_.find(obj_id);
       RAY_CHECK(it != object_pull_requests_.end());
       num_bytes_being_pulled_ += it->second.object_size;
-      // TODO(ekl) consider batching this and handling it at the end of
-      // UpdatePullsBasedOnAvailableMemory() to avoid pulling cancelled objs.
-      TryToMakeObjectLocal(obj_id);
+      objects_to_pull->push_back(obj_id);
     }
   }
 
@@ -94,7 +93,7 @@ bool PullManager::ActivateNextPullBundleRequest(
 }
 
 void PullManager::DeactivatePullBundleRequest(
-    const std::map<uint64_t, std::vector<rpc::ObjectReference>>::iterator &request_it) {
+    const std::map<uint64_t, std::vector<rpc::ObjectReference>>::iterator &request_it, std::unordered_set<ObjectID> *objects_to_cancel) {
   for (const auto &ref : request_it->second) {
     auto obj_id = ObjectRefToId(ref);
     RAY_CHECK(active_object_pull_requests_[obj_id].erase(request_it->first));
@@ -104,6 +103,10 @@ void PullManager::DeactivatePullBundleRequest(
       RAY_CHECK(it != object_pull_requests_.end());
       num_bytes_being_pulled_ -= it->second.object_size;
       active_object_pull_requests_.erase(obj_id);
+
+      if (objects_to_cancel) {
+        objects_to_cancel->insert(obj_id);
+      }
     }
   }
 
@@ -125,6 +128,7 @@ void PullManager::UpdatePullsBasedOnAvailableMemory(size_t num_bytes_available) 
   num_bytes_available_ = num_bytes_available;
 
   // While there is available capacity, activate the next pull request.
+  std::vector<ObjectID> objects_to_pull;
   while (num_bytes_being_pulled_ < num_bytes_available_) {
     // Get the next pull request in the queue.
     const auto last_request_it = pull_request_bundles_.find(highest_req_id_being_pulled_);
@@ -146,7 +150,7 @@ void PullManager::UpdatePullsBasedOnAvailableMemory(size_t num_bytes_available) 
                    << " num bytes available: " << num_bytes_available_;
     // There is another pull bundle request that we could try, and there is
     // enough space. Activate the next pull bundle request in the queue.
-    if (!ActivateNextPullBundleRequest(next_request_it)) {
+    if (!ActivateNextPullBundleRequest(next_request_it, &objects_to_pull)) {
       // This pull bundle request could not be activated, due to lack of object
       // size information. Wait until we have object size information before
       // activating this pull bundle.
@@ -163,10 +167,16 @@ void PullManager::UpdatePullsBasedOnAvailableMemory(size_t num_bytes_available) 
                    << " num bytes available: " << num_bytes_available_;
     const auto last_request_it = pull_request_bundles_.find(highest_req_id_being_pulled_);
     RAY_CHECK(last_request_it != pull_request_bundles_.end());
-    DeactivatePullBundleRequest(last_request_it);
+    DeactivatePullBundleRequest(last_request_it, &object_ids_to_cancel);
   }
 
   TriggerOutOfMemoryHandlingIfNeeded();
+
+  for (const auto &obj_id : objects_to_pull) {
+    if (object_ids_to_cancel.count(obj_id) == 0) {
+      TryToMakeObjectLocal(obj_id);
+    }
+  }
 }
 
 void PullManager::TriggerOutOfMemoryHandlingIfNeeded() {

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -146,12 +146,14 @@ class PullManager {
   /// any objects in the request that are not already being pulled.
   bool ActivateNextPullBundleRequest(
       const std::map<uint64_t, std::vector<rpc::ObjectReference>>::iterator
-          &next_request_it);
+          &next_request_it,
+      std::vector<ObjectID> *objects_to_pull);
 
   /// Deactivate a pull request in the queue. This cancels any pull or restore
   /// operations for the object.
   void DeactivatePullBundleRequest(
-      const std::map<uint64_t, std::vector<rpc::ObjectReference>>::iterator &request_it);
+      const std::map<uint64_t, std::vector<rpc::ObjectReference>>::iterator &request_it,
+      std::unordered_set<ObjectID> *objects_to_cancel = nullptr);
 
   /// Trigger out-of-memory handling if the first request in the queue needs
   /// more space than the bytes available. This is needed to make room for the

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2509,14 +2509,16 @@ rpc::ObjectStoreStats AccumulateStoreStats(
   rpc::ObjectStoreStats store_stats;
   for (const auto &reply : node_stats) {
     auto cur_store = reply.store_stats();
-    store_stats.set_spill_time_total_s(store_stats.spill_time_total_s() +
-                                       cur_store.spill_time_total_s());
+    // Use max aggregation for time, since the nodes are spilling concurrently.
+    store_stats.set_spill_time_total_s(
+        std::max(store_stats.spill_time_total_s(), cur_store.spill_time_total_s()));
+    store_stats.set_restore_time_total_s(
+        std::max(store_stats.restore_time_total_s(), cur_store.restore_time_total_s()));
+    // Use sum aggregation for the rest of the metrics.
     store_stats.set_spilled_bytes_total(store_stats.spilled_bytes_total() +
                                         cur_store.spilled_bytes_total());
     store_stats.set_spilled_objects_total(store_stats.spilled_objects_total() +
                                           cur_store.spilled_objects_total());
-    store_stats.set_restore_time_total_s(store_stats.restore_time_total_s() +
-                                         cur_store.restore_time_total_s());
     store_stats.set_restored_bytes_total(store_stats.restored_bytes_total() +
                                          cur_store.restored_bytes_total());
     store_stats.set_restored_objects_total(store_stats.restored_objects_total() +


### PR DESCRIPTION

## Why are these changes needed?

We discovered while testing object spilling that the current pull manager iterates over the entire list of active pull requests for each new pull request. This leads to O(n^2) CPU usage with respect to the number of object dependencies in Ray, causing the cluster to grind to a halt.