### PR TITLE
[New Scheduler]Make backlog test more explicit

### DIFF
--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -590,11 +590,7 @@ TEST_F(ClusterTaskManagerTest, BacklogReportTest) {
   task_manager_.FillResourceUsage(data);
 
   resource_load_by_shape = data->resource_load_by_shape();
-  shape1 = resource_load_by_shape.resource_demands()[0];
-
-  ASSERT_EQ(shape1.backlog_size(), 0);
-  ASSERT_EQ(shape1.num_infeasible_requests_queued(), 0);
-  ASSERT_EQ(shape1.num_ready_requests_queued(), 0);
+  ASSERT_TRUE(resource_load_by_shape.resource_demands().empty());
   AssertNoLeaks();
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

After all task being canceled, the size of `esource_load_by_shape.resource_demands` should be zero. The original check is reasonable but not explicit enough, it's easy to make people feel there's one element in it.

and also it will fail in debug compile mode.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
