### PR TITLE
[RLlib] Unify fcnet initializers for the value output layer (std=1.0 in torch, but 0.01 in tf).

### DIFF
--- a/rllib/models/torch/fcnet.py
+++ b/rllib/models/torch/fcnet.py
@@ -106,7 +106,7 @@ class FullyConnectedNetwork(TorchModelV2, nn.Module):
         self._value_branch = SlimFC(
             in_size=prev_layer_size,
             out_size=1,
-            initializer=normc_initializer(1.0),
+            initializer=normc_initializer(0.01),
             activation_fn=None)
         # Holds the current "base" output (before logits layer).
         self._features = None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

RLlib's FullyConnectedNetwork (tf and torch) have different initializers for their value output layer: std=1.0 in torch, but 0.01 in tf.
This PR changes torch's value to be 0.01 as well.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
