### PR TITLE
[Object Spilling] Remove job id from the io worker log name.

### DIFF
--- a/python/ray/ray_logging.py
+++ b/python/ray/ray_logging.py
@@ -165,15 +165,17 @@ def get_worker_log_file_name(worker_type):
             "please report it to Ray's Github issue.")
         worker_name = "worker"
     else:
-        job_id = ray.JobID.nil()
+        job_id = ""
         worker_name = "io_worker"
 
     # Make sure these values are set already.
     assert ray.worker._global_node is not None
     assert ray.worker.global_worker is not None
     filename = (f"{worker_name}-"
-                f"{binary_to_hex(ray.worker.global_worker.worker_id)}-"
-                f"{job_id}-{os.getpid()}")
+                f"{binary_to_hex(ray.worker.global_worker.worker_id)}-")
+    if job_id:
+        filename += f"{job_id}-"
+    filename += f"{os.getpid()}"
     return filename
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

IO workers don't have the job id, so we don't need them. Previously it showed us ugly filename like 
```
io_worker-ce95816338b7214154a6f1b49a08d24825225a41a3cb82bc8686e15e-(ffffff)-24664.out
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
