### PR TITLE
[ray_client]: hook runtime context

### DIFF
--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -1,5 +1,6 @@
 import ray.worker
 import logging
+from ray._private.client_mode_hook import client_mode_hook
 
 logger = logging.getLogger(__name__)
 
@@ -149,6 +150,7 @@ class RuntimeContext(object):
 _runtime_context = None
 
 
+@client_mode_hook
 def get_runtime_context():
     global _runtime_context
     if _runtime_context is None:


### PR DESCRIPTION
Calling `ray.util.connect` separately caused the issue. The intention at the start was `from ray.util.connect import ray` instead of just `import ray` -- and then we've been finding ways to hook "real" ray.

So we just gotta add the hook. One liner!


## Related issue number
Closes #13748 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
