### PR TITLE
[Serve] Add "endpoint registered" message to router log

### DIFF
--- a/python/ray/serve/router.py
+++ b/python/ray/serve/router.py
@@ -48,6 +48,7 @@ class Query:
 
 class ReplicaSet:
     """Data structure representing a set of replica actor handles"""
+
     def __init__(self):
         # NOTE(simon): We have to do this because max_concurrent_queries
         # and the replica handles come from different long poll keys.
@@ -141,9 +142,9 @@ class ReplicaSet:
             if num_finished == 0:
                 logger.debug(
                     "All replicas are busy, waiting for a free replica.")
-                await asyncio.wait(self._all_query_refs +
-                                   [self.config_updated_event.wait()],
-                                   return_when=asyncio.FIRST_COMPLETED)
+                await asyncio.wait(
+                    self._all_query_refs + [self.config_updated_event.wait()],
+                    return_when=asyncio.FIRST_COMPLETED)
                 if self.config_updated_event.is_set():
                     self.config_updated_event.clear()
             # We are pretty sure a free replica is ready now.
@@ -230,10 +231,10 @@ class Router:
                 del self.backend_replicas[backend_tag]
 
     async def assign_request(
-        self,
-        request_meta: RequestMetadata,
-        *request_args,
-        **request_kwargs,
+            self,
+            request_meta: RequestMetadata,
+            *request_args,
+            **request_kwargs,
     ):
         """Assign a query and returns an object ref represent the result"""
         endpoint = request_meta.endpoint

--- a/python/ray/serve/router.py
+++ b/python/ray/serve/router.py
@@ -48,7 +48,6 @@ class Query:
 
 class ReplicaSet:
     """Data structure representing a set of replica actor handles"""
-
     def __init__(self):
         # NOTE(simon): We have to do this because max_concurrent_queries
         # and the replica handles come from different long poll keys.
@@ -142,9 +141,9 @@ class ReplicaSet:
             if num_finished == 0:
                 logger.debug(
                     "All replicas are busy, waiting for a free replica.")
-                await asyncio.wait(
-                    self._all_query_refs + [self.config_updated_event.wait()],
-                    return_when=asyncio.FIRST_COMPLETED)
+                await asyncio.wait(self._all_query_refs +
+                                   [self.config_updated_event.wait()],
+                                   return_when=asyncio.FIRST_COMPLETED)
                 if self.config_updated_event.is_set():
                     self.config_updated_event.clear()
             # We are pretty sure a free replica is ready now.
@@ -231,10 +230,10 @@ class Router:
                 del self.backend_replicas[backend_tag]
 
     async def assign_request(
-            self,
-            request_meta: RequestMetadata,
-            *request_args,
-            **request_kwargs,
+        self,
+        request_meta: RequestMetadata,
+        *request_args,
+        **request_kwargs,
     ):
         """Assign a query and returns an object ref represent the result"""
         endpoint = request_meta.endpoint
@@ -256,6 +255,7 @@ class Router:
                 raise RayServeException(
                     f"Endpoint {endpoint} was removed. This request "
                     "cannot be completed.")
+            logger.info(f"Endpoint {endpoint} registered.")
 
         endpoint_policy = self.endpoint_policies[endpoint]
         chosen_backend, *shadow_backends = endpoint_policy.assign(query)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When a user creates an endpoint, sometimes they see the message

`2021-01-27 15:53:53,433 INFO router.py:249 -- Endpoint my_endpoint doesn't exist, waiting for registration.`

The endpoint ends up being registered but nothing further is printed, so the user is still left hanging and unsure whether the endpoint exists or not.  This PR adds another INFO log saying that the endpoint is registered.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
