### PR TITLE
[autoscaler][kubernetes][operator] Rudimentary error handling, make "MODIFIED" -> update event work. 

### DIFF
--- a/doc/source/cluster/k8s-operator.rst
+++ b/doc/source/cluster/k8s-operator.rst
@@ -19,8 +19,8 @@ The rest of this document explains step-by-step how to use the Ray Kubernetes Op
 .. role:: bash(code)
    :language: bash
 
-.. warning::
-   The Ray Kubernetes Operator is a beta feature. For the yaml files in the examples below, we recomend using the latest master version of Ray.
+.. note::
+   The Ray Kubernetes Operator is still experimental. For the yaml files in the examples below, we recomend using the latest master version of Ray.
 
 .. warning::
    The Ray Kubernetes Operator requires Kubernetes version at least ``v1.17.0``. Check Kubernetes version info with the command

--- a/doc/source/cluster/k8s-operator.rst
+++ b/doc/source/cluster/k8s-operator.rst
@@ -20,6 +20,9 @@ The rest of this document explains step-by-step how to use the Ray Kubernetes Op
    :language: bash
 
 .. warning::
+   The Ray Kubernetes Operator is a beta feature. For the yaml files in the examples below, we recomend using the latest master version of Ray.
+
+.. warning::
    The Ray Kubernetes Operator requires Kubernetes version at least ``v1.17.0``. Check Kubernetes version info with the command
    :bash:`kubectl version`.
 

--- a/python/ray/autoscaler/kubernetes/operator_configs/cluster_crd.yaml
+++ b/python/ray/autoscaler/kubernetes/operator_configs/cluster_crd.yaml
@@ -13,6 +13,16 @@ spec:
   - name: v1
     served: true
     storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+      - name: status
+        type: string
+        description: Running or Error
+        jsonPath: .status.phase
+      - name: age
+        type: date
+        jsonPath: .metadata.creationTimestamp
     schema:
       openAPIV3Schema:
         description: Ray cluster configuration
@@ -20,6 +30,12 @@ spec:
         required:
         - spec
         properties:
+          status:
+            type: object
+            properties:
+              phase:
+                description: Running or Error
+                type: string
           spec:
             type: object
             required:

--- a/python/ray/autoscaler/kubernetes/operator_configs/operator.yaml
+++ b/python/ray/autoscaler/kubernetes/operator_configs/operator.yaml
@@ -10,7 +10,7 @@ metadata:
   name: ray-operator-role
 rules:
 - apiGroups: ["", "cluster.ray.io"]
-  resources: ["rayclusters", "rayclusters/finalizers", "pods", "pods/exec"]
+  resources: ["rayclusters", "rayclusters/finalizers", "rayclusters/status", "pods", "pods/exec"]
   verbs: ["get", "watch", "list", "create", "delete", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/python/ray/ray_operator/operator.py
+++ b/python/ray/ray_operator/operator.py
@@ -105,6 +105,9 @@ last_generation = {}
 
 
 def handle_event(event_type, cluster_cr, cluster_name):
+    # TODO: This only detects errors in the parent process and thus doesn't
+    # catch cluster-specific autoscaling failures. Fix that (perhaps at
+    # the same time that we eliminate subprocesses).
     try:
         cluster_action(event_type, cluster_cr, cluster_name)
     except Exception:

--- a/python/ray/ray_operator/operator.py
+++ b/python/ray/ray_operator/operator.py
@@ -17,13 +17,16 @@ logger = logging.getLogger(__name__)
 
 class RayCluster():
     def __init__(self, config: Dict[str, Any]):
-        self.config = config
+        self.set_config(config)
         self.name = self.config["cluster_name"]
         self.config_path = operator_utils.config_path(self.name)
 
         self.setup_logging()
 
         self.subprocess = None  # type: Optional[mp.Process]
+
+    def set_config(self, config: Dict[str, Any]) -> None:
+        self.config = config
 
     def do_in_subprocess(self,
                          f: Callable[[], None],
@@ -98,7 +101,7 @@ class RayCluster():
 
 
 ray_clusters = {}
-cluster_crs = {}
+last_generation = {}
 
 
 def handle_event(event_type, cluster_cr, cluster_name):
@@ -115,24 +118,22 @@ def cluster_action(event_type, cluster_cr, cluster_name) -> None:
     cluster_name = cluster_config["cluster_name"]
 
     if event_type == "ADDED":
-        ray_clusters[cluster_name] = RayCluster(cluster_config)
         operator_utils.set_status(cluster_cr, cluster_name, "Running")
+        ray_clusters[cluster_name] = RayCluster(cluster_config)
         ray_clusters[cluster_name].create_or_update()
-        cluster_crs[cluster_name] = cluster_cr
+        last_generation[cluster_name] = cluster_cr["metadata"]["generation"]
     elif event_type == "MODIFIED":
-        # Modification of status subresource shouldn't trigger a response.
-        # For this reason, check if the spec has change before triggering an
-        # update.
-        old_cr = cluster_crs[cluster_name]
-        spec_changed = (cluster_cr["spec"] != old_cr["spec"])
-        if spec_changed:
+        # Check metadata.generation to determine if there's a spec change.
+        current_generation = cluster_cr["metadata"]["generation"]
+        if current_generation > last_generation[cluster_name]:
+            ray_clusters[cluster_name].set_config(cluster_config)
             ray_clusters[cluster_name].create_or_update()
-        cluster_crs[cluster_name] = cluster_cr
+            last_generation[cluster_name] = current_generation
 
     elif event_type == "DELETED":
         ray_clusters[cluster_name].clean_up()
         del ray_clusters[cluster_name]
-        del cluster_crs[cluster_name]
+        del last_generation[cluster_name]
 
 
 def main() -> None:

--- a/python/ray/ray_operator/operator.py
+++ b/python/ray/ray_operator/operator.py
@@ -126,8 +126,8 @@ def cluster_action(event_type, cluster_cr, cluster_name) -> None:
         old_cr = cluster_crs[cluster_name]
 
         spec_changed = (cluster_cr["spec"] != old_cr["spec"])
-        annotations_changed = (cluster_cr["metadata"].get(
-            "annotations") != old_cr["metadata"].get("annotations"))
+        annotations_changed = (cluster_cr["metadata"].get("annotations") !=
+                               old_cr["metadata"].get("annotations"))
 
         if spec_changed or annotations_changed:
             ray_clusters[cluster_name].create_or_update()

--- a/python/ray/ray_operator/operator.py
+++ b/python/ray/ray_operator/operator.py
@@ -121,15 +121,11 @@ def cluster_action(event_type, cluster_cr, cluster_name) -> None:
         cluster_crs[cluster_name] = cluster_cr
     elif event_type == "MODIFIED":
         # Modification of status subresource shouldn't trigger a response.
-        # Check if the spec or metadata.annotations fields have changed. If so,
-        # call create_or_update.
+        # For this reason, check if the spec has change before triggering an
+        # update.
         old_cr = cluster_crs[cluster_name]
-
         spec_changed = (cluster_cr["spec"] != old_cr["spec"])
-        annotations_changed = (cluster_cr["metadata"].get("annotations") !=
-                               old_cr["metadata"].get("annotations"))
-
-        if spec_changed or annotations_changed:
+        if spec_changed:
             ray_clusters[cluster_name].create_or_update()
         cluster_crs[cluster_name] = cluster_cr
 

--- a/python/ray/ray_operator/operator_utils.py
+++ b/python/ray/ray_operator/operator_utils.py
@@ -103,6 +103,7 @@ def translate(configuration: Dict[str, Any],
 
 def set_status(cluster_cr: Dict[str, Any], cluster_name: str,
                status: str) -> None:
+    # TODO: Add retry logic in case of 409 due to old resource version.
     cluster_cr["status"] = {"phase": status}
     custom_objects_api()\
         .patch_namespaced_custom_object_status(namespace=RAY_NAMESPACE,

--- a/python/ray/ray_operator/operator_utils.py
+++ b/python/ray/ray_operator/operator_utils.py
@@ -101,8 +101,7 @@ def translate(configuration: Dict[str, Any],
     }
 
 
-def set_status(cluster_cr: Dict[str, Any],
-               cluster_name: str,
+def set_status(cluster_cr: Dict[str, Any], cluster_name: str,
                status: str) -> None:
     cluster_cr["status"] = {"phase": status}
     custom_objects_api()\

--- a/python/ray/ray_operator/operator_utils.py
+++ b/python/ray/ray_operator/operator_utils.py
@@ -99,3 +99,16 @@ def translate(configuration: Dict[str, Any],
         dictionary[field]: configuration[field]
         for field in dictionary if field in configuration
     }
+
+
+def set_status(cluster_cr: Dict[str, Any],
+               cluster_name: str,
+               status: str) -> None:
+    cluster_cr["status"] = {"phase": status}
+    custom_objects_api()\
+        .patch_namespaced_custom_object_status(namespace=RAY_NAMESPACE,
+                                               group="cluster.ray.io",
+                                               version="v1",
+                                               plural="rayclusters",
+                                               name=cluster_name,
+                                               body=cluster_cr)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

**(A)**
This PR adds to the CRD a `status` subresource with a `phase` field.
The phase field is either `Running` when things are as normal or `Error` when there's an Python exception thrown processing one of the ADDED/MODIFIED/DELETED events for a RayCluster CR. 
(Previously an error would completely stop the operator.)

The status is printed with `kubectl get raycluster`. For example:
![Screen Shot 2021-01-27 at 9 17 38 PM](https://user-images.githubusercontent.com/62982571/106093493-410bc600-60e5-11eb-91da-d4cbafb17ed4.png)

**(B)**
This PR also fixes the operator's update logic -- previously, upon receiving a "MODIFIED" event for a CR, it would relaunch the cluster _without updating the cluster config_ . The config is now modified.


If this PR is merged, there would be an incompatibility between versions of [operator.yaml](https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/kubernetes/operator_configs/operator.yaml) slightly older than latest master and the operator code in `rayproject/ray:nightly` which is the image used in operator.yaml.
(The new operator code acts on `rayclusters/status` but the old `operator.yaml` doesn't grant that permission.)

Partly motivated by that, I've added a note to operator documentation saying that the operator is experimental and the config files from latest master should be used.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/13669

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   
Added logic testing that cluster update works to operator unit test. Unit test passes locally.
Manually tested the `Error` status logic by inserting nonsense into the `MODIFIED` elif branch. Figuring out how to unit test this is too much effort for now.