### PR TITLE
[RLlib] Fix get action shape

### DIFF
--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -709,7 +709,8 @@ class Policy(metaclass=ABCMeta):
         ret = {}
         for view_col, view_req in self.view_requirements.items():
             if isinstance(view_req.space, (gym.spaces.Dict, gym.spaces.Tuple)):
-                _, shape = ModelCatalog.get_action_shape(view_req.space, framework=self.config["framework"])
+                _, shape = ModelCatalog.get_action_shape(
+                    view_req.space, framework=self.config["framework"])
                 ret[view_col] = \
                     np.zeros((batch_size, ) + shape[1:], np.float32)
             else:

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -709,11 +709,12 @@ class Policy(metaclass=ABCMeta):
         ret = {}
         for view_col, view_req in self.view_requirements.items():
             if isinstance(view_req.space, (gym.spaces.Dict, gym.spaces.Tuple)):
-                _, shape = ModelCatalog.get_action_shape(view_req.space, framework=self.config['framework'])
+                _, shape = ModelCatalog.get_action_shape(
+                    view_req.space, framework=self.config["framework"])
                 ret[view_col] = \
                     np.zeros((batch_size, ) + shape[1:], np.float32)
             else:
-                # Range of indices on time-axis, e.g. "-50:-1".
+                # Range of indices on time-axis, e.g. "-50:-1"../s
                 if view_req.shift_from is not None:
                     ret[view_col] = np.zeros_like([[
                         view_req.space.sample()

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -709,7 +709,7 @@ class Policy(metaclass=ABCMeta):
         ret = {}
         for view_col, view_req in self.view_requirements.items():
             if isinstance(view_req.space, (gym.spaces.Dict, gym.spaces.Tuple)):
-                _, shape = ModelCatalog.get_action_shape(view_req.space)
+                _, shape = ModelCatalog.get_action_shape(view_req.space, framework=self.config['framework'])
                 ret[view_col] = \
                     np.zeros((batch_size, ) + shape[1:], np.float32)
             else:

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -709,12 +709,11 @@ class Policy(metaclass=ABCMeta):
         ret = {}
         for view_col, view_req in self.view_requirements.items():
             if isinstance(view_req.space, (gym.spaces.Dict, gym.spaces.Tuple)):
-                _, shape = ModelCatalog.get_action_shape(
-                    view_req.space, framework=self.config["framework"])
+                _, shape = ModelCatalog.get_action_shape(view_req.space, framework=self.config["framework"])
                 ret[view_col] = \
                     np.zeros((batch_size, ) + shape[1:], np.float32)
             else:
-                # Range of indices on time-axis, e.g. "-50:-1"../s
+                # Range of indices on time-axis, e.g. "-50:-1".
                 if view_req.shift_from is not None:
                     ret[view_col] = np.zeros_like([[
                         view_req.space.sample()


### PR DESCRIPTION
## Why are these changes needed?

Fixes the error in [13761](https://github.com/ray-project/ray/issues/13761). Added an argument specifying the framework in get_action_space() when called from rllib/policy/policy.py
## Related issue number
To close issue [13761](https://github.com/ray-project/ray/issues/13761)

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
