### PR TITLE
fix timeout_ms is set to -1 when timeout=0 is passed in

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -305,7 +305,11 @@ class Worker:
                     f"Attempting to call `get` on the value {object_ref}, "
                     "which is not an ray.ObjectRef.")
 
-        timeout_ms = int(timeout * 1000) if timeout else -1
+        if timeout is not None and timeout >= 0:
+            timeout_ms = int(timeout * 1000)
+        else:
+            timeout_ms = -1
+
         data_metadata_pairs = self.core_worker.get_objects(
             object_refs, self.current_task_id, timeout_ms)
         debugger_breakpoint = b""


### PR DESCRIPTION
## Why are these changes needed?

timeout_ms is set to -1 when timeout=0 is passed, due to the incorrect if condition. For testing, I re-run the scripts attached in the related issue (with timeout set to 0) and verified it's working.

## Related issue number

Closes #12680

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
