### PR TITLE
[Wheel] Build Py36 & Py38  in separate deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -197,6 +197,7 @@ matrix:
       env:
         # - PYTHON=3.6
         - LINUX_WHEELS=1 LINUX_JARS=1
+        - DOCKER_BUILD_PY37=1
         - PYTHONWARNINGS=ignore
         - RAY_INSTALL_JAVA=1
       language: java
@@ -493,7 +494,7 @@ deploy:
     on:
       repo: ray-project/ray
       all_branches: true
-      condition: $LINUX_WHEELS = 1 || $MAC_WHEELS = 1
+      condition: ($LINUX_WHEELS = 1 && $DOCKER_BUILD_PY37=1) || $MAC_WHEELS = 1
 
   - provider: s3
     edge: true # This supposedly opts in to deploy v2.
@@ -518,7 +519,7 @@ deploy:
     on:
       repo: ray-project/ray
       all_branches: true
-      condition: $LINUX_WHEELS = 1
+      condition: $LINUX_WHEELS = 1 && $DOCKER_BUILD_PY37 = 1
 
   # Upload jars so that we can debug locally for every commit
   - provider: s3
@@ -560,4 +561,4 @@ deploy:
     on:
       repo: ray-project/ray
       all_branches: true
-      condition: $LINUX_WHEELS = 1
+      condition: $LINUX_WHEELS = 1 && $DOCKER_BUILD_PY36_38 = 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -510,7 +510,7 @@ deploy:
     on:
       branch: master
       repo: ray-project/ray
-      condition: $LINUX_WHEELS = 1 || $MAC_WHEELS = 1
+      condition: ($LINUX_WHEELS = 1 && $DOCKER_BUILD_PY37=1) || $MAC_WHEELS = 1
 
   - provider: script
     edge: true # This supposedly opts in to deploy v2.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* We currently are running the "DEPLOY" step twice (once on the PY36 build & once on the PY37_PY38 build)
* This PR makes us
*  *  only deploy wheels on the Py37 build 
*  * deploy py37 imges and py36_py38 images on different builds

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
