### PR TITLE
[GCS]Replace DEL with UNLINK

### DIFF
--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -104,7 +104,8 @@ Status RedisStoreClient::AsyncDelete(const std::string &table_name,
   }
 
   std::string redis_key = GenRedisKey(table_name, key);
-  std::vector<std::string> args = {"DEL", redis_key};
+  // We always replace `DEL` with `UNLINK`.
+  std::vector<std::string> args = {"UNLINK", redis_key};
 
   auto shard_context = redis_client_->GetShardContext(redis_key);
   return shard_context->RunArgvAsync(args, delete_callback);
@@ -218,10 +219,11 @@ Status RedisStoreClient::DoPut(const std::string &key, const std::string &data,
 
 Status RedisStoreClient::DeleteByKeys(const std::vector<std::string> &keys,
                                       const StatusCallback &callback) {
-  // The `DEL` command for each shard.
+  // Delete for each shard.
+  // We always replace `DEL` with `UNLINK`.
   int total_count = 0;
   auto del_commands_by_shards =
-      GenCommandsByShards(redis_client_, "DEL", keys, &total_count);
+      GenCommandsByShards(redis_client_, "UNLINK", keys, &total_count);
 
   auto finished_count = std::make_shared<int>(0);
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`UNLINK` removes values in async way. In most case(in ray) it's better than `DEL`. We can replace `DEL` with `UNLINK` in delete operations.

see:
```
In a conclusion, if the value is small, DEL is at least, as good as UNLINK. If value is very large, e.g. LIST
 with thousands or millions of items, UNLINK is much better than DEL. You can always safely replace 
DEL with UNLINK. However, if you find the thread synchronization becomes a problem (multi-threading
 is always a headache), you can rollback to DEL.
```
https://stackoverflow.com/questions/45818371/is-the-unlink-command-always-better-than-del-command

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
