### PR TITLE
[autoscaler] run setup commands with restart_only=True

### DIFF
--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -648,7 +648,10 @@ def get_or_create_head_node(config: Dict[str, Any],
         if restart_only:
             # Some Command Runners may re-launch nodes, requiring setup
             # commands to be rerun.
-            setup_commands = config["head_setup_commands"]
+            if config.get("docker").get("container_name"):
+                setup_commands = config["head_setup_commands"]
+            else:
+                setup_commands = []
             ray_start_commands = config["head_start_ray_commands"]
         elif no_restart:
             setup_commands = config["head_setup_commands"]

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -646,7 +646,7 @@ def get_or_create_head_node(config: Dict[str, Any],
             cli_logger.print("Prepared bootstrap config")
 
         if restart_only:
-            # Some Command Runners may re-launch nodes, requiring setup
+            # Docker may re-launch nodes, requiring setup
             # commands to be rerun.
             if config.get("docker").get("container_name"):
                 setup_commands = config["head_setup_commands"]

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -646,7 +646,9 @@ def get_or_create_head_node(config: Dict[str, Any],
             cli_logger.print("Prepared bootstrap config")
 
         if restart_only:
-            setup_commands = []
+            # Some Command Runners may re-launch nodes, requiring setup
+            # commands to be rerun.
+            setup_commands = config["head_setup_commands"]
             ray_start_commands = config["head_start_ray_commands"]
         elif no_restart:
             setup_commands = config["head_setup_commands"]
@@ -678,7 +680,8 @@ def get_or_create_head_node(config: Dict[str, Any],
                 "rsync_exclude": config.get("rsync_exclude"),
                 "rsync_filter": config.get("rsync_filter")
             },
-            docker_config=config.get("docker"))
+            docker_config=config.get("docker"),
+            restart_only=restart_only)
         updater.start()
         updater.join()
 

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -648,7 +648,7 @@ def get_or_create_head_node(config: Dict[str, Any],
         if restart_only:
             # Docker may re-launch nodes, requiring setup
             # commands to be rerun.
-            if config.get("docker").get("container_name"):
+            if config.get("docker", {}).get("container_name"):
                 setup_commands = config["head_setup_commands"]
             else:
                 setup_commands = []

--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -48,6 +48,7 @@ class NodeUpdater:
         use_internal_ip: Wwhether the node_id belongs to an internal ip
             or external ip.
         docker_config: Docker section of autoscaler yaml
+        restart_only: Whether to skip setup commands & just restart ray
     """
 
     def __init__(self,
@@ -68,7 +69,8 @@ class NodeUpdater:
                  rsync_options=None,
                  process_runner=subprocess,
                  use_internal_ip=False,
-                 docker_config=None):
+                 docker_config=None,
+                 restart_only=False):
 
         self.log_prefix = "NodeUpdater: {}: ".format(node_id)
         use_internal_ip = (use_internal_ip
@@ -106,6 +108,7 @@ class NodeUpdater:
         self.auth_config = auth_config
         self.is_head_node = is_head_node
         self.docker_config = docker_config
+        self.restart_only = restart_only
 
     def run(self):
         if cmd_output_util.does_allow_interactive(
@@ -298,6 +301,11 @@ class NodeUpdater:
                 sync_run_yet=False)
             if init_required:
                 node_tags[TAG_RAY_RUNTIME_CONFIG] += "-invalidate"
+                # This ensures that `setup_commands` are not removed
+                self.restart_only = False
+
+        if self.restart_only:
+            self.setup_commands = []
 
         # runtime_hash will only change whenever the user restarts
         # or updates their cluster with `get_or_create_head_node`

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -500,7 +500,69 @@ class AutoscalingTest(unittest.TestCase):
             _provider=self.provider,
             _runner=runner)
         self.waitForNodes(1)
-        # Init & Setup commands msut be run for Docker!
+        # Init & Setup commands must be run for Docker!
+        runner.assert_has_call("1.2.3.4", "init_cmd")
+        runner.assert_has_call("1.2.3.4", "head_setup_cmd")
+        runner.assert_has_call("1.2.3.4", "start_ray_head")
+        self.assertEqual(self.provider.mock_nodes[0].node_type, None)
+        runner.assert_has_call("1.2.3.4", pattern="docker run")
+
+        docker_mount_prefix = get_docker_host_mount_location(
+            SMALL_CLUSTER["cluster_name"])
+        runner.assert_not_has_call(
+            "1.2.3.4",
+            pattern=f"-v {docker_mount_prefix}/~/ray_bootstrap_config")
+        runner.assert_has_call(
+            "1.2.3.4",
+            pattern=f"docker cp {docker_mount_prefix}/~/ray_bootstrap_key.pem")
+        pattern_to_assert = \
+            f"docker cp {docker_mount_prefix}/~/ray_bootstrap_config.yaml"
+        runner.assert_has_call("1.2.3.4", pattern=pattern_to_assert)
+
+        # This next section of code ensures that the following order of
+        # commands are executed:
+        # 1. mkdir -p {docker_mount_prefix}
+        # 2. rsync bootstrap files
+        # 3. docker cp bootstrap files into container
+        commands_with_mount = [
+            (i, cmd) for i, cmd in enumerate(runner.command_history())
+            if docker_mount_prefix in cmd
+        ]
+        first_mkdir = min(x[0] for x in commands_with_mount if "mkdir" in x[1])
+        for file_to_check in [
+                "ray_bootstrap_config.yaml", "ray_bootstrap_key.pem"
+        ]:
+            first_rsync = min(x[0] for x in rsync_commands
+                              if "ray_bootstrap_config.yaml" in x[1])
+            first_cp = min(
+                x[0] for x in docker_cp_commands if file_to_check in x[1])
+            assert first_mkdir < first_rsync
+            assert first_rsync < first_cp
+
+    def testGetOrCreateHeadNodeFromStoppedRestartOnly(self):
+        self.testGetOrCreateHeadNode()
+        self.provider.cache_stopped = True
+        existing_nodes = self.provider.non_terminated_nodes({})
+        assert len(existing_nodes) == 1
+        self.provider.terminate_node(existing_nodes[0])
+        config_path = self.write_config(SMALL_CLUSTER)
+        runner = MockProcessRunner()
+        runner.respond_to_call("json .Mounts", ["[]"])
+        # Two initial calls to docker cp, + 2 more calls during run_init
+        runner.respond_to_call(".State.Running",
+                               ["false", "false", "false", "false"])
+        runner.respond_to_call("json .Config.Env", ["[]"])
+        commands.get_or_create_head_node(
+            SMALL_CLUSTER,
+            printable_config_file=config_path,
+            no_restart=False,
+            restart_only=True,
+            yes=True,
+            override_cluster_name=None,
+            _provider=self.provider,
+            _runner=runner)
+        self.waitForNodes(1)
+        # Init & Setup commands must be run for Docker!
         runner.assert_has_call("1.2.3.4", "init_cmd")
         runner.assert_has_call("1.2.3.4", "head_setup_cmd")
         runner.assert_has_call("1.2.3.4", "start_ray_head")

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -524,9 +524,10 @@ class AutoscalingTest(unittest.TestCase):
         # 1. mkdir -p {docker_mount_prefix}
         # 2. rsync bootstrap files
         # 3. docker cp bootstrap files into container
-        commands_with_mount = [(i, cmd) for i, cmd in
-                               enumerate(runner.command_history())
-                               if docker_mount_prefix in cmd]
+        commands_with_mount = [
+            (i, cmd) for i, cmd in enumerate(runner.command_history())
+            if docker_mount_prefix in cmd
+        ]
         rsync_commands = [x for x in commands_with_mount if "rsync" in x[1]]
         docker_cp_commands = [
             x for x in commands_with_mount if "docker cp" in x[1]
@@ -2067,9 +2068,10 @@ MemAvailable:   33000000 kB
         first_pull = [(i, cmd)
                       for i, cmd in enumerate(runner.command_history())
                       if "docker pull" in cmd]
-        first_targeted_inspect = [(i, cmd) for i, cmd in
-                                  enumerate(runner.command_history())
-                                  if "docker inspect -f" in cmd]
+        first_targeted_inspect = [
+            (i, cmd) for i, cmd in enumerate(runner.command_history())
+            if "docker inspect -f" in cmd
+        ]
 
         # This checks for the bug mentioned #13128 where the image is inspected
         # before the image is present.

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -524,9 +524,12 @@ class AutoscalingTest(unittest.TestCase):
         # 1. mkdir -p {docker_mount_prefix}
         # 2. rsync bootstrap files
         # 3. docker cp bootstrap files into container
-        commands_with_mount = [
-            (i, cmd) for i, cmd in enumerate(runner.command_history())
-            if docker_mount_prefix in cmd
+        commands_with_mount = [(i, cmd) for i, cmd in
+                               enumerate(runner.command_history())
+                               if docker_mount_prefix in cmd]
+        rsync_commands = [x for x in commands_with_mount if "rsync" in x[1]]
+        docker_cp_commands = [
+            x for x in commands_with_mount if "docker cp" in x[1]
         ]
         first_mkdir = min(x[0] for x in commands_with_mount if "mkdir" in x[1])
         for file_to_check in [
@@ -566,44 +569,6 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_has_call("1.2.3.4", "init_cmd")
         runner.assert_has_call("1.2.3.4", "head_setup_cmd")
         runner.assert_has_call("1.2.3.4", "start_ray_head")
-        self.assertEqual(self.provider.mock_nodes[0].node_type, None)
-        runner.assert_has_call("1.2.3.4", pattern="docker run")
-
-        docker_mount_prefix = get_docker_host_mount_location(
-            SMALL_CLUSTER["cluster_name"])
-        runner.assert_not_has_call(
-            "1.2.3.4",
-            pattern=f"-v {docker_mount_prefix}/~/ray_bootstrap_config")
-        runner.assert_has_call(
-            "1.2.3.4",
-            pattern=f"docker cp {docker_mount_prefix}/~/ray_bootstrap_key.pem")
-        pattern_to_assert = \
-            f"docker cp {docker_mount_prefix}/~/ray_bootstrap_config.yaml"
-        runner.assert_has_call("1.2.3.4", pattern=pattern_to_assert)
-
-        # This next section of code ensures that the following order of
-        # commands are executed:
-        # 1. mkdir -p {docker_mount_prefix}
-        # 2. rsync bootstrap files
-        # 3. docker cp bootstrap files into container
-        commands_with_mount = [
-            (i, cmd) for i, cmd in enumerate(runner.command_history())
-            if docker_mount_prefix in cmd
-        ]
-        rsync_commands = [x for x in commands_with_mount if "rsync" in x[1]]
-        docker_cp_commands = [
-            x for x in commands_with_mount if "docker cp" in x[1]
-        ]
-        first_mkdir = min(x[0] for x in commands_with_mount if "mkdir" in x[1])
-        for file_to_check in [
-                "ray_bootstrap_config.yaml", "ray_bootstrap_key.pem"
-        ]:
-            first_rsync = min(x[0] for x in rsync_commands
-                              if "ray_bootstrap_config.yaml" in x[1])
-            first_cp = min(
-                x[0] for x in docker_cp_commands if file_to_check in x[1])
-            assert first_mkdir < first_rsync
-            assert first_rsync < first_cp
 
     @unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
     def testDockerFileMountsAdded(self):
@@ -2102,10 +2067,9 @@ MemAvailable:   33000000 kB
         first_pull = [(i, cmd)
                       for i, cmd in enumerate(runner.command_history())
                       if "docker pull" in cmd]
-        first_targeted_inspect = [
-            (i, cmd) for i, cmd in enumerate(runner.command_history())
-            if "docker inspect -f" in cmd
-        ]
+        first_targeted_inspect = [(i, cmd) for i, cmd in
+                                  enumerate(runner.command_history())
+                                  if "docker inspect -f" in cmd]
 
         # This checks for the bug mentioned #13128 where the image is inspected
         # before the image is present.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The Docker Command Runner may restart containers, requiring `setup_commands` to be re-run. 


NOTE: This does not apply to workers at the moment, as per #13861

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #13587

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
