### PR TITLE
[python/ray]: add cloudpickle dependency

### DIFF
--- a/python/requirements/requirements.txt
+++ b/python/requirements/requirements.txt
@@ -8,6 +8,7 @@
 aiohttp==3.7
 aioredis
 click >= 7.0
+cloudpickle
 colorama
 colorful
 filelock

--- a/python/setup.py
+++ b/python/setup.py
@@ -129,6 +129,7 @@ install_requires = [
     "aiohttp_cors",
     "aioredis",
     "click >= 7.0",
+    "cloudpickle",
     "colorama",
     "colorful",
     "filelock",


### PR DESCRIPTION
## Why are these changes needed?

As per #13609 we need cloudpickle because the cloudpickle in ray client is the real cloudpickle and not our vendored one.

We are figuring out how to remove the vendoring, but until then, a stopgap to triage errors is simply to install it.

## Related issue number

Closes #13609 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
