### PR TITLE
[Core] Ownership-based Object Directory - Changed infinite short-poll location subscription to long-poll.

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2221,7 +2221,7 @@ void CoreWorker::HandleGetObjectLocationsOwner(
   auto object_id = ObjectID::FromBinary(request.object_id());
   auto callback = [this, object_id, reply, send_reply_callback](
                       const absl::flat_hash_set<NodeID> &locations, int64_t object_size,
-                      uint64_t current_version) {
+                      int64_t current_version) {
     io_service_.post([object_id, reply, send_reply_callback, locations, object_size,
                       current_version]() {
       RAY_LOG(DEBUG) << "Replying to HandleGetObjectLocationsOwner for " << object_id

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2234,7 +2234,7 @@ void CoreWorker::HandleGetObjectLocationsOwner(
       send_reply_callback(Status::OK(), nullptr, nullptr);
     });
   };
-  auto status = reference_counter_->GetObjectLocationsAsync(
+  auto status = reference_counter_->SubscribeObjectLocations(
       object_id, request.last_version(), callback);
   if (!status.ok()) {
     send_reply_callback(status, nullptr, nullptr);

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2219,19 +2219,26 @@ void CoreWorker::HandleGetObjectLocationsOwner(
     return;
   }
   auto object_id = ObjectID::FromBinary(request.object_id());
-  absl::optional<absl::flat_hash_set<NodeID>> node_ids =
-      reference_counter_->GetObjectLocations(object_id);
-  Status status;
-  if (node_ids.has_value()) {
-    for (const auto &node_id : node_ids.value()) {
-      reply->add_node_ids(node_id.Binary());
-    }
-    status = Status::OK();
-  } else {
-    status = Status::ObjectNotFound("Object " + object_id.Hex() + " not found");
+  auto callback = [this, object_id, reply, send_reply_callback](
+                      const absl::flat_hash_set<NodeID> &locations, int64_t object_size,
+                      uint64_t current_version) {
+    io_service_.post([object_id, reply, send_reply_callback, locations, object_size,
+                      current_version]() {
+      RAY_LOG(DEBUG) << "Replying to HandleGetObjectLocationsOwner for " << object_id
+                     << " with location update version " << current_version;
+      for (const auto &node_id : locations) {
+        reply->add_node_ids(node_id.Binary());
+      }
+      reply->set_object_size(object_size);
+      reply->set_current_version(current_version);
+      send_reply_callback(Status::OK(), nullptr, nullptr);
+    });
+  };
+  auto status = reference_counter_->GetObjectLocationsAsync(
+      object_id, request.last_version(), callback);
+  if (!status.ok()) {
+    send_reply_callback(status, nullptr, nullptr);
   }
-  reply->set_object_size(reference_counter_->GetObjectSize(object_id));
-  send_reply_callback(status, nullptr, nullptr);
 }
 
 void CoreWorker::HandleWaitForRefRemoved(const rpc::WaitForRefRemovedRequest &request,

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -1007,7 +1007,7 @@ absl::optional<LocalityData> ReferenceCounter::GetLocalityData(
 }
 
 void ReferenceCounter::PushToLocationSubscribers(ReferenceTable::iterator it) {
-  auto callbacks = it->second.location_subscription_callbacks;
+  const auto callbacks = it->second.location_subscription_callbacks;
   it->second.location_subscription_callbacks.clear();
   it->second.location_version++;
   for (const auto callback : callbacks) {
@@ -1021,8 +1021,9 @@ Status ReferenceCounter::GetObjectLocationsAsync(
   absl::MutexLock lock(&mutex_);
   auto it = object_id_refs_.find(object_id);
   if (it == object_id_refs_.end()) {
-    RAY_LOG(WARNING) << "Tried to register a location subscriber for an object "
-                     << object_id << " that doesn't exist in the reference table";
+    RAY_LOG(INFO) << "Tried to register a location subscriber for an object " << object_id
+                  << " that doesn't exist in the reference table."
+                  << " The object has probably already been freed.";
     return Status::ObjectNotFound("Object " + object_id.Hex() + " not found");
   }
 

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -1024,7 +1024,7 @@ void ReferenceCounter::PushToLocationSubscribers(ReferenceTable::iterator it,
 }
 
 Status ReferenceCounter::GetObjectLocationsAsync(
-    const ObjectID &object_id, uint64_t last_location_version,
+    const ObjectID &object_id, int64_t last_location_version,
     const LocationSubscriptionCallback &callback) {
   absl::MutexLock lock(&mutex_);
   auto it = object_id_refs_.find(object_id);

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -1015,7 +1015,7 @@ void ReferenceCounter::PushToLocationSubscribers(ReferenceTable::iterator it) {
   }
 }
 
-Status ReferenceCounter::GetObjectLocationsAsync(
+Status ReferenceCounter::SubscribeObjectLocations(
     const ObjectID &object_id, int64_t last_location_version,
     const LocationSubscriptionCallback &callback) {
   absl::MutexLock lock(&mutex_);

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -51,7 +51,7 @@ class ReferenceCounterInterface {
 
 // Callback for location subscriptions.
 using LocationSubscriptionCallback =
-    std::function<void(const absl::flat_hash_set<NodeID> &, int64_t, uint64_t)>;
+    std::function<void(const absl::flat_hash_set<NodeID> &, int64_t, int64_t)>;
 
 /// Class used by the core worker to keep track of ObjectID reference counts for garbage
 /// collection. This class is thread safe.
@@ -409,8 +409,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// caller received. Only more recent location updates will be returned.
   /// \param[in] callback The callback to invoke with the location update.
   /// \return The status of the location get.
-  Status GetObjectLocationsAsync(const ObjectID &object_id,
-                                 uint64_t last_location_version,
+  Status GetObjectLocationsAsync(const ObjectID &object_id, int64_t last_location_version,
                                  const LocationSubscriptionCallback &callback)
       LOCKS_EXCLUDED(mutex_);
 
@@ -517,8 +516,9 @@ class ReferenceCounter : public ReferenceCounterInterface,
     /// object locations.
     absl::flat_hash_set<NodeID> locations;
     /// A logical counter for object location updates, used for object location
-    /// subscriptions.
-    uint64_t location_version = 1;
+    /// subscriptions. Subscribers use -1 to indicate that they want us to
+    /// immediately send them the current location data.
+    int64_t location_version = 0;
     // Whether this object can be reconstructed via lineage. If false, then the
     // object's value will be pinned as long as it is referenced by any other
     // object's lineage.

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -49,6 +49,10 @@ class ReferenceCounterInterface {
   virtual ~ReferenceCounterInterface() {}
 };
 
+// Callback for location subscriptions.
+using LocationSubscriptionCallback =
+    std::function<void(const absl::flat_hash_set<NodeID> &, int64_t, uint64_t)>;
+
 /// Class used by the core worker to keep track of ObjectID reference counts for garbage
 /// collection. This class is thread safe.
 class ReferenceCounter : public ReferenceCounterInterface,
@@ -397,6 +401,19 @@ class ReferenceCounter : public ReferenceCounterInterface,
   absl::optional<absl::flat_hash_set<NodeID>> GetObjectLocations(
       const ObjectID &object_id) LOCKS_EXCLUDED(mutex_);
 
+  /// Get object locations more recent than the given version, asynchronously. The
+  /// provided callback will be invoked when new locations become available.
+  ///
+  /// \param[in] object_id The object whose locations we want.
+  /// \param[in] last_location_version The version of the last location update the
+  /// caller received. Only more recent location updates will be returned.
+  /// \param[in] callback The callback to invoke with the location update.
+  /// \return The status of the location get.
+  Status GetObjectLocationsAsync(const ObjectID &object_id,
+                                 uint64_t last_location_version,
+                                 const LocationSubscriptionCallback &callback)
+      LOCKS_EXCLUDED(mutex_);
+
   /// Get an object's size. This will return 0 if the object is out of scope.
   ///
   /// \param[in] object_id The object whose size to get.
@@ -492,13 +509,16 @@ class ReferenceCounter : public ReferenceCounterInterface,
     /// process is a borrower, the borrower must add the owner's address before
     /// using the ObjectID.
     absl::optional<rpc::Address> owner_address;
-    // If this object is owned by us and stored in plasma, and reference
-    // counting is enabled, then some raylet must be pinning the object value.
-    // This is the address of that raylet.
+    /// If this object is owned by us and stored in plasma, and reference
+    /// counting is enabled, then some raylet must be pinning the object value.
+    /// This is the address of that raylet.
     absl::optional<NodeID> pinned_at_raylet_id;
-    // If this object is owned by us and stored in plasma, this contains all
-    // object locations.
+    /// If this object is owned by us and stored in plasma, this contains all
+    /// object locations.
     absl::flat_hash_set<NodeID> locations;
+    /// A logical counter for object location updates, used for object location
+    /// subscriptions.
+    uint64_t location_version = 1;
     // Whether this object can be reconstructed via lineage. If false, then the
     // object's value will be pinned as long as it is referenced by any other
     // object's lineage.
@@ -565,7 +585,9 @@ class ReferenceCounter : public ReferenceCounterInterface,
     size_t lineage_ref_count = 0;
     /// Whether this object has been spilled to external storage.
     bool spilled = false;
-
+    /// Location subscription callbacks registered by async location get requests.
+    /// These will be invoked whenever locations or object_size are changed.
+    std::vector<LocationSubscriptionCallback> location_subscription_callbacks;
     /// Callback that will be called when this ObjectID no longer has
     /// references.
     std::function<void(const ObjectID &)> on_delete;
@@ -687,6 +709,16 @@ class ReferenceCounter : public ReferenceCounterInterface,
 
   /// Helper method to decrement the lineage ref count for a list of objects.
   void ReleaseLineageReferencesInternal(const std::vector<ObjectID> &argument_ids)
+      EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+
+  /// Pushes location updates to subscribers of a particular reference, invoking all
+  /// callbacks registered for the reference by GetLocationsAsync calls. This method
+  /// also increments the reference's location version counter.
+  ///
+  /// Precondition: Provided lock has already been acquired.
+  /// Postcondition: Provided lock is released.
+  void PushToLocationSubscribers(ReferenceTable::iterator it,
+                                 absl::ReleasableMutexLock &lock)
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Address of our RPC server. This is used to determine whether we own a

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -714,11 +714,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// Pushes location updates to subscribers of a particular reference, invoking all
   /// callbacks registered for the reference by GetLocationsAsync calls. This method
   /// also increments the reference's location version counter.
-  ///
-  /// Precondition: Provided lock has already been acquired.
-  /// Postcondition: Provided lock is released.
-  void PushToLocationSubscribers(ReferenceTable::iterator it,
-                                 absl::ReleasableMutexLock &lock)
+  void PushToLocationSubscribers(ReferenceTable::iterator it)
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Address of our RPC server. This is used to determine whether we own a

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -401,16 +401,17 @@ class ReferenceCounter : public ReferenceCounterInterface,
   absl::optional<absl::flat_hash_set<NodeID>> GetObjectLocations(
       const ObjectID &object_id) LOCKS_EXCLUDED(mutex_);
 
-  /// Get object locations more recent than the given version, asynchronously. The
-  /// provided callback will be invoked when new locations become available.
+  /// Subscribe to object location changes that are more recent than the given version.
+  /// The provided callback will be invoked when new locations become available.
   ///
   /// \param[in] object_id The object whose locations we want.
   /// \param[in] last_location_version The version of the last location update the
   /// caller received. Only more recent location updates will be returned.
   /// \param[in] callback The callback to invoke with the location update.
   /// \return The status of the location get.
-  Status GetObjectLocationsAsync(const ObjectID &object_id, int64_t last_location_version,
-                                 const LocationSubscriptionCallback &callback)
+  Status SubscribeObjectLocations(const ObjectID &object_id,
+                                  int64_t last_location_version,
+                                  const LocationSubscriptionCallback &callback)
       LOCKS_EXCLUDED(mutex_);
 
   /// Get an object's size. This will return 0 if the object is out of scope.

--- a/src/ray/object_manager/ownership_based_object_directory.cc
+++ b/src/ray/object_manager/ownership_based_object_directory.cc
@@ -208,7 +208,7 @@ ray::Status OwnershipBasedObjectDirectory::SubscribeObjectLocations(
     rpc::GetObjectLocationsOwnerRequest request;
     request.set_intended_worker_id(owner_address.worker_id());
     request.set_object_id(object_id.Binary());
-    request.set_last_version(0);
+    request.set_last_version(-1);
     rpc_client->GetObjectLocationsOwner(
         request,
         std::bind(&OwnershipBasedObjectDirectory::SubscriptionCallback, this, object_id,

--- a/src/ray/object_manager/ownership_based_object_directory.cc
+++ b/src/ray/object_manager/ownership_based_object_directory.cc
@@ -80,11 +80,19 @@ ray::Status OwnershipBasedObjectDirectory::ReportObjectAdded(
   request.set_node_id(node_id.Binary());
 
   rpc_client->AddObjectLocationOwner(
-      request, [worker_id, object_id](Status status,
-                                      const rpc::AddObjectLocationOwnerReply &reply) {
+      request, [worker_id, object_id, node_id](
+                   Status status, const rpc::AddObjectLocationOwnerReply &reply) {
         if (!status.ok()) {
-          RAY_LOG(ERROR) << "Worker " << worker_id << " failed to add the location for "
-                         << object_id;
+          if (status.IsObjectNotFound()) {
+            RAY_LOG(INFO) << "Worker " << worker_id << " failed to add the location "
+                          << node_id << " for " << object_id
+                          << " because the owner no longer has the object; we assume the "
+                             "object was evicted.";
+          } else {
+            RAY_LOG(WARNING) << "Worker " << worker_id << " failed to add the location "
+                             << node_id << " for " << object_id << ": "
+                             << status.ToString();
+          }
         }
       });
   return Status::OK();
@@ -108,11 +116,19 @@ ray::Status OwnershipBasedObjectDirectory::ReportObjectRemoved(
   request.set_node_id(node_id.Binary());
 
   rpc_client->RemoveObjectLocationOwner(
-      request, [worker_id, object_id](Status status,
-                                      const rpc::RemoveObjectLocationOwnerReply &reply) {
+      request, [worker_id, object_id, node_id](
+                   Status status, const rpc::RemoveObjectLocationOwnerReply &reply) {
         if (!status.ok()) {
-          RAY_LOG(ERROR) << "Worker " << worker_id
-                         << " failed to remove the location for " << object_id;
+          if (status.IsObjectNotFound()) {
+            RAY_LOG(INFO) << "Worker " << worker_id << " failed to remove the location "
+                          << node_id << " for " << object_id
+                          << " because the owner no longer has the object; we assume the "
+                             "object was evicted.";
+          } else {
+            RAY_LOG(WARNING) << "Worker " << worker_id
+                             << " failed to remove the location " << node_id << " for "
+                             << object_id << ": " << status.ToString();
+          }
         }
       });
   return Status::OK();
@@ -121,16 +137,32 @@ ray::Status OwnershipBasedObjectDirectory::ReportObjectRemoved(
 void OwnershipBasedObjectDirectory::SubscriptionCallback(
     ObjectID object_id, WorkerID worker_id, Status status,
     const rpc::GetObjectLocationsOwnerReply &reply) {
+  // Objects are added to this map in SubscribeObjectLocations.
   auto it = listeners_.find(object_id);
+  // Do nothing for objects we are not listening for.
   if (it == listeners_.end()) {
     return;
   }
+  std::unordered_set<NodeID> node_ids;
+
+  if (!status.ok()) {
+    RAY_LOG(INFO) << "Worker " << worker_id << " failed to return location updates to "
+                  << "subscribers  for " << object_id << ": " << status.ToString()
+                  << ", assuming that the object was evicted.";
+    auto callbacks = it->second.callbacks;
+    for (const auto &callback_pair : callbacks) {
+      callback_pair.second(object_id, node_ids, "", NodeID::Nil(), 0);
+    }
+    return;
+  }
+
+  // Once this flag is set to true, it should never go back to false.
+  it->second.subscribed = true;
 
   if (reply.object_size() > 0) {
     it->second.object_size = reply.object_size();
   }
 
-  std::unordered_set<NodeID> node_ids;
   for (auto const &node_id : reply.node_ids()) {
     node_ids.emplace(NodeID::FromBinary(node_id));
   }
@@ -154,7 +186,7 @@ void OwnershipBasedObjectDirectory::SubscriptionCallback(
   rpc::GetObjectLocationsOwnerRequest request;
   request.set_intended_worker_id(worker_id.Binary());
   request.set_object_id(object_id.Binary());
-  // TODO(zhuohan): Fix this infinite loop.
+  request.set_last_version(reply.current_version());
   worker_it->second->GetObjectLocationsOwner(
       request,
       std::bind(&OwnershipBasedObjectDirectory::SubscriptionCallback, this, object_id,
@@ -176,6 +208,7 @@ ray::Status OwnershipBasedObjectDirectory::SubscribeObjectLocations(
     rpc::GetObjectLocationsOwnerRequest request;
     request.set_intended_worker_id(owner_address.worker_id());
     request.set_object_id(object_id.Binary());
+    request.set_last_version(0);
     rpc_client->GetObjectLocationsOwner(
         request,
         std::bind(&OwnershipBasedObjectDirectory::SubscriptionCallback, this, object_id,
@@ -188,6 +221,16 @@ ray::Status OwnershipBasedObjectDirectory::SubscribeObjectLocations(
     return Status::OK();
   }
   listener_state.callbacks.emplace(callback_id, callback);
+
+  // If we previously received some notifications about the object's locations,
+  // immediately notify the caller of the current known locations.
+  if (listener_state.subscribed) {
+    auto &locations = listener_state.current_object_locations;
+    auto object_size = it->second.object_size;
+    io_service_.post([callback, locations, object_size, object_id]() {
+      callback(object_id, locations, "", NodeID::Nil(), object_size);
+    });
+  }
   return Status::OK();
 }
 
@@ -221,6 +264,7 @@ ray::Status OwnershipBasedObjectDirectory::LookupLocations(
   rpc::GetObjectLocationsOwnerRequest request;
   request.set_intended_worker_id(owner_address.worker_id());
   request.set_object_id(object_id.Binary());
+  request.set_last_version(0);
 
   rpc_client->GetObjectLocationsOwner(
       request, [this, worker_id, object_id, callback](

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -178,15 +178,16 @@ message GetObjectLocationsOwnerRequest {
   bytes intended_worker_id = 1;
   bytes object_id = 2;
   // The version of the last location update. Only updates more recent than this version
-  // will be returned.
-  uint64 last_version = 3;
+  // will be returned. -1 indicates that the current location data should
+  // always be returned.
+  int64 last_version = 3;
 }
 
 message GetObjectLocationsOwnerReply {
   repeated bytes node_ids = 1;
   uint64 object_size = 2;
   // The version of the returned location updates.
-  uint64 current_version = 3;
+  int64 current_version = 3;
 }
 
 message KillActorRequest {

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -121,8 +121,7 @@ message DirectActorCallArgWaitCompleteRequest {
   int64 tag = 2;
 }
 
-message DirectActorCallArgWaitCompleteReply {
-}
+message DirectActorCallArgWaitCompleteReply {}
 
 message GetObjectStatusRequest {
   // The ID of the worker that owns this object. This is also
@@ -148,8 +147,7 @@ message WaitForActorOutOfScopeRequest {
   bytes actor_id = 2;
 }
 
-message WaitForActorOutOfScopeReply {
-}
+message WaitForActorOutOfScopeReply {}
 
 message WaitForObjectEvictionRequest {
   // The ID of the worker this message is intended for.
@@ -158,8 +156,7 @@ message WaitForObjectEvictionRequest {
   bytes object_id = 2;
 }
 
-message WaitForObjectEvictionReply {
-}
+message WaitForObjectEvictionReply {}
 
 message AddObjectLocationOwnerRequest {
   bytes intended_worker_id = 1;
@@ -167,8 +164,7 @@ message AddObjectLocationOwnerRequest {
   bytes node_id = 3;
 }
 
-message AddObjectLocationOwnerReply {
-}
+message AddObjectLocationOwnerReply {}
 
 message RemoveObjectLocationOwnerRequest {
   bytes intended_worker_id = 1;
@@ -176,17 +172,21 @@ message RemoveObjectLocationOwnerRequest {
   bytes node_id = 3;
 }
 
-message RemoveObjectLocationOwnerReply {
-}
+message RemoveObjectLocationOwnerReply {}
 
 message GetObjectLocationsOwnerRequest {
   bytes intended_worker_id = 1;
   bytes object_id = 2;
+  // The version of the last location update. Only updates more recent than this version
+  // will be returned.
+  uint64 last_version = 3;
 }
 
 message GetObjectLocationsOwnerReply {
   repeated bytes node_ids = 1;
   uint64 object_size = 2;
+  // The version of the returned location updates.
+  uint64 current_version = 3;
 }
 
 message KillActorRequest {
@@ -198,8 +198,7 @@ message KillActorRequest {
   bool no_restart = 3;
 }
 
-message KillActorReply {
-}
+message KillActorReply {}
 
 message CancelTaskRequest {
   // ID of task that should be killed.
@@ -224,8 +223,7 @@ message RemoteCancelTaskRequest {
   bool recursive = 3;
 }
 
-message RemoteCancelTaskReply {
-}
+message RemoteCancelTaskReply {}
 
 message GetCoreWorkerStatsRequest {
   // The ID of the worker this message is intended for.
@@ -284,18 +282,15 @@ message WaitForRefRemovedReply {
   repeated ObjectReferenceCount borrowed_refs = 1;
 }
 
-message LocalGCRequest {
-}
+message LocalGCRequest {}
 
-message LocalGCReply {
-}
+message LocalGCReply {}
 
 message PlasmaObjectReadyRequest {
   bytes object_id = 1;
 }
 
-message PlasmaObjectReadyReply {
-}
+message PlasmaObjectReadyReply {}
 
 message SpillObjectsRequest {
   // The IDs of objects to be spilled.
@@ -324,14 +319,11 @@ message DeleteSpilledObjectsRequest {
   repeated string spilled_objects_url = 1;
 }
 
-message DeleteSpilledObjectsReply {
-}
+message DeleteSpilledObjectsReply {}
 
-message ExitRequest {
-}
+message ExitRequest {}
 
-message ExitReply {
-}
+message ExitReply {}
 
 service CoreWorkerService {
   // Push a task directly to this worker from another.

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -121,7 +121,8 @@ message DirectActorCallArgWaitCompleteRequest {
   int64 tag = 2;
 }
 
-message DirectActorCallArgWaitCompleteReply {}
+message DirectActorCallArgWaitCompleteReply {
+}
 
 message GetObjectStatusRequest {
   // The ID of the worker that owns this object. This is also
@@ -147,7 +148,8 @@ message WaitForActorOutOfScopeRequest {
   bytes actor_id = 2;
 }
 
-message WaitForActorOutOfScopeReply {}
+message WaitForActorOutOfScopeReply {
+}
 
 message WaitForObjectEvictionRequest {
   // The ID of the worker this message is intended for.
@@ -156,7 +158,8 @@ message WaitForObjectEvictionRequest {
   bytes object_id = 2;
 }
 
-message WaitForObjectEvictionReply {}
+message WaitForObjectEvictionReply {
+}
 
 message AddObjectLocationOwnerRequest {
   bytes intended_worker_id = 1;
@@ -164,7 +167,8 @@ message AddObjectLocationOwnerRequest {
   bytes node_id = 3;
 }
 
-message AddObjectLocationOwnerReply {}
+message AddObjectLocationOwnerReply {
+}
 
 message RemoveObjectLocationOwnerRequest {
   bytes intended_worker_id = 1;
@@ -172,7 +176,8 @@ message RemoveObjectLocationOwnerRequest {
   bytes node_id = 3;
 }
 
-message RemoveObjectLocationOwnerReply {}
+message RemoveObjectLocationOwnerReply {
+}
 
 message GetObjectLocationsOwnerRequest {
   bytes intended_worker_id = 1;
@@ -199,7 +204,8 @@ message KillActorRequest {
   bool no_restart = 3;
 }
 
-message KillActorReply {}
+message KillActorReply {
+}
 
 message CancelTaskRequest {
   // ID of task that should be killed.
@@ -224,7 +230,8 @@ message RemoteCancelTaskRequest {
   bool recursive = 3;
 }
 
-message RemoteCancelTaskReply {}
+message RemoteCancelTaskReply {
+}
 
 message GetCoreWorkerStatsRequest {
   // The ID of the worker this message is intended for.
@@ -283,15 +290,18 @@ message WaitForRefRemovedReply {
   repeated ObjectReferenceCount borrowed_refs = 1;
 }
 
-message LocalGCRequest {}
+message LocalGCRequest {
+}
 
-message LocalGCReply {}
+message LocalGCReply {
+}
 
 message PlasmaObjectReadyRequest {
   bytes object_id = 1;
 }
 
-message PlasmaObjectReadyReply {}
+message PlasmaObjectReadyReply {
+}
 
 message SpillObjectsRequest {
   // The IDs of objects to be spilled.
@@ -320,11 +330,14 @@ message DeleteSpilledObjectsRequest {
   repeated string spilled_objects_url = 1;
 }
 
-message DeleteSpilledObjectsReply {}
+message DeleteSpilledObjectsReply {
+}
 
-message ExitRequest {}
+message ExitRequest {
+}
 
-message ExitReply {}
+message ExitReply {
+}
 
 service CoreWorkerService {
   // Push a task directly to this worker from another.


### PR DESCRIPTION
Ports the ownership-based object directory's infinite short-polling location subscription to long-polling.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The prior object location subscription implementation would repeatedly poll the owning core worker, without knowing whether there are new changes to pull and without a delay between polls. This PR changes the object location subscription to a long-poll, where the owning core worker only returns object location data if there is an update that the subscriber has not yet seen. This is implemented via a logical version counter maintained within the owner's reference counter and included in each subscription request and reply.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #12551

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## Testing note

Adding [unit tests](https://github.com/ray-project/ray/issues/12550) to the ownership-based object directory as a whole is slated for another PR. Currently, the ownership-based object directory doesn't have unit tests, the GCS-based object directory doesn't have unit tests, and the object manager's unit tests were recently removed, so the only current coverage are the e2e Python tests. I've confirmed that the basic OBOD implementation works by turning on the OBOD feature flag and running the Python tests locally, but I'll be adding comprehensive unit tests in a future PR given that it might require a sizable refactor and I wanted to keep this PR limited to the long-polling subscription implementation.

## Object spilling note

Object spilling is [not yet supported](https://github.com/ray-project/ray/issues/13701) in the ownership-based object directory; adding support for object spilling will be done in a future PR.