### PR TITLE
Unconditionally retry all RPC errors on client connect

### DIFF
--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -104,7 +104,7 @@ class Worker:
                 logger.info("Ray client server unavailable, "
                             f"retrying in {timeout}s...")
                 logger.debug(f"Received when checking init: {e.details()}")
-                # Ray is not ready yet, wait a timeout
+                # Ray is not ready yet, wait a timeout.
                 time.sleep(timeout)
             # Fallthrough, backoff, and retry at the top of the loop
             logger.info("Waiting for Ray to become ready on the server, "

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -101,17 +101,11 @@ class Worker:
                 # Note that channel_ready_future constitutes its own timeout,
                 # which is why we do not sleep here.
             except grpc.RpcError as e:
-                if e.code() == grpc.StatusCode.UNAVAILABLE:
-                    # UNAVAILABLE is gRPC's retryable error,
-                    # so we do that here.
-                    logger.info("Ray client server unavailable, "
-                                f"retrying in {timeout}s...")
-                    logger.debug(f"Received when checking init: {e.details()}")
-                    # Ray is not ready yet, wait a timeout
-                    time.sleep(timeout)
-                else:
-                    # Any other gRPC error gets a reraise
-                    raise e
+                logger.info("Ray client server unavailable, "
+                            f"retrying in {timeout}s...")
+                logger.debug(f"Received when checking init: {e.details()}")
+                # Ray is not ready yet, wait a timeout
+                time.sleep(timeout)
             # Fallthrough, backoff, and retry at the top of the loop
             logger.info("Waiting for Ray to become ready on the server, "
                         f"retry in {timeout}s...")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The server may spuriously return other errors such as 401, etc. Retry them all to be resilient.