### PR TITLE
[Core/Python] Better UX for Redis shard port fallback.

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -829,6 +829,13 @@ def start_redis(node_ip_address,
     redis_modules = [REDIS_MODULE]
 
     redis_stdout_file, redis_stderr_file = redirect_files[0]
+    # If no port is given, fallback to default Redis port for the primary
+    # shard.
+    if port is None:
+        port = ray_constants.DEFAULT_PORT
+        num_retries = 20
+    else:
+        num_retries = 1
     # Start the primary Redis shard.
     port, p = _start_redis_instance(
         redis_executable,
@@ -836,6 +843,7 @@ def start_redis(node_ip_address,
         port=port,
         password=password,
         redis_max_clients=redis_max_clients,
+        num_retries=num_retries,
         # Below we use None to indicate no limit on the memory of the
         # primary Redis shard.
         redis_max_memory=None,
@@ -869,17 +877,29 @@ def start_redis(node_ip_address,
     # Start other Redis shards. Each Redis shard logs to a separate file,
     # prefixed by "redis-<shard number>".
     redis_shards = []
+    # Attempt to start the other Redis shards port range right after the
+    # primary Redis shard port.
+    last_shard_port = port
     for i in range(num_redis_shards):
         redis_stdout_file, redis_stderr_file = redirect_files[i + 1]
         redis_executable = REDIS_EXECUTABLE
         redis_modules = [REDIS_MODULE]
+        redis_shard_port = redis_shard_ports[i]
+        # If no shard port is given, try to start this shard's Redis instance
+        # on the port right after the last shard's port.
+        if redis_shard_port is None:
+            redis_shard_port = last_shard_port + 1
+            num_retries = 20
+        else:
+            num_retries = 1
 
         redis_shard_port, p = _start_redis_instance(
             redis_executable,
             modules=redis_modules,
-            port=redis_shard_ports[i],
+            port=redis_shard_port,
             password=password,
             redis_max_clients=redis_max_clients,
+            num_retries=num_retries,
             redis_max_memory=redis_max_memory,
             stdout_file=redis_stdout_file,
             stderr_file=redis_stderr_file,
@@ -890,13 +910,14 @@ def start_redis(node_ip_address,
         redis_shards.append(shard_address)
         # Store redis shard information in the primary redis shard.
         primary_redis_client.rpush("RedisShards", shard_address)
+        last_shard_port = redis_shard_port
 
     return redis_address, redis_shards, processes
 
 
 def _start_redis_instance(executable,
                           modules,
-                          port=None,
+                          port,
                           redis_max_clients=None,
                           num_retries=20,
                           stdout_file=None,
@@ -907,20 +928,19 @@ def _start_redis_instance(executable,
     """Start a single Redis server.
 
     Notes:
-        If "port" is not None, then we will only use this port and try
-        only once. Otherwise, we will first try the default redis port,
-        and if it is unavailable, we will try random ports with
-        maximum retries of "num_retries".
+        We will initially try to start the Redis instance at the given port,
+        and then try at most `num_retries - 1` times to start the Redis
+        instance at successive random ports.
 
     Args:
         executable (str): Full path of the redis-server executable.
         modules (list of str): A list of pathnames, pointing to the redis
             module(s) that will be loaded in this redis server.
-        port (int): If provided, start a Redis server with this port.
+        port (int): Try to start a Redis server at this port.
         redis_max_clients: If this is provided, Ray will attempt to configure
             Redis with this maxclients number.
-        num_retries (int): The number of times to attempt to start Redis. If a
-            port is provided, this defaults to 1.
+        num_retries (int): The number of times to attempt to start Redis at
+            successive ports.
         stdout_file: A file handle opened for writing to redirect stdout to. If
             no redirection should happen, then this should be None.
         stderr_file: A file handle opened for writing to redirect stderr to. If
@@ -943,13 +963,6 @@ def _start_redis_instance(executable,
     for module in modules:
         assert os.path.isfile(module)
     counter = 0
-    if port is not None:
-        # If a port is specified, then try only once to connect.
-        # This ensures that we will use the given port.
-        num_retries = 1
-    else:
-        port = ray_constants.DEFAULT_PORT
-
     load_module_args = []
     for module in modules:
         load_module_args += ["--loadmodule", module]

--- a/python/ray/parameter.py
+++ b/python/ray/parameter.py
@@ -17,9 +17,12 @@ class RayParams:
             raylet, a plasma store, a plasma manager, and some workers.
             It will also kill these processes when Python exits.
         redis_port (int): The port that the primary Redis shard should listen
-            to. If None, then a random port will be chosen.
+            to. If None, then it will fall back to
+            ray.ray_constants.DEFAULT_PORT, or a random port if the default is
+            not available.
         redis_shard_ports: A list of the ports to use for the non-primary Redis
-            shards.
+            shards. If None, then it will fall back to the ports right after
+            redis_port, or random ports if those are not available.
         num_cpus (int): Number of CPUs to configure the raylet with.
         num_gpus (int): Number of GPUs to configure the raylet with.
         resources: A dictionary mapping the name of a resource to the quantity


### PR DESCRIPTION
Falls back to a random port instead of the default primary port for non-primary Redis shards, and attempts to cluster Redis shard ports close to each other.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If the user doesn't specify [`--redis-shard-ports`](https://github.com/ray-project/ray/blob/7166949194365593bb38813843d8a8ab6be38e06/python/ray/scripts/scripts.py#L241-L246), the Redis starter routine will [fallback to `None` for each port](https://github.com/ray-project/ray/blob/7166949194365593bb38813843d8a8ab6be38e06/python/ray/_private/services.py#L817-L818), and when [starting the Redis instance for a shard](https://github.com/ray-project/ray/blob/7166949194365593bb38813843d8a8ab6be38e06/python/ray/_private/services.py#L874-L883), [it will fall back](https://github.com/ray-project/ray/blob/7166949194365593bb38813843d8a8ab6be38e06/python/ray/_private/services.py#L943-L948) to the [default primary Redis shard port, 6379](https://github.com/ray-project/ray/blob/master/python/ray/ray_constants.py#L37-L39). The user will often specify a primary port other than 6379 because they plan on having another application use that port (e.g. a non-Ray Redis instance), so they aren't happy when a non-primary shard takes that port.

In this PR, we change the fallback logic as follows:
1. The primary Redis shard port falls back to the default primary port (6379), or to a random port if that's not available.
2. Other Redis shards fall back to the last shard's port + 1, or to a random port if that's not available.

The end result is that Redis shard ports try to cluster close to each other, but will hop to a new random range if they encounter a conflict.

Some examples:

1. User asks for 3 non-primary shards, doesn't specify a primary port or shard ports, and 6379-6382 are open:
  - Primary port: 6379
  - Other shard 1 port: 6380
  - Other shard 2 port: 6381
  - Other shard 3 port: 6382
2. User asks for 3 non-primary shards, specifies 6380 as their desired port, and 6380-6383 are open:
  - Primary port: 6380
  - Other shard 1 port: 6381
  - Other shard 2 port: 6382
  - Other shard 3 port: 6383
3. User asks for 3 non-primary shards, doesn't specify a primary port or shard ports, 6379 is not available, but 12345-12348 are:
  - Primary port: random port, say 12345
  - Other shard 1 port: 12346
  - Other shard 2 port: 12347
  - Other shard 3 port: 12348
4. User asks for 3 non-primary shards, doesn't specify a primary port or shard ports, 6379 and 6380 are available, but 6381 is not, and 12345 and 12346 are:
  - Primary port: 6379
  - Other shard 1 port: 6380
  - Other shard 2 port: random port, say 12345
  - Other shard 3 port: 12346

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #13085 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
