### PR TITLE
Remove LRU eviction docs

### DIFF
--- a/doc/source/walkthrough.rst
+++ b/doc/source/walkthrough.rst
@@ -401,21 +401,11 @@ works as follows.
     System.out.println(waitResult.getReady());  // List of ready objects.
     System.out.println(waitResult.getUnready());  // list of unready objects.
 
-Object Eviction
+Object Spilling
 ---------------
 
-When the object store gets full, objects will be evicted to make room for new objects.
-This happens in approximate LRU (least recently used) order. To avoid objects from
-being evicted, you can call ``get`` and store their values instead. Numpy array
-objects cannot be evicted while they are mapped in any Python process.
-
-.. note::
-
-    Objects created with ``put`` are pinned in memory while a Python/Java reference
-    to the object ref returned by the put exists. This only applies to the specific
-    ref returned by put, not refs in general or copies of that refs.
-
-See also: `object spilling <memory-management.html#object-spilling>`__.
+When the object store gets full, objects will be `spilled to disk <memory-management.html#object-spilling>`__.
+This feature is available in Ray 1.3+.
 
 Remote Classes (Actors)
 -----------------------


### PR DESCRIPTION
Remove LRU eviction docs now that object spilling is on by default. We can remove LRU eviction later on.