### PR TITLE
[docs] ray slack remove banners

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -300,7 +300,6 @@ More Information
 Getting Involved
 ----------------
 
-- `Community Slack`_: Join our Slack workspace.
 - `Forum`_: For discussions about development, questions about usage, and feature requests.
 - `GitHub Issues`_: For reporting bugs.
 - `Twitter`_: Follow updates on Twitter.
@@ -311,5 +310,4 @@ Getting Involved
 .. _`GitHub Issues`: https://github.com/ray-project/ray/issues
 .. _`StackOverflow`: https://stackoverflow.com/questions/tagged/ray
 .. _`Meetup Group`: https://www.meetup.com/Bay-Area-Ray-Meetup/
-.. _`Community Slack`: https://forms.gle/9TSdDYUgxYs8SA9e8
 .. _`Twitter`: https://twitter.com/raydistributed

--- a/doc/source/getting-involved.rst
+++ b/doc/source/getting-involved.rst
@@ -6,8 +6,7 @@ Getting Involved / Contributing
 Ray is more than a framework for distributed applications but also an active community of developers,
 researchers, and folks that love machine learning.
 
-.. tip:: Join our `community Slack <https://forms.gle/9TSdDYUgxYs8SA9e8>`_ to
-  discuss Ray or ask questions on `our forum <https://discuss.ray.io/>`_! The
+.. tip:: Ask questions on `our forum <https://discuss.ray.io/>`_! The
   community is extremely active in helping people succeed in building their
   Ray applications.
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -3,8 +3,6 @@
 Installing Ray
 ==============
 
-.. tip:: Join our `community slack <https://forms.gle/9TSdDYUgxYs8SA9e8>`_ to discuss Ray!
-
 Ray currently supports MacOS and Linux.
 Windows wheels are now available, but :ref:`Windows support <windows-support>` is experimental and under development.
 

--- a/doc/source/raysgd/raysgd.rst
+++ b/doc/source/raysgd/raysgd.rst
@@ -14,8 +14,6 @@ The main features are:
   - **Composability**: RaySGD is built on top of the Ray Actor API, enabling seamless integration with existing Ray applications such as RLlib, Tune, and Ray.Serve.
   - **Scale up and down**: Start on single CPU. Scale up to multi-node, multi-CPU, or multi-GPU clusters by changing 2 lines of code.
 
-.. tip:: Join our `community slack <https://forms.gle/9TSdDYUgxYs8SA9e8>`_ to discuss Ray!
-
 
 Getting Started
 ---------------

--- a/doc/source/rllib.rst
+++ b/doc/source/rllib.rst
@@ -9,8 +9,6 @@ RLlib is an open-source library for reinforcement learning that offers both high
 
 To get started, take a look over the `custom env example <https://github.com/ray-project/ray/blob/master/rllib/examples/custom_env.py>`__ and the `API documentation <rllib-toc.html>`__. If you're looking to develop custom algorithms with RLlib, also check out `concepts and custom algorithms <rllib-concepts.html>`__.
 
-.. tip:: Join our `community slack <https://forms.gle/9TSdDYUgxYs8SA9e8>`_ to discuss Ray/RLlib!
-
 RLlib in 60 seconds
 -------------------
 

--- a/doc/source/serve/index.rst
+++ b/doc/source/serve/index.rst
@@ -30,7 +30,7 @@ Ray Serve can be used in two primary ways to deploy your models at scale:
 
 
 .. tip::
-  Chat with Ray Serve users and developers on our `community Slack <https://forms.gle/9TSdDYUgxYs8SA9e8>`_ in the #serve channel and on our `forum <https://discuss.ray.io/>`_!
+  Chat with Ray Serve users and developers on our `forum <https://discuss.ray.io/>`_!
 
 .. note::
   Starting with Ray version 1.2.0, Ray Serve backends take in a Starlette Request object instead of a Flask Request object.

--- a/doc/source/tune/index.rst
+++ b/doc/source/tune/index.rst
@@ -21,9 +21,6 @@ Tune is a Python library for experiment execution and hyperparameter tuning at a
 
 **Want to get started?** Head over to the :doc:`Key Concepts page </tune/key-concepts>`.
 
-.. tip:: Join the `Ray community slack <https://forms.gle/9TSdDYUgxYs8SA9e8>`_ to discuss Ray Tune (and other Ray libraries)!
-
-
 Quick Start
 -----------
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

There are many slack banners. Getting rid of them, but leaving a couple references to the slack behind.

Note that this still leaves *some* references to the Ray Slack, but not as many.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(