### PR TITLE
Check in shuffle code as experimental

### DIFF
--- a/python/ray/experimental/shuffle.py
+++ b/python/ray/experimental/shuffle.py
@@ -147,7 +147,7 @@ class _StatusTracker:
         print("Num reduce tasks finished", self.num_reduce)
 
 
-if __name__ == "__main__":
+def main():
     import argparse
     import numpy as np
     import time
@@ -197,3 +197,7 @@ if __name__ == "__main__":
     print()
     print("Shuffled", int(sum(output_sizes) / (1024 * 1024)), "MiB in", delta,
           "seconds")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/ray/experimental/shuffle.py
+++ b/python/ray/experimental/shuffle.py
@@ -1,0 +1,112 @@
+from typing import TypeVar, List, Iterable
+
+import ray
+from ray import ObjectRef
+
+
+PartitionID = int
+InType = TypeVar("InType")
+OutType = TypeVar("OutType")
+
+
+def simple_shuffle[InType, OutType](
+        *,
+        input_reader: Callable[[PartitionID], Iterable[InType]],
+        output_num_partitions: int,
+        output_writer: Callable[[PartitionID, List[ObjectRef[InType]]], OutType],
+        partitioner: Callable[[Iterable[InType], int], Iterable[PartitionID]] = round_robin_partitioner,
+        input_combiner: InputCombiner = InputCombiner,
+    ) -> List[OutType]:
+
+
+    @ray.remote(num_returns=num_output_partitions)
+    def shuffle_map(i: PartitionID) -> List[List[ObjectRef[InType]]]:
+        combiners = [input_combiner() for _ in range(num_output_partitions)]
+        for out_i, item in partitioner(input_reader(i)):
+            combiners[out_i].add(item)
+        outputs = [
+            [ray.put(r) for r in c.results()]
+            for c in range(combiners)
+        ]
+        return outputs
+
+
+    @ray.remote
+    def shuffle_reduce(i: PartitionID, inputs: List[ObjectRef[InType]]) -> OutType:
+        return output_writer(i, inputs)
+
+
+    shuffle_map_out = ray.get(
+        [shuffle_map.remote(i) for i in range(num_partitions)])
+
+    shuffle_reduce_out = []
+    for j in range(output_num_partitions):
+        reduce_input = []
+        for map_output in shuffle_map_out:
+            reduce_input.extend(map_output[j])
+        shuffle_reduce_out.append(shuffle_reduce.remote(j, reduce_input))
+
+    return ray.get(shuffle_reduce_out)
+
+
+@ray.remote
+class _StatusTracker:
+    def __init__(self):
+        self.num_map = 0
+        self.num_reduce = 0
+
+    def inc(self):
+        self.num_map += 1
+        print("Num map tasks finished", self.num_map)
+
+    def inc2(self):
+        self.num_reduce += 1
+        print("Num reduce tasks finished", self.num_reduce)
+
+
+class InputCombiner:
+    def __init__(self):
+        self.results = []
+
+    def add(self, data: InType) -> None:
+        self.results.append(ray.put(data))
+
+    def finish() -> List[ObjectRef[InType]]:
+        return self.results
+
+
+def round_robin_partitioner(
+        input_stream: Iterable[InType], num_partitions: int) -> Iterable[Tuple[PartitionID, InType]]:
+    i = 0
+    for item in input_stream:
+        yield (i, item)
+        i += 1
+        i %= num_partitions
+
+
+if __name__ == "__main__":
+    partition_size = int(200e6)
+    num_partitions = 50
+    rows_per_partition = partition_size // (8 * 2)
+
+    tracker = _StatusTracker.remote()
+
+    def input_reader(i: PartitionID) -> Iterable[InType]:
+        for _ in range(num_partitions):
+            yield np.ones((rows_per_partition // num_partitions, 2), dtype=np.int64)
+        tracker.inc.remote()
+
+    def output_writer(i: PartitionID, shuffle_inputs: List[ObjectRef[InType]]) -> OutType:
+        for obj_ref in shuffle_inputs:
+            ray.get(obj_ref)
+        tracker.inc2.remote()
+
+    start = time.time()
+
+    output_size = simple_shuffle(
+        input_reader=input_reader,
+        output_num_partitions=num_partitions,
+        output_writer=output_writer)
+    delta = time.time() - start
+
+    print("Shuffled", int(output_size / (1024 * 1024)), "MiB in", delta, "seconds")

--- a/python/ray/experimental/shuffle.py
+++ b/python/ray/experimental/shuffle.py
@@ -183,7 +183,6 @@ def main():
         return total
 
     start = time.time()
-
     output_sizes = simple_shuffle(
         input_reader=input_reader,
         input_num_partitions=num_partitions,

--- a/python/ray/experimental/shuffle.py
+++ b/python/ray/experimental/shuffle.py
@@ -186,6 +186,7 @@ def main():
     def output_writer(i: PartitionID,
                       shuffle_inputs: List[ObjectRef]) -> OutType:
         total = 0
+        # TODO(ekl) using ray.wait can be more efficient.
         for obj_ref in shuffle_inputs:
             arr = ray.get(obj_ref)
             total += arr.size * arr.itemsize

--- a/python/ray/experimental/shuffle.py
+++ b/python/ray/experimental/shuffle.py
@@ -15,12 +15,12 @@ To try an example 10GB shuffle, run:
 This will print out some statistics on the shuffle execution such as:
 
     --- Aggregate object store stats across all nodes ---
-    Plasma memory usage 801 MiB, 21 objects, 84.0% full
-    Spilled 915 MiB, 24 objects, avg write throughput 1306 MiB/s
-    Restored 152 MiB, 4 objects, avg read throughput 2584 MiB/s
-    Objects consumed by Ray tasks: 953 MiB.
+    Plasma memory usage 0 MiB, 0 objects, 0.0% full
+    Spilled 9487 MiB, 2487 objects, avg write throughput 1023 MiB/s
+    Restored 9487 MiB, 2487 objects, avg read throughput 1358 MiB/s
+    Objects consumed by Ray tasks: 9537 MiB.
 
-    Shuffled 953 MiB in 0.8846073150634766 seconds
+    Shuffled 9536 MiB in 16.579771757125854 seconds
 """
 
 from typing import List, Iterable, Tuple, Callable, Any

--- a/python/ray/experimental/shuffle.py
+++ b/python/ray/experimental/shuffle.py
@@ -12,7 +12,15 @@ To try an example 10GB shuffle, run:
         --num-partitions=50 --partition-size=200e6 \
         --object-store-memory=1e9
 
-This will print out some statistics on the shuffle execution.
+This will print out some statistics on the shuffle execution such as:
+
+    --- Aggregate object store stats across all nodes ---
+    Plasma memory usage 801 MiB, 21 objects, 84.0% full
+    Spilled 915 MiB, 24 objects, avg write throughput 1306 MiB/s
+    Restored 152 MiB, 4 objects, avg read throughput 2584 MiB/s
+    Objects consumed by Ray tasks: 953 MiB.
+
+    Shuffled 953 MiB in 0.8846073150634766 seconds
 """
 
 from typing import List, Iterable, Tuple, Callable, Any

--- a/python/ray/experimental/shuffle.py
+++ b/python/ray/experimental/shuffle.py
@@ -186,7 +186,7 @@ def main():
     def output_writer(i: PartitionID,
                       shuffle_inputs: List[ObjectRef]) -> OutType:
         total = 0
-        # TODO(ekl) using ray.wait can be more efficient.
+        # TODO(ekl) using ray.wait can be more efficient for pipelining.
         for obj_ref in shuffle_inputs:
             arr = ray.get(obj_ref)
             total += arr.size * arr.itemsize

--- a/python/ray/experimental/shuffle.py
+++ b/python/ray/experimental/shuffle.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
     ray.init()
 
     partition_size = int(200e6)
-    num_partitions = 50
+    num_partitions = 5
     rows_per_partition = partition_size // (8 * 2)
 
     tracker = _StatusTracker.remote()
@@ -120,5 +120,7 @@ if __name__ == "__main__":
         output_writer=output_writer)
     delta = time.time() - start
 
+    time.sleep(1)
+    print(ray.internal.internal_api.memory_summary(stats_only=True))
     print("Shuffled", int(sum(output_sizes) / (1024 * 1024)), "MiB in", delta,
           "seconds")

--- a/python/ray/experimental/shuffle.py
+++ b/python/ray/experimental/shuffle.py
@@ -1,43 +1,59 @@
-from typing import TypeVar, List, Iterable
+from typing import TypeVar, List, Iterable, Tuple, Callable
 
 import ray
 from ray import ObjectRef
-
 
 PartitionID = int
 InType = TypeVar("InType")
 OutType = TypeVar("OutType")
 
 
-def simple_shuffle[InType, OutType](
+class InputCombiner:
+    def __init__(self):
+        self.results = []
+
+    def add(self, data: InType) -> None:
+        self.results.append(ray.put(data))
+
+    def finish(self) -> List[ObjectRef[InType]]:
+        return self.results
+
+
+def round_robin_partitioner(input_stream: Iterable[InType], num_partitions: int
+                            ) -> Iterable[Tuple[PartitionID, InType]]:
+    i = 0
+    for item in input_stream:
+        yield (i, item)
+        i += 1
+        i %= num_partitions
+
+
+def simple_shuffle(
         *,
         input_reader: Callable[[PartitionID], Iterable[InType]],
+        input_num_partitions: int,
         output_num_partitions: int,
-        output_writer: Callable[[PartitionID, List[ObjectRef[InType]]], OutType],
-        partitioner: Callable[[Iterable[InType], int], Iterable[PartitionID]] = round_robin_partitioner,
+        output_writer: Callable[[PartitionID, List[ObjectRef[InType]]],
+                                OutType],
+        partitioner: Callable[[Iterable[InType], int], Iterable[
+            PartitionID]] = round_robin_partitioner,
         input_combiner: InputCombiner = InputCombiner,
-    ) -> List[OutType]:
-
-
-    @ray.remote(num_returns=num_output_partitions)
+) -> List[OutType]:
+    @ray.remote(num_returns=output_num_partitions)
     def shuffle_map(i: PartitionID) -> List[List[ObjectRef[InType]]]:
-        combiners = [input_combiner() for _ in range(num_output_partitions)]
+        combiners = [input_combiner() for _ in range(output_num_partitions)]
         for out_i, item in partitioner(input_reader(i)):
             combiners[out_i].add(item)
-        outputs = [
-            [ray.put(r) for r in c.results()]
-            for c in range(combiners)
-        ]
+        outputs = [[ray.put(r) for r in c.results()] for c in range(combiners)]
         return outputs
 
-
     @ray.remote
-    def shuffle_reduce(i: PartitionID, inputs: List[ObjectRef[InType]]) -> OutType:
+    def shuffle_reduce(i: PartitionID,
+                       inputs: List[ObjectRef[InType]]) -> OutType:
         return output_writer(i, inputs)
 
-
     shuffle_map_out = ray.get(
-        [shuffle_map.remote(i) for i in range(num_partitions)])
+        [shuffle_map.remote(i) for i in range(input_num_partitions)])
 
     shuffle_reduce_out = []
     for j in range(output_num_partitions):
@@ -64,27 +80,10 @@ class _StatusTracker:
         print("Num reduce tasks finished", self.num_reduce)
 
 
-class InputCombiner:
-    def __init__(self):
-        self.results = []
-
-    def add(self, data: InType) -> None:
-        self.results.append(ray.put(data))
-
-    def finish() -> List[ObjectRef[InType]]:
-        return self.results
-
-
-def round_robin_partitioner(
-        input_stream: Iterable[InType], num_partitions: int) -> Iterable[Tuple[PartitionID, InType]]:
-    i = 0
-    for item in input_stream:
-        yield (i, item)
-        i += 1
-        i %= num_partitions
-
-
 if __name__ == "__main__":
+    import numpy as np
+    import time
+
     partition_size = int(200e6)
     num_partitions = 50
     rows_per_partition = partition_size // (8 * 2)
@@ -93,10 +92,12 @@ if __name__ == "__main__":
 
     def input_reader(i: PartitionID) -> Iterable[InType]:
         for _ in range(num_partitions):
-            yield np.ones((rows_per_partition // num_partitions, 2), dtype=np.int64)
+            yield np.ones(
+                (rows_per_partition // num_partitions, 2), dtype=np.int64)
         tracker.inc.remote()
 
-    def output_writer(i: PartitionID, shuffle_inputs: List[ObjectRef[InType]]) -> OutType:
+    def output_writer(i: PartitionID,
+                      shuffle_inputs: List[ObjectRef[InType]]) -> OutType:
         for obj_ref in shuffle_inputs:
             ray.get(obj_ref)
         tracker.inc2.remote()
@@ -105,8 +106,10 @@ if __name__ == "__main__":
 
     output_size = simple_shuffle(
         input_reader=input_reader,
+        input_num_partition=num_partitions,
         output_num_partitions=num_partitions,
         output_writer=output_writer)
     delta = time.time() - start
 
-    print("Shuffled", int(output_size / (1024 * 1024)), "MiB in", delta, "seconds")
+    print("Shuffled", int(output_size / (1024 * 1024)), "MiB in", delta,
+          "seconds")

--- a/python/ray/experimental/shuffle.py
+++ b/python/ray/experimental/shuffle.py
@@ -41,7 +41,9 @@ class ObjectStoreWriter:
     """This class is used to stream shuffle map outputs to the object store.
 
     It can be subclassed to optimize writing (e.g., batching together small
-    records into larger objects).
+    records into larger objects). This will be performance critical if your
+    input records are small (the example shuffle uses very large records, so
+    the naive strategy works well).
     """
 
     def __init__(self):

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -102,6 +102,7 @@ py_test_module_list(
     "test_queue.py",
     "test_ray_debugger.py",
     "test_ray_init.py",
+    "test_shuffle.py",
     "test_tempfile.py",
   ],
   size = "small",

--- a/python/ray/tests/test_shuffle.py
+++ b/python/ray/tests/test_shuffle.py
@@ -1,0 +1,12 @@
+import pytest
+import sys
+
+from ray.experimental import shuffle
+
+
+def test_shuffle():
+    shuffle.main()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
```
A simple distributed shuffle implementation in Ray.

This utility provides a `simple_shuffle` function that can be used to
redistribute M input partitions into N output partitions. It does this with
a single wave of shuffle map tasks followed by a single wave of shuffle reduce
tasks. Each shuffle map task generates O(N) output objects, and each shuffle
reduce task consumes O(M) input objects, for a total of O(N*M) objects.

To try an example 10GB shuffle, run:

    $ python -m ray.experimental.shuffle \
        --num-partitions=50 --partition-size=200e6 \
        --object-store-memory=1e9

This will print out some statistics on the shuffle execution such as:

    --- Aggregate object store stats across all nodes ---
    Plasma memory usage 0 MiB, 0 objects, 0.0% full
    Spilled 9487 MiB, 2487 objects, avg write throughput 1023 MiB/s
    Restored 9487 MiB, 2487 objects, avg read throughput 1358 MiB/s
    Objects consumed by Ray tasks: 9537 MiB.
    Shuffled 9536 MiB in 16.579771757125854 seconds
```