### PR TITLE
[hotfix][test][windows] Exclude k8s operator mock test from build.

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -170,6 +170,7 @@ test_python() {
       -python/ray/tests:test_stress_sharded  # timeout
       -python/ray/tests:test_k8s_cluster_launcher
       -python/ray/tests:test_k8s_operator_examples
+      -python/ray/tests:test_k8s_operator_mock
     )
   fi
   if [ 0 -lt "${#args[@]}" ]; then  # Any targets to test?


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The code path this tests runs on Linux in a Pod.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
