### PR TITLE
Use strict equality check for Ray client protocol version

### DIFF
--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -85,8 +85,8 @@ class RayAPIStub:
                 logger.warning(msg)
             else:
                 raise RuntimeError(msg)
-        if CURRENT_PROTOCOL_VERSION < conn_info["protocol_version"]:
-            msg = "Client Ray installation out of date:" + \
+        if CURRENT_PROTOCOL_VERSION != conn_info["protocol_version"]:
+            msg = "Client Ray installation incompatible with server:" + \
                   f" client is {CURRENT_PROTOCOL_VERSION}," + \
                   f" server is {conn_info['protocol_version']}"
             if ignore_version:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Instead of only checking the client is greater than the server, use a simpler and easier to reason about strict equality check. We can bump the version if there is ever a protocol change.