### PR TITLE
[Java] fix test hang occasionally when running FailureTest

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/runner/RunManager.java
+++ b/java/runtime/src/main/java/io/ray/runtime/runner/RunManager.java
@@ -96,7 +96,7 @@ public class RunManager {
    *
    * @param command The command to start the process with.
    */
-  private static String runCommand(List<String> command) throws IOException, InterruptedException {
+  public static String runCommand(List<String> command) throws IOException, InterruptedException {
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug("Starting process with command: {}", Joiner.on(" ").join(command));
     }

--- a/java/test.sh
+++ b/java/test.sh
@@ -57,6 +57,13 @@ if ! git diff --exit-code -- java src/ray/core_worker/lib/java; then
   exit 1
 fi
 
+# Install gdb on travis CI machine to get pstack output
+if ! command -v gdb; then
+  if [[ "${osversion}" == linux-gnu-ubuntu* ]]; then
+    sudo apt-get install -qq -o=Dpkg::Use-Pty=0 gdb
+  fi
+fi
+
 # NOTE(kfstrom): Java test troubleshooting only.
 # Set MAX_ROUNDS to a big number (e.g. 1000) to run Java tests repeatedly.
 # You may also want to modify java/testng.xml to run only a subset of test cases.

--- a/java/test.sh
+++ b/java/test.sh
@@ -67,20 +67,20 @@ fi
 
 round=1
 while true; do
-echo Starting cluster mode test round $round
+  echo Starting cluster mode test round $round
 
-echo "Running tests under cluster mode."
-# TODO(hchen): Ideally, we should use the following bazel command to run Java tests. However, if there're skipped tests,
-# TestNG will exit with code 2. And bazel treats it as test failure.
-# bazel test //java:all_tests --config=ci || cluster_exit_code=$?
-run_testng java -cp "$ROOT_DIR"/../bazel-bin/java/all_tests_deploy.jar org.testng.TestNG -d /tmp/ray_java_test_output "$ROOT_DIR"/testng.xml
+  echo "Running tests under cluster mode."
+  # TODO(hchen): Ideally, we should use the following bazel command to run Java tests. However, if there're skipped tests,
+  # TestNG will exit with code 2. And bazel treats it as test failure.
+  # bazel test //java:all_tests --config=ci || cluster_exit_code=$?
+  run_testng java -cp "$ROOT_DIR"/../bazel-bin/java/all_tests_deploy.jar org.testng.TestNG -d /tmp/ray_java_test_output "$ROOT_DIR"/testng.xml
 
-echo Finished cluster mode test round $round
-date
-round=$((round+1))
-if (( round > MAX_ROUNDS )); then
-  break
-fi
+  echo Finished cluster mode test round $round
+  date
+  round=$((round+1))
+  if (( round > MAX_ROUNDS )); then
+    break
+  fi
 done
 
 echo "Running tests under single-process mode."

--- a/java/test.sh
+++ b/java/test.sh
@@ -57,13 +57,6 @@ if ! git diff --exit-code -- java src/ray/core_worker/lib/java; then
   exit 1
 fi
 
-# Install gdb on travis CI machine to get pstack output
-if ! command -v pstack; then
-  if command -v apt-get; then
-    sudo apt-get install -qq -o=Dpkg::Use-Pty=0 gdb
-  fi
-fi
-
 # NOTE(kfstrom): Java test troubleshooting only.
 # Set MAX_ROUNDS to a big number (e.g. 1000) to run Java tests repeatedly.
 # You may also want to modify java/testng.xml to run only a subset of test cases.
@@ -85,7 +78,7 @@ run_testng java -cp "$ROOT_DIR"/../bazel-bin/java/all_tests_deploy.jar org.testn
 echo Finished cluster mode test round $round
 date
 round=$((round+1))
-if (( $round > $MAX_ROUNDS )); then
+if (( round > MAX_ROUNDS )); then
   break
 fi
 done

--- a/java/test.sh
+++ b/java/test.sh
@@ -59,7 +59,7 @@ fi
 
 # Install gdb on travis CI machine to get pstack output
 if ! command -v pstack; then
-  if [[ "${osversion}" == linux-gnu-ubuntu* ]]; then
+  if command -v apt-get; then
     sudo apt-get install -qq -o=Dpkg::Use-Pty=0 gdb
   fi
 fi

--- a/java/test.sh
+++ b/java/test.sh
@@ -78,7 +78,7 @@ run_testng java -cp "$ROOT_DIR"/../bazel-bin/java/all_tests_deploy.jar org.testn
 echo Finished cluster mode test round $round
 date
 round=$((round+1))
-if [ $round -gt $MAX_ROUNDS ]; then
+if (( $round > $MAX_ROUNDS )); then
   break
 fi
 done

--- a/java/test.sh
+++ b/java/test.sh
@@ -60,7 +60,7 @@ fi
 # NOTE(kfstrom): Java test troubleshooting only.
 # Set MAX_ROUNDS to a big number (e.g. 1000) to run Java tests repeatedly.
 # You may also want to modify java/testng.xml to run only a subset of test cases.
-MAX_ROUNDS=1
+MAX_ROUNDS=1000
 round=1
 while true; do
 echo Starting cluster mode test round $round

--- a/java/test.sh
+++ b/java/test.sh
@@ -58,7 +58,7 @@ if ! git diff --exit-code -- java src/ray/core_worker/lib/java; then
 fi
 
 # Install gdb on travis CI machine to get pstack output
-if ! command -v gdb; then
+if ! command -v pstack; then
   if [[ "${osversion}" == linux-gnu-ubuntu* ]]; then
     sudo apt-get install -qq -o=Dpkg::Use-Pty=0 gdb
   fi

--- a/java/test.sh
+++ b/java/test.sh
@@ -60,7 +60,7 @@ fi
 # NOTE(kfstrom): Java test troubleshooting only.
 # Set MAX_ROUNDS to a big number (e.g. 1000) to run Java tests repeatedly.
 # You may also want to modify java/testng.xml to run only a subset of test cases.
-MAX_ROUNDS=1000
+MAX_ROUNDS=1
 if [ $MAX_ROUNDS -gt 1 ]; then
   export RAY_BACKEND_LOG_LEVEL=debug
 fi

--- a/java/test.sh
+++ b/java/test.sh
@@ -61,6 +61,10 @@ fi
 # Set MAX_ROUNDS to a big number (e.g. 1000) to run Java tests repeatedly.
 # You may also want to modify java/testng.xml to run only a subset of test cases.
 MAX_ROUNDS=1000
+if [ $MAX_ROUNDS -gt 1 ]; then
+  export RAY_BACKEND_LOG_LEVEL=debug
+fi
+
 round=1
 while true; do
 echo Starting cluster mode test round $round

--- a/java/test/src/main/java/io/ray/test/TestProgressListener.java
+++ b/java/test/src/main/java/io/ray/test/TestProgressListener.java
@@ -16,6 +16,7 @@ import org.testng.IInvokedMethodListener;
 import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestResult;
+import org.testng.SkipException;
 
 public class TestProgressListener implements IInvokedMethodListener, ITestListener {
 
@@ -102,7 +103,7 @@ public class TestProgressListener implements IInvokedMethodListener, ITestListen
     boolean testFailed = false;
     if (result != null) {
       Throwable throwable = result.getThrowable();
-      if (throwable != null) {
+      if (throwable != null && !(throwable instanceof SkipException)) {
         testFailed = true;
         throwable.printStackTrace();
       }

--- a/java/test/src/main/java/io/ray/test/TestProgressListener.java
+++ b/java/test/src/main/java/io/ray/test/TestProgressListener.java
@@ -1,5 +1,7 @@
 package io.ray.test;
 
+import com.google.common.collect.ImmutableList;
+import io.ray.runtime.runner.RunManager;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -64,6 +66,7 @@ public class TestProgressListener implements IInvokedMethodListener, ITestListen
                   for (StackTraceElement element : testMainThread.getStackTrace()) {
                     System.out.println(element.toString());
                   }
+                  printJps();
                   printLogFiles();
                   printSection("ABORT TEST");
                   System.exit(1);
@@ -106,6 +109,17 @@ public class TestProgressListener implements IInvokedMethodListener, ITestListen
 
   @Override
   public void onFinish(ITestContext context) {}
+
+  private void printJps() {
+    printSection("JPS RESULT");
+    try {
+      System.out.println(RunManager.runCommand(ImmutableList.of("jps")));
+    } catch (Exception e) {
+      System.out.println("Failed to get jps result.");
+      e.printStackTrace();
+    }
+    printSection("JPS RESULT END");
+  }
 
   private void printLogFiles() {
     Collection<File> logFiles =

--- a/java/test/src/main/java/io/ray/test/TestProgressListener.java
+++ b/java/test/src/main/java/io/ray/test/TestProgressListener.java
@@ -3,16 +3,11 @@ package io.ray.test;
 import com.google.common.collect.ImmutableList;
 import io.ray.runtime.runner.RunManager;
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.testng.IInvokedMethod;
@@ -168,27 +163,8 @@ public class TestProgressListener implements IInvokedMethodListener, ITestListen
     Collection<File> logFiles =
         FileUtils.listFiles(new File("/tmp/ray/session_latest/logs"), null, false);
     for (File file : logFiles) {
-      tailFile(file.toPath());
-    }
-  }
-
-  private void tailFile(Path filePath) {
-    printSection(
-        String.format("LAST %d LINES OF LOG FILE %s", TAIL_NO_OF_LINES, filePath.getFileName()));
-    LinkedList<String> lastLines = new LinkedList<>();
-    try (Stream<String> stream = Files.lines(filePath)) {
-      stream.forEachOrdered(
-          line -> {
-            lastLines.push(line);
-            if (lastLines.size() > TAIL_NO_OF_LINES) {
-              lastLines.pop();
-            }
-          });
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-    while (lastLines.size() > 0) {
-      System.out.println(lastLines.pop());
+      runCommandSafely(
+          ImmutableList.of("tail", "-n", String.valueOf(TAIL_NO_OF_LINES), file.getAbsolutePath()));
     }
   }
 }

--- a/java/test/src/main/java/io/ray/test/TestProgressListener.java
+++ b/java/test/src/main/java/io/ray/test/TestProgressListener.java
@@ -67,7 +67,15 @@ public class TestProgressListener implements IInvokedMethodListener, ITestListen
                   Set<Integer> javaPids = getJavaPids();
                   for (Integer pid : javaPids) {
                     runCommandSafely(ImmutableList.of("jstack", pid.toString()));
-                    runCommandSafely(ImmutableList.of("pstack", pid.toString()));
+                    runCommandSafely(
+                        ImmutableList.of(
+                            "sudo",
+                            "gdb",
+                            "-ex",
+                            "thread apply all bt",
+                            "-batch",
+                            "-p",
+                            pid.toString()));
                   }
                   printLogFiles();
                   printSection("ABORT TEST");

--- a/java/test/src/main/java/io/ray/test/TestProgressListener.java
+++ b/java/test/src/main/java/io/ray/test/TestProgressListener.java
@@ -66,7 +66,7 @@ public class TestProgressListener implements IInvokedMethodListener, ITestListen
                   for (StackTraceElement element : testMainThread.getStackTrace()) {
                     System.out.println(element.toString());
                   }
-                  printJps();
+                  printJavaProcesses();
                   printLogFiles();
                   printSection("ABORT TEST");
                   System.exit(1);
@@ -110,7 +110,7 @@ public class TestProgressListener implements IInvokedMethodListener, ITestListen
   @Override
   public void onFinish(ITestContext context) {}
 
-  private void printJps() {
+  private void printJavaProcesses() {
     printSection("JPS RESULT");
     try {
       System.out.println(RunManager.runCommand(ImmutableList.of("jps")));
@@ -119,6 +119,15 @@ public class TestProgressListener implements IInvokedMethodListener, ITestListen
       e.printStackTrace();
     }
     printSection("JPS RESULT END");
+
+    printSection("PGREP JAVA RESULT");
+    try {
+      System.out.println(RunManager.runCommand(ImmutableList.of("pgrep", "java")));
+    } catch (Exception e) {
+      System.out.println("Failed to get pgrep java result.");
+      e.printStackTrace();
+    }
+    printSection("PGREP JAVA RESULT END");
   }
 
   private void printLogFiles() {

--- a/java/test/src/main/java/io/ray/test/TestProgressListener.java
+++ b/java/test/src/main/java/io/ray/test/TestProgressListener.java
@@ -20,7 +20,7 @@ import org.testng.ITestResult;
 public class TestProgressListener implements IInvokedMethodListener, ITestListener {
 
   // Travis aborts CI if no outputs for 10 minutes. So threshold needs to be smaller than 10m.
-  private static final long hangDetectionThresholdMillis = 1 * 1000;
+  private static final long hangDetectionThresholdMillis = 5 * 60 * 1000;
   private static final int TAIL_NO_OF_LINES = 500;
   private Thread testMainThread;
   private long testStartTimeMillis;

--- a/java/test/src/main/java/io/ray/test/TestProgressListener.java
+++ b/java/test/src/main/java/io/ray/test/TestProgressListener.java
@@ -134,7 +134,7 @@ public class TestProgressListener implements IInvokedMethodListener, ITestListen
         String.format("LAST %d LINES OF LOG FILE %s", TAIL_NO_OF_LINES, filePath.getFileName()));
     LinkedList<String> lastLines = new LinkedList<>();
     try (Stream<String> stream = Files.lines(filePath)) {
-      stream.forEach(
+      stream.forEachOrdered(
           line -> {
             lastLines.push(line);
             if (lastLines.size() > TAIL_NO_OF_LINES) {

--- a/java/test/src/main/java/io/ray/test/TestProgressListener.java
+++ b/java/test/src/main/java/io/ray/test/TestProgressListener.java
@@ -73,7 +73,6 @@ public class TestProgressListener implements IInvokedMethodListener, ITestListen
   @Override
   public void onTestSuccess(ITestResult result) {
     printTestStage("TEST SUCCESS", getFullTestName(result));
-    printDebugInfo(result, /*testHanged=*/ false);
   }
 
   @Override

--- a/java/testng.xml
+++ b/java/testng.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
-<suite name="RAY suite" verbose="2">
+<suite name="RAY suite" verbose="2" configfailurepolicy="continue">
     <test name = "RAY test">
         <packages>
             <package name = "io.ray.runtime.*" />

--- a/java/testng.xml
+++ b/java/testng.xml
@@ -2,10 +2,9 @@
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
 <suite name="RAY suite" verbose="2">
     <test name = "RAY test">
-        <packages>
-            <package name = "io.ray.runtime.*" />
-            <package name = "io.ray.test.*" />
-        </packages>
+        <classes>
+            <class name = "io.ray.test.FailureTest" />
+        </classes>
     </test>
     <listeners>
         <listener class-name="io.ray.test.RayAlterSuiteListener" />

--- a/java/testng.xml
+++ b/java/testng.xml
@@ -2,9 +2,10 @@
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
 <suite name="RAY suite" verbose="2">
     <test name = "RAY test">
-        <classes>
-            <class name = "io.ray.test.FailureTest" />
-        </classes>
+        <packages>
+            <package name = "io.ray.runtime.*" />
+            <package name = "io.ray.test.*" />
+        </packages>
     </test>
     <listeners>
         <listener class-name="io.ray.test.RayAlterSuiteListener" />

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -161,15 +161,14 @@ CoreWorkerProcess::CoreWorkerProcess(const CoreWorkerOptions &options)
   // RayConfig is generated in Java_io_ray_runtime_RayNativeRuntime_nativeInitialize
   // for java worker or in constructor of CoreWorker for python worker.
   ray::stats::Init(global_tags, options_.metrics_agent_port);
+
+  // Make sure CoreWorkerProcess is destructed before destructing other static variables
+  // (e.g. spdlog).
+  RAY_CHECK(std::atexit(CoreWorkerProcess::HandleAtExit) == 0);
 }
 
 CoreWorkerProcess::~CoreWorkerProcess() {
   RAY_LOG(INFO) << "Destructing CoreWorkerProcess. pid: " << getpid();
-  {
-    // Check that all `CoreWorker` instances have been removed.
-    absl::ReaderMutexLock lock(&worker_map_mutex_);
-    RAY_CHECK(workers_.empty());
-  }
   RAY_LOG(DEBUG) << "Stats stop in core worker.";
   // Shutdown stats module if worker process exits.
   ray::stats::Shutdown();
@@ -181,6 +180,10 @@ CoreWorkerProcess::~CoreWorkerProcess() {
 void CoreWorkerProcess::EnsureInitialized() {
   RAY_CHECK(instance_) << "The core worker process is not initialized yet or already "
                        << "shutdown.";
+}
+
+void CoreWorkerProcess::HandleAtExit() {
+  instance_.reset();
 }
 
 std::shared_ptr<CoreWorker> CoreWorkerProcess::TryGetWorker(const WorkerID &worker_id) {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -182,9 +182,7 @@ void CoreWorkerProcess::EnsureInitialized() {
                        << "shutdown.";
 }
 
-void CoreWorkerProcess::HandleAtExit() {
-  instance_.reset();
-}
+void CoreWorkerProcess::HandleAtExit() { instance_.reset(); }
 
 std::shared_ptr<CoreWorker> CoreWorkerProcess::TryGetWorker(const WorkerID &worker_id) {
   if (!instance_) {

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -265,6 +265,8 @@ class CoreWorkerProcess {
   /// \return Void.
   static void EnsureInitialized();
 
+  static void HandleAtExit();
+
   /// Get the `CoreWorker` instance by worker ID.
   ///
   /// \param[in] workerId The worker ID.

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -55,17 +55,6 @@
 
 namespace ray {
 
-RayLogLevel RayLog::severity_threshold_ = RayLogLevel::INFO;
-std::string RayLog::app_name_ = "";
-std::string RayLog::log_dir_ = "";
-// Format pattern is 2020-08-21 17:00:00,000 I 100 1001 msg.
-// %L is loglevel, %P is process id, %t for thread id.
-std::string RayLog::log_format_pattern_ = "[%Y-%m-%d %H:%M:%S,%e %L %P %t] %v";
-std::string RayLog::logger_name_ = "ray_log_sink";
-long RayLog::log_rotation_max_size_ = 1 << 29;
-long RayLog::log_rotation_file_num_ = 10;
-bool RayLog::is_failure_signal_handler_installed_ = false;
-
 std::string GetCallTrace() {
   std::string return_message = "Cannot get callstack information.";
 #if defined(RAY_USE_GLOG) || defined(RAY_USE_SPDLOG)
@@ -102,34 +91,23 @@ inline const char *ConstBasename(const char *filepath) {
   return base ? (base + 1) : filepath;
 }
 
-/// A logger that prints logs to stderr.
-/// This is the default logger if logging is not initialized.
-class DefaultStdErrLogger final {
- public:
-  DefaultStdErrLogger() {
-    default_stderr_logger_ = spdlog::stderr_color_mt("stderr");
-    default_stderr_logger_->set_pattern(RayLog::GetLogFormatPattern());
-  }
-  std::shared_ptr<spdlog::logger> GetDefaultLogger() { return default_stderr_logger_; }
-
- private:
-  std::shared_ptr<spdlog::logger> default_stderr_logger_;
-};
-
-/// NOTE(lingxuan.zlx): Default stderr logger must be singleton and global
-/// variable so core worker process can invoke `RAY_LOG` in its whole lifecyle.
-std::unique_ptr<DefaultStdErrLogger> default_stderr_logger(new DefaultStdErrLogger());
-
 class SpdLogMessage final {
  public:
   explicit SpdLogMessage(const char *file, int line, int loglevel) : loglevel_(loglevel) {
     stream() << ConstBasename(file) << ":" << line << ": ";
   }
+  inline std::shared_ptr<spdlog::logger> GetDefaultLogger() {
+    // We just emit all log informations to stderr when no default logger has been created
+    // before starting ray log, which is for glog compatible.
+    static auto logger = spdlog::stderr_color_mt("stderr");
+    logger->set_pattern(RayLog::GetLogFormatPattern());
+    return logger;
+  }
 
   inline void Flush() {
     auto logger = spdlog::get(RayLog::GetLoggerName());
     if (!logger) {
-      logger = default_stderr_logger->GetDefaultLogger();
+      logger = GetDefaultLogger();
     }
     // To avoid dump duplicated stacktrace with installed failure signal
     // handler, we have to check whether glog failure signal handler is enabled.
@@ -151,12 +129,11 @@ class SpdLogMessage final {
   inline std::ostream &stream() { return str_; }
 
  private:
-  SpdLogMessage(const SpdLogMessage &) = delete;
-  SpdLogMessage &operator=(const SpdLogMessage &) = delete;
-
- private:
   std::ostringstream str_;
   int loglevel_;
+
+  SpdLogMessage(const SpdLogMessage &) = delete;
+  SpdLogMessage &operator=(const SpdLogMessage &) = delete;
 };
 #endif
 
@@ -210,6 +187,17 @@ typedef ray::SpdLogMessage LoggingProvider;
 #else
 typedef ray::CerrLog LoggingProvider;
 #endif
+
+RayLogLevel RayLog::severity_threshold_ = RayLogLevel::INFO;
+std::string RayLog::app_name_ = "";
+std::string RayLog::log_dir_ = "";
+// Format pattern is 2020-08-21 17:00:00,000 I 100 1001 msg.
+// %L is loglevel, %P is process id, %t for thread id.
+std::string RayLog::log_format_pattern_ = "[%Y-%m-%d %H:%M:%S,%e %L %P %t] %v";
+std::string RayLog::logger_name_ = "ray_log_sink";
+long RayLog::log_rotation_max_size_ = 1 << 29;
+long RayLog::log_rotation_file_num_ = 10;
+bool RayLog::is_failure_signal_handler_installed_ = false;
 
 #ifdef RAY_USE_GLOG
 using namespace google;

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -55,6 +55,17 @@
 
 namespace ray {
 
+RayLogLevel RayLog::severity_threshold_ = RayLogLevel::INFO;
+std::string RayLog::app_name_ = "";
+std::string RayLog::log_dir_ = "";
+// Format pattern is 2020-08-21 17:00:00,000 I 100 1001 msg.
+// %L is loglevel, %P is process id, %t for thread id.
+std::string RayLog::log_format_pattern_ = "[%Y-%m-%d %H:%M:%S,%e %L %P %t] %v";
+std::string RayLog::logger_name_ = "ray_log_sink";
+long RayLog::log_rotation_max_size_ = 1 << 29;
+long RayLog::log_rotation_file_num_ = 10;
+bool RayLog::is_failure_signal_handler_installed_ = false;
+
 std::string GetCallTrace() {
   std::string return_message = "Cannot get callstack information.";
 #if defined(RAY_USE_GLOG) || defined(RAY_USE_SPDLOG)
@@ -91,23 +102,34 @@ inline const char *ConstBasename(const char *filepath) {
   return base ? (base + 1) : filepath;
 }
 
+/// A logger that prints logs to stderr.
+/// This is the default logger if logging is not initialized.
+class DefaultStdErrLogger final {
+ public:
+  DefaultStdErrLogger() {
+    default_stderr_logger_ = spdlog::stderr_color_mt("stderr");
+    default_stderr_logger_->set_pattern(RayLog::GetLogFormatPattern());
+  }
+  std::shared_ptr<spdlog::logger> GetDefaultLogger() { return default_stderr_logger_; }
+
+ private:
+  std::shared_ptr<spdlog::logger> default_stderr_logger_;
+};
+
+/// NOTE(lingxuan.zlx): Default stderr logger must be singleton and global
+/// variable so core worker process can invoke `RAY_LOG` in its whole lifecyle.
+std::unique_ptr<DefaultStdErrLogger> default_stderr_logger(new DefaultStdErrLogger());
+
 class SpdLogMessage final {
  public:
   explicit SpdLogMessage(const char *file, int line, int loglevel) : loglevel_(loglevel) {
     stream() << ConstBasename(file) << ":" << line << ": ";
   }
-  inline std::shared_ptr<spdlog::logger> GetDefaultLogger() {
-    // We just emit all log informations to stderr when no default logger has been created
-    // before starting ray log, which is for glog compatible.
-    static auto logger = spdlog::stderr_color_mt("stderr");
-    logger->set_pattern(RayLog::GetLogFormatPattern());
-    return logger;
-  }
 
   inline void Flush() {
     auto logger = spdlog::get(RayLog::GetLoggerName());
     if (!logger) {
-      logger = GetDefaultLogger();
+      logger = default_stderr_logger->GetDefaultLogger();
     }
     // To avoid dump duplicated stacktrace with installed failure signal
     // handler, we have to check whether glog failure signal handler is enabled.
@@ -129,11 +151,12 @@ class SpdLogMessage final {
   inline std::ostream &stream() { return str_; }
 
  private:
-  std::ostringstream str_;
-  int loglevel_;
-
   SpdLogMessage(const SpdLogMessage &) = delete;
   SpdLogMessage &operator=(const SpdLogMessage &) = delete;
+
+ private:
+  std::ostringstream str_;
+  int loglevel_;
 };
 #endif
 
@@ -187,17 +210,6 @@ typedef ray::SpdLogMessage LoggingProvider;
 #else
 typedef ray::CerrLog LoggingProvider;
 #endif
-
-RayLogLevel RayLog::severity_threshold_ = RayLogLevel::INFO;
-std::string RayLog::app_name_ = "";
-std::string RayLog::log_dir_ = "";
-// Format pattern is 2020-08-21 17:00:00,000 I 100 1001 msg.
-// %L is loglevel, %P is process id, %t for thread id.
-std::string RayLog::log_format_pattern_ = "[%Y-%m-%d %H:%M:%S,%e %L %P %t] %v";
-std::string RayLog::logger_name_ = "ray_log_sink";
-long RayLog::log_rotation_max_size_ = 1 << 29;
-long RayLog::log_rotation_file_num_ = 10;
-bool RayLog::is_failure_signal_handler_installed_ = false;
 
 #ifdef RAY_USE_GLOG
 using namespace google;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

In FailureTest, A worker may invoke `System.exit()`. We expect that the worker process will exit immediately and the caller will receive an exception when calling `Ray.get()`. But sometimes the worker process hangs. Here are the related stack traces ([Travis CI](https://travis-ci.com/github/ray-project/ray/jobs/480982063)):

```
Thread 19 (Thread 0x7f8b73fff700 (LWP 21058)):
3941
#0  0x00007f8bceefd017 in __pause_nocancel () from /lib/x86_64-linux-gnu/libpthread.so.0
3942
#1  0x00007f8bceef4b05 in __pthread_mutex_lock_full () from /lib/x86_64-linux-gnu/libpthread.so.0
3943
#2  0x00007f8bacc2ca62 in ray::SpdLogMessage::Flush() () from /tmp/ray/session_2021-02-06_17-47-17_013370_20870/libcore_worker_library_java.so
3944
#3  0x00007f8bacc2d02c in ray::RayLog::~RayLog() () from /tmp/ray/session_2021-02-06_17-47-17_013370_20870/libcore_worker_library_java.so
3945
#4  0x00007f8bacbd9706 in ray::stats::StdoutExporterClient::ReportMetrics(std::vector<ray::stats::MetricPoint, std::allocator<ray::stats::MetricPoint> > const&) () from /tmp/ray/session_2021-02-06_17-47-17_013370_20870/libcore_worker_library_java.so
3946
#5  0x00007f8bacbdca33 in ray::stats::MetricPointExporter::ExportViewData(std::vector<std::pair<opencensus::stats::ViewDescriptor, opencensus::stats::ViewData>, std::allocator<std::pair<opencensus::stats::ViewDescriptor, opencensus::stats::ViewData> > > const&) () from /tmp/ray/session_2021-02-06_17-47-17_013370_20870/libcore_worker_library_java.so
3947
#6  0x00007f8bacf4b43c in opencensus::stats::StatsExporterImpl::Export() () from /tmp/ray/session_2021-02-06_17-47-17_013370_20870/libcore_worker_library_java.so
3948
#7  0x00007f8bacf4b62e in opencensus::stats::StatsExporterImpl::RunWorkerLoop() () from /tmp/ray/session_2021-02-06_17-47-17_013370_20870/libcore_worker_library_java.so
3949
#8  0x00007f8bac2916df in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
4142
#9  0x00007f8bceef26db in start_thread () from /lib/x86_64-linux-gnu/libpthread.so.0
4143
#10 0x00007f8bce80071f in clone () from /lib/x86_64-linux-gnu/libc.so.6
```

```
Thread 5 (Thread 0x7f8baf0b6700 (LWP 21018)):
4080
#0  0x00007f8bceefd017 in __pause_nocancel () from /lib/x86_64-linux-gnu/libpthread.so.0
4097
#1  0x00007f8bceef4b05 in __pthread_mutex_lock_full () from /lib/x86_64-linux-gnu/libpthread.so.0
4098
#2  0x00007f8bacc2ca62 in ray::SpdLogMessage::Flush() () from /tmp/ray/session_2021-02-06_17-47-17_013370_20870/libcore_worker_library_java.so
4099
#3  0x00007f8bacc2d02c in ray::RayLog::~RayLog() () from /tmp/ray/session_2021-02-06_17-47-17_013370_20870/libcore_worker_library_java.so
4100
#4  0x00007f8bac8c7eeb in ray::CoreWorkerProcess::~CoreWorkerProcess() () from /tmp/ray/session_2021-02-06_17-47-17_013370_20870/libcore_worker_library_java.so
4101
#5  0x00007f8bac8c7f79 in std::unique_ptr<ray::CoreWorkerProcess, std::default_delete<ray::CoreWorkerProcess> >::~unique_ptr() () from /tmp/ray/session_2021-02-06_17-47-17_013370_20870/libcore_worker_library_java.so
4102
#6  0x00007f8bce722161 in ?? () from /lib/x86_64-linux-gnu/libc.so.6
4103
#7  0x00007f8bce72225a in exit () from /lib/x86_64-linux-gnu/libc.so.6
4104
#8  0x00007f8bcddd4d77 in vm_direct_exit(int) () from /usr/local/lib/jvm/openjdk8/jre/lib/amd64/server/libjvm.so
4105
#9  0x00007f8bce1ca812 in VM_Operation::evaluate() () from /usr/local/lib/jvm/openjdk8/jre/lib/amd64/server/libjvm.so
4106
#10 0x00007f8bce1c8b79 in VMThread::evaluate_operation(VM_Operation*) () from /usr/local/lib/jvm/openjdk8/jre/lib/amd64/server/libjvm.so
4107
#11 0x00007f8bce1c91ab in VMThread::loop() () from /usr/local/lib/jvm/openjdk8/jre/lib/amd64/server/libjvm.so
4108
#12 0x00007f8bce1c9613 in VMThread::run() () from /usr/local/lib/jvm/openjdk8/jre/lib/amd64/server/libjvm.so
4109
#13 0x00007f8bce030e72 in java_start(Thread*) () from /usr/local/lib/jvm/openjdk8/jre/lib/amd64/server/libjvm.so
4123
#14 0x00007f8bceef26db in start_thread () from /lib/x86_64-linux-gnu/libpthread.so.0
4124
#15 0x00007f8bce80071f in clone () from /lib/x86_64-linux-gnu/libc.so.6
```

I believe the root cause is that the destruction order of static variables is not guaranteed. Sometimes `CoreWorkerProcess::instance_` is destructed after spdlog destruction. By adding an atexit handler 
in `CoreWorkerProcess` constructor, we ensure that the handler is registered after spdlog static variable construction, hence when destructing, the handler is executed before spdlog static variable destruction. Inside the handler, we explicitly reset the `CoreWorkerProcess::instance_` unique_ptr to destruct `CoreWorkerProcess` manually. So now `CoreWorkerProcess` is always destructed before spdlog static variables.

I've run `FailureTest` on Travis repeatedly. We can reproduce the hang issue within ~30 rounds [w/o this fix](https://travis-ci.com/github/ray-project/ray/jobs/480982063
). But now I can't reproduce it with ~100 rounds [w/ this fix](https://travis-ci.com/github/ray-project/ray/jobs/481063616) (test case failed with another rare issue).

I also found that if an exception is thrown in "@BeforeMethod" in the base class, all later tests in subclasses inherited from the base class will be skipped. I've fixed it by adding `configfailurepolicy="continue"` in `java/testng.xml`. 

This PR also includes various improvements for debugging test failures:

* Printing latest session log files when a test failed.
* Detecting test hanging and printing stack traces (self and other Java worker processes) as well as latest session log files.
* A one-line change (setting `MAX_ROUNDS` to a big number in `java/test.sh`) to run test cases repeatedly.
* Only printing `hs_err_pid*.log` file of the TestNG process.

cc @simon-mo for debugging improvements.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
