### PR TITLE
[dask-on-ray] Fix Dask-on-Ray test: Python 3 dictionary .values() is a view, and is not indexable

### DIFF
--- a/python/ray/tests/test_dask_scheduler.py
+++ b/python/ray/tests/test_dask_scheduler.py
@@ -36,7 +36,8 @@ def test_ray_dask_persist(ray_start_regular_shared):
     arr = da.ones(5) + 2
     result = arr.persist(scheduler=ray_dask_get)
     np.testing.assert_array_equal(
-        next(iter(result.dask.values())), np.ones(5) + 2)
+        next(iter(result.dask.values())),
+        np.ones(5) + 2)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_dask_scheduler.py
+++ b/python/ray/tests/test_dask_scheduler.py
@@ -35,7 +35,8 @@ def test_ray_dask_basic(ray_start_regular_shared):
 def test_ray_dask_persist(ray_start_regular_shared):
     arr = da.ones(5) + 2
     result = arr.persist(scheduler=ray_dask_get)
-    np.testing.assert_array_equal(next(iter(result.dask.values())), np.ones(5) + 2)
+    np.testing.assert_array_equal(
+        next(iter(result.dask.values())), np.ones(5) + 2)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_dask_scheduler.py
+++ b/python/ray/tests/test_dask_scheduler.py
@@ -35,7 +35,7 @@ def test_ray_dask_basic(ray_start_regular_shared):
 def test_ray_dask_persist(ray_start_regular_shared):
     arr = da.ones(5) + 2
     result = arr.persist(scheduler=ray_dask_get)
-    np.testing.assert_array_equal(result.dask.values()[0], np.ones(5) + 2)
+    np.testing.assert_array_equal(next(iter(result.dask.values())), np.ones(5) + 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Python 3 dictionary `.values()` is a view, and is not indexable.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #13943

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
