### PR TITLE
[Hotfix] Master compilation error on MacOS.

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -89,7 +89,7 @@ py_test_module_list(
     "test_component_failures.py",
     "test_coordinator_server.py",
     "test_dask_callback.py",
-    #"test_dask_scheduler.py", # Skipped 13943
+    "test_dask_scheduler.py",
     "test_debug_tools.py",
     "test_job.py",
     "test_k8s_operator_mock.py",

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -89,7 +89,7 @@ py_test_module_list(
     "test_component_failures.py",
     "test_coordinator_server.py",
     "test_dask_callback.py",
-    "test_dask_scheduler.py",
+    #"test_dask_scheduler.py", # Skipped 13943
     "test_debug_tools.py",
     "test_job.py",
     "test_k8s_operator_mock.py",

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -1010,7 +1010,7 @@ void ReferenceCounter::PushToLocationSubscribers(ReferenceTable::iterator it) {
   const auto callbacks = it->second.location_subscription_callbacks;
   it->second.location_subscription_callbacks.clear();
   it->second.location_version++;
-  for (const auto& callback : callbacks) {
+  for (const auto &callback : callbacks) {
     callback(it->second.locations, it->second.object_size, it->second.location_version);
   }
 }

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -1010,7 +1010,7 @@ void ReferenceCounter::PushToLocationSubscribers(ReferenceTable::iterator it) {
   const auto callbacks = it->second.location_subscription_callbacks;
   it->second.location_subscription_callbacks.clear();
   it->second.location_version++;
-  for (const auto callback : callbacks) {
+  for (const auto& callback : callbacks) {
     callback(it->second.locations, it->second.object_size, it->second.location_version);
   }
 }


### PR DESCRIPTION
Ray won't compile on mac:
```

Use --sandbox_debug to see verbose messages from the sandbox
src/ray/core_worker/reference_count.cc:1013:19: error: loop variable 'callback' of type 'const std::__1::function<void (const absl::lts_2019_08_08::flat_hash_set<ray::NodeID, absl::lts_2019_08_08::hash_internal::Hash<ray::NodeID>, std::__1::equal_to<ray::NodeID>, std::__1::allocator<ray::NodeID> > &, long long, long long)>' creates a copy from type 'const std::__1::function<void (const absl::lts_2019_08_08::flat_hash_set<ray::NodeID, absl::lts_2019_08_08::hash_internal::Hash<ray::NodeID>, std::__1::equal_to<ray::NodeID>, std::__1::allocator<ray::NodeID> > &,
  0 [Hotfix] Master compile and dask test
 long long, long long)>' [-Werror,-Wrange-loop-analysis]
  for (const auto callback : callbacks) {
                  ^
src/ray/core_worker/reference_count.cc:1013:8: note: use reference type 'const std::__1::function<void (const absl::lts_2019_08_08::flat_hash_set<ray::NodeID, absl::lts_2019_08_08::hash_internal::Hash<ray::NodeID>, std::__1::equal_to<ray::NodeID>, std::__1::allocator<ray::NodeID> > &, long long, long long)> &' to prevent copying
  for (const auto callback : callbacks) {
       ^~~~~~~~~~~~~~~~~~~~~
                  &
1 error generated.
Target //:ray_pkg failed to build
INFO: Elapsed time: 11.263s, Critical Path: 10.72s
INFO: 2 processes: 2 darwin-sandbox.
```