### PR TITLE
[C++ API] simplify code of Arguments; avoid memory copy

### DIFF
--- a/cpp/include/ray/api/arguments.h
+++ b/cpp/include/ray/api/arguments.h
@@ -49,6 +49,8 @@ class Arguments {
   static void WrapArgs(std::vector<std::unique_ptr<::ray::TaskArg>> *task_args,
                        OtherArgTypes &...args) {
     (void)std::initializer_list<int>{(WrapArgsImpl(task_args, args), 0)...};
+    /// Silence gcc warning error.
+    (void)task_args;
   }
 
   template <typename ArgType>

--- a/cpp/include/ray/api/arguments.h
+++ b/cpp/include/ray/api/arguments.h
@@ -3,110 +3,74 @@
 
 #include <ray/api/object_ref.h>
 #include <ray/api/serializer.h>
-#include "ray/common/task/task_util.h"
 
 #include <msgpack.hpp>
+
+#include "ray/common/task/task_util.h"
 
 namespace ray {
 namespace api {
 
+/// Check T is ObjectRef or not.
+template <typename T>
+struct is_object_ref : std::false_type {};
+
+template <typename T>
+struct is_object_ref<ObjectRef<T>> : std::true_type {};
+
 class Arguments {
  public:
-  static void WrapArgs(std::vector<std::unique_ptr<::ray::TaskArg>> *task_args);
+  template <typename ArgType>
+  static void WrapArgsImpl(std::vector<std::unique_ptr<::ray::TaskArg>> *task_args,
+                           ArgType &arg) {
+    static_assert(!is_object_ref<ArgType>::value, "ObjectRef can not be wrapped");
 
-  template <typename Arg1Type>
+    /// TODO
+    /// The serialize code will move to Serializer after refactoring Serializer.
+    msgpack::sbuffer buffer;
+    msgpack::pack(buffer, arg);
+    auto memory_buffer = std::make_shared<::ray::LocalMemoryBuffer>(
+        reinterpret_cast<uint8_t *>(buffer.data()), buffer.size(), true);
+    /// Pass by value.
+    auto task_arg = new TaskArgByValue(std::make_shared<::ray::RayObject>(
+        memory_buffer, nullptr, std::vector<ObjectID>()));
+    task_args->emplace_back(task_arg);
+  }
+
+  template <typename ArgType>
+  static void WrapArgsImpl(std::vector<std::unique_ptr<::ray::TaskArg>> *task_args,
+                           ObjectRef<ArgType> &arg) {
+    /// Pass by reference.
+    auto task_arg = new TaskArgByReference(arg.ID(), rpc::Address());
+    task_args->emplace_back(task_arg);
+  }
+
+  template <typename... OtherArgTypes>
   static void WrapArgs(std::vector<std::unique_ptr<::ray::TaskArg>> *task_args,
-                       Arg1Type &arg1);
+                       OtherArgTypes &...args) {
+    (void)std::initializer_list<int>{(WrapArgsImpl(task_args, args), 0)...};
+  }
 
-  template <typename Arg1Type>
-  static void WrapArgs(std::vector<std::unique_ptr<::ray::TaskArg>> *task_args,
-                       ObjectRef<Arg1Type> &arg1);
+  template <typename ArgType>
+  static void UnwrapArgsImpl(const std::vector<std::shared_ptr<RayObject>> &args_buffer,
+                             int &arg_index, std::shared_ptr<ArgType> *arg) {
+    /// TODO
+    /// The Deserialize code will move to Serializer after refactoring Serializer.
+    msgpack::unpacked msg;
+    auto arg_buffer = args_buffer[arg_index]->GetData();
+    msgpack::unpack(msg, (const char *)arg_buffer->Data(), arg_buffer->Size());
+    *arg = std::make_shared<ArgType>(msg.get().as<ArgType>());
 
-  template <typename Arg1Type, typename... OtherArgTypes>
-  static void WrapArgs(std::vector<std::unique_ptr<::ray::TaskArg>> *task_args,
-                       Arg1Type &arg1, OtherArgTypes &... args);
+    arg_index++;
+  }
 
+  template <typename... OtherArgTypes>
   static void UnwrapArgs(const std::vector<std::shared_ptr<RayObject>> &args_buffer,
-                         int &arg_index);
-
-  template <typename Arg1Type>
-  static void UnwrapArgs(const std::vector<std::shared_ptr<RayObject>> &args_buffer,
-                         int &arg_index, std::shared_ptr<Arg1Type> *arg1);
-
-  template <typename Arg1Type, typename... OtherArgTypes>
-  static void UnwrapArgs(const std::vector<std::shared_ptr<RayObject>> &args_buffer,
-                         int &arg_index, std::shared_ptr<Arg1Type> *arg1,
-                         std::shared_ptr<OtherArgTypes> *... args);
+                         int &arg_index, std::shared_ptr<OtherArgTypes> *...args) {
+    (void)std::initializer_list<int>{
+        (UnwrapArgsImpl(args_buffer, arg_index, args), 0)...};
+  }
 };
-
-// --------- inline implementation ------------
-#include <typeinfo>
-
-inline void Arguments::WrapArgs(std::vector<std::unique_ptr<::ray::TaskArg>> *task_args) {
-}
-
-template <typename Arg1Type>
-inline void Arguments::WrapArgs(std::vector<std::unique_ptr<::ray::TaskArg>> *task_args,
-                                Arg1Type &arg1) {
-  /// TODO(Guyang Song): optimize the memory copy.
-  msgpack::sbuffer buffer;
-  msgpack::packer<msgpack::sbuffer> packer(buffer);
-  /// Notice ObjectRefClassPrefix should be modified by ObjectRef class name or namespace.
-  static const std::string ObjectRefClassPrefix = "N3ray3api9ObjectRef";
-  std::string type_name = typeid(arg1).name();
-  RAY_CHECK(type_name.rfind(ObjectRefClassPrefix, 0) != 0)
-      << "ObjectRef can not be wrapped";
-  Serializer::Serialize(packer, arg1);
-  auto memory_buffer = std::make_shared<::ray::LocalMemoryBuffer>(
-      reinterpret_cast<uint8_t *>(buffer.data()), buffer.size(), true);
-  /// Pass by value.
-  auto task_arg = new TaskArgByValue(std::make_shared<::ray::RayObject>(
-      memory_buffer, nullptr, std::vector<ObjectID>()));
-  task_args->emplace_back(task_arg);
-}
-
-template <typename Arg1Type>
-inline void Arguments::WrapArgs(std::vector<std::unique_ptr<::ray::TaskArg>> *task_args,
-                                ObjectRef<Arg1Type> &arg1) {
-  /// Pass by reference.
-  auto task_arg = new TaskArgByReference(arg1.ID(), rpc::Address());
-  task_args->emplace_back(task_arg);
-}
-
-template <typename Arg1Type, typename... OtherArgTypes>
-inline void Arguments::WrapArgs(std::vector<std::unique_ptr<::ray::TaskArg>> *task_args,
-                                Arg1Type &arg1, OtherArgTypes &... args) {
-  WrapArgs(task_args, arg1);
-  WrapArgs(task_args, args...);
-}
-
-inline void Arguments::UnwrapArgs(
-    const std::vector<std::shared_ptr<RayObject>> &args_buffer, int &arg_index) {}
-
-template <typename Arg1Type>
-inline void Arguments::UnwrapArgs(
-    const std::vector<std::shared_ptr<RayObject>> &args_buffer, int &arg_index,
-    std::shared_ptr<Arg1Type> *arg1) {
-  std::shared_ptr<msgpack::sbuffer> sbuffer;
-  auto arg_buffer = args_buffer[arg_index]->GetData();
-  sbuffer = std::make_shared<msgpack::sbuffer>(arg_buffer->Size());
-  /// TODO(Guyang Song): Avoid the memory copy.
-  sbuffer->write(reinterpret_cast<const char *>(arg_buffer->Data()), arg_buffer->Size());
-  msgpack::unpacker unpacker;
-  unpacker.reserve_buffer(sbuffer->size());
-  memcpy(unpacker.buffer(), sbuffer->data(), sbuffer->size());
-  unpacker.buffer_consumed(sbuffer->size());
-  Serializer::Deserialize(unpacker, arg1);
-  arg_index++;
-}
-
-template <typename Arg1Type, typename... OtherArgTypes>
-inline void Arguments::UnwrapArgs(
-    const std::vector<std::shared_ptr<RayObject>> &args_buffer, int &arg_index,
-    std::shared_ptr<Arg1Type> *arg1, std::shared_ptr<OtherArgTypes> *... args) {
-  UnwrapArgs(args_buffer, arg_index, arg1);
-  UnwrapArgs(args_buffer, arg_index, args...);
-}
 
 }  // namespace api
 }  // namespace ray

--- a/cpp/include/ray/api/arguments.h
+++ b/cpp/include/ray/api/arguments.h
@@ -47,7 +47,7 @@ class Arguments {
 
   template <typename... OtherArgTypes>
   static void WrapArgs(std::vector<std::unique_ptr<::ray::TaskArg>> *task_args,
-                       OtherArgTypes &...args) {
+                       OtherArgTypes &... args) {
     (void)std::initializer_list<int>{(WrapArgsImpl(task_args, args), 0)...};
     /// Silence gcc warning error.
     (void)task_args;
@@ -68,7 +68,7 @@ class Arguments {
 
   template <typename... OtherArgTypes>
   static void UnwrapArgs(const std::vector<std::shared_ptr<RayObject>> &args_buffer,
-                         int &arg_index, std::shared_ptr<OtherArgTypes> *...args) {
+                         int &arg_index, std::shared_ptr<OtherArgTypes> *... args) {
     (void)std::initializer_list<int>{
         (UnwrapArgsImpl(args_buffer, arg_index, args), 0)...};
   }


### PR DESCRIPTION
## Why are these changes needed?

Current code of Arguments has some duplicate code of using variadic template arguments, it can be simplified, another improvement is to simplify msgpack serialization/deserialization: simplify the code and avoid some memory copy.

## Related issue number


## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
