### PR TITLE
[C++ API] random a job id in c++ worker

### DIFF
--- a/cpp/src/ray/util/process_helper.cc
+++ b/cpp/src/ray/util/process_helper.cc
@@ -70,7 +70,12 @@ void ProcessHelper::RayStart(std::shared_ptr<RayConfig> config,
   options.store_socket = store_socket;
   options.raylet_socket = raylet_socket;
   if (options.worker_type == WorkerType::DRIVER) {
-    options.job_id = JobID::FromInt(0);
+    /// TODO(Guyang Song): Get next job id from core worker by GCS client.
+    /// Random a number to avoid repeated job ids.
+    /// The repeated job ids will lead to task hang when driver connects to a existing
+    /// cluster more than once.
+    std::srand(std::time(nullptr));
+    options.job_id = JobID::FromInt(std::rand());
   }
   options.gcs_options = gcs_options;
   options.enable_logging = true;


### PR DESCRIPTION
## Why are these changes needed?

- problem
    * `options.job_id = JobID::FromInt(0)` will make repeated job ids. It will lead to task hang when driver connects to a existing cluster more than once.

- solution
   * Random a number to avoid repeated job ids simply. And in long term, we need to get next job id from core worker by GCS client.
