### PR TITLE
Skip placement tests on Windows

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -165,6 +165,7 @@ test_python() {
       -python/ray/tests:test_multiprocessing  # test_connect_to_ray() fails to connect to raylet
       -python/ray/tests:test_node_manager
       -python/ray/tests:test_object_manager
+      -python/ray/tests:test_placement_group # timeout and OOM
       -python/ray/tests:test_ray_init  # test_redis_port() seems to fail here, but pass in isolation
       -python/ray/tests:test_resource_demand_scheduler
       -python/ray/tests:test_stress  # timeout


### PR DESCRIPTION
Windows has been timing out on and off.

```

================================== FAILURES ===================================
____________________________ test_mini_integration ____________________________

ray_start_cluster = <ray.cluster_utils.Cluster object at 0x000001A7C82CAD08>

    def test_mini_integration(ray_start_cluster):
        # Create bundles as many as number of gpus in the cluster.
        # Do some random work and make sure all resources are properly recovered.
    
        cluster = ray_start_cluster
    
        num_nodes = 5
        per_bundle_gpus = 2
        gpu_per_node = 4
        total_gpus = num_nodes * per_bundle_gpus * gpu_per_node
        per_node_gpus = per_bundle_gpus * gpu_per_node
    
        bundles_per_pg = 2
        total_num_pg = total_gpus // (bundles_per_pg * per_bundle_gpus)
    
        [
            cluster.add_node(num_cpus=2, num_gpus=per_bundle_gpus * gpu_per_node)
            for _ in range(num_nodes)
        ]
        cluster.wait_for_nodes()
        ray.init(address=cluster.address)
    
        @ray.remote(num_cpus=0, num_gpus=1)
        def random_tasks():
            import time
            import random
            sleep_time = random.uniform(0.1, 0.2)
            time.sleep(sleep_time)
            return True
    
        pgs = []
        pg_tasks = []
        # total bundle gpu usage = bundles_per_pg * total_num_pg * per_bundle_gpus
        # Note this is half of total
        for index in range(total_num_pg):
            pgs.append(
                ray.util.placement_group(
                    name=f"name{index}",
                    strategy="PACK",
                    bundles=[{
                        "GPU": per_bundle_gpus
                    } for _ in range(bundles_per_pg)]))
    
        # Schedule tasks.
        for i in range(total_num_pg):
            pg = pgs[i]
            pg_tasks.append([
                random_tasks.options(
                    placement_group=pg,
                    placement_group_bundle_index=bundle_index).remote()
                for bundle_index in range(bundles_per_pg)
            ])
    
        # Make sure tasks are done and we remove placement groups.
        num_removed_pg = 0
        pg_indexes = [2, 3, 1, 7, 8, 9, 0, 6, 4, 5]
        while num_removed_pg < total_num_pg:
            index = pg_indexes[num_removed_pg]
            pg = pgs[index]
>           assert all(ray.get(pg_tasks[index]))

\\?\C:\Users\RUNNER~1\AppData\Local\Temp\Bazel.runfiles_x6sg7r2j\runfiles\com_github_ray_project_ray\python\ray\tests\test_placement_group.py:826: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
d:\a\ray\ray\python\ray\_private\client_mode_hook.py:47: in wrapper
    return func(*args, **kwargs)
d:\a\ray\ray\python\ray\worker.py:1451: in get
    object_refs, timeout=timeout)
d:\a\ray\ray\python\ray\worker.py:320: in get_objects
    object_refs), debugger_breakpoint
d:\a\ray\ray\python\ray\worker.py:282: in deserialize_objects
    return context.deserialize_objects(data_metadata_pairs, object_refs)
d:\a\ray\ray\python\ray\serialization.py:246: in deserialize_objects
    self._deserialize_object(data, metadata, object_ref))
d:\a\ray\ray\python\ray\serialization.py:193: in _deserialize_object
    return self._deserialize_msgpack_data(data, metadata_fields)
d:\a\ray\ray\python\ray\serialization.py:168: in _deserialize_msgpack_data
    msgpack_data, pickle5_data = split_buffer(data)
python\ray\includes/serialization.pxi:195: in ray._raylet.split_buffer
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   MemoryError: Unable to allocate internal buffer.

....

================================== FAILURES ===================================
___________________ test_automatic_cleanup_detached_actors ____________________

ray_start_cluster = <ray.cluster_utils.Cluster object at 0x0000019EC50CDB08>

    def test_automatic_cleanup_detached_actors(ray_start_cluster):
        # Make sure the placement groups created by a
        # detached actors are cleaned properly.
        cluster = ray_start_cluster
        num_nodes = 3
        num_cpu_per_node = 2
        # Create 3 nodes cluster.
        for _ in range(num_nodes):
            cluster.add_node(num_cpus=num_cpu_per_node)
    
        info = ray.init(address=cluster.address)
        available_cpus = ray.available_resources()["CPU"]
        assert available_cpus == num_nodes * num_cpu_per_node
    
        driver_code = f"""
    import ray
    
    ray.init(address="{info["redis_address"]}")
    
    def create_pg():
        pg = ray.util.placement_group(
                [{{"CPU": 1}} for _ in range(3)],
                strategy="STRICT_SPREAD")
        ray.get(pg.ready())
        return pg
    
    # TODO(sang): Placement groups created by tasks launched by detached actor
    # is not cleaned with the current protocol.
    # @ray.remote(num_cpus=0)
    # def f():
    #     create_pg()
    
    @ray.remote(num_cpus=0, max_restarts=1)
    class A:
        def create_pg(self):
            create_pg()
        def create_child_pg(self):
            self.a = A.options(name="B").remote()
            ray.get(self.a.create_pg.remote())
        def kill_child_actor(self):
            ray.kill(self.a)
            try:
                ray.get(self.a.create_pg.remote())
            except Exception:
                pass
    
    a = A.options(lifetime="detached", name="A").remote()
    ray.get(a.create_pg.remote())
    # TODO(sang): Currently, child tasks are cleaned when a detached actor
    # is dead. We cannot test this scenario until it is fixed.
    # ray.get(a.create_child_pg.remote())
    
    ray.shutdown()
        """
    
        run_string_as_driver(driver_code)
    
        # Wait until the driver is reported as dead by GCS.
        def is_job_done():
            jobs = ray.jobs()
            for job in jobs:
                if "StopTime" in job:
                    return True
            return False
    
        def assert_num_cpus(expected_num_cpus):
            if expected_num_cpus == 0:
                return "CPU" not in ray.available_resources()
            return ray.available_resources()["CPU"] == expected_num_cpus
    
        wait_for_condition(is_job_done)
>       assert assert_num_cpus(num_nodes)
E       assert False
E        +  where False = <function test_automatic_cleanup_detached_actors.<locals>.assert_num_cpus at 0x0000019EC50F21F8>(3)

```