### PR TITLE
[Serve] [Doc] Add version warning

### DIFF
--- a/doc/source/serve/index.rst
+++ b/doc/source/serve/index.rst
@@ -32,9 +32,12 @@ Ray Serve can be used in two primary ways to deploy your models at scale:
 .. tip::
   Chat with Ray Serve users and developers on our `forum <https://discuss.ray.io/>`_!
 
-.. note::
+.. warning::
   Starting with Ray version 1.2.0, Ray Serve backends take in a Starlette Request object instead of a Flask Request object.
   See the `migration guide <https://docs.google.com/document/d/1CG4y5WTTc4G_MRQGyjnb_eZ7GK3G9dUX6TNLKLnKRAc/edit?usp=sharing>`_ for details.
+  
+  If you are not running the Ray nightly build, please refer to the 
+  `documentation for the latest pip release of Ray Serve <https://docs.ray.io/en/latest/serve/index.html>`_.
 
 Ray Serve Quickstart
 ====================

--- a/doc/source/serve/index.rst
+++ b/doc/source/serve/index.rst
@@ -1,5 +1,9 @@
 .. _rayserve:
 
+.. warning::
+  Ray Serve is changing fast!  You're probably running the latest pip release and not the nightly build, so please ensure you're viewing the correct version of this documentation.
+  `Here's the documentation for the latest pip release of Ray Serve <https://docs.ray.io/en/latest/serve/index.html>`_.
+
 ============================================
 Ray Serve: Scalable and Programmable Serving
 ============================================
@@ -32,12 +36,10 @@ Ray Serve can be used in two primary ways to deploy your models at scale:
 .. tip::
   Chat with Ray Serve users and developers on our `forum <https://discuss.ray.io/>`_!
 
-.. warning::
-  Starting with Ray version 1.2.0, Ray Serve backends take in a Starlette Request object instead of a Flask Request object.
+.. note::
+  Starting with Ray version 1.2.0, Ray Serve backends take in a Starlette Request object instead of a Flask Request object.  
   See the `migration guide <https://docs.google.com/document/d/1CG4y5WTTc4G_MRQGyjnb_eZ7GK3G9dUX6TNLKLnKRAc/edit?usp=sharing>`_ for details.
   
-  If you are not running the Ray nightly build, please refer to the 
-  `documentation for the latest pip release of Ray Serve <https://docs.ray.io/en/latest/serve/index.html>`_.
 
 Ray Serve Quickstart
 ====================

--- a/doc/source/serve/index.rst
+++ b/doc/source/serve/index.rst
@@ -37,7 +37,7 @@ Ray Serve can be used in two primary ways to deploy your models at scale:
   Chat with Ray Serve users and developers on our `forum <https://discuss.ray.io/>`_!
 
 .. note::
-  Starting with Ray version 1.2.0, Ray Serve backends take in a Starlette Request object instead of a Flask Request object.  
+  Starting with Ray version 1.2.0, Ray Serve backends take in a Starlette Request object instead of a Flask Request object.
   See the `migration guide <https://docs.google.com/document/d/1CG4y5WTTc4G_MRQGyjnb_eZ7GK3G9dUX6TNLKLnKRAc/edit?usp=sharing>`_ for details.
   
 

--- a/doc/source/serve/index.rst
+++ b/doc/source/serve/index.rst
@@ -39,7 +39,6 @@ Ray Serve can be used in two primary ways to deploy your models at scale:
 .. note::
   Starting with Ray version 1.2.0, Ray Serve backends take in a Starlette Request object instead of a Flask Request object.
   See the `migration guide <https://docs.google.com/document/d/1CG4y5WTTc4G_MRQGyjnb_eZ7GK3G9dUX6TNLKLnKRAc/edit?usp=sharing>`_ for details.
-  
 
 Ray Serve Quickstart
 ====================

--- a/doc/source/serve/index.rst
+++ b/doc/source/serve/index.rst
@@ -1,8 +1,8 @@
-.. _rayserve:
-
 .. warning::
   Ray Serve is changing fast!  You're probably running the latest pip release and not the nightly build, so please ensure you're viewing the correct version of this documentation.
   `Here's the documentation for the latest pip release of Ray Serve <https://docs.ray.io/en/latest/serve/index.html>`_.
+
+.. _rayserve:
 
 ============================================
 Ray Serve: Scalable and Programmable Serving


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Users often land on the master docs and run into errors running sample code because they are not running the Ray nightly.  This PR changes the Serve front page Starlette migration note from a note into a warning and adds a link to the v:latest version of the docs.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
