### PR TITLE
[tune] pass trainable function name when using `tune.with_parameters`

### DIFF
--- a/python/ray/tune/function_runner.py
+++ b/python/ray/tune/function_runner.py
@@ -644,11 +644,16 @@ def with_parameters(fn, **kwargs):
             fn_kwargs[k] = parameter_registry.get(prefix + k)
         fn(config, **fn_kwargs)
 
+    fn_name = getattr(fn, "__name__", "tune_with_parameters")
+    inner.__name__ = fn_name
+
     # Use correct function signature if no `checkpoint_dir` parameter is set
     if not use_checkpoint:
 
         def _inner(config):
             inner(config, checkpoint_dir=None)
+
+        _inner.__name__ = fn_name
 
         if hasattr(fn, "__mixins__"):
             _inner.__mixins__ = fn.__mixins__
@@ -656,4 +661,5 @@ def with_parameters(fn, **kwargs):
 
     if hasattr(fn, "__mixins__"):
         inner.__mixins__ = fn.__mixins__
+
     return inner

--- a/python/ray/tune/tests/test_function_api.py
+++ b/python/ray/tune/tests/test_function_api.py
@@ -455,6 +455,7 @@ class FunctionApiTest(unittest.TestCase):
         self.assertEquals(trial_1.last_result["hundred"], 1)
         self.assertEquals(trial_2.last_result["metric"], 500_000)
         self.assertEquals(trial_2.last_result["hundred"], 1)
+        self.assertTrue(str(trial_1).startswith("train_"))
 
         # With checkpoint dir parameter
         def train(config, checkpoint_dir="DIR", data=None):
@@ -469,6 +470,7 @@ class FunctionApiTest(unittest.TestCase):
         self.assertEquals(trial_1.last_result["cp"], "DIR")
         self.assertEquals(trial_2.last_result["metric"], 500_000)
         self.assertEquals(trial_2.last_result["cp"], "DIR")
+        self.assertTrue(str(trial_1).startswith("train_"))
 
     def testWithParameters2(self):
         class Data:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #14004

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
