### PR TITLE
Make requests sent by the dashboard reverse proxy compatible

### DIFF
--- a/dashboard/client/.env.production.local
+++ b/dashboard/client/.env.production.local
@@ -1,0 +1,1 @@
+PUBLIC_URL="."

--- a/dashboard/client/.gitignore
+++ b/dashboard/client/.gitignore
@@ -16,7 +16,6 @@
 .env.local
 .env.development.local
 .env.test.local
-.env.production.local
 
 npm-debug.log*
 yarn-debug.log*

--- a/dashboard/client/src/api.ts
+++ b/dashboard/client/src/api.ts
@@ -1,4 +1,4 @@
-const base = window.location.origin;
+import { formatUrl } from "./service/requestHandlers";
 
 type APIResponse<T> = {
   result: boolean;
@@ -7,12 +7,10 @@ type APIResponse<T> = {
 };
 // TODO(mitchellstern): Add JSON schema validation for the responses.
 const get = async <T>(path: string, params: { [key: string]: any }) => {
-  const url = new URL(path, base);
-  for (const [key, value] of Object.entries(params)) {
-    url.searchParams.set(key, value);
-  }
+  const formattedParams = Object.entries(params).map(pair => pair.join("=")).join("&");
+  const url = [formatUrl(path), formattedParams].filter(x => x!!).join("?");
 
-  const response = await fetch(url.toString());
+  const response = await fetch(url);
   const json: APIResponse<T> = await response.json();
 
   const { result, msg, data } = json;
@@ -323,10 +321,10 @@ export const checkProfilingStatus = (profilingId: string) =>
     profiling_id: profilingId,
   });
 
-export const getProfilingResultURL = (profilingId: string) =>
-  `${base}/speedscope/index.html#profileURL=${encodeURIComponent(
-    `${base}/api/get_profiling_info?profiling_id=${profilingId}`,
-  )}`;
+export const getProfilingResultURL = (profilingId: string) => {
+  const uriComponent = encodeURIComponent(formatUrl(`/api/get_profiling_info?profiling_id=${profilingId}`));
+  return formatUrl(`/speedscope/index.html#profileURL=${uriComponent}`)
+};
 
 export const launchKillActor = (
   actorId: string,

--- a/dashboard/client/src/api.ts
+++ b/dashboard/client/src/api.ts
@@ -7,8 +7,10 @@ type APIResponse<T> = {
 };
 // TODO(mitchellstern): Add JSON schema validation for the responses.
 const get = async <T>(path: string, params: { [key: string]: any }) => {
-  const formattedParams = Object.entries(params).map(pair => pair.join("=")).join("&");
-  const url = [formatUrl(path), formattedParams].filter(x => x!!).join("?");
+  const formattedParams = Object.entries(params)
+    .map((pair) => pair.join("="))
+    .join("&");
+  const url = [formatUrl(path), formattedParams].filter((x) => x!!).join("?");
 
   const response = await fetch(url);
   const json: APIResponse<T> = await response.json();
@@ -322,8 +324,10 @@ export const checkProfilingStatus = (profilingId: string) =>
   });
 
 export const getProfilingResultURL = (profilingId: string) => {
-  const uriComponent = encodeURIComponent(formatUrl(`/api/get_profiling_info?profiling_id=${profilingId}`));
-  return formatUrl(`/speedscope/index.html#profileURL=${uriComponent}`)
+  const uriComponent = encodeURIComponent(
+    formatUrl(`/api/get_profiling_info?profiling_id=${profilingId}`),
+  );
+  return formatUrl(`/speedscope/index.html#profileURL=${uriComponent}`);
 };
 
 export const launchKillActor = (

--- a/dashboard/client/src/service/actor.ts
+++ b/dashboard/client/src/service/actor.ts
@@ -1,5 +1,5 @@
-import { get } from "./requestHandlers";
 import { Actor } from "../type/actor";
+import { get } from "./requestHandlers";
 
 export const getActors = () => {
   return get<{

--- a/dashboard/client/src/service/actor.ts
+++ b/dashboard/client/src/service/actor.ts
@@ -1,8 +1,8 @@
-import axios from "axios";
+import { get } from "./requestHandlers";
 import { Actor } from "../type/actor";
 
 export const getActors = () => {
-  return axios.get<{
+  return get<{
     result: boolean;
     message: string;
     data: {

--- a/dashboard/client/src/service/cluster.ts
+++ b/dashboard/client/src/service/cluster.ts
@@ -1,5 +1,5 @@
-import { get } from "./requestHandlers";
 import { RayConfigRsp } from "../type/config";
+import { get } from "./requestHandlers";
 
 export const getRayConfig = () => {
   return get<RayConfigRsp>("api/ray_config");

--- a/dashboard/client/src/service/cluster.ts
+++ b/dashboard/client/src/service/cluster.ts
@@ -1,6 +1,6 @@
-import axios from "axios";
+import { get } from "./requestHandlers";
 import { RayConfigRsp } from "../type/config";
 
 export const getRayConfig = () => {
-  return axios.get<RayConfigRsp>("api/ray_config");
+  return get<RayConfigRsp>("api/ray_config");
 };

--- a/dashboard/client/src/service/job.ts
+++ b/dashboard/client/src/service/job.ts
@@ -1,10 +1,10 @@
-import axios from "axios";
+import { get } from "./requestHandlers";
 import { JobDetailRsp, JobListRsp } from "../type/job";
 
 export const getJobList = () => {
-  return axios.get<JobListRsp>("jobs?view=summary");
+  return get<JobListRsp>("jobs?view=summary");
 };
 
 export const getJobDetail = (id: string) => {
-  return axios.get<JobDetailRsp>(`jobs/${id}`);
+  return get<JobDetailRsp>(`jobs/${id}`);
 };

--- a/dashboard/client/src/service/job.ts
+++ b/dashboard/client/src/service/job.ts
@@ -1,5 +1,5 @@
-import { get } from "./requestHandlers";
 import { JobDetailRsp, JobListRsp } from "../type/job";
+import { get } from "./requestHandlers";
 
 export const getJobList = () => {
   return get<JobListRsp>("jobs?view=summary");

--- a/dashboard/client/src/service/log.ts
+++ b/dashboard/client/src/service/log.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import { get } from "./requestHandlers";
 
 export const getLogDetail = async (url: string) => {
   if (window.location.pathname !== "/" && url !== "log_index") {
@@ -12,7 +12,7 @@ export const getLogDetail = async (url: string) => {
       }
     }
   }
-  const rsp = await axios.get(
+  const rsp = await get(
     url === "log_index" ? url : `log_proxy?url=${encodeURIComponent(url)}`,
   );
   if (rsp.headers["content-type"]?.includes("html")) {

--- a/dashboard/client/src/service/node.ts
+++ b/dashboard/client/src/service/node.ts
@@ -1,10 +1,10 @@
-import axios from "axios";
+import { get } from "./requestHandlers";
 import { NodeDetailRsp, NodeListRsp } from "../type/node";
 
 export const getNodeList = async () => {
-  return await axios.get<NodeListRsp>("nodes?view=summary");
+  return await get<NodeListRsp>("nodes?view=summary");
 };
 
 export const getNodeDetail = async (id: string) => {
-  return await axios.get<NodeDetailRsp>(`nodes/${id}`);
+  return await get<NodeDetailRsp>(`nodes/${id}`);
 };

--- a/dashboard/client/src/service/node.ts
+++ b/dashboard/client/src/service/node.ts
@@ -1,5 +1,5 @@
-import { get } from "./requestHandlers";
 import { NodeDetailRsp, NodeListRsp } from "../type/node";
+import { get } from "./requestHandlers";
 
 export const getNodeList = async () => {
   return await get<NodeListRsp>("nodes?view=summary");

--- a/dashboard/client/src/service/requestHandlers.ts
+++ b/dashboard/client/src/service/requestHandlers.ts
@@ -1,21 +1,29 @@
+/**
+ * This utility file formats and sends HTTP requests such that
+ * they fullfill the requirements expected by users of the dashboard.
+ *
+ * All HTTP requests should be sent using the helpers in this file.
+ *
+ * More HTTP Methods helpers should be added to this file when the need
+ * arises.
+ */
+
 import axios, { AxiosResponse, AxiosRequestConfig } from "axios";
 
-const unformattedPrefix = (process.env.REACT_APP_API_PREFIX || "").trim();
-
-const getPrefix = (): string => {
-  if (unformattedPrefix[unformattedPrefix.length - 1] === "/") {
-    return unformattedPrefix.slice(0, unformattedPrefix.length - 1);
-  }
-  return unformattedPrefix;
-};
-
+/**
+ * This function formats URLs such that the user's browser
+ * sets the HTTP request's Request URL relative to the path at
+ * which the dashboard is served.
+ * This works behind a reverse proxy.
+ *
+ * @param {String} url The URL to be hit
+ * @return {String}    The reverse proxy compatible URL
+ */
 export const formatUrl = (url: string): string => {
-  const prefix = getPrefix();
-
   if (url.startsWith("/")) {
-    return `${prefix}${url}`;
+    return url.slice(1);
   }
-  return `${prefix}/${url}`;
+  return url;
 };
 
 export function get<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R> {

--- a/dashboard/client/src/service/requestHandlers.ts
+++ b/dashboard/client/src/service/requestHandlers.ts
@@ -1,0 +1,23 @@
+import axios, { AxiosResponse, AxiosRequestConfig } from "axios";
+
+const unformattedPrefix = (process.env.REACT_APP_API_PREFIX || "").trim();
+
+const getPrefix = (): string => {
+  if (unformattedPrefix[unformattedPrefix.length - 1] === "/") {
+    return unformattedPrefix.slice(0, unformattedPrefix.length - 1);
+  }
+  return unformattedPrefix;
+};
+
+export const formatUrl = (url: string): string => {
+  const prefix = getPrefix();
+
+  if (url.startsWith("/")) {
+    return `${prefix}${url}`;
+  }
+  return `${prefix}/${url}`;
+};
+
+export function get<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R> {
+  return axios.get<T, R>(formatUrl(url), config);
+}

--- a/dashboard/client/src/service/requestHandlers.ts
+++ b/dashboard/client/src/service/requestHandlers.ts
@@ -26,6 +26,9 @@ export const formatUrl = (url: string): string => {
   return url;
 };
 
-export const get = <T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R> => {
+export const get = <T = any, R = AxiosResponse<T>>(
+  url: string,
+  config?: AxiosRequestConfig,
+): Promise<R> => {
   return axios.get<T, R>(formatUrl(url), config);
-}
+};

--- a/dashboard/client/src/service/requestHandlers.ts
+++ b/dashboard/client/src/service/requestHandlers.ts
@@ -8,7 +8,7 @@
  * arises.
  */
 
-import axios, { AxiosResponse, AxiosRequestConfig } from "axios";
+import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 
 /**
  * This function formats URLs such that the user's browser
@@ -26,6 +26,6 @@ export const formatUrl = (url: string): string => {
   return url;
 };
 
-export function get<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R> {
+export const get = <T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R> => {
   return axios.get<T, R>(formatUrl(url), config);
 }

--- a/doc/requirements-rtd.txt
+++ b/doc/requirements-rtd.txt
@@ -6,6 +6,6 @@ pillow==7.2.0
 alabaster>=0.7,<0.8,!=0.7.5
 commonmark==0.8.1
 recommonmark==0.5.0
-sphinx<2
+sphinx==3.0.4
 readthedocs-sphinx-ext<1.1
 sphinx-book-theme

--- a/doc/source/ray-dashboard.rst
+++ b/doc/source/ray-dashboard.rst
@@ -167,6 +167,43 @@ More information on how to interpret the flamegraph is available at https://gith
 .. image:: https://raw.githubusercontent.com/ray-project/images/master/docs/dashboard/dashboard-profiling.png
     :align: center
 
+Running Behind a Reverse Proxy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In ray 2.0.0, the dashboard works out-of-the-box when accessed via a reverse proxy. API requests no
+longer need to be proxied individually.
+
+Always access the dashboard with a trailing ``/`` at the end of the URL.
+For example, if your proxy is set up to handle requests to ``/ray/dashboard``, view the dashboard at ``www.my-website.com/ray/dashboard/``.
+
+The dashboard now sends HTTP requests with relative URL paths. Browsers will handle these requests as expected when the ``window.location.href`` ends in a trailing ``/``.
+
+This is a peculiarity of how many browsers handle requests with relative URLs, despite what `MDN <https://developer.mozilla.org/en-US/docs/Learn/Common_questions/What_is_a_URL#examples_of_relative_urls>`_
+defines as the expected behavior.
+
+Make your dashboard visible without a trailing ``/`` by including a rule in your reverse proxy that
+redirects the user's browser to ``/``, i.e. ``/ray/dashboard`` --> ``/ray/dashboard/``.
+
+Below is an example with a `traefik <https://doc.traefik.io/traefik/getting-started/quick-start/>`_ TOML file that accomplishes this:
+
+.. code-block:: yaml
+
+  [http]
+    [http.routers]
+      [http.routers.to-dashboard]
+        rule = "PathPrefix(`/ray/dashboard`)"
+        middlewares = ["test-redirectregex", "strip"]
+        service = "dashboard"
+    [http.middlewares]
+      [http.middlewares.test-redirectregex.redirectRegex]
+        regex = "^(.*)/ray/dashboard$"
+        replacement = "${1}/ray/dashboard/"
+      [http.middlewares.strip.stripPrefix]
+        prefixes = ["/ray/dashboard"]
+    [http.services]
+      [http.services.dashboard.loadBalancer]
+        [[http.services.dashboard.loadBalancer.servers]]
+          url = "http://localhost:8265"
+
 References
 ----------
 


### PR DESCRIPTION
This PR needs manual testing and tests in general.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Many users serve the ray dashboard behind a reverse proxy. At the moment, not all of the requests sent by the ray dashboard are formatted such that they will find the ray dashboard server when it is served behind a reverse proxy.

The kinds of users that want to do this are those that want to integrate ray into a larger web application. Large web applications often have complex architectures, lots of routes of their own, and reverse proxying in order to send requests to the right place. This change is key to enabling these types of web applications to integrate with ray.

## key changes

### requestHandlers.ts

This file formats urls such that they are "reverse proxy compatible".  These changes should "just work".
I chose to create an HTTP request helper file because this will help safeguard future developers from accidentally writing requests that don't work behind a reverse proxy. This file should be treated as the canonical way to send HTTP requests in the dashboard.

### working with api.ts

In order to not disrupt the entire dashboard app too much, I opted to not replace the usage of `fetch` in this file and instead export a url formatting function from the `requestHandlers.ts` file. The dashboard to use the centralized handlers only in the future.

I had to remove the use of `URL`, because `URL` relies on the use of an absolute base url in order to instantiate the `URL` object. This PRs changes are directly in conflict with how the `URL` object is instantiated. I manually verified this in Chrome. My changes to this file will need testing and extra attention.

### how the dashboard is build

From now on, the dashboard will be built like `PUBLIC_URL="."`. The published ray package will be built with this env var. This makes it so that the static assets request URLs are relative to the path at which the dashboard is served.

### user facing doc changes

The user facing docs for building ray from source should include the `PUBLIC_URL="."` setting.

### Changelog

The changelog should mention that requests sent by the out-of-the-box dashboard will now be relative to the path at which the dashboard is served. It should warn that this may break reverse proxy rules and that there may no longer be a need for per-path reverse proxying. It should probably also give an example of what requests will look like now.

## Related issue number

https://github.com/ray-project/ray/issues/8432

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
