### PR TITLE
[docs] Add mode to Ray Tune quick start

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ This example runs a parallel grid search to optimize an example objective functi
             "beta": tune.choice([1, 2, 3])
         })
 
-    print("Best config: ", analysis.get_best_config(metric="mean_loss"))
+    print("Best config: ", analysis.get_best_config(metric="mean_loss", mode='min'))
 
     # Get a dataframe for analyzing trial results.
     df = analysis.results_df

--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ This example runs a parallel grid search to optimize an example objective functi
             "beta": tune.choice([1, 2, 3])
         })
 
-    print("Best config: ", analysis.get_best_config(metric="mean_loss", mode='min'))
+    print("Best config: ", analysis.get_best_config(metric="mean_loss", mode="min"))
 
     # Get a dataframe for analyzing trial results.
     df = analysis.results_df


### PR DESCRIPTION
## Why are these changes needed?

If `mode` is not specified in `analysis.get_best_config`, it gives this error:

```
Traceback (most recent call last):
  File "ray_quick.py", line 25, in <module>
    print("Best config: ", analysis.get_best_config(metric="mean_loss"))
  File "/users/Crissman/anaconda3/lib/python3.7/site-packages/ray/tune/analysis/experiment_analysis.py", line 607, in get_best_config
    best_trial = self.get_best_trial(metric, mode, scope)
  File "/users/Crissman/anaconda3/lib/python3.7/site-packages/ray/tune/analysis/experiment_analysis.py", line 538, in get_best_trial
    mode = self._validate_mode(mode)
  File "/users/Crissman/anaconda3/lib/python3.7/site-packages/ray/tune/analysis/experiment_analysis.py", line 82, in _validate_mode
    "No `mode` has been passed and  `default_mode` has "
ValueError: No `mode` has been passed and  `default_mode` has not been set. Please specify the `mode` parameter.
```

## Related issue number

N/A

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
