### PR TITLE
[autoscaler][kubernetes] autoscaling hotfix

### DIFF
--- a/python/ray/autoscaler/_private/kubernetes/config.py
+++ b/python/ray/autoscaler/_private/kubernetes/config.py
@@ -94,6 +94,11 @@ def get_autodetected_resources(container_data):
         for resource_name in ["cpu", "gpu"]
     }
 
+    # Throw out GPU from resource dict if the amount is 0.
+    for key in copy.deepcopy(node_type_resources):
+        if node_type_resources[key] == 0:
+            del node_type_resources[key]
+
     return node_type_resources
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Right now Kubernetes fill_out_available_node_type_resources logic fills "GPU":0 for non-gpu nodes, which interacts badly with the resource demand scheduler's gpu conservation logic, preventing autoscaling on k8s.
This fixes KubernetesNodeProvider's resource-filling logic to not fill fields with value 0.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

Did quick manual check that this fixes the problem.
Will add more test logic to the K8s operator unit test (not currently in CI) later.