### PR TITLE
Cpp worker refactor serializer

### DIFF
--- a/cpp/include/ray/api/arguments.h
+++ b/cpp/include/ray/api/arguments.h
@@ -54,7 +54,8 @@ class Arguments {
   static void UnwrapArgsImpl(const std::vector<std::shared_ptr<RayObject>> &args_buffer,
                              int &arg_index, std::shared_ptr<ArgType> *arg) {
     auto arg_buffer = args_buffer[arg_index]->GetData();
-    *arg = Serializer::Deserialize<std::shared_ptr<ArgType>>((const char *)arg_buffer->Data(), arg_buffer->Size());
+    *arg = Serializer::Deserialize<std::shared_ptr<ArgType>>(
+        (const char *)arg_buffer->Data(), arg_buffer->Size());
 
     arg_index++;
   }

--- a/cpp/include/ray/api/arguments.h
+++ b/cpp/include/ray/api/arguments.h
@@ -25,10 +25,7 @@ class Arguments {
                            ArgType &arg) {
     static_assert(!is_object_ref<ArgType>::value, "ObjectRef can not be wrapped");
 
-    /// TODO
-    /// The serialize code will move to Serializer after refactoring Serializer.
-    msgpack::sbuffer buffer;
-    msgpack::pack(buffer, arg);
+    msgpack::sbuffer buffer = Serializer::Serialize(arg);
     auto memory_buffer = std::make_shared<::ray::LocalMemoryBuffer>(
         reinterpret_cast<uint8_t *>(buffer.data()), buffer.size(), true);
     /// Pass by value.
@@ -56,12 +53,8 @@ class Arguments {
   template <typename ArgType>
   static void UnwrapArgsImpl(const std::vector<std::shared_ptr<RayObject>> &args_buffer,
                              int &arg_index, std::shared_ptr<ArgType> *arg) {
-    /// TODO
-    /// The Deserialize code will move to Serializer after refactoring Serializer.
-    msgpack::unpacked msg;
     auto arg_buffer = args_buffer[arg_index]->GetData();
-    msgpack::unpack(msg, (const char *)arg_buffer->Data(), arg_buffer->Size());
-    *arg = std::make_shared<ArgType>(msg.get().as<ArgType>());
+    *arg = Serializer::Deserialize<std::shared_ptr<ArgType>>((const char *)arg_buffer->Data(), arg_buffer->Size());
 
     arg_index++;
   }

--- a/cpp/src/ray/test/serialization_test.cc
+++ b/cpp/src/ray/test/serialization_test.cc
@@ -10,33 +10,20 @@ TEST(SerializationTest, TypeHybridTest) {
 
   // 1 arg
   // marshall
-  msgpack::sbuffer buffer1;
-  msgpack::packer<msgpack::sbuffer> pk1(&buffer1);
-  Serializer::Serialize(pk1, in_arg1);
+  msgpack::sbuffer buffer1 = Serializer::Serialize(in_arg1);
   // unmarshall
-  msgpack::unpacker upk1;
-  upk1.reserve_buffer(buffer1.size());
-  memcpy(upk1.buffer(), buffer1.data(), buffer1.size());
-  upk1.buffer_consumed(buffer1.size());
-
-  Serializer::Deserialize(upk1, &out_arg1);
+  out_arg1 = Serializer::Deserialize<uint32_t>(buffer1.data(), buffer1.size());
 
   EXPECT_EQ(in_arg1, out_arg1);
 
   // 2 args
   // marshall
-  msgpack::sbuffer buffer2;
-  msgpack::packer<msgpack::sbuffer> pk2(&buffer2);
-  Serializer::Serialize(pk2, in_arg1);
-  Serializer::Serialize(pk2, in_arg2);
+  msgpack::sbuffer buffer2 = Serializer::Serialize(std::make_tuple(in_arg1, in_arg2));
 
   // unmarshall
-  msgpack::unpacker upk2;
-  upk2.reserve_buffer(buffer2.size());
-  memcpy(upk2.buffer(), buffer2.data(), buffer2.size());
-  upk2.buffer_consumed(buffer2.size());
-  Serializer::Deserialize(upk2, &out_arg1);
-  Serializer::Deserialize(upk2, &out_arg2);
+  std::tie(out_arg1, out_arg2) =
+      Serializer::Deserialize<std::tuple<uint32_t, std::string>>(buffer2.data(),
+                                                                 buffer2.size());
 
   EXPECT_EQ(in_arg1, out_arg1);
   EXPECT_EQ(in_arg2, out_arg2);


### PR DESCRIPTION
## Why are these changes needed?

The current Serializer has additional memory copy when serializing or deserializing an object, we should avoid the memory copy;
The usage of current Serializer is not very easy to use, we can do better, provide more easier to use interface and simplify the code.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
