### PR TITLE
[RLlib] Issue #14022: Trajectory View API fails in MA-env where a new agent terminates right away (done=True right after initial obs).

### DIFF
--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -849,18 +849,26 @@ def _process_observations(
         # type: AgentID, EnvObsType
         for agent_id, raw_obs in agent_obs.items():
             assert agent_id != "__all__"
+
+            last_observation: EnvObsType = episode.last_observation_for(
+                agent_id)
+            agent_done = bool(all_agents_done or dones[env_id].get(agent_id))
+
+            # A new agent (initial obs) is already done -> Skip entirely.
+            if last_observation is None and agent_done:
+                continue
+
             policy_id: PolicyID = episode.policy_for(agent_id)
-            prepr = _get_or_raise(preprocessors, policy_id)
-            prep_obs: EnvObsType = prepr.transform(raw_obs)
+
+            prep_obs: EnvObsType = _get_or_raise(preprocessors,
+                                                 policy_id).transform(raw_obs)
             if log_once("prep_obs"):
                 logger.info("Preprocessed obs: {}".format(summarize(prep_obs)))
-
-            filter = _get_or_raise(obs_filters, policy_id)
-            filtered_obs: EnvObsType = filter(prep_obs)
+            filtered_obs: EnvObsType = _get_or_raise(obs_filters,
+                                                     policy_id)(prep_obs)
             if log_once("filtered_obs"):
                 logger.info("Filtered obs: {}".format(summarize(filtered_obs)))
 
-            agent_done = bool(all_agents_done or dones[env_id].get(agent_id))
             if not agent_done:
                 item = PolicyEvalData(env_id, agent_id, filtered_obs,
                                       infos[env_id].get(agent_id, {}),
@@ -869,8 +877,6 @@ def _process_observations(
                                       rewards[env_id][agent_id] or 0.0)
                 to_eval[policy_id].append(item)
 
-            last_observation: EnvObsType = episode.last_observation_for(
-                agent_id)
             episode._set_last_observation(agent_id, filtered_obs)
             episode._set_last_raw_obs(agent_id, raw_obs)
             episode._set_last_info(agent_id, infos[env_id].get(agent_id, {}))

--- a/rllib/examples/env/multi_agent.py
+++ b/rllib/examples/env/multi_agent.py
@@ -1,4 +1,5 @@
 import gym
+import random
 
 from ray.rllib.env.multi_agent_env import MultiAgentEnv, make_multi_agent
 from ray.rllib.examples.env.mock_env import MockEnv, MockEnv2
@@ -84,6 +85,62 @@ class EarlyDoneMultiAgent(MultiAgentEnv):
             self.dones.add(self.i)
         self.i = (self.i + 1) % len(self.agents)
         done["__all__"] = len(self.dones) == len(self.agents) - 1
+        return obs, rew, done, info
+
+
+class FlexAgentsMultiAgent(MultiAgentEnv):
+    """Env of independent agents, each of which exits after n steps."""
+
+    def __init__(self):
+        self.agents = {}
+        self.agentID = 0
+        self.dones = set()
+        self.observation_space = gym.spaces.Discrete(2)
+        self.action_space = gym.spaces.Discrete(2)
+        self.resetted = False
+
+    def spawn(self):
+        # Spawn a new agent into the current episode.
+        agentID = self.agentID
+        self.agents[agentID] = MockEnv(25)
+        self.agentID += 1
+        return agentID
+
+    def reset(self):
+        self.agents = {}
+        self.spawn()
+        self.resetted = True
+        self.dones = set()
+
+        obs = {}
+        for i, a in self.agents.items():
+            obs[i] = a.reset()
+
+        return obs
+
+    def step(self, action_dict):
+        obs, rew, done, info = {}, {}, {}, {}
+        # Apply the actions.
+        for i, action in action_dict.items():
+            obs[i], rew[i], done[i], info[i] = self.agents[i].step(action)
+            if done[i]:
+                self.dones.add(i)
+
+        # Sometimes, add a new agent to the episode.
+        if random.random() > 0.75:
+            i = self.spawn()
+            obs[i], rew[i], done[i], info[i] = self.agents[i].step(action)
+            if done[i]:
+                self.dones.add(i)
+
+        # Sometimes, kill an existing agent.
+        if len(self.agents) > 1 and random.random() > 0.25:
+            keys = list(self.agents.keys())
+            key = random.choice(keys)
+            done[key] = True
+            del self.agents[key]
+
+        done["__all__"] = len(self.dones) == len(self.agents)
         return obs, rew, done, info
 
 

--- a/rllib/tests/test_multi_agent_env.py
+++ b/rllib/tests/test_multi_agent_env.py
@@ -11,7 +11,8 @@ from ray.rllib.evaluation.episode import MultiAgentEpisode
 from ray.rllib.evaluation.rollout_worker import get_global_worker
 from ray.rllib.examples.policy.random_policy import RandomPolicy
 from ray.rllib.examples.env.multi_agent import MultiAgentCartPole, \
-    BasicMultiAgent, EarlyDoneMultiAgent, RoundRobinMultiAgent
+    BasicMultiAgent, EarlyDoneMultiAgent, FlexAgentsMultiAgent, \
+    RoundRobinMultiAgent
 from ray.rllib.evaluation.rollout_worker import RolloutWorker
 from ray.rllib.evaluation.tests.test_rollout_worker import MockPolicy
 from ray.rllib.env.base_env import _MultiAgentEnvToBaseEnv
@@ -253,6 +254,20 @@ class TestMultiAgentEnv(unittest.TestCase):
         self.assertRaisesRegexp(ValueError,
                                 ".*don't have a last observation.*",
                                 lambda: ev.sample())
+
+    def test_multi_agent_with_flex_agents(self):
+        register_env("flex_agents_multi_agent_cartpole",
+                     lambda _: FlexAgentsMultiAgent())
+        pg = PGTrainer(
+            env="flex_agents_multi_agent_cartpole",
+            config={
+                "num_workers": 0,
+                "framework": "tf",
+            })
+        for i in range(10):
+            result = pg.train()
+            print("Iteration {}, reward {}, timesteps {}".format(
+                i, result["episode_reward_mean"], result["timesteps_total"]))
 
     def test_multi_agent_sample_round_robin(self):
         act_space = gym.spaces.Discrete(2)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Issue #14022: Trajectory View API fails in MA-env where a new agent terminates right away (done=True right after initial obs).

<!-- Please give a short summary of the change and the problem this solves. -->

Issue #14022
## Related issue number

<!-- For example: "Closes #1234" -->
Closes #14022
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
