### PR TITLE
[RLlib] Issue #13824: `compress_observations=True` crashes for all algos not using a replay buffer.

### DIFF
--- a/rllib/agents/dqn/simple_q.py
+++ b/rllib/agents/dqn/simple_q.py
@@ -62,7 +62,7 @@ DEFAULT_CONFIG = with_common_config({
     # each worker will have a replay buffer of this size.
     "buffer_size": 50000,
     # Whether to LZ4 compress observations
-    "compress_observations": True,
+    "compress_observations": False,
 
     # === Optimization ===
     # Learning rate for adam optimizer

--- a/rllib/agents/dqn/tests/test_simple_q.py
+++ b/rllib/agents/dqn/tests/test_simple_q.py
@@ -18,7 +18,10 @@ class TestSimpleQ(unittest.TestCase):
     def test_simple_q_compilation(self):
         """Test whether a SimpleQTrainer can be built on all frameworks."""
         config = dqn.SIMPLE_Q_DEFAULT_CONFIG.copy()
-        config["num_workers"] = 0  # Run locally.
+        # Run locally.
+        config["num_workers"] = 0
+        # Test with compression.
+        config["compress_observations"] = True
         num_iterations = 2
 
         for _ in framework_iterator(config):

--- a/rllib/agents/ppo/tests/test_ppo.py
+++ b/rllib/agents/ppo/tests/test_ppo.py
@@ -83,6 +83,8 @@ class TestPPO(unittest.TestCase):
         config["model"]["lstm_cell_size"] = 10
         config["model"]["max_seq_len"] = 20
         config["train_batch_size"] = 128
+        # Test with compression.
+        config["compress_observations"] = True
         num_iterations = 2
 
         for _ in framework_iterator(config):

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -863,6 +863,8 @@ class RolloutWorker(ParallelIteratorWorker):
             for pid, batch in samples.policy_batches.items():
                 if pid not in self.policies_to_train:
                     continue
+                # Decompress SampleBatch, in case some columns are compressed.
+                batch.decompress_if_needed()
                 policy = self.policy_map[pid]
                 if builder and hasattr(policy, "_build_learn_on_batch"):
                     to_fetch[pid] = policy._build_learn_on_batch(

--- a/rllib/execution/train_ops.py
+++ b/rllib/execution/train_ops.py
@@ -181,8 +181,12 @@ class TrainTFMultiGPU:
             # (1) Load data into GPUs.
             num_loaded_tuples = {}
             for policy_id, batch in samples.policy_batches.items():
+                # Not a policy-to-train.
                 if policy_id not in self.policies:
                     continue
+
+                # Decompress SampleBatch, in case some columns are compressed.
+                batch.decompress_if_needed()
 
                 policy = self.workers.local_worker().get_policy(policy_id)
                 policy._debug_vars()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Issue #13824: `compress_observations=True` crashes for all algos not using a replay buffer.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
Issue #13824
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #13824 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
