### PR TITLE
[RLlib] Issue #13760: Dict flattening Preprocessor should not sort keys alphabetically in `write()`.

### DIFF
--- a/rllib/models/preprocessors.py
+++ b/rllib/models/preprocessors.py
@@ -263,7 +263,7 @@ class DictFlatteningPreprocessor(Preprocessor):
     def write(self, observation: TensorType, array: np.ndarray,
               offset: int) -> None:
         if not isinstance(observation, OrderedDict):
-            observation = OrderedDict(sorted(observation.items()))
+            observation = OrderedDict(observation.items())
         assert len(observation) == len(self.preprocessors), \
             (len(observation), len(self.preprocessors))
         for o, p in zip(observation.values(), self.preprocessors):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Issue #13760: Dict flattening Preprocessor should not sort keys alphabetically in `write()`.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
Issue #13760

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #13760 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
