### PR TITLE
[RLlib] Issue #13342: Add `validate_spaces` to MB-MPO.

### DIFF
--- a/rllib/agents/mbmpo/model_ensemble.py
+++ b/rllib/agents/mbmpo/model_ensemble.py
@@ -136,6 +136,8 @@ class DynamicsEnsembleCustomModel(TorchModelV2, nn.Module):
                 obs_space.low[0],
                 obs_space.high[0],
                 shape=(obs_space.shape[0] + action_space.shape[0], ))
+        else:
+            raise NotImplementedError
         super(DynamicsEnsembleCustomModel, self).__init__(
             input_space, action_space, num_outputs, model_config, name)
 

--- a/rllib/agents/sac/sac_tf_policy.py
+++ b/rllib/agents/sac/sac_tf_policy.py
@@ -652,7 +652,7 @@ def validate_spaces(policy: Policy, observation_space: gym.spaces.Space,
     Raises:
         UnsupportedSpaceException: If one of the spaces is not supported.
     """
-    # Only support single Box or single Discreete spaces.
+    # Only support single Box or single Discrete spaces.
     if not isinstance(action_space, (Box, Discrete, Simplex)):
         raise UnsupportedSpaceException(
             "Action space ({}) of {} is not supported for "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Issue #13342: Add `validate_spaces` to MB-MPO.
- MB-MPO does not warn/error when Tuple/Dict/Simplex/MultiDiscrete action spaces are used.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Issue #13342 

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Closes #13342 
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
