### PR TITLE
[Core] Ownership-based Object Directory - Disable the ownership-based object directory for all tests that use ray.objects()

### DIFF
--- a/python/ray/tests/test_advanced_3.py
+++ b/python/ray/tests/test_advanced_3.py
@@ -21,9 +21,8 @@ from ray import resource_spec
 import setproctitle
 import subprocess
 
-from ray.test_utils import (check_call_ray, RayTestTimeoutException,
-                            wait_for_condition, wait_for_num_actors,
-                            new_scheduler_enabled)
+from ray.test_utils import (check_call_ray, wait_for_condition,
+                            wait_for_num_actors, new_scheduler_enabled)
 
 logger = logging.getLogger(__name__)
 
@@ -154,15 +153,6 @@ def test_locality_aware_leasing(ray_start_cluster):
 
     # Test that task f() runs on the same node as non_local().
     assert ray.get(f.remote(non_local.remote())) == non_local_node.unique_id
-
-
-def wait_for_num_objects(num_objects, timeout=10):
-    start_time = time.time()
-    while time.time() - start_time < timeout:
-        if len(ray.objects()) >= num_objects:
-            return
-        time.sleep(0.1)
-    raise RayTestTimeoutException("Timed out while waiting for global state.")
 
 
 def test_global_state_api(shutdown_only):
@@ -624,7 +614,14 @@ def test_move_log_files_to_old(shutdown_only):
 
 
 def test_lease_request_leak(shutdown_only):
-    ray.init(num_cpus=1, _system_config={"object_timeout_milliseconds": 200})
+    ray.init(
+        num_cpus=1,
+        _system_config={
+            # This test uses ray.objects(), which only works with the GCS-based
+            # object directory
+            "ownership_based_object_directory_enabled": False,
+            "object_timeout_milliseconds": 200
+        })
     assert len(ray.objects()) == 0
 
     @ray.remote

--- a/python/ray/tests/test_client_references.py
+++ b/python/ray/tests/test_client_references.py
@@ -33,10 +33,17 @@ def server_actor_ref_count(server, n):
 
 
 @pytest.mark.parametrize(
-    "ray_start_cluster", [{
+    "ray_start_cluster",
+    [{
         "num_nodes": 1,
-        "do_init": False
-    }], indirect=True)
+        "do_init": False,
+        # This test uses ray.objects(), which only works with the GCS-based
+        # object directory
+        "_system_config": {
+            "ownership_based_object_directory_enabled": False
+        },
+    }],
+    indirect=True)
 def test_delete_refs_on_disconnect(ray_start_cluster):
     cluster = ray_start_cluster
     with ray_start_cluster_client_server_pair(cluster.address) as pair:

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -178,6 +178,16 @@ print("success")
         assert "success" in out
 
 
+@pytest.mark.parametrize(
+    "call_ray_start",
+    [
+        "ray start --head --num-cpus=1 --min-worker-port=0 "
+        "--max-worker-port=0 --port 0 --system-config="
+        # This test uses ray.objects(), which only works with the GCS-based
+        # object directory
+        "{\"ownership_based_object_directory_enabled\":false}",
+    ],
+    indirect=True)
 def test_cleanup_on_driver_exit(call_ray_start):
     # This test will create a driver that creates a bunch of objects and then
     # exits. The entries in the object table should be cleaned up.

--- a/python/ray/tune/tests/test_trial_scheduler_pbt.py
+++ b/python/ray/tune/tests/test_trial_scheduler_pbt.py
@@ -29,7 +29,14 @@ class MockParam(object):
 
 class PopulationBasedTrainingMemoryTest(unittest.TestCase):
     def setUp(self):
-        ray.init(num_cpus=1, object_store_memory=100 * MB)
+        ray.init(
+            num_cpus=1,
+            object_store_memory=100 * MB,
+            _system_config={
+                # This test uses ray.objects(), which only works with the
+                # GCS-based object directory
+                "ownership_based_object_directory_enabled": False,
+            })
 
     def tearDown(self):
         ray.shutdown()
@@ -90,7 +97,13 @@ class PopulationBasedTrainingMemoryTest(unittest.TestCase):
 
 class PopulationBasedTrainingFileDescriptorTest(unittest.TestCase):
     def setUp(self):
-        ray.init(num_cpus=2)
+        ray.init(
+            num_cpus=2,
+            _system_config={
+                # This test uses ray.objects(), which only works with the
+                # GCS-based object directory
+                "ownership_based_object_directory_enabled": False,
+            })
         os.environ["TUNE_GLOBAL_CHECKPOINT_S"] = "0"
 
     def tearDown(self):


### PR DESCRIPTION
`ray.objects()` queries the GCS for object location data, which will always be empty when the ownership-based object directory is enabled. The `ray.objects()` API [will be removed once we complete the move to the ownership-based object directory](https://github.com/ray-project/ray/issues/13792#issuecomment-770000229). For now, disable the ownership-based object directory for all tests that use `ray.objects()`. 

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When the ownership-based object directory is enabled, tests were either failing ([test_client_references. test_delete_refs_on_disconnect](https://travis-ci.com/github/ray-project/ray/jobs/482356399), [test_multi_node. test_cleanup_on_driver_exit](https://travis-ci.com/github/ray-project/ray/jobs/482356401)) or were silently not testing what they were supposed to be testing (such as [test_advanced_3.test_lease_request_leak](https://github.com/ray-project/ray/blob/2af1f0616de3f1e8267bc34e0fb8e3089c2baf7f/python/ray/tests/test_advanced_3.py#L626-L647), which only asserts that `len(ray.objects()) == 0`, which is always true when the ownership-based object directory is enabled).

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #13975

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
