### PR TITLE
[operator] expose RAY_CONFIG_DIR env var (fix #14074)

### DIFF
--- a/python/ray/ray_operator/operator_utils.py
+++ b/python/ray/ray_operator/operator_utils.py
@@ -10,7 +10,9 @@ from ray.autoscaler._private.providers import _get_default_config
 
 RAY_NAMESPACE = os.environ.get("RAY_OPERATOR_POD_NAMESPACE")
 
-RAY_CONFIG_DIR = os.path.expanduser("~/ray_cluster_configs")
+RAY_CONFIG_DIR = os.environ.get("RAY_CONFIG_DIR") or \
+    os.path.expanduser("~/ray_cluster_configs")
+
 CONFIG_SUFFIX = "_config.yaml"
 
 CONFIG_FIELDS = {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Exposing RAY_CONFIG_DIR environment variable to improve configurability of where ray writes config files

## Related issue number

Closes #14074

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
