### PR TITLE
[autoscaler] Add support for custom EC2 instance network interfaces

### DIFF
--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -208,6 +208,10 @@ def bootstrap_aws(config):
     # Used internally to store head IAM role.
     config["head_node"] = {}
 
+    # If NetworkInterfaces are provided, extract the necessary fields for the
+    # config stages below.
+    config = _configure_from_network_interfaces(config)
+
     # The head node needs to have an IAM role that allows it to create further
     # EC2 instances.
     config = _configure_iam_role(config)
@@ -757,6 +761,54 @@ def _get_key(key_name, config):
         handle_boto_error(exc, "Failed to fetch EC2 key pair {} from AWS.",
                           cf.bold(key_name))
         raise exc
+
+
+def _configure_from_network_interfaces(config):
+    for node_type in config["available_node_types"].values():
+        config = _configure_node_type_from_network_interface(config, node_type)
+    return config
+
+
+def _configure_node_type_from_network_interface(config, node_type):
+    node_cfg = node_type["node_config"]
+    if "NetworkInterfaces" not in node_cfg:
+        return config
+    _configure_subnets_and_groups_from_network_interfaces(node_cfg)
+    return config
+
+
+def _configure_subnets_and_groups_from_network_interfaces(node_cfg):
+    # If NetworkInterfaces are defined, SubnetId and SecurityGroupIds
+    # can't be specified in the same node type config.
+    conflict_keys = ["SubnetId", "SubnetIds", "SecurityGroupIds"]
+    if any(conflict in node_cfg for conflict in conflict_keys):
+        raise ValueError(
+            "If NetworkInterfaces are defined, subnets and security groups"
+            "must ONLY be given in each NetworkInterface.")
+    if not all(_subnets_in_network_config(node_cfg)):
+        raise ValueError(
+            "NetworkInterfaces are defined but at least one is missing a "
+            "subnet. Please ensure all interfaces have a subnet assigned.")
+    if not all(_security_groups_in_network_config(node_cfg)):
+        raise ValueError(
+            "NetworkInterfaces are defined but at least one is missing a "
+            "security group. Please ensure all interfaces have a security "
+            "group assigned.")
+    node_cfg["SubnetIds"] = _subnets_in_network_config(node_cfg)
+    node_cfg["SecurityGroupIds"] = _security_groups_in_network_config(node_cfg)
+
+
+def _subnets_in_network_config(config):
+    return [
+        ni.get("SubnetId", "") for ni in config.get("NetworkInterfaces", [])
+    ]
+
+
+def _security_groups_in_network_config(config):
+    lists = [
+        ni.get("Groups", []) for ni in config.get("NetworkInterfaces", [])
+    ]
+    return list(itertools.chain(*lists))
 
 
 def _client(name, config):

--- a/python/ray/autoscaler/_private/aws/utils.py
+++ b/python/ray/autoscaler/_private/aws/utils.py
@@ -1,6 +1,12 @@
 from collections import defaultdict
+from functools import lru_cache
+
+from boto3.exceptions import ResourceNotExistsError
+from botocore.config import Config
+import boto3
 
 from ray.autoscaler._private.cli_logger import cli_logger, cf
+from ray.autoscaler._private.constants import BOTO_MAX_RETRIES
 
 
 class LazyDefaultDict(defaultdict):
@@ -120,3 +126,38 @@ def boto_exception_handler(msg, *args, **kwargs):
                 handle_boto_error(value, msg, *args, **kwargs)
 
     return ExceptionHandlerContextManager()
+
+
+@lru_cache()
+def resource_cache(name, region, max_retries=BOTO_MAX_RETRIES, **kwargs):
+    cli_logger.verbose("Creating AWS resource `{}` in `{}`", cf.bold(name),
+                       cf.bold(region))
+    kwargs.setdefault(
+        "config",
+        Config(retries={"max_attempts": max_retries}),
+    )
+    return boto3.resource(
+        name,
+        region,
+        **kwargs,
+    )
+
+
+@lru_cache()
+def client_cache(name, region, max_retries=BOTO_MAX_RETRIES, **kwargs):
+    try:
+        # try to re-use a client from the resource cache first
+        return resource_cache(name, region, max_retries, **kwargs).meta.client
+    except ResourceNotExistsError:
+        # fall back for clients without an associated resource
+        cli_logger.verbose("Creating AWS client `{}` in `{}`", cf.bold(name),
+                           cf.bold(region))
+        kwargs.setdefault(
+            "config",
+            Config(retries={"max_attempts": max_retries}),
+        )
+        return boto3.client(
+            name,
+            region,
+            **kwargs,
+        )

--- a/python/ray/autoscaler/aws/example-network-interfaces.yaml
+++ b/python/ray/autoscaler/aws/example-network-interfaces.yaml
@@ -1,0 +1,113 @@
+cluster_name: network_interfaces
+
+max_workers: 2
+
+provider:
+    type: aws
+    # Ensure that all Security Group IDs associated with your network interfaces
+    # below are available in this region. If you are using Elastic Fabric
+    # Adaptors (EFA) with your network interfaces, then ensure that the
+    # available instance types in this region support EFA. To see the available
+    # instance types that support EFA in a Region, use the
+    # describe-instance-types command with the --region option and the
+    # appropriate Region code:
+    # aws ec2 describe-instance-types --region us-east-2 --filters Name=network-info.efa-supported,Values=true --query "InstanceTypes[*].[InstanceType]" --output text
+    region: us-west-2
+
+    # Note that availability zones can be omitted when using custom network
+    # interfaces with all node types, since each node will always be launched in
+    # the availability zone shared by its network interface subnets.
+    # If some of your node types have network interfaces configured and others
+    # do not, then node types without network interfaces will be limited to
+    # launching only in subnets available in the given availability zones.
+    # availability_zone: us-west-2a, us-west-2b, us-west-2c
+
+    # The example network interfaces below don't associate public IP addresses
+    # with Ray cluster nodes, so we need to explicitly tell Ray to connect to
+    # them via their private IP addresses. This also means that any instance
+    # running "ray up" or otherwise communicating with cluster nodes must be
+    # located in the same VPC to succeed. This line should be omitted if your
+    # network interfaces use public IP addresses.
+    use_internal_ips: True
+
+auth:
+    ssh_user: ubuntu
+
+# One or more NetworkInterfaces may be optionally defined for both head and
+# worker nodes. Each NetworkInterface must minimally contain an associated
+# DeviceIndex, SubnetID, and SecurityGroupID.
+
+# For more information, see the "NetworkInterfaces" parameter of:
+# https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances
+
+available_node_types:
+  ray.head.default:
+    max_workers: 0
+    node_config:
+      NetworkInterfaces:
+        - DeviceIndex: 0 # Primary network interface.
+          SubnetId: subnet-00000000 # Replace with your Subnet ID.
+          # Head node network interfaces can optionally associate fixed private
+          # addresses with the head node.
+          PrivateIpAddress: 172.31.64.10 # Replace with an IP in your subnet.
+          Groups:
+            - sg-00000000 # Replace with your Security Group ID.
+
+        # Multiple network interfaces can optionally be attached to a single
+        # node. Each interface should be assigned a different subnet, but each
+        # subnet should be in the same availability zone.
+        # For more information, see:
+        # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html
+        # When assigning multiple network interfaces to a node, the network
+        # interfaces CANNOT have associated public IP addresses.
+        - DeviceIndex: 1 # Secondary network interface.
+          SubnetId: subnet-11111111 # Replace with your Subnet ID.
+          PrivateIpAddress: 172.31.16.10 # Replace with an IP in your subnet.
+          Groups:
+            - sg-11111111 # Replace with your Security Group ID.
+
+      # Use any node and instance type with default network interface types.
+      ImageId: latest_dlami
+      InstanceType: m5.large
+
+  ray.worker.efa:
+    min_workers: 0
+    max_workers: 1
+    node_config:
+      # Worker node network interfaces should always use auto-assigned private
+      # IP addresses from their associated subnets to avoid conflicts between
+      # multiple workers trying to use the same private IP.
+      NetworkInterfaces:
+        - DeviceIndex: 0 # Primary network interface.
+          AssociatePublicIpAddress: False # Omit to let your Subnet auto-assign a public IP (if enabled).
+          SubnetId: subnet-22222222 # Replace with your actual Subnet ID
+          Groups:
+            - sg-22222222 # Replace with your actual Security Group ID.
+          InterfaceType: efa # Use EFA for higher throughput and lower latency.
+
+      # Use an AMI and instance type that supports Elastic Fabric Adapters (EFA).
+      # When using EFA, ideally all your cluster nodes should be Linux instances
+      # in the same subnet. This allows your EFA interfaces to leverage their
+      # OS-bypass capabilities and communicate directly with the device. See:
+      # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html
+      # In this case, we'll use EFA with NCCL on the latest Ubuntu Deep Learning
+      # AMI and a supported network-optimized GPU instance type.
+      # See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start-nccl-dlami.html
+      ImageId: latest_dlami
+      InstanceType: p3dn.24xlarge
+
+  ray.worker.default:
+    min_workers: 0
+    max_workers: 1
+    node_config:
+      NetworkInterfaces:
+        - DeviceIndex: 0 # Primary network interface.
+          AssociatePublicIpAddress: False # Omit to let your Subnet auto-assign a public IP (if enabled).
+          SubnetId: subnet-33333333 # Replace with your actual Subnet ID
+          Groups:
+            - sg-33333333 # Replace with your actual Security Group ID.
+
+      ImageId: latest_dlami
+      InstanceType: m5.large
+
+head_node_type: ray.head.default

--- a/python/ray/autoscaler/aws/example-network-interfaces.yaml
+++ b/python/ray/autoscaler/aws/example-network-interfaces.yaml
@@ -43,6 +43,7 @@ auth:
 available_node_types:
   ray.head.default:
     max_workers: 0
+    resources: {}
     node_config:
       NetworkInterfaces:
         - DeviceIndex: 0 # Primary network interface.
@@ -73,6 +74,7 @@ available_node_types:
   ray.worker.efa:
     min_workers: 0
     max_workers: 1
+    resources: {}
     node_config:
       # Worker node network interfaces should always use auto-assigned private
       # IP addresses from their associated subnets to avoid conflicts between
@@ -99,6 +101,7 @@ available_node_types:
   ray.worker.default:
     min_workers: 0
     max_workers: 1
+    resources: {}
     node_config:
       NetworkInterfaces:
         - DeviceIndex: 0 # Primary network interface.

--- a/python/ray/tests/aws/conftest.py
+++ b/python/ray/tests/aws/conftest.py
@@ -1,13 +1,14 @@
 import pytest
 
-from ray.autoscaler._private.aws.config import _resource_cache
+from ray.autoscaler._private.constants import BOTO_MAX_RETRIES
+from ray.autoscaler._private.aws.utils import resource_cache
 
 from botocore.stub import Stubber
 
 
 @pytest.fixture()
 def iam_client_stub():
-    resource = _resource_cache("iam", "us-west-2")
+    resource = resource_cache("iam", "us-west-2")
     with Stubber(resource.meta.client) as stubber:
         yield stubber
         stubber.assert_no_pending_responses()
@@ -15,7 +16,23 @@ def iam_client_stub():
 
 @pytest.fixture()
 def ec2_client_stub():
-    resource = _resource_cache("ec2", "us-west-2")
+    resource = resource_cache("ec2", "us-west-2")
+    with Stubber(resource.meta.client) as stubber:
+        yield stubber
+        stubber.assert_no_pending_responses()
+
+
+@pytest.fixture()
+def ec2_client_stub_fail_fast():
+    resource = resource_cache("ec2", "us-west-2", 0)
+    with Stubber(resource.meta.client) as stubber:
+        yield stubber
+        stubber.assert_no_pending_responses()
+
+
+@pytest.fixture()
+def ec2_client_stub_max_retries():
+    resource = resource_cache("ec2", "us-west-2", BOTO_MAX_RETRIES)
     with Stubber(resource.meta.client) as stubber:
         yield stubber
         stubber.assert_no_pending_responses()

--- a/python/ray/tests/aws/test_autoscaler_aws.py
+++ b/python/ray/tests/aws/test_autoscaler_aws.py
@@ -2,9 +2,12 @@ import copy
 
 import pytest
 
+from ray.autoscaler.tags import TAG_RAY_LAUNCH_CONFIG, TAG_RAY_NODE_KIND, \
+    NODE_KIND_HEAD, NODE_KIND_WORKER, TAG_RAY_USER_NODE_TYPE
 from ray.autoscaler._private.aws.config import _get_vpc_id_or_die, \
     bootstrap_aws, log_to_cli, \
     DEFAULT_AMI
+from ray.autoscaler._private.providers import _get_node_provider
 import ray.tests.aws.utils.stubs as stubs
 import ray.tests.aws.utils.helpers as helpers
 from ray.tests.aws.utils.constants import AUX_SUBNET, DEFAULT_SUBNET, \
@@ -12,7 +15,7 @@ from ray.tests.aws.utils.constants import AUX_SUBNET, DEFAULT_SUBNET, \
     DEFAULT_SG_WITH_RULES_AUX_SUBNET, AUX_SG, \
     DEFAULT_SG_WITH_RULES, DEFAULT_SG_WITH_NAME, \
     DEFAULT_SG_WITH_NAME_AND_RULES, CUSTOM_IN_BOUND_RULES, \
-    DEFAULT_KEY_PAIR, DEFAULT_INSTANCE_PROFILE
+    DEFAULT_KEY_PAIR, DEFAULT_INSTANCE_PROFILE, DEFAULT_CLUSTER_NAME
 
 
 def test_use_subnets_in_only_one_vpc(iam_client_stub, ec2_client_stub):
@@ -456,6 +459,69 @@ def test_log_to_cli(iam_client_stub, ec2_client_stub):
     log_to_cli(config)
     iam_client_stub.assert_no_pending_responses()
     ec2_client_stub.assert_no_pending_responses()
+
+
+def test_network_interfaces(ec2_client_stub, iam_client_stub,
+                            ec2_client_stub_fail_fast,
+                            ec2_client_stub_max_retries):
+
+    # use default stubs to skip ahead to subnet configuration
+    stubs.configure_iam_role_default(iam_client_stub)
+    stubs.configure_key_pair_default(ec2_client_stub)
+
+    # given the security groups associated with our network interfaces...
+    sgids = ["sg-00000000", "sg-11111111", "sg-22222222", "sg-33333333"]
+    security_groups = []
+    suffix = 0
+    for sgid in sgids:
+        sg = copy.deepcopy(DEFAULT_SG)
+        sg["GroupName"] += f"-{suffix}"
+        sg["GroupId"] = sgid
+        security_groups.append(sg)
+        suffix += 1
+    # expect to describe all security groups to ensure they share the same VPC
+    stubs.describe_sgs_by_id(ec2_client_stub, sgids, security_groups)
+
+    # use a default stub to skip subnet configuration
+    stubs.configure_subnet_default(ec2_client_stub)
+
+    # given our mocks and an example config file as input...
+    # expect the config to be loaded, validated, and bootstrapped successfully
+    config = helpers.bootstrap_aws_example_config_file(
+        "example-network-interfaces.yaml")
+
+    # instantiate a new node provider
+    new_provider = _get_node_provider(
+        config["provider"],
+        DEFAULT_CLUSTER_NAME,
+        False,
+    )
+
+    head_name = config["head_node_type"]
+    for name, node_type in config["available_node_types"].items():
+        node_cfg = node_type["node_config"]
+        node_kind = NODE_KIND_HEAD if name is head_name else NODE_KIND_WORKER
+        tags = {
+            TAG_RAY_NODE_KIND: node_kind,
+            TAG_RAY_LAUNCH_CONFIG: "test-ray-launch-config",
+            TAG_RAY_USER_NODE_TYPE: name,
+        }
+        # given our bootstrapped node config as input to create a new node...
+        # expect to first describe all stopped instances that could be reused
+        stubs.describe_instances_with_any_filter_consumer(
+            ec2_client_stub_max_retries)
+        # given no stopped EC2 instances to reuse...
+        # expect to create new nodes with the given network interface config
+        stubs.run_instances_with_network_interfaces_consumer(
+            ec2_client_stub_fail_fast,
+            node_cfg["NetworkInterfaces"],
+        )
+        new_provider.create_node(node_cfg, tags, 1)
+
+    iam_client_stub.assert_no_pending_responses()
+    ec2_client_stub.assert_no_pending_responses()
+    ec2_client_stub_fail_fast.assert_no_pending_responses()
+    ec2_client_stub_max_retries.assert_no_pending_responses()
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/aws/utils/stubs.py
+++ b/python/ray/tests/aws/utils/stubs.py
@@ -108,6 +108,18 @@ def create_sg_echo(ec2_client_stub, security_group):
         service_response={"GroupId": security_group["GroupId"]})
 
 
+def describe_sgs_by_id(ec2_client_stub, security_group_ids, security_groups):
+    ec2_client_stub.add_response(
+        "describe_security_groups",
+        expected_params={
+            "Filters": [{
+                "Name": "group-id",
+                "Values": security_group_ids
+            }]
+        },
+        service_response={"SecurityGroups": security_groups})
+
+
 def describe_sgs_on_vpc(ec2_client_stub, vpc_ids, security_groups):
     ec2_client_stub.add_response(
         "describe_security_groups",
@@ -133,3 +145,26 @@ def describe_sg_echo(ec2_client_stub, security_group):
         "describe_security_groups",
         expected_params={"GroupIds": [security_group["GroupId"]]},
         service_response={"SecurityGroups": [security_group]})
+
+
+def run_instances_with_network_interfaces_consumer(ec2_client_stub,
+                                                   network_interfaces):
+    ec2_client_stub.add_response(
+        "run_instances",
+        expected_params={
+            "NetworkInterfaces": network_interfaces,
+            "ImageId": ANY,
+            "InstanceType": ANY,
+            "KeyName": ANY,
+            "MinCount": ANY,
+            "MaxCount": ANY,
+            "TagSpecifications": ANY
+        },
+        service_response={})
+
+
+def describe_instances_with_any_filter_consumer(ec2_client_stub):
+    ec2_client_stub.add_response(
+        "describe_instances",
+        expected_params={"Filters": ANY},
+        service_response={})

--- a/python/ray/tests/test_autoscaler_yaml.py
+++ b/python/ray/tests/test_autoscaler_yaml.py
@@ -197,15 +197,14 @@ class AutoscalingConfigTest(unittest.TestCase):
                 }
             }]
         }
-        boto3_mock = Mock()
         describe_instance_types_mock = Mock()
         describe_instance_types_mock.describe_instance_types = MagicMock(
             return_value=boto3_dict)
-        boto3_mock.client = MagicMock(
+        client_cache_mock = MagicMock(
             return_value=describe_instance_types_mock)
         with patch.multiple(
                 "ray.autoscaler._private.aws.node_provider",
-                boto3=boto3_mock,
+                client_cache=client_cache_mock,
         ):
             new_config = prepare_config(new_config)
             importer = _NODE_PROVIDERS.get(new_config["provider"]["type"])


### PR DESCRIPTION
## Why are these changes needed?

These changes add AWS Autoscaler support for specifying custom EC2 instance network instances for Ray cluster Head and Worker nodes. Custom network interfaces offer users improved control over the network security posture, performance, and resilience of their cluster on AWS.

These changes have primarily been vetted through manual AWS Autoscaler integration tests. No new unit or release tests have yet been added as part of this PR, but can optionally be added to this PR as a follow-up action item or included in a separate PR.

<!-- Please give a short summary of the change and the problem this solves. -->
Partial resolution of: https://github.com/ray-project/ray/issues/9334

Closes: #16815 

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests
   - [ ] This PR is not tested :(
