### PR TITLE
[tune] Avoid crash in client mode when return results creating logdir

### DIFF
--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -1,6 +1,7 @@
 from typing import Callable, Dict, Sequence, Union
 import json
 
+import ray
 import ray.cloudpickle as cloudpickle
 from collections import deque
 import copy
@@ -640,4 +641,9 @@ class Trial:
 
         self.__dict__.update(state)
         validate_trainable(self.trainable_name)
-        self.init_logdir()  # Create logdir if it does not exist
+
+        # Avoid creating logdir in client mode for returned trial results,
+        # since the dir might not be creatable locally. TODO(ekl) thsi is kind
+        # of a hack.
+        if not ray.util.client.ray.is_connected():
+            self.init_logdir()  # Create logdir if it does not exist


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If the local client doesn't have permissions to create the logdir (e.g., /home/ray which doesn't exist), it crashes.