### PR TITLE
[tune] fix pb2 normalization error

### DIFF
--- a/python/ray/tune/schedulers/pb2_utils.py
+++ b/python/ray/tune/schedulers/pb2_utils.py
@@ -75,7 +75,7 @@ def normalize(data, wrt):
         which can be specified.
     """
     return (data - np.min(wrt, axis=0)) / (
-        np.max(wrt, axis=0) - np.min(wrt, axis=0))
+        np.max(wrt, axis=0) - np.min(wrt, axis=0) + 1e-8)
 
 
 def standardize(data):


### PR DESCRIPTION
## Why are these changes needed?

The normalize function doesn't contain a constant in case the max-min = 0, so can have NaNs. @richardliaw 

## Related issue number

Closes #14069

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
