### PR TITLE
[docs][autoscaler] Update AWS node config link

### DIFF
--- a/doc/source/cluster/config.rst
+++ b/doc/source/cluster/config.rst
@@ -163,7 +163,7 @@ Node config
 .. tabs::
     .. group-tab:: AWS
 
-        A YAML object as defined in `the AWS docs <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html>`_.
+        A YAML object which conforms to the EC2 ``create_instances`` API in `the AWS docs <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances>`_.
 
     .. group-tab:: Azure
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current docs link to the AWS CloudFormation docs for the EC2 Instance spec. While this looks nicer than the boto docs, unfortunately they are different. The Cloud Formation docs describe an ec2 instance, but not how to _create_ one. 

For example, pick a random field like `CapacityReservationSpecification` or `InstanceMarketOptions`, and you will find that they are not cloud formation fields (but InstanceMarketOptions is important for create_instances since it's how we specify spot instances). 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
