### PR TITLE
Fix `assert get_outer_ref None` failed + Support better traceback.

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -332,6 +332,17 @@ cdef prepare_args(
                         CCoreWorkerProcess.GetCoreWorker().GetRpcAddress())))
 
 
+cdef raise_if_dependency_failed(arg):
+    """This method is used to improve the readability of backtrace.
+
+    With this method, the backtrace will always contain
+    raise_if_dependency_failed when the task is failed with dependency
+    failures.
+    """
+    if isinstance(arg, RayError):
+        raise arg
+
+
 cdef execute_task(
         CTaskType task_type,
         const c_string name,
@@ -460,8 +471,7 @@ cdef execute_task(
                             metadata_pairs, object_refs)
 
                     for arg in args:
-                        if isinstance(arg, RayError):
-                            raise arg
+                        raise_if_dependency_failed(arg)
                     args, kwargs = ray.signature.recover_args(args)
 
             if (<int>task_type == <int>TASK_TYPE_ACTOR_CREATION_TASK):

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -164,11 +164,15 @@ class RaySystemError(RayError):
     This exception can be thrown when the raylet is killed.
     """
 
-    def __init__(self, client_exc):
+    def __init__(self, client_exc, traceback_str=None):
         self.client_exc = client_exc
+        self.traceback_str = traceback_str
 
     def __str__(self):
-        return f"System error: {self.client_exc}"
+        error_msg = f"System error: {self.client_exc}"
+        if self.traceback_str:
+            error_msg += f"\ntraceback: {self.traceback_str}"
+        return error_msg
 
 
 class ObjectStoreFullError(RayError):

--- a/python/ray/serialization.py
+++ b/python/ray/serialization.py
@@ -7,15 +7,8 @@ from ray import ray_constants
 import ray.utils
 from ray.gcs_utils import ErrorType
 from ray.exceptions import (
-    RayError,
-    PlasmaObjectNotAvailable,
-    RayTaskError,
-    RayActorError,
-    TaskCancelledError,
-    WorkerCrashedError,
-    ObjectLostError,
-    RaySystemError
-)
+    RayError, PlasmaObjectNotAvailable, RayTaskError, RayActorError,
+    TaskCancelledError, WorkerCrashedError, ObjectLostError, RaySystemError)
 from ray._raylet import (
     split_buffer,
     unpack_pickle5_buffers,

--- a/python/ray/serialization.py
+++ b/python/ray/serialization.py
@@ -243,7 +243,6 @@ class SerializationContext:
             except Exception as e:
                 logger.exception(e)
                 obj = RaySystemError(e, traceback.format_exc())
-            assert obj is not None
             results.append(obj)
             # Must clear ObjectRef to not hold a reference.
             self.set_outer_object_ref(None)

--- a/python/ray/serialization.py
+++ b/python/ray/serialization.py
@@ -1,5 +1,6 @@
 import logging
 import threading
+import traceback
 
 import ray.cloudpickle as pickle
 from ray import ray_constants
@@ -13,6 +14,7 @@ from ray.exceptions import (
     TaskCancelledError,
     WorkerCrashedError,
     ObjectLostError,
+    RaySystemError
 )
 from ray._raylet import (
     split_buffer,
@@ -242,8 +244,14 @@ class SerializationContext:
                                                 data_metadata_pairs):
             assert self.get_outer_object_ref() is None
             self.set_outer_object_ref(object_ref)
-            results.append(
-                self._deserialize_object(data, metadata, object_ref))
+            obj = None
+            try:
+                obj = self._deserialize_object(data, metadata, object_ref)
+            except Exception as e:
+                logger.exception(e)
+                obj = RaySystemError(e, traceback.format_exc())
+            assert obj is not None
+            results.append(obj)
             # Must clear ObjectRef to not hold a reference.
             self.set_outer_object_ref(None)
         return results

--- a/python/ray/util/dask/scheduler.py
+++ b/python/ray/util/dask/scheduler.py
@@ -342,18 +342,8 @@ def dask_task_wrapper(func, repack, key, ray_pretask_cbs, ray_posttask_cbs,
     # Recursively execute Dask-inlined tasks.
     actual_args = [_execute_task(a, repacked_deps) for a in repacked_args]
     # Execute the actual underlying Dask task.
-    try:
-        result = func(*actual_args)
-    except Exception as e:
-        print("\n")
-        print(f"type: {type(func)}")
-        print(f"args: {actual_args}")
-        print(f"func: {func}")
-        print(repacked_args)
-        print(repacked_deps)
-        logger.exception(e)
-        print('\n')
-        raise e
+    result = func(*actual_args)
+
     if ray_posttask_cbs is not None:
         for cb, pre_state in zip(ray_posttask_cbs, pre_states):
             if cb is not None:

--- a/python/ray/util/dask/scheduler.py
+++ b/python/ray/util/dask/scheduler.py
@@ -1,9 +1,8 @@
 import atexit
-from collections import defaultdict
-from multiprocessing.pool import ThreadPool
-from dataclasses import dataclass
 import threading
-import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from multiprocessing.pool import ThreadPool
 
 import ray
 
@@ -19,8 +18,6 @@ main_thread = threading.current_thread()
 default_pool = None
 pools = defaultdict(dict)
 pools_lock = threading.Lock()
-
-logger = logging.getLogger(__name__)
 
 
 def ray_dask_get(dsk, keys, **kwargs):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR is doing 2 things

Previously, if the `pickle.loads` called during deserialization failed, it failed silently (I assume the exception was caught somewhere and silently swallowed). After that since the next line which unset the outer ref wasn't called, in the subsequent call, it raised an exception. This also returns the system error object if the exception is generated from that code.

This also has a small refactoring to improve the readability of chained exception tasks. For example, suppose this scenario;
```python3
import ray

ray.init()

@ray.remote
def task(dep1, dep2):
    return 3

@ray.remote
def dep1():
    raise ValueError("haha")

@ray.remote
def dep2():
    raise TypeError("hoho")

print(ray.get(task.remote(dep1.remote(), dep2.remote())))
```

this previously printed 
```
Traceback (most recent call last):
  File "exc.py", line 17, in <module>
    print(ray.get(task.remote(dep1.remote(), dep2.remote())))
  File "/Users/sangbincho/work/ray/python/ray/_private/client_mode_hook.py", line 47, in wrapper
    return func(*args, **kwargs)
  File "/Users/sangbincho/work/ray/python/ray/worker.py", line 1458, in get
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(ValueError): ray::task() (pid=93203, ip=192.168.1.3)
  File "python/ray/_raylet.pyx", line 447, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 468, in ray._raylet.execute_task
ray.exceptions.RayTaskError: ray::dep1() (pid=93203, ip=192.168.1.3)
  File "python/ray/_raylet.pyx", line 490, in ray._raylet.execute_task
  File "exc.py", line 11, in dep1
    raise ValueError("haha")
ValueError: haha
```
which is very confusing because we don't know what the line 468 is doing. But after this PR, it will be 

```
Traceback (most recent call last):
  File "exc.py", line 17, in <module>
    print(ray.get(task.remote(dep1.remote(), dep2.remote())))
  File "/Users/sangbincho/work/ray/python/ray/_private/client_mode_hook.py", line 47, in wrapper
    return func(*args, **kwargs)
  File "/Users/sangbincho/work/ray/python/ray/worker.py", line 1458, in get
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(ValueError): ray::task() (pid=93203, ip=192.168.1.3)
  File "python/ray/_raylet.pyx", line 447, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 468, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 337, in ray._raylet.raise_if_dependency_failed
ray.exceptions.RayTaskError: ray::dep1() (pid=93203, ip=192.168.1.3)
  File "python/ray/_raylet.pyx", line 490, in ray._raylet.execute_task
  File "exc.py", line 11, in dep1
    raise ValueError("haha")
ValueError: haha
```
so that it is easier to understand the exception was caused by the dependency failure.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
