### PR TITLE
[Tune] Disable dcgan tests

### DIFF
--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -596,23 +596,27 @@ py_test(
     args = ["--smoke-test"]
 )
 
-py_test(
-    name = "pbt_dcgan_mnist_func",
-    size = "medium",
-    srcs = ["examples/pbt_dcgan_mnist/pbt_dcgan_mnist_func.py"],
-    deps = [":tune_lib"],
-    tags = ["exclusive", "example"],
-    args = ["--smoke-test"]
-)
+# Flaky after https://github.com/ray-project/ray/pull/14049.  
+# Might need to set RAY_IGNORE_UNHANDLED_ERRORS.
+# py_test(
+#     name = "pbt_dcgan_mnist_func",
+#     size = "medium",
+#     srcs = ["examples/pbt_dcgan_mnist/pbt_dcgan_mnist_func.py"],
+#     deps = [":tune_lib"],
+#     tags = ["exclusive", "example"],
+#     args = ["--smoke-test"]
+# )
 
-py_test(
-    name = "pbt_dcgan_mnist_trainable",
-    size = "medium",
-    srcs = ["examples/pbt_dcgan_mnist/pbt_dcgan_mnist_trainable.py"],
-    deps = [":tune_lib"],
-    tags = ["exclusive", "example"],
-    args = ["--smoke-test"]
-)
+# Flaky after https://github.com/ray-project/ray/pull/14049.  
+# Might need to set RAY_IGNORE_UNHANDLED_ERRORS.
+# py_test(
+#     name = "pbt_dcgan_mnist_trainable",
+#     size = "medium",
+#     srcs = ["examples/pbt_dcgan_mnist/pbt_dcgan_mnist_trainable.py"],
+#     deps = [":tune_lib"],
+#     tags = ["exclusive", "example"],
+#     args = ["--smoke-test"]
+# )
 
 py_test(
     name = "pbt_example",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
These tests are flaky after https://github.com/ray-project/ray/pull/14049.   One possible explanation is that errors that were being suppressed before are now raised.  The solution might be to set RAY_IGNORE_UNHANDLED_ERRORS as described in that PR.

```
2021-02-16 14:43:05,795	ERROR worker.py:74 -- Unhandled error (suppress with RAY_IGNORE_UNHANDLED_ERRORS=1): The actor died unexpectedly before finishing this task. Check python-core-worker-*.log files for more information.
1013-- Test timed out at 2021-02-16 14:47:12 UTC --
```


<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
