### PR TITLE
[docs] Remove sphinx-gallery example runtimes

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -169,10 +169,10 @@ sphinx_gallery_conf = {
     "gallery_dirs": ["auto_examples", "tune/tutorials"],
     "ignore_pattern": "../examples/doc_code/",
     "plot_gallery": "False",
+    "min_reported_time": sys.maxsize,
     # "filename_pattern": "tutorial.py",
     # "backreferences_dir": "False",
     # "show_memory': False,
-    # 'min_reported_time': False
 }
 
 for i in range(len(sphinx_gallery_conf["examples_dirs"])):


### PR DESCRIPTION
## Why are these changes needed?

## Related issue number

closes https://github.com/ray-project/ray/issues/14130

see https://github.com/sphinx-gallery/sphinx-gallery/blob/e7f65d9b213439b725453f5ce4032ff297166c69/doc/conf.py#L340

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
