### PR TITLE
Fix numpy ufunc serialization failures

### DIFF
--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -8,6 +8,7 @@ import sys
 import weakref
 
 import numpy as np
+from numpy import log
 import pytest
 
 import ray
@@ -622,6 +623,15 @@ def test_custom_serializer(ray_start_shared_local_modes):
 
     # deregister again takes no effects
     ray.util.deregister_serializer(A)
+
+
+def test_numpy_ufunc(ray_start_shared_local_modes):
+    @ray.remote
+    def f():
+        # add reference to the numpy ufunc
+        log
+
+    ray.get(f.remote())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Serializing numpy ufuncs would fail in some cases (example in the unit test). This is fixed in the numpy upstream: https://github.com/numpy/numpy/pull/17289. However, the upstream only includes the patch for numpy >= 1.20.0, which only supports python3.7+. This PR integrates the fix in cloudpickle so we can get rid of this issue for most users.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
