### PR TITLE
[docs] Fix broken link in README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ Tune Quick Start
 
 - Launch a multi-node distributed hyperparameter sweep in less than 10 lines of code.
 - Supports any deep learning framework, including PyTorch, `PyTorch Lightning <https://github.com/williamFalcon/pytorch-lightning>`_, TensorFlow, and Keras.
-- Visualize results with `TensorBoard <https://www.tensorflow.org/get_started/summaries_and_tensorboard>`__.
+- Visualize results with `TensorBoard <https://www.tensorflow.org/tensorboard>`__.
 - Choose among scalable SOTA algorithms such as `Population Based Training (PBT)`_, `Vizier's Median Stopping Rule`_, `HyperBand/ASHA`_.
 - Tune integrates with many optimization libraries such as `Facebook Ax <http://ax.dev>`_, `HyperOpt <https://github.com/hyperopt/hyperopt>`_, and `Bayesian Optimization <https://github.com/fmfn/BayesianOptimization>`_ and enables you to scale them transparently.
 


### PR DESCRIPTION
Minor bugfix, the link to TensorBoard was broken.