### PR TITLE
[core] Fix bugs in admission control

### DIFF
--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -641,7 +641,6 @@ class GlobalState:
                     object_ref, remote_node_id, _, _ = event["extra_data"]
 
                 elif event["event_type"] == "transfer_receive":
-                    print(event["extra_data"])
                     object_ref, remote_node_id, _ = event["extra_data"]
 
                 elif event["event_type"] == "receive_pull_request":

--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -641,7 +641,8 @@ class GlobalState:
                     object_ref, remote_node_id, _, _ = event["extra_data"]
 
                 elif event["event_type"] == "transfer_receive":
-                    object_ref, remote_node_id, _, _ = event["extra_data"]
+                    print(event["extra_data"])
+                    object_ref, remote_node_id, _ = event["extra_data"]
 
                 elif event["event_type"] == "receive_pull_request":
                     object_ref, remote_node_id = event["extra_data"]

--- a/python/ray/tests/test_advanced_3.py
+++ b/python/ray/tests/test_advanced_3.py
@@ -134,10 +134,12 @@ def test_load_balancing_under_constrained_memory(ray_start_cluster):
     for _ in range(num_nodes):
         cluster.add_node(
             num_cpus=num_cpus,
+            memory=(num_cpus - 2) * object_size,
             object_store_memory=(num_cpus - 2) * object_size)
     cluster.add_node(
         num_cpus=0,
         resources={"custom": 1},
+        memory=(num_tasks + 1) * object_size,
         object_store_memory=(num_tasks + 1) * object_size)
     ray.init(address=cluster.address)
 

--- a/python/ray/tests/test_advanced_3.py
+++ b/python/ray/tests/test_advanced_3.py
@@ -146,13 +146,17 @@ def test_load_balancing_under_constrained_memory(ray_start_cluster):
         return np.zeros(int(object_size), dtype=np.uint8)
 
     @ray.remote
-    def f(x):
+    def f(i, x):
         time.sleep(0.1)
+        print(i, ray.worker.global_worker.node.unique_id)
         return ray.worker.global_worker.node.unique_id
 
     # TODO(swang): Actually test load balancing.
     deps = [create_object.remote() for _ in range(num_tasks)]
-    ray.get([f.remote(dep) for dep in deps])
+    tasks = [f.remote(i, dep) for i, dep in enumerate(deps)]
+    for i, dep in enumerate(deps):
+        print(i, dep)
+    ray.get(tasks)
 
 
 def test_locality_aware_leasing(ray_start_cluster):

--- a/python/ray/tests/test_advanced_3.py
+++ b/python/ray/tests/test_advanced_3.py
@@ -145,10 +145,11 @@ def test_load_balancing_with_memory_constraints(ray_start_cluster):
     @ray.remote
     class Signal:
         def __init__(self):
-            pass
+            self.count = 0
 
         def ping(self, node):
-            print(node)
+            self.count += 1
+            print(node, count)
 
     signal = Signal.remote()
 

--- a/python/ray/tests/test_advanced_3.py
+++ b/python/ray/tests/test_advanced_3.py
@@ -132,10 +132,13 @@ def test_load_balancing_under_constrained_memory(ray_start_cluster):
     object_size = 4e7
     num_tasks = 100
     for _ in range(num_nodes):
-        cluster.add_node(num_cpus=num_cpus,
-                object_store_memory=(num_cpus - 2) * object_size)
-    cluster.add_node(num_cpus=0, resources={"custom": 1},
-            object_store_memory=(num_tasks + 1) * object_size)
+        cluster.add_node(
+            num_cpus=num_cpus,
+            object_store_memory=(num_cpus - 2) * object_size)
+    cluster.add_node(
+        num_cpus=0,
+        resources={"custom": 1},
+        object_store_memory=(num_tasks + 1) * object_size)
     ray.init(address=cluster.address)
 
     @ray.remote(num_cpus=0, resources={"custom": 1})

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -19,7 +19,8 @@
 
 namespace ray {
 
-ObjectBufferPool::ObjectBufferPool(std::shared_ptr<PullManager> pull_manager, const std::string &store_socket_name,
+ObjectBufferPool::ObjectBufferPool(std::shared_ptr<PullManager> pull_manager,
+                                   const std::string &store_socket_name,
                                    uint64_t chunk_size)
     : default_chunk_size_(chunk_size), pull_manager_(pull_manager) {
   store_socket_name_ = store_socket_name;
@@ -106,7 +107,9 @@ std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> ObjectBufferPool::Cr
   std::lock_guard<std::mutex> lock(pool_mutex_);
   if (!pull_manager_->IsObjectActive(object_id)) {
     // This object is no longer being actively pulled. Do not create the object.
-    return {errored_chunk_, ray::Status::IOError("Object is no longer being actively pulled due to cancellation or OOM")};
+    return {errored_chunk_,
+            ray::Status::IOError(
+                "Object is no longer being actively pulled due to cancellation or OOM")};
   }
   if (create_buffer_state_.count(object_id) == 0) {
     int64_t object_size = data_size - metadata_size;

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -164,23 +164,32 @@ void ObjectBufferPool::AbortCreateChunk(const ObjectID &object_id,
 
 void ObjectBufferPool::SealChunk(const ObjectID &object_id, const uint64_t chunk_index) {
   std::lock_guard<std::mutex> lock(pool_mutex_);
-  RAY_CHECK(create_buffer_state_[object_id].chunk_state[chunk_index] ==
-            CreateChunkState::REFERENCED);
-  create_buffer_state_[object_id].chunk_state[chunk_index] = CreateChunkState::SEALED;
-  create_buffer_state_[object_id].num_seals_remaining--;
-  if (create_buffer_state_[object_id].num_seals_remaining == 0) {
+  auto it = create_buffer_state_.find(object_id);
+  if (it == create_buffer_state_.end() || it->second.chunk_state[chunk_index] !=
+            CreateChunkState::REFERENCED) {
+    RAY_LOG(DEBUG) << "Object " << object_id << " aborted due to OOM before chunk " << chunk_index << " could be sealed";
+    return;
+  }
+  it->second.chunk_state[chunk_index] = CreateChunkState::SEALED;
+  it->second.num_seals_remaining--;
+  if (it->second.num_seals_remaining == 0) {
     RAY_CHECK_OK(store_client_.Seal(object_id));
     RAY_CHECK_OK(store_client_.Release(object_id));
-    create_buffer_state_.erase(object_id);
+    create_buffer_state_.erase(it);
     RAY_LOG(DEBUG) << "Have received all chunks for object " << object_id
                    << ", last chunk index: " << chunk_index;
   }
 }
 
 void ObjectBufferPool::AbortCreate(const ObjectID &object_id) {
-  RAY_CHECK_OK(store_client_.Release(object_id));
-  RAY_CHECK_OK(store_client_.Abort(object_id));
-  create_buffer_state_.erase(object_id);
+  std::lock_guard<std::mutex> lock(pool_mutex_);
+  auto it = create_buffer_state_.find(object_id);
+  if (it != create_buffer_state_.end()) {
+    RAY_LOG(INFO) << "Not enough memory to create requested object " << object_id << ", aborting";
+    RAY_CHECK_OK(store_client_.Release(object_id));
+    RAY_CHECK_OK(store_client_.Abort(object_id));
+    create_buffer_state_.erase(object_id);
+  }
 }
 
 std::vector<ObjectBufferPool::ChunkInfo> ObjectBufferPool::BuildChunks(

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -19,10 +19,9 @@
 
 namespace ray {
 
-ObjectBufferPool::ObjectBufferPool(std::shared_ptr<PullManager> pull_manager,
-                                   const std::string &store_socket_name,
+ObjectBufferPool::ObjectBufferPool(const std::string &store_socket_name,
                                    uint64_t chunk_size)
-    : default_chunk_size_(chunk_size), pull_manager_(pull_manager) {
+    : default_chunk_size_(chunk_size) {
   store_socket_name_ = store_socket_name;
   RAY_CHECK_OK(store_client_.Connect(store_socket_name_.c_str(), "", 0, 300));
 }
@@ -105,12 +104,6 @@ std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> ObjectBufferPool::Cr
     const ObjectID &object_id, const rpc::Address &owner_address, uint64_t data_size,
     uint64_t metadata_size, uint64_t chunk_index) {
   std::lock_guard<std::mutex> lock(pool_mutex_);
-  if (!pull_manager_->IsObjectActive(object_id)) {
-    // This object is no longer being actively pulled. Do not create the object.
-    return {errored_chunk_,
-            ray::Status::IOError(
-                "Object is no longer being actively pulled due to cancellation or OOM")};
-  }
   if (create_buffer_state_.count(object_id) == 0) {
     int64_t object_size = data_size - metadata_size;
     // Try to create shared buffer.
@@ -141,7 +134,7 @@ std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> ObjectBufferPool::Cr
     // There can be only one reference to this chunk at any given time.
     return std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status>(
         errored_chunk_,
-        ray::Status::IOError("Chunk already referenced by another thread."));
+        ray::Status::IOError("Chunk already received by a different thread."));
   }
   create_buffer_state_[object_id].chunk_state[chunk_index] = CreateChunkState::REFERENCED;
   return std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status>(

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -165,9 +165,10 @@ void ObjectBufferPool::AbortCreateChunk(const ObjectID &object_id,
 void ObjectBufferPool::SealChunk(const ObjectID &object_id, const uint64_t chunk_index) {
   std::lock_guard<std::mutex> lock(pool_mutex_);
   auto it = create_buffer_state_.find(object_id);
-  if (it == create_buffer_state_.end() || it->second.chunk_state[chunk_index] !=
-            CreateChunkState::REFERENCED) {
-    RAY_LOG(DEBUG) << "Object " << object_id << " aborted due to OOM before chunk " << chunk_index << " could be sealed";
+  if (it == create_buffer_state_.end() ||
+      it->second.chunk_state[chunk_index] != CreateChunkState::REFERENCED) {
+    RAY_LOG(DEBUG) << "Object " << object_id << " aborted due to OOM before chunk "
+                   << chunk_index << " could be sealed";
     return;
   }
   it->second.chunk_state[chunk_index] = CreateChunkState::SEALED;
@@ -185,7 +186,8 @@ void ObjectBufferPool::AbortCreate(const ObjectID &object_id) {
   std::lock_guard<std::mutex> lock(pool_mutex_);
   auto it = create_buffer_state_.find(object_id);
   if (it != create_buffer_state_.end()) {
-    RAY_LOG(INFO) << "Not enough memory to create requested object " << object_id << ", aborting";
+    RAY_LOG(INFO) << "Not enough memory to create requested object " << object_id
+                  << ", aborting";
     RAY_CHECK_OK(store_client_.Release(object_id));
     RAY_CHECK_OK(store_client_.Abort(object_id));
     create_buffer_state_.erase(object_id);

--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -25,7 +25,6 @@
 #include "ray/common/id.h"
 #include "ray/common/status.h"
 #include "ray/object_manager/plasma/client.h"
-#include "ray/object_manager/pull_manager.h"
 
 namespace ray {
 
@@ -51,8 +50,7 @@ class ObjectBufferPool {
   /// \param store_socket_name The socket name of the store to which plasma clients
   /// connect.
   /// \param chunk_size The chunk size into which objects are to be split.
-  ObjectBufferPool(std::shared_ptr<PullManager> pull_manager,
-                   const std::string &store_socket_name, const uint64_t chunk_size);
+  ObjectBufferPool(const std::string &store_socket_name, const uint64_t chunk_size);
 
   ~ObjectBufferPool();
 
@@ -207,9 +205,6 @@ class ObjectBufferPool {
   plasma::PlasmaClient store_client_;
   /// Socket name of plasma store.
   std::string store_socket_name_;
-  /// Pull manager. Used to check whether we should create
-  /// objects.
-  std::shared_ptr<PullManager> pull_manager_;
 };
 
 }  // namespace ray

--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -147,7 +147,6 @@ class ObjectBufferPool {
   std::string DebugString() const;
 
  private:
-
   /// Abort the get operation associated with an object.
   void AbortGet(const ObjectID &object_id);
 

--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -25,6 +25,7 @@
 #include "ray/common/id.h"
 #include "ray/common/status.h"
 #include "ray/object_manager/plasma/client.h"
+#include "ray/object_manager/pull_manager.h"
 
 namespace ray {
 
@@ -50,7 +51,7 @@ class ObjectBufferPool {
   /// \param store_socket_name The socket name of the store to which plasma clients
   /// connect.
   /// \param chunk_size The chunk size into which objects are to be split.
-  ObjectBufferPool(const std::string &store_socket_name, const uint64_t chunk_size);
+  ObjectBufferPool(std::shared_ptr<PullManager> pull_manager, const std::string &store_socket_name, const uint64_t chunk_size);
 
   ~ObjectBufferPool();
 
@@ -205,6 +206,9 @@ class ObjectBufferPool {
   plasma::PlasmaClient store_client_;
   /// Socket name of plasma store.
   std::string store_socket_name_;
+  /// Pull manager. Used to check whether we should create
+  /// objects.
+  std::shared_ptr<PullManager> pull_manager_;
 };
 
 }  // namespace ray

--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -137,15 +137,16 @@ class ObjectBufferPool {
   /// \return Void.
   void FreeObjects(const std::vector<ObjectID> &object_ids);
 
+  /// Abort the create operation associated with an object. This destroys the buffer
+  /// state, including create operations in progress for all chunks of the object.
+  void AbortCreate(const ObjectID &object_id);
+
   /// Returns debug string for class.
   ///
   /// \return string.
   std::string DebugString() const;
 
  private:
-  /// Abort the create operation associated with an object. This destroys the buffer
-  /// state, including create operations in progress for all chunks of the object.
-  void AbortCreate(const ObjectID &object_id);
 
   /// Abort the get operation associated with an object.
   void AbortGet(const ObjectID &object_id);

--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -51,7 +51,8 @@ class ObjectBufferPool {
   /// \param store_socket_name The socket name of the store to which plasma clients
   /// connect.
   /// \param chunk_size The chunk size into which objects are to be split.
-  ObjectBufferPool(std::shared_ptr<PullManager> pull_manager, const std::string &store_socket_name, const uint64_t chunk_size);
+  ObjectBufferPool(std::shared_ptr<PullManager> pull_manager,
+                   const std::string &store_socket_name, const uint64_t chunk_size);
 
   ~ObjectBufferPool();
 

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -324,7 +324,7 @@ void ObjectManager::HandleReceiveFinished(const ObjectID &object_id,
   // Encode the object ID, node ID, chunk index as a json list,
   // which will be parsed by the reader of the profile table.
   profile_event.set_extra_data("[\"" + object_id.Hex() + "\",\"" + node_id.Hex() + "\"," +
-                               std::to_string(chunk_index) + "\"]");
+                               std::to_string(chunk_index) + "]");
 
   std::lock_guard<std::mutex> lock(profile_mutex_);
   profile_events_.push_back(profile_event);

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -677,7 +677,10 @@ ray::Status ObjectManager::ReceiveObjectChunk(const NodeID &node_id,
                                               uint64_t data_size, uint64_t metadata_size,
                                               uint64_t chunk_index,
                                               const std::string &data) {
-  // TODO: Skip objects that are not being actively pulled.
+  if (!pull_manager_->IsObjectActive(object_id)) {
+    // This object is no longer being actively pulled. Do not create the object.
+    return ray::Status::OK();
+  }
   RAY_LOG(DEBUG) << "ReceiveObjectChunk on " << self_node_id_ << " from " << node_id
                  << " of object " << object_id << " chunk index: " << chunk_index
                  << ", chunk data size: " << data.size()

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -116,7 +116,8 @@ ObjectManager::ObjectManager(asio::io_service &main_service, const NodeID &self_
 
         static_cast<void>(spill_objects_callback());
       }));
-  buffer_pool_.reset(new ObjectBufferPool(pull_manager_, config_.store_socket_name, config_.object_chunk_size));
+  buffer_pool_.reset(new ObjectBufferPool(pull_manager_, config_.store_socket_name,
+                                          config_.object_chunk_size));
 
   store_notification_->SubscribeObjAdded(
       [this](const object_manager::protocol::ObjectInfoT &object_info) {
@@ -685,7 +686,7 @@ ray::Status ObjectManager::ReceiveObjectChunk(const NodeID &node_id,
 
   std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> chunk_status =
       buffer_pool_->CreateChunk(object_id, owner_address, data_size, metadata_size,
-                               chunk_index);
+                                chunk_index);
   ray::Status status;
   ObjectBufferPool::ChunkInfo chunk_info = chunk_status.first;
   num_chunks_received_total_++;

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -105,8 +105,8 @@ ObjectManager::ObjectManager(asio::io_service &main_service, const NodeID &self_
     available_memory = 0;
   }
   pull_manager_.reset(new PullManager(
-      self_node_id_, object_is_local, send_pull_request, cancel_pull_request, restore_spilled_object_,
-      get_time, config.pull_timeout_ms, available_memory,
+      self_node_id_, object_is_local, send_pull_request, cancel_pull_request,
+      restore_spilled_object_, get_time, config.pull_timeout_ms, available_memory,
       [spill_objects_callback, object_store_full_callback]() {
         // TODO(swang): This copies the out-of-memory handling in the
         // CreateRequestQueue. It would be nice to unify these.

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -324,8 +324,7 @@ void ObjectManager::HandleReceiveFinished(const ObjectID &object_id,
   // Encode the object ID, node ID, chunk index as a json list,
   // which will be parsed by the reader of the profile table.
   profile_event.set_extra_data("[\"" + object_id.Hex() + "\",\"" + node_id.Hex() + "\"," +
-                               std::to_string(chunk_index) +
-                               "\"]");
+                               std::to_string(chunk_index) + "\"]");
 
   std::lock_guard<std::mutex> lock(profile_mutex_);
   profile_events_.push_back(profile_event);
@@ -659,12 +658,13 @@ void ObjectManager::HandlePush(const rpc::PushRequest &request, rpc::PushReply *
 
   double start_time = absl::GetCurrentTimeNanos() / 1e9;
   bool success = ReceiveObjectChunk(node_id, object_id, owner_address, data_size,
-                                   metadata_size, chunk_index, data);
+                                    metadata_size, chunk_index, data);
   if (!success) {
     num_chunks_received_failed_++;
-    RAY_LOG(INFO) << "Received duplicate or cancelled chunk at index " << chunk_index << " of object "
-                  << object_id << ": overall " << num_chunks_received_failed_ << "/"
-                  << num_chunks_received_total_ << " failed";
+    RAY_LOG(INFO) << "Received duplicate or cancelled chunk at index " << chunk_index
+                  << " of object " << object_id << ": overall "
+                  << num_chunks_received_failed_ << "/" << num_chunks_received_total_
+                  << " failed";
   }
   double end_time = absl::GetCurrentTimeNanos() / 1e9;
 
@@ -672,12 +672,10 @@ void ObjectManager::HandlePush(const rpc::PushRequest &request, rpc::PushReply *
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }
 
-bool ObjectManager::ReceiveObjectChunk(const NodeID &node_id,
-                                              const ObjectID &object_id,
-                                              const rpc::Address &owner_address,
-                                              uint64_t data_size, uint64_t metadata_size,
-                                              uint64_t chunk_index,
-                                              const std::string &data) {
+bool ObjectManager::ReceiveObjectChunk(const NodeID &node_id, const ObjectID &object_id,
+                                       const rpc::Address &owner_address,
+                                       uint64_t data_size, uint64_t metadata_size,
+                                       uint64_t chunk_index, const std::string &data) {
   num_chunks_received_total_++;
   RAY_LOG(DEBUG) << "ReceiveObjectChunk on " << self_node_id_ << " from " << node_id
                  << " of object " << object_id << " chunk index: " << chunk_index
@@ -690,7 +688,7 @@ bool ObjectManager::ReceiveObjectChunk(const NodeID &node_id,
   }
   std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> chunk_status =
       buffer_pool_.CreateChunk(object_id, owner_address, data_size, metadata_size,
-                                chunk_index);
+                               chunk_index);
   if (!pull_manager_->IsObjectActive(object_id)) {
     // This object is no longer being actively pulled. Abort the object. We
     // have to check again here because the pull manager runs in a different

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -414,7 +414,7 @@ class ObjectManager : public ObjectManagerInterface,
   // Process notifications from Plasma. We make it a shared pointer because
   // we will decide its type at runtime, and we would pass it to Plasma Store.
   std::shared_ptr<ObjectStoreNotificationManager> store_notification_;
-  ObjectBufferPool buffer_pool_;
+  std::unique_ptr<ObjectBufferPool> buffer_pool_;
 
   /// Multi-thread asio service, deal with all outgoing and incoming RPC request.
   boost::asio::io_service rpc_service_;
@@ -474,7 +474,7 @@ class ObjectManager : public ObjectManagerInterface,
   std::unique_ptr<PushManager> push_manager_;
 
   /// Object pull manager.
-  std::unique_ptr<PullManager> pull_manager_;
+  std::shared_ptr<PullManager> pull_manager_;
 
   /// Running sum of the amount of memory used in the object store.
   int64_t used_memory_ = 0;

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -180,9 +180,9 @@ class ObjectManager : public ObjectManagerInterface,
   /// store. This can fail if the chunk was already received in the past, or if
   /// the object is no longer being actively pulled.
   bool ReceiveObjectChunk(const NodeID &node_id, const ObjectID &object_id,
-                                 const rpc::Address &owner_address, uint64_t data_size,
-                                 uint64_t metadata_size, uint64_t chunk_index,
-                                 const std::string &data);
+                          const rpc::Address &owner_address, uint64_t data_size,
+                          uint64_t metadata_size, uint64_t chunk_index,
+                          const std::string &data);
 
   /// Send pull request
   ///
@@ -406,7 +406,8 @@ class ObjectManager : public ObjectManagerInterface,
   /// chunk.
   /// \return Void.
   void HandleReceiveFinished(const ObjectID &object_id, const NodeID &node_id,
-                             uint64_t chunk_index, double start_time_us, double end_time_us);
+                             uint64_t chunk_index, double start_time_us,
+                             double end_time_us);
 
   /// Handle Push task timeout.
   void HandlePushTaskTimeout(const ObjectID &object_id, const NodeID &node_id);

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -159,7 +159,15 @@ class ObjectManager : public ObjectManagerInterface,
                        std::shared_ptr<rpc::ObjectManagerClient> rpc_client,
                        std::function<void(const Status &)> on_complete);
 
-  /// Receive object chunk from remote object manager, small object may contain one chunk
+  /// Receive an object chunk from a remote object manager. Small object may
+  /// fit in one chunk.
+  ///
+  /// If this is the last remaining chunk for an object, then the object will
+  /// be sealed. Else, we will keep the plasma buffer open until the remaining
+  /// chunks are received.
+  ///
+  /// If the object is no longer being actively pulled, the object will not be
+  /// created.
   ///
   /// \param node_id Node id of remote object manager which sends this chunk
   /// \param object_id Object id
@@ -168,7 +176,10 @@ class ObjectManager : public ObjectManagerInterface,
   /// \param metadata_size Metadata size
   /// \param chunk_index Chunk index
   /// \param data Chunk data
-  ray::Status ReceiveObjectChunk(const NodeID &node_id, const ObjectID &object_id,
+  /// \return Whether the chunk was successfully written into the local object
+  /// store. This can fail if the chunk was already received in the past, or if
+  /// the object is no longer being actively pulled.
+  bool ReceiveObjectChunk(const NodeID &node_id, const ObjectID &object_id,
                                  const rpc::Address &owner_address, uint64_t data_size,
                                  uint64_t metadata_size, uint64_t chunk_index,
                                  const std::string &data);
@@ -393,11 +404,9 @@ class ObjectManager : public ObjectManagerInterface,
   /// chunk.
   /// \param end_time_us The time when the object manager finished receiving the
   /// chunk.
-  /// \param status The status of the receive (e.g., did it succeed or fail).
   /// \return Void.
   void HandleReceiveFinished(const ObjectID &object_id, const NodeID &node_id,
-                             uint64_t chunk_index, double start_time_us,
-                             double end_time_us, ray::Status status);
+                             uint64_t chunk_index, double start_time_us, double end_time_us);
 
   /// Handle Push task timeout.
   void HandlePushTaskTimeout(const ObjectID &object_id, const NodeID &node_id);
@@ -414,7 +423,7 @@ class ObjectManager : public ObjectManagerInterface,
   // Process notifications from Plasma. We make it a shared pointer because
   // we will decide its type at runtime, and we would pass it to Plasma Store.
   std::shared_ptr<ObjectStoreNotificationManager> store_notification_;
-  std::unique_ptr<ObjectBufferPool> buffer_pool_;
+  ObjectBufferPool buffer_pool_;
 
   /// Multi-thread asio service, deal with all outgoing and incoming RPC request.
   boost::asio::io_service rpc_service_;
@@ -474,7 +483,7 @@ class ObjectManager : public ObjectManagerInterface,
   std::unique_ptr<PushManager> push_manager_;
 
   /// Object pull manager.
-  std::shared_ptr<PullManager> pull_manager_;
+  std::unique_ptr<PullManager> pull_manager_;
 
   /// Running sum of the amount of memory used in the object store.
   int64_t used_memory_ = 0;

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -166,7 +166,8 @@ void PlasmaStore::AddToClientObjectIds(const ObjectID &object_id, ObjectTableEnt
   }
   // Increase reference count.
   entry->ref_count++;
-  RAY_LOG(DEBUG) << "Object " << object_id << " in use by client" << ", num bytes in use is now " << num_bytes_in_use_;
+  RAY_LOG(DEBUG) << "Object " << object_id << " in use by client"
+                 << ", num bytes in use is now " << num_bytes_in_use_;
 
   // Add object id to the list of object ids that this client is using.
   client->object_ids.insert(object_id);
@@ -546,7 +547,8 @@ int PlasmaStore::RemoveFromClientObjectIds(const ObjectID &object_id,
     // that the object is no longer being used.
     if (entry->ref_count == 0) {
       num_bytes_in_use_ -= entry->data_size + entry->metadata_size;
-      RAY_LOG(DEBUG) << "Releasing object no longer in use " << object_id << ", num bytes in use is now " << num_bytes_in_use_;
+      RAY_LOG(DEBUG) << "Releasing object no longer in use " << object_id
+                     << ", num bytes in use is now " << num_bytes_in_use_;
       if (deletion_cache_.count(object_id) == 0) {
         // Tell the eviction policy that this object is no longer being used.
         eviction_policy_.EndObjectAccess(object_id);
@@ -577,7 +579,8 @@ void PlasmaStore::EraseFromObjectTable(const ObjectID &object_id) {
   if (object->ref_count > 0) {
     // A client was using this object.
     num_bytes_in_use_ -= object->data_size + object->metadata_size;
-    RAY_LOG(DEBUG) << "Erasing object " << object_id << " with nonzero ref count" << object_id << ", num bytes in use is now " << num_bytes_in_use_;
+    RAY_LOG(DEBUG) << "Erasing object " << object_id << " with nonzero ref count"
+                   << object_id << ", num bytes in use is now " << num_bytes_in_use_;
   }
   store_info_.objects.erase(object_id);
 }

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -327,6 +327,7 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID &object_id,
   eviction_policy_.ObjectCreated(object_id, client.get(), true);
   // Record that this client is using this object.
   AddToClientObjectIds(object_id, store_info_.objects[object_id].get(), client);
+  num_objects_unsealed_++;
   num_bytes_unsealed_ += data_size + metadata_size;
   return PlasmaError::OK;
 }
@@ -625,6 +626,7 @@ void PlasmaStore::SealObjects(const std::vector<ObjectID> &object_ids) {
     object_info.metadata_size = entry->metadata_size;
     infos.push_back(object_info);
 
+    num_objects_unsealed_--;
     num_bytes_unsealed_ -= entry->data_size + entry->metadata_size;
   }
 
@@ -648,6 +650,7 @@ int PlasmaStore::AbortObject(const ObjectID &object_id,
     return 0;
   } else {
     // The client requesting the abort is the creator. Free the object.
+    num_objects_unsealed_--;
     EraseFromObjectTable(object_id);
     client->object_ids.erase(it);
     return 1;

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -576,6 +576,7 @@ void PlasmaStore::EraseFromObjectTable(const ObjectID &object_id) {
   }
   if (object->state == ObjectState::PLASMA_CREATED) {
     num_bytes_unsealed_ -= object->data_size + object->metadata_size;
+    num_objects_unsealed_--;
   }
   if (object->ref_count > 0) {
     // A client was using this object.
@@ -650,7 +651,6 @@ int PlasmaStore::AbortObject(const ObjectID &object_id,
     return 0;
   } else {
     // The client requesting the abort is the creator. Free the object.
-    num_objects_unsealed_--;
     EraseFromObjectTable(object_id);
     client->object_ids.erase(it);
     return 1;

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -166,6 +166,7 @@ void PlasmaStore::AddToClientObjectIds(const ObjectID &object_id, ObjectTableEnt
   }
   // Increase reference count.
   entry->ref_count++;
+  RAY_LOG(DEBUG) << "Object " << object_id << " in use by client" << ", num bytes in use is now " << num_bytes_in_use_;
 
   // Add object id to the list of object ids that this client is using.
   client->object_ids.insert(object_id);
@@ -325,6 +326,7 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID &object_id,
   eviction_policy_.ObjectCreated(object_id, client.get(), true);
   // Record that this client is using this object.
   AddToClientObjectIds(object_id, store_info_.objects[object_id].get(), client);
+  num_bytes_unsealed_ += data_size + metadata_size;
   return PlasmaError::OK;
 }
 
@@ -538,12 +540,13 @@ int PlasmaStore::RemoveFromClientObjectIds(const ObjectID &object_id,
     client->object_ids.erase(it);
     // Decrease reference count.
     entry->ref_count--;
+    RAY_LOG(DEBUG) << "Object " << object_id << " no longer in use by client";
 
     // If no more clients are using this object, notify the eviction policy
     // that the object is no longer being used.
     if (entry->ref_count == 0) {
       num_bytes_in_use_ -= entry->data_size + entry->metadata_size;
-      RAY_LOG(DEBUG) << "Releasing object no longer in use " << object_id;
+      RAY_LOG(DEBUG) << "Releasing object no longer in use " << object_id << ", num bytes in use is now " << num_bytes_in_use_;
       if (deletion_cache_.count(object_id) == 0) {
         // Tell the eviction policy that this object is no longer being used.
         eviction_policy_.EndObjectAccess(object_id);
@@ -568,9 +571,13 @@ void PlasmaStore::EraseFromObjectTable(const ObjectID &object_id) {
   if (object->device_num == 0) {
     PlasmaAllocator::Free(object->pointer, buff_size);
   }
+  if (object->state == ObjectState::PLASMA_CREATED) {
+    num_bytes_unsealed_ -= object->data_size + object->metadata_size;
+  }
   if (object->ref_count > 0) {
     // A client was using this object.
     num_bytes_in_use_ -= object->data_size + object->metadata_size;
+    RAY_LOG(DEBUG) << "Erasing object " << object_id << " with nonzero ref count" << object_id << ", num bytes in use is now " << num_bytes_in_use_;
   }
   store_info_.objects.erase(object_id);
 }
@@ -614,6 +621,8 @@ void PlasmaStore::SealObjects(const std::vector<ObjectID> &object_ids) {
     object_info.owner_worker_id = entry->owner_worker_id.Binary();
     object_info.metadata_size = entry->metadata_size;
     infos.push_back(object_info);
+
+    num_bytes_unsealed_ -= entry->data_size + entry->metadata_size;
   }
 
   PushNotifications(infos);

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -214,7 +214,8 @@ class PlasmaStore {
     RAY_CHECK(num_bytes_in_use_ >= num_bytes_unsealed_);
     // We include unsealed objects because these may have been created by the
     // object manager.
-    int64_t num_bytes_in_use = static_cast<int64_t>(num_bytes_in_use_ - num_bytes_unsealed_);
+    int64_t num_bytes_in_use =
+        static_cast<int64_t>(num_bytes_in_use_ - num_bytes_unsealed_);
     RAY_CHECK(PlasmaAllocator::GetFootprintLimit() >= num_bytes_in_use);
     size_t available = PlasmaAllocator::GetFootprintLimit() - num_bytes_in_use;
     callback(available);

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -210,6 +210,8 @@ class PlasmaStore {
   /// Process queued requests to create an object.
   void ProcessCreateRequests();
 
+  /// Get the available memory for new objects to be created. This includes
+  /// memory that is currently being used for created but unsealed objects.
   void GetAvailableMemory(std::function<void(size_t)> callback) const {
     RAY_CHECK(num_bytes_in_use_ >= num_bytes_unsealed_);
     // We include unsealed objects because these may have been created by the

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -214,8 +214,8 @@ class PlasmaStore {
   /// memory that is currently being used for created but unsealed objects.
   void GetAvailableMemory(std::function<void(size_t)> callback) const {
     RAY_CHECK(num_bytes_in_use_ >= num_bytes_unsealed_);
-    // We include unsealed objects because these may have been created by the
-    // object manager.
+    // We do not count unsealed objects as in use because these may have been
+    // created by the object manager.
     int64_t num_bytes_in_use =
         static_cast<int64_t>(num_bytes_in_use_ - num_bytes_unsealed_);
     RAY_CHECK(PlasmaAllocator::GetFootprintLimit() >= num_bytes_in_use);

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -213,6 +213,10 @@ class PlasmaStore {
   /// Get the available memory for new objects to be created. This includes
   /// memory that is currently being used for created but unsealed objects.
   void GetAvailableMemory(std::function<void(size_t)> callback) const {
+    RAY_CHECK((num_bytes_unsealed_ > 0 && num_objects_unsealed_ > 0) ||
+              (num_bytes_unsealed_ == 0 && num_objects_unsealed_ == 0))
+        << "Tracking for available memory in the plasma store has gone out of sync. "
+           "Please file a GitHub issue.";
     RAY_CHECK(num_bytes_in_use_ >= num_bytes_unsealed_);
     // We do not count unsealed objects as in use because these may have been
     // created by the object manager.
@@ -328,6 +332,9 @@ class PlasmaStore {
   /// Total number of bytes allocated to objects that are created but not yet
   /// sealed.
   size_t num_bytes_unsealed_ = 0;
+
+  /// Number of objects that are created but not sealed.
+  size_t num_objects_unsealed_ = 0;
 
   /// Total plasma object bytes that are consumed by core workers.
   int64_t total_consumed_bytes_ = 0;

--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -180,10 +180,12 @@ void PullManager::UpdatePullsBasedOnAvailableMemory(size_t num_bytes_available) 
 
   TriggerOutOfMemoryHandlingIfNeeded();
 
-  for (const auto &obj_id : objects_to_pull) {
-    if (object_ids_to_cancel.count(obj_id) == 0) {
-      absl::MutexLock lock(&active_objects_mu_);
-      TryToMakeObjectLocal(obj_id);
+  {
+    absl::MutexLock lock(&active_objects_mu_);
+    for (const auto &obj_id : objects_to_pull) {
+      if (object_ids_to_cancel.count(obj_id) == 0) {
+        TryToMakeObjectLocal(obj_id);
+      }
     }
   }
 }

--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -24,8 +24,7 @@ PullManager::PullManager(
 
 uint64_t PullManager::Pull(const std::vector<rpc::ObjectReference> &object_ref_bundle,
                            std::vector<rpc::ObjectReference> *objects_to_locate) {
-  auto bundle_it =
-      pull_request_bundles_.emplace(next_req_id_++, std::move(object_ref_bundle)).first;
+  auto bundle_it = pull_request_bundles_.emplace(next_req_id_++, object_ref_bundle).first;
   RAY_LOG(DEBUG) << "Start pull request " << bundle_it->first;
 
   for (const auto &ref : object_ref_bundle) {
@@ -41,10 +40,6 @@ uint64_t PullManager::Pull(const std::vector<rpc::ObjectReference> &object_ref_b
       it = object_pull_requests_
                .emplace(obj_id, ObjectPullRequest(/*next_pull_time=*/get_time_()))
                .first;
-    } else {
-      if (it->second.object_size_set) {
-        bundle_it->second.RegisterObjectSize(it->second.object_size);
-      }
     }
     it->second.bundle_request_ids.insert(bundle_it->first);
   }
@@ -57,10 +52,28 @@ uint64_t PullManager::Pull(const std::vector<rpc::ObjectReference> &object_ref_b
 }
 
 bool PullManager::ActivateNextPullBundleRequest(
-    const std::map<uint64_t, PullBundleRequest>::iterator &next_request_it,
+    const std::map<uint64_t, std::vector<rpc::ObjectReference>>::iterator
+        &next_request_it,
     std::vector<ObjectID> *objects_to_pull) {
+  // Check that we have sizes for all of the objects in the bundle. If not, we
+  // should not activate the bundle, since it may put us over the available
+  // capacity.
+  for (const auto &ref : next_request_it->second) {
+    auto obj_id = ObjectRefToId(ref);
+    const auto it = object_pull_requests_.find(obj_id);
+    RAY_CHECK(it != object_pull_requests_.end());
+    if (!it->second.object_size_set) {
+      // NOTE(swang): The size could be 0 if we haven't received size
+      // information yet. If we receive the size later on, we will update the
+      // total bytes being pulled then.
+      RAY_LOG(DEBUG) << "No size for " << obj_id << ", canceling activation for pull "
+                     << next_request_it->first;
+      return false;
+    }
+  }
+
   // Activate the bundle.
-  for (const auto &ref : next_request_it->second.objects) {
+  for (const auto &ref : next_request_it->second) {
     auto obj_id = ObjectRefToId(ref);
     bool start_pull = active_object_pull_requests_.count(obj_id) == 0;
     active_object_pull_requests_[obj_id].insert(next_request_it->first);
@@ -84,9 +97,9 @@ bool PullManager::ActivateNextPullBundleRequest(
 }
 
 void PullManager::DeactivatePullBundleRequest(
-    const std::map<uint64_t, PullBundleRequest>::iterator &request_it,
+    const std::map<uint64_t, std::vector<rpc::ObjectReference>>::iterator &request_it,
     std::unordered_set<ObjectID> *objects_to_cancel) {
-  for (const auto &ref : request_it->second.objects) {
+  for (const auto &ref : request_it->second) {
     auto obj_id = ObjectRefToId(ref);
     RAY_CHECK(active_object_pull_requests_[obj_id].erase(request_it->first));
     if (active_object_pull_requests_[obj_id].empty()) {
@@ -135,12 +148,6 @@ void PullManager::UpdatePullsBasedOnAvailableMemory(size_t num_bytes_available) 
 
     if (next_request_it == pull_request_bundles_.end()) {
       // No requests in the queue.
-      break;
-    }
-
-    if (next_request_it->second.num_object_sizes_missing > 0) {
-      // There is at least one object size missing. We should not activate the
-      // bundle, since it may put us over the available capacity.
       break;
     }
 
@@ -193,9 +200,17 @@ void PullManager::TriggerOutOfMemoryHandlingIfNeeded() {
 
   // No requests are being pulled. Check whether this is because we don't have
   // object size information yet.
-  if (head->second.num_object_sizes_missing > 0) {
-    // Wait for the size information before triggering OOM
-    return;
+  size_t num_bytes_needed = 0;
+  for (const auto &ref : head->second) {
+    auto obj_id = ObjectRefToId(ref);
+    const auto it = object_pull_requests_.find(obj_id);
+    RAY_CHECK(it != object_pull_requests_.end());
+    if (!it->second.object_size_set) {
+      // We're not pulling the first request because we don't have size
+      // information. Wait for the size information before triggering OOM
+      return;
+    }
+    num_bytes_needed += it->second.object_size;
   }
 
   // The first request in the queue is not being pulled due to lack of space.
@@ -207,8 +222,8 @@ void PullManager::TriggerOutOfMemoryHandlingIfNeeded() {
     RAY_LOG(WARNING)
         << "There is not enough memory to pull objects needed by a queued task or "
            "a worker blocked in ray.get or ray.wait. "
-        << "Need " << head->second.num_bytes_needed << " bytes, but only "
-        << num_bytes_available_ << " bytes are available on this node. "
+        << "Need " << num_bytes_needed << " bytes, but only " << num_bytes_available_
+        << " bytes are available on this node. "
         << "This job may hang if no memory can be freed through garbage collection or "
            "object spilling. See "
            "https://docs.ray.io/en/master/memory-management.html for more information. "
@@ -230,7 +245,7 @@ std::vector<ObjectID> PullManager::CancelPull(uint64_t request_id) {
 
   // Erase this pull request.
   std::vector<ObjectID> object_ids_to_cancel;
-  for (const auto &ref : bundle_it->second.objects) {
+  for (const auto &ref : bundle_it->second) {
     auto obj_id = ObjectRefToId(ref);
     auto it = object_pull_requests_.find(obj_id);
     RAY_CHECK(it != object_pull_requests_.end());
@@ -269,11 +284,6 @@ void PullManager::OnLocationChange(const ObjectID &object_id,
   if (!it->second.object_size_set) {
     it->second.object_size = object_size;
     it->second.object_size_set = true;
-    for (auto &bundle_request_id : it->second.bundle_request_ids) {
-      auto bundle_it = pull_request_bundles_.find(bundle_request_id);
-      bundle_it->second.RegisterObjectSize(object_size);
-    }
-
     UpdatePullsBasedOnAvailableMemory(num_bytes_available_);
     RAY_LOG(DEBUG) << "Updated size of object " << object_id << " to " << object_size
                    << ", num bytes being pulled is now " << num_bytes_being_pulled_;

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -128,24 +128,6 @@ class PullManager {
     absl::flat_hash_set<uint64_t> bundle_request_ids;
   };
 
-  struct PullBundleRequest {
-    PullBundleRequest(const std::vector<rpc::ObjectReference> &requested_objects)
-        : objects(requested_objects), num_object_sizes_missing(objects.size()) {}
-    const std::vector<rpc::ObjectReference> objects;
-    size_t num_object_sizes_missing;
-    // The total number of bytes needed by this pull bundle request. Note that
-    // the objects may overlap with another request, so the actual amount of
-    // memory needed to activate this request may be less than this amount.
-    size_t num_bytes_needed = 0;
-    bool active = false;
-
-    void RegisterObjectSize(size_t object_size) {
-      RAY_CHECK(num_object_sizes_missing > 0);
-      num_object_sizes_missing--;
-      num_bytes_needed += object_size;
-    }
-  };
-
   /// Try to make an object local, by restoring the object from external
   /// storage or by fetching the object from one of its expected client
   /// locations. This does nothing if the object is not needed by any pull
@@ -169,13 +151,14 @@ class PullManager {
   /// Activate the next pull request in the queue. This will start pulls for
   /// any objects in the request that are not already being pulled.
   bool ActivateNextPullBundleRequest(
-      const std::map<uint64_t, PullBundleRequest>::iterator &next_request_it,
+      const std::map<uint64_t, std::vector<rpc::ObjectReference>>::iterator
+          &next_request_it,
       std::vector<ObjectID> *objects_to_pull);
 
   /// Deactivate a pull request in the queue. This cancels any pull or restore
   /// operations for the object.
   void DeactivatePullBundleRequest(
-      const std::map<uint64_t, PullBundleRequest>::iterator &request_it,
+      const std::map<uint64_t, std::vector<rpc::ObjectReference>>::iterator &request_it,
       std::unordered_set<ObjectID> *objects_to_cancel = nullptr);
 
   /// Trigger out-of-memory handling if the first request in the queue needs
@@ -199,7 +182,7 @@ class PullManager {
   /// The currently active pull requests. Each request is a bundle of objects
   /// that must be made local. The key is the ID that was assigned to that
   /// request, which can be used by the caller to cancel the request.
-  std::map<uint64_t, PullBundleRequest> pull_request_bundles_;
+  std::map<uint64_t, std::vector<rpc::ObjectReference>> pull_request_bundles_;
 
   /// The total number of bytes that we are currently pulling. This is the
   /// total size of the objects requested that we are actively pulling. To

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -15,7 +15,6 @@
 #include "ray/object_manager/common.h"
 #include "ray/object_manager/format/object_manager_generated.h"
 #include "ray/object_manager/notification/object_store_notification_manager_ipc.h"
-#include "ray/object_manager/object_buffer_pool.h"
 #include "ray/object_manager/object_directory.h"
 #include "ray/object_manager/ownership_based_object_directory.h"
 #include "ray/object_manager/plasma/store_runner.h"
@@ -162,7 +161,7 @@ class PullManager {
   /// operations for the object.
   void DeactivatePullBundleRequest(
       const std::map<uint64_t, std::vector<rpc::ObjectReference>>::iterator &request_it,
-      std::unordered_set<ObjectID> *objects_to_cancel = nullptr);
+      std::unordered_set<ObjectID> *objects_to_cancel);
 
   /// Trigger out-of-memory handling if the first request in the queue needs
   /// more space than the bytes available. This is needed to make room for the

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -135,7 +135,8 @@ class PullManager {
   /// locations. This does nothing if the object is not needed by any pull
   /// request or if it is already local. This also sets a timeout for when to
   /// make the next attempt to make the object local.
-  void TryToMakeObjectLocal(const ObjectID &object_id) EXCLUSIVE_LOCKS_REQUIRED(active_objects_mu_);
+  void TryToMakeObjectLocal(const ObjectID &object_id)
+      EXCLUSIVE_LOCKS_REQUIRED(active_objects_mu_);
 
   /// Try to Pull an object from one of its expected client locations. If there
   /// are more client locations to try after this attempt, then this method

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -32,13 +32,17 @@ class PullManager {
   ///
   /// \param self_node_id the current node
   /// \param object_is_local A callback which should return true if a given object is
-  /// already on the local node. \param send_pull_request A callback which should send a
+  /// already on the local node.
+  /// \param send_pull_request A callback which should send a
   /// pull request to the specified node.
+  /// \param cancel_pull_request A callback which should
+  /// cancel pulling an object.
   /// \param restore_spilled_object A callback which should
   /// retrieve an spilled object from the external store.
   PullManager(
       NodeID &self_node_id, const std::function<bool(const ObjectID &)> object_is_local,
       const std::function<void(const ObjectID &, const NodeID &)> send_pull_request,
+      const std::function<void(const ObjectID &)> cancel_pull_request,
       const RestoreSpilledObjectCallback restore_spilled_object,
       const std::function<double()> get_time, int pull_timeout_ms,
       size_t num_bytes_available, std::function<void()> object_store_full_callback);
@@ -183,6 +187,7 @@ class PullManager {
   NodeID self_node_id_;
   const std::function<bool(const ObjectID &)> object_is_local_;
   const std::function<void(const ObjectID &, const NodeID &)> send_pull_request_;
+  const std::function<void(const ObjectID &)> cancel_pull_request_;
   const RestoreSpilledObjectCallback restore_spilled_object_;
   const std::function<double()> get_time_;
   uint64_t pull_timeout_ms_;

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -124,6 +124,24 @@ class PullManager {
     absl::flat_hash_set<uint64_t> bundle_request_ids;
   };
 
+  struct PullBundleRequest {
+    PullBundleRequest(const std::vector<rpc::ObjectReference> &requested_objects)
+        : objects(requested_objects), num_object_sizes_missing(objects.size()) {}
+    const std::vector<rpc::ObjectReference> objects;
+    size_t num_object_sizes_missing;
+    // The total number of bytes needed by this pull bundle request. Note that
+    // the objects may overlap with another request, so the actual amount of
+    // memory needed to activate this request may be less than this amount.
+    size_t num_bytes_needed = 0;
+    bool active = false;
+
+    void RegisterObjectSize(size_t object_size) {
+      RAY_CHECK(num_object_sizes_missing > 0);
+      num_object_sizes_missing--;
+      num_bytes_needed += object_size;
+    }
+  };
+
   /// Try to make an object local, by restoring the object from external
   /// storage or by fetching the object from one of its expected client
   /// locations. This does nothing if the object is not needed by any pull
@@ -147,14 +165,13 @@ class PullManager {
   /// Activate the next pull request in the queue. This will start pulls for
   /// any objects in the request that are not already being pulled.
   bool ActivateNextPullBundleRequest(
-      const std::map<uint64_t, std::vector<rpc::ObjectReference>>::iterator
-          &next_request_it,
+      const std::map<uint64_t, PullBundleRequest>::iterator &next_request_it,
       std::vector<ObjectID> *objects_to_pull);
 
   /// Deactivate a pull request in the queue. This cancels any pull or restore
   /// operations for the object.
   void DeactivatePullBundleRequest(
-      const std::map<uint64_t, std::vector<rpc::ObjectReference>>::iterator &request_it,
+      const std::map<uint64_t, PullBundleRequest>::iterator &request_it,
       std::unordered_set<ObjectID> *objects_to_cancel = nullptr);
 
   /// Trigger out-of-memory handling if the first request in the queue needs
@@ -177,7 +194,7 @@ class PullManager {
   /// The currently active pull requests. Each request is a bundle of objects
   /// that must be made local. The key is the ID that was assigned to that
   /// request, which can be used by the caller to cancel the request.
-  std::map<uint64_t, std::vector<rpc::ObjectReference>> pull_request_bundles_;
+  std::map<uint64_t, PullBundleRequest> pull_request_bundles_;
 
   /// The total number of bytes that we are currently pulling. This is the
   /// total size of the objects requested that we are actively pulling. To

--- a/src/ray/object_manager/test/pull_manager_test.cc
+++ b/src/ray/object_manager/test/pull_manager_test.cc
@@ -24,6 +24,9 @@ class PullManagerTestWithCapacity {
                       [this](const ObjectID &object_id, const NodeID &node_id) {
                         num_send_pull_request_calls_++;
                       },
+                      [this](const ObjectID &object_id) {
+                        num_abort_calls_[object_id]++;
+                      },
                       [this](const ObjectID &, const std::string &, const NodeID &,
                              std::function<void(const ray::Status &)> callback) {
                         num_restore_spilled_object_calls_++;
@@ -48,6 +51,7 @@ class PullManagerTestWithCapacity {
   std::function<void(const ray::Status &)> restore_object_callback_;
   double fake_time_;
   PullManager pull_manager_;
+  std::unordered_map<ObjectID, int> num_abort_calls_;
 };
 
 class PullManagerTest : public PullManagerTestWithCapacity, public ::testing::Test {
@@ -100,6 +104,7 @@ TEST_F(PullManagerTest, TestStaleSubscription) {
   // There are no client ids to pull from.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
   ASSERT_EQ(num_restore_spilled_object_calls_, 0);
+  ASSERT_TRUE(num_abort_calls_.empty());
 
   auto objects_to_cancel = pull_manager_.CancelPull(req_id);
   ASSERT_EQ(objects_to_cancel, ObjectRefsToIds(refs));
@@ -114,6 +119,7 @@ TEST_F(PullManagerTest, TestStaleSubscription) {
   // Now we're getting a notification about an object that was already cancelled.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
   ASSERT_EQ(num_restore_spilled_object_calls_, 0);
+  ASSERT_EQ(num_abort_calls_[oid], 1);
 
   AssertNoLeaks();
 }
@@ -162,8 +168,10 @@ TEST_F(PullManagerTest, TestRestoreSpilledObject) {
                                  NodeID::FromRandom(), 0);
   ASSERT_EQ(num_restore_spilled_object_calls_, 0);
 
+  ASSERT_TRUE(num_abort_calls_.empty());
   auto objects_to_cancel = pull_manager_.CancelPull(req_id);
   ASSERT_EQ(objects_to_cancel, ObjectRefsToIds(refs));
+  ASSERT_EQ(num_abort_calls_[obj1], 1);
 
   AssertNoLeaks();
 }
@@ -216,7 +224,9 @@ TEST_F(PullManagerTest, TestRestoreObjectFailed) {
   ASSERT_EQ(num_send_pull_request_calls_, 1);
   ASSERT_EQ(num_restore_spilled_object_calls_, 2);
 
+  ASSERT_TRUE(num_abort_calls_.empty());
   auto objects_to_cancel = pull_manager_.CancelPull(req_id);
+  ASSERT_EQ(num_abort_calls_[obj1], 1);
   AssertNoLeaks();
 }
 
@@ -246,6 +256,7 @@ TEST_F(PullManagerTest, TestLoadBalancingRestorationRequest) {
   // Make sure the restore request wasn't sent since there are nodes that have a copied
   // object.
   ASSERT_EQ(num_restore_spilled_object_calls_, 0);
+  ASSERT_TRUE(num_abort_calls_.empty());
 }
 
 TEST_F(PullManagerTest, TestManyUpdates) {
@@ -269,8 +280,10 @@ TEST_F(PullManagerTest, TestManyUpdates) {
   ASSERT_EQ(num_send_pull_request_calls_, 1);
   ASSERT_EQ(num_restore_spilled_object_calls_, 0);
 
+  ASSERT_TRUE(num_abort_calls_.empty());
   auto objects_to_cancel = pull_manager_.CancelPull(req_id);
   ASSERT_EQ(objects_to_cancel, ObjectRefsToIds(refs));
+  ASSERT_EQ(num_abort_calls_[obj1], 1);
 
   AssertNoLeaks();
 }
@@ -316,8 +329,10 @@ TEST_F(PullManagerTest, TestRetryTimer) {
   }
   ASSERT_EQ(num_send_pull_request_calls_, 0);
 
+  ASSERT_TRUE(num_abort_calls_.empty());
   auto objects_to_cancel = pull_manager_.CancelPull(req_id);
   ASSERT_EQ(objects_to_cancel, ObjectRefsToIds(refs));
+  ASSERT_EQ(num_abort_calls_[obj1], 1);
 
   AssertNoLeaks();
 }
@@ -348,9 +363,13 @@ TEST_F(PullManagerTest, TestBasic) {
   }
   ASSERT_EQ(num_send_pull_request_calls_, 0);
 
+  ASSERT_TRUE(num_abort_calls_.empty());
   auto objects_to_cancel = pull_manager_.CancelPull(req_id);
   ASSERT_EQ(objects_to_cancel, oids);
   AssertNumActiveRequestsEquals(0);
+  for (auto &oid : oids) {
+    ASSERT_EQ(num_abort_calls_[oid], 1);
+  }
 
   // Don't pull a remote object if we've canceled.
   object_is_local_ = false;
@@ -387,6 +406,7 @@ TEST_F(PullManagerTest, TestDeduplicateBundles) {
 
   // Cancel one request.
   auto objects_to_cancel = pull_manager_.CancelPull(req_id1);
+  ASSERT_TRUE(num_abort_calls_.empty());
   ASSERT_TRUE(objects_to_cancel.empty());
   // Objects should still be pulled because the other request is still open.
   AssertNumActiveRequestsEquals(oids.size());
@@ -400,9 +420,13 @@ TEST_F(PullManagerTest, TestDeduplicateBundles) {
   }
 
   // Cancel the other request.
+  ASSERT_TRUE(num_abort_calls_.empty());
   objects_to_cancel = pull_manager_.CancelPull(req_id2);
   ASSERT_EQ(objects_to_cancel, oids);
   AssertNumActiveRequestsEquals(0);
+  for (auto &oid : oids) {
+    ASSERT_EQ(num_abort_calls_[oid], 1);
+  }
 
   // Don't pull a remote object if we've canceled.
   object_is_local_ = false;
@@ -438,10 +462,14 @@ TEST_F(PullManagerWithAdmissionControlTest, TestBasic) {
   ASSERT_TRUE(IsUnderCapacity(oids.size() * object_size));
 
   // Reduce the available memory.
+  ASSERT_TRUE(num_abort_calls_.empty());
   ASSERT_EQ(num_object_store_full_calls_, 0);
   pull_manager_.UpdatePullsBasedOnAvailableMemory(oids.size() * object_size - 1);
   AssertNumActiveRequestsEquals(0);
   ASSERT_EQ(num_object_store_full_calls_, 1);
+  for (auto &oid : oids) {
+    ASSERT_EQ(num_abort_calls_[oid], 1);
+  }
   // No new pull requests after the next tick.
   fake_time_ += 10;
   auto prev_pull_requests = num_send_pull_request_calls_;
@@ -460,8 +488,14 @@ TEST_F(PullManagerWithAdmissionControlTest, TestBasic) {
   // OOM was not triggered a second time.
   ASSERT_EQ(num_object_store_full_calls_, 1);
   num_object_store_full_calls_ = 0;
+  for (auto &oid : oids) {
+    ASSERT_EQ(num_abort_calls_[oid], 1);
+  }
 
   pull_manager_.CancelPull(req_id);
+  for (auto &oid : oids) {
+    ASSERT_EQ(num_abort_calls_[oid], 2);
+  }
   AssertNoLeaks();
 }
 

--- a/src/ray/object_manager/test/pull_manager_test.cc
+++ b/src/ray/object_manager/test/pull_manager_test.cc
@@ -36,6 +36,7 @@ class PullManagerTestWithCapacity {
   void AssertNoLeaks() {
     ASSERT_TRUE(pull_manager_.pull_request_bundles_.empty());
     ASSERT_TRUE(pull_manager_.object_pull_requests_.empty());
+    absl::MutexLock lock(&pull_manager_.active_objects_mu_);
     ASSERT_TRUE(pull_manager_.active_object_pull_requests_.empty());
     // Most tests should not throw OOM.
     ASSERT_EQ(num_object_store_full_calls_, 0);
@@ -57,6 +58,7 @@ class PullManagerTest : public PullManagerTestWithCapacity, public ::testing::Te
   PullManagerTest() : PullManagerTestWithCapacity(1) {}
 
   void AssertNumActiveRequestsEquals(size_t num_requests) {
+    absl::MutexLock lock(&pull_manager_.active_objects_mu_);
     ASSERT_EQ(pull_manager_.object_pull_requests_.size(), num_requests);
     ASSERT_EQ(pull_manager_.active_object_pull_requests_.size(), num_requests);
   }
@@ -68,6 +70,7 @@ class PullManagerWithAdmissionControlTest : public PullManagerTestWithCapacity,
   PullManagerWithAdmissionControlTest() : PullManagerTestWithCapacity(10) {}
 
   void AssertNumActiveRequestsEquals(size_t num_requests) {
+    absl::MutexLock lock(&pull_manager_.active_objects_mu_);
     ASSERT_EQ(pull_manager_.active_object_pull_requests_.size(), num_requests);
   }
 

--- a/src/ray/object_manager/test/pull_manager_test.cc
+++ b/src/ray/object_manager/test/pull_manager_test.cc
@@ -19,21 +19,19 @@ class PullManagerTestWithCapacity {
         num_restore_spilled_object_calls_(0),
         num_object_store_full_calls_(0),
         fake_time_(0),
-        pull_manager_(self_node_id_,
-                      [this](const ObjectID &object_id) { return object_is_local_; },
-                      [this](const ObjectID &object_id, const NodeID &node_id) {
-                        num_send_pull_request_calls_++;
-                      },
-                      [this](const ObjectID &object_id) {
-                        num_abort_calls_[object_id]++;
-                      },
-                      [this](const ObjectID &, const std::string &, const NodeID &,
-                             std::function<void(const ray::Status &)> callback) {
-                        num_restore_spilled_object_calls_++;
-                        restore_object_callback_ = callback;
-                      },
-                      [this]() { return fake_time_; }, 10000, num_available_bytes,
-                      [this]() { num_object_store_full_calls_++; }) {}
+        pull_manager_(
+            self_node_id_, [this](const ObjectID &object_id) { return object_is_local_; },
+            [this](const ObjectID &object_id, const NodeID &node_id) {
+              num_send_pull_request_calls_++;
+            },
+            [this](const ObjectID &object_id) { num_abort_calls_[object_id]++; },
+            [this](const ObjectID &, const std::string &, const NodeID &,
+                   std::function<void(const ray::Status &)> callback) {
+              num_restore_spilled_object_calls_++;
+              restore_object_callback_ = callback;
+            },
+            [this]() { return fake_time_; }, 10000, num_available_bytes,
+            [this]() { num_object_store_full_calls_++; }) {}
 
   void AssertNoLeaks() {
     ASSERT_TRUE(pull_manager_.pull_request_bundles_.empty());


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There are a few changes here:
1. Abort/do not create objects that have been deactivated by the PullManager. This is to fix a possible memory leak in the plasma store for inactive objects that are partially created, since these objects may not get pulled again.
2. Do not count created but unsealed objects in the plasma store's memory availability. The problem is that some of these objects may have been created by the PullManager, so the PullManager will end up double-counting an object's memory footprint. This can cause deadlock/livelock (PullManager pulls an object, starts creating it, then immediately cancels it because it thinks there's not enough memory to finish creating it).
3. Reset retry timer when starting to pull an object. This one is for performance, not correctness. I noticed in the regression test that the performance was very bad even with the above 2 fixes, not totally sure why retries were getting triggered for so many objects. We can revisit this issue but I think this is a much safer change now that we have admission control.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

Added a regression test for these changes. Without 1 and 2, the test will be slow and hang consistently. With 3, it finishes in about 30s. It seems like there are still a couple retries happening, which I don't think should happen in this test, but we can look into that later.