### PR TITLE
[ray_client]: Skip flaky test_cancel_chain on Windows

### DIFF
--- a/python/ray/tests/test_client_terminate.py
+++ b/python/ray/tests/test_client_terminate.py
@@ -1,4 +1,6 @@
 import pytest
+import sys
+
 from ray.util.client.ray_client_helpers import ray_start_client_server
 from ray.tests.client_test_utils import create_remote_signal_actor
 from ray.test_utils import wait_for_condition

--- a/python/ray/tests/test_client_terminate.py
+++ b/python/ray/tests/test_client_terminate.py
@@ -41,6 +41,7 @@ def test_kill_actor_immediately_after_creation(ray_start_regular):
         ray.kill(b)
         wait_for_condition(_all_actors_dead(ray), timeout=10)
 
+
 @pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
 @pytest.mark.parametrize("use_force", [True, False])
 def test_cancel_chain(ray_start_regular, use_force):

--- a/python/ray/tests/test_client_terminate.py
+++ b/python/ray/tests/test_client_terminate.py
@@ -41,7 +41,7 @@ def test_kill_actor_immediately_after_creation(ray_start_regular):
         ray.kill(b)
         wait_for_condition(_all_actors_dead(ray), timeout=10)
 
-
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
 @pytest.mark.parametrize("use_force", [True, False])
 def test_cancel_chain(ray_start_regular, use_force):
     with ray_start_client_server() as ray:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This test is very flaky on Windows, so we should skip it.

`test_client_terminate::test_cancel_chain[True]` appears to time out: https://github.com/ray-project/ray/runs/1913015469#step:7:3375
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
