### PR TITLE
[Tune] Raise error when PBT is used with search algorithm

### DIFF
--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -11,6 +11,7 @@ from ray.tune import trial_runner
 from ray.tune import trial_executor
 from ray.tune.error import TuneError
 from ray.tune.result import DEFAULT_METRIC, TRAINING_ITERATION
+from ray.tune.suggest import Searcher
 from ray.tune.utils.util import SafeFallbackEncoder
 from ray.tune.sample import Domain, Function
 from ray.tune.schedulers import FIFOScheduler, TrialScheduler
@@ -319,7 +320,8 @@ class PopulationBasedTraining(FIFOScheduler):
 
     def on_trial_add(self, trial_runner: "trial_runner.TrialRunner",
                      trial: Trial):
-        if trial_runner.search_alg is not None:
+        if trial_runner.search_alg is not None and isinstance(
+                trial_runner.search_alg, Searcher):
             raise ValueError("Search algorithms cannot be used with {} "
                              "schedulers. Please remove {}.".format(
                                  self.__class__.__name__,

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -319,6 +319,12 @@ class PopulationBasedTraining(FIFOScheduler):
 
     def on_trial_add(self, trial_runner: "trial_runner.TrialRunner",
                      trial: Trial):
+        if trial_runner.search_alg is not None:
+            raise ValueError("Search algorithms cannot be used with {} "
+                             "schedulers. Please remove {}.".format(
+                                 self.__class__.__name__,
+                                 trial_runner.search_alg))
+
         if not self._metric or not self._metric_op:
             raise ValueError(
                 "{} has been instantiated without a valid `metric` ({}) or "

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -11,7 +11,7 @@ from ray.tune import trial_runner
 from ray.tune import trial_executor
 from ray.tune.error import TuneError
 from ray.tune.result import DEFAULT_METRIC, TRAINING_ITERATION
-from ray.tune.suggest import Searcher
+from ray.tune.suggest import SearchGenerator
 from ray.tune.utils.util import SafeFallbackEncoder
 from ray.tune.sample import Domain, Function
 from ray.tune.schedulers import FIFOScheduler, TrialScheduler
@@ -321,7 +321,7 @@ class PopulationBasedTraining(FIFOScheduler):
     def on_trial_add(self, trial_runner: "trial_runner.TrialRunner",
                      trial: Trial):
         if trial_runner.search_alg is not None and isinstance(
-                trial_runner.search_alg, Searcher):
+                trial_runner.search_alg, SearchGenerator):
             raise ValueError("Search algorithms cannot be used with {} "
                              "schedulers. Please remove {}.".format(
                                  self.__class__.__name__,

--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -845,7 +845,7 @@ class PopulationBasedTestingSuite(unittest.TestCase):
         return pbt, runner
 
     def testSearchError(self):
-        pbt, runner = self.basicSetup()
+        pbt, runner = self.basicSetup(num_trials=0)
 
         def mock_train(config):
             return 1
@@ -2036,7 +2036,7 @@ class AsyncHyperBandSuite(unittest.TestCase):
     def testPBTNanInf(self):
         scheduler = PopulationBasedTraining(
             metric="episode_reward_mean", mode="max")
-        t1, t2, t3 = self.nanInfSetup(scheduler)
+        t1, t2, t3 = self.nanInfSetup(scheduler, runner=MagicMock())
         scheduler.on_trial_complete(None, t1, result(10, np.nan))
         scheduler.on_trial_complete(None, t2, result(10, float("inf")))
         scheduler.on_trial_complete(None, t3, result(10, float("-inf")))

--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -20,6 +20,7 @@ from ray.tune.schedulers import (FIFOScheduler, HyperBandScheduler,
 
 from ray.tune.schedulers.pbt import explore, PopulationBasedTrainingReplay
 from ray.tune.suggest import Searcher
+from ray.tune.suggest._mock import _MockSearcher
 from ray.tune.trial import Trial, Checkpoint
 from ray.tune.trial_executor import TrialExecutor
 from ray.tune.resources import Resources
@@ -236,6 +237,7 @@ class _MockTrialExecutor(TrialExecutor):
 class _MockTrialRunner():
     def __init__(self, scheduler):
         self._scheduler_alg = scheduler
+        self.search_alg = None
         self.trials = []
         self.trial_executor = _MockTrialExecutor()
 
@@ -854,7 +856,7 @@ class PopulationBasedTestingSuite(unittest.TestCase):
                 mock_train,
                 config={"x": 1},
                 scheduler=pbt,
-                search_alg=Searcher())
+                search_alg=_MockSearcher())
 
     def testMetricError(self):
         pbt, runner = self.basicSetup()

--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -19,6 +19,7 @@ from ray.tune.schedulers import (FIFOScheduler, HyperBandScheduler,
                                  TrialScheduler, HyperBandForBOHB)
 
 from ray.tune.schedulers.pbt import explore, PopulationBasedTrainingReplay
+from ray.tune.suggest import Searcher
 from ray.tune.trial import Trial, Checkpoint
 from ray.tune.trial_executor import TrialExecutor
 from ray.tune.resources import Resources
@@ -841,6 +842,19 @@ class PopulationBasedTestingSuite(unittest.TestCase):
                         TrialScheduler.CONTINUE)
         pbt.reset_stats()
         return pbt, runner
+
+    def testSearchError(self):
+        pbt, runner = self.basicSetup()
+
+        def mock_train(config):
+            return 1
+
+        with self.assertRaises(ValueError):
+            tune.run(
+                mock_train,
+                config={"x": 1},
+                scheduler=pbt,
+                search_alg=Searcher())
 
     def testMetricError(self):
         pbt, runner = self.basicSetup()

--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -19,7 +19,6 @@ from ray.tune.schedulers import (FIFOScheduler, HyperBandScheduler,
                                  TrialScheduler, HyperBandForBOHB)
 
 from ray.tune.schedulers.pbt import explore, PopulationBasedTrainingReplay
-from ray.tune.suggest import Searcher
 from ray.tune.suggest._mock import _MockSearcher
 from ray.tune.trial import Trial, Checkpoint
 from ray.tune.trial_executor import TrialExecutor

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -315,6 +315,10 @@ class TrialRunner:
         return self._resumed
 
     @property
+    def search_alg(self):
+        return self._search_alg
+
+    @property
     def scheduler_alg(self):
         return self._scheduler_alg
 

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -31,7 +31,8 @@ from ray.tune.utils.callback import create_default_callbacks
 from ray.tune.utils.log import Verbosity, has_verbosity, set_verbosity
 
 # Must come last to avoid circular imports
-from ray.tune.schedulers import FIFOScheduler, TrialScheduler
+from ray.tune.schedulers import FIFOScheduler, TrialScheduler, \
+    PopulationBasedTraining
 
 logger = logging.getLogger(__name__)
 
@@ -363,6 +364,12 @@ def run(
         raise ValueError(
             "The `mode` parameter passed to `tune.run()` has to be one of "
             "['min', 'max']")
+
+    if scheduler is not None and isinstance(scheduler,
+                                            PopulationBasedTraining) and \
+            search_alg is not None:
+        raise ValueError("Search algorithms cannot be used with PBT or PB2 "
+                         "schedulers. Please remove {}.".format(search_alg))
 
     set_verbosity(verbose)
 

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -31,8 +31,7 @@ from ray.tune.utils.callback import create_default_callbacks
 from ray.tune.utils.log import Verbosity, has_verbosity, set_verbosity
 
 # Must come last to avoid circular imports
-from ray.tune.schedulers import FIFOScheduler, TrialScheduler, \
-    PopulationBasedTraining
+from ray.tune.schedulers import FIFOScheduler, TrialScheduler
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -365,12 +365,6 @@ def run(
             "The `mode` parameter passed to `tune.run()` has to be one of "
             "['min', 'max']")
 
-    if scheduler is not None and isinstance(scheduler,
-                                            PopulationBasedTraining) and \
-            search_alg is not None:
-        raise ValueError("Search algorithms cannot be used with PBT or PB2 "
-                         "schedulers. Please remove {}.".format(search_alg))
-
     set_verbosity(verbose)
 
     config = config or {}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
We should raise an error when PBT or PB2 are used with a search algorithm to prevent usages like in https://github.com/huggingface/transformers/issues/10247

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
