### PR TITLE
[Core] Cancel timer for HandlePushTaskTimeout

### DIFF
--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -277,8 +277,12 @@ void ObjectManager::HandlePushTaskTimeout(const ObjectID &object_id,
                    << " after waiting for " << config_.push_timeout_ms << " ms.";
   auto iter = unfulfilled_push_requests_.find(object_id);
   RAY_CHECK(iter != unfulfilled_push_requests_.end());
-  size_t num_erased = iter->second.erase(node_id);
-  RAY_CHECK(num_erased == 1);
+  auto node_it = iter->second.find(node_id);
+  RAY_CHECK(node_it != iter->second.end());
+  if (node_it->second) {
+    node_it->second->cancel();
+  }
+  iter->second.erase(node_it);
   if (iter->second.size() == 0) {
     unfulfilled_push_requests_.erase(iter);
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I've seen this error when I ran some stressful workload;
```
(raylet) [2021-02-18 02:19:50,950 C 2855 2855] object_manager.cc:279:  Check failed: iter != unfulfilled_push_requests_.end() 
```

I failed to reason the exact race condition, but I noticed we didn't cancel the timer. I am not sure if this is the root cause, but this will certainly be a safer choice (and could isolate problems if we see the race condition again).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
