### PR TITLE
[Core] Fix grpc server is started check

### DIFF
--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -57,7 +57,7 @@ class Cluster:
         logger.info(output_info)
         self.connected = True
 
-    def add_node(self, **node_args):
+    def add_node(self, wait=True, **node_args):
         """Adds a node to the local Ray Cluster.
 
         All nodes are by default started with the following settings:
@@ -66,6 +66,7 @@ class Cluster:
             object_store_memory=150 * 1024 * 1024  # 150 MiB
 
         Args:
+            wait (bool): Whether to wait until the node is alive.
             node_args: Keyword arguments used in `start_ray_head` and
                 `start_ray_node`. Overrides defaults.
 
@@ -100,7 +101,7 @@ class Cluster:
             # We only need one log monitor per physical node.
             ray_params.update_if_absent(include_log_monitor=False)
             # Let grpc pick a port.
-            ray_params.update(node_manager_port=0)
+            ray_params.update_if_absent(node_manager_port=0)
             node = ray.node.Node(
                 ray_params,
                 head=False,
@@ -108,12 +109,13 @@ class Cluster:
                 spawn_reaper=self._shutdown_at_exit)
             self.worker_nodes.add(node)
 
-        # Wait for the node to appear in the client table. We do this so that
-        # the nodes appears in the client table in the order that the
-        # corresponding calls to add_node were made. We do this because in the
-        # tests we assume that the driver is connected to the first node that
-        # is added.
-        self._wait_for_node(node)
+        if wait:
+            # Wait for the node to appear in the client table. We do this so that
+            # the nodes appears in the client table in the order that the
+            # corresponding calls to add_node were made. We do this because in the
+            # tests we assume that the driver is connected to the first node that
+            # is added.
+            self._wait_for_node(node)
 
         return node
 

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -110,11 +110,11 @@ class Cluster:
             self.worker_nodes.add(node)
 
         if wait:
-            # Wait for the node to appear in the client table. We do this so that
-            # the nodes appears in the client table in the order that the
-            # corresponding calls to add_node were made. We do this because in the
-            # tests we assume that the driver is connected to the first node that
-            # is added.
+            # Wait for the node to appear in the client table. We do this so
+            # that the nodes appears in the client table in the order that the
+            # corresponding calls to add_node were made. We do this because in
+            # the tests we assume that the driver is connected to the first
+            # node that is added.
             self._wait_for_node(node)
 
         return node

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -1382,6 +1382,27 @@ def test_async_actor_task_retries(ray_start_regular):
     assert ray.get(ref_3) == 3
 
 
+def test_raylet_node_manager_server_failure(ray_start_cluster_head, log_pubsub):
+    cluster = ray_start_cluster_head
+    # An out-of-range port to make node manager grpc server fail to start.
+    cluster.add_node(wait=False, node_manager_port=9999999)
+    p = log_pubsub
+    msg = None
+    cnt = 0
+    # wait for max 10 seconds.
+    found = False
+    while cnt < 1000 and not found:
+        msg = p.get_message()
+        if msg is None:
+            time.sleep(0.01)
+            cnt += 1
+            continue
+        data = json.loads(ray.utils.decode(msg["data"]))
+        if data["pid"] == "raylet":
+            found = any("Failed to start the grpc server." in line for line in data["lines"])
+    assert found
+
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -1385,8 +1385,9 @@ def test_async_actor_task_retries(ray_start_regular):
 def test_raylet_node_manager_server_failure(ray_start_cluster_head,
                                             log_pubsub):
     cluster = ray_start_cluster_head
-    # An out-of-range port to make node manager grpc server fail to start.
-    cluster.add_node(wait=False, node_manager_port=9999999)
+    redis_port = int(cluster.address.split(":")[1])
+    # Reuse redis port to make node manager grpc server fail to start.
+    cluster.add_node(wait=False, node_manager_port=redis_port)
     p = log_pubsub
     cnt = 0
     # wait for max 10 seconds.

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -1388,7 +1388,6 @@ def test_raylet_node_manager_server_failure(ray_start_cluster_head,
     # An out-of-range port to make node manager grpc server fail to start.
     cluster.add_node(wait=False, node_manager_port=9999999)
     p = log_pubsub
-    msg = None
     cnt = 0
     # wait for max 10 seconds.
     found = False

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -1382,7 +1382,8 @@ def test_async_actor_task_retries(ray_start_regular):
     assert ray.get(ref_3) == 3
 
 
-def test_raylet_node_manager_server_failure(ray_start_cluster_head, log_pubsub):
+def test_raylet_node_manager_server_failure(ray_start_cluster_head,
+                                            log_pubsub):
     cluster = ray_start_cluster_head
     # An out-of-range port to make node manager grpc server fail to start.
     cluster.add_node(wait=False, node_manager_port=9999999)
@@ -1399,7 +1400,8 @@ def test_raylet_node_manager_server_failure(ray_start_cluster_head, log_pubsub):
             continue
         data = json.loads(ray.utils.decode(msg["data"]))
         if data["pid"] == "raylet":
-            found = any("Failed to start the grpc server." in line for line in data["lines"])
+            found = any("Failed to start the grpc server." in line
+                        for line in data["lines"])
     assert found
 
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -115,9 +115,6 @@ RAY_CONFIG(int64_t, max_direct_call_object_size, 100 * 1024)
 // limit in Ray to avoid crashing with many small inlined task arguments.
 RAY_CONFIG(int64_t, max_grpc_message_size, 100 * 1024 * 1024)
 
-// Number of times to retry creating a gRPC server.
-RAY_CONFIG(int64_t, grpc_server_num_retries, 1)
-
 // Retry timeout for trying to create a gRPC server. Only applies if the number
 // of retries is non zero.
 RAY_CONFIG(int64_t, grpc_server_retry_timeout_milliseconds, 1000)

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -37,9 +37,9 @@ void GrpcServer::Run() {
   // the requests sent to this port may be handled by any of the workers.
   builder.AddChannelArgument(GRPC_ARG_ALLOW_REUSEPORT, 0);
   builder.AddChannelArgument(GRPC_ARG_MAX_SEND_MESSAGE_LENGTH,
-                              RayConfig::instance().max_grpc_message_size());
+                             RayConfig::instance().max_grpc_message_size());
   builder.AddChannelArgument(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH,
-                              RayConfig::instance().max_grpc_message_size());
+                             RayConfig::instance().max_grpc_message_size());
   // TODO(hchen): Add options for authentication.
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials(), &port_);
   // Register all the services to this server.

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -59,7 +59,7 @@ void GrpcServer::Run() {
     }
     // Build and start server.
     server_ = builder.BuildAndStart();
-    if (port_ > 0) {
+    if (server_) {
       break;
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(
@@ -68,8 +68,8 @@ void GrpcServer::Run() {
   }
 
   // If the grpc server failed to bind the port, the `port_` will be set to 0.
-  RAY_CHECK(port_ > 0)
-      << "Port " << specified_port
+  RAY_CHECK(server_ && port_ > 0)
+      << "Failed to start the grpc server. Port " << specified_port
       << " specified by caller already in use. Try passing node_manager_port=... into "
          "ray.init() to pick a specific port";
   RAY_LOG(INFO) << name_ << " server started, listening on port " << port_ << ".";

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -67,7 +67,6 @@ void GrpcServer::Run() {
     num_retries--;
   }
 
-  // If the grpc server failed to bind the port, the `port_` will be set to 0.
   std::ostringstream ss;
   if (!server_) {
     ss << "Failed to start the grpc server.";

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -68,10 +68,19 @@ void GrpcServer::Run() {
   }
 
   // If the grpc server failed to bind the port, the `port_` will be set to 0.
-  RAY_CHECK(server_ && port_ > 0)
-      << "Failed to start the grpc server. Port " << specified_port
-      << " specified by caller already in use. Try passing node_manager_port=... into "
-         "ray.init() to pick a specific port";
+  std::ostringstream ss;
+  if (!server_) {
+    ss << "Failed to start the grpc server.";
+    if (specified_port != 0) {
+      ss << " Specified port is " << specified_port
+         << "and maybe it's already in use. Try passing node_manager_port=... into "
+            "ray.init() to pick a specific port";
+    } else {
+      ss << " No specified port.";
+    }
+    RAY_LOG(FATAL) << ss.str();
+  }
+  RAY_CHECK(port_ > 0);
   RAY_LOG(INFO) << name_ << " server started, listening on port " << port_ << ".";
 
   // Create calls for all the server call factories.

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -30,55 +30,34 @@ GrpcServer::GrpcServer(std::string name, const uint32_t port, int num_threads)
 }
 
 void GrpcServer::Run() {
-  uint32_t specified_port = port_;
   std::string server_address("0.0.0.0:" + std::to_string(port_));
-  int num_retries = RayConfig::instance().grpc_server_num_retries();
-  while (num_retries >= 0) {
-    grpc::ServerBuilder builder;
-    // Disable the SO_REUSEPORT option. We don't need it in ray. If the option is enabled
-    // (default behavior in grpc), we may see multiple workers listen on the same port and
-    // the requests sent to this port may be handled by any of the workers.
-    builder.AddChannelArgument(GRPC_ARG_ALLOW_REUSEPORT, 0);
-    builder.AddChannelArgument(GRPC_ARG_MAX_SEND_MESSAGE_LENGTH,
-                               RayConfig::instance().max_grpc_message_size());
-    builder.AddChannelArgument(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH,
-                               RayConfig::instance().max_grpc_message_size());
-    // TODO(hchen): Add options for authentication.
-    builder.AddListeningPort(server_address, grpc::InsecureServerCredentials(), &port_);
-    // Register all the services to this server.
-    if (services_.empty()) {
-      RAY_LOG(WARNING) << "No service is found when start grpc server " << name_;
-    }
-    for (auto &entry : services_) {
-      builder.RegisterService(&entry.get());
-    }
-    // Get hold of the completion queue used for the asynchronous communication
-    // with the gRPC runtime.
-    for (int i = 0; i < num_threads_; i++) {
-      cqs_[i] = builder.AddCompletionQueue();
-    }
-    // Build and start server.
-    server_ = builder.BuildAndStart();
-    if (server_) {
-      break;
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(
-        RayConfig::instance().grpc_server_retry_timeout_milliseconds()));
-    num_retries--;
+  grpc::ServerBuilder builder;
+  // Disable the SO_REUSEPORT option. We don't need it in ray. If the option is enabled
+  // (default behavior in grpc), we may see multiple workers listen on the same port and
+  // the requests sent to this port may be handled by any of the workers.
+  builder.AddChannelArgument(GRPC_ARG_ALLOW_REUSEPORT, 0);
+  builder.AddChannelArgument(GRPC_ARG_MAX_SEND_MESSAGE_LENGTH,
+                              RayConfig::instance().max_grpc_message_size());
+  builder.AddChannelArgument(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH,
+                              RayConfig::instance().max_grpc_message_size());
+  // TODO(hchen): Add options for authentication.
+  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials(), &port_);
+  // Register all the services to this server.
+  if (services_.empty()) {
+    RAY_LOG(WARNING) << "No service is found when start grpc server " << name_;
   }
+  for (auto &entry : services_) {
+    builder.RegisterService(&entry.get());
+  }
+  // Get hold of the completion queue used for the asynchronous communication
+  // with the gRPC runtime.
+  for (int i = 0; i < num_threads_; i++) {
+    cqs_[i] = builder.AddCompletionQueue();
+  }
+  // Build and start server.
+  server_ = builder.BuildAndStart();
 
-  std::ostringstream ss;
-  if (!server_) {
-    ss << "Failed to start the grpc server.";
-    if (specified_port != 0) {
-      ss << " Specified port is " << specified_port
-         << "and maybe it's already in use. Try passing node_manager_port=... into "
-            "ray.init() to pick a specific port";
-    } else {
-      ss << " No specified port.";
-    }
-    RAY_LOG(FATAL) << ss.str();
-  }
+  RAY_CHECK(server_) << "Failed to start the grpc server.";
   RAY_CHECK(port_ > 0);
   RAY_LOG(INFO) << name_ << " server started, listening on port " << port_ << ".";
 

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -30,6 +30,7 @@ GrpcServer::GrpcServer(std::string name, const uint32_t port, int num_threads)
 }
 
 void GrpcServer::Run() {
+  uint32_t specified_port = port_;
   std::string server_address("0.0.0.0:" + std::to_string(port_));
   grpc::ServerBuilder builder;
   // Disable the SO_REUSEPORT option. We don't need it in ray. If the option is enabled
@@ -57,7 +58,8 @@ void GrpcServer::Run() {
   // Build and start server.
   server_ = builder.BuildAndStart();
 
-  RAY_CHECK(server_) << "Failed to start the grpc server.";
+  RAY_CHECK(server_) << "Failed to start the grpc server. The specified port is "
+                     << specified_port;
   RAY_CHECK(port_ > 0);
   RAY_LOG(INFO) << name_ << " server started, listening on port " << port_ << ".";
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If the grpc server port is specified (`port_` is not 0), `port_` will not become 0 if the grpc server failed to start. According to [grpc doc](https://grpc.github.io/grpc/cpp/classgrpc_1_1_server_builder.html#a3ad1429e6575de79f8f17dad383fbc04), we should check if the return value of `BuildAndStart` is nullptr.

Raylet will report a more meaningful error message with this PR rather than crashing in `CreateCall` like #8254. 

Note: This is not the fix of #9615. 

## Related issue number

#9615

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
