### PR TITLE
 [Serve] Add RLlib tutorial

### DIFF
--- a/doc/source/rllib-examples.rst
+++ b/doc/source/rllib-examples.rst
@@ -41,7 +41,7 @@ Custom Envs and Models
    learn any Unity3D game (including support for multi-agent).
    Use this example to try things out and watch the game and the learning progress live in the editor.
    Providing a compiled game, this example could also run in distributed fashion with `num_workers > 0`.
-   For a more heavy-weight, distributed, cloud-based example, see `Unity3D client/server`_ below.
+   For a more heavy-weight, distributed, cloud-based example, see ``Unity3D client/server`` below.
 - `Registering a custom env and model <https://github.com/ray-project/ray/blob/master/rllib/examples/custom_env.py>`__:
    Example of defining and registering a gym env and model for use with RLlib.
 - `Custom Keras model <https://github.com/ray-project/ray/blob/master/rllib/examples/custom_keras_model.py>`__:
@@ -61,7 +61,6 @@ Custom Envs and Models
 
 Serving and Offline
 -------------------
-
 - :ref:`Serving RLlib models with Ray Serve <serve-rllib-tutorial>`: Example of using Ray Serve to serve RLlib models
    with HTTP and JSON interface. **This is the recommended way to expose RLlib for online serving use case**.
 - `Unity3D client/server <https://github.com/ray-project/ray/tree/master/rllib/examples/serving/unity3d_server.py>`__:

--- a/doc/source/rllib-examples.rst
+++ b/doc/source/rllib-examples.rst
@@ -62,8 +62,8 @@ Custom Envs and Models
 Serving and Offline
 -------------------
 
-.. _Unity3D client/server:
-
+- :ref:`Serving RLlib models with Ray Serve <serve-rllib-tutorial>`: Example of using Ray Serve to serve RLlib models
+   with HTTP and JSON interface. **This is the recommended way to expose RLlib for online serving use case**.
 - `Unity3D client/server <https://github.com/ray-project/ray/tree/master/rllib/examples/serving/unity3d_server.py>`__:
    Example of how to setup n distributed Unity3D (compiled) games in the cloud that function as data collecting
    clients against a central RLlib Policy server learning how to play the game.

--- a/doc/source/serve/core-apis.rst
+++ b/doc/source/serve/core-apis.rst
@@ -183,6 +183,9 @@ If you *do* want to enable this parallelism in your Serve backend, just set OMP_
   For example, if you're using OpenCV, you'll need to manually set the number of threads using ``cv2.setNumThreads(num_threads)`` (set to 0 to disable multi-threading).
   You can check the configuration using ``cv2.getNumThreads()`` and ``cv2.getNumberOfCPUs()``.
 
+.. _serve-batching:
+
+
 Batching to Improve Performance
 -------------------------------
 

--- a/doc/source/serve/ml-models.rst
+++ b/doc/source/serve/ml-models.rst
@@ -4,8 +4,6 @@ Serving Machine Learning Models
 
 .. contents::
 
-.. _serve-batching:
-
 Request Batching
 ================
 

--- a/doc/source/serve/ml-models.rst
+++ b/doc/source/serve/ml-models.rst
@@ -71,3 +71,4 @@ Below are tutorials with some of these frameworks to help get you started.
 - :ref:`PyTorch Tutorial<serve-pytorch-tutorial>`
 - :ref:`Scikit-Learn Tutorial<serve-sklearn-tutorial>`
 - :ref:`Keras and Tensorflow Tutorial<serve-tensorflow-tutorial>`
+- :ref:`RLlib Tutorial<serve-rllib-tutorial>`

--- a/doc/source/serve/tutorials/index.rst
+++ b/doc/source/serve/tutorials/index.rst
@@ -15,6 +15,7 @@ Ray Serve functionality and how to integrate different modeling frameworks.
    sklearn.rst
    batch.rst
    web-server-integration.rst
+   rllib.rst
 
 
 Other Topics:

--- a/doc/source/serve/tutorials/rllib.rst
+++ b/doc/source/serve/tutorials/rllib.rst
@@ -1,0 +1,56 @@
+.. _serve-rllib-tutorial:
+
+RLlib Tutorial
+=============================
+
+In this guide, we will train and deploy a simple Ray RLlib PPO model.
+In particular, we show:
+
+- How to load the model from checkpoint
+- How to parse the JSON request and evaluated in RLlib
+
+Please see the :doc:`../core-apis` to learn more general information about Ray Serve.
+
+
+Let's import Ray Serve and some other helpers.
+
+.. literalinclude:: ../../../../python/ray/serve/examples/doc/tutorial_rllib.py
+    :start-after: __doc_import_begin__
+    :end-before: __doc_import_end__
+
+We will train and checkpoint a simple PPO model with ``CartPole-v0`` environment.
+We are just writing to local disk for now. In production, you might want to consider
+loading the weights from a cloud storage (S3) or shared file system.
+
+.. literalinclude:: ../../../../python/ray/serve/examples/doc/tutorial_rllib.py
+    :start-after: __doc_train_model_begin__
+    :end-before: __doc_train_model_end__
+
+Services are just defined as normal classes with ``__init__`` and ``__call__`` methods.
+The ``__call__`` method will be invoked per request. For each request, the method
+retrieves the ``request.json()["observation"]`` as input.
+
+.. tip::
+    
+    Although we used a single input and ``trainer.compute_action(...)`` here, you
+    can process a batch of input using Ray Serve's :ref:`batching<serve-batching>` feature
+    and use ``trainer.compute_actions(...)`` (notice the plural!) to process a 
+    batch.
+
+.. literalinclude:: ../../../../python/ray/serve/examples/doc/tutorial_rllib.py
+    :start-after: __doc_define_servable_begin__
+    :end-before: __doc_define_servable_end__
+
+Now that we've defined our services, let's deploy the model to Ray Serve. We will
+define an endpoint for the route representing the ppo model, a
+backend correspond the physical implementation, and connect them together.
+
+.. literalinclude:: ../../../../python/ray/serve/examples/doc/tutorial_rllib.py
+    :start-after: __doc_deploy_begin__
+    :end-before: __doc_deploy_end__
+
+Let's query it!
+
+.. literalinclude:: ../../../../python/ray/serve/examples/doc/tutorial_rllib.py
+    :start-after: __doc_query_begin__
+    :end-before: __doc_query_end__

--- a/doc/source/serve/tutorials/rllib.rst
+++ b/doc/source/serve/tutorials/rllib.rst
@@ -7,7 +7,7 @@ In this guide, we will train and deploy a simple Ray RLlib PPO model.
 In particular, we show:
 
 - How to load the model from checkpoint
-- How to parse the JSON request and evaluated in RLlib
+- How to parse the JSON request and evaluate payload in RLlib
 
 Please see the :doc:`../core-apis` to learn more general information about Ray Serve.
 

--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -199,7 +199,7 @@ py_test(
 
 py_test(
     name = "tutorial_rllib",
-    size = "small",
+    size = "medium",
     srcs = glob(["examples/doc/*.py"]),
     tags = ["exclusive"],
     deps = [":serve_lib"]

--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -198,6 +198,14 @@ py_test(
 )
 
 py_test(
+    name = "tutorial_rllib",
+    size = "small",
+    srcs = glob(["examples/doc/*.py"]),
+    tags = ["exclusive"],
+    deps = [":serve_lib"]
+)
+
+py_test(
     name = "snippet_model_composition",
     size = "small",
     srcs = glob(["examples/doc/*.py"]),

--- a/python/ray/serve/examples/doc/tutorial_rllib.py
+++ b/python/ray/serve/examples/doc/tutorial_rllib.py
@@ -1,0 +1,79 @@
+# __doc_import_begin__
+import gym
+from starlette.requests import Request
+import requests
+
+import ray
+import ray.rllib.agents.ppo as ppo
+from ray import serve
+
+# __doc_import_end__
+
+
+# __doc_define_servable_begin__
+class ServePPOModel:
+    def __init__(self, checkpoint_path) -> None:
+        self.trainer = ppo.PPOTrainer(
+            config={
+                "framework": "torch",
+                # only 1 "local" worker with an env (not really used here).
+                "num_workers": 0,
+            },
+            env="CartPole-v0")
+        self.trainer.restore(checkpoint_path)
+
+    async def __call__(self, request: Request):
+        json_input = await request.json()
+        obs = json_input["observation"]
+
+        action = self.trainer.compute_action(obs)
+        return {"action": int(action)}
+
+
+# __doc_define_servable_end__
+
+
+# __doc_train_model_begin__
+def train_ppo_model():
+    trainer = ppo.PPOTrainer(
+        config={
+            "framework": "torch",
+            "num_workers": 0
+        },
+        env="CartPole-v0",
+    )
+    # Train for one iteration
+    trainer.train()
+    trainer.save("/tmp/rllib_checkpoint")
+    return "/tmp/rllib_checkpoint/checkpoint_1/checkpoint-1"
+
+
+checkpoint_path = train_ppo_model()
+# __doc_train_model_end__
+
+ray.init(num_cpus=8)
+# __doc_deploy_begin__
+client = serve.start()
+client.create_backend("ppo", ServePPOModel, checkpoint_path)
+client.create_endpoint("ppo-endpoint", backend="ppo", route="/cartpole-ppo")
+# __doc_deploy_end__
+
+# __doc_query_begin__
+# That's it! Let's test it
+for _ in range(10):
+    env = gym.make("CartPole-v0")
+    obs = env.reset()
+
+    print(f"-> Sending observation {obs}")
+    resp = requests.get(
+        "http://localhost:8000/cartpole-ppo",
+        json={"observation": obs.tolist()})
+    print(f"<- Received response {resp.json()}")
+# Output:
+# <- Received response {'action': 1}
+# -> Sending observation [0.04228249 0.02289503 0.00690076 0.03095441]
+# <- Received response {'action': 0}
+# -> Sending observation [ 0.04819471 -0.04702759 -0.00477937 -0.00735569]
+# <- Received response {'action': 0}
+# ...
+# __doc_query_end__


### PR DESCRIPTION
This PR adds a simple tutorial for deploying RLLib models in Serve.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
