### PR TITLE
[Core] fix gcs use-after-free from ASAN

### DIFF
--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -386,6 +386,7 @@ Status RedisStoreClient::RedisScanner::ScanKeys(
 
 void RedisStoreClient::RedisScanner::Scan(std::string match_pattern,
                                           const StatusCallback &callback) {
+  absl::MutexLock lock(&mutex_);
   if (shard_to_cursor_.empty()) {
     callback(Status::OK());
     return;

--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -386,6 +386,9 @@ Status RedisStoreClient::RedisScanner::ScanKeys(
 
 void RedisStoreClient::RedisScanner::Scan(std::string match_pattern,
                                           const StatusCallback &callback) {
+  // This lock guards the iterator over shard_to_cursor_ because the callbacks
+  // can remove items from the shard_to_cursor_ map. If performance is a concern,
+  // we should consider using a reader-writer lock.
   absl::MutexLock lock(&mutex_);
   if (shard_to_cursor_.empty()) {
     callback(Status::OK());


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Buildkite (which has much better CPUs than Travis) found a memory issue in gcs. I think (?) this should fix it but not sure if this is the right fix.

```
=================================================================
--
  | ==1678==ERROR: AddressSanitizer: heap-use-after-free on address 0x6030000405a0 at pc 0x7f71344419d0 bp 0x7fff1f1f94e0 sp 0x7fff1f1f94d0
  | READ of size 8 at 0x6030000405a0 thread T0
  | #0 0x7f71344419cf in std::__detail::_Node_iterator_base<std::pair<unsigned long const, unsigned long>, false>::_M_incr() /usr/include/c++/9/bits/hashtable_policy.h:299
  | #1 0x7f71344419cf in std::__detail::_Node_iterator<std::pair<unsigned long const, unsigned long>, false, false>::operator++() /usr/include/c++/9/bits/hashtable_policy.h:354
  | #2 0x7f71344419cf in ray::gcs::RedisStoreClient::RedisScanner::Scan(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void (ray::Status)> const&) src/ray/gcs/store_client/redis_store_client.cc:395
  | #3 0x7f713444212c in ray::gcs::RedisStoreClient::RedisScanner::ScanKeys(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void (ray::Status, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&)> const&) src/ray/gcs/store_client/redis_store_client.cc:383
...
```
https://buildkite.com/ray-project/ray-builders-pr/builds/1520#53fd23a8-6d0f-42d7-85bf-1c59f6f3546a/6-144
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
