### PR TITLE
[Core] Modify the low frequency log level of some critical path from DEBUG to INFO or WARNING

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -313,8 +313,8 @@ Status GcsActorManager::CreateActor(const ray::rpc::CreateActorRequest &request,
 
   auto iter = registered_actors_.find(actor_id);
   if (iter == registered_actors_.end()) {
-    RAY_LOG(DEBUG) << "Actor " << actor_id
-                   << " may be already destroyed, job id = " << actor_id.JobId();
+    RAY_LOG(WARNING) << "Actor " << actor_id
+                     << " may be already destroyed, job id = " << actor_id.JobId();
     return Status::Invalid("Actor may be already destroyed.");
   }
 
@@ -834,8 +834,8 @@ void GcsActorManager::Initialize(const GcsInitData &gcs_init_data) {
   // Notify raylets to release unused workers.
   gcs_actor_scheduler_->ReleaseUnusedWorkers(node_to_workers);
 
-  RAY_LOG(DEBUG) << "The number of registered actors is " << registered_actors_.size()
-                 << ", and the number of created actors is " << created_actors_.size();
+  RAY_LOG(INFO) << "The number of registered actors is " << registered_actors_.size()
+                << ", and the number of created actors is " << created_actors_.size();
   for (auto &item : registered_actors_) {
     auto &actor = item.second;
     if (actor->GetState() == ray::rpc::ActorTableData::PENDING_CREATION ||

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -49,7 +49,7 @@ void GcsResourceManager::HandleUpdateResources(
     const rpc::UpdateResourcesRequest &request, rpc::UpdateResourcesReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
   NodeID node_id = NodeID::FromBinary(request.node_id());
-  RAY_LOG(DEBUG) << "Updating resources, node id = " << node_id;
+  RAY_LOG(INFO) << "Updating resources, node id = " << node_id;
   auto changed_resources = std::make_shared<std::unordered_map<std::string, double>>();
   for (const auto &entry : request.resources()) {
     changed_resources->emplace(entry.first, entry.second.resource_capacity());
@@ -84,7 +84,7 @@ void GcsResourceManager::HandleUpdateResources(
                                          nullptr));
 
       GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
-      RAY_LOG(DEBUG) << "Finished updating resources, node id = " << node_id;
+      RAY_LOG(INFO) << "Finished updating resources, node id = " << node_id;
     };
 
     RAY_CHECK_OK(
@@ -101,7 +101,7 @@ void GcsResourceManager::HandleDeleteResources(
     const rpc::DeleteResourcesRequest &request, rpc::DeleteResourcesReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
   NodeID node_id = NodeID::FromBinary(request.node_id());
-  RAY_LOG(DEBUG) << "Deleting node resources, node id = " << node_id;
+  RAY_LOG(INFO) << "Deleting node resources, node id = " << node_id;
   auto resource_names = VectorFromProtobuf(request.resource_name_list());
   auto iter = cluster_scheduling_resources_.find(node_id);
   if (iter != cluster_scheduling_resources_.end()) {
@@ -138,7 +138,7 @@ void GcsResourceManager::HandleDeleteResources(
         gcs_table_storage_->NodeResourceTable().Put(node_id, resource_map, on_done));
   } else {
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
-    RAY_LOG(DEBUG) << "Finished deleting node resources, node id = " << node_id;
+    RAY_LOG(INFO) << "Finished deleting node resources, node id = " << node_id;
   }
   ++counts_[CountType::DELETE_RESOURCES_REQUEST];
 }

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -160,8 +160,8 @@ int main(int argc, char *argv[]) {
         node_manager_config.raylet_config = raylet_config;
         node_manager_config.resource_config =
             ray::ResourceSet(std::move(static_resource_conf));
-        RAY_LOG(DEBUG) << "Starting raylet with static resource configuration: "
-                       << node_manager_config.resource_config.ToString();
+        RAY_LOG(INFO) << "Starting raylet with static resource configuration: "
+                      << node_manager_config.resource_config.ToString();
         node_manager_config.node_manager_address = node_ip_address;
         node_manager_config.node_manager_port = node_manager_port;
         node_manager_config.num_workers_soft_limit = num_cpus;
@@ -235,11 +235,11 @@ int main(int argc, char *argv[]) {
         object_manager_config.object_chunk_size =
             RayConfig::instance().object_manager_default_chunk_size();
 
-        RAY_LOG(DEBUG) << "Starting object manager with configuration: \n"
-                       << "rpc_service_threads_number = "
-                       << object_manager_config.rpc_service_threads_number
-                       << ", object_chunk_size = "
-                       << object_manager_config.object_chunk_size;
+        RAY_LOG(INFO) << "Starting object manager with configuration: \n"
+                      << "rpc_service_threads_number = "
+                      << object_manager_config.rpc_service_threads_number
+                      << ", object_chunk_size = "
+                      << object_manager_config.object_chunk_size;
         // Initialize stats.
         const ray::stats::TagsType global_tags = {
             {ray::stats::ComponentKey, "raylet"},

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -356,7 +356,7 @@ void NodeManager::KillWorker(std::shared_ptr<WorkerInterface> worker) {
       RayConfig::instance().kill_worker_timeout_milliseconds());
   retry_timer->expires_from_now(retry_duration);
   retry_timer->async_wait([retry_timer, worker](const boost::system::error_code &error) {
-    RAY_LOG(DEBUG) << "Send SIGKILL to worker, pid=" << worker->GetProcess().GetId();
+    RAY_LOG(INFO) << "Send SIGKILL to worker, pid=" << worker->GetProcess().GetId();
     // Force kill worker
     worker->GetProcess().Kill();
   });
@@ -373,7 +373,7 @@ void NodeManager::DestroyWorker(std::shared_ptr<WorkerInterface> worker,
 }
 
 void NodeManager::HandleJobStarted(const JobID &job_id, const JobTableData &job_data) {
-  RAY_LOG(DEBUG) << "HandleJobStarted " << job_id;
+  RAY_LOG(INFO) << "HandleJobStarted " << job_id;
   RAY_CHECK(!job_data.is_dead());
 
   worker_pool_.HandleJobStarted(job_id, job_data.config());
@@ -384,7 +384,7 @@ void NodeManager::HandleJobStarted(const JobID &job_id, const JobTableData &job_
 }
 
 void NodeManager::HandleJobFinished(const JobID &job_id, const JobTableData &job_data) {
-  RAY_LOG(DEBUG) << "HandleJobFinished " << job_id;
+  RAY_LOG(INFO) << "HandleJobFinished " << job_id;
   RAY_CHECK(job_data.is_dead());
   worker_pool_.HandleJobFinished(job_id);
 
@@ -551,7 +551,7 @@ void NodeManager::HandleRestoreSpilledObject(
 void NodeManager::HandleReleaseUnusedBundles(
     const rpc::ReleaseUnusedBundlesRequest &request,
     rpc::ReleaseUnusedBundlesReply *reply, rpc::SendReplyCallback send_reply_callback) {
-  RAY_LOG(DEBUG) << "Releasing unused bundles.";
+  RAY_LOG(INFO) << "Releasing unused bundles.";
   std::unordered_set<BundleID, pair_hash> in_use_bundles;
   for (int index = 0; index < request.bundles_in_use_size(); ++index) {
     const auto &bundle_id = request.bundles_in_use(index).bundle_id();
@@ -575,13 +575,12 @@ void NodeManager::HandleReleaseUnusedBundles(
   }
 
   for (const auto &worker : workers_associated_with_unused_bundles) {
-    RAY_LOG(DEBUG)
-        << "Destroying worker since its bundle was unused. Placement group id: "
-        << worker->GetBundleId().first
-        << ", bundle index: " << worker->GetBundleId().second
-        << ", task id: " << worker->GetAssignedTaskId()
-        << ", actor id: " << worker->GetActorId()
-        << ", worker id: " << worker->WorkerId();
+    RAY_LOG(INFO) << "Destroying worker since its bundle was unused. Placement group id: "
+                  << worker->GetBundleId().first
+                  << ", bundle index: " << worker->GetBundleId().second
+                  << ", task id: " << worker->GetAssignedTaskId()
+                  << ", actor id: " << worker->GetActorId()
+                  << ", worker id: " << worker->WorkerId();
     DestroyWorker(worker, rpc::WorkerExitType::UNUSED_RESOURCE_RELEASED);
   }
 
@@ -683,10 +682,10 @@ void NodeManager::GetObjectManagerProfileInfo() {
 void NodeManager::NodeAdded(const GcsNodeInfo &node_info) {
   const NodeID node_id = NodeID::FromBinary(node_info.node_id());
 
-  RAY_LOG(DEBUG) << "[NodeAdded] Received callback from node id " << node_id;
+  RAY_LOG(INFO) << "[NodeAdded] Received callback from node id " << node_id;
   if (1 == cluster_resource_map_.count(node_id)) {
-    RAY_LOG(DEBUG) << "Received notification of a new node that already exists: "
-                   << node_id;
+    RAY_LOG(WARNING) << "Received notification of a new node that already exists: "
+                     << node_id;
     return;
   }
 
@@ -721,7 +720,7 @@ void NodeManager::NodeAdded(const GcsNodeInfo &node_info) {
 void NodeManager::NodeRemoved(const NodeID &node_id) {
   // TODO(swang): If we receive a notification for our own death, clean up and
   // exit immediately.
-  RAY_LOG(DEBUG) << "[NodeRemoved] Received callback from node id " << node_id;
+  RAY_LOG(INFO) << "[NodeRemoved] Received callback from node id " << node_id;
 
   RAY_CHECK(node_id != self_node_id_)
       << "Exiting because this node manager has mistakenly been marked dead by the "
@@ -736,8 +735,8 @@ void NodeManager::NodeRemoved(const NodeID &node_id) {
 
   // Remove the node from the resource map.
   if (!cluster_resource_scheduler_->RemoveNode(node_id.Binary())) {
-    RAY_LOG(DEBUG) << "Received NodeRemoved callback for an unknown node: " << node_id
-                   << ".";
+    RAY_LOG(WARNING) << "Received NodeRemoved callback for an unknown node: " << node_id
+                     << ".";
     return;
   }
 
@@ -804,9 +803,9 @@ void NodeManager::HandleUnexpectedWorkerFailure(const rpc::WorkerDeltaData &data
 
 void NodeManager::ResourceCreateUpdated(const NodeID &node_id,
                                         const ResourceSet &createUpdatedResources) {
-  RAY_LOG(DEBUG) << "[ResourceCreateUpdated] received callback from node id " << node_id
-                 << " with created or updated resources: "
-                 << createUpdatedResources.ToString() << ". Updating resource map.";
+  RAY_LOG(INFO) << "[ResourceCreateUpdated] received callback from node id " << node_id
+                << " with created or updated resources: "
+                << createUpdatedResources.ToString() << ". Updating resource map.";
 
   // Update local_available_resources_ and SchedulingResources
   for (const auto &resource_pair : createUpdatedResources.GetResourceMap()) {
@@ -830,9 +829,9 @@ void NodeManager::ResourceDeleted(const NodeID &node_id,
     for (auto &resource_name : resource_names) {
       oss << resource_name << ", ";
     }
-    RAY_LOG(DEBUG) << "[ResourceDeleted] received callback from node id " << node_id
-                   << " with deleted resources: " << oss.str()
-                   << ". Updating resource map.";
+    RAY_LOG(INFO) << "[ResourceDeleted] received callback from node id " << node_id
+                  << " with deleted resources: " << oss.str()
+                  << ". Updating resource map.";
   }
 
   // Update local_available_resources_ and SchedulingResources


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
- Problem
  - In the production environment, the log level of the engine is usually set to INFO, but some low-frequency key logs are currently DEBUG, which makes it extremely difficult to debug problems.
  - In the production environment, it is occasionally found that some subscription messages are not received by Rayet, which is suspected to be caused by subscription failure. However, it is difficult to confirm because the log of subscription success is not added.

- Solution
  - Modify the low frequency log level of some critical path from DEBUG to INFO or WARNING. 
  - Add INFO log when succeed in subscribing some topics.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
