### PR TITLE
[Core - Autoscaler] Upon autoscaler failure, propagate error message to all current and future drivers

### DIFF
--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -12,8 +12,6 @@ import time
 import yaml
 import collections
 
-from ray.experimental.internal_kv import _internal_kv_put, \
-    _internal_kv_initialized
 from ray.autoscaler.tags import (
     TAG_RAY_LAUNCH_CONFIG, TAG_RAY_RUNTIME_CONFIG,
     TAG_RAY_FILE_MOUNTS_CONTENTS, TAG_RAY_NODE_STATUS, TAG_RAY_NODE_KIND,
@@ -30,7 +28,7 @@ from ray.autoscaler._private.resource_demand_scheduler import \
     ResourceDict
 from ray.autoscaler._private.util import ConcurrentCounter, validate_config, \
     with_head_node_ip, hash_launch_conf, hash_runtime_conf, \
-    DEBUG_AUTOSCALING_ERROR, format_info_string
+    format_info_string
 from ray.autoscaler._private.constants import \
     AUTOSCALER_MAX_NUM_FAILURES, AUTOSCALER_MAX_LAUNCH_BATCH, \
     AUTOSCALER_MAX_CONCURRENT_LAUNCHES, AUTOSCALER_UPDATE_INTERVAL_S, \
@@ -138,9 +136,6 @@ class StandardAutoscaler:
         except Exception as e:
             logger.exception("StandardAutoscaler: "
                              "Error during autoscaling.")
-            if _internal_kv_initialized():
-                _internal_kv_put(
-                    DEBUG_AUTOSCALING_ERROR, str(e), overwrite=True)
             # Don't abort the autoscaler if the K8s API server is down.
             # https://github.com/ray-project/ray/issues/12255
             is_k8s_connection_error = (

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import logging.handlers
 import os
+import signal
 import time
 import traceback
 import json
@@ -18,13 +19,14 @@ from ray.autoscaler._private.event_summarizer import EventSummarizer
 from ray.autoscaler._private.load_metrics import LoadMetrics
 from ray.autoscaler._private.constants import \
     AUTOSCALER_MAX_RESOURCE_DEMAND_VECTOR_SIZE
-from ray.autoscaler._private.util import DEBUG_AUTOSCALING_STATUS
+from ray.autoscaler._private.util import DEBUG_AUTOSCALING_STATUS, \
+    DEBUG_AUTOSCALING_ERROR
 
 from ray.core.generated import gcs_service_pb2, gcs_service_pb2_grpc
 import ray.ray_constants as ray_constants
 from ray.ray_logging import setup_component_logger
 from ray.experimental.internal_kv import _internal_kv_put, \
-    _internal_kv_initialized, _internal_kv_get
+    _internal_kv_initialized, _internal_kv_get, _internal_kv_del
 
 logger = logging.getLogger(__name__)
 
@@ -106,18 +108,19 @@ class Monitor:
         self.load_metrics = LoadMetrics(local_ip=head_node_ip)
         self.last_avail_resources = None
         self.event_summarizer = EventSummarizer()
-        if autoscaling_config:
-            self.autoscaler = StandardAutoscaler(
-                autoscaling_config,
-                self.load_metrics,
-                prefix_cluster_info=prefix_cluster_info,
-                event_summarizer=self.event_summarizer)
-            self.autoscaling_config = autoscaling_config
-        else:
-            self.autoscaler = None
-            self.autoscaling_config = None
+        self.prefix_cluster_info = prefix_cluster_info
+        self.autoscaling_config = autoscaling_config
+        self.autoscaler = None
 
         logger.info("Monitor: Started")
+
+    def _initialize_autoscaler(self):
+        if self.autoscaling_config:
+            self.autoscaler = StandardAutoscaler(
+                self.autoscaling_config,
+                self.load_metrics,
+                prefix_cluster_info=self.prefix_cluster_info,
+                event_summarizer=self.event_summarizer)
 
     def update_load_metrics(self):
         """Fetches resource usage data from GCS and updates load metrics."""
@@ -158,7 +161,6 @@ class Monitor:
 
     def _run(self):
         """Run the monitor loop."""
-
         while True:
             self.update_load_metrics()
             self.update_resource_requests()
@@ -235,13 +237,40 @@ class Monitor:
                 logger.error("Monitor: Cleanup exception. Trying again...")
                 time.sleep(2)
 
+    def _handle_failure(self, error):
+        logger.exception("Error in monitor loop")
+        if self.autoscaler is not None:
+            self.autoscaler.kill_workers()
+            # Take down autoscaler workers if necessary.
+            self.destroy_autoscaler_workers()
+
+        # Something went wrong, so push an error to all current and future
+        # drivers.
+        message = f"The autoscaler failed with the following error:\n{error}"
+        if _internal_kv_initialized():
+            _internal_kv_put(DEBUG_AUTOSCALING_ERROR, message, overwrite=True)
+        redis_client = ray._private.services.create_redis_client(
+            args.redis_address, password=args.redis_password)
+        from ray.utils import push_error_to_driver_through_redis
+        push_error_to_driver_through_redis(
+            redis_client, ray_constants.MONITOR_DIED_ERROR, message)
+
+    def _signal_handler(self, sig, frame):
+        return self._handle_failure(f"Terminated with signal {sig}\n" +
+                                    "".join(traceback.format_stack(frame)))
+
     def run(self):
+        # Register signal handlers for autoscaler termination.
+        signal.signal(signal.SIGINT, self._signal_handler)
+        signal.signal(signal.SIGTERM, self._signal_handler)
         try:
+            if _internal_kv_initialized():
+                # Delete any previous autoscaling errors.
+                _internal_kv_del(DEBUG_AUTOSCALING_ERROR)
+            self._initialize_autoscaler()
             self._run()
         except Exception:
-            logger.exception("Error in monitor loop")
-            if self.autoscaler:
-                self.autoscaler.kill_workers()
+            self._handle_failure(traceback.format_exc())
             raise
 
 
@@ -326,18 +355,4 @@ if __name__ == "__main__":
         autoscaling_config,
         redis_password=args.redis_password)
 
-    try:
-        monitor.run()
-    except Exception as e:
-        # Take down autoscaler workers if necessary.
-        monitor.destroy_autoscaler_workers()
-
-        # Something went wrong, so push an error to all drivers.
-        redis_client = ray._private.services.create_redis_client(
-            args.redis_address, password=args.redis_password)
-        message = ("The monitor failed with the "
-                   f"following error:\n{traceback.format_exc()}")
-        from ray.utils import push_error_to_driver_through_redis
-        push_error_to_driver_through_redis(
-            redis_client, ray_constants.MONITOR_DIED_ERROR, message)
-        raise e
+    monitor.run()

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Iterator
 
 # Ray modules
 from ray.autoscaler._private.constants import AUTOSCALER_EVENTS
+from ray.autoscaler._private.util import DEBUG_AUTOSCALING_ERROR
 import ray.cloudpickle as pickle
 import ray.gcs_utils
 import ray.memory_monitor as memory_monitor
@@ -53,6 +54,8 @@ from ray.ray_logging import setup_logger
 from ray.ray_logging import global_worker_stdstream_dispatcher
 from ray.utils import _random_string, check_oversized_pickle
 from ray.util.inspect import is_cython
+from ray.experimental.internal_kv import _internal_kv_get, \
+    _internal_kv_initialized
 from ray._private.client_mode_hook import client_mode_hook
 
 SCRIPT_MODE = 0
@@ -851,7 +854,8 @@ normal_excepthook = sys.excepthook
 
 def custom_excepthook(type, value, tb):
     # If this is a driver, push the exception to GCS worker table.
-    if global_worker.mode == SCRIPT_MODE:
+    if global_worker.mode == SCRIPT_MODE and hasattr(global_worker,
+                                                     "worker_id"):
         error_message = "".join(traceback.format_tb(tb))
         worker_id = global_worker.worker_id
         worker_type = ray.gcs_utils.DRIVER
@@ -1082,7 +1086,12 @@ def listen_error_messages_raylet(worker, task_error_queue, threads_stopped):
     worker.error_message_pubsub_client.psubscribe(error_pubsub_channel)
 
     try:
-        # Get the errors that occurred before the call to subscribe.
+        if _internal_kv_initialized():
+            # Get any autoscaler errors that occurred before the call to
+            # subscribe.
+            error_message = _internal_kv_get(DEBUG_AUTOSCALING_ERROR)
+            if error_message is not None:
+                logger.warning(error_message.decode())
 
         while True:
             # Exit if we received a signal that we should stop.


### PR DESCRIPTION
## Why are these changes needed?

Previously, an autoscaler failing would notify all existing drivers that were currently connected to the cluster, but all future drivers would never see such an error. This PR ensures that all future drivers also see that autoscaling error.

### TODO:

- [x] Add test.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #13538 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
