### PR TITLE
[Logs] Print exception if Monitor constructor fails.

### DIFF
--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -321,12 +321,11 @@ if __name__ == "__main__":
     else:
         autoscaling_config = None
 
-    monitor = Monitor(
-        args.redis_address,
-        autoscaling_config,
-        redis_password=args.redis_password)
-
     try:
+        monitor = Monitor(
+            args.redis_address,
+            autoscaling_config,
+            redis_password=args.redis_password)
         monitor.run()
     except Exception as e:
         # Take down autoscaler workers if necessary.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Monitor constructor is not in try, except, so that if it fails, nothing will be printed. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
