### PR TITLE
simplify ObjectRef::Get

### DIFF
--- a/cpp/example/example.cc
+++ b/cpp/example/example.cc
@@ -59,41 +59,41 @@ int main(int argc, char **argv) {
 
   /// put and get object
   auto obj = Ray::Put(12345);
-  auto get_put_result = *(Ray::Get(obj));
+  auto get_put_result = Ray::Get(obj);
   std::cout << "get_put_result = " << get_put_result << std::endl;
 
   /// common task without args
   auto task_obj = Ray::Task(Return1).Remote();
-  int task_result1 = *(Ray::Get(task_obj));
+  int task_result1 = Ray::Get(task_obj);
   std::cout << "task_result1 = " << task_result1 << std::endl;
 
   /// common task with args
   task_obj = Ray::Task(Plus1, 5).Remote();
-  int task_result2 = *(Ray::Get(task_obj));
+  int task_result2 = Ray::Get(task_obj);
   std::cout << "task_result2 = " << task_result2 << std::endl;
 
   /// actor task without args
   ActorHandle<Counter> actor1 = Ray::Actor(Counter::FactoryCreate).Remote();
   auto actor_object1 = actor1.Task(&Counter::Plus1).Remote();
-  int actor_result1 = *(Ray::Get(actor_object1));
+  int actor_result1 = Ray::Get(actor_object1);
   std::cout << "actor_result1 = " << actor_result1 << std::endl;
 
   /// actor task with args
   ActorHandle<Counter> actor2 = Ray::Actor(Counter::FactoryCreate, 1).Remote();
   auto actor_object2 = actor2.Task(&Counter::Add, 5).Remote();
-  int actor_result2 = *(Ray::Get(actor_object2));
+  int actor_result2 = Ray::Get(actor_object2);
   std::cout << "actor_result2 = " << actor_result2 << std::endl;
 
   /// actor task with args which pass by reference
   ActorHandle<Counter> actor3 = Ray::Actor(Counter::FactoryCreate, 6, 0).Remote();
   auto actor_object3 = actor3.Task(&Counter::Add, actor_object2).Remote();
-  int actor_result3 = *(Ray::Get(actor_object3));
+  int actor_result3 = Ray::Get(actor_object3);
   std::cout << "actor_result3 = " << actor_result3 << std::endl;
 
   /// general function remote call（args passed by value）
   auto r0 = Ray::Task(Return1).Remote();
   auto r2 = Ray::Task(Plus, 3, 22).Remote();
-  int task_result3 = *(Ray::Get(r2));
+  int task_result3 = Ray::Get(r2);
   std::cout << "task_result3 = " << task_result3 << std::endl;
 
   /// general function remote call（args passed by reference）
@@ -101,15 +101,15 @@ int main(int argc, char **argv) {
   auto r4 = Ray::Task(Plus1, r3).Remote();
   auto r5 = Ray::Task(Plus, r4, r3).Remote();
   auto r6 = Ray::Task(Plus, r4, 10).Remote();
-  int task_result4 = *(Ray::Get(r6));
-  int task_result5 = *(Ray::Get(r5));
+  int task_result4 = Ray::Get(r6);
+  int task_result5 = Ray::Get(r5);
   std::cout << "task_result4 = " << task_result4 << ", task_result5 = " << task_result5
             << std::endl;
 
   /// create actor and actor function remote call with args passed by value
   ActorHandle<Counter> actor4 = Ray::Actor(Counter::FactoryCreate, 10).Remote();
   auto r10 = actor4.Task(&Counter::Add, 8).Remote();
-  int actor_result4 = *(Ray::Get(r10));
+  int actor_result4 = Ray::Get(r10);
   std::cout << "actor_result4 = " << actor_result4 << std::endl;
 
   /// create actor and task function remote call with args passed by reference
@@ -120,12 +120,12 @@ int main(int argc, char **argv) {
   auto r14 = actor5.Task(&Counter::Add, r13).Remote();
   auto r15 = Ray::Task(Plus, r0, r11).Remote();
   auto r16 = Ray::Task(Plus1, r15).Remote();
-  int result12 = *(Ray::Get(r12));
-  int result14 = *(Ray::Get(r14));
-  int result11 = *(Ray::Get(r11));
-  int result13 = *(Ray::Get(r13));
-  int result16 = *(Ray::Get(r16));
-  int result15 = *(Ray::Get(r15));
+  int result12 = Ray::Get(r12);
+  int result14 = Ray::Get(r14);
+  int result11 = Ray::Get(r11);
+  int result13 = Ray::Get(r13);
+  int result16 = Ray::Get(r16);
+  int result15 = Ray::Get(r15);
   std::cout << "Final result:" << std::endl;
   std::cout << "result11 = " << result11 << ", result12 = " << result12
             << ", result13 = " << result13 << ", result14 = " << result14

--- a/cpp/include/ray/api.h
+++ b/cpp/include/ray/api.h
@@ -49,7 +49,7 @@ class Ray {
   /// \param[in] object The object reference which should be returned.
   /// \return shared pointer of the result.
   template <typename T>
-  static std::shared_ptr<T> Get(const ObjectRef<T> &object);
+  static T Get(const ObjectRef<T> &object);
 
   /// Get a list of objects from the object store.
   /// This method will be blocked until all the objects are ready.
@@ -152,10 +152,9 @@ inline ObjectRef<T> Ray::Put(const T &obj) {
 }
 
 template <typename T>
-inline std::shared_ptr<T> Ray::Get(const ObjectRef<T> &object) {
+inline T Ray::Get(const ObjectRef<T> &object) {
   auto packed_object = runtime_->Get(object.ID());
-  return Serializer::Deserialize<std::shared_ptr<T>>(packed_object->data(),
-                                                     packed_object->size());
+  return Serializer::Deserialize<T>(packed_object->data(), packed_object->size());
 }
 
 template <typename T>

--- a/cpp/include/ray/api/object_ref.h
+++ b/cpp/include/ray/api/object_ref.h
@@ -29,7 +29,7 @@ class ObjectRef {
   /// This method will be blocked until the object is ready.
   ///
   /// \return shared pointer of the result.
-  std::shared_ptr<T> Get() const;
+  T Get() const;
 
   /// Make ObjectRef serializable
   MSGPACK_DEFINE(id_);
@@ -71,7 +71,7 @@ const ObjectID &ObjectRef<T>::ID() const {
 }
 
 template <typename T>
-inline std::shared_ptr<T> ObjectRef<T>::Get() const {
+inline T ObjectRef<T>::Get() const {
   return Ray::Get(*this);
 }
 }  // namespace api

--- a/cpp/src/ray/test/api_test.cc
+++ b/cpp/src/ray/test/api_test.cc
@@ -40,7 +40,7 @@ TEST(RayApiTest, PutTest) {
 
   auto obj1 = Ray::Put(1);
   auto i1 = obj1.Get();
-  EXPECT_EQ(1, *i1);
+  EXPECT_EQ(1, i1);
 }
 
 TEST(RayApiTest, StaticGetTest) {
@@ -48,12 +48,12 @@ TEST(RayApiTest, StaticGetTest) {
   /// `Get` member function
   auto obj_ref1 = Ray::Put(100);
   auto res1 = obj_ref1.Get();
-  EXPECT_EQ(100, *res1);
+  EXPECT_EQ(100, res1);
 
   /// `Get` static function
   auto obj_ref2 = Ray::Put(200);
   auto res2 = Ray::Get(obj_ref2);
-  EXPECT_EQ(200, *res2);
+  EXPECT_EQ(200, res2);
 }
 
 TEST(RayApiTest, WaitTest) {
@@ -77,9 +77,9 @@ TEST(RayApiTest, CallWithValueTest) {
   auto r1 = Ray::Task(Plus1, 3).Remote();
   auto r2 = Ray::Task(Plus, 2, 3).Remote();
 
-  int result0 = *(r0.Get());
-  int result1 = *(r1.Get());
-  int result2 = *(r2.Get());
+  int result0 = r0.Get();
+  int result1 = r1.Get();
+  int result2 = r2.Get();
 
   EXPECT_EQ(result0, 1);
   EXPECT_EQ(result1, 4);
@@ -93,11 +93,11 @@ TEST(RayApiTest, CallWithObjectTest) {
   auto rt3 = Ray::Task(Plus1, 3).Remote();
   auto rt4 = Ray::Task(Plus, rt2, rt3).Remote();
 
-  int return0 = *(rt0.Get());
-  int return1 = *(rt1.Get());
-  int return2 = *(rt2.Get());
-  int return3 = *(rt3.Get());
-  int return4 = *(rt4.Get());
+  int return0 = rt0.Get();
+  int return1 = rt1.Get();
+  int return2 = rt2.Get();
+  int return3 = rt3.Get();
+  int return4 = rt4.Get();
 
   EXPECT_EQ(return0, 1);
   EXPECT_EQ(return1, 2);
@@ -114,10 +114,10 @@ TEST(RayApiTest, ActorTest) {
   auto rt3 = actor.Task(&Counter::Add, 3).Remote();
   auto rt4 = actor.Task(&Counter::Add, rt3).Remote();
 
-  int return1 = *(rt1.Get());
-  int return2 = *(rt2.Get());
-  int return3 = *(rt3.Get());
-  int return4 = *(rt4.Get());
+  int return1 = rt1.Get();
+  int return2 = rt2.Get();
+  int return3 = rt3.Get();
+  int return4 = rt4.Get();
 
   EXPECT_EQ(return1, 1);
   EXPECT_EQ(return2, 3);
@@ -139,7 +139,7 @@ TEST(RayApiTest, CompareWithFuture) {
   // Ray API
   Ray::Init();
   auto f3 = Ray::Task(Plus1, 1).Remote();
-  int rt3 = *f3.Get();
+  int rt3 = f3.Get();
 
   EXPECT_EQ(rt1, 2);
   EXPECT_EQ(rt2, 2);

--- a/cpp/src/ray/test/cluster/cluster_mode_test.cc
+++ b/cpp/src/ray/test/cluster/cluster_mode_test.cc
@@ -46,35 +46,35 @@ TEST(RayClusterModeTest, FullTest) {
 
   /// put and get object
   auto obj = Ray::Put(12345);
-  auto get_result = *(Ray::Get(obj));
+  auto get_result = Ray::Get(obj);
   EXPECT_EQ(12345, get_result);
 
   /// common task without args
   auto task_obj = Ray::Task(Return1).Remote();
-  int task_result = *(Ray::Get(task_obj));
+  int task_result = Ray::Get(task_obj);
   EXPECT_EQ(1, task_result);
 
   /// common task with args
   task_obj = Ray::Task(Plus1, 5).Remote();
-  task_result = *(Ray::Get(task_obj));
+  task_result = Ray::Get(task_obj);
   EXPECT_EQ(6, task_result);
 
   /// actor task without args
   ActorHandle<Counter> actor1 = Ray::Actor(Counter::FactoryCreate).Remote();
   auto actor_object1 = actor1.Task(&Counter::Plus1).Remote();
-  int actor_task_result1 = *(Ray::Get(actor_object1));
+  int actor_task_result1 = Ray::Get(actor_object1);
   EXPECT_EQ(1, actor_task_result1);
 
   /// actor task with args
   ActorHandle<Counter> actor2 = Ray::Actor(Counter::FactoryCreate, 1).Remote();
   auto actor_object2 = actor2.Task(&Counter::Add, 5).Remote();
-  int actor_task_result2 = *(Ray::Get(actor_object2));
+  int actor_task_result2 = Ray::Get(actor_object2);
   EXPECT_EQ(6, actor_task_result2);
 
   /// actor task with args which pass by reference
   ActorHandle<Counter> actor3 = Ray::Actor(Counter::FactoryCreate, 6, 0).Remote();
   auto actor_object3 = actor3.Task(&Counter::Add, actor_object2).Remote();
-  int actor_task_result3 = *(Ray::Get(actor_object3));
+  int actor_task_result3 = Ray::Get(actor_object3);
   EXPECT_EQ(12, actor_task_result3);
 
   /// general function remote call（args passed by value）
@@ -82,9 +82,9 @@ TEST(RayClusterModeTest, FullTest) {
   auto r1 = Ray::Task(Plus1, 30).Remote();
   auto r2 = Ray::Task(Plus, 3, 22).Remote();
 
-  int result1 = *(Ray::Get(r1));
-  int result0 = *(Ray::Get(r0));
-  int result2 = *(Ray::Get(r2));
+  int result1 = Ray::Get(r1);
+  int result0 = Ray::Get(r0);
+  int result2 = Ray::Get(r2);
   EXPECT_EQ(result0, 1);
   EXPECT_EQ(result1, 31);
   EXPECT_EQ(result2, 25);
@@ -95,10 +95,10 @@ TEST(RayClusterModeTest, FullTest) {
   auto r5 = Ray::Task(Plus, r4, r3).Remote();
   auto r6 = Ray::Task(Plus, r4, 10).Remote();
 
-  int result5 = *(Ray::Get(r5));
-  int result4 = *(Ray::Get(r4));
-  int result6 = *(Ray::Get(r6));
-  int result3 = *(Ray::Get(r3));
+  int result5 = Ray::Get(r5);
+  int result4 = Ray::Get(r4);
+  int result6 = Ray::Get(r6);
+  int result3 = Ray::Get(r3);
   EXPECT_EQ(result0, 1);
   EXPECT_EQ(result3, 1);
   EXPECT_EQ(result4, 2);
@@ -112,10 +112,10 @@ TEST(RayClusterModeTest, FullTest) {
   auto r9 = actor4.Task(&Counter::Add, 3).Remote();
   auto r10 = actor4.Task(&Counter::Add, 8).Remote();
 
-  int result7 = *(Ray::Get(r7));
-  int result8 = *(Ray::Get(r8));
-  int result9 = *(Ray::Get(r9));
-  int result10 = *(Ray::Get(r10));
+  int result7 = Ray::Get(r7);
+  int result8 = Ray::Get(r8);
+  int result9 = Ray::Get(r9);
+  int result10 = Ray::Get(r10);
   EXPECT_EQ(result7, 15);
   EXPECT_EQ(result8, 16);
   EXPECT_EQ(result9, 19);
@@ -131,12 +131,12 @@ TEST(RayClusterModeTest, FullTest) {
   auto r15 = Ray::Task(Plus, r0, r11).Remote();
   auto r16 = Ray::Task(Plus1, r15).Remote();
 
-  int result12 = *(Ray::Get(r12));
-  int result14 = *(Ray::Get(r14));
-  int result11 = *(Ray::Get(r11));
-  int result13 = *(Ray::Get(r13));
-  int result16 = *(Ray::Get(r16));
-  int result15 = *(Ray::Get(r15));
+  int result12 = Ray::Get(r12);
+  int result14 = Ray::Get(r14);
+  int result11 = Ray::Get(r11);
+  int result13 = Ray::Get(r13);
+  int result16 = Ray::Get(r16);
+  int result15 = Ray::Get(r15);
 
   EXPECT_EQ(result11, 28);
   EXPECT_EQ(result12, 56);

--- a/cpp/src/ray/test/slow_function_test.cc
+++ b/cpp/src/ray/test/slow_function_test.cc
@@ -21,10 +21,10 @@ TEST(RaySlowFunctionTest, BaseTest) {
   auto r2 = Ray::Task(slow_function, 3).Remote();
   auto r3 = Ray::Task(slow_function, 4).Remote();
 
-  int result0 = *(r0.Get());
-  int result1 = *(r1.Get());
-  int result2 = *(r2.Get());
-  int result3 = *(r3.Get());
+  int result0 = r0.Get();
+  int result1 = r1.Get();
+  int result2 = r2.Get();
+  int result3 = r3.Get();
   auto time2 = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::system_clock::now().time_since_epoch());
 


### PR DESCRIPTION
## Why are these changes needed?

Simplify the usage of ObjectRef<T>::Get, make it more easier  to use.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
