### PR TITLE
[Object Spilling] Support multiple directories for spilling.

### DIFF
--- a/doc/source/memory-management.rst
+++ b/doc/source/memory-management.rst
@@ -194,13 +194,8 @@ To configure the directory where objects are placed, use:
         },
     )
 
-Note that it is also possible to specify multiple directories. There are 2 scenarios that it is useful.
-
-- When you'd like to improve the read and write performance. Ray uses IO workers to parallelize object spilling(read) and restoration(write).
-If you use multiple directories mounted at different devices, IO workers try using multiple devices at the same time,
-so that it can improve the general read and write bandwidth.
-- When you'd need more than one devices' storage space. Imagine you only have a single devices with 1TB space, but that's not enough.
-Intead, you can use multiple directories mounted at multiple 1TB devices, so that you can spill more than 1TB objects to the local storage.
+You can also specify multiple directories for spilling to spread the IO load and disk space
+usage across multiple physical devices if needed (e.g., SSD devices):
 
 .. code-block:: python
 

--- a/doc/source/memory-management.rst
+++ b/doc/source/memory-management.rst
@@ -194,6 +194,32 @@ To configure the directory where objects are placed, use:
         },
     )
 
+Note that it is also possible to specify multiple directories. There are 2 scenarios that it is useful.
+
+- When you'd like to improve the read and write performance. Ray uses IO workers to parallelize object spilling(read) and restoration(write).
+If you use multiple directories mounted at different devices, IO workers try using multiple devices at the same time,
+so that it can improve the general read and write bandwidth.
+- When you'd need more than one devices' storage space. Imagine you only have a single devices with 1TB space, but that's not enough.
+Intead, you can use multiple directories mounted at multiple 1TB devices, so that you can spill more than 1TB objects to the local storage.
+
+.. code-block:: python
+
+    ray.init(
+        _system_config={
+            "max_io_workers": 4,  # More IO workers for local storage. Each IO worker tries using a different directories.
+            "object_spilling_config": json.dumps(
+                {
+                  "type": "filesystem",
+                  "params": {
+                    # Each directory could mount at different devices.
+                    "directory_path": [
+                      "/tmp/spill",
+                      "/tmp/spill_1",
+                      "/tmp/spill_2"}},
+            )
+        },
+    )
+
 To enable object spilling to remote storage (any URI supported by `smart_open <https://pypi.org/project/smart-open/>`__):
 
 .. code-block:: python

--- a/python/ray/external_storage.py
+++ b/python/ray/external_storage.py
@@ -2,6 +2,7 @@ import abc
 import logging
 import os
 import shutil
+import random
 import urllib
 from collections import namedtuple
 from typing import List, IO, Tuple
@@ -226,20 +227,50 @@ class FileSystemStorage(ExternalStorage):
     """
 
     def __init__(self, directory_path):
+        # -- sub directory name --
         self.spill_dir_name = DEFAULT_OBJECT_PREFIX
-        self.directory_path = os.path.join(directory_path, self.spill_dir_name)
-        os.makedirs(self.directory_path, exist_ok=True)
-        if not os.path.exists(self.directory_path):
-            raise ValueError("The given directory path to store objects, "
-                             f"{self.directory_path}, could not be created.")
+        # -- A list of directory paths to spill objects --
+        self.directory_paths = []
+        # -- Current directory to spill objects --
+        self.current_directory_index = 0
+
+        # Validation.
+        assert directory_path is not None, (
+            "directory_path should be provided to use object spilling.")
+        if isinstance(directory_path, str):
+            directory_path = [directory_path]
+        assert isinstance(directory_path,
+                          list), ("Directory_path must be either a single "
+                                  "string or a list of strings")
+
+        # Create directories.
+        for path in directory_path:
+            full_dir_path = os.path.join(path, self.spill_dir_name)
+            os.makedirs(full_dir_path, exist_ok=True)
+            if not os.path.exists(full_dir_path):
+                raise ValueError("The given directory path to store objects, "
+                                 f"{full_dir_path}, could not be created.")
+            self.directory_paths.append(full_dir_path)
+        assert len(self.directory_paths) == len(directory_path)
+
+        # Choose the current directory.
+        # It chooses a random index to maximize multiple directories that are
+        # mounted at different point.
+        self.current_directory_index = random.randrange(
+            0, len(self.directory_paths))
 
     def spill_objects(self, object_refs, owner_addresses) -> List[str]:
         if len(object_refs) == 0:
             return []
+        # Choose the current directory path by round robin order.
+        self.current_directory_index = (
+            (self.current_directory_index + 1) % len(self.directory_paths))
+        directory_path = self.directory_paths[self.current_directory_index]
+
         # Always use the first object ref as a key when fusioning objects.
         first_ref = object_refs[0]
         filename = f"{first_ref.hex()}-multi-{len(object_refs)}"
-        url = f"{os.path.join(self.directory_path, filename)}"
+        url = f"{os.path.join(directory_path, filename)}"
         with open(url, "wb") as f:
             return self._write_multiple_objects(f, object_refs,
                                                 owner_addresses, url)
@@ -272,20 +303,21 @@ class FileSystemStorage(ExternalStorage):
 
     def delete_spilled_objects(self, urls: List[str]):
         for url in urls:
-            filename = parse_url_with_offset(url.decode()).base_url
-            os.remove(os.path.join(self.directory_path, filename))
+            path = parse_url_with_offset(url.decode()).base_url
+            os.remove(path)
 
     def destroy_external_storage(self):
-        # Q: Should we add stdout here to
-        # indicate we are deleting a directory?
+        for directory_path in self.directory_paths:
+            self._destroy_external_storage(directory_path)
 
+    def _destroy_external_storage(self, directory_path):
         # There's a race condition where IO workers are still
         # deleting each objects while we try deleting the
         # whole directory. So we should keep trying it until
         # The directory is actually deleted.
-        while os.path.isdir(self.directory_path):
+        while os.path.isdir(directory_path):
             try:
-                shutil.rmtree(self.directory_path)
+                shutil.rmtree(directory_path)
             except FileNotFoundError:
                 # If excpetion occurs when other IO workers are
                 # deleting the file at the same time.

--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -5,6 +5,7 @@ import random
 import platform
 import subprocess
 import sys
+from collections import defaultdict
 
 import numpy as np
 import pytest
@@ -805,7 +806,6 @@ def test_spill_objects_on_object_transfer(object_spilling_config,
     platform.system() in ["Windows"], reason="Failing on "
     "Windows and Mac.")
 def test_file_deleted_when_driver_exits(tmp_path, shutdown_only):
-    # Limit our object store to 75 MiB of memory.
     temp_folder = tmp_path / "spill"
     temp_folder.mkdir()
 
@@ -854,6 +854,73 @@ os.kill(os.getpid(), sig)
             run_string_as_driver(
                 driver.format(temp_dir=str(temp_folder), signum=2)))
     wait_for_condition(lambda: is_dir_empty(temp_folder, append_path=""))
+
+
+@pytest.mark.skipif(
+    platform.system() in ["Windows"], reason="Failing on "
+    "Windows and Mac.")
+def test_multiple_directories(tmp_path, shutdown_only):
+    num_dirs = 3
+    temp_dirs = []
+    for i in range(num_dirs):
+        temp_folder = tmp_path / f"spill_{i}"
+        temp_folder.mkdir()
+        temp_dirs.append(temp_folder)
+
+    # Limit our object store to 75 MiB of memory.
+    min_spilling_size = 0
+    object_spilling_config = json.dumps({
+        "type": "filesystem",
+        "params": {
+            "directory_path": [str(directory) for directory in temp_dirs]
+        }
+    })
+    address = ray.init(
+        object_store_memory=75 * 1024 * 1024,
+        _system_config={
+            "max_io_workers": 5,
+            "object_store_full_delay_ms": 100,
+            "object_spilling_config": object_spilling_config,
+            "min_spilling_size": min_spilling_size,
+        })
+
+    arr = np.ones(74 * 1024 * 1024, dtype=np.uint8)  # 74MB.
+    object_refs = []
+    # Now the storage is full.
+    object_refs.append(ray.put(arr))
+
+    num_object_spilled = 20
+    for _ in range(num_object_spilled):
+        object_refs.append(ray.put(arr))
+
+    num_files = defaultdict(int)
+    for temp_dir in temp_dirs:
+        temp_folder = temp_dir / ray.ray_constants.DEFAULT_OBJECT_PREFIX
+        for path in temp_folder.iterdir():
+            num_files[str(temp_folder)] += 1
+
+    for ref in object_refs:
+        assert np.array_equal(ray.get(ref), arr)
+
+    print("Check distribution...")
+    min_count = 5
+    assert all([n_files >= min_count for n_files in num_files.values()])
+
+    print("Check deletion...")
+    # Empty object refs.
+    object_refs = []
+    # Add a new object so that the last entry is evicted.
+    ref = ray.put(arr)
+    for temp_dir in temp_dirs:
+        temp_folder = temp_dir
+        wait_for_condition(lambda: is_dir_empty(temp_folder))
+    assert_no_thrashing(address["redis_address"])
+
+    # Now kill ray and see all directories are deleted.
+    print("Check directories are deleted...")
+    ray.shutdown()
+    for temp_dir in temp_dirs:
+        wait_for_condition(lambda: is_dir_empty(temp_dir, append_path=""))
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -904,7 +904,8 @@ def test_multiple_directories(tmp_path, shutdown_only):
 
     print("Check distribution...")
     min_count = 5
-    assert all([n_files >= min_count for n_files in num_files.values()])
+    is_distributed = [n_files >= min_count for n_files in num_files.values()]
+    assert all(is_distributed)
 
     print("Check deletion...")
     # Empty object refs.

--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -858,7 +858,7 @@ os.kill(os.getpid(), sig)
 
 @pytest.mark.skipif(
     platform.system() in ["Windows"], reason="Failing on "
-    "Windows and Mac.")
+    "Windows.")
 def test_multiple_directories(tmp_path, shutdown_only):
     num_dirs = 3
     temp_dirs = []


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

NOTE: It didn't handle cases where the spilling fails because the chosen directory is full. This requires more complicated test suites that I will support next week. 

## Related issue number

Closes https://github.com/ray-project/ray/issues/13958

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
