### PR TITLE
[Tune] Batch suggestions for HEBO

### DIFF
--- a/python/ray/tune/examples/hebo_example.py
+++ b/python/ray/tune/examples/hebo_example.py
@@ -74,13 +74,24 @@ if __name__ == "__main__":
     ]
     known_rewards = [-189, -1144]
 
+    # setting the n_suggestions parameter to >1 enables
+    # the evolutionary part of HEBO. For best results,
+    # use HEBOSearch with a ConcurrencyLimiter() set up
+    # as below
+    n_suggestions = 8
+
     algo = HEBOSearch(
         # space = space, # If you want to set the space
         points_to_evaluate=previously_run_params,
         evaluated_rewards=known_rewards,
         random_state_seed=123,  # for reproducibility
+        n_suggestions=n_suggestions,
     )
-    algo = ConcurrencyLimiter(algo, max_concurrent=4)
+    algo = ConcurrencyLimiter(
+        algo,
+        max_concurrent=n_suggestions,
+        batch=True,
+    )
 
     scheduler = AsyncHyperBandScheduler()
 

--- a/python/ray/tune/suggest/hebo.py
+++ b/python/ray/tune/suggest/hebo.py
@@ -75,7 +75,11 @@ class HEBOSearch(Searcher):
             on initalization and loading from checkpoint.
         n_suggestions (int, 1): If higher than one, suggestions will
             be made in batches and cached. Higher values may increase
-            convergence speed in certain cases.
+            convergence speed in certain cases (authors recommend 8).
+            For best results, wrap this searcher in a
+            ``ConcurrencyLimiter(max_concurrent=n, batch=True)``
+            where `n == n_suggestions`.
+            Refer to `tune/examples/hebo_example.py`.
         **kwargs: The keyword arguments will be passed to `HEBO()``.
 
     Tune automatically converts search spaces to HEBO's format:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

HEBO provides a parameter `n_suggestions` controlling the batching of suggestions. If `n_suggestions` is set over 1, it enables the evolutionary part of HEBO, increasing convergence speed in certain cases. Furthermore, it allows for the algorithm to work better in parallel settings (like Ray Tune). This PR allows the user to specify the value of that parameter and provides an example of how to use it with `ConcurrencyLimiter()` for best results.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
