### PR TITLE
[Buildkite] Fix java and lint failure

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get install -y -qq \
     sudo unzip apt-utils dialog tzdata wget rsync \
     language-pack-en tmux cmake gdb vim htop \
     libgtk2.0-dev zlib1g-dev libgl1-mesa-dev maven \
-    openjdk-8-jre openjdk-8-jdk
+    openjdk-8-jre openjdk-8-jdk clang-format-7
 
 RUN curl -o- https://get.docker.com | sh
 

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get install -y -qq \
     language-pack-en tmux cmake gdb vim htop \
     libgtk2.0-dev zlib1g-dev libgl1-mesa-dev maven \
     openjdk-8-jre openjdk-8-jdk clang-format-7
-
+RUN ln -s /usr/bin/clang-format-7 /usr/bin/clang-format
 RUN curl -o- https://get.docker.com | sh
 
 # System conf for tests


### PR DESCRIPTION
Fix Java test error in Buildkite CI https://buildkite.com/ray-project/ray-builders-branch/builds/449#8f995fe9-af64-4586-a477-6e33a037f175

```

+ clang-format -i io_ray_runtime_RayNativeRuntime.h
--
  | java/generate_jni_header_files.sh: line 14: clang-format: command not found


```