### PR TITLE
[logging] Don't try to kill autoscaler during log monitor cleanup 

### DIFF
--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -98,7 +98,8 @@ class LogMonitor:
                 # Test if the worker process that generated the log file
                 # is still alive. Only applies to worker processes.
                 if (file_info.worker_pid != "raylet"
-                        and file_info.worker_pid != "gcs_server"):
+                        and file_info.worker_pid != "gcs_server"
+                        and file_info.worker_pid != "autoscaler"):
                     os.kill(file_info.worker_pid, 0)
             except OSError:
                 # The process is not alive any more, so move the log file


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
If the `worker_pid` is the string `autoscale`, the `os.kill` function will through a type error as it only accepts type `int`.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #12565 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [X] This PR is not tested :(
