### PR TITLE
[Core] Start the non-primary Redis shard port range at a high random port.

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -877,9 +877,9 @@ def start_redis(node_ip_address,
     # Start other Redis shards. Each Redis shard logs to a separate file,
     # prefixed by "redis-<shard number>".
     redis_shards = []
-    # Attempt to start the other Redis shards port range right after the
-    # primary Redis shard port.
-    last_shard_port = port
+    # If Redis shard ports are not provided, start the port range of the
+    # other Redis shards at a high, random port.
+    last_shard_port = new_port() - 1
     for i in range(num_redis_shards):
         redis_stdout_file, redis_stderr_file = redirect_files[i + 1]
         redis_executable = REDIS_EXECUTABLE


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The first two user-facing ports to be specified when starting a Ray cluster are the GCS (Redis primary shard) port and the object manager port. If the user specifies them consecutively, such as `ray start --head --port=3001 --object-manager-port=3002`, non-primary Redis shards, which currently try to cluster close to the primary Redis shard by default, will produce a port conflict for the object manager. This PR opts to start the non-primary Redis shard port range at a high, random port in order to mitigate this port conflict issue.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #14098 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
