### PR TITLE
Bump the Ray client version

### DIFF
--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 # This version string is incremented to indicate breaking changes in the
 # protocol that require upgrading the client version.
-CURRENT_PROTOCOL_VERSION = "2020-02-01"
+CURRENT_PROTOCOL_VERSION = "2020-02-22"
 
 
 class RayAPIStub:


### PR DESCRIPTION
This forces client users to upgrade. We need a version bump due to https://github.com/ray-project/ray/pull/14122