### PR TITLE
[Core] Use iterator to instead of operator[] to avoid garbage inside ReconstructActor

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -642,14 +642,15 @@ void GcsActorManager::OnNodeDead(const NodeID &node_id) {
 }
 
 void GcsActorManager::ReconstructActor(const ActorID &actor_id, bool need_reschedule) {
-  auto &actor = registered_actors_[actor_id];
   // If the owner and this actor is dead at the same time, the actor
   // could've been destroyed and dereigstered before reconstruction.
-  if (actor == nullptr) {
+  auto iter = registered_actors_.find(actor_id);
+  if (iter == registered_actors_.end()) {
     RAY_LOG(DEBUG) << "Actor is destroyed before reconstruction, actor id = " << actor_id
                    << ", job id = " << actor_id.JobId();
     return;
   }
+  auto &actor = iter->second;
   auto node_id = actor->GetNodeID();
   auto worker_id = actor->GetWorkerID();
   auto mutable_actor_table_data = actor->GetMutableActorTableData();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
If an actor is already destroyed, the `registered_actors_[actor_id]` at the very beginning of the `ReconstructActor` will insert it again, which will cause garbage.

```
void GcsActorManager::ReconstructActor(const ActorID &actor_id, bool need_reschedule) {
  auto &actor = registered_actors_[actor_id];
  // If the owner and this actor is dead at the same time, the actor
  // could've been destroyed and dereigstered before reconstruction.
  if (actor == nullptr) {
    RAY_LOG(DEBUG) << "Actor is destroyed before reconstruction, actor id = " << actor_id
                   << ", job id = " << actor_id.JobId();
    return;
  }
  auto node_id = actor->GetNodeID();
  ...
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
