### PR TITLE
[Core] Locality-aware leasing: Milestone 2 - Owned refs, cached locations

### DIFF
--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -186,6 +186,48 @@ def test_locality_aware_leasing(ray_start_cluster):
     assert ray.get(f.remote(non_local.remote())) == non_local_node.unique_id
 
 
+def test_locality_aware_leasing_cached_objects(ray_start_cluster):
+    # This test ensures that a task will run where its task dependencies are
+    # located, even when those objects aren't primary copies.
+    cluster = ray_start_cluster
+
+    # Disable worker caching so worker leases are not reused, and disable
+    # inlining of return objects so return objects are always put into Plasma.
+    cluster.add_node(
+        num_cpus=1,
+        _system_config={
+            "worker_lease_timeout_milliseconds": 0,
+            "max_direct_call_object_size": 0,
+            "ownership_based_object_directory_enabled": True,
+        })
+    # Use a custom resource for pinning tasks to a node.
+    cluster.add_node(num_cpus=1, resources={"pin_worker1": 1})
+    worker2 = cluster.add_node(num_cpus=1, resources={"pin_worker2": 1})
+    ray.init(address=cluster.address)
+
+    @ray.remote
+    def f():
+        return ray.worker.global_worker.node.unique_id
+
+    @ray.remote
+    def g(x):
+        return ray.worker.global_worker.node.unique_id
+
+    @ray.remote
+    def h(x, y):
+        return ray.worker.global_worker.node.unique_id
+
+    # f_obj1 pinned on worker1.
+    f_obj1 = f.options(resources={"pin_worker1": 1}).remote()
+    # f_obj2 pinned on worker2.
+    f_obj2 = f.options(resources={"pin_worker2": 1}).remote()
+    # f_obj1 cached copy pulled to worker 2 in order to execute g() task.
+    ray.get(g.options(resources={"pin_worker2": 1}).remote(f_obj1))
+    # Confirm that h is scheduled onto worker 2, since it should have the
+    # primary copy of f_obj12 and a cached copy of f_obj1.
+    assert ray.get(h.remote(f_obj1, f_obj2)) == worker2.unique_id
+
+
 def test_lease_request_leak(shutdown_only):
     ray.init(
         num_cpus=1,

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -157,12 +157,18 @@ void ReferenceCounter::AddOwnedObject(const ObjectID &object_id,
   // If the entry doesn't exist, we initialize the direct reference count to zero
   // because this corresponds to a submitted task whose return ObjectID will be created
   // in the frontend language, incrementing the reference count.
-  object_id_refs_.emplace(object_id, Reference(owner_address, call_site, object_size,
-                                               is_reconstructable, pinned_at_raylet_id));
+  auto it = object_id_refs_
+                .emplace(object_id, Reference(owner_address, call_site, object_size,
+                                              is_reconstructable, pinned_at_raylet_id))
+                .first;
   if (!inner_ids.empty()) {
     // Mark that this object ID contains other inner IDs. Then, we will not GC
     // the inner objects until the outer object ID goes out of scope.
     AddNestedObjectIdsInternal(object_id, inner_ids, rpc_address_);
+  }
+  if (pinned_at_raylet_id.has_value()) {
+    // We eagerly add the pinned location to the set of object locations.
+    AddObjectLocationInternal(it, pinned_at_raylet_id.value());
   }
 }
 
@@ -553,6 +559,8 @@ void ReferenceCounter::UpdateObjectPinnedAtRaylet(const ObjectID &object_id,
     RAY_CHECK(it->second.owned_by_us);
     if (!it->second.OutOfScope(lineage_pinning_enabled_)) {
       it->second.pinned_at_raylet_id = raylet_id;
+      // We eagerly add the pinned location to the set of object locations.
+      AddObjectLocationInternal(it, raylet_id);
     }
   }
 }
@@ -920,9 +928,18 @@ bool ReferenceCounter::AddObjectLocation(const ObjectID &object_id,
                   << " that doesn't exist in the reference table";
     return false;
   }
-  it->second.locations.insert(node_id);
-  PushToLocationSubscribers(it);
+  AddObjectLocationInternal(it, node_id);
   return true;
+}
+
+void ReferenceCounter::AddObjectLocationInternal(ReferenceTable::iterator it,
+                                                 const NodeID &node_id) {
+  if (it->second.locations.emplace(node_id).second) {
+    // Only push to subscribers if we added a new location. We eagerly add the pinned
+    // location without waiting for the object store notification to trigger a location
+    // report, so there's a chance that we already knew about the node_id location.
+    PushToLocationSubscribers(it);
+  }
 }
 
 bool ReferenceCounter::RemoveObjectLocation(const ObjectID &object_id,
@@ -995,30 +1012,33 @@ absl::optional<LocalityData> ReferenceCounter::GetLocalityData(
   // Uses the reference table to return locality data for an object.
   auto it = object_id_refs_.find(object_id);
   if (it == object_id_refs_.end()) {
+    // We don't have any information about this object so we can't return valid locality
+    // data.
     RAY_LOG(DEBUG) << "Object " << object_id
                    << " not in reference table, locality data not available";
     return absl::nullopt;
   }
 
-  const auto &node_id = it->second.pinned_at_raylet_id;
-  if (!node_id.has_value()) {
-    RAY_LOG(DEBUG)
-        << "Reference " << it->second.call_site << " for object " << object_id
-        << " doesn't have a defined pinned raylet ID, locality data not available";
-    return absl::nullopt;
-  }
-  // The raylet ID to which this reference is pinned is defined.
-
+  // The size of this object.
   const auto object_size = it->second.object_size;
   if (object_size < 0) {
+    // We don't know the object size so we can't returned valid locality data.
     RAY_LOG(DEBUG) << "Reference " << it->second.call_site << " for object " << object_id
                    << " has an unknown object size, locality data not available";
     return absl::nullopt;
   }
-  // The object size of this reference is known.
 
+  // The locations of this object.
+  // - If we own this object and the ownership-based object directory is enabled, this
+  // will contain the complete up-to-date set of object locations.
+  // - If we own this object and the ownership-based object directory is disabled, this
+  // will only contain the pinned location, if known.
+  // - If we don't own this object, this will be empty.
+  const auto &node_ids = it->second.locations;
+
+  // We should only reach here if we have valid locality data to return.
   absl::optional<LocalityData> locality_data(
-      {static_cast<uint64_t>(object_size), {node_id.value()}});
+      {static_cast<uint64_t>(object_size), node_ids});
   return locality_data;
 }
 

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -727,9 +727,19 @@ class ReferenceCounter : public ReferenceCounterInterface,
   void ReleaseLineageReferencesInternal(const std::vector<ObjectID> &argument_ids)
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
+  /// Add a new location for the given object. The owner must have the object ref in
+  /// scope, and the caller must have already acquired mutex_.
+  ///
+  /// \param[in] it The reference iterator for the object.
+  /// \param[in] node_id The new object location to be added.
+  void AddObjectLocationInternal(ReferenceTable::iterator it, const NodeID &node_id)
+      EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+
   /// Pushes location updates to subscribers of a particular reference, invoking all
   /// callbacks registered for the reference by GetLocationsAsync calls. This method
   /// also increments the reference's location version counter.
+  ///
+  /// \param[in] it The reference iterator for the object.
   void PushToLocationSubscribers(ReferenceTable::iterator it)
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 

--- a/src/ray/core_worker/reference_count_test.cc
+++ b/src/ray/core_worker/reference_count_test.cc
@@ -341,17 +341,29 @@ TEST_F(ReferenceCountTest, TestGetLocalityData) {
   ASSERT_EQ(locality_data_obj1->nodes_containing_object,
             absl::flat_hash_set<NodeID>{node1});
 
+  if (RayConfig::instance().ownership_based_object_directory_enabled()) {
+    // Owned object with defined object size and at least one node location should return
+    // valid locality data.
+    rc->AddObjectLocation(obj1, node2);
+    auto locality_data_obj1 = rc->GetLocalityData(obj1);
+    ASSERT_TRUE(locality_data_obj1.has_value());
+    ASSERT_EQ(locality_data_obj1->object_size, object_size);
+    ASSERT_EQ(locality_data_obj1->nodes_containing_object,
+              absl::flat_hash_set<NodeID>({node1, node2}));
+  }
+
   // Fetching locality data for an object that doesn't have a reference in the table
   // should return a null optional.
   auto locality_data_obj2_not_exist = rc->GetLocalityData(obj2);
   ASSERT_FALSE(locality_data_obj2_not_exist.has_value());
 
   // Fetching locality data for an object that doesn't have a pinned node location
-  // defined should return a null optional.
+  // defined should return empty locations.
   rc->AddLocalReference(obj2, "file.py:43");
   rc->UpdateObjectSize(obj2, 200);
   auto locality_data_obj2_no_pinned_raylet = rc->GetLocalityData(obj2);
-  ASSERT_FALSE(locality_data_obj2_no_pinned_raylet.has_value());
+  ASSERT_TRUE(locality_data_obj2_no_pinned_raylet.has_value());
+  ASSERT_EQ(locality_data_obj2_no_pinned_raylet->nodes_containing_object.size(), 0);
   rc->RemoveLocalReference(obj2, nullptr);
 
   // Fetching locality data for an object that doesn't have an object size defined


### PR DESCRIPTION
Implements the second milestone of locality-aware leasing, where the locality cost is extended to include cached locations for owned refs.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #12814

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
