### PR TITLE
[dask-on-ray] Adds support for dask.persist() with inlined Ray futures.

### DIFF
--- a/python/ray/tests/test_dask_scheduler.py
+++ b/python/ray/tests/test_dask_scheduler.py
@@ -1,5 +1,4 @@
 import dask
-import numpy as np
 import dask.array as da
 import pytest
 
@@ -35,9 +34,7 @@ def test_ray_dask_basic(ray_start_regular_shared):
 def test_ray_dask_persist(ray_start_regular_shared):
     arr = da.ones(5) + 2
     result = arr.persist(scheduler=ray_dask_get)
-    np.testing.assert_array_equal(
-        next(iter(result.dask.values())),
-        np.ones(5) + 2)
+    assert isinstance(next(iter(result.dask.values())), ray.ObjectRef)
 
 
 if __name__ == "__main__":

--- a/python/ray/util/dask/__init__.py
+++ b/python/ray/util/dask/__init__.py
@@ -1,3 +1,4 @@
+import dask
 from .scheduler import ray_dask_get, ray_dask_get_sync
 from .callbacks import (
     RayDaskCallback,
@@ -6,10 +7,43 @@ from .callbacks import (
 )
 from .optimizations import dataframe_optimize
 
+dask_persist = dask.persist
+
+
+def ray_dask_persist(*args, **kwargs):
+    kwargs["ray_persist"] = True
+    return dask_persist(*args, **kwargs)
+
+
+ray_dask_persist.__doc__ = dask_persist.__doc__
+
+dask_persist_mixin = dask.base.DaskMethodsMixin.persist
+
+
+def ray_dask_persist_mixin(self, **kwargs):
+    kwargs["ray_persist"] = True
+    return dask_persist_mixin(self, **kwargs)
+
+
+ray_dask_persist_mixin.__doc__ = dask_persist_mixin.__doc__
+
+
+# We patch dask in order to inject a kwarg into its `dask.persist()` calls,
+# which the Dask-on-Ray scheduler needs.
+# FIXME(Clark): Monkey patching is bad and we should try to avoid this.
+def patch_dask(ray_dask_persist, ray_dask_persist_mixin):
+    dask.persist = ray_dask_persist
+    dask.base.DaskMethodsMixin.persist = ray_dask_persist_mixin
+
+
+patch_dask(ray_dask_persist, ray_dask_persist_mixin)
+
 __all__ = [
     # Schedulers
     "ray_dask_get",
     "ray_dask_get_sync",
+    # Helpers
+    "ray_dask_persist",
     # Callbacks
     "RayDaskCallback",
     "local_ray_callbacks",

--- a/python/ray/util/dask/scheduler.py
+++ b/python/ray/util/dask/scheduler.py
@@ -79,6 +79,7 @@ def ray_dask_get(dsk, keys, **kwargs):
                 pools[thread][num_workers] = pool
 
     ray_callbacks = kwargs.pop("ray_callbacks", None)
+    persist = kwargs.pop("ray_persist", False)
 
     with local_ray_callbacks(ray_callbacks) as ray_callbacks:
         # Unpack the Ray-specific callbacks.
@@ -116,7 +117,10 @@ def ray_dask_get(dsk, keys, **kwargs):
         # Ray tasks are done. Otherwise, no intermediate objects will be
         # cleaned up until all Ray tasks are done.
         del dsk
-        result = ray_get_unpack(object_refs)
+        if persist:
+            result = object_refs
+        else:
+            result = ray_get_unpack(object_refs)
         if ray_finish_cbs is not None:
             for cb in ray_finish_cbs:
                 cb(result)
@@ -409,6 +413,7 @@ def ray_dask_get_sync(dsk, keys, **kwargs):
     """
 
     ray_callbacks = kwargs.pop("ray_callbacks", None)
+    persist = kwargs.pop("ray_persist", False)
 
     with local_ray_callbacks(ray_callbacks) as ray_callbacks:
         # Unpack the Ray-specific callbacks.
@@ -444,7 +449,10 @@ def ray_dask_get_sync(dsk, keys, **kwargs):
         # Ray tasks are done. Otherwise, no intermediate objects will be
         # cleaned up until all Ray tasks are done.
         del dsk
-        result = ray_get_unpack(object_refs)
+        if persist:
+            result = object_refs
+        else:
+            result = ray_get_unpack(object_refs)
         if ray_finish_cbs is not None:
             for cb in ray_finish_cbs:
                 cb(result)


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Dask users like to use `dask.persist()` with Dask Distributed in order to kick off background computation and make subsequent `dask.compute()` calls on derived collections fast. This works by Dask Distributed inlining futures into the Dask collections, with future computations resolving those futures into concrete values. This matches nicely with Ray's paradigm of creating object reference futures by default, only requiring the Dask-on-Ray scheduler to not call `ray.get()` on the output futures, and instead let the repackaging logic inline the futures into the Dask collections. Future calls to `dask.compute()` work as expected.

Unfortunately, `dask.persist()` only does this future inlining for the Dask Distributed scheduler, requiring us to monkey patch `dask.persist()` and `dask.base.DaskMethodsMixin.persist()` to properly inject a `ray_persist` kwarg. This is obviously not ideal, but provides the expected end-user UX.

## Example usage

```python
import dask
import dask.array as da
import numpy as np
import ray
from ray.util.dask import ray_dask_get

a = da.from_array(np.random.rand(10)).mean()
# This is a Dask collection with Ray object futures inlined
b = a.persist(scheduler=ray_dask_get)
print(dask.base.collections_to_dsk([b]))
```
output
```
{('mean_agg-aggregate-ebb6acef8888b6ae8e5dc80975326246',): ObjectRef(b50edb9fa0547cf7ffffffffffffffffffffffff0100000001000000)}
```

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #14227

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
