### PR TITLE
[Core] Locality-aware leasing: Milestone 4 - Borrowed refs.

### DIFF
--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -228,6 +228,45 @@ def test_locality_aware_leasing_cached_objects(ray_start_cluster):
     assert ray.get(h.remote(f_obj1, f_obj2)) == worker2.unique_id
 
 
+def test_locality_aware_leasing_borrowed_objects(ray_start_cluster):
+    # This test ensures that a task will run where its task dependencies are
+    # located, even when those objects are borrowed.
+    cluster = ray_start_cluster
+
+    # Disable worker caching so worker leases are not reused, and disable
+    # inlining of return objects so return objects are always put into Plasma.
+    cluster.add_node(
+        num_cpus=1,
+        resources={"pin_head": 1},
+        _system_config={
+            "worker_lease_timeout_milliseconds": 0,
+            "max_direct_call_object_size": 0,
+        })
+    # Use a custom resource for pinning tasks to a node.
+    worker_node = cluster.add_node(num_cpus=1, resources={"pin_worker": 1})
+    ray.init(address=cluster.address)
+
+    @ray.remote
+    def f():
+        return ray.worker.global_worker.node.unique_id
+
+    @ray.remote
+    def g(x):
+        return ray.get(h.remote(x[0]))
+
+    @ray.remote
+    def h(x):
+        return ray.worker.global_worker.node.unique_id
+
+    # f will run on worker, f_obj will be pinned on worker.
+    f_obj = f.options(resources={"pin_worker": 1}).remote()
+    # g will run on head, f_obj will be borrowed by head, and we confirm that
+    # h(f_obj) is scheduled onto worker, the node that has f_obj.
+    assert ray.get(g.options(resources={
+        "pin_head": 1
+    }).remote([f_obj])) == worker_node.unique_id
+
+
 def test_lease_request_leak(shutdown_only):
     ray.init(
         num_cpus=1,

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -540,8 +540,14 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
           std::move(actor_creator),
           RayConfig::instance().max_tasks_in_flight_per_worker(),
           boost::asio::steady_timer(io_service_)));
-  future_resolver_.reset(
-      new FutureResolver(memory_store_, core_worker_client_pool_, rpc_address_));
+  auto report_locality_data_callback =
+      [this](const ObjectID &object_id, const absl::flat_hash_set<NodeID> &locations,
+             uint64_t object_size) {
+        reference_counter_->ReportLocalityData(object_id, locations, object_size);
+      };
+  future_resolver_.reset(new FutureResolver(memory_store_,
+                                            std::move(report_locality_data_callback),
+                                            core_worker_client_pool_, rpc_address_));
   // Unfortunately the raylet client has to be constructed after the receivers.
   if (direct_task_receiver_ != nullptr) {
     task_argument_waiter_.reset(new DependencyWaiterImpl(*local_raylet_client_));
@@ -2191,7 +2197,7 @@ void CoreWorker::HandleGetObjectStatus(const rpc::GetObjectStatusRequest &reques
     // Send the reply once the value has become available. The value is
     // guaranteed to become available eventually because we own the object and
     // its ref count is > 0.
-    memory_store_->GetAsync(object_id, [reply, send_reply_callback,
+    memory_store_->GetAsync(object_id, [this, object_id, reply, send_reply_callback,
                                         is_freed](std::shared_ptr<RayObject> obj) {
       if (is_freed) {
         reply->set_status(rpc::GetObjectStatusReply::FREED);
@@ -2216,6 +2222,14 @@ void CoreWorker::HandleGetObjectStatus(const rpc::GetObjectStatusRequest &reques
           object->add_nested_inlined_ids(nested_id.Binary());
         }
         reply->set_status(rpc::GetObjectStatusReply::CREATED);
+        // Set locality data.
+        const auto &locality_data = reference_counter_->GetLocalityData(object_id);
+        if (locality_data.has_value()) {
+          for (const auto &node_id : locality_data.value().nodes_containing_object) {
+            reply->add_node_ids(node_id.Binary());
+          }
+          reply->set_object_size(locality_data.value().object_size);
+        }
       }
       send_reply_callback(Status::OK(), nullptr, nullptr);
     });

--- a/src/ray/core_worker/future_resolver.h
+++ b/src/ray/core_worker/future_resolver.h
@@ -25,14 +25,19 @@
 
 namespace ray {
 
+using ReportLocalityDataCallback =
+    std::function<void(const ObjectID &, const absl::flat_hash_set<NodeID> &, uint64_t)>;
+
 // Resolve values for futures that were given to us before the value
 // was available. This class is thread-safe.
 class FutureResolver {
  public:
   FutureResolver(std::shared_ptr<CoreWorkerMemoryStore> store,
+                 ReportLocalityDataCallback report_locality_data_callback,
                  std::shared_ptr<rpc::CoreWorkerClientPool> core_worker_client_pool,
                  const rpc::Address &rpc_address)
       : in_memory_store_(store),
+        report_locality_data_callback_(std::move(report_locality_data_callback)),
         owner_clients_(core_worker_client_pool),
         rpc_address_(rpc_address) {}
 
@@ -50,6 +55,10 @@ class FutureResolver {
   /// Used to store values of resolved futures.
   std::shared_ptr<CoreWorkerMemoryStore> in_memory_store_;
 
+  /// Used to report locality data received during future resolution.
+  const ReportLocalityDataCallback report_locality_data_callback_;
+
+  /// Pool of owner core worker clients.
   std::shared_ptr<rpc::CoreWorkerClientPool> owner_clients_;
 
   /// Address of our RPC server. Used to notify borrowed objects' owners of our

--- a/src/ray/core_worker/lease_policy.h
+++ b/src/ray/core_worker/lease_policy.h
@@ -45,8 +45,8 @@ class LeasePolicyInterface {
   virtual ~LeasePolicyInterface() {}
 };
 
-typedef std::function<absl::optional<rpc::Address>(const NodeID &node_id)>
-    NodeAddrFactory;
+using NodeAddrFactory =
+    std::function<absl::optional<rpc::Address>(const NodeID &node_id)>;
 
 /// Class used by the core worker to implement a locality-aware lease policy for
 /// picking a worker node for a lease request. This class is not thread-safe.

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -434,8 +434,23 @@ class ReferenceCounter : public ReferenceCounterInterface,
   bool HandleObjectSpilled(const ObjectID &object_id, const std::string spilled_url,
                            const NodeID &spilled_node_id, int64_t size, bool release);
 
-  /// Get locality data for object.
+  /// Get locality data for object. This is used by the leasing policy to implement
+  /// locality-aware leasing.
+  ///
+  /// \param[in] object_id Object whose locality data we want.
+  /// \return Locality data.
   absl::optional<LocalityData> GetLocalityData(const ObjectID &object_id);
+
+  /// Report locality data for object. This is used by the FutureResolver to report
+  /// locality data for borrowed refs.
+  ///
+  /// \param[in] object_id Object whose locality data we're reporting.
+  /// \param[in] locations Locations of the object.
+  /// \param[in] object_size Size of the object.
+  /// \return True if the reference exists, false otherwise.
+  bool ReportLocalityData(const ObjectID &object_id,
+                          const absl::flat_hash_set<NodeID> &locations,
+                          uint64_t object_size);
 
  private:
   struct Reference {

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -151,6 +151,10 @@ message GetObjectStatusReply {
   // The Ray object: either a concrete value, an in-Plasma indicator, or an
   // exception.
   RayObject object = 2;
+  // This object's locations.
+  repeated bytes node_ids = 3;
+  // The size of the object in bytes.
+  uint64 object_size = 4;
 }
 
 message WaitForActorOutOfScopeRequest {


### PR DESCRIPTION
Implements the fourth milestone of locality-aware leasing, where the locality cost is extended to include locations of borrowed refs.

## TODOs

- [x] Add tests

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #12816

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
