### PR TITLE
Upgrading Redis to 6.0.10 in order to be functional on Apple silicon (M1)

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -80,8 +80,8 @@ def ray_deps_setup():
     auto_http_archive(
         name = "com_github_antirez_redis",
         build_file = "//bazel:BUILD.redis",
-        url = "https://github.com/redis/redis/archive/6.0.9.tar.gz",
-        sha256 = "2819b6d9c56be1f25cd157b9cb6b7c2733edcb46f4f6bcb1b79cefe639a2853b",
+        url = "https://github.com/redis/redis/archive/6.0.10.tar.gz",
+        sha256 = "900cb82227bac58242c9b7668e7113cd952253b256fe04bbdab1b78979cf255a",
         patches = [
             "//thirdparty/patches:redis-quiet.patch",
         ],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The ray won't start on Apple silicon (M1) in Rosetta 2 x86 translator because Redis crashes. This was acknowledged by Redis team in here https://github.com/redis/redis/issues/8062. The patch which fixes this is part of 6.0.10 version 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #12742

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
