### PR TITLE
[GCS]Cherry pick heartbeat function into another thread

### DIFF
--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -517,8 +517,6 @@ Status ServiceBasedNodeInfoAccessor::AsyncReportHeartbeat(
   request.mutable_heartbeat()->CopyFrom(*data_ptr);
   client_impl_->GetGcsRpcClient().ReportHeartbeat(
       request, [callback](const Status &status, const rpc::ReportHeartbeatReply &reply) {
-        RAY_LOG(INFO) << "wangtao heartbeat" << reply.status().code() << " message "
-                      << reply.status().message();
         if (callback) {
           callback(status);
         }

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -517,6 +517,8 @@ Status ServiceBasedNodeInfoAccessor::AsyncReportHeartbeat(
   request.mutable_heartbeat()->CopyFrom(*data_ptr);
   client_impl_->GetGcsRpcClient().ReportHeartbeat(
       request, [callback](const Status &status, const rpc::ReportHeartbeatReply &reply) {
+        RAY_LOG(INFO) << "wangtao heartbeat" << reply.status().code() << " message "
+                      << reply.status().message();
         if (callback) {
           callback(status);
         }

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -110,7 +110,7 @@ int main(int argc, char *argv[]) {
   gcs_client = std::make_shared<ray::gcs::ServiceBasedGcsClient>(client_options);
 
   RAY_CHECK_OK(gcs_client->Connect(main_service));
-  std::unique_ptr<ray::raylet::Raylet> server(nullptr);
+  std::unique_ptr<ray::raylet::Raylet> raylet(nullptr);
 
   RAY_CHECK_OK(gcs_client->Nodes().AsyncGetInternalConfig(
       [&](::ray::Status status,
@@ -229,22 +229,22 @@ int main(int argc, char *argv[]) {
         ray::stats::Init(global_tags, metrics_agent_port);
 
         // Initialize the node manager.
-        server.reset(new ray::raylet::Raylet(
+        raylet.reset(new ray::raylet::Raylet(
             main_service, raylet_socket_name, node_ip_address, redis_address, redis_port,
             redis_password, node_manager_config, object_manager_config, gcs_client,
             metrics_export_port));
 
-        server->Start();
+        raylet->Start();
       }));
 
   // Destroy the Raylet on a SIGTERM. The pointer to main_service is
   // guaranteed to be valid since this function will run the event loop
   // instead of returning immediately.
   // We should stop the service and remove the local socket file.
-  auto handler = [&main_service, &raylet_socket_name, &server, &gcs_client](
+  auto handler = [&main_service, &raylet_socket_name, &raylet, &gcs_client](
                      const boost::system::error_code &error, int signal_number) {
     RAY_LOG(INFO) << "Raylet received SIGTERM, shutting down...";
-    server->Stop();
+    raylet->Stop();
     gcs_client->Disconnect();
     ray::stats::Shutdown();
     main_service.stop();

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -336,7 +336,7 @@ ray::Status NodeManager::RegisterGcs() {
 
   // Start sending heartbeats to the GCS.
   last_heartbeat_at_ms_ = current_time_ms();
-  heartbeat_runner_.RunFnPeriodically(
+  heartbeat_runner_->RunFnPeriodically(
       [this] { Heartbeat(); },
       RayConfig::instance().raylet_heartbeat_period_milliseconds());
   periodical_runner_.RunFnPeriodically(

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -260,7 +260,7 @@ NodeManager::NodeManager(boost::asio::io_service &io_service, const NodeID &self
   heartbeat_thread_.reset(new std::thread([this] {
     SetThreadName("heartbeat");
     /// The asio work to keep io_service_ alive.
-    boost::asio::io_service::work io_service_work_(io_service_);
+    boost::asio::io_service::work io_service_work_(heartbeat_io_service_);
     heartbeat_io_service_.run();
   }));
   heartbeat_runner_.reset(new PeriodicalRunner(heartbeat_io_service_));

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -114,6 +114,57 @@ std::string WorkerOwnerString(std::shared_ptr<WorkerInterface> &worker) {
   return buffer.str();
 }
 
+HeartbeatSender::HeartbeatSender(NodeID self_node_id,
+                                 std::shared_ptr<gcs::GcsClient> gcs_client)
+    : self_node_id_(self_node_id), gcs_client_(gcs_client) {
+  // Init heartbeat thread and run its io service.
+  heartbeat_thread_.reset(new std::thread([this] {
+    SetThreadName("heartbeat");
+    /// The asio work to keep io_service_ alive.
+    boost::asio::io_service::work io_service_work_(heartbeat_io_service_);
+    heartbeat_io_service_.run();
+  }));
+  heartbeat_runner_.reset(new PeriodicalRunner(heartbeat_io_service_));
+
+  // Start sending heartbeats to the GCS.
+  last_heartbeat_at_ms_ = current_time_ms();
+  heartbeat_runner_->RunFnPeriodically(
+      [this] { Heartbeat(); },
+      RayConfig::instance().raylet_heartbeat_period_milliseconds());
+}
+
+HeartbeatSender::~HeartbeatSender() {
+  heartbeat_runner_.reset();
+  heartbeat_io_service_.stop();
+  if (heartbeat_thread_->joinable()) {
+    heartbeat_thread_->join();
+  }
+  heartbeat_thread_.reset();
+}
+
+void HeartbeatSender::Heartbeat() {
+  uint64_t now_ms = current_time_ms();
+  uint64_t interval = now_ms - last_heartbeat_at_ms_;
+  if (interval > RayConfig::instance().num_heartbeats_warning() *
+                     RayConfig::instance().raylet_heartbeat_period_milliseconds()) {
+    RAY_LOG(WARNING)
+        << "Last heartbeat was sent " << interval
+        << " ms ago. There might be resource pressure on this node. If heartbeat keeps "
+           "lagging, this node can be marked as dead mistakenly.";
+  }
+  last_heartbeat_at_ms_ = now_ms;
+  stats::HeartbeatReportMs.Record(interval);
+
+  auto heartbeat_data = std::make_shared<HeartbeatTableData>();
+  heartbeat_data->set_node_id(self_node_id_.Binary());
+  RAY_CHECK_OK(
+      gcs_client_->Nodes().AsyncReportHeartbeat(heartbeat_data, [](Status status) {
+        if (status.IsDisconnected()) {
+          RAY_LOG(FATAL) << "This node has beem marked as dead.";
+        }
+      }));
+}
+
 NodeManager::NodeManager(boost::asio::io_service &io_service, const NodeID &self_node_id,
                          const NodeManagerConfig &config, ObjectManager &object_manager,
                          std::shared_ptr<gcs::GcsClient> gcs_client,
@@ -175,7 +226,6 @@ NodeManager::NodeManager(boost::asio::io_service &io_service, const NodeID &self
             SendSpilledObjectRestorationRequestToRemoteNode(object_id, spilled_url,
                                                             node_id);
           }),
-      report_worker_backlog_(RayConfig::instance().report_worker_backlog()),
       last_local_gc_ns_(absl::GetCurrentTimeNanos()),
       local_gc_interval_ns_(RayConfig::instance().local_gc_interval_s() * 1e9),
       local_gc_min_interval_ns_(RayConfig::instance().local_gc_min_interval_s() * 1e9),
@@ -255,18 +305,11 @@ NodeManager::NodeManager(boost::asio::io_service &io_service, const NodeID &self
                        }));
 
   RAY_CHECK_OK(SetupPlasmaSubscription());
-
-  // Init heartbeat thread and run its io service.
-  heartbeat_thread_.reset(new std::thread([this] {
-    SetThreadName("heartbeat");
-    /// The asio work to keep io_service_ alive.
-    boost::asio::io_service::work io_service_work_(heartbeat_io_service_);
-    heartbeat_io_service_.run();
-  }));
-  heartbeat_runner_.reset(new PeriodicalRunner(heartbeat_io_service_));
 }
 
 ray::Status NodeManager::RegisterGcs() {
+  // Start sending heartbeat here to ensure it happening after raylet being registered.
+  heartbeat_sender_.reset(new HeartbeatSender(self_node_id_, gcs_client_));
   auto on_node_change = [this](const NodeID &node_id, const GcsNodeInfo &data) {
     if (data.state() == GcsNodeInfo::ALIVE) {
       NodeAdded(data);
@@ -334,11 +377,6 @@ ray::Status NodeManager::RegisterGcs() {
   RAY_RETURN_NOT_OK(
       gcs_client_->Jobs().AsyncSubscribeAll(job_subscribe_handler, nullptr));
 
-  // Start sending heartbeats to the GCS.
-  last_heartbeat_at_ms_ = current_time_ms();
-  heartbeat_runner_->RunFnPeriodically(
-      [this] { Heartbeat(); },
-      RayConfig::instance().raylet_heartbeat_period_milliseconds());
   periodical_runner_.RunFnPeriodically(
       [this] {
         DumpDebugState();
@@ -424,29 +462,6 @@ void NodeManager::HandleJobFinished(const JobID &job_id, const JobTableData &job
       KillWorker(worker);
     }
   }
-}
-
-void NodeManager::Heartbeat() {
-  uint64_t now_ms = current_time_ms();
-  uint64_t interval = now_ms - last_heartbeat_at_ms_;
-  if (interval > RayConfig::instance().num_heartbeats_warning() *
-                     RayConfig::instance().raylet_heartbeat_period_milliseconds()) {
-    RAY_LOG(WARNING)
-        << "Last heartbeat was sent " << interval
-        << " ms ago. There might be resource pressure on this node. If heartbeat keeps "
-           "lagging, this node can be marked as dead mistakenly.";
-  }
-  last_heartbeat_at_ms_ = now_ms;
-  stats::HeartbeatReportMs.Record(interval);
-
-  auto heartbeat_data = std::make_shared<HeartbeatTableData>();
-  heartbeat_data->set_node_id(self_node_id_.Binary());
-  RAY_CHECK_OK(
-      gcs_client_->Nodes().AsyncReportHeartbeat(heartbeat_data, [](Status status) {
-        if (status.IsDisconnected()) {
-          RAY_LOG(FATAL) << "This node has beem marked as dead.";
-        }
-      }));
 }
 
 void NodeManager::ReportResourceUsage() {
@@ -1447,7 +1462,7 @@ void NodeManager::HandleRequestWorkerLease(const rpc::RequestWorkerLeaseRequest 
   rpc::Task task_message;
   task_message.mutable_task_spec()->CopyFrom(request.resource_spec());
   auto backlog_size = -1;
-  if (report_worker_backlog_) {
+  if (RayConfig::instance().report_worker_backlog()) {
     backlog_size = request.backlog_size();
   }
   Task task(task_message, backlog_size);
@@ -2666,12 +2681,9 @@ void NodeManager::TriggerGlobalGC() {
 }
 
 void NodeManager::Stop() {
-  heartbeat_runner_.reset();
-  heartbeat_io_service_.stop();
-  if (heartbeat_thread_->joinable()) {
-    heartbeat_thread_->join();
+  if (heartbeat_sender_) {
+    heartbeat_sender_.reset();
   }
-  heartbeat_thread_.reset();
 }
 
 void NodeManager::RecordMetrics() {

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -160,6 +160,9 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// object ids.
   void TriggerGlobalGC();
 
+  /// Stop this node manager.
+  void Stop();
+
  private:
   /// Methods for handling nodes.
 
@@ -772,6 +775,12 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// ID of this node.
   NodeID self_node_id_;
   boost::asio::io_service &io_service_;
+  /// The io service used in heartbeat loop in case of it being
+  /// blocked by main thread.
+  boost::asio::io_service heartbeat_io_service_;
+  /// Heartbeat thread, using with heartbeat_io_service_.
+  std::unique_ptr<std::thread> heartbeat_thread_;
+  std::unique_ptr<PeriodicalRunner> heartbeat_runner_;
   ObjectManager &object_manager_;
   /// A Plasma object store client. This is used for creating new objects in
   /// the object store (e.g., for actor tasks that can't be run because the

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -124,6 +124,7 @@ void Raylet::Start() {
 void Raylet::Stop() {
   object_manager_.Stop();
   RAY_CHECK_OK(gcs_client_->Nodes().UnregisterSelf());
+  node_manager_.Stop();
   acceptor_.close();
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
In normal cases raylet main thread doesn't do too much heavy load, but sometime it could be blocked by some lock operation( we found servral times).
Heartbeat is a light but import action for thread, as it is depended by gcs node failure detecting. To avoid raylet being treated as lost by misunderstand, we'd like it sending heartbeat in a different thread from the main one.
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
