### PR TITLE
[Core] Skip GCS fault-tolerance test on Windows.

### DIFF
--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -48,6 +48,7 @@ def test_gcs_server_restart(ray_start_regular):
     assert result == 9
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows.")
 @pytest.mark.parametrize(
     "ray_start_regular", [
         generate_system_config_map(


### PR DESCRIPTION
This test is [consistently](https://flakey-tests.ray.io/) failing on Windows with an [access violation](https://github.com/ray-project/ray/runs/1970088434). It started failing on the merging of [this GCS PR](https://github.com/ray-project/ray/pull/14248), but I can't see how any of those changes would cause these failures.