### PR TITLE
[Serve] [Doc] fix servehandle docstring for sync/async

### DIFF
--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -32,12 +32,22 @@ class RayServeHandle:
     Example:
        >>> handle = serve_client.get_handle("my_endpoint")
        >>> handle
-       RayServeHandle(endpoint="my_endpoint")
-       >>> await handle.remote(my_request_content)
+       RayServeSyncHandle(endpoint="my_endpoint")
+       >>> handle.remote(my_request_content)
        ObjectRef(...)
-       >>> ray.get(await handle.remote(...))
+       >>> ray.get(handle.remote(...))
        # result
-       >>> ray.get(await handle.remote(let_it_crash_request))
+       >>> ray.get(handle.remote(let_it_crash_request))
+       # raises RayTaskError Exception
+
+       >>> async_handle = serve_client.get_handle("my_endpoint", sync=False)
+       >>> async_handle
+       RayServeHandle(endpoint="my_endpoint")
+       >>> await async_handle.remote(my_request_content)
+       ObjectRef(...)
+       >>> ray.get(await async_handle.remote(...))
+       # result
+       >>> ray.get(await async_handle.remote(let_it_crash_request))
        # raises RayTaskError Exception
     """
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Corrects the ServeHandle docstring which appears in the API reference.  `serve_client.get_handle("my_endpoint")` actually returns a *sync* handle by default, so we just have to remove some `awaits` from the original docstring.  For clarity, we include a full usage example with `sync=False` as well, even if it's a bit verbose.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
