### PR TITLE
[serve] Better validation for arguments to client.start()

### DIFF
--- a/python/ray/serve/http_proxy.py
+++ b/python/ray/serve/http_proxy.py
@@ -216,7 +216,9 @@ class HTTPProxyActor:
             sock.bind((self.host, self.port))
         except OSError:
             # The OS failed to bind a socket to the given host and port.
-            raise ValueError(f"Failed to bind HTTP proxy to '{self.host}:{self.port}'. Please make sure your http-host and http-port are specified correctly.")
+            raise ValueError(
+                f"""Failed to bind Ray Serve HTTP proxy to '{self.host}:{self.port}'.
+Please make sure your http-host and http-port are specified correctly.""")
 
         # Note(simon): we have to use lower level uvicorn Config and Server
         # class because we want to run the server as a coroutine. The only

--- a/python/ray/serve/http_proxy.py
+++ b/python/ray/serve/http_proxy.py
@@ -211,7 +211,12 @@ class HTTPProxyActor:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         if hasattr(socket, "SO_REUSEPORT"):
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
-        sock.bind((self.host, self.port))
+
+        try:
+            sock.bind((self.host, self.port))
+        except OSError:
+            # The OS failed to bind a socket to the given host and port.
+            raise ValueError(f"Failed to bind HTTP proxy to '{self.host}:{self.port}'. Please make sure your http-host and http-port are specified correctly.")
 
         # Note(simon): we have to use lower level uvicorn Config and Server
         # class because we want to run the server as a coroutine. The only

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -162,7 +162,7 @@ def test_middleware():
 
 def test_http_proxy_fail_loudly():
     # Test that if the http server fail to start, serve.start should fail.
-    with pytest.raises(socket.gaierror):
+    with pytest.raises(ValueError):
         serve.start(http_options={"host": "bad.ip.address"})
 
     ray.shutdown()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

1. Provide a clearer error message when running serve with invalid `http-host`

Before: 

```
    timeout=HTTP_PROXY_TIMEOUT,
  File "/usr/local/Caskroom/miniconda/base/envs/ray-dev/lib/python3.7/site-packages/ray/_private/client_mode_hook.py", line 47, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/Caskroom/miniconda/base/envs/ray-dev/lib/python3.7/site-packages/ray/worker.py", line 1428, in get
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(ValueError): ray::HTTPProxyActor.ready() (pid=60019, ip=192.168.1.194)
OSError: [Errno 49] Can't assign requested address
```

After:

```
    raise self._exception
  File "/usr/local/Caskroom/miniconda/base/envs/ray-dev/lib/python3.7/site-packages/ray/serve/http_proxy.py", line 204, in ready
    return await done_set.pop()
  File "/usr/local/Caskroom/miniconda/base/envs/ray-dev/lib/python3.7/site-packages/ray/serve/http_proxy.py", line 219, in run
    raise ValueError(f"Failed to bind HTTP proxy to '{self.host}:{self.port}'. Please make sure your http-host and http-port are specified correctly.")
ValueError: Failed to bind Ray Serve HTTP proxy to '0.0.:8000'. 
Please make sure your http-host and http-port are specified correctly.
```


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes: #12769

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
