### PR TITLE
Use more IO workers by default

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -336,7 +336,7 @@ RAY_CONFIG(std::string, object_spilling_config, "")
 RAY_CONFIG(bool, automatic_object_spilling_enabled, true)
 
 /// The maximum number of I/O worker that raylet starts.
-RAY_CONFIG(int, max_io_workers, 1)
+RAY_CONFIG(int, max_io_workers, 4)
 
 /// Ray's object spilling fuses small objects into a single file before flushing them
 /// to optimize the performance.


### PR DESCRIPTION
This is particularly important for restore workers, since there is no batching of requests there. In the future we can consider having a large number of restore workers (8?) and a smaller number of spill workers.