### PR TITLE
[Serve] Add Perf Tuning Doc

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -250,6 +250,7 @@ Papers
    serve/ml-models.rst
    serve/advanced-traffic.rst
    serve/advanced.rst
+   serve/performance.rst
    serve/architecture.rst
    serve/tutorials/index.rst
    serve/faq.rst

--- a/doc/source/serve/architecture.rst
+++ b/doc/source/serve/architecture.rst
@@ -1,3 +1,5 @@
+.. _serve-architecture:
+
 Serve Architecture
 ==================
 This document provides an overview of how each component in Serve works.

--- a/doc/source/serve/deployment.rst
+++ b/doc/source/serve/deployment.rst
@@ -203,6 +203,8 @@ Please refer to the Kubernetes documentation for more information.
 .. _`NodePort`: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
 
 
+.. _serve-monitoring:
+
 Monitoring
 ==========
 

--- a/doc/source/serve/ml-models.rst
+++ b/doc/source/serve/ml-models.rst
@@ -4,6 +4,8 @@ Serving Machine Learning Models
 
 .. contents::
 
+.. _serve-ml-batching:
+
 Request Batching
 ================
 

--- a/doc/source/serve/performance.rst
+++ b/doc/source/serve/performance.rst
@@ -71,6 +71,7 @@ to allow more coroutines running in the same replica.
 Scaling HTTP servers
 ^^^^^^^^^^^^^^^^^^^^
 Sometimes it’s not about your code: Serve’s HTTP server can become the bottleneck.
+If you observe that the CPU utilization for HTTPProxy actor spike up to 100%, the HTTP server is the bottleneck.
 Serve only starts a single HTTP server on the Ray head node by default. 
 This single HTTP server can handle about 3k queries per second. 
 If your workload exceeds this number, you might want to consider starting one

--- a/doc/source/serve/performance.rst
+++ b/doc/source/serve/performance.rst
@@ -1,0 +1,81 @@
+Performance Tuning
+==================
+
+This section should help you:
+
+- understand the performance characteristics of Ray Serve
+- find ways to debug and tune the performance of your Serve deployment
+
+.. note::
+    While this section offers some tips and tricks to improve the performance of your Serve deployment,
+    the :ref:`architecture doc <serve-architecture>` is helpful to gain a deeper understanding of these contexts and parameters.
+
+.. contents::
+
+Performance and known benchmarks
+--------------------------------
+We are continuously benchmarking Ray Serve. The metrics we care about are latency, throughput, and scalability. We can confidently say:
+
+- Ray Serve’s latency overhead is single digit milliseconds, often times just 1-2 milliseconds.
+- For throughput, Serve achieves about 3-4k queries per second on a single machine (8 cores) using 1 http proxy and 8 backend replicas performing noop.
+- It is horizontally scalable so you can add more machines to increase the overall throughput. Ray Serve is built on top of Ray, 
+  so its scalability is bounded by Ray’s scalability. Please check out Ray’s `scalability envelope <https://github.com/ray-project/ray/blob/master/benchmarks/README.md>`_
+  to learn more about the maximum number of nodes and other limitations.
+
+You can check out our `microbenchmark instruction <https://github.com/ray-project/ray/blob/master/python/ray/serve/benchmarks/README.md>`_
+to benchmark on your hardware.
+
+Debug performance Issue
+-----------------------
+A typical performance issue in Serve has the symptom of high client call latency and low throughput.
+This shows the system is processing fewer queries than desired! 
+
+If you have set up :ref:`monitoring <serve-monitoring>` with Ray and Ray Serve, you will observe that
+``serve_num_router_requests`` is constant while your load increases
+``serve_backend_queuing_latency_ms`` is spiking up as queries queue up in the background
+
+Given the symptom, there are several ways to fix it.
+
+Choosing the right hardware
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Make sure you are using the right hardware and resources. 
+Are you using GPUs (``actor_init_options={“num_gpus”: 1}``) or 1+ cores (``actor_init_options={“num_cpus”: 2}``, and setting ``OMP_NUM_THREADS``)
+to increase the performance of your deep learning framework?
+
+Batching
+^^^^^^^^
+If your backend can process a batch at a time at a sublinear latency 
+(for example, if it takes 1ms to process 1 query and 5ms to process 10 of them) 
+then batching is your best approach. Check out the :ref:`batching guide <serve-ml-batching>` to 
+make your backend accept batches. You might want to tune your ``max_batch_size`` and ``batch_wait_timeout`` to maximize the benefits:
+
+- ``max_batch_size`` specifies how big the batch should be. Generally, 
+   we recommend choosing the largest batch size your function can handle 
+   AND the performance improvement is no longer sublinear. Take a dummy 
+   example: suppose it takes 1ms to process 1 query, 5ms to process 10 queries,
+   and 6ms to process 11 queries. Here you should set the batch size to to 10 
+   because adding more queries won’t improve the performance.
+- ``batch_wait_timeout`` specifies how the maximum amount of time to wait before
+  a batch should be processed, even if it’s not full.  It should be set according 
+  to `batch-wait-timeout + full batch processing time ~= expected latency`. The idea 
+  here is to have the first query wait for the longest possible time to achieve high throughput.  
+  This means you should set batch-wait-timeout as large as possible without exceeding your desired expected latency in the equation above.
+
+Async functions
+^^^^^^^^^^^^^^^
+Are you using ``async def`` in your callable? If you are using asyncio and
+hitting the same queuing issue mentioned above, you might want to increase 
+``max_concurrent_queries``. Serve sets a low number by default so the client gets 
+proper backpressure. You can increase the value in the :mod:`backend config <ray.serve.config.BackendConfig>`
+to allow more coroutines running in the same replica.
+
+Scale HTTP servers
+^^^^^^^^^^^^^^^^^^
+Sometimes it’s not about your code: Serve’s HTTP server can become the bottleneck.
+Serve only starts a single HTTP server on the Ray head node by default. 
+This single HTTP server can handle about 3k queries per second. 
+If your workload exceeds this number, you might want to consider starting one
+HTTP server per Ray node to spread the load by ``serve.start(http_options={“location”: “EveryNode”})``.
+This configuration tells Serve to spawn one HTTP server per node. 
+You should put an external load balancer in front of it.
+

--- a/doc/source/serve/performance.rst
+++ b/doc/source/serve/performance.rst
@@ -16,8 +16,8 @@ Performance and known benchmarks
 --------------------------------
 We are continuously benchmarking Ray Serve. The metrics we care about are latency, throughput, and scalability. We can confidently say:
 
-- Ray Serve’s latency overhead is single digit milliseconds, often times just 1-2 milliseconds.
-- For throughput, Serve achieves about 3-4k queries per second on a single machine (8 cores) using 1 http proxy and 8 backend replicas performing noop.
+- Ray Serve’s latency overhead is single digit milliseconds, around 1-2 milliseconds on average.
+- For throughput, Serve achieves about 3-4k queries per second on a single machine (8 cores) using 1 http proxy and 8 backend replicas performing noop requests.
 - It is horizontally scalable so you can add more machines to increase the overall throughput. Ray Serve is built on top of Ray, 
   so its scalability is bounded by Ray’s scalability. Please check out Ray’s `scalability envelope <https://github.com/ray-project/ray/blob/master/benchmarks/README.md>`_
   to learn more about the maximum number of nodes and other limitations.
@@ -25,12 +25,12 @@ We are continuously benchmarking Ray Serve. The metrics we care about are latenc
 You can check out our `microbenchmark instruction <https://github.com/ray-project/ray/blob/master/python/ray/serve/benchmarks/README.md>`_
 to benchmark on your hardware.
 
-Debug performance Issue
+Debugging performance issues
 -----------------------
-A typical performance issue in Serve has the symptom of high client call latency and low throughput.
+The performance issue you're most likely to encounter is high latency and/or low throughput for requests.
 This shows the system is processing fewer queries than desired! 
 
-If you have set up :ref:`monitoring <serve-monitoring>` with Ray and Ray Serve, you will observe that
+If you have set up :ref:`monitoring <serve-monitoring>` with Ray and Ray Serve, you will likely observe that
 ``serve_num_router_requests`` is constant while your load increases
 ``serve_backend_queuing_latency_ms`` is spiking up as queries queue up in the background
 
@@ -69,7 +69,7 @@ hitting the same queuing issue mentioned above, you might want to increase
 proper backpressure. You can increase the value in the :mod:`backend config <ray.serve.config.BackendConfig>`
 to allow more coroutines running in the same replica.
 
-Scale HTTP servers
+Scaling HTTP servers
 ^^^^^^^^^^^^^^^^^^
 Sometimes it’s not about your code: Serve’s HTTP server can become the bottleneck.
 Serve only starts a single HTTP server on the Ray head node by default. 
@@ -78,4 +78,3 @@ If your workload exceeds this number, you might want to consider starting one
 HTTP server per Ray node to spread the load by ``serve.start(http_options={“location”: “EveryNode”})``.
 This configuration tells Serve to spawn one HTTP server per node. 
 You should put an external load balancer in front of it.
-

--- a/doc/source/serve/performance.rst
+++ b/doc/source/serve/performance.rst
@@ -26,9 +26,8 @@ You can check out our `microbenchmark instruction <https://github.com/ray-projec
 to benchmark on your hardware.
 
 Debugging performance issues
------------------------
+----------------------------
 The performance issue you're most likely to encounter is high latency and/or low throughput for requests.
-This shows the system is processing fewer queries than desired! 
 
 If you have set up :ref:`monitoring <serve-monitoring>` with Ray and Ray Serve, you will likely observe that
 ``serve_num_router_requests`` is constant while your load increases
@@ -47,14 +46,14 @@ Batching
 If your backend can process a batch at a time at a sublinear latency 
 (for example, if it takes 1ms to process 1 query and 5ms to process 10 of them) 
 then batching is your best approach. Check out the :ref:`batching guide <serve-ml-batching>` to 
-make your backend accept batches. You might want to tune your ``max_batch_size`` and ``batch_wait_timeout`` to maximize the benefits:
+make your backend accept batches (especially for GPU-based ML inference). You might want to tune your ``max_batch_size`` and ``batch_wait_timeout`` to maximize the benefits:
 
 - ``max_batch_size`` specifies how big the batch should be. Generally, 
-   we recommend choosing the largest batch size your function can handle 
-   AND the performance improvement is no longer sublinear. Take a dummy 
-   example: suppose it takes 1ms to process 1 query, 5ms to process 10 queries,
-   and 6ms to process 11 queries. Here you should set the batch size to to 10 
-   because adding more queries won’t improve the performance.
+  we recommend choosing the largest batch size your function can handle 
+  AND the performance improvement is no longer sublinear. Take a dummy 
+  example: suppose it takes 1ms to process 1 query, 5ms to process 10 queries,
+  and 6ms to process 11 queries. Here you should set the batch size to to 10 
+  because adding more queries won’t improve the performance.
 - ``batch_wait_timeout`` specifies how the maximum amount of time to wait before
   a batch should be processed, even if it’s not full.  It should be set according 
   to `batch-wait-timeout + full batch processing time ~= expected latency`. The idea 
@@ -70,7 +69,7 @@ proper backpressure. You can increase the value in the :mod:`backend config <ray
 to allow more coroutines running in the same replica.
 
 Scaling HTTP servers
-^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^
 Sometimes it’s not about your code: Serve’s HTTP server can become the bottleneck.
 Serve only starts a single HTTP server on the Ray head node by default. 
 This single HTTP server can handle about 3k queries per second. 


### PR DESCRIPTION
This PR adds the performance tuning guide for Ray Serve.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
