### PR TITLE
[RLLib] Dueling DQN doesn't work with masked actions

### DIFF
--- a/rllib/agents/dqn/dqn_torch_policy.py
+++ b/rllib/agents/dqn/dqn_torch_policy.py
@@ -364,6 +364,8 @@ def compute_q_values(policy: Policy,
             advantages_centered = action_scores - torch.unsqueeze(
                 advantages_mean, 1)
             value = state_score + advantages_centered
+            # if action masking we put back the mask
+            value.masked_fill_(action_scores == FLOAT_MIN, FLOAT_MIN)
     else:
         value = action_scores
 

--- a/rllib/utils/exploration/epsilon_greedy.py
+++ b/rllib/utils/exploration/epsilon_greedy.py
@@ -176,7 +176,7 @@ class EpsilonGreedy(Exploration):
                 # even consider them for exploration.
                 random_valid_action_logits = torch.where(
                     q_values <= FLOAT_MIN,
-                    torch.ones_like(q_values) * 0.0, torch.ones_like(q_values))
+                    torch.zeros_like(q_values), torch.ones_like(q_values))
                 # A random action.
                 random_actions = torch.squeeze(
                     torch.multinomial(random_valid_action_logits, 1), axis=1)

--- a/rllib/utils/torch_ops.py
+++ b/rllib/utils/torch_ops.py
@@ -77,16 +77,14 @@ def convert_to_torch_tensor(x, device=None):
         Any: A new struct with the same structure as `stats`, but with all
             values converted to torch Tensor types.
     """
-
     def mapping(item):
         # Already torch tensor -> make sure it's on right device.
         if torch.is_tensor(item):
             return item if device is None else item.to(device)
         # Special handling of "Repeated" values.
         elif isinstance(item, RepeatedValues):
-            return RepeatedValues(
-                tree.map_structure(mapping, item.values), item.lengths,
-                item.max_len)
+            return RepeatedValues(tree.map_structure(mapping, item.values),
+                                  item.lengths, item.max_len)
         # Numpy arrays.
         if isinstance(item, np.ndarray):
             # np.object_ type (e.g. info dicts in train batch): leave as-is.
@@ -167,12 +165,11 @@ def one_hot(x, space):
     if isinstance(space, Discrete):
         return nn.functional.one_hot(x.long(), space.n)
     elif isinstance(space, MultiDiscrete):
-        return torch.cat(
-            [
-                nn.functional.one_hot(x[:, i].long(), n)
-                for i, n in enumerate(space.nvec)
-            ],
-            dim=-1)
+        return torch.cat([
+            nn.functional.one_hot(x[:, i].long(), n)
+            for i, n in enumerate(space.nvec)
+        ],
+                         dim=-1)
     else:
         raise ValueError("Unsupported space for `one_hot`: {}".format(space))
 

--- a/rllib/utils/torch_ops.py
+++ b/rllib/utils/torch_ops.py
@@ -180,7 +180,7 @@ def one_hot(x, space):
 def reduce_mean_ignore_inf(x, axis):
     """Same as torch.mean() but ignores -inf values."""
     mask = torch.le(x, FLOAT_MIN)
-    x_zeroed = torch.where(mask, x, torch.zeros_like(x))
+    x_zeroed = torch.where(mask, torch.zeros_like(x), x)
     return torch.sum(x_zeroed, axis) / torch.sum(mask.float(), axis)
 
 

--- a/rllib/utils/torch_ops.py
+++ b/rllib/utils/torch_ops.py
@@ -179,7 +179,7 @@ def one_hot(x, space):
 
 def reduce_mean_ignore_inf(x, axis):
     """Same as torch.mean() but ignores -inf values."""
-    mask = torch.ne(x, float("-inf"))
+    mask = torch.le(x, FLOAT_MIN)
     x_zeroed = torch.where(mask, x, torch.zeros_like(x))
     return torch.sum(x_zeroed, axis) / torch.sum(mask.float(), axis)
 


### PR DESCRIPTION
## Why are these changes needed?

Currently, Dueling DQN is not working with the masked actions.
To make it work, we need to mask the output while computing the q-value based on the value and the advantage.
Also when computing the mean of the advantage we need to avoid taking into consideration inf and FLOAT_MIN value.
The initial modification I've made focuses on Pytorch, once it's done we could apply it to TensorFlow too.

# **I need help to make this work, there is an exception with the replay buffer:**

> 2021-02-25 18:43:18,202	INFO services.py:1171 -- View the Ray dashboard at http://127.0.0.1:8265
2021-02-25 18:43:20,443	INFO trainer.py:616 -- Current log_level is WARN. For more information, set 'log_level': 'INFO' / 'DEBUG' or use the -v and -vv flags.
2021-02-25 18:43:21,133	WARNING util.py:43 -- Install gputil for GPU system monitoring.
2021-02-25 18:43:21,134	WARNING deprecation.py:29 -- DeprecationWarning: `env_index` has been deprecated. Use `episode.env_id` instead. This will raise an error in the future!
/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/numpy/core/_methods.py:160: RuntimeWarning: overflow encountered in reduce
  ret = umr_sum(arr, axis, dtype, out, keepdims)
WARNING:root:NaN or Inf found in input tensor.
2021-02-25 18:43:23,021	WARNING logger.py:254 -- You are trying to log an invalid value (ray/tune/info/learner/default_policy/grad_gnorm=nan) via TBXLogger!
WARNING:root:NaN or Inf found in input tensor.
WARNING:root:NaN or Inf found in input tensor.
/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/rllib/execution/segment_tree.py:185: RuntimeWarning: invalid value encountered in double_scalars
  prefixsum -= self.value[update_idx]
/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/rllib/execution/replay_buffer.py:197: RuntimeWarning: divide by zero encountered in double_scalars
  max_weight = (p_min * len(self._storage))**(-beta)
/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/rllib/execution/replay_buffer.py:201: RuntimeWarning: divide by zero encountered in double_scalars
  weight = (p_sample * len(self._storage))**(-beta)
Traceback (most recent call last):
  File "/Users/ingambe/PycharmProjects/JSSFollowUp/JSS/main.py", line 239, in <module>
    train_func()
  File "/Users/ingambe/PycharmProjects/JSSFollowUp/JSS/main.py", line 228, in train_func
    result = trainer.train()
  File "/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/rllib/agents/trainer.py", line 508, in train
    raise e
  File "/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/rllib/agents/trainer.py", line 494, in train
    result = Trainable.train(self)
  File "/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/tune/trainable.py", line 183, in train
    result = self.step()
  File "/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/rllib/agents/trainer_template.py", line 147, in step
    res = next(self.train_exec_impl)
  File "/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/util/iter.py", line 756, in __next__
    return next(self.built_iterator)
  File "/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/util/iter.py", line 783, in apply_foreach
    for item in it:
  File "/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/util/iter.py", line 843, in apply_filter
    for item in it:
  File "/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/util/iter.py", line 843, in apply_filter
    for item in it:
  File "/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/util/iter.py", line 783, in apply_foreach
    for item in it:
  File "/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/util/iter.py", line 843, in apply_filter
    for item in it:
  File "/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/util/iter.py", line 1075, in build_union
    item = next(it)
  File "/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/util/iter.py", line 756, in __next__
    return next(self.built_iterator)
  File "/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/util/iter.py", line 783, in apply_foreach
    for item in it:
  File "/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/util/iter.py", line 783, in apply_foreach
    for item in it:
  File "/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/util/iter.py", line 783, in apply_foreach
    for item in it:
  [Previous line repeated 2 more times]
  File "/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/rllib/execution/replay_ops.py", line 90, in gen_replay
    item = local_buffer.replay()
  File "/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/rllib/execution/replay_buffer.py", line 362, in replay
    samples[policy_id] = replay_buffer.sample(
  File "/Users/ingambe/.conda/envs/JSSPPO/lib/python3.8/site-packages/ray/rllib/execution/replay_buffer.py", line 202, in sample
    count = self._storage[idx].count
**IndexError: list index out of range**


## Related issue number

#14355

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
