### PR TITLE
[RLlib] Remove flaky test case for mixed (tf+torch) policies trainer.

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2028,14 +2028,16 @@ py_test(
     args = ["--as-test", "--torch", "--stop-reward=70"]
 )
 
-py_test(
-    name = "examples/multi_agent_two_trainers_mixed_torch_tf",
-    main = "examples/multi_agent_two_trainers.py",
-    tags = ["examples", "examples_M"],
-    size = "medium",
-    srcs = ["examples/multi_agent_two_trainers.py"],
-    args = ["--as-test", "--mixed-torch-tf", "--stop-reward=70"]
-)
+# Taking out this test for now: Mixed torch- and tf- policies within the same
+# Trainer never really worked.
+# py_test(
+#     name = "examples/multi_agent_two_trainers_mixed_torch_tf",
+#     main = "examples/multi_agent_two_trainers.py",
+#     tags = ["examples", "examples_M"],
+#     size = "medium",
+#     srcs = ["examples/multi_agent_two_trainers.py"],
+#     args = ["--as-test", "--mixed-torch-tf", "--stop-reward=70"]
+# )
 
 py_test(
     name = "examples/nested_action_spaces_ppo_tf",

--- a/rllib/examples/multi_agent_two_trainers.py
+++ b/rllib/examples/multi_agent_two_trainers.py
@@ -22,8 +22,6 @@ from ray.tune.registry import register_env
 parser = argparse.ArgumentParser()
 # Use torch for both policies.
 parser.add_argument("--torch", action="store_true")
-# Mix PPO=tf and DQN=torch if set.
-parser.add_argument("--mixed-torch-tf", action="store_true")
 parser.add_argument("--as-test", action="store_true")
 parser.add_argument("--stop-iters", type=int, default=20)
 parser.add_argument("--stop-reward", type=float, default=50)
@@ -31,8 +29,6 @@ parser.add_argument("--stop-timesteps", type=int, default=100000)
 
 if __name__ == "__main__":
     args = parser.parse_args()
-    assert not (args.torch and args.mixed_torch_tf),\
-        "Use either --torch or --mixed-torch-tf, not both!"
 
     ray.init()
 
@@ -48,8 +44,8 @@ if __name__ == "__main__":
     policies = {
         "ppo_policy": (PPOTorchPolicy if args.torch else PPOTFPolicy,
                        obs_space, act_space, {}),
-        "dqn_policy": (DQNTorchPolicy if args.torch or args.mixed_torch_tf else
-                       DQNTFPolicy, obs_space, act_space, {}),
+        "dqn_policy": (DQNTorchPolicy if args.torch else DQNTFPolicy,
+                       obs_space, act_space, {}),
     }
 
     def policy_mapping_fn(agent_id):
@@ -87,7 +83,7 @@ if __name__ == "__main__":
             "n_step": 3,
             # Use GPUs iff `RLLIB_NUM_GPUS` env var set to > 0.
             "num_gpus": int(os.environ.get("RLLIB_NUM_GPUS", "0")),
-            "framework": "torch" if args.torch or args.mixed_torch_tf else "tf"
+            "framework": "torch" if args.torch else "tf"
         })
 
     # You should see both the printed X and Y approach 200 as this trains:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

This PR removes a flaky test case for mixed (tf+torch) policies trainer:

rllib/examples/multi_agent_two_trainers.py --mixed-torch-tf


<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
