### PR TITLE
[core] Randomize actor ID to avoid collisions

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -364,6 +364,7 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest",
         "@msgpack",
     ],

--- a/src/ray/common/id.cc
+++ b/src/ray/common/id.cc
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <mutex>
 #include <random>
+#include "absl/time/clock.h"
 
 #include "ray/common/constants.h"
 #include "ray/common/status.h"
@@ -126,8 +127,9 @@ ActorID ActorID::Of(const JobID &job_id, const TaskID &parent_task_id,
   // NOTE(swang): Include the current time in the hash for the actor ID so that
   // we avoid duplicating a previous actor ID, which is not allowed by the GCS.
   // See https://github.com/ray-project/ray/issues/10481.
-  auto data = GenerateUniqueBytes(job_id, parent_task_id, parent_task_counter,
-                                  current_time_ms(), ActorID::kUniqueBytesLength);
+  auto data =
+      GenerateUniqueBytes(job_id, parent_task_id, parent_task_counter,
+                          absl::GetCurrentTimeNanos(), ActorID::kUniqueBytesLength);
   std::copy_n(job_id.Data(), JobID::kLength, std::back_inserter(data));
   RAY_CHECK(data.size() == kLength);
   return ActorID::FromBinary(data);

--- a/src/ray/common/id.cc
+++ b/src/ray/common/id.cc
@@ -38,7 +38,8 @@ uint64_t MurmurHash64A(const void *key, int len, unsigned int seed);
 
 /// A helper function to generate the unique bytes by hash.
 std::string GenerateUniqueBytes(const JobID &job_id, const TaskID &parent_task_id,
-                                size_t parent_task_counter, size_t length) {
+                                size_t parent_task_counter, size_t extra_bytes,
+                                size_t length) {
   RAY_CHECK(length <= DIGEST_SIZE);
   SHA256_CTX ctx;
   sha256_init(&ctx);
@@ -46,6 +47,9 @@ std::string GenerateUniqueBytes(const JobID &job_id, const TaskID &parent_task_i
   sha256_update(&ctx, reinterpret_cast<const BYTE *>(parent_task_id.Data()),
                 parent_task_id.Size());
   sha256_update(&ctx, (const BYTE *)&parent_task_counter, sizeof(parent_task_counter));
+  if (extra_bytes > 0) {
+    sha256_update(&ctx, (const BYTE *)&extra_bytes, sizeof(extra_bytes));
+  }
 
   BYTE buff[DIGEST_SIZE];
   sha256_final(&ctx, buff);
@@ -119,8 +123,11 @@ uint64_t MurmurHash64A(const void *key, int len, unsigned int seed) {
 
 ActorID ActorID::Of(const JobID &job_id, const TaskID &parent_task_id,
                     const size_t parent_task_counter) {
+  // NOTE(swang): Include the current time in the hash for the actor ID so that
+  // we avoid duplicating a previous actor ID, which is not allowed by the GCS.
+  // See https://github.com/ray-project/ray/issues/10481.
   auto data = GenerateUniqueBytes(job_id, parent_task_id, parent_task_counter,
-                                  ActorID::kUniqueBytesLength);
+                                  current_time_ms(), ActorID::kUniqueBytesLength);
   std::copy_n(job_id.Data(), JobID::kLength, std::back_inserter(data));
   RAY_CHECK(data.size() == kLength);
   return ActorID::FromBinary(data);
@@ -165,7 +172,7 @@ TaskID TaskID::ForActorCreationTask(const ActorID &actor_id) {
 
 TaskID TaskID::ForActorTask(const JobID &job_id, const TaskID &parent_task_id,
                             size_t parent_task_counter, const ActorID &actor_id) {
-  std::string data = GenerateUniqueBytes(job_id, parent_task_id, parent_task_counter,
+  std::string data = GenerateUniqueBytes(job_id, parent_task_id, parent_task_counter, 0,
                                          TaskID::kUniqueBytesLength);
   std::copy_n(actor_id.Data(), ActorID::kLength, std::back_inserter(data));
   RAY_CHECK(data.size() == TaskID::kLength);
@@ -174,7 +181,7 @@ TaskID TaskID::ForActorTask(const JobID &job_id, const TaskID &parent_task_id,
 
 TaskID TaskID::ForNormalTask(const JobID &job_id, const TaskID &parent_task_id,
                              size_t parent_task_counter) {
-  std::string data = GenerateUniqueBytes(job_id, parent_task_id, parent_task_counter,
+  std::string data = GenerateUniqueBytes(job_id, parent_task_id, parent_task_counter, 0,
                                          TaskID::kUniqueBytesLength);
   const auto dummy_actor_id = ActorID::NilFromJob(job_id);
   std::copy_n(dummy_actor_id.Data(), ActorID::kLength, std::back_inserter(data));

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1458,12 +1458,9 @@ Status CoreWorker::CreateActor(const RayFunction &function,
         "Async actor is currently not supported for the local mode");
   }
   const auto next_task_index = worker_context_.GetNextTaskIndex();
-  // NOTE(swang): Include the current time in the hash for the actor ID so that
-  // we avoid duplicating a previous actor ID, which is not allowed by the GCS.
-  // See https://github.com/ray-project/ray/issues/10481.
   const ActorID actor_id =
       ActorID::Of(worker_context_.GetCurrentJobID(), worker_context_.GetCurrentTaskID(),
-                  current_time_ms());
+                  next_task_index);
   const TaskID actor_creation_task_id = TaskID::ForActorCreationTask(actor_id);
   const JobID job_id = worker_context_.GetCurrentJobID();
   // Propagate existing environment variable overrides, but override them with any new

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1458,9 +1458,12 @@ Status CoreWorker::CreateActor(const RayFunction &function,
         "Async actor is currently not supported for the local mode");
   }
   const auto next_task_index = worker_context_.GetNextTaskIndex();
+  // NOTE(swang): Include the current time in the hash for the actor ID so that
+  // we avoid duplicating a previous actor ID, which is not allowed by the GCS.
+  // See https://github.com/ray-project/ray/issues/10481.
   const ActorID actor_id =
       ActorID::Of(worker_context_.GetCurrentJobID(), worker_context_.GetCurrentTaskID(),
-                  next_task_index);
+                  current_time_ms());
   const TaskID actor_creation_task_id = TaskID::ForActorCreationTask(actor_id);
   const JobID job_id = worker_context_.GetCurrentJobID();
   // Propagate existing environment variable overrides, but override them with any new


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The GCS currently can't handle two actors with the same ID, even if the old one is already dead. This is the root cause of issue #10481.

This PR randomizes the actor ID according to the current time, to make it possible to re-execute a task that creates a child actor. In the future, we could return to a deterministic hash, but this would require the GCS to be able to handle a duplicated actor ID.

## Related issue number

Closes #10481.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
