### PR TITLE
Remove version reference in dashboard proxy docs

### DIFF
--- a/doc/source/ray-dashboard.rst
+++ b/doc/source/ray-dashboard.rst
@@ -171,8 +171,7 @@ More information on how to interpret the flamegraph is available at https://gith
 
 Running Behind a Reverse Proxy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In ray 2.0.0, the dashboard works out-of-the-box when accessed via a reverse proxy. API requests no
-longer need to be proxied individually.
+The dashboard should work out-of-the-box when accessed via a reverse proxy. API requests don't need to be proxied individually.
 
 Always access the dashboard with a trailing ``/`` at the end of the URL.
 For example, if your proxy is set up to handle requests to ``/ray/dashboard``, view the dashboard at ``www.my-website.com/ray/dashboard/``.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is a follow up PR to https://github.com/ray-project/ray/pull/14012, which changes an incorrect version reference in the dashboard docs, which I added.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
