### PR TITLE
[Build] Consolidate Bazel build and test action_env configs to prevent analysis cache discarding.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,16 +15,15 @@ build:clang-cl --compiler=clang-cl
 build:msvc --compiler=msvc-cl
 # `LC_ALL` and `LANG` is needed for cpp worker tests, because they will call "ray start".
 # If we don't add them, python's `click` library will raise an error.
-test --action_env=LC_ALL
-test --action_env=LANG
+build --action_env=LC_ALL
+build --action_env=LANG
 # Allow C++ worker tests to execute "ray start" with the correct version of Python.
-test --action_env=VIRTUAL_ENV
-test --action_env=PYENV_VIRTUAL_ENV
-test --action_env=PYENV_VERSION
-test --action_env=PYENV_SHELL
-test --action_env=RAY_ENABLE_NEW_SCHEDULER
+build --action_env=VIRTUAL_ENV
+build --action_env=PYENV_VIRTUAL_ENV
+build --action_env=PYENV_VERSION
+build --action_env=PYENV_SHELL
 # This is needed for some core tests to run correctly
-test:windows --enable_runfiles
+build:windows --enable_runfiles
 # TODO(mehrdadn): Revert the "-\\.(asm|S)$" exclusion when this Bazel bug
 #                 for compiling assembly files is fixed on Windows:
 #                 https://github.com/bazelbuild/bazel/issues/8924


### PR DESCRIPTION
## Why are these changes needed?

Changing the Bazel action environment will cause the analysis cache to be discarded, triggering a complete rebuild. By having different action environments for `build` and `test` commands, Bazel would require a complete rebuild when going between running C++ tests and running Python tests: the former runs `bazel test`, the latter runs `bazel build` to build the Python package. Given that [the `test` config inherits from the `build` config](https://docs.bazel.build/versions/master/guide.html#option-defaults), we should try to consolidate these action environment configurations in order for the analysis cache (and therefore the execution cache) to be shared between builds and tests, and therefore between the running of C++ tests and the running of Python tests.