### PR TITLE
[Autoscaler] Fix GCP User Inconsistency

### DIFF
--- a/python/ray/autoscaler/gcp/defaults.yaml
+++ b/python/ray/autoscaler/gcp/defaults.yaml
@@ -52,7 +52,7 @@ head_node:
         initializeParams:
           diskSizeGb: 50
           # See https://cloud.google.com/compute/docs/images for more images
-          sourceImage: projects/deeplearning-platform-release/global/images/family/tf-1-13-cpu
+          sourceImage: projects/deeplearning-platform-release/global/images/family/common-cpu
 
     # Additional options can be found in in the compute docs at
     # https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert
@@ -75,7 +75,7 @@ worker_nodes:
         initializeParams:
           diskSizeGb: 50
           # See https://cloud.google.com/compute/docs/images for more images
-          sourceImage: projects/deeplearning-platform-release/global/images/family/tf-1-13-cpu
+          sourceImage: projects/deeplearning-platform-release/global/images/family/common-cpu
     # Run workers on preemtible instance by default.
     # Comment this out to use on-demand.
     scheduling:

--- a/python/ray/autoscaler/gcp/example-full.yaml
+++ b/python/ray/autoscaler/gcp/example-full.yaml
@@ -66,7 +66,7 @@ head_node:
         initializeParams:
           diskSizeGb: 50
           # See https://cloud.google.com/compute/docs/images for more images
-          sourceImage: projects/deeplearning-platform-release/global/images/family/tf-1-13-cpu
+          sourceImage: projects/deeplearning-platform-release/global/images/family/common-cpu
 
     # Additional options can be found in in the compute docs at
     # https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert
@@ -89,7 +89,7 @@ worker_nodes:
         initializeParams:
           diskSizeGb: 50
           # See https://cloud.google.com/compute/docs/images for more images
-          sourceImage: projects/deeplearning-platform-release/global/images/family/tf-1-13-cpu
+          sourceImage: projects/deeplearning-platform-release/global/images/family/common-cpu
     # Run workers on preemtible instance by default.
     # Comment this out to use on-demand.
     scheduling:

--- a/python/ray/autoscaler/gcp/example-gpu-docker.yaml
+++ b/python/ray/autoscaler/gcp/example-gpu-docker.yaml
@@ -61,7 +61,7 @@ head_node:
         initializeParams:
           diskSizeGb: 50
           # See https://cloud.google.com/compute/docs/images for more images
-          sourceImage: projects/deeplearning-platform-release/global/images/family/tf-1-13-cu100
+          sourceImage: projects/deeplearning-platform-release/global/images/family/common-cu110
     guestAccelerators:
       - acceleratorType: projects/<project_id>/zones/us-west1-b/acceleratorTypes/nvidia-tesla-k80
         acceleratorCount: 1
@@ -84,7 +84,7 @@ worker_nodes:
         initializeParams:
           diskSizeGb: 50
           # See https://cloud.google.com/compute/docs/images for more images
-          sourceImage: projects/deeplearning-platform-release/global/images/family/tf-1-13-cu100
+          sourceImage: projects/deeplearning-platform-release/global/images/family/common-cu110
     guestAccelerators:
       - acceleratorType: projects/<project_id>/zones/us-west1-b/acceleratorTypes/nvidia-tesla-k80
         acceleratorCount: 1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Our previous GCP default OS had the default UID as 1001 (not 1000) and this caused problems with file permissions in our containers. The change here is also logical as we no longer need TF installed on the host OS if we are using containers!

This PR also bumps the CUDA version on the host to match the container version!

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
* Partially closes #14095 (a real fix is to solve for the general case where the user in the container != the host).

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
