### PR TITLE
Bump protobuf to the latest version

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -138,7 +138,7 @@ install_requires = [
     "jsonschema",
     "msgpack >= 1.0.0, < 2.0.0",
     "numpy >= 1.16",
-    "protobuf >= 3.8.0",
+    "protobuf >= 3.15.3",
     "py-spy >= 0.2.0",
     "pyyaml",
     "requests",


### PR DESCRIPTION
Closes #14363

seems like opencensus depends on higher version of the `protobuf` package, so we should have just bump it to ensure consistency. 