### PR TITLE
[Dashboard] Fix reporter agent

### DIFF
--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -52,6 +52,56 @@ def jsonify_asdict(o):
     return json.dumps(dashboard_utils.to_google_style(recursive_asdict(o)))
 
 
+# A list of gauges to record and export metrics.
+METRICS_GAUGES = {
+    "node_cpu_utilization": Gauge("node_cpu_utilization",
+                                  "Total CPU usage on a ray node",
+                                  "percentage", ["ip"]),
+    "node_cpu_count": Gauge("node_cpu_count",
+                            "Total CPUs available on a ray node", "cores",
+                            ["ip"]),
+    "node_mem_used": Gauge("node_mem_used", "Memory usage on a ray node",
+                           "bytes", ["ip"]),
+    "node_mem_available": Gauge("node_mem_available",
+                                "Memory available on a ray node", "bytes",
+                                ["ip"]),
+    "node_mem_total": Gauge("node_mem_total", "Total memory on a ray node",
+                            "bytes", ["ip"]),
+    "node_gpus_available": Gauge("node_gpus_available",
+                                 "Total GPUs available on a ray node",
+                                 "percentage", ["ip"]),
+    "node_gpus_utilization": Gauge("node_gpus_utilization",
+                                   "Total GPUs usage on a ray node",
+                                   "percentage", ["ip"]),
+    "node_gram_used": Gauge("node_gram_used",
+                            "Total GPU RAM usage on a ray node", "bytes",
+                            ["ip"]),
+    "node_gram_available": Gauge("node_gram_available",
+                                 "Total GPU RAM available on a ray node",
+                                 "bytes", ["ip"]),
+    "node_disk_usage": Gauge("node_disk_usage",
+                             "Total disk usage (bytes) on a ray node", "bytes",
+                             ["ip"]),
+    "node_disk_utilization_percentage": Gauge(
+        "node_disk_utilization_percentage",
+        "Total disk utilization (percentage) on a ray node", "percentage",
+        ["ip"]),
+    "node_network_sent": Gauge("node_network_sent", "Total network sent",
+                               "bytes", ["ip"]),
+    "node_network_received": Gauge("node_network_received",
+                                   "Total network received", "bytes", ["ip"]),
+    "node_network_send_speed": Gauge(
+        "node_network_send_speed", "Network send speed", "bytes/sec", ["ip"]),
+    "node_network_receive_speed": Gauge("node_network_receive_speed",
+                                        "Network receive speed", "bytes/sec",
+                                        ["ip"]),
+    "raylet_cpu": Gauge("raylet_cpu", "CPU usage of the raylet on a node.",
+                        "percentage", ["ip", "pid"]),
+    "raylet_mem": Gauge("raylet_mem", "Memory usage of the raylet on a node",
+                        "mb", ["ip", "pid"])
+}
+
+
 class ReporterAgent(dashboard_utils.DashboardAgentModule,
                     reporter_pb2_grpc.ReporterServiceServicer):
     """A monitor process for monitoring Ray nodes.
@@ -72,60 +122,6 @@ class ReporterAgent(dashboard_utils.DashboardAgentModule,
         self._metrics_agent = MetricsAgent(dashboard_agent.metrics_export_port)
         self._key = f"{reporter_consts.REPORTER_PREFIX}" \
                     f"{self._dashboard_agent.node_id}"
-        # A list of gauges to record and export metrics.
-        self._gauges = {
-            "node_cpu_utilization": Gauge("node_cpu_utilization",
-                                          "Total CPU usage on a ray node",
-                                          "percentage", ["ip"]),
-            "node_cpu_count": Gauge("node_cpu_count",
-                                    "Total CPUs available on a ray node",
-                                    "cores", ["ip"]),
-            "node_mem_used": Gauge("node_mem_used",
-                                   "Memory usage on a ray node", "bytes",
-                                   ["ip"]),
-            "node_mem_available": Gauge("node_mem_available",
-                                        "Memory available on a ray node",
-                                        "bytes", ["ip"]),
-            "node_mem_total": Gauge("node_mem_total",
-                                    "Total memory on a ray node", "bytes",
-                                    ["ip"]),
-            "node_gpus_available": Gauge("node_gpus_available",
-                                         "Total GPUs available on a ray node",
-                                         "percentage", ["ip"]),
-            "node_gpus_utilization": Gauge("node_gpus_utilization",
-                                           "Total GPUs usage on a ray node",
-                                           "percentage", ["ip"]),
-            "node_gram_used": Gauge("node_gram_used",
-                                    "Total GPU RAM usage on a ray node",
-                                    "bytes", ["ip"]),
-            "node_gram_available": Gauge(
-                "node_gram_available", "Total GPU RAM available on a ray node",
-                "bytes", ["ip"]),
-            "node_disk_usage": Gauge("node_disk_usage",
-                                     "Total disk usage (bytes) on a ray node",
-                                     "bytes", ["ip"]),
-            "node_disk_utilization_percentage": Gauge(
-                "node_disk_utilization_percentage",
-                "Total disk utilization (percentage) on a ray node",
-                "percentage", ["ip"]),
-            "node_network_sent": Gauge("node_network_sent",
-                                       "Total network sent", "bytes", ["ip"]),
-            "node_network_received": Gauge("node_network_received",
-                                           "Total network received", "bytes",
-                                           ["ip"]),
-            "node_network_send_speed": Gauge("node_network_send_speed",
-                                             "Network send speed", "bytes/sec",
-                                             ["ip"]),
-            "node_network_receive_speed": Gauge("node_network_receive_speed",
-                                                "Network receive speed",
-                                                "bytes/sec", ["ip"]),
-            "raylet_cpu": Gauge("raylet_cpu",
-                                "CPU usage of the raylet on a node.",
-                                "percentage", ["ip", "pid"]),
-            "raylet_mem": Gauge("raylet_mem",
-                                "Memory usage of the raylet on a node", "mb",
-                                ["ip", "pid"])
-        }
 
     async def GetProfilingStats(self, request, context):
         pid = request.pid
@@ -247,7 +243,7 @@ class ReporterAgent(dashboard_utils.DashboardAgentModule,
             pass
         return None
 
-    def _get_raylet_stats(self):
+    def _get_raylet(self):
         raylet_proc = self._get_raylet_proc()
         if raylet_proc is None:
             return {}
@@ -260,13 +256,6 @@ class ReporterAgent(dashboard_utils.DashboardAgentModule,
                 "cmdline",
                 "memory_info",
             ])
-
-    def _get_raylet_cmdline(self):
-        raylet_proc = self._get_raylet_proc()
-        if raylet_proc is None:
-            return []
-        else:
-            return raylet_proc.cmdline()
 
     def _get_load_avg(self):
         if sys.platform == "win32":
@@ -296,44 +285,47 @@ class ReporterAgent(dashboard_utils.DashboardAgentModule,
             "cpus": self._cpu_counts,
             "mem": self._get_mem_usage(),
             "workers": self._get_workers(),
+            "raylet": self._get_raylet(),
             "bootTime": self._get_boot_time(),
             "loadAvg": self._get_load_avg(),
             "disk": self._get_disk_usage(),
             "gpus": self._get_gpu_usage(),
             "network": network_stats,
             "network_speed": network_speed_stats,
-            "cmdline": self._get_raylet_cmdline(),
+            # Deprecated field, should be removed with frontend.
+            "cmdline": self._get_raylet().get("cmdline", []),
         }
 
-    def _record_stats(self, stats):
+    @staticmethod
+    def _record_stats(stats):
         records_reported = []
 
         ip = stats["ip"]
         # -- CPU per node --
         cpu_usage = float(stats["cpu"])
         cpu_record = Record(
-            gauge=self._gauges["node_cpu_utilization"],
+            gauge=METRICS_GAUGES["node_cpu_utilization"],
             value=cpu_usage,
             tags={"ip": ip})
 
         cpu_count, _ = stats["cpus"]
         cpu_count_record = Record(
-            gauge=self._gauges["node_cpu_count"],
+            gauge=METRICS_GAUGES["node_cpu_count"],
             value=cpu_count,
             tags={"ip": ip})
 
         # -- Mem per node --
         mem_total, mem_available, _, mem_used = stats["mem"]
         mem_used_record = Record(
-            gauge=self._gauges["node_mem_used"],
+            gauge=METRICS_GAUGES["node_mem_used"],
             value=mem_used,
             tags={"ip": ip})
         mem_available_record = Record(
-            gauge=self._gauges["node_mem_available"],
+            gauge=METRICS_GAUGES["node_mem_available"],
             value=mem_available,
             tags={"ip": ip})
         mem_total_record = Record(
-            gauge=self._gauges["node_mem_total"],
+            gauge=METRICS_GAUGES["node_mem_total"],
             value=mem_total,
             tags={"ip": ip})
 
@@ -351,19 +343,19 @@ class ReporterAgent(dashboard_utils.DashboardAgentModule,
             gram_available = gram_total - gram_used
 
             gpus_available_record = Record(
-                gauge=self._gauges["node_gpus_available"],
+                gauge=METRICS_GAUGES["node_gpus_available"],
                 value=gpus_available,
                 tags={"ip": ip})
             gpus_utilization_record = Record(
-                gauge=self._gauges["node_gpus_utilization"],
+                gauge=METRICS_GAUGES["node_gpus_utilization"],
                 value=gpus_utilization,
                 tags={"ip": ip})
             gram_used_record = Record(
-                gauge=self._gauges["node_gram_used"],
+                gauge=METRICS_GAUGES["node_gram_used"],
                 value=gram_used,
                 tags={"ip": ip})
             gram_available_record = Record(
-                gauge=self._gauges["node_gram_available"],
+                gauge=METRICS_GAUGES["node_gram_available"],
                 value=gram_available,
                 tags={"ip": ip})
             records_reported.extend([
@@ -378,41 +370,43 @@ class ReporterAgent(dashboard_utils.DashboardAgentModule,
             free += entry.free
         disk_utilization = float(used / (used + free)) * 100
         disk_usage_record = Record(
-            gauge=self._gauges["node_disk_usage"], value=used, tags={"ip": ip})
+            gauge=METRICS_GAUGES["node_disk_usage"],
+            value=used,
+            tags={"ip": ip})
         disk_utilization_percentage_record = Record(
-            gauge=self._gauges["node_disk_utilization_percentage"],
+            gauge=METRICS_GAUGES["node_disk_utilization_percentage"],
             value=disk_utilization,
             tags={"ip": ip})
 
         # -- Network speed (send/receive) stats per node --
         network_stats = stats["network"]
         network_sent_record = Record(
-            gauge=self._gauges["node_network_sent"],
+            gauge=METRICS_GAUGES["node_network_sent"],
             value=network_stats[0],
             tags={"ip": ip})
         network_received_record = Record(
-            gauge=self._gauges["node_network_received"],
+            gauge=METRICS_GAUGES["node_network_received"],
             value=network_stats[1],
             tags={"ip": ip})
 
         # -- Network speed (send/receive) per node --
         network_speed_stats = stats["network_speed"]
         network_send_speed_record = Record(
-            gauge=self._gauges["node_network_send_speed"],
+            gauge=METRICS_GAUGES["node_network_send_speed"],
             value=network_speed_stats[0],
             tags={"ip": ip})
         network_receive_speed_record = Record(
-            gauge=self._gauges["node_network_receive_speed"],
+            gauge=METRICS_GAUGES["node_network_receive_speed"],
             value=network_speed_stats[1],
             tags={"ip": ip})
 
-        raylet_stats = self._get_raylet_stats()
+        raylet_stats = stats["raylet"]
         if raylet_stats:
             raylet_pid = str(raylet_stats["pid"])
             # -- raylet CPU --
             raylet_cpu_usage = float(raylet_stats["cpu_percent"]) * 100
             raylet_cpu_record = Record(
-                gauge=self._gauges["raylet_cpu"],
+                gauge=METRICS_GAUGES["raylet_cpu"],
                 value=raylet_cpu_usage,
                 tags={
                     "ip": ip,
@@ -422,7 +416,7 @@ class ReporterAgent(dashboard_utils.DashboardAgentModule,
             # -- raylet mem --
             raylet_mem_usage = float(raylet_stats["memory_info"].rss) / 1e6
             raylet_mem_record = Record(
-                gauge=self._gauges["raylet_mem"],
+                gauge=METRICS_GAUGES["raylet_mem"],
                 value=raylet_mem_usage,
                 tags={
                     "ip": ip,
@@ -437,15 +431,15 @@ class ReporterAgent(dashboard_utils.DashboardAgentModule,
             network_received_record, network_send_speed_record,
             network_receive_speed_record
         ])
-
-        self._metrics_agent.record_reporter_stats(records_reported)
+        return records_reported
 
     async def _perform_iteration(self, aioredis_client):
         """Get any changes to the log files and push updates to Redis."""
         while True:
             try:
                 stats = self._get_all_stats()
-                self._record_stats(stats)
+                records_reported = self._record_stats(stats)
+                self._metrics_agent.record_reporter_stats(records_reported)
                 await aioredis_client.publish(self._key, jsonify_asdict(stats))
             except Exception:
                 logger.exception("Error publishing node physical stats.")

--- a/dashboard/modules/reporter/tests/test_reporter.py
+++ b/dashboard/modules/reporter/tests/test_reporter.py
@@ -8,6 +8,8 @@ import pytest
 import ray
 from ray import ray_constants
 from ray.new_dashboard.tests.conftest import *  # noqa
+from ray.new_dashboard.utils import Bunch
+from ray.new_dashboard.modules.reporter.reporter_agent import ReporterAgent
 from ray.test_utils import (format_web_url, RayTestTimeoutException,
                             wait_until_server_available, wait_for_condition,
                             fetch_prometheus)
@@ -133,6 +135,77 @@ def test_prometheus_physical_stats_record(enable_test_module, shutdown_only):
 
     wait_for_condition(test_case_stats_exist, retry_interval_ms=1000)
     wait_for_condition(test_case_ip_correct, retry_interval_ms=1000)
+
+
+def test_report_stats():
+    test_stats = {
+        "now": 1614826393.975763,
+        "hostname": "fake_hostname.local",
+        "ip": "127.0.0.1",
+        "cpu": 57.4,
+        "cpus": (8, 4),
+        "mem": (17179869184, 5723353088, 66.7, 9234341888),
+        "workers": [{
+            "memory_info": Bunch(
+                rss=55934976, vms=7026937856, pfaults=15354, pageins=0),
+            "cpu_percent": 0.0,
+            "cmdline": [
+                "ray::IDLE", "", "", "", "", "", "", "", "", "", "", ""
+            ],
+            "create_time": 1614826391.338613,
+            "pid": 7174,
+            "cpu_times": Bunch(
+                user=0.607899328,
+                system=0.274044032,
+                children_user=0.0,
+                children_system=0.0)
+        }],
+        "raylet": {
+            "memory_info": Bunch(
+                rss=18354176, vms=6921486336, pfaults=6206, pageins=3),
+            "cpu_percent": 0.0,
+            "cmdline": ["fake raylet cmdline"],
+            "create_time": 1614826390.274854,
+            "pid": 7153,
+            "cpu_times": Bunch(
+                user=0.03683138,
+                system=0.035913716,
+                children_user=0.0,
+                children_system=0.0)
+        },
+        "bootTime": 1612934656.0,
+        "loadAvg": ((4.4521484375, 3.61083984375, 3.5400390625), (0.56, 0.45,
+                                                                  0.44)),
+        "disk": {
+            "/": Bunch(
+                total=250790436864,
+                used=11316781056,
+                free=22748921856,
+                percent=33.2),
+            "/tmp": Bunch(
+                total=250790436864,
+                used=209532035072,
+                free=22748921856,
+                percent=90.2)
+        },
+        "gpus": [],
+        "network": (13621160960, 11914936320),
+        "network_speed": (8.435062128545095, 7.378462703142336),
+    }
+    records = ReporterAgent._record_stats(test_stats)
+    assert len(records) == 13
+    # Test stats without raylet
+    test_stats["raylet"] = {}
+    records = ReporterAgent._record_stats(test_stats)
+    assert len(records) == 11
+    # Test stats with gpus
+    test_stats["gpus"] = [{
+        "utilization_gpu": 1,
+        "memory_used": 100,
+        "memory_total": 1000
+    }]
+    records = ReporterAgent._record_stats(test_stats)
+    assert len(records) == 15
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- Problem
  - The `ReporterAgent._record_stats` may raises exception due to
    - the use of local variables referenced before assignment.
    - The `raylet_stats` may be an empty list, then access the key of `raylet_stats` will raise `TypeError: list indices must be integers or slices, not str`.
- Solution
  - Add metric record to `records_reported` if the record object is generated.
- Other
  - Add a `_get_raylet_proc()` method to get raylet proc object, returns None is the raylet proc is not available.

<!-- Please give a short summary of the change and the problem this solves. -->

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
