### PR TITLE
[Autoscaler] chown Ray_bootstrap Files in DockerCommandRunner

### DIFF
--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -858,7 +858,14 @@ class DockerCommandRunner(CommandRunnerInterface):
                                 self.ssh_command_runner.cluster_name), mount),
                         container=self.container_name,
                         dst=self._docker_expand_user(mount)))
-                self.run(f"sudo chown $(id -u):$(id -g) {mount} || true")
+                try:
+                    self.run(f"[[ $(id -u) = 0 ]] || "
+                             "sudo chown $(id -u):$(id -g) {mount}")
+                except Exception:
+                    cli_logger.warning(
+                        "The running user is neither `root`, "
+                        "nor is sudo installed. Ray may fail to autoscale "
+                        "because of permission issues.")
         self.initialized = True
         return docker_run_executed
 

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -858,6 +858,7 @@ class DockerCommandRunner(CommandRunnerInterface):
                                 self.ssh_command_runner.cluster_name), mount),
                         container=self.container_name,
                         dst=self._docker_expand_user(mount)))
+                self.run(f"sudo chown $(id -u):$(id -g) {mount} || true")
         self.initialized = True
         return docker_run_executed
 

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -861,7 +861,7 @@ class DockerCommandRunner(CommandRunnerInterface):
                 try:
                     # Check if the current user has read permission.
                     # If they do not, try to change ownership!
-                    self.run(f"cat {mount} > /dev/null || "
+                    self.run(f"cat {mount} >/dev/null 2>&1 || "
                              f"sudo chown $(id -u):$(id -g) {mount}")
                 except Exception:
                     lsl_string = self.run(

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -312,8 +312,8 @@ class SSHOptions:
         ssh_key_option = ["-i", self.ssh_key] if self.ssh_key else []
         return ssh_key_option + [
             x for y in (["-o", "{}={}".format(k, v)]
-                        for k, v in self.arg_dict.items() if v is not None)
-            for x in y
+                        for k, v in self.arg_dict.items()
+                        if v is not None) for x in y
         ]
 
 
@@ -912,9 +912,9 @@ class DockerCommandRunner(CommandRunnerInterface):
             shm_output = self.ssh_command_runner.run(
                 "cat /proc/meminfo || true",
                 with_output=True).decode().strip()
-            available_memory = int(
-                [ln for ln in shm_output.split("\n")
-                 if "MemAvailable" in ln][0].split()[1])
+            available_memory = int([
+                ln for ln in shm_output.split("\n") if "MemAvailable" in ln
+            ][0].split()[1])
             available_memory_bytes = available_memory * 1024
             # Overestimate SHM size by 10%
             shm_size = min((available_memory_bytes *


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We should not assume that the user outside the container is the same inside the container! This change enforces ensures that `ray_bootstrap_config.yaml` and `ray_bootstrap_key.pem` are owned by the user inside the container!

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #14095

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
