### PR TITLE
[Dashboard] Disable tune module if pandas version is incorrect

### DIFF
--- a/dashboard/modules/tune/tune_head.py
+++ b/dashboard/modules/tune/tune_head.py
@@ -9,13 +9,19 @@ import ray.new_dashboard.modules.tune.tune_consts \
 import ray.new_dashboard.utils as dashboard_utils
 from ray.new_dashboard.utils import async_loop_forever, rest_response
 
+logger = logging.getLogger(__name__)
+
 try:
     from ray.tune import Analysis
     from tensorboard import program
-except ImportError:
+# The `pip install ray` will not install pandas,
+# so `from ray.tune import Analysis` may raises
+# `AttributeError: module 'pandas' has no attribute 'core'`
+# if the pandas version is incorrect.
+except (ImportError, AttributeError) as ex:
+    logger.warning("tune module is not available: %s", ex)
     Analysis = None
 
-logger = logging.getLogger(__name__)
 routes = dashboard_utils.ClassMethodRouteTable
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- Problem
```log
2021-02-26 11:36:35,653 WARNING reporter_agent.py:31 -- Install gpustat with 'pip install gpustat' to enable GPU monitoring.
2021-02-26 11:36:35,831 ERROR dashboard.py:236 -- The dashboard on node dooku.inc.alipay.net failed with the following error:
Traceback (most recent call last):
  File "/home/admin/ray/python/ray/new_dashboard/dashboard.py", line 222, in <module>
    loop.run_until_complete(dashboard.run())
  File "/home/admin/.pyenv/versions/3.6.5/lib/python3.6/asyncio/base_events.py", line 468, in run_until_complete
    return future.result()
  File "/home/admin/ray/python/ray/new_dashboard/dashboard.py", line 118, in run
    await self.dashboard_head.run()
  File "/home/admin/ray/python/ray/new_dashboard/head.py", line 190, in run
    modules = self._load_modules()
  File "/home/admin/ray/python/ray/new_dashboard/head.py", line 128, in _load_modules
    dashboard_utils.DashboardHeadModule)
  File "/home/admin/ray/python/ray/new_dashboard/utils.py", line 208, in get_all_modules
    importlib.import_module(name)
  File "/home/admin/.pyenv/versions/3.6.5/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/admin/ray/python/ray/new_dashboard/modules/tune/tune_head.py", line 13, in <module>
    from ray.tune import Analysis
  File "/home/admin/ray/python/ray/tune/__init__.py", line 2, in <module>
    from ray.tune.tune import run_experiments, run
  File "/home/admin/ray/python/ray/tune/tune.py", line 12, in <module>
    from ray.tune.analysis import ExperimentAnalysis
  File "/home/admin/ray/python/ray/tune/analysis/__init__.py", line 1, in <module>
    from ray.tune.analysis.experiment_analysis import ExperimentAnalysis, Analysis
  File "/home/admin/ray/python/ray/tune/analysis/experiment_analysis.py", line 21, in <module>
    from ray.tune.trial import Trial
  File "/home/admin/ray/python/ray/tune/trial.py", line 27, in <module>
    from ray.tune.utils.trainable import TrainableUtil
  File "/home/admin/ray/python/ray/tune/utils/trainable.py", line 7, in <module>
    import pandas as pd
  File "/home/admin/.pyenv/versions/3.6.5/envs/ray/lib/python3.6/site-packages/pandas/__init__.py", line 55, in <module>
    from pandas.core.api import (
  File "/home/admin/.pyenv/versions/3.6.5/envs/ray/lib/python3.6/site-packages/pandas/core/api.py", line 29, in <module>
    from pandas.core.groupby import Grouper, NamedAgg
  File "/home/admin/.pyenv/versions/3.6.5/envs/ray/lib/python3.6/site-packages/pandas/core/groupby/__init__.py", line 1, in <module>
    from pandas.core.groupby.generic import DataFrameGroupBy, NamedAgg, SeriesGroupBy
  File "/home/admin/.pyenv/versions/3.6.5/envs/ray/lib/python3.6/site-packages/pandas/core/groupby/generic.py", line 56, in <module>
    import pandas.core.algorithms as algorithms
AttributeError: module 'pandas' has no attribute 'core'
```
Reproduce steps:
1. Python installed an incompatible version of pandas
2. pip install ray (ray does not require pandas)
3. ray.init() failed with above error

<!-- Please give a short summary of the change and the problem this solves. -->

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
