### PR TITLE
[tune] Lookup flat key first before trying to split

### DIFF
--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -303,6 +303,8 @@ def unflattened_lookup(flat_key, lookup, delimiter="/", **kwargs):
     Unflatten `flat_key` and iteratively look up in `lookup`. E.g.
     `flat_key="a/0/b"` will try to return `lookup["a"][0]["b"]`.
     """
+    if flat_key in lookup:
+        return lookup[flat_key]
     keys = deque(flat_key.split(delimiter))
     base = lookup
     while keys:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In `unflattened_lookup`, we should check first if the exact key exists in the result dictionary. 

## Related issue number

Closes #14237

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
