### PR TITLE
[Tune] use epoch for ptl checkpoint dir name

### DIFF
--- a/python/ray/tune/integration/pytorch_lightning.py
+++ b/python/ray/tune/integration/pytorch_lightning.py
@@ -26,10 +26,7 @@ class TuneCallback(Callback):
                     on, self._allowed))
         self._on = on
 
-    def _handle(self,
-                trainer: Trainer,
-                pl_module: Optional[LightningModule],
-                is_epoch: bool = False):
+    def _handle(self, trainer: Trainer, pl_module: Optional[LightningModule]):
         raise NotImplementedError
 
     def on_init_start(self, trainer: Trainer):
@@ -64,11 +61,11 @@ class TuneCallback(Callback):
 
     def on_epoch_start(self, trainer: Trainer, pl_module: LightningModule):
         if "epoch_start" in self._on:
-            self._handle(trainer, pl_module, is_epoch=True)
+            self._handle(trainer, pl_module)
 
     def on_epoch_end(self, trainer: Trainer, pl_module: LightningModule):
         if "epoch_end" in self._on:
-            self._handle(trainer, pl_module, is_epoch=True)
+            self._handle(trainer, pl_module)
 
     def on_batch_start(self, trainer: Trainer, pl_module: LightningModule):
         if "batch_start" in self._on:
@@ -172,10 +169,7 @@ class TuneReportCallback(TuneCallback):
             metrics = [metrics]
         self._metrics = metrics
 
-    def _handle(self,
-                trainer: Trainer,
-                pl_module: LightningModule,
-                is_epoch: bool = False):
+    def _handle(self, trainer: Trainer, pl_module: LightningModule):
         # Don't report if just doing initial validation sanity checks.
         if trainer.running_sanity_check:
             return
@@ -220,13 +214,10 @@ class _TuneCheckpointCallback(TuneCallback):
         super(_TuneCheckpointCallback, self).__init__(on)
         self._filename = filename
 
-    def _handle(self,
-                trainer: Trainer,
-                pl_module: LightningModule,
-                is_epoch: bool = False):
+    def _handle(self, trainer: Trainer, pl_module: LightningModule):
         if trainer.running_sanity_check:
             return
-        step = trainer.current_epoch if is_epoch else trainer.global_step
+        step = f"epoch={trainer.current_epoch}-step={trainer.global_step}"
         with tune.checkpoint_dir(step=step) as checkpoint_dir:
             trainer.save_checkpoint(
                 os.path.join(checkpoint_dir, self._filename))
@@ -276,9 +267,6 @@ class TuneReportCheckpointCallback(TuneCallback):
         self._checkpoint = _TuneCheckpointCallback(filename, on)
         self._report = TuneReportCallback(metrics, on)
 
-    def _handle(self,
-                trainer: Trainer,
-                pl_module: LightningModule,
-                is_epoch: bool = False):
-        self._checkpoint._handle(trainer, pl_module, is_epoch)
-        self._report._handle(trainer, pl_module, is_epoch)
+    def _handle(self, trainer: Trainer, pl_module: LightningModule):
+        self._checkpoint._handle(trainer, pl_module)
+        self._report._handle(trainer, pl_module)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
If using epoch level callbacks (on_epoch_start or on_epoch_end), then use `trainer.current_epoch` as the checkpoint directory name instead of `trainer.global_step`.

Closes https://github.com/ray-project/ray/issues/13971
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
