### PR TITLE
[Tune] Fix HEBO evaluated rewards for max mode & save/restore

### DIFF
--- a/python/ray/tune/suggest/hebo.py
+++ b/python/ray/tune/suggest/hebo.py
@@ -280,14 +280,18 @@ class HEBOSearch(Searcher):
             numpy_random_state = None
             torch_random_state = None
         with open(checkpoint_path, "wb") as f:
-            pickle.dump((self._opt, self._points_to_evaluate,
-                         numpy_random_state, torch_random_state), f)
+            pickle.dump((self._opt, self._initial_points, numpy_random_state,
+                         torch_random_state, self._live_trial_mapping,
+                         self._n_suggestions, self._suggestions_cache,
+                         self._space, self._hebo_config), f)
 
     def restore(self, checkpoint_path: str):
         """Restoring current optimizer state."""
         with open(checkpoint_path, "rb") as f:
-            (self._opt, self._points_to_evaluate, numpy_random_state,
-             torch_random_state) = pickle.load(f)
+            (self._opt, self._initial_points, numpy_random_state,
+             torch_random_state, self._live_trial_mapping, self._n_suggestions,
+             self._suggestions_cache, self._space,
+             self._hebo_config) = pickle.load(f)
         if numpy_random_state is not None:
             np.random.set_state(numpy_random_state)
         if torch_random_state is not None:

--- a/python/ray/tune/suggest/hebo.py
+++ b/python/ray/tune/suggest/hebo.py
@@ -209,7 +209,8 @@ class HEBOSearch(Searcher):
             if self._evaluated_rewards:
                 self._opt.observe(
                     pd.DataFrame(self._points_to_evaluate),
-                    np.array(self._evaluated_rewards))
+                    np.array(self._evaluated_rewards) * self._metric_op
+                )
             else:
                 self._initial_points = self._points_to_evaluate
 

--- a/python/ray/tune/suggest/hebo.py
+++ b/python/ray/tune/suggest/hebo.py
@@ -209,8 +209,7 @@ class HEBOSearch(Searcher):
             if self._evaluated_rewards:
                 self._opt.observe(
                     pd.DataFrame(self._points_to_evaluate),
-                    np.array(self._evaluated_rewards) * self._metric_op
-                )
+                    np.array(self._evaluated_rewards) * self._metric_op)
             else:
                 self._initial_points = self._points_to_evaluate
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If HEBO is set to maximize, evaluated rewards need to be multiplied by -1. Apologies, didn't catch that before.

Furthermore, this PR also makes sure that all the necessary attributes are saved and restored.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
