### PR TITLE
[Core] Initialize system config in CoreWorkerProcess constructor

### DIFF
--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -273,6 +273,8 @@ class CoreWorkerProcess {
 
   static void HandleAtExit();
 
+  void InitializeSystemConfig();
+
   /// Get the `CoreWorker` instance by worker ID.
   ///
   /// \param[in] workerId The worker ID.

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -237,7 +237,6 @@ struct GcsServerMocker {
       return ray::Status::OK();
     }
 
-    /// ConfigInterface
     void GetSystemConfig(const ray::rpc::ClientCallback<ray::rpc::GetSystemConfigReply>
                              &callback) override {}
 

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -237,6 +237,10 @@ struct GcsServerMocker {
       return ray::Status::OK();
     }
 
+    /// ConfigInterface
+    void GetSystemConfig(const ray::rpc::ClientCallback<ray::rpc::GetSystemConfigReply>
+                             &callback) override {}
+
     ~MockRayletClient() {}
 
     int num_workers_requested = 0;

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -204,6 +204,13 @@ message ReleaseUnusedBundlesRequest {
 message ReleaseUnusedBundlesReply {
 }
 
+message GetSystemConfigRequest {
+}
+
+message GetSystemConfigReply {
+  string system_config = 1;
+}
+
 // Service for inter-node-manager communication.
 service NodeManagerService {
   // Request a worker from the raylet.
@@ -251,4 +258,6 @@ service NodeManagerService {
   // are still needed. And Raylet will release other bundles.
   rpc ReleaseUnusedBundles(ReleaseUnusedBundlesRequest)
       returns (ReleaseUnusedBundlesReply);
+  // Get the system config.
+  rpc GetSystemConfig(GetSystemConfigRequest) returns (GetSystemConfigReply);
 }

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -147,8 +147,6 @@ table RegisterClientReply {
   raylet_id: string;
   // Port that this worker should listen on.
   port: int;
-  // Internal config options.
-  system_config: string;
   // The config bytes of this job serialized with protobuf.
   serialized_job_config: string;
 }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1075,7 +1075,6 @@ void NodeManager::ProcessRegisterClientRequestMessage(
     auto reply = ray::protocol::CreateRegisterClientReply(
         fbb, status.ok(), fbb.CreateString(status.ToString()),
         to_flatbuf(fbb, self_node_id_), assigned_port,
-        fbb.CreateString(initial_config_.raylet_config),
         fbb.CreateString(serialized_job_config));
     fbb.Finish(reply);
     client->WriteMessageAsync(
@@ -2399,6 +2398,13 @@ void NodeManager::HandlePinObjectIDs(const rpc::PinObjectIDsRequest &request,
   local_object_manager_.PinObjects(object_ids, std::move(results), owner_address);
   // Wait for the object to be freed by the owner, which keeps the ref count.
   local_object_manager_.WaitForObjectFree(owner_address, object_ids);
+  send_reply_callback(Status::OK(), nullptr, nullptr);
+}
+
+void NodeManager::HandleGetSystemConfig(const rpc::GetSystemConfigRequest &request,
+                                        rpc::GetSystemConfigReply *reply,
+                                        rpc::SendReplyCallback send_reply_callback) {
+  reply->set_system_config(initial_config_.raylet_config);
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }
 

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -606,6 +606,11 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
                                   rpc::ReleaseUnusedBundlesReply *reply,
                                   rpc::SendReplyCallback send_reply_callback) override;
 
+  /// Handle a `GetSystemConfig` request.
+  void HandleGetSystemConfig(const rpc::GetSystemConfigRequest &request,
+                             rpc::GetSystemConfigReply *reply,
+                             rpc::SendReplyCallback send_reply_callback) override;
+
   /// Trigger local GC on each worker of this raylet.
   void DoLocalGC();
 

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -86,7 +86,7 @@ raylet::RayletClient::RayletClient(
     const std::string &raylet_socket, const WorkerID &worker_id,
     rpc::WorkerType worker_type, const JobID &job_id, const Language &language,
     const std::string &ip_address, Status *status, NodeID *raylet_id, int *port,
-    std::string *system_config, std::string *serialized_job_config)
+    std::string *serialized_job_config)
     : grpc_client_(std::move(grpc_client)), worker_id_(worker_id), job_id_(job_id) {
   // For C++14, we could use std::make_unique
   conn_ = std::unique_ptr<raylet::RayletConnection>(
@@ -122,8 +122,6 @@ raylet::RayletClient::RayletClient(
   *raylet_id = NodeID::FromBinary(reply_message->raylet_id()->str());
   *port = reply_message->port();
 
-  RAY_CHECK(system_config);
-  *system_config = reply_message->system_config()->str();
   *serialized_job_config = reply_message->serialized_job_config()->str();
 }
 
@@ -425,6 +423,12 @@ void raylet::RayletClient::SubscribeToPlasma(const ObjectID &object_id,
   fbb.Finish(message);
 
   RAY_CHECK_OK(conn_->WriteMessage(MessageType::SubscribePlasmaReady, &fbb));
+}
+
+void raylet::RayletClient::GetSystemConfig(
+    const rpc::ClientCallback<rpc::GetSystemConfigReply> &callback) {
+  rpc::GetSystemConfigRequest request;
+  grpc_client_->GetSystemConfig(request, callback);
 }
 
 }  // namespace ray

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -139,24 +139,17 @@ class DependencyWaiterInterface {
   virtual ~DependencyWaiterInterface(){};
 };
 
-/// Interface for fetching config.
-class ConfigInterface {
+class RayletClientInterface : public PinObjectsInterface,
+                              public WorkerLeaseInterface,
+                              public DependencyWaiterInterface,
+                              public ResourceReserveInterface {
  public:
+  virtual ~RayletClientInterface(){};
+
   /// Get the system config from Raylet.
   /// \param callback Callback that will be called after raylet replied the system config.
   virtual void GetSystemConfig(
       const rpc::ClientCallback<rpc::GetSystemConfigReply> &callback) = 0;
-
-  virtual ~ConfigInterface(){};
-};
-
-class RayletClientInterface : public PinObjectsInterface,
-                              public WorkerLeaseInterface,
-                              public DependencyWaiterInterface,
-                              public ResourceReserveInterface,
-                              public ConfigInterface {
- public:
-  virtual ~RayletClientInterface(){};
 };
 
 namespace raylet {

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -139,10 +139,22 @@ class DependencyWaiterInterface {
   virtual ~DependencyWaiterInterface(){};
 };
 
+/// Interface for fetching config.
+class ConfigInterface {
+ public:
+  /// Get the system config from Raylet.
+  /// \param callback Callback that will be called after raylet replied the system config.
+  virtual void GetSystemConfig(
+      const rpc::ClientCallback<rpc::GetSystemConfigReply> &callback) = 0;
+
+  virtual ~ConfigInterface(){};
+};
+
 class RayletClientInterface : public PinObjectsInterface,
                               public WorkerLeaseInterface,
                               public DependencyWaiterInterface,
-                              public ResourceReserveInterface {
+                              public ResourceReserveInterface,
+                              public ConfigInterface {
  public:
   virtual ~RayletClientInterface(){};
 };
@@ -205,7 +217,7 @@ class RayletClient : public RayletClientInterface {
                const std::string &raylet_socket, const WorkerID &worker_id,
                rpc::WorkerType worker_type, const JobID &job_id, const Language &language,
                const std::string &ip_address, Status *status, NodeID *raylet_id,
-               int *port, std::string *system_config, std::string *serialized_job_config);
+               int *port, std::string *serialized_job_config);
 
   /// Connect to the raylet via grpc only.
   ///
@@ -388,6 +400,9 @@ class RayletClient : public RayletClientInterface {
   void PinObjectIDs(
       const rpc::Address &caller_address, const std::vector<ObjectID> &object_ids,
       const ray::rpc::ClientCallback<ray::rpc::PinObjectIDsReply> &callback) override;
+
+  void GetSystemConfig(
+      const rpc::ClientCallback<rpc::GetSystemConfigReply> &callback) override;
 
   void GlobalGC(const rpc::ClientCallback<rpc::GlobalGCReply> &callback);
 

--- a/src/ray/rpc/node_manager/node_manager_client.h
+++ b/src/ray/rpc/node_manager/node_manager_client.h
@@ -106,6 +106,9 @@ class NodeManagerWorkerClient
   /// Release unused bundles.
   VOID_RPC_CLIENT_METHOD(NodeManagerService, ReleaseUnusedBundles, grpc_client_, )
 
+  /// Get the system config from Raylet.
+  VOID_RPC_CLIENT_METHOD(NodeManagerService, GetSystemConfig, grpc_client_, )
+
  private:
   /// Constructor.
   ///

--- a/src/ray/rpc/node_manager/node_manager_server.h
+++ b/src/ray/rpc/node_manager/node_manager_server.h
@@ -37,7 +37,8 @@ namespace rpc {
   RPC_SERVICE_HANDLER(NodeManagerService, CancelResourceReserve)  \
   RPC_SERVICE_HANDLER(NodeManagerService, RequestObjectSpillage)  \
   RPC_SERVICE_HANDLER(NodeManagerService, RestoreSpilledObject)   \
-  RPC_SERVICE_HANDLER(NodeManagerService, ReleaseUnusedBundles)
+  RPC_SERVICE_HANDLER(NodeManagerService, ReleaseUnusedBundles)   \
+  RPC_SERVICE_HANDLER(NodeManagerService, GetSystemConfig)
 
 /// Interface of the `NodeManagerService`, see `src/ray/protobuf/node_manager.proto`.
 class NodeManagerServiceHandler {
@@ -110,6 +111,10 @@ class NodeManagerServiceHandler {
   virtual void HandleReleaseUnusedBundles(const ReleaseUnusedBundlesRequest &request,
                                           ReleaseUnusedBundlesReply *reply,
                                           SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleGetSystemConfig(const GetSystemConfigRequest &request,
+                                     GetSystemConfigReply *reply,
+                                     SendReplyCallback send_reply_callback) = 0;
 };
 
 /// The `GrpcService` for `NodeManagerService`.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Some system config values may be accessed before connecting to Raylet in the `CoreWorker` constructor, so we need to initialize the system config in the `CoreWorkerProcess` constructor.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
