### PR TITLE
[Java] Quit worker process after RunTaskExecutionLoop to avoid orphan Java worker processses

### DIFF
--- a/java/test/src/main/java/io/ray/test/ExitActorTest2.java
+++ b/java/test/src/main/java/io/ray/test/ExitActorTest2.java
@@ -1,0 +1,54 @@
+package io.ray.test;
+
+import static io.ray.runtime.util.SystemUtil.pid;
+
+import io.ray.api.ActorHandle;
+import io.ray.api.Ray;
+import io.ray.runtime.util.SystemUtil;
+import java.util.concurrent.TimeUnit;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Test(groups = {"cluster"})
+public class ExitActorTest2 extends BaseTest {
+
+  @BeforeClass
+  public void setUp() {
+    System.setProperty("ray.job.num-java-workers-per-process", "1");
+  }
+
+  private static class ExitingActor {
+    private final Thread thread;
+
+    public ExitingActor() {
+      thread =
+          new Thread(
+              () -> {
+                try {
+                  TimeUnit.MINUTES.sleep(1);
+                } catch (InterruptedException e) {
+                  throw new RuntimeException(e);
+                }
+              });
+      // Start a non-daemon thread
+      thread.start();
+    }
+
+    public int getPid() {
+      return pid();
+    }
+
+    public void exit() {
+      Ray.exitActor();
+    }
+  }
+
+  public void testExitActorWithUserCreatedThread() {
+    ActorHandle<ExitingActor> actor = Ray.actor(ExitingActor::new).remote();
+    int pid = actor.task(ExitingActor::getPid).remote().get();
+    Assert.assertTrue(SystemUtil.isProcessAlive(pid));
+    actor.task(ExitingActor::exit).remote();
+    Assert.assertTrue(TestUtils.waitForCondition(() -> !SystemUtil.isProcessAlive(pid), 10000));
+  }
+}

--- a/java/test/src/main/java/io/ray/test/TestUtils.java
+++ b/java/test/src/main/java/io/ray/test/TestUtils.java
@@ -42,20 +42,19 @@ public class TestUtils {
    * @return True if the condition is met within the timeout, false otherwise.
    */
   public static boolean waitForCondition(Supplier<Boolean> condition, int timeoutMs) {
-    int waitTime = 0;
+    long endTime = System.currentTimeMillis() + timeoutMs;
     while (true) {
       if (condition.get()) {
         return true;
       }
 
+      if (System.currentTimeMillis() >= endTime) {
+        break;
+      }
       try {
         java.util.concurrent.TimeUnit.MILLISECONDS.sleep(WAIT_INTERVAL_MS);
       } catch (InterruptedException e) {
         throw new RuntimeException(e);
-      }
-      waitTime += WAIT_INTERVAL_MS;
-      if (waitTime > timeoutMs) {
-        break;
       }
     }
     return false;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If user-created non-daemon Java threads are not cleaned up before calling `Ray.exitActor()`, the JVM won't exit. This results in worker process leakage.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
