### PR TITLE
[GCS]Revert ping_gcs_rpc_server_max_retries to 600

### DIFF
--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -10,20 +10,6 @@ from ray.test_utils import (RayTestTimeoutException, run_string_as_driver,
                             get_error_message)
 
 
-def test_remote_raylet_cleanup(ray_start_cluster):
-    cluster = ray_start_cluster
-    cluster.add_node()
-    cluster.add_node()
-    cluster.add_node()
-    cluster.wait_for_nodes()
-
-    def remote_raylets_dead():
-        return not cluster.remaining_processes_alive()
-
-    cluster.remove_node(cluster.head_node, allow_graceful=False)
-    wait_for_condition(remote_raylets_dead)
-
-
 def test_error_isolation(call_ray_start):
     address = call_ray_start
     # Connect a driver to the Ray cluster.

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -6,8 +6,7 @@ import time
 import ray
 from ray.test_utils import (RayTestTimeoutException, run_string_as_driver,
                             run_string_as_driver_nonblocking,
-                            wait_for_condition, init_error_pubsub,
-                            get_error_message)
+                            init_error_pubsub, get_error_message)
 
 
 def test_error_isolation(call_ray_start):

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -271,7 +271,7 @@ RAY_CONFIG(uint32_t, cancellation_retry_ms, 2000)
 RAY_CONFIG(int64_t, ping_gcs_rpc_server_interval_milliseconds, 1000)
 
 /// Maximum number of times to retry ping gcs rpc server when gcs server restarts.
-RAY_CONFIG(int32_t, ping_gcs_rpc_server_max_retries, 1)
+RAY_CONFIG(int32_t, ping_gcs_rpc_server_max_retries, 600)
 
 /// Minimum interval between reconnecting gcs rpc server when gcs server restarts.
 RAY_CONFIG(int32_t, minimum_gcs_reconnect_interval_milliseconds, 5000)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
At present, the number of reconnection between GCS client and GCS is 1. 
If GCS is restarted, GCS client will not reconnect. 
We set `ping_gcs_rpc_server_max_retries` to 600 and have been running steadily inside the ant group for 8 months.
So i open a PR to see the impact of setting `ping_gcs_rpc_server_max_retries` to 600 on CI test cases.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/pull/10579

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
