### PR TITLE
Require opt-in to switching plasma to /tmp instead of /dev/shm

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1675,6 +1675,14 @@ def determine_plasma_store_config(object_store_memory,
             # /dev/shm.
             if shm_avail > object_store_memory:
                 plasma_directory = "/dev/shm"
+            elif not os.environ.get("RAY_OBJECT_STORE_ALLOW_SLOW_STORAGE"):
+                raise ValueError(
+                    "The configured object store size exceeds the capacity of "
+                    "/dev/shm. This will harm performance. To proceed "
+                    "regardless of this warning, you can set "
+                    "RAY_OBJECT_STORE_ALLOW_SLOW_STORAGE=1. Consider deleting "
+                    "files in /dev/shm or increasing its size with "
+                    "--shm-size in Docker.")
             else:
                 plasma_directory = ray.utils.get_user_temp_dir()
                 logger.warning(

--- a/python/ray/resource_spec.py
+++ b/python/ray/resource_spec.py
@@ -166,6 +166,10 @@ class ResourceSpec(
             object_store_memory = int(
                 avail_memory *
                 ray_constants.DEFAULT_OBJECT_STORE_MEMORY_PROPORTION)
+            # Cap by shm size by default to avoid low performance.
+            if sys.platform == "linux" or sys.platform == "linux2":
+                shm_avail = ray.utils.get_shared_memory_bytes()
+                object_store_memory = min(shm_avail, object_store_memory)
             # Cap memory to avoid memory waste and perf issues on large nodes
             if (object_store_memory >
                     ray_constants.DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES):

--- a/python/ray/resource_spec.py
+++ b/python/ray/resource_spec.py
@@ -166,21 +166,19 @@ class ResourceSpec(
             object_store_memory = int(
                 avail_memory *
                 ray_constants.DEFAULT_OBJECT_STORE_MEMORY_PROPORTION)
+            max_cap = ray_constants.DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES
             # Cap by shm size by default to avoid low performance.
             if sys.platform == "linux" or sys.platform == "linux2":
                 shm_avail = ray.utils.get_shared_memory_bytes()
-                object_store_memory = min(shm_avail, object_store_memory)
+                max_cap = min(shm_avail, max_cap)
             # Cap memory to avoid memory waste and perf issues on large nodes
-            if (object_store_memory >
-                    ray_constants.DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES):
+            if object_store_memory > max_cap:
                 logger.debug(
                     "Warning: Capping object memory store to {}GB. ".format(
-                        ray_constants.DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES //
-                        1e9) +
+                        max_cap // 1e9) +
                     "To increase this further, specify `object_store_memory` "
                     "when calling ray.init() or ray start.")
-                object_store_memory = (
-                    ray_constants.DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES)
+                object_store_memory = max_cap
 
         redis_max_memory = self.redis_max_memory
         if redis_max_memory is None:


### PR DESCRIPTION
This PR:
- Avoids ever auto-setting object store size to be larger than /dev/shm
- Requires opt in to use /tmp instead of /dev/shm

This avoids severe hidden performance degradations (swapping). Using /tmp for swapping not longer be needed since we now have support for object spilling on by default.

Closes https://github.com/ray-project/ray/issues/14326