### PR TITLE
Disable windows tests for test_iter and test_reference_counting

### DIFF
--- a/python/ray/tests/test_iter.py
+++ b/python/ray/tests/test_iter.py
@@ -1,3 +1,4 @@
+import sys
 import time
 import collections
 from collections import Counter
@@ -286,6 +287,7 @@ def test_filter(ray_start_regular_shared):
     assert list(it.gather_sync()) == [0, 2, 1]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_local_shuffle(ray_start_regular_shared):
     # confirm that no data disappears, and they all stay within the same shard
     it = from_range(8, num_shards=2).local_shuffle(shuffle_buffer_size=2)

--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -2,6 +2,7 @@
 import copy
 import logging
 import os
+import sys
 import time
 
 import numpy as np
@@ -479,6 +480,7 @@ def test_actor_holding_serialized_reference(one_worker_100MiB, use_ray_put,
 # Test that a passed reference held by an actor after a task finishes
 # is kept until the reference is removed from the worker. Also tests giving
 # the worker a duplicate reference to the same object ref.
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize("use_ray_put,failure", [(False, False), (False, True),
                                                  (True, False), (True, True)])
 def test_worker_holding_serialized_reference(one_worker_100MiB, use_ray_put,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
cc @clarkzinzow

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(