### PR TITLE
[C++ worker] Add function name in CppFunctionDescriptor

### DIFF
--- a/cpp/include/ray/api/ray_runtime.h
+++ b/cpp/include/ray/api/ray_runtime.h
@@ -16,6 +16,7 @@ namespace api {
 
 struct MemberFunctionPtrHolder {
   uintptr_t value[2];
+  std::string function_name;
 };
 
 struct RemoteFunctionPtrHolder {
@@ -23,6 +24,7 @@ struct RemoteFunctionPtrHolder {
   uintptr_t function_pointer;
   /// The executable function pointer
   uintptr_t exec_function_pointer;
+  std::string function_name;
 };
 
 class RayRuntime {

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -78,6 +78,7 @@ message CppFunctionDescriptor {
   string function_offset = 2;
   /// Executable function offset from base address.
   string exec_function_offset = 3;
+  string function_name = 4;
 }
 
 // A union wrapper for various function descriptor types.


### PR DESCRIPTION
## Why are these changes needed?

We should support safe c++ worker API according the [doc](https://docs.google.com/document/d/1pBRUm-w2LKXTte8uXmvQ23l7gOJV2IOwirCTPjtPGWk/edit#heading=h.86fui9aqjkh6).  It is need to find function by function name, so add function name to CppFunctionDescriptor.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
