### PR TITLE
Include py.typed in MANIFEST.in to make sure it is packaged in wheels

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,1 +1,2 @@
 include ray/python/ray/autoscaler/ray-schema.json
+include ray/python/ray/py.typed


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The MacOS wheel of ray contains a `py.typed` file, whereas the Linux wheel does not. This file indicates that type checking can be performed against the types defined in Ray. Excluding the file on Linux means that type checkers like mypy work differently on different OSs on projects using Ray.

I added a line in MANIFEST.in to include `py.typed` in the release wheels. I believe this is the correct solution but I am only somewhat familiar with python packaging.

I am not sure of the best way to test this change. I looked into writing a release test a bit but this doesn't seem to fit in with any of the other test categories under `ray/release`. I am happy to work on tests if given some direction.

## Related issue number

Closes #14431

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
