### PR TITLE
[tune] Fixed save_to_dir w/ os.replace

### DIFF
--- a/python/ray/tune/suggest/suggestion.py
+++ b/python/ray/tune/suggest/suggestion.py
@@ -265,7 +265,7 @@ class Searcher:
             success = False
 
         if success and os.path.exists(tmp_search_ckpt_path):
-            os.rename(
+            os.replace(
                 tmp_search_ckpt_path,
                 os.path.join(checkpoint_dir,
                              self.CKPT_FILE_TMPL.format(session_str)))


### PR DESCRIPTION
The method save_to_dir of the class Searcher in ray.tune.suggest.suggestion.py uses the os.rename method to replace tmp_search_ckpt to current ckpt. os.rename method will raise the [WinError 183] or file exists error of other operating system. os.replace is the currect way.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Make the process resume correct by resolve the algorithm based on class Searcher checkpointing fail

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
