### PR TITLE
Split tests for timeout

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -18,6 +18,8 @@ py_test_module_list(
     "test_actor_resources.py",
     "test_advanced.py",
     "test_advanced_2.py",
+    "test_advanced_3.py",
+    "test_advanced_4.py",
     "test_array.py",
     "test_autoscaling_policy.py",
     "test_basic.py",
@@ -125,7 +127,6 @@ py_test_module_list(
   files = [
     "test_failure.py",
     "test_stress_failure.py",
-    "test_advanced_3.py",
   ],
   size = "large",
   extra_srcs = SRCS,

--- a/python/ray/tests/test_advanced_3.py
+++ b/python/ray/tests/test_advanced_3.py
@@ -18,7 +18,6 @@ import ray.cluster_utils
 import ray.test_utils
 from ray import resource_spec
 import setproctitle
-import subprocess
 
 from ray.test_utils import (check_call_ray, wait_for_condition,
                             wait_for_num_actors)
@@ -192,26 +191,6 @@ def test_object_ref_properties():
     id_dumps = pickle.dumps(object_ref)
     id_from_dumps = pickle.loads(id_dumps)
     assert id_from_dumps == object_ref
-
-
-@pytest.fixture
-def shutdown_only_with_initialization_check():
-    yield None
-    # The code after the yield will run as teardown code.
-    ray.shutdown()
-    assert not ray.is_initialized()
-
-
-def test_initialized(shutdown_only_with_initialization_check):
-    assert not ray.is_initialized()
-    ray.init(num_cpus=0)
-    assert ray.is_initialized()
-
-
-def test_initialized_local_mode(shutdown_only_with_initialization_check):
-    assert not ray.is_initialized()
-    ray.init(num_cpus=0, local_mode=True)
-    assert ray.is_initialized()
 
 
 def test_wait_reconstruction(shutdown_only):
@@ -412,17 +391,6 @@ def test_export_after_shutdown(ray_start_regular):
         ray.get(actor_handle.method.remote())
 
     ray.get(export_definitions_from_worker.remote(f, Actor))
-
-
-def test_ray_start_and_stop():
-    for i in range(10):
-        subprocess.check_call(["ray", "start", "--head"])
-        subprocess.check_call(["ray", "stop"])
-
-
-def test_ray_memory(shutdown_only):
-    ray.init(num_cpus=1)
-    subprocess.check_call(["ray", "memory"])
 
 
 def test_invalid_unicode_in_worker_log(shutdown_only):

--- a/python/ray/tests/test_advanced_4.py
+++ b/python/ray/tests/test_advanced_4.py
@@ -1,0 +1,39 @@
+import pytest
+import ray
+import subprocess
+
+
+@pytest.fixture
+def shutdown_only_with_initialization_check():
+    yield None
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+    assert not ray.is_initialized()
+
+
+def test_initialized(shutdown_only_with_initialization_check):
+    assert not ray.is_initialized()
+    ray.init(num_cpus=0)
+    assert ray.is_initialized()
+
+
+def test_initialized_local_mode(shutdown_only_with_initialization_check):
+    assert not ray.is_initialized()
+    ray.init(num_cpus=0, local_mode=True)
+    assert ray.is_initialized()
+
+
+def test_ray_start_and_stop():
+    for i in range(10):
+        subprocess.check_call(["ray", "start", "--head"])
+        subprocess.check_call(["ray", "stop"])
+
+
+def test_ray_memory(shutdown_only):
+    ray.init(num_cpus=1)
+    subprocess.check_call(["ray", "memory"])
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_advanced_4.py
+++ b/python/ray/tests/test_advanced_4.py
@@ -1,6 +1,7 @@
 import pytest
 import ray
 import subprocess
+import sys
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

```
=================================================================================================== slowest durations ====================================================================================================
60.63s call     ray/tests/test_advanced_3.py::test_ray_start_and_stop
8.13s call     ray/tests/test_advanced_3.py::test_export_after_shutdown
5.16s call     ray/tests/test_advanced_3.py::test_override_environment_variables_complex
4.60s call     ray/tests/test_advanced_3.py::test_logging_to_driver
4.54s call     ray/tests/test_advanced_3.py::test_ray_memory
4.37s call     ray/tests/test_advanced_3.py::test_ray_address_environment_variable[ray_start_cluster0]
4.32s call     ray/tests/test_advanced_3.py::test_global_state_api
3.67s setup    ray/tests/test_advanced_3.py::test_non_ascii_comment
3.67s setup    ray/tests/test_advanced_3.py::test_put_pins_object[157286400]
3.67s setup    ray/tests/test_advanced_3.py::test_ray_task_name_setproctitle
3.65s call     ray/tests/test_advanced_3.py::test_workers
3.63s setup    ray/tests/test_advanced_3.py::test_override_environment_variables_task
3.62s call     ray/tests/test_advanced_3.py::test_not_logging_to_driver
3.62s call     ray/tests/test_advanced_3.py::test_invalid_unicode_in_worker_log
3.61s call     ray/tests/test_advanced_3.py::test_wait_reconstruction
3.27s call     ray/tests/test_advanced_3.py::test_duplicated_arg
3.18s call     ray/tests/test_advanced_3.py::test_override_environment_variables_multitenancy
2.83s call     ray/tests/test_advanced_3.py::test_accelerator_type_api
2.76s setup    ray/tests/test_advanced_3.py::test_override_environment_variables_nested_task
2.70s setup    ray/tests/test_advanced_3.py::test_ray_setproctitle
2.68s setup    ray/tests/test_advanced_3.py::test_export_after_shutdown
2.66s setup    ray/tests/test_advanced_3.py::test_decorated_function
2.66s setup    ray/tests/test_advanced_3.py::test_raylet_is_robust_to_random_messages
2.66s call     ray/tests/test_advanced_3.py::test_ray_resources_environment_variable
2.63s setup    ray/tests/test_advanced_3.py::test_override_environment_variables_actor
2.62s call     ray/tests/test_advanced_3.py::test_sync_job_config
2.32s call     ray/tests/test_advanced_3.py::test_initialized
2.31s call     ray/tests/test_advanced_3.py::test_initialized_local_mode
2.30s setup    ray/tests/test_advanced_3.py::test_ray_address_environment_variable[ray_start_cluster0]
1.74s teardown ray/tests/test_advanced_3.py::test_global_state_api
1.70s teardown ray/tests/test_advanced_3.py::test_override_environment_variables_complex
1.69s teardown ray/tests/test_advanced_3.py::test_duplicated_arg
1.46s teardown ray/tests/test_advanced_3.py::test_decorated_function
1.45s teardown ray/tests/test_advanced_3.py::test_ray_memory
1.44s teardown ray/tests/test_advanced_3.py::test_raylet_is_robust_to_random_messages
1.41s teardown ray/tests/test_advanced_3.py::test_put_pins_object[157286400]
1.41s teardown ray/tests/test_advanced_3.py::test_ray_resources_environment_variable
1.40s teardown ray/tests/test_advanced_3.py::test_workers
1.39s teardown ray/tests/test_advanced_3.py::test_override_environment_variables_multitenancy
1.37s teardown ray/tests/test_advanced_3.py::test_sync_job_config
1.36s teardown ray/tests/test_advanced_3.py::test_accelerator_type_api
1.36s teardown ray/tests/test_advanced_3.py::test_override_environment_variables_actor
1.35s teardown ray/tests/test_advanced_3.py::test_initialized_local_mode
1.33s teardown ray/tests/test_advanced_3.py::test_logging_to_driver
1.31s teardown ray/tests/test_advanced_3.py::test_non_ascii_comment
1.30s teardown ray/tests/test_advanced_3.py::test_override_environment_variables_task
1.29s teardown ray/tests/test_advanced_3.py::test_ray_task_name_setproctitle
1.28s teardown ray/tests/test_advanced_3.py::test_export_after_shutdown
1.27s teardown ray/tests/test_advanced_3.py::test_ray_setproctitle
1.26s teardown ray/tests/test_advanced_3.py::test_invalid_unicode_in_worker_log
1.26s teardown ray/tests/test_advanced_3.py::test_override_environment_variables_nested_task
1.26s teardown ray/tests/test_advanced_3.py::test_initialized
1.25s teardown ray/tests/test_advanced_3.py::test_wait_reconstruction
1.21s teardown ray/tests/test_advanced_3.py::test_not_logging_to_driver
1.07s teardown ray/tests/test_advanced_3.py::test_ray_address_environment_variable[ray_start_cluster0]
0.56s call     ray/tests/test_advanced_3.py::test_override_environment_variables_nested_task
0.53s call     ray/tests/test_advanced_3.py::test_put_pins_object[157286400]
0.28s call     ray/tests/test_advanced_3.py::test_override_environment_variables_task
0.28s call     ray/tests/test_advanced_3.py::test_override_environment_variables_actor
0.13s call     ray/tests/test_advanced_3.py::test_ray_setproctitle
0.12s call     ray/tests/test_advanced_3.py::test_ray_task_name_setproctitle
0.02s call     ray/tests/test_advanced_3.py::test_raylet_is_robust_to_random_messages
0.01s call     ray/tests/test_advanced_3.py::test_decorated_function
```
Test was timing out.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(