### PR TITLE
[Core] Exit autoscaler with a non-zero exit code upon handling SIGINT/SIGTERM

### DIFF
--- a/python/ray/_private/monitor.py
+++ b/python/ray/_private/monitor.py
@@ -261,8 +261,9 @@ class Monitor:
             redis_client, ray_constants.MONITOR_DIED_ERROR, message)
 
     def _signal_handler(self, sig, frame):
-        return self._handle_failure(f"Terminated with signal {sig}\n" +
-                                    "".join(traceback.format_stack(frame)))
+        self._handle_failure(f"Terminated with signal {sig}\n" +
+                             "".join(traceback.format_stack(frame)))
+        sys.exit(1)
 
     def run(self):
         # Register signal handlers for autoscaler termination.

--- a/python/ray/_private/monitor.py
+++ b/python/ray/_private/monitor.py
@@ -263,7 +263,7 @@ class Monitor:
     def _signal_handler(self, sig, frame):
         self._handle_failure(f"Terminated with signal {sig}\n" +
                              "".join(traceback.format_stack(frame)))
-        sys.exit(1)
+        sys.exit(sig + 128)
 
     def run(self):
         # Register signal handlers for autoscaler termination.


### PR DESCRIPTION
When handling SIGINT/SIGTERM within the autoscaler, we should explicitly exit with a non-zero exit code.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
