### PR TITLE
Add an experimental load_package API

### DIFF
--- a/python/ray/_private/runtime_env.py
+++ b/python/ray/_private/runtime_env.py
@@ -8,7 +8,6 @@ from zipfile import ZipFile
 from ray.job_config import JobConfig
 from enum import Enum
 from ray.experimental import internal_kv
-from ray.core.generated.common_pb2 import RuntimeEnv
 from typing import List, Tuple
 from types import ModuleType
 from urllib.parse import urlparse
@@ -275,16 +274,15 @@ def upload_runtime_env_package_if_needed(job_config: JobConfig) -> None:
         logger.info(f"{pkg_uri} has been pushed with {pkg_size} bytes")
 
 
-def ensure_runtime_env_setup(runtime_env: RuntimeEnv) -> None:
+def ensure_runtime_env_setup(pkg_uri: str) -> None:
     """Make sure all required packages are downloaded it local.
 
     Necessary packages required to run the job will be downloaded
     into local file system if it doesn't exist.
 
     Args:
-        runtime_env (RuntimeEnv): Runtime environment of the job
+        pkg_uri (str): Package of the working dir for the runtime env.
     """
-    pkg_uri = runtime_env.working_dir_uri
     if not pkg_uri:
         return
     pkg_file = Path(_get_local_path(pkg_uri))
@@ -294,8 +292,8 @@ def ensure_runtime_env_setup(runtime_env: RuntimeEnv) -> None:
     with lock:
         # TODO(yic): checksum calculation is required
         if pkg_file.exists():
-            logger.info(f"{pkg_uri} has existed locally, skip downloading")
+            logger.debug(f"{pkg_uri} has existed locally, skip downloading")
         else:
             pkg_size = fetch_package(pkg_uri, pkg_file)
-            logger.info(f"Downloaded {pkg_size} bytes into {pkg_file}")
+            logger.debug(f"Downloaded {pkg_size} bytes into {pkg_file}")
     sys.path.insert(0, str(pkg_file))

--- a/python/ray/experimental/__init__.py
+++ b/python/ray/experimental/__init__.py
@@ -1,4 +1,3 @@
 from .dynamic_resources import set_resource
-__all__ = [
-    "set_resource",
-]
+from .packaging.load_package import load_package
+__all__ = ["set_resource", "load_package"]

--- a/python/ray/experimental/packaging/example_pkg/my_pkg/impl/__init__.py
+++ b/python/ray/experimental/packaging/example_pkg/my_pkg/impl/__init__.py
@@ -1,0 +1,2 @@
+def hello():
+    return "hello world"

--- a/python/ray/experimental/packaging/example_pkg/my_pkg/impl/__init__.py
+++ b/python/ray/experimental/packaging/example_pkg/my_pkg/impl/__init__.py
@@ -1,2 +1,3 @@
+# This code will be executed within the package's defined ``runtime_env``.
 def hello():
     return "hello world"

--- a/python/ray/experimental/packaging/example_pkg/my_pkg/stubs.py
+++ b/python/ray/experimental/packaging/example_pkg/my_pkg/stubs.py
@@ -1,17 +1,23 @@
+# NOTE: YOU ARE NOT ALLOWED TO IMPORT my_pkg at toplevel here, since this
+# file must be importable by the driver program, which has its own runtime
+# environment separate from that of this package.
+
 import ray
 
 
+# This actor will be instantiated within the package's defined ``runtime_env``.
 @ray.remote
 class MyActor:
     def __init__(self):
-        from my_pkg import impl
+        from my_pkg import impl  # Lazy import.
         self.impl = impl
 
     def f(self):
         return self.impl.hello()
 
 
+# This actor will be executed within the package's defined ``runtime_env``.
 @ray.remote
 def my_func():
-    from my_pkg import impl
+    from my_pkg import impl  # Lazy import.
     return impl.hello()

--- a/python/ray/experimental/packaging/example_pkg/my_pkg/stubs.py
+++ b/python/ray/experimental/packaging/example_pkg/my_pkg/stubs.py
@@ -1,0 +1,17 @@
+import ray
+
+
+@ray.remote
+class MyActor:
+    def __init__(self):
+        from my_pkg import impl
+        self.impl = impl
+
+    def f(self):
+        return self.impl.hello()
+
+
+@ray.remote
+def my_func():
+    from my_pkg import impl
+    return impl.hello()

--- a/python/ray/experimental/packaging/example_pkg/my_pkg/stubs.py
+++ b/python/ray/experimental/packaging/example_pkg/my_pkg/stubs.py
@@ -2,6 +2,9 @@
 # file must be importable by the driver program, which has its own runtime
 # environment separate from that of this package.
 
+# !!!
+# Stub files can only import ray + built-in packages.
+# !!!
 import ray
 
 

--- a/python/ray/experimental/packaging/example_pkg/ray_pkg.yaml
+++ b/python/ray/experimental/packaging/example_pkg/ray_pkg.yaml
@@ -2,5 +2,4 @@ name: example_package
 description: This is the example YAML for my package.
 stub_file: my_pkg/stubs.py
 runtime_env:
-    conda: conda.yaml
     docker: anyscale-ml/ray-ml:nightly-py38-cpu

--- a/python/ray/experimental/packaging/example_pkg/ray_pkg.yaml
+++ b/python/ray/experimental/packaging/example_pkg/ray_pkg.yaml
@@ -1,0 +1,6 @@
+name: example_package
+description: This is the example YAML for my package.
+stub_file: my_pkg/stubs.py
+runtime_env:
+    conda: conda.yaml
+    docker: anyscale-ml/ray-ml:nightly-py38-cpu

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -43,7 +43,7 @@ def _download_from_github_if_needed(config_path: str) -> str:
 
 
 def load_package(config_path: str) -> RuntimePackage:
-    config_path = _download_from_github_if_needed(config_path):
+    config_path = _download_from_github_if_needed(config_path)
     config = yaml.safe_load(open(config_path).read())
     base_dir = os.path.abspath(os.path.dirname(config_path))
     runtime_env = config["runtime_env"]

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -7,6 +7,8 @@ runtime environment, which can include:
  - Different Python libraries (e.g., conda environments, pip dependencies).
  - Different Docker container images.
 
+You can run this file for an example of loading a "hello world" package.
+
 Examples:
     >>> # Load from local
     >>> my_pkg = load_package(path = "~/path/to/my_pkg.yaml")

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -51,7 +51,7 @@ def load_package(config_path: str) -> "_RuntimePackage":
         >>> # Create actors from the package.
         >>> actor = my_pkg.MyActor.remote(3, 4)
 
-        >>> # Create new remote funcs in a package.
+        >>> # Create new remote funcs in the same env as a package.
         >>> @ray.remote(runtime_env=my_pkg._runtime_env)
         >>> def f(): ...
     """

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -79,7 +79,7 @@ def load_package(config_path: str) -> "_RuntimePackage":
             if not runtime_support.package_exists(pkg_uri):
                 raise RuntimeError(
                     "Failed to upload package {}".format(pkg_uri))
-            runtime_env["files"] = pkg_uri
+        runtime_env["files"] = pkg_uri
 
     # Autofill conda config.
     conda_yaml = os.path.join(base_dir, "conda.yaml")

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -37,8 +37,13 @@ class RuntimePackage:
             self._module, self._runtime_env)
 
 
-def load_package(config_path: str) -> RuntimePackage:
+def _download_from_github_if_needed(config_path: str) -> str:
     # TODO(ekl) support github URIs for the config.
+    return config_path
+
+
+def load_package(config_path: str) -> RuntimePackage:
+    config_path = _download_from_github_if_needed(config_path):
     config = yaml.safe_load(open(config_path).read())
     base_dir = os.path.abspath(os.path.dirname(config_path))
     runtime_env = config["runtime_env"]

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -190,8 +190,6 @@ class _RuntimePackage:
                         value.options(override_environment_variables={
                             "RAY_RUNTIME_ENV_FILES": runtime_env["files"]
                         }))
-                else:
-                    setattr(self, symbol, value)
 
     def __repr__(self):
         return "ray._RuntimePackage(module={}, runtime_env={})".format(

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -18,7 +18,7 @@ import ray
 import ray._private.runtime_env as runtime_support
 
 
-def load_package(config_path: str) -> _RuntimePackage:
+def load_package(config_path: str) -> "_RuntimePackage":
     """Load the code package given its config path.
 
     Args:

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -11,11 +11,17 @@ You can run this file for an example of loading a "hello world" package.
 
 Examples:
     >>> # Load from local
-    >>> my_pkg = load_package(path = "~/path/to/my_pkg.yaml")
+    >>> my_pkg = load_package("~/path/to/my_pkg.yaml")
+
+    >>> # Load from GitHub
+    >>> my_pkg = ray.util.load_package(
+    ...   "https://github.com/demo/foo/blob/v3.0/project/my_pkg.yaml")
 
     >>> # Inspect the package runtime env.
     >>> print(my_pkg._runtime_env)
-    ... {"conda": {...}, "files": "gcs://_ray_pkg_e2366b976a91975bbc73b.zip"}
+    ... {"conda": {...},
+    ...  "docker": "anyscale-ml/ray-ml:nightly-py38-cpu",
+    ...  "files": "https://github.com/demo/foo/blob/v3.0/project/"}
 
     >>> # Run remote functions from the package.
     >>> my_pkg.my_func.remote(1, 2)

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -19,7 +19,7 @@ import ray._private.runtime_env as runtime_support
 
 
 class _RuntimePackage:
-    """Represents a loaded Ray package.
+    """Represents a Ray package loaded via ``load_package()``.
 
     This class provides access to the symbols defined by the stub file of the
     package (e.g., remote functions and actor definitions). You can also

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -10,10 +10,10 @@ runtime environment, which can include:
 You can run this file for an example of loading a "hello world" package.
 
 Examples:
-    >>> # Load from local
+    >>> # Load from local.
     >>> my_pkg = load_package("~/path/to/my_pkg.yaml")
 
-    >>> # Load from GitHub
+    >>> # Load from GitHub.
     >>> my_pkg = ray.util.load_package(
     ...   "https://github.com/demo/foo/blob/v3.0/project/my_pkg.yaml")
 

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -126,11 +126,15 @@ def _download_from_github_if_needed(config_path: str) -> str:
         gh_repo = match.group(2)
         gh_branch = match.group(3)
         gh_subdir = match.group(4)
+
+        # Compute the cache key based on the URL.
         hasher = hashlib.sha1()
         hasher.update(config_path.encode("utf-8"))
         config_key = hasher.hexdigest()
         final_path = os.path.join(_pkg_tmp(),
                                   "github_snapshot_{}".format(config_key))
+
+        # Only download the repo if needed.
         if not os.path.exists(final_path):
             tmp = tempfile.mkdtemp(
                 prefix="github_{}".format(gh_repo), dir=_pkg_tmp())

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -27,9 +27,13 @@ class RuntimePackage:
                 value = getattr(self._module, symbol)
                 if (isinstance(value, ray.remote_function.RemoteFunction)
                         or isinstance(value, ray.actor.ActorClass)):
-                    # TODO(ekl) set the runtime env here.
-                    # setattr(self, symbol, value.option(runtime_env=runtime_env))
-                    setattr(self, symbol, value)
+                    # TODO(ekl) use the runtime_env option here.
+                    setattr(
+                        self,
+                        symbol,
+                        value.options(override_environment_variables={
+                            "PYTHONPATH": runtime_env["files"]
+                        }))
                 else:
                     setattr(self, symbol, value)
 
@@ -75,7 +79,7 @@ def load_package(config_path: str) -> RuntimePackage:
 if __name__ == "__main__":
     pkg = load_package("./example_pkg/ray_pkg.yaml")
     print("-> Loaded package", pkg)
-    print("-> Package symbols", dir(pkg))
+    print("-> Package symbols", [x for x in dir(pkg) if not x.startswith("_")])
 
     ray.init()
     print("-> Testing method call")

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -8,30 +8,6 @@ runtime environment, which can include:
  - Different Docker container images.
 
 You can run this file for an example of loading a "hello world" package.
-
-Examples:
-    >>> # Load from local.
-    >>> my_pkg = load_package("~/path/to/my_pkg.yaml")
-
-    >>> # Load from GitHub.
-    >>> my_pkg = ray.util.load_package(
-    ...   "https://github.com/demo/foo/blob/v3.0/project/my_pkg.yaml")
-
-    >>> # Inspect the package runtime env.
-    >>> print(my_pkg._runtime_env)
-    ... {"conda": {...},
-    ...  "docker": "anyscale-ml/ray-ml:nightly-py38-cpu",
-    ...  "files": "https://github.com/demo/foo/blob/v3.0/project/"}
-
-    >>> # Run remote functions from the package.
-    >>> my_pkg.my_func.remote(1, 2)
-
-    >>> # Create actors from the package.
-    >>> actor = my_pkg.MyActor.remote(3, 4)
-
-    >>> # Create new remote funcs in a package.
-    >>> @ray.remote(runtime_env=my_pkg._runtime_env)
-    >>> def f(): ...
 """
 
 import importlib.util
@@ -87,6 +63,38 @@ def _download_from_github_if_needed(config_path: str) -> str:
 
 
 def load_package(config_path: str) -> _RuntimePackage:
+    """Load the code package given its config path.
+
+    Args:
+        config_path (str): The path to the configuration YAML that defines
+            the package. For documentation on the packaging format, see the
+            example YAML in ``example_pkg/ray_pkg.yaml``.
+
+    Examples:
+        >>> # Load from local.
+        >>> my_pkg = load_package("~/path/to/my_pkg.yaml")
+
+        >>> # Load from GitHub.
+        >>> my_pkg = ray.util.load_package(
+        ...   "https://github.com/demo/foo/blob/v3.0/project/my_pkg.yaml")
+
+        >>> # Inspect the package runtime env.
+        >>> print(my_pkg._runtime_env)
+        ... {"conda": {...},
+        ...  "docker": "anyscale-ml/ray-ml:nightly-py38-cpu",
+        ...  "files": "https://github.com/demo/foo/blob/v3.0/project/"}
+
+        >>> # Run remote functions from the package.
+        >>> my_pkg.my_func.remote(1, 2)
+
+        >>> # Create actors from the package.
+        >>> actor = my_pkg.MyActor.remote(3, 4)
+
+        >>> # Create new remote funcs in a package.
+        >>> @ray.remote(runtime_env=my_pkg._runtime_env)
+        >>> def f(): ...
+    """
+
     if not os.path.exists(config_path):
         raise ValueError("Config file does not exist: {}".format(config_path))
 

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -104,6 +104,12 @@ def load_package(config_path: str) -> "_RuntimePackage":
 
 
 def _download_from_github_if_needed(config_path: str) -> str:
+    """Resolve a GitHub raw link to the config file to a local path.
+
+    If the user specifies a GitHub raw URL, download the repo specified at
+    that particular URL locally. This lets us treat YAMLs linked from GitHub
+    the same as local files.
+    """
     if config_path.startswith("http"):
         if "github" not in config_path:
             raise ValueError(

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -24,7 +24,7 @@ Examples:
     >>> actor = my_pkg.MyActor.remote(3, 4)
 
     >>> # Create new remote funcs in a package.
-    >>> @ray.remote(runtime_env=my_pkg.runtime_env())
+    >>> @ray.remote(runtime_env=my_pkg._runtime_env)
     >>> def f(): ...
 """
 

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -1,7 +1,7 @@
 """Support for loading code packages into Ray at runtime.
 
 Ray packages allow developers to define self-contained code modules that can
-be imported reproducibly into ny Ray cluster. Each package can define its own
+be imported reproducibly into any Ray cluster. Each package can define its own
 runtime environment, which can encapsulate:
  - Different versions of code (e.g., from different git commits).
  - Different Python libraries (e.g., conda environments, pip dependencies).

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -28,9 +28,10 @@ class RuntimePackage:
                 if (isinstance(value, ray.remote_function.RemoteFunction)
                         or isinstance(value, ray.actor.ActorClass)):
                     # TODO(ekl) set the runtime env here.
-                    setattr(self, symbol, getattr(self._module, symbol))
+                    # setattr(self, symbol, value.option(runtime_env=runtime_env))
+                    setattr(self, symbol, value)
                 else:
-                    setattr(self, symbol, getattr(self._module, symbol))
+                    setattr(self, symbol, value)
 
     def __repr__(self):
         return "ray.RuntimePackage(module={}, runtime_env={})".format(

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -36,7 +36,7 @@ def load_package(config_path: str) -> "_RuntimePackage":
 
         >>> # Load from GitHub.
         >>> my_pkg = ray.util.load_package(
-        ...   "https://raw.githubusercontent.com/user/repo/branch"
+        ...   "https://raw.githubusercontent.com/user/repo/refspec"
         ...   "/path/to/package/my_pkg.yaml")
 
         >>> # Inspect the package runtime env.

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -19,6 +19,13 @@ import ray._private.runtime_env as runtime_support
 
 
 class _RuntimePackage:
+    """Represents a loaded Ray package.
+
+    This class provides access to the symbols defined by the stub file of the
+    package (e.g., remote functions and actor definitions). You can also
+    access the raw runtime env defined by the package via ``pkg._runtime_env``.
+    """
+
     def __init__(self, name: str, desc: str, stub_file: str,
                  runtime_env: dict):
         self._name = name

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -1,3 +1,31 @@
+"""Support for loading code packages into Ray at runtime.
+
+Ray packages allow developers to define self-contained code modules that can
+be imported reproducibly into ny Ray cluster. Each package can define its own
+runtime environment, which can encapsulate:
+ - Different versions of code (e.g., from different git commits).
+ - Different Python libraries (e.g., conda environments, pip dependencies).
+ - Different Docker container images.
+
+Examples:
+    >>> # Load from local
+    >>> my_pkg = load_package(path = "~/path/to/my_pkg.yaml")
+
+    >>> # Inspect the package runtime env.
+    >>> print(my_pkg._runtime_env)
+    ... {"conda": {...}, "files": "gcs://_ray_pkg_e2366b976a91975bbc73b.zip"}
+
+    >>> # Run remote functions from the package.
+    >>> my_pkg.my_func.remote(1, 2)
+
+    >>> # Create actors from the package.
+    >>> actor = my_pkg.MyActor.remote(3, 4)
+
+    >>> # Create new remote funcs in a package.
+    >>> @ray.remote(runtime_env=my_pkg.runtime_env())
+    >>> def f(): ...
+"""
+
 import importlib.util
 import os
 import yaml

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -73,6 +73,8 @@ def load_package(config_path: str) -> _RuntimePackage:
             tmp_path = "/tmp/ray/_tmp{}".format(pkg_name)
             runtime_support.create_project_package(
                 working_dir=base_dir, modules=[], output_path=tmp_path)
+            # TODO(ekl) does this get garbage collected correctly with the
+            # current job id?
             runtime_support.push_package(pkg_uri, tmp_path)
             if not runtime_support.package_exists(pkg_uri):
                 raise RuntimeError(

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -36,8 +36,8 @@ def load_package(config_path: str) -> "_RuntimePackage":
 
         >>> # Load from GitHub.
         >>> my_pkg = ray.util.load_package(
-        ...   "https://raw.githubusercontent.com/user/repo/branch/"
-        ...   "path/to/package/my_pkg.yaml")
+        ...   "https://raw.githubusercontent.com/user/repo/branch"
+        ...   "/path/to/package/my_pkg.yaml")
 
         >>> # Inspect the package runtime env.
         >>> print(my_pkg._runtime_env)

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -44,6 +44,7 @@ def _download_from_github_if_needed(config_path: str) -> str:
 
 def load_package(config_path: str) -> RuntimePackage:
     config_path = _download_from_github_if_needed(config_path)
+    # TODO(ekl) validate schema?
     config = yaml.safe_load(open(config_path).read())
     base_dir = os.path.abspath(os.path.dirname(config_path))
     runtime_env = config["runtime_env"]

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -36,7 +36,8 @@ def load_package(config_path: str) -> "_RuntimePackage":
 
         >>> # Load from GitHub.
         >>> my_pkg = ray.util.load_package(
-        ...   "https://github.com/demo/foo/blob/v3.0/project/my_pkg.yaml")
+        ...   "https://raw.githubusercontent.com/user/repo/branch/"
+        ...   "path/to/package/my_pkg.yaml")
 
         >>> # Inspect the package runtime env.
         >>> print(my_pkg._runtime_env)

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -1,0 +1,55 @@
+import importlib.util
+import os
+import yaml
+
+import ray
+
+
+class RuntimePackage:
+    def __init__(self, name: str, desc: str, stub_file: str,
+                 runtime_env: dict):
+        self._name = name
+        self._description = desc
+        self._stub_file = stub_file
+        self._runtime_env = runtime_env
+
+        if not os.path.exists(stub_file):
+            raise ValueError("Stub file does not exist: {}".format(stub_file))
+
+        spec = importlib.util.spec_from_file_location(self._name,
+                                                      self._stub_file)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        self._module = module
+
+        for symbol in dir(self._module):
+            if not symbol.startswith("_"):
+                setattr(self, symbol, getattr(self._module, symbol))
+
+    def __repr__(self):
+        return "ray.RuntimePackage(module={}, runtime_env={})".format(
+            self._module, self._runtime_env)
+
+
+def load_package(config_path: str) -> RuntimePackage:
+    config = yaml.load(open(config_path).read())
+    base_dir = os.path.abspath(os.path.dirname(config_path))
+    pkg = RuntimePackage(
+        name=config["name"],
+        desc=config["description"],
+        stub_file=os.path.join(base_dir, config["stub_file"]),
+        runtime_env=config["runtime_env"])
+    return pkg
+
+
+if __name__ == "__main__":
+    pkg = load_package("./example_pkg/ray_pkg.yaml")
+    print("-> Loaded package", pkg)
+    print("-> Package symbols", dir(pkg))
+
+    ray.init()
+    print("-> Testing method call")
+    print(ray.get(pkg.my_func.remote()))
+    print("-> Testing actor call")
+    a = pkg.MyActor.remote()
+    print(ray.get(a.f.remote()))

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -2,7 +2,7 @@
 
 Ray packages allow developers to define self-contained code modules that can
 be imported reproducibly into any Ray cluster. Each package can define its own
-runtime environment, which can encapsulate:
+runtime environment, which can include:
  - Different versions of code (e.g., from different git commits).
  - Different Python libraries (e.g., conda environments, pip dependencies).
  - Different Docker container images.

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -4,7 +4,6 @@ import sys
 import unittest
 
 import ray
-from ray.experimental.packaging import load_package
 from ray.test_utils import run_string_as_driver
 
 driver_script = """
@@ -114,7 +113,7 @@ def test_two_node_uri(two_node_cluster, working_dir):
 @unittest.skipIf(sys.platform == "win32", "Fail to create temp dir.")
 def test_experimental_package(shutdown_only):
     ray.init(num_cpus=2)
-    pkg = load_package.load_package(
+    pkg = ray.experimental.load_package(
         os.path.join(
             os.path.dirname(__file__),
             "../experimental/packaging/example_pkg/ray_pkg.yaml"))
@@ -126,7 +125,7 @@ def test_experimental_package(shutdown_only):
 @unittest.skipIf(sys.platform == "win32", "Fail to create temp dir.")
 def test_experimental_package_github(shutdown_only):
     ray.init(num_cpus=2)
-    pkg = load_package.load_package(
+    pkg = ray.experimental.load_package(
         "http://raw.githubusercontent.com/ericl/ray/packaging/"
         "python/ray/experimental/packaging/example_pkg/ray_pkg.yaml")
     a = pkg.MyActor.remote()

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -115,8 +115,9 @@ def test_two_node_uri(two_node_cluster, working_dir):
 def test_experimental_package(shutdown_only):
     ray.init(num_cpus=2)
     pkg = load_package.load_package(
-        os.path.join(os.path.dirname(__file__),
-                     "../experimental/packaging/example_pkg/ray_pkg.yaml"))
+        os.path.join(
+            os.path.dirname(__file__),
+            "../experimental/packaging/example_pkg/ray_pkg.yaml"))
     a = pkg.MyActor.remote()
     assert ray.get(a.f.remote()) == "hello world"
     assert ray.get(pkg.my_func.remote()) == "hello world"

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -123,6 +123,17 @@ def test_experimental_package(shutdown_only):
     assert ray.get(pkg.my_func.remote()) == "hello world"
 
 
+@unittest.skipIf(sys.platform == "win32", "Fail to create temp dir.")
+def test_experimental_package_github(shutdown_only):
+    ray.init(num_cpus=2)
+    pkg = load_package.load_package(
+        "http://raw.githubusercontent.com/ericl/ray/packaging/"
+        "python/ray/experimental/packaging/example_pkg/ray_pkg.yaml")
+    a = pkg.MyActor.remote()
+    assert ray.get(a.f.remote()) == "hello world"
+    assert ray.get(pkg.my_func.remote()) == "hello world"
+
+
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1241,7 +1241,10 @@ def connect(node,
         runtime_env.upload_runtime_env_package_if_needed(job_config)
     elif mode == WORKER_MODE:
         runtime_env.ensure_runtime_env_setup(
-            worker.core_worker.get_job_config().runtime_env)
+            os.environ.get(
+                "RAY_RUNTIME_ENV_FILES",
+                worker.core_worker.get_job_config()
+                .runtime_env.working_dir_uri))
 
     if driver_object_store_memory is not None:
         worker.core_worker.set_object_store_client_options(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This adds a bare-bones load_package() API that implements https://github.com/ray-project/ray/issues/14177

More details can be found in the user-facing docs draft: https://docs.google.com/document/d/1gLGl_eNUsf0O2se4rKg7fbf9IhHtst1w8ydGPNCXnQI/edit

It currently supports:
- uploading the package working directory and adding it to the worker python path via the runtime_env mechanism.
- GitHub raw links to the YAML config

Future work:
- conda/docker support
- better integration with runtime_env option once that is working properly