### PR TITLE
[Autoscaler] Expose no_monitor_on_head as an SDK API param

### DIFF
--- a/python/ray/autoscaler/sdk.py
+++ b/python/ray/autoscaler/sdk.py
@@ -13,12 +13,13 @@ from ray.autoscaler._private.event_system import (  # noqa: F401
 from ray.autoscaler._private.cli_logger import cli_logger
 
 
-def create_or_update_cluster(cluster_config: Union[dict, str],
-                             *,
-                             no_restart: bool = False,
-                             restart_only: bool = False,
-                             no_config_cache: bool = False,
-                             no_monitor_on_head: bool = False) -> Dict[str, Any]:
+def create_or_update_cluster(
+        cluster_config: Union[dict, str],
+        *,
+        no_restart: bool = False,
+        restart_only: bool = False,
+        no_config_cache: bool = False,
+        no_monitor_on_head: bool = False) -> Dict[str, Any]:
     """Create or updates an autoscaling Ray cluster from a config json.
 
     Args:

--- a/python/ray/autoscaler/sdk.py
+++ b/python/ray/autoscaler/sdk.py
@@ -17,7 +17,8 @@ def create_or_update_cluster(cluster_config: Union[dict, str],
                              *,
                              no_restart: bool = False,
                              restart_only: bool = False,
-                             no_config_cache: bool = False) -> Dict[str, Any]:
+                             no_config_cache: bool = False,
+                             no_monitor_on_head: bool = False) -> Dict[str, Any]:
     """Create or updates an autoscaling Ray cluster from a config json.
 
     Args:
@@ -30,6 +31,10 @@ def create_or_update_cluster(cluster_config: Union[dict, str],
             restart Ray. This cannot be used with 'no-restart'.
         no_config_cache (bool): Whether to disable the config cache and fully
             resolve all environment settings from the Cloud provider again.
+        no_monitor_on_head (bool): Whether to skip syncing autoscaler config
+            files to head node. This saves some unnecessary cluster setup steps
+            if the autoscaler is running in a separate container or on a
+            separate machine, like in k8s environment.
     """
     with _as_config_file(cluster_config) as config_file:
         return commands.create_or_update_cluster(
@@ -42,7 +47,8 @@ def create_or_update_cluster(cluster_config: Union[dict, str],
             override_cluster_name=None,
             no_config_cache=no_config_cache,
             redirect_command_output=None,
-            use_login_shells=True)
+            use_login_shells=True,
+            no_monitor_on_head=no_monitor_on_head)
 
 
 def teardown_cluster(cluster_config: Union[dict, str],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This option saves some unnecessary cluster setup steps if the autoscaler is running in a separate container or on a separate machine, like in k8s environment.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
