### PR TITLE
Revert "reset memory for tasks and actors to 5% when cached memory ad…"

### DIFF
--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -409,21 +409,6 @@ def get_system_memory():
     return psutil_memory_in_bytes
 
 
-def get_cached_memory():
-    """Return the currently cached memory in bytes
-
-    Returns:
-        The total amount of cached memory
-    """
-    # Try to accurately figure out the cached memory.
-    psutil_virtual_memory = psutil.virtual_memory()
-    psutil_cached_memory_in_bytes = 0
-    if hasattr(psutil_virtual_memory, "cached"):
-        psutil_cached_memory_in_bytes = psutil_virtual_memory.cached
-
-    return psutil_cached_memory_in_bytes
-
-
 def _get_docker_cpus(
         cpu_quota_file_name="/sys/fs/cgroup/cpu/cpu.cfs_quota_us",
         cpu_share_file_name="/sys/fs/cgroup/cpu/cpu.cfs_period_us",
@@ -551,11 +536,7 @@ def estimate_available_memory():
         and total memory.
 
     """
-    # Linux, BSD has cached memory, which should
-    # also be considered as unused memory
-    # consider half of cached memory can be recycled.
-    # https://gitlab.com/procps-ng/procps/-/blob/master/proc/sysinfo.c#L805
-    return get_system_memory() - get_used_memory() + get_cached_memory() / 2
+    return get_system_memory() - get_used_memory()
 
 
 def get_shared_memory_bytes():


### PR DESCRIPTION

This reverts commit 6f151ad510e5f545a74475ab25e4229c72688c8d.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* This commit (from PR #14345) breaks Ray Cluster Launcher for Docker and K8s. 
* If we want to consider `cached_memory`, we should probably put it behind some environment variable or setting. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
