### PR TITLE
[autoscaler] Auto detect memory resource

### DIFF
--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -20,6 +20,7 @@ from ray.autoscaler._private.log_timer import LogTimer
 
 from ray.autoscaler._private.aws.utils import boto_exception_handler
 from ray.autoscaler._private.cli_logger import cli_logger, cf
+from ray.ray_constants import MEMORY_RESOURCE_UNIT_BYTES
 
 logger = logging.getLogger(__name__)
 
@@ -513,7 +514,14 @@ class AWSNodeProvider(NodeProvider):
             if instance_type in instances_dict:
                 cpus = instances_dict[instance_type]["VCpuInfo"][
                     "DefaultVCpus"]
-                autodetected_resources = {"CPU": cpus}
+                memory_total = instances_dict[instance_type]["MemoryInfo"][
+                    "SizeInMiB"]
+                memory_units = memory_total / MEMORY_RESOURCE_UNIT_BYTES
+                memory_resources = int(memory_units * 0.6)
+                object_store_memory = int(memory_units * 0.3)
+                autodetected_resources = {
+                    "CPU": cpus, "memory": memory_resources,
+                    "object_store_memory": object_store_memory}
                 gpus = instances_dict[instance_type].get("GpuInfo",
                                                          {}).get("Gpus")
                 if gpus is not None:

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -519,8 +519,8 @@ class AWSNodeProvider(NodeProvider):
                 memory_total = int(memory_total) * 1024 * 1024
                 memory_units = ray_constants.to_memory_units(
                     memory_total, False)
-                memory_resources = memory_units * 0.6
-                object_store_memory = memory_units * 0.3
+                memory_resources = int(memory_units * 0.6)
+                object_store_memory = int(memory_units * 0.3)
                 autodetected_resources = {
                     "CPU": cpus,
                     "memory": memory_resources,

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -20,7 +20,7 @@ from ray.autoscaler._private.log_timer import LogTimer
 
 from ray.autoscaler._private.aws.utils import boto_exception_handler
 from ray.autoscaler._private.cli_logger import cli_logger, cf
-from ray.ray_constants import MEMORY_RESOURCE_UNIT_BYTES
+import ray.ray_constants as ray_constants
 
 logger = logging.getLogger(__name__)
 
@@ -517,9 +517,10 @@ class AWSNodeProvider(NodeProvider):
                 memory_total = instances_dict[instance_type]["MemoryInfo"][
                     "SizeInMiB"]
                 memory_total = int(memory_total) * 1024 * 1024
-                memory_units = memory_total / MEMORY_RESOURCE_UNIT_BYTES
-                memory_resources = int(memory_units * 0.6)
-                object_store_memory = int(memory_units * 0.3)
+                memory_units = ray_constants.to_memory_units(
+                    memory_total, False)
+                memory_resources = memory_units * 0.6
+                object_store_memory = memory_units * 0.3
                 autodetected_resources = {
                     "CPU": cpus,
                     "memory": memory_resources,

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -516,12 +516,15 @@ class AWSNodeProvider(NodeProvider):
                     "DefaultVCpus"]
                 memory_total = instances_dict[instance_type]["MemoryInfo"][
                     "SizeInMiB"]
+                memory_total = int(memory_total) * 1024 * 1024
                 memory_units = memory_total / MEMORY_RESOURCE_UNIT_BYTES
                 memory_resources = int(memory_units * 0.6)
                 object_store_memory = int(memory_units * 0.3)
                 autodetected_resources = {
-                    "CPU": cpus, "memory": memory_resources,
-                    "object_store_memory": object_store_memory}
+                    "CPU": cpus,
+                    "memory": memory_resources,
+                    "object_store_memory": object_store_memory
+                }
                 gpus = instances_dict[instance_type].get("GpuInfo",
                                                          {}).get("Gpus")
                 if gpus is not None:

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -20,7 +20,6 @@ from ray.autoscaler._private.log_timer import LogTimer
 
 from ray.autoscaler._private.aws.utils import boto_exception_handler
 from ray.autoscaler._private.cli_logger import cli_logger, cf
-import ray.ray_constants as ray_constants
 
 logger = logging.getLogger(__name__)
 
@@ -517,10 +516,8 @@ class AWSNodeProvider(NodeProvider):
                 memory_total = instances_dict[instance_type]["MemoryInfo"][
                     "SizeInMiB"]
                 memory_total = int(memory_total) * 1024 * 1024
-                memory_units = ray_constants.to_memory_units(
-                    memory_total, False)
-                memory_resources = int(memory_units * 0.6)
-                object_store_memory = int(memory_units * 0.3)
+                memory_resources = int(memory_total * 0.6)
+                object_store_memory = int(memory_total * 0.3)
                 autodetected_resources = {
                     "CPU": cpus,
                     "memory": memory_resources,

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -20,6 +20,7 @@ from ray.autoscaler._private.log_timer import LogTimer
 
 from ray.autoscaler._private.aws.utils import boto_exception_handler
 from ray.autoscaler._private.cli_logger import cli_logger, cf
+import ray.ray_constants as ray_constants
 
 logger = logging.getLogger(__name__)
 
@@ -507,20 +508,26 @@ class AWSNodeProvider(NodeProvider):
             for instance in instances_list
         }
         available_node_types = cluster_config["available_node_types"]
+        head_node_type = cluster_config["head_node_type"]
         for node_type in available_node_types:
             instance_type = available_node_types[node_type]["node_config"][
                 "InstanceType"]
             if instance_type in instances_dict:
                 cpus = instances_dict[instance_type]["VCpuInfo"][
                     "DefaultVCpus"]
-                memory_total = instances_dict[instance_type]["MemoryInfo"][
-                    "SizeInMiB"]
-                memory_total = int(memory_total) * 1024 * 1024
-                memory_resources = int(memory_total * 0.6)
-                autodetected_resources = {
-                    "CPU": cpus,
-                    "memory": memory_resources
-                }
+
+                autodetected_resources = {"CPU": cpus}
+                if node_type != head_node_type:
+                    # we only autodetect worker node type memory resource
+                    memory_total = instances_dict[instance_type]["MemoryInfo"][
+                        "SizeInMiB"]
+                    memory_total = int(memory_total) * 1024 * 1024
+                    prop = (
+                        1 -
+                        ray_constants.DEFAULT_OBJECT_STORE_MEMORY_PROPORTION)
+                    memory_resources = int(memory_total * prop)
+                    autodetected_resources["memory"] = memory_resources
+
                 gpus = instances_dict[instance_type].get("GpuInfo",
                                                          {}).get("Gpus")
                 if gpus is not None:

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -517,11 +517,9 @@ class AWSNodeProvider(NodeProvider):
                     "SizeInMiB"]
                 memory_total = int(memory_total) * 1024 * 1024
                 memory_resources = int(memory_total * 0.6)
-                object_store_memory = int(memory_total * 0.3)
                 autodetected_resources = {
                     "CPU": cpus,
-                    "memory": memory_resources,
-                    "object_store_memory": object_store_memory
+                    "memory": memory_resources
                 }
                 gpus = instances_dict[instance_type].get("GpuInfo",
                                                          {}).get("Gpus")

--- a/python/ray/autoscaler/_private/kubernetes/config.py
+++ b/python/ray/autoscaler/_private/kubernetes/config.py
@@ -11,7 +11,13 @@ from ray.ray_constants import MEMORY_RESOURCE_UNIT_BYTES
 
 logger = logging.getLogger(__name__)
 
-MEMORY_SIZE_UNITS = {"K": 2**10, "M": 2**20, "G": 2**30, "T": 2**40, "P": 2**50}
+MEMORY_SIZE_UNITS = {
+    "K": 2**10,
+    "M": 2**20,
+    "G": 2**30,
+    "T": 2**40,
+    "P": 2**50
+}
 
 
 class InvalidNamespaceError(ValueError):
@@ -180,7 +186,7 @@ def _parse_memory_resource(resource):
         pass
     memory_size = re.sub(r"([KMGTP]+)", r" \1", resource_str)
     number, unit_index = [item.strip() for item in memory_size.split()]
-    unit_index = unit_index[0: 1]
+    unit_index = unit_index[0:1]
     return number * MEMORY_SIZE_UNITS[unit_index]
 
 

--- a/python/ray/autoscaler/_private/kubernetes/config.py
+++ b/python/ray/autoscaler/_private/kubernetes/config.py
@@ -7,7 +7,7 @@ from kubernetes import client
 from kubernetes.client.rest import ApiException
 
 from ray.autoscaler._private.kubernetes import auth_api, core_api, log_prefix
-from ray.ray_constants import MEMORY_RESOURCE_UNIT_BYTES
+import ray.ray_constants as ray_constants
 
 logger = logging.getLogger(__name__)
 
@@ -115,10 +115,10 @@ def get_autodetected_resources(container_data):
         if node_type_resources[key] == 0:
             del node_type_resources[key]
 
-    memory_limits = _get_resource(container_resources, "memory", "limit")
-    units = memory_limits / MEMORY_RESOURCE_UNIT_BYTES
-    node_type_resources["memory"] = int(units * 0.6)
-    node_type_resources["object_store_memory"] = int(units * 0.3)
+    memory_limits = _get_resource(container_resources, "memory", "limits")
+    units = ray_constants.to_memory_units(memory_limits, False)
+    node_type_resources["memory"] = units * 0.6
+    node_type_resources["object_store_memory"] = units * 0.3
 
     return node_type_resources
 

--- a/python/ray/autoscaler/_private/kubernetes/config.py
+++ b/python/ray/autoscaler/_private/kubernetes/config.py
@@ -91,8 +91,10 @@ def fillout_resources_kubernetes(config):
         autodetected_resources = get_autodetected_resources(container_data)
         if "resources" not in config["available_node_types"][node_type]:
             config["available_node_types"][node_type]["resources"] = {}
-        config["available_node_types"][node_type]["resources"].update(
-            autodetected_resources)
+        autodetected_resources.update(
+            config["available_node_types"][node_type]["resources"])
+        config["available_node_types"][node_type][
+            "resources"] = autodetected_resources
         logger.debug(
             "Updating the resources of node type {} to include {}.".format(
                 node_type, autodetected_resources))
@@ -116,7 +118,6 @@ def get_autodetected_resources(container_data):
 
     memory_limits = _get_resource(container_resources, "memory", "limits")
     node_type_resources["memory"] = int(memory_limits * 0.6)
-    node_type_resources["object_store_memory"] = int(memory_limits * 0.3)
 
     return node_type_resources
 

--- a/python/ray/autoscaler/_private/kubernetes/config.py
+++ b/python/ray/autoscaler/_private/kubernetes/config.py
@@ -187,7 +187,7 @@ def _parse_memory_resource(resource):
     memory_size = re.sub(r"([KMGTP]+)", r" \1", resource_str)
     number, unit_index = [item.strip() for item in memory_size.split()]
     unit_index = unit_index[0:1]
-    return number * MEMORY_SIZE_UNITS[unit_index]
+    return float(number) * MEMORY_SIZE_UNITS[unit_index]
 
 
 def _configure_namespace(provider_config):

--- a/python/ray/autoscaler/_private/kubernetes/config.py
+++ b/python/ray/autoscaler/_private/kubernetes/config.py
@@ -117,8 +117,8 @@ def get_autodetected_resources(container_data):
 
     memory_limits = _get_resource(container_resources, "memory", "limits")
     units = ray_constants.to_memory_units(memory_limits, False)
-    node_type_resources["memory"] = units * 0.6
-    node_type_resources["object_store_memory"] = units * 0.3
+    node_type_resources["memory"] = int(units * 0.6)
+    node_type_resources["object_store_memory"] = int(units * 0.3)
 
     return node_type_resources
 

--- a/python/ray/autoscaler/_private/kubernetes/config.py
+++ b/python/ray/autoscaler/_private/kubernetes/config.py
@@ -7,7 +7,6 @@ from kubernetes import client
 from kubernetes.client.rest import ApiException
 
 from ray.autoscaler._private.kubernetes import auth_api, core_api, log_prefix
-import ray.ray_constants as ray_constants
 
 logger = logging.getLogger(__name__)
 
@@ -116,9 +115,8 @@ def get_autodetected_resources(container_data):
             del node_type_resources[key]
 
     memory_limits = _get_resource(container_resources, "memory", "limits")
-    units = ray_constants.to_memory_units(memory_limits, False)
-    node_type_resources["memory"] = int(units * 0.6)
-    node_type_resources["object_store_memory"] = int(units * 0.3)
+    node_type_resources["memory"] = int(memory_limits * 0.6)
+    node_type_resources["object_store_memory"] = int(memory_limits * 0.3)
 
     return node_type_resources
 

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -306,12 +306,13 @@ class ResourceDemandScheduler:
                 self.node_types[node_type]["resources"] = resources
 
                 node_kind = tags[TAG_RAY_NODE_KIND]
-                if node_kind != NODE_KIND_HEAD:
-                    # Here, we do not record the resources have been updated,
-                    # because it need be updated by worker kind runtime
-                    # resource. The most difference between head and worker is
-                    # the memory resources. The head node needs to configure
-                    # redis memory which is not needed for worker nodes.
+                if node_kind == NODE_KIND_WORKER:
+                    # Here, we do not record the resources have been updated
+                    # if it is the head node kind. Because it need be updated
+                    # by worker kind runtime resource. The most difference
+                    # between head and worker is the memory resources. The head
+                    # node needs to configure redis memory which is not needed
+                    # for worker nodes.
                     self.node_resource_updated.add(node_type)
 
     def _infer_legacy_node_resources_if_needed(

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -300,7 +300,9 @@ class ResourceDemandScheduler:
             if runtime_resources:
                 runtime_resources = copy.deepcopy(runtime_resources)
                 resources = self.node_types[node_type].get("resources", {})
-                resources.update(runtime_resources)
+                for key in ["CPU", "GPU", "memory", "object_store_memory"]:
+                    if key in runtime_resources:
+                        resources[key] = runtime_resources[key]
                 self.node_types[node_type]["resources"] = resources
 
                 node_kind = tags[TAG_RAY_NODE_KIND]

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -52,6 +52,7 @@ class ResourceDemandScheduler:
                  upscaling_speed: float = 1) -> None:
         self.provider = provider
         self.node_types = copy.deepcopy(node_types)
+        self.node_resource_updated = set()
         self.max_workers = max_workers
         self.head_node_type = head_node_type
         self.upscaling_speed = upscaling_speed
@@ -144,6 +145,8 @@ class ResourceDemandScheduler:
             # When using legacy yaml files we need to infer the head & worker
             # node resources from the static node resources from LoadMetrics.
             self._infer_legacy_node_resources_if_needed(max_resources_by_ip)
+
+        self._update_node_resources_from_runtime(nodes, max_resources_by_ip)
 
         node_resources: List[ResourceDict]
         node_type_counts: Dict[NodeType, int]
@@ -264,6 +267,39 @@ class ResourceDemandScheduler:
                 return {NODE_TYPE_LEGACY_WORKER: max(1, workers_to_add)}
             else:
                 return {}
+
+    def _update_node_resources_from_runtime(
+            self, nodes: List[NodeID],
+            max_resources_by_ip: Dict[NodeIP, ResourceDict]):
+        """Update static node type resources with runtime resources
+
+        This will update the cached static node type resources with the runtime
+        resources. Because we can not know the correctly memory or
+        object_store_memory from config file.
+        """
+        need_update = len(self.node_types) != len(self.node_resource_updated)
+
+        if not need_update:
+            return
+        for node_id in nodes:
+            tags = self.provider.node_tags(node_id)
+
+            if TAG_RAY_USER_NODE_TYPE not in tags:
+                continue
+
+            node_type = tags[TAG_RAY_USER_NODE_TYPE]
+            if (node_type in self.node_resource_updated
+                    or node_type not in self.node_types):
+                # continue if the node type has been updated or is not an known
+                # node type
+                continue
+            ip = self.provider.internal_ip(node_id)
+            runtime_resources = max_resources_by_ip.get(ip)
+            runtime_resources = copy.deepcopy(runtime_resources)
+            resources = self.node_types[node_type].get("resources", {})
+            resources.update(runtime_resources)
+            self.node_types[node_type]["resources"] = resources
+            self.node_resource_updated.add(node_type)
 
     def _infer_legacy_node_resources_if_needed(
             self, max_resources_by_ip: Dict[NodeIP, ResourceDict]

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -310,11 +310,12 @@ class ResourceDemandScheduler:
                 continue
             ip = self.provider.internal_ip(node_id)
             runtime_resources = max_resources_by_ip.get(ip)
-            runtime_resources = copy.deepcopy(runtime_resources)
-            resources = self.node_types[node_type].get("resources", {})
-            resources.update(runtime_resources)
-            self.node_types[node_type]["resources"] = resources
-            self.node_resource_updated.add(node_type)
+            if runtime_resources:
+                runtime_resources = copy.deepcopy(runtime_resources)
+                resources = self.node_types[node_type].get("resources", {})
+                resources.update(runtime_resources)
+                self.node_types[node_type]["resources"] = resources
+                self.node_resource_updated.add(node_type)
 
     def _infer_legacy_node_resources_if_needed(
             self, max_resources_by_ip: Dict[NodeIP, ResourceDict]

--- a/python/ray/tests/test_autoscaler_yaml.py
+++ b/python/ray/tests/test_autoscaler_yaml.py
@@ -102,15 +102,18 @@ class AutoscalingConfigTest(unittest.TestCase):
         orig_new_config = copy.deepcopy(new_config)
         expected_available_node_types = orig_new_config["available_node_types"]
         expected_available_node_types["cpu_4_ondemand"]["resources"] = {
-            "CPU": 4
+            "CPU": 4,
+            "memory": 10307921510,
         }
         expected_available_node_types["cpu_16_spot"]["resources"] = {
             "CPU": 16,
+            "memory": 41231686041,
             "Custom1": 1,
             "is_spot": 1
         }
         expected_available_node_types["gpu_8_ondemand"]["resources"] = {
             "CPU": 32,
+            "memory": 157195803033,
             "GPU": 4,
             "accelerator_type:V100": 1
         }
@@ -120,16 +123,25 @@ class AutoscalingConfigTest(unittest.TestCase):
                 "InstanceType": "m4.xlarge",
                 "VCpuInfo": {
                     "DefaultVCpus": 4
+                },
+                "MemoryInfo": {
+                    "SizeInMiB": 16384
                 }
             }, {
                 "InstanceType": "m4.4xlarge",
                 "VCpuInfo": {
                     "DefaultVCpus": 16
+                },
+                "MemoryInfo": {
+                    "SizeInMiB": 65536
                 }
             }, {
                 "InstanceType": "p3.8xlarge",
                 "VCpuInfo": {
                     "DefaultVCpus": 32
+                },
+                "MemoryInfo": {
+                    "SizeInMiB": 249856
                 },
                 "GpuInfo": {
                     "Gpus": [{

--- a/python/ray/tests/test_autoscaler_yaml.py
+++ b/python/ray/tests/test_autoscaler_yaml.py
@@ -102,8 +102,7 @@ class AutoscalingConfigTest(unittest.TestCase):
         orig_new_config = copy.deepcopy(new_config)
         expected_available_node_types = orig_new_config["available_node_types"]
         expected_available_node_types["cpu_4_ondemand"]["resources"] = {
-            "CPU": 4,
-            "memory": 10307921510,
+            "CPU": 4
         }
         expected_available_node_types["cpu_16_spot"]["resources"] = {
             "CPU": 16,

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -43,21 +43,33 @@ boto3_list = [{
     "InstanceType": "t1.micro",
     "VCpuInfo": {
         "DefaultVCpus": 1
+    },
+    "MemoryInfo": {
+        "SizeInMiB": 627
     }
 }, {
     "InstanceType": "t3a.small",
     "VCpuInfo": {
         "DefaultVCpus": 2
+    },
+    "MemoryInfo": {
+        "SizeInMiB": 2048
     }
 }, {
     "InstanceType": "m4.4xlarge",
     "VCpuInfo": {
         "DefaultVCpus": 16
+    },
+    "MemoryInfo": {
+        "SizeInMiB": 65536
     }
 }, {
     "InstanceType": "p3.8xlarge",
     "VCpuInfo": {
         "DefaultVCpus": 32
+    },
+    "MemoryInfo": {
+        "SizeInMiB": 249856
     },
     "GpuInfo": {
         "Gpus": [{

--- a/python/ray/tests/test_cli_patterns/test_ray_up_record.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_up_record.txt
@@ -73,9 +73,9 @@
 .+\.py.*Full command is `ssh.+`
 .+\.py.*NodeUpdater: i-.+: Setup commands succeeded \[LogTimer=.+\]
 .+\.py.*\[7/7\] Starting the Ray runtime
-.+\.py.*Running `export RAY_OVERRIDE_RESOURCES='{"CPU":1,"memory":394474291}';ray stop`
+.+\.py.*Running `export RAY_OVERRIDE_RESOURCES='{"CPU":1}';ray stop`
 .+\.py.*Full command is `ssh.+`
-.+\.py.*Running `export RAY_OVERRIDE_RESOURCES='{"CPU":1,"memory":394474291}';ray start --head --autoscaling-config=~/ray_bootstrap_config\.yaml`
+.+\.py.*Running `export RAY_OVERRIDE_RESOURCES='{"CPU":1}';ray start --head --autoscaling-config=~/ray_bootstrap_config\.yaml`
 .+\.py.*Full command is `ssh.+`
 .+\.py.*NodeUpdater: i-.+: Ray start commands succeeded \[LogTimer=.+\]
 .+\.py.*NodeUpdater: i-.+: Applied config .+  \[LogTimer=.+\]

--- a/python/ray/tests/test_cli_patterns/test_ray_up_record.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_up_record.txt
@@ -73,9 +73,9 @@
 .+\.py.*Full command is `ssh.+`
 .+\.py.*NodeUpdater: i-.+: Setup commands succeeded \[LogTimer=.+\]
 .+\.py.*\[7/7\] Starting the Ray runtime
-.+\.py.*Running `export RAY_OVERRIDE_RESOURCES='{"CPU":1}';ray stop`
+.+\.py.*Running `export RAY_OVERRIDE_RESOURCES='{"CPU":1,"memory":394474291}';ray stop`
 .+\.py.*Full command is `ssh.+`
-.+\.py.*Running `export RAY_OVERRIDE_RESOURCES='{"CPU":1}';ray start --head --autoscaling-config=~/ray_bootstrap_config\.yaml`
+.+\.py.*Running `export RAY_OVERRIDE_RESOURCES='{"CPU":1,"memory":394474291}';ray start --head --autoscaling-config=~/ray_bootstrap_config\.yaml`
 .+\.py.*Full command is `ssh.+`
 .+\.py.*NodeUpdater: i-.+: Ray start commands succeeded \[LogTimer=.+\]
 .+\.py.*NodeUpdater: i-.+: Applied config .+  \[LogTimer=.+\]

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -530,6 +530,7 @@ def test_request_resources_existing_usage():
     # 5 nodes with 32 CPU and 8 GPU each
     provider.create_node({}, {
         TAG_RAY_USER_NODE_TYPE: "p2.8xlarge",
+        TAG_RAY_NODE_KIND: NODE_KIND_WORKER,
         TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE
     }, 2)
     all_nodes = provider.non_terminated_nodes({})
@@ -1164,14 +1165,14 @@ def test_handle_legacy_cluster_config_yaml():
             lm.get_static_node_resources_by_ip())
         # 4 nodes are necessary to meet resource demand.
         assert to_launch == {NODE_TYPE_LEGACY_WORKER: 4}
-        to_launch = scheduler.get_nodes_to_launch(nodes, pending_launches,
-                                                  demands, utilizations, [],
-                                                  lm.get_node_resources())
+        to_launch = scheduler.get_nodes_to_launch(
+            nodes, pending_launches, demands, utilizations, [],
+            lm.get_static_node_resources_by_ip())
         # 0 because there are 4 pending launches and we only need 4.
         assert to_launch == {}
         to_launch = scheduler.get_nodes_to_launch(
             nodes, pending_launches, demands * 2, utilizations, [],
-            lm.get_node_resources())
+            lm.get_static_node_resources_by_ip())
         # 1 because there are 4 pending launches and we only allow a max of 5.
         assert to_launch == {NODE_TYPE_LEGACY_WORKER: 1}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In the current autoscaler, we could auto detect cpu/gpu resources. However, we could not know the memory size when `min_workers` set to zero. This could lead to those tasks with `memory` requirements that could not be satisfied forever.

This patch adds memory auto detecting for k8s and aws.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/14553

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
