### PR TITLE
Use vendored cloudpickle for Ray client

### DIFF
--- a/python/ray/util/client/client_pickler.py
+++ b/python/ray/util/client/client_pickler.py
@@ -21,7 +21,6 @@ ClientPickler dumps things from the client into the appropriate stubs
 ServerUnpickler loads stubs from the server into their client counterparts.
 """
 
-import cloudpickle
 import io
 import sys
 
@@ -30,6 +29,7 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 
+import ray.cloudpickle as cloudpickle
 from ray.util.client import RayAPIStub
 from ray.util.client.common import ClientObjectRef
 from ray.util.client.common import ClientActorHandle

--- a/python/ray/util/client/server/server_pickler.py
+++ b/python/ray/util/client/server/server_pickler.py
@@ -11,7 +11,6 @@ ServerPickler dumps ray objects from the server into the appropriate stubs.
 ClientUnpickler loads stubs from the client and finds their associated handle
 in the server instance.
 """
-import cloudpickle
 import io
 import sys
 import ray
@@ -20,6 +19,7 @@ from typing import Any
 from typing import TYPE_CHECKING
 
 from ray._private.client_mode_hook import disable_client_hook
+import ray.cloudpickle as cloudpickle
 from ray.util.client.client_pickler import PickleStub
 from ray.util.client.server.server_stubs import ClientReferenceActor
 from ray.util.client.server.server_stubs import ClientReferenceFunction

--- a/python/setup.py
+++ b/python/setup.py
@@ -129,7 +129,6 @@ install_requires = [
     "aiohttp_cors",
     "aioredis",
     "click >= 7.0",
-    "cloudpickle",
     "colorama",
     "colorful",
     "filelock",


### PR DESCRIPTION
Switch to using the vendored cloudpickle, which ensures better serialization compatibility and avoids the extra dependency.