### PR TITLE
[Autoscaler] Get_Head_Node should return an `up-to-date` node

### DIFF
--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -1113,12 +1113,17 @@ def _get_running_head_node(config: Dict[str, Any],
     provider = _get_node_provider(config["provider"], config["cluster_name"])
     head_node_tags = {
         TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
-        TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
     }
     nodes = provider.non_terminated_nodes(head_node_tags)
+    head_node = None
+    for node in nodes:
+        node_state = provider.node_tags(TAG_RAY_NODE_STATUS)
+        if node_state == STATUS_UP_TO_DATE:
+            head_node = node
+        else:
+            cli_logger.warning(f"Head node ({node}) is in state {node_state}.")
 
-    if len(nodes) > 0:
-        head_node = nodes[0]
+    if head_node:
         return head_node
     elif create_if_needed:
         get_or_create_head_node(

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -30,9 +30,10 @@ from ray.autoscaler._private.util import validate_config, hash_runtime_conf, \
     hash_launch_conf, prepare_config
 from ray.autoscaler._private.providers import _get_node_provider, \
     _NODE_PROVIDERS, _PROVIDER_PRETTY_NAMES
-from ray.autoscaler.tags import TAG_RAY_NODE_KIND, TAG_RAY_LAUNCH_CONFIG, \
-    TAG_RAY_NODE_NAME, NODE_KIND_WORKER, NODE_KIND_HEAD, \
-    TAG_RAY_USER_NODE_TYPE, STATUS_UNINITIALIZED, STATUS_UP_TO_DATE, TAG_RAY_NODE_STATUS
+from ray.autoscaler.tags import (
+    TAG_RAY_NODE_KIND, TAG_RAY_LAUNCH_CONFIG, TAG_RAY_NODE_NAME,
+    NODE_KIND_WORKER, NODE_KIND_HEAD, TAG_RAY_USER_NODE_TYPE,
+    STATUS_UNINITIALIZED, STATUS_UP_TO_DATE, TAG_RAY_NODE_STATUS)
 from ray.autoscaler._private.cli_logger import cli_logger, cf
 from ray.autoscaler._private.updater import NodeUpdaterThread
 from ray.autoscaler._private.command_runner import set_using_login_shells, \

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -32,7 +32,7 @@ from ray.autoscaler._private.providers import _get_node_provider, \
     _NODE_PROVIDERS, _PROVIDER_PRETTY_NAMES
 from ray.autoscaler.tags import TAG_RAY_NODE_KIND, TAG_RAY_LAUNCH_CONFIG, \
     TAG_RAY_NODE_NAME, NODE_KIND_WORKER, NODE_KIND_HEAD, \
-    TAG_RAY_USER_NODE_TYPE, STATUS_UNINITIALIZED, TAG_RAY_NODE_STATUS
+    TAG_RAY_USER_NODE_TYPE, STATUS_UNINITIALIZED, STATUS_UP_TO_DATE, TAG_RAY_NODE_STATUS
 from ray.autoscaler._private.cli_logger import cli_logger, cf
 from ray.autoscaler._private.updater import NodeUpdaterThread
 from ray.autoscaler._private.command_runner import set_using_login_shells, \
@@ -1110,6 +1110,7 @@ def _get_head_node(config: Dict[str, Any],
     provider = _get_node_provider(config["provider"], config["cluster_name"])
     head_node_tags = {
         TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+        TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
     }
     nodes = provider.non_terminated_nodes(head_node_tags)
 

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -2191,18 +2191,29 @@ MemAvailable:   33000000 kB
     def testGetRunningHeadNode(self):
         config = copy.deepcopy(SMALL_CLUSTER)
         self.provider = MockProvider()
+
+        # Node 0 is failed.
+        self.provider.create_node({}, {
+            TAG_RAY_CLUSTER_NAME: "default",
+            TAG_RAY_NODE_KIND: "head",
+            TAG_RAY_NODE_STATUS: "update-failed"
+        }, 1)
+
+        # Node 1 is okay.
         self.provider.create_node({}, {
             TAG_RAY_CLUSTER_NAME: "default",
             TAG_RAY_NODE_KIND: "head",
             TAG_RAY_NODE_STATUS: "up-to-date"
         }, 1)
 
-        commands._get_running_head_node(
+        node = commands._get_running_head_node(
             config,
             "/fake/path",
             override_cluster_name=None,
             create_if_needed=False,
             _provider=self.provider)
+
+        assert node == 1
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -750,8 +750,14 @@ class AutoscalingTest(unittest.TestCase):
         assert SMALL_CLUSTER["docker"]["container_name"]
         config_path = self.write_config(SMALL_CLUSTER)
         self.provider = MockProvider(unique_ips=True)
-        self.provider.create_node({}, {TAG_RAY_NODE_KIND: "head"}, 1)
-        self.provider.create_node({}, {TAG_RAY_NODE_KIND: "worker"}, 10)
+        self.provider.create_node({}, {
+            TAG_RAY_NODE_KIND: "head",
+            TAG_RAY_NODE_STATUS: "up-to-date"
+        }, 1)
+        self.provider.create_node({}, {
+            TAG_RAY_NODE_KIND: "worker",
+            TAG_RAY_NODE_STATUS: "up-to-date"
+        }, 10)
         self.provider.finish_starting_nodes()
         ray.autoscaler.node_provider._get_node_provider = Mock(
             return_value=self.provider)
@@ -799,8 +805,14 @@ class AutoscalingTest(unittest.TestCase):
         cluster_cfg["docker"] = {}
         config_path = self.write_config(cluster_cfg)
         self.provider = MockProvider(unique_ips=True)
-        self.provider.create_node({}, {TAG_RAY_NODE_KIND: "head"}, 1)
-        self.provider.create_node({}, {TAG_RAY_NODE_KIND: "worker"}, 10)
+        self.provider.create_node({}, {
+            TAG_RAY_NODE_KIND: "head",
+            TAG_RAY_NODE_STATUS: "up-to-date"
+        }, 1)
+        self.provider.create_node({}, {
+            TAG_RAY_NODE_KIND: "worker",
+            TAG_RAY_NODE_STATUS: "up-to-date"
+        }, 10)
         self.provider.finish_starting_nodes()
         runner = MockProcessRunner()
         ray.autoscaler.node_provider._get_node_provider = Mock(

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -24,7 +24,7 @@ from ray.autoscaler._private.providers import (
 from ray.autoscaler.tags import TAG_RAY_NODE_KIND, TAG_RAY_NODE_STATUS, \
     STATUS_UP_TO_DATE, STATUS_UPDATE_FAILED, TAG_RAY_USER_NODE_TYPE, \
     NODE_TYPE_LEGACY_HEAD, NODE_TYPE_LEGACY_WORKER, NODE_KIND_HEAD, \
-    NODE_KIND_WORKER, STATUS_UNINITIALIZED
+    NODE_KIND_WORKER, STATUS_UNINITIALIZED, TAG_RAY_CLUSTER_NAME
 from ray.autoscaler.node_provider import NodeProvider
 from ray.test_utils import RayTestTimeoutException
 import pytest
@@ -2187,6 +2187,22 @@ MemAvailable:   33000000 kB
         assert min(x[0]
                    for x in first_pull) < min(x[0]
                                               for x in first_targeted_inspect)
+
+    def testGetRunningHeadNode(self):
+        config = copy.deepcopy(SMALL_CLUSTER)
+        self.provider = MockProvider()
+        self.provider.create_node({}, {
+            TAG_RAY_CLUSTER_NAME: "default",
+            TAG_RAY_NODE_KIND: "head",
+            TAG_RAY_NODE_STATUS: "up-to-date"
+        }, 1)
+
+        commands._get_running_head_node(
+            config,
+            "/fake/path",
+            override_cluster_name=None,
+            create_if_needed=False,
+            _provider=self.provider)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* If multiple head nodes exist (because one of them is in some sort of failed state), calling `get_head_node` can return the **failed node**. This PR ensures that `get_head_node` only returns a node in the `up-to-date` state.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
