### PR TITLE
[large scale]Add enable sharding option and disable sharding for gcs client

### DIFF
--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -277,8 +277,7 @@ cdef extern from "ray/core_worker/common.h" nogil:
 cdef extern from "ray/gcs/gcs_client.h" nogil:
     cdef cppclass CGcsClientOptions "ray::gcs::GcsClientOptions":
         CGcsClientOptions(const c_string &ip, int port,
-                          const c_string &password,
-                          c_bool is_test_client)
+                          const c_string &password)
 
 cdef extern from "src/ray/protobuf/gcs.pb.h" nogil:
     cdef cppclass CJobConfig "ray::rpc::JobConfig":

--- a/python/ray/includes/common.pxi
+++ b/python/ray/includes/common.pxi
@@ -13,14 +13,13 @@ cdef class GcsClientOptions:
         unique_ptr[CGcsClientOptions] inner
 
     def __init__(self, redis_ip, int redis_port,
-                 redis_password, c_bool is_test_client=False):
+                 redis_password):
         if not redis_password:
             redis_password = ""
         self.inner.reset(
             new CGcsClientOptions(redis_ip.encode("ascii"),
                                   redis_port,
-                                  redis_password.encode("ascii"),
-                                  is_test_client))
+                                  redis_password.encode("ascii")))
 
     cdef CGcsClientOptions* native(self):
         return <CGcsClientOptions*>(self.inner.get())

--- a/python/ray/includes/global_state_accessor.pxd
+++ b/python/ray/includes/global_state_accessor.pxd
@@ -13,8 +13,7 @@ from ray.includes.unique_ids cimport (
 cdef extern from "ray/gcs/gcs_client/global_state_accessor.h" nogil:
     cdef cppclass CGlobalStateAccessor "ray::gcs::GlobalStateAccessor":
         CGlobalStateAccessor(const c_string &redis_address,
-                             const c_string &redis_password,
-                             c_bool is_test)
+                             const c_string &redis_password)
         c_bool Connect()
         void Disconnect()
         c_vector[c_string] GetAllJobInfo()

--- a/python/ray/includes/global_state_accessor.pxi
+++ b/python/ray/includes/global_state_accessor.pxi
@@ -17,15 +17,13 @@ cdef class GlobalStateAccessor:
     cdef:
         unique_ptr[CGlobalStateAccessor] inner
 
-    def __init__(self, redis_address, redis_password,
-                 c_bool is_test_client=False):
+    def __init__(self, redis_address, redis_password):
         if not redis_password:
             redis_password = ""
         self.inner.reset(
             new CGlobalStateAccessor(
                 redis_address.encode("ascii"),
                 redis_password.encode("ascii"),
-                is_test_client,
             ),
         )
 

--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -91,7 +91,7 @@ class GlobalState:
         self.redis_client = services.create_redis_client(
             self.redis_address, self.redis_password)
         self.global_state_accessor = GlobalStateAccessor(
-            self.redis_address, self.redis_password, False)
+            self.redis_address, self.redis_password)
         self.global_state_accessor.connect()
         start_time = time.time()
 

--- a/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
@@ -40,7 +40,7 @@ inline ray::gcs::GcsClientOptions ToGcsClientOptions(JNIEnv *env,
   std::string password = JavaStringToNativeString(
       env,
       (jstring)env->GetObjectField(gcs_client_options, java_gcs_client_options_password));
-  return ray::gcs::GcsClientOptions(ip, port, password, /*is_test_client=*/false);
+  return ray::gcs::GcsClientOptions(ip, port, password);
 }
 
 jobject ToJavaArgs(JNIEnv *env, jbooleanArray java_check_results,

--- a/src/ray/gcs/gcs_client.h
+++ b/src/ray/gcs/gcs_client.h
@@ -38,12 +38,8 @@ class GcsClientOptions {
   /// \param port GCS service port.
   /// \param password GCS service password.
   /// \param is_test_client Whether this client is used for tests.
-  GcsClientOptions(const std::string &ip, int port, const std::string &password,
-                   bool is_test_client = false)
-      : server_ip_(ip),
-        server_port_(port),
-        password_(password),
-        is_test_client_(is_test_client) {}
+  GcsClientOptions(const std::string &ip, int port, const std::string &password)
+      : server_ip_(ip), server_port_(port), password_(password) {}
 
   GcsClientOptions() {}
 
@@ -53,9 +49,6 @@ class GcsClientOptions {
 
   // Password of GCS server.
   std::string password_;
-
-  // Whether this client is used for tests.
-  bool is_test_client_{false};
 };
 
 /// \class GcsClient

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -20,10 +20,8 @@ namespace ray {
 namespace gcs {
 
 GlobalStateAccessor::GlobalStateAccessor(const std::string &redis_address,
-                                         const std::string &redis_password,
-                                         bool is_test) {
-  RAY_LOG(DEBUG) << "Redis server address = " << redis_address
-                 << ", is test flag = " << is_test;
+                                         const std::string &redis_password) {
+  RAY_LOG(DEBUG) << "Redis server address = " << redis_address;
   std::vector<std::string> address;
   boost::split(address, redis_address, boost::is_any_of(":"));
   RAY_CHECK(address.size() == 2);
@@ -31,7 +29,6 @@ GlobalStateAccessor::GlobalStateAccessor(const std::string &redis_address,
   options.server_ip_ = address[0];
   options.server_port_ = std::stoi(address[1]);
   options.password_ = redis_password;
-  options.is_test_client_ = is_test;
   gcs_client_.reset(new ServiceBasedGcsClient(options));
 
   io_service_.reset(new boost::asio::io_service());

--- a/src/ray/gcs/gcs_client/global_state_accessor.h
+++ b/src/ray/gcs/gcs_client/global_state_accessor.h
@@ -30,9 +30,8 @@ class GlobalStateAccessor {
   ///
   /// \param redis_address The address of GCS Redis.
   /// \param redis_password The password of GCS Redis.
-  /// \param is_test Whether this accessor is used for tests.
   explicit GlobalStateAccessor(const std::string &redis_address,
-                               const std::string &redis_password, bool is_test = false);
+                               const std::string &redis_password);
 
   ~GlobalStateAccessor();
 

--- a/src/ray/gcs/gcs_client/service_based_gcs_client.cc
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.cc
@@ -38,8 +38,11 @@ Status ServiceBasedGcsClient::Connect(boost::asio::io_service &io_service) {
   }
 
   // Connect to redis.
+  // We don't access redis shardings in GCS client, so we set `enable_sharding_conn` to
+  // false.
   RedisClientOptions redis_client_options(options_.server_ip_, options_.server_port_,
-                                          options_.password_, options_.is_test_client_);
+                                          options_.password_,
+                                          /*enable_sharding_conn=*/false);
   redis_client_.reset(new RedisClient(redis_client_options));
   RAY_CHECK_OK(redis_client_->Connect(io_service));
 

--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -34,7 +34,7 @@ class GlobalStateAccessorTest : public ::testing::Test {
     config.grpc_server_name = "MockedGcsServer";
     config.grpc_server_thread_num = 1;
     config.redis_address = "127.0.0.1";
-    config.is_test = true;
+    config.enable_sharding_conn = false;
     config.redis_port = TEST_REDIS_SERVER_PORTS.front();
 
     io_service_.reset(new boost::asio::io_service());
@@ -54,14 +54,14 @@ class GlobalStateAccessorTest : public ::testing::Test {
 
     // Create GCS client.
     gcs::GcsClientOptions options(config.redis_address, config.redis_port,
-                                  config.redis_password, config.is_test);
+                                  config.redis_password);
     gcs_client_.reset(new gcs::ServiceBasedGcsClient(options));
     RAY_CHECK_OK(gcs_client_->Connect(*io_service_));
 
     // Create global state.
     std::stringstream address;
     address << config.redis_address << ":" << config.redis_port;
-    global_state_.reset(new gcs::GlobalStateAccessor(address.str(), "", true));
+    global_state_.reset(new gcs::GlobalStateAccessor(address.str(), ""));
     RAY_CHECK(global_state_->Connect());
   }
 

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -41,7 +41,7 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     config_.grpc_server_name = "MockedGcsServer";
     config_.grpc_server_thread_num = 1;
     config_.redis_address = "127.0.0.1";
-    config_.is_test = true;
+    config_.enable_sharding_conn = false;
     config_.redis_port = TEST_REDIS_SERVER_PORTS.front();
 
     client_io_service_.reset(new boost::asio::io_service());
@@ -67,7 +67,7 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
 
     // Create GCS client.
     gcs::GcsClientOptions options(config_.redis_address, config_.redis_port,
-                                  config_.redis_password, config_.is_test);
+                                  config_.redis_password);
     gcs_client_.reset(new gcs::ServiceBasedGcsClient(options));
     RAY_CHECK_OK(gcs_client_->Connect(*client_io_service_));
   }

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -44,7 +44,8 @@ GcsServer::~GcsServer() { Stop(); }
 void GcsServer::Start() {
   // Init backend client.
   RedisClientOptions redis_client_options(config_.redis_address, config_.redis_port,
-                                          config_.redis_password, config_.is_test);
+                                          config_.redis_password,
+                                          config_.enable_sharding_conn);
   redis_client_ = std::make_shared<RedisClient>(redis_client_options);
   auto status = redis_client_->Connect(main_service_);
   RAY_CHECK(status.ok()) << "Failed to init redis gcs client as " << status;

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -38,7 +38,7 @@ struct GcsServerConfig {
   std::string redis_address;
   uint16_t redis_port = 6379;
   bool retry_redis = true;
-  bool is_test = false;
+  bool enable_sharding_conn = true;
   std::string node_ip_address;
 };
 

--- a/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
@@ -32,7 +32,7 @@ class GcsServerTest : public ::testing::Test {
     config.grpc_server_name = "MockedGcsServer";
     config.grpc_server_thread_num = 1;
     config.redis_address = "127.0.0.1";
-    config.is_test = true;
+    config.enable_sharding_conn = false;
     config.redis_port = TEST_REDIS_SERVER_PORTS.front();
     gcs_server_.reset(new gcs::GcsServer(config, io_service_));
     gcs_server_->Start();

--- a/src/ray/gcs/gcs_server/test/redis_gcs_table_storage_test.cc
+++ b/src/ray/gcs/gcs_server/test/redis_gcs_table_storage_test.cc
@@ -28,7 +28,7 @@ class RedisGcsTableStorageTest : public gcs::GcsTableStorageTestBase {
 
   void SetUp() override {
     gcs::RedisClientOptions options("127.0.0.1", TEST_REDIS_SERVER_PORTS.front(), "",
-                                    true);
+                                    /*enable_sharding_conn=*/false);
     redis_client_ = std::make_shared<gcs::RedisClient>(options);
     RAY_CHECK_OK(redis_client_->Connect(io_service_pool_->GetAll()));
 

--- a/src/ray/gcs/pubsub/test/gcs_pub_sub_test.cc
+++ b/src/ray/gcs/pubsub/test/gcs_pub_sub_test.cc
@@ -36,7 +36,7 @@ class GcsPubSubTest : public ::testing::Test {
     }));
 
     gcs::RedisClientOptions redis_client_options(
-        "127.0.0.1", TEST_REDIS_SERVER_PORTS.front(), "", true);
+        "127.0.0.1", TEST_REDIS_SERVER_PORTS.front(), "", /*enable_sharding_conn=*/false);
     client_ = std::make_shared<gcs::RedisClient>(redis_client_options);
     RAY_CHECK_OK(client_->Connect(io_service_));
     pub_sub_ = std::make_shared<gcs::GcsPubSub>(client_);

--- a/src/ray/gcs/redis_client.cc
+++ b/src/ray/gcs/redis_client.cc
@@ -115,7 +115,7 @@ Status RedisClient::Connect(std::vector<boost::asio::io_service *> io_services) 
                                          /*sharding=*/true,
                                          /*password=*/options_.password_));
 
-  if (!options_.is_test_client_) {
+  if (options_.enable_sharding_conn_) {
     // Moving sharding into constructor defaultly means that sharding = true.
     // This design decision may worth a look.
     std::vector<std::string> addresses;
@@ -175,6 +175,7 @@ void RedisClient::Disconnect() {
 }
 
 std::shared_ptr<RedisContext> RedisClient::GetShardContext(const std::string &shard_key) {
+  RAY_CHECK(!shard_contexts_.empty());
   static std::hash<std::string> hash;
   size_t index = hash(shard_key) % shard_contexts_.size();
   return shard_contexts_[index];

--- a/src/ray/gcs/redis_client.h
+++ b/src/ray/gcs/redis_client.h
@@ -30,11 +30,11 @@ class RedisContext;
 class RedisClientOptions {
  public:
   RedisClientOptions(const std::string &ip, int port, const std::string &password,
-                     bool is_test_client = false)
+                     bool enable_sharding_conn = true)
       : server_ip_(ip),
         server_port_(port),
         password_(password),
-        is_test_client_(is_test_client) {}
+        enable_sharding_conn_(enable_sharding_conn) {}
 
   // Redis server address
   std::string server_ip_;
@@ -43,8 +43,8 @@ class RedisClientOptions {
   // Password of Redis.
   std::string password_;
 
-  // Whether this client is used for tests.
-  bool is_test_client_{false};
+  // Whether we enable sharding for accessing data.
+  bool enable_sharding_conn_{true};
 };
 
 /// \class RedisClient

--- a/src/ray/gcs/store_client/test/redis_store_client_test.cc
+++ b/src/ray/gcs/store_client/test/redis_store_client_test.cc
@@ -33,7 +33,8 @@ class RedisStoreClientTest : public StoreClientTestBase {
   static void TearDownTestCase() { TestSetupUtil::ShutDownRedisServers(); }
 
   void InitStoreClient() override {
-    RedisClientOptions options("127.0.0.1", TEST_REDIS_SERVER_PORTS.front(), "", true);
+    RedisClientOptions options("127.0.0.1", TEST_REDIS_SERVER_PORTS.front(), "",
+                               /*enable_sharding_conn=*/false);
     redis_client_ = std::make_shared<RedisClient>(options);
     RAY_CHECK_OK(redis_client_->Connect(io_service_pool_->GetAll()));
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Some redis client instances do not need sharding contexts for data accessing from redis, but only primary context or rpc client to gcs server, like those in `ServiceBasedGcsClient` and `GlobalStateAccessor`. We add a `enable_sharding_conn` option and disable them in gcs client and global state accessor.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

part of https://github.com/ray-project/ray/issues/14463

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
