### PR TITLE
[RLLib] fix reduce mean to take into consideration FLOAT_MIN

### DIFF
--- a/rllib/utils/torch_ops.py
+++ b/rllib/utils/torch_ops.py
@@ -178,7 +178,7 @@ def one_hot(x, space):
 
 
 def reduce_mean_ignore_inf(x, axis):
-    """Same as torch.mean() but ignores -inf values."""
+    """Same as torch.mean() but ignores -inf and < FLOAT_MIN values."""
     mask_inf = torch.ne(x, float("-inf"))
     mask_small = torch.ge(x, FLOAT_MIN)
     mask = torch.logical_or(mask_inf, mask_small)

--- a/rllib/utils/torch_ops.py
+++ b/rllib/utils/torch_ops.py
@@ -179,8 +179,8 @@ def one_hot(x, space):
 
 def reduce_mean_ignore_inf(x, axis):
     """Same as torch.mean() but ignores -inf values."""
-    mask = torch.ne(x, float("-inf"))
-    x_zeroed = torch.where(mask, x, torch.zeros_like(x))
+    mask = torch.le(x, FLOAT_MIN)
+    x_zeroed = torch.where(mask, torch.zeros_like(x), x)
     return torch.sum(x_zeroed, axis) / torch.sum(mask.float(), axis)
 
 

--- a/rllib/utils/torch_ops.py
+++ b/rllib/utils/torch_ops.py
@@ -179,8 +179,10 @@ def one_hot(x, space):
 
 def reduce_mean_ignore_inf(x, axis):
     """Same as torch.mean() but ignores -inf values."""
-    mask = torch.le(x, FLOAT_MIN)
-    x_zeroed = torch.where(mask, torch.zeros_like(x), x)
+    mask_inf = torch.ne(x, float("-inf"))
+    mask_small = torch.ge(x, FLOAT_MIN)
+    mask = torch.logical_or(mask_inf, mask_small)
+    x_zeroed = torch.where(mask, x, torch.zeros_like(x))
     return torch.sum(x_zeroed, axis) / torch.sum(mask.float(), axis)
 
 


### PR DESCRIPTION
## Why are these changes needed?

Current `reduce_mean_ignore_inf` ignore only `float('-inf')`values, by when using action masking we use the `FLOAT_MIN` constant, and this is not considered currently.

## Related issue number

#14355 I'm working on making dueling work for masked actions

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
