### PR TITLE
[serve] Deprecate system-level batching with warning, update the docs

### DIFF
--- a/doc/source/serve/architecture.rst
+++ b/doc/source/serve/architecture.rst
@@ -26,7 +26,8 @@ There are three kinds of actors that are created to make up a Serve instance:
   responds once they are completed.
 - Worker Replica: Worker replicas actually execute the code in response to a
   request. For example, they may contain an instantiation of an ML model. Each
-  replica processes individual requests or batches of requests from the routers.
+  replica processes individual requests from the routers (they may be batched
+  by the replica using @serve.batch).
 
 
 Lifetime of a Request
@@ -43,11 +44,10 @@ When an HTTP request is sent to the router, the follow things happen:
   are more than ``max_concurrent_queries`` requests outstanding), the request
   is left in the queue until an outstanding request is finished.
 
-Each replica maintains a queue of requests and processes one batch of requests at
-a time. By default the batch size is 1, you can increase the batch size <ref> to
-increase throughput. If the handler (the function for the backend or
-``__call__``) is ``async``, the replica will not wait for the handler to run;
-otherwise, the replica will block until the handler returns.
+Each replica maintains a queue of requests and one at a time, possibly using
+asyncio to process them concurrently. If the handler (the function for the
+backend or ``__call__``) is ``async``, the replica will not wait for the
+handler to run; otherwise, the replica will block until the handler returns.
 
 FAQ
 ---

--- a/doc/source/serve/architecture.rst
+++ b/doc/source/serve/architecture.rst
@@ -27,7 +27,7 @@ There are three kinds of actors that are created to make up a Serve instance:
 - Worker Replica: Worker replicas actually execute the code in response to a
   request. For example, they may contain an instantiation of an ML model. Each
   replica processes individual requests from the routers (they may be batched
-  by the replica using @serve.batch).
+  by the replica using ``@serve.batch``, see the :ref:`batching<serve-batching>` docs).
 
 
 Lifetime of a Request
@@ -44,8 +44,8 @@ When an HTTP request is sent to the router, the follow things happen:
   are more than ``max_concurrent_queries`` requests outstanding), the request
   is left in the queue until an outstanding request is finished.
 
-Each replica maintains a queue of requests and one at a time, possibly using
-asyncio to process them concurrently. If the handler (the function for the
+Each replica maintains a queue of requests and executes one at a time, possibly
+using asyncio to process them concurrently. If the handler (the function for the
 backend or ``__call__``) is ``async``, the replica will not wait for the
 handler to run; otherwise, the replica will block until the handler returns.
 

--- a/doc/source/serve/core-apis.rst
+++ b/doc/source/serve/core-apis.rst
@@ -102,7 +102,7 @@ Configuring a Backend
 =====================
 
 There are a number of things you'll likely want to do with your serving application including
-scaling out, splitting traffic, or configuring the number of in-flight requests for a backend.
+scaling out, splitting traffic, or configuring the maximum number of in-flight requests for a backend.
 All of these options are encapsulated in a ``BackendConfig`` object for each backend.
 
 The ``BackendConfig`` for a running backend can be updated using

--- a/doc/source/serve/deployment.rst
+++ b/doc/source/serve/deployment.rst
@@ -360,7 +360,7 @@ The following metrics are exposed by Ray Serve:
    * - ``serve_backend_replica_starts``
      - The number of times this replica has been restarted due to failure.
    * - ``serve_backend_queuing_latency_ms``
-     - The latency for queries in the replica's queue waiting to be processed or batched.
+     - The latency for queries in the replica's queue waiting to be processed.
    * - ``serve_backend_processing_latency_ms``
      - The latency for queries to be processed.
    * - ``serve_replica_queued_queries``

--- a/doc/source/serve/faq.rst
+++ b/doc/source/serve/faq.rst
@@ -51,7 +51,7 @@ To call a method via Python, use :mod:`handle.options <ray.serve.handle.RayServe
     handle.options(method_name="other_method").remote(5)
 
 The call is the same as a regular query except a different method is called
-within the replica. It is compatible with batching as well.
+within the replica.
 
 How do I use custom status codes in my response?
 ---------------------------------------------------------
@@ -99,8 +99,7 @@ get a ``ServeHandle`` corresponding to an ``endpoint``, similar how you can
 reach an endpoint through HTTP via a specific route. When you issue a request
 to an endpoint through ``ServeHandle``, the request goes through the same code
 path as an HTTP request would: choosing backends through :ref:`traffic
-policies <serve-split-traffic>`, finding the next available replica, and
-batching requests together.
+policies <serve-split-traffic>` and load balancing across available replicas.
 
 When the request arrives in the model, you can access the data similarly to how
 you would with HTTP request. Here are some examples how ServeRequest mirrors Starlette.Request:

--- a/doc/source/serve/ml-models.rst
+++ b/doc/source/serve/ml-models.rst
@@ -9,7 +9,7 @@ Serving Machine Learning Models
 Request Batching
 ================
 
-You can also have Ray Serve batch requests for performance, which is especially important for some ML models that run on GPUs. In order to do use this feature, you need to:
+You can also have Ray Serve batch requests for performance, which is especially important for some ML models that run on GPUs. In order to use this feature, you need to do the following two things:
 
 1. Use ``async def`` for your request handling logic to process queries concurrently.
 2. Use the ``@serve.batch`` decorator to batch individual queries that come into the replica. The method/function that's decorated should handle a list of requests and return a list of the same length.

--- a/doc/source/serve/ml-models.rst
+++ b/doc/source/serve/ml-models.rst
@@ -10,6 +10,7 @@ Request Batching
 ================
 
 You can also have Ray Serve batch requests for performance, which is especially important for some ML models that run on GPUs. In order to do use this feature, you need to:
+
 1. Use ``async def`` for your request handling logic to process queries concurrently.
 2. Use the ``@serve.batch`` decorator to batch individual queries that come into the replica. The method/function that's decorated should handle a list of requests and return a list of the same length.
 

--- a/doc/source/serve/ml-models.rst
+++ b/doc/source/serve/ml-models.rst
@@ -4,15 +4,14 @@ Serving Machine Learning Models
 
 .. contents::
 
-.. _serve-ml-batching:
+.. _serve-batching:
 
 Request Batching
 ================
 
-You can also have Ray Serve batch requests for performance, which is especially important for some ML models that run on GPUs.
-In order to do use this feature, you need to:
-1. Set the ``max_batch_size`` in the ``config`` dictionary.
-2. Modify your backend implementation to accept a list of requests and return a list of responses instead of handling a single request.
+You can also have Ray Serve batch requests for performance, which is especially important for some ML models that run on GPUs. In order to do use this feature, you need to:
+1. Use ``async def`` for your request handling logic to process queries concurrently.
+2. Use the ``@serve.batch`` decorator to batch individual queries that come into the replica. The method/function that's decorated should handle a list of requests and return a list of the same length.
 
 
 .. code-block:: python
@@ -21,15 +20,18 @@ In order to do use this feature, you need to:
       def __init__(self):
           self.count = 0
 
-      @serve.accept_batch
-      def __call__(self, requests):
+      @serve.batch
+      async def handle_batch(self, requests):
           responses = []
-              for request in requests:
-                  responses.append(request.json())
+          for request in requests:
+              responses.append(request.json())
+
           return responses
 
-  config = {"max_batch_size": 5}
-  client.create_backend("counter1", BatchingExample, config=config)
+      async def __call__(self, request):
+          return await self.handle_batch(request)
+
+  client.create_backend("counter1", BatchingExample)
   client.create_endpoint("counter1", backend="counter1", route="/increment")
 
 Please take a look at :ref:`Batching Tutorial<serve-batch-tutorial>` for a deep

--- a/doc/source/serve/performance.rst
+++ b/doc/source/serve/performance.rst
@@ -66,7 +66,7 @@ make your backend accept batches (especially for GPU-based ML inference). You mi
   a batch should be processed, even if it’s not full.  It should be set according 
   to `batch-wait-timeout + full batch processing time ~= expected latency`. The idea 
   here is to have the first query wait for the longest possible time to achieve high throughput.  
-  This means you should set batch-wait-timeout as large as possible without exceeding your desired expected latency in the equation above.
+  This means you should set ``batch_wait_timeout`` as large as possible without exceeding your desired expected latency in the equation above.
 
 Scaling HTTP servers
 ^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/serve/performance.rst
+++ b/doc/source/serve/performance.rst
@@ -41,12 +41,20 @@ Make sure you are using the right hardware and resources.
 Are you using GPUs (``actor_init_options={“num_gpus”: 1}``) or 1+ cores (``actor_init_options={“num_cpus”: 2}``, and setting ``OMP_NUM_THREADS``)
 to increase the performance of your deep learning framework?
 
+Async functions
+^^^^^^^^^^^^^^^
+Are you using ``async def`` in your callable? If you are using asyncio and
+hitting the same queuing issue mentioned above, you might want to increase 
+``max_concurrent_queries``. Serve sets a low number by default so the client gets 
+proper backpressure. You can increase the value in the :mod:`backend config <ray.serve.config.BackendConfig>`
+to allow more coroutines running in the same replica.
+
 Batching
 ^^^^^^^^
 If your backend can process a batch at a time at a sublinear latency 
 (for example, if it takes 1ms to process 1 query and 5ms to process 10 of them) 
-then batching is your best approach. Check out the :ref:`batching guide <serve-ml-batching>` to 
-make your backend accept batches (especially for GPU-based ML inference). You might want to tune your ``max_batch_size`` and ``batch_wait_timeout`` to maximize the benefits:
+then batching is your best approach. Check out the :ref:`batching guide <serve-batching>` to 
+make your backend accept batches (especially for GPU-based ML inference). You might want to tune your ``max_batch_size`` and ``batch_wait_timeout`` in the ``@serve.batch`` decorator to maximize the benefits:
 
 - ``max_batch_size`` specifies how big the batch should be. Generally, 
   we recommend choosing the largest batch size your function can handle 
@@ -59,14 +67,6 @@ make your backend accept batches (especially for GPU-based ML inference). You mi
   to `batch-wait-timeout + full batch processing time ~= expected latency`. The idea 
   here is to have the first query wait for the longest possible time to achieve high throughput.  
   This means you should set batch-wait-timeout as large as possible without exceeding your desired expected latency in the equation above.
-
-Async functions
-^^^^^^^^^^^^^^^
-Are you using ``async def`` in your callable? If you are using asyncio and
-hitting the same queuing issue mentioned above, you might want to increase 
-``max_concurrent_queries``. Serve sets a low number by default so the client gets 
-proper backpressure. You can increase the value in the :mod:`backend config <ray.serve.config.BackendConfig>`
-to allow more coroutines running in the same replica.
 
 Scaling HTTP servers
 ^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/serve/tutorials/batch.rst
+++ b/doc/source/serve/tutorials/batch.rst
@@ -54,6 +54,14 @@ they were a normal function call:
         async def __call__(self, request):
             await self.my_batch_handler(request)
 
+.. note::
+    By default, Ray Serve performs *opportunistic batching*. This means that as
+    soon as the batch handler is called, the method will be executed without
+    waiting for a full batch. If there are more queries available after this call
+    finishes, a larger batch may be executed. This behavior can be tuned using the
+    ``batch_wait_timeout_s`` option to ``@serve.batch`` (defaults to 0). Increasing this
+    timeout may improve throughput at the cost of latency under low load.
+
 Let's define a backend that takes in a list of requests, extracts the input value,
 converts them into an array, and uses NumPy to add 1 to each element.
 
@@ -64,14 +72,6 @@ converts them into an array, and uses NumPy to add 1 to each element.
 Let's deploy it. Note that in the ``@serve.batch`` decorator, we are specifying
 specifying the maximum batch size via ``max_batch_size=4``. This option limits
 the maximum possible batch size that will be executed at once.
-
-.. note::
-    By default, Ray Serve performs *opportunistic batching*. This means that as
-    soon as the batch handler is called, the method will be executed without
-    waiting for a full batch. If there are more queries available after this call
-    finishes, a larger batch may be executed. This behavior can be tuned using the
-    ``batch_wait_timeout_s`` option to ``@serve.batch`` (defaults to 0). Increasing this
-    timeout may improve throughput at the cost of latency under low load.
 
 .. literalinclude:: ../../../../python/ray/serve/examples/doc/tutorial_batch.py
     :start-after: __doc_deploy_begin__

--- a/doc/source/serve/tutorials/batch.rst
+++ b/doc/source/serve/tutorials/batch.rst
@@ -26,51 +26,49 @@ Let's import Ray Serve and some other helpers.
     :start-after: __doc_import_begin__
     :end-before: __doc_import_end__
 
-You can use the ``@serve.accept_batch`` decorator to annotate a function or a class.
-This annotation is needed because batched backends have different APIs compared
-to single request backends. In a batched backend, the inputs are a list of values.
-
-For single query backend, the input type is a single Starlette request or
-:mod:`ServeRequest <ray.serve.utils.ServeRequest>`:
+You can use the ``@serve.batch`` decorator to annotate a function or a method.
+This annotation will automatically cause calls to the function to be batched together.
+The function must handle a list of objects and will be called with a single object.
+This function must also be ``async def`` so that you can handle multiple queries concurrently:
 
 .. code-block:: python
 
-    def single_request(
-        request: Union[starlette.requests.Request, ServeRequest],
-    ):
+    @serve.batch
+    async def my_batch_handler(self, requests):
         pass
 
-For batched backends, the input types are converted to list of their original
-types:
+This batch handler can then be called from another ``async def`` method in your backend:
 
 .. code-block:: python
 
-    @serve.accept_batch
-    def batched_request(
-        request: List[Union[starlette.requests.Request, ServeRequest]],
-    ):
-        pass
+    class MyBackend:
+        async def my_batch_handler(self, requests: List[Union[starlette.Request, serve.ServeRequest]]):
+            results = []
+            for request in requests:
+                results.append(request.json())
+            return results
 
-Let's define the backend function. We will take in a list of requests, extract
-the input value, convert them into an array, and use NumPy to add 1 to each element.
+        async def __call__(self, request: Union[starlette.Request, serve.ServeRequest]):
+            await self.my_batch_handler(request)
+
+Let's define a backend that takes in a list of requests, extracts the input value,
+converts them into an array, and uses NumPy to add 1 to each element.
 
 .. literalinclude:: ../../../../python/ray/serve/examples/doc/tutorial_batch.py
-    :start-after: __doc_define_servable_v0_begin__
-    :end-before: __doc_define_servable_v0_end__
+    :start-after: __doc_define_servable_begin__
+    :end-before: __doc_define_servable_end__
 
-Let's deploy it. Note that in the ``config`` section of ``create_backend``, we
-are specifying the maximum batch size via ``config={"max_batch_size": 4}``. This
-configuration option limits the maximum possible batch size sent to the backend.
+Let's deploy it. Note that in the ``@serve.batch`` decorator, we are specifying
+specifying the maximum batch size via ``max_batch_size=4``. This option limits
+the maximum possible batch size that will be executed at once.
 
 .. note::
-    Ray Serve performs *opportunistic batching*. When a replica is free to evaluate
-    the next batch, Ray Serve will look at the pending queries and try to take
-    :mod:`max_batch_size <ray.serve.BackendConfig>` queries to form a batch.
-    If the batch has less than ``max_batch_size`` queries, the backend will
-    wait for :mod:`batch_wait_timeout <ray.serve.BackendConfig>`
-    seconds to wait for a full batch to arrive. The default wait is ``0s`` to
-    minimize query latency. You can increase the timeout to improve throughput
-    and increase utilization at the cost of some additional latency.
+    By default, Ray Serve performs *opportunistic batching*. This means that as
+    soon as the batch handler is called, the method will be executed without
+    waiting for a full batch. If there are more queries available after this call
+    finishes, a larger batch may be executed. This behavior can be tuned using the
+    batch_wait_timout_s option to ``@serve.batch`` (defaults to 0). Increasing this
+    timeout may improve throughput at the cost of latency under low load.
 
 .. literalinclude:: ../../../../python/ray/serve/examples/doc/tutorial_batch.py
     :start-after: __doc_deploy_begin__
@@ -90,20 +88,9 @@ queries via the Python API. A batch of queries can either come from the web serv
 or the Python API. Requests coming from the Python API will have a similar API
 to Starlette Request. See more on the API :ref:`here<serve-handle-explainer>`.
 
-.. literalinclude:: ../../../../python/ray/serve/examples/doc/tutorial_batch.py
-    :start-after: __doc_define_servable_v1_begin__
-    :end-before: __doc_define_servable_v1_end__
-
-Let's deploy the new version to the same endpoint. Don't forget to set
-``max_batch_size``!
-
-.. literalinclude:: ../../../../python/ray/serve/examples/doc/tutorial_batch.py
-    :start-after: __doc_deploy_v1_begin__
-    :end-before: __doc_deploy_v1_end__
-
 To query the backend via Python API, we can use ``serve.get_handle`` to receive
 a handle to the corresponding "endpoint". To enqueue a query, you can call
-``handle.remote(data, argument_name=argument_value)``. This call returns immediately
+``handle.remote(data)``. This call returns immediately
 with a :ref:`Ray ObjectRef<ray-object-refs>`. You can call `ray.get` to retrieve
 the result.
 

--- a/doc/source/serve/tutorials/batch.rst
+++ b/doc/source/serve/tutorials/batch.rst
@@ -70,7 +70,7 @@ the maximum possible batch size that will be executed at once.
     soon as the batch handler is called, the method will be executed without
     waiting for a full batch. If there are more queries available after this call
     finishes, a larger batch may be executed. This behavior can be tuned using the
-    batch_wait_timout_s option to ``@serve.batch`` (defaults to 0). Increasing this
+    ``batch_wait_timeout_s`` option to ``@serve.batch`` (defaults to 0). Increasing this
     timeout may improve throughput at the cost of latency under low load.
 
 .. literalinclude:: ../../../../python/ray/serve/examples/doc/tutorial_batch.py

--- a/doc/source/serve/tutorials/batch.rst
+++ b/doc/source/serve/tutorials/batch.rst
@@ -6,7 +6,7 @@ Batching Tutorial
 In this guide, we will deploy a simple vectorized adder that takes
 a batch of queries and adds them at once. In particular, we show:
 
-- How to implement and deploy Ray Serve model that accepts batches.
+- How to implement and deploy a Ray Serve backend that accepts batches.
 - How to configure the batch size.
 - How to query the model in Python.
 

--- a/doc/source/serve/tutorials/batch.rst
+++ b/doc/source/serve/tutorials/batch.rst
@@ -34,21 +34,24 @@ This function must also be ``async def`` so that you can handle multiple queries
 .. code-block:: python
 
     @serve.batch
-    async def my_batch_handler(self, requests):
+    async def my_batch_handler(self, requests: List):
         pass
 
-This batch handler can then be called from another ``async def`` method in your backend:
+This batch handler can then be called from another ``async def`` method in your backend.
+These calls will be batched and executed together, but return an individual result as if
+they were a normal function call:
 
 .. code-block:: python
 
     class MyBackend:
-        async def my_batch_handler(self, requests: List[Union[starlette.Request, serve.ServeRequest]]):
+        @serve.batch
+        async def my_batch_handler(self, requests: List):
             results = []
             for request in requests:
                 results.append(request.json())
             return results
 
-        async def __call__(self, request: Union[starlette.Request, serve.ServeRequest]):
+        async def __call__(self, request):
             await self.my_batch_handler(request)
 
 Let's define a backend that takes in a list of requests, extracts the input value,

--- a/python/ray/serve/__init__.py
+++ b/python/ray/serve/__init__.py
@@ -2,6 +2,7 @@ from ray.serve.api import (accept_batch, Client, connect, start,
                            get_replica_context)
 from ray.serve.batching import batch
 from ray.serve.config import BackendConfig, HTTPOptions
+from ray.serve.utils import ServeRequest
 
 # Mute the warning because Serve sometimes intentionally calls
 # ray.get inside async actors.
@@ -9,6 +10,13 @@ import ray.worker
 ray.worker.blocking_get_inside_async_warned = True
 
 __all__ = [
-    "accept_batch", "BackendConfig", "batch", "connect", "Client", "start",
-    "HTTPOptions", "get_replica_context"
+    "accept_batch",
+    "BackendConfig",
+    "batch",
+    "connect",
+    "Client",
+    "start",
+    "HTTPOptions",
+    "get_replica_context",
+    "ServeRequest",
 ]

--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -174,11 +174,11 @@ def batch(func: F) -> G:
 # "Decorator factory" use case (called with arguments).
 @overload
 def batch(max_batch_size: int = 10,
-          batch_wait_timeout_s: float = 0.1) -> Callable[[F], G]:
+          batch_wait_timeout_s: float = 0.0) -> Callable[[F], G]:
     pass
 
 
-def batch(_func=None, max_batch_size=10, batch_wait_timeout_s=0.1):
+def batch(_func=None, max_batch_size=10, batch_wait_timeout_s=0.0):
     """Converts a function to asynchronously handle batches.
 
     The function can be a standalone function or a class method, and must

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional
 import pydantic
 from pydantic import BaseModel, confloat, PositiveFloat, PositiveInt, validator
 from ray.serve.constants import DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT
+from ray.serve.utils import logger
 
 
 def _callable_accepts_batch(backend_def):
@@ -87,6 +88,15 @@ class BackendConfig(BaseModel):
                 "method does not accept batching. Please use "
                 "@serve.accept_batch to explicitly mark that the function or "
                 "method accepts a list of requests as an argument.")
+
+        if self.max_batch_size is not None:
+            logger.warning(
+                "Setting max_batch_size and batch_wait_timeout in the "
+                "BackendConfig are deprecated in favor of using the "
+                "@serve.batch decorator in the application level. Please see "
+                "the documentation for details: "
+                "https://docs.ray.io/en/master/serve/ml-models.html#request-batching."  # noqa:E501
+            )
 
     # This is not a pydantic validator, so that we may skip this method when
     # creating partially filled BackendConfig objects to pass as updates--for

--- a/python/ray/serve/examples/doc/tutorial_batch.py
+++ b/python/ray/serve/examples/doc/tutorial_batch.py
@@ -1,14 +1,14 @@
 # yapf: disable
 # __doc_import_begin__
-import ray
-from ray import serve
-
 from typing import List, Union
 import time
 
 import numpy as np
 import requests
 import starlette
+
+import ray
+from ray import serve
 # __doc_import_end__
 # yapf: enable
 

--- a/python/ray/serve/examples/doc/tutorial_batch.py
+++ b/python/ray/serve/examples/doc/tutorial_batch.py
@@ -17,7 +17,8 @@ import starlette
 class BatchAdder:
     @serve.batch(max_batch_size=4)
     async def handle_batch(
-            self, requests: List[Union[starlette.Request, serve.Request]]):
+            self,
+            requests: List[Union[starlette.Request, serve.ServeRequest]]):
         numbers = [int(request.query_params["number"]) for request in requests]
 
         input_array = np.array(numbers)
@@ -28,7 +29,8 @@ class BatchAdder:
         output_array = input_array + 1
         return output_array.astype(int).tolist()
 
-    async def __call__(self, request: starlette.Request):
+    async def __call__(self,
+                       request: Union[starlette.Request, serve.ServeRequest]):
         return await self.handle_batch(request)
 
 
@@ -66,7 +68,7 @@ print(handle)
 # Output
 # RayServeHandle(
 #    Endpoint="adder",
-#    Traffic={'adder:v1': 1}
+#    Traffic={'adder:v0': 1}
 # )
 
 input_batch = list(range(9))

--- a/python/ray/serve/examples/doc/tutorial_batch.py
+++ b/python/ray/serve/examples/doc/tutorial_batch.py
@@ -5,10 +5,11 @@ import time
 
 import numpy as np
 import requests
-import starlette
+from starlette.requests import Request
 
 import ray
 from ray import serve
+from serve import ServeRequest
 # __doc_import_end__
 # yapf: enable
 
@@ -16,9 +17,7 @@ from ray import serve
 # __doc_define_servable_begin__
 class BatchAdder:
     @serve.batch(max_batch_size=4)
-    async def handle_batch(
-            self,
-            requests: List[Union[starlette.Request, serve.ServeRequest]]):
+    async def handle_batch(self, requests: List[Union[Request, ServeRequest]]):
         numbers = [int(request.query_params["number"]) for request in requests]
 
         input_array = np.array(numbers)
@@ -29,8 +28,7 @@ class BatchAdder:
         output_array = input_array + 1
         return output_array.astype(int).tolist()
 
-    async def __call__(self,
-                       request: Union[starlette.Request, serve.ServeRequest]):
+    async def __call__(self, request: Union[Request, ServeRequest]):
         return await self.handle_batch(request)
 
 

--- a/python/ray/serve/examples/doc/tutorial_batch.py
+++ b/python/ray/serve/examples/doc/tutorial_batch.py
@@ -9,7 +9,7 @@ from starlette.requests import Request
 
 import ray
 from ray import serve
-from serve import ServeRequest
+from ray.serve import ServeRequest
 # __doc_import_end__
 # yapf: enable
 

--- a/python/ray/serve/examples/doc/tutorial_batch.py
+++ b/python/ray/serve/examples/doc/tutorial_batch.py
@@ -3,37 +3,41 @@
 import ray
 from ray import serve
 
-from typing import List
+from typing import List, Union
 import time
 
 import numpy as np
 import requests
+import starlette
 # __doc_import_end__
 # yapf: enable
 
 
-# __doc_define_servable_v0_begin__
-@serve.accept_batch
-def batch_adder_v0(starlette_requests: List):
-    numbers = [
-        int(request.query_params["number"]) for request in starlette_requests
-    ]
+# __doc_define_servable_begin__
+class BatchAdder:
+    @serve.batch(max_batch_size=4)
+    async def handle_batch(
+            self, requests: List[Union[starlette.Request, serve.Request]]):
+        numbers = [int(request.query_params["number"]) for request in requests]
 
-    input_array = np.array(numbers)
-    print("Our input array has shape:", input_array.shape)
-    # Sleep for 200ms, this could be performing CPU intensive computation
-    # in real models
-    time.sleep(0.2)
-    output_array = input_array + 1
-    return output_array.astype(int).tolist()
+        input_array = np.array(numbers)
+        print("Our input array has shape:", input_array.shape)
+        # Sleep for 200ms, this could be performing CPU intensive computation
+        # in real models
+        time.sleep(0.2)
+        output_array = input_array + 1
+        return output_array.astype(int).tolist()
+
+    async def __call__(self, request: starlette.Request):
+        return await self.handle_batch(request)
 
 
-# __doc_define_servable_v0_end__
+# __doc_define_servable_end__
 
-ray.init(num_cpus=8)
 # __doc_deploy_begin__
+ray.init(num_cpus=8)
 client = serve.start()
-client.create_backend("adder:v0", batch_adder_v0, config={"max_batch_size": 4})
+client.create_backend("adder:v0", BatchAdder)
 client.create_endpoint(
     "adder", backend="adder:v0", route="/adder", methods=["GET"])
 # __doc_deploy_end__
@@ -55,27 +59,6 @@ print("Result returned:", results)
 # (pid=...) Our input array has shape: (4,)
 # Result returned: [1, 2, 3, 4, 5, 6, 7, 8, 9]
 # __doc_query_end__
-
-
-# __doc_define_servable_v1_begin__
-@serve.accept_batch
-def batch_adder_v1(requests: List):
-    numbers = [int(request.query_params["number"]) for request in requests]
-    input_array = np.array(numbers)
-    print("Our input array has shape:", input_array.shape)
-    # Sleep for 200ms, this could be performing CPU intensive computation
-    # in real models
-    time.sleep(0.2)
-    output_array = input_array + 1
-    return output_array.astype(int).tolist()
-
-
-# __doc_define_servable_v1_end__
-
-# __doc_deploy_v1_begin__
-client.create_backend("adder:v1", batch_adder_v1, config={"max_batch_size": 4})
-client.set_traffic("adder", {"adder:v1": 1})
-# __doc_deploy_v1_end__
 
 # __doc_query_handle_begin__
 handle = client.get_handle("adder")

--- a/python/ray/serve/examples/echo_actor_batch.py
+++ b/python/ray/serve/examples/echo_actor_batch.py
@@ -30,28 +30,23 @@ class MagicCounter:
     def __init__(self, increment):
         self.increment = increment
 
-    @serve.accept_batch
-    def __call__(self, starlette_request_list, base_number=None):
+    @serve.batch(max_batch_size=5)
+    async def handle_batch(self, base_number):
+        result = []
+        for b in base_number:
+            ans = b + self.increment
+            result.append(ans)
+        return result
+
+    async def __call__(self, request, base_number=None):
         # batch_size = serve.context.batch_size
         if serve.context.web:
-            result = []
-            for starlette_request in starlette_request_list:
-                base_number = int(
-                    starlette_request.query_params.get("base_number", "0"))
-                result.append(base_number)
-            return list(map(lambda x: x + self.increment, result))
-        else:
-            result = []
-            for b in base_number:
-                ans = b + self.increment
-                result.append(ans)
-            return result
+            base_number = int(request.query_params.get("base_number", "0"))
+        return await self.handle_batch(base_number)
 
 
 client = serve.start()
-client.create_backend(
-    "counter:v1", MagicCounter, 42,
-    config={"max_batch_size": 5})  # increment=42
+client.create_backend("counter:v1", MagicCounter, 42)  # increment=42
 client.create_endpoint("magic_counter", backend="counter:v1", route="/counter")
 
 print("Sending ten queries via HTTP")

--- a/python/ray/serve/examples/echo_batching.py
+++ b/python/ray/serve/examples/echo_batching.py
@@ -10,29 +10,22 @@ class MagicCounter:
     def __init__(self, increment):
         self.increment = increment
 
-    @serve.accept_batch
-    def __call__(self, starlette_request, base_number=None):
-        # __call__ fn should preserve the batch size
-        # base_number is a python list
+    @serve.batch(max_batch_size=5)
+    async def handle_batch(self, base_numbers):
+        # Must preserve the batch size.
+        result = []
+        for base_num in base_numbers:
+            ret_str = "Number: {} Batch size: {}".format(
+                base_num, len(base_numbers))
+            result.append(ret_str)
+        return result
 
-        if serve.context.batch_size is not None:
-            batch_size = serve.context.batch_size
-            result = []
-            for base_num in base_number:
-                ret_str = "Number: {} Batch size: {}".format(
-                    base_num, batch_size)
-                result.append(ret_str)
-            return result
-        return ""
+    async def __call__(self, starlette_request, base_number=None):
+        return await self.handle_batch(base_number)
 
 
 client = serve.start()
-# specify max_batch_size in BackendConfig
-backend_config = {"max_batch_size": 5}
-client.create_backend(
-    "counter:v1", MagicCounter, 42, config=backend_config)  # increment=42
-print("Backend Config for backend: 'counter:v1'")
-print(backend_config)
+client.create_backend("counter:v1", MagicCounter, 42)  # increment=42
 client.create_endpoint("magic_counter", backend="counter:v1", route="/counter")
 
 handle = client.get_handle("magic_counter")

--- a/python/ray/serve/http_proxy.py
+++ b/python/ray/serve/http_proxy.py
@@ -11,12 +11,10 @@ from ray.exceptions import RayTaskError
 from ray.serve.common import EndpointTag
 from ray.serve.constants import LongPollKey
 from ray.util import metrics
-from ray.serve.utils import _get_logger
+from ray.serve.utils import logger
 from ray.serve.http_util import Response, build_starlette_request
 from ray.serve.long_poll import LongPollAsyncClient
 from ray.serve.handle import DEFAULT
-
-logger = _get_logger()
 
 
 class ServeStarletteEndpoint:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Deprecates the existing system-level batching codepath and instead recommends `@serve.batch`. The old codepath will still work after this PR, but print a warning pointing at the docs for the new workflow.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
