### PR TITLE
Example and Test for custom RLlibTrainer wrapper experiments

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1840,6 +1840,15 @@ py_test(
 )
 
 py_test(
+    name = "examples/custom_experiment",
+    main = "examples/custom_experiment.py",
+    tags = ["examples", "examples_C"],
+    size = "medium",
+    srcs = ["examples/custom_experiment.py"],
+    args = ["--train-iterations=10"]
+)
+
+py_test(
     name = "examples/custom_fast_model_tf",
     main = "examples/custom_fast_model.py",
     tags = ["examples", "examples_C"],

--- a/rllib/examples/custom_experiment.py
+++ b/rllib/examples/custom_experiment.py
@@ -1,0 +1,56 @@
+"""Example of a custom experiment wrapped around an RLlib trainer."""
+import argparse
+
+import ray
+from ray import tune
+from ray.rllib.agents import ppo
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--train-iterations", type=int, default=10)
+
+
+def trainable(config):
+    iterations = config.pop("train-iterations")
+    train_agent = ppo.PPOTrainer(config=config, env="CartPole-v0")
+    checkpoint = None
+    train_results = {}
+
+    # Train
+    for i in range(iterations):
+        train_results = train_agent.train()
+        if i % 2 == 0 or i == iterations - 1:
+            checkpoint = train_agent.save(tune.get_trial_dir())
+        tune.report(**train_results)
+    train_agent.stop()
+
+    # Manual Eval
+    config["num_workers"] = 0
+    eval_agent = ppo.PPOTrainer(config=config, env="CartPole-v0")
+    eval_agent.restore(checkpoint)
+    env = eval_agent.workers.local_worker().env
+
+    obs = env.reset()
+    done = False
+    eval_results = {"eval_reward": 0, "eval_eps_length": 0}
+    while not done:
+        action = eval_agent.compute_action(obs)
+        next_obs, reward, done, info = env.step(action)
+        eval_results["eval_reward"] += reward
+        eval_results["eval_eps_length"] += 1
+    results = {**train_results, **eval_results}
+    tune.report(results)
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    ray.init(num_cpus=3)
+    config = ppo.DEFAULT_CONFIG.copy()
+    config["train-iterations"] = args.train_iterations
+
+    config["env"] = "CartPole-v0"
+
+    tune.run(
+        trainable,
+        config=config,
+        resources_per_trial=ppo.PPOTrainer.default_resource_request(config))

--- a/rllib/examples/custom_experiment.py
+++ b/rllib/examples/custom_experiment.py
@@ -9,7 +9,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--train-iterations", type=int, default=10)
 
 
-def trainable(config):
+def experiment(config):
     iterations = config.pop("train-iterations")
     train_agent = ppo.PPOTrainer(config=config, env="CartPole-v0")
     checkpoint = None
@@ -51,6 +51,6 @@ if __name__ == "__main__":
     config["env"] = "CartPole-v0"
 
     tune.run(
-        trainable,
+        experiment,
         config=config,
         resources_per_trial=ppo.PPOTrainer.default_resource_request(config))


### PR DESCRIPTION
## Why are these changes needed?

There seems to be little testing around writing experiments that wrap RLlib trainers. I'm hoping with this included example we can assert that nightlies won't break this workflow.

## Related issue number

Improves checking for issues like #14621 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [x] This PR is not tested :(
