### PR TITLE
Bump Ray client protocol version; fix dataclasses dependency for py 3.6

### DIFF
--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 # This version string is incremented to indicate breaking changes in the
 # protocol that require upgrading the client version.
-CURRENT_PROTOCOL_VERSION = "2020-02-22"
+CURRENT_PROTOCOL_VERSION = "2020-03-12"
 
 
 class RayAPIStub:

--- a/python/setup.py
+++ b/python/setup.py
@@ -95,14 +95,8 @@ ray_files += [
 # also update the matching section of requirements/requirements.txt
 # in this directory
 extras = {
-    "serve": [
-        "uvicorn", "flask", "requests", "pydantic<1.7",
-        "starlette"
-    ],
-    "tune": [
-        "pandas", "tabulate",
-        "tensorboardX"
-    ],
+    "serve": ["uvicorn", "flask", "requests", "pydantic<1.7", "starlette"],
+    "tune": ["pandas", "tabulate", "tensorboardX"],
     "k8s": ["kubernetes"]
 }
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -97,10 +97,10 @@ ray_files += [
 extras = {
     "serve": [
         "uvicorn", "flask", "requests", "pydantic<1.7",
-        "dataclasses; python_version < '3.7'", "starlette"
+        "starlette"
     ],
     "tune": [
-        "dataclasses; python_version < '3.7'", "pandas", "tabulate",
+        "pandas", "tabulate",
         "tensorboardX"
     ],
     "k8s": ["kubernetes"]
@@ -131,6 +131,7 @@ install_requires = [
     "click >= 7.0",
     "colorama",
     "colorful",
+    "dataclasses; python_version < '3.7'",
     "filelock",
     "gpustat",
     "grpcio >= 1.28.1",


### PR DESCRIPTION
The addition of the .options(runtime_env) field breaks Ray client protocol compatibility. In addition, the dataclasses module was incorrectly moved to extras; it's needed for Ray client.