### PR TITLE
[Core] Object spilling - Changed (remote) object restoration request to a long-poll, with exponentially backed off retries on failures.

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -357,6 +357,10 @@ RAY_CONFIG(int64_t, oom_grace_period_s, 10)
 /// This is configured based on object_spilling_config.
 RAY_CONFIG(bool, is_external_storage_type_fs, true)
 
+/// The maximum number of in-flight restoration requests received by a node before a
+/// warning is logged.
+RAY_CONFIG(int64_t, max_in_flight_remote_restoration_requests, 10000)
+
 /* Configuration parameters for locality-aware scheduling. */
 /// Whether to enable locality-aware leasing. If enabled, then Ray will consider task
 /// dependency locality when choosing a worker for leasing.

--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -95,6 +95,7 @@ enum class StatusCode : char {
   CreationTaskError = 16,
   NotFound = 17,
   Disconnected = 18,
+  PendingRequiredData = 19,
   // object store status
   ObjectExists = 21,
   ObjectNotFound = 22,
@@ -185,6 +186,10 @@ class RAY_EXPORT Status {
     return Status(StatusCode::Disconnected, msg);
   }
 
+  static Status PendingRequiredData(const std::string &msg) {
+    return Status(StatusCode::PendingRequiredData, msg);
+  }
+
   static Status ObjectExists(const std::string &msg) {
     return Status(StatusCode::ObjectExists, msg);
   }
@@ -232,6 +237,7 @@ class RAY_EXPORT Status {
   }
   bool IsNotFound() const { return code() == StatusCode::NotFound; }
   bool IsDisconnected() const { return code() == StatusCode::Disconnected; }
+  bool IsPendingRequiredData() const { return code() == StatusCode::PendingRequiredData; }
   bool IsObjectExists() const { return code() == StatusCode::ObjectExists; }
   bool IsObjectNotFound() const { return code() == StatusCode::ObjectNotFound; }
   bool IsObjectAlreadySealed() const { return code() == StatusCode::ObjectAlreadySealed; }

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -128,6 +128,8 @@ class PullManager {
     double next_pull_time;
     uint8_t num_retries;
     bool object_size_set = false;
+    // Whether the object is currently being restored.
+    bool is_being_restored = false;
     size_t object_size = 0;
     // All bundle requests that haven't been canceled yet that require this
     // object. This includes bundle requests whose objects are not actively

--- a/src/ray/object_manager/test/pull_manager_test.cc
+++ b/src/ray/object_manager/test/pull_manager_test.cc
@@ -152,8 +152,16 @@ TEST_F(PullManagerTest, TestRestoreSpilledObject) {
   ASSERT_EQ(num_send_pull_request_calls_, 0);
   ASSERT_EQ(num_restore_spilled_object_calls_, 1);
 
+  // If object restoration is ongoing, we should wait to pull until it's done, and we
+  // shouldn't issue duplicate restoration requests.
+  pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar",
+                                 node_that_object_spilled, 0);
+  ASSERT_EQ(num_send_pull_request_calls_, 0);
+  ASSERT_EQ(num_restore_spilled_object_calls_, 1);
+
   // The restore object call will ask the remote node to restore the object, and the
   // client location is updated accordingly.
+  restore_object_callback_(ray::Status::OK());
   client_ids.insert(node_that_object_spilled);
   fake_time_ += 10.;
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar",

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -241,8 +241,11 @@ void LocalObjectManager::SpillObjectsInternal(
                           std::ostream_iterator<ObjectID>(object_id_stream, ", "));
                 object_id_stream << objects_to_spill.back();
                 RAY_LOG(ERROR) << "Failed to send object spilling request for objects "
-                               << object_id_stream.str() << " to IO worker "
-                               << io_worker->WorkerId() << ": " << status.ToString();
+                               << object_id_stream.str()
+                               << ", please check the logs for IO worker "
+                               << io_worker->WorkerId()
+                               << " and make note of the following failure status: "
+                               << status.ToString();
                 callback(status);
               } else {
                 AddSpilledUrls(objects_to_spill, r, callback);
@@ -392,8 +395,10 @@ void LocalObjectManager::AsyncRestoreSpilledObject(
           io_worker_pool_.PushRestoreWorker(io_worker);
           if (!status.ok()) {
             RAY_LOG(ERROR) << "Failed to send restore spilled object request for object "
-                           << object_id << " to IO worker " << io_worker->WorkerId()
-                           << ", restoring from URL " << object_url << ": "
+                           << object_id << ", restoring from URL " << object_url
+                           << ", please check the logs for the IO worker "
+                           << io_worker->WorkerId()
+                           << " and make note of the following failure status: "
                            << status.ToString();
           } else {
             auto now = absl::GetCurrentTimeNanos();

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -187,11 +187,9 @@ void LocalObjectManager::SpillObjectsInternal(
     // We should not spill an object that we are not the primary copy for, or
     // objects that are already being spilled.
     if (pinned_objects_.count(id) == 0 && objects_pending_spill_.count(id) == 0) {
-      if (callback) {
-        callback(
-            Status::Invalid("Requested spill for object that is not marked as "
-                            "the primary copy."));
-      }
+      callback(
+          Status::Invalid("Requested spill for object that is not marked as "
+                          "the primary copy."));
       return;
     }
 
@@ -208,9 +206,7 @@ void LocalObjectManager::SpillObjectsInternal(
   }
 
   if (objects_to_spill.empty()) {
-    if (callback) {
-      callback(Status::Invalid("All objects are already being spilled."));
-    }
+    callback(Status::Invalid("All objects are already being spilled."));
     return;
   }
   io_worker_pool_.PopSpillWorker(
@@ -247,9 +243,7 @@ void LocalObjectManager::SpillObjectsInternal(
                 RAY_LOG(ERROR) << "Failed to send object spilling request for objects "
                                << object_id_stream.str() << " to IO worker "
                                << io_worker->WorkerId() << ": " << status.ToString();
-                if (callback) {
-                  callback(status);
-                }
+                callback(status);
               } else {
                 AddSpilledUrls(objects_to_spill, r, callback);
               }
@@ -291,7 +285,7 @@ void LocalObjectManager::UnpinSpilledObjectCallback(
   }
 
   (*num_remaining)--;
-  if (*num_remaining == 0 && callback) {
+  if (*num_remaining == 0) {
     callback(status);
   }
 }
@@ -373,9 +367,7 @@ void LocalObjectManager::AsyncRestoreSpilledObject(
                  << object_url;
   if (is_external_storage_type_fs_ && spilled_objects_url_.count(object_id) == 0) {
     RAY_CHECK(!node_id.IsNil());
-    if (callback) {
-      callback(Status::PendingRequiredData("Object hasn't been spilled yet."));
-    }
+    callback(Status::PendingRequiredData("Object hasn't been spilled yet."));
     return;
   }
 
@@ -424,9 +416,7 @@ void LocalObjectManager::AsyncRestoreSpilledObject(
             }
             last_restore_finish_ns_ = now;
           }
-          if (callback) {
-            callback(status);
-          }
+          callback(status);
         });
   });
 }

--- a/src/ray/raylet/local_object_manager.h
+++ b/src/ray/raylet/local_object_manager.h
@@ -46,7 +46,8 @@ class LocalObjectManager {
       int64_t min_spilling_size, bool is_external_storage_type_fs,
       std::function<void(const std::vector<ObjectID> &)> on_objects_freed,
       std::function<bool(const ray::ObjectID &)> is_plasma_object_spillable,
-      std::function<void(const ObjectID &, const std::string &, const NodeID &)>
+      std::function<void(const ObjectID &, const std::string &, const NodeID &,
+                         std::function<void(const ray::Status &)>)>
           restore_object_from_remote_node)
       : self_node_id_(node_id),
         free_objects_period_ms_(free_objects_period_ms),
@@ -279,7 +280,8 @@ class LocalObjectManager {
   std::function<bool(const ray::ObjectID &)> is_plasma_object_spillable_;
 
   /// Callback to restore object of object id from a remote node of node id.
-  std::function<void(const ObjectID &, const std::string &, const NodeID &)>
+  std::function<void(const ObjectID &, const std::string &, const NodeID &,
+                     std::function<void(const ray::Status &)>)>
       restore_object_from_remote_node_;
 
   /// Used to decide spilling protocol.

--- a/src/ray/raylet/local_object_manager.h
+++ b/src/ray/raylet/local_object_manager.h
@@ -226,9 +226,10 @@ class LocalObjectManager {
       objects_pending_spill_;
 
   /// Objects that were spilled on this node but that are being restored.
-  /// The field is used to dedup the same restore request while restoration is in
-  /// progress.
-  absl::flat_hash_set<ObjectID> objects_pending_restore_;
+  /// Each callback corresponds to a node wishing to pull the object once it is
+  /// restored.
+  absl::flat_hash_map<ObjectID, std::vector<std::function<void(const ray::Status &)>>>
+      objects_pending_restore_;
 
   /// The time that we last sent a FreeObjects request to other nodes for
   /// objects that have gone out of scope in the application.

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -194,6 +194,8 @@ int main(int argc, char *argv[]) {
         node_manager_config.session_dir = session_dir;
         node_manager_config.max_io_workers = RayConfig::instance().max_io_workers();
         node_manager_config.min_spilling_size = RayConfig::instance().min_spilling_size();
+        node_manager_config.max_in_flight_remote_restoration_requests =
+            RayConfig::instance().max_in_flight_remote_restoration_requests();
 
         // Configuration for the object manager.
         ray::ObjectManagerConfig object_manager_config;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2225,10 +2225,8 @@ void NodeManager::SendSpilledObjectRestorationRequestToRemoteNode(
   if (!remote_node_manager_addresses_.contains(node_id)) {
     // It is possible the new node information is not received at this point. The caller
     // should retry at a later time.
-    if (callback) {
-      callback(ray::Status::PendingRequiredData(
-          "Waiting to get node manager address of remote node."));
-    }
+    callback(ray::Status::PendingRequiredData(
+        "Waiting to get node manager address of remote node."));
     return;
   }
   const auto &entry = remote_node_manager_addresses_.find(node_id);
@@ -2240,9 +2238,7 @@ void NodeManager::SendSpilledObjectRestorationRequestToRemoteNode(
       object_id, spilled_url, node_id,
       [callback = std::move(callback)](const ray::Status &status,
                                        const rpc::RestoreSpilledObjectReply &r) {
-        if (callback) {
-          callback(status);
-        }
+        callback(status);
       });
 }
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2238,14 +2238,8 @@ void NodeManager::SendSpilledObjectRestorationRequestToRemoteNode(
           entry->second.first, entry->second.second, client_call_manager_));
   raylet_client->RestoreSpilledObject(
       object_id, spilled_url, node_id,
-      [object_id, node_id, callback = std::move(callback)](
-          const ray::Status &status, const rpc::RestoreSpilledObjectReply &r) {
-        if (!status.ok()) {
-          RAY_LOG(WARNING) << "Failed to send a spilled object restoration request for "
-                           << object_id << " to a remote node " << node_id
-                           << ". This request will be retried. Error message: "
-                           << status.ToString();
-        }
+      [callback = std::move(callback)](const ray::Status &status,
+                                       const rpc::RestoreSpilledObjectReply &r) {
         if (callback) {
           callback(status);
         }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -198,28 +198,29 @@ NodeManager::NodeManager(instrumented_io_context &io_service, const NodeID &self
       agent_manager_service_(io_service, *agent_manager_service_handler_),
       client_call_manager_(io_service),
       worker_rpc_pool_(client_call_manager_),
-      local_object_manager_(
-          self_node_id_, RayConfig::instance().free_objects_batch_size(),
-          RayConfig::instance().free_objects_period_milliseconds(), worker_pool_,
-          gcs_client_->Objects(), worker_rpc_pool_,
-          /* automatic_object_deletion_enabled */
-          config.automatic_object_deletion_enabled,
-          /*max_io_workers*/ config.max_io_workers,
-          /*min_spilling_size*/ config.min_spilling_size,
-          /*is_external_storage_type_fs*/
-          RayConfig::instance().is_external_storage_type_fs(),
-          /*on_objects_freed*/
-          [this](const std::vector<ObjectID> &object_ids) {
-            object_manager_.FreeObjects(object_ids,
-                                        /*local_only=*/false);
-          },
-          is_plasma_object_spillable,
-          /*restore_object_from_remote_node*/
-          [this](const ObjectID &object_id, const std::string &spilled_url,
-                 const NodeID &node_id) {
-            SendSpilledObjectRestorationRequestToRemoteNode(object_id, spilled_url,
-                                                            node_id);
-          }),
+      local_object_manager_(self_node_id_,
+                            RayConfig::instance().free_objects_batch_size(),
+                            RayConfig::instance().free_objects_period_milliseconds(),
+                            worker_pool_, gcs_client_->Objects(), worker_rpc_pool_,
+                            /* automatic_object_deletion_enabled */
+                            config.automatic_object_deletion_enabled,
+                            /*max_io_workers*/ config.max_io_workers,
+                            /*min_spilling_size*/ config.min_spilling_size,
+                            /*is_external_storage_type_fs*/
+                            RayConfig::instance().is_external_storage_type_fs(),
+                            /*on_objects_freed*/
+                            [this](const std::vector<ObjectID> &object_ids) {
+                              object_manager_.FreeObjects(object_ids,
+                                                          /*local_only=*/false);
+                            },
+                            is_plasma_object_spillable,
+                            /*restore_object_from_remote_node*/
+                            [this](const ObjectID &object_id,
+                                   const std::string &spilled_url, const NodeID &node_id,
+                                   std::function<void(const ray::Status &)> callback) {
+                              SendSpilledObjectRestorationRequestToRemoteNode(
+                                  object_id, spilled_url, node_id, callback);
+                            }),
       last_local_gc_ns_(absl::GetCurrentTimeNanos()),
       local_gc_interval_ns_(RayConfig::instance().local_gc_interval_s() * 1e9),
       local_gc_min_interval_ns_(RayConfig::instance().local_gc_min_interval_s() * 1e9),
@@ -549,12 +550,11 @@ void NodeManager::HandleRestoreSpilledObject(
   RAY_LOG(DEBUG) << "Restore spilled object request received. Object id: " << object_id
                  << " spilled_node_id: " << self_node_id_
                  << " object url: " << object_url;
-  local_object_manager_.AsyncRestoreSpilledObject(object_id, object_url, spilled_node_id,
-                                                  nullptr);
-  // Just reply right away. The caller will keep hitting this RPC endpoint until
-  // restoration succeeds, so we can safely reply here without waiting for the
-  // restoreSpilledObject to be done.
-  send_reply_callback(Status::OK(), nullptr, nullptr);
+  local_object_manager_.AsyncRestoreSpilledObject(
+      object_id, object_url, spilled_node_id,
+      [send_reply_callback](const ray::Status &status) {
+        send_reply_callback(status, nullptr, nullptr);
+      });
 }
 
 void NodeManager::HandleReleaseUnusedBundles(
@@ -2219,11 +2219,16 @@ void NodeManager::PublishInfeasibleTaskError(const Task &task) const {
 }
 
 void NodeManager::SendSpilledObjectRestorationRequestToRemoteNode(
-    const ObjectID &object_id, const std::string &spilled_url, const NodeID &node_id) {
+    const ObjectID &object_id, const std::string &spilled_url, const NodeID &node_id,
+    std::function<void(const ray::Status &)> callback) {
   // Fetch from a remote node.
   if (!remote_node_manager_addresses_.contains(node_id)) {
-    // It is possible the new node information is not received at this point.
-    // In this case, the PullManager will handle retry, so we just return.
+    // It is possible the new node information is not received at this point. The caller
+    // should retry at a later time.
+    if (callback) {
+      callback(ray::Status::PendingRequiredData(
+          "Waiting to get node manager address of remote node."));
+    }
     return;
   }
   const auto &entry = remote_node_manager_addresses_.find(node_id);
@@ -2233,11 +2238,16 @@ void NodeManager::SendSpilledObjectRestorationRequestToRemoteNode(
           entry->second.first, entry->second.second, client_call_manager_));
   raylet_client->RestoreSpilledObject(
       object_id, spilled_url, node_id,
-      [](const ray::Status &status, const rpc::RestoreSpilledObjectReply &r) {
+      [object_id, node_id, callback = std::move(callback)](
+          const ray::Status &status, const rpc::RestoreSpilledObjectReply &r) {
         if (!status.ok()) {
-          RAY_LOG(WARNING) << "Failed to send a spilled object restoration request to a "
-                              "remote node. This request will be retried. Error message: "
+          RAY_LOG(WARNING) << "Failed to send a spilled object restoration request for "
+                           << object_id << " to a remote node " << node_id
+                           << ". This request will be retried. Error message: "
                            << status.ToString();
+        }
+        if (callback) {
+          callback(status);
         }
       });
 }

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -583,9 +583,9 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   void PublishInfeasibleTaskError(const Task &task) const;
 
   /// Send a object restoration request to a remote node of a given node id.
-  void SendSpilledObjectRestorationRequestToRemoteNode(const ObjectID &object_id,
-                                                       const std::string &spilled_url,
-                                                       const NodeID &node_id);
+  void SendSpilledObjectRestorationRequestToRemoteNode(
+      const ObjectID &object_id, const std::string &spilled_url, const NodeID &node_id,
+      std::function<void(const ray::Status &)> callback);
 
   /// Get pointers to objects stored in plasma. They will be
   /// released once the returned references go out of scope.

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -94,12 +94,15 @@ struct NodeManagerConfig {
   std::string session_dir;
   /// The raylet config list of this node.
   std::string raylet_config;
-  // The time between record metrics in milliseconds, or 0 to disable.
+  /// The time between record metrics in milliseconds, or 0 to disable.
   uint64_t record_metrics_period_ms;
-  // The number if max io workers.
+  /// The number if max io workers.
   int max_io_workers;
-  // The minimum object size that can be spilled by each spill operation.
+  /// The minimum object size that can be spilled by each spill operation.
   int64_t min_spilling_size;
+  /// The maximum number of in-flight restoration requests received by a node before a
+  /// warning is logged.
+  int64_t max_in_flight_remote_restoration_requests;
 };
 
 class HeartbeatSender {
@@ -681,6 +684,10 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// Map from node ids to addresses of the remote node managers.
   absl::flat_hash_map<NodeID, std::pair<std::string, int32_t>>
       remote_node_manager_addresses_;
+
+  /// Number of currently in-flight spilled object remote restoration requests; used
+  /// to log a warning when this gets too high.
+  int64_t num_in_flight_remote_restoration_requests_ = 0;
 
   /// Map of workers leased out to direct call clients.
   std::unordered_map<WorkerID, std::shared_ptr<WorkerInterface>> leased_workers_;


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The pull manager restoration requests currently retry without waiting for prior restoration requests to succeed or fail, resulting in a raylet getting spammed with restoration requests if those requests are failing or taking a long time to service.

This PR moves these restoration RPCs to a long-poll, where the RPC only returns when the restoration has either succeeded, in which case we try to pull the object, or failed, in which case we update the retry timer for this pull so the pull manager eventually retries the RPC (with exponential back off).

This PR also includes some drivebys that improve error messages.

## TODOs

- [x] Update local object manager tests.
- [ ] Test this manually on spamming failure case, once the wheel is built.

## Related issue number

Closes #14646 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
