### PR TITLE
Fix the docstring for ray.cancel

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1638,8 +1638,8 @@ def cancel(object_ref, *, force=False, recursive=True):
     If the specified task is pending execution, it will not be executed. If
     the task is currently executing, the behavior depends on the ``force``
     flag. When ``force=False``, a KeyboardInterrupt will be raised in Python
-    and when ``force=True``, the executing the task will immediately exit. If
-    the task is already finished, nothing will happen.
+    and when ``force=True``, the executing of the task will immediately exit.
+    If the task is already finished, nothing will happen.
 
     Only non-actor tasks can be canceled. Canceled tasks will not be
     retried (max_retries will not be respected).

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1638,7 +1638,7 @@ def cancel(object_ref, *, force=False, recursive=True):
     If the specified task is pending execution, it will not be executed. If
     the task is currently executing, the behavior depends on the ``force``
     flag. When ``force=False``, a KeyboardInterrupt will be raised in Python
-    and when ``force=True``, the executing of the task will immediately exit.
+    and when ``force=True``, the executing task will immediately exit.
     If the task is already finished, nothing will happen.
 
     Only non-actor tasks can be canceled. Canceled tasks will not be


### PR DESCRIPTION


## Why are these changes needed?

Fix docstring for ray.cancel in Python API

## Related issue number


## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
