### PR TITLE
[Serve] Disable auto conda env setting if using Ray Client

### DIFF
--- a/doc/source/serve/core-apis.rst
+++ b/doc/source/serve/core-apis.rst
@@ -262,7 +262,9 @@ Python versions must be the same in both environments.
   If a conda environment is not specified, your backend will be started in the
   same conda environment as the client (the process calling
   :mod:`client.create_backend <ray.serve.api.Client.create_backend>`) by
-  default.  This convenience feature is disabled when using :ref:`ray-client`.
+  default.  (When using :ref:`ray-client`, your backend will be started in the
+  conda environment that the Serve controller is running in, which by default is the
+  conda environment the remote Ray cluster was started in.)
 
 The dependencies required in the backend may be different than
 the dependencies installed in the driver program (the one running Serve API

--- a/doc/source/serve/core-apis.rst
+++ b/doc/source/serve/core-apis.rst
@@ -242,7 +242,7 @@ python dependencies.  For example, you can simultaneously serve one backend
 that uses legacy Tensorflow 1 and another backend that uses Tensorflow 2.
 
 Currently this is supported using `conda <https://docs.conda.io/en/latest/>`_
-via Ray's built-in `runtime_env` option for actors.
+via Ray's built-in ``runtime_env`` option for actors.
 As with all other actor options, pass these in via ``ray_actor_options`` in
 your call to
 :mod:`client.create_backend <ray.serve.api.Client.create_backend>`.
@@ -262,7 +262,7 @@ Python versions must be the same in both environments.
   If a conda environment is not specified, your backend will be started in the
   same conda environment as the client (the process calling
   :mod:`client.create_backend <ray.serve.api.Client.create_backend>`) by
-  default.
+  default.  This convenience feature is disabled when using :ref:`ray-client`.
 
 The dependencies required in the backend may be different than
 the dependencies installed in the driver program (the one running Serve API

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -379,12 +379,14 @@ class Client:
         # in ray_actor_options, default to conda env of this process (client).
         # Without this code, the backend would run in the controller's conda
         # env, which is likely different from that of the client.
-        if ray_actor_options.get("runtime_env") is None:
-            ray_actor_options["runtime_env"] = {}
-        if ray_actor_options["runtime_env"].get("conda_env") is None:
-            current_env = os.environ.get("CONDA_DEFAULT_ENV")
-            if current_env is not None and current_env != "":
-                ray_actor_options["runtime_env"]["conda_env"] = current_env
+        # If using Ray client, skip this convenience feature.
+        if not ray.util.client.ray.is_connected():
+            if ray_actor_options.get("runtime_env") is None:
+                ray_actor_options["runtime_env"] = {}
+            if ray_actor_options["runtime_env"].get("conda_env") is None:
+                current_env = os.environ.get("CONDA_DEFAULT_ENV")
+                if current_env is not None and current_env != "":
+                    ray_actor_options["runtime_env"]["conda_env"] = current_env
 
         replica_config = ReplicaConfig(
             backend_def, *init_args, ray_actor_options=ray_actor_options)

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -379,7 +379,9 @@ class Client:
         # in ray_actor_options, default to conda env of this process (client).
         # Without this code, the backend would run in the controller's conda
         # env, which is likely different from that of the client.
-        # If using Ray client, skip this convenience feature.
+        # If using Ray client, skip this convenience feature because the local
+        # client env doesn't create the Ray cluster (so the client env is
+        # likely not present on the cluster.)
         if not ray.util.client.ray.is_connected():
             if ray_actor_options.get("runtime_env") is None:
                 ray_actor_options["runtime_env"] = {}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
By default Serve starts backends in the conda env of the Serve client for convenience, as otherwise they would be started in the conda env of the controller, which could lead to unexpected behaviour.  

However when using Ray Client, the Serve client is not running on the Ray cluster.  The conda envs on the local machine don't necessarily have anything to do with the conda envs installed on the cluster, so this convenience feature doesn't make sense and should be disabled.  Users can still manually specify conda envs for their backends.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
