### PR TITLE
[Doc] Update Slurm documentation examples

### DIFF
--- a/doc/source/cluster/examples/simple-trainer.py
+++ b/doc/source/cluster/examples/simple-trainer.py
@@ -1,6 +1,7 @@
 # trainer.py
 from collections import Counter
 import os
+import socket
 import sys
 import time
 import ray
@@ -16,7 +17,7 @@ print(ray.nodes())
 @ray.remote
 def f():
     time.sleep(1)
-    return ray.services.get_node_ip_address()
+    return socket.gethostbyname(socket.gethostname())
 
 
 # The following takes one second (assuming that

--- a/doc/source/cluster/examples/slurm-basic.sh
+++ b/doc/source/cluster/examples/slurm-basic.sh
@@ -62,4 +62,4 @@ done
 
 # __doc_script_start__
 # ray/doc/source/cluster/examples/simple-trainer.py
-python -u simple-trainer.py
+python -u simple-trainer.py "$SLURM_CPUS_PER_TASK"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I was going through the Ray Cluster Slurm [docs](https://docs.ray.io/en/master/cluster/slurm.html) and found some code examples that didn't work on the most recent version of Ray. This PR has some small fixes for those examples.

<!-- Please give a short summary of the change and the problem this solves. -->

In [`ray/doc/source/cluster/examples/simple-trainer.py`](https://github.com/ray-project/ray/blob/master/doc/source/cluster/examples/simple-trainer.py), `ray.services.get_node_ip_address()` no longer exists in Ray, so I've replaced it with `socket.gethostbyname(socket.gethostname())`.

In [`ray/doc/source/cluster/examples/slurm-basic.sh`](https://github.com/ray-project/ray/blob/master/doc/source/cluster/examples/slurm-basic.sh), we have to pass in `$SLURM_CPUS_PER_TASK` as a command line argument so that `simple-trainer.py` can read it in `sys.argv[1]`.

<!-- ## Related issue number -->

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
