### PR TITLE
[Kubernetes] [Dashboard] Remove disk data from dashboard when running on K8s.

### DIFF
--- a/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
@@ -209,9 +209,11 @@ const NodeInfo: React.FC<{}> = () => {
   // Show GPU features only if there is at least one GPU in cluster.
   const showGPUs =
     nodes.map((n) => n.gpus).filter((gpus) => gpus.length !== 0).length !== 0;
+  // Don't show disk on K8s. K8s node disk usage should be monitored elsewhere.
+  const showDisk = !("KUBERNETES_SERVICE_HOST" in process.env);
   const filterPredicate = (
     feature: NodeInfoFeature | HeaderInfo<nodeInfoColumnId>,
-  ) => showGPUs || (feature.id !== "gpu" && feature.id !== "gram");
+  ) => (showGPUs || (feature.id !== "gpu" && feature.id !== "gram")) && (showDisk || (feature.id !== "disk"));
   const filteredFeatures = nodeInfoFeatures.filter(filterPredicate);
   const filteredHeaders = nodeInfoHeaders.filter(filterPredicate);
 

--- a/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
@@ -215,13 +215,13 @@ const NodeInfo: React.FC<{}> = () => {
   // If a Ray node is running in a K8s pod, it marks available disk as 1 byte.
   // (See ReporterAgent._get_disk_usage() in reporter_agent.py)
   // Check if there are any nodes with realistic disk total:
-  const showDisk =
-    nodes.filter((n) => n.disk["/"].total > 10).length !== 0;
+  const showDisk = nodes.filter((n) => n.disk["/"].total > 10).length !== 0;
 
   const filterPredicate = (
     feature: NodeInfoFeature | HeaderInfo<nodeInfoColumnId>,
-  ) => (showGPUs || (feature.id !== "gpu" && feature.id !== "gram")) &&
-       (showDisk || (feature.id !== "disk"));
+  ) =>
+    (showGPUs || (feature.id !== "gpu" && feature.id !== "gram")) &&
+    (showDisk || feature.id !== "disk");
   const filteredFeatures = nodeInfoFeatures.filter(filterPredicate);
   const filteredHeaders = nodeInfoHeaders.filter(filterPredicate);
 

--- a/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
@@ -209,8 +209,14 @@ const NodeInfo: React.FC<{}> = () => {
   // Show GPU features only if there is at least one GPU in cluster.
   const showGPUs =
     nodes.map((n) => n.gpus).filter((gpus) => gpus.length !== 0).length !== 0;
+
   // Don't show disk on K8s. K8s node disk usage should be monitored elsewhere.
-  const showDisk = !("KUBERNETES_SERVICE_HOST" in process.env);
+  // If a Ray node is running in a K8s pod, it marks total capacity as 0.
+  // (See _get_disk_usage() in reporter_agent.py.)
+  // The logic below checks if there are any nodes with total disk marked > 0.
+  const showDisk =
+    nodes.map((n) => node.disk["/"].total).filter((disk_total) => disk_total > 0 ).length !== 0;
+
   const filterPredicate = (
     feature: NodeInfoFeature | HeaderInfo<nodeInfoColumnId>,
   ) => (showGPUs || (feature.id !== "gpu" && feature.id !== "gram")) && (showDisk || (feature.id !== "disk"));

--- a/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
@@ -212,12 +212,11 @@ const NodeInfo: React.FC<{}> = () => {
 
   // Don't show disk on Kubernetes. K8s node disk usage should be monitored
   // elsewhere.
-  // If a Ray node is running in a K8s pod, it marks total and used disk as 0.
-  // Check if there are any nodes with total or used disk marked positive.
+  // If a Ray node is running in a K8s pod, it marks available disk as 1 byte.
+  // (See ReporterAgent._get_disk_usage() in reporter_agent.py)
+  // Check if there are any nodes with realistic disk total:
   const showDisk =
-    nodes.filter((n) => {
-      return n.disk["/"].total > 0 || n.disk["/"].used > 0;
-    }).length !== 0;
+    nodes.filter((n) => n.disk["/"].total > 10).length !== 0;
 
   const filterPredicate = (
     feature: NodeInfoFeature | HeaderInfo<nodeInfoColumnId>,

--- a/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
@@ -210,16 +210,19 @@ const NodeInfo: React.FC<{}> = () => {
   const showGPUs =
     nodes.map((n) => n.gpus).filter((gpus) => gpus.length !== 0).length !== 0;
 
-  // Don't show disk on K8s. K8s node disk usage should be monitored elsewhere.
-  // If a Ray node is running in a K8s pod, it marks total capacity as 0.
-  // (See _get_disk_usage() in reporter_agent.py.)
-  // The logic below checks if there are any nodes with total disk marked > 0.
+  // Don't show disk on Kubernetes. K8s node disk usage should be monitored
+  // elsewhere.
+  // If a Ray node is running in a K8s pod, it marks total and used disk as 0.
+  // Check if there are any nodes with total or used disk marked positive.
   const showDisk =
-    nodes.map((n) => node.disk["/"].total).filter((disk_total) => disk_total > 0 ).length !== 0;
+    nodes.filter((n) => {
+      return n.disk["/"].total > 0 || n.disk["/"].used > 0;
+    }).length !== 0;
 
   const filterPredicate = (
     feature: NodeInfoFeature | HeaderInfo<nodeInfoColumnId>,
-  ) => (showGPUs || (feature.id !== "gpu" && feature.id !== "gram")) && (showDisk || (feature.id !== "disk"));
+  ) => (showGPUs || (feature.id !== "gpu" && feature.id !== "gram")) &&
+       (showDisk || (feature.id !== "disk"));
   const filteredFeatures = nodeInfoFeatures.filter(filterPredicate);
   const filteredHeaders = nodeInfoHeaders.filter(filterPredicate);
 

--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -244,7 +244,7 @@ class ReporterAgent(dashboard_utils.DashboardAgentModule,
             # If in a K8s pod, disable disk display by passing in dummy values.
             return {
                 x: psutil._common.sdiskusage(
-                    total=0, used=0, free=0, percent=0)
+                    total=0, used=0, free=0, percent=0.0)
                 for x in dirs
             }
         else:

--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -244,7 +244,7 @@ class ReporterAgent(dashboard_utils.DashboardAgentModule,
             # If in a K8s pod, disable disk display by passing in dummy values.
             return {
                 x: psutil._common.sdiskusage(
-                    total=0, used=0, free=0, percent=0.0)
+                    total=1, used=0, free=1, percent=0.0)
                 for x in dirs
             }
         else:

--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -240,7 +240,15 @@ class ReporterAgent(dashboard_utils.DashboardAgentModule,
             os.environ["USERPROFILE"] if sys.platform == "win32" else os.sep,
             ray._private.utils.get_user_temp_dir(),
         ]
-        return {x: psutil.disk_usage(x) for x in dirs}
+        if IN_KUBERNETES_POD:
+            # If in a K8s pod, disable disk display by passing in dummy values.
+            return {
+                x: psutil._common.sdiskusage(
+                    total=0, used=0, free=0, percent=0)
+                for x in dirs
+            }
+        else:
+            return {x: psutil.disk_usage(x) for x in dirs}
 
     def _get_workers(self):
         raylet_proc = self._get_raylet_proc()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The dashboard currently shows incorrect/confusing information in the Disk column when using Ray on K8s.
For example, when running two Ray pods on one physical K8s node, the limit shown for each is the disk limit of the K8s node
and the limit of the K8s node gets counted twice in the "totals" section.

This PR removes the Disk field from the Dashboard when running on Kubernetes -- the Ray dashboard is not the right place to get info on K8s node disk usage. By default K8s does not  limit disk usable by a container.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

Tested manually, see discussion below.