### PR TITLE
[Testing] Deflake test_object_spilling

### DIFF
--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -98,7 +98,8 @@ def assert_no_thrashing(address):
     state = ray.state.GlobalState()
     state._initialize_global_state(address,
                                    ray.ray_constants.REDIS_DEFAULT_PASSWORD)
-    memory_summary = ray.internal.internal_api.memory_summary(stats_only=True)
+    memory_summary = ray.internal.internal_api.memory_summary(
+        address=address, stats_only=True)
     restored_bytes = 0
     consumed_bytes = 0
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

* This fixes problems where `assert_no_thrashing` calls `memory_summary`, but fails to pass in the `address`, resulting in :`Found multiple active Ray instances`
* See a stack trace below.

```
/ray/python/ray/tests/test_object_spilling.py:738:
--
  | _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  | /ray/python/ray/tests/test_object_spilling.py:726: in do_test_release_resource
  | assert_no_thrashing(address["redis_address"])
  | /ray/python/ray/tests/test_object_spilling.py:101: in assert_no_thrashing
  | memory_summary = ray.internal.internal_api.memory_summary(stats_only=True)
  | /ray/python/ray/internal/internal_api.py:27: in memory_summary
  | address = services.get_ray_address_to_use_or_die()
  | /ray/python/ray/_private/services.py:236: in get_ray_address_to_use_or_die
  | return find_redis_address_or_die()
  | _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  |  
  | def find_redis_address_or_die():
  |  
  | redis_addresses = find_redis_address()
  | if len(redis_addresses) > 1:
  | raise ConnectionError(
  | >               f"Found multiple active Ray instances: {redis_addresses}. "
  | "Please specify the one to connect to by setting `address`.")
  | E           ConnectionError: Found multiple active Ray instances: {'172.18.0.3:6379', '172.18.0.3:35090'}. Please specify the one to connect to by setting `address`.

```

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
