### PR TITLE
Revert "[Core] Added event loop metrics for posts. (#14546)"

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -50,7 +50,7 @@ RAY_CONFIG(uint64_t, num_resource_report_periods_warning, 5)
 /// The duration between dumping debug info to logs, or 0 to disable.
 RAY_CONFIG(uint64_t, debug_dump_period_milliseconds, 10000)
 
-RAY_CONFIG(bool, asio_event_loop_stats_collection_enabled, true)
+RAY_CONFIG(bool, asio_event_loop_stats_collection_enabled, false)
 
 /// Whether to enable fair queueing between task classes in raylet. When
 /// fair queueing is enabled, the raylet will try to balance the number


### PR DESCRIPTION
This reverts commit 566dcea56aedf0d920f94410faaff58d66c50370 by disabling the feature added in it.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* Java Tests have been flaky since right after this PR was merged:
* In this revert PR, the failure rate seems to have gone down.
<img width="2021" alt="Screen Shot 2021-03-16 at 10 36 54 AM" src="https://user-images.githubusercontent.com/21353794/111354526-a4c16280-8643-11eb-9847-a8f8fab20c5b.png">


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
