### PR TITLE
[client] Fix serialization of RayTaskError

### DIFF
--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -76,6 +76,11 @@ class RayTaskError(RayError):
                  ip=None):
         """Initialize a RayTaskError."""
         import ray
+
+        # BaseException implements a __reduce__ method that returns
+        # a tuple with the type and the value of self.args.
+        # https://stackoverflow.com/a/49715949/2213289
+        self.args = (function_name, traceback_str, cause, proctitle, pid, ip)
         if proctitle:
             self.proctitle = proctitle
         else:
@@ -108,6 +113,10 @@ class RayTaskError(RayError):
         class cls(RayTaskError, cause_cls):
             def __init__(self, cause):
                 self.cause = cause
+                # BaseException implements a __reduce__ method that returns
+                # a tuple with the type and the value of self.args.
+                # https://stackoverflow.com/a/49715949/2213289
+                self.args = (cause, )
 
             def __getattr__(self, name):
                 return getattr(self.cause, name)

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -425,7 +425,7 @@ def test_error_serialization(ray_start_regular_shared):
                 with open("/dev/asdf", "w") as f:
                     f.write("HI")
 
-            # grpc error
+            # Raises a PermissionError
             ray.get(g.remote())
 
 

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -415,6 +415,20 @@ def test_basic_named_actor(ray_start_regular_shared):
         assert ray.get(detatched_actor.get.remote()) == 6
 
 
+def test_error_serialization(ray_start_regular_shared):
+    """Test that errors will be serialized properly."""
+    with pytest.raises(PermissionError):
+        with ray_start_client_server() as ray:
+
+            @ray.remote
+            def g():
+                with open("/dev/asdf", "w") as f:
+                    f.write("HI")
+
+            # grpc error
+            ray.get(g.remote())
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_internal_kv(ray_start_regular_shared):
     with ray_start_client_server() as ray:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?


Before:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-b34c9e83cb1f> in <module>
     17
     18 # grpc error
---> 19 ray.get(g.remote())
     20
     21 # grpc error

~/ray/python/ray/_private/client_mode_hook.py in wrapper(*args, **kwargs)
     44     def wrapper(*args, **kwargs):
     45         if client_mode_should_convert():
---> 46             return getattr(ray, func.__name__)(*args, **kwargs)
     47         return func(*args, **kwargs)
     48

~/ray/python/ray/util/client/api.py in get(self, vals, timeout)
     33             timeout: Optional timeout in milliseconds
     34         """
---> 35         return self.worker.get(vals, timeout=timeout)
     36
     37     def put(self, *args, **kwargs):

~/ray/python/ray/util/client/worker.py in get(self, vals, timeout)
    194                     else:
    195                         op_timeout = MAX_BLOCKING_OPERATION_TIME_S
--> 196                     res = self._get(obj_ref, op_timeout)
    197                     break
    198                 except GetTimeoutError:

~/ray/python/ray/util/client/worker.py in _get(self, ref, timeout)
    213         if not data.valid:
    214             try:
--> 215                 err = cloudpickle.loads(data.error)
    216             except pickle.UnpicklingError:
    217                 logger.exception("Failed to deserialize {}".format(data.error))

TypeError: __init__() missing 1 required positional argument: 'cause'
```

After:
```
RayTaskError(PermissionError)             Traceback (most recent call last)
<ipython-input-1-b34c9e83cb1f> in <module>
     17
     18 # grpc error
---> 19 ray.get(g.remote())
     20
     21 # grpc error

~/ray/python/ray/_private/client_mode_hook.py in wrapper(*args, **kwargs)
     44     def wrapper(*args, **kwargs):
     45         if client_mode_should_convert():
---> 46             return getattr(ray, func.__name__)(*args, **kwargs)
     47         return func(*args, **kwargs)
     48

~/ray/python/ray/util/client/api.py in get(self, vals, timeout)
     33             timeout: Optional timeout in milliseconds
     34         """
---> 35         return self.worker.get(vals, timeout=timeout)
     36
     37     def put(self, *args, **kwargs):

~/ray/python/ray/util/client/worker.py in get(self, vals, timeout)
    194                     else:
    195                         op_timeout = MAX_BLOCKING_OPERATION_TIME_S
--> 196                     res = self._get(obj_ref, op_timeout)
    197                     break
    198                 except GetTimeoutError:

~/ray/python/ray/util/client/worker.py in _get(self, ref, timeout)
    217                 logger.exception("Failed to deserialize {}".format(data.error))
    218                 raise
--> 219             raise err
    220         return loads_from_server(data.data)
    221

RayTaskError(PermissionError): ray::g() (pid=5515, ip=192.168.1.115)
  File "python/ray/_raylet.pyx", line 501, in ray._raylet.execute_task
  File "<ipython-input-1-b34c9e83cb1f>", line 15, in g
PermissionError: [Errno 1] Operation not permitted: '/dev/asdf'
```
## Related issue number

Closes https://github.com/ray-project/ray/issues/13842, Closes https://github.com/ray-project/ray/issues/14172.

cc @yuduber

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(