### PR TITLE
[large scale]Disable async context in raylets' gcs client

### DIFF
--- a/src/ray/gcs/redis_client.cc
+++ b/src/ray/gcs/redis_client.cc
@@ -141,11 +141,9 @@ Status RedisClient::Connect(std::vector<instrumented_io_context *> io_services) 
     }
   } else {
     shard_contexts_.push_back(std::make_shared<RedisContext>(*io_services[0]));
-    RAY_CHECK_OK(shard_contexts_[0]->Connect(
-        options_.server_ip_, options_.server_port_,
-        /*sharding=*/true,
-        /*password=*/options_.password_, options_.enable_sync_conn_,
-        options_.enable_async_conn_, options_.enable_subscribe_conn_));
+    RAY_CHECK_OK(shard_contexts_[0]->Connect(options_.server_ip_, options_.server_port_,
+                                             /*sharding=*/true,
+                                             /*password=*/options_.password_));
   }
 
   Attach();
@@ -168,10 +166,14 @@ void RedisClient::Attach() {
   }
 
   instrumented_io_context &io_service = primary_context_->io_service();
-  asio_async_auxiliary_client_.reset(
-      new RedisAsioClient(io_service, primary_context_->async_context()));
-  asio_subscribe_auxiliary_client_.reset(
-      new RedisAsioClient(io_service, primary_context_->subscribe_context()));
+  if (options_.enable_async_conn_) {
+    asio_async_auxiliary_client_.reset(
+        new RedisAsioClient(io_service, primary_context_->async_context()));
+  }
+  if (options_.enable_subscribe_conn_) {
+    asio_subscribe_auxiliary_client_.reset(
+        new RedisAsioClient(io_service, primary_context_->subscribe_context()));
+  }
 }
 
 void RedisClient::Disconnect() {

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -105,7 +105,11 @@ int main(int argc, char *argv[]) {
   boost::asio::io_service::work main_work(main_service);
 
   // Initialize gcs client
-  ray::gcs::GcsClientOptions client_options(redis_address, redis_port, redis_password);
+  // Asynchrounous context is not used by `redis_client_` in `gcs_client`, so we set
+  // `enable_async_conn` as false.
+  ray::gcs::GcsClientOptions client_options(
+      redis_address, redis_port, redis_password, /*enable_sync_conn=*/true,
+      /*enable_async_conn=*/false, /*enable_subscribe_conn=*/true);
   std::shared_ptr<ray::gcs::GcsClient> gcs_client;
 
   gcs_client = std::make_shared<ray::gcs::ServiceBasedGcsClient>(client_options);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As a follow-up of https://github.com/ray-project/ray/pull/14617, we can disable asynchronous context of redis client in raylet side.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

part of #14463, final step of redis connection reducing in raylet side

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
