### PR TITLE
[large scale]Disable async/subscribe context in global state accessor

### DIFF
--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -30,6 +30,10 @@ GlobalStateAccessor::GlobalStateAccessor(const std::string &redis_address,
   options.server_ip_ = address[0];
   options.server_port_ = std::stoi(address[1]);
   options.password_ = redis_password;
+  // Only synchronous connection is needed.
+  options.enable_sync_conn_ = true;
+  options.enable_async_conn_ = false;
+  options.enable_subscribe_conn_ = false;
   gcs_client_.reset(new ServiceBasedGcsClient(options));
 
   io_service_.reset(new instrumented_io_context());

--- a/src/ray/gcs/redis_client.cc
+++ b/src/ray/gcs/redis_client.cc
@@ -161,17 +161,25 @@ void RedisClient::Attach() {
   RAY_CHECK(shard_asio_async_clients_.empty()) << "Attach shall be called only once";
   for (std::shared_ptr<RedisContext> context : shard_contexts_) {
     instrumented_io_context &io_service = context->io_service();
-    shard_asio_async_clients_.emplace_back(
-        new RedisAsioClient(io_service, context->async_context()));
-    shard_asio_subscribe_clients_.emplace_back(
-        new RedisAsioClient(io_service, context->subscribe_context()));
+    if (options_.enable_async_conn_) {
+      shard_asio_async_clients_.emplace_back(
+          new RedisAsioClient(io_service, context->async_context()));
+    }
+    if (options_.enable_subscribe_conn_) {
+      shard_asio_subscribe_clients_.emplace_back(
+          new RedisAsioClient(io_service, context->subscribe_context()));
+    }
   }
 
   instrumented_io_context &io_service = primary_context_->io_service();
-  asio_async_auxiliary_client_.reset(
-      new RedisAsioClient(io_service, primary_context_->async_context()));
-  asio_subscribe_auxiliary_client_.reset(
-      new RedisAsioClient(io_service, primary_context_->subscribe_context()));
+  if (options_.enable_async_conn_) {
+    asio_async_auxiliary_client_.reset(
+        new RedisAsioClient(io_service, primary_context_->async_context()));
+  }
+  if (options_.enable_subscribe_conn_) {
+    asio_subscribe_auxiliary_client_.reset(
+        new RedisAsioClient(io_service, primary_context_->subscribe_context()));
+  }
 }
 
 void RedisClient::Disconnect() {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Only synchronous context of redis client is needed in global state accessor, so we disable the other two to reduce redis connections.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

part of https://github.com/ray-project/ray/issues/14463

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
