### PR TITLE
[large scale]Always disable sync/subscribe context in sharding context

### DIFF
--- a/src/ray/gcs/redis_client.cc
+++ b/src/ray/gcs/redis_client.cc
@@ -134,18 +134,20 @@ Status RedisClient::Connect(std::vector<instrumented_io_context *> io_services) 
       instrumented_io_context &io_service = *io_services[io_service_index];
       // Populate shard_contexts.
       shard_contexts_.push_back(std::make_shared<RedisContext>(io_service));
+      // Only async context is used in sharding context, so wen disable the other two.
       RAY_CHECK_OK(shard_contexts_[i]->Connect(
           addresses[i], ports[i], /*sharding=*/true,
-          /*password=*/options_.password_, options_.enable_sync_conn_,
-          options_.enable_async_conn_, options_.enable_subscribe_conn_));
+          /*password=*/options_.password_, /*enable_sync_conn=*/false,
+          /*enable_async_conn=*/true, /*enable_subscribe_conn=*/false));
     }
   } else {
     shard_contexts_.push_back(std::make_shared<RedisContext>(*io_services[0]));
+    // Only async context is used in sharding context, so wen disable the other two.
     RAY_CHECK_OK(shard_contexts_[0]->Connect(
         options_.server_ip_, options_.server_port_,
         /*sharding=*/true,
-        /*password=*/options_.password_, options_.enable_sync_conn_,
-        options_.enable_async_conn_, options_.enable_subscribe_conn_));
+        /*password=*/options_.password_, /*enable_sync_conn=*/false,
+        /*enable_async_conn=*/true, /*enable_subscribe_conn=*/false));
   }
 
   Attach();

--- a/src/ray/gcs/redis_client.cc
+++ b/src/ray/gcs/redis_client.cc
@@ -165,15 +165,17 @@ void RedisClient::Attach() {
     instrumented_io_context &io_service = context->io_service();
     shard_asio_async_clients_.emplace_back(
         new RedisAsioClient(io_service, context->async_context()));
-    shard_asio_subscribe_clients_.emplace_back(
-        new RedisAsioClient(io_service, context->subscribe_context()));
   }
 
   instrumented_io_context &io_service = primary_context_->io_service();
-  asio_async_auxiliary_client_.reset(
-      new RedisAsioClient(io_service, primary_context_->async_context()));
-  asio_subscribe_auxiliary_client_.reset(
-      new RedisAsioClient(io_service, primary_context_->subscribe_context()));
+  if (options_.enable_async_conn_) {
+    asio_async_auxiliary_client_.reset(
+        new RedisAsioClient(io_service, primary_context_->async_context()));
+  }
+  if (options_.enable_subscribe_conn_) {
+    asio_subscribe_auxiliary_client_.reset(
+        new RedisAsioClient(io_service, primary_context_->subscribe_context()));
+  }
 }
 
 void RedisClient::Disconnect() {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Sharding context is used for getting data from redis, so only asynchronous context is used in its redis client. We can disable the other two.

## Related issue number

part of https://github.com/ray-project/ray/issues/14463

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
