### PR TITLE
[Autoscaler] Correct typing for Event Handler `execute_callback`

### DIFF
--- a/python/ray/autoscaler/_private/event_system.py
+++ b/python/ray/autoscaler/_private/event_system.py
@@ -73,7 +73,7 @@ class _EventSystem:
             []).extend([callback] if type(callback) is not list else callback)
 
     def execute_callback(self,
-                         event: str,
+                         event: CreateClusterEvent,
                          event_data: Optional[Dict[str, Any]] = None):
         """Executes all callbacks for event.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Fixes a wrong typing in `execute_callback`.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
