### PR TITLE
[Core] Event loop instrumentation concurrency fixes.

### DIFF
--- a/src/ray/common/asio/instrumented_io_context.cc
+++ b/src/ray/common/asio/instrumented_io_context.cc
@@ -19,6 +19,42 @@
 #include <iostream>
 #include <utility>
 
+namespace {
+
+/// A helper for creating a snapshot view of the global stats.
+/// This acquires a reader lock on the provided global stats, and creates a
+/// lockless copy of the stats.
+GlobalStats to_global_stats_view(std::shared_ptr<GuardedGlobalStats> stats) {
+  absl::MutexLock lock(&(stats->mutex));
+  return GlobalStats(stats->stats);
+}
+
+/// A helper for creating a snapshot view of the stats for a handler.
+/// This acquires a lock on the provided guarded handler stats, and creates a
+/// lockless copy of the stats.
+HandlerStats to_handler_stats_view(std::shared_ptr<GuardedHandlerStats> stats) {
+  absl::MutexLock lock(&(stats->mutex));
+  return HandlerStats(stats->stats);
+}
+
+/// A helper for converting a duration into a human readable string, such as "5.346 ms".
+std::string to_human_readable(double duration) {
+  static const std::array<std::string, 4> to_unit{{"ns", "us", "ms", "s"}};
+  size_t idx = std::min(to_unit.size() - 1,
+                        static_cast<size_t>(std::log(duration) / std::log(1000)));
+  double new_duration = duration / std::pow(1000, idx);
+  std::stringstream result;
+  result << std::fixed << std::setprecision(3) << new_duration << " " << to_unit[idx];
+  return result.str();
+}
+
+/// A helper for converting a duration into a human readable string, such as "5.346 ms".
+std::string to_human_readable(int64_t duration) {
+  return to_human_readable(static_cast<double>(duration));
+}
+
+}  // namespace
+
 void instrumented_io_context::post(std::function<void()> handler,
                                    const std::string &name) {
   if (!RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
@@ -96,24 +132,8 @@ void instrumented_io_context::post(std::function<void()> handler,
   });
 }
 
-/// A helper for creating a snapshot view of the global stats.
-/// This acquires a reader lock on the provided global stats, and creates a
-/// lockless copy of the stats.
-inline GlobalStats to_global_stats_view(std::shared_ptr<GuardedGlobalStats> stats) {
-  absl::MutexLock lock(&(stats->mutex));
-  return GlobalStats(stats->stats);
-}
-
 GlobalStats instrumented_io_context::get_global_stats() const {
   return to_global_stats_view(global_stats_);
-}
-
-/// A helper for creating a snapshot view of the stats for a handler.
-/// This acquires a lock on the provided guarded handler stats, and creates a
-/// lockless copy of the stats.
-inline HandlerStats to_handler_stats_view(std::shared_ptr<GuardedHandlerStats> stats) {
-  absl::MutexLock lock(&(stats->mutex));
-  return HandlerStats(stats->stats);
 }
 
 absl::optional<HandlerStats> instrumented_io_context::get_handler_stats(
@@ -138,20 +158,6 @@ instrumented_io_context::get_handler_stats() const {
         return std::make_pair(p.first, to_handler_stats_view(p.second));
       });
   return stats;
-}
-
-inline std::string to_human_readable(double duration) {
-  static const std::array<std::string, 4> to_unit{{"ns", "us", "ms", "s"}};
-  size_t idx = std::min(to_unit.size() - 1,
-                        static_cast<size_t>(std::log(duration) / std::log(1000)));
-  double new_duration = duration / std::pow(1000, idx);
-  std::stringstream result;
-  result << std::fixed << std::setprecision(3) << new_duration << " " << to_unit[idx];
-  return result.str();
-}
-
-inline std::string to_human_readable(int64_t duration) {
-  return to_human_readable(static_cast<double>(duration));
 }
 
 std::string instrumented_io_context::StatsString() const {

--- a/src/ray/common/asio/instrumented_io_context.h
+++ b/src/ray/common/asio/instrumented_io_context.h
@@ -64,6 +64,9 @@ struct GuardedGlobalStats {
 /// A proxy for boost::asio::io_context that collects statistics about posted handlers.
 class instrumented_io_context : public boost::asio::io_context {
  public:
+  /// Initializes the global stats struct after calling the base contructor.
+  instrumented_io_context() : global_stats_(std::make_shared<GuardedGlobalStats>()) {}
+
   /// A proxy post function that collects count, queueing, and execution statistics for
   /// the given handler.
   ///
@@ -103,7 +106,7 @@ class instrumented_io_context : public boost::asio::io_context {
 
  private:
   /// Global stats, across all handlers.
-  GuardedGlobalStats global_stats_;
+  std::shared_ptr<GuardedGlobalStats> global_stats_;
 
   /// Table of per-handler post stats.
   /// We use a std::shared_ptr value in order to ensure pointer stability.

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -50,7 +50,7 @@ RAY_CONFIG(uint64_t, num_resource_report_periods_warning, 5)
 /// The duration between dumping debug info to logs, or 0 to disable.
 RAY_CONFIG(uint64_t, debug_dump_period_milliseconds, 10000)
 
-RAY_CONFIG(bool, asio_event_loop_stats_collection_enabled, true)
+RAY_CONFIG(bool, asio_event_loop_stats_collection_enabled, false)
 
 /// Whether to enable fair queueing between task classes in raylet. When
 /// fair queueing is enabled, the raylet will try to balance the number

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -50,7 +50,7 @@ RAY_CONFIG(uint64_t, num_resource_report_periods_warning, 5)
 /// The duration between dumping debug info to logs, or 0 to disable.
 RAY_CONFIG(uint64_t, debug_dump_period_milliseconds, 10000)
 
-RAY_CONFIG(bool, asio_event_loop_stats_collection_enabled, false)
+RAY_CONFIG(bool, asio_event_loop_stats_collection_enabled, true)
 
 /// Whether to enable fair queueing between task classes in raylet. When
 /// fair queueing is enabled, the raylet will try to balance the number


### PR DESCRIPTION
## Why are these changes needed?

The event loop instrumentation was designed under the assumption that the thread that creates the `instrumented_io_context` object (the main thread) will join all handler executing threads (threads in which `io_context.run()` is called) before exiting itself, therefore ensuring that all `instrumented_io_context` members will outlive all handlers and allowing us to freely reference those members in the handlers. Although this holds true for Ray components in which we control the exit behavior (such as the raylet), the main core worker thread can be killed by language frontend code without joining the threads (e.g. via `sys.exit(-1)` in Java), which violates this assumption and can cause segfaults. This is currently happening in Java tests, which call `sys.exit(-1)` [in failure tests](https://github.com/ray-project/ray/blob/bd641a5e7137e23a340454902a6f1b95efe2f719/java/test/src/main/java/io/ray/test/FailureTest.java#L64).

This PR moves the likely culprit, the global stats struct, behind a shared pointer, and ensures that handler lambdas close over that stats struct by-value, thereby incrementing the reference count and ensuring that the global stats struct lifetime will be tied to the last handler that executes or the main thread, which ever lives longest. This PR also fixes a potential issue with unintentionally copying a handler stats struct outside of a lock, and ports the move capture helper function to use C++14 generalized lambda capture.

NOTE: Java tests still occasionally segfault, although seemingly less frequently. This might solve one of more than one hard exit segfault triggers.

## TODOs

~- [ ] Ensure that the Java tests pass several times in the CI.~ Failed on the third run.

## Related issue number

<!-- For example: "Closes #1234" -->

Towards #14715 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
