### PR TITLE
[Autoscaler Docs] Use `worker_run_options`

### DIFF
--- a/doc/source/cluster/config.rst
+++ b/doc/source/cluster/config.rst
@@ -182,7 +182,7 @@ Node Docker
 
     :ref:`image <cluster-configuration-image>`: str
     :ref:`pull_before_run <cluster-configuration-pull-before-run>`: bool
-    :ref:`run_options <cluster-configuration-run-options>`:
+    :ref:`worker_run_options <cluster-configuration-run-options>`:
         - str
     :ref:`disable_automatic_runtime_detection <cluster-configuration-disable-automatic-runtime-detection>`: bool
     :ref:`disable_shm_size_detection <cluster-configuration-disable-shm-size-detection>`: bool

--- a/doc/source/cluster/config.rst
+++ b/doc/source/cluster/config.rst
@@ -182,7 +182,7 @@ Node Docker
 
     :ref:`image <cluster-configuration-image>`: str
     :ref:`pull_before_run <cluster-configuration-pull-before-run>`: bool
-    :ref:`worker_run_options <cluster-configuration-run-options>`:
+    :ref:`worker_run_options <cluster-configuration-worker-run-options>`:
         - str
     :ref:`disable_automatic_runtime_detection <cluster-configuration-disable-automatic-runtime-detection>`: bool
     :ref:`disable_shm_size_detection <cluster-configuration-disable-shm-size-detection>`: bool


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The field is `worker_run_options`, not `run_options` for the multi-node-type-autoscaler

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
