### PR TITLE
[SGD] Worker Startup Fault Tolerance

### DIFF
--- a/python/ray/util/sgd/tests/test_torch_failure.py
+++ b/python/ray/util/sgd/tests/test_torch_failure.py
@@ -1,6 +1,8 @@
 from unittest.mock import patch
 import pytest
 import time
+
+import torch
 import torch.nn as nn
 import torch.distributed as dist
 from torch.utils.data import DataLoader
@@ -59,12 +61,12 @@ start_workers = TorchTrainer._start_workers
 
 def gen_start_with_fail(num_fails):
     def start_with_fail(self, *args, **kwargs):
-        start_workers(self, *args, **kwargs)
+        success = start_workers(self, *args, **kwargs)
         fail = self._num_failures < num_fails
-        if self.use_local:
-            self.worker_group.remote_worker_group.should_fail = fail
-        else:
-            self.worker_group.should_fail = fail
+        fail_worker_group = self.worker_group.remote_worker_group if \
+            self.use_local else self.worker_group
+        fail_worker_group.should_fail = fail
+        return success
 
     return start_with_fail
 
@@ -176,6 +178,112 @@ def test_fail_with_recover(ray_start_2_cpus, use_local):  # noqa: F811
             trainer1.train(max_retries=1)
 
         trainer1.shutdown(force=True)
+
+
+@patch.object(RemoteWorkerGroup, "_train", remote_worker_train_with_fail)
+def test_fail_state(ray_start_2_cpus):  # noqa: F811
+    """Tests if state of training with failure is same as training without."""
+    if not dist.is_available():
+        return
+
+    torch.manual_seed(0)
+
+    def single_loader(config):
+        dataset = LinearDataset(2, 5, size=1000000)
+        return DataLoader(dataset, batch_size=config.get("batch_size", 32))
+
+    TestOperator = TrainingOperator.from_creators(
+        model_creator,
+        optimizer_creator,
+        single_loader,
+        loss_creator=lambda config: nn.MSELoss())
+
+    def init_hook():
+        torch.manual_seed(0)
+
+    trainer1 = TorchTrainer(
+        training_operator_cls=TestOperator,
+        config={"batch_size": 100000},
+        timeout_s=5,
+        initialization_hook=init_hook,
+        num_workers=2)
+    initial_state = trainer1.state_dict()
+    trainer1.train()
+    trainer1_state = trainer1.state_dict()
+    assert trainer1_state != initial_state
+    trainer1.shutdown()
+
+    trainer2 = TorchTrainer(
+        training_operator_cls=TestOperator,
+        config={"batch_size": 100000},
+        timeout_s=5,
+        initialization_hook=init_hook,
+        num_workers=2)
+    trainer2.load_state_dict(initial_state)
+    trainer2.train()
+    assert trainer2.state_dict() == trainer1_state
+    trainer2.shutdown()
+
+    start_with_fail = gen_start_with_fail(1)
+    with patch.object(TorchTrainer, "_start_workers", start_with_fail):
+        trainer3 = TorchTrainer(
+            training_operator_cls=TestOperator,
+            config={"batch_size": 100000},
+            timeout_s=5,
+            initialization_hook=init_hook,
+            num_workers=2)
+        trainer3.load_state_dict(initial_state)
+        trainer3.train()
+        assert trainer3.state_dict() == trainer1_state
+        trainer3.shutdown()
+
+
+def gen_start_with_startup_fail(num_fails):
+    fail_start = gen_start_with_fail(num_fails)
+
+    def start_with_fail(self, *args, **kwargs):
+        if hasattr(self, "worker_group"):
+            # Fail during worker start just during the first training attempt.
+            def _raise():
+                import sys
+                sys.exit(1)
+
+            if not self.initialization_hook:
+                self.initialization_hook = _raise
+            else:
+                self.initialization_hook = None
+        return fail_start(self, *args, **kwargs)
+
+    return start_with_fail
+
+
+@patch.object(RemoteWorkerGroup, "_train", remote_worker_train_with_fail)
+def test_failure_during_resize(ray_start_2_cpus):  # noqa: F811
+    """Tests if training succeeds even with failures during worker resizing."""
+    if not dist.is_available():
+        return
+
+    def single_loader(config):
+        dataset = LinearDataset(2, 5, size=1000000)
+        return DataLoader(dataset, batch_size=config.get("batch_size", 32))
+
+    TestOperator = TrainingOperator.from_creators(
+        model_creator,
+        optimizer_creator,
+        single_loader,
+        loss_creator=lambda config: nn.MSELoss())
+
+    start_with_fail = gen_start_with_startup_fail(1)
+    with patch.object(TorchTrainer, "_start_workers", start_with_fail):
+        trainer1 = TorchTrainer(
+            training_operator_cls=TestOperator,
+            config={"batch_size": 100000},
+            timeout_s=5,
+            use_local=False,
+            num_workers=2)
+        trainer1.train()
+
+    trainer1.shutdown()
 
 
 if __name__ == "__main__":

--- a/python/ray/util/sgd/torch/worker_group.py
+++ b/python/ray/util/sgd/torch/worker_group.py
@@ -468,7 +468,7 @@ class LocalWorkerGroup(WorkerGroupInterface):
 
                 remote_pgs = self.remote_worker_group._setup_process_group(
                     address=address, world_size=num_workers, starting_rank=1)
-                # Use the local worker as rank 0. This will help with debugging.
+                # Use the local worker as rank 0. Helps with debugging.
                 self.local_worker.setup_process_group(
                     url=address,
                     world_rank=0,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Adds functionality to re-try worker creation when startup fails. Also fixes a bug with state dict not being properly handled when training is attempted additional times after failure.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
