### PR TITLE
[serve] Temporarily disable ray client test

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -49,13 +49,13 @@ py_test(
     deps = [":serve_lib"],
 )
 
-py_test(
-    name = "test_ray_client",
-    size = "small",
-    srcs = serve_tests_srcs,
-    tags = ["exclusive"],
-    deps = [":serve_lib"],
-)
+# py_test(
+    # name = "test_ray_client",
+    # size = "small",
+    # srcs = serve_tests_srcs,
+    # tags = ["exclusive"],
+    # deps = [":serve_lib"],
+# )
 
 py_test(
     name = "test_async_goal_manager",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray client test has been very flaky since it was merged. We should re-enable ASAP but disabling for now to avoid increasing failure rate.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
