### PR TITLE
[JAR Build] Prevent MacOS Jar Builds from Timing Out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -183,8 +183,8 @@ matrix:
       install:
         - . ./ci/travis/ci.sh init RAY_CI_MACOS_WHEELS_AFFECTED,RAY_CI_JAVA_AFFECTED,RAY_CI_STREAMING_JAVA_AFFECTED
       before_script:
-        - brew tap adoptopenjdk/openjdk
-        - brew install --cask adoptopenjdk8
+        - ./ci/keep_alive brew tap adoptopenjdk/openjdk
+        - ./ci/keep_alive brew install --cask adoptopenjdk8
         - export JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
         - java -version
         - ./ci/keep_alive bash ./ci/travis/ci.sh build


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Stop Mac Wheel builds from timing out
* NOTE: This doesn't explain why `brew tap adoptopenjdk/openjdk` takes **30+ minutes**.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
