### PR TITLE
[serve] Refactor to add basic unit tests for BackendState

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -110,7 +110,7 @@ py_test(
 
 py_test(
     name = "test_handle",
-    size = "small",
+    size = "medium",
     srcs = serve_tests_srcs,
     tags = ["exclusive"],
     deps = [":serve_lib"],

--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -66,6 +66,14 @@ py_test(
 )
 
 py_test(
+    name = "test_backend_state",
+    size = "small",
+    srcs = serve_tests_srcs,
+    tags = ["exclusive"],
+    deps = [":serve_lib"],
+)
+
+py_test(
     name = "test_backend_worker",
     size = "small",
     srcs = serve_tests_srcs,

--- a/python/ray/serve/async_goal_manager.py
+++ b/python/ray/serve/async_goal_manager.py
@@ -29,6 +29,9 @@ class AsyncGoalManager:
         if event:
             event.set()
 
+    def check_complete(self, goal_id: GoalId) -> bool:
+        return goal_id not in self._pending_goals
+
     async def wait_for_goal(self, goal_id: GoalId) -> None:
         start = time.time()
         if goal_id not in self._pending_goals:

--- a/python/ray/serve/async_goal_manager.py
+++ b/python/ray/serve/async_goal_manager.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 from uuid import uuid4
 
 from ray.serve.common import GoalId
@@ -10,9 +10,6 @@ from ray.serve.utils import logger
 class AsyncGoalManager:
     def __init__(self):
         self._pending_goals: Dict[GoalId, asyncio.Event] = dict()
-
-    def get_pending_goal_ids(self) -> List[GoalId]:
-        return list(self._pending_goals.keys())
 
     def num_pending_goals(self) -> int:
         return len(self._pending_goals)

--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -45,8 +45,7 @@ class ActorReplicaWrapper:
     """
 
     def __init__(self, actor_name: str, detached: bool, controller_name: str,
-                 replica_tag: ReplicaTag, backend_tag: BackendTag,
-                 version: str):
+                 replica_tag: ReplicaTag, backend_tag: BackendTag):
         self._actor_name = actor_name
         self._placement_group_name = self._actor_name + "_placement_group"
         self._detached = detached
@@ -58,7 +57,6 @@ class ActorReplicaWrapper:
         self._drain_obj_ref = None
         self._stopped = False
         self._actor_resources = None
-        self._version = version
 
         # Storing the handles is necessary to keep the actor and PG alive in
         # the non-detached case.
@@ -79,10 +77,6 @@ class ActorReplicaWrapper:
     @property
     def actor_handle(self) -> ActorHandle:
         return ray.get_actor(self._actor_name)
-
-    @property
-    def version(self):
-        return self._version
 
     def start(self, backend_info: BackendInfo):
         self._actor_resources = backend_info.replica_config.resource_dict
@@ -179,13 +173,15 @@ class BackendReplica:
     """
 
     def __init__(self, controller_name: str, detached: bool,
-                 replica_tag: ReplicaTag, backend_tag: BackendTag):
+                 replica_tag: ReplicaTag, backend_tag: BackendTag,
+                 version: str):
         self._actor = ActorReplicaWrapper(
             format_actor_name(replica_tag, controller_name), detached,
             controller_name, replica_tag, backend_tag)
         self._controller_name = controller_name
         self._replica_tag = replica_tag
         self._backend_tag = backend_tag
+        self._version = version
         self._start_time = None
         self._prev_slow_startup_warning_time = None
         self._state = ReplicaState.SHOULD_START
@@ -209,6 +205,10 @@ class BackendReplica:
     @property
     def replica_tag(self) -> ReplicaTag:
         return self._replica_tag
+
+    @property
+    def version(self):
+        return self._version
 
     @property
     def actor_handle(self) -> ActorHandle:

--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -2,7 +2,7 @@ import asyncio
 from collections import defaultdict
 from enum import Enum
 import time
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import ray
 import ray.cloudpickle as pickle
@@ -36,119 +36,208 @@ class ReplicaState(Enum):
     STOPPED = 6
 
 
-class BackendReplica:
-    def __init__(self, controller_name: str, detached: bool,
+class ActorReplicaWrapper:
+    """Wraps a Ray actor for a backend replica.
+
+    This is primarily defined so that we can mock out actual Ray operations
+    for unit testing.
+
+    *All Ray API calls should be made here, not in BackendState.*
+    """
+
+    def __init__(self, actor_name: str, detached: bool, controller_name: str,
                  replica_tag: ReplicaTag, backend_tag: BackendTag):
-        self._actor_name = format_actor_name(replica_tag, controller_name)
+        self._actor_name = actor_name
         self._placement_group_name = self._actor_name + "_placement_group"
-        self._controller_name = controller_name
         self._detached = detached
+        self._controller_name = controller_name
         self._replica_tag = replica_tag
         self._backend_tag = backend_tag
-        self._actor_handle = None
-        self._placement_group = None
-        self._start_time = None
-        self._prev_slow_startup_warning_time = None
+
         self._startup_obj_ref = None
         self._drain_obj_ref = None
-        self._state = ReplicaState.SHOULD_START
+        self._stopped = False
         self._actor_resources = None
 
-    def __get_state__(self):
+    def __get_state__(self) -> Dict[Any, Any]:
         clean_dict = self.__dict__.copy()
-        del clean_dict["_placement_group"]
-        del clean_dict["_actor_handle"]
         del clean_dict["_startup_obj_ref"]
         del clean_dict["_drain_obj_ref"]
         return clean_dict
 
-    def __set_state__(self, d):
+    def __set_state__(self, d: Dict[Any, Any]) -> None:
         self.__dict__ = d
-        self._actor_handle = None
         self._startup_obj_ref = None
         self._drain_obj_ref = None
-        self._recover_from_checkpoint()
 
-    def _recover_from_checkpoint(self):
-        if self._state == ReplicaState.STARTING:
-            # We do not need to pass in the class here because the actor
-            # creation has already been started if this class was checkpointed
-            # in the STARTING state.
-            self.start()
-        elif self._state == ReplicaState.RUNNING:
-            # Fetch actor handles for all backend replicas in the system.
-            # The actors must exist if this class was checkpointed in the
-            # RUNNING state.
-            self._placement_group = ray.util.get_placement_group(
-                self._placement_group_name)
-            self._actor_handle = ray.get_actor(self._actor_name)
-        elif self._state == ReplicaState.STOPPING:
-            self.stop()
+    @property
+    def actor_handle(self) -> ActorHandle:
+        return ray.get_actor(self._actor_name)
 
-    def start(self, backend_info: Optional[BackendInfo]):
-        assert self._state in {
-            ReplicaState.SHOULD_START, ReplicaState.STARTING
-        }, (f"State must be {ReplicaState.SHOULD_START} or "
-            f"{ReplicaState.STARTING}, *not* {self._state}")
-
-        if self._actor_resources is None:
-            self._actor_resources = backend_info.replica_config.resource_dict
+    def start(self, backend_info: BackendInfo):
+        self._actor_resources = backend_info.replica_config.resource_dict
 
         try:
-            self._placement_group = ray.util.get_placement_group(
-                self._placement_group_name)
+            pg = ray.util.get_placement_group(self._placement_group_name)
         except ValueError:
             logger.debug(
                 "Creating placement group '{}' for backend '{}'".format(
                     self._placement_group_name, self._backend_tag))
-            self._placement_group = ray.util.placement_group(
+            pg = ray.util.placement_group(
                 [self._actor_resources],
                 lifetime="detached",
                 name=self._placement_group_name)
 
         try:
-            self._actor_handle = ray.get_actor(self._actor_name)
+            actor_handle = ray.get_actor(self._actor_name)
         except ValueError:
             logger.debug("Starting replica '{}' for backend '{}'.".format(
                 self._replica_tag, self._backend_tag))
-            self._actor_handle = ray.remote(backend_info.worker_class).options(
+            actor_handle = ray.remote(backend_info.worker_class).options(
                 name=self._actor_name,
                 lifetime="detached" if self._detached else None,
                 max_restarts=-1,
                 max_task_retries=-1,
-                placement_group=self._placement_group,
+                placement_group=pg,
                 **backend_info.replica_config.ray_actor_options).remote(
                     self._backend_tag, self._replica_tag,
                     backend_info.replica_config.init_args,
                     backend_info.backend_config, self._controller_name)
+        self._startup_obj_ref = actor_handle.ready.remote()
+
+    def check_ready(self) -> bool:
+        ready, _ = ray.wait([self._startup_obj_ref], timeout=0)
+        return len(ready) == 1
+
+    def resource_requirements(
+            self) -> Tuple[Dict[str, float], Dict[str, float]]:
+        """Returns required and currently available resources.
+
+        Only resources with nonzero requirements will be included in the
+        required dict and only resources in the required dict will be
+        included in the available dict (filtered for relevance).
+        """
+        required = {k: v for k, v in self._actor_resources.items() if v > 0}
+        available = {
+            k: v
+            for k, v in ray.available_resources().items() if k in required
+        }
+        return required, available
+
+    def graceful_stop(self) -> None:
+        # NOTE: the replicas may already be stopped if we failed
+        # after stopping them but before writing a checkpoint.
+        if self._stopped:
+            return
+
+        try:
+            handle = ray.get_actor(self._actor_name)
+            self._drain_obj_ref = handle.drain_pending_queries.remote()
+        except ValueError:
+            self._stopped = True
+
+    def check_stopped(self) -> bool:
+        if self._stopped:
+            return True
+
+        try:
+            ray.get_actor(self._actor_name)
+            ready, _ = ray.wait([self._drain_obj_ref], timeout=0)
+            self._stopped = len(ready) == 1
+        except ValueError:
+            self._stopped = True
+
+        return self._stopped
+
+    def force_stop(self):
+        try:
+            ray.kill(ray.get_actor(self._actor_name))
+        except ValueError:
+            pass
+        try:
+            ray.util.remove_placement_group(
+                ray.util.get_placement_group(self._placement_group_name))
+        except ValueError:
+            pass
+
+
+class BackendReplica:
+    """Manages state transitions for backend replicas.
+
+    This is basically a checkpointable lightweight state machine.
+    """
+
+    def __init__(self, controller_name: str, detached: bool,
+                 replica_tag: ReplicaTag, backend_tag: BackendTag):
+        self._actor = ActorReplicaWrapper(
+            format_actor_name(replica_tag, controller_name), detached,
+            controller_name, replica_tag, backend_tag)
+        self._controller_name = controller_name
+        self._replica_tag = replica_tag
+        self._backend_tag = backend_tag
+        self._start_time = None
+        self._prev_slow_startup_warning_time = None
+        self._state = ReplicaState.SHOULD_START
+
+    def __get_state__(self) -> Dict[Any, Any]:
+        return self.__dict__.copy()
+
+    def __set_state__(self, d: Dict[Any, Any]) -> None:
+        self.__dict__ = d
+        self._recover_from_checkpoint()
+
+    def _recover_from_checkpoint(self) -> None:
+        if self._state == ReplicaState.STARTING:
+            # We do not need to pass in the class here because the actor
+            # creation has already been started if this class was checkpointed
+            # in the STARTING state.
+            self.start()
+        elif self._state == ReplicaState.STOPPING:
+            self.stop()
+
+    @property
+    def replica_tag(self) -> ReplicaTag:
+        return self._replica_tag
+
+    @property
+    def actor_handle(self) -> ActorHandle:
+        assert self._state is not ReplicaState.SHOULD_START, (
+            f"State must not be {ReplicaState.SHOULD_START}")
+        return self._actor.actor_handle
+
+    def start(self, backend_info: Optional[BackendInfo]) -> None:
+        """Transition from SHOULD_START -> STARTING.
+
+        Should handle the case where it's already STARTING.
+        """
+        assert self._state in {
+            ReplicaState.SHOULD_START, ReplicaState.STARTING
+        }, (f"State must be {ReplicaState.SHOULD_START} or "
+            f"{ReplicaState.STARTING}, *not* {self._state}")
+
+        self._actor.start(backend_info)
         self._start_time = time.time()
         self._prev_slow_startup_warning_time = time.time()
-        self._startup_obj_ref = self._actor_handle.ready.remote()
         self._state = ReplicaState.STARTING
 
-    def check_started(self):
+    def check_started(self) -> bool:
+        """Check if the replica has started. If so, transition to RUNNING.
+
+        Should handle the case where the replica has already stopped.
+        """
         if self._state == ReplicaState.RUNNING:
             return True
         assert self._state == ReplicaState.STARTING, (
             f"State must be {ReplicaState.STARTING}, *not* {self._state}")
-        ready, _ = ray.wait([self._startup_obj_ref], timeout=0)
-        if len(ready) == 1:
-            self._state = ReplicaState.RUNNING
+
+        if self._actor.check_ready():
             return True
 
         time_since_start = time.time() - self._start_time
         if (time_since_start > SLOW_STARTUP_WARNING_S
                 and time.time() - self._prev_slow_startup_warning_time >
                 SLOW_STARTUP_WARNING_PERIOD_S):
-            # Filter to relevant resources.
-            required = {
-                k: v
-                for k, v in self._actor_resources.items() if v > 0
-            }
-            available = {
-                k: v
-                for k, v in ray.available_resources().items() if k in required
-            }
+            required, available = self._actor.resource_requirements()
             logger.warning(
                 f"Replica '{self._replica_tag}' for backend "
                 f"'{self._backend_tag}' has taken more than "
@@ -160,11 +249,20 @@ class BackendReplica:
 
         return False
 
-    def set_should_stop(self, graceful_shutdown_timeout_s: Duration):
+    def set_should_stop(self, graceful_shutdown_timeout_s: Duration) -> None:
+        """Mark the replica to be stopped in the future.
+
+        Should handle the case where the replica has already been marked to
+        stop.
+        """
         self._state = ReplicaState.SHOULD_STOP
         self._graceful_shutdown_timeout_s = graceful_shutdown_timeout_s
 
-    def stop(self):
+    def stop(self) -> None:
+        """Stop the replica.
+
+        Should handle the case where the replica is already stopped.
+        """
         # We need to handle transitions from:
         #  SHOULD_START -> SHOULD_STOP -> STOPPING
         # This means that the replica_handle may not have been created.
@@ -174,52 +272,37 @@ class BackendReplica:
         }, (f"State must be {ReplicaState.SHOULD_STOP} or "
             f"{ReplicaState.STOPPING}, *not* {self._state}")
 
-        def drain_actor(actor_name):
-            # NOTE: the replicas may already be stopped if we failed
-            # after stopping them but before writing a checkpoint.
-            try:
-                replica = ray.get_actor(actor_name)
-            except ValueError:
-                return None
-            return replica.drain_pending_queries.remote()
-
+        self._actor.graceful_stop()
         self._state = ReplicaState.STOPPING
-        self._drain_obj_ref = drain_actor(self._actor_name)
         self._shutdown_deadline = time.time(
         ) + self._graceful_shutdown_timeout_s
 
-    def check_stopped(self):
+    def check_stopped(self) -> bool:
+        """Check if the replica has stopped. If so, transition to STOPPED.
+
+        Should handle the case where the replica has already stopped.
+        """
         if self._state == ReplicaState.STOPPED:
             return True
         assert self._state == ReplicaState.STOPPING, (
             f"State must be {ReplicaState.STOPPING}, *not* {self._state}")
 
-        try:
-            replica = ray.get_actor(self._actor_name)
-        except ValueError:
+        stopped = self._actor.check_stopped()
+        if stopped:
             self._state = ReplicaState.STOPPED
             return True
 
-        ready, _ = ray.wait([self._drain_obj_ref], timeout=0)
         timeout_passed = time.time() > self._shutdown_deadline
 
-        if len(ready) == 1 or timeout_passed:
-            if timeout_passed:
-                # Graceful period passed, kill it forcefully.
-                logger.debug(
-                    f"{self._actor_name} did not shutdown after "
-                    f"{self._graceful_shutdown_timeout_s}s, force-killing.")
+        if timeout_passed:
+            # Graceful period passed, kill it forcefully.
+            # This will be called repeatedly until the replica shuts down.
+            logger.debug(
+                f"Replica {self._replica_tag} did not shutdown after "
+                f"{self._graceful_shutdown_timeout_s}s, force-killing.")
 
-            ray.kill(replica, no_restart=True)
-            ray.util.remove_placement_group(self._placement_group)
-            self._state = ReplicaState.STOPPED
-            return True
+            self._actor.force_stop()
         return False
-
-    def get_actor_handle(self):
-        assert self._state == ReplicaState.RUNNING, (
-            f"State must be {ReplicaState.RUNNING}, *not* {self._state}")
-        return self._actor_handle
 
 
 class BackendState:
@@ -232,6 +315,7 @@ class BackendState:
     def __init__(self, controller_name: str, detached: bool,
                  kv_store: RayInternalKVStore, long_poll_host: LongPollHost,
                  goal_manager: AsyncGoalManager):
+
         self._controller_name = controller_name
         self._detached = detached
         self._kv_store = kv_store
@@ -269,18 +353,6 @@ class BackendState:
         self._long_poll_host.notify_changed(LongPollKey.BACKEND_CONFIGS,
                                             self.get_backend_configs())
 
-    def get_running_replica_handles(
-            self) -> Dict[BackendTag, Dict[ReplicaTag, ActorHandle]]:
-        return {
-            backend_tag: {
-                backend_replica._replica_tag:
-                backend_replica.get_actor_handle()
-                for backend_replica in state_to_replica_dict[
-                    ReplicaState.RUNNING]
-            }
-            for backend_tag, state_to_replica_dict in self._replicas.items()
-        }
-
     def _notify_replica_handles_changed(self) -> None:
         self._long_poll_host.notify_changed(
             LongPollKey.REPLICA_HANDLES, {
@@ -288,6 +360,17 @@ class BackendState:
                 for backend_tag, replica_dict in
                 self.get_running_replica_handles().items()
             })
+
+    def get_running_replica_handles(
+            self) -> Dict[BackendTag, Dict[ReplicaTag, ActorHandle]]:
+        return {
+            backend_tag: {
+                backend_replica._replica_tag: backend_replica.actor_handle
+                for backend_replica in state_to_replica_dict[
+                    ReplicaState.RUNNING]
+            }
+            for backend_tag, state_to_replica_dict in self._replicas.items()
+        }
 
     def get_backend_configs(self) -> Dict[BackendTag, BackendConfig]:
         return {

--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -576,7 +576,7 @@ class BackendState:
             state_dict = self._replicas.get(backend_tag, {})
             existing_info = state_dict.get(ReplicaState.RUNNING, [])
 
-            # If we have pending ops, the current goal is *not* ready
+            # If we have pending ops, the current goal is *not* ready.
             if (state_dict.get(ReplicaState.SHOULD_START)
                     or state_dict.get(ReplicaState.STARTING)
                     or state_dict.get(ReplicaState.SHOULD_STOP)
@@ -587,6 +587,7 @@ class BackendState:
             if (not desired_num_replicas or
                     desired_num_replicas == 0) and \
                     (not existing_info or len(existing_info) == 0):
+                print("CASE 1")
                 completed_goals.append(
                     self.backend_goals.pop(backend_tag, None))
 

--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -432,3 +432,5 @@ class RayServeReplica:
                     f"to shutdown replica {self.replica_tag} because "
                     f"num_queries_waiting {num_queries_waiting} and "
                     f"num_ongoing_requests {self.num_ongoing_requests}")
+
+        ray.actor.exit_actor()

--- a/python/ray/serve/tests/test_backend_state.py
+++ b/python/ray/serve/tests/test_backend_state.py
@@ -62,7 +62,7 @@ def mock_replica_factory(mock_replicas):
         def resource_requirements(
                 self) -> Tuple[Dict[str, float], Dict[str, float]]:
             assert self.started
-            return {"AVAILABLE_RESOURCE": 1.0}, {"REQUIRED_RESOURCE": 1.0}
+            return {"REQUIRED_RESOURCE": 1.0}, {"AVAILABLE_RESOURCE": 1.0}
 
         def graceful_stop(self) -> None:
             assert self.started

--- a/python/ray/serve/tests/test_backend_state.py
+++ b/python/ray/serve/tests/test_backend_state.py
@@ -128,6 +128,30 @@ def replica_count(backend_state, backend=None, states=None):
     return total
 
 
+def test_override_goals(mock_backend_state):
+    backend_state, _, _, goal_manager = mock_backend_state
+
+    b_config_1, r_config_1 = generate_configs()
+    initial_goal = backend_state.create_backend("tag1", b_config_1, r_config_1)
+    assert not goal_manager.check_complete(initial_goal)
+
+    b_config_2, r_config_2 = generate_configs(num_replicas=2)
+    new_goal = backend_state.create_backend("tag1", b_config_2, r_config_2)
+    assert goal_manager.check_complete(initial_goal)
+    assert not goal_manager.check_complete(new_goal)
+
+
+def test_return_existing_goal(mock_backend_state):
+    backend_state, _, _, goal_manager = mock_backend_state
+
+    b_config_1, r_config_1 = generate_configs()
+    initial_goal = backend_state.create_backend("tag1", b_config_1, r_config_1)
+    assert not goal_manager.check_complete(initial_goal)
+
+    new_goal = backend_state.create_backend("tag1", b_config_1, r_config_1)
+    assert initial_goal == new_goal
+
+
 def test_create_delete_single_replica(mock_backend_state):
     backend_state, timer, mock_replicas, goal_manager = mock_backend_state
 

--- a/python/ray/serve/tests/test_backend_state.py
+++ b/python/ray/serve/tests/test_backend_state.py
@@ -155,6 +155,7 @@ def test_return_existing_goal(mock_backend_state):
 
     new_goal = backend_state.create_backend("tag1", b_config_1, r_config_1)
     assert initial_goal == new_goal
+    assert not goal_manager.check_complete(initial_goal)
 
 
 def test_create_delete_single_replica(mock_backend_state):

--- a/python/ray/serve/tests/test_backend_state.py
+++ b/python/ray/serve/tests/test_backend_state.py
@@ -1,89 +1,216 @@
-import pytest
-from typing import Optional, Tuple
+import time
+from typing import Dict, Optional, Tuple
 from unittest.mock import patch, Mock
-from uuid import uuid4
 
-from ray.serve.common import BackendConfig, BackendInfo, ReplicaConfig
-from ray.serve.backend_state import BackendState
+import pytest
+
+from ray.actor import ActorHandle
+from ray.serve.common import (
+    BackendConfig,
+    BackendInfo,
+    BackendTag,
+    ReplicaConfig,
+    ReplicaTag,
+)
+from ray.serve.backend_state import BackendState, ReplicaState
 
 
-def generate_mock_backend_info(
-        num_replicas: Optional[int] = None) -> BackendInfo:
-    backend_info = BackendInfo(
-        worker_class=lambda x: x,
-        backend_config=BackendConfig(),
-        replica_config=ReplicaConfig(lambda x: x))
-    if num_replicas:
-        backend_info.backend_config.num_replicas = num_replicas
+def mock_replica_factory(mock_replicas):
+    class MockReplicaActorWrapper:
+        def __init__(self, actor_name: str, detached: bool,
+                     controller_name: str, replica_tag: ReplicaTag,
+                     backend_tag: BackendTag):
+            self._actor_name = actor_name
+            self._replica_tag = replica_tag
+            self._backend_tag = backend_tag
+            self._state = ReplicaState.SHOULD_START
 
-    return backend_info
+            mock_replicas.append(self)
+
+            # Will be set when `start()` is called.
+            self.started = False
+            # Expected to be set in the test.
+            self.ready = False
+            # Will be set when `graceful_stop()` is called.
+            self.stopped = False
+            # Expected to be set in the test.
+            self.done_stopping = False
+            # Will be set when `force_stop()` is called.
+            self.force_stopped_counter = 0
+
+        def __del__(self):
+            mock_replicas.remove(self)
+
+        @property
+        def actor_handle(self) -> ActorHandle:
+            return None
+
+        def set_ready(self):
+            self.ready = True
+
+        def set_done_stopping(self):
+            self.done_stopping = True
+
+        def start(self, backend_info: BackendInfo):
+            self.started = True
+
+        def check_ready(self) -> bool:
+            assert self.started
+            return self.ready
+
+        def resource_requirements(
+                self) -> Tuple[Dict[str, float], Dict[str, float]]:
+            assert self.started
+            return {"AVAILABLE_RESOURCE": 1.0}, {"REQUIRED_RESOURCE": 1.0}
+
+        def graceful_stop(self) -> None:
+            assert self.started
+            self.stopped = True
+
+        def check_stopped(self) -> bool:
+            return self.done_stopping
+
+        def force_stop(self):
+            self.force_stopped_counter += 1
+
+    return MockReplicaActorWrapper
+
+
+def generate_configs(num_replicas: Optional[int] = 1
+                     ) -> Tuple[BackendConfig, ReplicaConfig]:
+    return BackendConfig(num_replicas=num_replicas), ReplicaConfig(lambda x: x)
+
+
+class MockTimer:
+    def __init__(self, start_time=None):
+        if start_time is None:
+            start_time = time.time()
+        self._curr = start_time
+
+    def time(self):
+        return self._curr
+
+    def advance(self, by):
+        self._curr += by
 
 
 @pytest.fixture
-def mock_backend_state_inputs() -> Tuple[BackendState, Mock, Mock]:
+def mock_backend_state() -> Tuple[BackendState, Mock, Mock]:
+    timer = MockTimer()
+    mock_replicas = []
     with patch(
-            "ray.serve.kv_store.RayInternalKVStore") as mock_kv_store, patch(
-                "ray.serve.long_poll.LongPollHost") as mock_long_poll, patch(
-                    "ray.serve.async_goal_manager.AsyncGoalManager"
-                ) as mock_goal_manager:
+            "ray.serve.backend_state.ActorReplicaWrapper",
+            new=mock_replica_factory(mock_replicas)
+    ), patch(
+            "time.time", new=timer.time
+    ), patch("ray.serve.kv_store.RayInternalKVStore") as mock_kv_store, patch(
+            "ray.serve.long_poll.LongPollHost") as mock_long_poll, patch(
+                "ray.serve.async_goal_manager.AsyncGoalManager"
+            ) as mock_goal_manager, patch.object(
+                BackendState, "_checkpoint") as mock_checkpoint:
         mock_kv_store.get = Mock(return_value=None)
         backend_state = BackendState("name", True, mock_kv_store,
                                      mock_long_poll, mock_goal_manager)
-        yield backend_state, mock_kv_store, mock_long_poll, mock_goal_manager
+        mock_checkpoint.return_value = None
+        yield backend_state, timer, mock_replicas
 
 
-def test_completed_goals_deleted_backend(mock_backend_state_inputs):
-    backend_state = mock_backend_state_inputs[0]
-    b1 = "backend_one"
-    backend_state.backends[b1] = None
-    backend_state.backend_replicas[b1] = {}
-    result_uuid_b1 = uuid4()
-    backend_state.backend_goals[b1] = result_uuid_b1
+def replica_count(backend_state, backend=None, states=None):
+    total = 0
+    for backend_tag, state_dict in backend_state._replicas.items():
+        if backend is None or backend_tag == backend:
+            for state, replica_list in state_dict.items():
+                if states is None or state in states:
+                    total += len(replica_list)
 
-    assert backend_state._completed_goals() == [result_uuid_b1]
-
-    backend_state.backend_goals = {}
-
-    b2 = "backend_two"
-    backend_state.backends[b2] = None
-    result_uuid_b2 = uuid4()
-    backend_state.backend_goals[b2] = result_uuid_b2
-
-    assert backend_state._completed_goals() == [result_uuid_b2]
+    return total
 
 
-def test_completed_goals_delta_backend(mock_backend_state_inputs):
-    backend_state = mock_backend_state_inputs[0]
-    b1 = "backend_one"
-    backend_state.backends[b1] = generate_mock_backend_info()
-    backend_state.backend_replicas[b1] = {i: i for i in range(1)}
-    # NOTE(ilr): This test made it clear that the _completed_goals function
-    # should (.get) from the dict.
-    assert len(backend_state._completed_goals()) == 0
+def test_create_single_replica(mock_backend_state):
+    backend_state, timer, mock_replicas = mock_backend_state
 
-    backend_state.backends[b1] = generate_mock_backend_info(30)
-    result_uuid = uuid4()
-    backend_state.backend_goals[b1] = result_uuid
-    assert len(backend_state._completed_goals()) == 0
+    assert replica_count(backend_state) == 0
 
-    backend_state.backend_replicas[b1] = {i: i for i in range(30)}
-    assert backend_state._completed_goals() == [result_uuid]
+    b_config_1, r_config_1 = generate_configs()
+    backend_state.create_backend("tag1", b_config_1, r_config_1)
+
+    # Single replica should be created.
+    backend_state.update()
+    assert replica_count(backend_state) == 1
+    assert replica_count(backend_state, states=[ReplicaState.STARTING]) == 1
+    assert mock_replicas[0].started
+
+    # update() should not transition the state if the replica isn't ready.
+    backend_state.update()
+    assert replica_count(backend_state) == 1
+    assert replica_count(backend_state, states=[ReplicaState.STARTING]) == 1
+    mock_replicas[0].set_ready()
+
+    # Now the replica should be marked running.
+    backend_state.update()
+    assert replica_count(backend_state) == 1
+    assert replica_count(backend_state, states=[ReplicaState.RUNNING]) == 1
+
+    # Removing the replica should transition it to stopping.
+    backend_state.delete_backend("tag1")
+    backend_state.update()
+    assert replica_count(backend_state) == 1
+    assert replica_count(backend_state, states=[ReplicaState.STOPPING]) == 1
+    assert mock_replicas[0].stopped
+
+    # Once it's done stopping, replica should be removed.
+    mock_replicas[0].set_done_stopping()
+    backend_state.update()
+    assert replica_count(backend_state) == 0
 
 
-def test_completed_goals_created_backend(mock_backend_state_inputs):
-    backend_state = mock_backend_state_inputs[0]
-    assert len(backend_state._completed_goals()) == 0
+def test_force_kill(mock_backend_state):
+    backend_state, timer, mock_replicas = mock_backend_state
 
-    b1 = "backend_one"
-    backend_state.backends[b1] = generate_mock_backend_info()
-    result_uuid = uuid4()
-    backend_state.backend_goals[b1] = result_uuid
+    assert replica_count(backend_state) == 0
 
-    assert len(backend_state._completed_goals()) == 0
+    grace_period_s = 10
+    b_config_1, r_config_1 = generate_configs()
+    b_config_1.experimental_graceful_shutdown_timeout_s = grace_period_s
 
-    backend_state.backend_replicas[b1] = {i: i for i in range(1)}
+    # Create and delete the backend.
+    backend_state.create_backend("tag1", b_config_1, r_config_1)
+    backend_state.update()
+    mock_replicas[0].set_ready()
+    backend_state.update()
+    backend_state.delete_backend("tag1")
+    backend_state.update()
 
-    assert backend_state._completed_goals() == [result_uuid]
+    # Replica should remain in STOPPING until it finishes.
+    assert replica_count(backend_state) == 1
+    assert replica_count(backend_state, states=[ReplicaState.STOPPING]) == 1
+    assert mock_replicas[0].stopped
+
+    backend_state.update()
+    backend_state.update()
+
+    # force_stop shouldn't be called until after the timer.
+    assert not mock_replicas[0].force_stopped_counter
+    assert replica_count(backend_state) == 1
+    assert replica_count(backend_state, states=[ReplicaState.STOPPING]) == 1
+
+    # Advance the timer, now the replica should be force stopped.
+    timer.advance(grace_period_s + 0.1)
+    backend_state.update()
+    assert mock_replicas[0].force_stopped_counter == 1
+    assert replica_count(backend_state) == 1
+    assert replica_count(backend_state, states=[ReplicaState.STOPPING]) == 1
+
+    # Force stop should be called repeatedly until the replica stops.
+    backend_state.update()
+    assert mock_replicas[0].force_stopped_counter == 2
+    assert replica_count(backend_state) == 1
+    assert replica_count(backend_state, states=[ReplicaState.STOPPING]) == 1
+
+    # Once the replica is done stopping, it should be removed.
+    mock_replicas[0].set_done_stopping()
+    backend_state.update()
+    assert replica_count(backend_state) == 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We're about to make BackendState more complex by adding more logic for incremental rollouts, so we should get ahead of the curve and make it unit-testable now.

This actually already discovered a small bug that `force_kill` wouldn't be called repeatedly.

...and another that we were returning the existing goal when calling `create_backend` with the same args.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
