### PR TITLE
[Code Cleanup] Switch to  use `ray.util.get_node_ip_address()`

### DIFF
--- a/dashboard/head.py
+++ b/dashboard/head.py
@@ -45,7 +45,7 @@ class DashboardHead:
         self.aioredis_client = None
         self.aiogrpc_gcs_channel = None
         self.http_session = None
-        self.ip = ray._private.services.get_node_ip_address()
+        self.ip = ray.util.get_node_ip_address()
         self.server = aiogrpc.server(options=(("grpc.so_reuseport", 0), ))
         self.grpc_port = self.server.add_insecure_port("[::]:0")
         logger.info("Dashboard head grpc address: %s:%s", self.ip,

--- a/dashboard/modules/job/tests/test_job.py
+++ b/dashboard/modules/job/tests/test_job.py
@@ -34,7 +34,7 @@ def test_get_job_info(disable_aiohttp_cache, ray_start_with_dashboard):
     webui_url = ray_start_with_dashboard["webui_url"]
     webui_url = format_web_url(webui_url)
 
-    ip = ray._private.services.get_node_ip_address()
+    ip = ray.util.get_node_ip_address()
 
     def _check():
         resp = requests.get(f"{webui_url}/jobs?view=summary")

--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -139,7 +139,7 @@ class ReporterAgent(dashboard_utils.DashboardAgentModule,
             self._cpu_counts = (psutil.cpu_count(),
                                 psutil.cpu_count(logical=False))
 
-        self._ip = ray._private.services.get_node_ip_address()
+        self._ip = ray.util.get_node_ip_address()
         self._redis_address, _ = dashboard_agent.redis_address
         self._is_head_node = (self._ip == self._redis_address)
         self._hostname = socket.gethostname()

--- a/doc/examples/lm/ray_train.py
+++ b/doc/examples/lm/ray_train.py
@@ -72,7 +72,7 @@ class RayDistributedActor:
 
     def get_node_ip(self):
         """Returns the IP address of the current node."""
-        return ray._private.services.get_node_ip_address()
+        return ray.util.get_node_ip_address()
 
     def find_free_port(self):
         """Finds a free port on the current node."""

--- a/doc/examples/lm/ray_train.py
+++ b/doc/examples/lm/ray_train.py
@@ -72,7 +72,7 @@ class RayDistributedActor:
 
     def get_node_ip(self):
         """Returns the IP address of the current node."""
-        return ray.services.get_node_ip_address()
+        return ray._private.services.get_node_ip_address()
 
     def find_free_port(self):
         """Finds a free port on the current node."""

--- a/doc/examples/plot_example-lm.rst
+++ b/doc/examples/plot_example-lm.rst
@@ -133,7 +133,7 @@ Two main components of ``ray_train.py`` are a ``RayDistributedActor`` class and 
 
       def get_node_ip(self):
           """Returns the IP address of the current node."""
-          return ray.services.get_node_ip_address()
+          return ray._private.services.get_node_ip_address()
 
       def find_free_port(self):
           """Finds a free port on the current node."""

--- a/doc/source/cluster/cloud.rst
+++ b/doc/source/cluster/cloud.rst
@@ -435,7 +435,7 @@ To verify that the correct number of nodes have joined the cluster, you can run 
   @ray.remote
   def f():
       time.sleep(0.01)
-      return ray.services.get_node_ip_address()
+      return ray._private.services.get_node_ip_address()
 
   # Get a list of the IP addresses of the nodes that have joined the cluster.
   set(ray.get([f.remote() for _ in range(1000)]))

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -81,7 +81,7 @@ class RayTaskError(RayError):
         else:
             self.proctitle = setproctitle.getproctitle()
         self.pid = pid or os.getpid()
-        self.ip = ip or ray._private.services.get_node_ip_address()
+        self.ip = ip or ray.util.get_node_ip_address()
         self.function_name = function_name
         self.traceback_str = traceback_str
         # TODO(edoakes): should we handle non-serializable exception objects?

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -99,10 +99,10 @@ class Node:
         if ray_params.node_ip_address:
             node_ip_address = ray_params.node_ip_address
         elif ray_params.redis_address:
-            node_ip_address = ray._private.services.get_node_ip_address(
+            node_ip_address = ray.util.get_node_ip_address(
                 ray_params.redis_address)
         else:
-            node_ip_address = ray._private.services.get_node_ip_address()
+            node_ip_address = ray.util.get_node_ip_address()
         self._node_ip_address = node_ip_address
 
         if ray_params.raylet_ip_address:

--- a/python/ray/resource_spec.py
+++ b/python/ray/resource_spec.py
@@ -125,7 +125,7 @@ class ResourceSpec(
         assert "object_store_memory" not in resources, resources
 
         if node_ip_address is None:
-            node_ip_address = ray._private.services.get_node_ip_address()
+            node_ip_address = ray.util.get_node_ip_address()
 
         # Automatically create a node id resource on each node. This is
         # queryable with ray.state.node_ids() and ray.state.current_node_id().

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -3,4 +3,4 @@ import ray
 
 # TODO(ekl) deprecate and move this to ray.util
 def get_node_ip_address(address="8.8.8.8:53"):
-    return ray._private.services.get_node_ip_address(address)
+    return ray.util.get_node_ip_address(address)

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1,6 +1,13 @@
+import warnings
+
 import ray
 
 
-# TODO(ekl) deprecate and move this to ray.util
+# TODO(ekl) deprecate this
 def get_node_ip_address(address="8.8.8.8:53"):
+    warnings.warn(
+        DeprecationWarning(
+            "ray.services.get_node_ip_address has been moved to "
+            "ray.util.get_node_ip_address."),
+        stacklevel=2)
     return ray.util.get_node_ip_address(address)

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -3,11 +3,12 @@ import warnings
 import ray
 
 
-# TODO(ekl) deprecate this
+# TODO(ekl) deprecate this after Ray 1.4
 def get_node_ip_address(address="8.8.8.8:53"):
     warnings.warn(
         DeprecationWarning(
             "ray.services.get_node_ip_address has been moved to "
-            "ray.util.get_node_ip_address."),
+            "ray.util.get_node_ip_address. 'ray.services' will be "
+            "removed after Ray 1.4."),
         stacklevel=2)
     return ray.util.get_node_ip_address(address)

--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -896,8 +896,7 @@ def current_node_id():
     Returns:
         Id of the current node.
     """
-    return (ray.resource_spec.NODE_ID_PREFIX +
-            ray._private.services.get_node_ip_address())
+    return (ray.resource_spec.NODE_ID_PREFIX + ray.util.get_node_ip_address())
 
 
 def node_ids():

--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -640,7 +640,7 @@ def test_get_correct_node_ip():
         node_mock = MagicMock()
         node_mock.node_ip_address = "10.0.0.111"
         worker_mock._global_node = node_mock
-        found_ip = ray._private.services.get_node_ip_address()
+        found_ip = ray.util.get_node_ip_address()
         assert found_ip == "10.0.0.111"
 
 

--- a/python/ray/tests/test_global_state.py
+++ b/python/ray/tests/test_global_state.py
@@ -341,7 +341,7 @@ def test_heartbeat_ip(shutdown_only):
         cluster["redis_address"], ray.ray_constants.REDIS_DEFAULT_PASSWORD)
     global_state_accessor.connect()
 
-    self_ip = ray._private.services.get_node_ip_address()
+    self_ip = ray.util.get_node_ip_address()
 
     def self_ip_is_set():
         message = global_state_accessor.get_all_resource_usage()

--- a/python/ray/tests/test_global_state.py
+++ b/python/ray/tests/test_global_state.py
@@ -7,7 +7,6 @@ import time
 
 import ray
 import ray.ray_constants
-import ray.services
 import ray.test_utils
 
 from ray._raylet import GlobalStateAccessor
@@ -342,7 +341,7 @@ def test_heartbeat_ip(shutdown_only):
         cluster["redis_address"], ray.ray_constants.REDIS_DEFAULT_PASSWORD)
     global_state_accessor.connect()
 
-    self_ip = ray.services.get_node_ip_address()
+    self_ip = ray._private.services.get_node_ip_address()
 
     def self_ip_is_set():
         message = global_state_accessor.get_all_resource_usage()

--- a/python/ray/tune/integration/tensorflow.py
+++ b/python/ray/tune/integration/tensorflow.py
@@ -36,7 +36,7 @@ def setup_process_group(worker_addresses, index):
 
 
 def setup_address():
-    ip = ray.services.get_node_ip_address()
+    ip = ray._private.services.get_node_ip_address()
     port = find_free_port()
     return f"{ip}:{port}"
 

--- a/python/ray/tune/integration/tensorflow.py
+++ b/python/ray/tune/integration/tensorflow.py
@@ -36,7 +36,7 @@ def setup_process_group(worker_addresses, index):
 
 
 def setup_address():
-    ip = ray._private.services.get_node_ip_address()
+    ip = ray.util.get_node_ip_address()
     port = find_free_port()
     return f"{ip}:{port}"
 

--- a/python/ray/tune/tests/test_sync.py
+++ b/python/ray/tune/tests/test_sync.py
@@ -120,8 +120,7 @@ class TestSyncFunctionality(unittest.TestCase):
                 }).trials
 
         with patch.object(CommandBasedClient, "_execute") as mock_fn:
-            with patch(
-                    "ray._private.services.get_node_ip_address") as mock_sync:
+            with patch("ray.util.get_node_ip_address") as mock_sync:
                 sync_config = tune.SyncConfig(
                     sync_to_driver="echo {source} {target}")
                 mock_sync.return_value = "0.0.0.0"
@@ -217,7 +216,7 @@ class TestSyncFunctionality(unittest.TestCase):
         test_file_path = os.path.join(trial.logdir, "test.log2")
         self.assertFalse(os.path.exists(test_file_path))
 
-        with patch("ray._private.services.get_node_ip_address") as mock_sync:
+        with patch("ray.util.get_node_ip_address") as mock_sync:
             mock_sync.return_value = "0.0.0.0"
             sync_config = tune.SyncConfig(sync_to_driver=sync_func_driver)
             [trial] = tune.run(

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -143,7 +143,7 @@ class Trainable:
         return ""
 
     def get_current_ip(self):
-        self._local_ip = ray.services.get_node_ip_address()
+        self._local_ip = ray._private.services.get_node_ip_address()
         return self._local_ip
 
     def train_buffered(self,

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -143,7 +143,7 @@ class Trainable:
         return ""
 
     def get_current_ip(self):
-        self._local_ip = ray._private.services.get_node_ip_address()
+        self._local_ip = ray.util.get_node_ip_address()
         return self._local_ip
 
     def train_buffered(self,

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -9,7 +9,7 @@ import time
 import traceback
 import warnings
 
-from ray._private.services import get_node_ip_address
+from ray.util import get_node_ip_address
 from ray.tune import TuneError
 from ray.tune.callback import CallbackList
 from ray.tune.stopper import NoopStopper

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -9,7 +9,7 @@ import time
 import traceback
 import warnings
 
-from ray.services import get_node_ip_address
+from ray._private.services import get_node_ip_address
 from ray.tune import TuneError
 from ray.tune.callback import CallbackList
 from ray.tune.stopper import NoopStopper

--- a/python/ray/util/__init__.py
+++ b/python/ray/util/__init__.py
@@ -1,3 +1,4 @@
+from ray._private.services import get_node_ip_address
 from ray.util import iter
 from ray.util.actor_pool import ActorPool
 from ray.util.check_serialize import inspect_serializability
@@ -21,6 +22,7 @@ __all__ = [
     "placement_group",
     "placement_group_table",
     "get_placement_group",
+    "get_node_ip_address",
     "remove_placement_group",
     "inspect_serializability",
     "collective",

--- a/python/ray/util/collective/collective_group/gloo_collective_group.py
+++ b/python/ray/util/collective/collective_group/gloo_collective_group.py
@@ -40,7 +40,7 @@ class Rendezvous:
         self._redis_ip_address, self._redis_port = \
             ray.worker._global_node.redis_address.split(":")
         self._process_ip_address = \
-            ray._private.services.get_node_ip_address()
+            ray.util.get_node_ip_address()
         logger.debug("Redis address: {}, port: {}, this actor address: {}."
                      .format(self._redis_ip_address, self._redis_port,
                              self._process_ip_address))

--- a/python/ray/util/sgd/tf/tf_runner.py
+++ b/python/ray/util/sgd/tf/tf_runner.py
@@ -147,7 +147,7 @@ class TFRunner:
 
     def get_node_ip(self):
         """Returns the IP address of the current node."""
-        return ray.services.get_node_ip_address()
+        return ray._private.services.get_node_ip_address()
 
     def find_free_port(self):
         """Finds a free port on the current node."""

--- a/python/ray/util/sgd/tf/tf_runner.py
+++ b/python/ray/util/sgd/tf/tf_runner.py
@@ -147,7 +147,7 @@ class TFRunner:
 
     def get_node_ip(self):
         """Returns the IP address of the current node."""
-        return ray._private.services.get_node_ip_address()
+        return ray.util.get_node_ip_address()
 
     def find_free_port(self):
         """Finds a free port on the current node."""

--- a/python/ray/util/sgd/torch/distributed_torch_runner.py
+++ b/python/ray/util/sgd/torch/distributed_torch_runner.py
@@ -167,7 +167,7 @@ def clear_dummy_actor():
 
 
 def reserve_resources(num_cpus, num_gpus, retries=20):
-    ip = ray.services.get_node_ip_address()
+    ip = ray._private.services.get_node_ip_address()
 
     reserved_cuda_device = None
 

--- a/python/ray/util/sgd/torch/distributed_torch_runner.py
+++ b/python/ray/util/sgd/torch/distributed_torch_runner.py
@@ -167,7 +167,7 @@ def clear_dummy_actor():
 
 
 def reserve_resources(num_cpus, num_gpus, retries=20):
-    ip = ray._private.services.get_node_ip_address()
+    ip = ray.util.get_node_ip_address()
 
     reserved_cuda_device = None
 

--- a/python/ray/util/sgd/torch/torch_runner.py
+++ b/python/ray/util/sgd/torch/torch_runner.py
@@ -253,7 +253,7 @@ class TorchRunner:
         return self.models
 
     def get_node_ip(self):
-        return ray._private.services.get_node_ip_address()
+        return ray.util.get_node_ip_address()
 
     @property
     def models(self):

--- a/python/ray/util/sgd/torch/torch_runner.py
+++ b/python/ray/util/sgd/torch/torch_runner.py
@@ -253,7 +253,7 @@ class TorchRunner:
         return self.models
 
     def get_node_ip(self):
-        return ray.services.get_node_ip_address()
+        return ray._private.services.get_node_ip_address()
 
     @property
     def models(self):

--- a/python/ray/util/sgd/torch/utils.py
+++ b/python/ray/util/sgd/torch/utils.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def setup_address():
-    ip = ray._private.services.get_node_ip_address()
+    ip = ray.util.get_node_ip_address()
     port = find_free_port()
     return f"tcp://{ip}:{port}"
 

--- a/python/ray/util/sgd/torch/utils.py
+++ b/python/ray/util/sgd/torch/utils.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def setup_address():
-    ip = ray.services.get_node_ip_address()
+    ip = ray._private.services.get_node_ip_address()
     port = find_free_port()
     return f"tcp://{ip}:{port}"
 

--- a/python/ray/util/sgd/torch/worker_group.py
+++ b/python/ray/util/sgd/torch/worker_group.py
@@ -470,7 +470,7 @@ class LocalWorkerGroup(WorkerGroupInterface):
                 timeout=timedelta(seconds=self._timeout_s))
             ray.get(remote_pgs)
 
-            local_node_ip = ray._private.services.get_node_ip_address()
+            local_node_ip = ray.util.get_node_ip_address()
             rank_dict = defaultdict(int)
             self.local_worker.set_local_rank(local_rank=0)
             rank_dict[local_node_ip] += 1

--- a/python/ray/util/sgd/torch/worker_group.py
+++ b/python/ray/util/sgd/torch/worker_group.py
@@ -470,7 +470,7 @@ class LocalWorkerGroup(WorkerGroupInterface):
                 timeout=timedelta(seconds=self._timeout_s))
             ray.get(remote_pgs)
 
-            local_node_ip = ray.services.get_node_ip_address()
+            local_node_ip = ray._private.services.get_node_ip_address()
             rank_dict = defaultdict(int)
             self.local_worker.set_local_rank(local_rank=0)
             rank_dict[local_node_ip] += 1

--- a/release/xgboost_tests/workloads/ft_small_non_elastic.py
+++ b/release/xgboost_tests/workloads/ft_small_non_elastic.py
@@ -19,7 +19,7 @@ import os
 import time
 
 import ray
-from ray.services import get_node_ip_address
+from ray._private.services import get_node_ip_address
 
 from xgboost_ray import RayParams
 from xgboost_ray.session import get_actor_rank, put_queue

--- a/release/xgboost_tests/workloads/ft_small_non_elastic.py
+++ b/release/xgboost_tests/workloads/ft_small_non_elastic.py
@@ -19,7 +19,7 @@ import os
 import time
 
 import ray
-from ray._private.services import get_node_ip_address
+from ray.util import get_node_ip_address
 
 from xgboost_ray import RayParams
 from xgboost_ray.session import get_actor_rank, put_queue

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -1154,7 +1154,7 @@ class RolloutWorker(ParallelIteratorWorker):
 
     def get_node_ip(self) -> str:
         """Returns the IP address of the current node."""
-        return ray._private.services.get_node_ip_address()
+        return ray.util.get_node_ip_address()
 
     def find_free_port(self) -> int:
         """Finds a free port on the current node."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* This will allow us to deprecate `ray.services` completely. 
Example of warning:
```
  /home/ubuntu/ray/python/ray/tests/test_basic_2.py:644: DeprecationWarning: ray.services.get_node_ip_address has been moved to ray.util.get_node_ip_address.
    found_ip = get_node_ip_address()
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
