### PR TITLE
[packaging] Supporting loading package from dict config

### DIFF
--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -71,6 +71,8 @@ def load_package(package_def: Union[str, Dict[str, str]]) -> "_RuntimePackage":
     """
 
     if isinstance(package_def, dict):
+        # TODO(edoakes): when loading the package natively in Python, we should
+        # support passing in the stub module directly instead of a file.
         config = package_def
         base_dir = os.path.abspath(os.path.dirname(__file__))
     elif isinstance(package_def, str):

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -257,3 +257,17 @@ if __name__ == "__main__":
     print("-> Loaded package", pkg2)
     print("-> Testing method call")
     print(ray.get(pkg2.my_func.remote()))
+
+    print("-> Testing load from Python dict")
+    os.chdir("example_pkg")
+    pkg3 = load_package({
+        "name": "example_package",
+        "description": "This is the example config for my package.",
+        "stub_file": "my_pkg/stubs.py",
+        "runtime_env": {
+            "docker": "anyscale-ml/ray-ml:nightly-py38-cpu"
+        }
+    })
+    print("-> Loaded package", pkg3)
+    print("-> Testing method call")
+    print(ray.get(pkg3.my_func.remote()))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In an effort to keep things as "code native" as possible, support loading packages directly in Python without writing YAMLs. I imagine this would be the common case for Serve for example.

Ideally we should be able to provide the entire package in code without worrying about local files at all, but this is just a first cut.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
