### PR TITLE
[RLlib] Fixing conv filters config for ComplexInputNetwork

### DIFF
--- a/rllib/models/tf/complex_input_net.py
+++ b/rllib/models/tf/complex_input_net.py
@@ -50,8 +50,8 @@ class ComplexInputNetwork(TFModelV2):
             if len(component.shape) == 3:
                 config = {
                     "conv_filters": model_config["conv_filters"]
-                    if "conv_filters" in model_config
-                    else get_filter_config(obs_space.shape),
+                    if "conv_filters" in model_config else
+                    get_filter_config(obs_space.shape),
                     "conv_activation": model_config.get("conv_activation"),
                     "post_fcnet_hiddens": [],
                 }

--- a/rllib/models/tf/complex_input_net.py
+++ b/rllib/models/tf/complex_input_net.py
@@ -49,8 +49,9 @@ class ComplexInputNetwork(TFModelV2):
             # Image space.
             if len(component.shape) == 3:
                 config = {
-                    "conv_filters": model_config.get(
-                        "conv_filters", get_filter_config(component.shape)),
+                    "conv_filters": model_config["conv_filters"]
+                    if "conv_filters" in model_config
+                    else get_filter_config(obs_space.shape),
                     "conv_activation": model_config.get("conv_activation"),
                     "post_fcnet_hiddens": [],
                 }
@@ -82,7 +83,7 @@ class ComplexInputNetwork(TFModelV2):
         self.post_fc_stack = ModelCatalog.get_model_v2(
             Box(float("-inf"),
                 float("inf"),
-                shape=(concat_size, ),
+                shape=(concat_size,),
                 dtype=np.float32),
             self.action_space,
             None,
@@ -96,7 +97,7 @@ class ComplexInputNetwork(TFModelV2):
         if num_outputs:
             # Action-distribution head.
             concat_layer = tf.keras.layers.Input(
-                (self.post_fc_stack.num_outputs, ))
+                (self.post_fc_stack.num_outputs,))
             logits_layer = tf.keras.layers.Dense(
                 num_outputs,
                 activation=tf.keras.activations.linear,
@@ -151,6 +152,5 @@ class ComplexInputNetwork(TFModelV2):
     @override(ModelV2)
     def value_function(self):
         return self._value_out
-
 
 # __sphinx_doc_end__

--- a/rllib/models/tf/complex_input_net.py
+++ b/rllib/models/tf/complex_input_net.py
@@ -83,7 +83,7 @@ class ComplexInputNetwork(TFModelV2):
         self.post_fc_stack = ModelCatalog.get_model_v2(
             Box(float("-inf"),
                 float("inf"),
-                shape=(concat_size,),
+                shape=(concat_size, ),
                 dtype=np.float32),
             self.action_space,
             None,
@@ -97,7 +97,7 @@ class ComplexInputNetwork(TFModelV2):
         if num_outputs:
             # Action-distribution head.
             concat_layer = tf.keras.layers.Input(
-                (self.post_fc_stack.num_outputs,))
+                (self.post_fc_stack.num_outputs, ))
             logits_layer = tf.keras.layers.Dense(
                 num_outputs,
                 activation=tf.keras.activations.linear,
@@ -152,5 +152,6 @@ class ComplexInputNetwork(TFModelV2):
     @override(ModelV2)
     def value_function(self):
         return self._value_out
+
 
 # __sphinx_doc_end__

--- a/rllib/models/torch/complex_input_net.py
+++ b/rllib/models/torch/complex_input_net.py
@@ -55,7 +55,9 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
             # Image space.
             if len(component.shape) == 3:
                 config = {
-                    "conv_filters": model_config.get("conv_filters") if "conv_filters" in model_config else get_filter_config(obs_space.shape),
+                    "conv_filters": model_config["conv_filters"]
+                    if "conv_filters" in model_config
+                    else get_filter_config(obs_space.shape),
                     "conv_activation": model_config.get("conv_activation"),
                     "post_fcnet_hiddens": [],
                 }

--- a/rllib/models/torch/complex_input_net.py
+++ b/rllib/models/torch/complex_input_net.py
@@ -56,8 +56,8 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
             if len(component.shape) == 3:
                 config = {
                     "conv_filters": model_config["conv_filters"]
-                    if "conv_filters" in model_config
-                    else get_filter_config(obs_space.shape),
+                    if "conv_filters" in model_config else
+                    get_filter_config(obs_space.shape),
                     "conv_activation": model_config.get("conv_activation"),
                     "post_fcnet_hiddens": [],
                 }

--- a/rllib/models/torch/complex_input_net.py
+++ b/rllib/models/torch/complex_input_net.py
@@ -55,8 +55,7 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
             # Image space.
             if len(component.shape) == 3:
                 config = {
-                    "conv_filters": model_config.get(
-                        "conv_filters", get_filter_config(component.shape)),
+                    "conv_filters": model_config.get("conv_filters") if "conv_filters" in model_config else get_filter_config(obs_space.shape),
                     "conv_activation": model_config.get("conv_activation"),
                     "post_fcnet_hiddens": [],
                 }


### PR DESCRIPTION
## Why are these changes needed?

Both the torch and tf version of `ComplexInputNetwork` raise an exception when the obs_space.shape is not one of the predefined sizes in `utils.py/get_filter_config()`. This is because `get_filter_config` is used in the default argument, and is still called even if "conv_filters" is in the `model_config`.

This fix is to only call `get_filter_config` when "conv_filters" is not in the model config.

The exception:
```
File "C:\Users\Jack\PycharmProjects\marl-disaster-relief\venv\lib\site-packages\ray\worker.py", line 184, in reraise_actor_init_error
    raise self.actor_init_error
  File "python\ray\_raylet.pyx", line 484, in ray._raylet.execute_task
  File "python\ray\_raylet.pyx", line 491, in ray._raylet.execute_task
  File "python\ray\_raylet.pyx", line 501, in ray._raylet.execute_task
  File "python\ray\_raylet.pyx", line 444, in ray._raylet.execute_task.function_executor
  File "C:\Users\Jack\PycharmProjects\marl-disaster-relief\venv\lib\site-packages\ray\_private\function_manager.py", line 556, in actor_method_executor
    return method(__ray_actor, *args, **kwargs)
  File "C:\Users\Jack\PycharmProjects\marl-disaster-relief\venv\lib\site-packages\ray\rllib\evaluation\rollout_worker.py", line 487, in __init__
    policy_dict, policy_config)
  File "C:\Users\Jack\PycharmProjects\marl-disaster-relief\venv\lib\site-packages\ray\rllib\evaluation\rollout_worker.py", line 1129, in _build_policy_map
    policy_map[name] = cls(obs_space, act_space, merged_conf)
  File "C:\Users\Jack\PycharmProjects\marl-disaster-relief\venv\lib\site-packages\ray\rllib\policy\policy_template.py", line 234, in __init__
    framework=framework)
  File "C:\Users\Jack\PycharmProjects\marl-disaster-relief\venv\lib\site-packages\ray\rllib\models\catalog.py", line 568, in get_model_v2
    name, **model_kwargs)
  File "C:\Users\Jack\PycharmProjects\marl-disaster-relief\venv\lib\site-packages\ray\rllib\models\torch\complex_input_net.py", line 60, in __init__
    "conv_filters", get_filter_config(component.shape)),
  File "C:\Users\Jack\PycharmProjects\marl-disaster-relief\venv\lib\site-packages\ray\rllib\models\utils.py", line 103, in get_filter_config
    ", you must specify `conv_filters` manually as a model option. "
ValueError: No default configuration for obs shape [11, 11, 3], you must specify `conv_filters` manually as a model option. Default configurations are only available for inputs of shape [42, 42, K] and [84, 84, K]. You may alternatively want to use a custom model or preprocessor.
```

## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
