### PR TITLE
[autoscaler] fix azure config issues

### DIFF
--- a/python/ray/autoscaler/_private/azure/config.py
+++ b/python/ray/autoscaler/_private/azure/config.py
@@ -105,7 +105,7 @@ def _configure_key_pair(config):
 
     for node_type in config["available_node_types"].values():
         azure_arm_parameters = node_type.setdefault(
-            ["node_config"], {}).setdefault("azure_arm_parameters", {})
+            "node_config", {}).setdefault("azure_arm_parameters", {})
         azure_arm_parameters["adminUsername"] = ssh_user
         azure_arm_parameters["publicKey"] = public_key
 

--- a/python/ray/autoscaler/_private/azure/config.py
+++ b/python/ray/autoscaler/_private/azure/config.py
@@ -103,8 +103,10 @@ def _configure_key_pair(config):
             with open(key_path, "r") as f:
                 public_key = f.read()
 
-    for node_type in ["head_node", "worker_nodes"]:
-        config[node_type]["azure_arm_parameters"]["adminUsername"] = ssh_user
-        config[node_type]["azure_arm_parameters"]["publicKey"] = public_key
+    for node_type in config["available_node_types"].values():
+        azure_arm_parameters = node_type.setdefault(
+            ["node_config"], {}).setdefault("azure_arm_parameters", {})
+        azure_arm_parameters["adminUsername"] = ssh_user
+        azure_arm_parameters["publicKey"] = public_key
 
     return config

--- a/python/ray/autoscaler/_private/azure/config.py
+++ b/python/ray/autoscaler/_private/azure/config.py
@@ -104,8 +104,8 @@ def _configure_key_pair(config):
                 public_key = f.read()
 
     for node_type in config["available_node_types"].values():
-        azure_arm_parameters = node_type.setdefault(
-            "node_config", {}).setdefault("azure_arm_parameters", {})
+        azure_arm_parameters = node_type["node_config"].setdefault(
+            "azure_arm_parameters", {})
         azure_arm_parameters["adminUsername"] = ssh_user
         azure_arm_parameters["publicKey"] = public_key
 

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -248,6 +248,7 @@ CONFIG_CACHE_VERSION = 1
 def _bootstrap_config(config: Dict[str, Any],
                       no_config_cache: bool = False) -> Dict[str, Any]:
     config = prepare_config(config)
+    # NOTE: multi-node-type autoscaler is guaranteed to be in use after this.
 
     hasher = hashlib.sha1()
     hasher.update(json.dumps([config], sort_keys=True).encode("utf-8"))

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -97,7 +97,14 @@ def validate_config(config: Dict[str, Any]) -> None:
                 "sum of `min_workers` of all the available node types.")
 
 
-def prepare_config(config):
+def prepare_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    The returned config has the following properties:
+    - Uses the multi-node-type autoscaler configuration.
+    - Merged with the appropriate defaults.yaml
+    - Has a valid Docker configuration if provided.
+    - Has max_worker set for each node type.
+    """
     with_defaults = fillout_defaults(config)
     merge_setup_commands(with_defaults)
     validate_docker_config(with_defaults)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -43,6 +43,8 @@ starlette
 
 # Requirements for running tests
 blist; platform_system != "Windows"
+azure-common
+azure-mgmt-resource
 boto3
 cython==0.29.0
 dataclasses; python_version < '3.7'

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -45,6 +45,7 @@ starlette
 blist; platform_system != "Windows"
 azure-common
 azure-mgmt-resource
+msrestazure
 boto3
 cython==0.29.0
 dataclasses; python_version < '3.7'


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Azure Requires that certain fields (`adminUsername`, `publicKey`) be set in the `node_config`. We were setting those in the `head_node::azure_arm_parameters `, but they were getting overridden by `available_node_types::head_node_type::node_config::azure_arm_parameters` 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #14668
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
