### PR TITLE
[Serve] Add initial support for FastAPI

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -11,7 +11,7 @@ opencv-python-headless==4.3.0.36
 pandas
 pickle5
 pillow
-pydantic<1.7
+pydantic
 pygments
 pyyaml
 recommonmark

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -4,6 +4,7 @@ colorful
 filelock
 flask
 flatbuffers
+fastapi
 jsonschema
 mock
 numpy

--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -175,6 +175,21 @@ py_test(
     deps = [":serve_lib"],
 )
 
+py_test(
+    name = "test_pydantic_serialization",
+    size = "small",
+    srcs = serve_tests_srcs,
+    tags = ["exclusive"],
+    deps = [":serve_lib"],
+)
+
+py_test(
+    name = "test_fastapi",
+    size = "small",
+    srcs = serve_tests_srcs,
+    tags = ["exclusive"],
+    deps = [":serve_lib"],
+)
 
 # Runs test_api and test_failure with injected failures in the controller.
 # TODO(simon): Tests are disabled until #11683 is fixed.

--- a/python/ray/serve/__init__.py
+++ b/python/ray/serve/__init__.py
@@ -2,7 +2,7 @@ from ray.serve.api import (
     accept_batch, connect, start, get_replica_context, get_handle,
     shadow_traffic, set_traffic, delete_backend, list_backends, create_backend,
     get_backend_config, update_backend_config, list_endpoints, delete_endpoint,
-    create_endpoint, shutdown, deployment)
+    create_endpoint, shutdown, ingress)
 from ray.serve.batching import batch
 from ray.serve.config import BackendConfig, HTTPOptions
 from ray.serve.utils import ServeRequest
@@ -18,5 +18,5 @@ __all__ = [
     "shadow_traffic", "set_traffic", "delete_backend", "list_backends",
     "create_backend", "get_backend_config", "update_backend_config",
     "list_endpoints", "delete_endpoint", "create_endpoint", "shutdown",
-    "deployment"
+    "ingress"
 ]

--- a/python/ray/serve/__init__.py
+++ b/python/ray/serve/__init__.py
@@ -2,7 +2,7 @@ from ray.serve.api import (
     accept_batch, connect, start, get_replica_context, get_handle,
     shadow_traffic, set_traffic, delete_backend, list_backends, create_backend,
     get_backend_config, update_backend_config, list_endpoints, delete_endpoint,
-    create_endpoint, shutdown)
+    create_endpoint, shutdown, deployment)
 from ray.serve.batching import batch
 from ray.serve.config import BackendConfig, HTTPOptions
 from ray.serve.utils import ServeRequest
@@ -17,5 +17,6 @@ __all__ = [
     "HTTPOptions", "get_replica_context", "ServeRequest", "get_handle",
     "shadow_traffic", "set_traffic", "delete_backend", "list_backends",
     "create_backend", "get_backend_config", "update_backend_config",
-    "list_endpoints", "delete_endpoint", "create_endpoint", "shutdown"
+    "list_endpoints", "delete_endpoint", "create_endpoint", "shutdown",
+    "deployment"
 ]

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -9,6 +9,8 @@ from typing import Any, Callable, Coroutine, Dict, List, Optional, Type, Union
 from dataclasses import dataclass
 from warnings import warn
 
+from fastapi import FastAPI, APIRouter
+
 import ray
 from ray.serve.constants import (DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT,
                                  SERVE_CONTROLLER_NAME, HTTP_PROXY_TIMEOUT)
@@ -1014,11 +1016,6 @@ def accept_batch(f: Callable) -> Callable:
     """
     f._serve_accept_batch = True
     return f
-
-
-from fastapi import FastAPI, APIRouter
-from typing import Union
-from functools import wraps
 
 
 def deployment(app: Union[FastAPI, APIRouter]):

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1019,6 +1019,16 @@ def accept_batch(f: Callable) -> Callable:
 
 
 def deployment(app: Union[FastAPI, APIRouter]):
+    """Mark a FastAPI application for Serve.
+
+    Example:
+    >>> app = FastAPI()
+    >>> @serve.deployment(app)
+        @app.get("/")
+        def app():
+            pass
+    """
+
     def decorator(f):
         f._serve_asgi_app = app
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -2,6 +2,7 @@ import asyncio
 import atexit
 import time
 from functools import wraps
+import inspect
 import os
 from uuid import UUID
 import threading
@@ -1035,21 +1036,20 @@ def ingress(
     >>> app = FastAPI()
     >>> @serve.deployment
         @serve.ingress(app)
-        def app():
+        class App:
             pass
-    >>> app.deploy()
+    >>> App.deploy()
     """
 
-    def decorator(f):
+    def decorator(cls):
+        if not inspect.isclass(cls):
+            raise ValueError("@serve.ingress must be used with a class.")
+
         if app is not None:
-            f._serve_asgi_app = app
+            cls._serve_asgi_app = app
         if path_prefix is not None:
-            f._serve_path_prefix = path_prefix
+            cls._serve_path_prefix = path_prefix
 
-        @wraps(f)
-        def inner(*args, **kwargs):
-            return f(*args, **kwargs)
-
-        return inner
+        return cls
 
     return decorator

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -6,11 +6,10 @@ import inspect
 import os
 from uuid import UUID
 import threading
-from typing import Any, Callable, Coroutine, Dict, List, Optional, Type, Union
+from typing import (Any, Callable, Coroutine, Dict, List, Optional,
+                    TYPE_CHECKING, Type, Union)
 from dataclasses import dataclass
 from warnings import warn
-
-from fastapi import FastAPI, APIRouter
 
 import ray
 from ray.serve.constants import (DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT,
@@ -25,6 +24,9 @@ from ray.serve.config import (BackendConfig, ReplicaConfig, BackendMetadata,
                               HTTPOptions)
 from ray.serve.router import RequestMetadata, Router
 from ray.actor import ActorHandle
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI, APIRouter  # noqa: F401
 
 _INTERNAL_REPLICA_CONTEXT = None
 _global_async_loop = None
@@ -1021,7 +1023,7 @@ def accept_batch(f: Callable) -> Callable:
 
 
 def ingress(
-        app: Union[FastAPI, APIRouter, None] = None,
+        app: Union["FastAPI", "APIRouter", None] = None,
         path_prefix: Optional[str] = None,
 ):
     """Mark a FastAPI application ingress for Serve.

--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -242,6 +242,7 @@ class RayServeReplica:
 
         start = time.time()
         try:
+            # TODO(simon): Split this section out when invoke_batch is removed.
             if self.config.internal_metadata.is_asgi_app:
                 request: Request = arg
                 scope = request.scope
@@ -254,9 +255,8 @@ class RayServeReplica:
                 # redirection works.
                 request.scope["root_path"] = root_path
 
-                app = self.callable._serve_asgi_app
                 sender = ASGIHTTPSender()
-                await app(
+                await self.callable._serve_asgi_app(
                     request.scope,
                     request._receive,
                     sender,

--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -237,7 +237,6 @@ class RayServeReplica:
     async def invoke_single(self, request_item: Query) -> Any:
         logger.debug("Replica {} started executing request {}".format(
             self.replica_tag, request_item.metadata.request_id))
-        method_to_call = sync_to_async(self.get_runner_method(request_item))
         arg = parse_request_item(request_item)
 
         start = time.time()
@@ -263,6 +262,8 @@ class RayServeReplica:
                 )
                 result = sender.build_starlette_response()
             else:
+                method_to_call = sync_to_async(
+                    self.get_runner_method(request_item))
                 result = await method_to_call(arg)
             result = await self.ensure_serializable_response(result)
             self.request_counter.inc()

--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -278,7 +278,7 @@ class RayServeReplica:
                     def build_starlette_response(
                             self) -> starlette.responses.Response:
                         return starlette.responses.Response(
-                            b''.join(self.buffer),
+                            b"".join(self.buffer),
                             status_code=self.status_code,
                             headers=dict(self.header))
 

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -36,6 +36,7 @@ class BackendMetadata:
     accepts_batches: bool = False
     is_blocking: bool = True
     is_asgi_app: bool = False
+    path_prefix: Optional[str] = None
     autoscaling_config: Optional[Dict[str, Any]] = None
 
 
@@ -145,6 +146,7 @@ class ReplicaConfig:
         self.accepts_batches = _callable_accepts_batch(backend_def)
         self.is_blocking = _callable_is_blocking(backend_def)
         self.is_asgi_app = hasattr(backend_def, "_serve_asgi_app")
+        self.path_prefix = getattr(backend_def, "_serve_path_prefix", None)
         self.init_args = list(init_args)
         if ray_actor_options is None:
             self.ray_actor_options = {}

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -1,10 +1,10 @@
 import inspect
-from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
 import pydantic
-from pydantic import BaseModel, confloat, PositiveFloat, PositiveInt, validator
+from pydantic import BaseModel, PositiveInt, validator, NonNegativeFloat
+from pydantic.dataclasses import dataclass
 from ray.serve.constants import DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT
 from ray.serve.utils import logger
 
@@ -35,6 +35,7 @@ def _callable_is_blocking(backend_def):
 class BackendMetadata:
     accepts_batches: bool = False
     is_blocking: bool = True
+    is_asgi_app: bool = False
     autoscaling_config: Optional[Dict[str, Any]] = None
 
 
@@ -71,8 +72,8 @@ class BackendConfig(BaseModel):
     max_concurrent_queries: Optional[int] = None
     user_config: Any = None
 
-    experimental_graceful_shutdown_wait_loop_s: PositiveFloat = 2.0
-    experimental_graceful_shutdown_timeout_s: confloat(ge=0) = 20.0
+    experimental_graceful_shutdown_wait_loop_s: NonNegativeFloat = 2.0
+    experimental_graceful_shutdown_timeout_s: NonNegativeFloat = 20.0
 
     class Config:
         validate_assignment = True
@@ -143,6 +144,7 @@ class ReplicaConfig:
         self.backend_def = backend_def
         self.accepts_batches = _callable_accepts_batch(backend_def)
         self.is_blocking = _callable_is_blocking(backend_def)
+        self.is_asgi_app = hasattr(backend_def, "_serve_asgi_app")
         self.init_args = list(init_args)
         if ray_actor_options is None:
             self.ray_actor_options = {}

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -263,9 +263,22 @@ class ServeController:
             goal_id = self.backend_state.create_backend(
                 name, backend_config, replica_config, version)
 
-            self.endpoint_state.create_endpoint(name, f"/{name}",
-                                                ["GET", "POST"],
-                                                TrafficPolicy({
-                                                    name: 1.0
-                                                }))
+            route = f"/{name}"
+            methods = ["GET", "POST"]
+            if replica_config.is_asgi_app:
+                route += "/{wildcard:path}"
+                # https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
+                methods = [
+                    "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT",
+                    "OPTIONS", "TRACE", "PATCH"
+                ]
+
+            self.endpoint_state.create_endpoint(
+                name,
+                route,
+                methods,
+                TrafficPolicy({
+                    name: 1.0
+                }),
+            )
             return goal_id

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -270,14 +270,14 @@ class ServeController:
             # with a prefixed path as well as proxy all HTTP methods.
             # {wildcard:path} is used so HTTPProxy's Starlette router can match
             # arbitrary path.
-            route = f"/{replica_config.path_prefix}" + "/{wildcard:path}"
+            route = f"{replica_config.path_prefix}" + "/{wildcard:path}"
             # https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
             methods = [
                 "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS",
                 "TRACE", "PATCH"
             ]
         else:
-            route = replica_config.path_prefix or f"{name}"
+            route = replica_config.path_prefix
             # Generic endpoint should support a limited subset of HTTP methods.
             methods = ["GET", "POST"]
 

--- a/python/ray/serve/tests/pydantic_module.py
+++ b/python/ray/serve/tests/pydantic_module.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    name: str
+
+
+user = User(name="a")
+
+app = FastAPI()
+
+
+@app.get("/")
+def h(u: User) -> str:
+    return "a"
+
+
+def closure():
+    app = FastAPI()
+
+    @app.get("/")
+    def h(u: User) -> str:
+        return "a"
+
+    return app

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -90,15 +90,16 @@ def test_starlette_response(serve_instance):
                 await asyncio.sleep(0.01)
 
         return starlette.responses.StreamingResponse(
-            slow_numbers(), media_type="text/plain")
+            slow_numbers(), media_type="text/plain", status_code=418)
 
     serve.create_backend("streaming_response", streaming_response)
     serve.create_endpoint(
         "streaming_response",
         backend="streaming_response",
         route="/streaming_response")
-    assert requests.get(
-        "http://127.0.0.1:8000/streaming_response").text == "123"
+    resp = requests.get("http://127.0.0.1:8000/streaming_response")
+    assert resp.text == "123"
+    assert resp.status_code == 418
 
 
 def test_backend_user_config(serve_instance):

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+import requests
+
+from ray import serve
+
+
+def test_fastapi_function(serve_instance):
+    client = serve_instance
+    app = FastAPI()
+
+    @serve.deployment(app)
+    @app.get("/{a}")
+    def func(a: int):
+        return {"result": a}
+
+    client.deploy("f", func)
+
+    resp = requests.get(f"http://localhost:8000/f/100")
+    assert resp.json() == {"result": 100}
+
+    resp = requests.get(f"http://localhost:8000/f/not-number")
+    assert resp.status_code == 422  # Unprocessable Entity
+    assert resp.json()["detail"][0]["type"] == "type_error.integer"

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 import requests
+import pytest
 
 from ray import serve
 
@@ -21,3 +22,8 @@ def test_fastapi_function(serve_instance):
     resp = requests.get(f"http://localhost:8000/f/not-number")
     assert resp.status_code == 422  # Unprocessable Entity
     assert resp.json()["detail"][0]["type"] == "type_error.integer"
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -9,7 +9,7 @@ def test_fastapi_function(serve_instance):
     client = serve_instance
     app = FastAPI()
 
-    @serve.deployment(app)
+    @serve.ingress(app)
     @app.get("/{a}")
     def func(a: int):
         return {"result": a}
@@ -22,6 +22,21 @@ def test_fastapi_function(serve_instance):
     resp = requests.get(f"http://localhost:8000/f/not-number")
     assert resp.status_code == 422  # Unprocessable Entity
     assert resp.json()["detail"][0]["type"] == "type_error.integer"
+
+
+def test_ingress_prefix(serve_instance):
+    client = serve_instance
+    app = FastAPI()
+
+    @serve.ingress(app, path_prefix="/api")
+    @app.get("/{a}")
+    def func(a: int):
+        return {"result": a}
+
+    client.deploy("f", func)
+
+    resp = requests.get(f"http://localhost:8000/api/100")
+    assert resp.json() == {"result": 100}
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -9,12 +9,15 @@ def test_fastapi_function(serve_instance):
     client = serve_instance
     app = FastAPI()
 
-    @serve.ingress(app)
     @app.get("/{a}")
     def func(a: int):
         return {"result": a}
 
-    client.deploy("f", func)
+    @serve.ingress(app)
+    class FastAPIApp:
+        pass
+
+    client.deploy("f", FastAPIApp)
 
     resp = requests.get(f"http://localhost:8000/f/100")
     assert resp.json() == {"result": 100}
@@ -28,12 +31,15 @@ def test_ingress_prefix(serve_instance):
     client = serve_instance
     app = FastAPI()
 
-    @serve.ingress(app, path_prefix="/api")
     @app.get("/{a}")
     def func(a: int):
         return {"result": a}
 
-    client.deploy("f", func)
+    @serve.ingress(app, path_prefix="/api")
+    class App:
+        pass
+
+    client.deploy("f", App)
 
     resp = requests.get(f"http://localhost:8000/api/100")
     assert resp.json() == {"result": 100}

--- a/python/ray/serve/tests/test_pydantic_serialization.py
+++ b/python/ray/serve/tests/test_pydantic_serialization.py
@@ -1,0 +1,172 @@
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import pytest
+from fastapi import FastAPI
+from pydantic import BaseModel
+from ray.serve.utils import register_custom_serializers
+
+import ray
+
+
+@pytest.fixture(scope="session")
+def start_ray():
+    ray.init(ignore_reinit_error=True)
+    register_custom_serializers()
+
+
+def test_serialize_cls(start_ray):
+    class User(BaseModel):
+        name: str
+
+    ray.get(ray.put(User))
+
+
+def test_serialize_instance(start_ray):
+    class User(BaseModel):
+        name: str
+
+    ray.get(ray.put(User(name="a")))
+
+
+def test_serialize_imported_cls(start_ray):
+    from pydantic_module import User
+
+    ray.get(ray.put(User))
+
+
+def test_serialize_imported_instance(start_ray):
+    from pydantic_module import user
+
+    ray.get(ray.put(user))
+
+
+def test_serialize_app_no_route(start_ray):
+    app = FastAPI()
+    ray.get(ray.put(app))
+
+
+def test_serialize_app_no_validation(start_ray):
+    app = FastAPI()
+
+    @app.get("/")
+    def hello() -> str:
+        return "hi"
+
+    ray.get(ray.put(app))
+
+
+def test_serialize_app_primitive_type(start_ray):
+    app = FastAPI()
+
+    @app.get("/")
+    def hello(v: str) -> str:
+        return "hi"
+
+    ray.get(ray.put(app))
+
+
+def test_serialize_app_pydantic_type_imported(start_ray):
+    from pydantic_module import User
+
+    app = FastAPI()
+
+    @app.get("/")
+    def hello(v: str, u: User) -> str:
+        return "hi"
+
+    ray.get(ray.put(app))
+
+
+def test_serialize_app_pydantic_type_inline(start_ray):
+    class User(BaseModel):
+        name: str
+
+    app = FastAPI()
+
+    @app.get("/")
+    def hello(v: str, u: User) -> str:
+        return "hi"
+
+    ray.get(ray.put(app))
+
+
+def test_serialize_app_imported(start_ray):
+    from pydantic_module import app
+    ray.get(ray.put(app))
+
+
+def test_serialize_app_pydantic_type_closure_ref(start_ray):
+    class User(BaseModel):
+        name: str
+
+    def make():
+        app = FastAPI()
+
+        @app.get("/")
+        def hello(v: str, u: User) -> str:
+            return "hi"
+
+        return app
+
+    ray.get(ray.put(make))
+
+
+def test_serialize_app_pydantic_type_closure_ref_import(start_ray):
+    from pydantic_module import User
+
+    def make():
+        app = FastAPI()
+
+        @app.get("/")
+        def hello(v: str, u: User) -> str:
+            return "hi"
+
+        return app
+
+    ray.get(ray.put(make))
+
+
+def test_serialize_app_pydantic_type_closure(start_ray):
+    def make():
+        class User(BaseModel):
+            name: str
+
+        app = FastAPI()
+
+        @app.get("/")
+        def hello(v: str, u: User) -> str:
+            return "hi"
+
+        return app
+
+    ray.get(ray.put(make))
+
+
+def test_serialize_app_imported_closure(start_ray):
+    from pydantic_module import closure
+    ray.get(ray.put(closure))
+
+
+def test_serialize_serve_dataclass(start_ray):
+    @dataclass
+    class BackendMetadata:
+        accepts_batches: bool = False
+        is_blocking: bool = True
+        autoscaling_config: Optional[Dict[str, Any]] = None
+
+    class BackendConfig(BaseModel):
+        internal_metadata: BackendMetadata = BackendMetadata()
+
+    ray.get(ray.put(BackendConfig()))
+
+    @ray.remote
+    def consume(f):
+        pass
+
+    ray.get(consume.remote(BackendConfig()))
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -381,14 +381,14 @@ def register_custom_serializers():
                 "name": o.name,
                 "type_": o.type_,
                 "class_validators": o.class_validators,
-                "model_config":o.model_config,
+                "model_config": o.model_config,
                 "default": o.default,
                 "default_factory": o.default_factory,
                 "required": o.required,
                 "alias": o.alias,
                 "field_info": o.field_info,
             },
-            deserializer=lambda kwargs:pydantic.fields.ModelField(**kwargs),
+            deserializer=lambda kwargs: pydantic.fields.ModelField(**kwargs),
         )
     )
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -37,7 +37,7 @@ scipy==1.4.1
 tabulate
 tensorboardX
 uvicorn
-pydantic<1.7
+pydantic
 dataclasses; python_version < '3.7'
 starlette
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -73,5 +73,6 @@ testfixtures
 werkzeug
 xlrd
 starlette
+fastapi
 smart_open[s3]
 tqdm

--- a/python/setup.py
+++ b/python/setup.py
@@ -95,7 +95,7 @@ ray_files += [
 # also update the matching section of requirements/requirements.txt
 # in this directory
 extras = {
-    "serve": ["uvicorn", "flask", "requests", "pydantic<1.7", "starlette"],
+    "serve": ["uvicorn", "requests", "pydantic<1.7", "starlette", "fastapi"],
     "tune": ["pandas", "tabulate", "tensorboardX"],
     "k8s": ["kubernetes"]
 }


### PR DESCRIPTION
Add the most basic FastAPI support, passing the following test.

```
def test_fastapi_function(serve_instance):
    client = serve_instance
    app = FastAPI()

    @serve.deployment(app)
    @app.get("/{a}")
    def func(a: int):
        return {"result": a}

    client.deploy("f", func)

    resp = requests.get(f"http://localhost:8000/f/100")
    assert resp.json() == {"result": 100}

    resp = requests.get(f"http://localhost:8000/f/not-number")
    assert resp.status_code == 422  # Unprocessable Entity
    assert resp.json()["detail"][0]["type"] == "type_error.integer"
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
