### PR TITLE
[flaky test] Fix test_cli by disabling config cache for dashboard test

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -130,7 +130,13 @@ def cli(logging_level, logging_format):
     type=int,
     default=ray_constants.DEFAULT_DASHBOARD_PORT,
     help="The remote port your dashboard runs on")
-def dashboard(cluster_config_file, cluster_name, port, remote_port):
+@click.option(
+    "--no-config-cache",
+    is_flag=True,
+    default=False,
+    help="Disable the local cluster config cache.")
+def dashboard(cluster_config_file, cluster_name, port, remote_port,
+              no_config_cache):
     """Port-forward a Ray cluster's dashboard to the local machine."""
     # Sleeping in a loop is preferable to `sleep infinity` because the latter
     # only works on linux.
@@ -147,7 +153,8 @@ def dashboard(cluster_config_file, cluster_name, port, remote_port):
         exec_cluster(
             cluster_config_file,
             override_cluster_name=cluster_name,
-            port_forward=port_forward)
+            port_forward=port_forward,
+            no_config_cache=no_config_cache)
         click.echo("Successfully established connection.")
     except Exception as e:
         raise click.ClickException(

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -352,7 +352,8 @@ def test_ray_dashboard(configure_lang, configure_aws, _unlink_test_ssh_key):
         ])
         _die_on_error(result)
 
-        result = runner.invoke(scripts.dashboard, [DEFAULT_TEST_CONFIG_PATH])
+        result = runner.invoke(scripts.dashboard,
+                               [DEFAULT_TEST_CONFIG_PATH, "--no-config-cache"])
         _check_output_via_pattern("test_ray_dashboard.txt", result)
 
 

--- a/python/ray/tests/test_cli_patterns/test_ray_dashboard.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_dashboard.txt
@@ -1,4 +1,5 @@
 Attempting to establish dashboard locally at localhost:8265 connected to remote port 8265
+Checking AWS environment settings
 Fetched IP: .+
 Forwarding ports
 ubuntu@ip-.+:~\$ exit

--- a/python/ray/tests/test_cli_patterns/test_ray_dashboard.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_dashboard.txt
@@ -1,6 +1,4 @@
 Attempting to establish dashboard locally at localhost:8265 connected to remote port 8265
-Loaded cached provider configuration
-If you experience issues with the cloud provider, try re-running the command with --no-config-cache.
 Fetched IP: .+
 Forwarding ports
 ubuntu@ip-.+:~\$ exit


### PR DESCRIPTION
Otherwise, it deterministically fails on the first try.