### PR TITLE
[Test] Fix flaky object spilling test linux

### DIFF
--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -98,12 +98,11 @@ def assert_no_thrashing(address):
     state = ray.state.GlobalState()
     state._initialize_global_state(address,
                                    ray.ray_constants.REDIS_DEFAULT_PASSWORD)
-    memory_summary = ray.internal.internal_api.memory_summary(
-        address=address, stats_only=True)
+    summary = memory_summary(address=address, stats_only=True)
     restored_bytes = 0
     consumed_bytes = 0
 
-    for line in memory_summary.split("\n"):
+    for line in summary.split("\n"):
         if "Restored" in line:
             restored_bytes = int(line.split(" ")[1])
         if "consumed" in line:
@@ -346,7 +345,7 @@ def test_spill_stats(object_spilling_config, shutdown_only):
 
     x_id = f.remote()  # noqa
     ray.get(x_id)
-    s = memory_summary(stats_only=True)
+    s = memory_summary(address=address, stats_only=True)
     assert "Plasma memory usage 50 MiB, 1 objects, 50.0% full" in s, s
     assert "Spilled 200 MiB, 4 objects" in s, s
     assert "Restored 150 MiB, 3 objects" in s, s
@@ -360,7 +359,7 @@ def test_spill_stats(object_spilling_config, shutdown_only):
 
     ray.get(func_with_ref.remote(obj))
 
-    s = memory_summary(stats_only=True)
+    s = memory_summary(address=address, stats_only=True)
     # 50MB * 5 references + 30MB used for task execution.
     assert "Objects consumed by Ray tasks: 280 MiB." in s, s
     assert_no_thrashing(address["redis_address"])

--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -345,7 +345,7 @@ def test_spill_stats(object_spilling_config, shutdown_only):
 
     x_id = f.remote()  # noqa
     ray.get(x_id)
-    s = memory_summary(address=address, stats_only=True)
+    s = memory_summary(address=address["redis_address"], stats_only=True)
     assert "Plasma memory usage 50 MiB, 1 objects, 50.0% full" in s, s
     assert "Spilled 200 MiB, 4 objects" in s, s
     assert "Restored 150 MiB, 3 objects" in s, s
@@ -359,7 +359,7 @@ def test_spill_stats(object_spilling_config, shutdown_only):
 
     ray.get(func_with_ref.remote(obj))
 
-    s = memory_summary(address=address, stats_only=True)
+    s = memory_summary(address=address["redis_address"], stats_only=True)
     # 50MB * 5 references + 30MB used for task execution.
     assert "Objects consumed by Ray tasks: 280 MiB." in s, s
     assert_no_thrashing(address["redis_address"])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Address should be provided for memory summary, otherwise it fails when there are multiple instances (which can happen in testing environment commonly).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
