### PR TITLE
[docs] Suggest merge workflow instead of rebase on contributor docs

### DIFF
--- a/doc/source/getting-involved.rst
+++ b/doc/source/getting-involved.rst
@@ -45,13 +45,13 @@ Submitting and Merging a Contribution
 
 There are a couple steps to merge a contribution.
 
-1. First rebase your development branch on the most recent version of master.
+1. First merge the most recent version of master into your development branch.
 
    .. code:: bash
 
      git remote add upstream https://github.com/ray-project/ray.git
      git fetch upstream
-     git rebase upstream/master
+     git merge upstream/master
 
 2. Make sure all existing tests `pass <getting-involved.html#testing>`__.
 3. If introducing a new feature or patching a bug, be sure to add new test cases

--- a/doc/source/getting-involved.rst
+++ b/doc/source/getting-involved.rst
@@ -50,8 +50,7 @@ There are a couple steps to merge a contribution.
    .. code:: bash
 
      git remote add upstream https://github.com/ray-project/ray.git
-     git fetch upstream
-     git merge upstream/master
+     git pull upstream master
 
 2. Make sure all existing tests `pass <getting-involved.html#testing>`__.
 3. If introducing a new feature or patching a bug, be sure to add new test cases


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Merge workflow is considered best practice to avoid messing up GH reviewing with force-pushes.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
