### PR TITLE
[Client] Test Serialization in a platform independent way.

### DIFF
--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import time
 import sys
@@ -417,15 +418,16 @@ def test_basic_named_actor(ray_start_regular_shared):
 
 def test_error_serialization(ray_start_regular_shared):
     """Test that errors will be serialized properly."""
-    with pytest.raises(PermissionError):
+    fake_path = os.path.join(os.path.dirname(__file__), "not_a_real_file")
+    with pytest.raises(FileNotFoundError):
         with ray_start_client_server() as ray:
 
             @ray.remote
             def g():
-                with open("/dev/asdf", "w") as f:
-                    f.write("HI")
+                with open(fake_path, "r") as f:
+                    f.read()
 
-            # Raises a PermissionError
+            # Raises a FileNotFoundError
             ray.get(g.remote())
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* The existing test caused:
- `FileNotFound` on Windows (because `/dev` doesn't exist)
- **No Error** on BuildKite (I assume because the environment allows writing to `/dev`?)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
