### PR TITLE
[serve] Make replica state management unit-testable

### DIFF
--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -37,7 +37,7 @@ class ReplicaState(Enum):
     STOPPED = 6
 
 
-ALL_REPLICA_STATES = [s for s in ReplicaState]
+ALL_REPLICA_STATES = list(ReplicaState)
 
 
 class ActorReplicaWrapper:
@@ -373,7 +373,7 @@ class ReplicaStateContainer:
 
         assert isinstance(states, list)
 
-        return sum((self._replicas[state] for state in states), start=[])
+        return sum((self._replicas[state] for state in states), [])
 
     def pop(self,
             exclude_version: Optional[str] = None,

--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -1,3 +1,4 @@
+from abc import ABC
 from collections import defaultdict
 from enum import Enum
 import math
@@ -178,8 +179,13 @@ class ActorReplicaWrapper:
         except ValueError:
             pass
 
+class VersionedReplica(ABC):
+    @property
+    def version(self):
+        return self.version
 
-class BackendReplica:
+
+class BackendReplica(VersionedReplica):
     """Manages state transitions for backend replicas.
 
     This is basically a checkpointable lightweight state machine.
@@ -337,9 +343,9 @@ class ReplicaStateContainer:
         self._replicas: Dict[ReplicaState, List[BackendReplica]] = defaultdict(
             list)
 
-    def add(self, state: ReplicaState, replica: BackendReplica):
+    def add(self, state: ReplicaState, replica: VersionedReplica):
         assert isinstance(state, ReplicaState)
-        assert isinstance(replica, BackendReplica)
+        assert isinstance(replica, VersionedReplica)
         self._replicas[state].append(replica)
 
     def get(self, states: Optional[List[ReplicaState]] = None):

--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -340,16 +340,34 @@ class BackendReplica(VersionedReplica):
 
 
 class ReplicaStateContainer:
+    """Container for mapping ReplicaStates to lists of BackendReplicas."""
+
     def __init__(self):
         self._replicas: Dict[ReplicaState, List[BackendReplica]] = defaultdict(
             list)
 
     def add(self, state: ReplicaState, replica: VersionedReplica):
+        """Add the provided replica under the provided state.
+
+        Args:
+            state (ReplicaState): state to add the replica under.
+            replica (VersionedReplica): replica to add.
+        """
         assert isinstance(state, ReplicaState)
         assert isinstance(replica, VersionedReplica)
         self._replicas[state].append(replica)
 
-    def get(self, states: Optional[List[ReplicaState]] = None):
+    def get(self, states: Optional[List[ReplicaState]] = None
+            ) -> List[VersionedReplica]:
+        """Get all replicas of the given states.
+
+        This does not remove them from the container. Replicas are returned
+        in order of state as passed in.
+
+        Args:
+            states (str): states to consider. If not specified, all replicas
+                are considered.
+        """
         if states is None:
             states = ALL_REPLICA_STATES
 
@@ -360,7 +378,20 @@ class ReplicaStateContainer:
     def pop(self,
             exclude_version: Optional[str] = None,
             states: Optional[List[ReplicaState]] = None,
-            max_replicas: Optional[int] = math.inf):
+            max_replicas: Optional[int] = math.inf) -> List[VersionedReplica]:
+        """Get and remove all replicas of the given states.
+
+        This removes the replicas from the container. Replicas are returned
+        in order of state as passed in.
+
+        Args:
+            exclude_version (str): if specified, replicas of the provided
+                version will *not* be removed.
+            states (str): states to consider. If not specified, all replicas
+                are considered.
+            max_replicas (int): max number of replicas to return. If not
+                specified, will pop all replicas matching the criteria.
+        """
         if states is None:
             states = ALL_REPLICA_STATES
 
@@ -385,6 +416,12 @@ class ReplicaStateContainer:
         return replicas
 
     def count(self, states: Optional[List[ReplicaState]] = None):
+        """Get the total count of replicas of the given states.
+
+        Args:
+            states (str): states to consider. If not specified, all replicas
+                are considered.
+        """
         if states is None:
             states = ALL_REPLICA_STATES
         assert isinstance(states, list)

--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -630,8 +630,6 @@ class BackendState:
                     ],
                     max_replicas=-delta_num_replicas)
 
-                assert len(replicas_to_stop) == -delta_num_replicas
-
                 for replica in replicas_to_stop:
                     replica.set_should_stop(graceful_shutdown_timeout_s)
                     self._replicas[backend_tag].add(ReplicaState.SHOULD_STOP,

--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -179,6 +179,7 @@ class ActorReplicaWrapper:
         except ValueError:
             pass
 
+
 class VersionedReplica(ABC):
     @property
     def version(self):

--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -591,9 +591,12 @@ class BackendState:
     def _stop_wrong_version_replicas(
             self, backend_tag: BackendTag, version: str,
             graceful_shutdown_timeout_s: float) -> int:
-        # XXX
+        # NOTE(edoakes): this short-circuits when using the legacy
+        # `create_backend` codepath -- it can be removed once we deprecate
+        # that as the version should never be None.
         if version is None:
             return
+
         # TODO(edoakes): to implement rolling upgrade, all we should need to
         # do is cap the number of old version replicas that are stopped here.
         replicas_to_stop = self._replicas[backend_tag].pop(

--- a/python/ray/serve/tests/test_backend_state.py
+++ b/python/ray/serve/tests/test_backend_state.py
@@ -119,6 +119,7 @@ def mock_backend_state() -> Tuple[BackendState, Mock, Mock]:
         mock_checkpoint.return_value = None
         yield backend_state, timer, goal_manager
 
+
 def replica(version: Optional[str] = None) -> VersionedReplica:
     class MockVersionedReplica(VersionedReplica):
         def __init__(self, version):
@@ -127,7 +128,9 @@ def replica(version: Optional[str] = None) -> VersionedReplica:
         @property
         def version(self, version):
             return self._version
+
     return MockVersionedReplica(version)
+
 
 def test_replica_state_container_get():
     c = ReplicaStateContainer()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Unifies a lot of the code paths we have in `backend_state.py` and also uses the same ones for testing. This will make implementing rolling upgrade much easier.

Also allowed me to add some unit tests for the filtering, fetching, popping logic.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
