### PR TITLE
[Serve] Deflake and re-enable client serve test

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -57,13 +57,13 @@ py_test(
     deps = [":serve_lib"],
 )
 
-# py_test(
-    # name = "test_ray_client",
-    # size = "small",
-    # srcs = serve_tests_srcs,
-    # tags = ["exclusive"],
-    # deps = [":serve_lib"],
-# )
+py_test(
+    name = "test_ray_client",
+    size = "small",
+    srcs = serve_tests_srcs,
+    tags = ["exclusive"],
+    deps = [":serve_lib"],
+)
 
 py_test(
     name = "test_async_goal_manager",

--- a/python/ray/serve/tests/test_ray_client.py
+++ b/python/ray/serve/tests/test_ray_client.py
@@ -11,6 +11,7 @@ from ray import serve
 MIN_DYNAMIC_PORT = 49152
 MAX_DYNAMIC_PORT = 65535
 
+
 @pytest.fixture
 def ray_client_instance():
     port = random.randint(MIN_DYNAMIC_PORT, MAX_DYNAMIC_PORT)

--- a/python/ray/serve/tests/test_ray_client.py
+++ b/python/ray/serve/tests/test_ray_client.py
@@ -7,10 +7,13 @@ import requests
 import ray
 from ray import serve
 
+# https://tools.ietf.org/html/rfc6335#section-6
+MIN_DYNAMIC_PORT = 49152
+MAX_DYNAMIC_PORT = 65535
 
 @pytest.fixture
 def ray_client_instance():
-    port = random.randint(60000, 70000)
+    port = random.randint(MIN_DYNAMIC_PORT, MAX_DYNAMIC_PORT)
     subprocess.check_output([
         "ray", "start", "--head", "--num-cpus", "8",
         "--ray-client-server-port", f"{port}"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Reverts https://github.com/ray-project/ray/pull/14733.

Ideally we would run this test, say, 10 times in a loop in the test to really ensure it's no longer flaky, but disconnecting and reconnecting the Ray Client still doesn't work with Serve (even with a non-detached Serve instance) so this isn't possible at the moment.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
