### PR TITLE
[Ray Client] Validate ray client port number

### DIFF
--- a/doc/source/ray-client.rst
+++ b/doc/source/ray-client.rst
@@ -8,7 +8,7 @@ Ray Client
 Basic usage
 ===========
 
-The Ray client server is automatically started on port ``10001`` when you use ``ray start --head`` or Ray in an autoscaling cluster. The port can be changed by specifying --ray-client-server-port in the ``ray start`` command.
+The Ray client server is automatically started on port ``10001`` when you use ``ray start --head`` or Ray in an autoscaling cluster. The port can be changed by specifying ``--ray-client-server-port`` in the ``ray start`` command to be any integer between 1024 and 65535.
 
 To start the server manually, you can run:
 

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -320,7 +320,7 @@ class RayParams:
 
         # Used primarily for testing.
         if os.environ.get("RAY_USE_RANDOM_PORTS", False):
-            if self.min_worker_port is None and self.min_worker_port is None:
+            if self.min_worker_port is None and self.max_worker_port is None:
                 self.min_worker_port = 0
                 self.max_worker_port = 0
 

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -343,6 +343,12 @@ class RayParams:
                     raise ValueError("max_worker_port must be higher than "
                                      "min_worker_port.")
 
+        if self.ray_client_server_port is not None:
+            if (self.ray_client_server_port < 1024
+                    or self.ray_client_server_port > 65535):
+                raise ValueError("ray_client_server_port must be an integer "
+                                 "between 1024 and 65535.")
+
         if self.resources is not None:
             assert "CPU" not in self.resources, (
                 "'CPU' should not be included in the resource dictionary. Use "

--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -57,13 +57,13 @@ py_test(
     deps = [":serve_lib"],
 )
 
-# py_test(
-    # name = "test_ray_client",
-    # size = "small",
-    # srcs = serve_tests_srcs,
-    # tags = ["exclusive"],
-    # deps = [":serve_lib"],
-# )
+py_test(
+    name = "test_ray_client",
+    size = "small",
+    srcs = serve_tests_srcs,
+    tags = ["exclusive"],
+    deps = [":serve_lib"],
+)
 
 py_test(
     name = "test_async_goal_manager",

--- a/python/ray/serve/tests/test_ray_client.py
+++ b/python/ray/serve/tests/test_ray_client.py
@@ -11,6 +11,7 @@ from ray import serve
 MIN_DYNAMIC_PORT = 49152
 MAX_DYNAMIC_PORT = 65535
 
+
 @pytest.fixture
 def ray_client_instance():
     port = random.randint(MIN_DYNAMIC_PORT, MAX_DYNAMIC_PORT)

--- a/python/ray/serve/tests/test_ray_client.py
+++ b/python/ray/serve/tests/test_ray_client.py
@@ -7,10 +7,13 @@ import requests
 import ray
 from ray import serve
 
+# https://tools.ietf.org/html/rfc6335#section-6
+MIN_DYNAMIC_PORT = 49152
+MAX_DYNAMIC_PORT = 65535
 
 @pytest.fixture
 def ray_client_instance():
-    port = random.randint(60000, 70000)
+    port = random.randint(MIN_DYNAMIC_PORT, MAX_DYNAMIC_PORT)
     subprocess.check_output([
         "ray", "start", "--head", "--num-cpus", "8",
         "--ray-client-server-port", f"{port}"

--- a/python/ray/tests/test_client_init.py
+++ b/python/ray/tests/test_client_init.py
@@ -4,6 +4,7 @@ import pytest
 import time
 import random
 import sys
+import subprocess
 from unittest.mock import patch
 
 import ray.util.client.server.server as ray_client_server
@@ -60,6 +61,18 @@ def init_and_serve_lazy():
     yield server_handle
     ray_client_server.shutdown_with_server(server_handle.grpc_server)
     time.sleep(2)
+
+
+def test_validate_port():
+    """Check that ports outside of 1024-65535 are rejected."""
+    for port in [1000, 1023, 65536, 700000]:
+        with pytest.raises(subprocess.CalledProcessError) as excinfo:
+            subprocess.check_output([
+                "ray", "start", "--head", "--num-cpus", "8",
+                "--ray-client-server-port", f"{port}"
+            ])
+            assert "ValueError" in str(excinfo.traceback)
+            assert "65535" in str(excinfo.traceback)
 
 
 def test_basic_preregister(init_and_serve):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Previously, the Ray Client server could be started with a port outside the valid range without raising any error.  Subsequent calls to `ray.util.connect()` would time out.  

This PR checks the that the provided port is valid when starting the server. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
