### PR TITLE
[Autoscaler] Improved observability

### DIFF
--- a/python/ray/_private/monitor.py
+++ b/python/ray/_private/monitor.py
@@ -168,7 +168,9 @@ class Monitor:
             self.update_resource_requests()
             self.update_event_summary()
             status = {
-                "load_metrics_report": self.load_metrics.summary()._asdict()
+                "load_metrics_report": self.load_metrics.summary()._asdict(),
+                "time": time.time(),
+                "monitor_pid": os.getpid()
             }
 
             # Process autoscaling actions

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -104,13 +104,15 @@ def debug_status(status, error) -> str:
     else:
         status = status.decode("utf-8")
         as_dict = json.loads(status)
+        time = datetime.datetime.fromtimestamp(as_dict["time"])
         lm_summary = LoadMetricsSummary(**as_dict["load_metrics_report"])
         if "autoscaler_report" in as_dict:
             autoscaler_summary = AutoscalerSummary(
                 **as_dict["autoscaler_report"])
-            status = format_info_string(lm_summary, autoscaler_summary)
+            status = format_info_string(
+                lm_summary, autoscaler_summary, time=time)
         else:
-            status = format_info_string_no_node_types(lm_summary)
+            status = format_info_string_no_node_types(lm_summary, time=time)
     if error:
         status += "\n"
         status += error.decode("utf-8")
@@ -1239,8 +1241,8 @@ def get_cluster_dump_archive(cluster_config_file: Optional[str] = None,
 
     if not nodes:
         cli_logger.error(
-            f"No nodes found. Specify with `--host` or by passing a ray "
-            f"cluster config to `--cluster`.")
+            "No nodes found. Specify with `--host` or by passing a ray "
+            "cluster config to `--cluster`.")
         return None
 
     if cluster_config_file:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR includes a few small changes to help make it easier to debug autoscaler issues including displaying the time that the status report was generated (instead of the current time) and adding the pid of the monitor process. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

#14483 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
