### PR TITLE
[CI] Don't build ray for lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -169,7 +169,6 @@ matrix:
         - . ./ci/travis/ci.sh init
       before_script:
         - . ./ci/travis/ci.sh lint
-        - . ./ci/travis/ci.sh build
       script:
         - sleep 30  # we still need this block to exist, otherwise it will fall back to the global one
 


### PR DESCRIPTION
It looks like we're building Ray after running the lint. This doesn't really make sense, especially since we do the build _after_ actually running the linter.

For reference, the build takes 4 minutes, and the entire lint job takes 10 minutes. 

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
