### PR TITLE
[Core] Remove legacy code path for unhandled exception in asyncio

### DIFF
--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -85,7 +85,6 @@ cdef class ObjectRef(BaseID):
                     return
 
                 if isinstance(result, RayTaskError):
-                    ray.worker.last_task_error_raise_time = time.time()
                     py_future.set_exception(result.as_instanceof_cause())
                 elif isinstance(result, RayError):
                     # Directly raise exception for RayActorError


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Exception handling logic was revamp in cc156f7b3c554c5fccdb5465636e30777678c715. This PR removes the reference to old code path in asyncio code and add a test for it.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
