### PR TITLE
[RLlib] Issue 14119: Fix TD3 policy delay for torch.

### DIFF
--- a/rllib/agents/ddpg/ddpg_torch_policy.py
+++ b/rllib/agents/ddpg/ddpg_torch_policy.py
@@ -189,7 +189,7 @@ def make_ddpg_optimizers(policy, config):
     return policy._actor_optimizer, policy._critic_optimizer
 
 
-def apply_gradients_fn(policy):
+def apply_gradients_fn(policy, gradients):
     # For policy gradient, update policy net one time v.s.
     # update critic net `policy_delay` time(s).
     if policy.global_step % policy.config["policy_delay"] == 0:

--- a/rllib/agents/ddpg/tests/test_ddpg.py
+++ b/rllib/agents/ddpg/tests/test_ddpg.py
@@ -1,6 +1,7 @@
 import numpy as np
 import re
 import unittest
+from tempfile import TemporaryDirectory
 
 import ray
 import ray.rllib.agents.ddpg as ddpg
@@ -52,6 +53,23 @@ class TestDDPG(unittest.TestCase):
             else:
                 a = trainer.get_policy().global_step
             check(a, 500)
+            trainer.stop()
+
+    def test_ddpg_checkpoint_save_and_restore(self):
+        """Test whether a DDPGTrainer can save and load checkpoints."""
+        config = ddpg.DEFAULT_CONFIG.copy()
+        config["num_workers"] = 1
+        config["num_envs_per_worker"] = 2
+        config["learning_starts"] = 0
+        config["exploration_config"]["random_timesteps"] = 100
+
+        # Test against all frameworks.
+        for _ in framework_iterator(config):
+            trainer = ddpg.DDPGTrainer(config=config, env="Pendulum-v0")
+            trainer.train()
+            with TemporaryDirectory() as temp_dir:
+                checkpoint = trainer.save(temp_dir)
+                trainer.restore(checkpoint)
             trainer.stop()
 
     def test_ddpg_exploration_and_with_random_prerun(self):

--- a/rllib/agents/ddpg/tests/test_ddpg.py
+++ b/rllib/agents/ddpg/tests/test_ddpg.py
@@ -45,6 +45,13 @@ class TestDDPG(unittest.TestCase):
                 results = trainer.train()
                 print(results)
             check_compute_single_action(trainer)
+            # Ensure apply_gradient_fn is being called and updating global_step
+            if config["framework"] == "tf":
+                a = trainer.get_policy().global_step.eval(
+                    trainer.get_policy().get_session())
+            else:
+                a = trainer.get_policy().global_step
+            check(a, 500)
             trainer.stop()
 
     def test_ddpg_exploration_and_with_random_prerun(self):

--- a/rllib/policy/eager_tf_policy.py
+++ b/rllib/policy/eager_tf_policy.py
@@ -608,7 +608,10 @@ def build_eager_tf_policy(
         @override(Policy)
         def get_state(self):
             state = {"_state": super().get_state()}
-            state["_optimizer_variables"] = self._optimizer.variables()
+            if self._optimizer and \
+                    len(self._optimizer.variables()) > 0:
+                state["_optimizer_variables"] = \
+                    self._optimizer.variables()
             return state
 
         @override(Policy)

--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -398,8 +398,7 @@ class TorchPolicy(Policy):
         grads, fetches = self.compute_gradients(postprocessed_batch)
 
         # Step the optimizers.
-        for i, opt in enumerate(self._optimizers):
-            opt.step()
+        self.apply_gradients(_directStepOptimizerSingleton)
 
         if self.model:
             fetches["model"] = self.model.metrics()
@@ -497,13 +496,17 @@ class TorchPolicy(Policy):
     @override(Policy)
     @DeveloperAPI
     def apply_gradients(self, gradients: ModelGradients) -> None:
-        # TODO(sven): Not supported for multiple optimizers yet.
-        assert len(self._optimizers) == 1
-        for g, p in zip(gradients, self.model.parameters()):
-            if g is not None:
-                p.grad = torch.from_numpy(g).to(self.device)
+        if gradients == _directStepOptimizerSingleton:
+            for i, opt in enumerate(self._optimizers):
+                opt.step()
+        else:
+            # TODO(sven): Not supported for multiple optimizers yet.
+            assert len(self._optimizers) == 1
+            for g, p in zip(gradients, self.model.parameters()):
+                if g is not None:
+                    p.grad = torch.from_numpy(g).to(self.device)
 
-        self._optimizers[0].step()
+            self._optimizers[0].step()
 
     @override(Policy)
     @DeveloperAPI
@@ -747,3 +750,25 @@ class EntropyCoeffSchedule:
         super(EntropyCoeffSchedule, self).on_global_var_update(global_vars)
         self.entropy_coeff = self.entropy_coeff_schedule.value(
             global_vars["timestep"])
+
+
+@DeveloperAPI
+class DirectStepOptimizer:
+    """Typesafe method for indicating apply gradients can directly step the
+       optimizers with in-place gradients.
+    """
+    _instance = None
+
+    def __new__(cls):
+        if DirectStepOptimizer._instance is None:
+            DirectStepOptimizer._instance = super().__new__(cls)
+        return DirectStepOptimizer._instance
+
+    def __eq__(self, other):
+        return type(self) == type(other)
+
+    def __repr__(self):
+        return "DirectStepOptimizer"
+
+
+_directStepOptimizerSingleton = DirectStepOptimizer()


### PR DESCRIPTION
Fix DDPG edge cases due to multiple optimizers.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
These commits fix two issues with DDPG
* Torch version not using policy_delay for TD3
The torch policy was not calling the special cased apply_gradients function because of learn_on_batch. This commit adds a special fused case that calls apply gradients 
* eager_tf_policy get_state() does not check to make sure that policy._optimizer is not None. This fails when saving state for DDPG because it has has special variables for the optimizers policy._actor_optimizer and policy._critic_optimizer

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #14119
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
