### PR TITLE
Update sac_tf_policy.py

### DIFF
--- a/rllib/agents/sac/sac_tf_policy.py
+++ b/rllib/agents/sac/sac_tf_policy.py
@@ -323,7 +323,7 @@ def sac_actor_critic_loss(
 
     # Compute RHS of bellman equation for the Q-loss (critic(s)).
     q_t_selected_target = tf.stop_gradient(
-        train_batch[SampleBatch.REWARDS] +
+        tf.cast(train_batch[SampleBatch.REWARDS], tf.float32) +
         policy.config["gamma"]**policy.config["n_step"] * q_tp1_best_masked)
 
     # Compute the TD-error (potentially clipped).


### PR DESCRIPTION
Adapt the shape, so that offline training is possible

First time doing a commit 🔢 

The changes are needed because when doing offline learning the train_batch[SampleBatch.REWARDS] gets imported as tf.float64, so an error occures