### PR TITLE
[HotFix] Fix Colorful mock for `with_style`

### DIFF
--- a/python/ray/autoscaler/_private/cli_logger.py
+++ b/python/ray/autoscaler/_private/cli_logger.py
@@ -7,7 +7,7 @@ Supports color, bold text, italics, underlines, etc.
 (depending on TTY features)
 as well as indentation and other structured output.
 """
-
+from contextlib import contextmanager
 import sys
 import logging
 import inspect
@@ -51,6 +51,17 @@ except ModuleNotFoundError:
             pass
 
         def __getattr__(self, name):
+            if name == "with_style":
+
+                @contextmanager
+                def wrapper(x):
+                    class identityClass:
+                        def __getattr__(self, name):
+                            return lambda y: y
+
+                    yield identityClass()
+
+                return wrapper
             return self.identity
 
     _cf = _ColorfulMock()

--- a/python/ray/autoscaler/_private/cli_logger.py
+++ b/python/ray/autoscaler/_private/cli_logger.py
@@ -19,6 +19,37 @@ import click
 import warnings
 
 import colorama
+
+
+class _ColorfulMock:
+    def __init__(self):
+        # do not do any color work
+        self.identity = lambda x: x
+
+        self.colorful = self
+        self.colormode = None
+
+        self.NO_COLORS = None
+        self.ANSI_8_COLORS = None
+
+    def disable(self):
+        pass
+
+    @contextmanager
+    def with_style(self, x):
+        class IdentityClass:
+            def __getattr__(self, name):
+                return lambda y: y
+
+        yield IdentityClass()
+
+    def __getattr__(self, name):
+        if name == "with_style":
+            return self.with_style
+
+        return self.identity
+
+
 try:
     import colorful as _cf
     from colorful.core import ColorfulString
@@ -35,34 +66,6 @@ except ModuleNotFoundError:
     # the CliLogger code will still work.
     class ColorfulString:
         pass
-
-    class _ColorfulMock:
-        def __init__(self):
-            # do not do any color work
-            self.identity = lambda x: x
-
-            self.colorful = self
-            self.colormode = None
-
-            self.NO_COLORS = None
-            self.ANSI_8_COLORS = None
-
-        def disable(self):
-            pass
-
-        def __getattr__(self, name):
-            if name == "with_style":
-
-                @contextmanager
-                def wrapper(x):
-                    class identityClass:
-                        def __getattr__(self, name):
-                            return lambda y: y
-
-                    yield identityClass()
-
-                return wrapper
-            return self.identity
 
     _cf = _ColorfulMock()
 

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -82,6 +82,7 @@ py_test_module_list(
     "test_asyncio.py",
     "test_autoscaler.py",
     "test_autoscaler_yaml.py",
+    "test_cli_logger.py",
     "test_client_metadata.py",
     "test_client_references.py",
     "test_client_terminate.py",

--- a/python/ray/tests/test_cli_logger.py
+++ b/python/ray/tests/test_cli_logger.py
@@ -1,11 +1,13 @@
 from ray.autoscaler._private import cli_logger
 import pytest
 
+
 def test_colorful_mock_with_style():
     cm = cli_logger._ColorfulMock()
     with cm.with_style("some_style") as c:
         assert c.color_choice("text") == "text"
         assert c.another_color_choice("more_text") == "more_text"
+
 
 def test_colorful_mock_random_function():
     cm = cli_logger._ColorfulMock()

--- a/python/ray/tests/test_cli_logger.py
+++ b/python/ray/tests/test_cli_logger.py
@@ -1,0 +1,17 @@
+from ray.autoscaler._private import cli_logger
+import pytest
+
+def test_colorful_mock_with_style():
+    cm = cli_logger._ColorfulMock()
+    with cm.with_style("some_style") as c:
+        assert c.color_choice("text") == "text"
+        assert c.another_color_choice("more_text") == "more_text"
+
+def test_colorful_mock_random_function():
+    cm = cli_logger._ColorfulMock()
+    assert cm.bold("abc") == "abc"
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* The mock for `with_style` should yield a contextmanager, not a function.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #14849

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
