### PR TITLE
[tune] fixing Trainable.__init__ docstring reference to build() #14824

### DIFF
--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -59,7 +59,7 @@ class Trainable:
         Sets up logging and points ``self.logdir`` to a directory in which
         training outputs should be placed.
 
-        Subclasses should prefer defining ``build()`` instead of overriding
+        Subclasses should prefer defining ``setup()`` instead of overriding
         ``__init__()`` directly.
 
         Args:


### PR DESCRIPTION
## Why are these changes needed?

The docstring for `Trainable.__init__()` includes the text:
`Subclasses should prefer defining ``build()`` instead of overriding ``__init__()`` directly.`

Looking at the git history, it seems `build` was superseded by `setup`, yet this docstring wasn't updated. Another, related docstring was updated in #9448 but this instance was missed.

## Related issue number

Closes #14824 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested  - _simple docstring change_
