### PR TITLE
[Serve] FastAPI Simple Class Based View

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -54,7 +54,7 @@ class ReplicaContext:
     backend_tag: BackendTag
     replica_tag: ReplicaTag
     _internal_controller_name: str
-    servable_object: Any
+    servable_object: Callable
 
 
 def create_or_get_async_loop_in_thread():
@@ -69,8 +69,12 @@ def create_or_get_async_loop_in_thread():
     return _global_async_loop
 
 
-def _set_internal_replica_context(backend_tag, replica_tag, controller_name,
-                                  servable_object):
+def _set_internal_replica_context(
+        backend_tag: BackendTag,
+        replica_tag: ReplicaTag,
+        controller_name: str,
+        servable_object: Callable,
+):
     global _INTERNAL_REPLICA_CONTEXT
     _INTERNAL_REPLICA_CONTEXT = ReplicaContext(
         backend_tag, replica_tag, controller_name, servable_object)

--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -56,15 +56,19 @@ def create_backend_replica(backend_def: Union[Callable, Type[Callable], str]):
                 assert False, ("backend_def must be function, class, or "
                                "corresponding import path.")
 
-            # Set the controller name so that serve.connect() in the user's
-            # backend code will connect to the instance that this backend is
-            # running in.
-            ray.serve.api._set_internal_replica_context(
-                backend_tag, replica_tag, controller_name)
             if is_function:
                 _callable = backend
             else:
                 _callable = backend(*init_args)
+
+            # Set the controller name so that serve.connect() in the user's
+            # backend code will connect to the instance that this backend is
+            # running in.
+            ray.serve.api._set_internal_replica_context(
+                backend_tag,
+                replica_tag,
+                controller_name,
+                servable_object=_callable)
 
             assert controller_name, "Must provide a valid controller_name"
             controller_handle = ray.get_actor(controller_name)

--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -60,7 +60,10 @@ def create_backend_replica(backend_def: Union[Callable, Type[Callable], str]):
             # backend code will connect to the instance that this backend is
             # running in.
             ray.serve.api._set_internal_replica_context(
-                backend_tag, replica_tag, controller_name)
+                backend_tag,
+                replica_tag,
+                controller_name,
+                servable_object=None)
             if is_function:
                 _callable = backend
             else:

--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -56,14 +56,16 @@ def create_backend_replica(backend_def: Union[Callable, Type[Callable], str]):
                 assert False, ("backend_def must be function, class, or "
                                "corresponding import path.")
 
+            # Set the controller name so that serve.connect() in the user's
+            # backend code will connect to the instance that this backend is
+            # running in.
+            ray.serve.api._set_internal_replica_context(
+                backend_tag, replica_tag, controller_name)
             if is_function:
                 _callable = backend
             else:
                 _callable = backend(*init_args)
-
-            # Set the controller name so that serve.connect() in the user's
-            # backend code will connect to the instance that this backend is
-            # running in.
+            # Setting the context again to update the servable_object.
             ray.serve.api._set_internal_replica_context(
                 backend_tag,
                 replica_tag,

--- a/python/ray/serve/http_proxy.py
+++ b/python/ray/serve/http_proxy.py
@@ -91,7 +91,7 @@ class HTTPProxy:
         # Set the controller name so that serve.connect() will connect to the
         # controller instance this proxy is running in.
         ray.serve.api._set_internal_replica_context(None, None,
-                                                    controller_name)
+                                                    controller_name, None)
         self.client = ray.serve.connect()
 
         controller = ray.get_actor(controller_name)

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -45,6 +45,36 @@ def test_ingress_prefix(serve_instance):
     assert resp.json() == {"result": 100}
 
 
+def test_class_based_view(serve_instance):
+    client = serve_instance
+    app = FastAPI()
+
+    @app.get("/other")
+    def hello():
+        return "hello"
+
+    @serve.ingress(app)
+    class A:
+        def __init__(self):
+            self.val = 1
+
+        @app.get("/calc/{i}")
+        def b(self, i: int):
+            return i + self.val
+
+        @app.post("/calc/{i}")
+        def c(self, i: int):
+            return i - self.val
+
+    client.deploy("f", A)
+    resp = requests.get(f"http://localhost:8000/f/calc/41")
+    assert resp.json() == 42
+    resp = requests.post(f"http://localhost:8000/f/calc/41")
+    assert resp.json() == 40
+    resp = requests.get(f"http://localhost:8000/f/other")
+    assert resp.json() == "hello"
+
+
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -99,7 +99,7 @@ def test_make_fastapi_cbv_util():
     self_dep = app.routes[-1].dependant.dependencies[0]
     assert self_dep.name == "self"
     assert inspect.isfunction(self_dep.call)
-    assert "yield_current_servable" in str(self_dep.call)
+    assert "get_current_servable" in str(self_dep.call)
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -12,8 +12,6 @@ from typing import Iterable, List, Tuple, Dict, Optional, Type
 import os
 from collections import UserDict
 
-from fastapi import Depends, APIRouter, FastAPI
-from fastapi.routing import APIRoute
 import starlette.requests
 import starlette.responses
 import requests
@@ -436,7 +434,7 @@ class ASGIHTTPSender:
             headers=dict(self.header))
 
 
-def make_fastapi_class_based_view(fastapi_app: FastAPI, cls: Type) -> None:
+def make_fastapi_class_based_view(fastapi_app, cls: Type) -> None:
     """Transform the `cls`'s methods and class annotations to FastAPI routes.
 
     Modified from
@@ -452,6 +450,9 @@ def make_fastapi_class_based_view(fastapi_app: FastAPI, cls: Type) -> None:
     >>> make_fastapi_class_based_view(app, A)
     >>> # now app can be run properly
     """
+    # Delayed import to prevent ciruclar imports in workers.
+    from fastapi import Depends, APIRouter
+    from fastapi.routing import APIRoute
 
     def yield_current_servable_instance():
         from ray import serve

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -2,16 +2,19 @@ import asyncio
 from functools import singledispatch
 import importlib
 from itertools import groupby
+import inspect
 import json
 import logging
 import random
 import string
 import time
-from typing import Iterable, List, Tuple, Dict, Optional
+from typing import Iterable, List, Tuple, Dict, Optional, Type
 import os
+from fastapi.routing import APIRoute
 from ray.serve.exceptions import RayServeException
 from collections import UserDict
 
+from fastapi import Depends, APIRouter, FastAPI
 import starlette.requests
 import starlette.responses
 import requests
@@ -19,6 +22,7 @@ import numpy as np
 import pydantic
 
 import ray
+from ray import serve
 from ray.serve.constants import HTTP_PROXY_TIMEOUT
 
 ACTOR_FAILURE_RETRY_TIMEOUT_S = 60
@@ -431,3 +435,64 @@ class ASGIHTTPSender:
             b"".join(self.buffer),
             status_code=self.status_code,
             headers=dict(self.header))
+
+
+def make_fastapi_class_based_view(fastapi_app: FastAPI, cls: Type) -> None:
+    """Transform the `cls`'s methods and class annotations to FastAPI routes.
+
+    Modified from
+    https://github.com/dmontagu/fastapi-utils/blob/master/fastapi_utils/cbv.py
+
+    Usage:
+    >>> app = FastAPI()
+    >>> class A:
+            @app.route("/{i}")
+            def func(self, i: int) -> str:
+                return self.dep + i
+    >>> # just running the app won't work, here.
+    >>> make_fastapi_class_based_view(app, A)
+    >>> # now app can be run properly
+    """
+
+    def yield_current_servable_instance():
+        yield serve.get_replica_context().servable_object
+
+    # Find all the class method routes
+    member_methods = {
+        func
+        for _, func in inspect.getmembers(cls, inspect.isfunction)
+    }
+    class_method_routes = [
+        route for route in fastapi_app.routes
+        if isinstance(route, APIRoute) and route.endpoint in member_methods
+    ]
+
+    # Modify these routes and mount it to a new APIRouter.
+    # We need to to this (instead of modifying in place) because we want to use
+    # the laster fastapi_app.include_router to re-run the dependency analysis
+    # for each routes.
+    new_router = APIRouter()
+    for route in class_method_routes:
+        fastapi_app.routes.remove(route)
+
+        # This block just adds a default values to the self parameters so that
+        # FastAPI knows to inject the object when calling the route.
+        # Before: def method(self, i): ...
+        # After: def method(self=Depends(...), *, i):...
+        old_endpoint = route.endpoint
+        old_signature = inspect.signature(old_endpoint)
+        old_parameters = list(old_signature.parameters.values())
+        old_self_parameter = old_parameters[0]
+        new_self_parameter = old_self_parameter.replace(
+            default=Depends(yield_current_servable_instance))
+        new_parameters = [new_self_parameter] + [
+            # Make the rest of the parameters keyword only because
+            # the first argument is no longer positional.
+            parameter.replace(kind=inspect.Parameter.KEYWORD_ONLY)
+            for parameter in old_parameters[1:]
+        ]
+        new_signature = old_signature.replace(parameters=new_parameters)
+        setattr(route.endpoint, "__signature__", new_signature)
+        # route.endpoint.__signature__ = new_signature
+        new_router.routes.append(route)
+    fastapi_app.include_router(new_router)

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -10,11 +10,10 @@ import string
 import time
 from typing import Iterable, List, Tuple, Dict, Optional, Type
 import os
-from fastapi.routing import APIRoute
-from ray.serve.exceptions import RayServeException
 from collections import UserDict
 
 from fastapi import Depends, APIRouter, FastAPI
+from fastapi.routing import APIRoute
 import starlette.requests
 import starlette.responses
 import requests
@@ -22,8 +21,8 @@ import numpy as np
 import pydantic
 
 import ray
-from ray import serve
 from ray.serve.constants import HTTP_PROXY_TIMEOUT
+from ray.serve.exceptions import RayServeException
 
 ACTOR_FAILURE_RETRY_TIMEOUT_S = 60
 
@@ -455,6 +454,7 @@ def make_fastapi_class_based_view(fastapi_app: FastAPI, cls: Type) -> None:
     """
 
     def yield_current_servable_instance():
+        from ray import serve
         yield serve.get_replica_context().servable_object
 
     # Find all the class method routes

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -454,9 +454,9 @@ def make_fastapi_class_based_view(fastapi_app, cls: Type) -> None:
     from fastapi import Depends, APIRouter
     from fastapi.routing import APIRoute
 
-    def yield_current_servable_instance():
+    def get_current_servable_instance():
         from ray import serve
-        yield serve.get_replica_context().servable_object
+        return serve.get_replica_context().servable_object
 
     # Find all the class method routes
     member_methods = {
@@ -485,7 +485,7 @@ def make_fastapi_class_based_view(fastapi_app, cls: Type) -> None:
         old_parameters = list(old_signature.parameters.values())
         old_self_parameter = old_parameters[0]
         new_self_parameter = old_self_parameter.replace(
-            default=Depends(yield_current_servable_instance))
+            default=Depends(get_current_servable_instance))
         new_parameters = [new_self_parameter] + [
             # Make the rest of the parameters keyword only because
             # the first argument is no longer positional.


### PR DESCRIPTION
This PR adds support for decorate a class method with api route.
The magic is to transform the "self" argument into a FastAPI dependency
that's injected at runtime.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/pull/14858

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
