### PR TITLE
Revert "[Dashboard] Only auto find port in ray.init() case (#14333)"

### DIFF
--- a/python/ray/autoscaler/_private/constants.py
+++ b/python/ray/autoscaler/_private/constants.py
@@ -85,7 +85,7 @@ RAY_PROCESSES = [
     ["io.ray.runtime.runner.worker.DefaultWorker", False],  # Java worker.
     ["log_monitor.py", False],
     ["reporter.py", False],
-    ["new_dashboard/dashboard.py", False],
+    ["dashboard.py", False],
     ["new_dashboard/agent.py", False],
     ["ray_process_reaper.py", False],
 ]

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -79,7 +79,6 @@ class Cluster:
             "object_store_memory": 150 * 1024 * 1024,  # 150 MiB
             "min_worker_port": 0,
             "max_worker_port": 0,
-            "dashboard_port": None,
         }
         ray_params = ray._private.parameter.RayParams(**node_args)
         ray_params.update_if_absent(**default_kwargs)

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -32,7 +32,6 @@ def get_default_fixture_ray_kwargs():
     ray_kwargs = {
         "num_cpus": 1,
         "object_store_memory": 150 * 1024 * 1024,
-        "dashboard_port": None,
         "_system_config": system_config,
     }
     return ray_kwargs
@@ -53,7 +52,6 @@ def _ray_start(**kwargs):
 @pytest.fixture
 def ray_start_with_dashboard(request):
     param = getattr(request, "param", {})
-
     with _ray_start(
             num_cpus=1, include_dashboard=True, **param) as address_info:
         yield address_info

--- a/python/ray/tests/test_dashboard.py
+++ b/python/ray/tests/test_dashboard.py
@@ -1,92 +1,11 @@
 import re
-import socket
-import subprocess
 import sys
 import time
 
 import pytest
 import requests
-from ray.test_utils import run_string_as_driver, wait_for_condition
 
 import ray
-from ray import ray_constants
-
-
-@pytest.mark.skip("Flaky test")
-def test_ray_start_default_port_conflict(call_ray_stop_only, shutdown_only):
-    subprocess.check_call(["ray", "start", "--head"])
-    ray.init(address="auto")
-    assert str(ray_constants.DEFAULT_DASHBOARD_PORT) in ray.get_dashboard_url()
-
-    try:
-        subprocess.check_output(
-            [
-                "ray",
-                "start",
-                "--head",
-                "--port",
-                "9999",  # use a different gcs port
-            ],
-            stderr=subprocess.PIPE)
-    except subprocess.CalledProcessError as e:
-        assert b"already in use" in e.stderr
-
-
-def test_port_auto_increment(shutdown_only):
-    ray.init()
-    url = ray.get_dashboard_url()
-
-    def dashboard_available():
-        try:
-            requests.get("http://" + url).status_code == 200
-            return True
-        except Exception:
-            return False
-
-    wait_for_condition(dashboard_available)
-
-    run_string_as_driver(f"""
-import ray
-from ray.test_utils import wait_for_condition
-import requests
-ray.init()
-url = ray.get_dashboard_url()
-assert url != "{url}"
-def dashboard_available():
-    try:
-        requests.get("http://"+url).status_code == 200
-        return True
-    except:
-        return False
-wait_for_condition(dashboard_available)
-ray.shutdown()
-        """)
-
-
-@pytest.mark.skip("Test fails on master")
-def test_port_conflict(shutdown_only):
-    sock = socket.socket()
-    if hasattr(socket, "SO_REUSEPORT"):
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 0)
-    sock.bind(("127.0.0.1", 9999))
-
-    try:
-        subprocess.check_output(
-            [
-                "ray",
-                "start",
-                "--head",
-                "--dashboard-port",
-                "9999",
-            ],
-            stderr=subprocess.PIPE)
-    except subprocess.CalledProcessError as e:
-        assert b"already in use" in e.stderr
-
-    with pytest.raises(ValueError, match="already in use"):
-        ray.init(dashboard_port=9999)
-
-    sock.close()
 
 
 @pytest.mark.skipif(
@@ -121,7 +40,6 @@ def test_dashboard(shutdown_only):
 
 
 if __name__ == "__main__":
-    import sys
-
     import pytest
+    import sys
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -489,7 +489,7 @@ def init(
         ignore_reinit_error=False,
         include_dashboard=None,
         dashboard_host=ray_constants.DEFAULT_DASHBOARD_IP,
-        dashboard_port=None,
+        dashboard_port=ray_constants.DEFAULT_DASHBOARD_PORT,
         job_config=None,
         configure_logging=True,
         logging_level=logging.INFO,
@@ -562,9 +562,8 @@ def init(
             localhost (127.0.0.1) or 0.0.0.0 (available from all interfaces).
             By default, this is set to localhost to prevent access from
             external machines.
-        dashboard_port(int, None): The port to bind the dashboard server to.
-            Defaults to 8265 and Ray will automatically find a free port if
-            8265 is not available.
+        dashboard_port: The port to bind the dashboard server to. Defaults to
+            8265.
         job_config (ray.job_config.JobConfig): The job configuration.
         configure_logging: True (default) if configuration of logging is
             allowed here. Otherwise, the user may want to configure it


### PR DESCRIPTION
This reverts commit cc861750844a16ce68e9939528187e5f42f98efe.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This seems to be causing failures in MULTIPLATFORM_JARS and LINUX_WHEELS builds:
https://travis-ci.com/github/ray-project/ray/jobs/492574246

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
