### PR TITLE
Revert "[core] Set a configurable max memory for fetched objects (#14…

### DIFF
--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -1,4 +1,3 @@
-import asyncio
 from collections import defaultdict
 import multiprocessing
 import numpy as np
@@ -374,60 +373,6 @@ def test_pull_bundles_admission_control_dynamic(shutdown_only):
     allocated = [allocate.remote(i) for i in range(num_objects)]
     ray.get(tasks)
     del allocated
-
-
-@pytest.mark.parametrize("reservation", [0.5, 0.75])
-def test_task_args_memory_threshold(shutdown_only, reservation):
-    num_objs = 3
-    obj_size = int(1e8 // num_objs)
-
-    cluster = Cluster()
-    cluster.add_node(
-        num_cpus=0,
-        _system_config={
-            "pull_manager_memory_fraction": reservation / 10,
-        },
-        object_store_memory=1e9)
-    ray.init(address=cluster.address)
-    cluster.add_node(num_cpus=num_objs, object_store_memory=1e9)
-
-    @ray.remote
-    class Signal:
-        def __init__(self, num_events):
-            self.num_events = num_events
-            self.ready_event = asyncio.Event()
-
-        def send(self):
-            self.num_events -= 1
-            if self.num_events == 0:
-                self.ready_event.set()
-
-        async def wait(self):
-            await self.ready_event.wait()
-
-    @ray.remote
-    def f(actor, arg):
-        actor.send.remote()
-        time.sleep(1000)
-
-    @ray.remote
-    def empty():
-        return
-
-    num_tasks_expected = int(reservation / (1 / num_objs))
-    print(num_tasks_expected)
-    a = Signal.remote(num_tasks_expected)
-    x = np.zeros(obj_size, dtype=np.uint8)
-    objs = [ray.put(x) for _ in range(num_objs)]
-    # The tasks have to fetch the objects to the remote node to run. The remote
-    # node should only fetch objects up to the configured reservation.
-    for obj in objs:
-        f.remote(a, obj)
-    # Check that at least num_tasks_expected tasks are scheduled.
-    ray.get(a.wait.remote(), timeout=10)
-    # Check that at most num_tasks_expected tasks are scheduled.
-    num_cores = num_objs - num_tasks_expected
-    ray.get(empty.options(num_cpus=num_cores).remote(), timeout=10)
 
 
 if __name__ == "__main__":

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -375,9 +375,3 @@ RAY_CONFIG(int64_t, log_rotation_backup_count, 5)
 /// notification, in this case we'll wait for a fixed timeout value and then mark it
 /// as failed.
 RAY_CONFIG(int64_t, timeout_ms_task_wait_for_death_info, 1000)
-
-/// The maximum fraction of the object store used for objects pulled from
-/// remote nodes and restored from external storage. These objects are
-/// arguments of a locally scheduled task or objects requested by a worker
-/// through `ray.get` or `ray.wait`.
-RAY_CONFIG(float, pull_manager_memory_fraction, 0.7)

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -106,20 +106,10 @@ ObjectManager::ObjectManager(instrumented_io_context &main_service,
   if (available_memory < 0) {
     available_memory = 0;
   }
-
-  RAY_CHECK(RayConfig::instance().pull_manager_memory_fraction() > 0 &&
-            RayConfig::instance().pull_manager_memory_fraction() <= 1)
-      << "pull_manager_memory_fraction must be a nonzero decimal "
-         "less than 1.";
-  size_t pull_manager_reservation = SIZE_MAX;
-  if (plasma::plasma_store_runner != nullptr) {
-    pull_manager_reservation = RayConfig::instance().pull_manager_memory_fraction() *
-                               plasma::plasma_store_runner->GetMemoryCapacity();
-  }
   pull_manager_.reset(new PullManager(
       self_node_id_, object_is_local, send_pull_request, cancel_pull_request,
       restore_spilled_object_, get_time, config.pull_timeout_ms, available_memory,
-      pull_manager_reservation, [spill_objects_callback, object_store_full_callback]() {
+      [spill_objects_callback, object_store_full_callback]() {
         // TODO(swang): This copies the out-of-memory handling in the
         // CreateRequestQueue. It would be nice to unify these.
         if (object_store_full_callback) {

--- a/src/ray/object_manager/plasma/store_runner.h
+++ b/src/ray/object_manager/plasma/store_runner.h
@@ -30,11 +30,6 @@ class PlasmaStoreRunner {
                        "PlasmaStoreRunner.GetAvailableMemory");
   }
 
-  size_t GetMemoryCapacity() const {
-    RAY_CHECK(system_memory_ > 0);
-    return static_cast<size_t>(system_memory_);
-  }
-
  private:
   void Shutdown();
   absl::Mutex store_runner_mutex_;

--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -10,8 +10,7 @@ PullManager::PullManager(
     const std::function<void(const ObjectID &)> cancel_pull_request,
     const RestoreSpilledObjectCallback restore_spilled_object,
     const std::function<double()> get_time, int pull_timeout_ms,
-    size_t num_bytes_available, size_t max_reservation,
-    std::function<void()> object_store_full_callback)
+    size_t num_bytes_available, std::function<void()> object_store_full_callback)
     : self_node_id_(self_node_id),
       object_is_local_(object_is_local),
       send_pull_request_(send_pull_request),
@@ -20,7 +19,6 @@ PullManager::PullManager(
       get_time_(get_time),
       pull_timeout_ms_(pull_timeout_ms),
       num_bytes_available_(num_bytes_available),
-      max_reservation_(max_reservation),
       object_store_full_callback_(object_store_full_callback),
       gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {}
 
@@ -120,7 +118,6 @@ void PullManager::DeactivatePullBundleRequest(
 }
 
 void PullManager::UpdatePullsBasedOnAvailableMemory(size_t num_bytes_available) {
-  num_bytes_available = std::min(num_bytes_available, max_reservation_);
   if (num_bytes_available_ != num_bytes_available) {
     RAY_LOG(DEBUG) << "Updating pulls based on available memory: " << num_bytes_available;
   }

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -44,8 +44,7 @@ class PullManager {
       const std::function<void(const ObjectID &)> cancel_pull_request,
       const RestoreSpilledObjectCallback restore_spilled_object,
       const std::function<double()> get_time, int pull_timeout_ms,
-      size_t num_bytes_available, size_t max_reservation,
-      std::function<void()> object_store_full_callback);
+      size_t num_bytes_available, std::function<void()> object_store_full_callback);
 
   /// Add a new pull request for a bundle of objects. The objects in the
   /// request will get pulled once:
@@ -218,10 +217,6 @@ class PullManager {
   /// The total number of bytes that is available to store objects that we are
   /// pulling.
   size_t num_bytes_available_;
-
-  /// The maximum number of bytes that we are allowed to use (max value for
-  /// num_bytes_available_).
-  const size_t max_reservation_;
 
   /// Triggered when the first request in the queue can't be pulled due to
   /// out-of-memory. This callback should try to make more bytes available.

--- a/src/ray/object_manager/test/pull_manager_test.cc
+++ b/src/ray/object_manager/test/pull_manager_test.cc
@@ -12,7 +12,7 @@ using ::testing::ElementsAre;
 
 class PullManagerTestWithCapacity {
  public:
-  PullManagerTestWithCapacity(size_t num_available_bytes, size_t max_available_bytes)
+  PullManagerTestWithCapacity(size_t num_available_bytes)
       : self_node_id_(NodeID::FromRandom()),
         object_is_local_(false),
         num_send_pull_request_calls_(0),
@@ -31,7 +31,7 @@ class PullManagerTestWithCapacity {
               restore_object_callback_ = callback;
             },
             [this]() { return fake_time_; }, 10000, num_available_bytes,
-            max_available_bytes, [this]() { num_object_store_full_calls_++; }) {}
+            [this]() { num_object_store_full_calls_++; }) {}
 
   void AssertNoLeaks() {
     ASSERT_TRUE(pull_manager_.pull_request_bundles_.empty());
@@ -55,7 +55,7 @@ class PullManagerTestWithCapacity {
 
 class PullManagerTest : public PullManagerTestWithCapacity, public ::testing::Test {
  public:
-  PullManagerTest() : PullManagerTestWithCapacity(1, 1) {}
+  PullManagerTest() : PullManagerTestWithCapacity(1) {}
 
   void AssertNumActiveRequestsEquals(size_t num_requests) {
     absl::MutexLock lock(&pull_manager_.active_objects_mu_);
@@ -67,7 +67,7 @@ class PullManagerTest : public PullManagerTestWithCapacity, public ::testing::Te
 class PullManagerWithAdmissionControlTest : public PullManagerTestWithCapacity,
                                             public ::testing::Test {
  public:
-  PullManagerWithAdmissionControlTest() : PullManagerTestWithCapacity(10, 10) {}
+  PullManagerWithAdmissionControlTest() : PullManagerTestWithCapacity(10) {}
 
   void AssertNumActiveRequestsEquals(size_t num_requests) {
     absl::MutexLock lock(&pull_manager_.active_objects_mu_);
@@ -526,45 +526,10 @@ TEST_F(PullManagerWithAdmissionControlTest, TestBasic) {
   AssertNoLeaks();
 }
 
-TEST_F(PullManagerWithAdmissionControlTest, TestMaxReservation) {
-  /// Test admission control when the maximum reservation is less than the
-  /// reported availability.
-  for (auto &object_size : {5, 15}) {
-    num_send_pull_request_calls_ = 0;
-    num_object_store_full_calls_ = 0;
-    auto refs = CreateObjectRefs(1);
-    auto oids = ObjectRefsToIds(refs);
-    AssertNumActiveRequestsEquals(0);
-    std::vector<rpc::ObjectReference> objects_to_locate;
-    auto req_id = pull_manager_.Pull(refs, &objects_to_locate);
-    // Increase available bytes to more than the object size. We still don't pull
-    // the object because it is over the max.
-    pull_manager_.UpdatePullsBasedOnAvailableMemory(20);
-
-    std::unordered_set<NodeID> client_ids;
-    client_ids.insert(NodeID::FromRandom());
-    ASSERT_FALSE(pull_manager_.IsObjectActive(oids[0]));
-    pull_manager_.OnLocationChange(oids[0], client_ids, "", NodeID::Nil(), object_size);
-    if (object_size < 10) {
-      ASSERT_EQ(num_send_pull_request_calls_, 1);
-      ASSERT_TRUE(pull_manager_.IsObjectActive(oids[0]));
-      ASSERT_EQ(num_object_store_full_calls_, 0);
-    } else {
-      ASSERT_EQ(num_send_pull_request_calls_, 0);
-      ASSERT_FALSE(pull_manager_.IsObjectActive(oids[0]));
-      ASSERT_EQ(num_object_store_full_calls_, 1);
-    }
-
-    pull_manager_.CancelPull(req_id);
-  }
-  num_object_store_full_calls_ = 0;
-  AssertNoLeaks();
-}
-
 TEST_F(PullManagerWithAdmissionControlTest, TestQueue) {
   /// Test admission control for a queue of pull bundle requests. We should
   /// activate as many requests as we can, subject to the reported capacity.
-  int object_size = 1;
+  int object_size = 2;
   int num_oids_per_request = 2;
   int num_requests = 3;
 
@@ -589,7 +554,7 @@ TEST_F(PullManagerWithAdmissionControlTest, TestQueue) {
     }
   }
 
-  for (int capacity = 0; capacity < 10; capacity++) {
+  for (int capacity = 0; capacity < 20; capacity++) {
     int num_requests_expected =
         std::min(num_requests, capacity / (object_size * num_oids_per_request));
     pull_manager_.UpdatePullsBasedOnAvailableMemory(capacity);

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -196,13 +196,7 @@ class ClusterTaskManagerTest : public ::testing::Test {
   }
 
   void AssertPinnedTaskArgumentsEquals(const TaskID &task_id, size_t num_args_expected) {
-    size_t num_pinned = 0;
-    auto it = task_manager_.pinned_task_arguments_.find(task_id);
-    if (it != task_manager_.pinned_task_arguments_.end()) {
-      num_pinned = it->second.size();
-    }
-    ASSERT_EQ(num_pinned, num_args_expected);
-
+    ASSERT_EQ(task_manager_.pinned_task_arguments_[task_id].size(), num_args_expected);
     size_t num_args = 0;
     for (auto &args : task_manager_.pinned_task_arguments_) {
       num_args += args.second.size();
@@ -266,59 +260,6 @@ TEST_F(ClusterTaskManagerTest, BasicTest) {
   AssertNoLeaks();
 }
 
-TEST_F(ClusterTaskManagerTest, BasicTestWithArg) {
-  /*
-    Test basic scheduler functionality for a task with an argument:
-    1. Queue and attempt to schedule/dispatch a task with an argument that is
-    not available.
-    2. Task argument becomes available. The task's dependencies are subscribed
-    to and pinned for the duration of the task.
-   */
-  Task task = CreateTask({{ray::kCPU_ResourceLabel, 4}}, 1);
-  auto missing_arg = task.GetTaskSpecification().GetDependencyIds()[0];
-  missing_objects_.insert(missing_arg);
-
-  rpc::RequestWorkerLeaseReply reply;
-  bool callback_occurred = false;
-  bool *callback_occurred_ptr = &callback_occurred;
-  auto callback = [callback_occurred_ptr](Status, std::function<void()>,
-                                          std::function<void()>) {
-    *callback_occurred_ptr = true;
-  };
-
-  task_manager_.QueueAndScheduleTask(task, &reply, callback);
-  ASSERT_TRUE(
-      dependency_manager_.subscribed_tasks.count(task.GetTaskSpecification().TaskId()));
-  AssertPinnedTaskArgumentsEquals(task.GetTaskSpecification().TaskId(), 0);
-
-  ASSERT_FALSE(callback_occurred);
-  ASSERT_EQ(leased_workers_.size(), 0);
-  ASSERT_EQ(pool_.workers.size(), 0);
-
-  std::shared_ptr<MockWorker> worker =
-      std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234);
-  pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker));
-
-  missing_objects_.clear();
-  task_manager_.TasksUnblocked({task.GetTaskSpecification().TaskId()});
-
-  ASSERT_TRUE(callback_occurred);
-  ASSERT_EQ(leased_workers_.size(), 1);
-  ASSERT_EQ(pool_.workers.size(), 0);
-  ASSERT_EQ(node_info_calls_, 0);
-  ASSERT_TRUE(
-      dependency_manager_.subscribed_tasks.count(task.GetTaskSpecification().TaskId()));
-  AssertPinnedTaskArgumentsEquals(task.GetTaskSpecification().TaskId(), 1);
-
-  Task finished_task;
-  task_manager_.TaskFinished(leased_workers_.begin()->second, &finished_task);
-  ASSERT_EQ(finished_task.GetTaskSpecification().TaskId(),
-            task.GetTaskSpecification().TaskId());
-  AssertPinnedTaskArgumentsEquals(task.GetTaskSpecification().TaskId(), 0);
-
-  AssertNoLeaks();
-}
-
 TEST_F(ClusterTaskManagerTest, NoFeasibleNodeTest) {
   std::shared_ptr<MockWorker> worker =
       std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234);
@@ -368,7 +309,10 @@ TEST_F(ClusterTaskManagerTest, ResourceTakenWhileResolving) {
   auto task = CreateTask({{ray::kCPU_ResourceLabel, 5}}, 2);
   auto missing_arg = task.GetTaskSpecification().GetDependencyIds()[0];
   missing_objects_.insert(missing_arg);
+  std::unordered_set<TaskID> expected_subscribed_tasks = {
+      task.GetTaskSpecification().TaskId()};
   task_manager_.QueueAndScheduleTask(task, &reply, callback);
+  ASSERT_EQ(dependency_manager_.subscribed_tasks, expected_subscribed_tasks);
 
   ASSERT_EQ(num_callbacks, 0);
   ASSERT_EQ(leased_workers_.size(), 0);
@@ -380,6 +324,7 @@ TEST_F(ClusterTaskManagerTest, ResourceTakenWhileResolving) {
   /* This task can run */
   auto task2 = CreateTask({{ray::kCPU_ResourceLabel, 5}}, 1);
   task_manager_.QueueAndScheduleTask(task2, &reply, callback);
+  ASSERT_EQ(dependency_manager_.subscribed_tasks, expected_subscribed_tasks);
 
   AssertPinnedTaskArgumentsEquals(task2.GetTaskSpecification().TaskId(), 1);
   ASSERT_EQ(num_callbacks, 1);
@@ -392,6 +337,7 @@ TEST_F(ClusterTaskManagerTest, ResourceTakenWhileResolving) {
   auto id = task.GetTaskSpecification().TaskId();
   std::vector<TaskID> unblocked = {id};
   task_manager_.TasksUnblocked(unblocked);
+  ASSERT_EQ(dependency_manager_.subscribed_tasks, expected_subscribed_tasks);
 
   AssertPinnedTaskArgumentsEquals(task2.GetTaskSpecification().TaskId(), 1);
   ASSERT_EQ(num_callbacks, 1);
@@ -405,6 +351,7 @@ TEST_F(ClusterTaskManagerTest, ResourceTakenWhileResolving) {
   leased_workers_.clear();
 
   task_manager_.ScheduleAndDispatchTasks();
+  ASSERT_TRUE(dependency_manager_.subscribed_tasks.empty());
 
   // Task2 is now done so task can run.
   AssertPinnedTaskArgumentsEquals(task.GetTaskSpecification().TaskId(), 2);


### PR DESCRIPTION
…817)"

This reverts commit 8769953474899a42c8dbb863c7a2dd0451b9e870.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

test_object_spilling is failing.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
