### PR TITLE
[Java][Core] Support get current actor handle.

### DIFF
--- a/cpp/src/ray/runtime/task/local_mode_task_submitter.cc
+++ b/cpp/src/ray/runtime/task/local_mode_task_submitter.cc
@@ -39,7 +39,7 @@ ObjectID LocalModeTaskSubmitter::Submit(InvocationSpec &invocation) {
   if (invocation.task_type == TaskType::NORMAL_TASK) {
   } else if (invocation.task_type == TaskType::ACTOR_CREATION_TASK) {
     invocation.actor_id = local_mode_ray_tuntime_.GetNextActorID();
-    builder.SetActorCreationTaskSpec(invocation.actor_id);
+    builder.SetActorCreationTaskSpec(invocation.actor_id, "");
   } else if (invocation.task_type == TaskType::ACTOR_TASK) {
     const TaskID actor_creation_task_id =
         TaskID::ForActorCreationTask(invocation.actor_id);

--- a/java/api/src/main/java/io/ray/api/runtimecontext/RuntimeContext.java
+++ b/java/api/src/main/java/io/ray/api/runtimecontext/RuntimeContext.java
@@ -1,5 +1,6 @@
 package io.ray.api.runtimecontext;
 
+import io.ray.api.BaseActorHandle;
 import io.ray.api.id.ActorId;
 import io.ray.api.id.JobId;
 import io.ray.api.id.TaskId;
@@ -31,4 +32,9 @@ public interface RuntimeContext {
 
   /** Get all node information in Ray cluster. */
   List<NodeInfo> getAllNodeInfo();
+
+  /**
+   * Get the handle to the current actor itself. Note that this method must be invoked in an actor.
+   */
+  <T extends BaseActorHandle> T getCurrentActorHandle();
 }

--- a/java/runtime/src/main/java/io/ray/runtime/context/RuntimeContextImpl.java
+++ b/java/runtime/src/main/java/io/ray/runtime/context/RuntimeContextImpl.java
@@ -1,6 +1,7 @@
 package io.ray.runtime.context;
 
 import com.google.common.base.Preconditions;
+import io.ray.api.BaseActorHandle;
 import io.ray.api.id.ActorId;
 import io.ray.api.id.JobId;
 import io.ray.api.id.TaskId;
@@ -52,5 +53,10 @@ public class RuntimeContextImpl implements RuntimeContext {
   @Override
   public List<NodeInfo> getAllNodeInfo() {
     return runtime.getGcsClient().getAllNodeInfo();
+  }
+
+  @Override
+  public <T extends BaseActorHandle> T getCurrentActorHandle() {
+    return runtime.getActorHandle(getCurrentActorId());
   }
 }

--- a/java/test/src/main/java/io/ray/test/GetCurrentActorHandleTest.java
+++ b/java/test/src/main/java/io/ray/test/GetCurrentActorHandleTest.java
@@ -1,0 +1,32 @@
+package io.ray.test;
+
+import io.ray.api.ActorHandle;
+import io.ray.api.ObjectRef;
+import io.ray.api.Ray;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@Test
+public class GetCurrentActorHandleTest extends BaseTest {
+
+  private static class Echo {
+
+    public Echo() {}
+
+    public ObjectRef<String> echo(String str) {
+      ActorHandle<Echo> self = Ray.getRuntimeContext().getCurrentActorHandle();
+      return self.task(Echo::echo2, str).remote();
+    }
+
+    public String echo2(String str) {
+      return str;
+    }
+  }
+
+  @Test
+  public void testGetCurrentActorHandle() {
+    ActorHandle<Echo> echo1 = Ray.actor(Echo::new).remote();
+    ObjectRef<String> obj = echo1.task(Echo::echo, "hello").remote().get();
+    Assert.assertEquals("hello", obj.get());
+  }
+}

--- a/python/ray/tests/test_memstat.py
+++ b/python/ray/tests/test_memstat.py
@@ -132,15 +132,16 @@ def test_actor_task_refs(ray_start_regular):
     x_id = actor.f.remote(np.zeros(100000))
     info = ray.get(x_id)
     print(info)
-    assert num_objects(info) == 4, info
+    # Note, the actor will always hold a handle to the actor itself.
+    assert num_objects(info) == 5, info
     # Actor handle, task argument id, task return id.
     assert count(info, ACTOR_TASK_CALL_OBJ) == 3, info
     assert count(info, DRIVER_PID) == 3, info
-    assert count(info, WORKER_PID) == 1, info
+    assert count(info, WORKER_PID) == 2, info
     assert count(info, LOCAL_REF) == 1, info
     assert count(info, PINNED_IN_MEMORY) == 1, info
     assert count(info, USED_BY_PENDING_TASK) == 1, info
-    assert count(info, ACTOR_HANDLE) == 1, info
+    assert count(info, ACTOR_HANDLE) == 2, info
     assert count(info, DESER_ACTOR_TASK_ARG) == 1, info
     del x_id
 

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -92,6 +92,11 @@ TaskID TaskSpecification::TaskId() const {
   return TaskID::FromBinary(message_->task_id());
 }
 
+const std::string TaskSpecification::GetSerializedActorHandle() const {
+  RAY_CHECK(IsActorCreationTask());
+  return message_->actor_creation_task_spec().serialized_actor_handle();
+}
+
 JobID TaskSpecification::JobId() const {
   if (message_->job_id().empty() /* e.g., empty proto default */) {
     return JobID::Nil();

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -177,6 +177,8 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
 
   TaskID CallerId() const;
 
+  const std::string GetSerializedActorHandle() const;
+
   const rpc::Address &CallerAddress() const;
 
   WorkerID CallerWorkerId() const;

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -150,7 +150,8 @@ class TaskSpecBuilder {
   ///
   /// \return Reference to the builder object itself.
   TaskSpecBuilder &SetActorCreationTaskSpec(
-      const ActorID &actor_id, int64_t max_restarts = 0, int64_t max_task_retries = 0,
+      const ActorID &actor_id, const std::string &serialized_actor_handle,
+      int64_t max_restarts = 0, int64_t max_task_retries = 0,
       const std::vector<std::string> &dynamic_worker_options = {},
       int max_concurrency = 1, bool is_detached = false, std::string name = "",
       bool is_asyncio = false, const std::string &extension_data = "") {
@@ -167,6 +168,7 @@ class TaskSpecBuilder {
     actor_creation_spec->set_name(name);
     actor_creation_spec->set_is_asyncio(is_asyncio);
     actor_creation_spec->set_extension_data(extension_data);
+    actor_creation_spec->set_serialized_actor_handle(serialized_actor_handle);
     return *this;
   }
 

--- a/src/ray/core_worker/actor_handle.h
+++ b/src/ray/core_worker/actor_handle.h
@@ -38,7 +38,7 @@ class ActorHandle {
               const std::string &extension_data, int64_t max_task_retries);
 
   /// Constructs an ActorHandle from a serialized string.
-  ActorHandle(const std::string &serialized);
+  explicit ActorHandle(const std::string &serialized);
 
   /// Constructs an ActorHandle from a gcs::ActorTableData message.
   ActorHandle(const rpc::ActorTableData &actor_table_data);

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1698,25 +1698,26 @@ Status CoreWorker::CreateActor(const RayFunction &function,
       actor_creation_options.placement_group_capture_child_tasks,
       "", /* debugger_breakpoint */
       actor_creation_options.serialized_runtime_env, override_environment_variables);
-  builder.SetActorCreationTaskSpec(actor_id, actor_creation_options.max_restarts,
-                                   actor_creation_options.max_task_retries,
-                                   actor_creation_options.dynamic_worker_options,
-                                   actor_creation_options.max_concurrency,
-                                   actor_creation_options.is_detached, actor_name,
-                                   actor_creation_options.is_asyncio, extension_data);
 
-  // Add the actor handle before we submit the actor creation task, since the
-  // actor handle must be in scope by the time the GCS sends the
-  // WaitForActorOutOfScopeRequest.
   auto actor_handle = std::make_unique<ActorHandle>(
       actor_id, GetCallerId(), rpc_address_, job_id, /*actor_cursor=*/return_ids[0],
       function.GetLanguage(), function.GetFunctionDescriptor(), extension_data,
       actor_creation_options.max_task_retries);
+  std::string serialized_actor_handle;
+  actor_handle->Serialize(&serialized_actor_handle);
+  builder.SetActorCreationTaskSpec(
+      actor_id, serialized_actor_handle, actor_creation_options.max_restarts,
+      actor_creation_options.max_task_retries,
+      actor_creation_options.dynamic_worker_options,
+      actor_creation_options.max_concurrency, actor_creation_options.is_detached,
+      actor_name, actor_creation_options.is_asyncio, extension_data);
+  // Add the actor handle before we submit the actor creation task, since the
+  // actor handle must be in scope by the time the GCS sends the
+  // WaitForActorOutOfScopeRequest.
   RAY_CHECK(actor_manager_->AddNewActorHandle(std::move(actor_handle), GetCallerId(),
                                               CurrentCallSite(), rpc_address_,
                                               actor_creation_options.is_detached))
       << "Actor " << actor_id << " already exists";
-
   *return_actor_id = actor_id;
   TaskSpecification task_spec = builder.Build();
   Status status;
@@ -2124,6 +2125,13 @@ Status CoreWorker::ExecuteTask(const TaskSpecification &task_spec,
     return_ids.pop_back();
     task_type = TaskType::ACTOR_CREATION_TASK;
     SetActorId(task_spec.ActorCreationId());
+    {
+      std::unique_ptr<ActorHandle> self_actor_handle(
+          new ActorHandle(task_spec.GetSerializedActorHandle()));
+      // Register the handle to the current actor itself.
+      actor_manager_->RegisterActorHandle(std::move(self_actor_handle), ObjectID::Nil(),
+                                          GetCallerId(), CurrentCallSite(), rpc_address_);
+    }
     RAY_LOG(INFO) << "Creating actor: " << task_spec.ActorCreationId();
   } else if (task_spec.IsActorTask()) {
     RAY_CHECK(return_ids.size() > 0);

--- a/src/ray/gcs/test/gcs_test_util.h
+++ b/src/ray/gcs/test/gcs_test_util.h
@@ -43,8 +43,8 @@ struct Mocker {
                               Language::PYTHON, empty_descriptor, job_id, TaskID::Nil(),
                               0, TaskID::Nil(), owner_address, 1, resource, resource,
                               std::make_pair(PlacementGroupID::Nil(), -1), true, "");
-    builder.SetActorCreationTaskSpec(actor_id, max_restarts, /*max_task_retries=*/0, {},
-                                     1, detached, name);
+    builder.SetActorCreationTaskSpec(actor_id, {}, max_restarts, /*max_task_retries=*/0,
+                                     {}, 1, detached, name);
     return builder.Build();
   }
 

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -304,6 +304,8 @@ message ActorCreationTaskSpec {
   bool is_asyncio = 9;
   // Field used for storing application-level extensions to the actor definition.
   string extension_data = 10;
+  // Serialized bytes of the Handle to the actor that will be created by this task.
+  bytes serialized_actor_handle = 11;
 }
 
 // Task spec of an actor task.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
 Implement `Ray.getRuntimeContext().getCurrentActorHandle()` API with core worker changes.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#14899
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
