### PR TITLE
[RLlib][contrib][maddpg] update get/set_weights to use dictionaries

### DIFF
--- a/rllib/contrib/maddpg/maddpg_policy.py
+++ b/rllib/contrib/maddpg/maddpg_policy.py
@@ -297,12 +297,13 @@ class MADDPGTFPolicy(MADDPGPostprocessing, TFPolicy):
         var_list = []
         for var in self.vars.values():
             var_list += var
-        return self.sess.run(var_list)
+        return {"_state": self.sess.run(var_list)}
 
     @override(TFPolicy)
     def set_weights(self, weights):
         self.sess.run(
-            self.update_vars, feed_dict=dict(zip(self.vars_ph, weights)))
+            self.update_vars,
+            feed_dict=dict(zip(self.vars_ph, weights["_state"])))
 
     @override(Policy)
     def get_state(self):


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
maddpg get_weights is currently returning a list of weights rather than a dictionary. This causes tf_policy.py set_state to fail when trying to get "optimizer_vars".

<!-- Please give a short summary of the change and the problem this solves. -->
This commit updates maddpg to use a dictionary rather than a list in get/set_weights.

## Related issue number
Closes #14097
<!-- For example: "Closes #1234" -->

## Checks

- [x ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] Tested with script in the github issue.