### PR TITLE
Treat doc warnings as errors in Makefile to mirror CI linter

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -54,7 +54,7 @@ clean:
 	rm -rf site/_site site/Gemfile.lock site/.sass-cache
 
 html:
-	$(SPHINXBUILD) -b -W html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -W -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -54,7 +54,7 @@ clean:
 	rm -rf site/_site site/Gemfile.lock site/.sass-cache
 
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b -W html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
For docs changes to pass CI, they need to compile without warnings.  Specifically, the CI linter runs the doc build with the flag `-W` which treats warnings as errors.

We should mirror this on the developer side, because warnings are sometimes missed when developing locally and even if they're noticed, it might not be obvious that they will be rejected by CI.

This PR adds the -W flag into the makefile for the command `make html`, which is the command developers are told to run locally in the instructions for building docs.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
