### PR TITLE
[C++ Worker] Unify normal task remote interface

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -191,7 +191,7 @@ test_python() {
 test_cpp() {
   bazel build --config=ci //cpp:all
   # shellcheck disable=SC2046
-  bazel test --config=ci $(./scripts/bazel_export_options) //cpp:all --build_tests_only
+  bazel test --config=ci $(./scripts/bazel_export_options) --test_strategy=exclusive //cpp:all --build_tests_only
   # run the cpp example
   bazel run //cpp/example:example
 

--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -117,8 +117,8 @@ cc_binary(
         "src/ray/test/cluster/*.cc",
     ]),
     copts = COPTS,
-    linkstatic = True,
     linkopts = ["-shared"],
+    linkstatic = True,
     deps = [
         "ray_api",
         "@com_github_gflags_gflags//:gflags",

--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -136,8 +136,8 @@ cc_test(
     ],
     copts = COPTS,
     data = [
-        "ray_remote_cluster_test.so",
         "ray_cpp_pkg",
+        "ray_remote_cluster_test.so",
     ],
     linkstatic = True,
     deps = [

--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -85,6 +85,7 @@ cc_test(
     linkstatic = False,
     deps = [
         "ray_api",
+        "cluster_mode_test.so",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -118,6 +118,7 @@ cc_binary(
     ]),
     copts = COPTS,
     linkstatic = True,
+    linkopts = ["-shared"],
     deps = [
         "ray_api",
         "@com_github_gflags_gflags//:gflags",

--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -117,7 +117,6 @@ cc_binary(
         "src/ray/test/cluster/*.cc",
     ]),
     copts = COPTS,
-    linkopts = ["-shared"],
     linkstatic = True,
     deps = [
         "ray_api",

--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -38,6 +38,7 @@ cc_library(
         "//:ray_util",
         "@boost//:asio",
         "@boost//:callable_traits",
+        "@boost//:dll",
         "@boost//:thread",
         "@com_google_absl//absl/synchronization",
         "@msgpack",

--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -124,3 +124,40 @@ cc_binary(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "ray_remote_cluster_test",
+    testonly = 0,
+    srcs = glob([
+        "src/ray/test/ray_remote_cluster/*.cc",
+    ]),
+    args = [
+        "$(location ray_remote_cluster_test.so)",
+    ],
+    copts = COPTS,
+    data = [
+        "ray_remote_cluster_test.so",
+        "ray_cpp_pkg",
+    ],
+    linkstatic = True,
+    deps = [
+        "ray_api",
+        "@com_github_gflags_gflags//:gflags",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_binary(
+    name = "ray_remote_cluster_test.so",
+    srcs = glob([
+        "src/ray/test/ray_remote_cluster/*.cc",
+    ]),
+    copts = COPTS,
+    linkopts = ["-shared"],
+    linkstatic = True,
+    deps = [
+        "ray_api",
+        "@com_github_gflags_gflags//:gflags",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -85,7 +85,6 @@ cc_test(
     linkstatic = False,
     deps = [
         "ray_api",
-        "cluster_mode_test.so",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/cpp/example/BUILD.bazel
+++ b/cpp/example/BUILD.bazel
@@ -29,7 +29,6 @@ cc_binary(
         "*.cc",
     ]),
     copts = COPTS,
-    linkopts = ["-shared"],
     linkstatic = True,
     deps = [
         "//cpp:ray_api",

--- a/cpp/example/BUILD.bazel
+++ b/cpp/example/BUILD.bazel
@@ -29,6 +29,7 @@ cc_binary(
         "*.cc",
     ]),
     copts = COPTS,
+    linkopts = ["-shared"],
     linkstatic = True,
     deps = [
         "//cpp:ray_api",

--- a/cpp/example/example.cc
+++ b/cpp/example/example.cc
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
   std::cout << "task_result1 = " << task_result1 << std::endl;
 
   /// common task with args
-  task_obj = Ray::Task(Plus1, 5).Remote();
+  task_obj = Ray::Task(Plus1).Remote(5);
   int task_result2 = *(Ray::Get(task_obj));
   std::cout << "task_result2 = " << task_result2 << std::endl;
 
@@ -92,15 +92,15 @@ int main(int argc, char **argv) {
 
   /// general function remote call（args passed by value）
   auto r0 = Ray::Task(Return1).Remote();
-  auto r2 = Ray::Task(Plus, 3, 22).Remote();
+  auto r2 = Ray::Task(Plus).Remote(3, 22);
   int task_result3 = *(Ray::Get(r2));
   std::cout << "task_result3 = " << task_result3 << std::endl;
 
   /// general function remote call（args passed by reference）
   auto r3 = Ray::Task(Return1).Remote();
-  auto r4 = Ray::Task(Plus1, r3).Remote();
-  auto r5 = Ray::Task(Plus, r4, r3).Remote();
-  auto r6 = Ray::Task(Plus, r4, 10).Remote();
+  auto r4 = Ray::Task(Plus1).Remote(r3);
+  auto r5 = Ray::Task(Plus).Remote(r4, r3);
+  auto r6 = Ray::Task(Plus).Remote(r4, 10);
   int task_result4 = *(Ray::Get(r6));
   int task_result5 = *(Ray::Get(r5));
   std::cout << "task_result4 = " << task_result4 << ", task_result5 = " << task_result5
@@ -118,8 +118,8 @@ int main(int argc, char **argv) {
   auto r12 = actor5.Task(&Counter::Add, r11).Remote();
   auto r13 = actor5.Task(&Counter::Add, r10).Remote();
   auto r14 = actor5.Task(&Counter::Add, r13).Remote();
-  auto r15 = Ray::Task(Plus, r0, r11).Remote();
-  auto r16 = Ray::Task(Plus1, r15).Remote();
+  auto r15 = Ray::Task(Plus).Remote(r0, r11);
+  auto r16 = Ray::Task(Plus1).Remote(r15);
   int result12 = *(Ray::Get(r12));
   int result14 = *(Ray::Get(r14));
   int result11 = *(Ray::Get(r11));

--- a/cpp/include/ray/api.h
+++ b/cpp/include/ray/api.h
@@ -203,6 +203,16 @@ inline ActorCreator<ActorType> Ray::CreateActorInternal(FuncType &create_func,
 template <typename F, typename... Args>
 TaskCaller<boost::callable_traits::return_type_t<F>> Ray::Task(F func, Args... args) {
   using ReturnType = boost::callable_traits::return_type_t<F>;
+  if (ray::api::RayConfig::GetInstance()->use_ray_remote) {
+    auto function_name = ray::internal::FunctionManager::Instance().GetFunctionName(func);
+    if (function_name.empty()) {
+      throw RayException(function_name + " not exsit!");
+    }
+    /// TODO if function_name is empty, throw exception
+    return TaskCaller<ReturnType>(ray::internal::RayRuntime().get(),
+                                  std::move(function_name));
+  }
+
   return TaskInternal<ReturnType>(
       func, NormalExecFunction<ReturnType, typename FilterArgType<Args>::type...>,
       args...);

--- a/cpp/include/ray/api.h
+++ b/cpp/include/ray/api.h
@@ -206,11 +206,12 @@ TaskCaller<boost::callable_traits::return_type_t<F>> Ray::Task(F func, Args... a
   if (ray::api::RayConfig::GetInstance()->use_ray_remote) {
     auto function_name = ray::internal::FunctionManager::Instance().GetFunctionName(func);
     if (function_name.empty()) {
-      throw RayException(function_name + " not exsit!");
+      throw RayException(function_name +
+                         " not found. Please use RAY_REMOTE to register this function.");
     }
-    /// TODO if function_name is empty, throw exception
-    return TaskCaller<ReturnType>(ray::internal::RayRuntime().get(),
-                                  std::move(function_name));
+    RemoteFunctionPtrHolder fptr{};
+    fptr.function_name = std::move(function_name);
+    return TaskCaller<ReturnType>(ray::internal::RayRuntime().get(), std::move(fptr));
   }
 
   return TaskInternal<ReturnType>(

--- a/cpp/include/ray/api.h
+++ b/cpp/include/ray/api.h
@@ -78,8 +78,8 @@ class Ray {
   /// \param[in] func The function to be remote executed.
   /// \param[in] args The function arguments passed by a value or ObjectRef.
   /// \return TaskCaller.
-  template <typename F, typename... Args>
-  static TaskCaller<boost::callable_traits::return_type_t<F>> Task(F func, Args... args);
+  template <typename F>
+  static TaskCaller<boost::callable_traits::return_type_t<F>> Task(F func);
 
   /// Generic version of creating an actor
   /// It is used for creating an actor, such as: ActorCreator<Counter> creator =
@@ -98,10 +98,8 @@ class Ray {
  private:
   static std::once_flag is_inited_;
 
-  template <typename ReturnType, typename FuncType, typename ExecFuncType,
-            typename... ArgTypes>
-  static TaskCaller<ReturnType> TaskInternal(FuncType &func, ExecFuncType &exec_func,
-                                             ArgTypes &... args);
+  template <typename ReturnType, typename FuncType>
+  static TaskCaller<ReturnType> TaskInternal(FuncType &func);
 
   template <typename ActorType, typename FuncType, typename ExecFuncType,
             typename... ArgTypes>
@@ -172,15 +170,10 @@ inline WaitResult Ray::Wait(const std::vector<ObjectID> &ids, int num_objects,
   return ray::internal::RayRuntime()->Wait(ids, num_objects, timeout_ms);
 }
 
-template <typename ReturnType, typename FuncType, typename ExecFuncType,
-          typename... ArgTypes>
-inline TaskCaller<ReturnType> Ray::TaskInternal(FuncType &func, ExecFuncType &exec_func,
-                                                ArgTypes &... args) {
-  std::vector<std::unique_ptr<::ray::TaskArg>> task_args;
-  Arguments::WrapArgs(&task_args, args...);
+template <typename ReturnType, typename FuncType>
+inline TaskCaller<ReturnType> Ray::TaskInternal(FuncType &func) {
   RemoteFunctionPtrHolder ptr;
   ptr.function_pointer = reinterpret_cast<uintptr_t>(func);
-  ptr.exec_function_pointer = reinterpret_cast<uintptr_t>(exec_func);
   if (ray::api::RayConfig::GetInstance()->use_ray_remote) {
     auto function_name = ray::internal::FunctionManager::Instance().GetFunctionName(func);
     if (function_name.empty()) {
@@ -189,8 +182,7 @@ inline TaskCaller<ReturnType> Ray::TaskInternal(FuncType &func, ExecFuncType &ex
     }
     ptr.function_name = std::move(function_name);
   }
-  return TaskCaller<ReturnType>(ray::internal::RayRuntime().get(), ptr,
-                                std::move(task_args));
+  return TaskCaller<ReturnType>(ray::internal::RayRuntime().get(), ptr);
 }
 
 template <typename ActorType, typename FuncType, typename ExecFuncType,
@@ -208,13 +200,10 @@ inline ActorCreator<ActorType> Ray::CreateActorInternal(FuncType &create_func,
 }
 
 /// Normal task.
-template <typename F, typename... Args>
-TaskCaller<boost::callable_traits::return_type_t<F>> Ray::Task(F func, Args... args) {
+template <typename F>
+TaskCaller<boost::callable_traits::return_type_t<F>> Ray::Task(F func) {
   using ReturnType = boost::callable_traits::return_type_t<F>;
-
-  return TaskInternal<ReturnType>(
-      func, NormalExecFunction<ReturnType, typename FilterArgType<Args>::type...>,
-      args...);
+  return TaskInternal<ReturnType>(func);
 }
 
 /// Generic version of creating an actor.

--- a/cpp/include/ray/api/exec_funcs.h
+++ b/cpp/include/ray/api/exec_funcs.h
@@ -53,9 +53,8 @@ inline static msgpack::sbuffer CallInDll(
     const std::vector<std::shared_ptr<RayObject>> &args_buffer) {
   return TaskExecutionHandler(args_buffer);
 }
+BOOST_DLL_ALIAS(internal::CallInDll, CallInDll);
 }  // namespace internal
-
-BOOST_DLL_ALIAS(ray::internal::CallInDll, CallInDll);
 
 namespace api {
 /// The following execution functions are wrappers of remote functions.

--- a/cpp/include/ray/api/exec_funcs.h
+++ b/cpp/include/ray/api/exec_funcs.h
@@ -17,47 +17,11 @@
 #include <ray/api/arguments.h>
 #include <ray/api/function_manager.h>
 #include <ray/api/serializer.h>
-#include <boost/dll.hpp>
 #include <msgpack.hpp>
 #include "absl/utility/utility.h"
 #include "ray/core.h"
 
 namespace ray {
-
-namespace internal {
-/// Execute remote functions by networking stream.
-inline static msgpack::sbuffer TaskExecutionHandler(
-    const std::vector<std::shared_ptr<RayObject>> &args_buffer) {
-  if (args_buffer.empty()) {
-    return PackError("lack of required arguments");
-  }
-  auto &memory_buffer = args_buffer.at(0)->GetData();
-  msgpack::sbuffer result;
-  do {
-    try {
-      auto func_name = ray::api::Serializer::Deserialize<std::string>(
-          (char *)memory_buffer->Data(), memory_buffer->Size());
-      auto func_ptr = FunctionManager::Instance().GetFunction(func_name);
-      if (func_ptr == nullptr) {
-        result = PackError("unknown function: " + func_name);
-        break;
-      }
-
-      result = (*func_ptr)(args_buffer);
-    } catch (const std::exception &ex) {
-      result = PackError(ex.what());
-    }
-  } while (0);
-
-  return result;
-}
-
-inline static msgpack::sbuffer CallInDll(
-    const std::vector<std::shared_ptr<RayObject>> &args_buffer) {
-  return TaskExecutionHandler(args_buffer);
-}
-BOOST_DLL_ALIAS(internal::CallInDll, CallInDll);
-}  // namespace internal
 
 namespace api {
 /// The following execution functions are wrappers of remote functions.

--- a/cpp/include/ray/api/exec_funcs.h
+++ b/cpp/include/ray/api/exec_funcs.h
@@ -16,6 +16,7 @@
 
 #include <ray/api/arguments.h>
 #include <ray/api/serializer.h>
+#include "absl/utility/utility.h"
 
 namespace ray {
 namespace api {
@@ -26,10 +27,10 @@ namespace api {
 /// ActorExecFunction the wrapper of actor member function.
 
 template <typename ReturnType, typename CastReturnType, typename... OtherArgTypes>
-std::shared_ptr<msgpack::sbuffer> ExecuteNormalFunction(
-    uintptr_t base_addr, size_t func_offset,
-    const std::vector<std::shared_ptr<RayObject>> &args_buffer, TaskType task_type,
-    std::shared_ptr<OtherArgTypes> &&... args) {
+absl::enable_if_t<!std::is_void<ReturnType>::value, std::shared_ptr<msgpack::sbuffer>>
+ExecuteNormalFunction(uintptr_t base_addr, size_t func_offset,
+                      const std::vector<std::shared_ptr<RayObject>> &args_buffer,
+                      TaskType task_type, std::shared_ptr<OtherArgTypes> &&... args) {
   int arg_index = 0;
   Arguments::UnwrapArgs(args_buffer, arg_index, &args...);
 
@@ -41,6 +42,14 @@ std::shared_ptr<msgpack::sbuffer> ExecuteNormalFunction(
   // TODO: No need use shared_ptr here, refactor later.
   return std::make_shared<msgpack::sbuffer>(
       Serializer::Serialize((CastReturnType)(return_value)));
+}
+
+template <typename ReturnType, typename CastReturnType, typename... OtherArgTypes>
+absl::enable_if_t<std::is_void<ReturnType>::value> ExecuteNormalFunction(
+    uintptr_t base_addr, size_t func_offset,
+    const std::vector<std::shared_ptr<RayObject>> &args_buffer, TaskType task_type,
+    std::shared_ptr<OtherArgTypes> &&... args) {
+  // TODO: Will support void functions for old api later.
 }
 
 template <typename ReturnType, typename ActorType, typename... OtherArgTypes>
@@ -69,10 +78,19 @@ std::shared_ptr<msgpack::sbuffer> ExecuteActorFunction(
 }
 
 template <typename ReturnType, typename... Args>
-std::shared_ptr<msgpack::sbuffer> NormalExecFunction(
+absl::enable_if_t<!std::is_void<ReturnType>::value, std::shared_ptr<msgpack::sbuffer>>
+NormalExecFunction(uintptr_t base_addr, size_t func_offset,
+                   const std::vector<std::shared_ptr<RayObject>> &args_buffer) {
+  return ExecuteNormalFunction<ReturnType, ReturnType, Args...>(
+      base_addr, func_offset, args_buffer, TaskType::NORMAL_TASK,
+      std::shared_ptr<Args>{}...);
+}
+
+template <typename ReturnType, typename... Args>
+absl::enable_if_t<std::is_void<ReturnType>::value> NormalExecFunction(
     uintptr_t base_addr, size_t func_offset,
     const std::vector<std::shared_ptr<RayObject>> &args_buffer) {
-  return ExecuteNormalFunction<ReturnType, ReturnType, Args...>(
+  ExecuteNormalFunction<ReturnType, ReturnType, Args...>(
       base_addr, func_offset, args_buffer, TaskType::NORMAL_TASK,
       std::shared_ptr<Args>{}...);
 }

--- a/cpp/include/ray/api/exec_funcs.h
+++ b/cpp/include/ray/api/exec_funcs.h
@@ -28,6 +28,9 @@ namespace internal {
 /// Execute remote functions by networking stream.
 inline static msgpack::sbuffer TaskExecutionHandler(
     const std::vector<std::shared_ptr<RayObject>> &args_buffer) {
+  if (args_buffer.empty()) {
+    return PackError("lack of required arguments");
+  }
   auto &memory_buffer = args_buffer.at(0)->GetData();
   msgpack::sbuffer result;
   do {

--- a/cpp/include/ray/api/exec_funcs.h
+++ b/cpp/include/ray/api/exec_funcs.h
@@ -15,10 +15,48 @@
 #pragma once
 
 #include <ray/api/arguments.h>
+#include <ray/api/function_manager.h>
 #include <ray/api/serializer.h>
+#include <boost/dll.hpp>
+#include <msgpack.hpp>
 #include "absl/utility/utility.h"
+#include "ray/core.h"
 
 namespace ray {
+
+namespace internal {
+/// Execute remote functions by networking stream.
+inline static msgpack::sbuffer TaskExecutionHandler(
+    const std::vector<std::shared_ptr<RayObject>> &args_buffer) {
+  auto &memory_buffer = args_buffer.at(0)->GetData();
+  msgpack::sbuffer result;
+  do {
+    try {
+      auto func_name = ray::api::Serializer::Deserialize<std::string>(
+          (char *)memory_buffer->Data(), memory_buffer->Size());
+      auto func_ptr = FunctionManager::Instance().GetFunction(func_name);
+      if (func_ptr == nullptr) {
+        result = PackError("unknown function: " + func_name);
+        break;
+      }
+
+      result = (*func_ptr)(args_buffer);
+    } catch (const std::exception &ex) {
+      result = PackError(ex.what());
+    }
+  } while (0);
+
+  return result;
+}
+
+inline static msgpack::sbuffer CallInDll(
+    const std::vector<std::shared_ptr<RayObject>> &args_buffer) {
+  return TaskExecutionHandler(args_buffer);
+}
+}  // namespace internal
+
+BOOST_DLL_ALIAS(ray::internal::CallInDll, CallInDll);
+
 namespace api {
 /// The following execution functions are wrappers of remote functions.
 /// Execution functions make remote functions executable in distributed system.

--- a/cpp/include/ray/api/function_manager.h
+++ b/cpp/include/ray/api/function_manager.h
@@ -57,21 +57,16 @@ struct Invoker {
   static inline msgpack::sbuffer Apply(
       const Function &func, const std::vector<std::shared_ptr<RayObject>> &args_buffer) {
     using ArgsTuple = boost::callable_traits::args_t<Function>;
-    if (std::tuple_size<ArgsTuple>::value != args_buffer.size() - 1) {
+    if (std::tuple_size<ArgsTuple>::value != args_buffer.size()) {
       return PackError("Arguments number not match");
-    }
-
-    std::vector<std::shared_ptr<RayObject>> new_vector;
-    if (args_buffer.size() > 1) {
-      auto first = args_buffer.begin() + 1;
-      new_vector = std::vector<std::shared_ptr<RayObject>>(first, args_buffer.end());
     }
 
     msgpack::sbuffer result;
     ArgsTuple tp{};
     try {
-      bool is_ok = GetArgsTuple(
-          tp, new_vector, absl::make_index_sequence<std::tuple_size<ArgsTuple>::value>{});
+      bool is_ok =
+          GetArgsTuple(tp, args_buffer,
+                       absl::make_index_sequence<std::tuple_size<ArgsTuple>::value>{});
       if (!is_ok) {
         return PackError("arguments error");
       }

--- a/cpp/include/ray/api/function_manager.h
+++ b/cpp/include/ray/api/function_manager.h
@@ -132,6 +132,7 @@ struct Invoker {
   static absl::result_of_t<F(Args...)> CallInternal(const F &f,
                                                     const absl::index_sequence<I...> &,
                                                     std::tuple<Args...> tup) {
+    (void)tup;
     return f(std::move(std::get<I>(tup))...);
   }
 };

--- a/cpp/include/ray/api/function_manager.h
+++ b/cpp/include/ray/api/function_manager.h
@@ -42,7 +42,8 @@ inline static msgpack::sbuffer PackError(std::string error_msg) {
   msgpack::sbuffer sbuffer;
   msgpack::packer<msgpack::sbuffer> packer(sbuffer);
   packer.pack(msgpack::type::nil_t());
-  packer.pack(std::move(error_msg));
+  packer.pack(std::make_tuple((int)ray::rpc::ErrorType::TASK_EXECUTION_EXCEPTION,
+                              std::move(error_msg)));
 
   return sbuffer;
 }

--- a/cpp/include/ray/api/function_manager.h
+++ b/cpp/include/ray/api/function_manager.h
@@ -66,8 +66,6 @@ struct Invoker {
       new_vector = std::vector<std::shared_ptr<RayObject>>(first, args_buffer.end());
     }
 
-    std::cout << "args count: " << std::tuple_size<ArgsTuple>::value << '\n';
-
     msgpack::sbuffer result;
     ArgsTuple tp{};
     try {
@@ -167,6 +165,16 @@ class FunctionManager {
     }
 
     return RegisterNonMemberFunc(name, f);
+  }
+
+  template <typename Function>
+  std::string GetFunctionName(const Function &f) {
+    auto it = func_ptr_to_key_map_.find((uint64_t)f);
+    if (it == func_ptr_to_key_map_.end()) {
+      return "";
+    }
+
+    return it->second;
   }
 
  private:

--- a/cpp/include/ray/api/object_ref.h
+++ b/cpp/include/ray/api/object_ref.h
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include <ray/api/ray_config.h>
 #include <ray/api/ray_runtime_holder.h>
 #include <ray/api/serializer.h>
 
@@ -59,6 +60,13 @@ class ObjectRef {
 template <typename T>
 inline static std::shared_ptr<T> GetFromRuntime(const ObjectRef<T> &object) {
   auto packed_object = internal::RayRuntime()->Get(object.ID());
+  if (ray::api::RayConfig::GetInstance()->use_ray_remote) {
+    bool has_error = Serializer::HasError(packed_object->data(), packed_object->size());
+    if (has_error) {
+      throw RayException("has error");
+    }
+  }
+
   return Serializer::Deserialize<std::shared_ptr<T>>(packed_object->data(),
                                                      packed_object->size());
 }

--- a/cpp/include/ray/api/object_ref.h
+++ b/cpp/include/ray/api/object_ref.h
@@ -63,7 +63,9 @@ inline static std::shared_ptr<T> GetFromRuntime(const ObjectRef<T> &object) {
   if (ray::api::RayConfig::GetInstance()->use_ray_remote) {
     bool has_error = Serializer::HasError(packed_object->data(), packed_object->size());
     if (has_error) {
-      throw RayException("has error");
+      std::string err_msg = Serializer::Deserialize<std::string>(
+          packed_object->data(), packed_object->size(), 1);
+      throw RayException(err_msg);
     }
   }
 

--- a/cpp/include/ray/api/object_ref.h
+++ b/cpp/include/ray/api/object_ref.h
@@ -103,5 +103,58 @@ template <typename T>
 inline std::shared_ptr<T> ObjectRef<T>::Get() const {
   return GetFromRuntime(*this);
 }
+
+template <>
+class ObjectRef<void> {
+ public:
+  ObjectRef() = default;
+  ~ObjectRef() {
+    if (CoreWorkerProcess::IsInitialized()) {
+      auto &core_worker = CoreWorkerProcess::GetCoreWorker();
+      core_worker.RemoveLocalReference(id_);
+    }
+  }
+
+  ObjectRef(const ObjectRef &rhs) { CopyAndAddRefrence(rhs.id_); }
+
+  ObjectRef &operator=(const ObjectRef &rhs) {
+    CopyAndAddRefrence(rhs.id_);
+    return *this;
+  }
+
+  ObjectRef(const ObjectID &id) { CopyAndAddRefrence(id); }
+
+  bool operator==(const ObjectRef<void> &object) const { return id_ == object.id_; }
+
+  /// Get a untyped ID of the object
+  const ObjectID &ID() const { return id_; }
+
+  /// Get the object from the object store.
+  /// This method will be blocked until the object is ready.
+  ///
+  /// \return shared pointer of the result.
+  void Get() const {
+    auto packed_object = internal::RayRuntime()->Get(id_);
+    bool has_error = Serializer::HasError(packed_object->data(), packed_object->size());
+    if (has_error) {
+      std::string err_msg = Serializer::Deserialize<std::string>(
+          packed_object->data(), packed_object->size(), 1);
+      throw RayException(err_msg);
+    }
+  }
+
+  /// Make ObjectRef serializable
+  MSGPACK_DEFINE(id_);
+
+ private:
+  void CopyAndAddRefrence(const ObjectID &id) {
+    id_ = id;
+    if (CoreWorkerProcess::IsInitialized()) {
+      auto &core_worker = CoreWorkerProcess::GetCoreWorker();
+      core_worker.AddLocalReference(id_);
+    }
+  }
+  ObjectID id_;
+};
 }  // namespace api
 }  // namespace ray

--- a/cpp/include/ray/api/object_ref.h
+++ b/cpp/include/ray/api/object_ref.h
@@ -65,6 +65,7 @@ inline static std::shared_ptr<T> GetFromRuntime(const ObjectRef<T> &object) {
     if (has_error) {
       std::string err_msg = Serializer::Deserialize<std::string>(
           packed_object->data(), packed_object->size(), 1);
+      RAY_LOG(WARNING) << "Exception message: " << err_msg;
       throw RayException(err_msg);
     }
   }
@@ -139,6 +140,7 @@ class ObjectRef<void> {
     if (has_error) {
       std::string err_msg = Serializer::Deserialize<std::string>(
           packed_object->data(), packed_object->size(), 1);
+      RAY_LOG(WARNING) << "Exception message: " << err_msg;
       throw RayException(err_msg);
     }
   }

--- a/cpp/include/ray/api/object_ref.h
+++ b/cpp/include/ray/api/object_ref.h
@@ -63,9 +63,11 @@ inline static std::shared_ptr<T> GetFromRuntime(const ObjectRef<T> &object) {
   if (ray::api::RayConfig::GetInstance()->use_ray_remote) {
     bool has_error = Serializer::HasError(packed_object->data(), packed_object->size());
     if (has_error) {
-      std::string err_msg = Serializer::Deserialize<std::string>(
+      auto tp = Serializer::Deserialize<std::tuple<int, std::string>>(
           packed_object->data(), packed_object->size(), 1);
-      RAY_LOG(WARNING) << "Exception message: " << err_msg;
+      std::string err_msg = std::get<1>(tp);
+      RAY_LOG(WARNING) << "Exception code: " << std::get<0>(tp)
+                       << ", Exception message: " << err_msg;
       throw RayException(err_msg);
     }
   }
@@ -138,9 +140,11 @@ class ObjectRef<void> {
     auto packed_object = internal::RayRuntime()->Get(id_);
     bool has_error = Serializer::HasError(packed_object->data(), packed_object->size());
     if (has_error) {
-      std::string err_msg = Serializer::Deserialize<std::string>(
+      auto tp = Serializer::Deserialize<std::tuple<int, std::string>>(
           packed_object->data(), packed_object->size(), 1);
-      RAY_LOG(WARNING) << "Exception message: " << err_msg;
+      std::string err_msg = std::get<1>(tp);
+      RAY_LOG(WARNING) << "Exception code: " << std::get<0>(tp)
+                       << ", Exception message: " << err_msg;
       throw RayException(err_msg);
     }
   }

--- a/cpp/include/ray/api/ray_config.h
+++ b/cpp/include/ray/api/ray_config.h
@@ -32,6 +32,8 @@ class RayConfig {
 
   std::string session_dir = "";
 
+  bool use_ray_remote = false;
+
   static std::shared_ptr<RayConfig> GetInstance();
 
   void SetRedisAddress(const std::string address) {

--- a/cpp/include/ray/api/ray_runtime.h
+++ b/cpp/include/ray/api/ray_runtime.h
@@ -23,6 +23,7 @@ struct RemoteFunctionPtrHolder {
   uintptr_t function_pointer;
   /// The executable function pointer
   uintptr_t exec_function_pointer;
+  std::string function_name;
 };
 
 class RayRuntime {

--- a/cpp/include/ray/api/serializer.h
+++ b/cpp/include/ray/api/serializer.h
@@ -19,15 +19,26 @@ class Serializer {
 
   template <typename T>
   static T Deserialize(const char *data, size_t size) {
-    try {
-      msgpack::unpacked unpacked;
-      msgpack::unpack(unpacked, data, size);
-      return unpacked.get().as<T>();
-    } catch (std::exception &e) {
-      throw RayException(std::string("unpack failed, reason: ") + e.what());
-    } catch (...) {
-      throw RayException("unpack failed, reason: unknown error");
-    }
+    msgpack::unpacked unpacked;
+    msgpack::unpack(unpacked, data, size);
+    return unpacked.get().as<T>();
+  }
+
+  template <typename T>
+  static T Deserialize(const char *data, size_t size, size_t offset) {
+    return Deserialize<T>(data + offset, size - offset);
+  }
+
+  template <typename T>
+  static T Deserialize(const char *data, size_t size, size_t &off) {
+    msgpack::unpacked unpacked = msgpack::unpack(data, size, off);
+    return unpacked.get().as<T>();
+  }
+
+  static bool HasError(char *data, size_t size) {
+    size_t off = 0;
+    msgpack::unpacked unpacked = msgpack::unpack(data, 1, off);
+    return unpacked.get().is_nil() && size > off;
   }
 };
 

--- a/cpp/include/ray/api/serializer.h
+++ b/cpp/include/ray/api/serializer.h
@@ -35,6 +35,18 @@ class Serializer {
     return unpacked.get().as<T>();
   }
 
+  template <typename T>
+  static std::pair<bool, T> DeserializeWhenNil(const char *data, size_t size) {
+    T val;
+    size_t off = 0;
+    msgpack::unpacked unpacked = msgpack::unpack(data, size, off);
+    if (!unpacked.get().convert_if_not_nil(val)) {
+      return {false, {}};
+    }
+
+    return {true, val};
+  }
+
   static bool HasError(char *data, size_t size) {
     size_t off = 0;
     msgpack::unpacked unpacked = msgpack::unpack(data, 1, off);

--- a/cpp/include/ray/api/task_caller.h
+++ b/cpp/include/ray/api/task_caller.h
@@ -11,11 +11,13 @@ class TaskCaller {
  public:
   TaskCaller();
 
-  TaskCaller(RayRuntime *runtime, RemoteFunctionPtrHolder ptr,
-             std::vector<std::unique_ptr<::ray::TaskArg>> &&args);
+  TaskCaller(RayRuntime *runtime, RemoteFunctionPtrHolder ptr);
 
   template <typename... Args>
   ObjectRef<ReturnType> Remote(Args... args) {
+    Arguments::WrapArgs(&args_, args...);
+    ptr_.exec_function_pointer = reinterpret_cast<uintptr_t>(
+        NormalExecFunction<ReturnType, typename FilterArgType<Args>::type...>);
     auto returned_object_id = runtime_->Call(ptr_, args_);
     return ObjectRef<ReturnType>(returned_object_id);
   }
@@ -33,8 +35,7 @@ template <typename ReturnType>
 TaskCaller<ReturnType>::TaskCaller() {}
 
 template <typename ReturnType>
-TaskCaller<ReturnType>::TaskCaller(RayRuntime *runtime, RemoteFunctionPtrHolder ptr,
-                                   std::vector<std::unique_ptr<::ray::TaskArg>> &&args)
-    : runtime_(runtime), ptr_(ptr), args_(std::move(args)) {}
+TaskCaller<ReturnType>::TaskCaller(RayRuntime *runtime, RemoteFunctionPtrHolder ptr)
+    : runtime_(runtime), ptr_(ptr) {}
 }  // namespace api
 }  // namespace ray

--- a/cpp/include/ray/api/task_caller.h
+++ b/cpp/include/ray/api/task_caller.h
@@ -11,8 +11,8 @@ class TaskCaller {
  public:
   TaskCaller();
 
-  TaskCaller(RayRuntime *runtime, std::string function_name)
-      : runtime_(runtime), function_name_(std::move(function_name)) {}
+  TaskCaller(RayRuntime *runtime, RemoteFunctionPtrHolder ptr)
+      : runtime_(runtime), ptr_(ptr) {}
 
   TaskCaller(RayRuntime *runtime, RemoteFunctionPtrHolder ptr,
              std::vector<std::unique_ptr<::ray::TaskArg>> &&args);
@@ -20,7 +20,7 @@ class TaskCaller {
   template <typename... Args>
   ObjectRef<ReturnType> Remote(Args... args) {
     if (ray::api::RayConfig::GetInstance()->use_ray_remote) {
-      Arguments::WrapArgs(&args_, function_name_, args...);
+      Arguments::WrapArgs(&args_, args...);
     }
 
     auto returned_object_id = runtime_->Call(ptr_, args_);

--- a/cpp/include/ray/api/task_caller.h
+++ b/cpp/include/ray/api/task_caller.h
@@ -29,7 +29,7 @@ class TaskCaller {
 
  private:
   RayRuntime *runtime_;
-  RemoteFunctionPtrHolder ptr_;
+  RemoteFunctionPtrHolder ptr_{};
   std::string function_name_;
   std::vector<std::unique_ptr<::ray::TaskArg>> args_;
 };

--- a/cpp/include/ray/api/task_caller.h
+++ b/cpp/include/ray/api/task_caller.h
@@ -11,18 +11,11 @@ class TaskCaller {
  public:
   TaskCaller();
 
-  TaskCaller(RayRuntime *runtime, RemoteFunctionPtrHolder ptr)
-      : runtime_(runtime), ptr_(ptr) {}
-
   TaskCaller(RayRuntime *runtime, RemoteFunctionPtrHolder ptr,
              std::vector<std::unique_ptr<::ray::TaskArg>> &&args);
 
   template <typename... Args>
   ObjectRef<ReturnType> Remote(Args... args) {
-    if (ray::api::RayConfig::GetInstance()->use_ray_remote) {
-      Arguments::WrapArgs(&args_, args...);
-    }
-
     auto returned_object_id = runtime_->Call(ptr_, args_);
     return ObjectRef<ReturnType>(returned_object_id);
   }

--- a/cpp/include/ray/api/task_caller.h
+++ b/cpp/include/ray/api/task_caller.h
@@ -11,14 +11,26 @@ class TaskCaller {
  public:
   TaskCaller();
 
+  TaskCaller(RayRuntime *runtime, std::string function_name)
+      : runtime_(runtime), function_name_(std::move(function_name)) {}
+
   TaskCaller(RayRuntime *runtime, RemoteFunctionPtrHolder ptr,
              std::vector<std::unique_ptr<::ray::TaskArg>> &&args);
 
-  ObjectRef<ReturnType> Remote();
+  template <typename... Args>
+  ObjectRef<ReturnType> Remote(Args... args) {
+    if (ray::api::RayConfig::GetInstance()->use_ray_remote) {
+      Arguments::WrapArgs(&args_, function_name_, args...);
+    }
+
+    auto returned_object_id = runtime_->Call(ptr_, args_);
+    return ObjectRef<ReturnType>(returned_object_id);
+  }
 
  private:
   RayRuntime *runtime_;
   RemoteFunctionPtrHolder ptr_;
+  std::string function_name_;
   std::vector<std::unique_ptr<::ray::TaskArg>> args_;
 };
 
@@ -31,11 +43,5 @@ template <typename ReturnType>
 TaskCaller<ReturnType>::TaskCaller(RayRuntime *runtime, RemoteFunctionPtrHolder ptr,
                                    std::vector<std::unique_ptr<::ray::TaskArg>> &&args)
     : runtime_(runtime), ptr_(ptr), args_(std::move(args)) {}
-
-template <typename ReturnType>
-ObjectRef<ReturnType> TaskCaller<ReturnType>::Remote() {
-  auto returned_object_id = runtime_->Call(ptr_, args_);
-  return ObjectRef<ReturnType>(returned_object_id);
-}
 }  // namespace api
 }  // namespace ray

--- a/cpp/src/ray/runtime/task/local_mode_task_submitter.cc
+++ b/cpp/src/ray/runtime/task/local_mode_task_submitter.cc
@@ -32,7 +32,8 @@ ObjectID LocalModeTaskSubmitter::Submit(InvocationSpec &invocation) {
   auto exec_func_offset =
       (size_t)(invocation.fptr.exec_function_pointer - dynamic_library_base_addr);
   auto functionDescriptor = FunctionDescriptorBuilder::BuildCpp(
-      "SingleProcess", std::to_string(func_offset), std::to_string(exec_func_offset));
+      "SingleProcess", std::to_string(func_offset), std::to_string(exec_func_offset),
+      invocation.fptr.function_name);
   rpc::Address address;
   std::unordered_map<std::string, double> required_resources;
   std::unordered_map<std::string, double> required_placement_resources;

--- a/cpp/src/ray/runtime/task/native_task_submitter.cc
+++ b/cpp/src/ray/runtime/task/native_task_submitter.cc
@@ -10,8 +10,8 @@ namespace api {
 
 RayFunction BuildRayFunction(InvocationSpec &invocation) {
   if (ray::api::RayConfig::GetInstance()->use_ray_remote) {
-    auto function_descriptor =
-        FunctionDescriptorBuilder::BuildCpp(invocation.lib_name, "", "");
+    auto function_descriptor = FunctionDescriptorBuilder::BuildCpp(
+        invocation.lib_name, "", "", invocation.fptr.function_name);
     return RayFunction(Language::CPP, function_descriptor);
   }
 
@@ -20,7 +20,8 @@ RayFunction BuildRayFunction(InvocationSpec &invocation) {
   auto func_offset = (size_t)(invocation.fptr.function_pointer - base_addr);
   auto exec_func_offset = (size_t)(invocation.fptr.exec_function_pointer - base_addr);
   auto function_descriptor = FunctionDescriptorBuilder::BuildCpp(
-      invocation.lib_name, std::to_string(func_offset), std::to_string(exec_func_offset));
+      invocation.lib_name, std::to_string(func_offset), std::to_string(exec_func_offset),
+      invocation.fptr.function_name);
   return RayFunction(Language::CPP, function_descriptor);
 }
 

--- a/cpp/src/ray/runtime/task/native_task_submitter.cc
+++ b/cpp/src/ray/runtime/task/native_task_submitter.cc
@@ -9,6 +9,12 @@ namespace ray {
 namespace api {
 
 RayFunction BuildRayFunction(InvocationSpec &invocation) {
+  if (ray::api::RayConfig::GetInstance()->use_ray_remote) {
+    auto function_descriptor =
+        FunctionDescriptorBuilder::BuildCpp(invocation.lib_name, "", "");
+    return RayFunction(Language::CPP, function_descriptor);
+  }
+
   auto base_addr =
       GetBaseAddressOfLibraryFromAddr((void *)invocation.fptr.function_pointer);
   auto func_offset = (size_t)(invocation.fptr.function_pointer - base_addr);

--- a/cpp/src/ray/runtime/task/task_executor.cc
+++ b/cpp/src/ray/runtime/task/task_executor.cc
@@ -64,14 +64,11 @@ Status TaskExecutor::ExecuteTask(
                             args_buffer, current_actor_);
   } else {  // NORMAL_TASK
     if (func_offset.empty()) {
-      auto lib = FunctionHelper::GetInstance().LoadDll(lib_name);
-      if (lib == nullptr) {
-        RAY_LOG(WARNING) << "Load library " << lib_name << " failed.";
+      auto execute_func = FunctionHelper::GetInstance().GetExecuteFunction(lib_name);
+      if (execute_func == nullptr) {
         return ray::Status::NotFound(lib_name + " not found");
       }
-      RAY_LOG(DEBUG) << "Begin to get execute function with ray remote";
-      auto execute_func = boost::dll::import_alias<msgpack::sbuffer(
-          const std::vector<std::shared_ptr<::ray::RayObject>> &)>(*lib, "CallInDll");
+
       RAY_LOG(DEBUG) << "Get execute function ok";
       auto result = execute_func(args_buffer);
       RAY_LOG(DEBUG) << "Execute function ok";

--- a/cpp/src/ray/runtime/task/task_executor.cc
+++ b/cpp/src/ray/runtime/task/task_executor.cc
@@ -69,12 +69,12 @@ Status TaskExecutor::ExecuteTask(
         RAY_LOG(WARNING) << "Load library " << lib_name << " failed.";
         return ray::Status::NotFound(lib_name + " not found");
       }
-      RAY_LOG(INFO) << "begin to execute function with ray remote";
+      RAY_LOG(DEBUG) << "Begin to get execute function with ray remote";
       auto execute_func = boost::dll::import_alias<msgpack::sbuffer(
           const std::vector<std::shared_ptr<::ray::RayObject>> &)>(*lib, "CallInDll");
-      RAY_LOG(INFO) << "get function ok";
+      RAY_LOG(DEBUG) << "Get execute function ok";
       auto result = execute_func(args_buffer);
-      RAY_LOG(INFO) << "end execute function";
+      RAY_LOG(DEBUG) << "Execute function ok";
       data = std::make_shared<msgpack::sbuffer>(std::move(result));
     } else {
       typedef std::shared_ptr<msgpack::sbuffer> (*ExecFunction)(

--- a/cpp/src/ray/runtime/task/task_executor.cc
+++ b/cpp/src/ray/runtime/task/task_executor.cc
@@ -40,7 +40,7 @@ Status TaskExecutor::ExecuteTask(
   std::string func_offset = typed_descriptor->FunctionOffset();
   std::string exec_func_offset = typed_descriptor->ExecFunctionOffset();
   uintptr_t base_addr = 0;
-  if (func_offset.empty()) {
+  if (!func_offset.empty()) {
     base_addr = FunctionHelper::GetInstance().GetBaseAddress(lib_name);
   }
 

--- a/cpp/src/ray/runtime/task/task_executor.cc
+++ b/cpp/src/ray/runtime/task/task_executor.cc
@@ -60,8 +60,7 @@ Status TaskExecutor::ExecuteTask(
                             args_buffer, current_actor_);
   } else {  // NORMAL_TASK
     if (ray::api::RayConfig::GetInstance()->use_ray_remote) {
-      auto lib =
-          FunctionHelper::GetInstance().LoadDll(lib_name);
+      auto lib = FunctionHelper::GetInstance().LoadDll(lib_name);
       RAY_CHECK(lib);
 
       auto execute_func = boost::dll::import_alias<msgpack::sbuffer(

--- a/cpp/src/ray/runtime/task/task_executor.h
+++ b/cpp/src/ray/runtime/task/task_executor.h
@@ -19,14 +19,13 @@ inline static msgpack::sbuffer TaskExecutionHandler(const char *data, std::size_
       auto &func_name = std::get<0>(p);
       auto func_ptr = FunctionManager::Instance().GetFunction(func_name);
       if (func_ptr == nullptr) {
-        result = PackReturnValue(internal::ErrorCode::FAIL,
-                                 "unknown function: " + func_name, 0);
+        result = PackError("unknown function: " + func_name);
         break;
       }
 
       result = (*func_ptr)(data, size);
     } catch (const std::exception &ex) {
-      result = PackReturnValue(internal::ErrorCode::FAIL, ex.what());
+      result = PackError(ex.what());
     }
   } while (0);
 

--- a/cpp/src/ray/runtime/task/task_executor.h
+++ b/cpp/src/ray/runtime/task/task_executor.h
@@ -8,33 +8,6 @@
 #include "ray/core.h"
 
 namespace ray {
-namespace internal {
-
-/// Execute remote functions by networking stream.
-inline static msgpack::sbuffer TaskExecutionHandler(
-    const std::vector<std::shared_ptr<RayObject>> &args_buffer) {
-  auto &memory_buffer = args_buffer.at(0)->GetData();
-  msgpack::sbuffer result;
-  do {
-    try {
-      auto func_name = ray::api::Serializer::Deserialize<std::string>(
-          (char *)memory_buffer->Data(), memory_buffer->Size());
-      auto func_ptr = FunctionManager::Instance().GetFunction(func_name);
-      if (func_ptr == nullptr) {
-        result = PackError("unknown function: " + func_name);
-        break;
-      }
-
-      result = (*func_ptr)(args_buffer);
-    } catch (const std::exception &ex) {
-      result = PackError(ex.what());
-    }
-  } while (0);
-
-  return result;
-}
-}  // namespace internal
-
 namespace api {
 
 class AbstractRayRuntime;

--- a/cpp/src/ray/runtime/task/task_executor.h
+++ b/cpp/src/ray/runtime/task/task_executor.h
@@ -13,16 +13,15 @@ namespace ray {
 namespace internal {
 /// Execute remote functions by networking stream.
 inline static msgpack::sbuffer TaskExecutionHandler(
+    const std::string &func_name,
     const std::vector<std::shared_ptr<RayObject>> &args_buffer) {
-  if (args_buffer.empty()) {
-    return PackError("lack of required arguments");
+  if (func_name.empty()) {
+    return PackError("Task function name is empty");
   }
-  auto &memory_buffer = args_buffer.at(0)->GetData();
+
   msgpack::sbuffer result;
   do {
     try {
-      auto func_name = ray::api::Serializer::Deserialize<std::string>(
-          (char *)memory_buffer->Data(), memory_buffer->Size());
       auto func_ptr = FunctionManager::Instance().GetFunction(func_name);
       if (func_ptr == nullptr) {
         result = PackError("unknown function: " + func_name);

--- a/cpp/src/ray/test/api_test.cc
+++ b/cpp/src/ray/test/api_test.cc
@@ -63,8 +63,8 @@ TEST(RayApiTest, StaticGetTest) {
 TEST(RayApiTest, WaitTest) {
   Ray::Init();
   auto r0 = Ray::Task(Return1).Remote();
-  auto r1 = Ray::Task(Plus1, 3).Remote();
-  auto r2 = Ray::Task(Plus, 2, 3).Remote();
+  auto r1 = Ray::Task(Plus1).Remote(3);
+  auto r2 = Ray::Task(Plus).Remote(2, 3);
   std::vector<ObjectID> objects = {r0.ID(), r1.ID(), r2.ID()};
   WaitResult result = Ray::Wait(objects, 3, 1000);
   EXPECT_EQ(result.ready.size(), 3);
@@ -78,9 +78,9 @@ TEST(RayApiTest, WaitTest) {
 
 TEST(RayApiTest, CallWithValueTest) {
   auto r0 = Ray::Task(Return1).Remote();
-  auto r1 = Ray::Task(Plus1, 3).Remote();
-  auto r2 = Ray::Task(Plus, 2, 3).Remote();
-  auto r3 = Ray::Task(Triple, 1, 2, 3).Remote();
+  auto r1 = Ray::Task(Plus1).Remote(3);
+  auto r2 = Ray::Task(Plus).Remote(2, 3);
+  auto r3 = Ray::Task(Triple).Remote(1, 2, 3);
 
   int result0 = *(r0.Get());
   int result1 = *(r1.Get());
@@ -95,10 +95,10 @@ TEST(RayApiTest, CallWithValueTest) {
 
 TEST(RayApiTest, CallWithObjectTest) {
   auto rt0 = Ray::Task(Return1).Remote();
-  auto rt1 = Ray::Task(Plus1, rt0).Remote();
-  auto rt2 = Ray::Task(Plus, rt1, 3).Remote();
-  auto rt3 = Ray::Task(Plus1, 3).Remote();
-  auto rt4 = Ray::Task(Plus, rt2, rt3).Remote();
+  auto rt1 = Ray::Task(Plus1).Remote(rt0);
+  auto rt2 = Ray::Task(Plus).Remote(rt1, 3);
+  auto rt3 = Ray::Task(Plus1).Remote(3);
+  auto rt4 = Ray::Task(Plus).Remote(rt2, rt3);
 
   int return0 = *(rt0.Get());
   int return1 = *(rt1.Get());
@@ -148,7 +148,7 @@ TEST(RayApiTest, CompareWithFuture) {
 
   // Ray API
   Ray::Init();
-  auto f3 = Ray::Task(Plus1, 1).Remote();
+  auto f3 = Ray::Task(Plus1).Remote(1);
   int rt3 = *f3.Get();
 
   EXPECT_EQ(rt1, 2);

--- a/cpp/src/ray/test/cluster/cluster_mode_test.cc
+++ b/cpp/src/ray/test/cluster/cluster_mode_test.cc
@@ -55,7 +55,7 @@ TEST(RayClusterModeTest, FullTest) {
   EXPECT_EQ(1, task_result);
 
   /// common task with args
-  task_obj = Ray::Task(Plus1, 5).Remote();
+  task_obj = Ray::Task(Plus1).Remote(5);
   task_result = *(Ray::Get(task_obj));
   EXPECT_EQ(6, task_result);
 
@@ -79,8 +79,8 @@ TEST(RayClusterModeTest, FullTest) {
 
   /// general function remote call（args passed by value）
   auto r0 = Ray::Task(Return1).Remote();
-  auto r1 = Ray::Task(Plus1, 30).Remote();
-  auto r2 = Ray::Task(Plus, 3, 22).Remote();
+  auto r1 = Ray::Task(Plus1).Remote(30);
+  auto r2 = Ray::Task(Plus).Remote(3, 22);
 
   int result1 = *(Ray::Get(r1));
   int result0 = *(Ray::Get(r0));
@@ -91,9 +91,9 @@ TEST(RayClusterModeTest, FullTest) {
 
   /// general function remote call（args passed by reference）
   auto r3 = Ray::Task(Return1).Remote();
-  auto r4 = Ray::Task(Plus1, r3).Remote();
-  auto r5 = Ray::Task(Plus, r4, r3).Remote();
-  auto r6 = Ray::Task(Plus, r4, 10).Remote();
+  auto r4 = Ray::Task(Plus1).Remote(r3);
+  auto r5 = Ray::Task(Plus).Remote(r4, r3);
+  auto r6 = Ray::Task(Plus).Remote(r4, 10);
 
   int result5 = *(Ray::Get(r5));
   int result4 = *(Ray::Get(r4));
@@ -128,8 +128,8 @@ TEST(RayClusterModeTest, FullTest) {
   auto r12 = actor5.Task(&Counter::Add, r11).Remote();
   auto r13 = actor5.Task(&Counter::Add, r10).Remote();
   auto r14 = actor5.Task(&Counter::Add, r13).Remote();
-  auto r15 = Ray::Task(Plus, r0, r11).Remote();
-  auto r16 = Ray::Task(Plus1, r15).Remote();
+  auto r15 = Ray::Task(Plus).Remote(r0, r11);
+  auto r16 = Ray::Task(Plus1).Remote(r15);
 
   int result12 = *(Ray::Get(r12));
   int result14 = *(Ray::Get(r14));

--- a/cpp/src/ray/test/cluster/cluster_mode_test.cc
+++ b/cpp/src/ray/test/cluster/cluster_mode_test.cc
@@ -46,8 +46,8 @@ TEST(RayClusterModeTest, TestDll) {
   std::function<msgpack::sbuffer(const std::vector<std::shared_ptr<::ray::RayObject>> &)>
       execute_func = boost::dll::import_alias<msgpack::sbuffer(
           const std::vector<std::shared_ptr<::ray::RayObject>> &)>(*lib, "CallInDll");
-  // auto result = execute_func(std::vector<std::shared_ptr<::ray::RayObject>>{});
-  EXPECT_TRUE(execute_func);
+  auto result = execute_func(std::vector<std::shared_ptr<::ray::RayObject>>{});
+  EXPECT_TRUE(Serializer::HasError(result.data(), result.size()));
 }
 
 TEST(RayClusterModeTest, FullTest) {

--- a/cpp/src/ray/test/cluster/cluster_mode_test.cc
+++ b/cpp/src/ray/test/cluster/cluster_mode_test.cc
@@ -2,7 +2,6 @@
 #include <gtest/gtest.h>
 #include <ray/api.h>
 #include <ray/api/ray_config.h>
-#include "cpp/src/ray/util/function_helper.h"
 
 using namespace ::ray::api;
 
@@ -36,19 +35,6 @@ class Counter {
 std::string lib_name = "";
 
 std::string redis_ip = "";
-
-TEST(RayClusterModeTest, TestDll) {
-  auto lib = FunctionHelper::GetInstance().LoadDll(lib_name);
-  if (lib == nullptr) {
-    return;
-  }
-
-  std::function<msgpack::sbuffer(const std::vector<std::shared_ptr<::ray::RayObject>> &)>
-      execute_func = boost::dll::import_alias<msgpack::sbuffer(
-          const std::vector<std::shared_ptr<::ray::RayObject>> &)>(*lib, "CallInDll");
-  auto result = execute_func(std::vector<std::shared_ptr<::ray::RayObject>>{});
-  EXPECT_TRUE(Serializer::HasError(result.data(), result.size()));
-}
 
 TEST(RayClusterModeTest, FullTest) {
   /// initialization to cluster mode

--- a/cpp/src/ray/test/cluster/cluster_mode_test.cc
+++ b/cpp/src/ray/test/cluster/cluster_mode_test.cc
@@ -38,19 +38,16 @@ std::string lib_name = "";
 std::string redis_ip = "";
 
 TEST(RayClusterModeTest, TestDll) {
-  ray::api::RayConfig::GetInstance()->use_ray_remote = true;
-
   auto lib = FunctionHelper::GetInstance().LoadDll(lib_name);
   if (lib == nullptr) {
     return;
   }
 
-  auto execute_func = boost::dll::import_alias<msgpack::sbuffer(
-      const std::vector<std::shared_ptr<::ray::RayObject>> &)>(*lib, "CallInDll");
-  auto result = execute_func(std::vector<std::shared_ptr<::ray::RayObject>>{});
-  EXPECT_TRUE(ray::api::Serializer::HasError(result.data(), result.size()));
-
-  ray::api::RayConfig::GetInstance()->use_ray_remote = false;
+  std::function<msgpack::sbuffer(const std::vector<std::shared_ptr<::ray::RayObject>> &)>
+      execute_func = boost::dll::import_alias<msgpack::sbuffer(
+          const std::vector<std::shared_ptr<::ray::RayObject>> &)>(*lib, "CallInDll");
+  // auto result = execute_func(std::vector<std::shared_ptr<::ray::RayObject>>{});
+  EXPECT_TRUE(execute_func);
 }
 
 TEST(RayClusterModeTest, FullTest) {

--- a/cpp/src/ray/test/ray_remote_cluster/ray_remote_cluster_test.cc
+++ b/cpp/src/ray/test/ray_remote_cluster/ray_remote_cluster_test.cc
@@ -32,14 +32,14 @@ TEST(RayClusterModeTest, FullTest) {
   EXPECT_EQ(1, task_result);
 
   /// common task with args
-  task_obj = Ray::Task(Plus1).Remote(5);
+  task_obj = Ray::Task(Plus1, 5).Remote();
   task_result = *(Ray::Get(task_obj));
   EXPECT_EQ(6, task_result);
 
   /// general function remote call（args passed by value）
   auto r0 = Ray::Task(Return1).Remote();
-  auto r1 = Ray::Task(Plus1).Remote(30);
-  auto r2 = Ray::Task(Plus).Remote(3, 22);
+  auto r1 = Ray::Task(Plus1, 30).Remote();
+  auto r2 = Ray::Task(Plus, 3, 22).Remote();
 
   int result1 = *(Ray::Get(r1));
   int result0 = *(Ray::Get(r0));
@@ -50,9 +50,9 @@ TEST(RayClusterModeTest, FullTest) {
 
   /// general function remote call（args passed by reference）
   auto r3 = Ray::Task(Return1).Remote();
-  auto r4 = Ray::Task(Plus1).Remote(r3);
-  auto r5 = Ray::Task(Plus).Remote(r4, r3);
-  auto r6 = Ray::Task(Plus).Remote(r4, 10);
+  auto r4 = Ray::Task(Plus1, r3).Remote();
+  auto r5 = Ray::Task(Plus, r4, r3).Remote();
+  auto r6 = Ray::Task(Plus, r4, 10).Remote();
 
   int result5 = *(Ray::Get(r5));
   int result4 = *(Ray::Get(r4));

--- a/cpp/src/ray/test/ray_remote_cluster/ray_remote_cluster_test.cc
+++ b/cpp/src/ray/test/ray_remote_cluster/ray_remote_cluster_test.cc
@@ -32,14 +32,14 @@ TEST(RayClusterModeTest, FullTest) {
   EXPECT_EQ(1, task_result);
 
   /// common task with args
-  task_obj = Ray::Task(Plus1, 5).Remote();
+  task_obj = Ray::Task(Plus1).Remote(5);
   task_result = *(Ray::Get(task_obj));
   EXPECT_EQ(6, task_result);
 
   /// general function remote call（args passed by value）
   auto r0 = Ray::Task(Return1).Remote();
-  auto r1 = Ray::Task(Plus1, 30).Remote();
-  auto r2 = Ray::Task(Plus, 3, 22).Remote();
+  auto r1 = Ray::Task(Plus1).Remote(30);
+  auto r2 = Ray::Task(Plus).Remote(3, 22);
 
   int result1 = *(Ray::Get(r1));
   int result0 = *(Ray::Get(r0));
@@ -50,9 +50,9 @@ TEST(RayClusterModeTest, FullTest) {
 
   /// general function remote call（args passed by reference）
   auto r3 = Ray::Task(Return1).Remote();
-  auto r4 = Ray::Task(Plus1, r3).Remote();
-  auto r5 = Ray::Task(Plus, r4, r3).Remote();
-  auto r6 = Ray::Task(Plus, r4, 10).Remote();
+  auto r4 = Ray::Task(Plus1).Remote(r3);
+  auto r5 = Ray::Task(Plus).Remote(r4, r3);
+  auto r6 = Ray::Task(Plus).Remote(r4, 10);
 
   int result5 = *(Ray::Get(r5));
   int result4 = *(Ray::Get(r4));

--- a/cpp/src/ray/test/ray_remote_cluster/ray_remote_cluster_test.cc
+++ b/cpp/src/ray/test/ray_remote_cluster/ray_remote_cluster_test.cc
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+#include <ray/api.h>
+#include <ray/api/ray_config.h>
+
+using namespace ::ray::api;
+
+/// general function of user code
+int Return1() { return 1; }
+int Plus1(int x) { return x + 1; }
+int Plus(int x, int y) { return x + y; }
+
+RAY_REMOTE(Return1);
+RAY_REMOTE(Plus1);
+RAY_REMOTE(Plus);
+
+std::string lib_name = "";
+
+std::string redis_ip = "";
+
+TEST(RayClusterModeTest, FullTest) {
+  /// initialization to cluster mode
+  ray::api::RayConfig::GetInstance()->run_mode = RunMode::CLUSTER;
+  ray::api::RayConfig::GetInstance()->lib_name = lib_name;
+  ray::api::RayConfig::GetInstance()->redis_ip = redis_ip;
+  Ray::Init();
+
+  ray::api::RayConfig::GetInstance()->use_ray_remote = true;
+
+  /// common task without args
+  auto task_obj = Ray::Task(Return1).Remote();
+  int task_result = *(Ray::Get(task_obj));
+  EXPECT_EQ(1, task_result);
+
+  /// common task with args
+  task_obj = Ray::Task(Plus1).Remote(5);
+  task_result = *(Ray::Get(task_obj));
+  EXPECT_EQ(6, task_result);
+
+  /// general function remote call（args passed by value）
+  auto r0 = Ray::Task(Return1).Remote();
+  auto r1 = Ray::Task(Plus1).Remote(30);
+  auto r2 = Ray::Task(Plus).Remote(3, 22);
+
+  int result1 = *(Ray::Get(r1));
+  int result0 = *(Ray::Get(r0));
+  int result2 = *(Ray::Get(r2));
+  EXPECT_EQ(result0, 1);
+  EXPECT_EQ(result1, 31);
+  EXPECT_EQ(result2, 25);
+
+  /// general function remote call（args passed by reference）
+  auto r3 = Ray::Task(Return1).Remote();
+  auto r4 = Ray::Task(Plus1).Remote(r3);
+  auto r5 = Ray::Task(Plus).Remote(r4, r3);
+  auto r6 = Ray::Task(Plus).Remote(r4, 10);
+
+  int result5 = *(Ray::Get(r5));
+  int result4 = *(Ray::Get(r4));
+  int result6 = *(Ray::Get(r6));
+  int result3 = *(Ray::Get(r3));
+  EXPECT_EQ(result0, 1);
+  EXPECT_EQ(result3, 1);
+  EXPECT_EQ(result4, 2);
+  EXPECT_EQ(result5, 3);
+  EXPECT_EQ(result6, 12);
+  ray::api::RayConfig::GetInstance()->use_ray_remote = false;
+  Ray::Shutdown();
+}
+
+int main(int argc, char **argv) {
+  RAY_CHECK(argc == 2 || argc == 3);
+  lib_name = std::string(argv[1]);
+  if (argc == 3) {
+    redis_ip = std::string(argv[2]);
+  }
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/cpp/src/ray/test/ray_remote_test.cc
+++ b/cpp/src/ray/test/ray_remote_test.cc
@@ -60,7 +60,7 @@ TEST(RayApiTest, NormalTask) {
   auto r = Ray::Task(Return).Remote();
   EXPECT_EQ(1, *(r.Get()));
 
-  auto r1 = Ray::Task(PlusOne, 1).Remote();
+  auto r1 = Ray::Task(PlusOne).Remote(1);
   EXPECT_EQ(2, *(r1.Get()));
 }
 
@@ -69,17 +69,17 @@ TEST(RayApiTest, VoidFunction) {
   r2.Get();
   EXPECT_EQ(1, out_for_void_func);
 
-  auto r3 = Ray::Task(VoidFuncWithArgs, 1, 2).Remote();
+  auto r3 = Ray::Task(VoidFuncWithArgs).Remote(1, 2);
   r3.Get();
   EXPECT_EQ(3, out_for_void_func_no_args);
 }
 
 TEST(RayApiTest, CallWithObjectRef) {
   auto rt0 = Ray::Task(Return).Remote();
-  auto rt1 = Ray::Task(PlusOne, rt0).Remote();
-  auto rt2 = Ray::Task(PlusTwo, rt1, 3).Remote();
-  auto rt3 = Ray::Task(PlusOne, 3).Remote();
-  auto rt4 = Ray::Task(PlusTwo, rt2, rt3).Remote();
+  auto rt1 = Ray::Task(PlusOne).Remote(rt0);
+  auto rt2 = Ray::Task(PlusTwo).Remote(rt1, 3);
+  auto rt3 = Ray::Task(PlusOne).Remote(3);
+  auto rt4 = Ray::Task(PlusTwo).Remote(rt2, rt3);
 
   int return0 = *(rt0.Get());
   int return1 = *(rt1.Get());
@@ -105,17 +105,17 @@ TEST(RayApiTest, ArgumentsNotMatch) {
   auto r = Ray::Task(PlusOne).Remote();
   EXPECT_THROW(r.Get(), RayException);
 
-  auto r1 = Ray::Task(PlusOne, 1, 2).Remote();
+  auto r1 = Ray::Task(PlusOne).Remote(1, 2);
   EXPECT_THROW(r1.Get(), RayException);
 
   auto r2 = Ray::Task(ExceptionFunc).Remote();
   EXPECT_THROW(r2.Get(), RayException);
 
-  auto r3 = Ray::Task(ExceptionFunc, 1, 2).Remote();
+  auto r3 = Ray::Task(ExceptionFunc).Remote(1, 2);
   EXPECT_THROW(r3.Get(), RayException);
 
   /// Normal task Exception.
-  auto r4 = Ray::Task(ExceptionFunc, 2).Remote();
+  auto r4 = Ray::Task(ExceptionFunc).Remote(2);
   EXPECT_THROW(r4.Get(), RayException);
 
   ray::api::RayConfig::GetInstance()->use_ray_remote = false;

--- a/cpp/src/ray/test/ray_remote_test.cc
+++ b/cpp/src/ray/test/ray_remote_test.cc
@@ -60,34 +60,26 @@ TEST(RayApiTest, NormalTask) {
   auto r = Ray::Task(Return).Remote();
   EXPECT_EQ(1, *(r.Get()));
 
-  auto r1 = Ray::Task(PlusOne).Remote(1);
+  auto r1 = Ray::Task(PlusOne, 1).Remote();
   EXPECT_EQ(2, *(r1.Get()));
-
-  ray::api::RayConfig::GetInstance()->use_ray_remote = false;
 }
 
 TEST(RayApiTest, VoidFunction) {
-  ray::api::RayConfig::GetInstance()->use_ray_remote = true;
-
   auto r2 = Ray::Task(VoidFuncNoArgs).Remote();
   r2.Get();
   EXPECT_EQ(1, out_for_void_func);
 
-  auto r3 = Ray::Task(VoidFuncWithArgs).Remote(1, 2);
+  auto r3 = Ray::Task(VoidFuncWithArgs, 1, 2).Remote();
   r3.Get();
   EXPECT_EQ(3, out_for_void_func_no_args);
-
-  ray::api::RayConfig::GetInstance()->use_ray_remote = false;
 }
 
 TEST(RayApiTest, CallWithObjectRef) {
-  ray::api::RayConfig::GetInstance()->use_ray_remote = true;
-
   auto rt0 = Ray::Task(Return).Remote();
-  auto rt1 = Ray::Task(PlusOne).Remote(rt0);
-  auto rt2 = Ray::Task(PlusTwo).Remote(rt1, 3);
-  auto rt3 = Ray::Task(PlusOne).Remote(3);
-  auto rt4 = Ray::Task(PlusTwo).Remote(rt2, rt3);
+  auto rt1 = Ray::Task(PlusOne, rt0).Remote();
+  auto rt2 = Ray::Task(PlusTwo, rt1, 3).Remote();
+  auto rt3 = Ray::Task(PlusOne, 3).Remote();
+  auto rt4 = Ray::Task(PlusTwo, rt2, rt3).Remote();
 
   int return0 = *(rt0.Get());
   int return1 = *(rt1.Get());
@@ -100,46 +92,31 @@ TEST(RayApiTest, CallWithObjectRef) {
   EXPECT_EQ(return2, 5);
   EXPECT_EQ(return3, 4);
   EXPECT_EQ(return4, 9);
-
-  ray::api::RayConfig::GetInstance()->use_ray_remote = false;
 }
 
 /// We should consider the driver so is not same with the worker so, and find the error
 /// reason.
 TEST(RayApiTest, NotExistFunction) {
-  ray::api::RayConfig::GetInstance()->use_ray_remote = true;
-
   EXPECT_THROW(Ray::Task(NotRegisteredFunc), RayException);
-
-  ray::api::RayConfig::GetInstance()->use_ray_remote = false;
 }
 
 TEST(RayApiTest, ArgumentsNotMatch) {
-  ray::api::RayConfig::GetInstance()->use_ray_remote = true;
-
   /// Arguments number is not match.
   auto r = Ray::Task(PlusOne).Remote();
   EXPECT_THROW(r.Get(), RayException);
 
-  auto r1 = Ray::Task(PlusOne).Remote(1, 2);
+  auto r1 = Ray::Task(PlusOne, 1, 2).Remote();
   EXPECT_THROW(r1.Get(), RayException);
 
   auto r2 = Ray::Task(ExceptionFunc).Remote();
   EXPECT_THROW(r2.Get(), RayException);
 
-  auto r3 = Ray::Task(ExceptionFunc).Remote(1, 2);
+  auto r3 = Ray::Task(ExceptionFunc, 1, 2).Remote();
   EXPECT_THROW(r3.Get(), RayException);
 
-  /// Arguments not match.
-  auto r4 = Ray::Task(PlusOne).Remote("invalid argument");
-  EXPECT_THROW(r4.Get(), RayException);
-
-  auto r5 = Ray::Task(ExceptionFunc).Remote("invalid argument");
-  EXPECT_THROW(r5.Get(), RayException);
-
   /// Normal task Exception.
-  auto r6 = Ray::Task(ExceptionFunc).Remote(2);
-  EXPECT_THROW(r6.Get(), RayException);
+  auto r4 = Ray::Task(ExceptionFunc, 2).Remote();
+  EXPECT_THROW(r4.Get(), RayException);
 
   ray::api::RayConfig::GetInstance()->use_ray_remote = false;
 }

--- a/cpp/src/ray/test/ray_remote_test.cc
+++ b/cpp/src/ray/test/ray_remote_test.cc
@@ -143,19 +143,3 @@ TEST(RayApiTest, ArgumentsNotMatch) {
 
   ray::api::RayConfig::GetInstance()->use_ray_remote = false;
 }
-
-TEST(RayApiTest, TestDll) {
-  ray::api::RayConfig::GetInstance()->use_ray_remote = true;
-
-  auto lib = FunctionHelper::GetInstance().LoadDll("bazel-bin/cpp/cluster_mode_test.so");
-  if (lib == nullptr) {
-    return;
-  }
-
-  auto execute_func = boost::dll::import_alias<msgpack::sbuffer(
-      const std::vector<std::shared_ptr<::ray::RayObject>> &)>(*lib, "CallInDll");
-  auto result = execute_func(std::vector<std::shared_ptr<::ray::RayObject>>{});
-  EXPECT_TRUE(ray::api::Serializer::HasError(result.data(), result.size()));
-
-  ray::api::RayConfig::GetInstance()->use_ray_remote = false;
-}

--- a/cpp/src/ray/test/ray_remote_test.cc
+++ b/cpp/src/ray/test/ray_remote_test.cc
@@ -22,8 +22,23 @@ using namespace ray::internal;
 
 int Return() { return 1; }
 int PlusOne(int x) { return x + 1; }
+int PlusTwo(int x, int y) { return x + y; }
+
+int out_for_void_func = 0;
+int out_for_void_func_no_args = 0;
+
+void VoidFuncNoArgs() { out_for_void_func = 1; }
+void VoidFuncWithArgs(int x, int y) { out_for_void_func_no_args = (x + y); }
+
+int NotRegisteredFunc(int x) { return x; }
+
+void ExceptionFunc(int x) { throw std::invalid_argument(std::to_string(x)); }
 
 RAY_REMOTE(PlusOne);
+RAY_REMOTE(PlusTwo);
+RAY_REMOTE(VoidFuncNoArgs);
+RAY_REMOTE(VoidFuncWithArgs);
+RAY_REMOTE(ExceptionFunc);
 
 TEST(RayApiTest, DuplicateRegister) {
   bool r = FunctionManager::Instance().RegisterRemoteFunction("Return", Return);
@@ -37,44 +52,92 @@ TEST(RayApiTest, DuplicateRegister) {
   EXPECT_FALSE(r2);
 }
 
-TEST(RayApiTest, FindAndExecuteFunction) {
-  /// Find and call the registered function.
-  auto args = std::make_tuple("PlusOne", 1);
-  auto buf = Serializer::Serialize(args);
-  auto result_buf = TaskExecutionHandler(buf.data(), buf.size());
+TEST(RayApiTest, NormalTask) {
+  ray::api::RayConfig::GetInstance()->use_ray_remote = true;
 
-  /// Deserialize result.
-  auto response =
-      Serializer::Deserialize<Response<int>>(result_buf.data(), result_buf.size());
+  auto r = Ray::Task(Return).Remote();
+  EXPECT_EQ(1, *(r.Get()));
 
-  EXPECT_EQ(response.error_code, ErrorCode::OK);
-  EXPECT_EQ(response.data, 2);
+  auto r1 = Ray::Task(PlusOne).Remote(1);
+  EXPECT_EQ(2, *(r1.Get()));
+
+  ray::api::RayConfig::GetInstance()->use_ray_remote = false;
 }
 
 TEST(RayApiTest, VoidFunction) {
-  auto buf1 = Serializer::Serialize(std::make_tuple("Return"));
-  auto result_buf = TaskExecutionHandler(buf1.data(), buf1.size());
-  auto response =
-      Serializer::Deserialize<VoidResponse>(result_buf.data(), result_buf.size());
-  EXPECT_EQ(response.error_code, ErrorCode::OK);
+  ray::api::RayConfig::GetInstance()->use_ray_remote = true;
+
+  auto r2 = Ray::Task(VoidFuncNoArgs).Remote();
+  r2.Get();
+  EXPECT_EQ(1, out_for_void_func);
+
+  auto r3 = Ray::Task(VoidFuncWithArgs).Remote(1, 2);
+  r3.Get();
+  EXPECT_EQ(3, out_for_void_func_no_args);
+
+  ray::api::RayConfig::GetInstance()->use_ray_remote = false;
+}
+
+TEST(RayApiTest, CallWithObjectRef) {
+  ray::api::RayConfig::GetInstance()->use_ray_remote = true;
+
+  auto rt0 = Ray::Task(Return).Remote();
+  auto rt1 = Ray::Task(PlusOne).Remote(rt0);
+  auto rt2 = Ray::Task(PlusTwo).Remote(rt1, 3);
+  auto rt3 = Ray::Task(PlusOne).Remote(3);
+  auto rt4 = Ray::Task(PlusTwo).Remote(rt2, rt3);
+
+  int return0 = *(rt0.Get());
+  int return1 = *(rt1.Get());
+  int return2 = *(rt2.Get());
+  int return3 = *(rt3.Get());
+  int return4 = *(rt4.Get());
+
+  EXPECT_EQ(return0, 1);
+  EXPECT_EQ(return1, 2);
+  EXPECT_EQ(return2, 5);
+  EXPECT_EQ(return3, 4);
+  EXPECT_EQ(return4, 9);
+
+  ray::api::RayConfig::GetInstance()->use_ray_remote = false;
 }
 
 /// We should consider the driver so is not same with the worker so, and find the error
 /// reason.
 TEST(RayApiTest, NotExistFunction) {
-  auto buf2 = Serializer::Serialize(std::make_tuple("Return11"));
-  auto result_buf = TaskExecutionHandler(buf2.data(), buf2.size());
-  auto response =
-      Serializer::Deserialize<VoidResponse>(result_buf.data(), result_buf.size());
-  EXPECT_EQ(response.error_code, ErrorCode::FAIL);
-  EXPECT_FALSE(response.error_msg.empty());
+  ray::api::RayConfig::GetInstance()->use_ray_remote = true;
+
+  EXPECT_THROW(Ray::Task(NotRegisteredFunc), RayException);
+
+  ray::api::RayConfig::GetInstance()->use_ray_remote = false;
 }
 
 TEST(RayApiTest, ArgumentsNotMatch) {
-  auto buf = Serializer::Serialize(std::make_tuple("PlusOne", "invalid arguments"));
-  auto result_buf = TaskExecutionHandler(buf.data(), buf.size());
-  auto response =
-      Serializer::Deserialize<Response<int>>(result_buf.data(), result_buf.size());
-  EXPECT_EQ(response.error_code, ErrorCode::FAIL);
-  EXPECT_FALSE(response.error_msg.empty());
+  ray::api::RayConfig::GetInstance()->use_ray_remote = true;
+
+  /// Arguments number is not match.
+  auto r = Ray::Task(PlusOne).Remote();
+  EXPECT_THROW(r.Get(), RayException);
+
+  auto r1 = Ray::Task(PlusOne).Remote(1, 2);
+  EXPECT_THROW(r1.Get(), RayException);
+
+  auto r2 = Ray::Task(ExceptionFunc).Remote();
+  EXPECT_THROW(r2.Get(), RayException);
+
+  auto r3 = Ray::Task(ExceptionFunc).Remote(1, 2);
+  EXPECT_THROW(r3.Get(), RayException);
+
+  /// Arguments not match.
+  auto r4 = Ray::Task(PlusOne).Remote("invalid argument");
+  EXPECT_THROW(r4.Get(), RayException);
+
+  auto r5 = Ray::Task(ExceptionFunc).Remote("invalid argument");
+  EXPECT_THROW(r5.Get(), RayException);
+
+  /// Normal task Exception.
+  auto r6 = Ray::Task(ExceptionFunc).Remote(2);
+  EXPECT_THROW(r6.Get(), RayException);
+
+  ray::api::RayConfig::GetInstance()->use_ray_remote = false;
 }

--- a/cpp/src/ray/test/slow_function_test.cc
+++ b/cpp/src/ray/test/slow_function_test.cc
@@ -16,10 +16,10 @@ TEST(RaySlowFunctionTest, BaseTest) {
   Ray::Init();
   auto time1 = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::system_clock::now().time_since_epoch());
-  auto r0 = Ray::Task(slow_function, 1).Remote();
-  auto r1 = Ray::Task(slow_function, 2).Remote();
-  auto r2 = Ray::Task(slow_function, 3).Remote();
-  auto r3 = Ray::Task(slow_function, 4).Remote();
+  auto r0 = Ray::Task(slow_function).Remote(1);
+  auto r1 = Ray::Task(slow_function).Remote(2);
+  auto r2 = Ray::Task(slow_function).Remote(3);
+  auto r3 = Ray::Task(slow_function).Remote(4);
 
   int result0 = *(r0.Get());
   int result1 = *(r1.Get());

--- a/cpp/src/ray/util/function_helper.cc
+++ b/cpp/src/ray/util/function_helper.cc
@@ -3,6 +3,7 @@
 #include <dlfcn.h>
 #include <stdio.h>
 #include <string.h>
+#include <boost/filesystem.hpp>
 #include <memory>
 #include "address_helper.h"
 #include "ray/core.h"
@@ -22,6 +23,12 @@ std::shared_ptr<boost::dll::shared_library> FunctionHelper::LoadDll(
   auto it = libraries_.find(lib_name);
   if (it != libraries_.end()) {
     return it->second;
+  }
+
+  auto absolute_path = boost::filesystem::absolute(lib_name);
+  if (boost::filesystem::exists(absolute_path)) {
+    RAY_LOG(WARNING) << "File not found, absolute_path: " << absolute_path;
+    return nullptr;
   }
 
   std::shared_ptr<boost::dll::shared_library> lib = nullptr;

--- a/cpp/src/ray/util/function_helper.cc
+++ b/cpp/src/ray/util/function_helper.cc
@@ -26,8 +26,9 @@ std::shared_ptr<boost::dll::shared_library> FunctionHelper::LoadDll(
   }
 
   auto absolute_path = boost::filesystem::absolute(lib_name);
-  if (boost::filesystem::exists(absolute_path)) {
-    RAY_LOG(WARNING) << "File not found, absolute_path: " << absolute_path;
+  if (!boost::filesystem::exists(absolute_path)) {
+    RAY_LOG(WARNING) << lib_name << " dll not found, absolute_path: " << absolute_path
+                     << ", current path" << boost::filesystem::current_path();
     return nullptr;
   }
 

--- a/cpp/src/ray/util/function_helper.cc
+++ b/cpp/src/ray/util/function_helper.cc
@@ -53,7 +53,8 @@ std::shared_ptr<boost::dll::shared_library> FunctionHelper::LoadDll(
   return lib;
 }
 
-std::function<msgpack::sbuffer(const std::vector<std::shared_ptr<::ray::RayObject>> &)>
+std::function<msgpack::sbuffer(const std::string &,
+                               const std::vector<std::shared_ptr<::ray::RayObject>> &)>
 FunctionHelper::GetExecuteFunction(const std::string &lib_name) {
   auto it = funcs_.find(lib_name);
   if (it != funcs_.end()) {
@@ -67,8 +68,8 @@ FunctionHelper::GetExecuteFunction(const std::string &lib_name) {
 
   try {
     auto execute_func = boost::dll::import_alias<msgpack::sbuffer(
-        const std::vector<std::shared_ptr<::ray::RayObject>> &)>(*lib,
-                                                                 "TaskExecutionHandler");
+        const std::string &, const std::vector<std::shared_ptr<::ray::RayObject>> &)>(
+        *lib, "TaskExecutionHandler");
     funcs_.emplace(lib_name, execute_func);
     return execute_func;
   } catch (std::exception &e) {

--- a/cpp/src/ray/util/function_helper.cc
+++ b/cpp/src/ray/util/function_helper.cc
@@ -67,7 +67,8 @@ FunctionHelper::GetExecuteFunction(const std::string &lib_name) {
 
   try {
     auto execute_func = boost::dll::import_alias<msgpack::sbuffer(
-        const std::vector<std::shared_ptr<::ray::RayObject>> &)>(*lib, "CallInDll");
+        const std::vector<std::shared_ptr<::ray::RayObject>> &)>(*lib,
+                                                                 "TaskExecutionHandler");
     funcs_.emplace(lib_name, execute_func);
     return execute_func;
   } catch (std::exception &e) {

--- a/cpp/src/ray/util/function_helper.h
+++ b/cpp/src/ray/util/function_helper.h
@@ -2,8 +2,10 @@
 
 #include <boost/dll.hpp>
 #include <memory>
+#include <msgpack.hpp>
 #include <string>
 #include <unordered_map>
+#include "ray/core.h"
 
 namespace ray {
 namespace api {
@@ -18,6 +20,8 @@ class FunctionHelper {
   }
 
   std::shared_ptr<boost::dll::shared_library> LoadDll(const std::string &lib_name);
+  std::function<msgpack::sbuffer(const std::vector<std::shared_ptr<::ray::RayObject>> &)>
+  GetExecuteFunction(const std::string &lib_name);
 
  private:
   FunctionHelper() = default;
@@ -29,6 +33,10 @@ class FunctionHelper {
 
   std::unordered_map<std::string, uintptr_t> loaded_library_;
   std::unordered_map<std::string, std::shared_ptr<boost::dll::shared_library>> libraries_;
+  std::unordered_map<std::string,
+                     std::function<msgpack::sbuffer(
+                         const std::vector<std::shared_ptr<::ray::RayObject>> &)>>
+      funcs_;
 };
 }  // namespace api
 }  // namespace ray

--- a/cpp/src/ray/util/function_helper.h
+++ b/cpp/src/ray/util/function_helper.h
@@ -20,7 +20,8 @@ class FunctionHelper {
   }
 
   std::shared_ptr<boost::dll::shared_library> LoadDll(const std::string &lib_name);
-  std::function<msgpack::sbuffer(const std::vector<std::shared_ptr<::ray::RayObject>> &)>
+  std::function<msgpack::sbuffer(const std::string &,
+                                 const std::vector<std::shared_ptr<::ray::RayObject>> &)>
   GetExecuteFunction(const std::string &lib_name);
 
  private:
@@ -33,9 +34,10 @@ class FunctionHelper {
 
   std::unordered_map<std::string, uintptr_t> loaded_library_;
   std::unordered_map<std::string, std::shared_ptr<boost::dll::shared_library>> libraries_;
-  std::unordered_map<std::string,
-                     std::function<msgpack::sbuffer(
-                         const std::vector<std::shared_ptr<::ray::RayObject>> &)>>
+  std::unordered_map<
+      std::string,
+      std::function<msgpack::sbuffer(
+          const std::string &, const std::vector<std::shared_ptr<::ray::RayObject>> &)>>
       funcs_;
 };
 }  // namespace api

--- a/cpp/src/ray/util/function_helper.h
+++ b/cpp/src/ray/util/function_helper.h
@@ -1,4 +1,7 @@
 #pragma once
+
+#include <boost/dll.hpp>
+#include <memory>
 #include <string>
 #include <unordered_map>
 
@@ -14,9 +17,18 @@ class FunctionHelper {
     return functionHelper;
   }
 
+  std::shared_ptr<boost::dll::shared_library> LoadDll(const std::string &lib_name);
+
  private:
-  std::unordered_map<std::string, uintptr_t> loaded_library_;
+  FunctionHelper() = default;
+  ~FunctionHelper() = default;
+  FunctionHelper(FunctionHelper const &) = delete;
+  FunctionHelper(FunctionHelper &&) = delete;
+
   uintptr_t LoadLibrary(std::string lib_name);
+
+  std::unordered_map<std::string, uintptr_t> loaded_library_;
+  std::unordered_map<std::string, std::shared_ptr<boost::dll::shared_library>> libraries_;
 };
 }  // namespace api
 }  // namespace ray

--- a/src/ray/common/function_descriptor.cc
+++ b/src/ray/common/function_descriptor.cc
@@ -46,12 +46,13 @@ FunctionDescriptor FunctionDescriptorBuilder::BuildPython(
 
 FunctionDescriptor FunctionDescriptorBuilder::BuildCpp(
     const std::string &lib_name, const std::string &function_offset,
-    const std::string &exec_function_offset) {
+    const std::string &exec_function_offset, const std::string &function_name) {
   rpc::FunctionDescriptor descriptor;
   auto typed_descriptor = descriptor.mutable_cpp_function_descriptor();
   typed_descriptor->set_lib_name(lib_name);
   typed_descriptor->set_function_offset(function_offset);
   typed_descriptor->set_exec_function_offset(exec_function_offset);
+  typed_descriptor->set_function_name(function_name);
   return ray::FunctionDescriptor(new CppFunctionDescriptor(std::move(descriptor)));
 }
 
@@ -89,11 +90,12 @@ FunctionDescriptor FunctionDescriptorBuilder::FromVector(
         function_descriptor_list[3]   // function hash
     );
   } else if (language == rpc::Language::CPP) {
-    RAY_CHECK(function_descriptor_list.size() == 3);
+    RAY_CHECK(function_descriptor_list.size() == 4);
     return FunctionDescriptorBuilder::BuildCpp(
         function_descriptor_list[0],  // lib name
         function_descriptor_list[1],  // function offset
-        function_descriptor_list[2]   // exec function offset
+        function_descriptor_list[2],  // exec function offset
+        function_descriptor_list[3]   // function name
     );
   } else {
     RAY_LOG(FATAL) << "Unspported language " << language;

--- a/src/ray/common/function_descriptor.h
+++ b/src/ray/common/function_descriptor.h
@@ -263,6 +263,8 @@ class CppFunctionDescriptor : public FunctionDescriptorInterface {
     return typed_message_->exec_function_offset();
   }
 
+  const std::string &FunctionName() const { return typed_message_->function_name(); }
+
  private:
   const rpc::CppFunctionDescriptor *typed_message_;
 };
@@ -330,7 +332,8 @@ class FunctionDescriptorBuilder {
   /// \return a ray::CppFunctionDescriptor
   static FunctionDescriptor BuildCpp(const std::string &lib_name,
                                      const std::string &function_offset,
-                                     const std::string &exec_function_offset);
+                                     const std::string &exec_function_offset,
+                                     const std::string &function_name);
 
   /// Build a ray::FunctionDescriptor according to input message.
   ///

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -78,6 +78,7 @@ message CppFunctionDescriptor {
   string function_offset = 2;
   /// Executable function offset from base address.
   string exec_function_offset = 3;
+  string function_name = 4;
 }
 
 // A union wrapper for various function descriptor types.

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -104,21 +104,27 @@ inline const char *ConstBasename(const char *filepath) {
 
 /// A logger that prints logs to stderr.
 /// This is the default logger if logging is not initialized.
+/// NOTE(lingxuan.zlx): Default stderr logger must be singleton and global
+/// variable so core worker process can invoke `RAY_LOG` in its whole lifecyle.
 class DefaultStdErrLogger final {
  public:
+  std::shared_ptr<spdlog::logger> GetDefaultLogger() { return default_stderr_logger_; }
+
+  static DefaultStdErrLogger &Instance() {
+    static DefaultStdErrLogger instance;
+    return instance;
+  }
+
+ private:
   DefaultStdErrLogger() {
     default_stderr_logger_ = spdlog::stderr_color_mt("stderr");
     default_stderr_logger_->set_pattern(RayLog::GetLogFormatPattern());
   }
-  std::shared_ptr<spdlog::logger> GetDefaultLogger() { return default_stderr_logger_; }
-
- private:
+  ~DefaultStdErrLogger() = default;
+  DefaultStdErrLogger(DefaultStdErrLogger const &) = delete;
+  DefaultStdErrLogger(DefaultStdErrLogger &&) = delete;
   std::shared_ptr<spdlog::logger> default_stderr_logger_;
 };
-
-/// NOTE(lingxuan.zlx): Default stderr logger must be singleton and global
-/// variable so core worker process can invoke `RAY_LOG` in its whole lifecyle.
-std::unique_ptr<DefaultStdErrLogger> default_stderr_logger(new DefaultStdErrLogger());
 
 class SpdLogMessage final {
  public:
@@ -129,7 +135,7 @@ class SpdLogMessage final {
   inline void Flush() {
     auto logger = spdlog::get(RayLog::GetLoggerName());
     if (!logger) {
-      logger = default_stderr_logger->GetDefaultLogger();
+      logger = DefaultStdErrLogger::Instance().GetDefaultLogger();
     }
     // To avoid dump duplicated stacktrace with installed failure signal
     // handler, we have to check whether glog failure signal handler is enabled.


### PR DESCRIPTION
## Why are these changes needed?
We should support safe c++ worker API according the [doc](https://docs.google.com/document/d/1pBRUm-w2LKXTte8uXmvQ23l7gOJV2IOwirCTPjtPGWk/edit#heading=h.86fui9aqjkh6), this pr unify normal task remote interface.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(