### PR TITLE
[rllib] Use CUDA only when num_gpus is set

### DIFF
--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -105,7 +105,7 @@ class TorchPolicy(Policy):
         """
         self.framework = "torch"
         super().__init__(observation_space, action_space, config)
-        if torch.cuda.is_available():
+        if torch.cuda.is_available() and config["num_gpus"] > 0:
             logger.info("TorchPolicy running on GPU.")
             self.device = torch.device("cuda")
         else:


### PR DESCRIPTION
## Why are these changes needed?

Currently `TorchPolicy` is always initialized with CUDA when such device is available. This, however, should be controlled with `num_gpus` parameter. For example, if we train on CPU and then we load a checkpoint and collect a rollout, then the checkpoint is being deserialized on CUDA, which is not an expected behavior.

## Related issue number

None

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
