### PR TITLE
[doc][Kubernetes][minor] Restructure section labels for operator launch

### DIFF
--- a/doc/source/cluster/kubernetes.rst
+++ b/doc/source/cluster/kubernetes.rst
@@ -137,9 +137,16 @@ in ``example_cluster.yaml`` and ``example_cluster2.yaml``.
    1. The Ray Kubernetes Operator is still experimental. For the yaml files in the examples below, we recommend using the latest master version of Ray.
    2. The Ray Kubernetes Operator requires Kubernetes version at least ``v1.17.0``. Check Kubernetes version info with the command :bash:`kubectl version`.
 
+Starting the Operator
+---------------------
 
-Applying the RayCluster Custom Resource Definition
---------------------------------------------------
+Set-up for the Ray Operator consists of three steps --
+:ref:`applying a CRD <apply-crd>`, :ref:`picking a namespace <operator-namespace>`, and :ref:`launching the Operator Pod <operator-pod-launch>`.
+
+.. _apply-crd:
+
+(1) Applying the RayCluster Custom Resource Definition
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The Ray Kubernetes operator works by managing a user-submitted `Kubernetes Custom Resource`_ (CR) called a ``RayCluster``.
 A RayCluster custom resource describes the desired state of the Ray cluster.
 
@@ -157,8 +164,10 @@ To get started, we need to apply the `Kubernetes Custom Resource Definition`_ (C
     The file ``cluster_crd.yaml`` defining the CRD is not meant to meant to be modified by the user. Rather, users :ref:`configure <operator-launch>` a RayCluster CR via a file like `ray/python/ray/autoscaler/kubernetes/operator_configs/example_cluster.yaml <https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/kubernetes/operator_configs/example_cluster.yaml>`__.
     The Kubernetes API server then validates the user-submitted RayCluster resource against the CRD.
 
-Picking a Kubernetes Namespace
--------------------------------
+.. _operator-namespace:
+
+(2) Picking a Kubernetes Namespace
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The rest of the Kubernetes resources we will use are `namespaced`_.
 You can use an existing namespace for your Ray clusters or create a new one if you have permissions.
 For this example, we will create a namespace called ``ray``.
@@ -169,8 +178,10 @@ For this example, we will create a namespace called ``ray``.
 
  namespace/ray created
 
-Starting the Operator
-----------------------
+.. _operator-pod-launch:
+
+(3) Launching the Operator Pod
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To launch the operator in our namespace, we execute the following command.
 
@@ -190,7 +201,7 @@ The ServiceAccount, Role, and RoleBinding we have created grant the operator pod
 
 Launching Ray Clusters
 ----------------------
-Finally, to launch a Ray cluster, we create a RayCluster custom resource.
+Having set up the Operator, we can now launch Ray clusters. To launch a Ray cluster, we create a RayCluster custom resource.
 
 .. code-block:: shell
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

People often miss the step about creating a CRD.

To clarify things, this PR reshuffles things so that the part about creating a CRD is under the "Starting the Operator" heading. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
