### PR TITLE
Fix deserializer in metrics.Counter

### DIFF
--- a/python/ray/util/metrics.py
+++ b/python/ray/util/metrics.py
@@ -165,7 +165,7 @@ class Counter(Metric):
                                    self._tag_keys)
 
     def __reduce__(self):
-        deserializer = Count
+        deserializer = self.__class__
         serialized_data = (self._name, self._description, self._tag_keys)
         return deserializer, serialized_data
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

See https://github.com/ray-project/ray/pull/14498#pullrequestreview-622617383

This fixes the warning that appears when we pickle/unpickle a `ray.util.metrics.Counter` object:

```
WARNING metrics.py:206 -- `metrics.Count` has been renamed to `metrics.Counter`. `metrics.Count` will be removed in a future release.
```

## Related issue number

<!-- For example: "Closes #1234" -->

n/a

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
