### PR TITLE
[autoscaler][Kubernetes] Fix non_terminated_nodes consistency

### DIFF
--- a/python/ray/autoscaler/_private/kubernetes/node_provider.py
+++ b/python/ray/autoscaler/_private/kubernetes/node_provider.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 MAX_TAG_RETRIES = 3
 DELAY_BEFORE_TAG_RETRY = .5
-TERMINATION_WAIT_S = 10
 
 
 def to_label_selector(tags):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`KubernetesNodeProvider.non_terminated_nodes` currently lists all pods in `Running` or `Pending` phase.
This can cause problems scaling down, as a pod can remain in `Running` status for a while after `delete_namespaced_pod` is called.

However after `delete_namespaced_pod` is called, K8s does immediately mark it for deletion by setting `metadata.DeletionTimestamp`.

This PR fixes `KubernetesNodeProvider.non_terminated_nodes` by having it return only pods which don't have `metadata.DeletionTimestamp` set.


## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/14812

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
  
Checked experimentally that with current master, autoscaler consistently breaks while scaling down from 15 worker pods.
After making this change, scale down from 15 pods works consistently.

e2e test logic for this will appear in another PR.
