### PR TITLE
[C++ Worker] Improve normal task remote interface

### DIFF
--- a/cpp/example/example.cc
+++ b/cpp/example/example.cc
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
   std::cout << "task_result1 = " << task_result1 << std::endl;
 
   /// common task with args
-  task_obj = Ray::Task(Plus1, 5).Remote();
+  task_obj = Ray::Task(Plus1).Remote(5);
   int task_result2 = *(Ray::Get(task_obj));
   std::cout << "task_result2 = " << task_result2 << std::endl;
 
@@ -92,15 +92,15 @@ int main(int argc, char **argv) {
 
   /// general function remote call（args passed by value）
   auto r0 = Ray::Task(Return1).Remote();
-  auto r2 = Ray::Task(Plus, 3, 22).Remote();
+  auto r2 = Ray::Task(Plus).Remote(3, 22);
   int task_result3 = *(Ray::Get(r2));
   std::cout << "task_result3 = " << task_result3 << std::endl;
 
   /// general function remote call（args passed by reference）
   auto r3 = Ray::Task(Return1).Remote();
-  auto r4 = Ray::Task(Plus1, r3).Remote();
-  auto r5 = Ray::Task(Plus, r4, r3).Remote();
-  auto r6 = Ray::Task(Plus, r4, 10).Remote();
+  auto r4 = Ray::Task(Plus1).Remote(r3);
+  auto r5 = Ray::Task(Plus).Remote(r4, r3);
+  auto r6 = Ray::Task(Plus).Remote(r4, 10);
   int task_result4 = *(Ray::Get(r6));
   int task_result5 = *(Ray::Get(r5));
   std::cout << "task_result4 = " << task_result4 << ", task_result5 = " << task_result5
@@ -118,8 +118,8 @@ int main(int argc, char **argv) {
   auto r12 = actor5.Task(&Counter::Add, r11).Remote();
   auto r13 = actor5.Task(&Counter::Add, r10).Remote();
   auto r14 = actor5.Task(&Counter::Add, r13).Remote();
-  auto r15 = Ray::Task(Plus, r0, r11).Remote();
-  auto r16 = Ray::Task(Plus1, r15).Remote();
+  auto r15 = Ray::Task(Plus).Remote(r0, r11);
+  auto r16 = Ray::Task(Plus1).Remote(r15);
   int result12 = *(Ray::Get(r12));
   int result14 = *(Ray::Get(r14));
   int result11 = *(Ray::Get(r11));

--- a/cpp/include/ray/api/task_caller.h
+++ b/cpp/include/ray/api/task_caller.h
@@ -11,11 +11,13 @@ class TaskCaller {
  public:
   TaskCaller();
 
-  TaskCaller(RayRuntime *runtime, RemoteFunctionPtrHolder ptr,
-             std::vector<std::unique_ptr<::ray::TaskArg>> &&args);
+  TaskCaller(RayRuntime *runtime, RemoteFunctionPtrHolder ptr);
 
   template <typename... Args>
   ObjectRef<ReturnType> Remote(Args... args) {
+    Arguments::WrapArgs(&args_, args...);
+    ptr_.exec_function_pointer = reinterpret_cast<uintptr_t>(
+        NormalExecFunction<ReturnType, typename FilterArgType<Args>::type...>);
     auto returned_object_id = runtime_->Call(ptr_, args_);
     return ObjectRef<ReturnType>(returned_object_id);
   }
@@ -33,8 +35,7 @@ template <typename ReturnType>
 TaskCaller<ReturnType>::TaskCaller() {}
 
 template <typename ReturnType>
-TaskCaller<ReturnType>::TaskCaller(RayRuntime *runtime, RemoteFunctionPtrHolder ptr,
-                                   std::vector<std::unique_ptr<::ray::TaskArg>> &&args)
-    : runtime_(runtime), ptr_(ptr), args_(std::move(args)) {}
+TaskCaller<ReturnType>::TaskCaller(RayRuntime *runtime, RemoteFunctionPtrHolder ptr)
+    : runtime_(runtime), ptr_(ptr) {}
 }  // namespace api
 }  // namespace ray

--- a/cpp/src/ray/test/api_test.cc
+++ b/cpp/src/ray/test/api_test.cc
@@ -63,8 +63,8 @@ TEST(RayApiTest, StaticGetTest) {
 TEST(RayApiTest, WaitTest) {
   Ray::Init();
   auto r0 = Ray::Task(Return1).Remote();
-  auto r1 = Ray::Task(Plus1, 3).Remote();
-  auto r2 = Ray::Task(Plus, 2, 3).Remote();
+  auto r1 = Ray::Task(Plus1).Remote(3);
+  auto r2 = Ray::Task(Plus).Remote(2, 3);
   std::vector<ObjectID> objects = {r0.ID(), r1.ID(), r2.ID()};
   WaitResult result = Ray::Wait(objects, 3, 1000);
   EXPECT_EQ(result.ready.size(), 3);
@@ -78,9 +78,9 @@ TEST(RayApiTest, WaitTest) {
 
 TEST(RayApiTest, CallWithValueTest) {
   auto r0 = Ray::Task(Return1).Remote();
-  auto r1 = Ray::Task(Plus1, 3).Remote();
-  auto r2 = Ray::Task(Plus, 2, 3).Remote();
-  auto r3 = Ray::Task(Triple, 1, 2, 3).Remote();
+  auto r1 = Ray::Task(Plus1).Remote(3);
+  auto r2 = Ray::Task(Plus).Remote(2, 3);
+  auto r3 = Ray::Task(Triple).Remote(1, 2, 3);
 
   int result0 = *(r0.Get());
   int result1 = *(r1.Get());
@@ -95,10 +95,10 @@ TEST(RayApiTest, CallWithValueTest) {
 
 TEST(RayApiTest, CallWithObjectTest) {
   auto rt0 = Ray::Task(Return1).Remote();
-  auto rt1 = Ray::Task(Plus1, rt0).Remote();
-  auto rt2 = Ray::Task(Plus, rt1, 3).Remote();
-  auto rt3 = Ray::Task(Plus1, 3).Remote();
-  auto rt4 = Ray::Task(Plus, rt2, rt3).Remote();
+  auto rt1 = Ray::Task(Plus1).Remote(rt0);
+  auto rt2 = Ray::Task(Plus).Remote(rt1, 3);
+  auto rt3 = Ray::Task(Plus1).Remote(3);
+  auto rt4 = Ray::Task(Plus).Remote(rt2, rt3);
 
   int return0 = *(rt0.Get());
   int return1 = *(rt1.Get());
@@ -148,7 +148,7 @@ TEST(RayApiTest, CompareWithFuture) {
 
   // Ray API
   Ray::Init();
-  auto f3 = Ray::Task(Plus1, 1).Remote();
+  auto f3 = Ray::Task(Plus1).Remote(1);
   int rt3 = *f3.Get();
 
   EXPECT_EQ(rt1, 2);

--- a/cpp/src/ray/test/cluster/cluster_mode_test.cc
+++ b/cpp/src/ray/test/cluster/cluster_mode_test.cc
@@ -55,7 +55,7 @@ TEST(RayClusterModeTest, FullTest) {
   EXPECT_EQ(1, task_result);
 
   /// common task with args
-  task_obj = Ray::Task(Plus1, 5).Remote();
+  task_obj = Ray::Task(Plus1).Remote(5);
   task_result = *(Ray::Get(task_obj));
   EXPECT_EQ(6, task_result);
 
@@ -79,8 +79,8 @@ TEST(RayClusterModeTest, FullTest) {
 
   /// general function remote call（args passed by value）
   auto r0 = Ray::Task(Return1).Remote();
-  auto r1 = Ray::Task(Plus1, 30).Remote();
-  auto r2 = Ray::Task(Plus, 3, 22).Remote();
+  auto r1 = Ray::Task(Plus1).Remote(30);
+  auto r2 = Ray::Task(Plus).Remote(3, 22);
 
   int result1 = *(Ray::Get(r1));
   int result0 = *(Ray::Get(r0));
@@ -91,9 +91,9 @@ TEST(RayClusterModeTest, FullTest) {
 
   /// general function remote call（args passed by reference）
   auto r3 = Ray::Task(Return1).Remote();
-  auto r4 = Ray::Task(Plus1, r3).Remote();
-  auto r5 = Ray::Task(Plus, r4, r3).Remote();
-  auto r6 = Ray::Task(Plus, r4, 10).Remote();
+  auto r4 = Ray::Task(Plus1).Remote(r3);
+  auto r5 = Ray::Task(Plus).Remote(r4, r3);
+  auto r6 = Ray::Task(Plus).Remote(r4, 10);
 
   int result5 = *(Ray::Get(r5));
   int result4 = *(Ray::Get(r4));
@@ -128,8 +128,8 @@ TEST(RayClusterModeTest, FullTest) {
   auto r12 = actor5.Task(&Counter::Add, r11).Remote();
   auto r13 = actor5.Task(&Counter::Add, r10).Remote();
   auto r14 = actor5.Task(&Counter::Add, r13).Remote();
-  auto r15 = Ray::Task(Plus, r0, r11).Remote();
-  auto r16 = Ray::Task(Plus1, r15).Remote();
+  auto r15 = Ray::Task(Plus).Remote(r0, r11);
+  auto r16 = Ray::Task(Plus1).Remote(r15);
 
   int result12 = *(Ray::Get(r12));
   int result14 = *(Ray::Get(r14));

--- a/cpp/src/ray/test/ray_remote_cluster/ray_remote_cluster_test.cc
+++ b/cpp/src/ray/test/ray_remote_cluster/ray_remote_cluster_test.cc
@@ -32,14 +32,14 @@ TEST(RayClusterModeTest, FullTest) {
   EXPECT_EQ(1, task_result);
 
   /// common task with args
-  task_obj = Ray::Task(Plus1, 5).Remote();
+  task_obj = Ray::Task(Plus1).Remote(5);
   task_result = *(Ray::Get(task_obj));
   EXPECT_EQ(6, task_result);
 
   /// general function remote call（args passed by value）
   auto r0 = Ray::Task(Return1).Remote();
-  auto r1 = Ray::Task(Plus1, 30).Remote();
-  auto r2 = Ray::Task(Plus, 3, 22).Remote();
+  auto r1 = Ray::Task(Plus1).Remote(30);
+  auto r2 = Ray::Task(Plus).Remote(3, 22);
 
   int result1 = *(Ray::Get(r1));
   int result0 = *(Ray::Get(r0));
@@ -50,9 +50,9 @@ TEST(RayClusterModeTest, FullTest) {
 
   /// general function remote call（args passed by reference）
   auto r3 = Ray::Task(Return1).Remote();
-  auto r4 = Ray::Task(Plus1, r3).Remote();
-  auto r5 = Ray::Task(Plus, r4, r3).Remote();
-  auto r6 = Ray::Task(Plus, r4, 10).Remote();
+  auto r4 = Ray::Task(Plus1).Remote(r3);
+  auto r5 = Ray::Task(Plus).Remote(r4, r3);
+  auto r6 = Ray::Task(Plus).Remote(r4, 10);
 
   int result5 = *(Ray::Get(r5));
   int result4 = *(Ray::Get(r4));

--- a/cpp/src/ray/test/ray_remote_test.cc
+++ b/cpp/src/ray/test/ray_remote_test.cc
@@ -60,7 +60,7 @@ TEST(RayApiTest, NormalTask) {
   auto r = Ray::Task(Return).Remote();
   EXPECT_EQ(1, *(r.Get()));
 
-  auto r1 = Ray::Task(PlusOne, 1).Remote();
+  auto r1 = Ray::Task(PlusOne).Remote(1);
   EXPECT_EQ(2, *(r1.Get()));
 }
 
@@ -69,17 +69,17 @@ TEST(RayApiTest, VoidFunction) {
   r2.Get();
   EXPECT_EQ(1, out_for_void_func);
 
-  auto r3 = Ray::Task(VoidFuncWithArgs, 1, 2).Remote();
+  auto r3 = Ray::Task(VoidFuncWithArgs).Remote(1, 2);
   r3.Get();
   EXPECT_EQ(3, out_for_void_func_no_args);
 }
 
 TEST(RayApiTest, CallWithObjectRef) {
   auto rt0 = Ray::Task(Return).Remote();
-  auto rt1 = Ray::Task(PlusOne, rt0).Remote();
-  auto rt2 = Ray::Task(PlusTwo, rt1, 3).Remote();
-  auto rt3 = Ray::Task(PlusOne, 3).Remote();
-  auto rt4 = Ray::Task(PlusTwo, rt2, rt3).Remote();
+  auto rt1 = Ray::Task(PlusOne).Remote(rt0);
+  auto rt2 = Ray::Task(PlusTwo).Remote(rt1, 3);
+  auto rt3 = Ray::Task(PlusOne).Remote(3);
+  auto rt4 = Ray::Task(PlusTwo).Remote(rt2, rt3);
 
   int return0 = *(rt0.Get());
   int return1 = *(rt1.Get());
@@ -105,17 +105,17 @@ TEST(RayApiTest, ArgumentsNotMatch) {
   auto r = Ray::Task(PlusOne).Remote();
   EXPECT_THROW(r.Get(), RayException);
 
-  auto r1 = Ray::Task(PlusOne, 1, 2).Remote();
+  auto r1 = Ray::Task(PlusOne).Remote(1, 2);
   EXPECT_THROW(r1.Get(), RayException);
 
   auto r2 = Ray::Task(ExceptionFunc).Remote();
   EXPECT_THROW(r2.Get(), RayException);
 
-  auto r3 = Ray::Task(ExceptionFunc, 1, 2).Remote();
+  auto r3 = Ray::Task(ExceptionFunc).Remote(1, 2);
   EXPECT_THROW(r3.Get(), RayException);
 
   /// Normal task Exception.
-  auto r4 = Ray::Task(ExceptionFunc, 2).Remote();
+  auto r4 = Ray::Task(ExceptionFunc).Remote(2);
   EXPECT_THROW(r4.Get(), RayException);
 
   ray::api::RayConfig::GetInstance()->use_ray_remote = false;

--- a/cpp/src/ray/test/slow_function_test.cc
+++ b/cpp/src/ray/test/slow_function_test.cc
@@ -16,10 +16,10 @@ TEST(RaySlowFunctionTest, BaseTest) {
   Ray::Init();
   auto time1 = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::system_clock::now().time_since_epoch());
-  auto r0 = Ray::Task(slow_function, 1).Remote();
-  auto r1 = Ray::Task(slow_function, 2).Remote();
-  auto r2 = Ray::Task(slow_function, 3).Remote();
-  auto r3 = Ray::Task(slow_function, 4).Remote();
+  auto r0 = Ray::Task(slow_function).Remote(1);
+  auto r1 = Ray::Task(slow_function).Remote(2);
+  auto r2 = Ray::Task(slow_function).Remote(3);
+  auto r3 = Ray::Task(slow_function).Remote(4);
 
   int result0 = *(r0.Get());
   int result1 = *(r1.Get());


### PR DESCRIPTION
## Why are these changes needed?
We should support safe c++ worker API according the [doc](https://docs.google.com/document/d/1pBRUm-w2LKXTte8uXmvQ23l7gOJV2IOwirCTPjtPGWk/edit#heading=h.86fui9aqjkh6), this pr improve normal task remote interface to support lazy bind arguments.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests