### PR TITLE
[Tests] Fix memory scheduling flaky test

### DIFF
--- a/python/ray/tests/test_memory_scheduling.py
+++ b/python/ray/tests/test_memory_scheduling.py
@@ -8,7 +8,7 @@ MB = 1024 * 1024
 
 
 def object_store_memory(a, delta=MB):
-    b = ray.available_resources()["object_store_memory"]
+    b = ray.available_resources().get("object_store_memory", 0)
     return abs(a - b) < delta
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Looks like the function raises an exception because when the available object store memory is 0, it is not included in the `available_resources()` map. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
