### PR TITLE
Fixed Dask on Ray for dask>=2021.3.1 which dropped Python 3.6

### DIFF
--- a/python/ray/util/dask/common.py
+++ b/python/ray/util/dask/common.py
@@ -7,7 +7,18 @@ import ray
 
 from dask.base import quote
 from dask.core import get as get_sync
-from dask.compatibility import apply, is_dataclass, dataclass_fields
+from dask.compatibility import apply
+
+
+try:
+    from dataclasses import is_dataclass, fields as dataclass_fields
+except ImportError:
+    # Python < 3.7
+    def is_dataclass(x):
+        return False
+
+    def dataclass_fields(x):
+        return []
 
 
 def unpack_object_refs(*args):

--- a/python/ray/util/dask/common.py
+++ b/python/ray/util/dask/common.py
@@ -9,7 +9,6 @@ from dask.base import quote
 from dask.core import get as get_sync
 from dask.compatibility import apply
 
-
 try:
     from dataclasses import is_dataclass, fields as dataclass_fields
 except ImportError:


### PR DESCRIPTION
Fixes #14992.

Dask dropped Python 3.6 support in https://github.com/dask/dask/pull/7006, and removed these checks in the process.

Because Dask on Ray needs to continue to support versions of Dask before `2021.3.1` and Python 3.6, these removed functions can safely be replicated here for now.

cc @clarkzinzow 