### PR TITLE
[Serve] Set controller and HTTP proxy num_cpus=0 by default

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -641,12 +641,14 @@ class Client:
         return handle
 
 
-def start(detached: bool = False,
-          http_host: Optional[str] = DEFAULT_HTTP_HOST,
-          http_port: int = DEFAULT_HTTP_PORT,
-          http_middlewares: List[Any] = [],
-          http_options: Optional[Union[dict, HTTPOptions]] = None,
-          dedicated_cpu: bool = False,) -> Client:
+def start(
+        detached: bool = False,
+        http_host: Optional[str] = DEFAULT_HTTP_HOST,
+        http_port: int = DEFAULT_HTTP_PORT,
+        http_middlewares: List[Any] = [],
+        http_options: Optional[Union[dict, HTTPOptions]] = None,
+        dedicated_cpu: bool = False,
+) -> Client:
     """Initialize a serve instance.
 
     By default, the instance will be scoped to the lifetime of the returned

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -670,7 +670,7 @@ def start(detached: bool = False,
               this to "0.0.0.0".
             - port(int): Port for HTTP server. Defaults to 8000.
             - middlewares(list): A list of Starlette middlewares that will be
-              applied to the HTTP servers in the cluster.
+              applied to the HTTP servers in the cluster. Defaults to [].
             - location(str, serve.config.DeploymentMode): The deployment
               location of HTTP servers:
 
@@ -680,9 +680,9 @@ def start(detached: bool = False,
                 - "EveryNode": start one HTTP server per node.
                 - "NoServer" or None: disable HTTP server.
             - dedicated_cpu(bool): Whether to set `num_cpus=1` for each
-              internal HTTP proxy Actor.  Defaults to False (`num_cpus=0`).
+              internal HTTP proxy actor.  Defaults to False (`num_cpus=0`).
         dedicated_cpu (bool): Whether to set `num_cpus=1` for the internal
-          Serve controller Actor.  Defaults to False (`num_cpus=0`).
+          Serve controller actor.  Defaults to False (`num_cpus=0`).
     """
     if ((http_host != DEFAULT_HTTP_HOST) or (http_port != DEFAULT_HTTP_PORT)
             or (len(http_middlewares) != 0)):

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -646,7 +646,7 @@ def start(detached: bool = False,
           http_port: int = DEFAULT_HTTP_PORT,
           http_middlewares: List[Any] = [],
           http_options: Optional[Union[dict, HTTPOptions]] = None,
-          dedicated_cpu: bool = False) -> Client:
+          dedicated_cpu: bool = False,) -> Client:
     """Initialize a serve instance.
 
     By default, the instance will be scoped to the lifetime of the returned

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -679,10 +679,10 @@ def start(detached: bool = False,
                   on. This is the default.
                 - "EveryNode": start one HTTP server per node.
                 - "NoServer" or None: disable HTTP server.
-            - dedicated_cpu(bool): Whether to set `num_cpus=1` for each
-              internal HTTP proxy actor.  Defaults to False (`num_cpus=0`).
-        dedicated_cpu (bool): Whether to set `num_cpus=1` for the internal
-          Serve controller actor.  Defaults to False (`num_cpus=0`).
+            - num_cpus (int): The number of CPU cores to reserve for each
+              internal Serve HTTP proxy actor.  Defaults to 0.
+        dedicated_cpu (bool): Whether to reserve a CPU core for the internal
+          Serve controller actor.  Defaults to False.
     """
     if ((http_host != DEFAULT_HTTP_HOST) or (http_port != DEFAULT_HTTP_PORT)
             or (len(http_middlewares) != 0)):

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -641,14 +641,12 @@ class Client:
         return handle
 
 
-def start(
-        detached: bool = False,
-        http_host: Optional[str] = DEFAULT_HTTP_HOST,
-        http_port: int = DEFAULT_HTTP_PORT,
-        http_middlewares: List[Any] = [],
-        http_options: Optional[Union[dict, HTTPOptions]] = None,
-        dedicated_cpu: bool = False
-) -> Client:
+def start(detached: bool = False,
+          http_host: Optional[str] = DEFAULT_HTTP_HOST,
+          http_port: int = DEFAULT_HTTP_PORT,
+          http_middlewares: List[Any] = [],
+          http_options: Optional[Union[dict, HTTPOptions]] = None,
+          dedicated_cpu: bool = False) -> Client:
     """Initialize a serve instance.
 
     By default, the instance will be scoped to the lifetime of the returned

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -647,6 +647,7 @@ def start(
         http_port: int = DEFAULT_HTTP_PORT,
         http_middlewares: List[Any] = [],
         http_options: Optional[Union[dict, HTTPOptions]] = None,
+        dedicated_cpu: bool = False
 ) -> Client:
     """Initialize a serve instance.
 
@@ -680,6 +681,10 @@ def start(
                   on. This is the default.
                 - "EveryNode": start one HTTP server per node.
                 - "NoServer" or None: disable HTTP server.
+            - dedicated_cpu(bool): Whether to set `num_cpus=1` for each
+              internal HTTP proxy Actor.  Defaults to False (`num_cpus=0`).
+        dedicated_cpu (bool): Whether to set `num_cpus=1` for the internal
+          Serve controller Actor.  Defaults to False (`num_cpus=0`).
     """
     if ((http_host != DEFAULT_HTTP_HOST) or (http_port != DEFAULT_HTTP_PORT)
             or (len(http_middlewares) != 0)):
@@ -724,6 +729,7 @@ def start(
             host=http_host, port=http_port, middlewares=http_middlewares)
 
     controller = ServeController.options(
+        num_cpus=(1 if dedicated_cpu else 0),
         name=controller_name,
         lifetime="detached" if detached else None,
         max_restarts=-1,

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -241,7 +241,7 @@ class HTTPOptions(pydantic.BaseModel):
     port: int = DEFAULT_HTTP_PORT
     middlewares: List[Any] = []
     location: Optional[DeploymentMode] = DeploymentMode.HeadOnly
-    dedicated_cpu: bool = False
+    num_cpus: int = 0
 
     @validator("location", always=True)
     def location_backfill_no_server(cls, v, values):

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -241,7 +241,8 @@ class HTTPOptions(pydantic.BaseModel):
     port: int = DEFAULT_HTTP_PORT
     middlewares: List[Any] = []
     location: Optional[DeploymentMode] = DeploymentMode.HeadOnly
-
+    dedicated_cpu: bool = False
+    
     @validator("location", always=True)
     def location_backfill_no_server(cls, v, values):
         if values["host"] is None or v is None:

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -242,7 +242,7 @@ class HTTPOptions(pydantic.BaseModel):
     middlewares: List[Any] = []
     location: Optional[DeploymentMode] = DeploymentMode.HeadOnly
     dedicated_cpu: bool = False
-    
+
     @validator("location", always=True)
     def location_backfill_no_server(cls, v, values):
         if values["host"] is None or v is None:

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -32,7 +32,7 @@ CHECKPOINT_KEY = "serve-controller-checkpoint"
 CONTROL_LOOP_PERIOD_S = 0.1
 
 
-@ray.remote
+@ray.remote(num_cpus=0)
 class ServeController:
     """Responsible for managing the state of the serving system.
 

--- a/python/ray/serve/examples/doc/quickstart_class.py
+++ b/python/ray/serve/examples/doc/quickstart_class.py
@@ -2,7 +2,7 @@ import ray
 from ray import serve
 import requests
 
-ray.init(num_cpus=4)
+ray.init()
 serve.start()
 
 

--- a/python/ray/serve/examples/doc/quickstart_function.py
+++ b/python/ray/serve/examples/doc/quickstart_function.py
@@ -2,7 +2,7 @@ import ray
 from ray import serve
 import requests
 
-ray.init(num_cpus=4)
+ray.init()
 serve.start()
 
 

--- a/python/ray/serve/http_proxy.py
+++ b/python/ray/serve/http_proxy.py
@@ -160,7 +160,7 @@ class HTTPProxy:
         await self.router(scope, receive, send)
 
 
-@ray.remote
+@ray.remote(num_cpus=0)
 class HTTPProxyActor:
     async def __init__(
             self,

--- a/python/ray/serve/http_state.py
+++ b/python/ray/serve/http_state.py
@@ -69,6 +69,7 @@ class HTTPState:
                                 name, node_id, self._config.host,
                                 self._config.port))
                 proxy = HTTPProxyActor.options(
+                    num_cpus=(1 if self._config.dedicated_cpu else 0),
                     name=name,
                     lifetime="detached" if self._detached else None,
                     max_concurrency=ASYNC_CONCURRENCY,

--- a/python/ray/serve/http_state.py
+++ b/python/ray/serve/http_state.py
@@ -69,7 +69,7 @@ class HTTPState:
                                 name, node_id, self._config.host,
                                 self._config.port))
                 proxy = HTTPProxyActor.options(
-                    num_cpus=(1 if self._config.dedicated_cpu else 0),
+                    num_cpus=self._config.num_cpus,
                     name=name,
                     lifetime="detached" if self._detached else None,
                     max_concurrency=ASYNC_CONCURRENCY,

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -138,9 +138,9 @@ def test_dedicated_cpu(controller_cpu, num_proxy_cpus, ray_cluster):
     serve.start(
         dedicated_cpu=controller_cpu,
         http_options=HTTPOptions(num_cpus=num_proxy_cpus))
+    available_cpus = num_cluster_cpus - num_cpus_used
     wait_for_condition(
-        lambda: ray.available_resources().get("CPU") == num_cluster_cpus - num_cpus_used
-    )
+        lambda: (ray.available_resources().get("CPU") == available_cpus))
     serve.shutdown()
     ray.shutdown()
 

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -121,6 +121,7 @@ def test_connect(detached, ray_shutdown):
     ray.get(serve.get_handle("endpoint").remote())
     assert "backend-ception" in serve.list_backends().keys()
 
+
 @pytest.mark.parametrize("controller_cpu", [True, False])
 @pytest.mark.parametrize("proxy_cpu", [True, False])
 def test_dedicated_cpu(controller_cpu, proxy_cpu, ray_cluster):
@@ -132,7 +133,8 @@ def test_dedicated_cpu(controller_cpu, proxy_cpu, ray_cluster):
     serve.start(
         dedicated_cpu=controller_cpu,
         http_options=HTTPOptions(dedicated_cpu=proxy_cpu))
-    wait_for_condition(lambda: ray.available_resources().get("CPU") == 4 - num_cpus_used)
+    wait_for_condition(
+        lambda: ray.available_resources().get("CPU") == 4 - num_cpus_used)
 
 
 @pytest.mark.skipif(

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -121,7 +121,7 @@ def test_connect(detached, ray_shutdown):
     ray.get(serve.get_handle("endpoint").remote())
     assert "backend-ception" in serve.list_backends().keys()
 
-
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows")
 @pytest.mark.parametrize("controller_cpu", [True, False])
 @pytest.mark.parametrize("num_proxy_cpus", [0, 1, 2])
 def test_dedicated_cpu(controller_cpu, num_proxy_cpus, ray_cluster):

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -328,7 +328,7 @@ def test_http_head_only(ray_cluster):
         r["CPU"]
         for r in ray.state.state._available_resources_per_node().values()
     }
-    assert cpu_per_nodes == {2, 4}
+    assert cpu_per_nodes == {4, 4}
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -121,6 +121,7 @@ def test_connect(detached, ray_shutdown):
     ray.get(serve.get_handle("endpoint").remote())
     assert "backend-ception" in serve.list_backends().keys()
 
+
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows")
 @pytest.mark.parametrize("controller_cpu", [True, False])
 @pytest.mark.parametrize("num_proxy_cpus", [0, 1, 2])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Previously the Serve controller took 1 CPU and each HTTP proxy actor took 1 CPU.  This is unnecessarily constraining in most cases.  For example, on a machine with 2 CPUs, Serve wouldn't have any available CPUs remaining to start new replicas.

This PR sets num_cpus=0 for the Serve controller actor and the Serve HTTP proxy actors by default.  It also adds the option `dedicated_cpu: bool = False` in  `serve.start()` for the controller, and an option `num_cpus = 0` in`HTTPOptions` for the HTTP proxies, to allow the user to reserve CPUs as needed. The controller can thus have either 0 or 1 CPU, the proxies can each have any number of CPUs (the same number of CPUs for each proxy.)
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
