### PR TITLE
[Wheel] Turn off 3.9 build for macOS only

### DIFF
--- a/ci/travis/test-wheels.sh
+++ b/ci/travis/test-wheels.sh
@@ -45,10 +45,11 @@ function retry {
 
 if [[ "$platform" == "linux" ]]; then
   # Install miniconda.
-  PY_WHEEL_VERSIONS=("36" "37" "38")
+  PY_WHEEL_VERSIONS=("36" "37" "38" "39")
   PY_MMS=("3.6.9"
           "3.7.6"
-          "3.8.2")
+          "3.8.2"
+          "3.9.1")
   wget --quiet "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh" -O miniconda3.sh
   "${ROOT_DIR}"/../suppress_output bash miniconda3.sh -b -p "$HOME/miniconda3"
   export PATH="$HOME/miniconda3/bin:$PATH"
@@ -91,11 +92,10 @@ if [[ "$platform" == "linux" ]]; then
 
 elif [[ "$platform" == "macosx" ]]; then
   MACPYTHON_PY_PREFIX=/Library/Frameworks/Python.framework/Versions
-  PY_WHEEL_VERSIONS=("36" "37" "38" "39")
+  PY_WHEEL_VERSIONS=("36" "37" "38")
   PY_MMS=("3.6"
           "3.7"
-          "3.8"
-          "3.9")
+          "3.8")
 
   for ((i=0; i<${#PY_MMS[@]}; ++i)); do
     PY_MM="${PY_MMS[i]}"

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -32,7 +32,7 @@ You can install the nightly Ray wheels via the following links. These daily rele
 ===================  ===================  ======================
        Linux                MacOS         Windows (experimental)
 ===================  ===================  ======================
-`Linux Python 3.9`_  `MacOS Python 3.9`_  `Windows Python 3.9`_
+`Linux Python 3.9`_                       `Windows Python 3.9`_
 `Linux Python 3.8`_  `MacOS Python 3.8`_  `Windows Python 3.8`_
 `Linux Python 3.7`_  `MacOS Python 3.7`_  `Windows Python 3.7`_
 `Linux Python 3.6`_  `MacOS Python 3.6`_  `Windows Python 3.6`_
@@ -47,7 +47,6 @@ You can install the nightly Ray wheels via the following links. These daily rele
 .. _`Linux Python 3.7`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
 .. _`Linux Python 3.6`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp36-cp36m-manylinux2014_x86_64.whl
 
-.. _`MacOS Python 3.9`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp39-cp39-macosx_10_13_x86_64.whl
 .. _`MacOS Python 3.8`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-macosx_10_13_x86_64.whl
 .. _`MacOS Python 3.7`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp37-cp37m-macosx_10_13_intel.whl
 .. _`MacOS Python 3.6`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp36-cp36m-macosx_10_13_intel.whl

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -16,21 +16,17 @@ DOWNLOAD_DIR=python_downloads
 NODE_VERSION="14"
 PY_VERSIONS=("3.6.1"
              "3.7.0"
-             "3.8.2"
-             "3.9.1")
+             "3.8.2")
 PY_INSTS=("python-3.6.1-macosx10.6.pkg"
           "python-3.7.0-macosx10.6.pkg"
-          "python-3.8.2-macosx10.9.pkg"
-          "python-3.9.1-macosx10.9.pkg")
+          "python-3.8.2-macosx10.9.pkg")
 PY_MMS=("3.6"
         "3.7"
-        "3.8"
-        "3.9")
+        "3.8")
 
 NUMPY_VERSIONS=("1.14.5"
                 "1.14.5"
-                "1.14.5"
-                "1.19.3")
+                "1.14.5")
 
 ./ci/travis/install-bazel.sh
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Wheels build for macOS is still broken. This attempt to fix it.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
