### PR TITLE
[tune] Reconcile placement groups every N seconds to avoid bottlenecks when running many short trials

### DIFF
--- a/doc/source/tune/user-guide.rst
+++ b/doc/source/tune/user-guide.rst
@@ -818,6 +818,11 @@ These are the environment variables Ray Tune currently considers:
 * **TUNE_PLACEMENT_GROUP_PREFIX**: Prefix for placement groups created by Ray Tune. This prefix is used
   e.g. to identify placement groups that should be cleaned up on start/stop of the tuning run. This is
   initialized to a unique name at the start of the first run.
+* **TUNE_PLACEMENT_GROUP_RECON_INTERVAL**: How often to reconcile placement groups. Reconcilation is
+  used to make sure that the number of requested placement groups and pending/running trials are in sync.
+  In normal circumstances these shouldn't differ anyway, but reconcilation makes sure to capture cases when
+  placement groups are manually destroyed. Reconcilation doesn't take much time, but it can add up when
+  running a large number of short trials. Defaults to every ``5`` (seconds).
 * **TUNE_PLACEMENT_GROUP_WAIT_S**: Default time the trial executor waits for placement
   groups to be placed before continuing the tuning loop. Setting this to a float
   will block for that many seconds. This is mostly used for testing purposes. Defaults

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -1005,8 +1005,9 @@ class RayTrialExecutor(TrialExecutor):
             self._update_avail_resources()
             return self._avail_resources.gpu > 0
 
-    def cleanup(self):
+    def cleanup(self, trial_runner):
         self._trial_cleanup.cleanup(partial=False)
+        self._pg_manager.reconcile_placement_groups(trial_runner.get_trials())
         self._pg_manager.cleanup(force=True)
         self._pg_manager.cleanup_existing_pg(block=True)
 

--- a/python/ray/tune/tests/test_trial_runner_pg.py
+++ b/python/ray/tune/tests/test_trial_runner_pg.py
@@ -69,6 +69,9 @@ class TrialRunnerPlacementGroupTest(unittest.TestCase):
 
         Eventually they should be scheduled sequentially (i.e. in pairs
         of two)."""
+        # Since we check per-step placement groups, set the reconcilation
+        # interval to 0
+        os.environ["TUNE_PLACEMENT_GROUP_RECON_INTERVAL"] = "0"
 
         def train(config):
             time.sleep(1)

--- a/python/ray/tune/trial_executor.py
+++ b/python/ray/tune/trial_executor.py
@@ -278,7 +278,7 @@ class TrialExecutor:
         """Returns True if GPUs are detected on the cluster."""
         return None
 
-    def cleanup(self, trial):
+    def cleanup(self, trial_runner):
         """Ensures that trials are cleaned up after stopping."""
         pass
 

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -1144,7 +1144,7 @@ class TrialRunner:
         self.trial_executor.stop_trial(trial, error=error, error_msg=error_msg)
 
     def cleanup_trials(self):
-        self.trial_executor.cleanup()
+        self.trial_executor.cleanup(self)
 
     def __getstate__(self):
         """Gets state for trial.

--- a/rllib/tests/test_placement_groups.py
+++ b/rllib/tests/test_placement_groups.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 import ray
@@ -52,6 +53,7 @@ class _TestCallback(Callback):
 
 class TestPlacementGroups(unittest.TestCase):
     def setUp(self) -> None:
+        os.environ["TUNE_PLACEMENT_GROUP_RECON_INTERVAL"] = "1"
         ray.init(num_cpus=6)
 
     def tearDown(self) -> None:

--- a/rllib/tests/test_placement_groups.py
+++ b/rllib/tests/test_placement_groups.py
@@ -53,7 +53,7 @@ class _TestCallback(Callback):
 
 class TestPlacementGroups(unittest.TestCase):
     def setUp(self) -> None:
-        os.environ["TUNE_PLACEMENT_GROUP_RECON_INTERVAL"] = "1"
+        os.environ["TUNE_PLACEMENT_GROUP_RECON_INTERVAL"] = "0"
         ray.init(num_cpus=6)
 
     def tearDown(self) -> None:


### PR DESCRIPTION
## Why are these changes needed?

We're reconciling placement groups at every step. This involves looping through all trials and counting their statuses. With a large number of trials, this operation is still relatively fast, but the cost increases - e.g. from about 0.05 seconds to 0.1 seconds (1k trials vs. 2.5k trials in benchmarking experiments). In our release tests where 16 trials finished at the same time, this lead to delays of about 1.6 seconds (and growing), accumulating to an overhead of 45 minutes (60 minutes total runtime vs. 15 minutes expected).

Placement groups should usually be in sync anyways, the reconcilation is mostly used to make sure we catch (manually) destroyed placement groups. Thus, we can call this much less often. This PR introduces an interval to only reconcile placement groups every 5 seconds. In my experiment, even every 1 second was sufficient to dramatically lower experiment runtime.

## Related issue number

Closes #14987 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
