### PR TITLE
[RLlib] Add support for Int-Box action spaces.

### DIFF
--- a/rllib/agents/es/es_tf_policy.py
+++ b/rllib/agents/es/es_tf_policy.py
@@ -153,7 +153,8 @@ class ESTFPolicy(Policy):
         return action[0], state_outs, extra_fetches
 
     def _add_noise(self, single_action, single_action_space):
-        if isinstance(single_action_space, gym.spaces.Box):
+        if isinstance(single_action_space, gym.spaces.Box) and \
+                single_action_space.dtype.name.startswith("float"):
             single_action += np.random.randn(*single_action.shape) * \
                 self.action_noise_std
         return single_action

--- a/rllib/agents/es/es_torch_policy.py
+++ b/rllib/agents/es/es_torch_policy.py
@@ -74,7 +74,8 @@ def before_init(policy, observation_space, action_space, config):
 
         def _add_noise(single_action, single_action_space):
             single_action = single_action.detach().cpu().numpy()
-            if add_noise and isinstance(single_action_space, gym.spaces.Box):
+            if add_noise and isinstance(single_action_space, gym.spaces.Box) \
+                    and single_action_space.dtype.name.startswith("float"):
                 single_action += np.random.randn(*single_action.shape) * \
                                  policy.action_noise_std
             return single_action

--- a/rllib/models/torch/torch_action_dist.py
+++ b/rllib/models/torch/torch_action_dist.py
@@ -89,8 +89,11 @@ class TorchMultiCategorical(TorchDistributionWrapper):
     """MultiCategorical distribution for MultiDiscrete action spaces."""
 
     @override(TorchDistributionWrapper)
-    def __init__(self, inputs: List[TensorType], model: TorchModelV2,
-                 input_lens: Union[List[int], np.ndarray, Tuple[int, ...]]):
+    def __init__(self,
+                 inputs: List[TensorType],
+                 model: TorchModelV2,
+                 input_lens: Union[List[int], np.ndarray, Tuple[int, ...]],
+                 action_space=None):
         super().__init__(inputs, model)
         # If input_lens is np.ndarray or list, force-make it a tuple.
         inputs_split = self.inputs.split(tuple(input_lens), dim=1)
@@ -98,23 +101,36 @@ class TorchMultiCategorical(TorchDistributionWrapper):
             torch.distributions.categorical.Categorical(logits=input_)
             for input_ in inputs_split
         ]
+        # Used in case we are dealing with an Int Box.
+        self.action_space = action_space
 
     @override(TorchDistributionWrapper)
     def sample(self) -> TensorType:
         arr = [cat.sample() for cat in self.cats]
-        self.last_sample = torch.stack(arr, dim=1)
-        return self.last_sample
+        sample_ = torch.stack(arr, dim=1)
+        if isinstance(self.action_space, gym.spaces.Box):
+            sample_ = torch.reshape(sample_,
+                                    [-1] + list(self.action_space.shape))
+        self.last_sample = sample_
+        return sample_
 
     @override(ActionDistribution)
     def deterministic_sample(self) -> TensorType:
         arr = [torch.argmax(cat.probs, -1) for cat in self.cats]
-        self.last_sample = torch.stack(arr, dim=1)
-        return self.last_sample
+        sample_ = torch.stack(arr, dim=1)
+        if isinstance(self.action_space, gym.spaces.Box):
+            sample_ = torch.reshape(sample_,
+                                    [-1] + list(self.action_space.shape))
+        self.last_sample = sample_
+        return sample_
 
     @override(TorchDistributionWrapper)
     def logp(self, actions: TensorType) -> TensorType:
         # # If tensor is provided, unstack it into list.
         if isinstance(actions, torch.Tensor):
+            if isinstance(self.action_space, gym.spaces.Box):
+                actions = torch.reshape(
+                    actions, [-1, int(np.product(self.action_space.shape))])
             actions = torch.unbind(actions, dim=1)
         logps = torch.stack(
             [cat.log_prob(act) for cat, act in zip(self.cats, actions)])
@@ -147,7 +163,17 @@ class TorchMultiCategorical(TorchDistributionWrapper):
     def required_model_output_shape(
             action_space: gym.Space,
             model_config: ModelConfigDict) -> Union[int, np.ndarray]:
-        return np.sum(action_space.nvec)
+        # Int Box.
+        if isinstance(action_space, gym.spaces.Box):
+            assert action_space.dtype.name.startswith("int")
+            low_ = np.min(action_space.low)
+            high_ = np.max(action_space.high)
+            assert np.all(action_space.low == low_)
+            assert np.all(action_space.high == high_)
+            np.product(action_space.shape) * (high_ - low_ + 1)
+        # MultiDiscrete space.
+        else:
+            return np.sum(action_space.nvec)
 
 
 class TorchDiagGaussian(TorchDistributionWrapper):

--- a/rllib/models/torch/torch_action_dist.py
+++ b/rllib/models/torch/torch_action_dist.py
@@ -116,7 +116,7 @@ class TorchMultiCategorical(TorchDistributionWrapper):
 
     @override(ActionDistribution)
     def deterministic_sample(self) -> TensorType:
-        arr = [cat.deterministic_sample() for cat in self.cats]
+        arr = [torch.argmax(cat.probs, -1) for cat in self.cats]
         sample_ = torch.stack(arr, dim=1)
         if isinstance(self.action_space, gym.spaces.Box):
             sample_ = torch.reshape(sample_,

--- a/rllib/models/torch/torch_action_dist.py
+++ b/rllib/models/torch/torch_action_dist.py
@@ -116,7 +116,7 @@ class TorchMultiCategorical(TorchDistributionWrapper):
 
     @override(ActionDistribution)
     def deterministic_sample(self) -> TensorType:
-        arr = [torch.argmax(cat.probs, -1) for cat in self.cats]
+        arr = [cat.deterministic_sample() for cat in self.cats]
         sample_ = torch.stack(arr, dim=1)
         if isinstance(self.action_space, gym.spaces.Box):
             sample_ = torch.reshape(sample_,

--- a/rllib/tests/test_supported_spaces.py
+++ b/rllib/tests/test_supported_spaces.py
@@ -16,6 +16,7 @@ ACTION_SPACES_TO_TEST = {
     "discrete": Discrete(5),
     "vector": Box(-1.0, 1.0, (5, ), dtype=np.float32),
     "vector2": Box(-1.0, 1.0, (5, 5), dtype=np.float32),
+    "int_actions": Box(0, 3, (2, 3), dtype=np.int32),
     "multidiscrete": MultiDiscrete([1, 2, 3, 4]),
     "tuple": Tuple(
         [Discrete(2),

--- a/rllib/utils/exploration/random.py
+++ b/rllib/utils/exploration/random.py
@@ -88,11 +88,18 @@ class Random(Exploration):
                 elif isinstance(component, Box):
                     if component.bounded_above.all() and \
                             component.bounded_below.all():
-                        return tf.random.uniform(
-                            shape=(batch_size, ) + component.shape,
-                            minval=component.low,
-                            maxval=component.high,
-                            dtype=component.dtype)
+                        if component.dtype.name.startswith("int"):
+                            return tf.random.uniform(
+                                shape=(batch_size, ) + component.shape,
+                                minval=component.low.flat[0],
+                                maxval=component.high.flat[0],
+                                dtype=component.dtype)
+                        else:
+                            return tf.random.uniform(
+                                shape=(batch_size, ) + component.shape,
+                                minval=component.low,
+                                maxval=component.high,
+                                dtype=component.dtype)
                     else:
                         return tf.random.normal(
                             shape=(batch_size, ) + component.shape,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Add support for Int-Box action spaces.
- +test case (test_supported_spaces.py)
- Box(dtype=int32|64) action spaces can have arbitrary shapes, but must have uniform low/high values.
- RLlib will use the existing MultiCategorical to performa sampling, logp, entropy, etc.. calculations.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
