### PR TITLE
Revert "skip on windows (#14988)"

### DIFF
--- a/python/ray/tests/test_dask_callback.py
+++ b/python/ray/tests/test_dask_callback.py
@@ -1,10 +1,8 @@
 import dask
 import pytest
-import sys
 
 import ray
-if sys.platform != "win32":
-    from ray.util.dask import ray_dask_get, RayDaskCallback
+from ray.util.dask import ray_dask_get, RayDaskCallback
 
 
 @dask.delayed
@@ -12,7 +10,6 @@ def add(x, y):
     return x + y
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_callback_active():
     """Test that callbacks are active within context"""
     assert not RayDaskCallback.ray_active
@@ -23,7 +20,6 @@ def test_callback_active():
     assert not RayDaskCallback.ray_active
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_presubmit_shortcircuit(ray_start_regular_shared):
     """
     Test that presubmit return short-circuits task submission, and that task's
@@ -45,7 +41,6 @@ def test_presubmit_shortcircuit(ray_start_regular_shared):
     assert result == 0
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_pretask_posttask_shared_state(ray_start_regular_shared):
     """
     Test that pretask return value is passed to corresponding posttask
@@ -66,7 +61,6 @@ def test_pretask_posttask_shared_state(ray_start_regular_shared):
     assert result == 5
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_postsubmit(ray_start_regular_shared):
     """
     Test that postsubmit is called after each task.
@@ -100,7 +94,6 @@ def test_postsubmit(ray_start_regular_shared):
     assert result == 5
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_postsubmit_all(ray_start_regular_shared):
     """
     Test that postsubmit_all is called once.
@@ -133,7 +126,6 @@ def test_postsubmit_all(ray_start_regular_shared):
     assert result == 5
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_finish(ray_start_regular_shared):
     """
     Test that finish callback is called once.
@@ -166,7 +158,6 @@ def test_finish(ray_start_regular_shared):
     assert result == 5
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_multiple_callbacks(ray_start_regular_shared):
     """
     Test that multiple callbacks are supported.
@@ -203,7 +194,6 @@ def test_multiple_callbacks(ray_start_regular_shared):
     assert result == 5
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_pretask_posttask_shared_state_multi(ray_start_regular_shared):
     """
     Test that pretask return values are passed to the correct corresponding

--- a/python/ray/tests/test_dask_scheduler.py
+++ b/python/ray/tests/test_dask_scheduler.py
@@ -1,15 +1,11 @@
-import sys
-
 import dask
 import dask.array as da
 import pytest
 
 import ray
-if sys.platform != "win32":
-    from ray.util.dask import ray_dask_get
+from ray.util.dask import ray_dask_get
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_ray_dask_basic(ray_start_regular_shared):
     @ray.remote
     def stringify(x):
@@ -35,7 +31,6 @@ def test_ray_dask_basic(ray_start_regular_shared):
     assert ans == "The answer is 6", ans
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_ray_dask_persist(ray_start_regular_shared):
     arr = da.ones(5) + 2
     result = arr.persist(scheduler=ray_dask_get)


### PR DESCRIPTION
This reverts commit fe39c88a57c8053ece102d17647b960807f9a724, which skipped the Dask-on-Ray tests on Windows.

The underlying issue was fixed in [this PR](https://github.com/ray-project/ray/pull/14991), as you can see from the [passing Windows build](https://github.com/ray-project/ray/runs/2220277907) (the PR was based on an older master that still had the tests enabled).
