### PR TITLE
[RLlib] Issue: Agent_id -> Policy_id mapping should not need to be fixed between episodes.

### DIFF
--- a/rllib/evaluation/collectors/simple_list_collector.py
+++ b/rllib/evaluation/collectors/simple_list_collector.py
@@ -486,10 +486,7 @@ class SimpleListCollector(SampleCollector):
                      init_obs: TensorType) -> None:
         # Make sure our mappings are up to date.
         agent_key = (episode.episode_id, agent_id)
-        if agent_key not in self.agent_key_to_policy_id:
-            self.agent_key_to_policy_id[agent_key] = policy_id
-        else:
-            assert self.agent_key_to_policy_id[agent_key] == policy_id
+        self.agent_key_to_policy_id[agent_key] = policy_id
         policy = self.policy_map[policy_id]
         view_reqs = policy.model.view_requirements if \
             getattr(policy, "model", None) else policy.view_requirements

--- a/rllib/examples/multi_agent_cartpole.py
+++ b/rllib/examples/multi_agent_cartpole.py
@@ -76,6 +76,11 @@ if __name__ == "__main__":
     }
     policy_ids = list(policies.keys())
 
+    def policy_mapping_fn(agent_id):
+        pol_id = random.choice(policy_ids)
+        print(f"mapping {agent_id} to {pol_id}")
+        return pol_id
+
     config = {
         "env": MultiAgentCartPole,
         "env_config": {
@@ -86,7 +91,7 @@ if __name__ == "__main__":
         "num_sgd_iter": 10,
         "multiagent": {
             "policies": policies,
-            "policy_mapping_fn": (lambda agent_id: random.choice(policy_ids)),
+            "policy_mapping_fn": policy_mapping_fn,
         },
         "framework": args.framework,
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Issue: Agent_id -> Policy_id mapping should not need to be fixed between episodes.
See this discussion here:
https://discuss.ray.io/t/agent-key-and-policy-id-mismatch-on-multiagent-ensemble-training/995/9

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
