### PR TITLE
[serve] Add tests for reconnecting to cluster with ray client

### DIFF
--- a/python/ray/serve/tests/test_ray_client.py
+++ b/python/ray/serve/tests/test_ray_client.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 
 import ray
+from ray.test_utils import run_string_as_driver
 from ray import serve
 
 # https://tools.ietf.org/html/rfc6335#section-6
@@ -16,7 +17,7 @@ MAX_DYNAMIC_PORT = 65535
 def ray_client_instance():
     port = random.randint(MIN_DYNAMIC_PORT, MAX_DYNAMIC_PORT)
     subprocess.check_output([
-        "ray", "start", "--head", "--num-cpus", "8",
+        "ray", "start", "--head", "--num-cpus", "16",
         "--ray-client-server-port", f"{port}"
     ])
     try:
@@ -27,27 +28,50 @@ def ray_client_instance():
 
 def test_ray_client(ray_client_instance):
     ray.util.connect(ray_client_instance)
-    serve.start(detached=True)
 
-    # TODO(edoakes): disconnecting and reconnecting causes the test to
-    # spuriously hang.
-    # ray.util.disconnect()
+    start = """
+import ray
+ray.util.connect("{}")
 
-    # ray.util.connect(ray_client_instance)
+from ray import serve
 
-    def f(*args):
-        return "hello"
+serve.start(detached=True)
+""".format(ray_client_instance)
+    run_string_as_driver(start)
 
-    serve.create_backend("test1", f)
-    serve.create_endpoint("test1", backend="test1", route="/hello")
+    serve.connect()
+
+    deploy = """
+import ray
+ray.util.connect("{}")
+
+from ray import serve
+
+def f(*args):
+    return "hello"
+
+serve.create_backend("test1", f)
+serve.create_endpoint("test1", backend="test1", route="/hello")
+""".format(ray_client_instance)
+    run_string_as_driver(deploy)
+
+    assert "test1" in serve.list_backends()
+    assert "test1" in serve.list_endpoints()
     assert requests.get("http://localhost:8000/hello").text == "hello"
-    # TODO(edoakes): the below tests currently hang.
-    # assert ray.get(serve.get_handle("test1").remote()) == "hello"
-    ray.util.disconnect()
 
-    # ray.util.connect(ray_client_instance)
-    # serve.delete_endpoint("test1")
-    # serve.delete_backend("test1")
+    delete = """
+import ray
+ray.util.connect("{}")
+
+from ray import serve
+
+serve.delete_endpoint("test1")
+serve.delete_backend("test1")
+""".format(ray_client_instance)
+    run_string_as_driver(delete)
+
+    assert "test1" not in serve.list_backends()
+    assert "test1" not in serve.list_endpoints()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
