### PR TITLE
[Tests] Skip autoscaler tests on Windows

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -145,6 +145,7 @@ test_python() {
       -python/ray/tests:test_actor_advanced # timeout
       -python/ray/tests:test_advanced_2
       -python/ray/tests:test_advanced_3  # test_invalid_unicode_in_worker_log() fails on Windows
+      -python/ray/tests:test_autoscaler # We don't support Autoscaler on Windows
       -python/ray/tests:test_autoscaler_aws
       -python/ray/tests:test_component_failures
       -python/ray/tests:test_component_failures_3 # timeout
@@ -154,6 +155,7 @@ test_python() {
       -python/ray/tests:test_basic_3_client_mode
       -python/ray/tests:test_cli
       -python/ray/tests:test_client_init # timeout
+      -python/ray/tests:test_command_runner # We don't support Autoscaler on Windows
       -python/ray/tests:test_failure
       -python/ray/tests:test_global_gc
       -python/ray/tests:test_job

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -442,7 +442,6 @@ class AutoscalingTest(unittest.TestCase):
         except ValidationError:
             self.fail("Default config did not pass validation test!")
 
-    @unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
     def testGetOrCreateHeadNode(self):
         config = copy.deepcopy(SMALL_CLUSTER)
         head_run_option = "--kernel-memory=10g"
@@ -512,7 +511,6 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_has_call("1.2.3.4", pattern=pattern_to_assert)
         return config
 
-    @unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
     def testGetOrCreateHeadNodePodman(self):
         config = copy.deepcopy(SMALL_CLUSTER)
         config["docker"]["use_podman"] = True
@@ -559,7 +557,6 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_has_call("1.2.3.4", "podman inspect")
         runner.assert_has_call("1.2.3.4", "podman exec")
 
-    @unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
     def testGetOrCreateHeadNodeFromStopped(self):
         config = self.testGetOrCreateHeadNode()
         self.provider.cache_stopped = True
@@ -654,7 +651,6 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_has_call("1.2.3.4", "head_setup_cmd")
         runner.assert_has_call("1.2.3.4", "start_ray_head")
 
-    @unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
     def testDockerFileMountsAdded(self):
         config = copy.deepcopy(SMALL_CLUSTER)
         config["file_mounts"] = {"source": "/dev/null"}
@@ -703,7 +699,6 @@ class AutoscalingTest(unittest.TestCase):
             f"docker cp {docker_mount_prefix}/~/ray_bootstrap_config.yaml"
         runner.assert_has_call("1.2.3.4", pattern=pattern_to_assert)
 
-    @unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
     def testDockerFileMountsRemoved(self):
         config = copy.deepcopy(SMALL_CLUSTER)
         config["file_mounts"] = {}
@@ -753,7 +748,6 @@ class AutoscalingTest(unittest.TestCase):
             f"docker cp {docker_mount_prefix}/~/ray_bootstrap_config.yaml"
         runner.assert_has_call("1.2.3.4", pattern=pattern_to_assert)
 
-    @unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
     def testRsyncCommandWithDocker(self):
         assert SMALL_CLUSTER["docker"]["container_name"]
         config_path = self.write_config(SMALL_CLUSTER)
@@ -807,7 +801,6 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_has_call("172.0.0.4", pattern="docker cp")
         runner.assert_has_call("172.0.0.4", pattern="rsync")
 
-    @unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
     def testRsyncCommandWithoutDocker(self):
         cluster_cfg = SMALL_CLUSTER.copy()
         cluster_cfg["docker"] = {}
@@ -1992,7 +1985,6 @@ class AutoscalingTest(unittest.TestCase):
             runner.assert_has_call("172.0.0.{}".format(i), "setup_cmd")
             runner.assert_has_call("172.0.0.{}".format(i), "start_ray_worker")
 
-    @unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
     def testContinuousFileMounts(self):
         file_mount_dir = tempfile.mkdtemp()
 

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -10,7 +10,6 @@ import unittest
 from unittest.mock import Mock
 import yaml
 import copy
-import sys
 from jsonschema.exceptions import ValidationError
 
 import ray

--- a/python/ray/tests/test_command_runner.py
+++ b/python/ray/tests/test_command_runner.py
@@ -59,7 +59,6 @@ def test_command_runner_interface_abstraction_violation():
         assert allowed_public_interface_functions == subclass_public_functions
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_ssh_command_runner():
     process_runner = MockProcessRunner()
     provider = MockProvider()
@@ -172,7 +171,6 @@ def test_kubernetes_command_runner():
     assert pytest_wrapped_e.value.code == 1
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_docker_command_runner():
     process_runner = MockProcessRunner()
     provider = MockProvider()
@@ -221,7 +219,6 @@ def test_docker_command_runner():
     process_runner.assert_has_call("1.2.3.4", exact=expected)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_docker_rsync():
     process_runner = MockProcessRunner()
     provider = MockProvider()

--- a/python/ray/tests/test_command_runner.py
+++ b/python/ray/tests/test_command_runner.py
@@ -1,6 +1,5 @@
 import logging
 import pytest
-import sys
 from unittest.mock import patch
 
 from ray.tests.test_autoscaler import MockProvider, MockProcessRunner


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* Since we do not support most of autoscaler on windows, we can just skip those tests to:
  a) decrease test time 
  b) remove a bunch of tests marked as `pytest.mark.skipif(sys.platform == "win32")`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
