### PR TITLE
[tune] Fix type annotation in choice

### DIFF
--- a/python/ray/tune/sample.py
+++ b/python/ray/tune/sample.py
@@ -466,7 +466,7 @@ def qloguniform(lower: float, upper: float, q: float, base: float = 10):
     return Float(lower, upper).loguniform(base).quantized(q)
 
 
-def choice(categories: List):
+def choice(categories: Sequence):
     """Sample a categorical value.
 
     Sampling from ``tune.choice([1, 2])`` is equivalent to sampling from


### PR DESCRIPTION
## Why are these changes needed?

The `Categorical.__init__()` takes any sequence, so the type annotation on `choice()` can be relaxed.

## Related issue number

Closes #15037

## Checks

- [] I've run `scripts/format.sh` to lint the changes in this PR.
- [] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
