### PR TITLE
[serve] Use longest prefix matching for path routing

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -34,6 +34,14 @@ py_test(
 )
 
 py_test(
+    name = "test_http_routes",
+    size = "medium",
+    srcs = serve_tests_srcs,
+    tags = ["exclusive"],
+    deps = [":serve_lib"],
+)
+
+py_test(
     name = "test_advanced",
     size = "medium",
     srcs = serve_tests_srcs,

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1092,6 +1092,10 @@ def ingress(
             # the fast api routes here.
             make_fastapi_class_based_view(app, cls)
         if path_prefix is not None:
+            if not path_prefix.startswith("/"):
+                raise ValueError("path_prefix must start with '/'")
+            if "{" in path_prefix or "}" in path_prefix:
+                raise ValueError("path_prefix may not contain wildcards")
             cls._serve_path_prefix = path_prefix
 
         return cls
@@ -1101,7 +1105,7 @@ def ingress(
 
 class ServeDeployment(ABC):
     @classmethod
-    def deploy(self, *init_args) -> None:
+    def deploy(cls, *init_args) -> None:
         """Deploy this deployment.
 
         Args:
@@ -1112,17 +1116,17 @@ class ServeDeployment(ABC):
         raise NotImplementedError()
 
     @classmethod
-    def delete(self) -> None:
+    def delete(cls) -> None:
         """Delete this deployment."""
         raise NotImplementedError()
 
     @classmethod
-    def get_handle(self, sync: Optional[bool] = True
+    def get_handle(cls, sync: Optional[bool] = True
                    ) -> Union[RayServeHandle, RayServeSyncHandle]:
         raise NotImplementedError()
 
     @classmethod
-    def options(self,
+    def options(cls,
                 backend_def: Optional[Callable] = None,
                 name: Optional[str] = None,
                 version: Optional[str] = None,

--- a/python/ray/serve/constants.py
+++ b/python/ray/serve/constants.py
@@ -41,3 +41,13 @@ BACKEND_RECONFIGURE_METHOD = "reconfigure"
 #: Internally reserved version tag that cannot be used by applications.
 # TODO(edoakes): this should be removed when we remove the old codepath.
 RESERVED_VERSION_TAG = "__serve_version__"
+
+#: All defined HTTP methods.
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
+ALL_HTTP_METHODS = [
+    "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE",
+    "PATCH"
+]
+
+#: Path suffix used to wildcard all subpaths.
+WILDCARD_PATH_SUFFIX = "/{wildcard:path}"

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -16,7 +16,11 @@ from ray.serve.common import (
     TrafficPolicy,
 )
 from ray.serve.config import BackendConfig, HTTPOptions, ReplicaConfig
-from ray.serve.constants import RESERVED_VERSION_TAG
+from ray.serve.constants import (
+    ALL_HTTP_METHODS,
+    RESERVED_VERSION_TAG,
+    WILDCARD_PATH_SUFFIX,
+)
 from ray.serve.endpoint_state import EndpointState
 from ray.serve.http_state import HTTPState
 from ray.serve.kv_store import RayInternalKVStore
@@ -258,18 +262,19 @@ class ServeController:
             # Backend config should be synchronized so the backend worker
             # is aware of it.
             backend_config.internal_metadata.path_prefix = f"/{name}"
+        else:
+            if ("{" in replica_config.path_prefix
+                    or "}" in replica_config.path_prefix):
+                raise ValueError(
+                    "Wildcard routes are not supported for deployment paths.")
 
         if replica_config.is_asgi_app:
             # When the backend is asgi application, we want to proxy it
             # with a prefixed path as well as proxy all HTTP methods.
             # {wildcard:path} is used so HTTPProxy's Starlette router can match
             # arbitrary path.
-            http_route = f"{replica_config.path_prefix}" + "/{wildcard:path}"
-            # https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
-            http_methods = [
-                "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS",
-                "TRACE", "PATCH"
-            ]
+            http_route = replica_config.path_prefix + WILDCARD_PATH_SUFFIX
+            http_methods = ALL_HTTP_METHODS
         else:
             http_route = replica_config.path_prefix
             # Generic endpoint should support a limited subset of HTTP methods.

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -274,14 +274,18 @@ class ServeController:
             if ("{" in replica_config.path_prefix
                     or "}" in replica_config.path_prefix):
                 raise ValueError(
-                    "Wildcard routes are not supported for deployment paths.")
+                    "Wildcard routes are not supported for deployment paths. "
+                    "Please use @serve.ingress with FastAPI instead.")
 
         if replica_config.is_asgi_app:
             # When the backend is asgi application, we want to proxy it
             # with a prefixed path as well as proxy all HTTP methods.
             # {wildcard:path} is used so HTTPProxy's Starlette router can match
             # arbitrary path.
-            http_route = replica_config.path_prefix + WILDCARD_PATH_SUFFIX
+            path_prefix = replica_config.path_prefix
+            if path_prefix.endswith("/"):
+                path_prefix = path_prefix[:-1]
+            http_route = path_prefix + WILDCARD_PATH_SUFFIX
             http_methods = ALL_HTTP_METHODS
         else:
             http_route = replica_config.path_prefix

--- a/python/ray/serve/http_proxy.py
+++ b/python/ray/serve/http_proxy.py
@@ -118,7 +118,7 @@ class HTTPProxy:
             starlette.routing.Route(
                 route, ServeStarletteEndpoint(endpoint_tag), methods=methods)
             for route, (endpoint_tag, methods) in sorted(
-                route_table.items(), key=lambda tag, _: len(tag), reverse=True)
+                route_table.items(), key=lambda x: len(x[0]), reverse=True)
             if not self._is_headless(route)
         ]
 

--- a/python/ray/serve/http_proxy.py
+++ b/python/ray/serve/http_proxy.py
@@ -118,7 +118,7 @@ class HTTPProxy:
             starlette.routing.Route(
                 route, ServeStarletteEndpoint(endpoint_tag), methods=methods)
             for route, (endpoint_tag, methods) in sorted(
-                route_table.items(), key=lambda x: len(x[0]), reverse=True)
+                route_table.items(), key=lambda tag, _: len(tag), reverse=True)
             if not self._is_headless(route)
         ]
 

--- a/python/ray/serve/tests/test_http_routes.py
+++ b/python/ray/serve/tests/test_http_routes.py
@@ -1,0 +1,140 @@
+from fastapi import FastAPI
+import pytest
+import requests
+
+from ray import serve
+from ray.serve.constants import ALL_HTTP_METHODS
+
+
+def test_path_validation(serve_instance):
+    # Path prefix must start with /.
+    with pytest.raises(ValueError):
+
+        @serve.ingress(path_prefix="hello")
+        class D1:
+            pass
+
+    # Wildcards not allowed with new ingress support.
+    with pytest.raises(ValueError):
+
+        @serve.ingress(path_prefix="/{wildcard}")
+        class D2:
+            pass
+
+    @serve.deployment("test")
+    @serve.ingress(path_prefix="/duplicate")
+    class D3:
+        pass
+
+    D3.deploy()
+
+    # Reject duplicate route.
+    with pytest.raises(ValueError):
+        D3.options(name="test2").deploy()
+
+
+def test_routes_endpoint(serve_instance):
+    @serve.deployment("D1")
+    @serve.ingress
+    class D1:
+        pass
+
+    @serve.deployment("D2")
+    @serve.ingress(path_prefix="/hello/world")
+    class D2:
+        pass
+
+    D1.deploy()
+    D2.deploy()
+
+    routes = requests.get("http://localhost:8000/-/routes").json()
+
+    assert len(routes) == 2
+    assert routes["/D1"] == ["D1", ["GET", "POST"]]
+    assert routes["/hello/world"] == ["D2", ["GET", "POST"]]
+
+    D1.delete()
+
+    routes = requests.get("http://localhost:8000/-/routes").json()
+    assert len(routes) == 1
+    assert routes["/hello/world"] == ["D2", ["GET", "POST"]]
+
+    D2.delete()
+    routes = requests.get("http://localhost:8000/-/routes").json()
+    assert len(routes) == 0
+
+    app = FastAPI()
+
+    @serve.deployment("D3")
+    @serve.ingress(app, path_prefix="/hello")
+    class D3:
+        pass
+
+    D3.deploy()
+
+    routes = requests.get("http://localhost:8000/-/routes").json()
+    assert len(routes) == 1
+    assert routes["/hello"] == ["D3", ALL_HTTP_METHODS]
+
+
+def test_path_prefixing(serve_instance):
+    def req(subpath):
+        return requests.get(f"http://localhost:8000{subpath}").text
+
+    @serve.deployment("D1")
+    @serve.ingress(path_prefix="/")
+    class D1:
+        def __call__(self, *args):
+            return "1"
+
+    D1.deploy()
+    assert req("/") == "1"
+    assert req("/a") != "1"
+
+    @serve.deployment("D2")
+    @serve.ingress(path_prefix="/hello")
+    class D2:
+        def __call__(self, *args):
+            return "2"
+
+    D2.deploy()
+    assert req("/") == "1"
+    assert req("/hello") == "2"
+
+    @serve.deployment("D3")
+    @serve.ingress(path_prefix="/hello/world")
+    class D3:
+        def __call__(self, *args):
+            return "3"
+
+    D3.deploy()
+    assert req("/") == "1"
+    assert req("/hello") == "2"
+    assert req("/hello/world") == "3"
+
+    app = FastAPI()
+
+    @serve.deployment("D4")
+    @serve.ingress(app, path_prefix="/hello/world/again")
+    class D4:
+        @app.get("/")
+        def root(self):
+            return "4"
+
+        @app.get("/{p}")
+        def subpath(self, p: str):
+            return p
+
+    D4.deploy()
+    assert req("/") == "1"
+    assert req("/hello") == "2"
+    assert req("/hello/world") == "3"
+    # TODO(edoakes): these fail with an obscure error message right now.
+    # assert req("/hello/world/again") == "4"
+    # assert req("/hello/world/again/") == "4"
+    assert req("/hello/world/again/hi") == "\"hi\""
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/test_http_routes.py
+++ b/python/ray/serve/tests/test_http_routes.py
@@ -132,7 +132,7 @@ def test_path_prefixing(serve_instance):
     # TODO(edoakes): these fail with an obscure error message right now.
     # assert req("/hello/world/again") == "4"
     # assert req("/hello/world/again/") == "4"
-    assert req("/hello/world/again/hi") == "\"hi\""
+    assert req("/hello/world/again/hi") == '"hi"'
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_http_routes.py
+++ b/python/ray/serve/tests/test_http_routes.py
@@ -119,7 +119,7 @@ def test_path_prefixing(serve_instance):
     class D4:
         @app.get("/")
         def root(self):
-            return "4"
+            return 4
 
         @app.get("/{p}")
         def subpath(self, p: str):
@@ -129,9 +129,8 @@ def test_path_prefixing(serve_instance):
     assert req("/") == "1"
     assert req("/hello") == "2"
     assert req("/hello/world") == "3"
-    # TODO(edoakes): these fail with an obscure error message right now.
-    # assert req("/hello/world/again") == "4"
-    # assert req("/hello/world/again/") == "4"
+    assert req("/hello/world/again") == "4"
+    assert req("/hello/world/again/") == "4"
     assert req("/hello/world/again/hi") == '"hi"'
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/14994
Closes https://github.com/ray-project/ray/issues/15067

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
