### PR TITLE
[RLlib] Update alpha_zero_policy.py

### DIFF
--- a/rllib/contrib/alpha_zero/core/alpha_zero_policy.py
+++ b/rllib/contrib/alpha_zero/core/alpha_zero_policy.py
@@ -138,9 +138,9 @@ class AlphaZeroPolicy(TorchPolicy):
         grad_info = self.extra_grad_info(train_batch)
         grad_info.update(grad_process_info)
         grad_info.update({
-            "total_loss": loss_out.detach().numpy(),
-            "policy_loss": policy_loss.detach().numpy(),
-            "value_loss": value_loss.detach().numpy()
+            "total_loss": loss_out.detach().cpu().numpy(),
+            "policy_loss": policy_loss.detach().cpu().numpy(),
+            "value_loss": value_loss.detach().cpu().numpy()
         })
 
         return {LEARNER_STATS_KEY: grad_info}


### PR DESCRIPTION
debug line 141~143. when using torch in gpu mode, gpu tensors can only be converted into numpy arrays with Tensor.cpu().numpy() not Tensor.numpy()

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
For debugging

<!-- Please give a short summary of the change and the problem this solves. -->

debug line 141~143. when using torch in gpu mode, gpu tensors can only be converted into numpy arrays with Tensor.cpu().numpy() not Tensor.numpy() 

## Related issue number
None

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
