### PR TITLE
Serve: make sure test_imported_backend is ran

### DIFF
--- a/python/ray/serve/tests/test_imported_backend.py
+++ b/python/ray/serve/tests/test_imported_backend.py
@@ -36,3 +36,9 @@ def test_imported_backend(serve_instance):
     serve.create_endpoint("imported_func", backend="imported_func")
     handle = serve.get_handle("imported_func")
     assert ray.get(handle.remote("hello")) == "hello"
+
+
+if __name__ == "__main__":
+    import sys
+    import pytest
+    sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
```
//python/ray/serve:test_imported_backend                                 PASSED in 0.6s
```

found in one of the master build: https://buildkite.com/ray-project/ray-builders-branch/builds/919#f5d5bd45-f62f-487b-b15a-58cde83e3ff9/130-7038
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
