### PR TITLE
ci: Fix broken symlink detection

### DIFF
--- a/ci/travis/install-bazel.sh
+++ b/ci/travis/install-bazel.sh
@@ -34,7 +34,7 @@ esac
   missing_symlinks=()
   while read -r mode _ _ path; do
     if [ "${mode}" = 120000 ]; then
-      test -L "${path}" || missing_symlinks+=("${paths}")
+      test -L "${path}" || missing_symlinks+=("${path}")
     fi
   done
   if [ ! 0 -eq "${#missing_symlinks[@]}" ]; then


### PR DESCRIPTION
The `paths` variable is not defined, it's the `path` that contains the path to the symlink.

### Why are these changes needed?

As a result of this bug, the build process of Python wheels breaks if a symlink is broken and expected error reporting does not work.