### PR TITLE
fix setproctitle break /proc/PID/environ

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -4,9 +4,6 @@ from os.path import dirname
 import platform
 import sys
 
-# Add SPT_NOENV env, prevent setproctitle break /proc/PID/environ
-os.environ["SPT_NOENV"] = "1"
-
 logger = logging.getLogger(__name__)
 
 # MUST add pickle5 to the import path because it will be imported by some

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -4,6 +4,9 @@ from os.path import dirname
 import platform
 import sys
 
+# Add SPT_NOENV env, prevent setproctitle break /proc/PID/environ
+os.environ["SPT_NOENV"] = "1"
+
 logger = logging.getLogger(__name__)
 
 # MUST add pickle5 to the import path because it will be imported by some

--- a/python/ray/tests/test_environ.py
+++ b/python/ray/tests/test_environ.py
@@ -1,20 +1,29 @@
 import os
 import pytest
+import ray
+
+@pytest.mark.skipif("sys.platform != 'linux'")
+def test_environ_file_on_linux(ray_start_10_cpus):
+
+    @ray.remote
+    class Actor1:
+        def __init__(self):
+            pass
+
+        def get_env_from_proc(self):
+            pid = os.getpid()
+            f = open('/proc/%d/environ' % pid, 'r')
+            return f.readlines()
+
+        def get_os_environ(self):
+            return os.environ
 
 
-@pytest.mark.linux
-def test_environ_file_on_linux():
-    def get_env(pid):
-        f = open('/proc/%d/environ' % pid, 'r')
-        return f.readlines()
-
-    pid = os.getpid()
-    orig_env = get_env(pid)
-
-    import ray
-
-    new_env = get_env(pid)
-    assert new_env == orig_env
+    a = Actor1.remote()
+    actor_proc_environ = ray.get(a.get_env_from_proc.remote())
+    actor_os_environ = ray.get(a.get_os_environ.remote())
+    assert len(actor_proc_environ) > 0 
+    assert len(actor_os_environ) > 0
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_environ.py
+++ b/python/ray/tests/test_environ.py
@@ -2,9 +2,9 @@ import os
 import pytest
 import ray
 
+
 @pytest.mark.skipif("sys.platform != 'linux'")
 def test_environ_file_on_linux(ray_start_10_cpus):
-
     @ray.remote
     class Actor1:
         def __init__(self):
@@ -23,7 +23,6 @@ def test_environ_file_on_linux(ray_start_10_cpus):
 
         def get_os_environ(self):
             return os.environ
-
 
     a = Actor1.remote()
     actor_proc_environ = ray.get(a.get_env_from_proc.remote())

--- a/python/ray/tests/test_environ.py
+++ b/python/ray/tests/test_environ.py
@@ -1,0 +1,26 @@
+import os
+import pytest
+
+
+@pytest.mark.linux
+def test_environ_file_on_linux():
+    def get_env(pid):
+        f = open('/proc/%d/environ' % pid, 'r')
+        return f.readlines()
+
+    pid = os.getpid()
+    orig_env = get_env(pid)
+
+    import ray
+
+    new_env = get_env(pid)
+    assert new_env == orig_env
+
+
+if __name__ == "__main__":
+    import pytest
+    import sys
+
+    os.environ["LC_ALL"] = "en_US.UTF-8"
+    os.environ["LANG"] = "en_US.UTF-8"
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_environ.py
+++ b/python/ray/tests/test_environ.py
@@ -27,7 +27,6 @@ def test_environ_file_on_linux(ray_start_10_cpus):
 
     a = Actor1.remote()
     actor_proc_environ = ray.get(a.get_env_from_proc.remote())
-    print(len(actor_proc_environ))
     actor_os_environ = ray.get(a.get_os_environ.remote())
     assert len(actor_proc_environ) > 0
     assert len(actor_os_environ) > 0

--- a/python/ray/tests/test_environ.py
+++ b/python/ray/tests/test_environ.py
@@ -13,11 +13,11 @@ def test_environ_file_on_linux(ray_start_10_cpus):
         def get_env_from_proc(self):
             pid = os.getpid()
             env = {}
-            with open('/proc/%s/environ' % pid) as fd:
-                for envspec in fd.read().split('\000'):
+            with open("/proc/%s/environ" % pid) as fd:
+                for envspec in fd.read().split("\000"):
                     if not envspec:
                         continue
-                    varname, varval = envspec.split('=', 1)
+                    varname, varval = envspec.split("=", 1)
                     env[varname] = varval
             return env
 

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -279,8 +279,10 @@ Process WorkerPool::StartWorkerProcess(
     env[pair.first] = pair.second;
   }
 
-  // When import ray, it will import setproctitle.
-  // Add SPT_NOENV env, prevent setproctitle break /proc/PID/environ
+  // We use setproctitle to change python worker process title, 
+  // causing the process's /proc/PID/environ being empty. 
+  // Add `SPT_NOENV` env to prevent setproctitle breaking /proc/PID/environ. 
+  // Refer this issue for more details: https://github.com/ray-project/ray/issues/15061
   if (language == Language::PYTHON) {
     env.insert({"SPT_NOENV", "1"});
   }

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -279,9 +279,9 @@ Process WorkerPool::StartWorkerProcess(
     env[pair.first] = pair.second;
   }
 
-  // We use setproctitle to change python worker process title, 
-  // causing the process's /proc/PID/environ being empty. 
-  // Add `SPT_NOENV` env to prevent setproctitle breaking /proc/PID/environ. 
+  // We use setproctitle to change python worker process title,
+  // causing the process's /proc/PID/environ being empty.
+  // Add `SPT_NOENV` env to prevent setproctitle breaking /proc/PID/environ.
   // Refer this issue for more details: https://github.com/ray-project/ray/issues/15061
   if (language == Language::PYTHON) {
     env.insert({"SPT_NOENV", "1"});

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -278,6 +278,13 @@ Process WorkerPool::StartWorkerProcess(
   for (const auto &pair : override_environment_variables) {
     env[pair.first] = pair.second;
   }
+
+  // When import ray, it will import setproctitle.
+  // Add SPT_NOENV env, prevent setproctitle break /proc/PID/environ
+  if (language == Language::PYTHON) {
+    env.insert("SPT_NOENV", "1");
+  }
+
   // Start a process and measure the startup time.
   auto start = std::chrono::high_resolution_clock::now();
   Process proc = StartProcess(worker_command_args, env);

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -282,7 +282,7 @@ Process WorkerPool::StartWorkerProcess(
   // When import ray, it will import setproctitle.
   // Add SPT_NOENV env, prevent setproctitle break /proc/PID/environ
   if (language == Language::PYTHON) {
-    env.insert("SPT_NOENV", "1");
+    env.insert({"SPT_NOENV", "1"});
   }
 
   // Start a process and measure the startup time.


### PR DESCRIPTION
## Why are these changes needed?

Ray use setproctitle to  change python worker process title, the process's /proc/PID/environ will be cleared.

The root cause is:  the setproctitle lib will reset process title and unfortunately breaks /proc/PID/environ.

According to https://github.com/dvarrazzo/py-setproctitle#environment-variables, add "SPT_NOENV" env to prevent setproctitle clearing /proc/PID/environ

## Related issue number

https://github.com/ray-project/ray/issues/15061

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
