### PR TITLE
Make client able to skip uploading

### DIFF
--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -33,6 +33,7 @@ class RayAPIStub:
                 secure: bool = False,
                 metadata: List[Tuple[str, str]] = None,
                 connection_retries: int = 3,
+                _skip_uploading=False,
                 *,
                 ignore_version: bool = False) -> Dict[str, Any]:
         """Connect the Ray Client to a server.
@@ -69,7 +70,7 @@ class RayAPIStub:
                 metadata=metadata,
                 connection_retries=connection_retries)
             self.api.worker = self.client_worker
-            self.client_worker._server_init(job_config)
+            self.client_worker._server_init(job_config, _skip_uploading)
             conn_info = self.client_worker.connection_info()
             self._check_versions(conn_info, ignore_version)
             return conn_info


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Give workers the ability to skip the uploading in case server want to prepare env on their side.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
