### PR TITLE
Generate raylet ID from node ip address (IPv4).

### DIFF
--- a/src/ray/common/id.h
+++ b/src/ray/common/id.h
@@ -16,6 +16,8 @@
 
 #include <inttypes.h>
 #include <limits.h>
+#include <boost/asio/ip/address_v4.hpp>
+#include <boost/system/error_code.hpp>
 
 #include <chrono>
 #include <cstring>
@@ -495,6 +497,18 @@ std::string BaseID<T>::Hex() const {
   }
   return result;
 }
+
+/// Generate a NodeID from an IP address (IPv4).
+/// The IP address will be filled to the first 12 characters of the generated NodeID's
+/// hexadecimal representation, and the remaining will be padded with random binary data.
+/// For example, if the input IP address is `1.10.0.122`, the output will be
+/// `0010100001226f7a6e09a0f51136c6243b502bcd2fac0cf21e05e874`.
+///
+/// \param ip_address The IP address.
+///
+/// \return NodeID, in its hexadecimal representation, the first 12 digits represent the
+/// IP address.
+NodeID GenerateNodeIdFromIpAddress(const std::string &ip_address);
 
 }  // namespace ray
 

--- a/src/ray/common/id_test.cc
+++ b/src/ray/common/id_test.cc
@@ -14,8 +14,8 @@
 
 #include "gtest/gtest.h"
 #include "ray/common/common_protocol.h"
+#include "ray/common/network_util.h"
 #include "ray/common/task/task_spec.h"
-
 namespace ray {
 
 void TestFromIndexObjectId(const TaskID &task_id, int64_t index) {
@@ -97,6 +97,35 @@ TEST(HashTest, TestNilHash) {
   ObjectID id2 = ObjectID::FromBinary(ObjectID::FromRandom().Binary());
   ASSERT_NE(nil_hash, id2.Hash());
   ASSERT_NE(id1.Hash(), id2.Hash());
+}
+
+TEST(PlacementGroupIDTest, TestPlacementGroup) {
+  {
+    // test from binary
+    PlacementGroupID placement_group_id_1 = PlacementGroupID::Of(JobID::FromInt(1));
+    const auto placement_group_id_1_binary = placement_group_id_1.Binary();
+    const auto placement_group_id_2 =
+        PlacementGroupID::FromBinary(placement_group_id_1_binary);
+    ASSERT_EQ(placement_group_id_1, placement_group_id_2);
+    const auto placement_group_id_1_hex = placement_group_id_1.Hex();
+    const auto placement_group_id_3 = PlacementGroupID::FromHex(placement_group_id_1_hex);
+    ASSERT_EQ(placement_group_id_1, placement_group_id_3);
+  }
+
+  {
+    // test get job id
+    auto job_id = JobID::FromInt(1);
+    const PlacementGroupID placement_group_id = PlacementGroupID::Of(job_id);
+    ASSERT_EQ(job_id, placement_group_id.JobId());
+  }
+}
+
+TEST(NodeIDTest, TestGenerateNodeIdFromIpAddress) {
+  {
+    std::string ip = std::string("1.10.0.122");
+    const NodeID node_id = GenerateNodeIdFromIpAddress(ip);
+    ASSERT_EQ("001010000122", node_id.Hex().substr(0, 12));
+  }
 }
 
 }  // namespace ray

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -61,7 +61,7 @@ Raylet::Raylet(instrumented_io_context &main_service, const std::string &socket_
                const ObjectManagerConfig &object_manager_config,
                std::shared_ptr<gcs::GcsClient> gcs_client, int metrics_export_port)
     : main_service_(main_service),
-      self_node_id_(NodeID::FromRandom()),
+      self_node_id_(GenerateNodeIdFromIpAddress(node_ip_address)),
       gcs_client_(gcs_client),
       object_directory_(
           RayConfig::instance().ownership_based_object_directory_enabled()


### PR DESCRIPTION
Introduce GenerateNodeIdFromIpAddress

The IP address will be filled to the first 12 characters of the generated RayLet's(NodeID) hexadecimal representation, and the remaining will be padded with random binary data.


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
