### PR TITLE
Fix c++ gcs test bug

### DIFF
--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -1249,7 +1249,7 @@ TEST_F(ServiceBasedGcsClientTest, TestMultiThreadSubAndUnsub) {
   // The number of times each thread executes subscribe & resubscribe & unsubscribe.
   int sub_and_unsub_loop_count = 20;
 
-  // Multithreading subscribe/resubscribe/unsubscribe actors.
+  // Multithreading subscribe/unsubscribe actors.
   auto job_id = JobID::FromInt(1);
   for (int index = 0; index < size; ++index) {
     threads[index].reset(new std::thread([this, sub_and_unsub_loop_count, job_id] {
@@ -1257,7 +1257,6 @@ TEST_F(ServiceBasedGcsClientTest, TestMultiThreadSubAndUnsub) {
         auto actor_id = ActorID::Of(job_id, RandomTaskId(), 0);
         ASSERT_TRUE(SubscribeActor(
             actor_id, [](const ActorID &id, const rpc::ActorTableData &result) {}));
-        gcs_client_->Actors().AsyncResubscribe(false);
         UnsubscribeActor(actor_id);
       }
     }));
@@ -1267,7 +1266,7 @@ TEST_F(ServiceBasedGcsClientTest, TestMultiThreadSubAndUnsub) {
     thread.reset();
   }
 
-  // Multithreading subscribe/resubscribe/unsubscribe objects.
+  // Multithreading subscribe/unsubscribe objects.
   for (int index = 0; index < size; ++index) {
     threads[index].reset(new std::thread([this, sub_and_unsub_loop_count] {
       for (int index = 0; index < sub_and_unsub_loop_count; ++index) {
@@ -1275,7 +1274,6 @@ TEST_F(ServiceBasedGcsClientTest, TestMultiThreadSubAndUnsub) {
         ASSERT_TRUE(SubscribeToLocations(
             object_id, [](const ObjectID &id,
                           const std::vector<rpc::ObjectLocationChange> &result) {}));
-        gcs_client_->Objects().AsyncResubscribe(false);
         UnsubscribeToLocations(object_id);
       }
     }));

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -1246,7 +1246,7 @@ TEST_F(ServiceBasedGcsClientTest, TestMultiThreadSubAndUnsub) {
   std::vector<std::unique_ptr<std::thread>> threads;
   threads.resize(size);
 
-  // The number of times each thread executes subscribe & resubscribe & unsubscribe.
+  // The number of times each thread executes subscribe & unsubscribe.
   int sub_and_unsub_loop_count = 20;
 
   // Multithreading subscribe/unsubscribe actors.
@@ -1317,16 +1317,17 @@ TEST_F(ServiceBasedGcsClientTest, DISABLED_TestGetActorPerf) {
 TEST_F(ServiceBasedGcsClientTest, TestEvictExpiredDestroyedActors) {
   // Register actors and the actors will be destroyed.
   JobID job_id = JobID::FromInt(1);
+  absl::flat_hash_set<ActorID> actor_ids;
   int actor_count = RayConfig::instance().maximum_gcs_destroyed_actor_cached_count();
   for (int index = 0; index < actor_count; ++index) {
     auto actor_table_data = Mocker::GenActorTableData(job_id);
     RegisterActor(actor_table_data, false);
+    actor_ids.insert(ActorID::FromBinary(actor_table_data->actor_id()));
   }
 
   // Restart GCS.
   RestartGcsServer();
 
-  absl::flat_hash_set<ActorID> actor_ids;
   for (int index = 0; index < actor_count; ++index) {
     auto actor_table_data = Mocker::GenActorTableData(job_id);
     RegisterActor(actor_table_data, false);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In this pr, we try to fix test case flaky bug:
1. `TestEvictExpiredDestroyedActors`
I reproduce it and found the root cause. 
After GCS is restarted, the failed requests for actor registration will be re registered again, resulting in more than 10 destroyed actors(GCS doesn't consider this situation, so I added code judgment). At the same time, GCS does not guarantee the order of RPC requests, which leads to the fact that the queried actor information cannot be guaranteed.
2. `TestMultiThreadSubAndUnsub `
I didn't reproduce it, but I guess it has something to do with resubscribe (because it will fetch data from GCS), so I'll remove resubscribe first and watch if it worked.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
