### PR TITLE
[serve] Get handle in starlette endpoint constructor instead of lazily

### DIFF
--- a/python/ray/serve/http_proxy.py
+++ b/python/ray/serve/http_proxy.py
@@ -37,14 +37,12 @@ class ServeStarletteEndpoint:
         # This will be lazily populated when the first request comes in.
         # TODO(edoakes): we should be able to construct the handle here, but
         # that currently breaks pytest. This seems like a bug.
-        self.handle = None
+        self.handle = serve.get_handle(self.endpoint_tag, sync=False)
 
     async def __call__(self, scope, receive, send):
         http_body_bytes = await self.receive_http_body(scope, receive, send)
 
         headers = {k.decode(): v.decode() for k, v in scope["headers"]}
-        if self.handle is None:
-            self.handle = serve.get_handle(self.endpoint_tag, sync=False)
 
         object_ref = await self.handle.options(
             method_name=headers.get("X-SERVE-CALL-METHOD".lower(),

--- a/python/ray/serve/http_proxy.py
+++ b/python/ray/serve/http_proxy.py
@@ -34,9 +34,6 @@ class ServeStarletteEndpoint:
 
     def __init__(self, endpoint_tag: EndpointTag):
         self.endpoint_tag = endpoint_tag
-        # This will be lazily populated when the first request comes in.
-        # TODO(edoakes): we should be able to construct the handle here, but
-        # that currently breaks pytest. This seems like a bug.
         self.handle = serve.get_handle(self.endpoint_tag, sync=False)
 
     async def __call__(self, scope, receive, send):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
