### PR TITLE
[Serve] Fix serializing nested fields in Pydantic

### DIFF
--- a/python/ray/serve/tests/test_pydantic_serialization.py
+++ b/python/ray/serve/tests/test_pydantic_serialization.py
@@ -167,7 +167,6 @@ def test_serialize_serve_dataclass(start_ray):
     ray.get(consume.remote(BackendConfig()))
 
 
-@pytest.mark.skip("Fails. https://github.com/ray-project/ray/issues/14960.")
 def test_serialize_nested_field(start_ray):
     class B(BaseModel):
         v: List[int]

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -384,7 +384,7 @@ def register_custom_serializers():
             pydantic.fields.ModelField,
             serializer=lambda o: {
                 "name": o.name,
-                "type_": o.type_,
+                "type_": o.outer_type_,
                 "class_validators": o.class_validators,
                 "model_config": o.model_config,
                 "default": o.default,

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -384,6 +384,9 @@ def register_custom_serializers():
             pydantic.fields.ModelField,
             serializer=lambda o: {
                 "name": o.name,
+                # outer_type_ is the original type for ModelFields,
+                # while type_ can be updated later with the nested type
+                # like int for List[int].
                 "type_": o.outer_type_,
                 "class_validators": o.class_validators,
                 "model_config": o.model_config,


### PR DESCRIPTION
Pydantic ModelField has two kinds of type_
```
        self.type_: Any = type_
        self.outer_type_: Any = type_
```
We were using the `self.type_` but turns out `self.outer_type_` is the
correct one to use because `self.type_` can be later updated with the
inner type (like `int` for `List[int]`

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #14960
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
