### PR TITLE
[Core] Fix plasma store segfault

### DIFF
--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -361,7 +361,7 @@ void PlasmaObject_init(PlasmaObject *object, ObjectTableEntry *entry) {
   object->device_num = entry->device_num;
 }
 
-void PlasmaStore::RemoveGetRequest(std::shared_ptr<GetRequest> get_request) {
+void PlasmaStore::RemoveGetRequest(const std::shared_ptr<GetRequest> &get_request) {
   // Remove the get request from each of the relevant object_get_requests hash
   // tables if it is present there. It should only be present there if the get
   // request timed out or if it was issued by a client that has disconnected.
@@ -388,7 +388,7 @@ void PlasmaStore::RemoveGetRequest(std::shared_ptr<GetRequest> get_request) {
 void PlasmaStore::RemoveGetRequestsForClient(const std::shared_ptr<Client> &client) {
   std::unordered_set<std::shared_ptr<GetRequest>> get_requests_to_remove;
   for (auto const &pair : object_get_requests_) {
-    for (const auto get_request : pair.second) {
+    for (const auto &get_request : pair.second) {
       if (get_request->client == client) {
         get_requests_to_remove.insert(get_request);
       }
@@ -398,12 +398,12 @@ void PlasmaStore::RemoveGetRequestsForClient(const std::shared_ptr<Client> &clie
   // It shouldn't be possible for a given client to be in the middle of multiple get
   // requests.
   RAY_CHECK(get_requests_to_remove.size() <= 1);
-  for (const auto get_request : get_requests_to_remove) {
+  for (const auto &get_request : get_requests_to_remove) {
     RemoveGetRequest(get_request);
   }
 }
 
-void PlasmaStore::ReturnFromGet(std::shared_ptr<GetRequest> get_req) {
+void PlasmaStore::ReturnFromGet(const std::shared_ptr<GetRequest> &get_req) {
   // If the get request is already removed, do no-op. This can happen because the boost
   // timer is not atomic. See https://github.com/ray-project/ray/pull/15071.
   if (get_req->IsRemoved()) {

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -475,7 +475,8 @@ void PlasmaStore::ProcessGetRequest(const std::shared_ptr<Client> &client,
                                     const std::vector<ObjectID> &object_ids,
                                     int64_t timeout_ms, bool is_from_worker) {
   // Create a get request for this object.
-  auto get_req = std::make_shared<GetRequest>(GetRequest(io_context_, client, object_ids, is_from_worker));
+  auto get_req = std::make_shared<GetRequest>(
+      GetRequest(io_context_, client, object_ids, is_from_worker));
   for (auto object_id : object_ids) {
     // Check if this object is already present
     // locally. If so, record that the object is being used and mark it as accounted for.

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -238,14 +238,14 @@ class PlasmaStore {
   /// Remove a GetRequest and clean up the relevant data structures.
   ///
   /// \param get_request The GetRequest to remove.
-  void RemoveGetRequest(std::shared_ptr<GetRequest> get_request);
+  void RemoveGetRequest(const std::shared_ptr<GetRequest> &get_request);
 
   /// Remove all of the GetRequests for a given client.
   ///
   /// \param client The client whose GetRequests should be removed.
   void RemoveGetRequestsForClient(const std::shared_ptr<Client> &client);
 
-  void ReturnFromGet(std::shared_ptr<GetRequest> get_req);
+  void ReturnFromGet(const std::shared_ptr<GetRequest> &get_req);
 
   void UpdateObjectGetRequests(const ObjectID &object_id);
 

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -277,7 +277,8 @@ class PlasmaStore {
   QuotaAwarePolicy eviction_policy_;
   /// A hash table mapping object IDs to a vector of the get requests that are
   /// waiting for the object to arrive.
-  std::unordered_map<ObjectID, std::vector<std::shared_ptr<GetRequest>>> object_get_requests_;
+  std::unordered_map<ObjectID, std::vector<std::shared_ptr<GetRequest>>>
+      object_get_requests_;
 
   std::unordered_set<ObjectID> deletion_cache_;
 

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -238,14 +238,14 @@ class PlasmaStore {
   /// Remove a GetRequest and clean up the relevant data structures.
   ///
   /// \param get_request The GetRequest to remove.
-  void RemoveGetRequest(GetRequest *get_request);
+  void RemoveGetRequest(std::shared_ptr<GetRequest> get_request);
 
   /// Remove all of the GetRequests for a given client.
   ///
   /// \param client The client whose GetRequests should be removed.
   void RemoveGetRequestsForClient(const std::shared_ptr<Client> &client);
 
-  void ReturnFromGet(GetRequest *get_req);
+  void ReturnFromGet(std::shared_ptr<GetRequest> get_req);
 
   void UpdateObjectGetRequests(const ObjectID &object_id);
 
@@ -277,7 +277,7 @@ class PlasmaStore {
   QuotaAwarePolicy eviction_policy_;
   /// A hash table mapping object IDs to a vector of the get requests that are
   /// waiting for the object to arrive.
-  std::unordered_map<ObjectID, std::vector<GetRequest *>> object_get_requests_;
+  std::unordered_map<ObjectID, std::vector<std::shared_ptr<GetRequest>>> object_get_requests_;
 
   std::unordered_set<ObjectID> deletion_cache_;
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It looks like when there are some pressure to the object store, this type of segfault rarely happens.

```
(raylet) [2021-04-01 14:17:37,987 E 65464 2851189] logging.cc:441: *** Aborted at 1617311857 (unix time) try "date -d @1617311857" if you are using GNU date ***
(raylet) [2021-04-01 14:17:37,987 E 65464 2851189] logging.cc:441: PC: @                0x0 (unknown)
(raylet) [2021-04-01 14:17:37,988 E 65464 2851189] logging.cc:441: *** SIGSEGV (@0x0) received by PID 65464 (TID 0x70000422a000) stack trace: ***
(raylet) [2021-04-01 14:17:37,993 E 65464 2851189] logging.cc:441:     @     0x7fff68fb35fd _sigtramp
(raylet) [2021-04-01 14:17:37,993 E 65464 2851189] logging.cc:441:     @     0x7fbe61910a80 (unknown)
(raylet) [2021-04-01 14:17:38,005 E 65464 2851189] logging.cc:441:     @        0x10644c36f plasma::PlasmaStore::ReturnFromGet()
(raylet) [2021-04-01 14:17:38,005 E 65464 2851189] logging.cc:441:     @        0x106452e89 boost::asio::detail::executor_function<>::do_complete()
(raylet) [2021-04-01 14:17:38,006 E 65464 2851189] logging.cc:441:     @        0x1062f7adb boost::asio::io_context::executor_type::dispatch<>()
(raylet) [2021-04-01 14:17:38,006 E 65464 2851189] logging.cc:441:     @        0x106452afe boost::asio::executor::dispatch<>()
(raylet) [2021-04-01 14:17:38,006 E 65464 2851189] logging.cc:441:     @        0x10645297b boost::asio::detail::wait_handler<>::do_complete()
(raylet) [2021-04-01 14:17:38,007 E 65464 2851189] logging.cc:441:     @        0x106c116a9 boost::asio::detail::scheduler::do_run_one()
(raylet) [2021-04-01 14:17:38,007 E 65464 2851189] logging.cc:441:     @        0x106c08a92 boost::asio::detail::scheduler::run()
(raylet) [2021-04-01 14:17:38,007 E 65464 2851189] logging.cc:441:     @        0x106c089bb boost::asio::io_context::run()
(raylet) [2021-04-01 14:17:38,008 E 65464 2851189] logging.cc:441:     @        0x1064571ac plasma::PlasmaStoreRunner::Start()
(raylet) [2021-04-01 14:17:38,008 E 65464 2851189] logging.cc:441:     @        0x1063f3c75 std::__1::__thread_proxy<>()
(raylet) [2021-04-01 14:17:38,008 E 65464 2851189] logging.cc:441:     @     0x7fff68fbf109 _pthread_start
(raylet) [2021-04-01 14:17:38,008 E 65464 2851189] logging.cc:441:     @     0x7fff68fbab8b thread_start
```

I looked into code, and it seems like we are using the raw pointer for `GetRequest`. It is highly likely the `GetRequest` is already GC'ed when ReturnFromGet is called. (Most likely due to this part of code)

```
    get_req->AsyncWait(timeout_ms, [this, get_req](const boost::system::error_code &ec) {
      if (ec != boost::asio::error::operation_aborted) {
        // Timer was not cancelled, take necessary action.
        ReturnFromGet(get_req);
      }
    });
```

This try fixing the issue by using the shared pointer in this path. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
