### PR TITLE
[doc] Fix inconsistent doc about ObjectID bytes

### DIFF
--- a/src/ray/design_docs/id_specification.md
+++ b/src/ray/design_docs/id_specification.md
@@ -48,9 +48,9 @@ The following table shows the layouts of all kinds of task id.
 Note: Dummy actor id is an `ActorID` whose unique part is nil.
 ```
 
-#### ObjectID (20 bytes)
+#### ObjectID (28 bytes)
 An `ObjectID` contains 2 parts:
 - `index bytes`: 4 bytes to indicate the index of the object within its creator task.
   1 <= idx <= num_return_objects is reserved for the task's return objects, while
   idx > num_return_objects is available for the task's put objects.
-- `TaskID`: 16 bytes to indicate the ID of the task to which this object belongs.
+- `TaskID`: 24 bytes to indicate the ID of the task to which this object belongs.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
