### PR TITLE
[Pubsub] Batch messages

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -390,4 +390,4 @@ RAY_CONFIG(int64_t, asio_stats_print_interval_ms, -1)
 RAY_CONFIG(float, max_task_args_memory_fraction, 0.7)
 
 /// The maximum number of objects to publish for each publish calls.
-RAY_CONFIG(int64_t, publish_batch_size, 1000)
+RAY_CONFIG(uint64_t, publish_batch_size, 5000)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -388,3 +388,6 @@ RAY_CONFIG(int64_t, asio_stats_print_interval_ms, -1)
 
 /// Maximum amount of memory that will be used by running tasks' args.
 RAY_CONFIG(float, max_task_args_memory_fraction, 0.7)
+
+/// The maximum number of objects to publish for each publish calls.
+RAY_CONFIG(int64_t, publish_batch_size, 1000)

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -562,7 +562,8 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
                                              task_manager_));
 
   object_status_publisher_ = std::make_shared<Publisher>(
-      /*is_node_dead=*/[this](const NodeID &node_id) {
+      /*is_node_dead=*/
+      [this](const NodeID &node_id) {
         if (auto node_info =
                 gcs_client_->Nodes().Get(node_id, /*filter_dead_nodes=*/false)) {
           return node_info->state() ==
@@ -571,7 +572,8 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
         // Node information is probably not
         // subscribed yet, so report that the node is alive.
         return true;
-      });
+      },
+      /*publish_batch_size_=*/RayConfig::instance().publish_batch_size());
 
   auto node_addr_factory = [this](const NodeID &node_id) {
     absl::optional<rpc::Address> addr;

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2408,8 +2408,8 @@ void CoreWorker::HandlePubsubLongPolling(const rpc::PubsubLongPollingRequest &re
         send_reply_callback(Status::OK(), nullptr, nullptr);
       };
   RAY_LOG(DEBUG) << "Got long polling request from node " << subscriber_id;
-  object_status_publisher_->Connect(subscriber_id,
-                                    std::move(long_polling_reply_callback));
+  object_status_publisher_->ConnectToSubscriber(subscriber_id,
+                                                std::move(long_polling_reply_callback));
 }
 
 void CoreWorker::HandleAddObjectLocationOwner(

--- a/src/ray/core_worker/pubsub/publisher.cc
+++ b/src/ray/core_worker/pubsub/publisher.cc
@@ -125,8 +125,9 @@ bool Subscriber::PublishIfPossible(bool force) {
   if (force || mailbox_.size() > 0) {
     std::vector<ObjectID> mails_to_post;
     while (mailbox_.size() > 0 && mails_to_post.size() < publish_batch_size_) {
-      mails_to_post.push_back(mailbox_.back());
-      mailbox_.pop_back();
+      // It ensures that mails are posted in the FIFO order.
+      mails_to_post.push_back(mailbox_.front());
+      mailbox_.pop_front();
     }
     long_polling_reply_callback_(mails_to_post);
     long_polling_reply_callback_ = nullptr;

--- a/src/ray/core_worker/pubsub/publisher.h
+++ b/src/ray/core_worker/pubsub/publisher.h
@@ -70,7 +70,9 @@ class SubscriptionIndex {
 /// Abstraction to each subscriber for the coordinator.
 class Subscriber {
  public:
-  explicit Subscriber() {}
+  explicit Subscriber(const uint64_t publish_batch_size)
+      : publish_batch_size_(publish_batch_size) {}
+
   ~Subscriber() = default;
 
   /// Connect to the subscriber. Currently, it means we cache the long polling request to
@@ -102,6 +104,8 @@ class Subscriber {
   LongPollConnectCallback long_polling_reply_callback_ = nullptr;
   /// Queued messages to publish.
   std::vector<ObjectID> mailbox_;
+  /// The maximum number of objects to publish for each publish calls.
+  const uint64_t publish_batch_size_;
 };
 
 /// Pubsub server.
@@ -110,8 +114,9 @@ class Publisher {
   /// Pubsub coordinator constructor.
   ///
   /// \param is_node_dead A callback that returns true if the given node id is dead.
-  explicit Publisher(std::function<bool(const NodeID &)> is_node_dead)
-      : is_node_dead_(is_node_dead) {}
+  explicit Publisher(std::function<bool(const NodeID &)> is_node_dead,
+                     const uint64_t publish_batch_size)
+      : is_node_dead_(is_node_dead), publish_batch_size_(publish_batch_size) {}
 
   ~Publisher() = default;
 
@@ -167,6 +172,9 @@ class Publisher {
 
   /// Index that stores the mapping of objects <-> subscribers.
   SubscriptionIndex subscription_index_ GUARDED_BY(mutex_);
+
+  /// The maximum number of objects to publish for each publish calls.
+  const uint64_t publish_batch_size_;
 };
 
 }  // namespace ray

--- a/src/ray/core_worker/pubsub/publisher.h
+++ b/src/ray/core_worker/pubsub/publisher.h
@@ -103,7 +103,7 @@ class Subscriber {
   /// Cached long polling reply callback.
   LongPollConnectCallback long_polling_reply_callback_ = nullptr;
   /// Queued messages to publish.
-  std::vector<ObjectID> mailbox_;
+  std::list<ObjectID> mailbox_;
   /// The maximum number of objects to publish for each publish calls.
   const uint64_t publish_batch_size_;
 };

--- a/src/ray/core_worker/pubsub/publisher.h
+++ b/src/ray/core_worker/pubsub/publisher.h
@@ -78,7 +78,7 @@ class Subscriber {
   ///
   /// \param long_polling_reply_callback reply callback to the long polling request.
   /// \return True if connection is new. False if there were already connections cached.
-  bool Connect(LongPollConnectCallback long_polling_reply_callback);
+  bool ConnectToSubscriber(LongPollConnectCallback long_polling_reply_callback);
 
   /// Queue the object id to publish to the subscriber.
   ///
@@ -119,8 +119,8 @@ class Publisher {
   // TODO(sang): Currently, we need to pass the callback for connection because we are
   // using long polling internally. This should be changed once the bidirectional grpc
   // streaming is supported.
-  void Connect(const NodeID &subscriber_node_id,
-               LongPollConnectCallback long_poll_connect_callback);
+  void ConnectToSubscriber(const NodeID &subscriber_node_id,
+                           LongPollConnectCallback long_poll_connect_callback);
 
   /// Register the subscription.
   ///

--- a/src/ray/core_worker/test/publisher_test.cc
+++ b/src/ray/core_worker/test/publisher_test.cc
@@ -199,9 +199,9 @@ TEST_F(PublisherTest, TestSubscriber) {
   // If there's no connection, it will return false.
   ASSERT_FALSE(subscriber.PublishIfPossible());
   // Try connecting it. Should return true.
-  ASSERT_TRUE(subscriber.Connect(reply));
+  ASSERT_TRUE(subscriber.ConnectToSubscriber(reply));
   // If connecting it again, it should fail the request.
-  ASSERT_FALSE(subscriber.Connect(reply));
+  ASSERT_FALSE(subscriber.ConnectToSubscriber(reply));
   // Since there's no published objects, it should return false.
   ASSERT_FALSE(subscriber.PublishIfPossible());
 
@@ -223,7 +223,7 @@ TEST_F(PublisherTest, TestSubscriber) {
   }
   // Since there's no connection, objects won't be published.
   ASSERT_FALSE(subscriber.PublishIfPossible());
-  ASSERT_TRUE(subscriber.Connect(reply));
+  ASSERT_TRUE(subscriber.ConnectToSubscriber(reply));
   ASSERT_TRUE(subscriber.PublishIfPossible());
   for (auto oid : published_objects) {
     ASSERT_TRUE(object_ids_published.count(oid) > 0);
@@ -241,7 +241,7 @@ TEST_F(PublisherTest, TestBasicSingleSubscriber) {
   const auto subscriber_node_id = NodeID::FromRandom();
   const auto oid = ObjectID::FromRandom();
 
-  object_status_publisher_->Connect(subscriber_node_id, long_polling_connect);
+  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, long_polling_connect);
   object_status_publisher_->RegisterSubscription(subscriber_node_id, oid);
   object_status_publisher_->Publish(oid);
   ASSERT_EQ(batched_ids[0], oid);
@@ -261,7 +261,7 @@ TEST_F(PublisherTest, TestNoConnectionWhenRegistered) {
   object_status_publisher_->Publish(oid);
   // Nothing has been published because there's no connection.
   ASSERT_EQ(batched_ids.size(), 0);
-  object_status_publisher_->Connect(subscriber_node_id, long_polling_connect);
+  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, long_polling_connect);
   // When the connection is coming, it should be published.
   ASSERT_EQ(batched_ids[0], oid);
 }
@@ -285,7 +285,7 @@ TEST_F(PublisherTest, TestMultiObjectsFromSingleNode) {
   ASSERT_EQ(batched_ids.size(), 0);
 
   // Now connection is initiated, and all oids are published.
-  object_status_publisher_->Connect(subscriber_node_id, long_polling_connect);
+  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, long_polling_connect);
   for (int i = 0; i < num_oids; i++) {
     const auto oid_test = oids[i];
     const auto published_oid = batched_ids[i];
@@ -320,7 +320,8 @@ TEST_F(PublisherTest, TestMultiObjectsFromMultiNodes) {
   // Check all of nodes are publishing objects properly.
   for (int i = 0; i < num_nodes; i++) {
     const auto subscriber_node_id = subscribers[i];
-    object_status_publisher_->Connect(subscriber_node_id, long_polling_connect);
+    object_status_publisher_->ConnectToSubscriber(subscriber_node_id,
+                                                  long_polling_connect);
     const auto oid_test = oids[i];
     const auto published_oid = batched_ids[i];
     ASSERT_EQ(oid_test, published_oid);
@@ -347,7 +348,7 @@ TEST_F(PublisherTest, TestBatch) {
   ASSERT_EQ(batched_ids.size(), 0);
 
   // Now connection is initiated, and all oids are published.
-  object_status_publisher_->Connect(subscriber_node_id, long_polling_connect);
+  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, long_polling_connect);
   for (int i = 0; i < num_oids; i++) {
     const auto oid_test = oids[i];
     const auto published_oid = batched_ids[i];
@@ -363,7 +364,7 @@ TEST_F(PublisherTest, TestBatch) {
     object_status_publisher_->RegisterSubscription(subscriber_node_id, oid);
     object_status_publisher_->Publish(oid);
   }
-  object_status_publisher_->Connect(subscriber_node_id, long_polling_connect);
+  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, long_polling_connect);
   for (int i = 0; i < num_oids; i++) {
     const auto oid_test = oids[i];
     const auto published_oid = batched_ids[i];
@@ -380,7 +381,7 @@ TEST_F(PublisherTest, TestNodeFailureWhenConnectionExisted) {
 
   const auto subscriber_node_id = NodeID::FromRandom();
   const auto oid = ObjectID::FromRandom();
-  object_status_publisher_->Connect(subscriber_node_id, long_polling_connect);
+  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, long_polling_connect);
   dead_nodes_.emplace(subscriber_node_id);
   // All these ops should be no-op.
   object_status_publisher_->RegisterSubscription(subscriber_node_id, oid);
@@ -414,7 +415,7 @@ TEST_F(PublisherTest, TestNodeFailureWhenConnectionDoesntExist) {
   ASSERT_EQ(long_polling_connection_replied, false);
 
   // Connect should reply right away to avoid memory leak.
-  object_status_publisher_->Connect(subscriber_node_id, long_polling_connect);
+  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, long_polling_connect);
   ASSERT_EQ(long_polling_connection_replied, true);
   long_polling_connection_replied = false;
 
@@ -429,7 +430,7 @@ TEST_F(PublisherTest, TestNodeFailureWhenConnectionDoesntExist) {
   ///
   subscriber_node_id = NodeID::FromRandom();
   oid = ObjectID::FromRandom();
-  object_status_publisher_->Connect(subscriber_node_id, long_polling_connect);
+  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, long_polling_connect);
   dead_nodes_.emplace(subscriber_node_id);
   erased = object_status_publisher_->UnregisterSubscriber(subscriber_node_id);
   ASSERT_EQ(long_polling_connection_replied, true);
@@ -447,7 +448,7 @@ TEST_F(PublisherTest, TestUnregisterSubscription) {
 
   const auto subscriber_node_id = NodeID::FromRandom();
   const auto oid = ObjectID::FromRandom();
-  object_status_publisher_->Connect(subscriber_node_id, long_polling_connect);
+  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, long_polling_connect);
   object_status_publisher_->RegisterSubscription(subscriber_node_id, oid);
   ASSERT_EQ(long_polling_connection_replied, false);
 
@@ -482,7 +483,7 @@ TEST_F(PublisherTest, TestUnregisterSubscriber) {
   // Test basic.
   const auto subscriber_node_id = NodeID::FromRandom();
   const auto oid = ObjectID::FromRandom();
-  object_status_publisher_->Connect(subscriber_node_id, long_polling_connect);
+  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, long_polling_connect);
   object_status_publisher_->RegisterSubscription(subscriber_node_id, oid);
   ASSERT_EQ(long_polling_connection_replied, false);
   int erased = object_status_publisher_->UnregisterSubscriber(subscriber_node_id);
@@ -492,7 +493,7 @@ TEST_F(PublisherTest, TestUnregisterSubscriber) {
 
   // Test when registration wasn't done.
   long_polling_connection_replied = false;
-  object_status_publisher_->Connect(subscriber_node_id, long_polling_connect);
+  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, long_polling_connect);
   erased = object_status_publisher_->UnregisterSubscriber(subscriber_node_id);
   ASSERT_FALSE(erased);
   ASSERT_EQ(long_polling_connection_replied, true);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When there are many objects to batch to the long polling reply, it can cause various issues (e.g., grpc size limit is reached or there are too many iterations which can block core worker). This PR fixes that problem by only batching upto batch_size objects at a time. 

## Related issue number

https://github.com/ray-project/ray/issues/14762

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
