### PR TITLE
Bugfix for set_verbosity ignoring certain inputs

### DIFF
--- a/python/ray/tune/utils/log.py
+++ b/python/ray/tune/utils/log.py
@@ -21,7 +21,7 @@ def set_verbosity(level: Union[int, Verbosity]):
     if isinstance(level, int):
         verbosity = Verbosity(level)
     else:
-        verbosity = verbosity
+        verbosity = level
 
 
 def has_verbosity(level: Union[int, Verbosity]) -> bool:


### PR DESCRIPTION
## Why are these changes needed?

The function set_verbosity would ignore verbosity levels given as the enum literal of Verbosity. For example `set_verbosity(Verbosity.V1_EXPERIMENT)`. This patch fixes the problem.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
