### PR TITLE
[flaky] Fix gcs test failure

### DIFF
--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -75,14 +75,14 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
 
   void TearDown() override {
     client_io_service_->stop();
+    client_io_service_thread_->join();
     gcs_client_->Disconnect();
 
-    gcs_server_->Stop();
     server_io_service_->stop();
     server_io_service_thread_->join();
+    gcs_server_->Stop();
     gcs_server_.reset();
     TestSetupUtil::FlushAllRedisServers();
-    client_io_service_thread_->join();
   }
 
   void RestartGcsServer() {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The failure is due to the wrong order of TearDown. We should join the thread first and then other services.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #15099 15099
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
