### PR TITLE
Deflak dask related task on win32

### DIFF
--- a/python/ray/tests/test_dask_callback.py
+++ b/python/ray/tests/test_dask_callback.py
@@ -13,7 +13,7 @@ def add(x, y):
 @unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
 def test_callback_active():
     """Test that callbacks are active within context"""
-    from ray.util.dask import ray_dask_get, RayDaskCallback
+    from ray.util.dask import RayDaskCallback
     assert not RayDaskCallback.ray_active
 
     with RayDaskCallback():

--- a/python/ray/tests/test_dask_callback.py
+++ b/python/ray/tests/test_dask_callback.py
@@ -1,8 +1,9 @@
 import dask
 import pytest
-
+import sys
 import ray
 import unittest
+
 
 @dask.delayed
 def add(x, y):

--- a/python/ray/tests/test_dask_callback.py
+++ b/python/ray/tests/test_dask_callback.py
@@ -2,7 +2,7 @@ import dask
 import pytest
 
 import ray
-
+import unittest
 
 @dask.delayed
 def add(x, y):
@@ -29,6 +29,7 @@ def test_presubmit_shortcircuit(ray_start_regular_shared):
     """
 
     from ray.util.dask import ray_dask_get, RayDaskCallback
+
     class PresubmitShortcircuitCallback(RayDaskCallback):
         def _ray_presubmit(self, task, key, deps):
             return 0
@@ -52,6 +53,7 @@ def test_pretask_posttask_shared_state(ray_start_regular_shared):
     """
 
     from ray.util.dask import ray_dask_get, RayDaskCallback
+
     class PretaskPosttaskCallback(RayDaskCallback):
         def _ray_pretask(self, key, object_refs):
             return key
@@ -73,6 +75,7 @@ def test_postsubmit(ray_start_regular_shared):
     """
 
     from ray.util.dask import ray_dask_get, RayDaskCallback
+
     class PostsubmitCallback(RayDaskCallback):
         def __init__(self, postsubmit_actor):
             self.postsubmit_actor = postsubmit_actor
@@ -108,6 +111,7 @@ def test_postsubmit_all(ray_start_regular_shared):
     """
 
     from ray.util.dask import ray_dask_get, RayDaskCallback
+
     class PostsubmitAllCallback(RayDaskCallback):
         def __init__(self, postsubmit_all_actor):
             self.postsubmit_all_actor = postsubmit_all_actor
@@ -142,6 +146,7 @@ def test_finish(ray_start_regular_shared):
     """
 
     from ray.util.dask import ray_dask_get, RayDaskCallback
+
     class FinishCallback(RayDaskCallback):
         def __init__(self, finish_actor):
             self.finish_actor = finish_actor
@@ -176,6 +181,7 @@ def test_multiple_callbacks(ray_start_regular_shared):
     """
 
     from ray.util.dask import ray_dask_get, RayDaskCallback
+
     class PostsubmitCallback(RayDaskCallback):
         def __init__(self, postsubmit_actor):
             self.postsubmit_actor = postsubmit_actor
@@ -215,6 +221,7 @@ def test_pretask_posttask_shared_state_multi(ray_start_regular_shared):
     """
 
     from ray.util.dask import ray_dask_get, RayDaskCallback
+
     class PretaskPosttaskCallback(RayDaskCallback):
         def __init__(self, suffix):
             self.suffix = suffix

--- a/python/ray/tests/test_dask_callback.py
+++ b/python/ray/tests/test_dask_callback.py
@@ -2,7 +2,6 @@ import dask
 import pytest
 
 import ray
-from ray.util.dask import ray_dask_get, RayDaskCallback
 
 
 @dask.delayed
@@ -10,8 +9,10 @@ def add(x, y):
     return x + y
 
 
+@unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
 def test_callback_active():
     """Test that callbacks are active within context"""
+    from ray.util.dask import ray_dask_get, RayDaskCallback
     assert not RayDaskCallback.ray_active
 
     with RayDaskCallback():
@@ -20,12 +21,14 @@ def test_callback_active():
     assert not RayDaskCallback.ray_active
 
 
+@unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
 def test_presubmit_shortcircuit(ray_start_regular_shared):
     """
     Test that presubmit return short-circuits task submission, and that task's
     result is set to the presubmit return value.
     """
 
+    from ray.util.dask import ray_dask_get, RayDaskCallback
     class PresubmitShortcircuitCallback(RayDaskCallback):
         def _ray_presubmit(self, task, key, deps):
             return 0
@@ -41,12 +44,14 @@ def test_presubmit_shortcircuit(ray_start_regular_shared):
     assert result == 0
 
 
+@unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
 def test_pretask_posttask_shared_state(ray_start_regular_shared):
     """
     Test that pretask return value is passed to corresponding posttask
     callback.
     """
 
+    from ray.util.dask import ray_dask_get, RayDaskCallback
     class PretaskPosttaskCallback(RayDaskCallback):
         def _ray_pretask(self, key, object_refs):
             return key
@@ -61,11 +66,13 @@ def test_pretask_posttask_shared_state(ray_start_regular_shared):
     assert result == 5
 
 
+@unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
 def test_postsubmit(ray_start_regular_shared):
     """
     Test that postsubmit is called after each task.
     """
 
+    from ray.util.dask import ray_dask_get, RayDaskCallback
     class PostsubmitCallback(RayDaskCallback):
         def __init__(self, postsubmit_actor):
             self.postsubmit_actor = postsubmit_actor
@@ -94,11 +101,13 @@ def test_postsubmit(ray_start_regular_shared):
     assert result == 5
 
 
+@unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
 def test_postsubmit_all(ray_start_regular_shared):
     """
     Test that postsubmit_all is called once.
     """
 
+    from ray.util.dask import ray_dask_get, RayDaskCallback
     class PostsubmitAllCallback(RayDaskCallback):
         def __init__(self, postsubmit_all_actor):
             self.postsubmit_all_actor = postsubmit_all_actor
@@ -126,11 +135,13 @@ def test_postsubmit_all(ray_start_regular_shared):
     assert result == 5
 
 
+@unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
 def test_finish(ray_start_regular_shared):
     """
     Test that finish callback is called once.
     """
 
+    from ray.util.dask import ray_dask_get, RayDaskCallback
     class FinishCallback(RayDaskCallback):
         def __init__(self, finish_actor):
             self.finish_actor = finish_actor
@@ -158,11 +169,13 @@ def test_finish(ray_start_regular_shared):
     assert result == 5
 
 
+@unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
 def test_multiple_callbacks(ray_start_regular_shared):
     """
     Test that multiple callbacks are supported.
     """
 
+    from ray.util.dask import ray_dask_get, RayDaskCallback
     class PostsubmitCallback(RayDaskCallback):
         def __init__(self, postsubmit_actor):
             self.postsubmit_actor = postsubmit_actor
@@ -194,12 +207,14 @@ def test_multiple_callbacks(ray_start_regular_shared):
     assert result == 5
 
 
+@unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
 def test_pretask_posttask_shared_state_multi(ray_start_regular_shared):
     """
     Test that pretask return values are passed to the correct corresponding
     posttask callbacks when multiple callbacks are given.
     """
 
+    from ray.util.dask import ray_dask_get, RayDaskCallback
     class PretaskPosttaskCallback(RayDaskCallback):
         def __init__(self, suffix):
             self.suffix = suffix


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Due to the API change in dask release, we need to disable tasks on dask on w32.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
