### PR TITLE
[rllib][Bugfix] Multiagent normalize action wrapper

### DIFF
--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -688,9 +688,9 @@ class Trainer(Trainable):
                     return NormalizeMultiAgentActionWrapper(env, self.config)
                 else:
                     raise ValueError(
-                        "Cannot apply NormalalizeWrapper to env of type {}, "
-                        "which does not subclass gym.Env or MultiAgentEnv.",
-                        type(env))
+                        "Cannot apply NormalalizeWrapper to env of type"
+                        "{}, which does not subclass gym.Env".format(
+                            type(env)), " or MultiAgentEnv.")
 
             self.env_creator = lambda env_config: normalize(inner(env_config))
 

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -14,13 +14,9 @@ import ray
 from ray.actor import ActorHandle
 from ray.exceptions import RayError
 from ray.rllib.agents.callbacks import DefaultCallbacks
-<<<<<<< HEAD
-=======
-from ray.rllib.env.normalize_actions import \
-    NormalizeActionWrapper, NormalizeMultiAgentActionWrapper
->>>>>>> normalize multiagent action wrapper added, modified trainer
 from ray.rllib.env.env_context import EnvContext
-from ray.rllib.env.normalize_actions import NormalizeActionWrapper
+from ray.rllib.env.normalize_actions import NormalizeActionWrapper, \
+    NormalizeMultiAgentActionWrapper
 from ray.rllib.env.utils import gym_env_creator
 from ray.rllib.evaluation.collectors.simple_list_collector import \
     SimpleListCollector

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -14,6 +14,11 @@ import ray
 from ray.actor import ActorHandle
 from ray.exceptions import RayError
 from ray.rllib.agents.callbacks import DefaultCallbacks
+<<<<<<< HEAD
+=======
+from ray.rllib.env.normalize_actions import \
+    NormalizeActionWrapper, NormalizeMultiAgentActionWrapper
+>>>>>>> normalize multiagent action wrapper added, modified trainer
 from ray.rllib.env.env_context import EnvContext
 from ray.rllib.env.normalize_actions import NormalizeActionWrapper
 from ray.rllib.env.utils import gym_env_creator
@@ -676,11 +681,16 @@ class Trainer(Trainable):
 
             def normalize(env):
                 import gym  # soft dependency
-                if not isinstance(env, gym.Env):
+                from ray.rllib.env.multi_agent_env import MultiAgentEnv
+                if isinstance(env, gym.Env):
+                    return NormalizeActionWrapper(env)
+                elif isinstance(env, MultiAgentEnv):
+                    return NormalizeMultiAgentActionWrapper(env, self.config)
+                else:
                     raise ValueError(
-                        "Cannot apply NormalizeActionActionWrapper to env of "
-                        "type {}, which does not subclass gym.Env.", type(env))
-                return NormalizeActionWrapper(env)
+                        "Cannot apply NormalalizeWrapper to env of type {}, "
+                        "which does not subclass gym.Env or MultiAgentEnv.",
+                        type(env))
 
             self.env_creator = lambda env_config: normalize(inner(env_config))
 

--- a/rllib/env/normalize_actions.py
+++ b/rllib/env/normalize_actions.py
@@ -1,6 +1,7 @@
 import gym
 from gym import spaces
 import numpy as np
+from ray.rllib.env.multi_agent_env import MultiAgentEnv
 
 
 class NormalizeActionWrapper(gym.ActionWrapper):
@@ -19,3 +20,55 @@ class NormalizeActionWrapper(gym.ActionWrapper):
 
     def reverse_action(self, action):
         raise NotImplementedError
+
+
+class NormalizeMultiAgentActionWrapper(MultiAgentEnv):
+    """Rescale the action space of multi agent environment"""
+
+    def __init__(self, env, config):
+        self.env = env
+        self.config = config
+        self.action_space = self.env.action_space
+        self.observation_space = self.env.observation_space
+        self.action_space_map = None
+
+    def step(self, action):
+        return self.env.step(self.action(action))
+
+    def reset(self):
+        return self.env.reset()
+
+    def action(self, action):
+        if not isinstance(self.env.action_space, spaces.Box):
+            return action
+
+        if self.action_space_map is None:
+            self.action_space_map = self.get_action_space_map(action)
+
+        for agent_id in action.keys():
+            action[agent_id] = self.rescale_action(
+                action[agent_id], self.action_space_map[agent_id])
+
+        return action
+
+    def rescale_action(self, action, action_space):
+        low, high = action_space.low, action_space.high
+        scaled_action = low + (action + 1.0) * (high - low) / 2.0
+        scaled_action = np.clip(scaled_action, low, high)
+        return scaled_action
+
+    def get_action_space_map(self, action):
+        action_space_map = {}
+        policies = self.config["multiagent"]["policies"]
+        policy_mapping_fn = self.config["multiagent"]["policy_mapping_fn"]
+
+        if len(policies) > 0 and policy_mapping_fn:
+            for agent_id in action.keys():
+                policy_id = policy_mapping_fn(agent_id)
+                policy_config = policies[policy_id]
+                action_space_map[agent_id] = policy_config[2]
+        else:
+            # When multiagent config is not given, use default action space
+            for agent_id in action.keys():
+                action_space_map[agent_id] = self.env.action_space
+        return action_space_map

--- a/rllib/tests/test_multi_agent_env.py
+++ b/rllib/tests/test_multi_agent_env.py
@@ -14,7 +14,7 @@ from ray.rllib.evaluation.rollout_worker import get_global_worker
 from ray.rllib.examples.policy.random_policy import RandomPolicy
 from ray.rllib.examples.env.multi_agent import MultiAgentCartPole, \
     BasicMultiAgent, EarlyDoneMultiAgent, FlexAgentsMultiAgent, \
-    RoundRobinMultiAgent, MultiAgentPendulum,
+    RoundRobinMultiAgent, MultiAgentPendulum
 from ray.rllib.evaluation.rollout_worker import RolloutWorker
 from ray.rllib.evaluation.tests.test_rollout_worker import MockPolicy
 from ray.rllib.env.base_env import _MultiAgentEnvToBaseEnv
@@ -453,7 +453,7 @@ class TestMultiAgentEnv(unittest.TestCase):
     def test_train_multiagent_sac_normalize_action(self):
         n = 2
         register_env("multi_agent_pendulum",
-                        lambda _: MultiAgentPendulum({"num_agents": n}))
+                     lambda _: MultiAgentPendulum({"num_agents": n}))
         single_env = gym.make("Pendulum-v0")
 
         def gen_policy():
@@ -483,6 +483,7 @@ class TestMultiAgentEnv(unittest.TestCase):
             if result["episode_reward_max"] >= -200 * n:
                 return
         raise Exception("failed to improve reward")
+
 
 if __name__ == "__main__":
     import pytest

--- a/rllib/tests/test_supported_multi_agent.py
+++ b/rllib/tests/test_supported_multi_agent.py
@@ -119,7 +119,7 @@ class TestSupportedMultiAgentOffPolicy(unittest.TestCase):
         check_support_multiagent("SAC", {
             "num_workers": 0,
             "buffer_size": 1000,
-            "normalize_actions": False,
+            "normalize_actions": True,
         })
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When using SAC in a multi-agent setting with config["normalize_actions"] as True, NormalizeActionWrapper error occurs.
This is because NormalizeActionWrapper only supports single agent gym.Env.

A simple solution to this is just setting "normalize_actions" as False. 
However, when "normalize_actions" is False, SAC is not working properly since the output of actor is not squashed by hyper tangent(ex. In torch model, this is done by TorchSquashedGaussian).
This can be shown easily by setting normalize_action as False which results in single agent SAC on Pendulum-v0 diverging.

This PR adds NormalizeMultiAgentActionWrapper for multiagent env(which inherits MultiAgentEnv) and modified agents/trainer.py where the wrapper is called.

Also, a test is added to test_multi_agent_env.py to show multiagent SAC in MultiAgentPendulum runs just as a single agent.
Lastly, test_supported_multi_agent.py is slightly modified such that "normalize_actions" in multiagent SAC config is True.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Fixes issue #7173, #8519

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
