### PR TITLE
[kubernetes][operator][test] Job fix

### DIFF
--- a/python/ray/tests/test_k8s_operator_examples.py
+++ b/python/ray/tests/test_k8s_operator_examples.py
@@ -72,7 +72,7 @@ def wait_for_job(job_pod):
     except subprocess.CalledProcessError as e:
         print(">>>Failed to check job logs.")
         print(e.output.decode())
-        raise e
+        return False
     success = "success" in out.lower()
     if success:
         print(">>>Job submission succeeded.")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

The logging improvement in PR https://github.com/ray-project/ray/pull/15074 revealed an issue with the operator test:
The test sometimes tries to read logs from a pod run by a job before the pod has started its container.
Currently this results in the test raising an error. 
This PR makes the test retry instead.

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
