### PR TITLE
[autoscaler][aws] Update _configure_key_pair to available_node_types

### DIFF
--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -363,8 +363,8 @@ def _key_assert_msg(node_type):
     elif node_type == NODE_TYPE_LEGACY_HEAD:
         return "`KeyName` missing for head node."
     else:
-        return "`KeyName` missing from the `node_config` of"
-        f" node type {node_type}"
+        return ("`KeyName` missing from the `node_config` of"
+                f" node type `{node_type}`.")
 
 
 def _configure_subnet(config):

--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -357,7 +357,7 @@ def _configure_key_pair(config):
     return config
 
 
-def _key_assert_msg(node_type):
+def _key_assert_msg(node_type: str) -> str:
     if node_type == NODE_TYPE_LEGACY_WORKER:
         return "`KeyName` missing for worker nodes."
     elif node_type == NODE_TYPE_LEGACY_HEAD:

--- a/python/ray/tests/test_k8s_operator_examples.py
+++ b/python/ray/tests/test_k8s_operator_examples.py
@@ -72,7 +72,7 @@ def wait_for_job(job_pod):
     except subprocess.CalledProcessError as e:
         print(">>>Failed to check job logs.")
         print(e.output.decode())
-        raise e
+        return False
     success = "success" in out.lower()
     if success:
         print(">>>Job submission succeeded.")

--- a/python/ray/tests/test_k8s_operator_examples.py
+++ b/python/ray/tests/test_k8s_operator_examples.py
@@ -72,7 +72,7 @@ def wait_for_job(job_pod):
     except subprocess.CalledProcessError as e:
         print(">>>Failed to check job logs.")
         print(e.output.decode())
-        return False
+        raise e
     success = "success" in out.lower()
     if success:
         print(">>>Job submission succeeded.")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Closes https://github.com/ray-project/ray/issues/15096 
Addresses key_pair part of https://github.com/ray-project/ray/issues/14856

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

Added tests to check key-pair filling logic and assertion error on missing KeyName.

Did manual test: Can launch AWS cluster by specifying KeyName under available node types.