### PR TITLE
[wip] fix doc theme

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -25,7 +25,7 @@ sphinx-gallery
 sphinx-jsonschema
 sphinx-tabs
 sphinx-version-warning
-sphinx-book-theme
+sphinx-book-theme==0.0.40
 sphinxcontrib.yt
 starlette
 tabulate

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -25,7 +25,7 @@ sphinx-gallery
 sphinx-jsonschema
 sphinx-tabs
 sphinx-version-warning
-sphinx-book-theme==0.0.40
+sphinx-book-theme==0.0.39
 sphinxcontrib.yt
 starlette
 tabulate

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -25,7 +25,7 @@ sphinx-gallery
 sphinx-jsonschema
 sphinx-tabs
 sphinx-version-warning
-sphinx-book-theme==0.0.39
+sphinx-book-theme==0.0.37
 sphinxcontrib.yt
 starlette
 tabulate


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It currently looks like there is a big space after each title in the ray docs. This attempts to fix it.

cc @edoakes @simon-mo 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(