### PR TITLE
[kubernetes][autoscaler][test] Kubernetes scale tests

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -176,9 +176,6 @@ test_python() {
       -python/ray/tests:test_resource_demand_scheduler
       -python/ray/tests:test_stress  # timeout
       -python/ray/tests:test_stress_sharded  # timeout
-      -python/ray/tests:test_k8s_cluster_launcher
-      -python/ray/tests/kubernetes_e2e:test_k8s_operator_examples
-      -python/ray/tests/kubernetes_e2e:test_k8s_operator_scaling
       -python/ray/tests:test_k8s_operator_mock
     )
   fi

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -177,7 +177,8 @@ test_python() {
       -python/ray/tests:test_stress  # timeout
       -python/ray/tests:test_stress_sharded  # timeout
       -python/ray/tests:test_k8s_cluster_launcher
-      -python/ray/tests:test_k8s_operator_examples
+      -python/ray/tests/kubernetes_e2e:test_k8s_operator_examples
+      -python/ray/tests/kubernetes_e2e:test_k8s_operator_scaling
       -python/ray/tests:test_k8s_operator_mock
     )
   fi

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -118,17 +118,6 @@ py_test_module_list(
 
 py_test_module_list(
   files = [
-    "test_k8s_cluster_launcher.py",
-    "test_k8s_operator_examples.py",
-  ],
-  size = "medium",
-  extra_srcs = SRCS,
-  deps = ["//:ray_lib"],
-  tags = ["kubernetes"]
-)
-
-py_test_module_list(
-  files = [
     "test_failure.py",
     "test_failure_2.py",
     "test_stress_failure.py",

--- a/python/ray/tests/kubernetes_e2e/test_k8s_operator_examples.py
+++ b/python/ray/tests/kubernetes_e2e/test_k8s_operator_examples.py
@@ -160,7 +160,7 @@ class KubernetesOperatorTest(unittest.TestCase):
             # Check that autoscaling respects minWorkers by waiting for
             # six pods in the namespace.
             print(">>>Waiting for pods to join clusters.")
-            wait_for_pods(30)
+            wait_for_pods(6)
 
             # Check that logging output looks normal (two workers connected to
             # ray cluster example-cluster.)

--- a/python/ray/tests/kubernetes_e2e/test_k8s_operator_examples.py
+++ b/python/ray/tests/kubernetes_e2e/test_k8s_operator_examples.py
@@ -25,14 +25,15 @@ PULL_POLICY_ENV = "KUBERNETES_OPERATOR_TEST_PULL_POLICY"
 PULL_POLICY = os.getenv(PULL_POLICY_ENV, "Always")
 
 RAY_PATH = os.path.abspath(
-    os.path.dirname(os.path.dirname(
-        os.path.dirname(os.path.dirname(os.path.dirname(__file__))))))
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.dirname(__file__))))))
 
 
 def retry_until_true(f):
     # Retry 60 times with 1 second delay between attempts.
     def f_with_retries(*args, **kwargs):
-        for _ in range(120):
+        for _ in range(240):
             if f(*args, **kwargs):
                 return
             else:

--- a/python/ray/tests/kubernetes_e2e/test_k8s_operator_examples.py
+++ b/python/ray/tests/kubernetes_e2e/test_k8s_operator_examples.py
@@ -1,5 +1,5 @@
 """Tests launch, teardown, and update of multiple Ray clusters using Kubernetes
-operator."""
+operator. Also tests submission of jobs via Ray client."""
 import copy
 import sys
 import os
@@ -25,8 +25,8 @@ PULL_POLICY_ENV = "KUBERNETES_OPERATOR_TEST_PULL_POLICY"
 PULL_POLICY = os.getenv(PULL_POLICY_ENV, "Always")
 
 RAY_PATH = os.path.abspath(
-    os.path.dirname(
-        os.path.dirname(os.path.dirname(os.path.dirname(__file__)))))
+    os.path.dirname(os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.dirname(__file__))))))
 
 
 def retry_until_true(f):
@@ -83,10 +83,8 @@ def wait_for_job(job_pod):
 
 
 def kubernetes_configs_directory():
-    here = os.path.realpath(__file__)
-    ray_python_root = os.path.dirname(os.path.dirname(here))
-    relative_path = "autoscaler/kubernetes"
-    return os.path.join(ray_python_root, relative_path)
+    relative_path = "python/ray/autoscaler/kubernetes"
+    return os.path.join(RAY_PATH, relative_path)
 
 
 def get_kubernetes_config_path(name):
@@ -162,7 +160,7 @@ class KubernetesOperatorTest(unittest.TestCase):
             # Check that autoscaling respects minWorkers by waiting for
             # six pods in the namespace.
             print(">>>Waiting for pods to join clusters.")
-            wait_for_pods(6)
+            wait_for_pods(30)
 
             # Check that logging output looks normal (two workers connected to
             # ray cluster example-cluster.)

--- a/python/ray/tests/kubernetes_e2e/test_k8s_operator_scaling.py
+++ b/python/ray/tests/kubernetes_e2e/test_k8s_operator_scaling.py
@@ -109,8 +109,9 @@ class KubernetesScaleTest(unittest.TestCase):
 
             command = f"kubectl -n {NAMESPACE}"\
                 " port-forward service/example-cluster-ray-head 10001:10001"
-            print("Port-forwarding head service")
-            self.proc = subprocess.Popen(command, shell=True)
+            command = command.split()
+            print(">>>Port-forwarding head service")
+            self.proc = subprocess.Popen(command)
             try:
                 submit_scaling_job(client_port="10001", num_tasks=15)
                 self.proc.kill()

--- a/python/ray/tests/kubernetes_e2e/test_k8s_operator_scaling.py
+++ b/python/ray/tests/kubernetes_e2e/test_k8s_operator_scaling.py
@@ -41,7 +41,7 @@ def submit_scaling_job(client_port, num_tasks):
     print(">>>Waiting for task output.")
     task_output = ray.get(futures, timeout=360)
 
-    assert task_output == [i for i in range(num_tasks)], "Tasks did not"\
+    assert task_output == list(range(num_tasks)), "Tasks did not"\
         "complete with expected output."
 
 

--- a/python/ray/tests/kubernetes_e2e/test_k8s_operator_scaling.py
+++ b/python/ray/tests/kubernetes_e2e/test_k8s_operator_scaling.py
@@ -1,0 +1,135 @@
+"""
+Tests scaling behavior of Kubernetes operator.
+"""
+import copy
+import kubernetes
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+import pytest
+import yaml
+
+import ray
+from test_k8s_operator_examples import\
+    get_operator_config_path, wait_for_pods, IMAGE, PULL_POLICY, NAMESPACE
+
+
+def submit_scaling_job(client_port, num_tasks):
+    @ray.remote(num_cpus=1)
+    def f(i):
+        time.sleep(60)
+        return i
+
+    # Wait a bit for the port-forwarding
+    time.sleep(5)
+
+    print(">>>Submitting tasks with Ray client.")
+    ray.util.connect(f"127.0.0.1:{client_port}")
+    futures = [f.remote(i) for i in range(num_tasks)]
+
+    print(">>>Verifying scale-up.")
+    # Operator pod plus number of tasks
+    # (each Ray pod has 1 CPU).
+    wait_for_pods(num_tasks + 1)
+
+    print(">>>Waiting for task output.")
+    task_output = ray.get(futures, timeout=360)
+
+    assert task_output == [i for i in range(num_tasks)], "Tasks did not"\
+        "complete with expected output."
+
+
+class KubernetesScaleTest(unittest.TestCase):
+    def test_scaling(self):
+        with tempfile.NamedTemporaryFile("w+") as example_cluster_file, \
+                tempfile.NamedTemporaryFile("w+") as operator_file:
+
+            example_cluster_config_path = get_operator_config_path(
+                "example_cluster.yaml")
+            operator_config_path = get_operator_config_path("operator.yaml")
+
+            operator_config = list(
+                yaml.safe_load_all(open(operator_config_path).read()))
+            example_cluster_config = yaml.safe_load(
+                open(example_cluster_config_path).read())
+
+            # Set image and pull policy
+            podTypes = example_cluster_config["spec"]["podTypes"]
+            pod_specs = [operator_config[-1]["spec"]] + [
+                podType["podConfig"]["spec"] for podType in podTypes
+            ]
+            for pod_spec in pod_specs:
+                pod_spec["containers"][0]["image"] = IMAGE
+                pod_spec["containers"][0]["imagePullPolicy"] = PULL_POLICY
+
+            # Config set-up for this test.
+            example_cluster_config["spec"]["maxWorkers"] = 100
+            example_cluster_config["spec"]["idleTimeoutMinutes"] = 1
+            worker_type = podTypes[1]
+            # Make sure we have the right one
+            assert "worker" in worker_type["name"]
+            worker_type["maxWorkers"] = 100
+            # Key for the first part of the test
+            worker_type["minWorkers"] = 30
+
+            yaml.dump(example_cluster_config, example_cluster_file)
+            yaml.dump_all(operator_config, operator_file)
+
+            files = [example_cluster_file, operator_file]
+            for file in files:
+                file.flush()
+
+            # Start operator and a 30-pod-cluster.
+            print(">>>Starting operator and a cluster.")
+            for file in files:
+                cmd = f"kubectl -n {NAMESPACE} apply -f {file.name}"
+                subprocess.check_call(cmd, shell=True)
+
+            # Check that autoscaling respects minWorkers by waiting for
+            # 32 pods in the namespace.
+            print(">>>Waiting for pods to join clusters.")
+            wait_for_pods(32)
+
+            # Check for graceful scale-down.
+            print(">>>Decreasing min workers to 0.")
+            example_cluster_edit = copy.deepcopy(example_cluster_config)
+            # No workers required:
+            example_cluster_edit["spec"]["podTypes"][1]["minWorkers"] = 0
+            yaml.dump(example_cluster_edit, example_cluster_file)
+            example_cluster_file.flush()
+            cm = f"kubectl -n {NAMESPACE} apply -f {example_cluster_file.name}"
+            subprocess.check_call(cm, shell=True)
+            print(">>>Sleeping for a minute while workers time-out.")
+            time.sleep(60)
+            print(">>>Verifying scale-down.")
+            wait_for_pods(2)
+
+            command = f"kubectl -n {NAMESPACE}"\
+                " port-forward service/example-cluster-ray-head 10001:10001"
+            print("Port-forwarding head service")
+            self.proc = subprocess.Popen(command, shell=True)
+            try:
+                submit_scaling_job(client_port="10001", num_tasks=15)
+                self.proc.terminate()
+            except Exception as e:
+                self.proc.terminate()
+                raise (e)
+
+            print(">>>Sleeping for a minute while workers time-out.")
+            time.sleep(60)
+            print(">>>Verifying scale-down.")
+            wait_for_pods(2)
+
+    def __del__(self):
+        try:
+            self.proc.terminate()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    kubernetes.config.load_kube_config()
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/kubernetes_e2e/test_k8s_operator_scaling.py
+++ b/python/ray/tests/kubernetes_e2e/test_k8s_operator_scaling.py
@@ -136,6 +136,7 @@ class KubernetesScaleTest(unittest.TestCase):
 
     def __del__(self):
         # To be safer, kill again:
+        # (does not raise an error if the process has already been killed)
         self.proc.kill()
 
 

--- a/python/ray/tests/kubernetes_e2e/test_k8s_operator_scaling.py
+++ b/python/ray/tests/kubernetes_e2e/test_k8s_operator_scaling.py
@@ -72,10 +72,10 @@ class KubernetesScaleTest(unittest.TestCase):
             example_cluster_config["spec"]["maxWorkers"] = 100
             example_cluster_config["spec"]["idleTimeoutMinutes"] = 1
             worker_type = podTypes[1]
-            # Make sure we have the right one
+            # Make sure we have the right type
             assert "worker" in worker_type["name"]
             worker_type["maxWorkers"] = 100
-            # Key for the first part of the test
+            # Key for the first part of this test:
             worker_type["minWorkers"] = 30
 
             yaml.dump(example_cluster_config, example_cluster_file)
@@ -99,7 +99,7 @@ class KubernetesScaleTest(unittest.TestCase):
             # Check scale-down.
             print(">>>Decreasing min workers to 0.")
             example_cluster_edit = copy.deepcopy(example_cluster_config)
-            # No workers required:
+            # Set minWorkers to 0:
             example_cluster_edit["spec"]["podTypes"][1]["minWorkers"] = 0
             yaml.dump(example_cluster_edit, example_cluster_file)
             example_cluster_file.flush()
@@ -119,12 +119,13 @@ class KubernetesScaleTest(unittest.TestCase):
             try:
                 # Wait a bit for the port-forwarding connection to be
                 # established.
-                time.sleep(5)
-                # Check that submission works
+                time.sleep(10)
+                # Check that job submission works
                 submit_scaling_job(client_port="10001", num_tasks=15)
                 # Clean up
                 self.proc.kill()
             except Exception as e:
+                # Clean up on failure
                 self.proc.kill()
                 raise (e)
 
@@ -134,10 +135,8 @@ class KubernetesScaleTest(unittest.TestCase):
             wait_for_pods(2)
 
     def __del__(self):
-        try:
-            self.proc.kill()
-        except Exception:
-            pass
+        # To be safer, kill again:
+        self.proc.kill()
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/kubernetes_e2e/test_k8s_operator_scaling.py
+++ b/python/ray/tests/kubernetes_e2e/test_k8s_operator_scaling.py
@@ -110,15 +110,13 @@ class KubernetesScaleTest(unittest.TestCase):
             command = f"kubectl -n {NAMESPACE}"\
                 " port-forward service/example-cluster-ray-head 10001:10001"
             command = command.split()
-            print(">>>Port-forwarding head service")
+            print(">>>Port-forwarding head service.")
             self.proc = subprocess.Popen(command)
             try:
                 submit_scaling_job(client_port="10001", num_tasks=15)
                 self.proc.kill()
-                self.proc.communicate()
             except Exception as e:
                 self.proc.kill()
-                self.proc.communicate()
                 raise (e)
 
             print(">>>Sleeping for a minute while workers time-out.")
@@ -129,7 +127,6 @@ class KubernetesScaleTest(unittest.TestCase):
     def __del__(self):
         try:
             self.proc.kill()
-            self.proc.communicate()
         except Exception:
             pass
 

--- a/python/ray/tests/kubernetes_e2e/test_k8s_operator_scaling.py
+++ b/python/ray/tests/kubernetes_e2e/test_k8s_operator_scaling.py
@@ -90,7 +90,7 @@ class KubernetesScaleTest(unittest.TestCase):
 
             # Check that autoscaling respects minWorkers by waiting for
             # 32 pods in the namespace.
-            print(">>>Waiting for pods to join clusters.")
+            print(">>>Waiting for pods to join cluster.")
             wait_for_pods(32)
 
             # Check for graceful scale-down.
@@ -113,9 +113,11 @@ class KubernetesScaleTest(unittest.TestCase):
             self.proc = subprocess.Popen(command, shell=True)
             try:
                 submit_scaling_job(client_port="10001", num_tasks=15)
-                self.proc.terminate()
+                self.proc.kill()
+                self.proc.communicate()
             except Exception as e:
-                self.proc.terminate()
+                self.proc.kill()
+                self.proc.communicate()
                 raise (e)
 
             print(">>>Sleeping for a minute while workers time-out.")
@@ -125,7 +127,8 @@ class KubernetesScaleTest(unittest.TestCase):
 
     def __del__(self):
         try:
-            self.proc.terminate()
+            self.proc.kill()
+            self.proc.communicate()
         except Exception:
             pass
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This is PR add an e2e test verifying scaling of the K8s operator under moderate loads.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
 
Tests pass consistently on the GKE cluster I use for experiments and on the relevant EKS cluster.
