### PR TITLE
[Core] Event loop instrumentation - manual instrumentation hooks, instrumentation for deadline timer and local stream socket.

### DIFF
--- a/src/ray/common/asio/instrumented_io_context.cc
+++ b/src/ray/common/asio/instrumented_io_context.cc
@@ -92,7 +92,6 @@ std::shared_ptr<StatsHandle> instrumented_io_context::RecordStart(const std::str
 
 void instrumented_io_context::RecordExecution(std::function<void()> fn,
                                               std::shared_ptr<StatsHandle> handle) {
-  handle->execution_recorded = true;
   int64_t start_execution = absl::GetCurrentTimeNanos();
   // Execute actual handler.
   fn();

--- a/src/ray/common/asio/instrumented_io_context.cc
+++ b/src/ray/common/asio/instrumented_io_context.cc
@@ -115,6 +115,7 @@ void instrumented_io_context::RecordExecution(const std::function<void()> &fn,
       global_stats->stats.max_queue_time = queue_time_ns;
     }
   }
+  handle->execution_recorded = true;
 }
 
 std::shared_ptr<GuardedHandlerStats> instrumented_io_context::GetOrCreate(

--- a/src/ray/common/asio/instrumented_io_context.cc
+++ b/src/ray/common/asio/instrumented_io_context.cc
@@ -92,6 +92,7 @@ std::shared_ptr<StatsHandle> instrumented_io_context::RecordStart(const std::str
 
 void instrumented_io_context::RecordExecution(std::function<void()> fn,
                                               std::shared_ptr<StatsHandle> handle) {
+  handle->execution_recorded = true;
   int64_t start_execution = absl::GetCurrentTimeNanos();
   // Execute actual handler.
   fn();

--- a/src/ray/common/asio/instrumented_io_context.h
+++ b/src/ray/common/asio/instrumented_io_context.h
@@ -72,10 +72,10 @@ struct StatsHandle {
   StatsHandle(std::string handler_name_, int64_t start_time_,
               std::shared_ptr<GuardedHandlerStats> handler_stats_,
               std::shared_ptr<GuardedGlobalStats> global_stats_)
-      : handler_name(handler_name_),
+      : handler_name(std::move(handler_name_)),
         start_time(start_time_),
-        handler_stats(handler_stats_),
-        global_stats(global_stats_) {}
+        handler_stats(std::move(handler_stats_)),
+        global_stats(std::move(global_stats_)) {}
 };
 
 /// A proxy for boost::asio::io_context that collects statistics about posted handlers.
@@ -114,7 +114,7 @@ class instrumented_io_context : public boost::asio::io_context {
   ///
   /// \param fn The function to execute and instrument.
   /// \param handle An opaque stats handle returned by RecordStart().
-  static void RecordExecution(std::function<void()> &fn,
+  static void RecordExecution(const std::function<void()> &fn,
                               std::shared_ptr<StatsHandle> handle);
 
   /// Returns a snapshot view of the global count, queueing, and execution statistics

--- a/src/ray/common/asio/instrumented_io_context.h
+++ b/src/ray/common/asio/instrumented_io_context.h
@@ -76,48 +76,48 @@ class instrumented_io_context : public boost::asio::io_context {
   void post(std::function<void()> handler, const std::string name = "UNKNOWN")
       LOCKS_EXCLUDED(mutex_);
 
-  /// Increments the  current and cumulative counts and returns the enqueueing time
+  /// Increments the current and cumulative counts and returns the enqueueing time
   /// for this handler.
   /// The returned enqueueing time and handler stats pointer should be given to a
-  /// subsequent Instrument() call. The handler stats is also returned in order to
+  /// subsequent RecordExecution() call. The handler stats is also returned in order to
   /// obviate the need for multiple handler stats table lookups, therefore reducing
   /// contention on the table lock.
   ///
   /// \param name A human-readable name to which collected stats will be associated.
   /// \return The time at which this handler was enqueued, in nanoseconds, and the
   ///  handler stats.
-  std::pair<int64_t, std::shared_ptr<GuardedHandlerStats>> Enqueue(
-      const std::string name = "UNKNOWN");
+  std::pair<int64_t, std::shared_ptr<GuardedHandlerStats>> RecordStart(
+      const std::string name);
 
   /// Increments the current and cumulative counts and returns the enqueueing time
   /// for this handler.
-  /// The returned enqueueing time should be given to a subsequent Instrument() call.
+  /// The returned enqueueing time should be given to a subsequent RecordExecution() call.
   ///
   /// \param stats The handler stats.
   /// \return The time at which this handler was enqueued, in nanonseconds.
-  static int64_t Enqueue(std::shared_ptr<GuardedHandlerStats> stats);
+  static int64_t RecordStart(std::shared_ptr<GuardedHandlerStats> stats);
 
   /// Records stats about the provided function's execution. This version of the
-  /// function exists in case there was no sensible Enqueue() call to be made.
+  /// function exists in case there was no sensible RecordStart() call to be made.
   ///
   /// \param fn The function to execute and instrument.
   /// \param name The human-readable name for the handler.
   /// \return The stats for this handler.
-  std::shared_ptr<GuardedHandlerStats> Instrument(std::function<void()> fn,
-                                                  const std::string name = "UNKNOWN");
+  std::shared_ptr<GuardedHandlerStats> RecordExecution(std::function<void()> fn,
+                                                       const std::string name);
 
   /// Records stats about the provided function's execution. The stats and enqueue_time
-  /// arguments should be taken from an Enqueue("some_handler_name") call.
+  /// arguments should be taken from a RecordStart("some_handler_name") call.
   ///
   /// \param fn The function to execute and instrument.
   /// \param stats The stats for the provided handler.
   /// \param global_stats The global stats for this event loop.
   /// \param enqueue_time The time at which this handler was enqueued for execution, in
   ///  nanoseconds.
-  static void Instrument(std::function<void()> fn,
-                         std::shared_ptr<GuardedHandlerStats> stats,
-                         std::shared_ptr<GuardedGlobalStats> global_stats,
-                         absl::optional<int64_t> enqueue_time = absl::nullopt);
+  static void RecordExecution(std::function<void()> fn,
+                              std::shared_ptr<GuardedHandlerStats> stats,
+                              std::shared_ptr<GuardedGlobalStats> global_stats,
+                              absl::optional<int64_t> enqueue_time = absl::nullopt);
 
   /// Returns a live guarded view of the global count, queueing, and execution statistics
   /// across all handlers.

--- a/src/ray/common/asio/instrumented_io_context.h
+++ b/src/ray/common/asio/instrumented_io_context.h
@@ -68,6 +68,7 @@ struct StatsHandle {
   int64_t start_time;
   std::shared_ptr<GuardedHandlerStats> handler_stats;
   std::shared_ptr<GuardedGlobalStats> global_stats;
+  bool execution_recorded = false;
 
   StatsHandle(std::string handler_name_, int64_t start_time_,
               std::shared_ptr<GuardedHandlerStats> handler_stats_,
@@ -76,6 +77,12 @@ struct StatsHandle {
         start_time(start_time_),
         handler_stats(handler_stats_),
         global_stats(global_stats_) {}
+
+  ~StatsHandle() {
+    RAY_CHECK(execution_recorded) << "Opaque stats handle for handler " << handler_name
+                                  << " returned from RecordStart() "
+                                     "must be passed to RecordExecution().";
+  }
 };
 
 /// A proxy for boost::asio::io_context that collects statistics about posted handlers.

--- a/src/ray/common/asio/instrumented_io_context.h
+++ b/src/ray/common/asio/instrumented_io_context.h
@@ -68,7 +68,6 @@ struct StatsHandle {
   int64_t start_time;
   std::shared_ptr<GuardedHandlerStats> handler_stats;
   std::shared_ptr<GuardedGlobalStats> global_stats;
-  bool execution_recorded = false;
 
   StatsHandle(std::string handler_name_, int64_t start_time_,
               std::shared_ptr<GuardedHandlerStats> handler_stats_,
@@ -77,12 +76,6 @@ struct StatsHandle {
         start_time(start_time_),
         handler_stats(handler_stats_),
         global_stats(global_stats_) {}
-
-  ~StatsHandle() {
-    RAY_CHECK(execution_recorded) << "Opaque stats handle for handler " << handler_name
-                                  << " returned from RecordStart() "
-                                     "must be passed to RecordExecution().";
-  }
 };
 
 /// A proxy for boost::asio::io_context that collects statistics about posted handlers.

--- a/src/ray/common/asio/instrumented_io_context.h
+++ b/src/ray/common/asio/instrumented_io_context.h
@@ -61,6 +61,23 @@ struct GuardedGlobalStats {
   mutable absl::Mutex mutex;
 };
 
+/// An opaque stats handle, used to manually instrument event loop handlers that don't
+/// hook into a .post() call.
+struct StatsHandle {
+  std::string handler_name;
+  int64_t start_time;
+  std::shared_ptr<GuardedHandlerStats> handler_stats;
+  std::shared_ptr<GuardedGlobalStats> global_stats;
+
+  StatsHandle(std::string handler_name_, int64_t start_time_,
+              std::shared_ptr<GuardedHandlerStats> handler_stats_,
+              std::shared_ptr<GuardedGlobalStats> global_stats_)
+      : handler_name(handler_name_),
+        start_time(start_time_),
+        handler_stats(handler_stats_),
+        global_stats(global_stats_) {}
+};
+
 /// A proxy for boost::asio::io_context that collects statistics about posted handlers.
 class instrumented_io_context : public boost::asio::io_context {
  public:
@@ -76,62 +93,29 @@ class instrumented_io_context : public boost::asio::io_context {
   void post(std::function<void()> handler, const std::string name = "UNKNOWN")
       LOCKS_EXCLUDED(mutex_);
 
-  /// Increments the current and cumulative counts and returns the enqueueing time
-  /// for this handler.
-  /// The returned enqueueing time and handler stats pointer should be given to a
-  /// subsequent RecordExecution() call. The handler stats is also returned in order to
-  /// obviate the need for multiple handler stats table lookups, therefore reducing
-  /// contention on the table lock.
+  /// Sets the queueing start time, increments the current and cumulative counts and
+  /// returns an opaque handle for these stats. This is used in conjunction with
+  /// RecordExecution() to manually instrument an event loop handler that doesn't call
+  /// .post().
+  ///
+  /// The returned opaque stats handle should be given to a subsequent RecordExecution()
+  /// call.
   ///
   /// \param name A human-readable name to which collected stats will be associated.
-  /// \return The time at which this handler was enqueued, in nanoseconds, and the
-  ///  handler stats.
-  std::pair<int64_t, std::shared_ptr<GuardedHandlerStats>> RecordStart(
-      const std::string name);
-
-  /// Increments the current and cumulative counts and returns the enqueueing time
-  /// for this handler.
-  /// The returned enqueueing time should be given to a subsequent RecordExecution() call.
-  ///
-  /// \param stats The handler stats.
-  /// \return The time at which this handler was enqueued, in nanonseconds.
-  static int64_t RecordStart(std::shared_ptr<GuardedHandlerStats> stats);
-
-  /// Records stats about the provided function's execution. This version of the
-  /// function exists in case there was no sensible RecordStart() call to be made.
-  ///
-  /// \param fn The function to execute and instrument.
-  /// \param name The human-readable name for the handler.
-  /// \return The stats for this handler.
-  std::shared_ptr<GuardedHandlerStats> RecordExecution(std::function<void()> fn,
-                                                       const std::string name);
-
-  /// Records stats about the provided function's execution. The stats and enqueue_time
-  /// arguments should be taken from a RecordStart("some_handler_name") call.
-  ///
-  /// \param fn The function to execute and instrument.
-  /// \param stats The stats for the provided handler.
-  /// \param global_stats The global stats for this event loop.
-  /// \param enqueue_time The time at which this handler was enqueued for execution, in
+  /// \param pad_start_ns How much to pad the observed queueing start time, in
   ///  nanoseconds.
+  /// \return An opaque stats handle, to be given to RecordExecution().
+  std::shared_ptr<StatsHandle> RecordStart(const std::string name,
+                                           int64_t pad_start_ns = 0);
+
+  /// Records stats about the provided function's execution. This is used in conjunction
+  /// with RecordStart() to manually instrument an event loop handler that doesn't call
+  /// .post().
+  ///
+  /// \param fn The function to execute and instrument.
+  /// \param handle An opaque stats handle returned by RecordStart().
   static void RecordExecution(std::function<void()> fn,
-                              std::shared_ptr<GuardedHandlerStats> stats,
-                              std::shared_ptr<GuardedGlobalStats> global_stats,
-                              absl::optional<int64_t> enqueue_time = absl::nullopt);
-
-  /// Returns a live guarded view of the global count, queueing, and execution statistics
-  /// across all handlers.
-  ///
-  /// \return A live guarded view of the global handler stats.
-  std::shared_ptr<GuardedGlobalStats> get_guarded_global_stats() const;
-
-  /// Returns a live guarded view of the count, queueing, and execution statistics for the
-  /// provided handler. If the handler stats doesn't yet exist, one is created.
-  ///
-  /// \param handler_name The name of the handler whose stats should be returned.
-  /// \return A live guarded view of the handler's stats.
-  std::shared_ptr<GuardedHandlerStats> get_guarded_handler_stats(
-      const std::string &handler_name) LOCKS_EXCLUDED(mutex_);
+                              std::shared_ptr<StatsHandle> handle);
 
   /// Returns a snapshot view of the global count, queueing, and execution statistics
   /// across all handlers.
@@ -164,7 +148,7 @@ class instrumented_io_context : public boost::asio::io_context {
  private:
   using HandlerStatsTable =
       absl::flat_hash_map<std::string, std::shared_ptr<GuardedHandlerStats>>;
-  /// Get an iterator to the stats for this handler if it exists, otherwise create the
+  /// Get the mutex-guarded stats for this handler if it exists, otherwise create the
   /// stats for this handler and return an iterator pointing to it.
   ///
   /// \param name A human-readable name for the handler, to be used for viewing stats

--- a/src/ray/common/asio/instrumented_io_context.h
+++ b/src/ray/common/asio/instrumented_io_context.h
@@ -105,7 +105,7 @@ class instrumented_io_context : public boost::asio::io_context {
   /// \param pad_start_ns How much to pad the observed queueing start time, in
   ///  nanoseconds.
   /// \return An opaque stats handle, to be given to RecordExecution().
-  std::shared_ptr<StatsHandle> RecordStart(const std::string name,
+  std::shared_ptr<StatsHandle> RecordStart(const std::string &name,
                                            int64_t pad_start_ns = 0);
 
   /// Records stats about the provided function's execution. This is used in conjunction
@@ -114,7 +114,7 @@ class instrumented_io_context : public boost::asio::io_context {
   ///
   /// \param fn The function to execute and instrument.
   /// \param handle An opaque stats handle returned by RecordStart().
-  static void RecordExecution(std::function<void()> fn,
+  static void RecordExecution(std::function<void()> &fn,
                               std::shared_ptr<StatsHandle> handle);
 
   /// Returns a snapshot view of the global count, queueing, and execution statistics
@@ -153,7 +153,7 @@ class instrumented_io_context : public boost::asio::io_context {
   ///
   /// \param name A human-readable name for the handler, to be used for viewing stats
   /// for the provided handler.
-  std::shared_ptr<GuardedHandlerStats> GetOrCreate(const std::string name);
+  std::shared_ptr<GuardedHandlerStats> GetOrCreate(const std::string &name);
 
   /// Global stats, across all handlers.
   std::shared_ptr<GuardedGlobalStats> global_stats_;

--- a/src/ray/common/asio/periodical_runner.cc
+++ b/src/ray/common/asio/periodical_runner.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "ray/common/asio/periodical_runner.h"
+#include "ray/common/ray_config.h"
 
 #include "ray/util/logging.h"
 
@@ -28,18 +29,24 @@ PeriodicalRunner::~PeriodicalRunner() {
   timers_.clear();
 }
 
-void PeriodicalRunner::RunFnPeriodically(std::function<void()> fn, uint64_t period_ms) {
+void PeriodicalRunner::RunFnPeriodically(std::function<void()> fn, uint64_t period_ms,
+                                         const std::string name) {
   if (period_ms > 0) {
     auto timer = std::make_shared<boost::asio::deadline_timer>(io_service_);
     timers_.push_back(timer);
-    DoRunFnPeriodically(fn, boost::posix_time::milliseconds(period_ms), *timer);
+    if (RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
+      DoRunFnPeriodically(fn, boost::posix_time::milliseconds(period_ms), *timer,
+                          io_service_.get_guarded_handler_stats(name),
+                          io_service_.get_guarded_global_stats());
+    } else {
+      DoRunFnPeriodically(fn, boost::posix_time::milliseconds(period_ms), *timer);
+    }
   }
 }
 
 void PeriodicalRunner::DoRunFnPeriodically(std::function<void()> fn,
                                            boost::posix_time::milliseconds period,
                                            boost::asio::deadline_timer &timer) {
-  fn();
   timer.expires_from_now(period);
   timer.async_wait([this, fn, period, &timer](const boost::system::error_code &error) {
     if (error == boost::asio::error::operation_aborted) {
@@ -49,6 +56,32 @@ void PeriodicalRunner::DoRunFnPeriodically(std::function<void()> fn,
     }
     RAY_CHECK(!error) << error.message();
     DoRunFnPeriodically(fn, period, timer);
+  });
+}
+
+void PeriodicalRunner::DoRunFnPeriodically(
+    std::function<void()> fn, boost::posix_time::milliseconds period,
+    boost::asio::deadline_timer &timer,
+    std::shared_ptr<GuardedHandlerStats> handler_stats,
+    std::shared_ptr<GuardedGlobalStats> global_stats,
+    absl::optional<int64_t> enqueue_time) {
+  io_service_.Instrument(fn, handler_stats, global_stats, enqueue_time);
+  timer.expires_from_now(period);
+  enqueue_time = io_service_.Enqueue(handler_stats);
+  timer.async_wait([this, fn, period, &timer, handler_stats, global_stats,
+                    enqueue_time](const boost::system::error_code &error) {
+    if (error == boost::asio::error::operation_aborted) {
+      // `operation_aborted` is set when `timer` is canceled or destroyed.
+      // The Monitor lifetime may be short than the object who use it. (e.g. gcs_server)
+      return;
+    }
+    RAY_CHECK(!error) << error.message();
+    RAY_CHECK(enqueue_time.has_value());
+    // NOTE: We add the timer period to the enqueue time in order only measure the time
+    // in which the handler was elgible to execute on the event loop but was queued by
+    // the event loop.
+    DoRunFnPeriodically(fn, period, timer, handler_stats, global_stats,
+                        enqueue_time.value() + period.total_nanoseconds());
   });
 }
 

--- a/src/ray/common/asio/periodical_runner.cc
+++ b/src/ray/common/asio/periodical_runner.cc
@@ -43,24 +43,26 @@ void PeriodicalRunner::RunFnPeriodically(std::function<void()> fn, uint64_t peri
   }
 }
 
-void PeriodicalRunner::DoRunFnPeriodically(std::function<void()> fn,
+void PeriodicalRunner::DoRunFnPeriodically(const std::function<void()> &fn,
                                            boost::posix_time::milliseconds period,
                                            boost::asio::deadline_timer &timer) {
   fn();
   timer.expires_from_now(period);
-  timer.async_wait([this, fn, period, &timer](const boost::system::error_code &error) {
-    if (error == boost::asio::error::operation_aborted) {
-      // `operation_aborted` is set when `timer` is canceled or destroyed.
-      // The Monitor lifetime may be short than the object who use it. (e.g. gcs_server)
-      return;
-    }
-    RAY_CHECK(!error) << error.message();
-    DoRunFnPeriodically(fn, period, timer);
-  });
+  timer.async_wait(
+      [this, fn = std::move(fn), period, &timer](const boost::system::error_code &error) {
+        if (error == boost::asio::error::operation_aborted) {
+          // `operation_aborted` is set when `timer` is canceled or destroyed.
+          // The Monitor lifetime may be short than the object who use it. (e.g.
+          // gcs_server)
+          return;
+        }
+        RAY_CHECK(!error) << error.message();
+        DoRunFnPeriodically(fn, period, timer);
+      });
 }
 
 void PeriodicalRunner::DoRunFnPeriodicallyInstrumented(
-    std::function<void()> &fn, boost::posix_time::milliseconds period,
+    const std::function<void()> &fn, boost::posix_time::milliseconds period,
     boost::asio::deadline_timer &timer, const std::string name) {
   fn();
   timer.expires_from_now(period);
@@ -68,10 +70,11 @@ void PeriodicalRunner::DoRunFnPeriodicallyInstrumented(
   // which the handler was elgible to execute on the event loop but was queued by the
   // event loop.
   auto stats_handle = io_service_.RecordStart(name, period.total_nanoseconds());
-  timer.async_wait([this, fn, period, &timer, stats_handle = std::move(stats_handle),
+  timer.async_wait([this, fn = std::move(fn), period, &timer,
+                    stats_handle = std::move(stats_handle),
                     name](const boost::system::error_code &error) {
     io_service_.RecordExecution(
-        [this, fn, error, period, &timer, name]() {
+        [this, fn = std::move(fn), error, period, &timer, name]() {
           if (error == boost::asio::error::operation_aborted) {
             // `operation_aborted` is set when `timer` is canceled or destroyed.
             // The Monitor lifetime may be short than the object who use it. (e.g.

--- a/src/ray/common/asio/periodical_runner.cc
+++ b/src/ray/common/asio/periodical_runner.cc
@@ -60,7 +60,7 @@ void PeriodicalRunner::DoRunFnPeriodically(std::function<void()> fn,
 }
 
 void PeriodicalRunner::DoRunFnPeriodicallyInstrumented(
-    std::function<void()> fn, boost::posix_time::milliseconds period,
+    std::function<void()> &fn, boost::posix_time::milliseconds period,
     boost::asio::deadline_timer &timer, const std::string name) {
   fn();
   timer.expires_from_now(period);

--- a/src/ray/common/asio/periodical_runner.h
+++ b/src/ray/common/asio/periodical_runner.h
@@ -39,12 +39,10 @@ class PeriodicalRunner {
                            boost::posix_time::milliseconds period,
                            boost::asio::deadline_timer &timer);
 
-  void DoRunFnPeriodically(std::function<void()> fn,
-                           boost::posix_time::milliseconds period,
-                           boost::asio::deadline_timer &timer,
-                           std::shared_ptr<GuardedHandlerStats> handler_stats,
-                           std::shared_ptr<GuardedGlobalStats> global_stats,
-                           absl::optional<int64_t> enqueue_time = absl::nullopt);
+  void DoRunFnPeriodicallyInstrumented(std::function<void()> fn,
+                                       boost::posix_time::milliseconds period,
+                                       boost::asio::deadline_timer &timer,
+                                       const std::string name);
 
   instrumented_io_context &io_service_;
   std::vector<std::shared_ptr<boost::asio::deadline_timer>> timers_;

--- a/src/ray/common/asio/periodical_runner.h
+++ b/src/ray/common/asio/periodical_runner.h
@@ -31,12 +31,20 @@ class PeriodicalRunner {
 
   ~PeriodicalRunner();
 
-  void RunFnPeriodically(std::function<void()> fn, uint64_t period_ms);
+  void RunFnPeriodically(std::function<void()> fn, uint64_t period_ms,
+                         const std::string name = "UNKNOWN");
 
  private:
   void DoRunFnPeriodically(std::function<void()> fn,
                            boost::posix_time::milliseconds period,
                            boost::asio::deadline_timer &timer);
+
+  void DoRunFnPeriodically(std::function<void()> fn,
+                           boost::posix_time::milliseconds period,
+                           boost::asio::deadline_timer &timer,
+                           std::shared_ptr<GuardedHandlerStats> handler_stats,
+                           std::shared_ptr<GuardedGlobalStats> global_stats,
+                           absl::optional<int64_t> enqueue_time = absl::nullopt);
 
   instrumented_io_context &io_service_;
   std::vector<std::shared_ptr<boost::asio::deadline_timer>> timers_;

--- a/src/ray/common/asio/periodical_runner.h
+++ b/src/ray/common/asio/periodical_runner.h
@@ -35,11 +35,11 @@ class PeriodicalRunner {
                          const std::string name = "UNKNOWN");
 
  private:
-  void DoRunFnPeriodically(std::function<void()> fn,
+  void DoRunFnPeriodically(const std::function<void()> &fn,
                            boost::posix_time::milliseconds period,
                            boost::asio::deadline_timer &timer);
 
-  void DoRunFnPeriodicallyInstrumented(std::function<void()> fn,
+  void DoRunFnPeriodicallyInstrumented(const std::function<void()> &fn,
                                        boost::posix_time::milliseconds period,
                                        boost::asio::deadline_timer &timer,
                                        const std::string name);

--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -108,7 +108,7 @@ void ServerConnection::WriteBufferAsync(
     const std::function<void(const ray::Status &)> &handler) {
   // Wait for the message to be written.
   if (RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
-    const auto &io_context =
+    auto &io_context =
         static_cast<instrumented_io_context &>(socket_.get_executor().context());
     const auto stats_handle =
         io_context.RecordStart("ClientConnection.async_write.WriteBufferAsync");
@@ -158,7 +158,7 @@ void ServerConnection::ReadBufferAsync(
   if (RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
     auto &io_context =
         static_cast<instrumented_io_context &>(socket_.get_executor().context());
-    auto stats_handle =
+    const auto stats_handle =
         io_context.RecordStart("ClientConnection.async_read.ReadBufferAsync");
     boost::asio::async_read(
         socket_, buffer,
@@ -290,7 +290,7 @@ void ServerConnection::DoAsyncWrites() {
   if (RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
     auto &io_context =
         static_cast<instrumented_io_context &>(socket_.get_executor().context());
-    auto stats_handle =
+    const auto stats_handle =
         io_context.RecordStart("ClientConnection.async_write.DoAsyncWrites");
     boost::asio::async_write(
         socket_, message_buffers,
@@ -382,7 +382,7 @@ void ClientConnection::ProcessMessages() {
     auto this_ptr = shared_ClientConnection_from_this();
     auto &io_context = static_cast<instrumented_io_context &>(
         ServerConnection::socket_.get_executor().context());
-    auto stats_handle =
+    const auto stats_handle =
         io_context.RecordStart("ClientConnection.async_read.ReadBufferAsync");
     boost::asio::async_read(
         ServerConnection::socket_, header,
@@ -423,7 +423,7 @@ void ClientConnection::ProcessMessageHeader(const boost::system::error_code &err
     auto this_ptr = shared_ClientConnection_from_this();
     auto &io_context = static_cast<instrumented_io_context &>(
         ServerConnection::socket_.get_executor().context());
-    auto stats_handle =
+    const auto stats_handle =
         io_context.RecordStart("ClientConnection.async_read.ReadBufferAsync");
     boost::asio::async_read(
         ServerConnection::socket_, boost::asio::buffer(read_message_),

--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -108,9 +108,9 @@ void ServerConnection::WriteBufferAsync(
     const std::function<void(const ray::Status &)> &handler) {
   // Wait for the message to be written.
   if (RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
-    auto &io_context =
+    const auto &io_context =
         static_cast<instrumented_io_context &>(socket_.get_executor().context());
-    auto stats_handle =
+    const auto stats_handle =
         io_context.RecordStart("ClientConnection.async_write.WriteBufferAsync");
     boost::asio::async_write(
         socket_, buffer,

--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -107,11 +107,28 @@ void ServerConnection::WriteBufferAsync(
     const std::vector<boost::asio::const_buffer> &buffer,
     const std::function<void(const ray::Status &)> &handler) {
   // Wait for the message to be written.
-  boost::asio::async_write(
-      socket_, buffer,
-      [handler](const boost::system::error_code &ec, size_t bytes_transferred) {
-        handler(boost_to_ray_status(ec));
-      });
+  if (RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
+    auto &io_context =
+        static_cast<instrumented_io_context &>(socket_.get_executor().context());
+    auto enqueue_time_and_stats =
+        io_context.Enqueue("ClientConnection.async_write.WriteBufferAsync");
+    auto global_stats = io_context.get_guarded_global_stats();
+    boost::asio::async_write(
+        socket_, buffer,
+        [handler, enqueue_time = enqueue_time_and_stats.first,
+         stats = enqueue_time_and_stats.second, global_stats,
+         &io_context](const boost::system::error_code &ec, size_t bytes_transferred) {
+          io_context.Instrument([handler, ec, enqueue_time, stats,
+                                 global_stats]() { handler(boost_to_ray_status(ec)); },
+                                stats, global_stats, enqueue_time);
+        });
+  } else {
+    boost::asio::async_write(
+        socket_, buffer,
+        [handler](const boost::system::error_code &ec, size_t bytes_transferred) {
+          handler(boost_to_ray_status(ec));
+        });
+  }
 }
 
 Status ServerConnection::ReadBuffer(
@@ -140,11 +157,28 @@ void ServerConnection::ReadBufferAsync(
     const std::vector<boost::asio::mutable_buffer> &buffer,
     const std::function<void(const ray::Status &)> &handler) {
   // Wait for the message to be read.
-  boost::asio::async_read(
-      socket_, buffer,
-      [handler](const boost::system::error_code &ec, size_t bytes_transferred) {
-        handler(boost_to_ray_status(ec));
-      });
+  if (RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
+    auto &io_context =
+        static_cast<instrumented_io_context &>(socket_.get_executor().context());
+    auto enqueue_time_and_stats =
+        io_context.Enqueue("ClientConnection.async_read.ReadBufferAsync");
+    auto global_stats = io_context.get_guarded_global_stats();
+    boost::asio::async_read(
+        socket_, buffer,
+        [handler, enqueue_time = enqueue_time_and_stats.first,
+         stats = enqueue_time_and_stats.second, global_stats,
+         &io_context](const boost::system::error_code &ec, size_t bytes_transferred) {
+          io_context.Instrument([handler, ec, enqueue_time, stats,
+                                 global_stats]() { handler(boost_to_ray_status(ec)); },
+                                stats, global_stats, enqueue_time);
+        });
+  } else {
+    boost::asio::async_read(
+        socket_, buffer,
+        [handler](const boost::system::error_code &ec, size_t bytes_transferred) {
+          handler(boost_to_ray_status(ec));
+        });
+  }
 }
 
 ray::Status ServerConnection::WriteMessage(int64_t type, int64_t length,
@@ -257,25 +291,58 @@ void ServerConnection::DoAsyncWrites() {
     return;
   }
   auto this_ptr = this->shared_from_this();
-  boost::asio::async_write(
-      ServerConnection::socket_, message_buffers,
-      [this, this_ptr, num_messages, call_handlers](
-          const boost::system::error_code &error, size_t bytes_transferred) {
-        ray::Status status = boost_to_ray_status(error);
-        if (error.value() == boost::system::errc::errc_t::broken_pipe) {
-          RAY_LOG(ERROR) << "Broken Pipe happened during calling "
-                         << "ServerConnection::DoAsyncWrites.";
-          // From now on, calling DoAsyncWrites will directly call the handler
-          // with this broken-pipe status.
-          async_write_broken_pipe_ = true;
-        } else if (!status.ok()) {
-          RAY_LOG(ERROR) << "Error encountered during calling "
-                         << "ServerConnection::DoAsyncWrites, message: "
-                         << status.message()
-                         << ", error code: " << static_cast<int>(error.value());
-        }
-        call_handlers(status, num_messages);
-      });
+  if (RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
+    auto &io_context =
+        static_cast<instrumented_io_context &>(socket_.get_executor().context());
+    auto enqueue_time_and_stats =
+        io_context.Enqueue("ClientConnection.async_write.DoAsyncWrites");
+    auto global_stats = io_context.get_guarded_global_stats();
+    boost::asio::async_write(
+        socket_, message_buffers,
+        [this, this_ptr, num_messages, call_handlers,
+         enqueue_time = enqueue_time_and_stats.first,
+         stats = enqueue_time_and_stats.second, global_stats = std::move(global_stats),
+         &io_context](const boost::system::error_code &error, size_t bytes_transferred) {
+          io_context.Instrument(
+              [this, this_ptr, num_messages, call_handlers, error, bytes_transferred]() {
+                ray::Status status = boost_to_ray_status(error);
+                if (error.value() == boost::system::errc::errc_t::broken_pipe) {
+                  RAY_LOG(ERROR) << "Broken Pipe happened during calling "
+                                 << "ServerConnection::DoAsyncWrites.";
+                  // From now on, calling DoAsyncWrites will directly call the handler
+                  // with this broken-pipe status.
+                  async_write_broken_pipe_ = true;
+                } else if (!status.ok()) {
+                  RAY_LOG(ERROR)
+                      << "Error encountered during calling "
+                      << "ServerConnection::DoAsyncWrites, message: " << status.message()
+                      << ", error code: " << static_cast<int>(error.value());
+                }
+                call_handlers(status, num_messages);
+              },
+              stats, global_stats, enqueue_time);
+        });
+  } else {
+    boost::asio::async_write(
+        ServerConnection::socket_, message_buffers,
+        [this, this_ptr, num_messages, call_handlers](
+            const boost::system::error_code &error, size_t bytes_transferred) {
+          ray::Status status = boost_to_ray_status(error);
+          if (error.value() == boost::system::errc::errc_t::broken_pipe) {
+            RAY_LOG(ERROR) << "Broken Pipe happened during calling "
+                           << "ServerConnection::DoAsyncWrites.";
+            // From now on, calling DoAsyncWrites will directly call the handler
+            // with this broken-pipe status.
+            async_write_broken_pipe_ = true;
+          } else if (!status.ok()) {
+            RAY_LOG(ERROR) << "Error encountered during calling "
+                           << "ServerConnection::DoAsyncWrites, message: "
+                           << status.message()
+                           << ", error code: " << static_cast<int>(error.value());
+          }
+          call_handlers(status, num_messages);
+        });
+  }
 }
 
 std::shared_ptr<ClientConnection> ClientConnection::Create(
@@ -317,10 +384,27 @@ void ClientConnection::ProcessMessages() {
       boost::asio::buffer(&read_type_, sizeof(read_type_)),
       boost::asio::buffer(&read_length_, sizeof(read_length_)),
   };
-  boost::asio::async_read(
-      ServerConnection::socket_, header,
-      boost::bind(&ClientConnection::ProcessMessageHeader,
-                  shared_ClientConnection_from_this(), boost::asio::placeholders::error));
+  if (RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
+    auto this_ptr = shared_ClientConnection_from_this();
+    auto &io_context = static_cast<instrumented_io_context &>(
+        ServerConnection::socket_.get_executor().context());
+    auto enqueue_time_and_stats =
+        io_context.Enqueue("ClientConnection.async_read.ReadBufferAsync");
+    auto global_stats = io_context.get_guarded_global_stats();
+    boost::asio::async_read(
+        ServerConnection::socket_, header,
+        [this, this_ptr, enqueue_time = enqueue_time_and_stats.first,
+         stats = enqueue_time_and_stats.second, global_stats,
+         &io_context](const boost::system::error_code &ec, size_t bytes_transferred) {
+          io_context.Instrument([this, this_ptr, ec]() { ProcessMessageHeader(ec); },
+                                stats, global_stats, enqueue_time);
+        });
+  } else {
+    boost::asio::async_read(ServerConnection::socket_, header,
+                            boost::bind(&ClientConnection::ProcessMessageHeader,
+                                        shared_ClientConnection_from_this(),
+                                        boost::asio::placeholders::error));
+  }
 }
 
 void ClientConnection::ProcessMessageHeader(const boost::system::error_code &error) {
@@ -343,10 +427,27 @@ void ClientConnection::ProcessMessageHeader(const boost::system::error_code &err
   read_message_.resize(read_length_);
   ServerConnection::bytes_read_ += read_length_;
   // Wait for the message to be read.
-  boost::asio::async_read(
-      ServerConnection::socket_, boost::asio::buffer(read_message_),
-      boost::bind(&ClientConnection::ProcessMessage, shared_ClientConnection_from_this(),
-                  boost::asio::placeholders::error));
+  if (RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
+    auto this_ptr = shared_ClientConnection_from_this();
+    auto &io_context = static_cast<instrumented_io_context &>(
+        ServerConnection::socket_.get_executor().context());
+    auto enqueue_time_and_stats =
+        io_context.Enqueue("ClientConnection.async_read.ReadBufferAsync");
+    auto global_stats = io_context.get_guarded_global_stats();
+    boost::asio::async_read(
+        ServerConnection::socket_, boost::asio::buffer(read_message_),
+        [this, this_ptr, enqueue_time = enqueue_time_and_stats.first,
+         stats = enqueue_time_and_stats.second, global_stats,
+         &io_context](const boost::system::error_code &ec, size_t bytes_transferred) {
+          io_context.Instrument([this, this_ptr, ec]() { ProcessMessage(ec); }, stats,
+                                global_stats, enqueue_time);
+        });
+  } else {
+    boost::asio::async_read(ServerConnection::socket_, boost::asio::buffer(read_message_),
+                            boost::bind(&ClientConnection::ProcessMessage,
+                                        shared_ClientConnection_from_this(),
+                                        boost::asio::placeholders::error));
+  }
 }
 
 bool ClientConnection::CheckRayCookie() {

--- a/src/ray/common/client_connection.h
+++ b/src/ray/common/client_connection.h
@@ -21,6 +21,7 @@
 #include <deque>
 #include <memory>
 
+#include "ray/common/asio/instrumented_io_context.h"
 #include "ray/common/id.h"
 #include "ray/common/status.h"
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -50,7 +50,7 @@ RAY_CONFIG(uint64_t, num_resource_report_periods_warning, 5)
 /// The duration between dumping debug info to logs, or 0 to disable.
 RAY_CONFIG(uint64_t, debug_dump_period_milliseconds, 10000)
 
-RAY_CONFIG(bool, asio_event_loop_stats_collection_enabled, true)
+RAY_CONFIG(bool, asio_event_loop_stats_collection_enabled, false)
 
 /// Whether to enable fair queueing between task classes in raylet. When
 /// fair queueing is enabled, the raylet will try to balance the number

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -50,7 +50,7 @@ RAY_CONFIG(uint64_t, num_resource_report_periods_warning, 5)
 /// The duration between dumping debug info to logs, or 0 to disable.
 RAY_CONFIG(uint64_t, debug_dump_period_milliseconds, 10000)
 
-RAY_CONFIG(bool, asio_event_loop_stats_collection_enabled, false)
+RAY_CONFIG(bool, asio_event_loop_stats_collection_enabled, true)
 
 /// Whether to enable fair queueing between task classes in raylet. When
 /// fair queueing is enabled, the raylet will try to balance the number

--- a/src/ray/core_worker/profiling.cc
+++ b/src/ray/core_worker/profiling.cc
@@ -37,7 +37,9 @@ Profiler::Profiler(WorkerContext &worker_context, const std::string &node_ip_add
   rpc_profile_data_->set_component_type(WorkerTypeString(worker_context.GetWorkerType()));
   rpc_profile_data_->set_component_id(worker_context.GetWorkerID().Binary());
   rpc_profile_data_->set_node_ip_address(node_ip_address);
-  periodical_runner_.RunFnPeriodically([this] { FlushEvents(); }, 1000);
+  periodical_runner_.RunFnPeriodically(
+      [this] { FlushEvents(); }, 1000,
+      "CoreWorker.deadline_timer.flush_profiling_events");
 }
 
 void Profiler::AddEvent(const rpc::ProfileTableData::ProfileEvent &event) {

--- a/src/ray/gcs/gcs_client/service_based_gcs_client.cc
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.cc
@@ -91,7 +91,8 @@ Status ServiceBasedGcsClient::Connect(instrumented_io_context &io_service) {
   periodical_runner_.reset(new PeriodicalRunner(io_service));
   periodical_runner_->RunFnPeriodically(
       [this] { PeriodicallyCheckGcsServerAddress(); },
-      RayConfig::instance().gcs_service_address_check_interval_milliseconds());
+      RayConfig::instance().gcs_service_address_check_interval_milliseconds(),
+      "GcsClient.deadline_timer.check_gcs_service_address");
 
   is_connected_ = true;
 

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -542,9 +542,9 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
   std::unique_ptr<instrumented_io_context> server_io_service_;
 
   // GCS client.
-  std::unique_ptr<gcs::GcsClient> gcs_client_;
   std::unique_ptr<std::thread> client_io_service_thread_;
   std::unique_ptr<instrumented_io_context> client_io_service_;
+  std::unique_ptr<gcs::GcsClient> gcs_client_;
 
   // Timeout waiting for GCS server reply, default is 2s.
   const std::chrono::milliseconds timeout_ms_{2000};

--- a/src/ray/gcs/gcs_server/gcs_heartbeat_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_heartbeat_manager.cc
@@ -51,7 +51,8 @@ void GcsHeartbeatManager::Start() {
         if (!is_started_) {
           periodical_runner_.RunFnPeriodically(
               [this] { DetectDeadNodes(); },
-              RayConfig::instance().raylet_heartbeat_period_milliseconds());
+              RayConfig::instance().raylet_heartbeat_period_milliseconds(),
+              "GcsHeartbeatManager.deadline_timer.detect_dead_nodes");
           is_started_ = true;
         }
       },

--- a/src/ray/gcs/gcs_server/gcs_redis_failure_detector.cc
+++ b/src/ray/gcs/gcs_server/gcs_redis_failure_detector.cc
@@ -30,7 +30,8 @@ void GcsRedisFailureDetector::Start() {
   RAY_LOG(INFO) << "Starting redis failure detector.";
   periodical_runner_.RunFnPeriodically(
       [this] { DetectRedis(); },
-      RayConfig::instance().gcs_redis_heartbeat_interval_milliseconds());
+      RayConfig::instance().gcs_redis_heartbeat_interval_milliseconds(),
+      "GcsRedisFailureDetector.deadline_timer.detect_redis_failure");
 }
 
 void GcsRedisFailureDetector::DetectRedis() {

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -27,7 +27,8 @@ GcsResourceManager::GcsResourceManager(
       gcs_table_storage_(gcs_table_storage) {
   periodical_runner_.RunFnPeriodically(
       [this] { SendBatchedResourceUsage(); },
-      RayConfig::instance().raylet_report_resources_period_milliseconds());
+      RayConfig::instance().raylet_report_resources_period_milliseconds(),
+      "GcsResourceManager.deadline_timer.send_batched_resource_usage");
 }
 
 void GcsResourceManager::HandleGetResources(const rpc::GetResourcesRequest &request,

--- a/src/ray/gcs/gcs_server/gcs_resource_report_poller.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_report_poller.cc
@@ -39,7 +39,9 @@ void GcsResourceReportPoller::Start() {
     RAY_LOG(DEBUG) << "GCSResourceReportPoller has stopped. This should only happen if "
                       "the cluster has stopped";
   }});
-  ticker_.RunFnPeriodically([this] { TryPullResourceReport(); }, 10);
+  ticker_.RunFnPeriodically(
+      [this] { TryPullResourceReport(); }, 10,
+      "GcsResourceReportPoller.deadline_timer.pull_resource_report");
 }
 
 void GcsResourceReportPoller::Stop() {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -131,7 +131,8 @@ HeartbeatSender::HeartbeatSender(NodeID self_node_id,
   last_heartbeat_at_ms_ = current_time_ms();
   heartbeat_runner_->RunFnPeriodically(
       [this] { Heartbeat(); },
-      RayConfig::instance().raylet_heartbeat_period_milliseconds());
+      RayConfig::instance().raylet_heartbeat_period_milliseconds(),
+      "NodeManager.deadline_timer.heartbeat");
 }
 
 HeartbeatSender::~HeartbeatSender() {
@@ -371,24 +372,29 @@ ray::Status NodeManager::RegisterGcs() {
         DumpDebugState();
         WarnResourceDeadlock();
       },
-      RayConfig::instance().debug_dump_period_milliseconds());
+      RayConfig::instance().debug_dump_period_milliseconds(),
+      "NodeManager.deadline_timer.debug_state_dump");
   uint64_t now_ms = current_time_ms();
   last_metrics_recorded_at_ms_ = now_ms;
   periodical_runner_.RunFnPeriodically([this] { RecordMetrics(); },
-                                       record_metrics_period_ms_);
+                                       record_metrics_period_ms_,
+                                       "NodeManager.deadline_timer.record_metrics");
   if (RayConfig::instance().free_objects_period_milliseconds() > 0) {
     periodical_runner_.RunFnPeriodically(
         [this] { local_object_manager_.FlushFreeObjects(); },
-        RayConfig::instance().free_objects_period_milliseconds());
+        RayConfig::instance().free_objects_period_milliseconds(),
+        "NodeManager.deadline_timer.flush_free_objects");
   }
   last_resource_report_at_ms_ = now_ms;
-  periodical_runner_.RunFnPeriodically([this] { ReportResourceUsage(); },
-                                       report_resources_period_ms_);
+  periodical_runner_.RunFnPeriodically(
+      [this] { ReportResourceUsage(); }, report_resources_period_ms_,
+      "NodeManager.deadline_timer.report_resource_usage");
   // Start the timer that gets object manager profiling information and sends it
   // to the GCS.
   periodical_runner_.RunFnPeriodically(
       [this] { GetObjectManagerProfileInfo(); },
-      RayConfig::instance().raylet_heartbeat_period_milliseconds());
+      RayConfig::instance().raylet_heartbeat_period_milliseconds(),
+      "NodeManager.deadline_timer.object_manager_profiling");
 
   /// If periodic asio stats print is enabled, it will print it.
   const auto asio_stats_print_interval_ms =
@@ -399,7 +405,8 @@ ray::Status NodeManager::RegisterGcs() {
         [this] {
           RAY_LOG(INFO) << "Event loop stats:\n\n" << io_service_.StatsString() << "\n\n";
         },
-        asio_stats_print_interval_ms);
+        asio_stats_print_interval_ms,
+        "NodeManager.deadline_timer.print_event_loop_stats");
   }
 
   return ray::Status::OK();

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -110,7 +110,8 @@ WorkerPool::WorkerPool(instrumented_io_context &io_service, const NodeID node_id
   if (RayConfig::instance().kill_idle_workers_interval_ms() > 0) {
     periodical_runner_.RunFnPeriodically(
         [this] { TryKillingIdleWorkers(); },
-        RayConfig::instance().kill_idle_workers_interval_ms());
+        RayConfig::instance().kill_idle_workers_interval_ms(),
+        "RayletWorkerPool.deadline_timer.kill_idle_workers");
   }
 }
 


### PR DESCRIPTION
## Why are these changes needed?

Unfortunately, the `io_context` automatic instrumentation hooks don't work with deadline timers and local stream sockets (`ClientConnection`), which creates a blind spot in our event loop instrumentation. This PR adds manual `RecordStart` and `RecordExecution` hooks for manually instrumenting a function, where `RecordStart` is used to let the instrumentation know that the handler is about to be submitted to the event loop, and `RecordExecution` wraps the handler with the rest of the instrumentation logic. We use these hooks to approximate a real instrumentation of deadline timers and local stream sockets.

I'm not very happy with the instrumentation complexity that's leaked to the application-level code nor the implementation in general, and I mainly consider this a stopgap solution to a better event loop instrumentation architecture.

This has been tested locally with the event loop instrumentation feature flag turned on; however, we will keep that feature flag off in master until #14715 is fixed.

## TODOs

- [x] Properly respect the feature flag for manual instrumentations (e.g. deadline timer and local stream socket instrumentations).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
