### PR TITLE
[serve] Make serve.start() idempotent

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -711,15 +711,18 @@ def start(
 
     register_custom_serializers()
 
+    try:
+        _get_global_client()
+        logger.info("Connecting to existing Serve instance.")
+        return
+    except RayServeException:
+        pass
+
     # Try to get serve controller if it exists
     if detached:
         controller_name = SERVE_CONTROLLER_NAME
         try:
             ray.get_actor(controller_name)
-            raise RayServeException("Called serve.start(detached=True) but a "
-                                    "detached instance is already running. "
-                                    "Please use serve.connect() to connect to "
-                                    "the running instance instead.")
         except ValueError:
             pass
     else:

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -721,10 +721,6 @@ def start(
     # Try to get serve controller if it exists
     if detached:
         controller_name = SERVE_CONTROLLER_NAME
-        try:
-            ray.get_actor(controller_name)
-        except ValueError:
-            pass
     else:
         controller_name = format_actor_name(SERVE_CONTROLLER_NAME,
                                             get_random_letters())

--- a/python/ray/serve/tests/test_api_new.py
+++ b/python/ray/serve/tests/test_api_new.py
@@ -301,6 +301,21 @@ def test_starlette_request(serve_instance):
     assert resp == long_string
 
 
+def test_start_idempotent(serve_instance):
+    @serve.deployment(name="start")
+    def func(*args):
+        pass
+
+    func.deploy()
+
+    assert "start" in serve.list_backends()
+    serve.start(detached=True)
+    serve.start()
+    serve.start(detached=True)
+    serve.start()
+    assert "start" in serve.list_backends()
+
+
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Avoids messy try/except logic.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
