### PR TITLE
Prioritize worker requests for objects over queued task arguments

### DIFF
--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -433,8 +433,8 @@ def test_ray_get_task_args_deadlock(shutdown_only):
         foo.remote(*task_args)
         ray.get(get_args)
 
-    for i in range(10):
-        print(i)
+    for i in range(5):
+        start = time.time()
         get_args = [
             ray.put(np.zeros(object_size, dtype=np.uint8))
             for _ in range(num_objects)
@@ -444,6 +444,7 @@ def test_ray_get_task_args_deadlock(shutdown_only):
             for _ in range(num_objects)
         ]
         ray.get(test_deadlock.remote(get_args, task_args))
+        print(f"round {i} finished in {time.time() - start}")
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -408,6 +408,44 @@ def test_max_pinned_args_memory(shutdown_only):
     ray.get(large_arg.remote(ref))
 
 
+@pytest.mark.timeout(30)
+def test_ray_get_task_args_deadlock(shutdown_only):
+    cluster = Cluster()
+    object_size = int(6e6)
+    num_objects = 10
+    # Head node can fit all of the objects at once.
+    cluster.add_node(
+        num_cpus=0, object_store_memory=4 * num_objects * object_size)
+    cluster.wait_for_nodes()
+    ray.init(address=cluster.address)
+
+    # Worker node can only fit 1 task at a time.
+    cluster.add_node(
+        num_cpus=1, object_store_memory=1.5 * num_objects * object_size)
+    cluster.wait_for_nodes()
+
+    @ray.remote
+    def foo(*args):
+        return
+
+    @ray.remote
+    def test_deadlock(get_args, task_args):
+        foo.remote(*task_args)
+        ray.get(get_args)
+
+    for i in range(10):
+        print(i)
+        get_args = [
+            ray.put(np.zeros(object_size, dtype=np.uint8))
+            for _ in range(num_objects)
+        ]
+        task_args = [
+            ray.put(np.zeros(object_size, dtype=np.uint8))
+            for _ in range(num_objects)
+        ]
+        ray.get(test_deadlock.remote(get_args, task_args))
+
+
 if __name__ == "__main__":
     import pytest
     import sys

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -210,7 +210,7 @@ uint64_t ObjectManager::Pull(const std::vector<rpc::ObjectReference> &object_ref
                              bool is_worker_request) {
   std::vector<rpc::ObjectReference> objects_to_locate;
   auto request_id =
-      pull_manager_->Pull(object_refs, &objects_to_locate, is_worker_request);
+      pull_manager_->Pull(object_refs, is_worker_request, &objects_to_locate);
 
   const auto &callback = [this](const ObjectID &object_id,
                                 const std::unordered_set<NodeID> &client_ids,

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -206,9 +206,11 @@ void ObjectManager::HandleObjectDeleted(const ObjectID &object_id) {
   pull_manager_->ResetRetryTimer(object_id);
 }
 
-uint64_t ObjectManager::Pull(const std::vector<rpc::ObjectReference> &object_refs) {
+uint64_t ObjectManager::Pull(const std::vector<rpc::ObjectReference> &object_refs,
+                             bool is_worker_request) {
   std::vector<rpc::ObjectReference> objects_to_locate;
-  auto request_id = pull_manager_->Pull(object_refs, &objects_to_locate);
+  auto request_id =
+      pull_manager_->Pull(object_refs, &objects_to_locate, is_worker_request);
 
   const auto &callback = [this](const ObjectID &object_id,
                                 const std::unordered_set<NodeID> &client_ids,

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -98,7 +98,8 @@ class ObjectStoreRunner {
 
 class ObjectManagerInterface {
  public:
-  virtual uint64_t Pull(const std::vector<rpc::ObjectReference> &object_refs) = 0;
+  virtual uint64_t Pull(const std::vector<rpc::ObjectReference> &object_refs,
+                        bool is_worker_request) = 0;
   virtual void CancelPull(uint64_t request_id) = 0;
   virtual bool PullRequestActiveOrWaitingForMetadata(uint64_t request_id) const = 0;
   virtual ~ObjectManagerInterface(){};
@@ -247,8 +248,12 @@ class ObjectManager : public ObjectManagerInterface,
   /// bundle local until the request is canceled with the returned ID.
   ///
   /// \param object_refs The bundle of objects that must be made local.
+  /// \param is_worker_request Whether this is a (`ray.get` or `ray.wait`)
+  /// request from a worker. If false, then it should be a request for a queued
+  /// task's arguments.
   /// \return A request ID that can be used to cancel the request.
-  uint64_t Pull(const std::vector<rpc::ObjectReference> &object_refs) override;
+  uint64_t Pull(const std::vector<rpc::ObjectReference> &object_refs,
+                bool is_worker_request) override;
 
   /// Cancels the pull request with the given ID. This cancels any fetches for
   /// objects that were passed to the original pull request, if no other pull

--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -23,9 +23,18 @@ PullManager::PullManager(
       gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {}
 
 uint64_t PullManager::Pull(const std::vector<rpc::ObjectReference> &object_ref_bundle,
-                           std::vector<rpc::ObjectReference> *objects_to_locate) {
-  auto bundle_it =
-      pull_request_bundles_.emplace(next_req_id_++, std::move(object_ref_bundle)).first;
+                           std::vector<rpc::ObjectReference> *objects_to_locate,
+                           bool is_worker_request) {
+  Queue::iterator bundle_it;
+  if (is_worker_request) {
+    bundle_it =
+        worker_request_bundles_.emplace(next_req_id_++, std::move(object_ref_bundle))
+            .first;
+  } else {
+    bundle_it =
+        task_argument_bundles_.emplace(next_req_id_++, std::move(object_ref_bundle))
+            .first;
+  }
   RAY_LOG(DEBUG) << "Start pull request " << bundle_it->first
                  << ". Bundle size: " << bundle_it->second.objects.size();
 
@@ -57,10 +66,34 @@ uint64_t PullManager::Pull(const std::vector<rpc::ObjectReference> &object_ref_b
   return bundle_it->first;
 }
 
-bool PullManager::ActivateNextPullBundleRequest(
-    const std::map<uint64_t, PullBundleRequest>::iterator &next_request_it,
-    std::vector<ObjectID> *objects_to_pull) {
-  // Activate the bundle.
+bool PullManager::ActivateNextPullBundleRequest(const Queue &bundles,
+                                                uint64_t *highest_req_id_being_pulled,
+                                                std::vector<ObjectID> *objects_to_pull) {
+  // Get the next pull request in the queue.
+  const auto last_request_it = bundles.find(*highest_req_id_being_pulled);
+  auto next_request_it = last_request_it;
+  if (next_request_it == bundles.end()) {
+    // No requests are active. Get the first request in the queue.
+    next_request_it = bundles.begin();
+  } else {
+    next_request_it++;
+  }
+
+  if (next_request_it == bundles.end()) {
+    // No requests in the queue.
+    return false;
+  }
+
+  if (next_request_it->second.num_object_sizes_missing > 0) {
+    // There is at least one object size missing. We should not activate the
+    // bundle, since it may put us over the available capacity.
+    return false;
+  }
+
+  RAY_LOG(DEBUG) << "Activating request " << next_request_it->first
+                 << " num bytes being pulled: " << num_bytes_being_pulled_
+                 << " num bytes available: " << num_bytes_available_;
+  // Activate the pull bundle request.
   for (const auto &ref : next_request_it->second.objects) {
     absl::MutexLock lock(&active_objects_mu_);
     auto obj_id = ObjectRefToId(ref);
@@ -80,13 +113,14 @@ bool PullManager::ActivateNextPullBundleRequest(
   }
 
   // Update the pointer to the last pull request that we are actively pulling.
-  RAY_CHECK(next_request_it->first > highest_req_id_being_pulled_);
-  highest_req_id_being_pulled_ = next_request_it->first;
+  RAY_CHECK(next_request_it->first > *highest_req_id_being_pulled);
+  *highest_req_id_being_pulled = next_request_it->first;
   return true;
 }
 
 void PullManager::DeactivatePullBundleRequest(
-    const std::map<uint64_t, PullBundleRequest>::iterator &request_it,
+    const Queue &bundles, const Queue::iterator &request_it,
+    uint64_t *highest_req_id_being_pulled,
     std::unordered_set<ObjectID> *objects_to_cancel) {
   for (const auto &ref : request_it->second.objects) {
     absl::MutexLock lock(&active_objects_mu_);
@@ -108,11 +142,11 @@ void PullManager::DeactivatePullBundleRequest(
 
   // If this was the last active request, update the pointer to its
   // predecessor, if one exists.
-  if (highest_req_id_being_pulled_ == request_it->first) {
-    if (request_it == pull_request_bundles_.begin()) {
-      highest_req_id_being_pulled_ = 0;
+  if (*highest_req_id_being_pulled == request_it->first) {
+    if (request_it == bundles.begin()) {
+      *highest_req_id_being_pulled = 0;
     } else {
-      highest_req_id_being_pulled_ = std::prev(request_it)->first;
+      *highest_req_id_being_pulled = std::prev(request_it)->first;
     }
   }
 }
@@ -123,54 +157,74 @@ void PullManager::UpdatePullsBasedOnAvailableMemory(size_t num_bytes_available) 
   }
   num_bytes_available_ = num_bytes_available;
 
-  // While there is available capacity, activate the next pull request.
+  // If there are task requests being pulled and worker requests queued, try to
+  // activate all of the worker requests, even if it puts us over the number of
+  // bytes available. We do this to prioritize worker requests over task
+  // requests.
   std::vector<ObjectID> objects_to_pull;
+  if (highest_task_req_id_being_pulled_ != 0) {
+    bool requests_remaining = true;
+    while (requests_remaining) {
+      requests_remaining = ActivateNextPullBundleRequest(
+          worker_request_bundles_, &highest_worker_req_id_being_pulled_,
+          &objects_to_pull);
+    }
+  }
+
+  // While we are under capacity, try to activate requests, starting with the
+  // worker request queue, then moving to the task request queue.
   while (num_bytes_being_pulled_ < num_bytes_available_) {
-    // Get the next pull request in the queue.
-    const auto last_request_it = pull_request_bundles_.find(highest_req_id_being_pulled_);
-    auto next_request_it = last_request_it;
-    if (next_request_it == pull_request_bundles_.end()) {
-      // No requests are active. Get the first request in the queue.
-      next_request_it = pull_request_bundles_.begin();
-    } else {
-      next_request_it++;
-    }
-
-    if (next_request_it == pull_request_bundles_.end()) {
-      // No requests in the queue.
+    if (!ActivateNextPullBundleRequest(worker_request_bundles_,
+                                       &highest_worker_req_id_being_pulled_,
+                                       &objects_to_pull)) {
       break;
     }
-
-    if (next_request_it->second.num_object_sizes_missing > 0) {
-      // There is at least one object size missing. We should not activate the
-      // bundle, since it may put us over the available capacity.
-      break;
-    }
-
-    RAY_LOG(DEBUG) << "Activating request " << next_request_it->first
-                   << " num bytes being pulled: " << num_bytes_being_pulled_
-                   << " num bytes available: " << num_bytes_available_;
-    // There is another pull bundle request that we could try, and there is
-    // enough space. Activate the next pull bundle request in the queue.
-    if (!ActivateNextPullBundleRequest(next_request_it, &objects_to_pull)) {
-      // This pull bundle request could not be activated, due to lack of object
-      // size information. Wait until we have object size information before
-      // activating this pull bundle.
+  }
+  while (num_bytes_being_pulled_ < num_bytes_available_) {
+    if (!ActivateNextPullBundleRequest(task_argument_bundles_,
+                                       &highest_task_req_id_being_pulled_,
+                                       &objects_to_pull)) {
       break;
     }
   }
 
   std::unordered_set<ObjectID> object_ids_to_cancel;
-  // While the total bytes requested is over the available capacity, deactivate
-  // the last pull request, ordered by request ID.
+  // While we are over capacity, deactivate requests starting from the back of
+  // the task request queue.
   while (num_bytes_being_pulled_ > num_bytes_available_) {
-    RAY_LOG(DEBUG) << "Deactivating request " << highest_req_id_being_pulled_
+    if (highest_task_req_id_being_pulled_ == 0) {
+      // No task requests are active.
+      break;
+    }
+    RAY_LOG(DEBUG) << "Deactivating task args request "
+                   << highest_task_req_id_being_pulled_
                    << " num bytes being pulled: " << num_bytes_being_pulled_
                    << " num bytes available: " << num_bytes_available_;
-    const auto last_request_it = pull_request_bundles_.find(highest_req_id_being_pulled_);
-    RAY_CHECK(last_request_it != pull_request_bundles_.end());
-    DeactivatePullBundleRequest(last_request_it, &object_ids_to_cancel);
+    const auto last_request_it =
+        task_argument_bundles_.find(highest_task_req_id_being_pulled_);
+    RAY_CHECK(last_request_it != task_argument_bundles_.end());
+    DeactivatePullBundleRequest(task_argument_bundles_, last_request_it,
+                                &highest_task_req_id_being_pulled_,
+                                &object_ids_to_cancel);
   }
+
+  // If we are still over capacity, deactivate requests starting from the back
+  // of the worker request queue.
+  while (num_bytes_being_pulled_ > num_bytes_available_) {
+    RAY_LOG(DEBUG) << "Deactivating worker request "
+                   << highest_worker_req_id_being_pulled_
+                   << " num bytes being pulled: " << num_bytes_being_pulled_
+                   << " num bytes available: " << num_bytes_available_;
+    const auto last_request_it =
+        worker_request_bundles_.find(highest_worker_req_id_being_pulled_);
+    RAY_CHECK(last_request_it != worker_request_bundles_.end());
+    DeactivatePullBundleRequest(worker_request_bundles_, last_request_it,
+                                &highest_worker_req_id_being_pulled_,
+                                &object_ids_to_cancel);
+  }
+
+  // While the total bytes requested is over the available capacity, deactivate
+  // the last pull request, ordered by request ID.
   for (const auto &obj_id : object_ids_to_cancel) {
     // Call the cancellation callback outside of the lock.
     cancel_pull_request_(obj_id);
@@ -189,22 +243,24 @@ void PullManager::UpdatePullsBasedOnAvailableMemory(size_t num_bytes_available) 
 }
 
 void PullManager::TriggerOutOfMemoryHandlingIfNeeded() {
-  if (pull_request_bundles_.empty()) {
-    // No requests queued.
-    return;
-  }
-
-  const auto head = pull_request_bundles_.begin();
-  if (highest_req_id_being_pulled_ >= head->first) {
-    // At least one request is being actively pulled, so there is currently
-    // enough space.
+  if (highest_worker_req_id_being_pulled_ > 0 || highest_task_req_id_being_pulled_ > 0) {
+    // At least one worker request is being actively pulled, so there is
+    // currently enough space.
     return;
   }
 
   // No requests are being pulled. Check whether this is because we don't have
   // object size information yet.
+  auto head = worker_request_bundles_.begin();
+  if (head == worker_request_bundles_.end()) {
+    head = task_argument_bundles_.begin();
+    if (head == task_argument_bundles_.end()) {
+      // No requests queued.
+      return;
+    }
+  }
   if (head->second.num_object_sizes_missing > 0) {
-    // Wait for the size information before triggering OOM
+    // Wait for the size information before triggering OOM.
     return;
   }
 
@@ -230,13 +286,25 @@ void PullManager::TriggerOutOfMemoryHandlingIfNeeded() {
 
 std::vector<ObjectID> PullManager::CancelPull(uint64_t request_id) {
   RAY_LOG(DEBUG) << "Cancel pull request " << request_id;
-  auto bundle_it = pull_request_bundles_.find(request_id);
-  RAY_CHECK(bundle_it != pull_request_bundles_.end());
+
+  Queue *request_queue = nullptr;
+  uint64_t *highest_req_id_being_pulled = nullptr;
+  auto bundle_it = worker_request_bundles_.find(request_id);
+  if (bundle_it != worker_request_bundles_.end()) {
+    request_queue = &worker_request_bundles_;
+    highest_req_id_being_pulled = &highest_worker_req_id_being_pulled_;
+  } else {
+    bundle_it = task_argument_bundles_.find(request_id);
+    request_queue = &task_argument_bundles_;
+    highest_req_id_being_pulled = &highest_task_req_id_being_pulled_;
+    RAY_CHECK(bundle_it != task_argument_bundles_.end());
+  }
 
   // If the pull request was being actively pulled, deactivate it now.
-  if (bundle_it->first <= highest_req_id_being_pulled_) {
+  if (bundle_it->first <= *highest_req_id_being_pulled) {
     std::unordered_set<ObjectID> object_ids_to_cancel;
-    DeactivatePullBundleRequest(bundle_it, &object_ids_to_cancel);
+    DeactivatePullBundleRequest(*request_queue, bundle_it, highest_req_id_being_pulled,
+                                &object_ids_to_cancel);
     for (const auto &obj_id : object_ids_to_cancel) {
       // Call the cancellation callback outside of the lock.
       cancel_pull_request_(obj_id);
@@ -260,7 +328,7 @@ std::vector<ObjectID> PullManager::CancelPull(uint64_t request_id) {
       object_ids_to_cancel_subscription.push_back(obj_id);
     }
   }
-  pull_request_bundles_.erase(bundle_it);
+  request_queue->erase(bundle_it);
 
   // We need to update the pulls in case there is another request(s) after this
   // request that can now be activated. We do this after erasing the cancelled
@@ -290,7 +358,11 @@ void PullManager::OnLocationChange(const ObjectID &object_id,
     it->second.object_size = object_size;
     it->second.object_size_set = true;
     for (auto &bundle_request_id : it->second.bundle_request_ids) {
-      auto bundle_it = pull_request_bundles_.find(bundle_request_id);
+      auto bundle_it = worker_request_bundles_.find(bundle_request_id);
+      if (bundle_it == worker_request_bundles_.end()) {
+        bundle_it = task_argument_bundles_.find(bundle_request_id);
+        RAY_CHECK(bundle_it != task_argument_bundles_.end());
+      }
       bundle_it->second.RegisterObjectSize(object_size);
     }
 
@@ -450,13 +522,21 @@ bool PullManager::IsObjectActive(const ObjectID &object_id) const {
 }
 
 bool PullManager::PullRequestActiveOrWaitingForMetadata(uint64_t request_id) const {
-  if (request_id <= highest_req_id_being_pulled_) {
+  const uint64_t *highest_req_id_being_pulled = nullptr;
+  auto bundle_it = worker_request_bundles_.find(request_id);
+  if (bundle_it != worker_request_bundles_.end()) {
+    highest_req_id_being_pulled = &highest_worker_req_id_being_pulled_;
+  } else {
+    bundle_it = task_argument_bundles_.find(request_id);
+    RAY_CHECK(bundle_it != task_argument_bundles_.end());
+    highest_req_id_being_pulled = &highest_task_req_id_being_pulled_;
+  }
+
+  if (request_id <= *highest_req_id_being_pulled) {
     // This request is in the prefix of the queue that is being pulled.
     return true;
   }
-  auto it = pull_request_bundles_.find(request_id);
-  RAY_CHECK(it != pull_request_bundles_.end());
-  return it->second.num_object_sizes_missing > 0;
+  return bundle_it->second.num_object_sizes_missing > 0;
 }
 
 std::string PullManager::DebugString() const {
@@ -465,7 +545,8 @@ std::string PullManager::DebugString() const {
   result << "PullManager:";
   result << "\n- num bytes available for pulled objects: " << num_bytes_available_;
   result << "\n- num bytes being pulled: " << num_bytes_being_pulled_;
-  result << "\n- num pull request bundles: " << pull_request_bundles_.size();
+  result << "\n- num worker request bundles: " << worker_request_bundles_.size();
+  result << "\n- num task request bundles: " << task_argument_bundles_.size();
   result << "\n- num objects requested pull: " << object_pull_requests_.size();
   result << "\n- num objects actively being pulled: "
          << active_object_pull_requests_.size();

--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -165,7 +165,7 @@ void PullManager::UpdatePullsBasedOnAvailableMemory(size_t num_bytes_available) 
   // by canceling worker requests.
   bool worker_requests_remaining = !worker_request_bundles_.empty();
   while (worker_requests_remaining) {
-    while (num_bytes_being_pulled_ > num_bytes_available_ and
+    while (num_bytes_being_pulled_ > num_bytes_available_ &&
            highest_task_req_id_being_pulled_ != 0) {
       // We are over capacity and there is at least one active task request.
       // Try to cancel a task request to make space for the next worker

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -54,7 +54,7 @@ class PullManager {
   /// should subscribe to, and call OnLocationChange for.
   /// \return A request ID that can be used to cancel the request.
   uint64_t Pull(const std::vector<rpc::ObjectReference> &object_ref_bundle,
-                std::vector<rpc::ObjectReference> *objects_to_locate);
+                std::vector<rpc::ObjectReference> *objects_to_locate, bool is_worker_req);
 
   /// Update the pull requests that are currently being pulled, according to
   /// the current capacity. The PullManager will choose the objects to pull by
@@ -149,6 +149,8 @@ class PullManager {
     }
   };
 
+  using Queue = std::map<uint64_t, PullBundleRequest>;
+
   /// Try to make an object local, by restoring the object from external
   /// storage or by fetching the object from one of its expected client
   /// locations. This does nothing if the object is not needed by any pull
@@ -172,15 +174,16 @@ class PullManager {
 
   /// Activate the next pull request in the queue. This will start pulls for
   /// any objects in the request that are not already being pulled.
-  bool ActivateNextPullBundleRequest(
-      const std::map<uint64_t, PullBundleRequest>::iterator &next_request_it,
-      std::vector<ObjectID> *objects_to_pull);
+  bool ActivateNextPullBundleRequest(const Queue &bundles,
+                                     uint64_t *highest_req_id_being_pulled,
+                                     std::vector<ObjectID> *objects_to_pull);
 
   /// Deactivate a pull request in the queue. This cancels any pull or restore
   /// operations for the object.
-  void DeactivatePullBundleRequest(
-      const std::map<uint64_t, PullBundleRequest>::iterator &request_it,
-      std::unordered_set<ObjectID> *objects_to_cancel);
+  void DeactivatePullBundleRequest(const Queue &bundles,
+                                   const Queue::iterator &request_it,
+                                   uint64_t *highest_req_id_being_pulled,
+                                   std::unordered_set<ObjectID> *objects_to_cancel);
 
   /// Trigger out-of-memory handling if the first request in the queue needs
   /// more space than the bytes available. This is needed to make room for the
@@ -203,7 +206,17 @@ class PullManager {
   /// The currently active pull requests. Each request is a bundle of objects
   /// that must be made local. The key is the ID that was assigned to that
   /// request, which can be used by the caller to cancel the request.
-  std::map<uint64_t, PullBundleRequest> pull_request_bundles_;
+  ///
+  /// The pull requests are split into requests made by workers (`ray.get` or
+  /// `ray.wait`) and arguments of queued tasks. This is so that we prioritize
+  /// freeing resources held by workers over scheduling new tasks that may
+  /// require those resources. If we try to pull arguments for a new task
+  /// before handling a worker's request, we could deadlock.
+  ///
+  /// Queue of `ray.get` and `ray.wait` requests made by workers.
+  Queue worker_request_bundles_;
+  /// Queue of arguments of queued tasks.
+  Queue task_argument_bundles_;
 
   /// The total number of bytes that we are currently pulling. This is the
   /// total size of the objects requested that we are actively pulling. To
@@ -227,7 +240,9 @@ class PullManager {
   /// pulling. We always pull a contiguous prefix of the active pull requests.
   /// This means that all requests with a lower ID are either already canceled
   /// or their objects are also being pulled.
-  uint64_t highest_req_id_being_pulled_ = 0;
+  uint64_t highest_worker_req_id_being_pulled_ = 0;
+
+  uint64_t highest_task_req_id_being_pulled_ = 0;
 
   /// The objects that this object manager has been asked to fetch from remote
   /// object managers.

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -50,11 +50,14 @@ class PullManager {
   /// preceding this one, is within the capacity of the local object store.
   ///
   /// \param object_refs The bundle of objects that must be made local.
+  /// \param is_worker_req Whether this is a request from a worker executing a
+  /// task, versus the arguments of a queued task. Worker requests are
   /// \param objects_to_locate The objects whose new locations the caller
   /// should subscribe to, and call OnLocationChange for.
+  /// prioritized over queued task arguments.
   /// \return A request ID that can be used to cancel the request.
   uint64_t Pull(const std::vector<rpc::ObjectReference> &object_ref_bundle,
-                std::vector<rpc::ObjectReference> *objects_to_locate, bool is_worker_req);
+                bool is_worker_req, std::vector<rpc::ObjectReference> *objects_to_locate);
 
   /// Update the pull requests that are currently being pulled, according to
   /// the current capacity. The PullManager will choose the objects to pull by
@@ -240,8 +243,10 @@ class PullManager {
   /// pulling. We always pull a contiguous prefix of the active pull requests.
   /// This means that all requests with a lower ID are either already canceled
   /// or their objects are also being pulled.
+  ///
+  /// We keep one pointer for each request queue, since we prioritize worker
+  /// requests over task argument requests.
   uint64_t highest_worker_req_id_being_pulled_ = 0;
-
   uint64_t highest_task_req_id_being_pulled_ = 0;
 
   /// The objects that this object manager has been asked to fetch from remote

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -177,6 +177,11 @@ class PullManager {
 
   /// Activate the next pull request in the queue. This will start pulls for
   /// any objects in the request that are not already being pulled.
+  ///
+  /// Returns whether the request was successfully activated. If this returns
+  /// false, then there are no more requests in the queue that can be activated
+  /// (because we have reached the end of the queue or because there is missing
+  /// size information).
   bool ActivateNextPullBundleRequest(const Queue &bundles,
                                      uint64_t *highest_req_id_being_pulled,
                                      std::vector<ObjectID> *objects_to_pull);

--- a/src/ray/object_manager/test/pull_manager_test.cc
+++ b/src/ray/object_manager/test/pull_manager_test.cc
@@ -56,7 +56,8 @@ class PullManagerTestWithCapacity {
   std::unordered_map<ObjectID, int> num_abort_calls_;
 };
 
-class PullManagerTest : public PullManagerTestWithCapacity, public ::testing::TestWithParam<bool> {
+class PullManagerTest : public PullManagerTestWithCapacity,
+                        public ::testing::TestWithParam<bool> {
  public:
   PullManagerTest() : PullManagerTestWithCapacity(1) {}
 
@@ -661,11 +662,13 @@ TEST_F(PullManagerWithAdmissionControlTest, TestPrioritizeWorkerRequests) {
   // First submit two task args requests that can be pulled at the same time.
   std::vector<rpc::ObjectReference> objects_to_locate;
   auto refs = CreateObjectRefs(1);
-  auto task_req_id1 = pull_manager_.Pull(refs, &objects_to_locate, /*is_worker_request=*/false);
+  auto task_req_id1 =
+      pull_manager_.Pull(refs, &objects_to_locate, /*is_worker_request=*/false);
   task_oids.push_back(ObjectRefsToIds(refs)[0]);
 
   refs = CreateObjectRefs(1);
-  auto task_req_id2 = pull_manager_.Pull(refs, &objects_to_locate, /*is_worker_request=*/false);
+  auto task_req_id2 =
+      pull_manager_.Pull(refs, &objects_to_locate, /*is_worker_request=*/false);
   task_oids.push_back(ObjectRefsToIds(refs)[0]);
 
   std::unordered_set<NodeID> client_ids;
@@ -682,7 +685,8 @@ TEST_F(PullManagerWithAdmissionControlTest, TestPrioritizeWorkerRequests) {
 
   // A worker request comes in.
   refs = CreateObjectRefs(1);
-  auto worker_req_id1 = pull_manager_.Pull(refs, &objects_to_locate, /*is_worker_request=*/true);
+  auto worker_req_id1 =
+      pull_manager_.Pull(refs, &objects_to_locate, /*is_worker_request=*/true);
   worker_oids.push_back(ObjectRefsToIds(refs)[0]);
   // Nothing has changed yet because the size information for the worker's
   // request is not available.
@@ -702,7 +706,8 @@ TEST_F(PullManagerWithAdmissionControlTest, TestPrioritizeWorkerRequests) {
   // Another worker request comes in. It takes priority over the task requests
   // once its size is available.
   refs = CreateObjectRefs(1);
-  auto worker_req_id2 = pull_manager_.Pull(refs, &objects_to_locate, /*is_worker_request=*/true);
+  auto worker_req_id2 =
+      pull_manager_.Pull(refs, &objects_to_locate, /*is_worker_request=*/true);
   worker_oids.push_back(ObjectRefsToIds(refs)[0]);
   AssertNumActiveRequestsEquals(2);
   ASSERT_TRUE(pull_manager_.IsObjectActive(worker_oids[0]));
@@ -747,13 +752,11 @@ TEST_F(PullManagerWithAdmissionControlTest, TestPrioritizeWorkerRequests) {
   AssertNoLeaks();
 }
 
-INSTANTIATE_TEST_CASE_P(WorkerOrTaskRequests,
-                         PullManagerTest,
-                         testing::Values(true, false));
+INSTANTIATE_TEST_CASE_P(WorkerOrTaskRequests, PullManagerTest,
+                        testing::Values(true, false));
 
-INSTANTIATE_TEST_CASE_P(WorkerOrTaskRequests,
-                         PullManagerWithAdmissionControlTest,
-                         testing::Values(true, false));
+INSTANTIATE_TEST_CASE_P(WorkerOrTaskRequests, PullManagerWithAdmissionControlTest,
+                        testing::Values(true, false));
 }  // namespace ray
 
 int main(int argc, char **argv) {

--- a/src/ray/raylet/dependency_manager.cc
+++ b/src/ray/raylet/dependency_manager.cc
@@ -62,7 +62,8 @@ void DependencyManager::StartOrUpdateWaitRequest(
       auto it = GetOrInsertRequiredObject(obj_id, ref);
       it->second.dependent_wait_requests.insert(worker_id);
       if (it->second.wait_request_id == 0) {
-        it->second.wait_request_id = object_manager_.Pull({ref});
+        it->second.wait_request_id = object_manager_.Pull({ref},
+                                                          /*is_worker_request=*/true);
         RAY_LOG(DEBUG) << "Started pull for wait request for object " << obj_id
                        << " request: " << it->second.wait_request_id;
       }
@@ -117,7 +118,8 @@ void DependencyManager::StartOrUpdateGetRequest(
     }
     // Pull the new dependencies before canceling the old request, in case some
     // of the old dependencies are still being fetched.
-    uint64_t new_request_id = object_manager_.Pull(refs);
+    uint64_t new_request_id = object_manager_.Pull(refs,
+                                                   /*is_worker_request=*/true);
     if (get_request.second != 0) {
       RAY_LOG(DEBUG) << "Canceling pull for get request from worker " << worker_id
                      << " request: " << get_request.second;
@@ -173,7 +175,8 @@ bool DependencyManager::RequestTaskDependencies(
   }
 
   if (!required_objects.empty()) {
-    task_entry.pull_request_id = object_manager_.Pull(required_objects);
+    task_entry.pull_request_id = object_manager_.Pull(required_objects,
+                                                      /*is_worker_request=*/false);
     RAY_LOG(DEBUG) << "Started pull for dependencies of task " << task_id
                    << " request: " << task_entry.pull_request_id;
   }

--- a/src/ray/raylet/dependency_manager_test.cc
+++ b/src/ray/raylet/dependency_manager_test.cc
@@ -31,19 +31,29 @@ using ::testing::Return;
 
 class MockObjectManager : public ObjectManagerInterface {
  public:
-  uint64_t Pull(const std::vector<rpc::ObjectReference> &object_refs) {
-    active_requests.insert(req_id);
+  uint64_t Pull(const std::vector<rpc::ObjectReference> &object_refs,
+                bool is_worker_request) {
+    if (is_worker_request) {
+      active_worker_requests.insert(req_id);
+    } else {
+      active_task_requests.insert(req_id);
+    }
     return req_id++;
   }
 
-  void CancelPull(uint64_t request_id) { ASSERT_TRUE(active_requests.erase(request_id)); }
+  void CancelPull(uint64_t request_id) {
+    ASSERT_TRUE(active_worker_requests.erase(request_id) ||
+                active_task_requests.erase(request_id));
+  }
 
   bool PullRequestActiveOrWaitingForMetadata(uint64_t request_id) const {
-    return active_requests.count(request_id);
+    return active_worker_requests.count(request_id) ||
+           active_task_requests.count(request_id);
   }
 
   uint64_t req_id = 1;
-  std::unordered_set<uint64_t> active_requests;
+  std::unordered_set<uint64_t> active_worker_requests;
+  std::unordered_set<uint64_t> active_task_requests;
 };
 
 class DependencyManagerTest : public ::testing::Test {
@@ -57,7 +67,8 @@ class DependencyManagerTest : public ::testing::Test {
     ASSERT_TRUE(dependency_manager_.get_requests_.empty());
     ASSERT_TRUE(dependency_manager_.wait_requests_.empty());
     // All pull requests are canceled.
-    ASSERT_TRUE(object_manager_mock_.active_requests.empty());
+    ASSERT_TRUE(object_manager_mock_.active_task_requests.empty());
+    ASSERT_TRUE(object_manager_mock_.active_worker_requests.empty());
   }
 
   MockObjectManager object_manager_mock_;
@@ -77,7 +88,7 @@ TEST_F(DependencyManagerTest, TestSimpleTask) {
   bool ready =
       dependency_manager_.RequestTaskDependencies(task_id, ObjectIdsToRefs(arguments));
   ASSERT_FALSE(ready);
-  ASSERT_EQ(object_manager_mock_.active_requests.size(), 1);
+  ASSERT_EQ(object_manager_mock_.active_task_requests.size(), 1);
 
   // For each argument, tell the task dependency manager that the argument is
   // local. All arguments should be canceled as they become available locally.
@@ -109,7 +120,7 @@ TEST_F(DependencyManagerTest, TestMultipleTasks) {
         task_id, ObjectIdsToRefs({argument_id}));
     ASSERT_FALSE(ready);
     // The object should be requested from the object manager once for each task.
-    ASSERT_EQ(object_manager_mock_.active_requests.size(), i + 1);
+    ASSERT_EQ(object_manager_mock_.active_task_requests.size(), i + 1);
   }
 
   // Tell the task dependency manager that the object is local.
@@ -202,18 +213,18 @@ TEST_F(DependencyManagerTest, TestGet) {
     // Subscribe to the task's dependencies. All arguments except the last are
     // duplicates of previous subscription calls. Each argument should only be
     // requested from the node manager once.
-    auto prev_pull_reqs = object_manager_mock_.active_requests;
+    auto prev_pull_reqs = object_manager_mock_.active_worker_requests;
     dependency_manager_.StartOrUpdateGetRequest(worker_id, ObjectIdsToRefs(arguments));
     // Previous pull request for this worker should be canceled upon each new
     // bundle.
-    ASSERT_EQ(object_manager_mock_.active_requests.size(), 1);
-    ASSERT_NE(object_manager_mock_.active_requests, prev_pull_reqs);
+    ASSERT_EQ(object_manager_mock_.active_worker_requests.size(), 1);
+    ASSERT_NE(object_manager_mock_.active_worker_requests, prev_pull_reqs);
   }
 
   // Nothing happens if the same bundle is requested.
-  auto prev_pull_reqs = object_manager_mock_.active_requests;
+  auto prev_pull_reqs = object_manager_mock_.active_worker_requests;
   dependency_manager_.StartOrUpdateGetRequest(worker_id, ObjectIdsToRefs(arguments));
-  ASSERT_EQ(object_manager_mock_.active_requests, prev_pull_reqs);
+  ASSERT_EQ(object_manager_mock_.active_worker_requests, prev_pull_reqs);
 
   // Cancel the pull request once the worker cancels the `ray.get`.
   dependency_manager_.CancelGetRequest(worker_id);
@@ -231,7 +242,7 @@ TEST_F(DependencyManagerTest, TestWait) {
     oids.push_back(ObjectID::FromRandom());
   }
   dependency_manager_.StartOrUpdateWaitRequest(worker_id, ObjectIdsToRefs(oids));
-  ASSERT_EQ(object_manager_mock_.active_requests.size(), num_objects);
+  ASSERT_EQ(object_manager_mock_.active_worker_requests.size(), num_objects);
 
   for (int i = 0; i < num_objects; i++) {
     // Object is local.
@@ -241,7 +252,7 @@ TEST_F(DependencyManagerTest, TestWait) {
     // reactivated.
     auto waiting_task_ids = dependency_manager_.HandleObjectMissing(oids[i]);
     ASSERT_TRUE(waiting_task_ids.empty());
-    ASSERT_EQ(object_manager_mock_.active_requests.size(), num_objects - i - 1);
+    ASSERT_EQ(object_manager_mock_.active_worker_requests.size(), num_objects - i - 1);
   }
   AssertNoLeaks();
 }
@@ -259,12 +270,12 @@ TEST_F(DependencyManagerTest, TestWaitThenCancel) {
   }
   // Simulate a worker calling `ray.wait` on some objects.
   dependency_manager_.StartOrUpdateWaitRequest(worker_id, ObjectIdsToRefs(oids));
-  ASSERT_EQ(object_manager_mock_.active_requests.size(), num_objects);
-  auto prev_pull_reqs = object_manager_mock_.active_requests;
+  ASSERT_EQ(object_manager_mock_.active_worker_requests.size(), num_objects);
+  auto prev_pull_reqs = object_manager_mock_.active_worker_requests;
   // Check that it's okay to call `ray.wait` on the same objects again. No new
   // calls should be made to try and make the objects local.
   dependency_manager_.StartOrUpdateWaitRequest(worker_id, ObjectIdsToRefs(oids));
-  ASSERT_EQ(object_manager_mock_.active_requests, prev_pull_reqs);
+  ASSERT_EQ(object_manager_mock_.active_worker_requests, prev_pull_reqs);
   // Cancel the worker's `ray.wait`.
   dependency_manager_.CancelWaitRequest(worker_id);
   AssertNoLeaks();
@@ -287,12 +298,12 @@ TEST_F(DependencyManagerTest, TestWaitObjectLocal) {
   auto ready_task_ids = dependency_manager_.HandleObjectLocal(local_object_id);
   ASSERT_TRUE(ready_task_ids.empty());
   dependency_manager_.StartOrUpdateWaitRequest(worker_id, ObjectIdsToRefs(oids));
-  ASSERT_EQ(object_manager_mock_.active_requests.size(), num_objects - 1);
+  ASSERT_EQ(object_manager_mock_.active_worker_requests.size(), num_objects - 1);
   // Simulate the local object getting evicted. The `ray.wait` call should not
   // be reactivated.
   auto waiting_task_ids = dependency_manager_.HandleObjectMissing(local_object_id);
   ASSERT_TRUE(waiting_task_ids.empty());
-  ASSERT_EQ(object_manager_mock_.active_requests.size(), num_objects - 1);
+  ASSERT_EQ(object_manager_mock_.active_worker_requests.size(), num_objects - 1);
   // Cancel the worker's `ray.wait`.
   dependency_manager_.CancelWaitRequest(worker_id);
   AssertNoLeaks();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This breaks a potential deadlock between worker requests for objects (through `ray.get` or `ray.wait`) and arguments of queued tasks, when the amount of memory is limited. See #14886 for more details.

The fix is to split the request queue in the PullManager into two queues, one for requests made by a worker and one for arguments of a queued task. The interface is pretty much the same as before, but the implementation is a bit more complicated because requests can now be served out-of-order (e.g., if a worker request is submitted after a task request).

## Related issue number

Closes #14886.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
