### PR TITLE
[Pubsub] Generalize pubsub, Move pubsub code to pubsub_lib module

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -489,12 +489,12 @@ cc_library(
     strip_include_prefix = "src",
     visibility = ["//visibility:public"],
     deps = [
-        ":worker_rpc",
         ":ray_common",
-        "@com_google_absl//absl/container:flat_hash_set",
+        ":worker_rpc",
+        "//src/ray/protobuf:common_cc_proto",
         "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/synchronization",
-        "//src/ray/protobuf:common_cc_proto"
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/synchronization"
     ],
 )
 
@@ -568,10 +568,10 @@ cc_library(
         ":agent_manager_rpc",
         ":gcs",
         ":node_manager_fbs",
-        ":pubsub_lib",
         ":node_manager_rpc",
         ":object_manager",
         ":plasma_client",
+        ":pubsub_lib",
         ":ray_common",
         ":ray_util",
         ":service_based_gcs_client_lib",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -476,6 +476,28 @@ cc_binary(
     ],
 )
 
+# worker server and client.
+cc_library(
+    name = "pubsub_lib",
+    srcs = glob([
+        "src/ray/pubsub/*.cc",
+    ]),
+    hdrs = glob([
+        "src/ray/pubsub/*.h",
+    ]),
+    copts = COPTS,
+    strip_include_prefix = "src",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":worker_rpc",
+        ":ray_common",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/synchronization",
+        "//src/ray/protobuf:common_cc_proto"
+    ],
+)
+
 cc_library(
     name = "stats_lib",
     srcs = glob(
@@ -546,6 +568,7 @@ cc_library(
         ":agent_manager_rpc",
         ":gcs",
         ":node_manager_fbs",
+        ":pubsub_lib",
         ":node_manager_rpc",
         ":object_manager",
         ":plasma_client",
@@ -628,6 +651,7 @@ cc_library(
     deps = [
         ":gcs",
         ":plasma_client",
+        ":pubsub_lib",
         ":ray_common",
         ":ray_util",
         ":raylet_client_lib",
@@ -742,16 +766,6 @@ cc_test(
 )
 
 cc_test(
-    name = "publisher_test",
-    srcs = ["src/ray/core_worker/test/publisher_test.cc"],
-    copts = COPTS,
-    deps = [
-        ":core_worker_lib",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
-cc_test(
     name = "scheduling_queue_test",
     srcs = ["src/ray/core_worker/test/scheduling_queue_test.cc"],
     copts = COPTS,
@@ -831,18 +845,6 @@ cc_test(
     name = "local_object_manager_test",
     srcs = [
         "src/ray/raylet/test/local_object_manager_test.cc",
-    ],
-    copts = COPTS,
-    deps = [
-        ":raylet_lib",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
-cc_test(
-    name = "subscriber_test",
-    srcs = [
-        "src/ray/raylet/test/subscriber_test.cc",
     ],
     copts = COPTS,
     deps = [
@@ -990,6 +992,28 @@ cc_test(
     copts = COPTS,
     deps = [
         ":ray_common",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "publisher_test",
+    srcs = ["src/ray/pubsub/test/publisher_test.cc"],
+    copts = COPTS,
+    deps = [
+        ":pubsub_lib",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "subscriber_test",
+    srcs = [
+        "src/ray/pubsub/test/subscriber_test.cc",
+    ],
+    copts = COPTS,
+    deps = [
+        ":pubsub_lib",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -476,7 +476,7 @@ cc_binary(
     ],
 )
 
-# worker server and client.
+# Ray native pubsub module.
 cc_library(
     name = "pubsub_lib",
     srcs = glob([

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -494,7 +494,7 @@ cc_library(
         "//src/ray/protobuf:common_cc_proto",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
-        "@com_google_absl//absl/synchronization"
+        "@com_google_absl//absl/synchronization",
     ],
 )
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -562,7 +562,7 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
       new CoreWorkerDirectActorTaskSubmitter(core_worker_client_pool_, memory_store_,
                                              task_manager_));
 
-  object_status_publisher_ = std::make_shared<Publisher>(
+  object_status_publisher_ = std::make_shared<pubsub::Publisher>(
       /*periodical_runner=*/&periodical_runner_,
       /*get_time_ms=*/[]() { return absl::GetCurrentTimeNanos() / 1e6; },
       /*subscriber_timeout_ms=*/RayConfig::instance().subscriber_timeout_ms(),

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -27,13 +27,13 @@
 #include "ray/core_worker/lease_policy.h"
 #include "ray/core_worker/object_recovery_manager.h"
 #include "ray/core_worker/profiling.h"
-#include "ray/core_worker/pubsub/publisher.h"
 #include "ray/core_worker/reference_count.h"
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
 #include "ray/core_worker/store_provider/plasma_store_provider.h"
 #include "ray/core_worker/transport/direct_actor_transport.h"
 #include "ray/core_worker/transport/direct_task_transport.h"
 #include "ray/gcs/gcs_client.h"
+#include "ray/pubsub/publisher.h"
 #include "ray/raylet_client/raylet_client.h"
 #include "ray/rpc/node_manager/node_manager_client.h"
 #include "ray/rpc/worker/core_worker_client.h"
@@ -1222,7 +1222,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   std::shared_ptr<CoreWorkerDirectActorTaskSubmitter> direct_actor_submitter_;
 
   // Server that handles pubsub operations of raylets / core workers.
-  std::shared_ptr<Publisher> object_status_publisher_;
+  std::shared_ptr<pubsub::Publisher> object_status_publisher_;
 
   // Interface to submit non-actor tasks directly to leased workers.
   std::unique_ptr<CoreWorkerDirectTaskSubmitter> direct_task_submitter_;

--- a/src/ray/pubsub/publisher.cc
+++ b/src/ray/pubsub/publisher.cc
@@ -169,8 +169,8 @@ void Publisher::ConnectToSubscriber(const SubscriberID &subscriber_id,
   if (it == subscribers_.end()) {
     it = subscribers_
              .emplace(subscriber_id,
-                      std::make_shared<pub_internal::Subscriber>(get_time_ms_, subscriber_timeout_ms_,
-                                                   publish_batch_size_))
+                      std::make_shared<pub_internal::Subscriber>(
+                          get_time_ms_, subscriber_timeout_ms_, publish_batch_size_))
              .first;
   }
   auto &subscriber = it->second;
@@ -187,9 +187,9 @@ void Publisher::RegisterSubscription(const SubscriberID &subscriber_id,
 
   absl::MutexLock lock(&mutex_);
   if (subscribers_.count(subscriber_id) == 0) {
-    subscribers_.emplace(
-        subscriber_id, std::make_shared<pub_internal::Subscriber>(get_time_ms_, subscriber_timeout_ms_,
-                                                    publish_batch_size_));
+    subscribers_.emplace(subscriber_id,
+                         std::make_shared<pub_internal::Subscriber>(
+                             get_time_ms_, subscriber_timeout_ms_, publish_batch_size_));
   }
   subscription_index_.AddEntry(object_id, subscriber_id);
 }

--- a/src/ray/pubsub/publisher.cc
+++ b/src/ray/pubsub/publisher.cc
@@ -12,9 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ray/core_worker/pubsub/publisher.h"
+#include "ray/pubsub/publisher.h"
 
 namespace ray {
+
+namespace pubsub {
+
+namespace pub_internal {
 
 void SubscriptionIndex::AddEntry(const ObjectID &object_id,
                                  const SubscriberID &subscriber_id) {
@@ -153,6 +157,8 @@ bool Subscriber::IsActiveConnectionTimedOut() const {
          get_time_ms_() - last_connection_update_time_ms_ >= connection_timeout_ms_;
 }
 
+}  // namespace pub_internal
+
 void Publisher::ConnectToSubscriber(const SubscriberID &subscriber_id,
                                     LongPollConnectCallback long_poll_connect_callback) {
   RAY_LOG(DEBUG) << "Long polling connection initiated by " << subscriber_id;
@@ -163,7 +169,7 @@ void Publisher::ConnectToSubscriber(const SubscriberID &subscriber_id,
   if (it == subscribers_.end()) {
     it = subscribers_
              .emplace(subscriber_id,
-                      std::make_shared<Subscriber>(get_time_ms_, subscriber_timeout_ms_,
+                      std::make_shared<pub_internal::Subscriber>(get_time_ms_, subscriber_timeout_ms_,
                                                    publish_batch_size_))
              .first;
   }
@@ -182,7 +188,7 @@ void Publisher::RegisterSubscription(const SubscriberID &subscriber_id,
   absl::MutexLock lock(&mutex_);
   if (subscribers_.count(subscriber_id) == 0) {
     subscribers_.emplace(
-        subscriber_id, std::make_shared<Subscriber>(get_time_ms_, subscriber_timeout_ms_,
+        subscriber_id, std::make_shared<pub_internal::Subscriber>(get_time_ms_, subscriber_timeout_ms_,
                                                     publish_batch_size_));
   }
   subscription_index_.AddEntry(object_id, subscriber_id);
@@ -258,5 +264,7 @@ bool Publisher::AssertNoLeak() const {
   }
   return subscription_index_.AssertNoLeak();
 }
+
+}  // namespace pubsub
 
 }  // namespace ray

--- a/src/ray/pubsub/publisher.h
+++ b/src/ray/pubsub/publisher.h
@@ -66,7 +66,6 @@ class SubscriptionIndex {
   bool AssertNoLeak() const;
 
  private:
-
   /// Mapping from objects -> subscribers.
   absl::flat_hash_map<ObjectID, absl::flat_hash_set<SubscriberID>>
       objects_to_subscribers_;
@@ -247,8 +246,8 @@ class Publisher {
   mutable absl::Mutex mutex_;
 
   /// Mapping of node id -> subscribers.
-  absl::flat_hash_map<SubscriberID, std::shared_ptr<pub_internal::Subscriber>> subscribers_
-      GUARDED_BY(mutex_);
+  absl::flat_hash_map<SubscriberID, std::shared_ptr<pub_internal::Subscriber>>
+      subscribers_ GUARDED_BY(mutex_);
 
   /// Index that stores the mapping of objects <-> subscribers.
   pub_internal::SubscriptionIndex subscription_index_ GUARDED_BY(mutex_);
@@ -257,6 +256,6 @@ class Publisher {
   const uint64_t publish_batch_size_;
 };
 
-}  // namespace pubsub 
+}  // namespace pubsub
 
 }  // namespace ray

--- a/src/ray/pubsub/subscriber.cc
+++ b/src/ray/pubsub/subscriber.cc
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ray/raylet/pubsub/subscriber.h"
+#include "ray/pubsub/subscriber.h"
 
 namespace ray {
+
+namespace pubsub {
 
 void Subscriber::SubcribeObject(
     const rpc::Address &publisher_address, const ObjectID &object_id,
@@ -183,5 +185,7 @@ bool Subscriber::AssertNoLeak() const {
   }
   return subscription_map_.size() == 0;
 }
+
+}  // namespace pubsub
 
 }  // namespace ray

--- a/src/ray/pubsub/subscriber.h
+++ b/src/ray/pubsub/subscriber.h
@@ -20,6 +20,8 @@
 
 namespace ray {
 
+namespace pubsub {
+
 using SubscriberID = UniqueID;
 using PublisherID = UniqueID;
 using SubscriptionCallback = std::function<void(const ObjectID &)>;
@@ -148,5 +150,7 @@ class Subscriber : public SubscriberInterface {
   /// Cache of gRPC clients to publishers.
   rpc::CoreWorkerClientPool &publisher_client_pool_;
 };
+
+}  // namespace pubsub
 
 }  // namespace ray

--- a/src/ray/pubsub/test/publisher_test.cc
+++ b/src/ray/pubsub/test/publisher_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ray/core_worker/pubsub/publisher.h"
+#include "ray/pubsub/publisher.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -23,6 +23,8 @@
 namespace ray {
 
 using ::testing::_;
+using namespace pubsub;
+using namespace pub_internal;
 
 class PublisherTest : public ::testing::Test {
  public:

--- a/src/ray/pubsub/test/subscriber_test.cc
+++ b/src/ray/pubsub/test/subscriber_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ray/raylet/pubsub/subscriber.h"
+#include "ray/pubsub/subscriber.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -20,6 +20,7 @@
 namespace ray {
 
 using ::testing::_;
+using namespace pubsub;
 
 class MockWorkerClient : public rpc::CoreWorkerClientInterface {
  public:

--- a/src/ray/raylet/local_object_manager.h
+++ b/src/ray/raylet/local_object_manager.h
@@ -22,7 +22,7 @@
 #include "ray/common/ray_object.h"
 #include "ray/gcs/accessor.h"
 #include "ray/object_manager/common.h"
-#include "ray/raylet/pubsub/subscriber.h"
+#include "ray/pubsub/subscriber.h"
 #include "ray/raylet/worker_pool.h"
 #include "ray/rpc/worker/core_worker_client_pool.h"
 #include "ray/util/util.h"
@@ -47,7 +47,7 @@ class LocalObjectManager {
       int64_t max_fused_object_count,
       std::function<void(const std::vector<ObjectID> &)> on_objects_freed,
       std::function<bool(const ray::ObjectID &)> is_plasma_object_spillable,
-      std::shared_ptr<SubscriberInterface> core_worker_subscriber)
+      std::shared_ptr<pubsub::SubscriberInterface> core_worker_subscriber)
       : self_node_id_(node_id),
         self_node_address_(self_node_address),
         self_node_port_(self_node_port),
@@ -289,7 +289,7 @@ class LocalObjectManager {
 
   /// The raylet client to initiate the pubsub to core workers (owners).
   /// It is used to subscribe objects to evict.
-  std::shared_ptr<SubscriberInterface> core_worker_subscriber_;
+  std::shared_ptr<pubsub::SubscriberInterface> core_worker_subscriber_;
 
   ///
   /// Stats

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -247,8 +247,9 @@ NodeManager::NodeManager(instrumented_io_context &io_service, const NodeID &self
             return object_manager_.IsPlasmaObjectSpillable(object_id);
           },
           /*core_worker_subscriber_=*/
-          std::make_shared<Subscriber>(self_node_id_, config.node_manager_address,
-                                       config.node_manager_port, worker_rpc_pool_)),
+          std::make_shared<pubsub::Subscriber>(self_node_id_, config.node_manager_address,
+                                               config.node_manager_port,
+                                               worker_rpc_pool_)),
       last_local_gc_ns_(absl::GetCurrentTimeNanos()),
       local_gc_interval_ns_(RayConfig::instance().local_gc_interval_s() * 1e9),
       local_gc_min_interval_ns_(RayConfig::instance().local_gc_min_interval_s() * 1e9),

--- a/src/ray/raylet/test/local_object_manager_test.cc
+++ b/src/ray/raylet/test/local_object_manager_test.cc
@@ -19,7 +19,7 @@
 #include "ray/common/asio/instrumented_io_context.h"
 #include "ray/common/id.h"
 #include "ray/gcs/accessor.h"
-#include "ray/raylet/pubsub/subscriber.h"
+#include "ray/pubsub/subscriber.h"
 #include "ray/raylet/test/util.h"
 #include "ray/raylet/worker_pool.h"
 #include "ray/rpc/grpc_client.h"
@@ -34,12 +34,12 @@ namespace raylet {
 
 using ::testing::_;
 
-class MockSubscriber : public SubscriberInterface {
+class MockSubscriber : public pubsub::SubscriberInterface {
  public:
   void SubcribeObject(
       const rpc::Address &owner_address, const ObjectID &object_id,
-      SubscriptionCallback subscription_callback,
-      SubscriptionFailureCallback subscription_failure_callback) override {
+      pubsub::SubscriptionCallback subscription_callback,
+      pubsub::SubscriptionFailureCallback subscription_failure_callback) override {
     callbacks.push_back(std::make_pair(object_id, subscription_callback));
   }
 
@@ -59,7 +59,7 @@ class MockSubscriber : public SubscriberInterface {
 
   bool AssertNoLeak() const override { return true; }
 
-  std::deque<std::pair<ObjectID, SubscriptionCallback>> callbacks;
+  std::deque<std::pair<ObjectID, pubsub::SubscriptionCallback>> callbacks;
 };
 
 class MockWorkerClient : public rpc::CoreWorkerClientInterface {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This moves the pubsub code to `pubsub_lib`. I couldn't use `ray_common` because of circular dependency issues (`ray_common` is required for `worker_rpc`, which required for the pubsub module). 

### IMPORTANT
All subscriber/publisher.[h|cc] are the same as before, but they are now under `pubsub` namespace`.

## Related issue number

https://github.com/ray-project/ray/issues/14322
Part of https://github.com/ray-project/ray/issues/14762

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
