### PR TITLE
[serve] Defer building starlette request to backend replica

### DIFF
--- a/python/ray/serve/benchmarks/microbenchmark.py
+++ b/python/ray/serve/benchmarks/microbenchmark.py
@@ -76,10 +76,11 @@ async def trial(intermediate_handles, num_replicas, max_batch_size,
                 return await self.handle.remote()
 
         ForwardActor.deploy()
-        assert f"/api" in routes, routes
+        routes = requests.get("http://localhost:8000/-/routes").json()
+        assert "/api" in routes, routes
 
     @serve.deployment(
-        deployment_name,
+        name=deployment_name,
         num_replicas=num_replicas,
         max_concurrent_queries=max_concurrent_queries)
     class Backend:
@@ -94,7 +95,6 @@ async def trial(intermediate_handles, num_replicas, max_batch_size,
                 return b"ok"
 
     Backend.deploy()
-
     routes = requests.get("http://localhost:8000/-/routes").json()
     assert f"/{deployment_name}" in routes, routes
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Unnecessary serialization cost in the HTTP proxy.

Before:
```
intermediate_handles=False,num_replicas=1,max_batch_size=1,max_concurrent_queries=10000,data_size=small:
        8 clients small data 1008.31 +- 8.11 requests/s
```

After:
```
intermediate_handles=False,num_replicas=8,max_batch_size=1,max_concurrent_queries=10000,data_size=small:
        8 clients small data 1388.63 +- 17.16 requests/s
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
