### PR TITLE
Update ray client protocol version

### DIFF
--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 # This version string is incremented to indicate breaking changes in the
 # protocol that require upgrading the client version.
-CURRENT_PROTOCOL_VERSION = "2020-03-12"
+CURRENT_PROTOCOL_VERSION = "2020-04-07"
 
 
 class RayAPIStub:


### PR DESCRIPTION
I believe some of the new changes having introduced breaking changes; bump the protocol version as a safeguard:
```
grpc._channel._MultiThreadedRendezvous: <_MultiThreadedRendezvous of RPC that terminated with:
	status = StatusCode.UNKNOWN
	details = "Exception iterating responses: Unreachable code: Request type None not handled in Datapath"
	debug_error_string = "{"created":"@1617836251.178482285","description":"Error received from peer ipv4:34.220.36.215:8081","file":"src/core/lib/surface/call.cc","file_line":1061,"grpc_message":"Exception iterating responses: Unreachable code: Request type None not handled in Datapath","grpc_status":2}"
```

This is an example error ^