### PR TITLE
[client][rllib] Add client_mode_hook for ray.get_gpu_ids

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -29,6 +29,7 @@ py_test_module_list(
     "test_cli.py",
     "test_client.py",
     "test_client_init.py",
+    "test_client_library_integration.py",
     "test_component_failures_2.py",
     "test_component_failures_3.py",
     "test_error_ray_not_initialized.py",

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -9,8 +9,7 @@ import _thread
 import ray.util.client.server.server as ray_client_server
 from ray.util.client.common import ClientObjectRef
 from ray.util.client.ray_client_helpers import ray_start_client_server
-from ray._private.client_mode_hook import _enable_client_hook,\
-    _explicitly_enable_client_mode
+from ray._private.client_mode_hook import _explicitly_enable_client_mode
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
@@ -504,8 +503,8 @@ def test_client_gpu_ids(call_ray_stop_only):
     # No client connection.
     with pytest.raises(Exception) as e:
         ray.get_gpu_ids()
-    assert str(e.value) == 'Ray Client is not connected.'\
-        ' Please connect by calling `ray.connect`.'
+    assert str(e.value) == "Ray Client is not connected."\
+        " Please connect by calling `ray.connect`."
 
     with ray_start_client_server():
         # Now have a client connection.

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -500,23 +500,16 @@ def test_client_gpu_ids(call_ray_stop_only):
     import ray
     ray.init(num_cpus=2)
 
-    with ray_start_client_server() as ray:
-        assert ray.get_gpu_ids() == []
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
-def test_client_gpu_ids_hook():
-    """
-    Validate that ray.get_gpu_ids is wrapped by client_mode_hook.
-    """
-    import ray
-    # These two lines ensure client mode hook will be in effect.
-    _enable_client_hook(True)
     _explicitly_enable_client_mode()
+    # No client connection.
+    with pytest.raises(Exception) as e:
+        ray.get_gpu_ids()
+    assert str(e.value) == 'Ray Client is not connected.'\
+        ' Please connect by calling `ray.connect`.'
 
-    # Ray isn't actually initialized. However, client mode is on, so we
-    # get the expected result.
-    assert ray.get_gpu_ids() == []
+    with ray_start_client_server():
+        # Now have a client connection.
+        assert ray.get_gpu_ids() == []
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -9,6 +9,8 @@ import _thread
 import ray.util.client.server.server as ray_client_server
 from ray.util.client.common import ClientObjectRef
 from ray.util.client.ray_client_helpers import ray_start_client_server
+from ray._private.client_mode_hook import _enable_client_hook,\
+    _explicitly_enable_client_mode
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
@@ -500,6 +502,21 @@ def test_client_gpu_ids(call_ray_stop_only):
 
     with ray_start_client_server() as ray:
         assert ray.get_gpu_ids() == []
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+def test_client_gpu_ids_hook():
+    """
+    Validate that ray.get_gpu_ids is wrapped by client_mode_hook.
+    """
+    import ray
+    # These two lines ensure client mode hook will be in effect.
+    _enable_client_hook(True)
+    _explicitly_enable_client_mode()
+
+    # Ray isn't actually initialized. However, client mode is on, so we
+    # get the expected result.
+    assert ray.get_gpu_ids() == []
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_client_library_integration.py
+++ b/python/ray/tests/test_client_library_integration.py
@@ -6,11 +6,10 @@ import ray
 import ray.util.client.server.server as ray_client_server
 
 from ray.rllib.examples import rock_paper_scissors_multiagent
-from ray.util.client.common import ClientObjectRef
-from ray.util.client.ray_client_helpers import ray_start_client_server
+
 
 def test_rllib_integration(call_ray_stop_only):
-    ray.init(num_cpus = 1)
+    ray.init(num_cpus=1)
     ray_client_server.serve("localhost:50051")
     # Connection timeout. Help.
     ray.util.connect("localhost:50051")

--- a/python/ray/tests/test_client_library_integration.py
+++ b/python/ray/tests/test_client_library_integration.py
@@ -1,0 +1,22 @@
+import sys
+
+import pytest
+
+import ray
+import ray.util.client.server.server as ray_client_server
+
+from ray.rllib.examples import rock_paper_scissors_multiagent
+from ray.util.client.common import ClientObjectRef
+from ray.util.client.ray_client_helpers import ray_start_client_server
+
+def test_rllib_integration(call_ray_stop_only):
+    ray.init(num_cpus = 1)
+    ray_client_server.serve("localhost:50051")
+    # Connection timeout. Help.
+    ray.util.connect("localhost:50051")
+
+    rock_paper_scissors_multiagent.main()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-s", __file__]))

--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -150,10 +150,6 @@ class RayAPIStub:
                                                _exiting_interpreter)
         self._server = None
 
-    # Client process isn't assigned any GPUs.
-    def get_gpu_ids(self) -> list:
-        return []
-
 
 ray = RayAPIStub()
 

--- a/python/ray/util/client/api.py
+++ b/python/ray/util/client/api.py
@@ -243,6 +243,10 @@ class ClientAPI:
         """
         return ClientWorkerPropertyAPI(self.worker).build_runtime_context()
 
+    # Client process isn't assigned any GPUs.
+    def get_gpu_ids(self) -> list:
+        return []
+
     def _internal_kv_initialized(self) -> bool:
         """Hook for internal_kv._internal_kv_initialized."""
         return self.is_initialized()

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -94,6 +94,7 @@ class Worker:
         else:
             self.channel = grpc.insecure_channel(
                 conn_str, options=grpc_options)
+
         self.channel.subscribe(self._on_channel_state_change)
 
         # Retry the connection until the channel responds to something

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -94,7 +94,6 @@ class Worker:
         else:
             self.channel = grpc.insecure_channel(
                 conn_str, options=grpc_options)
-
         self.channel.subscribe(self._on_channel_state_change)
 
         # Retry the connection until the channel responds to something

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -395,7 +395,7 @@ class Worker:
         self.core_worker.run_task_loop()
         sys.exit(0)
 
-
+@client_mode_hook
 def get_gpu_ids():
     """Get the IDs of the GPUs that are available to the worker.
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -395,7 +395,7 @@ class Worker:
         self.core_worker.run_task_loop()
         sys.exit(0)
 
-@client_mode_hook
+
 def get_gpu_ids():
     """Get the IDs of the GPUs that are available to the worker.
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -396,6 +396,7 @@ class Worker:
         sys.exit(0)
 
 
+@client_mode_hook
 def get_gpu_ids():
     """Get the IDs of the GPUs that are available to the worker.
 

--- a/rllib/examples/rock_paper_scissors_multiagent.py
+++ b/rllib/examples/rock_paper_scissors_multiagent.py
@@ -12,6 +12,7 @@ from gym.spaces import Discrete
 import os
 import random
 
+import ray; ray.util.connect("127.0.0.1:10001")
 from ray import tune
 from ray.rllib.agents.pg import PGTrainer, PGTFPolicy, PGTorchPolicy
 from ray.rllib.agents.registry import get_trainer_class

--- a/rllib/examples/rock_paper_scissors_multiagent.py
+++ b/rllib/examples/rock_paper_scissors_multiagent.py
@@ -12,7 +12,6 @@ from gym.spaces import Discrete
 import os
 import random
 
-import ray; ray.util.connect("127.0.0.1:10001")
 from ray import tune
 from ray.rllib.agents.pg import PGTrainer, PGTFPolicy, PGTorchPolicy
 from ray.rllib.agents.registry import get_trainer_class

--- a/rllib/examples/rock_paper_scissors_multiagent.py
+++ b/rllib/examples/rock_paper_scissors_multiagent.py
@@ -137,7 +137,7 @@ def run_with_custom_entropy_loss(args, stop):
     run_heuristic_vs_learned(args, use_lstm=True, trainer=EntropyLossPG)
 
 
-if __name__ == "__main__":
+def main():
     args = parser.parse_args()
 
     stop = {
@@ -157,3 +157,7 @@ if __name__ == "__main__":
 
     run_with_custom_entropy_loss(args, stop=stop)
     print("run_with_custom_entropy_loss: ok.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://github.com/ray-project/ray/pull/15173 forgot to add a `@client_mode_hook` decorator for `ray.get_gpu_ids`
The hook is necessary for apis to be delegated to RayClientStub when in client mode.

This PR fixes that issue and adds a unit test confirming the fix.

I've also tried to test client integration with the RLLIB rock-paper-scissors example, but I'm unable to get the client connection working, see comments below.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
