### PR TITLE
[core] Fix periodical runner edge case

### DIFF
--- a/src/ray/common/asio/periodical_runner.cc
+++ b/src/ray/common/asio/periodical_runner.cc
@@ -39,20 +39,18 @@ void PeriodicalRunner::RunFnPeriodically(std::function<void()> fn, uint64_t peri
 void PeriodicalRunner::DoRunFnPeriodically(std::function<void()> fn,
                                            boost::posix_time::milliseconds period,
                                            boost::asio::deadline_timer &timer) {
-  io_service_.post(
-                   [this, fn, period, &timer] () {
-                     fn();
-                     timer.expires_from_now(period);
-                     timer.async_wait([this, fn, period, &timer](const boost::system::error_code &error) {
-                                        if (error == boost::asio::error::operation_aborted) {
-                                          // `operation_aborted` is set when `timer` is canceled or destroyed.
-                                          // The Monitor lifetime may be short than the object who use it. (e.g. gcs_server)
-                                          return;
-                                        }
-                                        RAY_CHECK(!error) << error.message();
-                                        DoRunFnPeriodically(fn, period, timer);
-                   }
-                   );
+  io_service_.post([this, fn, period, &timer]() {
+    fn();
+    timer.expires_from_now(period);
+    timer.async_wait([this, fn, period, &timer](const boost::system::error_code &error) {
+      if (error == boost::asio::error::operation_aborted) {
+        // `operation_aborted` is set when `timer` is canceled or destroyed.
+        // The Monitor lifetime may be short than the object who use it. (e.g. gcs_server)
+        return;
+      }
+      RAY_CHECK(!error) << error.message();
+      DoRunFnPeriodically(fn, period, timer);
+    });
   });
 }
 

--- a/src/ray/common/asio/periodical_runner.cc
+++ b/src/ray/common/asio/periodical_runner.cc
@@ -39,16 +39,20 @@ void PeriodicalRunner::RunFnPeriodically(std::function<void()> fn, uint64_t peri
 void PeriodicalRunner::DoRunFnPeriodically(std::function<void()> fn,
                                            boost::posix_time::milliseconds period,
                                            boost::asio::deadline_timer &timer) {
-  fn();
-  timer.expires_from_now(period);
-  timer.async_wait([this, fn, period, &timer](const boost::system::error_code &error) {
-    if (error == boost::asio::error::operation_aborted) {
-      // `operation_aborted` is set when `timer` is canceled or destroyed.
-      // The Monitor lifetime may be short than the object who use it. (e.g. gcs_server)
-      return;
-    }
-    RAY_CHECK(!error) << error.message();
-    DoRunFnPeriodically(fn, period, timer);
+  io_service_.post(
+                   [this, fn, period, &timer] () {
+                     fn();
+                     timer.expires_from_now(period);
+                     timer.async_wait([this, fn, period, &timer](const boost::system::error_code &error) {
+                                        if (error == boost::asio::error::operation_aborted) {
+                                          // `operation_aborted` is set when `timer` is canceled or destroyed.
+                                          // The Monitor lifetime may be short than the object who use it. (e.g. gcs_server)
+                                          return;
+                                        }
+                                        RAY_CHECK(!error) << error.message();
+                                        DoRunFnPeriodically(fn, period, timer);
+                   }
+                   );
   });
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The periodical runner should always run the provided function on the provided io context. Running on the wrong service can be quite bad if the caller and service are running on different threads.

This fixes an edge case where the function may be run on the wrong service in the first iteration.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
