### PR TITLE
[Core] Fix symbol issues in bazel build

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -671,7 +671,7 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
 
   // Start the IO thread after all other members have been initialized, in case
   // the thread calls back into any of our members.
-  io_thread_ = std::thread(&CoreWorker::RunIOService, this);
+  io_thread_ = std::thread([this]() { RunIOService(); });
   // Tell the raylet the port that we are listening on.
   // NOTE: This also marks the worker as available in Raylet. We do this at the
   // very end in case there is a problem during construction.

--- a/src/ray/object_manager/plasma/client.cc
+++ b/src/ray/object_manager/plasma/client.cc
@@ -49,7 +49,7 @@ using fb::PlasmaError;
 
 /// A Buffer class that automatically releases the backing plasma object
 /// when it goes out of scope. This is returned by Get.
-class RAY_NO_EXPORT PlasmaBuffer : public SharedMemoryBuffer {
+class PlasmaBuffer : public SharedMemoryBuffer {
  public:
   ~PlasmaBuffer();
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This will possibly change issues that memory profiler didn't show the correct function names. 

```
ld: warning: cannot export hidden symbol std::__1::thread::thread<void (ray::CoreWorker::*)(), ray::CoreWorker*, void>(void (ray::CoreWorker::*&&)(), ray::CoreWorker*&&) from bazel-out/darwin-opt/bin/libcore_worker_lib.a(core_worker.pic.o)

ld: warning: cannot export hidden symbol std::__1::shared_ptr<plasma::PlasmaBuffer> 
std::__1::shared_ptr<plasma::PlasmaBuffer>::make_shared<std::__1::shared_ptr<plasma::PlasmaClient::Impl>, ray::ObjectID const&, std::__1::shared_ptr<ray::Buffer> const&>(std::__1::shared_ptr<plasma::PlasmaClient::Impl>&&, ray::ObjectID const&, std::__1::shared_ptr<ray::Buffer> const&) from bazel-out/darwin-opt/bin/libplasma_client.a(client.pic.o)
```

2 Problems
- Plasma buffer is used by core worker, but it uses RAY_NO_EXPORT (which sets visibility is equal to hidden).
- It looks like `io_thread_` field receives the callback `RunIOService`, and this was not recognized for some reason. The easy fix is just to pass a basic callback.



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
