### PR TITLE
handle array custom metrics correctly in rllib evaluate

### DIFF
--- a/rllib/evaluation/metrics.py
+++ b/rllib/evaluation/metrics.py
@@ -167,7 +167,7 @@ def summarize_episodes(
         hist_stats["policy_{}_reward".format(policy_id)] = rewards
 
     for k, v_list in custom_metrics.copy().items():
-        filt = [v for v in v_list if not np.isnan(v)]
+        filt = [v for v in v_list if not np.any(np.isnan(v))]
         custom_metrics[k + "_mean"] = np.mean(filt)
         if filt:
             custom_metrics[k + "_min"] = np.min(filt)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When using custom metrics in rllib which are arrays (like for videos/ images,...)  np.isnan() returns a boolean array

## Related issue number

Minor fix and only an issue for people who use arrays for custom metrics.

https://discuss.ray.io/t/how-to-log-render-to-tensorboard/1607?u=sertingolix


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :( (sorry. Only tested such that nothing breaks)
