### PR TITLE
Resolves LogMonitor stacktrace

### DIFF
--- a/python/ray/_private/log_monitor.py
+++ b/python/ray/_private/log_monitor.py
@@ -243,7 +243,7 @@ class LogMonitor:
                     lines_to_publish.append(next_line)
                 except Exception:
                     logger.error(
-                        f"Error: Reading file: {file_info.full_path}, "
+                        f"Error: Reading file: {file_info.filename}, "
                         f"position: {file_info.file_info.file_handle.tell()} "
                         "failed.")
                     raise


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/log_monitor.py", line 363, in <module>
    log_monitor.run()
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/log_monitor.py", line 285, in run
    anything_published = self.check_log_files_and_publish_updates()
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/log_monitor.py", line 246, in check_log_files_and_publish_updates
    f"Error: Reading file: {file_info.full_path}, "
AttributeError: 'LogFileInfo' object has no attribute 'full_path'
```

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The property `full_path` has been removed from LogFileInfo. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
