### PR TITLE
Revert "Revert "[GCS]Increase heartbeat interval to reduce pressure o…

### DIFF
--- a/python/ray/tests/test_actor_resources.py
+++ b/python/ray/tests/test_actor_resources.py
@@ -239,7 +239,7 @@ def test_actor_multiple_gpus_from_multiple_tasks(ray_start_cluster):
         cluster.add_node(
             num_cpus=10 * num_gpus_per_raylet,
             num_gpus=num_gpus_per_raylet,
-            _system_config={"num_heartbeats_timeout": 1000} if i == 0 else {})
+            _system_config={"num_heartbeats_timeout": 100} if i == 0 else {})
     ray.init(address=cluster.address)
 
     @ray.remote

--- a/python/ray/tests/test_component_failures_2.py
+++ b/python/ray/tests/test_component_failures_2.py
@@ -147,7 +147,7 @@ def check_components_alive(cluster, component_type, check_component_alive):
         "num_cpus": 8,
         "num_nodes": 4,
         "_system_config": {
-            "num_heartbeats_timeout": 100
+            "num_heartbeats_timeout": 10
         },
     }],
     indirect=True)
@@ -172,7 +172,7 @@ def test_get_address_info_after_raylet_died(ray_start_cluster_head):
 
     cluster.head_node.kill_raylet()
     wait_for_condition(
-        lambda: not cluster.global_state.node_table()[0]["Alive"])
+        lambda: not cluster.global_state.node_table()[0]["Alive"], timeout=30)
     with pytest.raises(RuntimeError):
         get_address_info()
 

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -23,7 +23,7 @@ def increase(x):
 @pytest.mark.parametrize(
     "ray_start_regular", [
         generate_system_config_map(
-            num_heartbeats_timeout=20, ping_gcs_rpc_server_max_retries=60)
+            num_heartbeats_timeout=2, ping_gcs_rpc_server_max_retries=60)
     ],
     indirect=True)
 def test_gcs_server_restart(ray_start_regular):
@@ -74,7 +74,7 @@ def test_gcs_server_restart_during_actor_creation(ray_start_regular):
 @pytest.mark.parametrize(
     "ray_start_cluster_head", [
         generate_system_config_map(
-            num_heartbeats_timeout=20, ping_gcs_rpc_server_max_retries=60)
+            num_heartbeats_timeout=2, ping_gcs_rpc_server_max_retries=60)
     ],
     indirect=True)
 def test_node_failure_detector_when_gcs_server_restart(ray_start_cluster_head):

--- a/python/ray/tests/test_multi_node_2.py
+++ b/python/ray/tests/test_multi_node_2.py
@@ -36,7 +36,7 @@ def test_shutdown():
 @pytest.mark.parametrize(
     "ray_start_cluster_head", [
         generate_system_config_map(
-            num_heartbeats_timeout=20, object_timeout_milliseconds=12345)
+            num_heartbeats_timeout=2, object_timeout_milliseconds=12345)
     ],
     indirect=True)
 def test_system_config(ray_start_cluster_head):
@@ -54,7 +54,7 @@ def test_system_config(ray_start_cluster_head):
     @ray.remote
     def f():
         assert ray._config.object_timeout_milliseconds() == 12345
-        assert ray._config.num_heartbeats_timeout() == 20
+        assert ray._config.num_heartbeats_timeout() == 2
 
     ray.get([f.remote() for _ in range(5)])
 

--- a/python/ray/tests/test_multi_node_2.py
+++ b/python/ray/tests/test_multi_node_2.py
@@ -8,7 +8,8 @@ from ray.util.placement_group import placement_group, remove_placement_group
 from ray.autoscaler.sdk import request_resources
 from ray.autoscaler._private.monitor import Monitor
 from ray.cluster_utils import Cluster
-from ray.test_utils import generate_system_config_map, SignalActor
+from ray.test_utils import (generate_system_config_map, wait_for_condition,
+                            SignalActor)
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +37,7 @@ def test_shutdown():
 @pytest.mark.parametrize(
     "ray_start_cluster_head", [
         generate_system_config_map(
-            num_heartbeats_timeout=2, object_timeout_milliseconds=12345)
+            num_heartbeats_timeout=3, object_timeout_milliseconds=12345)
     ],
     indirect=True)
 def test_system_config(ray_start_cluster_head):
@@ -54,7 +55,7 @@ def test_system_config(ray_start_cluster_head):
     @ray.remote
     def f():
         assert ray._config.object_timeout_milliseconds() == 12345
-        assert ray._config.num_heartbeats_timeout() == 2
+        assert ray._config.num_heartbeats_timeout() == 3
 
     ray.get([f.remote() for _ in range(5)])
 
@@ -62,8 +63,11 @@ def test_system_config(ray_start_cluster_head):
     time.sleep(1)
     assert ray.cluster_resources()["CPU"] == 2
 
-    time.sleep(2)
-    assert ray.cluster_resources()["CPU"] == 1
+    def _node_removed():
+        return ray.cluster_resources()["CPU"] == 1
+
+    time.sleep(3)
+    wait_for_condition(_node_removed, timeout=3)
 
 
 def setup_monitor(address):

--- a/python/ray/tests/test_multi_node_2.py
+++ b/python/ray/tests/test_multi_node_2.py
@@ -66,7 +66,6 @@ def test_system_config(ray_start_cluster_head):
     def _node_removed():
         return ray.cluster_resources()["CPU"] == 1
 
-    time.sleep(3)
     wait_for_condition(_node_removed, timeout=3)
 
 

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -1181,7 +1181,7 @@ ray.shutdown()
 @pytest.mark.parametrize(
     "ray_start_cluster_head", [
         generate_system_config_map(
-            num_heartbeats_timeout=20, ping_gcs_rpc_server_max_retries=60)
+            num_heartbeats_timeout=2, ping_gcs_rpc_server_max_retries=60)
     ],
     indirect=True)
 def test_create_placement_group_after_gcs_server_restart(
@@ -1219,7 +1219,7 @@ def test_create_placement_group_after_gcs_server_restart(
 @pytest.mark.parametrize(
     "ray_start_cluster_head", [
         generate_system_config_map(
-            num_heartbeats_timeout=20, ping_gcs_rpc_server_max_retries=60)
+            num_heartbeats_timeout=2, ping_gcs_rpc_server_max_retries=60)
     ],
     indirect=True)
 def test_create_actor_with_placement_group_after_gcs_server_restart(
@@ -1243,7 +1243,7 @@ def test_create_actor_with_placement_group_after_gcs_server_restart(
 @pytest.mark.parametrize(
     "ray_start_cluster_head", [
         generate_system_config_map(
-            num_heartbeats_timeout=20, ping_gcs_rpc_server_max_retries=60)
+            num_heartbeats_timeout=2, ping_gcs_rpc_server_max_retries=60)
     ],
     indirect=True)
 def test_create_placement_group_during_gcs_server_restart(
@@ -1268,7 +1268,7 @@ def test_create_placement_group_during_gcs_server_restart(
 @pytest.mark.parametrize(
     "ray_start_cluster_head", [
         generate_system_config_map(
-            num_heartbeats_timeout=20, ping_gcs_rpc_server_max_retries=60)
+            num_heartbeats_timeout=2, ping_gcs_rpc_server_max_retries=60)
     ],
     indirect=True)
 def test_placement_group_wait_api(ray_start_cluster_head):

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -30,11 +30,11 @@ RAY_CONFIG(int64_t, ray_cookie, 0x5241590000000000)
 RAY_CONFIG(int64_t, handler_warning_timeout_ms, 1000)
 
 /// The duration between heartbeats sent by the raylets.
-RAY_CONFIG(uint64_t, raylet_heartbeat_period_milliseconds, 100)
+RAY_CONFIG(uint64_t, raylet_heartbeat_period_milliseconds, 1000)
 /// If a component has not sent a heartbeat in the last num_heartbeats_timeout
 /// heartbeat intervals, the raylet monitor process will report
 /// it as dead to the db_client table.
-RAY_CONFIG(int64_t, num_heartbeats_timeout, 300)
+RAY_CONFIG(int64_t, num_heartbeats_timeout, 30)
 /// For a raylet, if the last heartbeat was sent more than this many
 /// heartbeat periods ago, then a warning will be logged that the heartbeat
 /// handler is drifting.


### PR DESCRIPTION
…n gcs server (#14203)" (#15194)"

This reverts commit a9ac4ad890fab4355f1e5db6998c6a3395fca08f.

The node timeout value in test is 2 seconds. I think the flakey test may be caused by different environments.
I've increase the timeout value to 3 and optimize check logic. Run `test_multi_node_2` 10 times on my laptop and see no failure.
![image](https://user-images.githubusercontent.com/5276001/114143936-56079f80-9947-11eb-9d4e-56f4ddff47cc.png)

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
