### PR TITLE
[RLlib] Discussion 1513: `on_episode_step()` callback called after very first reset (should not).

### DIFF
--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -863,12 +863,17 @@ def _process_observations(
                     rewards[env_id][agent_id] or 0.0)
                 to_eval[policy_id].append(item)
 
-        # Invoke the step callback after the step is logged to the episode
-        callbacks.on_episode_step(
-            worker=worker,
-            base_env=base_env,
-            episode=episode,
-            env_index=env_id)
+        # Invoke the `on_episode_step` callback after the step is logged
+        # to the episode.
+        # Exception: The very first env.poll() call causes the env to get reset
+        # (no step taken yet, just a single starting observation logged).
+        # We need to skip this callback in this case.
+        if episode.length > 0:
+            callbacks.on_episode_step(
+                worker=worker,
+                base_env=base_env,
+                episode=episode,
+                env_index=env_id)
 
         # Episode is done for all agents (dones[__all__] == True)
         # or we hit the horizon.

--- a/rllib/examples/custom_metrics_and_callbacks.py
+++ b/rllib/examples/custom_metrics_and_callbacks.py
@@ -26,16 +26,19 @@ class MyCallbacks(DefaultCallbacks):
     def on_episode_start(self, *, worker: RolloutWorker, base_env: BaseEnv,
                          policies: Dict[str, Policy],
                          episode: MultiAgentEpisode, env_index: int, **kwargs):
-        print("episode {} (env-idx={}) started.".format(
-            episode.episode_id, env_index))
+        # Make sure this episode has just been started (only initial obs
+        # logged so far).
         assert episode.length == 0, \
             "ERROR: `on_episode_start()` callback should be called right " \
             "after env reset!"
+        print("episode {} (env-idx={}) started.".format(
+            episode.episode_id, env_index))
         episode.user_data["pole_angles"] = []
         episode.hist_data["pole_angles"] = []
 
     def on_episode_step(self, *, worker: RolloutWorker, base_env: BaseEnv,
                         episode: MultiAgentEpisode, env_index: int, **kwargs):
+        # Make sure this episode is ongoing.
         assert episode.length > 0, \
             "ERROR: `on_episode_step()` callback should not be called right " \
             "after env reset!"
@@ -47,6 +50,7 @@ class MyCallbacks(DefaultCallbacks):
     def on_episode_end(self, *, worker: RolloutWorker, base_env: BaseEnv,
                        policies: Dict[str, Policy], episode: MultiAgentEpisode,
                        env_index: int, **kwargs):
+        # Make sure this episode is really done.
         assert episode.batch_builder.policy_collectors[
             "default_policy"].buffers["dones"][-1], \
             "ERROR: `on_episode_end()` should only be called " \

--- a/rllib/examples/custom_metrics_and_callbacks.py
+++ b/rllib/examples/custom_metrics_and_callbacks.py
@@ -28,12 +28,17 @@ class MyCallbacks(DefaultCallbacks):
                          episode: MultiAgentEpisode, env_index: int, **kwargs):
         print("episode {} (env-idx={}) started.".format(
             episode.episode_id, env_index))
-
+        assert episode.length == 0, \
+            "ERROR: `on_episode_start()` callback should be called right " \
+            "after env reset!"
         episode.user_data["pole_angles"] = []
         episode.hist_data["pole_angles"] = []
 
     def on_episode_step(self, *, worker: RolloutWorker, base_env: BaseEnv,
                         episode: MultiAgentEpisode, env_index: int, **kwargs):
+        assert episode.length > 0, \
+            "ERROR: `on_episode_step()` callback should not be called right " \
+            "after env reset!"
         pole_angle = abs(episode.last_observation_for()[2])
         raw_angle = abs(episode.last_raw_obs_for()[2])
         assert pole_angle == raw_angle
@@ -42,6 +47,10 @@ class MyCallbacks(DefaultCallbacks):
     def on_episode_end(self, *, worker: RolloutWorker, base_env: BaseEnv,
                        policies: Dict[str, Policy], episode: MultiAgentEpisode,
                        env_index: int, **kwargs):
+        assert episode.batch_builder.policy_collectors[
+            "default_policy"].buffers["dones"][-1], \
+            "ERROR: `on_episode_end()` should only be called " \
+            "after episode is done!"
         pole_angle = np.mean(episode.user_data["pole_angles"])
         print("episode {} (env-idx={}) ended with length {} and pole "
               "angles {}".format(episode.episode_id, env_index, episode.length,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

`on_episode_step()` callback called after very first reset (should not):
See also:
https://discuss.ray.io/t/callbacks-on-episode-step-called-an-extra-time-during-the-first-episode-played-after-the-first-call-to-env-reset/1513/3

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
