### PR TITLE
[Client] Add metadata to Terminate Calls to make ray.kill() and ray.cancel() work

### DIFF
--- a/python/ray/tests/test_client_terminate.py
+++ b/python/ray/tests/test_client_terminate.py
@@ -119,16 +119,16 @@ def test_kill_cancel_metadata(ray_start_regular):
         ray.api.worker.server.Terminate = mock_terminate
 
         # Verify the expected exception is raised with ray.kill.
-        with pytest.raises(MetadataIsCorrectlyPassedException) as e:
+        # Check that argument of the exception matches "key" from the
+        # metadata above.
+        with pytest.raises(MetadataIsCorrectlyPassedException, match="key"):
             actor = A.remote()
             ray.kill(actor)
-        assert str(e.value) == "key"
 
         # Verify the expected exception is raised with ray.cancel.
-        with pytest.raises(MetadataIsCorrectlyPassedException) as e:
+        with pytest.raises(MetadataIsCorrectlyPassedException, match="key"):
             task_ref = f.remote()
             ray.cancel(task_ref)
-        assert str(e.value) == "key"
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_client_terminate.py
+++ b/python/ray/tests/test_client_terminate.py
@@ -92,7 +92,8 @@ def test_cancel_chain(ray_start_regular, use_force):
 def test_kill_cancel_metadata(ray_start_regular):
     """
     Verify that client worker's terminate_actor and terminate_task methods
-    pass worker's metadata attribute server grpc stub's Terminate method.
+    pass worker's metadata attribute server to the grpc stub's Terminate
+    method.
     """
     with ray_start_client_server(metadata=[("foo", "bar")]) as ray:
 

--- a/python/ray/tests/test_client_terminate.py
+++ b/python/ray/tests/test_client_terminate.py
@@ -121,13 +121,13 @@ def test_kill_cancel_metadata(ray_start_regular):
         # Verify the expected exception is raised with ray.kill.
         # Check that argument of the exception matches "key" from the
         # metadata above.
+        actor = A.remote()
         with pytest.raises(MetadataIsCorrectlyPassedException, match="key"):
-            actor = A.remote()
             ray.kill(actor)
 
         # Verify the expected exception is raised with ray.cancel.
+        task_ref = f.remote()
         with pytest.raises(MetadataIsCorrectlyPassedException, match="key"):
-            task_ref = f.remote()
             ray.cancel(task_ref)
 
 

--- a/python/ray/util/client/ray_client_helpers.py
+++ b/python/ray/util/client/ray_client_helpers.py
@@ -6,17 +6,17 @@ from ray.util.client import ray
 
 
 @contextmanager
-def ray_start_client_server():
-    with ray_start_client_server_pair() as pair:
+def ray_start_client_server(metadata=None):
+    with ray_start_client_server_pair(metadata=metadata) as pair:
         client, server = pair
         yield client
 
 
 @contextmanager
-def ray_start_client_server_pair():
+def ray_start_client_server_pair(metadata=None):
     ray._inside_client_test = True
     server = ray_client_server.serve("localhost:50051")
-    ray.connect("localhost:50051")
+    ray.connect("localhost:50051", metadata=metadata)
     try:
         yield ray, server
     finally:

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -358,7 +358,7 @@ class Worker:
         try:
             term = ray_client_pb2.TerminateRequest(actor=term_actor)
             term.client_id = self._client_id
-            self.server.Terminate(term)
+            self.server.Terminate(term, metadata=self.metadata)
         except grpc.RpcError as e:
             raise decode_exception(e.details())
 
@@ -375,7 +375,7 @@ class Worker:
         try:
             term = ray_client_pb2.TerminateRequest(task_object=term_object)
             term.client_id = self._client_id
-            self.server.Terminate(term)
+            self.server.Terminate(term, metadata=self.metadata)
         except grpc.RpcError as e:
             raise decode_exception(e.details())
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* Metadata is not set in these calls, meaning that issues may arise when making this calls!

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
