### PR TITLE
[client] Handle `ray.put` failures

### DIFF
--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 # This version string is incremented to indicate breaking changes in the
 # protocol that require upgrading the client version.
-CURRENT_PROTOCOL_VERSION = "2020-04-07"
+CURRENT_PROTOCOL_VERSION = "2021-04-09"
 
 
 class RayAPIStub:

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -248,6 +248,12 @@ class Worker:
         if client_ref_id is not None:
             req.client_ref_id = client_ref_id
         resp = self.data_client.PutObject(req)
+        if not resp.valid:
+            try:
+                raise cloudpickle.loads(resp.error)
+            except pickle.UnpicklingError:
+                logger.exception("Failed to deserialize {}".format(resp.error))
+                raise
         return ClientObjectRef(resp.id)
 
     # TODO(ekl) respect MAX_BLOCKING_OPERATION_TIME_S for wait too

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -103,6 +103,12 @@ message PutRequest {
 message PutResponse {
   // The reference ID for the data that the server has stored.
   bytes id = 1;
+
+  // Whether or not the put was successful.
+  bool valid = 2;
+
+  // An error blob (for example, an exception) on failure.
+  bytes error = 3;
 }
 
 // Requests data from the server.

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -101,11 +101,11 @@ message PutRequest {
 }
 
 message PutResponse {
-  // Whether or not the put was successful.
-  bool valid = 1;
-
   // The reference ID for the data that the server has stored.
-  bytes id = 2;
+  bytes id = 1;
+
+  // Whether or not the put was successful.
+  bool valid = 2;
 
   // An error blob (for example, an exception) on failure.
   bytes error = 3;

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -101,11 +101,11 @@ message PutRequest {
 }
 
 message PutResponse {
-  // The reference ID for the data that the server has stored.
-  bytes id = 1;
-
   // Whether or not the put was successful.
-  bool valid = 2;
+  bool valid = 1;
+
+  // The reference ID for the data that the server has stored.
+  bytes id = 2;
 
   // An error blob (for example, an exception) on failure.
   bytes error = 3;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Actually handle failures when `ray.put` fails. Without this, the failure is an unhandled gRPC connection and leads to the **client disconnecting**. While the likelihood of a user initiated `ray.put` failing is relatively low, this can crop up in situation where the server is missing a library (or the library is out of sync with the client.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #15220

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
