### PR TITLE
[RLlib] Discussion 681: Metrics prepends newest episodes instead of appending.

### DIFF
--- a/rllib/execution/metric_ops.py
+++ b/rllib/execution/metric_ops.py
@@ -80,7 +80,7 @@ class CollectMetrics:
         orig_episodes = list(episodes)
         missing = self.min_history - len(episodes)
         if missing > 0:
-            episodes.extend(self.episode_history[-missing:])
+            episodes = self.episode_history[-missing:] + episodes
             assert len(episodes) <= self.min_history
         self.episode_history.extend(orig_episodes)
         self.episode_history = self.episode_history[-self.min_history:]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Discussion 681: Metrics prepends newest episodes instead of appending.
Also see this discussion here:
https://discuss.ray.io/t/possible-to-access-default-logger-from-environment/681/13

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
