### PR TITLE
[dask-on-ray][client] Support ClientObjectRefs in the Dask-on-Ray scheduler.

### DIFF
--- a/python/ray/tests/test_dask_callback.py
+++ b/python/ray/tests/test_dask_callback.py
@@ -2,6 +2,8 @@ import dask
 import pytest
 
 import ray
+from ray._private.client_mode_hook import _explicitly_enable_client_mode
+from ray.util.client.ray_client_helpers import ray_start_client_server
 from ray.util.dask import ray_dask_get, RayDaskCallback
 
 
@@ -59,6 +61,8 @@ def test_pretask_posttask_shared_state(ray_start_regular_shared):
         result = z.compute(scheduler=ray_dask_get)
 
     assert result == 5
+
+
 
 
 def test_postsubmit(ray_start_regular_shared):
@@ -225,6 +229,43 @@ def test_pretask_posttask_shared_state_multi(ray_start_regular_shared):
     with cb1, cb2, cb3, cb4:
         z = add(2, 3)
         result = z.compute(scheduler=ray_dask_get)
+
+    assert result == 5
+
+
+def test_pretask_posttask_shared_state_multi_client(ray_start_regular_shared):
+    """
+    Test that pretask return values are passed to the correct corresponding
+    posttask callbacks when multiple callbacks are given.
+    """
+
+    class PretaskPosttaskCallback(RayDaskCallback):
+        def __init__(self, suffix):
+            self.suffix = suffix
+
+        def _ray_pretask(self, key, object_refs):
+            return key + self.suffix
+
+        def _ray_posttask(self, key, result, pre_state):
+            assert pre_state == key + self.suffix
+
+    class PretaskOnlyCallback(RayDaskCallback):
+        def _ray_pretask(self, key, object_refs):
+            return "baz"
+
+    class PosttaskOnlyCallback(RayDaskCallback):
+        def _ray_posttask(self, key, result, pre_state):
+            assert pre_state is None
+
+    cb1 = PretaskPosttaskCallback("foo")
+    cb2 = PretaskOnlyCallback()
+    cb3 = PosttaskOnlyCallback()
+    cb4 = PretaskPosttaskCallback("bar")
+    with ray_start_client_server():
+        _explicitly_enable_client_mode()
+        with cb1, cb2, cb3, cb4:
+            z = add(2, 3)
+            result = z.compute(scheduler=ray_dask_get)
 
     assert result == 5
 

--- a/python/ray/tests/test_dask_callback.py
+++ b/python/ray/tests/test_dask_callback.py
@@ -233,8 +233,7 @@ def test_pretask_posttask_shared_state_multi(ray_start_regular_shared):
 
 def test_pretask_posttask_shared_state_multi_client(ray_start_regular_shared):
     """
-    Test that pretask return values are passed to the correct corresponding
-    posttask callbacks when multiple callbacks are given.
+    Repeat the last test with Ray client.
     """
 
     class PretaskPosttaskCallback(RayDaskCallback):

--- a/python/ray/tests/test_dask_callback.py
+++ b/python/ray/tests/test_dask_callback.py
@@ -63,8 +63,6 @@ def test_pretask_posttask_shared_state(ray_start_regular_shared):
     assert result == 5
 
 
-
-
 def test_postsubmit(ray_start_regular_shared):
     """
     Test that postsubmit is called after each task.

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -39,6 +39,9 @@ class ClientBaseRef:
     def binary(self):
         return self.id
 
+    def hex(self):
+        return self.id.hex()
+
     def __eq__(self, other):
         return self.id == other.id
 

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -92,8 +92,8 @@ class ClientRemoteFunc(ClientStub):
         self._options = validate_options(options)
 
     def __call__(self, *args, **kwargs):
-        raise TypeError(f"Remote function cannot be called directly. "
-                        "Use {self._name}.remote method instead")
+        raise TypeError("Remote function cannot be called directly. "
+                        f"Use {self._name}.remote method instead")
 
     def remote(self, *args, **kwargs):
         return return_refs(ray.call_remote(self, *args, **kwargs))
@@ -156,8 +156,8 @@ class ClientActorClass(ClientStub):
         self._options = validate_options(options)
 
     def __call__(self, *args, **kwargs):
-        raise TypeError(f"Remote actor cannot be instantiated directly. "
-                        "Use {self._name}.remote() instead")
+        raise TypeError("Remote actor cannot be instantiated directly. "
+                        f"Use {self._name}.remote() instead")
 
     def _ensure_ref(self):
         with self._lock:

--- a/python/ray/util/dask/common.py
+++ b/python/ray/util/dask/common.py
@@ -4,6 +4,7 @@ from operator import getitem
 import uuid
 
 import ray
+from ray.util.client.common import ClientObjectRef
 
 from dask.base import quote
 from dask.core import get as get_sync
@@ -22,7 +23,7 @@ except ImportError:
 
 def unpack_object_refs(*args):
     """
-    Extract `ray.ObjectRef`s from a set of potentially arbitrarily nested
+    Extract Ray object refs from a set of potentially arbitrarily nested
     Python objects.
 
     Intended use is to find all Ray object references in a set of (possibly
@@ -46,7 +47,7 @@ def unpack_object_refs(*args):
     object_refs_token = uuid.uuid4().hex
 
     def _unpack(expr):
-        if isinstance(expr, ray.ObjectRef):
+        if isinstance(expr, (ray.ObjectRef, ClientObjectRef)):
             token = expr.hex()
             repack_dsk[token] = (getitem, object_refs_token, len(object_refs))
             object_refs.append(expr)

--- a/python/ray/util/dask/scheduler.py
+++ b/python/ray/util/dask/scheduler.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from multiprocessing.pool import ThreadPool
 
 import ray
+from ray.util.client.common import ClientObjectRef
 
 from dask.core import istask, ishashable, _execute_task
 from dask.system import CPU_COUNT
@@ -369,8 +370,9 @@ def ray_get_unpack(object_refs):
     if isinstance(object_refs, tuple):
         object_refs = list(object_refs)
 
-    if isinstance(object_refs, list) and any(not isinstance(x, ray.ObjectRef)
-                                             for x in object_refs):
+    if isinstance(object_refs, list) and any(
+            not isinstance(x, (ray.ObjectRef, ClientObjectRef))
+            for x in object_refs):
         # We flatten the object references before calling ray.get(), since Dask
         # loves to nest collections in nested tuples and Ray expects a flat
         # list of object references. We repack the results after ray.get()


### PR DESCRIPTION
## Why are these changes needed?

Currently, the Dask-on-Ray scheduler only properly unpacks and repacks plain object refs, while client object refs are never unpacked and are therefore never properly resolved. This prevents Dask-on-Ray from working correctly with Ray Client.

This PR makes the Dask-on-Ray scheduler `ClientObjectRef`-aware, ensuring that those refs are properly unpacked from Python data structures, resolved (via `ray.get()`), and repacked into those data structures.

## TODOs

- [ ] Manually test that this works.
- [ ] Add Ray Client unit test.

## Related issue number

Closes #15158 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
