### PR TITLE
[tune] deflake test_convergence, add `seed` parameter to OptunaSearch

### DIFF
--- a/python/ray/tune/suggest/optuna.py
+++ b/python/ray/tune/suggest/optuna.py
@@ -69,6 +69,9 @@ class OptunaSearch(Searcher):
             configurations.
         sampler (optuna.samplers.BaseSampler): Optuna sampler used to
             draw hyperparameter configurations. Defaults to ``TPESampler``.
+        seed (int): Seed to initialize sampler with. This parameter is only
+            used when ``sampler=None``. In all other cases, the sampler
+            you pass should be initialized with the seed already.
 
     Tune automatically converts search spaces to Optuna's format:
 
@@ -116,7 +119,8 @@ class OptunaSearch(Searcher):
                  metric: Optional[str] = None,
                  mode: Optional[str] = None,
                  points_to_evaluate: Optional[List[Dict]] = None,
-                 sampler: Optional[BaseSampler] = None):
+                 sampler: Optional[BaseSampler] = None,
+                 seed: Optional[int] = None):
         assert ot is not None, (
             "Optuna must be installed! Run `pip install optuna`.")
         super(OptunaSearch, self).__init__(
@@ -149,7 +153,15 @@ class OptunaSearch(Searcher):
         self._points_to_evaluate = points_to_evaluate or []
 
         self._study_name = "optuna"  # Fixed study name for in-memory storage
-        self._sampler = sampler or ot.samplers.TPESampler()
+
+        if sampler and seed:
+            logger.warning(
+                "You passed an initialized sampler to `OptunaSearch`. The "
+                "`seed` parameter has to be passed to the sampler directly "
+                "and will be ignored.")
+
+        self._sampler = sampler or ot.samplers.TPESampler(seed=seed)
+
         assert isinstance(self._sampler, BaseSampler), \
             "You can only pass an instance of `optuna.samplers.BaseSampler` " \
             "as a sampler to `OptunaSearcher`."

--- a/python/ray/tune/tests/test_convergence.py
+++ b/python/ray/tune/tests/test_convergence.py
@@ -114,7 +114,6 @@ class ConvergenceTest(unittest.TestCase):
 
         assert math.isclose(analysis.best_config["x"], 0, abs_tol=1e-3)
 
-    @pytest.mark.skip(reason="Flaky. Skip temporarily.")
     def testConvergenceOptuna(self):
         from ray.tune.suggest.optuna import OptunaSearch
 
@@ -127,9 +126,9 @@ class ConvergenceTest(unittest.TestCase):
 
         # This assertion is much weaker than in the BO case, but TPE
         # don't converge too close. It is still unlikely to get to this
-        # tolerance with random search (~0.01% chance)
+        # tolerance with random search (5 * 0.05 = 0.25% chance)
         assert len(analysis.trials) < 100
-        assert math.isclose(analysis.best_config["x"], 0, abs_tol=1e-2)
+        assert math.isclose(analysis.best_config["x"], 0, abs_tol=5e-2)
 
     def testConvergenceSkOpt(self):
         from ray.tune.suggest.skopt import SkOptSearch
@@ -153,6 +152,5 @@ class ConvergenceTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import pytest
     import sys
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tune/tests/test_convergence.py
+++ b/python/ray/tune/tests/test_convergence.py
@@ -118,7 +118,7 @@ class ConvergenceTest(unittest.TestCase):
         from ray.tune.suggest.optuna import OptunaSearch
 
         np.random.seed(1)
-        searcher = OptunaSearch()
+        searcher = OptunaSearch(seed=1)
         analysis = self._testConvergence(
             searcher,
             top=5,

--- a/python/ray/tune/tests/test_convergence.py
+++ b/python/ray/tune/tests/test_convergence.py
@@ -126,9 +126,9 @@ class ConvergenceTest(unittest.TestCase):
 
         # This assertion is much weaker than in the BO case, but TPE
         # don't converge too close. It is still unlikely to get to this
-        # tolerance with random search (5 * 0.05 = 0.25% chance)
+        # tolerance with random search (5 * 0.1 = 0.5% chance)
         assert len(analysis.trials) < 100
-        assert math.isclose(analysis.best_config["x"], 0, abs_tol=5e-2)
+        assert math.isclose(analysis.best_config["x"], 0, abs_tol=1e-1)
 
     def testConvergenceSkOpt(self):
         from ray.tune.suggest.skopt import SkOptSearch


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
