### PR TITLE
[Hotfix] Pin `dm-tree` package version

### DIFF
--- a/ci/asan_tests/ray-project/requirements.txt
+++ b/ci/asan_tests/ray-project/requirements.txt
@@ -3,7 +3,7 @@ blist
 boto3
 cython==0.29.0
 dataclasses; python_version < '3.7'
-dm-tree
+dm-tree==0.1.5
 feather-format
 flask
 grpcio

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -273,7 +273,7 @@ install_dependencies() {
   fi
 
   # Install modules needed in all jobs.
-  pip install --no-clean dm-tree  # --no-clean is due to: https://github.com/deepmind/tree/issues/5
+  pip install --no-clean dm-tree==0.1.5  # --no-clean is due to: https://github.com/deepmind/tree/issues/5
 
   if [ -n "${PYTHON-}" ]; then
     # Remove this entire section once RLlib and Serve dependencies are fixed.


### PR DESCRIPTION
`dm-tree` released a new version https://pypi.org/project/dm-tree/#history
and it depends on `bazel` to build from source, and it conflicts with
our current bazel setup (this conflict is non-trivial to fix).

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
