### PR TITLE
Temporarily disable flaky tests.

### DIFF
--- a/python/ray/tests/test_failure_2.py
+++ b/python/ray/tests/test_failure_2.py
@@ -374,6 +374,7 @@ def test_connect_with_disconnected_node(shutdown_only):
     p.close()
 
 
+@pytest.mark.skip(reason="Temporarily disabled due to flakyniess.")
 @pytest.mark.parametrize(
     "ray_start_cluster_head", [{
         "num_cpus": 5,

--- a/python/ray/tests/test_global_gc.py
+++ b/python/ray/tests/test_global_gc.py
@@ -52,6 +52,7 @@ def test_auto_local_gc(shutdown_only):
         gc.enable()
 
 
+@pytest.mark.skip(reason="Temporarily disabled due to flakyniess.")
 def test_global_gc(shutdown_only):
     cluster = ray.cluster_utils.Cluster()
     for _ in range(2):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

cc @clarkzinzow Can you make sure `test_global_gc` is re-enabled by this week? 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
