### PR TITLE
[dask-on-ray] Don't leak a global enabling of client mode in Dask callback test.

### DIFF
--- a/python/ray/_private/client_mode_hook.py
+++ b/python/ray/_private/client_mode_hook.py
@@ -37,6 +37,15 @@ def disable_client_hook():
         _enable_client_hook(val)
 
 
+@contextmanager
+def enable_client_hook():
+    _enable_client_hook(True)
+    try:
+        yield None
+    finally:
+        _disable_client_hook()
+
+
 def client_mode_hook(func):
     """Decorator for ray module methods to delegate to ray client"""
     from ray.util.client import ray

--- a/python/ray/_private/client_mode_hook.py
+++ b/python/ray/_private/client_mode_hook.py
@@ -28,6 +28,11 @@ def _explicitly_enable_client_mode():
     client_mode_enabled = True
 
 
+def _explicitly_disable_client_mode():
+    global client_mode_enabled
+    client_mode_enabled = False
+
+
 @contextmanager
 def disable_client_hook():
     val = _disable_client_hook()
@@ -38,12 +43,12 @@ def disable_client_hook():
 
 
 @contextmanager
-def enable_client_hook():
-    _enable_client_hook(True)
+def enable_client_mode():
+    _explicitly_enable_client_mode()
     try:
         yield None
     finally:
-        _disable_client_hook()
+        _explicitly_disable_client_mode()
 
 
 def client_mode_hook(func):

--- a/python/ray/tests/test_dask_callback.py
+++ b/python/ray/tests/test_dask_callback.py
@@ -2,7 +2,7 @@ import dask
 import pytest
 
 import ray
-from ray._private.client_mode_hook import enable_client_hook
+from ray._private.client_mode_hook import enable_client_mode
 from ray.util.client.ray_client_helpers import ray_start_client_server
 from ray.util.dask import ray_dask_get, RayDaskCallback
 
@@ -258,7 +258,7 @@ def test_pretask_posttask_shared_state_multi_client(ray_start_regular_shared):
     cb2 = PretaskOnlyCallback()
     cb3 = PosttaskOnlyCallback()
     cb4 = PretaskPosttaskCallback("bar")
-    with ray_start_client_server(), enable_client_hook():
+    with ray_start_client_server(), enable_client_mode():
         with cb1, cb2, cb3, cb4:
             z = add(2, 3)
             result = z.compute(scheduler=ray_dask_get)

--- a/python/ray/tests/test_dask_callback.py
+++ b/python/ray/tests/test_dask_callback.py
@@ -2,7 +2,7 @@ import dask
 import pytest
 
 import ray
-from ray._private.client_mode_hook import _explicitly_enable_client_mode
+from ray._private.client_mode_hook import enable_client_hook
 from ray.util.client.ray_client_helpers import ray_start_client_server
 from ray.util.dask import ray_dask_get, RayDaskCallback
 
@@ -258,8 +258,7 @@ def test_pretask_posttask_shared_state_multi_client(ray_start_regular_shared):
     cb2 = PretaskOnlyCallback()
     cb3 = PosttaskOnlyCallback()
     cb4 = PretaskPosttaskCallback("bar")
-    with ray_start_client_server():
-        _explicitly_enable_client_mode()
+    with ray_start_client_server(), enable_client_hook():
         with cb1, cb2, cb3, cb4:
             z = add(2, 3)
             result = z.compute(scheduler=ray_dask_get)


### PR DESCRIPTION
## Why are these changes needed?

Currently, `test_dask_callback.py:test_pretask_posttask_shared_state_multi_client` will enable client mode globally and never disable it, meaning that all subsequent Python tests running within the same Python process will run with client mode enabled. This PR adds an `enable_client_hook()` context manager and uses that instead.

```
ubuntu@ip-172-31-46-244:(ws)/ray $ pytest python/ray/tests/test_dask_scheduler.py
python/ray/tests/test_dask_scheduler.py ..                                                                                                                                                                                                                                                                                                                                                                                                                                                         [100%]
===== 2 passed in 6.87s =====
ubuntu@ip-172-31-46-244:(ws)/ray $ pytest python/ray/tests/test_dask_callback.py python/ray/tests/test_dask_scheduler.py
python/ray/tests/test_dask_callback.py .........                                                                                                                                                                                                                                                                                                                                                                                                                                                   [ 81%]
python/ray/tests/test_dask_scheduler.py .F                                                                                                                                                                                                                                                                                                                                                                                                                                                         [100%]
===== FAILURES =====
test_ray_dask_persist 
    @unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
    def test_ray_dask_persist(ray_start_regular_shared):
        from ray.util.dask import ray_dask_get
        arr = da.ones(5) + 2
>       result = arr.persist(scheduler=ray_dask_get)
python/ray/tests/test_dask_scheduler.py:41:
python/ray/util/dask/__init__.py:25: in ray_dask_persist_mixin
    return dask_persist_mixin(self, **kwargs)
/home/ubuntu/.local/lib/python3.7/site-packages/dask/base.py:257: in persist
    (result,) = persist(self, traverse=False, **kwargs)
/home/ubuntu/.local/lib/python3.7/site-packages/dask/base.py:772: in persist
    results = schedule(dsk, keys, **kwargs)
python/ray/util/dask/scheduler.py:111: in ray_dask_get
    **kwargs,
python/ray/util/dask/scheduler_utils.py:354: in get_async
    raise_exception(exc, tb)
python/ray/util/dask/scheduler_utils.py:206: in reraise
    raise exc
python/ray/util/dask/scheduler.py:214: in _rayify_task_wrapper
    ray_posttask_cbs,
python/ray/util/dask/scheduler.py:298: in _rayify_task
    *arg_object_refs,
python/ray/remote_function.py:168: in remote
    name=name)
python/ray/remote_function.py:209: in _remote
    name=name)
python/ray/_private/client_mode_hook.py:72: in client_mode_convert_function
    client_func = ray._get_converted(key)
python/ray/util/client/api.py:288: in _get_converted
    return self.worker._get_converted(key)
self = <ray.util.client.worker.Worker object at 0x7f028052da50>, key = '751a7fe20c5140fe9ea5e12bf15fd864'
    def _get_converted(self, key: str) -> "ClientStub":
        """Given a UUID, return the converted object"""
>       return self._converted[key]
E       KeyError: '751a7fe20c5140fe9ea5e12bf15fd864'
python/ray/util/client/worker.py:507: KeyError
==== short test summary info ====
FAILED python/ray/tests/test_dask_scheduler.py::test_ray_dask_persist - KeyError: '751a7fe20c5140fe9ea5e12bf15fd864'
==== 1 failed, 10 passed in 13.41s ====
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
