### PR TITLE
[tune] Cache MNIST and restore MNIST tests

### DIFF
--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -258,9 +258,9 @@ install_toolchains() {
 }
 
 download_mnist() {
-  mkdir -p ${HOME}/data
-  curl -o ${HOME}/data/mnist.zip https://ray-ci-mnist.s3-us-west-2.amazonaws.com/mnist.zip
-  unzip ${HOME}/data/mnist.zip -d ${HOME}/data
+  mkdir -p "${HOME}/data"
+  curl -o "${HOME}/data/mnist.zip" https://ray-ci-mnist.s3-us-west-2.amazonaws.com/mnist.zip
+  unzip "${HOME}/data/mnist.zip" -d "${HOME}/data"
 }
 
 install_dependencies() {

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -257,6 +257,12 @@ install_toolchains() {
   fi
 }
 
+download_mnist() {
+  mkdir -p ${HOME}/data
+  curl -o ${HOME}/data/mnist.zip https://ray-ci-mnist.s3-us-west-2.amazonaws.com/mnist.zip
+  unzip ${HOME}/data/mnist.zip -d ${HOME}/data
+}
+
 install_dependencies() {
 
   install_bazel
@@ -325,6 +331,7 @@ install_dependencies() {
   # Additional Tune/SGD/Doc test dependencies.
   if [ "${TUNE_TESTING-}" = 1 ] || [ "${SGD_TESTING-}" = 1 ] || [ "${DOC_TESTING-}" = 1 ]; then
     pip install -r "${WORKSPACE_DIR}"/python/requirements/requirements_tune.txt
+    download_mnist
   fi
 
   # For Tune, install upstream dependencies.

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -283,7 +283,7 @@ install_dependencies() {
       local torch_url="https://download.pytorch.org/whl/torch_stable.html"
       case "${OSTYPE}" in
         darwin*) pip install torch torchvision;;
-        *) pip install torch==1.7.0+cpu torchvision==0.8.1+cpu -f "${torch_url}";;
+        *) pip install torch==1.8.1+cpu torchvision==0.9.1+cpu -f "${torch_url}";;
       esac
     fi
 
@@ -337,13 +337,13 @@ install_dependencies() {
     # If CI has deemed that a different version of Tensorflow or Torch
     # should be installed, then upgrade/downgrade to that specific version.
     if [ -n "${TORCH_VERSION-}" ] || [ -n "${TFP_VERSION-}" ] || [ -n "${TF_VERSION-}" ]; then
-      case "${TORCH_VERSION-1.7}" in
-        1.7) TORCHVISION_VERSION=0.8.1;;
+      case "${TORCH_VERSION-1.8.1}" in
+        1.8.1) TORCHVISION_VERSION=0.9.1;;
         1.5) TORCHVISION_VERSION=0.6.0;;
         *) TORCHVISION_VERSION=0.5.0;;
       esac
       pip install --use-deprecated=legacy-resolver --upgrade tensorflow-probability=="${TFP_VERSION-0.8}" \
-        torch=="${TORCH_VERSION-1.7}" torchvision=="${TORCHVISION_VERSION}" \
+        torch=="${TORCH_VERSION-1.8.1}" torchvision=="${TORCHVISION_VERSION}" \
         tensorflow=="${TF_VERSION-2.2.0}" gym
     fi
   fi

--- a/doc/BUILD
+++ b/doc/BUILD
@@ -3,19 +3,19 @@
 # Please keep these sorted alphabetically, but start with the
 # root directory.
 # --------------------------------------------------------------------
-# py_test(
-#     name = "plot_hyperparameter",
-#     size = "small",
-#     srcs = ["examples/plot_hyperparameter.py"],
-#     tags = ["exclusive"]
-# )
+py_test(
+    name = "plot_hyperparameter",
+    size = "small",
+    srcs = ["examples/plot_hyperparameter.py"],
+    tags = ["exclusive"]
+)
 
-# py_test(
-#     name = "plot_parameter_server",
-#     size = "medium",
-#     srcs = ["examples/plot_parameter_server.py"],
-#     tags = ["exclusive"]
-# )
+py_test(
+    name = "plot_parameter_server",
+    size = "medium",
+    srcs = ["examples/plot_parameter_server.py"],
+    tags = ["exclusive"]
+)
 
 py_test(
     name = "plot_pong_example",
@@ -71,11 +71,11 @@ py_test(
     args = ["--smoke-test"]
 )
 
-# py_test(
-#     name = "tune_serve_integration_mnist",
-#     size = "medium",
-#     main = "source/tune/_tutorials/tune-serve-integration-mnist.py",
-#     srcs = ["source/tune/_tutorials/tune-serve-integration-mnist.py"],
-#     tags = ["exclusive", "example"],
-#     args = ["--smoke-test", "--from_scratch", "--day 0"]
-# )
+py_test(
+    name = "tune_serve_integration_mnist",
+    size = "medium",
+    main = "source/tune/_tutorials/tune-serve-integration-mnist.py",
+    srcs = ["source/tune/_tutorials/tune-serve-integration-mnist.py"],
+    tags = ["exclusive", "example"],
+    args = ["--smoke-test", "--from_scratch", "--day 0"]
+)

--- a/doc/examples/doc_code/torch_example.py
+++ b/doc/examples/doc_code/torch_example.py
@@ -82,25 +82,25 @@ def dataset_creator(use_cuda):
     with FileLock("./data.lock"):
         train_loader = torch.utils.data.DataLoader(
             datasets.MNIST(
-                "./data",
+                "~/data",
                 train=True,
                 download=True,
                 transform=transforms.Compose([
                     transforms.ToTensor(),
                     transforms.Normalize((0.1307, ), (0.3081, ))
                 ])),
-            128,
+            batch_size=128,
             shuffle=True,
             **kwargs)
     test_loader = torch.utils.data.DataLoader(
         datasets.MNIST(
-            "./data",
+            "~/data",
             train=False,
             transform=transforms.Compose([
                 transforms.ToTensor(),
                 transforms.Normalize((0.1307, ), (0.3081, ))
             ])),
-        128,
+        batch_size=128,
         shuffle=True,
         **kwargs)
 

--- a/doc/examples/doc_code/torch_example.py
+++ b/doc/examples/doc_code/torch_example.py
@@ -7,11 +7,6 @@ but we put comments right after code blocks to prevent large white spaces
 in the documentation.
 """
 # yapf: disable
-if __name__ == "__main__":
-    # temporarily disable due to mnist outage
-    import sys
-    sys.exit(0)
-
 # __torch_model_start__
 import torch
 import torch.nn as nn

--- a/doc/source/tune/_tutorials/tune-serve-integration-mnist.py
+++ b/doc/source/tune/_tutorials/tune-serve-integration-mnist.py
@@ -287,7 +287,7 @@ def train_mnist(config,
 # that affect the model complexity (such as the layer size), since it
 # does not have to be compatible to an existing model.
 def tune_from_scratch(num_samples=10, num_epochs=10, gpus_per_trial=0., day=0):
-    data_interface = MNISTDataInterface("/tmp/mnist_data", max_days=10)
+    data_interface = MNISTDataInterface("~/data", max_days=10)
     num_examples = data_interface._get_day_slice(day)
 
     config = {

--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -327,13 +327,13 @@ py_test(
 )
 
 # Todo: Ensure MPLBACKEND=Agg
-# py_test(
-#     name = "tutorial",
-#     size = "medium",
-#     srcs = ["tests/tutorial.py"],
-#     deps = [":tune_lib"],
-#     tags = ["exclusive", "example"],
-# )
+py_test(
+    name = "tutorial",
+    size = "medium",
+    srcs = ["tests/tutorial.py"],
+    deps = [":tune_lib"],
+    tags = ["exclusive", "example"],
+)
 
 # --------------------------------------------------------------------
 # Examples from the python/ray/tune/examples directory.
@@ -407,14 +407,14 @@ py_test(
     deps = [":tune_lib"],
 )
 
-# py_test(
-#     name = "ddp_mnist_torch",
-#     size = "small",
-#     srcs = ["examples/ddp_mnist_torch.py"],
-#     deps = [":tune_lib"],
-#     tags = ["exclusive", "example", "pytorch"],
-#     args = ["--num-workers=2"]
-# )
+py_test(
+    name = "ddp_mnist_torch",
+    size = "small",
+    srcs = ["examples/ddp_mnist_torch.py"],
+    deps = [":tune_lib"],
+    tags = ["exclusive", "example", "pytorch"],
+    args = ["--num-workers=2"]
+)
 
 py_test(
     name = "tf_distributed_keras_example",
@@ -523,50 +523,50 @@ py_test(
  tags = ["exclusive", "example"]
 )
 
-# py_test(
-#     name = "mlflow_ptl",
-#     size = "medium",
-#     srcs = ["examples/mlflow_ptl.py"],
-#     deps = [":tune_lib"],
-#     tags = ["exclusive", "example", "py37", "pytorch"],
-#     args = ["--smoke-test"]
-# )
+py_test(
+    name = "mlflow_ptl",
+    size = "medium",
+    srcs = ["examples/mlflow_ptl.py"],
+    deps = [":tune_lib"],
+    tags = ["exclusive", "example", "py37", "pytorch"],
+    args = ["--smoke-test"]
+)
 
-# py_test(
-#     name = "mnist_pytorch",
-#     size = "small",
-#     srcs = ["examples/mnist_pytorch.py"],
-#     deps = [":tune_lib"],
-#     tags = ["exclusive", "example", "pytorch"],
-#     args = ["--smoke-test"]
-# )
+py_test(
+    name = "mnist_pytorch",
+    size = "small",
+    srcs = ["examples/mnist_pytorch.py"],
+    deps = [":tune_lib"],
+    tags = ["exclusive", "example", "pytorch"],
+    args = ["--smoke-test"]
+)
 
-# py_test(
-#     name = "mnist_pytorch_lightning",
-#     size = "medium",
-#     srcs = ["examples/mnist_pytorch_lightning.py"],
-#     deps = [":tune_lib"],
-#     tags = ["exclusive", "example", "pytorch"],
-#     args = ["--smoke-test"]
-# )
+py_test(
+    name = "mnist_pytorch_lightning",
+    size = "medium",
+    srcs = ["examples/mnist_pytorch_lightning.py"],
+    deps = [":tune_lib"],
+    tags = ["exclusive", "example", "pytorch"],
+    args = ["--smoke-test"]
+)
 
-# py_test(
-#     name = "mnist_ptl_mini",
-#     size = "medium",
-#     srcs = ["examples/mnist_ptl_mini.py"],
-#     deps = [":tune_lib"],
-#     tags = ["exclusive", "example", "pytorch"],
-#     args = ["--smoke-test"]
-# )
+py_test(
+    name = "mnist_ptl_mini",
+    size = "medium",
+    srcs = ["examples/mnist_ptl_mini.py"],
+    deps = [":tune_lib"],
+    tags = ["exclusive", "example", "pytorch"],
+    args = ["--smoke-test"]
+)
 
-# py_test(
-#     name = "mnist_pytorch_trainable",
-#     size = "small",
-#     srcs = ["examples/mnist_pytorch_trainable.py"],
-#     deps = [":tune_lib"],
-#     tags = ["exclusive", "example", "pytorch"],
-#     args = ["--smoke-test"]
-# )
+py_test(
+    name = "mnist_pytorch_trainable",
+    size = "small",
+    srcs = ["examples/mnist_pytorch_trainable.py"],
+    deps = [":tune_lib"],
+    tags = ["exclusive", "example", "pytorch"],
+    args = ["--smoke-test"]
+)
 
 py_test(
     name = "mxnet_example",
@@ -604,41 +604,41 @@ py_test(
     args = ["--smoke-test"]
 )
 
-# py_test(
-#     name = "pbt_convnet_example",
-#     size = "small",
-#     srcs = ["examples/pbt_convnet_example.py"],
-#     deps = [":tune_lib"],
-#     tags = ["exclusive", "example"],
-#     args = ["--smoke-test"]
-# )
+py_test(
+    name = "pbt_convnet_example",
+    size = "small",
+    srcs = ["examples/pbt_convnet_example.py"],
+    deps = [":tune_lib"],
+    tags = ["exclusive", "example"],
+    args = ["--smoke-test"]
+)
 
-# py_test(
-#     name = "pbt_convnet_function_example",
-#     size = "small",
-#     srcs = ["examples/pbt_convnet_function_example.py"],
-#     deps = [":tune_lib"],
-#     tags = ["exclusive", "example"],
-#     args = ["--smoke-test"]
-# )
+py_test(
+    name = "pbt_convnet_function_example",
+    size = "small",
+    srcs = ["examples/pbt_convnet_function_example.py"],
+    deps = [":tune_lib"],
+    tags = ["exclusive", "example"],
+    args = ["--smoke-test"]
+)
 
-# py_test(
-#     name = "pbt_dcgan_mnist_func",
-#     size = "medium",
-#     srcs = ["examples/pbt_dcgan_mnist/pbt_dcgan_mnist_func.py"],
-#     deps = [":tune_lib"],
-#     tags = ["exclusive", "example"],
-#     args = ["--smoke-test"]
-# )
+py_test(
+    name = "pbt_dcgan_mnist_func",
+    size = "medium",
+    srcs = ["examples/pbt_dcgan_mnist/pbt_dcgan_mnist_func.py"],
+    deps = [":tune_lib"],
+    tags = ["exclusive", "example"],
+    args = ["--smoke-test"]
+)
 
-# py_test(
-#     name = "pbt_dcgan_mnist_trainable",
-#     size = "medium",
-#     srcs = ["examples/pbt_dcgan_mnist/pbt_dcgan_mnist_trainable.py"],
-#     deps = [":tune_lib"],
-#     tags = ["exclusive", "example"],
-#     args = ["--smoke-test"]
-# )
+py_test(
+    name = "pbt_dcgan_mnist_trainable",
+    size = "medium",
+    srcs = ["examples/pbt_dcgan_mnist/pbt_dcgan_mnist_trainable.py"],
+    deps = [":tune_lib"],
+    tags = ["exclusive", "example"],
+    args = ["--smoke-test"]
+)
 
 py_test(
     name = "pbt_example",

--- a/python/ray/tune/examples/mnist_pytorch_lightning.py
+++ b/python/ray/tune/examples/mnist_pytorch_lightning.py
@@ -192,7 +192,7 @@ def train_mnist_tune_checkpoint(config,
 
 # __tune_asha_begin__
 def tune_mnist_asha(num_samples=10, num_epochs=10, gpus_per_trial=0):
-    data_dir = os.path.join(tempfile.gettempdir(), "mnist_data_")
+    data_dir = os.path.expanduser("~/data")
     LightningMNISTClassifier.download_data(data_dir)
 
     config = {
@@ -231,13 +231,12 @@ def tune_mnist_asha(num_samples=10, num_epochs=10, gpus_per_trial=0):
 
     print("Best hyperparameters found were: ", analysis.best_config)
 
-    shutil.rmtree(data_dir)
 # __tune_asha_end__
 
 
 # __tune_pbt_begin__
 def tune_mnist_pbt(num_samples=10, num_epochs=10, gpus_per_trial=0):
-    data_dir = os.path.join(tempfile.gettempdir(), "mnist_data_")
+    data_dir = os.path.expanduser("~/data")
     LightningMNISTClassifier.download_data(data_dir)
 
     config = {
@@ -278,7 +277,6 @@ def tune_mnist_pbt(num_samples=10, num_epochs=10, gpus_per_trial=0):
 
     print("Best hyperparameters found were: ", analysis.best_config)
 
-    shutil.rmtree(data_dir)
 # __tune_pbt_end__
 
 

--- a/python/ray/tune/examples/pbt_dcgan_mnist/common.py
+++ b/python/ray/tune/examples/pbt_dcgan_mnist/common.py
@@ -18,7 +18,7 @@ import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 
 # Training parameters
-dataroot = ray._private.utils.get_user_temp_dir() + os.sep
+dataroot = "~/data"
 workers = 2
 batch_size = 64
 image_size = 32

--- a/python/ray/tune/tests/test_tune_restore.py
+++ b/python/ray/tune/tests/test_tune_restore.py
@@ -390,12 +390,12 @@ class TuneExampleTest(unittest.TestCase):
         validate_save_restore(Cifar10Model)
         validate_save_restore(Cifar10Model, use_object_store=True)
 
-    # def testPyTorchMNIST(self):
-    #     from ray.tune.examples.mnist_pytorch_trainable import TrainMNIST
-    #     from torchvision import datasets
-    #     datasets.MNIST("~/data", train=True, download=True)
-    #     validate_save_restore(TrainMNIST)
-    #     validate_save_restore(TrainMNIST, use_object_store=True)
+    def testPyTorchMNIST(self):
+        from ray.tune.examples.mnist_pytorch_trainable import TrainMNIST
+        from torchvision import datasets
+        datasets.MNIST("~/data", train=True, download=True)
+        validate_save_restore(TrainMNIST)
+        validate_save_restore(TrainMNIST, use_object_store=True)
 
     def testHyperbandExample(self):
         from ray.tune.examples.hyperband_example import MyTrainableClass

--- a/python/ray/util/lightning_accelerators/BUILD
+++ b/python/ray/util/lightning_accelerators/BUILD
@@ -16,14 +16,14 @@ py_test(
 # Please keep these sorted alphabetically.
 # --------------------------------------------------------------------
 
-# py_test(
-#     name = "ptl_horovod_ray_example",
-#     size = "medium",
-#     srcs = ["examples/ptl_horovod_ray_example.py"],
-#     tags = ["exclusive", "example", "pytorch-lightning", "pytorch", "horovod"],
-#     deps = [":accelerator_lib"],
-#     args = ["--smoke-test"]
-# )
+py_test(
+    name = "ptl_horovod_ray_example",
+    size = "medium",
+    srcs = ["examples/ptl_horovod_ray_example.py"],
+    tags = ["exclusive", "example", "pytorch-lightning", "pytorch", "horovod"],
+    deps = [":accelerator_lib"],
+    args = ["--smoke-test"]
+)
 
 # # This is a dummy test dependency that causes the above tests to be
 # # re-run if any of these files changes.

--- a/python/ray/util/lightning_accelerators/examples/ptl_horovod_ray_example.py
+++ b/python/ray/util/lightning_accelerators/examples/ptl_horovod_ray_example.py
@@ -181,7 +181,7 @@ if __name__ == "__main__":
     else:
         ray.init(address=args.address)
 
-    data_dir = os.path.join(tempfile.gettempdir(), "mnist_data_")
+    data_dir = "~/data"
 
     if args.tune:
         raise NotImplementedError("Using Tune + Pytorch Lightning with "

--- a/python/ray/util/lightning_accelerators/examples/ptl_horovod_ray_example.py
+++ b/python/ray/util/lightning_accelerators/examples/ptl_horovod_ray_example.py
@@ -1,7 +1,4 @@
 """Example using Pytorch Lightning with a Horovod on Ray Accelerator."""
-import os
-import tempfile
-
 import pytorch_lightning as pl
 import torch
 from torch.utils.data import random_split, DataLoader

--- a/python/ray/util/sgd/BUILD
+++ b/python/ray/util/sgd/BUILD
@@ -140,14 +140,14 @@ py_test(
     args = ["--smoke-test"]
 )
 
-# py_test(
-#     name = "dcgan",
-#     size = "small",
-#     srcs = ["torch/examples/dcgan.py"],
-#     tags = ["exclusive", "pytorch"],
-#     deps = [":sgd_lib"],
-#     args = ["--smoke-test", "--num-workers=2"]
-# )
+py_test(
+    name = "dcgan",
+    size = "small",
+    srcs = ["torch/examples/dcgan.py"],
+    tags = ["exclusive", "pytorch"],
+    deps = [":sgd_lib"],
+    args = ["--smoke-test", "--num-workers=2"]
+)
 
 py_test(
     name = "raysgd_torch_signatures",
@@ -232,14 +232,14 @@ py_test(
     args = ["--no-gpu", "--mock-data", "--smoke-test", "--ray-num-workers=2", "--model=mobilenetv3_small_075", "data"]
 )
 
-# py_test(
-#     name = "mnist-ptl",
-#     size = "small",
-#     srcs = ["torch/examples/pytorch-lightning/mnist-ptl.py"],
-#     tags = ["exclusive", "pytorch", "pytorch-lightning"],
-#     deps = [":sgd_lib"],
-#     args = ["--smoke-test"]
-# )
+py_test(
+    name = "mnist-ptl",
+    size = "small",
+    srcs = ["torch/examples/pytorch-lightning/mnist-ptl.py"],
+    tags = ["exclusive", "pytorch", "pytorch-lightning"],
+    deps = [":sgd_lib"],
+    args = ["--smoke-test"]
+)
 
 # --------------------------------------------------------------------
 # SGD related tests from the ../../../../release directory.

--- a/python/ray/util/sgd/torch/examples/dcgan.py
+++ b/python/ray/util/sgd/torch/examples/dcgan.py
@@ -117,7 +117,7 @@ class GANOperator(TrainingOperator):
 
         with FileLock(".ray.lock"):
             dataset = datasets.MNIST(
-                root="~/mnist/",
+                root="~/data/",
                 download=True,
                 transform=transforms.Compose([
                     transforms.Resize(32),

--- a/python/requirements/requirements_tune.txt
+++ b/python/requirements/requirements_tune.txt
@@ -31,14 +31,14 @@ tensorflow-probability==0.11.1
 timm==0.3.2
 
 
-torch==1.7.1;sys_platform=="darwin"
-torchvision==0.8.2;sys_platform=="darwin"
+torch==1.8.1;sys_platform=="darwin"
+torchvision==0.9.1;sys_platform=="darwin"
 
 # On non-OSX machines only install CPU version of torch and torchvision
 -f https://download.pytorch.org/whl/torch_stable.html
-torch==1.7.1+cpu;sys_platform!="darwin"
+torch==1.8.1+cpu;sys_platform!="darwin"
 -f https://download.pytorch.org/whl/torch_stable.html
-torchvision==0.8.2+cpu;sys_platform!="darwin"
+torchvision==0.9.1+cpu;sys_platform!="darwin"
 
 
 transformers==4.3.2


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
MNIST tests are flaky and download takes forever. This caches the MNIST download across all builds with a public anyscale bucket.

cc @amogkam @krfricke
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(