### PR TITLE
[client] Asyncio Support

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -173,6 +173,7 @@ py_test_module_list(
     "test_basic.py",
     "test_basic_2.py",
     "test_basic_3.py",
+    "test_asyncio.py"
   ],
   size = "medium",
   extra_srcs = SRCS,

--- a/python/ray/tests/test_asyncio.py
+++ b/python/ray/tests/test_asyncio.py
@@ -256,6 +256,7 @@ def test_async_function_errored(ray_start_regular_shared):
         ray.get(ref)
 
 
+@pytest.mark.asyncio
 async def test_async_obj_unhandled_errors(ray_start_regular_shared):
     @ray.remote
     def f():

--- a/python/ray/tests/test_asyncio.py
+++ b/python/ray/tests/test_asyncio.py
@@ -155,7 +155,10 @@ async def test_asyncio_get(ray_start_regular_shared, event_loop):
     with pytest.raises(ray.exceptions.RayTaskError):
         await actor.throw_error.remote().as_future()
 
-    kill_actor_and_wait_for_failure(actor)
+    # Wrap in Remote Function to work with Ray client.
+    kill_actor_ref = ray.remote(kill_actor_and_wait_for_failure).remote(actor)
+    ray.get(kill_actor_ref)
+
     with pytest.raises(ray.exceptions.RayActorError):
         await actor.echo.remote(1)
 

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -482,7 +482,7 @@ def test_startup_retry(ray_start_regular_shared):
     time.sleep(3)
     server = ray_client_server.serve("localhost:50051")
     thread.join()
-    server.stop(0)
+    server.shutdown(0)
     ray_client._inside_client_test = False
 
 
@@ -497,7 +497,7 @@ def test_dataclient_server_drop(ray_start_regular_shared):
 
     def stop_server(server):
         time.sleep(2)
-        server.stop(0)
+        server.shutdown(0)
 
     server = ray_client_server.serve("localhost:50051")
     ray_client.connect("localhost:50051")

--- a/python/ray/tests/test_client_init.py
+++ b/python/ray/tests/test_client_init.py
@@ -44,7 +44,7 @@ class C:
 def init_and_serve():
     server_handle, _ = ray_client_server.init_and_serve("localhost:50051")
     yield server_handle
-    ray_client_server.shutdown_with_server(server_handle.grpc_server)
+    ray_client_server.shutdown_with_server_handle(server_handle)
     time.sleep(2)
 
 
@@ -59,7 +59,7 @@ def init_and_serve_lazy():
 
     server_handle = ray_client_server.serve("localhost:50051", connect)
     yield server_handle
-    ray_client_server.shutdown_with_server(server_handle.grpc_server)
+    ray_client_server.shutdown_with_server_handle(server_handle)
     time.sleep(2)
 
 

--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -136,7 +136,7 @@ class RayAPIStub:
         import ray.util.client.server.server as ray_client_server
         server_handle, address_info = ray_client_server.init_and_serve(
             "localhost:50051", *args, **kwargs)
-        self._server = server_handle.grpc_server
+        self._server = server_handle
         self.connect("localhost:50051")
         self._connected_with_init = True
         return address_info
@@ -146,8 +146,8 @@ class RayAPIStub:
         import ray.util.client.server.server as ray_client_server
         if self._server is None:
             return
-        ray_client_server.shutdown_with_server(self._server,
-                                               _exiting_interpreter)
+        ray_client_server.shutdown_with_server_handle(self._server,
+                                                      _exiting_interpreter)
         self._server = None
 
 

--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 # This version string is incremented to indicate breaking changes in the
 # protocol that require upgrading the client version.
-CURRENT_PROTOCOL_VERSION = "2021-04-09"
+CURRENT_PROTOCOL_VERSION = "2021-04-19"
 
 
 class RayAPIStub:

--- a/python/ray/util/client/api.py
+++ b/python/ray/util/client/api.py
@@ -1,6 +1,7 @@
 """This file defines the interface between the ray client worker
 and the overall ray module API.
 """
+import asyncio
 from ray.util.client.runtime_context import ClientWorkerPropertyAPI
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -294,3 +295,6 @@ class ClientAPI:
                 "available within Ray remote functions and is not yet "
                 "implemented in the client API.".format(key))
         return self.__getattribute__(key)
+
+    def _asyncio_get(self, ref: "ClientObjectRef") -> asyncio.Future:
+        return self.worker.asyncio_get(ref)

--- a/python/ray/util/client/api.py
+++ b/python/ray/util/client/api.py
@@ -1,9 +1,8 @@
 """This file defines the interface between the ray client worker
 and the overall ray module API.
 """
-import asyncio
 from ray.util.client.runtime_context import ClientWorkerPropertyAPI
-from typing import TYPE_CHECKING
+from typing import Callable, TYPE_CHECKING
 if TYPE_CHECKING:
     from ray.actor import ActorClass
     from ray.remote_function import RemoteFunction
@@ -296,5 +295,6 @@ class ClientAPI:
                 "implemented in the client API.".format(key))
         return self.__getattribute__(key)
 
-    def _asyncio_get(self, ref: "ClientObjectRef") -> asyncio.Future:
-        return self.worker.asyncio_get(ref)
+    def _register_callback(self, ref: "ClientObjectRef",
+                           callback: Callable[..., None]) -> None:
+        self.worker.register_callback(ref, callback)

--- a/python/ray/util/client/api.py
+++ b/python/ray/util/client/api.py
@@ -296,5 +296,5 @@ class ClientAPI:
         return self.__getattribute__(key)
 
     def _register_callback(self, ref: "ClientObjectRef",
-                           callback: Callable[..., None]) -> None:
+                           callback: Callable[["DataResponse"], None]) -> None:
         self.worker.register_callback(ref, callback)

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -82,8 +82,15 @@ class ClientObjectRef(ClientBaseRef):
         return fut
 
     def _on_completed(self, py_callback: Callable[[Any], None]) -> None:
+        """Register a callback that will be called after Object is ready.
+        If the ObjectRef is already ready, the callback will be called soon.
+        The callback should take the result as the only argument. The result
+        can be an exception object in case of task error.
+        """
+        from ray.util.client.client_pickler import loads_from_server
+
         def deserialize_obj(resp):
-            from ray.util.client.client_pickler import loads_from_server
+            """Converts from a GetResponse proto to a python object."""
             obj = resp.get
             data = None
             if not obj.valid:

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -63,7 +63,7 @@ class ClientBaseRef:
 
 class ClientObjectRef(ClientBaseRef):
     def __await__(self):
-        return self.as_future.__await__()
+        return self.as_future().__await__()
 
     def as_future(self):
         loop = asyncio.get_event_loop()

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -63,6 +63,9 @@ class ClientBaseRef:
 
 class ClientObjectRef(ClientBaseRef):
     def __await__(self):
+        return self.as_future.__await__()
+
+    def as_future(self):
         loop = asyncio.get_event_loop()
         fut = loop.create_future()
 
@@ -79,7 +82,7 @@ class ClientObjectRef(ClientBaseRef):
             loop.call_soon_threadsafe(inner_set_value)
 
         ray._register_callback(self, set_value)
-        return fut.__await__()
+        return fut
 
     def _on_completed(self, py_callback: Callable[[Any], None]) -> None:
         def deserialize_obj(resp):

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -79,6 +79,9 @@ class ClientObjectRef(ClientBaseRef):
             loop.call_soon_threadsafe(inner_set_value)
 
         self._on_completed(set_value)
+
+        # Prevent this object ref from being released.
+        fut.object_ref = self
         return fut
 
     def _on_completed(self, py_callback: Callable[[Any], None]) -> None:

--- a/python/ray/util/client/dataclient.py
+++ b/python/ray/util/client/dataclient.py
@@ -1,7 +1,6 @@
 """This file implements a threaded stream controller to abstract a data stream
 back to the ray clientserver.
 """
-
 import logging
 import queue
 import threading

--- a/python/ray/util/client/dataclient.py
+++ b/python/ray/util/client/dataclient.py
@@ -66,7 +66,6 @@ class DataClient:
             wait_for_ready=True)
         try:
             for response in resp_stream:
-                logger.error(f"Got Response: {response}")
                 if response.req_id == 0:
                     # This is not being waited for.
                     logger.debug(f"Got unawaited response {response}")

--- a/python/ray/util/client/dataclient.py
+++ b/python/ray/util/client/dataclient.py
@@ -66,6 +66,7 @@ class DataClient:
             wait_for_ready=True)
         try:
             for response in resp_stream:
+                logger.error(f"Got Response: {response}")
                 if response.req_id == 0:
                     # This is not being waited for.
                     logger.debug(f"Got unawaited response {response}")

--- a/python/ray/util/client/dataclient.py
+++ b/python/ray/util/client/dataclient.py
@@ -69,7 +69,10 @@ class DataClient:
                     continue
                 if response.req_id in self.asyncio_waiting_data:
                     cb = self.asyncio_waiting_data.pop(response.req_id)
-                    cb(response)
+                    try:
+                        cb(response)
+                    except Exception:
+                        logger.exception("Callback error:")
                 else:
                     with self.cv:
                         self.ready_data[response.req_id] = response

--- a/python/ray/util/client/dataclient.py
+++ b/python/ray/util/client/dataclient.py
@@ -34,9 +34,9 @@ class DataClient:
         self.ready_data: Dict[int, Any] = {}
         self.cv = threading.Condition()
         self.lock = threading.RLock()
-        # NOTE: Thread safety for asyncio_waiting_data is maintained by enqueue
-        # operations happening before request_queue insertion and removals
-        # happening after rquest_queue polling.
+
+        # NOTE: Dictionary insertion is guaranteed to complete before lookup
+        # and/or removal because of synchronization via the request_queue.
         self.asyncio_waiting_data: Dict[int, Callable[
             [ray_client_pb2.DataResponse], None]] = {}
         self._req_id = 0

--- a/python/ray/util/client/ray_client_helpers.py
+++ b/python/ray/util/client/ray_client_helpers.py
@@ -22,7 +22,7 @@ def ray_start_client_server_pair(metadata=None):
     finally:
         ray._inside_client_test = False
         ray.disconnect()
-        server.stop(0)
+        server.shutdown(0)
 
 
 @contextmanager
@@ -40,4 +40,4 @@ def ray_start_cluster_client_server_pair(address):
     finally:
         ray._inside_client_test = False
         ray.disconnect()
-        server.stop(0)
+        server.shutdown(0)

--- a/python/ray/util/client/server/dataservicer.py
+++ b/python/ray/util/client/server/dataservicer.py
@@ -48,8 +48,17 @@ class DataServicer(ray_client_pb2_grpc.RayletDataStreamerServicer):
                 else:
                     assert accepted_connection
                     if req_type == "get":
-                        get_resp = self.basic_service._get_object(
-                            req.get, client_id)
+                        get_resp = None
+                        if req.get.asynchronous:
+                            get_resp = self.basic_service._async_get_object(
+                                req.get, client_id, req.req_id, context)
+                            if get_resp is None:
+                                # The response for this request will be sent
+                                # when the object is ready.
+                                continue
+                        else:
+                            get_resp = self.basic_service._get_object(
+                                req.get, client_id)
                         resp = ray_client_pb2.DataResponse(get=get_resp)
                     elif req_type == "put":
                         put_resp = self.basic_service._put_object(

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -271,14 +271,14 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
                         get_resp = ray_client_pb2.GetResponse(
                             valid=True, data=serialized)
                     except Exception as e:
-                        ray_client_pb2.GetResponse(
+                        get_resp = ray_client_pb2.GetResponse(
                             valid=False, error=cloudpickle.dumps(e))
 
                     resp = ray_client_pb2.DataResponse(
                         get=get_resp, req_id=req_id)
                     resp.req_id = req_id
 
-                    loop.call_soon_threadsafe(lambda: context.write(resp))
+                    asyncio.run_coroutine_threadsafe(context.write(resp), loop)
 
                 object_ref._on_completed(send_get_response)
                 return None

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -170,7 +170,7 @@ class Worker:
     def register_callback(
             self, ref: ClientObjectRef,
             callback: Callable[[ray_client_pb2.DataResponse], None]) -> None:
-        req = ray_client_pb2.GetRequest(id=ref.id)
+        req = ray_client_pb2.GetRequest(id=ref.id, asynchronous=True)
         self.data_client.RegisterGetCallback(req, callback)
 
     def get(self, vals, *, timeout: Optional[float] = None) -> Any:

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -2,7 +2,6 @@
 It implements the Ray API functions that are forwarded through grpc calls
 to the server.
 """
-import asyncio
 import base64
 import json
 import logging
@@ -10,6 +9,7 @@ import time
 import uuid
 from collections import defaultdict
 from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Tuple
@@ -167,9 +167,11 @@ class Worker:
             "protocol_version": data.protocol_version,
         }
 
-    def asyncio_get(self, ref: ClientObjectRef) -> asyncio.Future:
+    def register_callback(
+            self, ref: ClientObjectRef,
+            callback: Callable[[ray_client_pb2.DataResponse], None]) -> None:
         req = ray_client_pb2.GetRequest(id=ref.id)
-        return self.data_client.AsyncioGetObject(req)
+        self.data_client.RegisterGetCallback(req, callback)
 
     def get(self, vals, *, timeout: Optional[float] = None) -> Any:
         to_get = []

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -2,6 +2,7 @@
 It implements the Ray API functions that are forwarded through grpc calls
 to the server.
 """
+import asyncio
 import base64
 import json
 import logging
@@ -165,6 +166,10 @@ class Worker:
             "ray_commit": data.ray_commit,
             "protocol_version": data.protocol_version,
         }
+
+    def asyncio_get(self, ref: ClientObjectRef) -> asyncio.Future:
+        req = ray_client_pb2.GetRequest(id=ref.id)
+        return self.data_client.AsyncioGetObject(req)
 
     def get(self, vals, *, timeout: Optional[float] = None) -> Any:
         to_get = []

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -117,6 +117,8 @@ message GetRequest {
   bytes id = 1;
   // Length of time to wait for data to be available, in seconds. Zero is no timeout.
   float timeout = 2;
+  // Whether to schedule this as a callback on the server side.
+  bool asynchronous = 3;
 }
 
 message GetResponse {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* Adds asyncio support to the ClientObjectRef in the form of `__await__` (making it 'awaitable') and `as_future()` 
* It also adds the private helper method `_on_completed` to bring it to parity with `ObjectRef.pxi`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #13747

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests <-- NOTE: This just reuses `test_asyncio.py`
