### PR TITLE
[serve][release] Fix bad API call in serve long running failure test

### DIFF
--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -56,7 +56,6 @@ class RandomKiller:
 
 class RandomTest:
     def __init__(self, max_deployments=1):
-        self.client = serve.connect()
         self.max_deployments = max_deployments
         self.weighted_actions = [
             (self.create_deployment, 1),
@@ -69,8 +68,7 @@ class RandomTest:
     def create_deployment(self):
         if len(self.deployments) == self.max_deployments:
             deployment_to_delete = self.deployments.pop()
-            self.client.delete_deployment(deployment_to_delete)
-            self.client.delete_backend(deployment_to_delete)
+            serve.delete_deployment(deployment_to_delete)
 
         new_name = "".join(
             [random.choice(string.ascii_letters) for _ in range(10)])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/15270

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
