### PR TITLE
[Tune] Set correct Optuna `TrialState` in `on_trial_complete`

### DIFF
--- a/python/ray/tune/suggest/optuna.py
+++ b/python/ray/tune/suggest/optuna.py
@@ -12,9 +12,11 @@ from ray.tune.utils.util import flatten_dict, unflatten_dict
 
 try:
     import optuna as ot
+    from optuna.trial import TrialState as OptunaTrialState
     from optuna.samplers import BaseSampler
 except ImportError:
     ot = None
+    OptunaTrialState = None
     BaseSampler = None
 
 from ray.tune.suggest import Searcher
@@ -241,8 +243,14 @@ class OptunaSearch(Searcher):
         ot_trial = self._ot_trials[trial_id]
 
         val = result.get(self.metric, None) if result else None
+        ot_trial_state = OptunaTrialState.COMPLETE
+        if val is None:
+            if error:
+                ot_trial_state = OptunaTrialState.FAIL
+            else:
+                ot_trial_state = OptunaTrialState.PRUNED
         try:
-            self._ot_study.tell(ot_trial, val)
+            self._ot_study.tell(ot_trial, val, state=ot_trial_state)
         except ValueError as exc:
             logger.warning(exc)  # E.g. if NaN was reported
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Optuna's ask-tell interface supports passing a `TrialState` to `tell()`. By default, that `TrialState` is `TrialState.COMPLETE`. However, if `values` are `None`, then an exception is raised - while that exception is caught by `OptunaSearch`, it results in the Trial not being saved in Optuna. As the `values` are set to `None` when a Trial is pruned by Tune's Scheduler, this results in pruned trials not being saved at all, degrading optimization performance. This PR fixes this by setting the correct `TrialState`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
