### PR TITLE
[RLlib] Remove atari dependency for RLlib (in favor of detailed error message).

### DIFF
--- a/python/requirements_rllib.txt
+++ b/python/requirements_rllib.txt
@@ -1,27 +1,36 @@
+# Deep learning.
+# --------------
 tensorflow-probability
-gast
-# Version requirement to match Tune
+#gast #Test whether we can do w/o
+# Version requirement to match Tune.
 torch>=1.6.0
-# Version requirement to match Tune
+# Version requirement to match Tune.
 torchvision>=0.6.0
-# For auto-generating a rendering Window.
-pyglet
-smart_open
 
-# For testing in MuJoCo-like envs (in PyBullet).
-pybullet
-# For tests on PettingZoo's multi-agent envs.
-pettingzoo>=1.4.0
-# For tests on RecSim and Kaggle envs.
-recsim
+# Environment adapters.
+# ---------------------
+# Atari
+atari_py
+gym[atari]
+# Kaggle envs.
 kaggle_environments
-
-# For MAML on PyTorch.
-higher
-
 # Unity3D testing
 mlagents
 mlagents_envs
+# For tests on PettingZoo's multi-agent envs.
+pettingzoo>=1.4.0
+# For testing in MuJoCo-like envs (in PyBullet).
+pybullet
+# For tests on RecSim and Kaggle envs.
+recsim
 
+# Other.
+# ------
+# For MAML on PyTorch.
+higher
+# For auto-generating an env-rendering Window.
+pyglet
+# For JSON reader/writer.
+smart_open
 # Ray Serve example
 starlette

--- a/python/requirements_rllib.txt
+++ b/python/requirements_rllib.txt
@@ -1,7 +1,6 @@
 # Deep learning.
 # --------------
 tensorflow-probability
-#gast #Test whether we can do w/o
 # Version requirement to match Tune.
 torch>=1.6.0
 # Version requirement to match Tune.

--- a/python/setup.py
+++ b/python/setup.py
@@ -101,9 +101,8 @@ extras = {
 }
 
 extras["rllib"] = extras["tune"] + [
-    "atari_py",
     "dm_tree",
-    "gym[atari]",
+    "gym",
     "lz4",
     "opencv-python-headless<=4.3.0.36",
     "pyyaml",

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -1,33 +1,35 @@
-from datetime import datetime
-import numpy as np
 import copy
+from datetime import datetime
+import functools
 import logging
 import math
+import numpy as np
 import os
 import pickle
-import time
 import tempfile
+import time
 from typing import Callable, Dict, List, Optional, Type, Union
 
 import ray
 from ray.exceptions import RayError
 from ray.rllib.agents.callbacks import DefaultCallbacks
-from ray.rllib.env.normalize_actions import NormalizeActionWrapper
 from ray.rllib.env.env_context import EnvContext
+from ray.rllib.env.normalize_actions import NormalizeActionWrapper
+from ray.rllib.env.utils import gym_env_creator
 from ray.rllib.evaluation.collectors.simple_list_collector import \
     SimpleListCollector
+from ray.rllib.evaluation.metrics import collect_metrics
 from ray.rllib.evaluation.rollout_worker import RolloutWorker
+from ray.rllib.evaluation.worker_set import WorkerSet
 from ray.rllib.models import MODEL_DEFAULTS
 from ray.rllib.policy import Policy
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
-from ray.rllib.evaluation.metrics import collect_metrics
-from ray.rllib.evaluation.worker_set import WorkerSet
 from ray.rllib.utils import FilterManager, deep_update, merge_dicts
-from ray.rllib.utils.spaces import space_utils
-from ray.rllib.utils.framework import try_import_tf, TensorStructType
 from ray.rllib.utils.annotations import override, PublicAPI, DeveloperAPI
 from ray.rllib.utils.deprecation import deprecation_warning, DEPRECATED_VALUE
+from ray.rllib.utils.framework import try_import_tf, TensorStructType
 from ray.rllib.utils.from_config import from_config
+from ray.rllib.utils.spaces import space_utils
 from ray.rllib.utils.typing import TrainerConfigDict, \
     PartialTrainerConfigDict, EnvInfoDict, ResultDict, EnvType, PolicyID
 from ray.tune.logger import Logger, UnifiedLogger
@@ -621,38 +623,8 @@ class Trainer(Trainable):
                     lambda env_context: from_config(env, env_context)
             # Try gym/PyBullet/Vizdoom.
             else:
-
-                def _creator(env_context):
-                    import gym
-                    # Allow for PyBullet or VizdoomGym envs to be used as well
-                    # (via string). This allows for doing things like
-                    # `env=CartPoleContinuousBulletEnv-v0` or
-                    # `env=VizdoomBasic-v0`.
-                    try:
-                        import pybullet_envs
-                        pybullet_envs.getList()
-                    except (ModuleNotFoundError, ImportError):
-                        pass
-                    try:
-                        import vizdoomgym
-                        vizdoomgym.__name__  # trick LINTer.
-                    except (ModuleNotFoundError, ImportError):
-                        pass
-                    # Try creating a gym env. If this fails we can output a
-                    # decent error message.
-                    try:
-                        return gym.make(env, **env_context)
-                    except gym.error.Error:
-                        raise ValueError(
-                            "The env string you provided ({}) is a) not a "
-                            "known gym/PyBullet/VizdoomEnv environment "
-                            "specifier or b) not registered! To register your "
-                            "custom envs, do `from ray import tune; "
-                            "tune.register('[name]', lambda cfg: [return "
-                            "actual env from here using cfg])`. Then you can "
-                            "use [name] as your config['env'].".format(env))
-
-                self.env_creator = _creator
+                self.env_creator = functools.partial(
+                    gym_env_creator, env_descriptor=env)
         else:
             self.env_creator = lambda env_config: None
 

--- a/rllib/env/utils.py
+++ b/rllib/env/utils.py
@@ -2,7 +2,7 @@ from ray.rllib.env.env_context import EnvContext
 
 
 def gym_env_creator(env_context: EnvContext, env_descriptor: str):
-    """Tries to create a gym env given a descriptor and EnvContext object.
+    """Tries to create a gym env given am EnvContext object and descriptor.
 
     Note: This function tries to construct the env from a string descriptor
     only using possibly installed RL env packages (such as gym, pybullet_envs,
@@ -11,18 +11,18 @@ def gym_env_creator(env_context: EnvContext, env_descriptor: str):
     necessary imports and construction logic below.
 
     Args:
-        env_descriptor (str): The env descriptor, e.g. CartPole-v0,
-            MsPacmanNoFrameskip-v4, VizdoomBasic-v0, or
-            CartPoleContinuousBulletEnv-v0.
         env_context (EnvContext): The env context object to configure the env.
             Note that this is a config dict, plus the properties:
             `worker_index`, `vector_index`, and `remote`.
+        env_descriptor (str): The env descriptor, e.g. CartPole-v0,
+            MsPacmanNoFrameskip-v4, VizdoomBasic-v0, or
+            CartPoleContinuousBulletEnv-v0.
 
     Returns:
         gym.Env: The actual gym environment object.
 
     Raises:
-         gym.error.Error: If the env cannot be constructed.
+        gym.error.Error: If the env cannot be constructed.
     """
     import gym
     # Allow for PyBullet or VizdoomGym envs to be used as well

--- a/rllib/env/utils.py
+++ b/rllib/env/utils.py
@@ -1,0 +1,66 @@
+from ray.rllib.env.env_context import EnvContext
+
+
+def gym_env_creator(env_context: EnvContext, env_descriptor: str):
+    """Tries to create a gym env given a descriptor and EnvContext object.
+
+    Note: This function tries to construct the env from a string descriptor
+    only using possibly installed RL env packages (such as gym, pybullet_envs,
+    vizdoomgym, etc..). These packages are no installation requirements for
+    RLlib. In case you would like to support more such env packages, add the
+    necessary imports and construction logic below.
+
+    Args:
+        env_descriptor (str): The env descriptor, e.g. CartPole-v0,
+            MsPacmanNoFrameskip-v4, VizdoomBasic-v0, or
+            CartPoleContinuousBulletEnv-v0.
+        env_context (EnvContext): The env context object to configure the env.
+            Note that this is a config dict, plus the properties:
+            `worker_index`, `vector_index`, and `remote`.
+
+    Returns:
+        gym.Env: The actual gym environment object.
+
+    Raises:
+         gym.error.Error: If the env cannot be constructed.
+    """
+    import gym
+    # Allow for PyBullet or VizdoomGym envs to be used as well
+    # (via string). This allows for doing things like
+    # `env=CartPoleContinuousBulletEnv-v0` or
+    # `env=VizdoomBasic-v0`.
+    try:
+        import pybullet_envs
+        pybullet_envs.getList()
+    except (ModuleNotFoundError, ImportError):
+        pass
+    try:
+        import vizdoomgym
+        vizdoomgym.__name__  # trick LINTer.
+    except (ModuleNotFoundError, ImportError):
+        pass
+
+    # Try creating a gym env. If this fails we can output a
+    # decent error message.
+    try:
+        return gym.make(env_descriptor, **env_context)
+    except gym.error.Error:
+        error_msg = f"The env string you provided ('{env_descriptor}') is:" + \
+            """
+a) Not a supported/installed environment.
+b) Not a tune-registered environment creator.
+c) Not a valid env class string.
+
+Try one of the following:
+a) For Atari support: `pip install gym[atari] atari_py`.
+   For VizDoom support: Install VizDoom
+   (https://github.com/mwydmuch/ViZDoom/blob/master/doc/Building.md) and
+   `pip install vizdoomgym`.
+   For PyBullet support: `pip install pybullet pybullet_envs`.
+b) To register your custom env, do `from ray import tune;
+   tune.register('[name]', lambda cfg: [return env obj from here using cfg])`.
+   Then in your config, do `config['env'] = [name]`.
+c) Make sure you provide a fully qualified classpath, e.g.:
+   `ray.rllib.examples.env.repeat_after_me_env.RepeatAfterMeEnv`
+"""
+        raise gym.error.Error(error_msg)

--- a/rllib/env/utils.py
+++ b/rllib/env/utils.py
@@ -2,7 +2,7 @@ from ray.rllib.env.env_context import EnvContext
 
 
 def gym_env_creator(env_context: EnvContext, env_descriptor: str):
-    """Tries to create a gym env given am EnvContext object and descriptor.
+    """Tries to create a gym env given an EnvContext object and descriptor.
 
     Note: This function tries to construct the env from a string descriptor
     only using possibly installed RL env packages (such as gym, pybullet_envs,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

This PR removes the atari_py and gym[atari] dependencies for RLlib.
- Adds detailed error message on what to do if a env descriptor (e.g. "MsPacman-NoFrameskip-v4") is not supported.
- This error also covers and explains what to do in order to add other supported (but not installed-by-default) env packages, such as VizDoom and PyBullet.

See also this discussion here:
https://discuss.ray.io/t/how-do-i-install-ray-rllib-without-atari-py/1684/2

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
