### PR TITLE
[Tune] Fix max len trial name

### DIFF
--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -31,13 +31,6 @@ from ray._private.utils import binary_to_hex, hex_to_binary
 
 DEBUG_PRINT_INTERVAL = 5
 logger = logging.getLogger(__name__)
-if "MAX_LEN_IDENTIFIER" in os.environ:
-    logger.error(
-        "The MAX_LEN_IDENTIFIER environment variable is deprecated and will "
-        "be removed in the future. Use TUNE_MAX_LEN_IDENTIFIER instead.")
-MAX_LEN_IDENTIFIER = int(
-    os.environ.get("TUNE_MAX_LEN_IDENTIFIER",
-                   os.environ.get("MAX_LEN_IDENTIFIER", 130)))
 
 
 class Location:
@@ -628,6 +621,13 @@ class Trial:
         if self.custom_dirname:
             generated_dirname = self.custom_dirname
         else:
+            if "MAX_LEN_IDENTIFIER" in os.environ:
+                logger.error(
+                    "The MAX_LEN_IDENTIFIER environment variable is deprecated and will "
+                    "be removed in the future. Use TUNE_MAX_LEN_IDENTIFIER instead.")
+            MAX_LEN_IDENTIFIER = int(
+                os.environ.get("TUNE_MAX_LEN_IDENTIFIER",
+                               os.environ.get("MAX_LEN_IDENTIFIER", 130)))
             generated_dirname = f"{str(self)}_{self.experiment_tag}"
             generated_dirname = generated_dirname[:MAX_LEN_IDENTIFIER]
             generated_dirname += f"_{date_str()}"

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -622,9 +622,9 @@ class Trial:
             generated_dirname = self.custom_dirname
         else:
             if "MAX_LEN_IDENTIFIER" in os.environ:
-                logger.error(
-                    "The MAX_LEN_IDENTIFIER environment variable is deprecated and will "
-                    "be removed in the future. Use TUNE_MAX_LEN_IDENTIFIER instead.")
+                logger.error("The MAX_LEN_IDENTIFIER environment variable is "
+                             "deprecated and will be removed in the future. "
+                             "Use TUNE_MAX_LEN_IDENTIFIER instead.")
             MAX_LEN_IDENTIFIER = int(
                 os.environ.get("TUNE_MAX_LEN_IDENTIFIER",
                                os.environ.get("MAX_LEN_IDENTIFIER", 130)))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When we set the environment variable `TUNE_MAX_LEN_IDENTIFIER` after some import statement as follows:
```
import os
from ray import tune
os.environ["TUNE_MAX_LEN_IDENTIFIER"] = "220"
```
the setting takes no effect since [the global variable value](https://github.com/ray-project/ray/blob/aaa14d63a70f2f78a87acde3df297c602e5ada7c/python/ray/tune/trial.py#L38) has been set when running `from ray import tune`.

This PR checks this environment variable when the function `_generate_dirname` uses it.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(

After running `scripts/format.sh`, it shows
```
WARNING: clang-format is not installed!
WARNING:java is not installed, skip format java files!
From https://github.com/ray-project/ray
 * branch            master     -> FETCH_HEAD
fatal: There is nothing to exclude from by :(exclude) patterns.
Perhaps you forgot to add either ':/' or '.' ?
```