### PR TITLE
Revert "[runtime_env] Add support of exclusion (#15241)"

### DIFF
--- a/python/ray/_private/runtime_env.py
+++ b/python/ray/_private/runtime_env.py
@@ -11,7 +11,7 @@ from ray.experimental.internal_kv import (_internal_kv_put, _internal_kv_get,
                                           _internal_kv_exists,
                                           _internal_kv_initialized)
 
-from typing import List, Tuple, Optional, Set, Callable
+from typing import List, Tuple, Optional
 from urllib.parse import urlparse
 import os
 import sys
@@ -109,42 +109,19 @@ def _xor_bytes(left: bytes, right: bytes) -> bytes:
     return left or right
 
 
-def _dir_travel(
-        path: Path,
-        excludes: Set[Path],
-        handler: Callable,
-):
-    if path in excludes:
-        return
-    handler(path)
-    if path.is_dir():
-        for sub_path in path.iterdir():
-            _dir_travel(sub_path, excludes, handler)
-
-
-def _zip_module(root: Path, relative_path: Path, excludes: Set[Path],
-                zip_handler: ZipFile) -> None:
+def _zip_module(path: Path, relative_path: Path, zip_handler: ZipFile) -> None:
     """Go through all files and zip them into a zip file"""
-
-    def handler(path: Path):
-        # Pack this path if it's an empty directory or it's a file.
-        if path.is_dir() and next(path.iterdir()) is None or path.is_file():
-            file_size = path.stat().st_size
-            if file_size >= FILE_SIZE_WARNING:
-                logger.warning(
-                    f"File {path} is very large ({file_size} bytes). "
-                    "Consider excluding this file from the working directory.")
-            to_path = path.relative_to(relative_path)
-            zip_handler.write(path, to_path)
-
-    _dir_travel(root, excludes, handler)
+    for from_file_name in path.glob("**/*"):
+        file_size = from_file_name.stat().st_size
+        if file_size >= FILE_SIZE_WARNING:
+            logger.warning(
+                f"File {from_file_name} is very large ({file_size} bytes). "
+                "Consider excluding this file from the working directory.")
+        to_file_name = from_file_name.relative_to(relative_path)
+        zip_handler.write(from_file_name, to_file_name)
 
 
-def _hash_modules(
-        root: Path,
-        relative_path: Path,
-        excludes: Set[Path],
-) -> bytes:
+def _hash_modules(path: Path) -> bytes:
     """Helper function to create hash of a directory.
 
     It'll go through all the files in the directory and xor
@@ -152,20 +129,16 @@ def _hash_modules(
     """
     hash_val = None
     BUF_SIZE = 4096 * 1024
-
-    def handler(path: Path):
+    for from_file_name in path.glob("**/*"):
         md5 = hashlib.md5()
-        md5.update(str(path.relative_to(relative_path)).encode())
-        if not path.is_dir():
-            with path.open("rb") as f:
+        md5.update(str(from_file_name).encode())
+        if not Path(from_file_name).is_dir():
+            with open(from_file_name, mode="rb") as f:
                 data = f.read(BUF_SIZE)
                 while len(data) != 0:
                     md5.update(data)
                     data = f.read(BUF_SIZE)
-        nonlocal hash_val
         hash_val = _xor_bytes(hash_val, md5.digest())
-
-    _dir_travel(root, excludes, handler)
     return hash_val
 
 
@@ -182,8 +155,7 @@ def _parse_uri(pkg_uri: str) -> Tuple[Protocol, str]:
 
 
 # TODO(yic): Fix this later to handle big directories in better way
-def get_project_package_name(working_dir: str, py_modules: List[str],
-                             excludes: List[str]) -> str:
+def get_project_package_name(working_dir: str, py_modules: List[str]) -> str:
     """Get the name of the package by working dir and modules.
 
     This function will generate the name of the package by the working
@@ -204,29 +176,23 @@ def get_project_package_name(working_dir: str, py_modules: List[str],
     Args:
         working_dir (str): The working directory.
         py_modules (list[str]): The python module.
-        excludes (set[str]): The dir or files that should be excluded
 
     Returns:
         Package name as a string.
     """
     RAY_PKG_PREFIX = "_ray_pkg_"
     hash_val = None
-    excludes = {Path(p).absolute() for p in excludes}
     if working_dir:
         assert isinstance(working_dir, str)
         assert Path(working_dir).exists()
-        working_dir = Path(working_dir).absolute()
-        hash_val = _xor_bytes(
-            hash_val, _hash_modules(working_dir, working_dir, excludes))
+        hash_val = _xor_bytes(hash_val, _hash_modules(Path(working_dir)))
     for py_module in py_modules or []:
-        module_dir = Path(py_module).absolute()
-        hash_val = _xor_bytes(
-            hash_val, _hash_modules(module_dir, module_dir.parent, excludes))
+        hash_val = _xor_bytes(hash_val, _hash_modules(Path(py_module).parent))
     return RAY_PKG_PREFIX + hash_val.hex() + ".zip" if hash_val else None
 
 
 def create_project_package(working_dir: str, py_modules: List[str],
-                           excludes: List[str], output_path: str) -> None:
+                           output_path: str) -> None:
     """Create a pckage that will be used by workers.
 
     This function is used to create a package file based on working directory
@@ -236,19 +202,16 @@ def create_project_package(working_dir: str, py_modules: List[str],
         working_dir (str): The working directory.
         py_modules (list[str]): The list of path of python modules to be
             included.
-        excludes (List(str)): The directories or file to be excluded.
         output_path (str): The path of file to be created.
     """
-    pkg_file = Path(output_path).absolute()
-    excludes = [Path(e).absolute() for e in excludes]
+    pkg_file = Path(output_path)
     with ZipFile(pkg_file, "w") as zip_handler:
         if working_dir:
             # put all files in /path/working_dir into zip
-            working_path = Path(working_dir).absolute()
-            _zip_module(working_path, working_path, excludes, zip_handler)
+            working_path = Path(working_dir)
+            _zip_module(working_path, working_path, zip_handler)
         for py_module in py_modules or []:
-            module_path = Path(py_module).absolute()
-            _zip_module(module_path, module_path.parent, excludes, zip_handler)
+            _zip_module(Path(py_module), Path(py_module).parent, zip_handler)
 
 
 def fetch_package(pkg_uri: str) -> int:
@@ -342,13 +305,10 @@ def rewrite_working_dir_uri(job_config: JobConfig) -> None:
     # For now, we only support local directory and packages
     working_dir = job_config.runtime_env.get("working_dir")
     py_modules = job_config.runtime_env.get("py_modules")
-    excludes = job_config.runtime_env.get("excludes")
 
     if (not job_config.runtime_env.get("working_dir_uri")) and (working_dir
                                                                 or py_modules):
-        if excludes is None:
-            excludes = set()
-        pkg_name = get_project_package_name(working_dir, py_modules, excludes)
+        pkg_name = get_project_package_name(working_dir, py_modules)
         job_config.runtime_env[
             "working_dir_uri"] = Protocol.GCS.value + "://" + pkg_name
 
@@ -372,12 +332,10 @@ def upload_runtime_env_package_if_needed(job_config: JobConfig) -> None:
             pkg_file = Path(file_path)
             working_dir = job_config.runtime_env.get("working_dir")
             py_modules = job_config.runtime_env.get("py_modules")
-            excludes = job_config.runtime_env.get("excludes") or []
             logger.info(f"{pkg_uri} doesn't exist. Create new package with"
                         f" {working_dir} and {py_modules}")
             if not pkg_file.exists():
-                create_project_package(working_dir, py_modules, excludes,
-                                       file_path)
+                create_project_package(working_dir, py_modules, file_path)
             # Push the data to remote storage
             pkg_size = push_package(pkg_uri, pkg_file)
             logger.info(f"{pkg_uri} has been pushed with {pkg_size} bytes")

--- a/python/ray/experimental/packaging/load_package.py
+++ b/python/ray/experimental/packaging/load_package.py
@@ -69,17 +69,14 @@ def load_package(config_path: str) -> "_RuntimePackage":
     # Autofill working directory by uploading to GCS storage.
     if "working_dir" not in runtime_env:
         pkg_name = runtime_support.get_project_package_name(
-            working_dir=base_dir, py_modules=[], excludes=[])
+            working_dir=base_dir, py_modules=[])
         pkg_uri = runtime_support.Protocol.GCS.value + "://" + pkg_name
 
         def do_register_package():
             if not runtime_support.package_exists(pkg_uri):
                 tmp_path = os.path.join(_pkg_tmp(), "_tmp{}".format(pkg_name))
                 runtime_support.create_project_package(
-                    working_dir=base_dir,
-                    py_modules=[],
-                    excludes=[],
-                    output_path=tmp_path)
+                    working_dir=base_dir, py_modules=[], output_path=tmp_path)
                 # TODO(ekl) does this get garbage collected correctly with the
                 # current job id?
                 runtime_support.push_package(pkg_uri, tmp_path)

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -48,11 +48,8 @@ def run_test():
 
 @ray.remote
 def check_file(name):
-    try:
-        with open(name) as f:
-            return f.read()
-    except:
-        return "FAILED"
+    with open(name) as f:
+        return f.read()
 
 @ray.remote
 class TestActor(object):
@@ -178,80 +175,15 @@ print(sum([int(v) for v in vals]))
 
 @unittest.skipIf(sys.platform == "win32", "Fail to create temp dir.")
 @pytest.mark.parametrize("client_mode", [True, False])
-def test_exclusion(working_dir, ray_start_cluster_head, client_mode):
-    cluster = ray_start_cluster_head
-    (address, env, PKG_DIR) = start_client_server(cluster, client_mode)
-    working_path = Path(working_dir)
-
-    def create_file(p):
-        if not p.parent.exists():
-            p.parent.mkdir()
-        with p.open("w") as f:
-            f.write("Test")
-
-    create_file(working_path / "tmp_dir" / "test_1")
-    create_file(working_path / "tmp_dir" / "test_2")
-    create_file(working_path / "tmp_dir" / "test_3")
-    create_file(working_path / "tmp_dir" / "sub_dir" / "test_1")
-    create_file(working_path / "tmp_dir" / "sub_dir" / "test_2")
-    create_file(working_path / "test1")
-    create_file(working_path / "test2")
-    create_file(working_path / "test3")
-    tmp_dir_test_3 = str((working_path / "tmp_dir" / "test_3").absolute())
-    runtime_env = f"""{{
-        "working_dir": r"{working_dir}",
-    }}"""
-    execute_statement = """
-    vals = ray.get([
-        check_file.remote('test1'),
-        check_file.remote('test2'),
-        check_file.remote('test3'),
-        check_file.remote(os.path.join('tmp_dir', 'test_1')),
-        check_file.remote(os.path.join('tmp_dir', 'test_2')),
-        check_file.remote(os.path.join('tmp_dir', 'test_3')),
-        check_file.remote(os.path.join('tmp_dir', 'sub_dir', 'test_1')),
-        check_file.remote(os.path.join('tmp_dir', 'sub_dir', 'test_2')),
-    ])
-    print(','.join(vals))
-"""
-    script = driver_script.format(**locals())
-    out = run_string_as_driver(script, env)
-    # Test it works before
-    assert out.strip().split("\n")[-1] == \
-        "Test,Test,Test,Test,Test,Test,Test,Test"
-    runtime_env = f"""{{
-        "working_dir": r"{working_dir}",
-        "excludes": [
-            # exclude by absolute path
-            r"{tmp_dir_test_3}",
-            # exclude by relative path
-            r"{str(working_path / "test2")}",
-            # exclude by dir
-            r"{str(working_path / "tmp_dir" / "sub_dir")}",
-            # exclude part of the dir
-            r"{str(working_path / "tmp_dir" / "test_1")}",
-            # exclude part of the dir
-            r"{str(working_path / "tmp_dir" / "test_2")}",
-        ]
-    }}"""
-    script = driver_script.format(**locals())
-    out = run_string_as_driver(script, env)
-    # Test it works before
-    assert out.strip().split("\n")[-1] == \
-        "Test,FAILED,Test,FAILED,FAILED,FAILED,FAILED,FAILED"
-
-
-@unittest.skipIf(sys.platform == "win32", "Fail to create temp dir.")
-@pytest.mark.parametrize("client_mode", [True, False])
 def test_two_node_uri(two_node_cluster, working_dir, client_mode):
     cluster, _ = two_node_cluster
     (address, env, PKG_DIR) = start_client_server(cluster, client_mode)
     import ray._private.runtime_env as runtime_env
     import tempfile
     with tempfile.NamedTemporaryFile(suffix="zip") as tmp_file:
-        pkg_name = runtime_env.get_project_package_name(working_dir, [], [])
+        pkg_name = runtime_env.get_project_package_name(working_dir, [])
         pkg_uri = runtime_env.Protocol.PIN_GCS.value + "://" + pkg_name
-        runtime_env.create_project_package(working_dir, [], [], tmp_file.name)
+        runtime_env.create_project_package(working_dir, [], tmp_file.name)
         runtime_env.push_package(pkg_uri, tmp_file.name)
         runtime_env = f"""{{ "working_dir_uri": "{pkg_uri}" }}"""
         # Execute the following cmd in driver with runtime_env


### PR DESCRIPTION
This reverts commit 359b5ce06bd1014ef75b698afa12955abb1014b1.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR makes the Windows test flaky because the teardown path is somehow called although the test is skipped.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
