### PR TITLE
[core] Log warning on bad max task args value

### DIFF
--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -371,6 +371,11 @@ bool ClusterTaskManager::PinTaskArgsIfMemoryAvailable(const TaskSpecification &s
   }
   PinTaskArgs(spec, std::move(args));
   RAY_LOG(DEBUG) << "Size of pinned task args is now " << pinned_task_arguments_bytes_;
+  if (max_pinned_task_arguments_bytes_ == 0) {
+    // Max threshold for pinned args is not set.
+    return true;
+  }
+
   if (task_arg_bytes > max_pinned_task_arguments_bytes_) {
     RAY_LOG(WARNING)
         << "Dispatched task " << spec.TaskId() << " has arguments of size "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#15027 might cause a crash if object store memory isn't specified correctly. There isn't actually a reported issue related to this, but it appears to be blocking the 1.3 release.