### PR TITLE
[autoscaler] Do not divide by zero in resource demand scheduler

### DIFF
--- a/benchmarks/distributed/config.yaml
+++ b/benchmarks/distributed/config.yaml
@@ -16,11 +16,12 @@ available_node_types:
     head_node:
         node_config:
             InstanceType: r5dn.16xlarge # Network optimized.
-            ImageId: ami-0a2363a9cff180a64 
+            ImageId: ami-0a2363a9cff180a64
         resources:
           CPU: 0
           node: 1
           small: 1
+        max_workers: 0
     worker_node:
         node_config:
             InstanceType: m5.16xlarge

--- a/doc/source/cluster/config.rst
+++ b/doc/source/cluster/config.rst
@@ -966,7 +966,7 @@ The minimum number of workers to maintain for this node type regardless of utili
 ``available_node_types.<node_type_name>.node_type.max_workers``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The maximum number of workers to have in the cluster for this node type regardless of utilization. This takes precedence over :ref:`minimum workers <cluster-configuration-node-min-workers>`. By default, the number of workers of a node type is unbounded, constrained only by the cluster-wide :ref:`max_workers <cluster-configuration-max-workers>`.
+The maximum number of workers to have in the cluster for this node type regardless of utilization. This takes precedence over :ref:`minimum workers <cluster-configuration-node-min-workers>`. By default, the number of workers of a node type is unbounded, constrained only by the cluster-wide :ref:`max_workers <cluster-configuration-max-workers>`. (Prior to Ray 1.3.0, the default value for this field was 0.)
 
 * **Required:** No
 * **Importance:** High

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -754,6 +754,11 @@ def _utilization_score(node_resources: ResourceDict,
 
     util_by_resources = []
     for k, v in node_resources.items():
+        # Don't divide by zero.
+        if v < 1:
+            # Could test v == 0 on the nose, but v < 1 feels safer.
+            # (Note that node resources are integers.)
+            continue
         util = (v - remaining[k]) / v
         util_by_resources.append(v * (util**3))
 

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -12,7 +12,9 @@ import numpy as np
 import logging
 import collections
 from numbers import Number
-from typing import List, Dict
+from typing import Dict
+from typing import List
+from typing import Optional
 
 from ray.autoscaler.node_provider import NodeProvider
 from ray.gcs_utils import PlacementGroupTableData
@@ -733,7 +735,7 @@ def get_nodes_for(node_types: Dict[NodeType, NodeTypeConfigDict],
 
 
 def _utilization_score(node_resources: ResourceDict,
-                       resources: List[ResourceDict]) -> float:
+                       resources: List[ResourceDict]) -> Optional[float]:
     remaining = copy.deepcopy(node_resources)
     is_gpu_node = "GPU" in node_resources
     any_gpu_task = any("GPU" in r for r in resources)

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -762,6 +762,10 @@ def _utilization_score(node_resources: ResourceDict,
         util = (v - remaining[k]) / v
         util_by_resources.append(v * (util**3))
 
+    # Could happen if node_resources has only zero values.
+    if not util_by_resources:
+        return None
+
     # Prioritize using all resources first, then prioritize overall balance
     # of multiple resources.
     return (min(util_by_resources), np.mean(util_by_resources))

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -34,6 +34,8 @@ HEAD_TYPE_MAX_WORKERS_WARN_TEMPLATE = "Setting `max_workers` for node type"\
     "Note that `max_workers: 0` was the default value prior to Ray 1.3.0."\
     " Your current version is Ray {version}.\n"\
     "See the docs for more information:\n"\
+    "https://docs.ray.io/en/master/cluster/config.html"\
+    "#cluster-configuration-node-max-workers\n"\
     "https://docs.ray.io/en/master/cluster/config.html#full-configuration"
 
 logger = logging.getLogger(__name__)
@@ -235,9 +237,7 @@ def fill_node_type_max_workers(config):
                 HEAD_TYPE_MAX_WORKERS_WARN_TEMPLATE.format(
                     node_type=node_type_name,
                     max_workers=config["max_workers"],
-                    version=ray.__version__
-                )
-            )
+                    version=ray.__version__))
 
         # The key part of this function:
         node_type_data.setdefault("max_workers", config["max_workers"])

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -26,7 +26,6 @@ py_test_module_list(
     "test_basic_2.py",
     "test_basic_3.py",
     "test_cancel.py",
-    "test_cli.py",
     "test_client.py",
     "test_client_init.py",
     "test_client_library_integration.py",
@@ -119,6 +118,7 @@ py_test_module_list(
 
 py_test_module_list(
   files = [
+    "test_cli.py",
     "test_failure.py",
     "test_failure_2.py",
     "test_stress_failure.py",

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -35,6 +35,7 @@ from click.testing import CliRunner
 from testfixtures import Replacer
 from testfixtures.popen import MockPopen, PopenBehaviour
 
+import ray
 import ray.autoscaler._private.aws.config as aws_config
 import ray.scripts.scripts as scripts
 from ray.test_utils import wait_for_condition
@@ -176,8 +177,16 @@ def _setup_popen_mock(commands_mock):
 def _load_output_pattern(name):
     pattern_dir = Path(__file__).parent / "test_cli_patterns"
     with open(str(pattern_dir / name)) as f:
-        # remove \n
-        return [x[:-1] for x in f.readlines()]
+        # Remove \n from each line.
+        # Substitute the Ray version in each line containing the string
+        # {ray_version}.
+        out = []
+        for x in f.readlines():
+            if "{ray_version}" in x:
+                out.append(x[:-1].format(ray_version=ray.__version__))
+            else:
+                out.append(x[:-1])
+        return out
 
 
 def _check_output_via_pattern(name, result):
@@ -196,6 +205,10 @@ def _check_output_via_pattern(name, result):
 
 DEFAULT_TEST_CONFIG_PATH = str(
     Path(__file__).parent / "test_cli_patterns" / "test_ray_up_config.yaml")
+
+MISSING_MAX_WORKER_CONFIG_PATH = str(
+    Path(__file__).parent / "test_cli_patterns" /
+    "test_ray_up_no_max_worker_config.yaml")
 
 DOCKER_TEST_CONFIG_PATH = str(
     Path(__file__).parent / "test_cli_patterns" /
@@ -242,6 +255,36 @@ def test_ray_up(configure_lang, _unlink_test_ssh_key, configure_aws):
             "--log-style=pretty", "--log-color", "False"
         ])
         _check_output_via_pattern("test_ray_up.txt", result)
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin" and "travis" in os.environ.get("USER", ""),
+    reason=("Mac builds don't provide proper locale support"))
+@mock_ec2
+@mock_iam
+def test_ray_up_no_head_max_workers(configure_lang, _unlink_test_ssh_key,
+                                    configure_aws):
+    def commands_mock(command, stdin):
+        # if we want to have e.g. some commands fail,
+        # we can have overrides happen here.
+        # unfortunately, cutting out SSH prefixes and such
+        # is, to put it lightly, non-trivial
+        if "uptime" in command:
+            return PopenBehaviour(stdout=b"MOCKED uptime")
+        if "rsync" in command:
+            return PopenBehaviour(stdout=b"MOCKED rsync")
+        if "ray" in command:
+            return PopenBehaviour(stdout=b"MOCKED ray")
+        return PopenBehaviour(stdout=b"MOCKED GENERIC")
+
+    with _setup_popen_mock(commands_mock):
+        # config cache does not work with mocks
+        runner = CliRunner()
+        result = runner.invoke(scripts.up, [
+            MISSING_MAX_WORKER_CONFIG_PATH, "--no-config-cache", "-y",
+            "--log-style=pretty", "--log-color", "False"
+        ])
+        _check_output_via_pattern("test_ray_up_no_max_worker.txt", result)
 
 
 @pytest.mark.skipif(

--- a/python/ray/tests/test_cli_patterns/test_ray_up_config.yaml
+++ b/python/ray/tests/test_cli_patterns/test_ray_up_config.yaml
@@ -6,6 +6,7 @@ file_mounts:
 available_node_types:
     head_node:
         resources: {}
+        max_workers: 0
         node_config:
             ImageId: latest_dlami
             InstanceType: t1.micro

--- a/python/ray/tests/test_cli_patterns/test_ray_up_no_max_worker.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_up_no_max_worker.txt
@@ -1,0 +1,53 @@
+Cluster: test-cli
+
+Setting `max_workers` for node type `head_node` to the global `max_workers` value of 2. To avoid spawning worker nodes of type `head_node`, explicitly set `max_workers: 0` for `head_node`.
+Note that `max_workers: 0` was the default value prior to Ray 1.3.0. Your current version is Ray {ray_version}.
+See the docs for more information:
+https://docs.ray.io/en/master/cluster/config.html#cluster-configuration-node-max-workers
+https://docs.ray.io/en/master/cluster/config.html#full-configuration
+Checking AWS environment settings
+AWS config
+  IAM Profile: .+ \[default\]
+  EC2 Key pair \(head & workers\): .+ \[default\]
+  VPC Subnets \(head & workers\): subnet-.+ \[default\]
+  EC2 Security groups \(head & workers\): sg-.+ \[default\]
+  EC2 AMI \(head & workers\): ami-.+ \[dlami\]
+
+No head node found\. Launching a new cluster\. Confirm \[y/N\]: y \[automatic, due to --yes\]
+
+Acquiring an up-to-date head node
+  Launched 1 nodes \[subnet_id=subnet-.+\]
+    Launched instance i-.+ \[state=pending, info=pending\]
+  Launched a new head node
+  Fetching the new head node
+
+<1/1> Setting up head node
+  Prepared bootstrap config
+  New status: waiting-for-ssh
+  \[1/7\] Waiting for SSH to become available
+    Running `uptime` as a test\.
+    Fetched IP: .+
+    Success\.
+  Updating cluster configuration\. \[hash=.+\]
+  New status: syncing-files
+  \[2/7\] Processing file mounts
+    ~/tests/ from ./
+  \[3/7\] No worker file mounts to sync
+  New status: setting-up
+  \[4/7\] Running initialization commands
+  \[5/7\] Initalizing command runner
+  \[6/7\] Running setup commands
+    \(0/4\) echo a
+    \(1/4\) echo b
+    \(2/4\) echo \${echo hi}
+    \(3/4\) echo head
+  \[7/7\] Starting the Ray runtime
+  New status: up-to-date
+
+Useful commands
+  Monitor autoscaling with
+    ray exec .+ 'tail -n 100 -f /tmp/ray/session_latest/logs/monitor\*'
+  Connect to a terminal on the cluster head:
+    ray attach .+
+  Get a remote shell to the cluster manually:
+    ssh .+

--- a/python/ray/tests/test_cli_patterns/test_ray_up_no_max_worker_config.yaml
+++ b/python/ray/tests/test_cli_patterns/test_ray_up_no_max_worker_config.yaml
@@ -1,17 +1,11 @@
 auth:
     ssh_user: ubuntu
 cluster_name: test-cli
-docker:
-    image: rayproject/ray:1.0.0
-    container_name: raydocker
-    pull_before_run: True
-    run_options: []
 file_mounts:
     ~/tests: .
 available_node_types:
     head_node:
         resources: {}
-        max_workers: 0
         node_config:
             ImageId: latest_dlami
             InstanceType: t1.micro

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -117,6 +117,13 @@ def test_gpu_node_util_score():
     assert _utilization_score({"GPU": 1, "CPU": 1}, [{"GPU": 1}]) == (0.0, 0.5)
 
 
+def test_zero_resource():
+    # Test edge case of node type with all zero resource values.
+    assert _utilization_score({"CPU": 0, "custom": 0}, [{"custom": 1}]) is None
+    # Just check that we don't have a division by zero error.
+    _utilization_score({"CPU": 0, "custom": 1}, [{"custom": 1}])
+
+
 def test_bin_pack():
     assert get_bin_pack_residual([], [{"GPU": 2}, {"GPU": 2}])[0] == \
         [{"GPU": 2}, {"GPU": 2}]

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -120,7 +120,7 @@ def test_gpu_node_util_score():
 def test_zero_resource():
     # Test edge case of node type with all zero resource values.
     assert _utilization_score({"CPU": 0, "custom": 0}, [{"custom": 1}]) is None
-    # Just check that we don't have a division by zero error.
+    # Just check that we don't have a division-by-zero error.
     _utilization_score({"CPU": 0, "custom": 1}, [{"custom": 1}])
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The resource demand scheduler currently tries to divide by zero if a node type has a resource with value 0 specified.

The logic has been unchanged for many months so something blocking zero values from appearing here must have changed??

In any case, this PR solves the issue by skipping resources with value 0 when computing the utilization score of a node type.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/15315 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
