### PR TITLE
Fix release test -- client remote put

### DIFF
--- a/python/ray/_private/ray_client_microbenchmark.py
+++ b/python/ray/_private/ray_client_microbenchmark.py
@@ -76,9 +76,9 @@ def main():
     }
 
     def ray_connect_handler(job_config=None):
-        import ray as real_ray
         from ray._private.client_mode_hook import disable_client_hook
         with disable_client_hook():
+            import ray as real_ray
             if not real_ray.is_initialized():
                 real_ray.init(**ray_config)
 

--- a/python/ray/util/client/ray_client_helpers.py
+++ b/python/ray/util/client/ray_client_helpers.py
@@ -6,16 +6,16 @@ from ray.util.client import ray
 
 
 @contextmanager
-def ray_start_client_server(metadata=None):
-    with ray_start_client_server_pair(metadata=metadata) as pair:
+def ray_start_client_server(metadata=None, ray_connect_handler=None):
+    with ray_start_client_server_pair(metadata=metadata, ray_connect_handler=ray_connect_handler) as pair:
         client, server = pair
         yield client
 
 
 @contextmanager
-def ray_start_client_server_pair(metadata=None):
+def ray_start_client_server_pair(metadata=None, ray_connect_handler=None):
     ray._inside_client_test = True
-    server = ray_client_server.serve("localhost:50051")
+    server = ray_client_server.serve("localhost:50051", ray_connect_handler=ray_connect_handler)
     ray.connect("localhost:50051", metadata=metadata)
     try:
         yield ray, server

--- a/python/ray/util/client/ray_client_helpers.py
+++ b/python/ray/util/client/ray_client_helpers.py
@@ -7,7 +7,9 @@ from ray.util.client import ray
 
 @contextmanager
 def ray_start_client_server(metadata=None, ray_connect_handler=None):
-    with ray_start_client_server_pair(metadata=metadata, ray_connect_handler=ray_connect_handler) as pair:
+    with ray_start_client_server_pair(
+            metadata=metadata,
+            ray_connect_handler=ray_connect_handler) as pair:
         client, server = pair
         yield client
 
@@ -15,7 +17,8 @@ def ray_start_client_server(metadata=None, ray_connect_handler=None):
 @contextmanager
 def ray_start_client_server_pair(metadata=None, ray_connect_handler=None):
     ray._inside_client_test = True
-    server = ray_client_server.serve("localhost:50051", ray_connect_handler=ray_connect_handler)
+    server = ray_client_server.serve(
+        "localhost:50051", ray_connect_handler=ray_connect_handler)
     ray.connect("localhost:50051", metadata=metadata)
     try:
         yield ray, server

--- a/python/ray/util/client/server/dataservicer.py
+++ b/python/ray/util/client/server/dataservicer.py
@@ -82,7 +82,6 @@ class DataServicer(ray_client_pb2_grpc.RayletDataStreamerServicer):
         finally:
             logger.debug(f"Lost data connection from client {client_id}")
             self.basic_service.release_all(client_id)
-
             with self.clients_lock:
                 if accepted_connection:
                     # Could fail before client accounting happens
@@ -91,8 +90,8 @@ class DataServicer(ray_client_pb2_grpc.RayletDataStreamerServicer):
 
                 # It's important to keep the Ray shutdown
                 # within this locked context or else Ray could hang.
-                with disable_client_hook():
-                    if self.num_clients == 0:
+                if self.num_clients == 0:
+                    with disable_client_hook():
                         logger.debug("Shutting down ray.")
                         ray.shutdown()
 

--- a/python/ray/util/client/server/dataservicer.py
+++ b/python/ray/util/client/server/dataservicer.py
@@ -90,8 +90,8 @@ class DataServicer(ray_client_pb2_grpc.RayletDataStreamerServicer):
 
                 # It's important to keep the Ray shutdown
                 # within this locked context or else Ray could hang.
-                if self.num_clients == 0:
-                    with disable_client_hook():
+                with disable_client_hook():
+                    if self.num_clients == 0:
                         logger.debug("Shutting down ray.")
                         ray.shutdown()
 

--- a/python/ray/util/client/server/dataservicer.py
+++ b/python/ray/util/client/server/dataservicer.py
@@ -82,6 +82,7 @@ class DataServicer(ray_client_pb2_grpc.RayletDataStreamerServicer):
         finally:
             logger.debug(f"Lost data connection from client {client_id}")
             self.basic_service.release_all(client_id)
+
             with self.clients_lock:
                 if accepted_connection:
                     # Could fail before client accounting happens


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Enables a system config for the ray client tests:

New output for `remote put`:
```
2021-04-14 20:52:48,892	INFO logservicer.py:102 -- New logs connection established. Total clients: 1
client: remote put calls per second 68286.7 +- 3223.44
```

Prior to this PR:
```
client: remote put calls per second 7104.87 +- 154.42
```

Full run:
```
(raybuild) ➜  scripts git:(fix-benchmark) ✗ ray microbenchmark
Tip: set TESTS_TO_RUN='pattern' to run a subset of benchmarks
2021-04-14 20:47:54,835	INFO services.py:1264 -- View the Ray dashboard at http://127.0.0.1:8265
single client get calls per second 51038.52 +- 1901.46
single client put calls per second 31553.03 +- 1743.21
multi client put calls per second 97801.13 +- 2437.81
2021-04-14 20:48:26,564	INFO services.py:1264 -- View the Ray dashboard at http://127.0.0.1:8265
single client get calls (Plasma Store) per second 9160.23 +- 619.74
single client put calls (Plasma Store) per second 4707.35 +- 100.23
multi client put calls (Plasma Store) per second 6917.51 +- 417.71
single client put gigabytes per second 2.62 +- 2.41
multi client put gigabytes per second 3.46 +- 0.53
single client tasks sync per second 1835.03 +- 78.99
single client tasks async per second 12123.7 +- 296.05
multi client tasks async per second 19161.18 +- 715.67
1:1 actor calls sync per second 2703.54 +- 83.52
1:1 actor calls async per second 7024.55 +- 188.21
1:1 actor calls concurrent per second 7773.28 +- 519.77
1:n actor calls async per second 14367.64 +- 334.6
n:n actor calls async per second 24377.59 +- 828.75
n:n actor calls with arg async per second 8593.7 +- 213.81
1:1 async-actor calls sync per second 1759.53 +- 52.62
1:1 async-actor calls async per second 3961.22 +- 77.88
1:1 async-actor calls with args async per second 3017.21 +- 27.51
1:n async-actor calls async per second 9922.37 +- 259.87
n:n async-actor calls async per second 14935.92 +- 664.38
2021-04-14 20:52:22,179	INFO logservicer.py:102 -- New logs connection established. Total clients: 1
client: get calls per second 2660.24 +- 90.76
2021-04-14 20:52:35,455	INFO logservicer.py:102 -- New logs connection established. Total clients: 1
client: put calls per second 1451.36 +- 7.64
2021-04-14 20:52:48,892	INFO logservicer.py:102 -- New logs connection established. Total clients: 1
client: remote put calls per second 68286.7 +- 3223.44
2021-04-14 20:53:02,733	INFO logservicer.py:102 -- New logs connection established. Total clients: 1
2021-04-14 20:53:03,820	INFO services.py:1264 -- View the Ray dashboard at http://127.0.0.1:8265
client: 1:1 actor calls sync per second 814.32 +- 14.79
client: 1:1 actor calls async per second 908.16 +- 13.03
client: 1:1 actor calls concurrent per second 910.06 +- 9.59
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Addresses part of #15247 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(