### PR TITLE
[RLlib] Improve example scripts for attention nets, CartPole LSTM, and custom RNN-models.

### DIFF
--- a/rllib/examples/attention_net.py
+++ b/rllib/examples/attention_net.py
@@ -75,18 +75,23 @@ if __name__ == "__main__":
     # >> from ray.rllib.agents.ppo import PPOTrainer
     # >>
     # >> trainer = PPOTrainer(config)
+    # >> num_transformers = config["model"]["attention_num_transformer_units"]
     # >> env = RepeatAfterMeEnv({})
     # >> obs = env.reset()
-    # >> init_state = state = np.zeros(
-    #    [100 (attention_memory_inference), 64 (attention_dim)], np.float32)
+    # >> init_state = state = [
+    # ..     np.zeros([100, 32], np.float32) for _ in range(num_transformers)
+    # .. ]
     # >> while True:
-    # >>     a, state_out, _ = trainer.compute_action(obs, [state])
+    # >>     a, state_out, _ = trainer.compute_action(obs, state)
     # >>     obs, reward, done, _ = env.step(a)
     # >>     if done:
     # >>         obs = env.reset()
     # >>         state = init_state
     # >>     else:
-    # >>         state = np.concatenate([state, [state_out[0]]])[1:]
+    # >>         state = [
+    # ..             np.concatenate([state[i], [state_out[i]]], axis=0)[1:]
+    # ..             for i in range(num_transformers)
+    # ..         ]
 
     # We use tune here, which handles env and trainer creation for us.
     results = tune.run(args.run, config=config, stop=stop, verbose=2)

--- a/rllib/examples/cartpole_lstm.py
+++ b/rllib/examples/cartpole_lstm.py
@@ -47,6 +47,7 @@ if __name__ == "__main__":
             "num_gpus": int(os.environ.get("RLLIB_NUM_GPUS", "0")),
             "model": {
                 "use_lstm": True,
+                "lstm_cell_size": 256,
                 "lstm_use_prev_action": args.use_prev_action,
                 "lstm_use_prev_reward": args.use_prev_reward,
             },
@@ -60,6 +61,39 @@ if __name__ == "__main__":
         "timesteps_total": args.stop_timesteps,
         "episode_reward_mean": args.stop_reward,
     }
+
+    # To run the Trainer without tune.run, using our LSTM model and
+    # manual state-in handling, do the following:
+
+    # Example (use `config` from the above code):
+    # >> import numpy as np
+    # >> from ray.rllib.agents.ppo import PPOTrainer
+    # >>
+    # >> trainer = PPOTrainer(config)
+    # >> lstm_cell_size = config["model"]["lstm_cell_size"]
+    # >> env = StatelessCartPole()
+    # >> obs = env.reset()
+    # >>
+    # >> # range(2) b/c h- and c-states of the LSTM.
+    # >> init_state = state = [
+    # ..     np.zeros([lstm_cell_size], np.float32) for _ in range(2)
+    # .. ]
+    # >> prev_a = 0
+    # >> prev_r = 0.0
+    # >>
+    # >> while True:
+    # >>     a, state_out, _ = trainer.compute_action(
+    # ..         obs, state, prev_a, prev_r)
+    # >>     obs, reward, done, _ = env.step(a)
+    # >>     if done:
+    # >>         obs = env.reset()
+    # >>         state = init_state
+    # >>         prev_a = 0
+    # >>         prev_r = 0.0
+    # >>     else:
+    # >>         state = state_out
+    # >>         prev_a = a
+    # >>         prev_r = reward
 
     results = tune.run(args.run, config=config, stop=stop, verbose=2)
 

--- a/rllib/examples/custom_rnn_model.py
+++ b/rllib/examples/custom_rnn_model.py
@@ -48,6 +48,9 @@ if __name__ == "__main__":
         "model": {
             "custom_model": "rnn",
             "max_seq_len": 20,
+            "custom_model_config": {
+                "cell_size": 32,
+            },
         },
         "framework": "torch" if args.torch else "tf",
     }
@@ -57,6 +60,32 @@ if __name__ == "__main__":
         "timesteps_total": args.stop_timesteps,
         "episode_reward_mean": args.stop_reward,
     }
+
+    # To run the Trainer without tune.run, using our RNN model and
+    # manual state-in handling, do the following:
+
+    # Example (use `config` from the above code):
+    # >> import numpy as np
+    # >> from ray.rllib.agents.ppo import PPOTrainer
+    # >>
+    # >> trainer = PPOTrainer(config)
+    # >> lstm_cell_size = config["model"]["custom_model_config"]["cell_size"]
+    # >> env = RepeatAfterMeEnv({})
+    # >> obs = env.reset()
+    # >>
+    # >> # range(2) b/c h- and c-states of the LSTM.
+    # >> init_state = state = [
+    # ..     np.zeros([lstm_cell_size], np.float32) for _ in range(2)
+    # .. ]
+    # >>
+    # >> while True:
+    # >>     a, state_out, _ = trainer.compute_action(obs, state)
+    # >>     obs, reward, done, _ = env.step(a)
+    # >>     if done:
+    # >>         obs = env.reset()
+    # >>         state = init_state
+    # >>     else:
+    # >>         state = state_out
 
     results = tune.run(args.run, config=config, stop=stop, verbose=1)
 

--- a/rllib/examples/env/repeat_after_me_env.py
+++ b/rllib/examples/env/repeat_after_me_env.py
@@ -6,7 +6,8 @@ import random
 class RepeatAfterMeEnv(gym.Env):
     """Env in which the observation at timestep minus n must be repeated."""
 
-    def __init__(self, config):
+    def __init__(self, config=None):
+        config = config or {}
         self.observation_space = Discrete(2)
         self.action_space = Discrete(2)
         self.delay = config.get("repeat_delay", 1)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Improve example scripts for attention nets, CartPole LSTM, and custom RNN-models.

- Add example code on how to run trained policies with `trainer.compute_action` (feeding in the correct internal state arrays).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
