### PR TITLE
[RLlib] Remove all (soft-deprecated) `SampleBatch.data` from code.

### DIFF
--- a/rllib/agents/cql/cql.py
+++ b/rllib/agents/cql/cql.py
@@ -106,7 +106,7 @@ def execution_plan(workers, config):
                 td_error = info.get("td_error",
                                     info[LEARNER_STATS_KEY].get("td_error"))
                 prio_dict[policy_id] = (samples.policy_batches[policy_id]
-                                        .data.get("batch_indexes"), td_error)
+                                        .get("batch_indexes"), td_error)
             local_replay_buffer.update_priorities(prio_dict)
         return info_dict
 

--- a/rllib/agents/dqn/learner_thread.py
+++ b/rllib/agents/dqn/learner_thread.py
@@ -54,8 +54,9 @@ class LearnerThread(threading.Thread):
                         td_error = info.get(
                             "td_error",
                             info[LEARNER_STATS_KEY].get("td_error"))
-                        prio_dict[pid] = (replay.policy_batches[pid].data.get(
-                            "batch_indexes"), td_error)
+                        prio_dict[pid] = (
+                            replay.policy_batches[pid].get("batch_indexes"),
+                            td_error)
                         self.stats[pid] = get_learner_stats(info)
                     self.grad_timer.push_units_processed(replay.count)
                 self.outqueue.put((ra, prio_dict, replay.count))

--- a/rllib/agents/marwil/marwil_tf_policy.py
+++ b/rllib/agents/marwil/marwil_tf_policy.py
@@ -66,7 +66,7 @@ def postprocess_advantages(policy,
         # requirements. It's a single-timestep (last one in trajectory)
         # input_dict.
         # Create an input dict according to the Model's requirements.
-        index = "last" if SampleBatch.NEXT_OBS in sample_batch.data else -1
+        index = "last" if SampleBatch.NEXT_OBS in sample_batch else -1
         input_dict = policy.model.get_input_dict(sample_batch, index=index)
         last_r = policy._value(**input_dict)
 

--- a/rllib/contrib/maddpg/maddpg.py
+++ b/rllib/contrib/maddpg/maddpg.py
@@ -123,12 +123,10 @@ def before_learn_on_batch(multi_agent_batch, policies, train_batch_size):
     # Modify keys.
     for pid, p in policies.items():
         i = p.config["agent_id"]
-        keys = multi_agent_batch.policy_batches[pid].data.keys()
+        keys = multi_agent_batch.policy_batches[pid].keys()
         keys = ["_".join([k, str(i)]) for k in keys]
         samples.update(
-            dict(
-                zip(keys,
-                    multi_agent_batch.policy_batches[pid].data.values())))
+            dict(zip(keys, multi_agent_batch.policy_batches[pid].values())))
 
     # Make ops and feed_dict to get "new_obs" from target action sampler.
     new_obs_ph_n = [p.new_obs_ph for p in policies.values()]

--- a/rllib/evaluation/tests/test_trajectory_view_api.py
+++ b/rllib/evaluation/tests/test_trajectory_view_api.py
@@ -27,7 +27,7 @@ class MyCallbacks(DefaultCallbacks):
     def on_learn_on_batch(self, *, policy, train_batch, result, **kwargs):
         assert train_batch.count == 201
         assert sum(train_batch.seq_lens) == 201
-        for k, v in train_batch.data.items():
+        for k, v in train_batch.items():
             if k == "state_in_0":
                 assert len(v) == len(train_batch.seq_lens)
             else:
@@ -90,7 +90,7 @@ class TestTrajectoryViewAPI(unittest.TestCase):
                 config["num_envs_per_worker"] * \
                 config["rollout_fragment_length"]
             assert sample_batch.count == expected_count
-            for v in sample_batch.data.values():
+            for v in sample_batch.values():
                 assert len(v) == expected_count
             trainer.stop()
 
@@ -195,7 +195,7 @@ class TestTrajectoryViewAPI(unittest.TestCase):
         rollout_worker_w_api.policy_map[DEFAULT_POLICY_ID].view_requirements[
             "dones"] = ViewRequirement()
         batch = rollout_worker_w_api.sample()
-        self.assertTrue("next_actions" in batch.data)
+        self.assertTrue("next_actions" in batch)
         expected_a_ = None  # expected next action
         for i in range(len(batch["actions"])):
             a, d, a_ = batch["actions"][i], batch["dones"][i], \
@@ -257,7 +257,7 @@ class TestTrajectoryViewAPI(unittest.TestCase):
 
             result = rollout_worker_wo_api.sample()
             pol_batch_wo = result.policy_batches["pol0"]
-            check(pol_batch_w.data, pol_batch_wo.data)
+            check(pol_batch_w, pol_batch_wo)
 
     def test_traj_view_attention_functionality(self):
         action_space = Box(-float("inf"), float("inf"), shape=(3, ))

--- a/rllib/offline/json_writer.py
+++ b/rllib/offline/json_writer.py
@@ -114,7 +114,7 @@ def _to_json(batch: SampleBatchType, compress_columns: List[str]) -> str:
         policy_batches = {}
         for policy_id, sub_batch in batch.policy_batches.items():
             policy_batches[policy_id] = {}
-            for k, v in sub_batch.data.items():
+            for k, v in sub_batch.items():
                 policy_batches[policy_id][k] = _to_jsonable(
                     v, compress=k in compress_columns)
         out["policy_batches"] = policy_batches

--- a/rllib/offline/off_policy_estimator.py
+++ b/rllib/offline/off_policy_estimator.py
@@ -68,8 +68,8 @@ class OffPolicyEstimator:
             actions=batch[SampleBatch.ACTIONS],
             obs_batch=batch[SampleBatch.CUR_OBS],
             state_batches=[batch[k] for k in state_keys],
-            prev_action_batch=batch.data.get(SampleBatch.PREV_ACTIONS),
-            prev_reward_batch=batch.data.get(SampleBatch.PREV_REWARDS))
+            prev_action_batch=batch.get(SampleBatch.PREV_ACTIONS),
+            prev_reward_batch=batch.get(SampleBatch.PREV_REWARDS))
         log_likelihoods = convert_to_numpy(log_likelihoods)
         return np.exp(log_likelihoods)
 

--- a/rllib/policy/rnn_sequencing.py
+++ b/rllib/policy/rnn_sequencing.py
@@ -391,10 +391,10 @@ def timeslice_along_seq_lens_with_overlap(
                         shape=(zero_length, ) + v.shape[1:], dtype=v.dtype),
                     v[data_begin:end]
                 ])
-                for k, v in sample_batch.data.items()
+                for k, v in sample_batch.items()
             }
         else:
-            data = {k: v[begin:end] for k, v in sample_batch.data.items()}
+            data = {k: v[begin:end] for k, v in sample_batch.items()}
 
         if zero_init_states_:
             i = 0

--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -654,7 +654,7 @@ class TorchPolicy(Policy):
         Args:
             export_dir (str): Local writable directory or filename.
         """
-        dummy_inputs = self._lazy_tensor_dict(self._dummy_batch.data)
+        dummy_inputs = self._lazy_tensor_dict(self._dummy_batch)
         # Provide dummy state inputs if not an RNN (torch cannot jit with
         # returned empty internal states list).
         if "state_in_0" not in dummy_inputs:

--- a/rllib/utils/sgd.py
+++ b/rllib/utils/sgd.py
@@ -64,7 +64,7 @@ def minibatches(samples, sgd_minibatch_size):
             "Minibatching not implemented for multi-agent in simple mode")
 
     # Replace with `if samples.seq_lens` check.
-    if "state_in_0" in samples.data or "state_out_0" in samples.data:
+    if "state_in_0" in samples or "state_out_0" in samples:
         if log_once("not_shuffling_rnn_data_in_simple_mode"):
             logger.warning("Not time-shuffling RNN data for SGD.")
     else:

--- a/rllib/utils/tracking_dict.py
+++ b/rllib/utils/tracking_dict.py
@@ -40,7 +40,8 @@ class UsageTrackingDict(dict):
     @property
     def data(self):
         # Make sure, if we use UsageTrackingDict wrapping a SampleBatch,
-        # one can still do: sample_batch.data[some_key].
+        # one can still do: sample_batch.data[some_key] even if it has been
+        # deprecated.
         return self
 
     def __getitem__(self, key):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Remove all (soft-deprecated) `SampleBatch.data` from code.
- Accessing values in SampleBatch via `SampleBatch.data[some-key]` is still valid, but causes a deprecation warning (do `SampleBatch[some-key]` instead).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
