### PR TITLE
[tune] Allow 0 CPU head bundles in for placement group factories

### DIFF
--- a/python/ray/tune/tests/test_trial_runner_pg.py
+++ b/python/ray/tune/tests/test_trial_runner_pg.py
@@ -231,6 +231,20 @@ class TrialRunnerPlacementGroupTest(unittest.TestCase):
         self.testPlacementGroupDistributedTraining(reuse_actors=True)
 
 
+class PlacementGroupNoAutoSetupTest(unittest.TestCase):
+    def testPlacementGroupNoCPUDriver(self):
+        """Bundles with only GPU:1 but no CPU should work"""
+        ray.init(num_gpus=1, num_cpus=1)
+
+        pgf = PlacementGroupFactory([{"GPU": 1, "CPU": 0}, {"CPU": 1}])
+
+        def train(config):
+            time.sleep(1)
+            return 5
+
+        tune.run(train, resources_per_trial=pgf)
+
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tune/utils/placement_groups.py
+++ b/python/ray/tune/utils/placement_groups.py
@@ -118,6 +118,10 @@ class PlacementGroupFactory:
 
         self._bind()
 
+    @property
+    def head_cpus(self):
+        return self._bundles[0].get("CPU", None)
+
     def _bind(self):
         sig = signature(placement_group)
         try:
@@ -399,6 +403,11 @@ class PlacementGroupManager:
 
         # Only custom resources remain in `first_bundle`
         resources = first_bundle or None
+
+        if num_cpus is None:
+            # If the placement group specifically set the number
+            # of CPUs to 0, use this.
+            num_cpus = pgf.head_cpus
 
         logger.debug(f"For trial {trial} use pg {pg.id}")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Enables specifically passing cpu=0 to placement group factory head bundles.

## Related issue number

Addresses (and possibly solves) #15211

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
