### PR TITLE
[flaky] fix mnist ptl data cache

### DIFF
--- a/python/ray/util/sgd/torch/examples/pytorch-lightning/mnist-ptl.py
+++ b/python/ray/util/sgd/torch/examples/pytorch-lightning/mnist-ptl.py
@@ -60,7 +60,10 @@ class LitMNIST(LightningModule):
 
         # prepare transforms standard to MNIST
         mnist_train = MNIST(
-            os.getcwd(), train=True, download=True, transform=transform)
+            os.path.expanduser("~/data"),
+            train=True,
+            download=True,
+            transform=transform)
 
         self.mnist_train, self.mnist_val = random_split(
             mnist_train, [55000, 5000])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Make it so that we access the cached dataset in the example


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(