### PR TITLE
[Core] Fix event loop instrumentation causing Java segfaults in tests.

### DIFF
--- a/src/ray/common/asio/instrumented_io_context.cc
+++ b/src/ray/common/asio/instrumented_io_context.cc
@@ -66,9 +66,10 @@ void instrumented_io_context::post(std::function<void()> handler,
   // GuardedHandlerStats synchronizes internal access, we can concurrently write to the
   // handler stats it->second from multiple threads without acquiring a table-level
   // readers lock in the callback.
-  boost::asio::io_context::post([handler = std::move(handler), stats_handle]() mutable {
-    RecordExecution(handler, std::move(stats_handle));
-  });
+  boost::asio::io_context::post(
+      [handler = std::move(handler), stats_handle = std::move(stats_handle)]() {
+        RecordExecution(handler, std::move(stats_handle));
+      });
 }
 
 std::shared_ptr<StatsHandle> instrumented_io_context::RecordStart(const std::string &name,

--- a/src/ray/common/asio/instrumented_io_context.cc
+++ b/src/ray/common/asio/instrumented_io_context.cc
@@ -66,10 +66,9 @@ void instrumented_io_context::post(std::function<void()> handler,
   // GuardedHandlerStats synchronizes internal access, we can concurrently write to the
   // handler stats it->second from multiple threads without acquiring a table-level
   // readers lock in the callback.
-  boost::asio::io_context::post(
-      [handler = std::move(handler), stats_handle = std::move(stats_handle)]() {
-        RecordExecution(handler, std::move(stats_handle));
-      });
+  boost::asio::io_context::post([handler = std::move(handler), stats_handle]() mutable {
+    RecordExecution(handler, std::move(stats_handle));
+  });
 }
 
 std::shared_ptr<StatsHandle> instrumented_io_context::RecordStart(const std::string &name,

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -50,7 +50,7 @@ RAY_CONFIG(uint64_t, num_resource_report_periods_warning, 5)
 /// The duration between dumping debug info to logs, or 0 to disable.
 RAY_CONFIG(uint64_t, debug_dump_period_milliseconds, 10000)
 
-RAY_CONFIG(bool, asio_event_loop_stats_collection_enabled, false)
+RAY_CONFIG(bool, asio_event_loop_stats_collection_enabled, true)
 
 /// Whether to enable fair queueing between task classes in raylet. When
 /// fair queueing is enabled, the raylet will try to balance the number


### PR DESCRIPTION
## Why are these changes needed?

Ran the Java tests locally a few times with event loop instrumentation reenabled and they all passed, pushing up a PR to see if I can reproduce the segfault in CI. The event loop instrumentation has changed (added support for manual instrumentation), so this might have accidentally fixed. 🤞

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #14715

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
- [ ] Confirm Java test doesn't segfault.
- Java test runs:
   - [x] Run 1
   - [x] Run 2
   - [ ] Run 3