### PR TITLE
[tune] Fix 15367

### DIFF
--- a/python/ray/tune/tests/test_experiment_analysis.py
+++ b/python/ray/tune/tests/test_experiment_analysis.py
@@ -203,6 +203,23 @@ class ExperimentAnalysisSuite(unittest.TestCase):
         df = analysis.dataframe(self.metric, mode="max")
         self.assertEquals(df.shape[0], 1)
 
+    def testGetTrialCheckpointsPathsByPathWithSpecialCharacters(self):
+        analysis = tune.run(
+            MyTrainableClass,
+            name="test_example",
+            local_dir=self.test_dir,
+            stop={"training_iteration": 1},
+            num_samples=1,
+            config={"test": tune.grid_search([[1, 2], [3, 4]])},
+            checkpoint_at_end=True,
+        )
+        logdir = analysis.get_best_logdir(self.metric, mode="max")
+        checkpoints_metrics = analysis.get_trial_checkpoints_paths(logdir)
+        expected_path = os.path.join(logdir, "checkpoint_000001/",
+                                     "checkpoint")
+        assert checkpoints_metrics[0][0] == expected_path
+        assert checkpoints_metrics[0][1] == 1
+
 
 class ExperimentAnalysisPropertySuite(unittest.TestCase):
     def testBestProperties(self):

--- a/python/ray/tune/utils/trainable.py
+++ b/python/ray/tune/utils/trainable.py
@@ -149,12 +149,12 @@ class TrainableUtil:
             FileNotFoundError if the directory is not found.
         """
         marker_paths = glob.glob(
-            os.path.join(logdir, "checkpoint_*/.is_checkpoint"))
+            os.path.join(glob.escape(logdir), "checkpoint_*/.is_checkpoint"))
         iter_chkpt_pairs = []
         for marker_path in marker_paths:
             chkpt_dir = os.path.dirname(marker_path)
             metadata_file = glob.glob(
-                os.path.join(chkpt_dir, "*.tune_metadata"))
+                os.path.join(glob.escape(chkpt_dir), "*.tune_metadata"))
             if len(metadata_file) != 1:
                 raise ValueError(
                     "{} has zero or more than one tune_metadata.".format(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Lists of lists in `tune.grid_search` break `Analysis.get_trial_checkpoints_paths` due to special characters being included in the logdir. The change is to use `glob.escape` to escape the special characters.
<!-- Please give a short summary of the change and the problem this solves. -->


## Related issue number

Closes #15367 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
