### PR TITLE
[client][placement groups] Client placement group hooks, attempt #3

### DIFF
--- a/python/ray/_private/client_mode_hook.py
+++ b/python/ray/_private/client_mode_hook.py
@@ -81,7 +81,7 @@ def client_mode_wrap(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         if client_mode_should_convert():
-            f = ray.remote(func)
+            f = ray.remote(num_cpus=0)(func)
             ref = f.remote(*args, **kwargs)
             return ray.get(ref)
         return func(*args, **kwargs)

--- a/python/ray/_private/client_mode_hook.py
+++ b/python/ray/_private/client_mode_hook.py
@@ -100,7 +100,11 @@ def client_mode_convert_function(func_cls, in_args, in_kwargs, **kwargs):
     from ray.util.client import ray
 
     key = getattr(func_cls, RAY_CLIENT_MODE_ATTR, None)
-    if key is None:
+
+    # The first part of the "or" is redundant.
+    # We need the second part in case func_cls is reused between client
+    # sessions in one python interpreter session.
+    if (key is None) or (not ray._converted_key_exists(key)):
         key = ray._convert_function(func_cls)
         setattr(func_cls, RAY_CLIENT_MODE_ATTR, key)
     client_func = ray._get_converted(key)
@@ -118,7 +122,10 @@ def client_mode_convert_actor(actor_cls, in_args, in_kwargs, **kwargs):
     from ray.util.client import ray
 
     key = getattr(actor_cls, RAY_CLIENT_MODE_ATTR, None)
-    if key is None:
+    # The first part of the "or" is redundant.
+    # We need the second part in case actor_cls is reused between client
+    # sessions in one python interpreter session.
+    if (key is None) or (not ray._converted_key_exists(key)):
         key = ray._convert_actor(actor_cls)
         setattr(actor_cls, RAY_CLIENT_MODE_ATTR, key)
     client_actor = ray._get_converted(key)

--- a/python/ray/_private/client_mode_hook.py
+++ b/python/ray/_private/client_mode_hook.py
@@ -70,11 +70,15 @@ def client_mode_should_convert():
 
 
 def client_mode_wrap(func):
-    """Decorator to wrap a function call in a task.
+    """Wraps a function called during client mode for execution as a remote
+    task.
 
-    This is useful for functions where the goal isn't to delegate
-    module calls to the ray client equivalent, but to instead implement
-    ray client features that can be executed by tasks on the server side.
+    Can be used to implement public features of Ray client which do not
+    belong in the main ray API (`ray.*`), yet require server-side execution.
+    An example is the creation of placement groups:
+    `ray.util.placement_group.placement_group()`. When called on the client
+    side, this function is wrapped in a task to facilitate interaction with
+    the GCS.
     """
     from ray.util.client import ray
 

--- a/python/ray/_private/client_mode_hook.py
+++ b/python/ray/_private/client_mode_hook.py
@@ -69,6 +69,26 @@ def client_mode_should_convert():
     return client_mode_enabled and _client_hook_enabled
 
 
+def client_mode_wrap(func):
+    """Decorator to wrap a function call in a task.
+
+    This is useful for functions where the goal isn't to delegate
+    module calls to the ray client equivalent, but to instead implement
+    ray client features that can be executed by tasks on the server side.
+    """
+    from ray.util.client import ray
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if client_mode_should_convert():
+            f = ray.remote(func)
+            ref = f.remote(*args, **kwargs)
+            return ray.get(ref)
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
 def client_mode_convert_function(func_cls, in_args, in_kwargs, **kwargs):
     """Runs a preregistered ray RemoteFunction through the ray client.
 

--- a/python/ray/_private/client_mode_hook.py
+++ b/python/ray/_private/client_mode_hook.py
@@ -101,9 +101,8 @@ def client_mode_convert_function(func_cls, in_args, in_kwargs, **kwargs):
 
     key = getattr(func_cls, RAY_CLIENT_MODE_ATTR, None)
 
-    # The first part of the "or" is redundant.
-    # We need the second part in case func_cls is reused between client
-    # sessions in one python interpreter session.
+    # Second part of "or" is needed in case func_cls is reused between Ray
+    # client sessions in one Python interpreter session.
     if (key is None) or (not ray._converted_key_exists(key)):
         key = ray._convert_function(func_cls)
         setattr(func_cls, RAY_CLIENT_MODE_ATTR, key)
@@ -122,9 +121,8 @@ def client_mode_convert_actor(actor_cls, in_args, in_kwargs, **kwargs):
     from ray.util.client import ray
 
     key = getattr(actor_cls, RAY_CLIENT_MODE_ATTR, None)
-    # The first part of the "or" is redundant.
-    # We need the second part in case actor_cls is reused between client
-    # sessions in one python interpreter session.
+    # Second part of "or" is needed in case actor_cls is reused between Ray
+    # client sessions in one Python interpreter session.
     if (key is None) or (not ray._converted_key_exists(key)):
         key = ray._convert_actor(actor_cls)
         setattr(actor_cls, RAY_CLIENT_MODE_ATTR, key)

--- a/python/ray/_private/client_mode_hook.py
+++ b/python/ray/_private/client_mode_hook.py
@@ -73,7 +73,7 @@ def client_mode_wrap(func):
     """Wraps a function called during client mode for execution as a remote
     task.
 
-    Can be used to implement public features of Ray client which do not
+    Can be used to implement public features of ray client which do not
     belong in the main ray API (`ray.*`), yet require server-side execution.
     An example is the creation of placement groups:
     `ray.util.placement_group.placement_group()`. When called on the client

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -149,6 +149,13 @@ def ray_start_cluster(request):
 
 
 @pytest.fixture
+def ray_start_cluster_init(request):
+    param = getattr(request, "param", {})
+    with _ray_start_cluster(do_init=True, **param) as res:
+        yield res
+
+
+@pytest.fixture
 def ray_start_cluster_head(request):
     param = getattr(request, "param", {})
     with _ray_start_cluster(do_init=True, num_nodes=1, **param) as res:

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -181,6 +181,10 @@ def test_remote_functions(ray_start_regular_shared):
     with ray_start_client_server() as ray:
 
         @ray.remote
+        def sleep_for(t):
+            time.sleep(t)
+
+        @ray.remote
         def plus2(x):
             return x + 2
 
@@ -219,6 +223,12 @@ def test_remote_functions(ray_start_regular_shared):
         assert [] == res[1]
         all_vals = ray.get(res[0])
         assert all_vals == [236, 2_432_902_008_176_640_000, 120, 3628800]
+        sleeping_ref = sleep_for.remote(1)
+        res = ray.wait([sleeping_ref], timeout=0)
+        assert res[0] == [] and len(res[1]) == 1
+        time.sleep(2)
+        res = ray.wait([sleeping_ref], timeout=2)
+        assert len(res[0]) == 1 and res[1] == []
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -232,7 +232,7 @@ def test_remote_functions(ray_start_regular_shared):
         ray.get(signaler.send.remote())
         ready_ref = signaler.wait.remote()
         # Ready.
-        res = ray.wait([ready_ref], timeout=0)
+        res = ray.wait([ready_ref], timeout=10)
         assert len(res[0]) == 1 and res[1] == []
 
 

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -11,8 +11,8 @@ from ray.tests.client_test_utils import create_remote_signal_actor
 from ray.util.client.common import ClientObjectRef
 from ray.util.client.ray_client_helpers import connect_to_client_or_not
 from ray.util.client.ray_client_helpers import ray_start_client_server
-from ray._private.client_mode_hook import _explicitly_enable_client_mode
 from ray._private.client_mode_hook import client_mode_should_convert
+from ray._private.client_mode_hook import enable_client_mode
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
@@ -540,16 +540,16 @@ def test_client_gpu_ids(call_ray_stop_only):
     import ray
     ray.init(num_cpus=2)
 
-    _explicitly_enable_client_mode()
-    # No client connection.
-    with pytest.raises(Exception) as e:
-        ray.get_gpu_ids()
-    assert str(e.value) == "Ray Client is not connected."\
-        " Please connect by calling `ray.connect`."
+    with enable_client_mode():
+        # No client connection.
+        with pytest.raises(Exception) as e:
+            ray.get_gpu_ids()
+        assert str(e.value) == "Ray Client is not connected."\
+            " Please connect by calling `ray.connect`."
 
-    with ray_start_client_server():
-        # Now have a client connection.
-        assert ray.get_gpu_ids() == []
+        with ray_start_client_server():
+            # Now have a client connection.
+            assert ray.get_gpu_ids() == []
 
 
 def test_client_serialize_addon(call_ray_stop_only):

--- a/python/ray/tests/test_client_init.py
+++ b/python/ray/tests/test_client_init.py
@@ -76,19 +76,26 @@ def test_validate_port():
 
 
 def test_basic_preregister(init_and_serve):
+    """Tests conversion of Ray actors and remote functions to client actors
+    and client remote functions.
+
+    Checks that the conversion works when disconnecting and reconnecting client
+    sessions.
+    """
     from ray.util.client import ray
-    ray.connect("localhost:50051")
-    val = ray.get(hello_world.remote())
-    print(val)
-    assert val >= 20
-    assert val <= 200
-    c = C.remote(3)
-    x = c.double.remote()
-    y = c.double.remote()
-    ray.wait([x, y])
-    val = ray.get(c.get.remote())
-    assert val == 12
-    ray.disconnect()
+    for _ in range(2):
+        ray.connect("localhost:50051")
+        val = ray.get(hello_world.remote())
+        print(val)
+        assert val >= 20
+        assert val <= 200
+        c = C.remote(3)
+        x = c.double.remote()
+        y = c.double.remote()
+        ray.wait([x, y])
+        val = ray.get(c.get.remote())
+        assert val == 12
+        ray.disconnect()
 
 
 def test_num_clients(init_and_serve_lazy):

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -1693,14 +1693,14 @@ def test_placement_group_client_option_serialization():
 
     # Tests conversion from dict to placement group and back.
     def dict_to_pg_to_dict(pg_dict_in):
-        pg = PlacementGroup.from_json_serializable(pg_dict_in)
-        pg_dict_out = pg.to_json_serializable()
+        pg = PlacementGroup.from_dict(pg_dict_in)
+        pg_dict_out = pg.to_dict()
         assert pg_dict_in == pg_dict_out
 
     # Tests conversion from placement group to dict and back.
     def pg_to_dict_to_pg(pg_in):
-        pg_dict = pg_in.to_json_serializable()
-        pg_out = PlacementGroup.from_json_serializable(pg_dict)
+        pg_dict = pg_in.to_dict()
+        pg_out = PlacementGroup.from_dict(pg_dict)
         assert pg_out.id == pg_in.id
         assert pg_out.bundle_cache == pg_in.bundle_cache
 

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -20,6 +20,8 @@ from ray._raylet import PlacementGroupID
 from ray.util.placement_group import (PlacementGroup, placement_group,
                                       remove_placement_group,
                                       get_current_placement_group)
+from ray.util.client.ray_client_helpers import connect_to_client_or_not
+from ray._private.client_mode_hook import client_mode_should_convert
 
 
 @ray.remote
@@ -28,7 +30,8 @@ class Increase:
         return x + 2
 
 
-def test_placement_group_pack(ray_start_cluster):
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_placement_group_pack(ray_start_cluster, connect_to_client):
     @ray.remote(num_cpus=2)
     class Actor(object):
         def __init__(self):
@@ -43,44 +46,56 @@ def test_placement_group_pack(ray_start_cluster):
         cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
 
-    placement_group = ray.util.placement_group(
-        name="name",
-        strategy="PACK",
-        bundles=[
-            {
-                "CPU": 2,
-                "GPU": 0  # Test 0 resource spec doesn't break tests.
-            },
-            {
-                "CPU": 2
-            }
-        ])
-    ray.get(placement_group.ready())
-    actor_1 = Actor.options(
-        placement_group=placement_group,
-        placement_group_bundle_index=0).remote()
-    actor_2 = Actor.options(
-        placement_group=placement_group,
-        placement_group_bundle_index=1).remote()
+    with connect_to_client_or_not(connect_to_client):
+        # Quick validation of the context manager:
+        if connect_to_client:
+            # Client mode is on.
+            assert client_mode_should_convert() is True
+            # We're connected to Ray client.
+            assert ray.util.client.ray.is_connected() is True
+        else:
+            assert client_mode_should_convert() is False
+            assert ray.util.client.ray.is_connected() is False
 
-    ray.get(actor_1.value.remote())
-    ray.get(actor_2.value.remote())
+        placement_group = ray.util.placement_group(
+            name="name",
+            strategy="PACK",
+            bundles=[
+                {
+                    "CPU": 2,
+                    "GPU": 0  # Test 0 resource spec doesn't break tests.
+                },
+                {
+                    "CPU": 2
+                }
+            ])
+        ray.get(placement_group.ready())
+        actor_1 = Actor.options(
+            placement_group=placement_group,
+            placement_group_bundle_index=0).remote()
+        actor_2 = Actor.options(
+            placement_group=placement_group,
+            placement_group_bundle_index=1).remote()
 
-    # Get all actors.
-    actor_infos = ray.actors()
+        ray.get(actor_1.value.remote())
+        ray.get(actor_2.value.remote())
 
-    # Make sure all actors in counter_list are collocated in one node.
-    actor_info_1 = actor_infos.get(actor_1._actor_id.hex())
-    actor_info_2 = actor_infos.get(actor_2._actor_id.hex())
+        # Get all actors.
+        actor_infos = ray.actors()
 
-    assert actor_info_1 and actor_info_2
+        # Make sure all actors in counter_list are collocated in one node.
+        actor_info_1 = actor_infos.get(actor_1._actor_id.hex())
+        actor_info_2 = actor_infos.get(actor_2._actor_id.hex())
 
-    node_of_actor_1 = actor_info_1["Address"]["NodeID"]
-    node_of_actor_2 = actor_info_2["Address"]["NodeID"]
-    assert node_of_actor_1 == node_of_actor_2
+        assert actor_info_1 and actor_info_2
+
+        node_of_actor_1 = actor_info_1["Address"]["NodeID"]
+        node_of_actor_2 = actor_info_2["Address"]["NodeID"]
+        assert node_of_actor_1 == node_of_actor_2
 
 
-def test_placement_group_strict_pack(ray_start_cluster):
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_placement_group_strict_pack(ray_start_cluster, connect_to_client):
     @ray.remote(num_cpus=2)
     class Actor(object):
         def __init__(self):
@@ -95,42 +110,43 @@ def test_placement_group_strict_pack(ray_start_cluster):
         cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
 
-    placement_group = ray.util.placement_group(
-        name="name",
-        strategy="STRICT_PACK",
-        bundles=[
-            {
-                "memory": 50 * 1024 *
-                1024,  # Test memory resource spec doesn't break tests.
-                "CPU": 2
-            },
-            {
-                "CPU": 2
-            }
-        ])
-    ray.get(placement_group.ready())
-    actor_1 = Actor.options(
-        placement_group=placement_group,
-        placement_group_bundle_index=0).remote()
-    actor_2 = Actor.options(
-        placement_group=placement_group,
-        placement_group_bundle_index=1).remote()
+    with connect_to_client_or_not(connect_to_client):
+        placement_group = ray.util.placement_group(
+            name="name",
+            strategy="STRICT_PACK",
+            bundles=[
+                {
+                    "memory": 50 * 1024 *
+                    1024,  # Test memory resource spec doesn't break tests.
+                    "CPU": 2
+                },
+                {
+                    "CPU": 2
+                }
+            ])
+        ray.get(placement_group.ready())
+        actor_1 = Actor.options(
+            placement_group=placement_group,
+            placement_group_bundle_index=0).remote()
+        actor_2 = Actor.options(
+            placement_group=placement_group,
+            placement_group_bundle_index=1).remote()
 
-    ray.get(actor_1.value.remote())
-    ray.get(actor_2.value.remote())
+        ray.get(actor_1.value.remote())
+        ray.get(actor_2.value.remote())
 
-    # Get all actors.
-    actor_infos = ray.actors()
+        # Get all actors.
+        actor_infos = ray.actors()
 
-    # Make sure all actors in counter_list are collocated in one node.
-    actor_info_1 = actor_infos.get(actor_1._actor_id.hex())
-    actor_info_2 = actor_infos.get(actor_2._actor_id.hex())
+        # Make sure all actors in counter_list are collocated in one node.
+        actor_info_1 = actor_infos.get(actor_1._actor_id.hex())
+        actor_info_2 = actor_infos.get(actor_2._actor_id.hex())
 
-    assert actor_info_1 and actor_info_2
+        assert actor_info_1 and actor_info_2
 
-    node_of_actor_1 = actor_info_1["Address"]["NodeID"]
-    node_of_actor_2 = actor_info_2["Address"]["NodeID"]
-    assert node_of_actor_1 == node_of_actor_2
+        node_of_actor_1 = actor_info_1["Address"]["NodeID"]
+        node_of_actor_2 = actor_info_2["Address"]["NodeID"]
+        assert node_of_actor_1 == node_of_actor_2
 
 
 def test_placement_group_spread(ray_start_cluster):

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -338,12 +338,7 @@ def test_placement_group_hang(ray_start_cluster, connect_to_client):
 @pytest.mark.parametrize("connect_to_client", [False, True])
 def test_remove_placement_group(ray_start_cluster, connect_to_client):
     cluster = ray_start_cluster
-    if not connect_to_client:
-        cluster.add_node(num_cpus=4)
-    else:
-        # If in client mode, add an extra CPU for tasks that operate on
-        # placement group.
-        cluster.add_node(num_cpus=5)
+    cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
 
     with connect_to_client_or_not(connect_to_client):
@@ -677,9 +672,6 @@ def test_pending_placement_group_wait(ray_start_cluster, connect_to_client):
 def test_placement_group_wait(ray_start_cluster, connect_to_client):
     cluster = ray_start_cluster
     [cluster.add_node(num_cpus=2) for _ in range(2)]
-    if connect_to_client:
-        # Spare CPU for placement group tasks.
-        cluster.add_node(num_cpus=1)
     ray.init(address=cluster.address)
     cluster.wait_for_nodes()
 
@@ -1382,12 +1374,7 @@ def test_placement_group_wait_api(ray_start_cluster_head):
 
 @pytest.mark.parametrize("connect_to_client", [False, True])
 def test_schedule_placement_groups_at_the_same_time(connect_to_client):
-    if not connect_to_client:
-        ray.init(num_cpus=4)
-    else:
-        # This is a hack: Get an odd number of CPUs so that one CPU will be
-        # left over for the remove_placement_group task below.
-        ray.init(num_cpus=5)
+    ray.init(num_cpus=4)
 
     with connect_to_client_or_not(connect_to_client):
         pgs = [placement_group([{"CPU": 2}]) for _ in range(6)]

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -1069,7 +1069,8 @@ def test_capture_child_tasks(ray_start_cluster, connect_to_client):
             placement_group=pg,
             placement_group_capture_child_tasks=False).remote(0, 1)
         pgs = ray.get(t2)
-        # All placement group should be None since we don't capture child tasks
+        # All placement groups should be None since we don't capture child
+        # tasks.
         assert not all(pgs)
 
 

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -769,7 +769,8 @@ def test_atomic_creation(ray_start_cluster, connect_to_client):
         # placement group creation should've failed.
         pg_actor = NormalActor.options(
             placement_group=pg,
-            placement_group_bundle_index=num_nodes * bundle_per_node - 1).remote()
+            placement_group_bundle_index=num_nodes * bundle_per_node -
+            1).remote()
 
         # Wait on the placement group now. It should be unready
         # because normal actor takes resources that are required
@@ -780,8 +781,8 @@ def test_atomic_creation(ray_start_cluster, connect_to_client):
         # Wait until all tasks are done.
         assert all(ray.get(tasks))
 
-        # Wait on the placement group creation. Since resources are now available,
-        # it should be ready soon.
+        # Wait on the placement group creation. Since resources are now
+        # available, it should be ready soon.
         ready, unready = ray.wait([pg.ready()])
         assert len(ready) == 1
         assert len(unready) == 0

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -21,7 +21,6 @@ from ray.util.placement_group import (PlacementGroup, placement_group,
                                       remove_placement_group,
                                       get_current_placement_group)
 from ray.util.client.ray_client_helpers import connect_to_client_or_not
-from ray._private.client_mode_hook import client_mode_should_convert
 
 
 @ray.remote
@@ -47,16 +46,6 @@ def test_placement_group_pack(ray_start_cluster, connect_to_client):
     ray.init(address=cluster.address)
 
     with connect_to_client_or_not(connect_to_client):
-        # Quick validation of the context manager:
-        if connect_to_client:
-            # Client mode is on.
-            assert client_mode_should_convert() is True
-            # We're connected to Ray client.
-            assert ray.util.client.ray.is_connected() is True
-        else:
-            assert client_mode_should_convert() is False
-            assert ray.util.client.ray.is_connected() is False
-
         placement_group = ray.util.placement_group(
             name="name",
             strategy="PACK",

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -276,7 +276,9 @@ def test_placement_group_actor_resource_ids(ray_start_cluster):
     assert "CPU_group_" in list(resources.keys())[0], resources
 
 
-def test_placement_group_task_resource_ids(ray_start_cluster):
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_placement_group_task_resource_ids(ray_start_cluster,
+                                           connect_to_client):
     @ray.remote(num_cpus=1)
     def f():
         return ray.get_resource_ids()
@@ -287,24 +289,28 @@ def test_placement_group_task_resource_ids(ray_start_cluster):
         cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
 
-    g1 = ray.util.placement_group([{"CPU": 2}])
-    o1 = f.options(placement_group=g1).remote()
-    resources = ray.get(o1)
-    assert len(resources) == 1, resources
-    assert "CPU_group_" in list(resources.keys())[0], resources
-    assert "CPU_group_0_" not in list(resources.keys())[0], resources
+    with connect_to_client_or_not(connect_to_client):
+        g1 = ray.util.placement_group([{"CPU": 2}])
+        o1 = f.options(placement_group=g1).remote()
+        resources = ray.get(o1)
+        assert len(resources) == 1, resources
+        assert "CPU_group_" in list(resources.keys())[0], resources
+        assert "CPU_group_0_" not in list(resources.keys())[0], resources
 
-    # Now retry with a bundle index constraint.
-    o1 = f.options(placement_group=g1, placement_group_bundle_index=0).remote()
-    resources = ray.get(o1)
-    assert len(resources) == 2, resources
-    keys = list(resources.keys())
-    assert "CPU_group_" in keys[0], resources
-    assert "CPU_group_" in keys[1], resources
-    assert "CPU_group_0_" in keys[0] or "CPU_group_0_" in keys[1], resources
+        # Now retry with a bundle index constraint.
+        o1 = f.options(
+            placement_group=g1, placement_group_bundle_index=0).remote()
+        resources = ray.get(o1)
+        assert len(resources) == 2, resources
+        keys = list(resources.keys())
+        assert "CPU_group_" in keys[0], resources
+        assert "CPU_group_" in keys[1], resources
+        assert ("CPU_group_0_" in keys[0]
+                or "CPU_group_0_" in keys[1]), resources
 
 
-def test_placement_group_hang(ray_start_cluster):
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_placement_group_hang(ray_start_cluster, connect_to_client):
     @ray.remote(num_cpus=1)
     def f():
         return ray.get_resource_ids()
@@ -315,109 +321,123 @@ def test_placement_group_hang(ray_start_cluster):
         cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
 
-    # Warm workers up, so that this triggers the hang rice.
-    ray.get(f.remote())
+    with connect_to_client_or_not(connect_to_client):
+        # Warm workers up, so that this triggers the hang rice.
+        ray.get(f.remote())
 
-    g1 = ray.util.placement_group([{"CPU": 2}])
-    # This will start out infeasible. The placement group will then be created
-    # and it transitions to feasible.
-    o1 = f.options(placement_group=g1).remote()
+        g1 = ray.util.placement_group([{"CPU": 2}])
+        # This will start out infeasible. The placement group will then be
+        # created and it transitions to feasible.
+        o1 = f.options(placement_group=g1).remote()
 
-    resources = ray.get(o1)
-    assert len(resources) == 1, resources
-    assert "CPU_group_" in list(resources.keys())[0], resources
+        resources = ray.get(o1)
+        assert len(resources) == 1, resources
+        assert "CPU_group_" in list(resources.keys())[0], resources
 
 
-def test_remove_placement_group(ray_start_cluster):
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_remove_placement_group(ray_start_cluster, connect_to_client):
     cluster = ray_start_cluster
-    cluster.add_node(num_cpus=4)
+    if not connect_to_client:
+        cluster.add_node(num_cpus=4)
+    else:
+        # If in client mode, add an extra CPU for tasks that operate on
+        # placement group.
+        cluster.add_node(num_cpus=5)
     ray.init(address=cluster.address)
-    # First try to remove a placement group that doesn't
-    # exist. This should not do anything.
-    random_group_id = PlacementGroupID.from_random()
-    random_placement_group = PlacementGroup(random_group_id)
-    for _ in range(3):
-        ray.util.remove_placement_group(random_placement_group)
 
-    # Creating a placement group as soon as it is
-    # created should work.
-    placement_group = ray.util.placement_group([{"CPU": 2}, {"CPU": 2}])
-    assert placement_group.wait(10)
-    ray.util.remove_placement_group(placement_group)
+    with connect_to_client_or_not(connect_to_client):
+        # First try to remove a placement group that doesn't
+        # exist. This should not do anything.
+        random_group_id = PlacementGroupID.from_random()
+        random_placement_group = PlacementGroup(random_group_id)
+        for _ in range(3):
+            ray.util.remove_placement_group(random_placement_group)
 
-    def is_placement_group_removed():
-        table = ray.util.placement_group_table(placement_group)
-        if "state" not in table:
-            return False
-        return table["state"] == "REMOVED"
+        # Creating a placement group as soon as it is
+        # created should work.
+        placement_group = ray.util.placement_group([{"CPU": 2}, {"CPU": 2}])
+        assert placement_group.wait(10)
 
-    wait_for_condition(is_placement_group_removed)
-
-    # # Now let's create a placement group.
-    placement_group = ray.util.placement_group([{"CPU": 2}, {"CPU": 2}])
-    assert placement_group.wait(10)
-
-    # Create an actor that occupies resources.
-    @ray.remote(num_cpus=2)
-    class A:
-        def f(self):
-            return 3
-
-    # Currently, there's no way to prevent
-    # tasks to be retried for removed placement group.
-    # Set max_retrie=0 for testing.
-    # TODO(sang): Handle this edge case.
-    @ray.remote(num_cpus=2, max_retries=0)
-    def long_running_task():
-        print(os.getpid())
-        import time
-        time.sleep(50)
-
-    # Schedule a long running task and actor.
-    task_ref = long_running_task.options(
-        placement_group=placement_group).remote()
-    a = A.options(placement_group=placement_group).remote()
-    assert ray.get(a.f.remote()) == 3
-
-    ray.util.remove_placement_group(placement_group)
-    # Subsequent remove request shouldn't do anything.
-    for _ in range(3):
         ray.util.remove_placement_group(placement_group)
 
-    # Make sure placement group resources are
-    # released and we can schedule this task.
-    @ray.remote(num_cpus=4)
-    def f():
-        return 3
+        def is_placement_group_removed():
+            table = ray.util.placement_group_table(placement_group)
+            if "state" not in table:
+                return False
+            return table["state"] == "REMOVED"
 
-    assert ray.get(f.remote()) == 3
-    # Since the placement group is removed,
-    # the actor should've been killed.
-    # That means this request should fail.
-    with pytest.raises(ray.exceptions.RayActorError, match="actor died"):
-        ray.get(a.f.remote(), timeout=3.0)
-    with pytest.raises(ray.exceptions.WorkerCrashedError):
-        ray.get(task_ref)
+        wait_for_condition(is_placement_group_removed)
+
+        # # Now let's create a placement group.
+        placement_group = ray.util.placement_group([{"CPU": 2}, {"CPU": 2}])
+        assert placement_group.wait(10)
+
+        # Create an actor that occupies resources.
+        @ray.remote(num_cpus=2)
+        class A:
+            def f(self):
+                return 3
+
+        # Currently, there's no way to prevent
+        # tasks to be retried for removed placement group.
+        # Set max_retrie=0 for testing.
+        # TODO(sang): Handle this edge case.
+        @ray.remote(num_cpus=2, max_retries=0)
+        def long_running_task():
+            print(os.getpid())
+            import time
+            time.sleep(50)
+
+        # Schedule a long running task and actor.
+        task_ref = long_running_task.options(
+            placement_group=placement_group).remote()
+        a = A.options(placement_group=placement_group).remote()
+        assert ray.get(a.f.remote()) == 3
+
+        ray.util.remove_placement_group(placement_group)
+        # Subsequent remove request shouldn't do anything.
+        for _ in range(3):
+            ray.util.remove_placement_group(placement_group)
+
+        # Make sure placement group resources are
+        # released and we can schedule this task.
+        @ray.remote(num_cpus=4)
+        def f():
+            return 3
+
+        assert ray.get(f.remote()) == 3
+        # Since the placement group is removed,
+        # the actor should've been killed.
+        # That means this request should fail.
+        with pytest.raises(ray.exceptions.RayActorError, match="actor died"):
+            ray.get(a.f.remote(), timeout=3.0)
+        with pytest.raises(ray.exceptions.WorkerCrashedError):
+            ray.get(task_ref)
 
 
-def test_remove_pending_placement_group(ray_start_cluster):
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_remove_pending_placement_group(ray_start_cluster, connect_to_client):
     cluster = ray_start_cluster
     cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
-    # Create a placement group that cannot be scheduled now.
-    placement_group = ray.util.placement_group([{"GPU": 2}, {"CPU": 2}])
-    ray.util.remove_placement_group(placement_group)
 
-    # TODO(sang): Add state check here.
-    @ray.remote(num_cpus=4)
-    def f():
-        return 3
+    with connect_to_client_or_not(connect_to_client):
+        # Create a placement group that cannot be scheduled now.
+        placement_group = ray.util.placement_group([{"GPU": 2}, {"CPU": 2}])
+        ray.util.remove_placement_group(placement_group)
 
-    # Make sure this task is still schedulable.
-    assert ray.get(f.remote()) == 3
+        # TODO(sang): Add state check here.
+        @ray.remote(num_cpus=4)
+        def f():
+            return 3
+
+        # Make sure this task is still schedulable.
+        assert ray.get(f.remote()) == 3
 
 
-def test_placement_group_table(ray_start_cluster):
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_placement_group_table(ray_start_cluster, connect_to_client):
     @ray.remote(num_cpus=2)
     class Actor(object):
         def __init__(self):
@@ -432,56 +452,60 @@ def test_placement_group_table(ray_start_cluster):
         cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
 
-    # Originally placement group creation should be pending because
-    # there are no resources.
-    name = "name"
-    strategy = "PACK"
-    bundles = [{"CPU": 2, "GPU": 1}, {"CPU": 2}]
-    placement_group = ray.util.placement_group(
-        name=name, strategy=strategy, bundles=bundles)
-    result = ray.util.placement_group_table(placement_group)
-    assert result["name"] == name
-    assert result["strategy"] == strategy
-    for i in range(len(bundles)):
-        assert bundles[i] == result["bundles"][i]
-    assert result["state"] == "PENDING"
+    with connect_to_client_or_not(connect_to_client):
+        # Originally placement group creation should be pending because
+        # there are no resources.
+        name = "name"
+        strategy = "PACK"
+        bundles = [{"CPU": 2, "GPU": 1}, {"CPU": 2}]
+        placement_group = ray.util.placement_group(
+            name=name, strategy=strategy, bundles=bundles)
+        result = ray.util.placement_group_table(placement_group)
+        assert result["name"] == name
+        assert result["strategy"] == strategy
+        for i in range(len(bundles)):
+            assert bundles[i] == result["bundles"][i]
+        assert result["state"] == "PENDING"
 
-    # Now the placement group should be scheduled.
-    cluster.add_node(num_cpus=5, num_gpus=1)
+        # Now the placement group should be scheduled.
+        cluster.add_node(num_cpus=5, num_gpus=1)
 
-    cluster.wait_for_nodes()
-    actor_1 = Actor.options(
-        placement_group=placement_group,
-        placement_group_bundle_index=0).remote()
-    ray.get(actor_1.value.remote())
+        cluster.wait_for_nodes()
+        actor_1 = Actor.options(
+            placement_group=placement_group,
+            placement_group_bundle_index=0).remote()
+        ray.get(actor_1.value.remote())
 
-    result = ray.util.placement_group_table(placement_group)
-    assert result["state"] == "CREATED"
+        result = ray.util.placement_group_table(placement_group)
+        assert result["state"] == "CREATED"
 
-    # Add tow more placement group for placement group table test.
-    second_strategy = "SPREAD"
-    ray.util.placement_group(
-        name="second_placement_group",
-        strategy=second_strategy,
-        bundles=bundles)
-    ray.util.placement_group(
-        name="third_placement_group",
-        strategy=second_strategy,
-        bundles=bundles)
+        # Add tow more placement group for placement group table test.
+        second_strategy = "SPREAD"
+        ray.util.placement_group(
+            name="second_placement_group",
+            strategy=second_strategy,
+            bundles=bundles)
+        ray.util.placement_group(
+            name="third_placement_group",
+            strategy=second_strategy,
+            bundles=bundles)
 
-    placement_group_table = ray.util.placement_group_table()
-    assert len(placement_group_table) == 3
+        placement_group_table = ray.util.placement_group_table()
+        assert len(placement_group_table) == 3
 
-    true_name_set = {"name", "second_placement_group", "third_placement_group"}
-    get_name_set = set()
+        true_name_set = {
+            "name", "second_placement_group", "third_placement_group"
+        }
+        get_name_set = set()
 
-    for _, placement_group_data in placement_group_table.items():
-        get_name_set.add(placement_group_data["name"])
+        for _, placement_group_data in placement_group_table.items():
+            get_name_set.add(placement_group_data["name"])
 
-    assert true_name_set == get_name_set
+        assert true_name_set == get_name_set
 
 
-def test_cuda_visible_devices(ray_start_cluster):
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_cuda_visible_devices(ray_start_cluster, connect_to_client):
     @ray.remote(num_gpus=1)
     def f():
         return os.environ["CUDA_VISIBLE_DEVICES"]
@@ -492,14 +516,17 @@ def test_cuda_visible_devices(ray_start_cluster):
         cluster.add_node(num_gpus=1)
     ray.init(address=cluster.address)
 
-    g1 = ray.util.placement_group([{"CPU": 1, "GPU": 1}])
-    o1 = f.options(placement_group=g1).remote()
+    with connect_to_client_or_not(connect_to_client):
+        g1 = ray.util.placement_group([{"CPU": 1, "GPU": 1}])
+        o1 = f.options(placement_group=g1).remote()
 
-    devices = ray.get(o1)
-    assert devices == "0", devices
+        devices = ray.get(o1)
+        assert devices == "0", devices
 
 
-def test_placement_group_reschedule_when_node_dead(ray_start_cluster):
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_placement_group_reschedule_when_node_dead(ray_start_cluster,
+                                                   connect_to_client):
     @ray.remote(num_cpus=1)
     class Actor(object):
         def __init__(self):
@@ -520,54 +547,56 @@ def test_placement_group_reschedule_when_node_dead(ray_start_cluster):
     assert len(nodes) == 3
     assert nodes[0]["alive"] and nodes[1]["alive"] and nodes[2]["alive"]
 
-    placement_group = ray.util.placement_group(
-        name="name",
-        strategy="SPREAD",
-        bundles=[{
-            "CPU": 2
-        }, {
-            "CPU": 2
-        }, {
-            "CPU": 2
-        }])
-    actor_1 = Actor.options(
-        placement_group=placement_group,
-        placement_group_bundle_index=0,
-        lifetime="detached").remote()
-    actor_2 = Actor.options(
-        placement_group=placement_group,
-        placement_group_bundle_index=1,
-        lifetime="detached").remote()
-    actor_3 = Actor.options(
-        placement_group=placement_group,
-        placement_group_bundle_index=2,
-        lifetime="detached").remote()
-    ray.get(actor_1.value.remote())
-    ray.get(actor_2.value.remote())
-    ray.get(actor_3.value.remote())
+    with connect_to_client_or_not(connect_to_client):
+        placement_group = ray.util.placement_group(
+            name="name",
+            strategy="SPREAD",
+            bundles=[{
+                "CPU": 2
+            }, {
+                "CPU": 2
+            }, {
+                "CPU": 2
+            }])
+        actor_1 = Actor.options(
+            placement_group=placement_group,
+            placement_group_bundle_index=0,
+            lifetime="detached").remote()
+        actor_2 = Actor.options(
+            placement_group=placement_group,
+            placement_group_bundle_index=1,
+            lifetime="detached").remote()
+        actor_3 = Actor.options(
+            placement_group=placement_group,
+            placement_group_bundle_index=2,
+            lifetime="detached").remote()
+        ray.get(actor_1.value.remote())
+        ray.get(actor_2.value.remote())
+        ray.get(actor_3.value.remote())
 
-    cluster.remove_node(get_other_nodes(cluster, exclude_head=True)[-1])
-    cluster.wait_for_nodes()
+        cluster.remove_node(get_other_nodes(cluster, exclude_head=True)[-1])
+        cluster.wait_for_nodes()
 
-    actor_4 = Actor.options(
-        placement_group=placement_group,
-        placement_group_bundle_index=0,
-        lifetime="detached").remote()
-    actor_5 = Actor.options(
-        placement_group=placement_group,
-        placement_group_bundle_index=1,
-        lifetime="detached").remote()
-    actor_6 = Actor.options(
-        placement_group=placement_group,
-        placement_group_bundle_index=2,
-        lifetime="detached").remote()
-    ray.get(actor_4.value.remote())
-    ray.get(actor_5.value.remote())
-    ray.get(actor_6.value.remote())
-    ray.shutdown()
+        actor_4 = Actor.options(
+            placement_group=placement_group,
+            placement_group_bundle_index=0,
+            lifetime="detached").remote()
+        actor_5 = Actor.options(
+            placement_group=placement_group,
+            placement_group_bundle_index=1,
+            lifetime="detached").remote()
+        actor_6 = Actor.options(
+            placement_group=placement_group,
+            placement_group_bundle_index=2,
+            lifetime="detached").remote()
+        ray.get(actor_4.value.remote())
+        ray.get(actor_5.value.remote())
+        ray.get(actor_6.value.remote())
+        ray.shutdown()
 
 
-def test_check_bundle_index(ray_start_cluster):
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_check_bundle_index(ray_start_cluster, connect_to_client):
     @ray.remote(num_cpus=2)
     class Actor(object):
         def __init__(self):
@@ -580,113 +609,124 @@ def test_check_bundle_index(ray_start_cluster):
     cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
 
-    placement_group = ray.util.placement_group(
-        name="name", strategy="SPREAD", bundles=[{
-            "CPU": 2
-        }, {
-            "CPU": 2
-        }])
+    with connect_to_client_or_not(connect_to_client):
+        placement_group = ray.util.placement_group(
+            name="name", strategy="SPREAD", bundles=[{
+                "CPU": 2
+            }, {
+                "CPU": 2
+            }])
 
-    error_count = 0
-    try:
-        Actor.options(
-            placement_group=placement_group,
-            placement_group_bundle_index=3).remote()
-    except ValueError:
-        error_count = error_count + 1
-    assert error_count == 1
+        error_count = 0
+        try:
+            Actor.options(
+                placement_group=placement_group,
+                placement_group_bundle_index=3).remote()
+        except ValueError:
+            error_count = error_count + 1
+        assert error_count == 1
 
-    try:
-        Actor.options(
-            placement_group=placement_group,
-            placement_group_bundle_index=-2).remote()
-    except ValueError:
-        error_count = error_count + 1
-    assert error_count == 2
+        try:
+            Actor.options(
+                placement_group=placement_group,
+                placement_group_bundle_index=-2).remote()
+        except ValueError:
+            error_count = error_count + 1
+        assert error_count == 2
 
-    try:
-        Actor.options(placement_group_bundle_index=0).remote()
-    except ValueError:
-        error_count = error_count + 1
-    assert error_count == 3
+        try:
+            Actor.options(placement_group_bundle_index=0).remote()
+        except ValueError:
+            error_count = error_count + 1
+        assert error_count == 3
 
 
-def test_pending_placement_group_wait(ray_start_cluster):
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_pending_placement_group_wait(ray_start_cluster, connect_to_client):
     cluster = ray_start_cluster
     [cluster.add_node(num_cpus=2) for _ in range(1)]
     ray.init(address=cluster.address)
     cluster.wait_for_nodes()
 
-    # Wait on placement group that cannot be created.
-    placement_group = ray.util.placement_group(
-        name="name",
-        strategy="SPREAD",
-        bundles=[
-            {
-                "CPU": 2
-            },
-            {
-                "CPU": 2
-            },
-            {
-                "GPU": 2
-            },
-        ])
-    ready, unready = ray.wait([placement_group.ready()], timeout=0.1)
-    assert len(unready) == 1
-    assert len(ready) == 0
-    table = ray.util.placement_group_table(placement_group)
-    assert table["state"] == "PENDING"
-    with pytest.raises(ray.exceptions.GetTimeoutError):
-        ray.get(placement_group.ready(), timeout=0.1)
+    with connect_to_client_or_not(connect_to_client):
+        # Wait on placement group that cannot be created.
+        placement_group = ray.util.placement_group(
+            name="name",
+            strategy="SPREAD",
+            bundles=[
+                {
+                    "CPU": 2
+                },
+                {
+                    "CPU": 2
+                },
+                {
+                    "GPU": 2
+                },
+            ])
+        ready, unready = ray.wait([placement_group.ready()], timeout=0.1)
+        assert len(unready) == 1
+        assert len(ready) == 0
+        table = ray.util.placement_group_table(placement_group)
+        assert table["state"] == "PENDING"
+        with pytest.raises(ray.exceptions.GetTimeoutError):
+            ray.get(placement_group.ready(), timeout=0.1)
 
 
-def test_placement_group_wait(ray_start_cluster):
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_placement_group_wait(ray_start_cluster, connect_to_client):
     cluster = ray_start_cluster
     [cluster.add_node(num_cpus=2) for _ in range(2)]
+    if connect_to_client:
+        # Spare CPU for placement group tasks.
+        cluster.add_node(num_cpus=1)
     ray.init(address=cluster.address)
     cluster.wait_for_nodes()
 
-    # Wait on placement group that cannot be created.
-    placement_group = ray.util.placement_group(
-        name="name", strategy="SPREAD", bundles=[
-            {
-                "CPU": 2
-            },
-            {
-                "CPU": 2
-            },
-        ])
-    ready, unready = ray.wait([placement_group.ready()])
-    assert len(unready) == 0
-    assert len(ready) == 1
-    table = ray.util.placement_group_table(placement_group)
-    assert table["state"] == "CREATED"
+    with connect_to_client_or_not(connect_to_client):
+        # Wait on placement group that cannot be created.
+        placement_group = ray.util.placement_group(
+            name="name", strategy="SPREAD", bundles=[
+                {
+                    "CPU": 2
+                },
+                {
+                    "CPU": 2
+                },
+            ])
+        ready, unready = ray.wait([placement_group.ready()])
+        assert len(unready) == 0
+        assert len(ready) == 1
+        table = ray.util.placement_group_table(placement_group)
+        assert table["state"] == "CREATED"
 
-    pg = ray.get(placement_group.ready())
-    assert pg.bundle_specs == placement_group.bundle_specs
-    assert pg.id.binary() == placement_group.id.binary()
+        pg = ray.get(placement_group.ready())
+        assert pg.bundle_specs == placement_group.bundle_specs
+        assert pg.id.binary() == placement_group.id.binary()
 
 
-def test_schedule_placement_group_when_node_add(ray_start_cluster):
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_schedule_placement_group_when_node_add(ray_start_cluster,
+                                                connect_to_client):
     cluster = ray_start_cluster
     cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
 
-    # Creating a placement group that cannot be satisfied yet.
-    placement_group = ray.util.placement_group([{"GPU": 2}, {"CPU": 2}])
+    with connect_to_client_or_not(connect_to_client):
+        # Creating a placement group that cannot be satisfied yet.
+        placement_group = ray.util.placement_group([{"GPU": 2}, {"CPU": 2}])
 
-    def is_placement_group_created():
-        table = ray.util.placement_group_table(placement_group)
-        if "state" not in table:
-            return False
-        return table["state"] == "CREATED"
+        def is_placement_group_created():
+            table = ray.util.placement_group_table(placement_group)
+            if "state" not in table:
+                return False
+            return table["state"] == "CREATED"
 
-    # Add a node that has GPU.
-    cluster.add_node(num_cpus=4, num_gpus=4)
+        # Add a node that has GPU.
+        cluster.add_node(num_cpus=4, num_gpus=4)
 
-    # Make sure the placement group is created.
-    wait_for_condition(is_placement_group_created)
+        # Make sure the placement group is created.
+        wait_for_condition(is_placement_group_created)
 
 
 def test_atomic_creation(ray_start_cluster):
@@ -796,7 +836,8 @@ def test_atomic_creation(ray_start_cluster):
     assert all(ray.get(check_without_pg))
 
 
-def test_mini_integration(ray_start_cluster):
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_mini_integration(ray_start_cluster, connect_to_client):
     # Create bundles as many as number of gpus in the cluster.
     # Do some random work and make sure all resources are properly recovered.
 
@@ -818,217 +859,223 @@ def test_mini_integration(ray_start_cluster):
     cluster.wait_for_nodes()
     ray.init(address=cluster.address)
 
-    @ray.remote(num_cpus=0, num_gpus=1)
-    def random_tasks():
-        import time
-        import random
-        sleep_time = random.uniform(0.1, 0.2)
-        time.sleep(sleep_time)
-        return True
+    with connect_to_client_or_not(connect_to_client):
 
-    pgs = []
-    pg_tasks = []
-    # total bundle gpu usage = bundles_per_pg * total_num_pg * per_bundle_gpus
-    # Note this is half of total
-    for index in range(total_num_pg):
-        pgs.append(
-            ray.util.placement_group(
-                name=f"name{index}",
-                strategy="PACK",
-                bundles=[{
-                    "GPU": per_bundle_gpus
-                } for _ in range(bundles_per_pg)]))
-
-    # Schedule tasks.
-    for i in range(total_num_pg):
-        pg = pgs[i]
-        pg_tasks.append([
-            random_tasks.options(
-                placement_group=pg,
-                placement_group_bundle_index=bundle_index).remote()
-            for bundle_index in range(bundles_per_pg)
-        ])
-
-    # Make sure tasks are done and we remove placement groups.
-    num_removed_pg = 0
-    pg_indexes = [2, 3, 1, 7, 8, 9, 0, 6, 4, 5]
-    while num_removed_pg < total_num_pg:
-        index = pg_indexes[num_removed_pg]
-        pg = pgs[index]
-        assert all(ray.get(pg_tasks[index]))
-        ray.util.remove_placement_group(pg)
-        num_removed_pg += 1
-
-    @ray.remote(num_cpus=2, num_gpus=per_node_gpus)
-    class A:
-        def ping(self):
+        @ray.remote(num_cpus=0, num_gpus=1)
+        def random_tasks():
+            import time
+            import random
+            sleep_time = random.uniform(0.1, 0.2)
+            time.sleep(sleep_time)
             return True
 
-    # Make sure all resources are properly returned by scheduling
-    # actors that take up all existing resources.
-    actors = [A.remote() for _ in range(num_nodes)]
-    assert all(ray.get([a.ping.remote() for a in actors]))
+        pgs = []
+        pg_tasks = []
+        # total bundle gpu usage = bundles_per_pg*total_num_pg*per_bundle_gpus
+        # Note this is half of total
+        for index in range(total_num_pg):
+            pgs.append(
+                ray.util.placement_group(
+                    name=f"name{index}",
+                    strategy="PACK",
+                    bundles=[{
+                        "GPU": per_bundle_gpus
+                    } for _ in range(bundles_per_pg)]))
+
+        # Schedule tasks.
+        for i in range(total_num_pg):
+            pg = pgs[i]
+            pg_tasks.append([
+                random_tasks.options(
+                    placement_group=pg,
+                    placement_group_bundle_index=bundle_index).remote()
+                for bundle_index in range(bundles_per_pg)
+            ])
+
+        # Make sure tasks are done and we remove placement groups.
+        num_removed_pg = 0
+        pg_indexes = [2, 3, 1, 7, 8, 9, 0, 6, 4, 5]
+        while num_removed_pg < total_num_pg:
+            index = pg_indexes[num_removed_pg]
+            pg = pgs[index]
+            assert all(ray.get(pg_tasks[index]))
+            ray.util.remove_placement_group(pg)
+            num_removed_pg += 1
+
+        @ray.remote(num_cpus=2, num_gpus=per_node_gpus)
+        class A:
+            def ping(self):
+                return True
+
+        # Make sure all resources are properly returned by scheduling
+        # actors that take up all existing resources.
+        actors = [A.remote() for _ in range(num_nodes)]
+        assert all(ray.get([a.ping.remote() for a in actors]))
 
 
-def test_capture_child_actors(ray_start_cluster):
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_capture_child_actors(ray_start_cluster, connect_to_client):
     cluster = ray_start_cluster
     total_num_actors = 4
     for _ in range(2):
         cluster.add_node(num_cpus=total_num_actors)
     ray.init(address=cluster.address)
 
-    pg = ray.util.placement_group(
-        [{
-            "CPU": 2
-        }, {
-            "CPU": 2
-        }], strategy="STRICT_PACK")
-    ray.get(pg.ready())
+    with connect_to_client_or_not(connect_to_client):
+        pg = ray.util.placement_group(
+            [{
+                "CPU": 2
+            }, {
+                "CPU": 2
+            }], strategy="STRICT_PACK")
+        ray.get(pg.ready())
 
-    # If get_current_placement_group is used when the current worker/driver
-    # doesn't belong to any of placement group, it should return None.
-    assert get_current_placement_group() is None
+        # If get_current_placement_group is used when the current worker/driver
+        # doesn't belong to any of placement group, it should return None.
+        assert get_current_placement_group() is None
 
-    # Test actors first.
-    @ray.remote(num_cpus=1)
-    class NestedActor:
-        def ready(self):
-            return True
+        # Test actors first.
+        @ray.remote(num_cpus=1)
+        class NestedActor:
+            def ready(self):
+                return True
 
-    @ray.remote(num_cpus=1)
-    class Actor:
-        def __init__(self):
-            self.actors = []
+        @ray.remote(num_cpus=1)
+        class Actor:
+            def __init__(self):
+                self.actors = []
 
-        def ready(self):
-            return True
+            def ready(self):
+                return True
 
-        def schedule_nested_actor(self):
-            # Make sure we can capture the current placement group.
-            assert get_current_placement_group() is not None
-            # Actors should be implicitly captured.
-            actor = NestedActor.remote()
-            ray.get(actor.ready.remote())
-            self.actors.append(actor)
+            def schedule_nested_actor(self):
+                # Make sure we can capture the current placement group.
+                assert get_current_placement_group() is not None
+                # Actors should be implicitly captured.
+                actor = NestedActor.remote()
+                ray.get(actor.ready.remote())
+                self.actors.append(actor)
 
-        def schedule_nested_actor_outside_pg(self):
-            # Don't use placement group.
-            actor = NestedActor.options(placement_group=None).remote()
-            ray.get(actor.ready.remote())
-            self.actors.append(actor)
+            def schedule_nested_actor_outside_pg(self):
+                # Don't use placement group.
+                actor = NestedActor.options(placement_group=None).remote()
+                ray.get(actor.ready.remote())
+                self.actors.append(actor)
 
-    a = Actor.options(placement_group=pg).remote()
-    ray.get(a.ready.remote())
-    # 1 top level actor + 3 children.
-    for _ in range(total_num_actors - 1):
-        ray.get(a.schedule_nested_actor.remote())
-    # Make sure all the actors are scheduled on the same node.
-    # (why? The placement group has STRICT_PACK strategy).
-    node_id_set = set()
-    for actor_info in ray.actors().values():
-        node_id = actor_info["Address"]["NodeID"]
-        node_id_set.add(node_id)
-
-    # Since all node id should be identical, set should be equal to 1.
-    assert len(node_id_set) == 1
-
-    # Kill an actor and wait until it is killed.
-    kill_actor_and_wait_for_failure(a)
-    with pytest.raises(ray.exceptions.RayActorError):
+        a = Actor.options(placement_group=pg).remote()
         ray.get(a.ready.remote())
+        # 1 top level actor + 3 children.
+        for _ in range(total_num_actors - 1):
+            ray.get(a.schedule_nested_actor.remote())
+        # Make sure all the actors are scheduled on the same node.
+        # (why? The placement group has STRICT_PACK strategy).
+        node_id_set = set()
+        for actor_info in ray.actors().values():
+            node_id = actor_info["Address"]["NodeID"]
+            node_id_set.add(node_id)
 
-    # Now create an actor, but do not capture the current tasks
-    a = Actor.options(
-        placement_group=pg,
-        placement_group_capture_child_tasks=False).remote()
-    ray.get(a.ready.remote())
-    # 1 top level actor + 3 children.
-    for _ in range(total_num_actors - 1):
-        ray.get(a.schedule_nested_actor.remote())
-    # Make sure all the actors are not scheduled on the same node.
-    # It is because the child tasks are not scheduled on the same
-    # placement group.
-    node_id_set = set()
-    for actor_info in ray.actors().values():
-        node_id = actor_info["Address"]["NodeID"]
-        node_id_set.add(node_id)
+        # Since all node id should be identical, set should be equal to 1.
+        assert len(node_id_set) == 1
 
-    assert len(node_id_set) == 2
+        # Kill an actor and wait until it is killed.
+        kill_actor_and_wait_for_failure(a)
+        with pytest.raises(ray.exceptions.RayActorError):
+            ray.get(a.ready.remote())
 
-    # Kill an actor and wait until it is killed.
-    kill_actor_and_wait_for_failure(a)
-    with pytest.raises(ray.exceptions.RayActorError):
+        # Now create an actor, but do not capture the current tasks
+        a = Actor.options(
+            placement_group=pg,
+            placement_group_capture_child_tasks=False).remote()
         ray.get(a.ready.remote())
+        # 1 top level actor + 3 children.
+        for _ in range(total_num_actors - 1):
+            ray.get(a.schedule_nested_actor.remote())
+        # Make sure all the actors are not scheduled on the same node.
+        # It is because the child tasks are not scheduled on the same
+        # placement group.
+        node_id_set = set()
+        for actor_info in ray.actors().values():
+            node_id = actor_info["Address"]["NodeID"]
+            node_id_set.add(node_id)
 
-    # Lastly, make sure when None is specified, actors are not scheduled
-    # on the same placement group.
-    a = Actor.options(placement_group=pg).remote()
-    ray.get(a.ready.remote())
-    # 1 top level actor + 3 children.
-    for _ in range(total_num_actors - 1):
-        ray.get(a.schedule_nested_actor_outside_pg.remote())
-    # Make sure all the actors are not scheduled on the same node.
-    # It is because the child tasks are not scheduled on the same
-    # placement group.
-    node_id_set = set()
-    for actor_info in ray.actors().values():
-        node_id = actor_info["Address"]["NodeID"]
-        node_id_set.add(node_id)
+        assert len(node_id_set) == 2
 
-    assert len(node_id_set) == 2
+        # Kill an actor and wait until it is killed.
+        kill_actor_and_wait_for_failure(a)
+        with pytest.raises(ray.exceptions.RayActorError):
+            ray.get(a.ready.remote())
+
+        # Lastly, make sure when None is specified, actors are not scheduled
+        # on the same placement group.
+        a = Actor.options(placement_group=pg).remote()
+        ray.get(a.ready.remote())
+        # 1 top level actor + 3 children.
+        for _ in range(total_num_actors - 1):
+            ray.get(a.schedule_nested_actor_outside_pg.remote())
+        # Make sure all the actors are not scheduled on the same node.
+        # It is because the child tasks are not scheduled on the same
+        # placement group.
+        node_id_set = set()
+        for actor_info in ray.actors().values():
+            node_id = actor_info["Address"]["NodeID"]
+            node_id_set.add(node_id)
+
+        assert len(node_id_set) == 2
 
 
-def test_capture_child_tasks(ray_start_cluster):
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_capture_child_tasks(ray_start_cluster, connect_to_client):
     cluster = ray_start_cluster
     total_num_tasks = 4
     for _ in range(2):
         cluster.add_node(num_cpus=total_num_tasks, num_gpus=total_num_tasks)
     ray.init(address=cluster.address)
 
-    pg = ray.util.placement_group(
-        [{
-            "CPU": 2,
-            "GPU": 2,
-        }, {
-            "CPU": 2,
-            "GPU": 2,
-        }],
-        strategy="STRICT_PACK")
-    ray.get(pg.ready())
+    with connect_to_client_or_not(connect_to_client):
+        pg = ray.util.placement_group(
+            [{
+                "CPU": 2,
+                "GPU": 2,
+            }, {
+                "CPU": 2,
+                "GPU": 2,
+            }],
+            strategy="STRICT_PACK")
+        ray.get(pg.ready())
 
-    # If get_current_placement_group is used when the current worker/driver
-    # doesn't belong to any of placement group, it should return None.
-    assert get_current_placement_group() is None
+        # If get_current_placement_group is used when the current worker/driver
+        # doesn't belong to any of placement group, it should return None.
+        assert get_current_placement_group() is None
 
-    # Test if tasks capture child tasks.
-    @ray.remote
-    def task():
-        return get_current_placement_group()
+        # Test if tasks capture child tasks.
+        @ray.remote
+        def task():
+            return get_current_placement_group()
 
-    @ray.remote
-    def create_nested_task(child_cpu, child_gpu):
-        assert get_current_placement_group() is not None
-        return ray.get([
-            task.options(num_cpus=child_cpu, num_gpus=child_gpu).remote()
-            for _ in range(3)
-        ])
+        @ray.remote
+        def create_nested_task(child_cpu, child_gpu):
+            assert get_current_placement_group() is not None
+            return ray.get([
+                task.options(num_cpus=child_cpu, num_gpus=child_gpu).remote()
+                for _ in range(3)
+            ])
 
-    t = create_nested_task.options(
-        num_cpus=1, num_gpus=0, placement_group=pg).remote(1, 0)
-    pgs = ray.get(t)
-    # Every task should have current placement group because they
-    # should be implicitly captured by default.
-    assert None not in pgs
+        t = create_nested_task.options(
+            num_cpus=1, num_gpus=0, placement_group=pg).remote(1, 0)
+        pgs = ray.get(t)
+        # Every task should have current placement group because they
+        # should be implicitly captured by default.
+        assert None not in pgs
 
-    # Test if tasks don't capture child tasks when the option is off.
-    t2 = create_nested_task.options(
-        num_cpus=0,
-        num_gpus=1,
-        placement_group=pg,
-        placement_group_capture_child_tasks=False).remote(0, 1)
-    pgs = ray.get(t2)
-    # All placement group should be None because we don't capture child tasks.
-    assert not all(pgs)
+        # Test if tasks don't capture child tasks when the option is off.
+        t2 = create_nested_task.options(
+            num_cpus=0,
+            num_gpus=1,
+            placement_group=pg,
+            placement_group_capture_child_tasks=False).remote(0, 1)
+        pgs = ray.get(t2)
+        # All placement group should be None since we don't capture child tasks
+        assert not all(pgs)
 
 
 def test_ready_warning_suppressed(ray_start_regular, error_pubsub):
@@ -1333,25 +1380,32 @@ def test_placement_group_wait_api(ray_start_cluster_head):
         placement_group1.wait(10)
 
 
-def test_schedule_placement_groups_at_the_same_time():
-    ray.init(num_cpus=4)
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_schedule_placement_groups_at_the_same_time(connect_to_client):
+    if not connect_to_client:
+        ray.init(num_cpus=4)
+    else:
+        # This is a hack: Get an odd number of CPUs so that one CPU will be
+        # left over for the remove_placement_group task below.
+        ray.init(num_cpus=5)
 
-    pgs = [placement_group([{"CPU": 2}]) for _ in range(6)]
+    with connect_to_client_or_not(connect_to_client):
+        pgs = [placement_group([{"CPU": 2}]) for _ in range(6)]
 
-    wait_pgs = {pg.ready(): pg for pg in pgs}
+        wait_pgs = {pg.ready(): pg for pg in pgs}
 
-    def is_all_placement_group_removed():
-        ready, _ = ray.wait(list(wait_pgs.keys()), timeout=0.5)
-        if ready:
-            ready_pg = wait_pgs[ready[0]]
-            remove_placement_group(ready_pg)
-            del wait_pgs[ready[0]]
+        def is_all_placement_group_removed():
+            ready, _ = ray.wait(list(wait_pgs.keys()), timeout=0.5)
+            if ready:
+                ready_pg = wait_pgs[ready[0]]
+                remove_placement_group(ready_pg)
+                del wait_pgs[ready[0]]
 
-        if len(wait_pgs) == 0:
-            return True
-        return False
+            if len(wait_pgs) == 0:
+                return True
+            return False
 
-    wait_for_condition(is_all_placement_group_removed)
+        wait_for_condition(is_all_placement_group_removed)
 
     ray.shutdown()
 
@@ -1552,37 +1606,41 @@ ray.shutdown()
     assert error_count == 1
 
 
-def test_placement_group_synchronous_registration(ray_start_cluster):
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_placement_group_synchronous_registration(ray_start_cluster,
+                                                  connect_to_client):
     cluster = ray_start_cluster
     # One node which only has one CPU.
     cluster.add_node(num_cpus=1)
     cluster.wait_for_nodes()
     ray.init(address=cluster.address)
 
-    # Create a placement group that has two bundles and `STRICT_PACK` strategy,
-    # so, its registration will successful but scheduling failed.
-    placement_group = ray.util.placement_group(
-        name="name",
-        strategy="STRICT_PACK",
-        bundles=[{
-            "CPU": 1,
-        }, {
-            "CPU": 1
-        }])
-    # Make sure we can properly remove it immediately
-    # as its registration is synchronous.
-    ray.util.remove_placement_group(placement_group)
+    with connect_to_client_or_not(connect_to_client):
+        # Create a placement group that has two bundles and `STRICT_PACK`
+        # strategy so its registration will successful but scheduling failed.
+        placement_group = ray.util.placement_group(
+            name="name",
+            strategy="STRICT_PACK",
+            bundles=[{
+                "CPU": 1,
+            }, {
+                "CPU": 1
+            }])
+        # Make sure we can properly remove it immediately
+        # as its registration is synchronous.
+        ray.util.remove_placement_group(placement_group)
 
-    def is_placement_group_removed():
-        table = ray.util.placement_group_table(placement_group)
-        if "state" not in table:
-            return False
-        return table["state"] == "REMOVED"
+        def is_placement_group_removed():
+            table = ray.util.placement_group_table(placement_group)
+            if "state" not in table:
+                return False
+            return table["state"] == "REMOVED"
 
-    wait_for_condition(is_placement_group_removed)
+        wait_for_condition(is_placement_group_removed)
 
 
-def test_placement_group_gpu_set(ray_start_cluster):
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_placement_group_gpu_set(ray_start_cluster, connect_to_client):
     cluster = ray_start_cluster
     # One node which only has one CPU.
     cluster.add_node(num_cpus=1, num_gpus=1)
@@ -1590,35 +1648,37 @@ def test_placement_group_gpu_set(ray_start_cluster):
     cluster.wait_for_nodes()
     ray.init(address=cluster.address)
 
-    placement_group = ray.util.placement_group(
-        name="name",
-        strategy="PACK",
-        bundles=[{
-            "CPU": 1,
-            "GPU": 1
-        }, {
-            "CPU": 1,
-            "GPU": 1
-        }])
+    with connect_to_client_or_not(connect_to_client):
+        placement_group = ray.util.placement_group(
+            name="name",
+            strategy="PACK",
+            bundles=[{
+                "CPU": 1,
+                "GPU": 1
+            }, {
+                "CPU": 1,
+                "GPU": 1
+            }])
 
-    @ray.remote(num_gpus=1)
-    def get_gpus():
-        return ray.get_gpu_ids()
+        @ray.remote(num_gpus=1)
+        def get_gpus():
+            return ray.get_gpu_ids()
 
-    result = get_gpus.options(
-        placement_group=placement_group,
-        placement_group_bundle_index=0).remote()
-    result = ray.get(result)
-    assert result == [0]
+        result = get_gpus.options(
+            placement_group=placement_group,
+            placement_group_bundle_index=0).remote()
+        result = ray.get(result)
+        assert result == [0]
 
-    result = get_gpus.options(
-        placement_group=placement_group,
-        placement_group_bundle_index=1).remote()
-    result = ray.get(result)
-    assert result == [0]
+        result = get_gpus.options(
+            placement_group=placement_group,
+            placement_group_bundle_index=1).remote()
+        result = ray.get(result)
+        assert result == [0]
 
 
-def test_placement_group_gpu_assigned(ray_start_cluster):
+@pytest.mark.parametrize("connect_to_client", [False, True])
+def test_placement_group_gpu_assigned(ray_start_cluster, connect_to_client):
     cluster = ray_start_cluster
     cluster.add_node(num_gpus=2)
     ray.init(address=cluster.address)
@@ -1629,19 +1689,20 @@ def test_placement_group_gpu_assigned(ray_start_cluster):
         import os
         return os.environ["CUDA_VISIBLE_DEVICES"]
 
-    pg1 = ray.util.placement_group([{"GPU": 1}])
-    pg2 = ray.util.placement_group([{"GPU": 1}])
+    with connect_to_client_or_not(connect_to_client):
+        pg1 = ray.util.placement_group([{"GPU": 1}])
+        pg2 = ray.util.placement_group([{"GPU": 1}])
 
-    assert pg1.wait(10)
-    assert pg2.wait(10)
+        assert pg1.wait(10)
+        assert pg2.wait(10)
 
-    gpu_ids_res.add(ray.get(f.options(placement_group=pg1).remote()))
-    gpu_ids_res.add(ray.get(f.options(placement_group=pg2).remote()))
+        gpu_ids_res.add(ray.get(f.options(placement_group=pg1).remote()))
+        gpu_ids_res.add(ray.get(f.options(placement_group=pg2).remote()))
 
-    assert len(gpu_ids_res) == 2
+        assert len(gpu_ids_res) == 2
 
 
-def test_placement_group_serialization():
+def test_placement_group_client_option_serialization():
     """Tests conversion of placement group to json-serializable dict and back.
 
     Tests conversion

--- a/python/ray/util/client/api.py
+++ b/python/ray/util/client/api.py
@@ -289,7 +289,7 @@ class ClientAPI:
 
     def _converted_key_exists(self, key: str) -> bool:
         """Check if a key UUID is present in the store of converted objects."""
-        return self.worker._converted_key_exists()
+        return self.worker._converted_key_exists(key)
 
     def __getattr__(self, key: str):
         if not key.startswith("_"):

--- a/python/ray/util/client/api.py
+++ b/python/ray/util/client/api.py
@@ -287,6 +287,10 @@ class ClientAPI:
         """Given a UUID, return the converted object"""
         return self.worker._get_converted(key)
 
+    def _converted_key_exists(self, key: str) -> bool:
+        """Check if a key UUID is present in the store of converted objects."""
+        return self.worker._converted_key_exists()
+
     def __getattr__(self, key: str):
         if not key.startswith("_"):
             raise NotImplementedError(

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -310,8 +310,9 @@ def set_task_options(task: ray_client_pb2.ClientTask,
         return
 
     if "placement_group" in options:
-        pg = options["placement_group"]  # type: PlacementGroup
-        options["placement_group"] = pg.to_json_serializable()
+        pg = options["placement_group"]  # type: Optional[PlacementGroup]
+        if pg:
+            options["placement_group"] = pg.to_json_serializable()
 
     options_str = json.dumps(options)
     getattr(task, field).json_options = options_str

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -6,6 +6,7 @@ import uuid
 import os
 import inspect
 from ray.util.inspect import is_cython
+from ray.util.placement_group import PlacementGroup
 import json
 import threading
 from typing import Any
@@ -307,6 +308,11 @@ def set_task_options(task: ray_client_pb2.ClientTask,
     if options is None:
         task.ClearField(field)
         return
+
+    if "placement_group" in options:
+        pg = options["placement_group"]  # type: PlacementGroup
+        options["placement_group"] = pg.to_json_serializable()
+
     options_str = json.dumps(options)
     getattr(task, field).json_options = options_str
 

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -309,10 +309,10 @@ def set_task_options(task: ray_client_pb2.ClientTask,
         task.ClearField(field)
         return
 
-    if "placement_group" in options:
-        pg = options["placement_group"]  # type: Optional[PlacementGroup]
-        if pg:
-            options["placement_group"] = pg.to_json_serializable()
+    # If there's a non-null "placement_group" in `options`, convert the
+    # placement group to a dict so that `options` can be passed to json.dumps.
+    if options.get("placement_group", None):
+        options["placement_group"] = options["placement_group"].to_dict()
 
     options_str = json.dumps(options)
     getattr(task, field).json_options = options_str

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -6,7 +6,6 @@ import uuid
 import os
 import inspect
 from ray.util.inspect import is_cython
-from ray.util.placement_group import PlacementGroup
 import json
 import threading
 from typing import Any

--- a/python/ray/util/client/ray_client_helpers.py
+++ b/python/ray/util/client/ray_client_helpers.py
@@ -85,7 +85,7 @@ def connect_to_client_or_not(connect_to_client: bool):
     def test_<name>(args, connect_to_client)
     <initialize a ray cluster>
     with connect_to_client_or_not(connect_to_client):
-        <use the ray clluster>
+        <use the ray cluster>
 
     Parameterize the argument connect over True, False to run the test with and
     without a Ray client connection.

--- a/python/ray/util/client/ray_client_helpers.py
+++ b/python/ray/util/client/ray_client_helpers.py
@@ -4,6 +4,7 @@ import ray as real_ray
 import ray.cloudpickle as pickle
 import ray.util.client.server.server as ray_client_server
 from ray.util.client import ray
+from ray._private.client_mode_hook import enable_client_mode
 
 
 @contextmanager
@@ -62,3 +63,36 @@ class RayClientSerializationContext:
 
         # construct a reducer
         pickle.CloudPickler.dispatch[cls] = _CloudPicklerReducer
+
+
+@contextmanager
+def connect_to_client_or_not(connect_to_client: bool):
+    """Utility for running test logic with and without a Ray client connection.
+
+    If client_connect is True, will connect to Ray client in context.
+    If client_connect is False, does nothing.
+
+    How to use:
+    Given a test of the following form:
+
+    def test_<name>(args):
+        <initialize a ray cluster>
+        <use the ray cluster>
+
+    Modify the test to
+
+    @pytest.mark.parametrize("connect_to_client", [False, True])
+    def test_<name>(args, connect_to_client)
+    <initialize a ray cluster>
+    with connect_to_client_or_not(connect_to_client):
+        <use the ray clluster>
+
+    Parameterize the argument connect over True, False to run the test with and
+    without a Ray client connection.
+    """
+
+    if connect_to_client:
+        with ray_start_client_server(), enable_client_mode():
+            yield
+    else:
+        yield

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -512,12 +512,11 @@ def decode_options(
     opts = json.loads(options.json_options)
     assert isinstance(opts, dict)
 
-    if "placement_group" in opts:
-        pg_dict = opts["placement_group"]
-        if pg_dict is not None:
-            assert isinstance(pg_dict, dict)
-            opts["placement_group"] = PlacementGroup.from_json_serializable(
-                pg_dict)
+    if opts.get("placement_group", None):
+        # Placement groups in Ray client options are serialized as dicts.
+        # Convert the dict to a PlacementGroup.
+        opts["placement_group"] = PlacementGroup.from_dict(
+            opts["placement_group"])
 
     return opts
 

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -514,9 +514,10 @@ def decode_options(
 
     if "placement_group" in opts:
         pg_dict = opts["placement_group"]
-        assert isinstance(pg_dict, dict)
-        opts["placement_group"] = PlacementGroup.from_json_serializable(
-            pg_dict)
+        if pg_dict is not None:
+            assert isinstance(pg_dict, dict)
+            opts["placement_group"] = PlacementGroup.from_json_serializable(
+                pg_dict)
 
     return opts
 

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -31,6 +31,7 @@ from ray.util.client.server.server_pickler import loads_from_client
 from ray.util.client.server.dataservicer import DataServicer
 from ray.util.client.server.logservicer import LogstreamServicer
 from ray.util.client.server.server_stubs import current_server
+from ray.util.placement_group import PlacementGroup
 from ray._private.client_mode_hook import disable_client_hook
 
 logger = logging.getLogger(__name__)
@@ -510,6 +511,13 @@ def decode_options(
         return None
     opts = json.loads(options.json_options)
     assert isinstance(opts, dict)
+
+    if "placement_group" in opts:
+        pg_dict = opts["placement_group"]
+        assert isinstance(pg_dict, dict)
+        opts["placement_group"] = PlacementGroup.from_json_serializable(
+            pg_dict)
+
     return opts
 
 

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -274,7 +274,7 @@ class Worker:
         data = {
             "object_ids": [object_ref.id for object_ref in object_refs],
             "num_returns": num_returns,
-            "timeout": timeout if timeout else -1,
+            "timeout": timeout if (timeout is not None) else -1,
             "client_id": self._client_id,
         }
         req = ray_client_pb2.WaitRequest(**data)

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -512,6 +512,10 @@ class Worker:
         """Given a UUID, return the converted object"""
         return self._converted[key]
 
+    def _converted_key_exists(self, key: str) -> bool:
+        """Check if a key UUID is present in the store of converted objects."""
+        return key in self._converted
+
 
 def make_client_id() -> str:
     id = uuid.uuid4()

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -14,7 +14,7 @@ from ray._private.client_mode_hook import client_mode_should_convert
 from ray._private.client_mode_hook import client_mode_wrap
 
 if TYPE_CHECKING:
-    from ray.util.common import ClientObjectRef
+    from ray.util.common import ClientObjectRef  # noqa
 
 bundle_reservation_check = None
 

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -120,7 +120,7 @@ class PlacementGroup:
         self._fill_bundle_cache_if_needed()
         return len(self.bundle_cache)
 
-    def to_json_serializable(self) -> dict:
+    def to_dict(self) -> dict:
         """Convert this placement group into a dict for purposes of json
         serialization.
 
@@ -136,7 +136,7 @@ class PlacementGroup:
         return {"id": self.id.hex(), "bundle_cache": self.bundle_cache}
 
     @staticmethod
-    def from_json_serializable(serializable_form: dict) -> "PlacementGroup":
+    def from_dict(pg_dict: dict) -> "PlacementGroup":
         """Instantiate and return a PlacementGroup from its json-serializable
         dict representation.
 
@@ -148,18 +148,18 @@ class PlacementGroup:
         Return:
             A placement group made from the data in the input dict.
         """
-
         # Validate serialized dict
-        assert serializable_form.keys() == {"id", "bundle_cache"}
+        assert isinstance(pg_dict, dict)
+        assert pg_dict.keys() == {"id", "bundle_cache"}
         # The value associated to key "id" is a hex string.
-        assert isinstance(serializable_form["id"], str)
-        if serializable_form["bundle_cache"] is not None:
-            assert isinstance(serializable_form["bundle_cache"], list)
+        assert isinstance(pg_dict["id"], str)
+        if pg_dict["bundle_cache"] is not None:
+            assert isinstance(pg_dict["bundle_cache"], list)
 
         # Deserialize and return a Placement Group.
-        id_bytes = bytes.fromhex(serializable_form["id"])
+        id_bytes = bytes.fromhex(pg_dict["id"])
         pg_id = PlacementGroupID(id_bytes)
-        bundle_cache = serializable_form["bundle_cache"]
+        bundle_cache = pg_dict["bundle_cache"]
         return PlacementGroup(pg_id, bundle_cache)
 
     def _get_a_non_zero_resource(self, bundle: Dict):

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
 bundle_reservation_check = None
 
+
 # We need to import this method to use for ready API.
 # But ray.remote is only available in runtime, and
 # if we define this method inside ready method, this function is
@@ -41,7 +42,8 @@ class PlacementGroup:
     def empty():
         return PlacementGroup(PlacementGroupID.nil())
 
-    def __init__(self, id: PlacementGroupID,
+    def __init__(self,
+                 id: PlacementGroupID,
                  bundle_cache: Optional[List[Dict]] = None):
         self.id = id
         self.bundle_cache = bundle_cache
@@ -180,8 +182,8 @@ def _call_placement_group_ready(pg_id: PlacementGroupID,
     worker = ray.worker.global_worker
     worker.check_connected()
 
-    return worker.core_worker.wait_placement_group_ready(pg_id,
-                                                         timeout_seconds)
+    return worker.core_worker.wait_placement_group_ready(
+        pg_id, timeout_seconds)
 
 
 @client_mode_wrap

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -10,6 +10,7 @@ from ray._raylet import ObjectRef
 from ray._raylet import PlacementGroupID
 from ray._private.utils import hex_to_binary
 from ray.ray_constants import (to_memory_units, MEMORY_RESOURCE_UNIT_BYTES)
+from ray._private.client_mode_hook import client_mode_should_convert
 from ray._private.client_mode_hook import client_mode_wrap
 
 if TYPE_CHECKING:

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -40,7 +40,7 @@ class PlacementGroup:
     """A handle to a placement group."""
 
     @staticmethod
-    def empty():
+    def empty() -> "PlacementGroup":
         return PlacementGroup(PlacementGroupID.nil())
 
     def __init__(self,
@@ -136,7 +136,7 @@ class PlacementGroup:
         return {"id": self.id.hex(), "bundle_cache": self.bundle_cache}
 
     @staticmethod
-    def from_json_serializable(serializable_form: dict):
+    def from_json_serializable(serializable_form: dict) -> "PlacementGroup":
         """Instantiate and return a PlacementGroup from its json-serializable
         dict representation.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Allows usage of the new Placement Group API in client mode.
Basically the same as this PR:
https://github.com/ray-project/ray/pull/14060

The strategy is to use cpu=0 remote functions for placement group operations which invoke `ray.worker.global_worker.core_worker`.

Other changes:

- Ray Client uses json to serialize and deserialize options, so PlacementGroup objects are converted to and from json-serializable format when passed into and retrieved from options.
- Added a context manager for Ray client tests and used it in most of the existing placement group tests.
- Modified conversion of normal actors/remote functions to client actors/remote functions to work when client session is disconnected and reconnected.
- Corrected behavior of client mode ray.wait with timeout 0.

## Related issue number

Closes https://github.com/ray-project/ray/issues/13147

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
