### PR TITLE
[docs] Add link for launching ray manually in quickstart

### DIFF
--- a/doc/source/cluster/quickstart.rst
+++ b/doc/source/cluster/quickstart.rst
@@ -5,6 +5,8 @@ Ray Cluster Quick Start
 
 This quick start demonstrates the capabilities of the Ray cluster. Using the Ray cluster, we'll take a sample application designed to run on a laptop and scale it up in the cloud. Ray will launch clusters and scale Python with just a few commands.
 
+For launching Ray cluster manually,  you can refer to the :ref:`Launching Cloud Clusters <cluster-cloud>`
+
 About the demo
 --------------
 

--- a/doc/source/cluster/quickstart.rst
+++ b/doc/source/cluster/quickstart.rst
@@ -5,7 +5,7 @@ Ray Cluster Quick Start
 
 This quick start demonstrates the capabilities of the Ray cluster. Using the Ray cluster, we'll take a sample application designed to run on a laptop and scale it up in the cloud. Ray will launch clusters and scale Python with just a few commands.
 
-For launching Ray cluster manually,  you can refer to the :ref:`Launching Cloud Clusters <cluster-cloud>` page.
+For launching Ray cluster manually,  you can refer to the :ref:`on premise cluster setup <cluster-private-setup>` guide.
 
 About the demo
 --------------

--- a/doc/source/cluster/quickstart.rst
+++ b/doc/source/cluster/quickstart.rst
@@ -5,7 +5,7 @@ Ray Cluster Quick Start
 
 This quick start demonstrates the capabilities of the Ray cluster. Using the Ray cluster, we'll take a sample application designed to run on a laptop and scale it up in the cloud. Ray will launch clusters and scale Python with just a few commands.
 
-For launching Ray cluster manually,  you can refer to the :ref:`Launching Cloud Clusters <cluster-cloud>`
+For launching Ray cluster manually,  you can refer to the :ref:`Launching Cloud Clusters <cluster-cloud>`.
 
 About the demo
 --------------

--- a/doc/source/cluster/quickstart.rst
+++ b/doc/source/cluster/quickstart.rst
@@ -5,7 +5,7 @@ Ray Cluster Quick Start
 
 This quick start demonstrates the capabilities of the Ray cluster. Using the Ray cluster, we'll take a sample application designed to run on a laptop and scale it up in the cloud. Ray will launch clusters and scale Python with just a few commands.
 
-For launching Ray cluster manually,  you can refer to the :ref:`Launching Cloud Clusters <cluster-cloud>`.
+For launching Ray cluster manually,  you can refer to the :ref:`Launching Cloud Clusters <cluster-cloud>` page.
 
 About the demo
 --------------


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add link for launching ray manually.  For beginner users, their navigation path can be 
1. https://docs.ray.io/en/master/cluster/index.html#cluster-index
2. https://docs.ray.io/en/master/cluster/quickstart.html#ref-cluster-quick-start
However, at this time, user may not committed to purchase a few machine in the cloud provider to try out Ray. And for enterprise user, they may have couple avaliable machines in their private data center. We should add a link in cluster quickstart, so user can easily navigate to learn how to launch ray cluster manually as needed.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
 