### PR TITLE
[Core] Add `concurrent.futures.Future` wrapper for ObjectRef

### DIFF
--- a/doc/source/async_api.rst
+++ b/doc/source/async_api.rst
@@ -83,6 +83,26 @@ you can do:
 Please refer to `asyncio doc <https://docs.python.org/3/library/asyncio-task.html>`__
 for more `asyncio` patterns including timeouts and ``asyncio.gather``.
 
+If you need to directly access the future object, you can call:
+
+.. code-block:: python
+
+    fut: asyncio.Future = asyncio.wrap_future(ref.future())
+
+ObjectRefs as concurrent.futures.Futures
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ObjectRefs can also be wrapped into ``concurrent.futures.Future`` objects. This
+is useful for interfacing with existing ``concurrent.futures`` APIs:
+
+.. code-block:: python
+
+    refs = [fun.remote() for _ in range(4)]
+    futs = [ref.future() for ref in refs]
+    for fut in concurrent.futures.as_completed(futs):
+        assert fut.done()
+        print(fut.result())
+
+
 Defining an Async Actor
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -91,8 +91,12 @@ cdef class ObjectRef(BaseID):
     def __await__(self):
         return self.as_asyncio_future().__await__()
 
-    def as_asyncio_future(self):
-        """Wrap ObjectRef into an asyncio.Future object."""
+    def as_asyncio_future(self) -> asyncio.Future:
+        """Wrap ObjectRef with an asyncio.Future.
+
+        Note that the future cancellation will not cancel the correspoding
+        task when the ObjectRef representing return object of a task.
+        """
         loop = asyncio.get_event_loop()
         py_future = loop.create_future()
 
@@ -108,7 +112,13 @@ cdef class ObjectRef(BaseID):
         return py_future
 
     def as_concurrent_future(self) -> concurrent.futures.Future:
-        """Wrap ObjectRef into a concurrent.futures.Future"""
+        """Wrap ObjectRef with a concurrent.futures.Future
+
+        Note that the future cancellation will not cancel the correspoding
+        task when the ObjectRef representing return object of a task.
+        Additionally, future.running() will always be ``False`` even if the
+        underlying task is running.
+        """
         py_future = concurrent.futures.Future()
 
         self._on_completed(

--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -3,9 +3,12 @@ from ray.includes.unique_ids cimport CObjectID
 import asyncio
 import concurrent.futures
 import functools
+import logging
 from typing import Callable, Any, Union
 
 import ray
+
+logger = logging.getLogger(__name__)
 
 
 def _set_future_helper(
@@ -116,6 +119,8 @@ cdef class ObjectRef(BaseID):
         Note that the future cancellation will not cancel the correspoding
         task when the ObjectRef representing return object of a task.
         """
+        logger.warning("ref.as_future() is deprecated in favor of "
+                       "asyncio.wrap_future(ref.future()).")
         return asyncio.wrap_future(self.future())
 
     def _on_completed(self, py_callback: Callable[[Any], None]):

--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -2,14 +2,16 @@ from ray.includes.unique_ids cimport CObjectID
 
 import asyncio
 import concurrent.futures
+import functools
 from typing import Callable, Any, Union
 
 import ray
 
 
 def _set_future_helper(
-    py_future: Union[asyncio.Future, concurrent.futures.Future],
     result: Any,
+    *,
+    py_future: Union[asyncio.Future, concurrent.futures.Future],
 ):
     # Issue #11030, #8841
     # If this future has result set already, we just need to
@@ -99,7 +101,7 @@ cdef class ObjectRef(BaseID):
         py_future = concurrent.futures.Future()
 
         self._on_completed(
-            functools.partial(_set_future_helper, py_future, result))
+            functools.partial(_set_future_helper, py_future=py_future))
 
         # A hack to keep a reference to the object ref for ref counting.
         py_future.object_ref = self

--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -88,7 +88,7 @@ cdef class ObjectRef(BaseID):
     def from_random(cls):
         return cls(CObjectID.FromRandom().Binary())
 
-    def as_concurrent_future(self) -> concurrent.futures.Future:
+    def future(self) -> concurrent.futures.Future:
         """Wrap ObjectRef with a concurrent.futures.Future
 
         Note that the future cancellation will not cancel the correspoding
@@ -106,15 +106,15 @@ cdef class ObjectRef(BaseID):
         return py_future
 
     def __await__(self):
-        return self._as_asyncio_future().__await__()
+        return self.as_future().__await__()
 
-    def _as_asyncio_future(self) -> asyncio.Future:
+    def as_future(self) -> asyncio.Future:
         """Wrap ObjectRef with an asyncio.Future.
 
         Note that the future cancellation will not cancel the correspoding
         task when the ObjectRef representing return object of a task.
         """
-        return asyncio.wrap_future(self.as_concurrent_future())
+        return asyncio.wrap_future(self.future())
 
     def _on_completed(self, py_callback: Callable[[Any], None]):
         """Register a callback that will be called after Object is ready.

--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -89,9 +89,9 @@ cdef class ObjectRef(BaseID):
         return cls(CObjectID.FromRandom().Binary())
 
     def __await__(self):
-        return self.as_future().__await__()
+        return self.as_asyncio_future().__await__()
 
-    def as_future(self):
+    def as_asyncio_future(self):
         """Wrap ObjectRef into an asyncio.Future object."""
         loop = asyncio.get_event_loop()
         py_future = loop.create_future()

--- a/python/ray/tests/test_async.py
+++ b/python/ray/tests/test_async.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import sys
 import time
 
@@ -7,6 +8,7 @@ import numpy as np
 import pytest
 
 import ray
+from ray.test_utils import wait_for_condition
 
 
 @pytest.fixture
@@ -118,6 +120,39 @@ async def test_garbage_collection(ray_start_regular_shared):
     for _ in range(10):
         put_id = ray.put(np.zeros(40 * 1024 * 1024, dtype=np.uint8))
         await put_id
+
+
+def test_concurrent_future(ray_start_regular_shared):
+    ref = ray.put(1)
+
+    fut = ref.as_concurrent_future()
+    assert isinstance(fut, concurrent.futures.Future)
+    wait_for_condition(lambda: fut.done())
+
+    global_result = None
+
+    def cb(fut):
+        nonlocal global_result
+        global_result = fut.result()
+
+    fut.add_done_callback(cb)
+    assert global_result == 1
+    assert fut.result() == 1
+
+
+def test_concurrent_future_many(ray_start_regular_shared):
+    @ray.remote
+    def task(i):
+        return i
+
+    refs = [task.remote(i) for i in range(100)]
+    futs = [ref.as_concurrent_future() for ref in refs]
+    result = set()
+
+    for fut in concurrent.futures.as_completed(futs):
+        assert fut.done()
+        result.add(fut.result())
+    assert result == set(range(100))
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_async.py
+++ b/python/ray/tests/test_async.py
@@ -76,7 +76,12 @@ def test_gather_mixup(init):
         await asyncio.sleep(n * 0.1)
         return n, np.zeros(1024 * 1024, dtype=np.uint8)
 
-    tasks = [f.remote(1).as_asyncio_future(), g(2), f.remote(3).as_asyncio_future(), g(4)]
+    tasks = [
+        f.remote(1).as_asyncio_future(),
+        g(2),
+        f.remote(3).as_asyncio_future(),
+        g(4)
+    ]
     results = loop.run_until_complete(asyncio.gather(*tasks))
     assert [result[0] for result in results] == [1, 2, 3, 4]
 
@@ -96,7 +101,12 @@ def test_wait_mixup(init):
 
         return asyncio.ensure_future(_g(n))
 
-    tasks = [f.remote(0.1).as_asyncio_future(), g(7), f.remote(5).as_asyncio_future(), g(2)]
+    tasks = [
+        f.remote(0.1).as_asyncio_future(),
+        g(7),
+        f.remote(5).as_asyncio_future(),
+        g(2)
+    ]
     ready, _ = loop.run_until_complete(asyncio.wait(tasks, timeout=4))
     assert set(ready) == {tasks[0], tasks[-1]}
 

--- a/python/ray/tests/test_async.py
+++ b/python/ray/tests/test_async.py
@@ -34,7 +34,7 @@ def test_simple(init):
         time.sleep(1)
         return np.zeros(1024 * 1024, dtype=np.uint8)
 
-    future = f.remote().as_asyncio_future()
+    future = f.remote()._as_asyncio_future()
     result = asyncio.get_event_loop().run_until_complete(future)
     assert isinstance(result, np.ndarray)
 
@@ -42,7 +42,7 @@ def test_simple(init):
 def test_gather(init):
     loop = asyncio.get_event_loop()
     tasks = gen_tasks()
-    futures = [obj_ref.as_asyncio_future() for obj_ref in tasks]
+    futures = [obj_ref._as_asyncio_future() for obj_ref in tasks]
     results = loop.run_until_complete(asyncio.gather(*futures))
     assert all(a[0] == b[0] for a, b in zip(results, ray.get(tasks)))
 
@@ -50,7 +50,7 @@ def test_gather(init):
 def test_wait(init):
     loop = asyncio.get_event_loop()
     tasks = gen_tasks()
-    futures = [obj_ref.as_asyncio_future() for obj_ref in tasks]
+    futures = [obj_ref._as_asyncio_future() for obj_ref in tasks]
     results, _ = loop.run_until_complete(asyncio.wait(futures))
     assert set(results) == set(futures)
 
@@ -58,7 +58,7 @@ def test_wait(init):
 def test_wait_timeout(init):
     loop = asyncio.get_event_loop()
     tasks = gen_tasks(10)
-    futures = [obj_ref.as_asyncio_future() for obj_ref in tasks]
+    futures = [obj_ref._as_asyncio_future() for obj_ref in tasks]
     fut = asyncio.wait(futures, timeout=5)
     results, _ = loop.run_until_complete(fut)
     assert list(results)[0] == futures[0]
@@ -77,9 +77,9 @@ def test_gather_mixup(init):
         return n, np.zeros(1024 * 1024, dtype=np.uint8)
 
     tasks = [
-        f.remote(1).as_asyncio_future(),
+        f.remote(1)._as_asyncio_future(),
         g(2),
-        f.remote(3).as_asyncio_future(),
+        f.remote(3)._as_asyncio_future(),
         g(4)
     ]
     results = loop.run_until_complete(asyncio.gather(*tasks))
@@ -102,9 +102,9 @@ def test_wait_mixup(init):
         return asyncio.ensure_future(_g(n))
 
     tasks = [
-        f.remote(0.1).as_asyncio_future(),
+        f.remote(0.1)._as_asyncio_future(),
         g(7),
-        f.remote(5).as_asyncio_future(),
+        f.remote(5)._as_asyncio_future(),
         g(2)
     ]
     ready, _ = loop.run_until_complete(asyncio.wait(tasks, timeout=4))

--- a/python/ray/tests/test_async.py
+++ b/python/ray/tests/test_async.py
@@ -34,7 +34,7 @@ def test_simple(init):
         time.sleep(1)
         return np.zeros(1024 * 1024, dtype=np.uint8)
 
-    future = f.remote().as_future()
+    future = f.remote().as_asyncio_future()
     result = asyncio.get_event_loop().run_until_complete(future)
     assert isinstance(result, np.ndarray)
 
@@ -42,7 +42,7 @@ def test_simple(init):
 def test_gather(init):
     loop = asyncio.get_event_loop()
     tasks = gen_tasks()
-    futures = [obj_ref.as_future() for obj_ref in tasks]
+    futures = [obj_ref.as_asyncio_future() for obj_ref in tasks]
     results = loop.run_until_complete(asyncio.gather(*futures))
     assert all(a[0] == b[0] for a, b in zip(results, ray.get(tasks)))
 
@@ -50,7 +50,7 @@ def test_gather(init):
 def test_wait(init):
     loop = asyncio.get_event_loop()
     tasks = gen_tasks()
-    futures = [obj_ref.as_future() for obj_ref in tasks]
+    futures = [obj_ref.as_asyncio_future() for obj_ref in tasks]
     results, _ = loop.run_until_complete(asyncio.wait(futures))
     assert set(results) == set(futures)
 
@@ -58,7 +58,7 @@ def test_wait(init):
 def test_wait_timeout(init):
     loop = asyncio.get_event_loop()
     tasks = gen_tasks(10)
-    futures = [obj_ref.as_future() for obj_ref in tasks]
+    futures = [obj_ref.as_asyncio_future() for obj_ref in tasks]
     fut = asyncio.wait(futures, timeout=5)
     results, _ = loop.run_until_complete(fut)
     assert list(results)[0] == futures[0]
@@ -76,7 +76,7 @@ def test_gather_mixup(init):
         await asyncio.sleep(n * 0.1)
         return n, np.zeros(1024 * 1024, dtype=np.uint8)
 
-    tasks = [f.remote(1).as_future(), g(2), f.remote(3).as_future(), g(4)]
+    tasks = [f.remote(1).as_asyncio_future(), g(2), f.remote(3).as_asyncio_future(), g(4)]
     results = loop.run_until_complete(asyncio.gather(*tasks))
     assert [result[0] for result in results] == [1, 2, 3, 4]
 
@@ -96,7 +96,7 @@ def test_wait_mixup(init):
 
         return asyncio.ensure_future(_g(n))
 
-    tasks = [f.remote(0.1).as_future(), g(7), f.remote(5).as_future(), g(2)]
+    tasks = [f.remote(0.1).as_asyncio_future(), g(7), f.remote(5).as_asyncio_future(), g(2)]
     ready, _ = loop.run_until_complete(asyncio.wait(tasks, timeout=4))
     assert set(ready) == {tasks[0], tasks[-1]}
 

--- a/python/ray/tests/test_asyncio.py
+++ b/python/ray/tests/test_asyncio.py
@@ -120,14 +120,14 @@ async def test_asyncio_get(ray_start_regular_shared, event_loop):
     def task():
         return 1
 
-    assert await task.remote()._as_asyncio_future() == 1
+    assert await task.remote().as_future() == 1
 
     @ray.remote
     def task_throws():
         1 / 0
 
     with pytest.raises(ray.exceptions.RayTaskError):
-        await task_throws.remote()._as_asyncio_future()
+        await task_throws.remote().as_future()
 
     # Test actor calls.
     str_len = 200 * 1024
@@ -146,14 +146,14 @@ async def test_asyncio_get(ray_start_regular_shared, event_loop):
 
     actor = Actor.remote()
 
-    actor_call_future = actor.echo.remote(2)._as_asyncio_future()
+    actor_call_future = actor.echo.remote(2).as_future()
     assert await actor_call_future == 2
 
-    promoted_to_plasma_future = actor.big_object.remote()._as_asyncio_future()
+    promoted_to_plasma_future = actor.big_object.remote().as_future()
     assert await promoted_to_plasma_future == "a" * str_len
 
     with pytest.raises(ray.exceptions.RayTaskError):
-        await actor.throw_error.remote()._as_asyncio_future()
+        await actor.throw_error.remote().as_future()
 
     kill_actor_and_wait_for_failure(actor)
     with pytest.raises(ray.exceptions.RayActorError):
@@ -187,7 +187,7 @@ async def test_asyncio_double_await(ray_start_regular_shared):
     signal = SignalActor.remote()
     waiting = signal.wait.remote()
 
-    future = waiting._as_asyncio_future()
+    future = waiting.as_future()
     with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(future, timeout=0.1)
     assert future.cancelled()

--- a/python/ray/tests/test_asyncio.py
+++ b/python/ray/tests/test_asyncio.py
@@ -120,14 +120,14 @@ async def test_asyncio_get(ray_start_regular_shared, event_loop):
     def task():
         return 1
 
-    assert await task.remote().as_asyncio_future() == 1
+    assert await task.remote()._as_asyncio_future() == 1
 
     @ray.remote
     def task_throws():
         1 / 0
 
     with pytest.raises(ray.exceptions.RayTaskError):
-        await task_throws.remote().as_asyncio_future()
+        await task_throws.remote()._as_asyncio_future()
 
     # Test actor calls.
     str_len = 200 * 1024
@@ -146,14 +146,14 @@ async def test_asyncio_get(ray_start_regular_shared, event_loop):
 
     actor = Actor.remote()
 
-    actor_call_future = actor.echo.remote(2).as_asyncio_future()
+    actor_call_future = actor.echo.remote(2)._as_asyncio_future()
     assert await actor_call_future == 2
 
-    promoted_to_plasma_future = actor.big_object.remote().as_asyncio_future()
+    promoted_to_plasma_future = actor.big_object.remote()._as_asyncio_future()
     assert await promoted_to_plasma_future == "a" * str_len
 
     with pytest.raises(ray.exceptions.RayTaskError):
-        await actor.throw_error.remote().as_asyncio_future()
+        await actor.throw_error.remote()._as_asyncio_future()
 
     kill_actor_and_wait_for_failure(actor)
     with pytest.raises(ray.exceptions.RayActorError):
@@ -187,7 +187,7 @@ async def test_asyncio_double_await(ray_start_regular_shared):
     signal = SignalActor.remote()
     waiting = signal.wait.remote()
 
-    future = waiting.as_asyncio_future()
+    future = waiting._as_asyncio_future()
     with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(future, timeout=0.1)
     assert future.cancelled()

--- a/python/ray/tests/test_asyncio.py
+++ b/python/ray/tests/test_asyncio.py
@@ -120,14 +120,14 @@ async def test_asyncio_get(ray_start_regular_shared, event_loop):
     def task():
         return 1
 
-    assert await task.remote().as_future() == 1
+    assert await task.remote().as_asyncio_future() == 1
 
     @ray.remote
     def task_throws():
         1 / 0
 
     with pytest.raises(ray.exceptions.RayTaskError):
-        await task_throws.remote().as_future()
+        await task_throws.remote().as_asyncio_future()
 
     # Test actor calls.
     str_len = 200 * 1024
@@ -146,14 +146,14 @@ async def test_asyncio_get(ray_start_regular_shared, event_loop):
 
     actor = Actor.remote()
 
-    actor_call_future = actor.echo.remote(2).as_future()
+    actor_call_future = actor.echo.remote(2).as_asyncio_future()
     assert await actor_call_future == 2
 
-    promoted_to_plasma_future = actor.big_object.remote().as_future()
+    promoted_to_plasma_future = actor.big_object.remote().as_asyncio_future()
     assert await promoted_to_plasma_future == "a" * str_len
 
     with pytest.raises(ray.exceptions.RayTaskError):
-        await actor.throw_error.remote().as_future()
+        await actor.throw_error.remote().as_asyncio_future()
 
     kill_actor_and_wait_for_failure(actor)
     with pytest.raises(ray.exceptions.RayActorError):
@@ -187,7 +187,7 @@ async def test_asyncio_double_await(ray_start_regular_shared):
     signal = SignalActor.remote()
     waiting = signal.wait.remote()
 
-    future = waiting.as_future()
+    future = waiting.as_asyncio_future()
     with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(future, timeout=0.1)
     assert future.cancelled()


### PR DESCRIPTION
This PR adds a `concurrent.futures.Future` wrapper for Ray ObjectRef. The API is as follows:

```python
ref = ray.put(1) # or func.remote()
future = ref.as_concurrent_future()

assert isinstance(future, concurrent.futures.Future)
assert future.get() == 1

future.add_done_callback(fut: print("result is", fut.get()) # callback will be invoked when object is ready.
```

**Motivation**: 
- The asyncio.Future interface has one critical issue, it requires a running asyncio event loop. This often requires users to rewrite their entire code to be wrapped inside an asyncio loop.
- `concurrent.futures.Future` allows users to continue with their regular flow of program while the result is fulfilled by Ray in the background (concretely, it will be the core worker thread calling `future.set_result/set_exception`.
- There are requests for this interface since the early days #1883
- One of the concrete use case would be allowing Ray Serve to attach callbacks to ObjectRef, which facilitate proper back pressure and queuing.

**API Renaming**:
To disambiguate, this PR also change existing `ref.as_future()` into `ref.as_asyncio_future()`.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
