### PR TITLE
[RLlib] Discussion 1709: IMPALA (tf and torch) reports sum of losses (over batch) in stats. Should report mean instead. 

### DIFF
--- a/rllib/agents/impala/vtrace_tf_policy.py
+++ b/rllib/agents/impala/vtrace_tf_policy.py
@@ -93,13 +93,16 @@ class VTraceLoss:
             self.value_targets = self.vtrace_returns.vs
 
         # The policy gradients loss.
-        self.pi_loss = -tf.reduce_sum(
-            tf.boolean_mask(actions_logp * self.vtrace_returns.pg_advantages,
-                            valid_mask))
+        masked_pi_loss = tf.boolean_mask(
+            actions_logp * self.vtrace_returns.pg_advantages, valid_mask)
+        self.pi_loss = -tf.reduce_sum(masked_pi_loss)
+        self.mean_pi_loss = -tf.reduce_mean(masked_pi_loss)
 
         # The baseline loss.
         delta = tf.boolean_mask(values - self.vtrace_returns.vs, valid_mask)
-        self.vf_loss = 0.5 * tf.reduce_sum(tf.math.square(delta))
+        delta_squarred = tf.math.square(delta)
+        self.vf_loss = 0.5 * tf.reduce_sum(delta_squarred)
+        self.mean_vf_loss = 0.5 * tf.reduce_mean(delta_squarred)
 
         # The entropy loss.
         masked_entropy = tf.boolean_mask(actions_entropy, valid_mask)
@@ -226,11 +229,11 @@ def stats(policy, train_batch):
 
     return {
         "cur_lr": tf.cast(policy.cur_lr, tf.float64),
-        "policy_loss": policy.loss.pi_loss,
+        "policy_loss": policy.loss.mean_pi_loss,
         "entropy": policy.loss.mean_entropy,
         "entropy_coeff": tf.cast(policy.entropy_coeff, tf.float64),
         "var_gnorm": tf.linalg.global_norm(policy.model.trainable_variables()),
-        "vf_loss": policy.loss.vf_loss,
+        "vf_loss": policy.loss.mean_vf_loss,
         "vf_explained_var": explained_variance(
             tf.reshape(policy.loss.value_targets, [-1]),
             tf.reshape(values_batched, [-1])),

--- a/rllib/agents/impala/vtrace_torch_policy.py
+++ b/rllib/agents/impala/vtrace_torch_policy.py
@@ -93,13 +93,16 @@ class VTraceLoss:
         self.value_targets = self.vtrace_returns.vs.to(device)
 
         # The policy gradients loss.
-        self.pi_loss = -torch.sum(
-            actions_logp * self.vtrace_returns.pg_advantages.to(device) *
-            valid_mask)
+        masked_pi_loss = actions_logp * \
+            self.vtrace_returns.pg_advantages.to(device) * valid_mask
+        self.pi_loss = -torch.sum(masked_pi_loss)
+        self.mean_pi_loss = -torch.mean(masked_pi_loss)
 
         # The baseline loss.
         delta = (values - self.value_targets) * valid_mask
-        self.vf_loss = 0.5 * torch.sum(torch.pow(delta, 2.0))
+        squarred_delta = torch.pow(delta, 2.0)
+        self.vf_loss = 0.5 * torch.sum(squarred_delta)
+        self.mean_vf_loss = 0.5 * torch.mean(squarred_delta)
 
         # The entropy loss.
         self.entropy = torch.sum(actions_entropy * valid_mask)
@@ -230,11 +233,11 @@ def stats(policy, train_batch):
 
     return {
         "cur_lr": policy.cur_lr,
-        "policy_loss": policy.loss.pi_loss,
+        "policy_loss": policy.loss.mean_pi_loss,
         "entropy": policy.loss.mean_entropy,
         "entropy_coeff": policy.entropy_coeff,
         "var_gnorm": global_norm(policy.model.trainable_variables()),
-        "vf_loss": policy.loss.vf_loss,
+        "vf_loss": policy.loss.mean_vf_loss,
         "vf_explained_var": explained_variance(
             torch.reshape(policy.loss.value_targets, [-1]),
             torch.reshape(values_batched, [-1])),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Discussion 1709: IMPALA (tf and torch) reports sum of policy and value function losses (over batch) in stats. Should report mean instead, as in PPO.

Also see this discussion here:
https://discuss.ray.io/t/entropy-value-in-impala/1709
And the pull request that made the same change on entropy here:
https://github.com/ray-project/ray/pull/15290

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
