### PR TITLE
[serve] Make fastapi wrapper a normal serve backend

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1,5 +1,6 @@
 import asyncio
 import atexit
+import collections
 import inspect
 import os
 import time
@@ -10,18 +11,20 @@ from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple,
 from warnings import warn
 from weakref import WeakValueDictionary
 
+from starlette.requests import Request
+
 from ray.actor import ActorHandle
 from ray.serve.common import BackendInfo, GoalId
-from ray.serve.config import (BackendConfig, BackendMetadata, HTTPOptions,
-                              ReplicaConfig)
+from ray.serve.config import (BackendConfig, HTTPOptions, ReplicaConfig)
 from ray.serve.constants import (DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT,
                                  HTTP_PROXY_TIMEOUT, SERVE_CONTROLLER_NAME)
 from ray.serve.controller import BackendTag, ReplicaTag, ServeController
 from ray.serve.exceptions import RayServeException
 from ray.serve.handle import RayServeHandle, RayServeSyncHandle
+from ray.serve.http_util import (ASGIHTTPSender, make_fastapi_class_based_view,
+                                 make_startup_shutdown_hooks)
 from ray.serve.utils import (format_actor_name, get_current_node_resource_key,
-                             get_random_letters, logger,
-                             make_fastapi_class_based_view)
+                             get_random_letters, logger)
 
 import ray
 
@@ -332,15 +335,11 @@ class Client:
 
         replica_config = ReplicaConfig(
             backend_def, *init_args, ray_actor_options=ray_actor_options)
-        metadata = BackendMetadata()
 
         if isinstance(config, dict):
-            backend_config = BackendConfig.parse_obj({
-                **config, "internal_metadata": metadata
-            })
+            backend_config = BackendConfig.parse_obj({**config})
         elif isinstance(config, BackendConfig):
-            backend_config = config.copy(
-                update={"internal_metadata": metadata})
+            backend_config = config
         else:
             raise TypeError("config must be a BackendConfig or a dictionary.")
 
@@ -380,15 +379,11 @@ class Client:
 
         replica_config = ReplicaConfig(
             backend_def, *init_args, ray_actor_options=ray_actor_options)
-        metadata = BackendMetadata(is_asgi_app=replica_config.is_asgi_app)
 
         if isinstance(config, dict):
-            backend_config = BackendConfig.parse_obj({
-                **config, "internal_metadata": metadata
-            })
+            backend_config = BackendConfig.parse_obj({**config})
         elif isinstance(config, BackendConfig):
-            backend_config = config.copy(
-                update={"internal_metadata": metadata})
+            backend_config = config
         else:
             raise TypeError("config must be a BackendConfig or a dictionary.")
 
@@ -941,7 +936,7 @@ def get_replica_context() -> ReplicaContext:
     return _INTERNAL_REPLICA_CONTEXT
 
 
-def ingress(app: Union["FastAPI", "APIRouter"], ):
+def ingress(app: Union["FastAPI", "APIRouter"]):
     """Mark a FastAPI application ingress for Serve.
 
     Args:
@@ -961,12 +956,35 @@ def ingress(app: Union["FastAPI", "APIRouter"], ):
         if not inspect.isclass(cls):
             raise ValueError("@serve.ingress must be used with a class.")
 
-        cls._serve_asgi_app = app
+        if issubclass(cls, collections.abc.Callable):
+            raise ValueError(
+                "Class passed to @serve.ingress may not have __call__ method.")
+
         # Sometimes there are decorators on the methods. We want to fix
         # the fast api routes here.
         make_fastapi_class_based_view(app, cls)
+        startup_hook, shutdown_hook = make_startup_shutdown_hooks(app)
 
-        return cls
+        class FastAPIWrapper(cls):
+            async def __init__(self, *args, **kwargs):
+                # TODO(edoakes): should the startup_hook run before or after
+                # the constructor?
+                await startup_hook()
+                super().__init__(*args, **kwargs)
+
+            async def __call__(self, request: Request):
+                sender = ASGIHTTPSender()
+                await app(
+                    request.scope,
+                    request._receive,
+                    sender,
+                )
+                return sender.build_starlette_response()
+
+            def __del__(self):
+                asyncio.get_event_loop().run_until_complete(shutdown_hook())
+
+        return FastAPIWrapper
 
     return decorator
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -984,6 +984,7 @@ def ingress(app: Union["FastAPI", "APIRouter"]):
             def __del__(self):
                 asyncio.get_event_loop().run_until_complete(shutdown_hook())
 
+        FastAPIWrapper.__name__ = cls.__name__
         return FastAPIWrapper
 
     return decorator

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -337,7 +337,7 @@ class Client:
             backend_def, *init_args, ray_actor_options=ray_actor_options)
 
         if isinstance(config, dict):
-            backend_config = BackendConfig.parse_obj({**config})
+            backend_config = BackendConfig.parse_obj(config)
         elif isinstance(config, BackendConfig):
             backend_config = config
         else:
@@ -381,7 +381,7 @@ class Client:
             backend_def, *init_args, ray_actor_options=ray_actor_options)
 
         if isinstance(config, dict):
-            backend_config = BackendConfig.parse_obj({**config})
+            backend_config = BackendConfig.parse_obj(config)
         elif isinstance(config, BackendConfig):
             backend_config = config
         else:

--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -64,6 +64,8 @@ def create_backend_replica(backend_def: Union[Callable, Type[Callable], str]):
             if is_function:
                 _callable = backend
             else:
+                # This allows backends to define an async __init__ method
+                # (required for FastAPI backend definition).
                 _callable = backend.__new__(backend)
                 await sync_to_async(_callable.__init__)(*init_args)
             # Setting the context again to update the servable_object.

--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -2,18 +2,17 @@ import asyncio
 import logging
 import traceback
 import inspect
-from typing import Union, Any, Callable, Type, Optional
+from typing import Union, Any, Callable, Type
 import time
 
 import starlette.responses
-from starlette.requests import Request
 
 import ray
 from ray.actor import ActorHandle
 from ray._private.async_compat import sync_to_async
 
-from ray.serve.utils import (ASGIHTTPSender, parse_request_item, _get_logger,
-                             import_attr)
+from ray.serve.http_util import ASGIHTTPSender
+from ray.serve.utils import (parse_request_item, _get_logger, import_attr)
 from ray.serve.exceptions import RayServeException
 from ray.util import metrics
 from ray.serve.config import BackendConfig
@@ -23,7 +22,6 @@ from ray.serve.constants import (
     BACKEND_RECONFIGURE_METHOD,
     DEFAULT_LATENCY_BUCKET_MS,
 )
-from ray.serve.http_util import make_startup_shutdown_hooks
 from ray.exceptions import RayTaskError
 
 logger = _get_logger()
@@ -66,7 +64,8 @@ def create_backend_replica(backend_def: Union[Callable, Type[Callable], str]):
             if is_function:
                 _callable = backend
             else:
-                _callable = backend(*init_args)
+                _callable = backend.__new__(backend)
+                await sync_to_async(_callable.__init__)(*init_args)
             # Setting the context again to update the servable_object.
             ray.serve.api._set_internal_replica_context(
                 backend_tag,
@@ -74,22 +73,10 @@ def create_backend_replica(backend_def: Union[Callable, Type[Callable], str]):
                 controller_name,
                 servable_object=_callable)
 
-            self.shutdown_hook: Optional[Callable] = None
-            if backend_config.internal_metadata.is_asgi_app:
-                app = _callable._serve_asgi_app
-                startup_hook, self.shutdown_hook = make_startup_shutdown_hooks(
-                    app)
-                await startup_hook()
-
             assert controller_name, "Must provide a valid controller_name"
             controller_handle = ray.get_actor(controller_name)
             self.backend = RayServeReplica(_callable, backend_config,
                                            is_function, controller_handle)
-
-        def __del__(self):
-            if hasattr(self, "shutdown_hook") and self.shutdown_hook:
-                asyncio.get_event_loop().run_until_complete(
-                    self.shutdown_hook())
 
         @ray.method(num_returns=2)
         async def handle_request(
@@ -246,20 +233,10 @@ class RayServeReplica:
         start = time.time()
         method_to_call = None
         try:
-            # TODO(simon): Split this section out when invoke_batch is removed.
-            if self.config.internal_metadata.is_asgi_app:
-                request: Request = args[0]
-                sender = ASGIHTTPSender()
-                await self.callable._serve_asgi_app(
-                    request.scope,
-                    request._receive,
-                    sender,
-                )
-                result = sender.build_starlette_response()
-            else:
-                method_to_call = sync_to_async(
-                    self.get_runner_method(request_item))
-                result = await method_to_call(*args, **kwargs)
+            method_to_call = sync_to_async(
+                self.get_runner_method(request_item))
+            result = await method_to_call(*args, **kwargs)
+
             result = await self.ensure_serializable_response(result)
             self.request_counter.inc()
         except Exception as e:

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -1,18 +1,10 @@
 import inspect
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 import pydantic
 from pydantic import BaseModel, PositiveInt, validator, NonNegativeFloat
-from pydantic.dataclasses import dataclass
 from ray.serve.constants import DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT
-
-
-@dataclass
-class BackendMetadata:
-    is_asgi_app: bool = False
-    path_prefix: Optional[str] = None
-    autoscaling_config: Optional[Dict[str, Any]] = None
 
 
 class BackendConfig(BaseModel):
@@ -35,7 +27,6 @@ class BackendConfig(BaseModel):
             for shutdown. Defaults to 20s.
     """
 
-    internal_metadata: BackendMetadata = BackendMetadata()
     num_replicas: PositiveInt = 1
     max_concurrent_queries: Optional[int] = None
     user_config: Any = None
@@ -62,7 +53,6 @@ class BackendConfig(BaseModel):
 class ReplicaConfig:
     def __init__(self, backend_def, *init_args, ray_actor_options=None):
         self.backend_def = backend_def
-        self.is_asgi_app = hasattr(backend_def, "_serve_asgi_app")
         self.init_args = init_args
         if ray_actor_options is None:
             self.ray_actor_options = {}

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -278,14 +278,6 @@ class ServeController:
         if route_prefix is not None:
             assert route_prefix.startswith("/")
 
-        if replica_config.is_asgi_app:
-            # When the backend is asgi application, we want to proxy it
-            # with a prefixed path as well as proxy all HTTP methods.
-            http_methods = ALL_HTTP_METHODS
-        else:
-            # Generic endpoint should support a limited subset of HTTP methods.
-            http_methods = ["GET", "POST"]
-
         python_methods = []
         if inspect.isclass(replica_config.backend_def):
             for method_name, _ in inspect.getmembers(
@@ -302,7 +294,7 @@ class ServeController:
 
             goal_id = self.backend_state.deploy_backend(name, backend_info)
             endpoint_info = EndpointInfo(
-                http_methods,
+                ALL_HTTP_METHODS,
                 route=route_prefix,
                 python_methods=python_methods)
             self.endpoint_state.update_endpoint(name, endpoint_info,

--- a/python/ray/serve/http_util.py
+++ b/python/ray/serve/http_util.py
@@ -1,7 +1,8 @@
 import asyncio
 from dataclasses import dataclass
+import inspect
 import json
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 import starlette.requests
 
@@ -152,3 +153,94 @@ async def receive_http_body(scope, receive, send):
         body_buffer.append(message["body"])
 
     return b"".join(body_buffer)
+
+
+class ASGIHTTPSender:
+    """Implement the interface for ASGI sender, build Starlette Response"""
+
+    def __init__(self) -> None:
+        self.status_code: Optional[int] = 200
+        self.header: Dict[str, str] = {}
+        self.buffer: List[bytes] = []
+
+    async def __call__(self, message):
+        if (message["type"] == "http.response.start"):
+            self.status_code = message["status"]
+            for key, value in message["headers"]:
+                self.header[key.decode()] = value.decode()
+        elif (message["type"] == "http.response.body"):
+            self.buffer.append(message["body"])
+        else:
+            raise ValueError("ASGI type must be one of "
+                             "http.responses.{body,start}.")
+
+    def build_starlette_response(self) -> starlette.responses.Response:
+        return starlette.responses.Response(
+            b"".join(self.buffer),
+            status_code=self.status_code,
+            headers=dict(self.header))
+
+
+def make_fastapi_class_based_view(fastapi_app, cls: Type) -> None:
+    """Transform the `cls`'s methods and class annotations to FastAPI routes.
+
+    Modified from
+    https://github.com/dmontagu/fastapi-utils/blob/master/fastapi_utils/cbv.py
+
+    Usage:
+    >>> app = FastAPI()
+    >>> class A:
+            @app.route("/{i}")
+            def func(self, i: int) -> str:
+                return self.dep + i
+    >>> # just running the app won't work, here.
+    >>> make_fastapi_class_based_view(app, A)
+    >>> # now app can be run properly
+    """
+    # Delayed import to prevent ciruclar imports in workers.
+    from fastapi import Depends, APIRouter
+    from fastapi.routing import APIRoute
+
+    def get_current_servable_instance():
+        from ray import serve
+        return serve.get_replica_context().servable_object
+
+    # Find all the class method routes
+    member_methods = {
+        func
+        for _, func in inspect.getmembers(cls, inspect.isfunction)
+    }
+    class_method_routes = [
+        route for route in fastapi_app.routes
+        if isinstance(route, APIRoute) and route.endpoint in member_methods
+    ]
+
+    # Modify these routes and mount it to a new APIRouter.
+    # We need to to this (instead of modifying in place) because we want to use
+    # the laster fastapi_app.include_router to re-run the dependency analysis
+    # for each routes.
+    new_router = APIRouter()
+    for route in class_method_routes:
+        fastapi_app.routes.remove(route)
+
+        # This block just adds a default values to the self parameters so that
+        # FastAPI knows to inject the object when calling the route.
+        # Before: def method(self, i): ...
+        # After: def method(self=Depends(...), *, i):...
+        old_endpoint = route.endpoint
+        old_signature = inspect.signature(old_endpoint)
+        old_parameters = list(old_signature.parameters.values())
+        old_self_parameter = old_parameters[0]
+        new_self_parameter = old_self_parameter.replace(
+            default=Depends(get_current_servable_instance))
+        new_parameters = [new_self_parameter] + [
+            # Make the rest of the parameters keyword only because
+            # the first argument is no longer positional.
+            parameter.replace(kind=inspect.Parameter.KEYWORD_ONLY)
+            for parameter in old_parameters[1:]
+        ]
+        new_signature = old_signature.replace(parameters=new_parameters)
+        setattr(route.endpoint, "__signature__", new_signature)
+        # route.endpoint.__signature__ = new_signature
+        new_router.routes.append(route)
+    fastapi_app.include_router(new_router)

--- a/python/ray/serve/tests/test_backend_worker.py
+++ b/python/ray/serve/tests/test_backend_worker.py
@@ -6,7 +6,7 @@ import ray
 from ray.serve.backend_worker import create_backend_replica, wrap_to_ray_error
 from ray.serve.controller import TrafficPolicy
 from ray.serve.router import RequestMetadata, EndpointRouter
-from ray.serve.config import BackendConfig, BackendMetadata
+from ray.serve.config import BackendConfig
 from ray.serve.utils import get_random_letters
 
 pytestmark = pytest.mark.asyncio
@@ -157,8 +157,7 @@ async def test_task_runner_perform_async(serve_instance,
         await barrier.wait.remote()
         return "done!"
 
-    config = BackendConfig(
-        max_concurrent_queries=10, internal_metadata=BackendMetadata())
+    config = BackendConfig(max_concurrent_queries=10)
 
     worker, router = await add_servable_to_router(
         wait_and_go, *mock_controller_with_name, backend_config=config)
@@ -233,9 +232,7 @@ async def test_graceful_shutdown(serve_instance, mock_controller_with_name):
         KeepInflight,
         *mock_controller_with_name,
         backend_config=BackendConfig(
-            num_replicas=1,
-            internal_metadata=BackendMetadata(),
-            user_config={"release": False}))
+            num_replicas=1, user_config={"release": False}))
 
     query_param = make_request_param()
 

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -11,8 +11,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
+import ray
 from ray import serve
-from ray.serve.utils import make_fastapi_class_based_view
+from ray.serve.http_util import make_fastapi_class_based_view
 
 
 def test_fastapi_function(serve_instance):
@@ -76,14 +77,24 @@ def test_class_based_view(serve_instance):
         def c(self, i: int):
             return i - self.val
 
+        def other(self, msg: str):
+            return msg
+
     A.deploy()
 
+    # Test HTTP calls.
     resp = requests.get("http://localhost:8000/f/calc/41")
     assert resp.json() == 42
     resp = requests.post("http://localhost:8000/f/calc/41")
     assert resp.json() == 40
     resp = requests.get("http://localhost:8000/f/other")
     assert resp.json() == "hello"
+
+    # Test handle calls.
+    handle = A.get_handle()
+    assert ray.get(handle.b.remote(41)) == 42
+    assert ray.get(handle.c.remote(41)) == 40
+    assert ray.get(handle.other.remote("world")) == "world"
 
 
 def test_make_fastapi_cbv_util():

--- a/python/ray/serve/tests/test_http_routes.py
+++ b/python/ray/serve/tests/test_http_routes.py
@@ -55,16 +55,16 @@ def test_routes_endpoint(serve_instance):
 
     assert len(routes) == 2, routes
     assert "/D1" in routes, routes
-    assert routes["/D1"] == ["D1", ["GET", "POST"]], routes
+    assert routes["/D1"] == ["D1", ALL_HTTP_METHODS], routes
     assert "/hello/world" in routes, routes
-    assert routes["/hello/world"] == ["D2", ["GET", "POST"]], routes
+    assert routes["/hello/world"] == ["D2", ALL_HTTP_METHODS], routes
 
     D1.delete()
 
     routes = requests.get("http://localhost:8000/-/routes").json()
     assert len(routes) == 1, routes
     assert "/hello/world" in routes, routes
-    assert routes["/hello/world"] == ["D2", ["GET", "POST"]], routes
+    assert routes["/hello/world"] == ["D2", ALL_HTTP_METHODS], routes
 
     D2.delete()
     routes = requests.get("http://localhost:8000/-/routes").json()
@@ -95,16 +95,16 @@ def test_deployment_options_default_route(serve_instance):
     routes = requests.get("http://localhost:8000/-/routes").json()
     assert len(routes) == 1
     assert "/1" in routes, routes
-    assert routes["/1"] == ["1", ["GET", "POST"]]
+    assert routes["/1"] == ["1", ALL_HTTP_METHODS]
 
     D1.options(name="2").deploy()
 
     routes = requests.get("http://localhost:8000/-/routes").json()
     assert len(routes) == 2
     assert "/1" in routes, routes
-    assert routes["/1"] == ["1", ["GET", "POST"]]
+    assert routes["/1"] == ["1", ALL_HTTP_METHODS]
     assert "/2" in routes, routes
-    assert routes["/2"] == ["2", ["GET", "POST"]]
+    assert routes["/2"] == ["2", ALL_HTTP_METHODS]
 
 
 def test_path_prefixing(serve_instance):

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -1,12 +1,11 @@
 import importlib
 from itertools import groupby
-import inspect
 import json
 import logging
 import random
 import string
 import time
-from typing import Iterable, List, Tuple, Dict, Optional, Type
+from typing import Iterable, Tuple
 import os
 from collections import UserDict
 
@@ -306,94 +305,3 @@ def get_current_node_resource_key() -> str:
                     return key
     else:
         raise ValueError("Cannot found the node dictionary for current node.")
-
-
-class ASGIHTTPSender:
-    """Implement the interface for ASGI sender, build Starlette Response"""
-
-    def __init__(self) -> None:
-        self.status_code: Optional[int] = 200
-        self.header: Dict[str, str] = {}
-        self.buffer: List[bytes] = []
-
-    async def __call__(self, message):
-        if (message["type"] == "http.response.start"):
-            self.status_code = message["status"]
-            for key, value in message["headers"]:
-                self.header[key.decode()] = value.decode()
-        elif (message["type"] == "http.response.body"):
-            self.buffer.append(message["body"])
-        else:
-            raise ValueError("ASGI type must be one of "
-                             "http.responses.{body,start}.")
-
-    def build_starlette_response(self) -> starlette.responses.Response:
-        return starlette.responses.Response(
-            b"".join(self.buffer),
-            status_code=self.status_code,
-            headers=dict(self.header))
-
-
-def make_fastapi_class_based_view(fastapi_app, cls: Type) -> None:
-    """Transform the `cls`'s methods and class annotations to FastAPI routes.
-
-    Modified from
-    https://github.com/dmontagu/fastapi-utils/blob/master/fastapi_utils/cbv.py
-
-    Usage:
-    >>> app = FastAPI()
-    >>> class A:
-            @app.route("/{i}")
-            def func(self, i: int) -> str:
-                return self.dep + i
-    >>> # just running the app won't work, here.
-    >>> make_fastapi_class_based_view(app, A)
-    >>> # now app can be run properly
-    """
-    # Delayed import to prevent ciruclar imports in workers.
-    from fastapi import Depends, APIRouter
-    from fastapi.routing import APIRoute
-
-    def get_current_servable_instance():
-        from ray import serve
-        return serve.get_replica_context().servable_object
-
-    # Find all the class method routes
-    member_methods = {
-        func
-        for _, func in inspect.getmembers(cls, inspect.isfunction)
-    }
-    class_method_routes = [
-        route for route in fastapi_app.routes
-        if isinstance(route, APIRoute) and route.endpoint in member_methods
-    ]
-
-    # Modify these routes and mount it to a new APIRouter.
-    # We need to to this (instead of modifying in place) because we want to use
-    # the laster fastapi_app.include_router to re-run the dependency analysis
-    # for each routes.
-    new_router = APIRouter()
-    for route in class_method_routes:
-        fastapi_app.routes.remove(route)
-
-        # This block just adds a default values to the self parameters so that
-        # FastAPI knows to inject the object when calling the route.
-        # Before: def method(self, i): ...
-        # After: def method(self=Depends(...), *, i):...
-        old_endpoint = route.endpoint
-        old_signature = inspect.signature(old_endpoint)
-        old_parameters = list(old_signature.parameters.values())
-        old_self_parameter = old_parameters[0]
-        new_self_parameter = old_self_parameter.replace(
-            default=Depends(get_current_servable_instance))
-        new_parameters = [new_self_parameter] + [
-            # Make the rest of the parameters keyword only because
-            # the first argument is no longer positional.
-            parameter.replace(kind=inspect.Parameter.KEYWORD_ONLY)
-            for parameter in old_parameters[1:]
-        ]
-        new_signature = old_signature.replace(parameters=new_parameters)
-        setattr(route.endpoint, "__signature__", new_signature)
-        # route.endpoint.__signature__ = new_signature
-        new_router.routes.append(route)
-    fastapi_app.include_router(new_router)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Removes the fastapi-specific code from backend_worker and makes it a normal (wrapped) backend definition. This allows us to support handle method calls on the backend as well as invoking via HTTP.

## Related issue number

Closes https://github.com/ray-project/ray/issues/15170

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
