### PR TITLE
[kubernetes][doc][minor] Add namespace to job creation command

### DIFF
--- a/doc/source/cluster/kubernetes.rst
+++ b/doc/source/cluster/kubernetes.rst
@@ -418,7 +418,7 @@ The following command submits a Job which executes an `example Ray program`_.
 
 .. code-block:: yaml
 
-  $ kubectl create -f ray/doc/kubernetes/job-example.yaml
+  $ kubectl -n ray create -f ray/doc/kubernetes/job-example.yaml
 
 The program executed by the Job waits for three Ray nodes to connect and then tests object transfer
 between the nodes. Note that the program uses the environment variables


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Typo: the namespace is left off the job creation command in the docs.
https://discuss.ray.io/t/test-job-in-minikube-created-but-not-found/1816/2

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
