### PR TITLE
[Serve] Add handle_tag to ReplicaSet's metric

### DIFF
--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -90,10 +90,10 @@ class RayServeHandle:
             "serve_handle_request_counter",
             description=("The number of handle.remote() calls that have been "
                          "made on this handle."),
-            tag_keys=("handle", "endpoint"))
+            tag_keys=("endpoint", "handle"))
         self.request_counter.set_default_tags({
+            "endpoint": self.endpoint_name,
             "handle": self.handle_tag,
-            "endpoint": self.endpoint_name
         })
 
         self.router: EndpointRouter = _router or self._make_router()
@@ -103,6 +103,7 @@ class RayServeHandle:
             self.controller_handle,
             self.endpoint_name,
             asyncio.get_event_loop(),
+            self.handle_tag,
         )
 
     def options(self,

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -31,7 +31,6 @@ def test_serve_metrics(serve_instance):
 
         expected_metrics = [
             # counter
-            "num_router_requests_total",
             "num_http_requests_total",
             "backend_queued_queries_total",
             "backend_request_counter_requests_total",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
One of the critical metrics user want to monitoring is the number of queries being queued in replica set. However, that metrics is not scoped by handle_tag so it can easily override each other, leading to wrong metrics. This PR adds handle_tag to the ReplicaSet.

Additionally, it removes the `serve_num_router_requests` because it doesn't make sense anymore, as it's exactly equivalent to ServeHandle's request counter.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
