### PR TITLE
[API] Remove Top Level, Non-Ray Modules

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -136,3 +136,6 @@ __all__ += [
     "UniqueID",
     "PlacementGroupID",
 ]
+
+# Remove modules from top-level ray. This prevents things like: ray.os.path
+del ctypes, logging, os, platform, sys

--- a/python/ray/tests/test_top_level_api.py
+++ b/python/ray/tests/test_top_level_api.py
@@ -48,6 +48,13 @@ def test_non_ray_modules():
             mod), f"Module {mod} should not be reachable via ray.{name}"
 
 
+def test_for_strings():
+    strings = getmembers(ray, lambda obj: isinstance(obj, str))
+    for string, _ in strings:
+        assert string.startswith("__"), f"Invalid string: {string} found in "
+        "top level Ray. Please delete at the end of __init__.py."
+
+
 if __name__ == "__main__":
     import pytest
     import sys

--- a/python/ray/tests/test_top_level_api.py
+++ b/python/ray/tests/test_top_level_api.py
@@ -1,4 +1,4 @@
-from inspect import getmembers, isfunction
+from inspect import getmembers, isfunction, ismodule
 
 import ray
 
@@ -39,6 +39,13 @@ def test_api_functions():
     functions = getmembers(ray, isfunction)
     function_names = [f[0] for f in functions]
     assert set(function_names) == set(PYTHON_API + OTHER_ALLOWED_FUNCTIONS)
+
+
+def test_non_ray_modules():
+    modules = getmembers(ray, ismodule)
+    for name, mod in modules:
+        assert "ray" in str(
+            mod), f"Module {mod} should not be reachable via ray.{name}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* This avoids the possibility of a user doing `ray.os.path`.
* This is accomplished by deleting them from `__init__.py`
* For reference, tensorflow does this [here](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/__init__.py)
* Specifically removes the following from `ray.*`:
{'CDLL',
 'ctypes',
 'logging',
 'os',
 'pickle5_path',
 'platform',
 'python_shared_lib_suffix',
 'so_path',
 'sys',
 'thirdparty_files'}

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
