### PR TITLE
Clean up ray namespace

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -62,12 +62,8 @@ if os.path.exists(so_path):
 
 import ray._raylet  # noqa: E402
 
-from ray._raylet import (  # noqa: E402
-    ActorClassID, ActorID, NodeID, Config as _Config, JobID, WorkerID,
-    FunctionID, ObjectID, ObjectRef, TaskID, UniqueID, Language,
-    PlacementGroupID)
-
-_config = _Config()
+_config = ray._raylet.Config()
+del ray._raylet
 
 from ray.profiling import profile  # noqa: E402
 from ray.state import (  # noqa: E402
@@ -75,12 +71,10 @@ from ray.state import (  # noqa: E402
     cluster_resources, available_resources,
 )
 from ray.worker import (  # noqa: E402,F401
-    LOCAL_MODE, SCRIPT_MODE, WORKER_MODE, RESTORE_WORKER_MODE,
-    UTIL_WORKER_MODE, SPILL_WORKER_MODE, cancel, get, get_actor, get_gpu_ids,
+    cancel, get, get_actor, get_gpu_ids,
     get_resource_ids, get_dashboard_url, init, is_initialized, put, kill,
     remote, shutdown, show_in_dashboard, wait,
 )
-import ray.internal  # noqa: E402
 # We import ray.actor because some code is run in actor.py which initializes
 # some functions in the worker.
 import ray.actor  # noqa: E402,F401
@@ -95,9 +89,7 @@ __version__ = "2.0.0.dev0"
 
 __all__ = [
     "__version__",
-    "_config",
     "get_runtime_context",
-    "actor",
     "actors",
     "available_resources",
     "cancel",
@@ -108,13 +100,11 @@ __all__ = [
     "get_resource_ids",
     "get_dashboard_url",
     "init",
-    "internal",
     "is_initialized",
     "java_actor_class",
     "java_function",
     "jobs",
     "kill",
-    "Language",
     "method",
     "nodes",
     "objects",
@@ -127,22 +117,12 @@ __all__ = [
     "timeline",
     "util",
     "wait",
-    "LOCAL_MODE",
-    "SCRIPT_MODE",
-    "WORKER_MODE",
 ]
 
-# ID types
-__all__ += [
-    "ActorClassID",
-    "ActorID",
-    "NodeID",
-    "JobID",
-    "WorkerID",
-    "FunctionID",
-    "ObjectID",
-    "ObjectRef",
-    "TaskID",
-    "UniqueID",
-    "PlacementGroupID",
-]
+del CDLL, ctypes, dirname, logging, os, sys, platform
+del (actor, autoscaler, cloudpickle, core, exceptions,
+     gcs_utils, job_config, logger, node, pickle5_path,
+     profiling, python_shared_lib_suffix, ray_constants,
+     remote_function, resource_spec, serialization, serialization_addons, so_path, state,
+     thirdparty_files, worker)
+del _config, _private

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -61,26 +61,18 @@ if os.path.exists(so_path):
     CDLL(so_path, ctypes.RTLD_GLOBAL)
 
 import ray._raylet  # noqa: E402
-
 _config = ray._raylet.Config()
 del ray._raylet
 
-from ray.profiling import profile  # noqa: E402
 from ray.state import (  # noqa: E402
-    jobs, nodes, actors, objects, timeline, object_transfer_timeline,
-    cluster_resources, available_resources,
+    timeline, cluster_resources, available_resources,
 )
 from ray.worker import (  # noqa: E402,F401
     cancel, get, get_actor, get_gpu_ids,
-    get_resource_ids, get_dashboard_url, init, is_initialized, put, kill,
-    remote, shutdown, show_in_dashboard, wait,
+    init, is_initialized, put, kill,
+    remote, shutdown, wait,
 )
-# We import ray.actor because some code is run in actor.py which initializes
-# some functions in the worker.
-import ray.actor  # noqa: E402,F401
 from ray.actor import method  # noqa: E402
-from ray.cross_language import java_function, java_actor_class  # noqa: E402
-from ray.runtime_context import get_runtime_context  # noqa: E402
 from ray import util  # noqa: E402
 
 # Replaced with the current commit when building the wheels.
@@ -89,31 +81,21 @@ __version__ = "2.0.0.dev0"
 
 __all__ = [
     "__version__",
-    "get_runtime_context",
-    "actors",
     "available_resources",
     "cancel",
     "cluster_resources",
     "get",
     "get_actor",
     "get_gpu_ids",
-    "get_resource_ids",
-    "get_dashboard_url",
     "init",
     "is_initialized",
     "java_actor_class",
     "java_function",
-    "jobs",
     "kill",
     "method",
-    "nodes",
-    "objects",
-    "object_transfer_timeline",
-    "profile",
     "put",
     "remote",
     "shutdown",
-    "show_in_dashboard",
     "timeline",
     "util",
     "wait",
@@ -126,3 +108,5 @@ del (actor, autoscaler, cloudpickle, core, exceptions,
      remote_function, resource_spec, serialization, serialization_addons, so_path, state,
      thirdparty_files, worker)
 del _config, _private
+
+del cross_language, external_storage

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -11,8 +11,7 @@ import ray.worker
 from ray.util.placement_group import (
     PlacementGroup, check_placement_group_index, get_current_placement_group)
 
-from ray import ActorClassID, Language
-from ray._raylet import PythonFunctionDescriptor
+from ray._raylet import ActorClassID, Language, PythonFunctionDescriptor
 from ray._private.client_mode_hook import client_mode_hook
 from ray._private.client_mode_hook import client_mode_should_convert
 from ray._private.client_mode_hook import client_mode_convert_actor

--- a/python/ray/cross_language.py
+++ b/python/ray/cross_language.py
@@ -2,8 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from ray import Language
-from ray._raylet import JavaFunctionDescriptor
+from ray._raylet import JavaFunctionDescriptor, Language
 
 __all__ = [
     "java_function",

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -2,8 +2,8 @@ import logging
 from functools import wraps
 
 from ray import cloudpickle as pickle
-from ray._raylet import PythonFunctionDescriptor
-from ray import cross_language, Language
+from ray._raylet import PythonFunctionDescriptor, Language
+from ray import cross_language
 from ray._private.client_mode_hook import client_mode_convert_function
 from ray._private.client_mode_hook import client_mode_should_convert
 from ray.util.placement_group import (

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -32,9 +32,9 @@ import ray._private.runtime_env as runtime_env
 import ray._private.import_thread as import_thread
 import ray
 import setproctitle
-import ray.state
+from ray.state import state
 
-from ray import (
+from ray._raylet import (
     ActorID,
     JobID,
     ObjectRef,
@@ -827,7 +827,7 @@ def shutdown(_exiting_interpreter=False):
         del global_worker.core_worker
 
     # Disconnect global state from GCS.
-    ray.state.state.disconnect()
+    state.disconnect()
 
     # Shut down the Ray processes.
     global _global_node
@@ -870,8 +870,8 @@ def custom_excepthook(type, value, tb):
         worker_type = ray.gcs_utils.DRIVER
         worker_info = {"exception": error_message}
 
-        ray.state.state._check_connected()
-        ray.state.state.add_worker(worker_id, worker_type, worker_info)
+        state._check_connected()
+        state.add_worker(worker_id, worker_type, worker_info)
     # Call the normal excepthook.
     normal_excepthook(type, value, tb)
 
@@ -1228,7 +1228,7 @@ def connect(node,
     # Create an object for interfacing with the global state.
     # Note, global state should be intialized after `CoreWorker`, because it
     # will use glog, which is intialized in `CoreWorker`.
-    ray.state.state._initialize_global_state(
+    state._initialize_global_state(
         node.redis_address, redis_password=node.redis_password)
     # If it's a driver and it's not coming from ray client, we'll prepare the
     # environment here. If it's ray client, the environmen will be prepared


### PR DESCRIPTION
A few comments.
- This is not mergeable or high quality or intended to be reviewed, this is just an example of how we could clean up the top level namespace a lot
- `ray.init()` doesn't work in this PR, a bunch of import statements need to be changed to make this work

# Before
<img width="901" alt="Screen Shot 2021-04-25 at 2 03 04 PM" src="https://user-images.githubusercontent.com/249517/116009498-f52ac900-a5ce-11eb-8c14-46053157b9eb.png">


# After
<img width="858" alt="Screen Shot 2021-04-25 at 2 00 43 PM" src="https://user-images.githubusercontent.com/249517/116009476-cd3b6580-a5ce-11eb-9958-78d2cad667c1.png">

## Related issue number
Some related discussion in https://github.com/ray-project/ray/issues/7787.
