### PR TITLE
Fix reported dashboard ip when using 0.0.0.0

### DIFF
--- a/dashboard/head.py
+++ b/dashboard/head.py
@@ -3,6 +3,7 @@ import socket
 import json
 import asyncio
 import logging
+import ipaddress
 
 import aiohttp
 import aiohttp.web
@@ -210,6 +211,8 @@ class DashboardHead:
             raise Exception(f"Failed to find a valid port for dashboard after "
                             f"{self.http_port_retries} retries: {last_ex}")
         http_host, http_port, *_ = site._server.sockets[0].getsockname()
+        http_host = self.ip if ipaddress.ip_address(
+            http_host).is_unspecified else http_host
         logger.info("Dashboard head http address: %s:%s", http_host, http_port)
 
         # Write the dashboard head port to redis.

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -5,6 +5,7 @@ import json
 import time
 import logging
 import asyncio
+import ipaddress
 import subprocess
 import collections
 
@@ -154,6 +155,24 @@ def test_basic(ray_start_with_dashboard):
     key = f"{dashboard_consts.DASHBOARD_AGENT_PORT_PREFIX}{node_id}"
     agent_ports = client.get(key)
     assert agent_ports is not None
+
+
+@pytest.mark.parametrize(
+    "ray_start_with_dashboard", [{
+        "dashboard_host": "127.0.0.1"
+    }, {
+        "dashboard_host": "0.0.0.0"
+    }, {
+        "dashboard_host": "::"
+    }],
+    indirect=True)
+def test_dashboard_address(ray_start_with_dashboard):
+    webui_url = ray_start_with_dashboard["webui_url"]
+    webui_ip = webui_url.split(":")[0]
+    assert not ipaddress.ip_address(webui_ip).is_unspecified
+    assert webui_ip in [
+        "127.0.0.1", ray_start_with_dashboard["node_ip_address"]
+    ]
 
 
 def test_nodes_update(enable_test_module, ray_start_with_dashboard):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- Problem
  - The dashboard address may not be connectable. e.g. `ray.init(dashboard_host='0.0.0.0'` returns a `http://0.0.0.0:8265` as the webui url.
- Solution
  - Use node ip address as the ip of webui url if the dashboard address is an unspecified address. Please refer to https://docs.python.org/3/library/ipaddress.html?highlight=ipaddress#ipaddress.IPv4Address.is_unspecified

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
N/A

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
