### PR TITLE
[RLlib] Mask out padded values for A3C loss with recurrent policy

### DIFF
--- a/rllib/agents/a3c/a3c_torch_policy.py
+++ b/rllib/agents/a3c/a3c_torch_policy.py
@@ -9,7 +9,7 @@ from ray.rllib.policy.policy_template import build_policy_class
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.deprecation import deprecation_warning
 from ray.rllib.utils.framework import try_import_torch
-from ray.rllib.utils.torch_ops import apply_grad_clipping
+from ray.rllib.utils.torch_ops import apply_grad_clipping, sequence_mask
 from ray.rllib.utils.typing import TrainerConfigDict
 
 torch, nn = try_import_torch()
@@ -33,20 +33,28 @@ def add_advantages(policy,
 def actor_critic_loss(policy, model, dist_class, train_batch):
     logits, _ = model.from_batch(train_batch)
     values = model.value_function()
+
+    if policy.is_recurrent():
+        max_seq_len = torch.max(train_batch["seq_lens"])
+        mask_orig = sequence_mask(train_batch["seq_lens"], max_seq_len)
+        valid_mask = torch.reshape(mask_orig, [-1])
+    else:
+        valid_mask = torch.ones_like(values, dtype=torch.bool)
+
     dist = dist_class(logits, model)
-    log_probs = dist.logp(train_batch[SampleBatch.ACTIONS])
-    policy.entropy = dist.entropy().sum()
-    policy.pi_err = -train_batch[Postprocessing.ADVANTAGES].dot(
-        log_probs.reshape(-1))
-    policy.value_err = torch.sum(
+    log_probs = dist.logp(train_batch[SampleBatch.ACTIONS]).reshape(-1)
+    policy.pi_err = -torch.sum(
+        torch.masked_select(log_probs * train_batch[Postprocessing.ADVANTAGES],
+                            valid_mask))
+    policy.value_err = 0.5 * torch.sum(
         torch.pow(
-            values.reshape(-1) - train_batch[Postprocessing.VALUE_TARGETS],
-            2.0))
-    overall_err = sum([
-        policy.pi_err,
-        policy.config["vf_loss_coeff"] * policy.value_err,
-        -policy.config["entropy_coeff"] * policy.entropy,
-    ])
+            torch.masked_select(
+                values.reshape(-1) - train_batch[Postprocessing.VALUE_TARGETS],
+                valid_mask), 2.0))
+    policy.entropy = torch.sum(torch.masked_select(dist.entropy(), valid_mask))
+    overall_err = (
+        policy.pi_err + policy.value_err * policy.config["vf_loss_coeff"] -
+        policy.entropy * policy.config["entropy_coeff"])
     return overall_err
 
 

--- a/rllib/agents/a3c/tests/test_a2c.py
+++ b/rllib/agents/a3c/tests/test_a2c.py
@@ -18,7 +18,7 @@ class TestA2C(unittest.TestCase):
 
     def test_a2c_compilation(self):
         """Test whether an A2CTrainer can be built with both frameworks."""
-        config = a3c.DEFAULT_CONFIG.copy()
+        config = a3c.a2c.A2C_DEFAULT_CONFIG.copy()
         config["num_workers"] = 2
         config["num_envs_per_worker"] = 2
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The A3C loss does not mask out padded states when using a recurrent network.
I based these changes on the vtrace_[tf/torch]_policy.py implementations for masking.
I also made the loss order and formulas consistent between the torch and tf versions.

## Related issue number
Closes  #15523

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [N/A] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
