### PR TITLE
Actor id inequality fix

### DIFF
--- a/python/ray/includes/unique_ids.pxi
+++ b/python/ray/includes/unique_ids.pxi
@@ -62,7 +62,7 @@ cdef class BaseID:
         return type(self) == type(other) and self.binary() == other.binary()
 
     def __ne__(self, other):
-        return self.binary() != other.binary()
+        return type(self) != type(other) or self.binary() != other.binary()
 
     def __bytes__(self):
         return self.binary()

--- a/python/ray/tests/test_runtime_context.py
+++ b/python/ray/tests/test_runtime_context.py
@@ -79,6 +79,7 @@ def test_get_context_dict(ray_start_regular):
             assert context_dict["job_id"] == job_id
             assert context_dict["actor_id"] is not None
             assert context_dict["task_id"] is not None
+            assert context_dict["actor_id"] != "not an ActorID"
 
     a = Actor.remote()
     ray.get(a.check.remote(context_dict["node_id"], context_dict["job_id"]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Add a type check to `__ne__` in BaseID.

## Why are these changes needed?

`__ne__` shouldn't error on missing "binary()" method when compared to a non ActorID, just return false. Likely isn't intended behavior, but as implemented now it looks like you might be able to see a false comparison on two different ID types (e.g. ActorID != PlacementGroupID) in the off chance that somehow they have the same .binary() repr. 

<!-- Please give a short summary of the change and the problem this solves. -->

Add type check to `__ne__` (consistent with __eq__). Added check in existing runtime_context tests that involves an ActorID compared to non-actor ID

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #15528 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
