### PR TITLE
[RLlib] Discussion 1928: Initial lr wrong if schedule used that includes ts=0 (both tf and torch).

### DIFF
--- a/rllib/policy/tf_policy.py
+++ b/rllib/policy/tf_policy.py
@@ -943,6 +943,7 @@ class LearningRateSchedule:
 
     @DeveloperAPI
     def __init__(self, lr, lr_schedule):
+        self._lr_schedule = None
         if lr_schedule is None:
             self.cur_lr = tf1.get_variable(
                 "lr", initializer=lr, trainable=False)

--- a/rllib/policy/tf_policy.py
+++ b/rllib/policy/tf_policy.py
@@ -943,11 +943,14 @@ class LearningRateSchedule:
 
     @DeveloperAPI
     def __init__(self, lr, lr_schedule):
-        self.cur_lr = tf1.get_variable("lr", initializer=lr, trainable=False)
-        self._lr_schedule = lr_schedule
-        if self._lr_schedule is not None:
+        if lr_schedule is None:
+            self.cur_lr = tf1.get_variable(
+                "lr", initializer=lr, trainable=False)
+        else:
             self._lr_schedule = PiecewiseSchedule(
                 lr_schedule, outside_value=lr_schedule[-1][-1], framework=None)
+            self.cur_lr = tf1.get_variable(
+                "lr", initializer=self._lr_schedule.value(0), trainable=False)
             if self.framework == "tf":
                 self._lr_placeholder = tf1.placeholder(
                     dtype=tf.float32, name="lr")

--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -880,20 +880,22 @@ class LearningRateSchedule:
 
     @DeveloperAPI
     def __init__(self, lr, lr_schedule):
-        self.cur_lr = lr
+        self._lr_schedule = None
         if lr_schedule is None:
-            self.lr_schedule = ConstantSchedule(lr, framework=None)
+            self.cur_lr = lr
         else:
-            self.lr_schedule = PiecewiseSchedule(
+            self._lr_schedule = PiecewiseSchedule(
                 lr_schedule, outside_value=lr_schedule[-1][-1], framework=None)
+            self.cur_lr = self._lr_schedule.value(0)
 
     @override(Policy)
     def on_global_var_update(self, global_vars):
         super().on_global_var_update(global_vars)
-        self.cur_lr = self.lr_schedule.value(global_vars["timestep"])
-        for opt in self._optimizers:
-            for p in opt.param_groups:
-                p["lr"] = self.cur_lr
+        if self._lr_schedule:
+            self.cur_lr = self._lr_schedule.value(global_vars["timestep"])
+            for opt in self._optimizers:
+                for p in opt.param_groups:
+                    p["lr"] = self.cur_lr
 
 
 @DeveloperAPI


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Discussion 1928: Initial lr wrong if schedule used that includes ts=0 (both tf and torch).
- The impala test was modified to check for this bug.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
