### PR TITLE
[Serve] Make sure ingress can be called before ray.init

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -24,8 +24,9 @@ from ray.serve.exceptions import RayServeException
 from ray.serve.handle import RayServeHandle, RayServeSyncHandle
 from ray.serve.http_util import (ASGIHTTPSender, make_fastapi_class_based_view,
                                  make_startup_shutdown_hooks)
-from ray.serve.utils import (format_actor_name, get_current_node_resource_key,
-                             get_random_letters, logger)
+from ray.serve.utils import (ensure_serialization_context, format_actor_name,
+                             get_current_node_resource_key, get_random_letters,
+                             logger)
 
 import ray
 
@@ -968,6 +969,7 @@ def ingress(app: Union["FastAPI", "APIRouter"]):
         # Free the state of the app so subsequent modification won't affect
         # this ingress deployment. We don't use copy.copy here to avoid
         # recursion issue.
+        ensure_serialization_context()
         frozen_app = cloudpickle.loads(cloudpickle.dumps(app))
 
         startup_hook, shutdown_hook = make_startup_shutdown_hooks(frozen_app)

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -15,6 +15,8 @@ import numpy as np
 import pydantic
 
 import ray
+import ray.serialization_addons
+from ray.util.serialization import StandaloneSerializationContext
 from ray.serve.constants import HTTP_PROXY_TIMEOUT
 from ray.serve.exceptions import RayServeException
 from ray.serve.http_util import build_starlette_request, HTTPRequestWrapper
@@ -286,3 +288,10 @@ def get_current_node_resource_key() -> str:
                     return key
     else:
         raise ValueError("Cannot found the node dictionary for current node.")
+
+
+def ensure_serialization_context():
+    """Ensure the serialization addons on registered, even when Ray has not
+    been started."""
+    ctx = StandaloneSerializationContext()
+    ray.serialization_addons.apply(ctx)

--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -85,9 +85,8 @@ class RayAPIStub:
         regular worker's serialization_context mechanism.
         """
         import ray.serialization_addons
-        from ray.util.client.ray_client_helpers import (
-            RayClientSerializationContext)
-        ctx = RayClientSerializationContext()
+        from ray.util.serialization import StandaloneSerializationContext
+        ctx = StandaloneSerializationContext()
         ray.serialization_addons.apply(ctx)
 
     def _check_versions(self, conn_info: Dict[str, Any],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
@serve.ingress originally assumed the serialization_context has already setup. But this might not be true because it can be ran before ray.init. So we will ensure the serialization_context is setup properly inside ingress decorator. We will borrow the same components from Ray Client. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #15511
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
