### PR TITLE
Replace sample_collector of sample_collector_class in COMMON_CONFIG

### DIFF
--- a/doc/source/rllib-sample-collection.rst
+++ b/doc/source/rllib-sample-collection.rst
@@ -104,7 +104,7 @@ RLlib's default ``SampleCollector`` class is the ``SimpleListCollector``, which 
 to lists, then builds SampleBatches from these and sends them to the downstream processing functions.
 It thereby tries to avoid collecting duplicate data separately (OBS and NEXT_OBS use the same underlying list).
 If you want to implement your own collection logic and data structures, you can sub-class ``SampleCollector``
-and specify that new class under the Trainer's "sample_collector" config key.
+and specify that new class under the Trainer's "sample_collector_class" config key.
 
 Let's now look at how the Policy's Model lets the RolloutWorker and its SampleCollector
 know, what data in the ongoing episode/trajectory to use for the different required method calls

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -251,7 +251,7 @@ COMMON_CONFIG: TrainerConfigDict = {
     # The SampleCollector class to be used to collect and retrieve
     # environment-, model-, and sampler data. Override the SampleCollector base
     # class to implement your own collection/buffering/retrieval logic.
-    "sample_collector": SimpleListCollector,
+    "sample_collector_class": SimpleListCollector,
 
     # Element-wise observation filter, either "NoFilter" or "MeanStdFilter".
     "observation_filter": "NoFilter",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`sample_collector` is not be used anywhere. It should be replaced by `sample_collector_class` which is used in `ray/rllib/evaluation/rollout_worker.py`.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
