### PR TITLE
Changed base GPU image to devel to compile Horovod CUDA kernels

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -17,7 +17,7 @@ key="$1"
 case $key in
     --gpu)
     GPU="-gpu"
-    BASE_IMAGE="nvidia/cuda:11.0-cudnn8-runtime-ubuntu18.04"
+    BASE_IMAGE="nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04"
     ;;
     --no-cache-build)
     NO_CACHE="--no-cache"

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -17,7 +17,7 @@ key="$1"
 case $key in
     --gpu)
     GPU="-gpu"
-    BASE_IMAGE="nvidia/cuda:11.0.0-cudnn8-devel-ubuntu18.04"
+    BASE_IMAGE="nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04"
     ;;
     --no-cache-build)
     NO_CACHE="--no-cache"

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -17,7 +17,7 @@ key="$1"
 case $key in
     --gpu)
     GPU="-gpu"
-    BASE_IMAGE="nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04"
+    BASE_IMAGE="nvidia/cuda:11.3-cudnn8-devel-ubuntu18.04"
     ;;
     --no-cache-build)
     NO_CACHE="--no-cache"

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -17,7 +17,7 @@ key="$1"
 case $key in
     --gpu)
     GPU="-gpu"
-    BASE_IMAGE="nvidia/cuda:11.3-cudnn8-devel-ubuntu18.04"
+    BASE_IMAGE="nvidia/cuda:11.3.0-cudnn8-devel-ubuntu18.04"
     ;;
     --no-cache-build)
     NO_CACHE="--no-cache"

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -17,7 +17,7 @@ key="$1"
 case $key in
     --gpu)
     GPU="-gpu"
-    BASE_IMAGE="nvidia/cuda:11.3.0-cudnn8-devel-ubuntu18.04"
+    BASE_IMAGE="nvidia/cuda:11.0.0-cudnn8-devel-ubuntu18.04"
     ;;
     --no-cache-build)
     NO_CACHE="--no-cache"

--- a/ci/travis/build-docker-images.py
+++ b/ci/travis/build-docker-images.py
@@ -103,7 +103,7 @@ def _build_cpu_gpu_images(image_name, no_cache=True) -> List[str]:
 
             if image_name == "base-deps":
                 build_args["BASE_IMAGE"] = (
-                    "nvidia/cuda:11.0-cudnn8-runtime-ubuntu18.04"
+                    "nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04"
                     if gpu == "-gpu" else "ubuntu:focal")
             else:
                 # NOTE(ilr) This is a bit of an abuse of the name "GPU"

--- a/ci/travis/build-docker-images.py
+++ b/ci/travis/build-docker-images.py
@@ -103,7 +103,7 @@ def _build_cpu_gpu_images(image_name, no_cache=True) -> List[str]:
 
             if image_name == "base-deps":
                 build_args["BASE_IMAGE"] = (
-                    "nvidia/cuda:11.3.0-cudnn8-devel-ubuntu18.04"
+                    "nvidia/cuda:11.0.0-cudnn8-devel-ubuntu18.04"
                     if gpu == "-gpu" else "ubuntu:focal")
             else:
                 # NOTE(ilr) This is a bit of an abuse of the name "GPU"

--- a/ci/travis/build-docker-images.py
+++ b/ci/travis/build-docker-images.py
@@ -103,7 +103,7 @@ def _build_cpu_gpu_images(image_name, no_cache=True) -> List[str]:
 
             if image_name == "base-deps":
                 build_args["BASE_IMAGE"] = (
-                    "nvidia/cuda:11.3-cudnn8-devel-ubuntu18.04"
+                    "nvidia/cuda:11.3.0-cudnn8-devel-ubuntu18.04"
                     if gpu == "-gpu" else "ubuntu:focal")
             else:
                 # NOTE(ilr) This is a bit of an abuse of the name "GPU"

--- a/ci/travis/build-docker-images.py
+++ b/ci/travis/build-docker-images.py
@@ -103,7 +103,7 @@ def _build_cpu_gpu_images(image_name, no_cache=True) -> List[str]:
 
             if image_name == "base-deps":
                 build_args["BASE_IMAGE"] = (
-                    "nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04"
+                    "nvidia/cuda:11.3-cudnn8-devel-ubuntu18.04"
                     if gpu == "-gpu" else "ubuntu:focal")
             else:
                 # NOTE(ilr) This is a bit of an abuse of the name "GPU"

--- a/ci/travis/build-docker-images.py
+++ b/ci/travis/build-docker-images.py
@@ -103,7 +103,7 @@ def _build_cpu_gpu_images(image_name, no_cache=True) -> List[str]:
 
             if image_name == "base-deps":
                 build_args["BASE_IMAGE"] = (
-                    "nvidia/cuda:11.0.0-cudnn8-devel-ubuntu18.04"
+                    "nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04"
                     if gpu == "-gpu" else "ubuntu:focal")
             else:
                 # NOTE(ilr) This is a bit of an abuse of the name "GPU"

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -1,6 +1,6 @@
 # The base-deps Docker image installs main libraries needed to run Ray
 
-# The GPU option is nvidia/cuda:11.3-cudnn8-devel-ubuntu18.04
+# The GPU option is nvidia/cuda:11.3.0-cudnn8-devel-ubuntu18.04
 ARG BASE_IMAGE="ubuntu:focal"
 FROM ${BASE_IMAGE}
 # If this arg is not "autoscaler" then no autoscaler requirements will be included

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -1,6 +1,6 @@
 # The base-deps Docker image installs main libraries needed to run Ray
 
-# The GPU option is nvidia/cuda:11.3.0-cudnn8-devel-ubuntu18.04
+# The GPU option is nvidia/cuda:11.0.0-cudnn8-devel-ubuntu18.04
 ARG BASE_IMAGE="ubuntu:focal"
 FROM ${BASE_IMAGE}
 # If this arg is not "autoscaler" then no autoscaler requirements will be included

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -1,6 +1,6 @@
 # The base-deps Docker image installs main libraries needed to run Ray
 
-# The GPU option is nvidia/cuda:11.0-cudnn8-runtime-ubuntu18.04
+# The GPU option is nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04
 ARG BASE_IMAGE="ubuntu:focal"
 FROM ${BASE_IMAGE}
 # If this arg is not "autoscaler" then no autoscaler requirements will be included

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -1,6 +1,6 @@
 # The base-deps Docker image installs main libraries needed to run Ray
 
-# The GPU option is nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04
+# The GPU option is nvidia/cuda:11.3-cudnn8-devel-ubuntu18.04
 ARG BASE_IMAGE="ubuntu:focal"
 FROM ${BASE_IMAGE}
 # If this arg is not "autoscaler" then no autoscaler requirements will be included

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -1,6 +1,6 @@
 # The base-deps Docker image installs main libraries needed to run Ray
 
-# The GPU option is nvidia/cuda:11.0.0-cudnn8-devel-ubuntu18.04
+# The GPU option is nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04
 ARG BASE_IMAGE="ubuntu:focal"
 FROM ${BASE_IMAGE}
 # If this arg is not "autoscaler" then no autoscaler requirements will be included


### PR DESCRIPTION
## Why are these changes needed?

The existing Ray GPU images do not come with the CUDA compiler toolchain, which prevents users from compiling custom CUDA kernels during install for frameworks like Horovod (see https://github.com/horovod/horovod/issues/2815).

By using the devel image instead of runtime from NVIDIA, Horovod and other compiled frameworks can use `nvcc` to build their custom CUDA kernels at install time. 

## Related issue number

https://github.com/horovod/horovod/issues/2815

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
