### PR TITLE
[client] make client disconnect idempotent

### DIFF
--- a/python/ray/tests/test_client_init.py
+++ b/python/ray/tests/test_client_init.py
@@ -97,6 +97,7 @@ def test_basic_preregister(init_and_serve):
         assert val == 12
         ray.disconnect()
 
+
 def test_idempotent_disconnect(init_and_serve):
     from ray.util.client import ray
     ray.disconnect()

--- a/python/ray/tests/test_client_init.py
+++ b/python/ray/tests/test_client_init.py
@@ -97,6 +97,14 @@ def test_basic_preregister(init_and_serve):
         assert val == 12
         ray.disconnect()
 
+def test_idempotent_disconnect(init_and_serve):
+    from ray.util.client import ray
+    ray.disconnect()
+    ray.disconnect()
+    ray.connect("localhost:50051")
+    ray.disconnect()
+    ray.disconnect()
+
 
 def test_num_clients(init_and_serve_lazy):
     # Tests num clients reporting; useful if you want to build an app that

--- a/python/ray/util/client_connect.py
+++ b/python/ray/util/client_connect.py
@@ -35,6 +35,5 @@ def connect(conn_str: str,
 
 
 def disconnect():
-    if not ray.is_connected():
-        raise RuntimeError("Ray Client is currently disconnected.")
+    """This command is idempotent."""
     return ray.disconnect()

--- a/python/ray/util/client_connect.py
+++ b/python/ray/util/client_connect.py
@@ -35,5 +35,5 @@ def connect(conn_str: str,
 
 
 def disconnect():
-    """This command is idempotent."""
+    """Disconnects from server; is idempotent."""
     return ray.disconnect()


### PR DESCRIPTION

## Why are these changes needed?

Previously, client is_connected would return False even if `APIstub.client_worker is not None`.
You would not be able to actually remove the client worker because disconnect would fail.

It is easiest (also seems harmless) to make client.disconnect() idempotent and always execute the full disconnect routine.

cc @yuduber


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(