### PR TITLE
[Docker][GPU] Keep CUDA Tooling

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -3,6 +3,8 @@
 # The GPU option is nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04
 ARG BASE_IMAGE="ubuntu:focal"
 FROM ${BASE_IMAGE}
+# FROM directive resets ARG
+ARG BASE_IMAGE
 # If this arg is not "autoscaler" then no autoscaler requirements will be included
 ARG AUTOSCALER="autoscaler"
 ENV TZ=America/Los_Angeles
@@ -61,7 +63,10 @@ RUN sudo apt-get update -y && sudo apt-get upgrade -y \
     # AttributeError: 'numpy.ufunc' object has no attribute '__module__'
     && $HOME/anaconda3/bin/pip uninstall -y dask \ 
     # We install cmake temporarily to get psutil, blist & atari-py
-    && sudo apt-get autoremove -y cmake g++ zlib1g-dev \
+    && sudo apt-get autoremove -y cmake zlib1g-dev \
+        # We keep g++ on GPU images, because uninstalling removes CUDA Devel tooling
+        $(if [ "$BASE_IMAGE" = "ubuntu:focal" ]; then echo \
+        g++; fi) \
     # Either install kubectl or remove wget 
     && (if [ "$AUTOSCALER" = "autoscaler" ]; \
         then wget -O - -q https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add - \


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* This prevents the uninstallation of most CUDA devel tooling.
* Without this change:
```
$ docker run -it rayproject/base-deps:nightly-gpu ls /usr/local/cuda/bin
nvprof
```
* Whereas the base image has: 
```
$ docker run -it nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04 ls /usr/local/cuda/bin
bin2c		   cuda-gdb	   cudafe++   nvcc	    nvlink   ptxas
compute-sanitizer  cuda-gdbserver  cuobjdump  nvcc.profile  nvprof
crt		   cuda-memcheck   fatbinary  nvdisasm	    nvprune
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks
* Makes the changes of #15559 fruitful :) 

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
