### PR TITLE
[serve] Un-revert OpenAPI doc generation test

### DIFF
--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -1,6 +1,7 @@
 import time
 from typing import Any, List, Optional
 import tempfile
+import sys
 
 import pytest
 import inspect
@@ -346,6 +347,7 @@ def test_fastapi_duplicate_routes(serve_instance):
         assert resp.status_code == 404
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows")
 @pytest.mark.parametrize("route_prefix", [None, "/", "/subpath"])
 def test_doc_generation(serve_instance, route_prefix):
     app = FastAPI()

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -346,6 +346,64 @@ def test_fastapi_duplicate_routes(serve_instance):
         assert resp.status_code == 404
 
 
+@pytest.mark.parametrize("route_prefix", [None, "/", "/subpath"])
+def test_doc_generation(serve_instance, route_prefix):
+    app = FastAPI()
+
+    @serve.deployment(route_prefix=route_prefix)
+    @serve.ingress(app)
+    class App:
+        @app.get("/")
+        def func1(self, arg: str):
+            return "hello"
+
+    App.deploy()
+
+    if route_prefix is None:
+        prefix = "/App"
+    else:
+        prefix = route_prefix
+
+    if not prefix.endswith("/"):
+        prefix += "/"
+
+    r = requests.get(f"http://localhost:8000{prefix}openapi.json")
+    assert r.status_code == 200
+    assert len(r.json()["paths"]) == 1
+    assert "/" in r.json()["paths"]
+    assert len(r.json()["paths"]["/"]) == 1
+    assert "get" in r.json()["paths"]["/"]
+
+    r = requests.get(f"http://localhost:8000{prefix}docs")
+    assert r.status_code == 200
+
+    @serve.deployment(route_prefix=route_prefix)
+    @serve.ingress(app)
+    class App:
+        @app.get("/")
+        def func1(self, arg: str):
+            return "hello"
+
+        @app.post("/hello")
+        def func2(self, arg: int):
+            return "hello"
+
+    App.deploy()
+
+    r = requests.get(f"http://localhost:8000{prefix}openapi.json")
+    assert r.status_code == 200
+    assert len(r.json()["paths"]) == 2
+    assert "/" in r.json()["paths"]
+    assert len(r.json()["paths"]["/"]) == 1
+    assert "get" in r.json()["paths"]["/"]
+    assert "/hello" in r.json()["paths"]
+    assert len(r.json()["paths"]["/hello"]) == 1
+    assert "post" in r.json()["paths"]["/hello"]
+
+    r = requests.get(f"http://localhost:8000{prefix}docs")
+    assert r.status_code == 200
+
+
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Was reverted due to failing on windows, so skipping on windows.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
