### PR TITLE
[runtime_env] Deprecate working_dir_uri and use uris instead

### DIFF
--- a/python/ray/_private/runtime_env.py
+++ b/python/ray/_private/runtime_env.py
@@ -391,9 +391,8 @@ def rewrite_runtime_env_uris(job_config: JobConfig) -> None:
         job_config (JobConfig): The job config.
     """
     # For now, we only support local directory and packages
-    working_dir_uri = job_config.runtime_env.get("working_dir_uri")
-    if working_dir_uri is not None:
-        job_config.runtime_env["uris"] = [working_dir_uri]
+    uris = job_config.runtime_env.get("uris")
+    if uris is not None:
         return
     working_dir = job_config.runtime_env.get("working_dir")
     py_modules = job_config.runtime_env.get("py_modules")

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -441,7 +441,7 @@ def test_two_node_uri(two_node_cluster, working_dir, client_mode):
         pkg_uri = runtime_env.Protocol.PIN_GCS.value + "://" + pkg_name
         runtime_env.create_project_package(working_dir, [], [], tmp_file.name)
         runtime_env.push_package(pkg_uri, tmp_file.name)
-        runtime_env = f"""{{ "working_dir_uri": "{pkg_uri}" }}"""
+        runtime_env = f"""{{ "uris": ["{pkg_uri}"] }}"""
         # Execute the following cmd in driver with runtime_env
         execute_statement = "print(sum(ray.get([run_test.remote()] * 1000)))"
     script = driver_script.format(**locals())


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
We are trying to unify all resources into uris. Deprecate working_dir_uri here so that it can accept more kinds of resources.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
