### PR TITLE
[RLlib] Discussion 2022: PPO should auto-adjust `rollout_fragment_length` if other settings do not align with `train_batch_size`.

### DIFF
--- a/rllib/agents/ppo/ppo.py
+++ b/rllib/agents/ppo/ppo.py
@@ -125,12 +125,13 @@ def validate_config(config: TrainerConfigDict) -> None:
     # Check for mismatches between `train_batch_size` and
     # `rollout_fragment_length` and auto-adjust `rollout_fragment_length`
     # if necessary.
+    num_workers = config["num_workers"] or 1
     calculated_min_rollout_size = \
-        (config["num_workers"] or 1) * config["num_envs_per_worker"] * \
+        num_workers * config["num_envs_per_worker"] * \
         config["rollout_fragment_length"]
     if config["train_batch_size"] % calculated_min_rollout_size != 0:
         new_rollout_fragment_length = config["train_batch_size"] / (
-            config["num_workers"] * config["num_envs_per_worker"])
+            num_workers * config["num_envs_per_worker"])
         logger.warning(
             "`train_batch_size` ({}) cannot be achieved with your other "
             "settings (num_workers={} num_envs_per_worker={} "

--- a/rllib/agents/ppo/ppo.py
+++ b/rllib/agents/ppo/ppo.py
@@ -126,7 +126,7 @@ def validate_config(config: TrainerConfigDict) -> None:
     # `rollout_fragment_length` and auto-adjust `rollout_fragment_length`
     # if necessary.
     calculated_min_rollout_size = \
-        config["num_workers"] * config["num_envs_per_worker"] * \
+        (config["num_workers"] or 1) * config["num_envs_per_worker"] * \
         config["rollout_fragment_length"]
     if config["train_batch_size"] % calculated_min_rollout_size != 0:
         new_rollout_fragment_length = config["train_batch_size"] / (

--- a/rllib/agents/ppo/ppo.py
+++ b/rllib/agents/ppo/ppo.py
@@ -122,6 +122,26 @@ def validate_config(config: TrainerConfigDict) -> None:
                              config["sgd_minibatch_size"],
                              config["train_batch_size"]))
 
+    # Check for mismatches between `train_batch_size` and
+    # `rollout_fragment_length` and auto-adjust `rollout_fragment_length`
+    # if necessary.
+    calculated_min_rollout_size = \
+        config["num_workers"] * config["num_envs_per_worker"] * \
+        config["rollout_fragment_length"]
+    if config["train_batch_size"] % calculated_min_rollout_size != 0:
+        new_rollout_fragment_length = config["train_batch_size"] / (
+            config["num_workers"] * config["num_envs_per_worker"])
+        logger.warning(
+            "`train_batch_size` ({}) cannot be achieved with your other "
+            "settings (num_workers={} num_envs_per_worker={} "
+            "rollout_fragment_length={})! Auto-adjusting "
+            "`rollout_fragment_length` to {}.".format(
+                config["train_batch_size"], config["num_workers"],
+                config["num_envs_per_worker"],
+                config["rollout_fragment_length"],
+                new_rollout_fragment_length))
+        config["rollout_fragment_length"] = new_rollout_fragment_length
+
     # Episodes may only be truncated (and passed into PPO's
     # `postprocessing_fn`), iff generalized advantage estimation is used
     # (value function estimate at end of truncated episode to estimate

--- a/rllib/agents/ppo/ppo.py
+++ b/rllib/agents/ppo/ppo.py
@@ -130,7 +130,7 @@ def validate_config(config: TrainerConfigDict) -> None:
         num_workers * config["num_envs_per_worker"] * \
         config["rollout_fragment_length"]
     if config["train_batch_size"] % calculated_min_rollout_size != 0:
-        new_rollout_fragment_length = config["train_batch_size"] / (
+        new_rollout_fragment_length = config["train_batch_size"] // (
             num_workers * config["num_envs_per_worker"])
         logger.warning(
             "`train_batch_size` ({}) cannot be achieved with your other "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

To avoid confusion about batch sizes being very different in `Policy.learn_on_batch` from the given `train_batch_size`, PPO should auto-adjust `rollout_fragment_length` is other settings do not align with `train_batch_size`.

Also see this discussion here:
https://discuss.ray.io/t/batch-size-for-complete-episodes-issue/2022/2

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
