### PR TITLE
[tune] Reduce default number of maximum pending trials to max(16, cluster_cpus)

### DIFF
--- a/doc/source/tune/user-guide.rst
+++ b/doc/source/tune/user-guide.rst
@@ -807,7 +807,7 @@ These are the environment variables Ray Tune currently considers:
 * **TUNE_MAX_LEN_IDENTIFIER**: Maximum length of trial subdirectory names (those
   with the parameter values in them)
 * **TUNE_MAX_PENDING_TRIALS_PG**: Maximum number of pending trials when placement groups are used. Defaults
-  to ``auto``, which will be updated to ``1000`` for random/grid search and ``1`` for any other search algorithms.
+  to ``auto``, which will be updated to ``max(16, cluster_cpus * 1.1)`` for random/grid search and ``1`` for any other search algorithms.
 * **TUNE_PLACEMENT_GROUP_AUTO_DISABLED**: Ray Tune automatically uses placement groups
   instead of the legacy resource requests. Setting this to 1 enables legacy placement.
 * **TUNE_PLACEMENT_GROUP_CLEANUP_DISABLED**: Ray Tune cleans up existing placement groups

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -211,6 +211,7 @@ class ProgressReporterTest(unittest.TestCase):
         os.environ["TUNE_PLACEMENT_GROUP_WAIT_S"] = "5"
         # Block for results even when placement groups are pending
         os.environ["TUNE_TRIAL_STARTUP_GRACE_PERIOD"] = "0"
+        os.environ["TUNE_MAX_PENDING_TRIALS_PG"] = "auto"
 
     def mock_trial(self, status, i):
         mock = MagicMock()
@@ -409,6 +410,7 @@ class ProgressReporterTest(unittest.TestCase):
     def testEndToEndReporting(self):
         try:
             os.environ["_TEST_TUNE_TRIAL_UUID"] = "xxxxx"
+            os.environ["TUNE_MAX_PENDING_TRIALS_PG"] = "100"
             output = run_string_as_driver(END_TO_END_COMMAND)
             try:
                 assert EXPECTED_END_TO_END_START in output

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -9,6 +9,7 @@ import time
 import traceback
 import warnings
 
+import ray
 from ray.util import get_node_ip_address
 from ray.tune import TuneError
 from ray.tune.callback import CallbackList
@@ -219,7 +220,22 @@ class TrialRunner:
         if max_pending_trials == "auto":
             # Auto detect
             if isinstance(self._search_alg, BasicVariantGenerator):
-                self._max_pending_trials = 1000
+                # Use a minimum of 16 to trigger fast autoscaling
+                # Scale up to at most the number of available cluster CPUs
+                cluster_cpus = ray.cluster_resources().get("CPU", 1.)
+                self._max_pending_trials = max(16, cluster_cpus)
+
+                if self._max_pending_trials > 128:
+                    logger.warning(
+                        f"The maximum number of pending trials has been "
+                        f"automatically set to the number of available "
+                        f"cluster CPUs, which is high "
+                        f"({self._max_pending_trials} CPUs/pending trials). "
+                        f"If you're running an experiment with a large number "
+                        f"of trials, this could lead to scheduling overhead. "
+                        f"In this case, consider setting the "
+                        f"`TUNE_MAX_PENDING_TRIALS_PG` environment variable "
+                        f"to the desired maximum number of concurrent trials.")
             else:
                 self._max_pending_trials = 1
         else:

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -223,7 +223,7 @@ class TrialRunner:
                 # Use a minimum of 16 to trigger fast autoscaling
                 # Scale up to at most the number of available cluster CPUs
                 cluster_cpus = ray.cluster_resources().get("CPU", 1.)
-                self._max_pending_trials = max(16, cluster_cpus)
+                self._max_pending_trials = max(16, int(cluster_cpus * 1.1))
 
                 if self._max_pending_trials > 128:
                     logger.warning(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The default number of 1000 pending trials for random search leads to unnecessary logs being produced and scheduling overhead, as well as clogging and growing the gcs_server.out logfile to gigabytes when running long running trials.

1000 trials were chosen to ensure that autoscaling can be aggressively triggered. This PR instead sets a minimum of 16 pending trials to enforce a lower bound of autoscaling behavior. If the number of available cluster CPUs is higher than this number, the number of available CPUs is used instead. If this is a high number, a warning is raised.

To trigger more aggressive autoscaling behavior, users will have to set the `TUNE_MAX_PENDING_TRIALS_PG` environment variable.

cc @ericl @max0x7ba 

## Related issue number

Addresses #15504
Addresses #15595
Addresses https://discuss.ray.io/t/ray-tune-log-grows-extremely-large/1992/3

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
