### PR TITLE
[hotfix] Fix worker setup hook default when starting Ray from CLI

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -997,7 +997,8 @@ def import_attr(full_path: str):
     Returns:
         Imported attr
     """
-
+    if full_path is None:
+        raise TypeError("import path cannot be None")
     last_period_idx = full_path.rfind(".")
     attr_name = full_path[last_period_idx + 1:]
     module_name = full_path[:last_period_idx]

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -447,7 +447,7 @@ def debug(address):
 @click.option(
     "--worker-setup-hook",
     hidden=True,
-    default=None,
+    default=ray_constants.DEFAULT_WORKER_SETUP_HOOK,
     type=str,
     help="Module path to the Python function that will be used to set up the "
     "environment for the worker process.")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
The default worker setup hook was only being set in `ray.init()`, not when calling `ray start --head`.  In `ray start --head` it was being set to None when it should have been set to `ray_constants.DEFAULT_WORKER_SETUP_HOOK`, which is `"ray.workers.setup_runtime_env.setup"`.  This PR fixes this oversight.
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/15637
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] Tested manually
