### PR TITLE
[Serve] Fix a small bug for mounted fastapi app

### DIFF
--- a/python/ray/serve/http_util.py
+++ b/python/ray/serve/http_util.py
@@ -253,6 +253,8 @@ def make_fastapi_class_based_view(fastapi_app, cls: Type) -> None:
     # Remove endpoints that belong to other class based views.
     routes = fastapi_app.routes
     for route in routes:
+        if not isinstance(route, APIRoute):
+            continue
         serve_cls = getattr(route.endpoint, "_serve_cls", None)
         if serve_cls is not None and serve_cls != cls:
             routes.remove(route)

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -312,6 +312,27 @@ def test_fastapi_features(serve_instance):
     assert resp.headers["access-control-allow-origin"] == "*", resp.headers
 
 
+def test_fast_api_mounted_app(serve_instance):
+    app = FastAPI()
+    subapp = FastAPI()
+
+    @subapp.get("/hi")
+    def hi():
+        return "world"
+
+    app.mount("/mounted", subapp)
+
+    @serve.deployment(route_prefix="/api")
+    @serve.ingress(app)
+    class A:
+        pass
+
+    A.deploy()
+
+    assert requests.get(
+        "http://localhost:8000/api/mounted/hi").json() == "world"
+
+
 def test_fastapi_duplicate_routes(serve_instance):
     app = FastAPI()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
```python
Traceback (most recent call last):
--
  | File "run_serve.py", line 6, in <module>
  | @serve.ingress(app)
  | File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/serve/api.py", line 967, in decorator
  | make_fastapi_class_based_view(app, cls)
  | File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/serve/http_util.py", line 256, in make_fastapi_class_based_view
  | serve_cls = getattr(route.endpoint, "_serve_cls", None)
  | AttributeError: 'Mount' object has no attribute 'endpoint'
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
