### PR TITLE
[autoscaler][kubernetes] Restart after head failure, more consistent operator restart behavior.

### DIFF
--- a/doc/source/cluster/kubernetes-manual.rst
+++ b/doc/source/cluster/kubernetes-manual.rst
@@ -32,7 +32,7 @@ Starting a Ray Cluster
 
 
 A Ray cluster consists of a single head node and a set of worker nodes (the
-provided ``ray-cluster.yaml`` file will start 3 worker nodes). In the example
+provided `ray-cluster.yaml <https://github.com/ray-project/ray/blob/master/doc/kubernetes/ray-cluster.yaml>`__ file will start 3 worker nodes). In the example
 Kubernetes configuration, this is implemented as:
 
 - A ``ray-head`` `Kubernetes Service`_ that enables the worker nodes to discover the location of the head node on start up.

--- a/python/ray/autoscaler/_private/_kubernetes/config.py
+++ b/python/ray/autoscaler/_private/_kubernetes/config.py
@@ -62,7 +62,11 @@ def bootstrap_kubernetes(config):
             "currently supported. Please set "
             "'use_internal_ips' to false.")
 
-    namespace = _configure_namespace(config["provider"])
+    if config["provider"].get("_operator"):
+        namespace = config["provider"]["namespace"]
+    else:
+        namespace = _configure_namespace(config["provider"])
+
     _configure_services(namespace, config["provider"])
 
     if not config["provider"].get("_operator"):

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -610,8 +610,10 @@ def get_or_create_head_node(config: Dict[str, Any],
         head_node_resources = head_config.get("resources")
 
     launch_hash = hash_launch_conf(head_node_config, config["auth"])
+    launching_new_head = False
     if head_node is None or provider.node_tags(head_node).get(
             TAG_RAY_LAUNCH_CONFIG) != launch_hash:
+        launching_new_head = True
         with cli_logger.group("Acquiring an up-to-date head node"):
             global_event_system.execute_callback(
                 CreateClusterEvent.acquiring_new_head_node)
@@ -680,7 +682,9 @@ def get_or_create_head_node(config: Dict[str, Any],
             else:
                 setup_commands = []
             ray_start_commands = config["head_start_ray_commands"]
-        elif no_restart:
+        # If user passed in --no-restart and we're not launching a new head,
+        # omit start commands.
+        elif no_restart and not launching_new_head:
             setup_commands = config["head_setup_commands"]
             ray_start_commands = []
         else:

--- a/python/ray/autoscaler/_private/constants.py
+++ b/python/ray/autoscaler/_private/constants.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from ray.ray_constants import (  # noqa F401
     AUTOSCALER_RESOURCE_REQUEST_CHANNEL, DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES,
@@ -8,7 +9,11 @@ from ray.ray_constants import (  # noqa F401
 
 def env_integer(key, default):
     if key in os.environ:
-        return int(os.environ[key])
+        val = os.environ[key]
+        if val == "inf":
+            return sys.maxsize
+        else:
+            return int(os.environ[key])
     return default
 
 

--- a/python/ray/autoscaler/_private/constants.py
+++ b/python/ray/autoscaler/_private/constants.py
@@ -13,7 +13,7 @@ def env_integer(key, default):
         if val == "inf":
             return sys.maxsize
         else:
-            return int(os.environ[key])
+            return int(val)
     return default
 
 

--- a/python/ray/autoscaler/kubernetes/operator_configs/cluster_crd.yaml
+++ b/python/ray/autoscaler/kubernetes/operator_configs/cluster_crd.yaml
@@ -18,7 +18,7 @@ spec:
     additionalPrinterColumns:
       - name: status
         type: string
-        description: Running, Error, or AutoscalingExceptionRecovery
+        description: Updating, Running, Error, or AutoscalingExceptionRecovery
         jsonPath: .status.phase
       - name: restarts
         type: integer
@@ -38,7 +38,7 @@ spec:
             type: object
             properties:
               phase:
-                description: Running, Error, or AutoscalingExceptionRecovery
+                description: Updating, Running, Error, or AutoscalingExceptionRecovery
                 type: string
               autoscalerRetries:
                 description: Number of Ray cluster restarts triggered by autoscaler failure.

--- a/python/ray/autoscaler/kubernetes/operator_configs/cluster_crd.yaml
+++ b/python/ray/autoscaler/kubernetes/operator_configs/cluster_crd.yaml
@@ -18,8 +18,12 @@ spec:
     additionalPrinterColumns:
       - name: status
         type: string
-        description: Running or Error
+        description: Running, Error, or AutoscalingExceptionRecovery
         jsonPath: .status.phase
+      - name: restarts
+        type: integer
+        description: Number of Ray cluster restarts triggered by autoscaler failure.
+        jsonPath: .status.autoscalerRetries
       - name: age
         type: date
         jsonPath: .metadata.creationTimestamp

--- a/python/ray/autoscaler/kubernetes/operator_configs/cluster_crd.yaml
+++ b/python/ray/autoscaler/kubernetes/operator_configs/cluster_crd.yaml
@@ -18,7 +18,7 @@ spec:
     additionalPrinterColumns:
       - name: status
         type: string
-        description: Running, Error, or AutoscalingExceptionRecovery
+        description: Unitialized, Running, Error, or AutoscalingExceptionRecovery
         jsonPath: .status.phase
       - name: restarts
         type: integer
@@ -40,9 +40,11 @@ spec:
               phase:
                 description: Running, Error, or AutoscalingExceptionRecovery
                 type: string
+                default: "Uninitialized"
               autoscalerRetries:
                 description: Number of Ray cluster restarts triggered by autoscaler failure.
                 type: integer
+                default: 0
           spec:
             type: object
             required:

--- a/python/ray/autoscaler/kubernetes/operator_configs/cluster_crd.yaml
+++ b/python/ray/autoscaler/kubernetes/operator_configs/cluster_crd.yaml
@@ -34,8 +34,11 @@ spec:
             type: object
             properties:
               phase:
-                description: Running or Error
+                description: Running, Error, or AutoscalingExceptionRecovery
                 type: string
+              autoscalerRetries:
+                description: Number of Ray cluster restarts triggered by autoscaler failure.
+                type: integer
           spec:
             type: object
             required:

--- a/python/ray/autoscaler/kubernetes/operator_configs/cluster_crd.yaml
+++ b/python/ray/autoscaler/kubernetes/operator_configs/cluster_crd.yaml
@@ -18,7 +18,7 @@ spec:
     additionalPrinterColumns:
       - name: status
         type: string
-        description: Unitialized, Running, Error, or AutoscalingExceptionRecovery
+        description: Running, Error, or AutoscalingExceptionRecovery
         jsonPath: .status.phase
       - name: restarts
         type: integer
@@ -40,11 +40,9 @@ spec:
               phase:
                 description: Running, Error, or AutoscalingExceptionRecovery
                 type: string
-                default: "Uninitialized"
               autoscalerRetries:
                 description: Number of Ray cluster restarts triggered by autoscaler failure.
                 type: integer
-                default: 0
           spec:
             type: object
             required:

--- a/python/ray/autoscaler/kubernetes/operator_configs/operator_cluster_scoped.yaml
+++ b/python/ray/autoscaler/kubernetes/operator_configs/operator_cluster_scoped.yaml
@@ -47,6 +47,9 @@ spec:
         imagePullPolicy: Always
         image: rayproject/ray:nightly
         command: ["ray-operator"]
+        env:
+        - name: AUTOSCALER_MAX_NUM_FAILURES
+          value: "999999"
         resources:
           requests:
             cpu: 1

--- a/python/ray/autoscaler/kubernetes/operator_configs/operator_cluster_scoped.yaml
+++ b/python/ray/autoscaler/kubernetes/operator_configs/operator_cluster_scoped.yaml
@@ -49,7 +49,7 @@ spec:
         command: ["ray-operator"]
         env:
         - name: AUTOSCALER_MAX_NUM_FAILURES
-          value: "999999"
+          value: "inf"
         resources:
           requests:
             cpu: 1

--- a/python/ray/autoscaler/kubernetes/operator_configs/operator_namespaced.yaml
+++ b/python/ray/autoscaler/kubernetes/operator_configs/operator_namespaced.yaml
@@ -50,6 +50,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: AUTOSCALER_MAX_NUM_FAILURES
+          value: "999999"
         resources:
           requests:
             cpu: 1

--- a/python/ray/autoscaler/kubernetes/operator_configs/operator_namespaced.yaml
+++ b/python/ray/autoscaler/kubernetes/operator_configs/operator_namespaced.yaml
@@ -51,7 +51,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: AUTOSCALER_MAX_NUM_FAILURES
-          value: "999999"
+          value: "inf"
         resources:
           requests:
             cpu: 1

--- a/python/ray/ray_operator/operator.py
+++ b/python/ray/ray_operator/operator.py
@@ -29,13 +29,21 @@ cluster_status_q = mp.Queue()  # type: mp.Queue[Tuple[str, str, str]]
 
 
 class RayCluster():
+    """Manages an autoscaling Ray cluster.
+
+    Attributes:
+        config: Autoscaling configuration dict.
+        subprocess: The subprocess used to create, update, and monitor the
+        Ray cluster.
+    """
+
     def __init__(self, config: Dict[str, Any]):
         self.set_config(config)
         self.name = self.config["cluster_name"]
         self.namespace = self.config["provider"]["namespace"]
 
         # Make directory for configs of clusters in the namespace,
-        # if the director doesn't exist already.
+        # if the directory doesn't exist already.
         namespace_dir = operator_utils.namespace_dir(self.namespace)
         if not os.path.isdir(namespace_dir):
             os.mkdir(namespace_dir)
@@ -51,6 +59,7 @@ class RayCluster():
         # autoscaler failure.
         self._num_retries = 0
 
+        # Monitor subprocess
         self.subprocess = None  # type: Optional[mp.Process]
         # Monitor logs for this cluster will be prefixed by the monitor
         # subprocess name:
@@ -59,36 +68,16 @@ class RayCluster():
 
         self.setup_logging()
 
-    def set_config(self, config: Dict[str, Any]) -> None:
-        self.config = config
-
-    def set_generation(self, generation: int) -> None:
-        self._generation = generation
-
-    def set_num_retries(self, num_retries: int) -> None:
-        self._num_retries = num_retries
-
-    def get_generation(self) -> int:
-        return self._generation
-
-    def get_num_retries(self) -> int:
-        return self._num_retries
-
-    def do_in_subprocess(self, f: Callable[[], None], args: Tuple) -> None:
-        # First stop the subprocess if it's alive
-        self.clean_up_subprocess()
-        # Reinstantiate process with f as target and start.
-        self.subprocess = mp.Process(
-            name=self.subprocess_name, target=f, args=args, daemon=True)
-        self.subprocess.start()
-
-    def clean_up_subprocess(self):
-        if self.subprocess and self.subprocess.is_alive():
-            self.monitor_stop_event.set()
-            self.subprocess.join()
-            self.monitor_stop_event.clear()
-
     def create_or_update(self, restart_ray: bool = False) -> None:
+        """ Create/update the Ray Cluster and run the monitoring loop, all in a
+        subprocess.
+
+        The main function of the Operator is managing the
+        subprocesses started by this method.
+
+        Args:
+            restart_ray: If True, restarts Ray to recover from failure.
+        """
         self.do_in_subprocess(self._create_or_update, args=(restart_ray, ))
 
     def _create_or_update(self, restart_ray: bool = False) -> None:
@@ -99,12 +88,16 @@ class RayCluster():
             # Report failed autoscaler status to trigger cluster restart.
             cluster_status_q.put((self.name, self.namespace,
                                   STATUS_AUTOSCALING_EXCEPTION))
+            # `status_handling_loop` will increment the
+            # `status.AutoscalerRetries` of the CR. A restart will trigger
+            # at the subsequent "MODIFIED" event.
             raise
 
     def start_head(self, restart_ray: bool = False) -> None:
         self.write_config()
         # Don't restart Ray on head unless recovering from failure.
         no_restart = not restart_ray
+        # Create or update cluster head and record config side effects.
         self.config = commands.create_or_update_cluster(
             self.config_path,
             override_min_workers=None,
@@ -114,9 +107,11 @@ class RayCluster():
             yes=True,
             no_config_cache=True,
             no_monitor_on_head=True)
+        # Write the resulting config for use by the autoscaling monitor:
         self.write_config()
 
     def start_monitor(self) -> None:
+        """Runs the autoscaling monitor."""
         ray_head_pod_ip = commands.get_head_node_ip(self.config_path)
         port = operator_utils.infer_head_port(self.config)
         redis_address = services.address(ray_head_pod_ip, port)
@@ -128,7 +123,33 @@ class RayCluster():
             stop_event=self.monitor_stop_event)
         self.mtr.run()
 
+    def do_in_subprocess(self, f: Callable[[], None], args: Tuple) -> None:
+        # First stop the subprocess if it's alive
+        self.clean_up_subprocess()
+        # Reinstantiate process with f as target and start.
+        self.subprocess = mp.Process(
+            name=self.subprocess_name, target=f, args=args, daemon=True)
+        self.subprocess.start()
+
+    def clean_up_subprocess(self):
+        """
+        Clean up the monitor process.
+
+        Executed when CR for this cluster is "DELETED".
+        Executed when Autoscaling monitor is restarted.
+        """
+        if self.subprocess and self.subprocess.is_alive():
+            # Triggers graceful stop of the monitor loop.
+            self.monitor_stop_event.set()
+            self.subprocess.join()
+            # Clears the event for subsequent runs of the monitor.
+            self.monitor_stop_event.clear()
+
     def clean_up(self) -> None:
+        """Executed when the CR for this cluster is "DELETED".
+
+        The key thing is to end the monitoring subprocess.
+        """
         self.clean_up_subprocess()
         self.clean_up_logging()
         self.delete_config()
@@ -150,12 +171,28 @@ class RayCluster():
     def clean_up_logging(self) -> None:
         operator_utils.root_logger.removeHandler(self.handler)
 
+    def set_config(self, config: Dict[str, Any]) -> None:
+        self.config = config
+
     def write_config(self) -> None:
+        """Write config to disk for use by the autoscaling monitor."""
         with open(self.config_path, "w") as file:
             yaml.dump(self.config, file)
 
     def delete_config(self) -> None:
         os.remove(self.config_path)
+
+    def set_generation(self, generation: int) -> None:
+        self._generation = generation
+
+    def set_num_retries(self, num_retries: int) -> None:
+        self._num_retries = num_retries
+
+    def get_generation(self) -> int:
+        return self._generation
+
+    def get_num_retries(self) -> int:
+        return self._num_retries
 
 
 # Maps ray cluster (name, namespace) pairs to RayCluster python objects.
@@ -232,7 +269,7 @@ def cluster_action(event_type: str, cluster_cr: Dict[str, Any],
         autoscaler_retries = status.get(AUTOSCALER_RETRIES_FIELD, 0)
 
         # True if there's been a chamge to the spec of the custom resource,
-        # triggering an increment of metadata.generation.
+        # triggering an increment of metadata.generation:
         spec_changed = current_generation > ray_cluster.get_generation()
         # True if monitor has failed, triggering an increment of
         # status.autoscalerRetries:
@@ -249,6 +286,7 @@ def cluster_action(event_type: str, cluster_cr: Dict[str, Any],
         # recovery from autoscaler failure.
         if spec_changed or ray_restart_required:
             ray_cluster.set_config(cluster_config)
+            # Trigger Ray restart only if there's been a failure.
             ray_cluster.create_or_update(restart_ray=ray_restart_required)
             cluster_status_q.put((cluster_name, cluster_namespace,
                                   STATUS_RUNNING))

--- a/python/ray/ray_operator/operator.py
+++ b/python/ray/ray_operator/operator.py
@@ -244,8 +244,7 @@ def cluster_action(event_type: str, cluster_cr: Dict[str, Any],
         if spec_changed or retry_required:
             ray_cluster.set_config(cluster_config)
             ray_cluster.create_or_update()
-
-        cluster_status_q.put((cluster_name, cluster_namespace, STATUS_RUNNING))
+            cluster_status_q.put((cluster_name, cluster_namespace, STATUS_RUNNING))
 
     elif event_type == "DELETED":
         ray_cluster = ray_clusters[cluster_identifier]

--- a/python/ray/ray_operator/operator.py
+++ b/python/ray/ray_operator/operator.py
@@ -39,7 +39,7 @@ class RayCluster():
     """
 
     def __init__(self, config: Dict[str, Any]):
-        self.set_config(config)
+        self.config = config
         self.name = self.config["cluster_name"]
         self.namespace = self.config["provider"]["namespace"]
 

--- a/python/ray/ray_operator/operator_utils.py
+++ b/python/ray/ray_operator/operator_utils.py
@@ -268,7 +268,7 @@ def _set_status(cluster_name: str, cluster_namespace: str,
             name=cluster_name)
     status = cluster_cr.get("status", {})
     autoscaler_retries = status.get(AUTOSCALER_RETRIES_FIELD, 0)
-    if status == STATUS_AUTOSCALING_EXCEPTION:
+    if phase == STATUS_AUTOSCALING_EXCEPTION:
         autoscaler_retries += 1
     cluster_cr["status"] = {"phase": phase,
                             AUTOSCALER_RETRIES_FIELD: autoscaler_retries}

--- a/python/ray/ray_operator/operator_utils.py
+++ b/python/ray/ray_operator/operator_utils.py
@@ -24,6 +24,7 @@ RAYCLUSTER_PLURAL = "rayclusters"
 STATUS_AUTOSCALING_EXCEPTION = "AutoscalingExceptionRecovery"
 STATUS_ERROR = "Error"
 STATUS_RUNNING = "Running"
+STATUS_UPDATING = "Running"
 AUTOSCALER_RETRIES_FIELD = "autoscalerRetries"
 
 MAX_STATUS_RETRIES = 3

--- a/python/ray/ray_operator/operator_utils.py
+++ b/python/ray/ray_operator/operator_utils.py
@@ -257,8 +257,7 @@ def set_status(cluster_name: str, cluster_namespace: str, status: str) -> None:
     _set_status(cluster_name, cluster_namespace, status)
 
 
-def _set_status(cluster_name: str, cluster_namespace: str,
-                phase: str) -> None:
+def _set_status(cluster_name: str, cluster_namespace: str, phase: str) -> None:
     cluster_cr = custom_objects_api()\
         .get_namespaced_custom_object(
             namespace=cluster_namespace,
@@ -270,8 +269,10 @@ def _set_status(cluster_name: str, cluster_namespace: str,
     autoscaler_retries = status.get(AUTOSCALER_RETRIES_FIELD, 0)
     if phase == STATUS_AUTOSCALING_EXCEPTION:
         autoscaler_retries += 1
-    cluster_cr["status"] = {"phase": phase,
-                            AUTOSCALER_RETRIES_FIELD: autoscaler_retries}
+    cluster_cr["status"] = {
+        "phase": phase,
+        AUTOSCALER_RETRIES_FIELD: autoscaler_retries
+    }
     custom_objects_api()\
         .patch_namespaced_custom_object_status(namespace=cluster_namespace,
                                                group=RAY_API_GROUP,

--- a/python/ray/tests/kubernetes_e2e/test_k8s_operator_examples.py
+++ b/python/ray/tests/kubernetes_e2e/test_k8s_operator_examples.py
@@ -165,7 +165,6 @@ def num_services():
 
 class KubernetesOperatorTest(unittest.TestCase):
     def test_examples(self):
-        print("\n")
         # Validate terminate_node error handling
         provider = KubernetesNodeProvider({
             "namespace": NAMESPACE
@@ -226,7 +225,7 @@ class KubernetesOperatorTest(unittest.TestCase):
                 file.flush()
 
             # Start operator and two clusters
-            print(">>>Starting operator and two clusters.")
+            print("\n>>>Starting operator and two clusters.")
             for file in files:
                 cmd = f"kubectl -n {NAMESPACE} apply -f {file.name}"
                 subprocess.check_call(cmd, shell=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR allows the Kubernetes operator to restart Ray clusters after head failure.
The update/restart behavior of the operator Deployment is also improved. 
Very small API change to Ray up.

Details:

1. If a Ray cluster's head pod fails or there's a failure of critical Ray head processes, then
    * All Ray processes in the Ray cluster will terminate
    * The Ray cluster will restart with a healthy head pod
2. If the operator Deployment restarts, Ray clusters will be unaffected.
3. Edits to a Ray cluster's CRD will only result in a Ray cluster restart if the head podConfig is edited.    

The mechanism for the head restart behavior in 1. above is this: Ray head failure causes monitor failure, which is detected and used to trigger a restart. In particular, 

4. If the operator pod does not restart, but the monitor subprocess managing a Ray cluster fails, then the behavior will be the same as 1.
5. However, autoscaler errors will not lead to monitor failure. (`AUTOSCALER_MAX_NUM_FAILURES` set to infinity for the K8s operator). 
6. Slight API change to Ray up: If you pass flag "no-restart" but a new head node is launched, ray start commands will run. (In the current setup, you'd get a head node with no ray processes.)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/15608
Closes https://github.com/ray-project/ray/issues/14634

Random doc fix:
Closes https://github.com/ray-project/ray/issues/14837

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
