### PR TITLE
[dashboard] Avoid global min_workers

### DIFF
--- a/dashboard/modules/reporter/reporter_head.py
+++ b/dashboard/modules/reporter/reporter_head.py
@@ -77,8 +77,8 @@ class ReportHead(dashboard_utils.DashboardHeadModule):
                     message="Invalid config, could not load YAML.")
 
             payload = {
-                "min_workers": cfg["min_workers"],
-                "max_workers": cfg["max_workers"]
+                "min_workers": cfg.get("min_workers", "unspecified"),
+                "max_workers": cfg.get("max_workers", "unspecified")
             }
 
             try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* `min_workers` is deprecated and shouldn't be expected to be present.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
