### PR TITLE
[Serve] Move the doc warning location

### DIFF
--- a/doc/source/serve/index.rst
+++ b/doc/source/serve/index.rst
@@ -1,3 +1,9 @@
+.. _rayserve:
+
+============================================
+Ray Serve: Scalable and Programmable Serving
+============================================
+
 .. warning::
   Ray Serve is changing fast!  You're probably running the latest pip release and not the nightly build, so please ensure you're viewing the correct version of this documentation.
   `Here's the documentation for the latest pip release of Ray Serve <https://docs.ray.io/en/latest/serve/index.html>`_.
@@ -6,11 +12,6 @@
 .. warning::
   As of Ray 1.4, Serve has a new API centered around the concept of "Deployments." Deployments offer a more streamlined API and can be declaratively updated, which should improve both development and production workflows. The existing APIs have not changed from Ray 1.4 and will continue to work until Ray 1.5, at which point they will be removed (see the package reference if you're not sure about a specific API). Please see the `migration guide <https://docs.google.com/document/d/1Tgm-bHz6au0B8F_Ps0SLPXh9oyw8pIaGWKWunnK-Kuw>`_ for details on how to update your existing Serve application to use this new API and as always we welcome feedback on `Slack <https://docs.google.com/forms/u/1/d/e/1FAIpQLSfAcoiLCHOguOm8e7Jnn-JJdZaCxPGjgVCvFijHB5PLaQLeig/viewform?usp=send_form>`_, `GitHub <https://github.com/ray-project/ray/issues>`_, or the `Ray forum <http://discuss.ray.io/>`_!
 
-.. _rayserve:
-
-============================================
-Ray Serve: Scalable and Programmable Serving
-============================================
 
 .. image:: logo.svg
     :align: center


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Before, clicking Ray Serve  https://docs.ray.io/en/master/serve/index.html#rayserve directly jump to the title and hide the warnings.
![image](https://user-images.githubusercontent.com/21118851/117343285-fc689700-ae58-11eb-91de-0a0d987124bf.png)

After, the warnings are center and clear
![image](https://user-images.githubusercontent.com/21118851/117343334-08545900-ae59-11eb-923d-20a29626035f.png)


<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
