### PR TITLE
Add prepopulate plasma memory flag for debugging

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -101,6 +101,14 @@ RAY_CONFIG(size_t, free_objects_batch_size, 100)
 
 RAY_CONFIG(bool, lineage_pinning_enabled, false)
 
+/// Whether to re-populate plasma memory. This avoids memory allocation failures
+/// at runtime (SIGBUS errors creating new objects), however it will use more memory
+/// upfront and can slow down Ray startup.
+/// See also: https://github.com/ray-project/ray/issues/14182
+RAY_CONFIG(bool, preallocate_plasma_memory,
+           getenv("RAY_PREALLOCATE_PLASMA_MEMORY") != nullptr &&
+               getenv("RAY_PREALLOCATE_PLASMA_MEMORY") != std::string("0"))
+
 /// Pick between 2 scheduling spillback strategies. Load balancing mode picks the node at
 /// uniform random from the valid options. The other mode is more likely to spill back
 /// many tasks to the same node.

--- a/src/ray/object_manager/plasma/dlmalloc.cc
+++ b/src/ray/object_manager/plasma/dlmalloc.cc
@@ -63,6 +63,10 @@ int fake_munmap(void *, int64_t);
 #undef DEBUG
 #endif
 
+#ifndef MAP_POPULATE
+#define MAP_POPULATE 0
+#endif
+
 constexpr int GRANULARITY_MULTIPLIER = 2;
 
 static void *pointer_advance(void *p, ptrdiff_t n) { return (unsigned char *)p + n; }

--- a/src/ray/object_manager/plasma/dlmalloc.cc
+++ b/src/ray/object_manager/plasma/dlmalloc.cc
@@ -114,6 +114,9 @@ void create_and_mmap_buffer(int64_t size, void **pointer, int *fd) {
   // when mmapping the files. Only supported on Linux.
   auto flags = MAP_SHARED;
   if (RayConfig::instance().preallocate_plasma_memory()) {
+    if (!MAP_POPULATE) {
+      RAY_LOG(FATAL) << "MAP_POPULATE is not supported on this platform.";
+    }
     RAY_LOG(INFO) << "Preallocating all plasma memory using MAP_POPULATE.";
     flags |= MAP_POPULATE;
   }


### PR DESCRIPTION
This adds an experimental flag for debugging https://github.com/ray-project/ray/issues/14182

It may or may not be a long term solution. The problem is that pre-population can be pretty expensive, especially on a laptop. However, in production it is desirable to improve stability by preallocating all shared memory.