### PR TITLE
Remove unnecessary flaky branch of test_object_spilling_2 on OSX

### DIFF
--- a/python/ray/tests/test_object_spilling_2.py
+++ b/python/ray/tests/test_object_spilling_2.py
@@ -4,6 +4,7 @@ import random
 import platform
 import subprocess
 import sys
+import time
 from collections import defaultdict
 
 import numpy as np

--- a/python/ray/tests/test_object_spilling_2.py
+++ b/python/ray/tests/test_object_spilling_2.py
@@ -295,14 +295,13 @@ def do_test_release_resource(object_spilling_config, expect_released):
     def f(dep):
         while True:
             try:
-                ray.get(dep[0], timeout=0.01)
+                ray.get(dep[0], timeout=0.001)
             except ray.exceptions.GetTimeoutError:
                 pass
 
     done = f.remote([plasma_obj])  # noqa
-    time.sleep(2)
     canary = sneaky_task_tries_to_steal_released_resources.remote()
-    ready, _ = ray.wait([canary], timeout=5)
+    ready, _ = ray.wait([canary], timeout=2)
     if expect_released:
         assert ready
     else:
@@ -314,12 +313,6 @@ def do_test_release_resource(object_spilling_config, expect_released):
     platform.system() == "Windows", reason="Failing on Windows.")
 def test_no_release_during_plasma_fetch(object_spilling_config, shutdown_only):
     do_test_release_resource(object_spilling_config, expect_released=False)
-
-
-@pytest.mark.skipif(
-    platform.system() == "Windows", reason="Failing on Windows.")
-def test_release_during_plasma_fetch(object_spilling_config, shutdown_only):
-    do_test_release_resource(object_spilling_config, expect_released=True)
 
 
 @pytest.mark.skipif(

--- a/python/ray/tests/test_object_spilling_2.py
+++ b/python/ray/tests/test_object_spilling_2.py
@@ -4,7 +4,6 @@ import random
 import platform
 import subprocess
 import sys
-import time
 from collections import defaultdict
 
 import numpy as np

--- a/python/ray/tests/test_object_spilling_2.py
+++ b/python/ray/tests/test_object_spilling_2.py
@@ -294,13 +294,14 @@ def do_test_release_resource(object_spilling_config, expect_released):
     def f(dep):
         while True:
             try:
-                ray.get(dep[0], timeout=0.001)
+                ray.get(dep[0], timeout=0.01)
             except ray.exceptions.GetTimeoutError:
                 pass
 
     done = f.remote([plasma_obj])  # noqa
+    time.sleep(2)
     canary = sneaky_task_tries_to_steal_released_resources.remote()
-    ready, _ = ray.wait([canary], timeout=2)
+    ready, _ = ray.wait([canary], timeout=5)
     if expect_released:
         assert ready
     else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The path being tested is deprecated (the feature flag is only for debugging). Remove the test case for that path since it's flaky on OSX.