### PR TITLE
Add objectStore stats to dashboard API.

### DIFF
--- a/dashboard/datacenter.py
+++ b/dashboard/datacenter.py
@@ -168,8 +168,8 @@ class DataOrganizer:
 
         return node_info
 
-    @staticmethod
-    async def get_node_summary(node_id):
+    @classmethod
+    async def get_node_summary(cls, node_id):
         node_physical_stats = dict(
             DataSource.node_physical_stats.get(node_id, {}))
         node_stats = dict(DataSource.node_stats.get(node_id, {}))
@@ -177,11 +177,16 @@ class DataOrganizer:
 
         node_physical_stats.pop("workers", None)
         node_stats.pop("workersStats", None)
+        view_data = node_stats.get("viewData", [])
+        ray_stats = cls._extract_view_data(
+            view_data,
+            {"object_store_used_memory", "object_store_available_memory"})
         node_stats.pop("viewData", None)
 
         node_summary = node_physical_stats
         # Merge node stats to node physical stats
         node_summary["raylet"] = node_stats
+        node_summary["raylet"].update(ray_stats)
         # Merge GcsNodeInfo to node physical stats
         node_summary["raylet"].update(node)
 

--- a/dashboard/modules/stats_collector/tests/test_stats_collector.py
+++ b/dashboard/modules/stats_collector/tests/test_stats_collector.py
@@ -83,6 +83,8 @@ def test_node_info(disable_aiohttp_cache, ray_start_with_dashboard):
             assert "workers" not in summary
             assert "actors" not in summary
             assert "viewData" not in summary["raylet"]
+            assert "objectStoreAvailableMemory" in summary["raylet"]
+            assert "objectStoreUsedMemory" in summary["raylet"]
             break
         except Exception as ex:
             last_ex = ex


### PR DESCRIPTION
## Why are these changes needed?
Add objectStoreAvailableMemory and objectStoreUsedMemory to dashboard API '/nodes?view=summary'. After merge this, we can add a frontend view about object store memory in experimental dashboard.

## Related issue number

https://github.com/ray-project/ray/issues/13890