### PR TITLE
[tune] add `max_concurrent` option to BasicVariantGenerator

### DIFF
--- a/python/ray/tune/suggest/suggestion.py
+++ b/python/ray/tune/suggest/suggestion.py
@@ -342,6 +342,13 @@ class ConcurrencyLimiter(Searcher):
         self.batch = batch
         self.live_trials = set()
         self.cached_results = {}
+
+        if not isinstance(searcher, Searcher):
+            raise RuntimeError(
+                f"The `ConcurrencyLimiter` only works with `Searcher` "
+                f"objects (got {type(searcher)}). Please try to pass "
+                f"`max_concurrent` to the search generator directly.")
+
         super(ConcurrencyLimiter, self).__init__(
             metric=self.searcher.metric, mode=self.searcher.mode)
 

--- a/python/ray/tune/tests/test_trial_runner_3.py
+++ b/python/ray/tune/tests/test_trial_runner_3.py
@@ -15,6 +15,7 @@ from ray.tune import TuneError
 from ray.tune.result import TRAINING_ITERATION
 from ray.tune.schedulers import TrialScheduler, FIFOScheduler
 from ray.tune.experiment import Experiment
+from ray.tune.suggest import BasicVariantGenerator
 from ray.tune.trial import Trial
 from ray.tune.trial_runner import TrialRunner
 from ray.tune.resources import Resources, json_to_resources, resources_to_json
@@ -879,6 +880,51 @@ class SearchAlgorithmTest(unittest.TestCase):
         limiter2.on_trial_complete("test_1", {"result": 3})
         limiter2.on_trial_complete("test_2", {"result": 3})
         assert limiter2.suggest("test_3")["score"] == 3
+
+    def testBasicVariantLimiter(self):
+        search_alg = BasicVariantGenerator(max_concurrent=2)
+
+        experiment_spec = {
+            "run": "__fake",
+            "num_samples": 5,
+            "stop": {
+                "training_iteration": 1
+            }
+        }
+        search_alg.add_configurations({"test": experiment_spec})
+
+        trial1 = search_alg.next_trial()
+        self.assertTrue(trial1)
+
+        trial2 = search_alg.next_trial()
+        self.assertTrue(trial2)
+
+        # Returns None because of limiting
+        trial3 = search_alg.next_trial()
+        self.assertFalse(trial3)
+
+        # Finish trial, now trial 3 should be created
+        search_alg.on_trial_complete(trial1.trial_id, None, False)
+        trial3 = search_alg.next_trial()
+        self.assertTrue(trial3)
+
+        trial4 = search_alg.next_trial()
+        self.assertFalse(trial4)
+
+        search_alg.on_trial_complete(trial2.trial_id, None, False)
+        search_alg.on_trial_complete(trial3.trial_id, None, False)
+
+        trial4 = search_alg.next_trial()
+        self.assertTrue(trial4)
+
+        trial5 = search_alg.next_trial()
+        self.assertTrue(trial5)
+
+        search_alg.on_trial_complete(trial4.trial_id, None, False)
+
+        # Should also be None because search is finished
+        trial6 = search_alg.next_trial()
+        self.assertFalse(trial6)
 
     def testBatchLimiter(self):
         class TestSuggestion(Searcher):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Introduces concurrency limiting for random search. This can be useful to limit resource utilization (even though workarounds exist for this). 

Making the `ConcurrencyLimiter` work with the `BasicVariantGenerator` would require extensive refactoring of the latter. Instead we just add a `max_concurrent` option.

## Related issue number

Closes #15156

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
