### PR TITLE
[Core] Don't consider a worker to be idle if it has in-flight object pinning RPCs.

### DIFF
--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -409,7 +409,13 @@ void raylet::RayletClient::PinObjectIDs(
   for (const ObjectID &object_id : object_ids) {
     request.add_object_ids(object_id.Binary());
   }
-  grpc_client_->PinObjectIDs(request, callback);
+  pins_in_flight_++;
+  auto rpc_callback = [this, callback = std::move(callback)](
+                          Status status, const rpc::PinObjectIDsReply &reply) {
+    pins_in_flight_--;
+    callback(status, reply);
+  };
+  grpc_client_->PinObjectIDs(request, rpc_callback);
 }
 
 void raylet::RayletClient::GlobalGC(

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -424,6 +424,8 @@ class RayletClient : public RayletClientInterface {
 
   const ResourceMappingType &GetResourceIDs() const { return resource_ids_; }
 
+  int64_t GetPinsInFlight() const { return pins_in_flight_.load(); }
+
  private:
   /// gRPC client to the raylet. Right now, this is only used for a couple
   /// request types.
@@ -437,6 +439,9 @@ class RayletClient : public RayletClientInterface {
   ResourceMappingType resource_ids_;
   /// The connection to the raylet server.
   std::unique_ptr<RayletConnection> conn_;
+
+  /// The number of object ID pin RPCs currently in flight.
+  std::atomic_int64_t pins_in_flight_{0};
 };
 
 }  // namespace raylet


### PR DESCRIPTION
## Why are these changes needed?

When the raylet attempts to kill idle workers (workers with no assigned tasks), it sends an RPC to the candidate worker asking if it's truly idle. Currently, the worker only checks if it owns any objects that are still in scope, and considers itself to be idle if it does not. However, killing the worker while certain RPCs are outstanding can break e.g. the object pinning protocol, so we should also consider the worker to not be idle if it has such outstanding RPCs.

This PR adds tracking for outstanding object pinning RPCs, and changes the worker's idle logic to not consider itself idle unless it doesn't own any objects _and_ it doesn't have any object pinning RPCs currently in flight.

## Related issue number

Closes #14577

## TODOs

~- Test coverage: could we devise an e2e Python test that tests this new idle logic?~
~- Should any other outstandingRPCs be idle blockers?~

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
