### PR TITLE
[RLlib] fix tf2 multidiscrete action-dist logp when passed a numpy array

### DIFF
--- a/rllib/models/tf/tf_action_dist.py
+++ b/rllib/models/tf/tf_action_dist.py
@@ -136,6 +136,14 @@ class MultiCategorical(TFActionDistribution):
                 actions = tf.reshape(
                     actions, [-1, int(np.product(self.action_space.shape))])
             actions = tf.unstack(tf.cast(actions, tf.int32), axis=1)
+        if isinstance(actions, np.ndarray):
+            actions = actions.astype(np.int32)
+            if isinstance(self.action_space, gym.spaces.Box):
+                actions = np.reshape(
+                    actions, [-1, int(np.product(self.action_space.shape))])
+            actions = [
+                np.take(actions, i, axis=-1) for i in range(actions.shape[-1])
+            ]
         logps = tf.stack(
             [cat.logp(act) for cat, act in zip(self.cats, actions)])
         return tf.reduce_sum(logps, axis=0)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The tensorflow actiondist converts a multidiscrete action tensor into a list of action tensors for each discrete category in the multidiscrete. With the Tensorflow 2 curiosity exploration sometimes the actions passed in are of type np.ndarray instead of tf.Tensor. In those cases, the array is not reshaped and an error ensues in the subsequent zip of logits and actions. See the discussion in the issue below.

**QUESTION**
I based it on the code used in the check for a tf tensor but I am not sure why we are handling a Box action distribution inside the multidiscrete. Any thoughts or insights there?


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #15676
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [N/A] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :( I could not think of a way to test logp with a multidiscrete in tf2 and ensure it was passed a numpy array. I am open to adding one if an approach is suggested.
