### PR TITLE
[RLlib] ensure curiosity exploration actions are passed in as tf tens…

### DIFF
--- a/rllib/utils/exploration/curiosity.py
+++ b/rllib/utils/exploration/curiosity.py
@@ -290,7 +290,7 @@ class Curiosity(Exploration):
                     dist_inputs, self.model, self.action_space.nvec)
             # Neg log(p); p=probability of observed action given the inverse-NN
             # predicted action distribution.
-            inverse_loss = -action_dist.logp(actions)
+            inverse_loss = -action_dist.logp(tf.convert_to_tensor(actions))
             inverse_loss = tf.reduce_mean(inverse_loss)
 
             # Calculate the ICM loss.


### PR DESCRIPTION
…or when using tfe/tf2

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
When using tfe/tf2 the actions are passed into logp as a numpy array rather than a torch tensor. When the actions are multidiscrete, this prevents logp from converting them into a list of tensors for each category. 

This fix works with with tf1 and tfe/tf2. I wrote a unit test but did not include it in the commit because I was not sure if it was desired for an already fixed edge case. I am happy to add it to the PR on request.

## Related issue number
Closes #15676
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [N/A] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
