### PR TITLE
[RLlib] Do not deepcopy input dict for efficiency and consistency with similar methods.

### DIFF
--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -248,7 +248,8 @@ def deep_update(original,
 
 
 def flatten_dict(dt, delimiter="/", prevent_delimiter=False):
-    dt = copy.deepcopy(dt)
+    """Flatten dict."""
+    dt = copy.copy(dt)
     if prevent_delimiter and any(delimiter in key for key in dt):
         # Raise if delimiter is any of the keys
         raise ValueError(


### PR DESCRIPTION
## Why are these changes needed?

`flatten_dict` method used primarily for tensorboard logging is performing deepcopy of the input dict instead of shadow copy. It seems to be unnecessary, but maybe I missed a few edge cases. It may have a significant impact in performance on real world applications (~20%).

## Related issue number

Closes #15699

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
