### PR TITLE
[Serve] Fix ASGI Lifespan

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -24,8 +24,7 @@ from ray.serve.constants import (DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT,
 from ray.serve.controller import BackendTag, ReplicaTag, ServeController
 from ray.serve.exceptions import RayServeException
 from ray.serve.handle import RayServeHandle, RayServeSyncHandle
-from ray.serve.http_util import (ASGIHTTPSender, make_fastapi_class_based_view,
-                                 make_startup_shutdown_hooks)
+from ray.serve.http_util import (ASGIHTTPSender, make_fastapi_class_based_view)
 from ray.serve.utils import (ensure_serialization_context, format_actor_name,
                              get_current_node_resource_key, get_random_letters,
                              logger)

--- a/python/ray/serve/http_util.py
+++ b/python/ray/serve/http_util.py
@@ -2,7 +2,7 @@ import asyncio
 from dataclasses import dataclass
 import inspect
 import json
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Optional, Type
 
 import starlette.requests
 

--- a/python/ray/serve/http_util.py
+++ b/python/ray/serve/http_util.py
@@ -101,47 +101,6 @@ class Response:
         await send({"type": "http.response.body", "body": self.body})
 
 
-def make_startup_shutdown_hooks(app: Callable) -> Tuple[Callable, Callable]:
-    """Given ASGI app, return two async callables (on_startup, on_shutdown)
-
-    Detail spec at
-    https://asgi.readthedocs.io/en/latest/specs/lifespan.html
-    """
-    scope = {"type": "lifespan"}
-
-    class LifespanHandler:
-        def __init__(self, lifespan_type):
-            assert lifespan_type in {"startup", "shutdown"}
-            self.lifespan_type = lifespan_type
-
-        async def receive(self):
-            return {"type": f"lifespan.{self.lifespan_type}"}
-
-        async def send(self, msg):
-            # We are not doing a strict equality check here because sometimes
-            # starlette will output shutdown.complete on startup lifecycle
-            # event!
-            # https://github.com/encode/starlette/blob/5ee04ef9b1bc11dc14d299e6c855c9a3f7d5ff16/starlette/routing.py#L557 # noqa
-            if msg["type"].endswith(".complete"):
-                return
-            elif msg["type"].endswith(".failed"):
-                raise RayServeException(
-                    f"Failed to run {self.lifespan_type} events for asgi app. "
-                    f"Error: {msg.get('message', '')}")
-            else:
-                raise ValueError(f"Unknown ASGI type {msg}")
-
-    async def startup():
-        handler = LifespanHandler("startup")
-        await app(scope, handler.receive, handler.send)
-
-    async def shutdown():
-        handler = LifespanHandler("shutdown")
-        await app(scope, handler.receive, handler.send)
-
-    return startup, shutdown
-
-
 async def receive_http_body(scope, receive, send):
     body_buffer = []
     more_body = True

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -78,14 +78,24 @@ def test_class_based_view(serve_instance):
         def c(self, i: int):
             return i - self.val
 
+        def other(self, msg: str):
+            return msg
+
     A.deploy()
 
+    # Test HTTP calls.
     resp = requests.get("http://localhost:8000/f/calc/41")
     assert resp.json() == 42
     resp = requests.post("http://localhost:8000/f/calc/41")
     assert resp.json() == 40
     resp = requests.get("http://localhost:8000/f/other")
     assert resp.json() == "hello"
+
+    # Test handle calls.
+    handle = A.get_handle()
+    assert ray.get(handle.b.remote(41)) == 42
+    assert ray.get(handle.c.remote(41)) == 40
+    assert ray.get(handle.other.remote("world")) == "world"
 
 
 def test_make_fastapi_cbv_util():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
It turns out our original implement of ASGI lifespan was not correct. The lifespan.shutdown message is expected to be received within the _same_ coroutine as the lifespan.startup.

This is starlette's logic:
https://github.com/encode/starlette/blob/b7aeae70fd24d568553d83b5acfa5b6c4cfbc179/starlette/routing.py#L489-L492
https://github.com/encode/starlette/blob/b7aeae70fd24d568553d83b5acfa5b6c4cfbc179/starlette/routing.py#L548-L553

Basically, `receive` is called twice, once for startup and once for shutdown. Our old implement was not correct because it was sending startup and shutdown in separate `self.app(scope, send, receive)` call.

In order to make less mistake, I just grabbed `uvicorn`'s implementation and used it to properly handle lifespan. it's about 80 lines of code!
https://github.com/encode/uvicorn/blob/0.13.4/uvicorn/lifespan/on.py#L11-L97 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
