### PR TITLE
[RLlib] Issue 15556: Fix R2D2 using chunks from previous episodes in the "burn-in" window.

### DIFF
--- a/rllib/policy/rnn_sequencing.py
+++ b/rllib/policy/rnn_sequencing.py
@@ -326,8 +326,7 @@ def timeslice_along_seq_lens_with_overlap(
             at. If None, use `sample_batch["seq_lens"]`.
         zero_pad_max_seq_len (int): If >0, already zero-pad the resulting
             slices up to this length. NOTE: This max-len will include the
-            additional timesteps gained via setting pre_overlap or
-            post_overlap > 0 (see Example).
+            additional timesteps gained via setting pre_overlap (see Example).
         pre_overlap (int): If >0, will overlap each two consecutive slices by
             this many timesteps (toward the left side). This will cause
             zero-padding at the very beginning of the batch.
@@ -361,19 +360,20 @@ def timeslice_along_seq_lens_with_overlap(
     start = 0
     slices = []
     for seq_len in seq_lens:
-        begin = start - pre_overlap
-        end = start + seq_len  # + post_overlap
-        slices.append((begin, end))
+        pre_begin = start - pre_overlap
+        slice_begin = start
+        end = start + seq_len
+        slices.append((pre_begin, slice_begin, end))
         start += seq_len
 
     timeslices = []
-    for begin, end in slices:
+    for begin, slice_begin, end in slices:
         zero_length = None
         data_begin = 0
         zero_init_states_ = zero_init_states
         if begin < 0:
-            zero_length = -begin
-            data_begin = 0
+            zero_length = pre_overlap
+            data_begin = slice_begin
             zero_init_states_ = True
         else:
             eps_ids = sample_batch[SampleBatch.EPS_ID][begin if begin >= 0 else

--- a/rllib/tuned_examples/dqn/cartpole-r2d2.yaml
+++ b/rllib/tuned_examples/dqn/cartpole-r2d2.yaml
@@ -1,5 +1,5 @@
 cartpole-r2d2:
-    env: CartPole-v0
+    env: ray.rllib.examples.env.stateless_cartpole.StatelessCartPole
     run: R2D2
     stop:
         episode_reward_mean: 150


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Issue 15556: Fix R2D2 using chunks from previous episodes in the "burn-in" window.


<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
Issue #15556 
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Closes #15556 
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
