### PR TITLE
[Build] Explicitly set protobuf dependency version to 3.16.0

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -77,6 +77,15 @@ def auto_http_archive(*, name=None, url=None, urls=True,
 
 def ray_deps_setup():
 
+    # Explicitly bring in protobuf dependency to work around
+    # https://github.com/ray-project/ray/issues/14117
+    http_archive(
+        name = "com_google_protobuf",
+        strip_prefix = "protobuf-3.16.0",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.16.0.tar.gz"],
+        sha256 = "7892a35d979304a404400a101c46ce90e85ec9e2a766a86041bb361f626247f5",
+    )
+
     auto_http_archive(
         name = "com_github_antirez_redis",
         build_file = "//bazel:BUILD.redis",

--- a/java/dependencies.bzl
+++ b/java/dependencies.bzl
@@ -5,7 +5,7 @@ def gen_java_deps():
         artifacts = [
             "com.google.code.gson:gson:2.8.5",
             "com.google.guava:guava:27.0.1-jre",
-            "com.google.protobuf:protobuf-java:3.8.0",
+            "com.google.protobuf:protobuf-java:3.16.0",
             "com.puppycrawl.tools:checkstyle:8.15",
             "com.sun.xml.bind:jaxb-core:2.3.0",
             "com.sun.xml.bind:jaxb-impl:2.3.0",

--- a/java/runtime/pom.xml
+++ b/java/runtime/pom.xml
@@ -52,7 +52,7 @@
 <dependency>
   <groupId>com.google.protobuf</groupId>
   <artifactId>protobuf-java</artifactId>
-  <version>3.8.0</version>
+  <version>3.16.0</version>
 </dependency>
 <dependency>
   <groupId>com.typesafe</groupId>

--- a/java/test/pom.xml
+++ b/java/test/pom.xml
@@ -44,7 +44,7 @@
 <dependency>
   <groupId>com.google.protobuf</groupId>
   <artifactId>protobuf-java</artifactId>
-  <version>3.8.0</version>
+  <version>3.16.0</version>
 </dependency>
 <dependency>
   <groupId>com.sun.xml.bind</groupId>


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This change is based on https://github.com/ray-project/ray/issues/14117#issuecomment-801136895 and  #14728. It allows building ray with bazel 4.0.0 which is the latest version. By including the protobuf dependency explicitly, likely we avoid implicitly using an older version of protobuf.

Java protobuf dependencies are also updated to the same version, to avoid build failures.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #14117

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
