### PR TITLE
Ensure output params are initialized before calling IsPlasmaObjectPinnedOrSpilled()

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1382,9 +1382,9 @@ void CoreWorker::SpillOwnedObject(const ObjectID &object_id,
   }
 
   // Find the raylet that hosts the primary copy of the object.
+  bool owned_by_us = false;
   NodeID pinned_at;
-  bool spilled;
-  bool owned_by_us;
+  bool spilled = false;
   RAY_CHECK(reference_counter_->IsPlasmaObjectPinnedOrSpilled(object_id, &owned_by_us,
                                                               &pinned_at, &spilled));
   RAY_CHECK(owned_by_us);

--- a/src/ray/core_worker/reference_count_test.cc
+++ b/src/ray/core_worker/reference_count_test.cc
@@ -2054,9 +2054,9 @@ TEST_F(ReferenceCountLineageEnabledTest, TestPlasmaLocation) {
 
   ObjectID borrowed_id = ObjectID::FromRandom();
   rc->AddLocalReference(borrowed_id, "");
-  bool owned_by_us;
+  bool owned_by_us = false;
   NodeID pinned_at;
-  bool spilled;
+  bool spilled = false;
   ASSERT_TRUE(
       rc->IsPlasmaObjectPinnedOrSpilled(borrowed_id, &owned_by_us, &pinned_at, &spilled));
   ASSERT_FALSE(owned_by_us);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`IsPlasmaObjectPinnedOrSpilled()` does not set `owned_by_us` unless it is true. But `owned_by_us` might be uninitialized when passed to `IsPlasmaObjectPinnedOrSpilled()` as an output param with a value evaluating to true. I believe this is causing the flakiness of `//python/ray/tests:test_reference_counting` like https://github.com/ray-project/ray/runs/2562089610.

Explicitly initialize the output params here. Alternatively in `IsPlasmaObjectPinnedOrSpilled()` we can set these values from all branches, or return by value.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
