### PR TITLE
[Test][RLlib] Allow `kill` to fail

### DIFF
--- a/rllib/env/tests/test_local_inference.sh
+++ b/rllib/env/tests/test_local_inference.sh
@@ -21,4 +21,4 @@ done
 
 sleep 2
 python $basedir/cartpole_client.py --stop-reward=150 --inference-mode=local
-kill $pid
+kill $pid || true

--- a/rllib/env/tests/test_remote_inference.sh
+++ b/rllib/env/tests/test_remote_inference.sh
@@ -21,5 +21,5 @@ done
 
 sleep 2
 python $basedir/cartpole_client.py --stop-reward=150 --inference-mode=remote
-kill $pid
+kill $pid || true
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
It looks like these tests sometimes fail when `kill` returns with:
```
rllib/env/tests/test_local_inference: line 24: kill: (17996) - No such process
```
* One example [here](https://buildkite.com/ray-project/ray-builders-branch/builds/1323#3608dc60-0efc-40ef-bec5-deded858f19d). 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
