### PR TITLE
[Core] Fix global state keep initializing in busy loop

### DIFF
--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -41,9 +41,11 @@ class GlobalState:
             RuntimeError: An exception is raised if ray.init() has not been
                 called yet.
         """
-        if self.redis_address is not None:
+        if (self.redis_address is not None
+                and self.global_state_accessor is None):
             self._really_init_global_state()
 
+        # _really_init_global_state should have set self.global_state_accessor
         if self.global_state_accessor is None:
             raise ray.exceptions.RaySystemError(
                 "Ray has not been started yet. You can start Ray with "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Ray Serve has a logic that checks global resource in a while true loop (sleep 0.1). And we identified high CPU usage when it shouldn't be #15776. 

It turns out the each global state's API calls `_check_connected()` which calls  
https://github.com/ray-project/ray/blob/78d0ed35035df7041905ba07c6771be481eee34e/python/ray/state.py#L35-L50

https://github.com/ray-project/ray/blob/78d0ed35035df7041905ba07c6771be481eee34e/python/ray/state.py#L77-L80

The thing is that `_check_connected` will always calls `_really_init_global_state`, which establish a gcs connection each time, causing high cpu usage when it shouldn't. 

(cc @edoakes this _might_ be the root cause of the weird file descriptor error for Serve, because it's creating new network connection each 0.1s).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #15776 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
