### PR TITLE
fix atomic compiling error

### DIFF
--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -441,7 +441,7 @@ class RayletClient : public RayletClientInterface {
   std::unique_ptr<RayletConnection> conn_;
 
   /// The number of object ID pin RPCs currently in flight.
-  std::atomic_int64_t pins_in_flight_{0};
+  std::atomic<int64_t> pins_in_flight_{0};
 };
 
 }  // namespace raylet


### PR DESCRIPTION
## Why are these changes needed?
Master branch compiled error in my linux machine which uses gcc 6.5.1. The error message:
![image](https://user-images.githubusercontent.com/26714159/118121991-d167df80-b424-11eb-9c73-4eb0a1135544.png)


This error appeared after the pr https://github.com/ray-project/ray/pull/15686.




