### PR TITLE
[Tests] Mark test_scheduling & test_memstat as Flaky

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -49,6 +49,7 @@ py_test_module_list(
   files = [
     "test_actor.py",
     "test_global_gc.py",
+    "test_memstat.py",
   ],
   size = "medium",
   extra_srcs = SRCS,
@@ -145,17 +146,6 @@ py_test_module_list(
   size = "large",
   extra_srcs = SRCS,
   tags = ["exclusive"],
-  deps = ["//:ray_lib"],
-)
-
-
-py_test_module_list(
-  files = [
-    "test_memstat.py",
-  ],
-  size = "small",
-  extra_srcs = SRCS,
-  tags = ["exclusive", "flaky"],
   deps = ["//:ray_lib"],
 )
 

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -71,7 +71,6 @@ py_test_module_list(
     "test_reconstruction.py",
     "test_reference_counting.py",
     "test_resource_demand_scheduler.py",
-    "test_scheduling.py",
     "test_serialization.py",
     "test_stress.py",
     "test_stress_sharded.py",
@@ -89,6 +88,7 @@ py_test_module_list(
     "test_object_manager.py",
     "test_reference_counting_2.py",
     "test_multi_tenancy.py",
+    "test_scheduling.py",
   ],
   size = "medium",
   extra_srcs = SRCS,
@@ -116,7 +116,6 @@ py_test_module_list(
     "test_job.py",
     "test_k8s_operator_unit_tests.py",
     "test_kv.py",
-    "test_memstat.py",
     "test_metrics_agent.py",
     "test_microbenchmarks.py",
     "test_mini.py",
@@ -146,6 +145,17 @@ py_test_module_list(
   size = "large",
   extra_srcs = SRCS,
   tags = ["exclusive"],
+  deps = ["//:ray_lib"],
+)
+
+
+py_test_module_list(
+  files = [
+    "test_memstat.py",
+  ],
+  size = "small",
+  extra_srcs = SRCS,
+  tags = ["exclusive", "flaky"],
   deps = ["//:ray_lib"],
 )
 


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* Test Scheduling:
<img width="1663" alt="Screen Shot 2021-05-13 at 12 13 49 PM" src="https://user-images.githubusercontent.com/21353794/118175229-b07f9a00-b3e4-11eb-81ff-8acc583d2575.png">
* Test Memstat (Moved both to `medium` and to `flaky`:
<img width="1648" alt="Screen Shot 2021-05-13 at 12 14 16 PM" src="https://user-images.githubusercontent.com/21353794/118175274-bf664c80-b3e4-11eb-846b-d97cebc9c0f2.png">


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
