### PR TITLE
[serve] Fix shutdown logic + add test

### DIFF
--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -503,6 +503,13 @@ class BackendState:
         self._notify_backend_configs_changed()
         self._notify_replica_handles_changed()
 
+    def shutdown(self) -> None:
+        for replica_dict in self.get_running_replica_handles().values():
+            for replica in replica_dict.values():
+                ray.kill(replica, no_restart=True)
+
+        self._kv_store.delete(CHECKPOINT_KEY)
+
     def _checkpoint(self) -> None:
         self._kv_store.put(
             CHECKPOINT_KEY,

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -32,7 +32,6 @@ from ray.serve.utils import logger
 # Used for testing purposes only. If this is set, the controller will crash
 # after writing each checkpoint with the specified probability.
 _CRASH_AFTER_CHECKPOINT_PROBABILITY = 0
-CHECKPOINT_KEY = "serve-controller-checkpoint"
 
 # How often to call the control loop on the controller.
 CONTROL_LOOP_PERIOD_S = 0.1
@@ -264,13 +263,9 @@ class ServeController:
     async def shutdown(self) -> None:
         """Shuts down the serve instance completely."""
         async with self.write_lock:
-            for proxy in self.http_state.get_http_proxy_handles().values():
-                ray.kill(proxy, no_restart=True)
-            for replica_dict in self.backend_state.get_running_replica_handles(
-            ).values():
-                for replica in replica_dict.values():
-                    ray.kill(replica, no_restart=True)
-            self.kv_store.delete(CHECKPOINT_KEY)
+            self.backend_state.shutdown()
+            self.endpoint_state.shutdown()
+            self.http_state.shutdown()
 
     async def deploy(self, name: str, backend_config: BackendConfig,
                      replica_config: ReplicaConfig, version: Optional[str],

--- a/python/ray/serve/endpoint_state.py
+++ b/python/ray/serve/endpoint_state.py
@@ -32,6 +32,9 @@ class EndpointState:
         self._notify_route_table_changed()
         self._notify_traffic_policies_changed()
 
+    def shutdown(self):
+        self._kv_store.delete(CHECKPOINT_KEY)
+
     def _checkpoint(self):
         self._kv_store.put(
             CHECKPOINT_KEY,

--- a/python/ray/serve/http_state.py
+++ b/python/ray/serve/http_state.py
@@ -28,6 +28,10 @@ class HTTPState:
         # Will populate self.proxy_actors with existing actors.
         self._start_proxies_if_needed()
 
+    def shutdown(self) -> None:
+        for proxy in self.get_http_proxy_handles().values():
+            ray.kill(proxy, no_restart=True)
+
     def get_config(self):
         return self._config
 

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -340,5 +340,27 @@ def test_http_head_only(ray_cluster):
     assert cpu_per_nodes == {4, 4}
 
 
+def test_serve_shutdown(ray_shutdown):
+    serve.start(detached=True)
+
+    @serve.deployment
+    class A:
+        def __call__(self, *args):
+            return "hi"
+
+    A.deploy()
+
+    assert len(serve.list_deployments()) == 1
+
+    serve.shutdown()
+    serve.start(detached=True)
+
+    assert len(serve.list_deployments()) == 0
+
+    A.deploy()
+
+    assert len(serve.list_deployments()) == 1
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Cannot start another serve instance after calling `serve.shutdown()`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
