### PR TITLE
[tune] Allow to set buffer_length via tune.run

### DIFF
--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -142,6 +142,7 @@ class RayTrialExecutor(TrialExecutor):
     def __init__(self,
                  queue_trials: bool = False,
                  reuse_actors: bool = False,
+                 result_buffer_length: Optional[int] = None,
                  refresh_period: Optional[float] = None,
                  wait_for_placement_group: Optional[float] = None):
         super(RayTrialExecutor, self).__init__(queue_trials)
@@ -184,7 +185,8 @@ class RayTrialExecutor(TrialExecutor):
         self.pg_recon_interval = float(
             os.environ.get("TUNE_PLACEMENT_GROUP_RECON_INTERVAL", "5"))
 
-        self._buffer_length = int(os.getenv("TUNE_RESULT_BUFFER_LENGTH", 1000))
+        self._buffer_length = result_buffer_length or int(
+            os.getenv("TUNE_RESULT_BUFFER_LENGTH", 1000))
         self._buffer_min_time_s = float(
             os.getenv("TUNE_RESULT_BUFFER_MIN_TIME_S", 0.))
         self._buffer_max_time_s = float(

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -75,7 +75,6 @@ def run(
         mode: Optional[str] = None,
         stop: Union[None, Mapping, Stopper, Callable[[str, Mapping],
                                                      bool]] = None,
-        result_buffer_length: Optional[int] = None,
         time_budget_s: Union[None, int, float, datetime.timedelta] = None,
         config: Optional[Dict[str, Any]] = None,
         resources_per_trial: Union[None, Mapping[str, Union[
@@ -176,8 +175,6 @@ def run(
             ``ray.tune.Stopper``, which allows users to implement
             custom experiment-wide stopping (i.e., stopping an entire Tune
             run based on some time constraint).
-        result_buffer_length (int): Maximum number of results to buffer.
-            If set, env var 'TUNE_RESULT_BUFFER_LENGTH' will be ignored.
         time_budget_s (int|float|datetime.timedelta): Global time budget in
             seconds after which all trials are stopped. Can also be a
             ``datetime.timedelta`` object.
@@ -307,7 +304,6 @@ def run(
                 metric,
                 mode,
                 stop,
-                result_buffer_length,
                 time_budget_s,
                 config,
                 resources_per_trial,
@@ -382,9 +378,7 @@ def run(
         num_samples = sys.maxsize
 
     trial_executor = trial_executor or RayTrialExecutor(
-        reuse_actors=reuse_actors,
-        queue_trials=queue_trials,
-        result_buffer_length=result_buffer_length)
+        reuse_actors=reuse_actors, queue_trials=queue_trials)
     if isinstance(run_or_experiment, list):
         experiments = run_or_experiment
     else:

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -382,7 +382,8 @@ def run(
         num_samples = sys.maxsize
 
     trial_executor = trial_executor or RayTrialExecutor(
-        reuse_actors=reuse_actors, queue_trials=queue_trials,
+        reuse_actors=reuse_actors,
+        queue_trials=queue_trials,
         result_buffer_length=result_buffer_length)
     if isinstance(run_or_experiment, list):
         experiments = run_or_experiment

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -75,6 +75,7 @@ def run(
         mode: Optional[str] = None,
         stop: Union[None, Mapping, Stopper, Callable[[str, Mapping],
                                                      bool]] = None,
+        result_buffer_length: Optional[int] = None,
         time_budget_s: Union[None, int, float, datetime.timedelta] = None,
         config: Optional[Dict[str, Any]] = None,
         resources_per_trial: Union[None, Mapping[str, Union[
@@ -175,6 +176,8 @@ def run(
             ``ray.tune.Stopper``, which allows users to implement
             custom experiment-wide stopping (i.e., stopping an entire Tune
             run based on some time constraint).
+        result_buffer_length (int): Maximum number of results to buffer.
+            If set, env var 'TUNE_RESULT_BUFFER_LENGTH' will be ignored.
         time_budget_s (int|float|datetime.timedelta): Global time budget in
             seconds after which all trials are stopped. Can also be a
             ``datetime.timedelta`` object.
@@ -304,6 +307,7 @@ def run(
                 metric,
                 mode,
                 stop,
+                result_buffer_length,
                 time_budget_s,
                 config,
                 resources_per_trial,
@@ -378,7 +382,8 @@ def run(
         num_samples = sys.maxsize
 
     trial_executor = trial_executor or RayTrialExecutor(
-        reuse_actors=reuse_actors, queue_trials=queue_trials)
+        reuse_actors=reuse_actors, queue_trials=queue_trials,
+        result_buffer_length=result_buffer_length)
     if isinstance(run_or_experiment, list):
         experiments = run_or_experiment
     else:


### PR DESCRIPTION
See discussion [here](https://discuss.ray.io/t/pass-buffer-length-as-a-function-argument/2151).

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
