### PR TITLE
[serve] Add optional `prev_version` check to `.deploy()` for users to avoid race conditions

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -27,7 +27,7 @@ py_test(
 
 py_test(
     name = "test_deploy",
-    size = "medium",
+    size = "large",
     srcs = serve_tests_srcs,
     tags = ["exclusive"],
     deps = [":serve_lib"],

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1084,6 +1084,8 @@ class Deployment:
             raise TypeError("name must be a string.")
         if not (version is None or isinstance(version, str)):
             raise TypeError("version must be a string.")
+        if not (prev_version is None or isinstance(prev_version, str)):
+            raise TypeError("prev_version must be a string.")
         if not (init_args is None or isinstance(init_args, tuple)):
             raise TypeError("init_args must be a tuple.")
         if route_prefix is not None:
@@ -1310,6 +1312,7 @@ def deployment(func_or_class: Callable) -> Deployment:
 @overload
 def deployment(name: Optional[str] = None,
                version: Optional[str] = None,
+               prev_version: Optional[str] = None,
                num_replicas: Optional[int] = None,
                init_args: Optional[Tuple[Any]] = None,
                ray_actor_options: Optional[Dict] = None,
@@ -1323,6 +1326,7 @@ def deployment(
         _func_or_class: Optional[Callable] = None,
         name: Optional[str] = None,
         version: Optional[str] = None,
+        prev_version: Optional[str] = None,
         num_replicas: Optional[int] = None,
         init_args: Optional[Tuple[Any]] = None,
         route_prefix: Optional[str] = None,
@@ -1340,6 +1344,11 @@ def deployment(
             with a version change, a rolling update of the replicas will be
             performed. If not provided, every deployment will be treated as a
             new version.
+        prev_version (Optional[str]): Version of the existing deployment which
+            is used as a precondition for the next deployment. If prev_version
+            does not match with the existing deployment's version, the
+            deployment will fail. If not provided, deployment procedure will
+            not check the existing deployment's version.
         num_replicas (Optional[int]): The number of processes to start up that
             will handle requests to this backend. Defaults to 1.
         init_args (Optional[Tuple]): Arguments to be passed to the class
@@ -1391,6 +1400,7 @@ def deployment(
             name if name is not None else _func_or_class.__name__,
             config,
             version=version,
+            prev_version=prev_version,
             init_args=init_args,
             route_prefix=route_prefix,
             ray_actor_options=ray_actor_options,

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -400,9 +400,9 @@ class Client:
                 python_methods.append(method_name)
 
         goal_id, updating = ray.get(
-            self._controller.deploy.remote(name, backend_config,
-                                           replica_config, python_methods,
-                                           version, prev_version, route_prefix))
+            self._controller.deploy.remote(
+                name, backend_config, replica_config, python_methods, version,
+                prev_version, route_prefix))
 
         if updating:
             msg = f"Updating deployment '{name}'"

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -400,9 +400,9 @@ class Client:
                 python_methods.append(method_name)
 
         goal_id, updating = ray.get(
-            self._controller.deploy.remote(
-                name, backend_config, replica_config, python_methods, version,
-                prev_version, route_prefix))
+            self._controller.deploy.remote(name, backend_config,
+                                           replica_config, python_methods,
+                                           version, prev_version, route_prefix))
 
         if updating:
             msg = f"Updating deployment '{name}'"

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -271,10 +271,11 @@ class ServeController:
             self.endpoint_state.shutdown()
             self.http_state.shutdown()
 
-    async def deploy(self, name: str, backend_config: BackendConfig,
-                     replica_config: ReplicaConfig, python_methods: List[str],
-                     version: Optional[str], prev_version: Optional[str], route_prefix: Optional[str]
-                     ) -> Tuple[Optional[GoalId], bool]:
+    async def deploy(
+            self, name: str, backend_config: BackendConfig,
+            replica_config: ReplicaConfig, python_methods: List[str],
+            version: Optional[str], prev_version: Optional[str],
+            route_prefix: Optional[str]) -> Tuple[Optional[GoalId], bool]:
         if route_prefix is not None:
             assert route_prefix.startswith("/")
 
@@ -282,9 +283,10 @@ class ServeController:
             if prev_version is not None:
                 existing_backend_info = self.backend_state.get_backend(name)
                 if existing_backend_info.version != prev_version:
-                    raise ValueError(
-                        "prev_version '{}' does not match with "
-                        "the existing version '{}'".format(prev_version, existing_backend_info.version))
+                    raise ValueError("prev_version '{}' does not match with "
+                                     "the existing version '{}'".format(
+                                         prev_version,
+                                         existing_backend_info.version))
 
             backend_info = BackendInfo(
                 actor_def=ray.remote(

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -284,9 +284,8 @@ class ServeController:
                 existing_backend_info = self.backend_state.get_backend(name)
                 if (existing_backend_info is None
                         or not existing_backend_info.version):
-                    raise ValueError(
-                        f"prev_version '{prev_version}' is specified but "
-                        "there is no existing deployment")
+                    raise ValueError(f"prev_version '{prev_version}' is specified but "
+                                     "there is no existing deployment")
                 if existing_backend_info.version != prev_version:
                     raise ValueError(f"prev_version '{prev_version}' does not match with "
                                      "the existing version '{existing_backend_info.version}'")

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -230,7 +230,7 @@ class ServeController:
             for endpoint, info in self.endpoint_state.get_endpoints().items():
                 if (backend_tag in info["traffic"]
                         or backend_tag in info["shadows"]):
-                    raise ValueError("Backend '{}' is used by endpoint '{}' "
+                    raise ValueError(f"Backend '{}' is used by endpoint '{}' "
                                      "and cannot be deleted. Please remove "
                                      "the backend from all endpoints and try "
                                      "again.".format(backend_tag, endpoint))
@@ -285,11 +285,11 @@ class ServeController:
                 if (existing_backend_info is None
                         or not existing_backend_info.version):
                     raise ValueError(
-                        "prev_version '{}' is specified but "
-                        "there is no existing deployment".format(prev_version))
+                        f"prev_version '{prev_version}' is specified but "
+                        "there is no existing deployment")
                 if existing_backend_info.version != prev_version:
-                    raise ValueError("prev_version '{}' does not match with "
-                                     "the existing version '{}'".format(
+                    raise ValueError(f"prev_version '{prev_version}' does not match with "
+                                     "the existing version '{existing_backend_info.version}'".format(
                                          prev_version,
                                          existing_backend_info.version))
 

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -284,11 +284,14 @@ class ServeController:
                 existing_backend_info = self.backend_state.get_backend(name)
                 if (existing_backend_info is None
                         or not existing_backend_info.version):
-                    raise ValueError(f"prev_version '{prev_version}' is specified but "
-                                     "there is no existing deployment.")
+                    raise ValueError(
+                        f"prev_version '{prev_version}' is specified but "
+                        "there is no existing deployment.")
                 if existing_backend_info.version != prev_version:
-                    raise ValueError(f"prev_version '{prev_version}' does not match with "
-                                     f"the existing version '{existing_backend_info.version}'.")
+                    raise ValueError(
+                        f"prev_version '{prev_version}' "
+                        "does not match with the existing "
+                        f"version '{existing_backend_info.version}'.")
 
             backend_info = BackendInfo(
                 actor_def=ray.remote(

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -230,10 +230,10 @@ class ServeController:
             for endpoint, info in self.endpoint_state.get_endpoints().items():
                 if (backend_tag in info["traffic"]
                         or backend_tag in info["shadows"]):
-                    raise ValueError(f"Backend '{}' is used by endpoint '{}' "
-                                     "and cannot be deleted. Please remove "
-                                     "the backend from all endpoints and try "
-                                     "again.".format(backend_tag, endpoint))
+                    raise ValueError(f"Backend '{backend_tag}' is used by "
+                                     "endpoint '{endpoint}' and cannot be "
+                                     "deleted. Please remove the backend "
+                                     "from all endpoints and try again.")
             return self.backend_state.delete_backend(backend_tag, force_kill)
 
     async def update_backend_config(self, backend_tag: BackendTag,

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -271,10 +271,11 @@ class ServeController:
             self.endpoint_state.shutdown()
             self.http_state.shutdown()
 
-    async def deploy(self, name: str, backend_config: BackendConfig,
-                     replica_config: ReplicaConfig, python_methods: List[str],
-                     version: Optional[str], prev_version: Optional[str], route_prefix: Optional[str]
-                     ) -> Tuple[Optional[GoalId], bool]:
+    async def deploy(
+            self, name: str, backend_config: BackendConfig,
+            replica_config: ReplicaConfig, python_methods: List[str],
+            version: Optional[str], prev_version: Optional[str],
+            route_prefix: Optional[str]) -> Tuple[Optional[GoalId], bool]:
         if route_prefix is not None:
             assert route_prefix.startswith("/")
 

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -231,7 +231,7 @@ class ServeController:
                 if (backend_tag in info["traffic"]
                         or backend_tag in info["shadows"]):
                     raise ValueError(f"Backend '{backend_tag}' is used by "
-                                     "endpoint '{endpoint}' and cannot be "
+                                     f"endpoint '{endpoint}' and cannot be "
                                      "deleted. Please remove the backend "
                                      "from all endpoints and try again.")
             return self.backend_state.delete_backend(backend_tag, force_kill)
@@ -285,10 +285,10 @@ class ServeController:
                 if (existing_backend_info is None
                         or not existing_backend_info.version):
                     raise ValueError(f"prev_version '{prev_version}' is specified but "
-                                     "there is no existing deployment")
+                                     "there is no existing deployment.")
                 if existing_backend_info.version != prev_version:
                     raise ValueError(f"prev_version '{prev_version}' does not match with "
-                                     "the existing version '{existing_backend_info.version}'")
+                                     f"the existing version '{existing_backend_info.version}'.")
 
             backend_info = BackendInfo(
                 actor_def=ray.remote(

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -271,11 +271,10 @@ class ServeController:
             self.endpoint_state.shutdown()
             self.http_state.shutdown()
 
-    async def deploy(
-            self, name: str, backend_config: BackendConfig,
-            replica_config: ReplicaConfig, python_methods: List[str],
-            version: Optional[str], prev_version: Optional[str],
-            route_prefix: Optional[str]) -> Tuple[Optional[GoalId], bool]:
+    async def deploy(self, name: str, backend_config: BackendConfig,
+                     replica_config: ReplicaConfig, python_methods: List[str],
+                     version: Optional[str], prev_version: Optional[str], route_prefix: Optional[str]
+                     ) -> Tuple[Optional[GoalId], bool]:
         if route_prefix is not None:
             assert route_prefix.startswith("/")
 
@@ -293,7 +292,7 @@ class ServeController:
 
             backend_info = BackendInfo(
                 actor_def=ray.remote(
-                    create_backend_replica(g
+                    create_backend_replica(
                         name, replica_config.serialized_backend_def)),
                 version=version,
                 backend_config=backend_config,

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -282,6 +282,11 @@ class ServeController:
         async with self.write_lock:
             if prev_version is not None:
                 existing_backend_info = self.backend_state.get_backend(name)
+                if (existing_backend_info is None
+                        or not existing_backend_info.version):
+                    raise ValueError(
+                        "prev_version '{}' is specified but "
+                        "there is no existing deployment".format(prev_version))
                 if existing_backend_info.version != prev_version:
                     raise ValueError("prev_version '{}' does not match with "
                                      "the existing version '{}'".format(

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -289,13 +289,11 @@ class ServeController:
                         "there is no existing deployment")
                 if existing_backend_info.version != prev_version:
                     raise ValueError(f"prev_version '{prev_version}' does not match with "
-                                     "the existing version '{existing_backend_info.version}'".format(
-                                         prev_version,
-                                         existing_backend_info.version))
+                                     "the existing version '{existing_backend_info.version}'")
 
             backend_info = BackendInfo(
                 actor_def=ray.remote(
-                    create_backend_replica(
+                    create_backend_replica(g
                         name, replica_config.serialized_backend_def)),
                 version=version,
                 backend_config=backend_config,

--- a/python/ray/serve/tests/test_deploy.py
+++ b/python/ray/serve/tests/test_deploy.py
@@ -128,6 +128,77 @@ def test_deploy_no_version(serve_instance, use_handle):
 
 
 @pytest.mark.parametrize("use_handle", [True, False])
+def test_deploy_prev_version(serve_instance, use_handle):
+    name = "test"
+
+    @serve.deployment(name=name)
+    def v1(*args):
+        return f"1|{os.getpid()}"
+
+    def call():
+        if use_handle:
+            ret = ray.get(v1.get_handle().remote())
+        else:
+            ret = requests.get(f"http://localhost:8000/{name}").text
+
+        return ret.split("|")[0], ret.split("|")[1]
+
+    # Deploy with prev_version specified, where there is no existing deployment
+    with pytest.raises(ValueError):
+        v1.options(version="1", prev_version="0").deploy()
+
+    v1.deploy()
+    val1, pid1 = call()
+    assert val1 == "1"
+
+    @serve.deployment(name=name)
+    def v2(*args):
+        return f"2|{os.getpid()}"
+
+    # Deploying without specifying prev_version should still be possible.
+    v2.deploy()
+    val2, pid2 = call()
+    assert val2 == "2"
+    assert pid2 != pid1
+
+    v2.options(version="1").deploy()
+    val3, pid3 = call()
+    assert val3 == "2"
+    assert pid3 != pid2
+
+    @serve.deployment(name=name)
+    def v3(*args):
+        return f"3|{os.getpid()}"
+
+    # If prev_version does not match with the existing version, it should fail.
+    with pytest.raises(ValueError):
+        v3.options(version="2", prev_version="0").deploy()
+
+    # If prev_version matches with the existing version, it should succeed.
+    v3.options(version="2", prev_version="1").deploy()
+    val4, pid4 = call()
+    assert val4 == "3"
+    assert pid4 != pid3
+
+    # Specifying the version should stop updates from happening.
+    v3.options(version="2").deploy()
+    val5, pid5 = call()
+    assert val5 == "3"
+    assert pid5 == pid4
+
+    v2.options(version="3", prev_version="2").deploy()
+    val6, pid6 = call()
+    assert val6 == "2"
+    assert pid6 != pid5
+
+    # Deploying without specifying prev_version should still be possible.
+    v1.deploy()
+    val7, pid7 = call()
+    assert val7 == "1"
+    assert pid7 != pid6
+
+
+@pytest.mark.parametrize("use_handle", [True, False])
 def test_config_change(serve_instance, use_handle):
     @serve.deployment(version="1")
     class D:


### PR DESCRIPTION
## Why are these changes needed?
Having prev_version for Ray Serve's `deploy` method prevents race conditions when multiple processes tries to deploy for the same Serve instance at the same time

## Related issue number
#15642

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
