### PR TITLE
Fix test_scheduling

### DIFF
--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -76,7 +76,6 @@ def test_hybrid_policy(ray_start_cluster):
     # Add the memory resource because the cpu will be released in the ray.get
     @ray.remote(num_cpus=1, memory=1)
     def get_node():
-        # Sleep to avoid lease reuse.
         ray.get(block_driver.release.remote())
         ray.get(block_task.acquire.remote())
         return ray.worker.global_worker.current_node_id

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -70,7 +70,9 @@ def test_hybrid_policy(ray_start_cluster):
     cluster.wait_for_nodes()
     ray.init(address=cluster.address)
 
+	# `block_task` ensures that scheduled tasks do not return until all are running.
     block_task = Semaphore.remote(0)
+    # `block_driver` ensures that the driver does not allow tasks to continue until all are running.
     block_driver = Semaphore.remote(0)
 
     # Add the memory resource because the cpu will be released in the ray.get

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -14,7 +14,8 @@ import ray.util.accelerators
 import ray.cluster_utils
 import ray.test_utils
 
-from ray.test_utils import (wait_for_condition, new_scheduler_enabled)
+from ray.test_utils import (wait_for_condition, new_scheduler_enabled,
+                            Semaphore)
 
 logger = logging.getLogger(__name__)
 
@@ -60,35 +61,38 @@ def test_load_balancing(ray_start_cluster):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Times out on Windows")
 def test_hybrid_policy(ray_start_cluster):
-    @ray.remote(num_cpus=1)
-    def get_node():
-        # Sleep to avoid lease reuse.
-        time.sleep(3)
-        return ray.worker.global_worker.current_node_id
 
     cluster = ray_start_cluster
     num_nodes = 2
     num_cpus = 10
     for _ in range(num_nodes):
-        cluster.add_node(num_cpus=num_cpus)
+        cluster.add_node(num_cpus=num_cpus, memory=num_cpus)
     cluster.wait_for_nodes()
     ray.init(address=cluster.address)
 
-    # Warm the worker pool in order to isolate the test to only test the
-    # scheduling policy.
-    node_resources = [
-        resource for resource in ray.cluster_resources() if "node:" in resource
-    ]
-    for node_ip in node_resources:
-        print("Warming worker pool on ", node_ip)
-        ray.get([get_node.remote() for _ in range(num_cpus)])
+    block_task = Semaphore.remote(0)
+    block_driver = Semaphore.remote(0)
+
+    # Add the memory resource because the cpu will be released in the ray.get
+    @ray.remote(num_cpus=1, memory=1)
+    def get_node():
+        # Sleep to avoid lease reuse.
+        ray.get(block_driver.release.remote())
+        ray.get(block_task.acquire.remote())
+        return ray.worker.global_worker.current_node_id
 
     # Below the hybrid threshold we pack on the local node first.
-    nodes = ray.get([get_node.remote() for _ in range(5)])
+    refs = [get_node.remote() for _ in range(5)]
+    ray.get([block_driver.acquire.remote() for _ in refs])
+    ray.get([block_task.release.remote() for _ in refs])
+    nodes = ray.get(refs)
     assert len(set(nodes)) == 1
 
     # We pack the second node to the hybrid threshold.
-    nodes = ray.get([get_node.remote() for _ in range(10)])
+    refs = [get_node.remote() for _ in range(10)]
+    ray.get([block_driver.acquire.remote() for _ in refs])
+    ray.get([block_task.release.remote() for _ in refs])
+    nodes = ray.get(refs)
     counter = collections.Counter(nodes)
     for node_id in counter:
         print(f"{node_id}: {counter[node_id]}")
@@ -97,7 +101,10 @@ def test_hybrid_policy(ray_start_cluster):
     # Once all nodes are past the hybrid threshold we round robin.
     # TODO (Alex): Ideally we could schedule less than 20 nodes here, but the
     # policy is imperfect if a resource report interrupts the process.
-    nodes = ray.get([get_node.remote() for _ in range(20)])
+    refs = [get_node.remote() for _ in range(20)]
+    ray.get([block_driver.acquire.remote() for _ in refs])
+    ray.get([block_task.release.remote() for _ in refs])
+    nodes = ray.get(refs)
     counter = collections.Counter(nodes)
     for node_id in counter:
         print(f"{node_id}: {counter[node_id]}")

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -70,9 +70,11 @@ def test_hybrid_policy(ray_start_cluster):
     cluster.wait_for_nodes()
     ray.init(address=cluster.address)
 
-	# `block_task` ensures that scheduled tasks do not return until all are running.
+    # `block_task` ensures that scheduled tasks do not return until all are
+    # running.
     block_task = Semaphore.remote(0)
-    # `block_driver` ensures that the driver does not allow tasks to continue until all are running.
+    # `block_driver` ensures that the driver does not allow tasks to continue
+    # until all are running.
     block_driver = Semaphore.remote(0)
 
     # Add the memory resource because the cpu will be released in the ray.get


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Test scheduling was flakey due to timing issues with working startup time, resource reports, and sleeping in the test case.

This fixes it by using semaphores instead of relying on timing.

Note: We need the memory resource, because it's the only one that satisfies the requirements of
* Being part of the critical resource utilization calculation
* Being manually settable (and not auto-filled like object store memory)
* Not borrow-able by `ray.get`


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
