### PR TITLE
[Serve] [Core] Fix serve on Windows by disabling runtime env on Windows

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -431,7 +431,7 @@ Conda Environments for Tasks and Actors
 Starting with Ray 1.3.0, Ray supports starting tasks and actors in `conda environments <https://docs.conda.io/en/latest/>`_.
 This allows you to use tasks and actors with different (possibly conflicting) package dependencies within a single Ray runtime.
 You will need to have the desired conda environments installed beforehand on all nodes in your Ray cluster, and they
-must all use the same Python minor version (e.g., Python 3.8).
+must all use the same Python minor version (e.g., Python 3.8).  Note that this feature is currently unavailable on Windows.
 
 To start a specific task or an actor in an existing conda environment, pass in the environment name to your task or 
 actor via the ``runtime_env`` parameter as follows:

--- a/doc/source/serve/core-apis.rst
+++ b/doc/source/serve/core-apis.rst
@@ -238,7 +238,7 @@ Ray Serve supports serving deployments with different (possibly conflicting)
 python dependencies.  For example, you can simultaneously serve one deployment
 that uses legacy Tensorflow 1 and another that uses Tensorflow 2.
 
-Currently this is supported using `conda <https://docs.conda.io/en/latest/>`_
+Currently this is supported on Mac OS and Linux using `conda <https://docs.conda.io/en/latest/>`_
 via Ray's built-in ``runtime_env`` option for actors.
 As with all other actor options, pass these in via ``ray_actor_options`` in
 your deployment.

--- a/python/ray/_private/runtime_env.py
+++ b/python/ray/_private/runtime_env.py
@@ -88,7 +88,7 @@ class RuntimeEnvDict:
         # TODO(architkulkarni) support env_vars, docker
 
         # TODO(architkulkarni) This is to make it easy for the worker caching
-        # code in C++ to check if the env is empty without deserializing and 
+        # code in C++ to check if the env is empty without deserializing and
         # parsing it.  We should use a less confusing approach here.
         if all(val is None for val in self._dict.values()):
             self._dict = {}

--- a/python/ray/_private/runtime_env.py
+++ b/python/ray/_private/runtime_env.py
@@ -60,14 +60,16 @@ class RuntimeEnvDict:
     """
 
     def __init__(self, runtime_env_json: dict):
-        if sys.platform == "win32":
-            raise NotImplementedError("runtime_env is currently not supported "
-                                      "on Windows.")
         # Simple dictionary with all options validated. This will always
-        # contain all supported keys; values will be set to None if unspecified
+        # contain all supported keys; values will be set to None if
+        # unspecified.  However, if all values are None this is set to {}.
         self._dict = {}
         self._dict["conda"] = None
         if "conda" in runtime_env_json:
+            if sys.platform == "win32":
+                raise NotImplementedError("The 'conda' field in runtime_env "
+                                          "is not currently supported on "
+                                          "Windows.")
             conda = runtime_env_json["conda"]
             if isinstance(conda, str):
                 self._dict["conda"] = conda
@@ -85,9 +87,9 @@ class RuntimeEnvDict:
         # TODO(ekl) support py_modules
         # TODO(architkulkarni) support env_vars, docker
 
-        # TODO(architkulkarni) remove once workers are cached by runtime env.
-        # Currently the worker pool just checks for a nonempty runtime env
-        # and if so, starts a new worker process and calls the shim process.
+        # TODO(architkulkarni) This is to make it easy for the worker caching
+        # code in C++ to check if the env is empty without deserializing and 
+        # parsing it.  We should use a less confusing approach here.
         if all(val is None for val in self._dict.values()):
             self._dict = {}
 

--- a/python/ray/_private/runtime_env.py
+++ b/python/ray/_private/runtime_env.py
@@ -60,6 +60,9 @@ class RuntimeEnvDict:
     """
 
     def __init__(self, runtime_env_json: dict):
+        if sys.platform == "win32":
+            raise NotImplementedError("runtime_env is currently not supported "
+                                      "on Windows.")
         # Simple dictionary with all options validated. This will always
         # contain all supported keys; values will be set to None if unspecified
         self._dict = {}

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -3,6 +3,7 @@ import atexit
 import collections
 import inspect
 import os
+import sys
 import time
 from dataclasses import dataclass
 from functools import wraps
@@ -328,7 +329,7 @@ class Client:
         # If using Ray client, skip this convenience feature because the local
         # client env doesn't create the Ray cluster (so the client env is
         # likely not present on the cluster.)
-        if not ray.util.client.ray.is_connected():
+        if not ray.util.client.ray.is_connected() and sys.platform != "win32":
             if ray_actor_options.get("runtime_env") is None:
                 ray_actor_options["runtime_env"] = {}
             if ray_actor_options["runtime_env"].get("conda") is None:
@@ -373,7 +374,7 @@ class Client:
         # If using Ray client, skip this convenience feature because the local
         # client env doesn't create the Ray cluster (so the client env is
         # likely not present on the cluster.)
-        if not ray.util.client.ray.is_connected():
+        if not ray.util.client.ray.is_connected() and sys.platform != "win32":
             if ray_actor_options.get("runtime_env") is None:
                 ray_actor_options["runtime_env"] = {}
             if ray_actor_options["runtime_env"].get("conda") is None:

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -59,6 +59,7 @@ def conda_envs():
 @pytest.mark.skipif(
     os.environ.get("CONDA_DEFAULT_ENV") is None,
     reason="must be run from within a conda environment")
+@pytest.mark.skipif(sys.platform == "win32", reason="Unsupported on Windows.")
 def test_task_conda_env(conda_envs, shutdown_only):
     import tensorflow as tf
     ray.init()
@@ -77,6 +78,7 @@ def test_task_conda_env(conda_envs, shutdown_only):
 @pytest.mark.skipif(
     os.environ.get("CONDA_DEFAULT_ENV") is None,
     reason="must be run from within a conda environment")
+@pytest.mark.skipif(sys.platform == "win32", reason="Unsupported on Windows.")
 def test_actor_conda_env(conda_envs, shutdown_only):
     import tensorflow as tf
     ray.init()
@@ -96,6 +98,7 @@ def test_actor_conda_env(conda_envs, shutdown_only):
 @pytest.mark.skipif(
     os.environ.get("CONDA_DEFAULT_ENV") is None,
     reason="must be run from within a conda environment")
+@pytest.mark.skipif(sys.platform == "win32", reason="Unsupported on Windows.")
 def test_inheritance_conda_env(conda_envs, shutdown_only):
     import tensorflow as tf
     ray.init()
@@ -125,6 +128,7 @@ def test_inheritance_conda_env(conda_envs, shutdown_only):
 @pytest.mark.skipif(
     os.environ.get("CONDA_DEFAULT_ENV") is None,
     reason="must be run from within a conda environment")
+@pytest.mark.skipif(sys.platform == "win32", reason="Unsupported on Windows.")
 def test_job_config_conda_env(conda_envs, shutdown_only):
     import tensorflow as tf
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Due to the way the shim process is currently implemented using `exec`, runtime envs do not work on Windows, and therefore dependency management using conda is also broken.  

By default Serve uses runtime_envs as a convenience feature when running inside a conda environment to ensure that backends are created in the conda environment of the driver script.  Thus Serve will fail on Windows when running inside a conda environment on Windows, even when running the "quickstart" example.  

Until runtime envs for Windows is supported, we should disable it explicitly and add mention this in the docs.  This PR does that, and also removes the feature above for Serve when running on Windows.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/15703 
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
