### PR TITLE
[rllib] Read "logger_config" first before "prefix".

### DIFF
--- a/rllib/examples/custom_logger.py
+++ b/rllib/examples/custom_logger.py
@@ -36,7 +36,7 @@ class MyPrintLogger(Logger):
         # Custom init function.
         print("Initializing ...")
         # Setting up our log-line prefix.
-        self.prefix = self.config.get("prefix")
+        self.prefix = self.config.get("logger_config").get("prefix")
 
     def on_result(self, result: dict):
         # Define, what should happen on receiving a `result` (dict).


### PR DESCRIPTION

## Why are these changes needed?

Bug fix the custom logger example. This example is linked from the documentation in the RLlib section.

## Related issue number

None

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
