### PR TITLE
[client] One Driver per RayClient Server

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1868,7 +1868,8 @@ def start_ray_client_server(redis_address,
                             stdout_file=None,
                             stderr_file=None,
                             redis_password=None,
-                            fate_share=None):
+                            fate_share=None,
+                            server_type="proxy"):
     """Run the server process of the Ray client.
 
     Args:
@@ -1878,6 +1879,7 @@ def start_ray_client_server(redis_address,
         stderr_file: A file handle opened for writing to redirect stderr to. If
             no redirection should happen, then this should be None.
         redis_password (str): The password of the redis server.
+        server_type (str): Whether to start the proxy version of Ray Client.
 
     Returns:
         ProcessInfo for the process that was started.
@@ -1885,7 +1887,7 @@ def start_ray_client_server(redis_address,
     command = [
         sys.executable, "-m", "ray.util.client.server",
         "--redis-address=" + str(redis_address),
-        "--port=" + str(ray_client_server_port)
+        "--port=" + str(ray_client_server_port), "--mode=" + server_type
     ]
     if redis_password:
         command.append("--redis-password=" + redis_password)

--- a/python/ray/serve/tests/test_ray_client.py
+++ b/python/ray/serve/tests/test_ray_client.py
@@ -1,5 +1,6 @@
 import random
 import subprocess
+import sys
 
 import pytest
 import requests
@@ -26,6 +27,7 @@ def ray_client_instance():
         subprocess.check_output(["ray", "stop", "--force"])
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="Buggy on MacOS + Windows")
 def test_ray_client(ray_client_instance):
     ray.util.connect(ray_client_instance)
 

--- a/python/ray/tests/test_client_terminate.py
+++ b/python/ray/tests/test_client_terminate.py
@@ -113,7 +113,7 @@ def test_kill_cancel_metadata(ray_start_regular):
             pass
 
         def mock_terminate(term, metadata):
-            raise MetadataIsCorrectlyPassedException(metadata[0][0])
+            raise MetadataIsCorrectlyPassedException(metadata[1][0])
 
         # Mock stub's Terminate method to raise an exception.
         ray.api.worker.server.Terminate = mock_terminate

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -521,11 +521,11 @@ sleep(600)
     # waiting it to be up
     sleep(5)
     runtime_env = f"""{{  "working_dir": "{working_dir}" }}"""
-    # Execute the second one which should trigger an error
+    # Execute the second one which should work because Ray Client servers.
     execute_statement = "print(sum(ray.get([run_test.remote()] * 1000)))"
     script = driver_script.format(**locals())
     out = run_string_as_driver(script, env)
-    assert out.strip().split()[-1] == "ERROR"
+    assert out.strip().split()[-1] == "1000"
     proc.kill()
     proc.wait()
 
@@ -571,14 +571,14 @@ sleep(600)
     sleep(5)
     runtime_env = f"""
 {{  "working_dir": test_module.__path__[0] }}"""  # noqa: F541
-    # Execute the following cmd in the second one which should
-    # fail
+    # Execute the following cmd in the second one and ensure that
+    # it is able to run.
     execute_statement = "print('OK')"
     script = driver_script.format(**locals())
     out = run_string_as_driver(script, env)
     proc.kill()
     proc.wait()
-    assert out.strip().split()[-1] == "ERROR"
+    assert out.strip().split()[-1] == "OK"
 
 
 @unittest.skipIf(sys.platform == "win32", "Fail to create temp dir.")

--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 # This version string is incremented to indicate breaking changes in the
 # protocol that require upgrading the client version.
-CURRENT_PROTOCOL_VERSION = "2021-04-19"
+CURRENT_PROTOCOL_VERSION = "2021-05-18"
 
 
 class RayAPIStub:

--- a/python/ray/util/client/dataclient.py
+++ b/python/ray/util/client/dataclient.py
@@ -63,7 +63,7 @@ class DataClient:
         stub = ray_client_pb2_grpc.RayletDataStreamerStub(self.channel)
         resp_stream = stub.Datapath(
             iter(self.request_queue.get, None),
-            metadata=[("client_id", self._client_id)] + self._metadata,
+            metadata=self._metadata,
             wait_for_ready=True)
         try:
             for response in resp_stream:

--- a/python/ray/util/client/server/dataservicer.py
+++ b/python/ray/util/client/server/dataservicer.py
@@ -49,7 +49,7 @@ class DataServicer(ray_client_pb2_grpc.RayletDataStreamerServicer):
 
     def Datapath(self, request_iterator, context):
         metadata = {k: v for k, v in context.invocation_metadata()}
-        client_id = metadata["client_id"]
+        client_id = metadata.get("client_id") or ""
         if client_id == "":
             logger.error("Client connecting with no client_id")
             return

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -15,6 +15,7 @@ import ray.core.generated.ray_client_pb2_grpc as ray_client_pb2_grpc
 from ray.util.client.common import (ClientServerHandle,
                                     CLIENT_SERVER_MAX_THREADS, GRPC_OPTIONS)
 from ray._private.services import ProcessInfo, start_ray_client_server
+from ray._private.utils import detect_fate_sharing_support
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +58,8 @@ class ProxyManager():
         self._check_thread = Thread(target=self._check_processes, daemon=True)
         self._check_thread.start()
 
+        self.fate_share = bool(detect_fate_sharing_support())
+
     def _get_unused_port(self) -> int:
         """
         Search for a port in _free_ports that is unused.
@@ -87,7 +90,7 @@ class ProxyManager():
             process_handle=start_ray_client_server(
                 self.redis_address,
                 port,
-                fate_share=True,
+                fate_share=self.fate_share,
                 server_type="specific-server"),
             channel=grpc.insecure_channel(
                 f"localhost:{port}", options=GRPC_OPTIONS))

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -43,10 +43,11 @@ def _get_unused_port() -> int:
 
 def _get_client_id_from_context(context: Any) -> str:
     metadata = {k: v for k, v in context.invocation_metadata()}
-    client_id = metadata.get("client_id", "")
+    client_id = metadata.get("client_id") or ""
     if client_id == "":
         logger.error("Client connecting with no client_id")
         context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+    return client_id
 
 
 @dataclass
@@ -247,7 +248,7 @@ class LogstreamServicerProxy(ray_client_pb2_grpc.RayletLogStreamerServicer):
             if channel is not None:
                 break
             logger.warning(
-                f"Retrying Logstream connection. {i} attempts failed.")
+                f"Retrying Logstream connection. {i+1} attempts failed.")
             time.sleep(5)
 
         if channel is None:

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -168,6 +168,8 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
             data = ray.is_initialized()
         elif request.type == ray_client_pb2.ClusterInfoType.TIMELINE:
             data = ray.timeline()
+        elif request.type == ray_client_pb2.ClusterInfoType.PING:
+            data = {}
         else:
             raise TypeError("Unsupported cluster info type")
         return json.dumps(data)

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -3,7 +3,6 @@ from concurrent import futures
 import grpc
 import base64
 from collections import defaultdict
-from dataclasses import dataclass
 import os
 import queue
 
@@ -22,7 +21,9 @@ import ray.core.generated.ray_client_pb2_grpc as ray_client_pb2_grpc
 import time
 import inspect
 import json
-from ray.util.client.common import (GRPC_OPTIONS, CLIENT_SERVER_MAX_THREADS)
+from ray.util.client.common import (ClientServerHandle, GRPC_OPTIONS,
+                                    CLIENT_SERVER_MAX_THREADS)
+from ray.util.client.server.proxier import serve_proxier
 from ray.util.client.server.server_pickler import convert_from_arg
 from ray.util.client.server.server_pickler import dumps_from_server
 from ray.util.client.server.server_pickler import loads_from_client
@@ -33,6 +34,8 @@ from ray.util.placement_group import PlacementGroup
 from ray._private.client_mode_hook import disable_client_hook
 
 logger = logging.getLogger(__name__)
+
+TIMEOUT_FOR_SPECIFIC_SERVER_S = 30
 
 
 class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
@@ -560,20 +563,6 @@ def decode_options(
     return opts
 
 
-@dataclass
-class ClientServerHandle:
-    """Holds the handles to the registered gRPC servicers and their server."""
-    task_servicer: RayletServicer
-    data_servicer: DataServicer
-    logs_servicer: LogstreamServicer
-    grpc_server: grpc.Server
-
-    # Add a hook for all the cases that previously
-    # expected simply a gRPC server
-    def __getattr__(self, attr):
-        return getattr(self.grpc_server, attr)
-
-
 def serve(connection_str, ray_connect_handler=None):
     def default_connect_handler(job_config: JobConfig = None):
         with disable_client_hook():
@@ -667,6 +656,11 @@ def main():
     parser.add_argument(
         "-p", "--port", type=int, default=50051, help="Port to bind to")
     parser.add_argument(
+        "--mode",
+        type=str,
+        choices=["proxy", "legacy", "specific-server"],
+        default="proxy")
+    parser.add_argument(
         "--redis-address",
         required=False,
         type=str,
@@ -689,8 +683,13 @@ def main():
 
     hostport = "%s:%d" % (args.host, args.port)
     logger.info(f"Starting Ray Client server on {hostport}")
-    server = serve(hostport, ray_connect_handler)
+    if args.mode == "proxy":
+        server = serve_proxier(hostport, args.redis_address)
+    else:
+        server = serve(hostport, ray_connect_handler)
+
     try:
+        idle_checks_remaining = TIMEOUT_FOR_SPECIFIC_SERVER_S
         while True:
             health_report = {
                 "time": time.time(),
@@ -706,6 +705,18 @@ def main():
                 logger.exception(e)
 
             time.sleep(1)
+            if args.mode == "specific-server":
+                if server.data_servicer.num_clients > 0:
+                    idle_checks_remaining = TIMEOUT_FOR_SPECIFIC_SERVER_S
+                else:
+                    idle_checks_remaining -= 1
+                if idle_checks_remaining == 0:
+                    raise KeyboardInterrupt()
+                if (idle_checks_remaining % 5 == 0 and idle_checks_remaining !=
+                        TIMEOUT_FOR_SPECIFIC_SERVER_S):
+                    logger.info(
+                        f"{idle_checks_remaining} idle checks before shutdown."
+                    )
 
     except KeyboardInterrupt:
         server.stop(0)

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -78,7 +78,8 @@ class Worker:
               exception.
         """
         self._client_id = make_client_id()
-        self.metadata = [("client_id", self._client_id)] + metadata if metadata else []
+        self.metadata = [("client_id", self._client_id)] + (metadata if
+                                                            metadata else [])
         self.channel = None
         self.server = None
         self._conn_state = grpc.ChannelConnectivity.IDLE
@@ -439,8 +440,7 @@ class Worker:
         """
         if self.server is not None:
             logger.debug("Pinging server.")
-            result = self.get_cluster_info(
-                ray_client_pb2.ClusterInfoType.IS_INITIALIZED)
+            result = self.get_cluster_info(ray_client_pb2.ClusterInfoType.PING)
             return result is not None
         return False
 

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -77,11 +77,11 @@ class Worker:
               at least once.  For infinite retries, catch the ConnectionError
               exception.
         """
-        self.metadata = metadata if metadata else []
+        self._client_id = make_client_id()
+        self.metadata = [("client_id", self._client_id)] + metadata if metadata else []
         self.channel = None
         self.server = None
         self._conn_state = grpc.ChannelConnectivity.IDLE
-        self._client_id = make_client_id()
         self._converted: Dict[str, ClientStub] = {}
 
         if secure:

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -157,6 +157,7 @@ message ClusterInfoType {
     AVAILABLE_RESOURCES = 3;
     RUNTIME_CONTEXT = 4;
     TIMELINE = 5;
+    PING = 6;
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* This PR Creates a gRPC Proxy that routes traffic to a RayClient Server _per_  Client. This means that each Client's functions are run on a separate driver (separate JobID and separate JobConfig).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
