### PR TITLE
[Nightly Dashboard] Fix the nightly shuffle test bug

### DIFF
--- a/python/ray/internal/internal_api.py
+++ b/python/ray/internal/internal_api.py
@@ -27,6 +27,9 @@ def memory_summary(address=None,
     from ray.new_dashboard.memory_utils import memory_summary
     if not address:
         address = services.get_ray_address_to_use_or_die()
+    if address == "auto":
+        address = services.find_redis_address_or_die()
+
     state = GlobalState()
     state._initialize_global_state(address, redis_password)
     if stats_only:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When RAY_ADDRESS="auto" is provided, `memory_summary` function passes "auto" as a redis address to cpp code which causes the crash. This has the correct translation of redis address when "auto" is given.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
