### PR TITLE
Pubsub registration / unregistration idempotency

### DIFF
--- a/src/ray/core_worker/reference_count_test.cc
+++ b/src/ray/core_worker/reference_count_test.cc
@@ -164,13 +164,13 @@ class MockDistributedPublisher : public pubsub::PublisherInterface {
         subscription_callback_map_(subscription_callback_map),
         subscription_failure_callback_map_(subscription_failure_callback_map),
         publisher_id_(publisher_id) {}
-
   ~MockDistributedPublisher() = default;
 
-  void RegisterSubscription(const rpc::ChannelType channel_type,
+  bool RegisterSubscription(const rpc::ChannelType channel_type,
                             const pubsub::SubscriberID &subscriber_id,
                             const std::string &key_id_binary) {
     RAY_CHECK(false) << "No need to implement it for testing.";
+    return false;
   }
 
   void Publish(const rpc::ChannelType channel_type, const rpc::PubMessage &pub_message,

--- a/src/ray/pubsub/mock_pubsub.h
+++ b/src/ray/pubsub/mock_pubsub.h
@@ -37,7 +37,7 @@ class MockSubscriber : public pubsub::SubscriberInterface {
 
 class MockPublisher : public pubsub::PublisherInterface {
  public:
-  MOCK_METHOD3(RegisterSubscription, void(const rpc::ChannelType channel_type,
+  MOCK_METHOD3(RegisterSubscription, bool(const rpc::ChannelType channel_type,
                                           const pubsub::SubscriberID &subscriber_id,
                                           const std::string &key_id_binary));
 

--- a/src/ray/pubsub/publisher.cc
+++ b/src/ray/pubsub/publisher.cc
@@ -21,13 +21,16 @@ namespace pubsub {
 namespace pub_internal {
 
 template <typename KeyIdType>
-void SubscriptionIndex<KeyIdType>::AddEntry(const std::string &key_id_binary,
+bool SubscriptionIndex<KeyIdType>::AddEntry(const std::string &key_id_binary,
                                             const SubscriberID &subscriber_id) {
   const auto key_id = KeyIdType::FromBinary(key_id_binary);
   auto &subscribing_key_ids = subscribers_to_key_id_[subscriber_id];
-  subscribing_key_ids.emplace(key_id);
+  auto key_added = subscribing_key_ids.emplace(key_id).second;
   auto &subscriber_map = key_id_to_subscribers_[key_id];
-  subscriber_map.emplace(subscriber_id);
+  auto subscriber_added = subscriber_map.emplace(subscriber_id).second;
+
+  RAY_CHECK(key_added == subscriber_added);
+  return key_added;
 }
 
 template <typename KeyIdType>
@@ -215,7 +218,7 @@ void Publisher::ConnectToSubscriber(const SubscriberID &subscriber_id,
   subscriber->PublishIfPossible();
 }
 
-void Publisher::RegisterSubscription(const rpc::ChannelType channel_type,
+bool Publisher::RegisterSubscription(const rpc::ChannelType channel_type,
                                      const SubscriberID &subscriber_id,
                                      const std::string &key_id_binary) {
   absl::MutexLock lock(&mutex_);
@@ -226,7 +229,7 @@ void Publisher::RegisterSubscription(const rpc::ChannelType channel_type,
   }
   auto subscription_index_it = subscription_index_map_.find(channel_type);
   RAY_CHECK(subscription_index_it != subscription_index_map_.end());
-  subscription_index_it->second.AddEntry(key_id_binary, subscriber_id);
+  return subscription_index_it->second.AddEntry(key_id_binary, subscriber_id);
 }
 
 void Publisher::Publish(const rpc::ChannelType channel_type,

--- a/src/ray/pubsub/publisher.cc
+++ b/src/ray/pubsub/publisher.cc
@@ -25,9 +25,9 @@ void SubscriptionIndex<KeyIdType>::AddEntry(const std::string &key_id_binary,
                                             const SubscriberID &subscriber_id) {
   const auto key_id = KeyIdType::FromBinary(key_id_binary);
   auto &subscribing_key_ids = subscribers_to_key_id_[subscriber_id];
-  RAY_CHECK(subscribing_key_ids.emplace(key_id).second);
+  subscribing_key_ids.emplace(key_id);
   auto &subscriber_map = key_id_to_subscribers_[key_id];
-  RAY_CHECK(subscriber_map.emplace(subscriber_id).second);
+  subscriber_map.emplace(subscriber_id);
 }
 
 template <typename KeyIdType>
@@ -82,7 +82,7 @@ bool SubscriptionIndex<KeyIdType>::EraseSubscriber(const SubscriberID &subscribe
 template <typename KeyIdType>
 bool SubscriptionIndex<KeyIdType>::EraseEntry(const std::string &key_id_binary,
                                               const SubscriberID &subscriber_id) {
-  // Erase from subscribers_to_objects_;
+  // Erase keys from subscribers.
   const auto key_id = KeyIdType::FromBinary(key_id_binary);
   auto subscribers_to_message_it = subscribers_to_key_id_.find(subscriber_id);
   if (subscribers_to_message_it == subscribers_to_key_id_.end()) {
@@ -99,7 +99,7 @@ bool SubscriptionIndex<KeyIdType>::EraseEntry(const std::string &key_id_binary,
     subscribers_to_key_id_.erase(subscribers_to_message_it);
   }
 
-  // Erase from objects_to_subscribers_.
+  // Erase subscribers from keys (reverse index).
   auto key_id_to_subscriber_it = key_id_to_subscribers_.find(key_id);
   // If code reaches this line, that means the object id was in the index.
   RAY_CHECK(key_id_to_subscriber_it != key_id_to_subscribers_.end());

--- a/src/ray/pubsub/publisher.h
+++ b/src/ray/pubsub/publisher.h
@@ -43,7 +43,7 @@ class SubscriptionIndex {
 
   /// Add a new entry to the index.
   /// NOTE: The method is idempotent. If it adds a duplicated entry, it will be no-op.
-  void AddEntry(const std::string &key_id_binary, const SubscriberID &subscriber_id);
+  bool AddEntry(const std::string &key_id_binary, const SubscriberID &subscriber_id);
 
   /// Return the set of subscriber ids that are subscribing to the given object ids.
   absl::optional<std::reference_wrapper<const absl::flat_hash_set<SubscriberID>>>
@@ -159,7 +159,8 @@ class PublisherInterface {
   /// \param channel_type The type of the channel.
   /// \param subscriber_id The node id of the subscriber.
   /// \param key_id_binary The key_id that the subscriber is subscribing to.
-  virtual void RegisterSubscription(const rpc::ChannelType channel_type,
+  /// \return True if registration is new. False otherwise.
+  virtual bool RegisterSubscription(const rpc::ChannelType channel_type,
                                     const SubscriberID &subscriber_id,
                                     const std::string &key_id_binary) = 0;
 
@@ -243,7 +244,8 @@ class Publisher : public PublisherInterface {
   /// \param channel_type The type of the channel.
   /// \param subscriber_id The node id of the subscriber.
   /// \param key_id_binary The key_id that the subscriber is subscribing to.
-  void RegisterSubscription(const rpc::ChannelType channel_type,
+  /// \return True if the registration is new. False otherwise.
+  bool RegisterSubscription(const rpc::ChannelType channel_type,
                             const SubscriberID &subscriber_id,
                             const std::string &key_id_binary) override;
 
@@ -308,6 +310,7 @@ class Publisher : public PublisherInterface {
   FRIEND_TEST(PublisherTest, TestNodeFailureWhenConnectionDoesntExist);
   FRIEND_TEST(PublisherTest, TestUnregisterSubscription);
   FRIEND_TEST(PublisherTest, TestUnregisterSubscriber);
+  FRIEND_TEST(PublisherTest, TestRegistrationIdempotency);
   /// Testing only. Return true if there's no metadata remained in the private attribute.
   bool CheckNoLeaks() const;
 

--- a/src/ray/pubsub/publisher.h
+++ b/src/ray/pubsub/publisher.h
@@ -42,7 +42,7 @@ class SubscriptionIndex {
   ~SubscriptionIndex() = default;
 
   /// Add a new entry to the index.
-  /// NOTE: If the entry already exists, it raises assert failure.
+  /// NOTE: The method is idempotent. If it adds a duplicated entry, it will be no-op.
   void AddEntry(const std::string &key_id_binary, const SubscriberID &subscriber_id);
 
   /// Return the set of subscriber ids that are subscribing to the given object ids.
@@ -53,9 +53,7 @@ class SubscriptionIndex {
   /// NOTE: It cannot erase subscribers that were never added.
   bool EraseSubscriber(const SubscriberID &subscriber_id);
 
-  /// Erase the object id and subscriber id from the index. Return the number of erased
-  /// entries.
-  /// NOTE: It cannot erase subscribers that were never added.
+  /// Erase the object id and subscriber id from the index.
   bool EraseEntry(const std::string &key_id_binary, const SubscriberID &subscriber_id);
 
   /// Return true if the object id exists in the index.

--- a/src/ray/pubsub/test/publisher_test.cc
+++ b/src/ray/pubsub/test/publisher_test.cc
@@ -923,6 +923,31 @@ TEST_F(PublisherTest, TestUnregisterSubscriber) {
   ASSERT_TRUE(object_status_publisher_->CheckNoLeaks());
 }
 
+// Test if registration / unregistration is idempotent.
+TEST_F(PublisherTest, TestRegistrationIdempotency) {
+  const auto subscriber_node_id = NodeID::FromRandom();
+  const auto oid = ObjectID::FromRandom();
+  ASSERT_TRUE(object_status_publisher_->RegisterSubscription(
+      rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary()));
+  ASSERT_FALSE(object_status_publisher_->RegisterSubscription(
+      rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary()));
+  ASSERT_FALSE(object_status_publisher_->RegisterSubscription(
+      rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary()));
+  ASSERT_FALSE(object_status_publisher_->RegisterSubscription(
+      rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary()));
+  ASSERT_FALSE(object_status_publisher_->CheckNoLeaks());
+  ASSERT_TRUE(object_status_publisher_->UnregisterSubscription(
+      rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary()));
+  ASSERT_FALSE(object_status_publisher_->UnregisterSubscription(
+      rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary()));
+  ASSERT_TRUE(object_status_publisher_->CheckNoLeaks());
+  ASSERT_TRUE(object_status_publisher_->RegisterSubscription(
+      rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary()));
+  ASSERT_FALSE(object_status_publisher_->CheckNoLeaks());
+  ASSERT_TRUE(object_status_publisher_->UnregisterSubscription(
+      rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary()));
+}
+
 }  // namespace pubsub
 
 }  // namespace ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Make registration / unregistration idempotent to allow callers to call them multiple times without strong restrction.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
