### PR TITLE
[RLlib] Issue 15887: MARWIL adv norm update mismatch for tf (static-graph) vs torch versions.

### DIFF
--- a/rllib/agents/marwil/marwil_tf_policy.py
+++ b/rllib/agents/marwil/marwil_tf_policy.py
@@ -102,7 +102,7 @@ class MARWILLoss:
             if policy.config["framework"] in ["tf2", "tfe"]:
                 update_term = adv_squared - policy._moving_average_sqd_adv_norm
                 policy._moving_average_sqd_adv_norm.assign_add(
-                    1e-8 * update_term)
+                    1e-7 * update_term)
 
                 # Exponentially weighted advantages.
                 c = tf.math.sqrt(policy._moving_average_sqd_adv_norm)
@@ -111,7 +111,7 @@ class MARWILLoss:
             else:
                 update_adv_norm = tf1.assign_add(
                     ref=policy._moving_average_sqd_adv_norm,
-                    value=1e-6 *
+                    value=1e-7 *
                     (adv_squared - policy._moving_average_sqd_adv_norm))
 
                 # Exponentially weighted advantages.

--- a/rllib/agents/marwil/marwil_torch_policy.py
+++ b/rllib/agents/marwil/marwil_torch_policy.py
@@ -26,7 +26,7 @@ def marwil_loss(policy, model, dist_class, train_batch):
 
     # Policy loss.
     # Update averaged advantage norm.
-    policy.ma_adv_norm.add_(1e-6 * (adv_squared - policy.ma_adv_norm))
+    policy.ma_adv_norm.add_(1e-7 * (adv_squared - policy.ma_adv_norm))
     # Exponentially weighted advantages.
     exp_advs = torch.exp(policy.config["beta"] *
                          (adv / (1e-8 + torch.pow(policy.ma_adv_norm, 0.5))))

--- a/rllib/agents/marwil/tests/test_marwil.py
+++ b/rllib/agents/marwil/tests/test_marwil.py
@@ -92,7 +92,7 @@ class TestMARWIL(unittest.TestCase):
         # Learn from offline data.
         config["input"] = [data_file]
 
-        for fw, sess in framework_iterator(config, frameworks=["tf", "torch", "tf2"], session=True):
+        for fw, sess in framework_iterator(config, session=True):
             reader = JsonReader(inputs=[data_file])
             batch = reader.next()
 
@@ -131,7 +131,6 @@ class TestMARWIL(unittest.TestCase):
             expected_pol_loss = -1.0 * np.mean(exp_advs * logp)
             expected_loss = \
                 expected_pol_loss + config["vf_coeff"] * expected_vf_loss
-            expected_adv_norm = 100.0 + 1e-8 * (adv_squared - 100.0)
 
             # Calculate the algorithm's loss (to check against our own
             # calculation above).
@@ -141,10 +140,11 @@ class TestMARWIL(unittest.TestCase):
                 else marwil.marwil_torch_policy.marwil_loss
             if fw != "tf":
                 policy._lazy_tensor_dict(postprocessed_batch)
-                loss_out = loss_func(policy, model, policy.dist_class, postprocessed_batch)
+                loss_out = loss_func(policy, model, policy.dist_class,
+                                     postprocessed_batch)
             else:
-                loss_out, v_loss, p_loss, adv_norm = policy.get_session().run(
-                    [policy._loss, policy.loss.v_loss, policy.loss.p_loss, policy._moving_average_sqd_adv_norm],
+                loss_out, v_loss, p_loss = policy.get_session().run(
+                    [policy._loss, policy.loss.v_loss, policy.loss.p_loss],
                     feed_dict=policy._get_loss_inputs_dict(
                         postprocessed_batch, shuffle=False))
 

--- a/rllib/agents/marwil/tests/test_marwil.py
+++ b/rllib/agents/marwil/tests/test_marwil.py
@@ -92,7 +92,7 @@ class TestMARWIL(unittest.TestCase):
         # Learn from offline data.
         config["input"] = [data_file]
 
-        for fw in framework_iterator(config, frameworks=["torch", "tf2"]):
+        for fw, sess in framework_iterator(config, frameworks=["tf", "torch", "tf2"], session=True):
             reader = JsonReader(inputs=[data_file])
             batch = reader.next()
 
@@ -106,9 +106,13 @@ class TestMARWIL(unittest.TestCase):
                 batch, 0.0, config["gamma"], 1.0, False, False)["advantages"]
             if fw == "torch":
                 cummulative_rewards = torch.tensor(cummulative_rewards)
-            batch = policy._lazy_tensor_dict(batch)
+            if fw != "tf":
+                batch = policy._lazy_tensor_dict(batch)
             model_out, _ = model.from_batch(batch)
             vf_estimates = model.value_function()
+            if fw == "tf":
+                model_out, vf_estimates = \
+                    policy.get_session().run([model_out, vf_estimates])
             adv = cummulative_rewards - vf_estimates
             if fw == "torch":
                 adv = adv.detach().cpu().numpy()
@@ -116,14 +120,18 @@ class TestMARWIL(unittest.TestCase):
             c_2 = 100.0 + 1e-8 * (adv_squared - 100.0)
             c = np.sqrt(c_2)
             exp_advs = np.exp(config["beta"] * (adv / c))
-            logp = policy.dist_class(model_out, model).logp(batch["actions"])
+            dist = policy.dist_class(model_out, model)
+            logp = dist.logp(batch["actions"])
             if fw == "torch":
                 logp = logp.detach().cpu().numpy()
+            elif fw == "tf":
+                logp = sess.run(logp)
             # Calculate all expected loss components.
             expected_vf_loss = 0.5 * adv_squared
             expected_pol_loss = -1.0 * np.mean(exp_advs * logp)
             expected_loss = \
                 expected_pol_loss + config["vf_coeff"] * expected_vf_loss
+            expected_adv_norm = 100.0 + 1e-8 * (adv_squared - 100.0)
 
             # Calculate the algorithm's loss (to check against our own
             # calculation above).
@@ -131,13 +139,22 @@ class TestMARWIL(unittest.TestCase):
             postprocessed_batch = policy.postprocess_trajectory(batch)
             loss_func = marwil.marwil_tf_policy.marwil_loss if fw != "torch" \
                 else marwil.marwil_torch_policy.marwil_loss
-            loss_out = loss_func(policy, model, policy.dist_class,
-                                 policy._lazy_tensor_dict(postprocessed_batch))
+            if fw != "tf":
+                policy._lazy_tensor_dict(postprocessed_batch)
+                loss_out = loss_func(policy, model, policy.dist_class, postprocessed_batch)
+            else:
+                loss_out, v_loss, p_loss, adv_norm = policy.get_session().run(
+                    [policy._loss, policy.loss.v_loss, policy.loss.p_loss, policy._moving_average_sqd_adv_norm],
+                    feed_dict=policy._get_loss_inputs_dict(
+                        postprocessed_batch, shuffle=False))
 
             # Check all components.
             if fw == "torch":
                 check(policy.v_loss, expected_vf_loss, decimals=4)
                 check(policy.p_loss, expected_pol_loss, decimals=4)
+            elif fw == "tf":
+                check(v_loss, expected_vf_loss, decimals=4)
+                check(p_loss, expected_pol_loss, decimals=4)
             else:
                 check(policy.loss.v_loss, expected_vf_loss, decimals=4)
                 check(policy.loss.p_loss, expected_pol_loss, decimals=4)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Issue 15887: MARWIL adv norm update mismatch for tf (static-graph) vs torch versions.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Issue #15887 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #15887 
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
