### PR TITLE
[Object spilling] Avoid worker crash when an object is spilled right after being restored

### DIFF
--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -347,7 +347,9 @@ def test_spill_stats(object_spilling_config, shutdown_only):
 
 @pytest.mark.skipif(
     platform.system() == "Windows", reason="Failing on Windows.")
-def test_spill_during_get(object_spilling_config, shutdown_only):
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_async", [False, True])
+async def test_spill_during_get(object_spilling_config, shutdown_only, is_async):
     object_spilling_config, _ = object_spilling_config
     address = ray.init(
         num_cpus=4,
@@ -361,20 +363,36 @@ def test_spill_during_get(object_spilling_config, shutdown_only):
         },
     )
 
-    @ray.remote
-    def f():
-        return np.zeros(10 * 1024 * 1024)
+    if is_async:
+        @ray.remote
+        class Actor:
+            async def f(self):
+                return np.zeros(10 * 1024 * 1024)
+    else:
+        @ray.remote
+        def f():
+            return np.zeros(10 * 1024 * 1024)
 
+    if is_async:
+        a = Actor.remote()
     ids = []
     for i in range(10):
-        x = f.remote()
+        if is_async:
+            x = a.f.remote()
+        else:
+            x = f.remote()
         print(i, x)
         ids.append(x)
 
     # Concurrent gets, which require restoring from external storage, while
     # objects are being created.
     for x in ids:
-        print(ray.get(x).shape)
+        if is_async:
+            obj = await x
+        else:
+            obj = ray.get(x)
+        print(obj.shape)
+        del obj
     assert_no_thrashing(address["redis_address"])
 
 

--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -349,7 +349,8 @@ def test_spill_stats(object_spilling_config, shutdown_only):
     platform.system() == "Windows", reason="Failing on Windows.")
 @pytest.mark.asyncio
 @pytest.mark.parametrize("is_async", [False, True])
-async def test_spill_during_get(object_spilling_config, shutdown_only, is_async):
+async def test_spill_during_get(object_spilling_config, shutdown_only,
+                                is_async):
     object_spilling_config, _ = object_spilling_config
     address = ray.init(
         num_cpus=4,
@@ -364,11 +365,13 @@ async def test_spill_during_get(object_spilling_config, shutdown_only, is_async)
     )
 
     if is_async:
+
         @ray.remote
         class Actor:
             async def f(self):
                 return np.zeros(10 * 1024 * 1024)
     else:
+
         @ray.remote
         def f():
             return np.zeros(10 * 1024 * 1024)

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2862,10 +2862,11 @@ void CoreWorker::PlasmaCallback(SetResultCallback success,
   bool object_is_local = false;
   if (Contains(object_id, &object_is_local).ok() && object_is_local) {
     std::vector<std::shared_ptr<RayObject>> vec;
-    RAY_CHECK_OK(Get(std::vector<ObjectID>{object_id}, 0, &vec));
-    RAY_CHECK(vec.size() > 0)
-        << "Failed to get local object but Raylet notified object is local.";
-    return success(vec.front(), object_id, py_future);
+    if (Get(std::vector<ObjectID>{object_id}, 0, &vec).ok()) {
+      RAY_CHECK(vec.size() > 0)
+          << "Failed to get local object but Raylet notified object is local.";
+      return success(vec.front(), object_id, py_future);
+    }
   }
 
   // Object is not available locally. We now add the callback to listener queue.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When the object store memory pressure is high, e.g. object store is almost full due to pinned objects, an object which is recently restored may be spilled again in a short time. The existing code in `CoreWorker::PlasmaCallback` involves `Contains` and `Get` calls. Object spilling may happen between the two calls. So here we can't use `RAY_CHECK_OK` on the `Get` call. Instead, we should fall back to the object-not-local code path.

## Related issue number

Closes #15808

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
