### PR TITLE
[Hofix][Test] Use Same Namespace in Serve Client Test

### DIFF
--- a/python/ray/serve/tests/test_ray_client.py
+++ b/python/ray/serve/tests/test_ray_client.py
@@ -29,11 +29,11 @@ def ray_client_instance():
 
 @pytest.mark.skipif(sys.platform != "linux", reason="Buggy on MacOS + Windows")
 def test_ray_client(ray_client_instance):
-    ray.util.connect(ray_client_instance)
+    ray.util.connect(ray_client_instance, namespace="")
 
     start = """
 import ray
-ray.util.connect("{}")
+ray.util.connect("{}", namespace="")
 
 from ray import serve
 
@@ -45,7 +45,7 @@ serve.start(detached=True)
 
     deploy = """
 import ray
-ray.util.connect("{}")
+ray.util.connect("{}", namespace="")
 
 from ray import serve
 
@@ -63,7 +63,7 @@ f.deploy()
 
     delete = """
 import ray
-ray.util.connect("{}")
+ray.util.connect("{}", namespace="")
 
 from ray import serve
 
@@ -76,7 +76,7 @@ serve.get_deployment("test1").delete()
 
     fastapi = """
 import ray
-ray.util.connect("{}")
+ray.util.connect("{}", namespace="")
 
 from ray import serve
 from fastapi import FastAPI


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* The test previously relied on buggy behaviour where multiple clients belonged to the same anonymous namespace. This fixes that by ensuring that they all belong to the same anonymous namespace.

* #15875 Actually corrected the behavior (each client is in a separate namespace), but broke the buggy test.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
