### PR TITLE
[Core] Add minimal support for pip in runtime env

### DIFF
--- a/python/ray/_private/runtime_env.py
+++ b/python/ray/_private/runtime_env.py
@@ -40,8 +40,8 @@ class RuntimeEnvDict:
             modules to add to the `sys.path`.
             Examples:
                 ["/path/to/other_module", "/other_path/local_project.zip"]
-        pip: A string containing the contents of a pip requirements.txt file.
-            This will be dynamically installed in the runtime env.
+        pip (str): A string containing the contents of a pip requirements.txt
+            file.  This will be dynamically installed in the runtime env.
         conda (dict | str): Either the conda YAML config or the name of a
             local conda env (e.g., "pytorch_p36"). The Ray dependency will be
             automatically injected into the conda env to ensure compatibility
@@ -87,6 +87,10 @@ class RuntimeEnvDict:
 
         self._dict["pip"] = None
         if "pip" in runtime_env_json:
+            if sys.platform == "win32":
+                raise NotImplementedError("The 'pip' field in runtime_env "
+                                          "is not currently supported on "
+                                          "Windows.")
             pip = runtime_env_json["pip"]
             if isinstance(pip, str):
                 self._dict["pip"] = pip

--- a/python/ray/_private/runtime_env.py
+++ b/python/ray/_private/runtime_env.py
@@ -40,11 +40,17 @@ class RuntimeEnvDict:
             modules to add to the `sys.path`.
             Examples:
                 ["/path/to/other_module", "/other_path/local_project.zip"]
+        pip: A string containing the contents of a pip requirements.txt file.
+            This will be dynamically installed in the runtime env.
         conda (dict | str): Either the conda YAML config or the name of a
             local conda env (e.g., "pytorch_p36"). The Ray dependency will be
             automatically injected into the conda env to ensure compatibility
             with the cluster Ray. The conda name may be mangled automatically
             to avoid conflicts between runtime envs.
+            This field overrides the pip field.  To use pip with conda, please
+            specify your pip dependencies within the conda YAML config:
+            https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-e
+            nvironments.html#create-env-file-manually
             Examples:
                 {"channels": ["defaults"], "dependencies": ["codecov"]}
                 "pytorch_p36"   # Found on DLAMIs
@@ -78,6 +84,15 @@ class RuntimeEnvDict:
             elif conda is not None:
                 raise TypeError("runtime_env['conda'] must be of type str or "
                                 "dict")
+
+        self._dict["pip"] = None
+        if "pip" in runtime_env_json:
+            pip = runtime_env_json["pip"]
+            if isinstance(pip, str):
+                self._dict["pip"] = pip
+            else:
+                raise TypeError("runtime_env['pip'] must be of type str")
+
         if "working_dir" in runtime_env_json:
             self._dict["working_dir"] = runtime_env_json["working_dir"]
         else:

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -185,11 +185,23 @@ def test_get_conda_env_dir(tmp_path):
         assert (env_dir == str(tmp_path / "envs" / "tf2"))
 
 
+"""
+Note(architkulkarni): For runtime_env tests that involve conda or pip installs,
+"opentelemetry-api==1.0.0rc1" and "opentelemetry-sdk==1.0.0rc1" must be
+included as dependencies, because they are installed in the CI's conda env but
+are not included in the Ray dependencies, so they cause an unpickling issue.
+
+Also, these tests only run on Buildkite in a special job that runs
+after the wheel is built, because the tests pass in the wheel as a dependency
+in the runtime env.  Buildkite only supports Linux for now.
+"""
+
+
 @pytest.mark.skipif(
     os.environ.get("CI") is None,
     reason="This test is only run on CI because it uses the built Ray wheel.")
 @pytest.mark.skipif(
-    sys.platform != "linux", reason="This test is only run for Linux.")
+    sys.platform != "linux", reason="This test is only run on Buildkite.")
 def test_conda_create_task(shutdown_only):
     """Tests dynamic creation of a conda env in a task's runtime env."""
     ray.init()
@@ -229,7 +241,7 @@ def test_conda_create_task(shutdown_only):
     os.environ.get("CI") is None,
     reason="This test is only run on CI because it uses the built Ray wheel.")
 @pytest.mark.skipif(
-    sys.platform != "linux", reason="This test is only run for Linux.")
+    sys.platform != "linux", reason="This test is only run on Buildkite.")
 def test_conda_create_job_config(shutdown_only):
     """Tests dynamic conda env creation in a runtime env in the JobConfig."""
 
@@ -268,19 +280,28 @@ def test_conda_create_job_config(shutdown_only):
     os.environ.get("CI") is None,
     reason="This test is only run on CI because it uses the built Ray wheel.")
 @pytest.mark.skipif(
-    sys.platform != "linux", reason="This test is only run for Linux.")
-def test_pip_task(shutdown_only):
+    sys.platform != "linux", reason="This test is only run on Buildkite.")
+@pytest.mark.parametrize("pip_as_str", [True, False])
+def test_pip_task(shutdown_only, pip_as_str):
     """Tests pip installs in the runtime env specified in the job config."""
 
     ray.init()
     ray_wheel_path = os.path.join("/ray/.whl", get_wheel_filename())
-    requirements_txt = f"""
-    {ray_wheel_path}
-    pip-install-test==0.5
-    opentelemetry-api==1.0.0rc1
-    opentelemetry-sdk==1.0.0rc1
-    """
-    runtime_env = {"pip": requirements_txt}
+    if pip_as_str:
+        requirements_txt = f"""
+        {ray_wheel_path}
+        pip-install-test==0.5
+        opentelemetry-api==1.0.0rc1
+        opentelemetry-sdk==1.0.0rc1
+        """
+        runtime_env = {"pip": requirements_txt}
+    else:
+        runtime_env = {
+            "pip": [
+                ray_wheel_path, "pip-install-test==0.5",
+                "opentelemetry-api==1.0.0rc1", "opentelemetry-sdk==1.0.0rc1"
+            ]
+        }
 
     @ray.remote
     def f():
@@ -300,18 +321,27 @@ def test_pip_task(shutdown_only):
     os.environ.get("CI") is None,
     reason="This test is only run on CI because it uses the built Ray wheel.")
 @pytest.mark.skipif(
-    sys.platform != "linux", reason="This test is only run for Linux.")
-def test_pip_job_config(shutdown_only):
+    sys.platform != "linux", reason="This test is only run on Buildkite.")
+@pytest.mark.parametrize("pip_as_str", [True, False])
+def test_pip_job_config(shutdown_only, pip_as_str):
     """Tests dynamic installation of pip packages in a task's runtime env."""
 
     ray_wheel_path = os.path.join("/ray/.whl", get_wheel_filename())
-    requirements_txt = f"""
-    {ray_wheel_path}
-    pip-install-test==0.5
-    opentelemetry-api==1.0.0rc1
-    opentelemetry-sdk==1.0.0rc1
-    """
-    runtime_env = {"pip": requirements_txt}
+    if pip_as_str:
+        requirements_txt = f"""
+        {ray_wheel_path}
+        pip-install-test==0.5
+        opentelemetry-api==1.0.0rc1
+        opentelemetry-sdk==1.0.0rc1
+        """
+        runtime_env = {"pip": requirements_txt}
+    else:
+        runtime_env = {
+            "pip": [
+                ray_wheel_path, "pip-install-test==0.5",
+                "opentelemetry-api==1.0.0rc1", "opentelemetry-sdk==1.0.0rc1"
+            ]
+        }
 
     ray.init(job_config=JobConfig(runtime_env=runtime_env))
 

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -277,6 +277,8 @@ def test_pip_task(shutdown_only):
     requirements_txt = f"""
     {ray_wheel_path}
     pip-install-test==0.5
+    opentelemetry-api==1.0.0rc1
+    opentelemetry-sdk==1.0.0rc1
     """
     runtime_env = {"pip": requirements_txt}
 
@@ -306,6 +308,8 @@ def test_pip_job_config(shutdown_only):
     requirements_txt = f"""
     {ray_wheel_path}
     pip-install-test==0.5
+    opentelemetry-api==1.0.0rc1
+    opentelemetry-sdk==1.0.0rc1
     """
     runtime_env = {"pip": requirements_txt}
 

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -272,6 +272,7 @@ def test_conda_create_job_config(shutdown_only):
 def test_pip_task(shutdown_only):
     """Tests pip installs in the runtime env specified in the job config."""
 
+    ray.init()
     ray_wheel_path = os.path.join("/ray/.whl", get_wheel_filename())
     requirements_txt = f"""
     {ray_wheel_path}
@@ -301,7 +302,6 @@ def test_pip_task(shutdown_only):
 def test_pip_job_config(shutdown_only):
     """Tests dynamic installation of pip packages in a task's runtime env."""
 
-    ray.init()
     ray_wheel_path = os.path.join("/ray/.whl", get_wheel_filename())
     requirements_txt = f"""
     {ray_wheel_path}

--- a/python/ray/workers/setup_runtime_env.py
+++ b/python/ray/workers/setup_runtime_env.py
@@ -4,12 +4,13 @@ import argparse
 import json
 import logging
 import yaml
+import hashlib
+import subprocess
 
 from filelock import FileLock
 
 from ray._private.conda import (get_conda_activate_commands,
                                 get_or_create_conda_env)
-from ray._private.runtime_env import RuntimeEnvDict
 from ray._private.utils import try_to_create_directory
 logger = logging.getLogger(__name__)
 
@@ -31,8 +32,7 @@ def setup(input_args):
     args, remaining_args = parser.parse_known_args(args=input_args)
 
     commands = []
-    runtime_env: RuntimeEnvDict = json.loads(args.serialized_runtime_env
-                                             or "{}")
+    runtime_env: dict = json.loads(args.serialized_runtime_env or "{}")
 
     py_executable: str = sys.executable
 
@@ -57,8 +57,49 @@ def setup(input_args):
                     conda_yaml_path, conda_dir)
                 if os.path.exists(conda_yaml_path):
                     os.remove(conda_yaml_path)
-                logger.error(conda_env_name)
-                commands += get_conda_activate_commands(conda_env_name)
+            commands += get_conda_activate_commands(conda_env_name)
+    elif runtime_env.get("pip"):
+        # Install pip requirements into an empty conda env.
+        py_executable = "python"
+        requirements_txt = runtime_env["pip"]
+
+        pip_contents_hash = "pip-%s" % hashlib.sha1(
+            requirements_txt.encode("utf-8")).hexdigest()
+        # E.g. 3.6.13
+        py_version = ".".join(map(str, sys.version_info[:3]))
+        conda_dict = {
+            "name": pip_contents_hash,
+            "dependencies": [f"python={py_version}", "pip"]
+        }
+        with FileLock(
+                os.path.join(args.session_dir, "ray-conda-install.lock")):
+            conda_dir = os.path.join(args.session_dir, "runtime_resources",
+                                     "conda")
+            try_to_create_directory(conda_dir)
+            conda_yaml_path = os.path.join(conda_dir,
+                                           f"env-{pip_contents_hash}.yml")
+            with open(conda_yaml_path, "w") as file:
+                yaml.dump(conda_dict, file, sort_keys=True)
+            conda_env_name = get_or_create_conda_env(conda_yaml_path,
+                                                     conda_dir)
+            if os.path.exists(conda_yaml_path):
+                os.remove(conda_yaml_path)
+            requirements_txt_path = os.path.join(
+                conda_dir, f"requirements-{pip_contents_hash}.txt")
+            with open(requirements_txt_path, "w") as file:
+                file.write(requirements_txt)
+
+            # In a subprocess, activate the conda env and install pip packages.
+
+            pip_install_commands = []
+            pip_install_commands += get_conda_activate_commands(conda_env_name)
+            pip_install_commands += [f"pip install -r {requirements_txt_path}"]
+            pip_install_command_str = " && ".join(pip_install_commands)
+
+            subprocess.run(pip_install_command_str, shell=True, check=True)
+            logger.info("Successfully installed pip packages.")
+
+        commands += get_conda_activate_commands(conda_env_name)
 
     commands += [" ".join([f"exec {py_executable}"] + remaining_args)]
     command_separator = " && "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR allows users to supply a `str` containing the contents of a `requirements.txt` file to the `pip` field in runtime_env, or a `List[str]` representing a list of pip packages.  The `requirements.txt` file will be dynamically installed in the shim process.  A few basic tests are added.

Example:
```python
requirements_txt = f"""
    {ray_wheel_path}
    pip-install-test==0.5
    """
runtime_env = {"pip": requirements_txt}
f.options(runtime_env=runtime_env).remote()
```

Currently, specifying `conda` and `pip` at the same time is not supported--the `conda` field will take precedence.  Of course, `pip` packages can be specified in the conda dependencies.

The isolation mechanism is provided by conda.  Namely, an empty conda env is created with `pip` as a dependency, and then `pip install -r requirements.txt` is called inside after activating the environment.  This installs the dependencies in the conda environment.




<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
