### PR TITLE
[autoscaler] Bump config cache version

### DIFF
--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -243,7 +243,7 @@ def create_or_update_cluster(
     return config
 
 
-CONFIG_CACHE_VERSION = 1
+CONFIG_CACHE_VERSION = 2
 
 
 def _bootstrap_config(config: Dict[str, Any],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The constant `CONFIG_CACHE_VERSION` in commands.py has been a bit lost in time -- it should be increased each time there's a change that breaks compatibility of config cacheing/retrieving, e.g. https://github.com/ray-project/ray/pull/15584.
Thanks @ckw017 for noticing this.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
