### PR TITLE
Prevent object store from allocating over the specified limit even if there is memory fragmentation

### DIFF
--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -49,7 +49,7 @@ def test_actor_spilled(ray_start_regular):
     # Submit enough methods on the actor so that they exceed the size of the
     # object store.
     objects = []
-    num_objects = 20
+    num_objects = 40
     for _ in range(num_objects):
         obj = a.create_object.remote(object_store_memory // num_objects)
         objects.append(obj)

--- a/python/ray/tests/test_async.py
+++ b/python/ray/tests/test_async.py
@@ -113,12 +113,12 @@ async def test_garbage_collection(ray_start_regular_shared):
 
     @ray.remote
     def f():
-        return np.zeros(40 * 1024 * 1024, dtype=np.uint8)
+        return np.zeros(20 * 1024 * 1024, dtype=np.uint8)
 
     for _ in range(10):
         await f.remote()
     for _ in range(10):
-        put_id = ray.put(np.zeros(40 * 1024 * 1024, dtype=np.uint8))
+        put_id = ray.put(np.zeros(20 * 1024 * 1024, dtype=np.uint8))
         await put_id
 
 

--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -32,7 +32,7 @@ def one_worker_100MiB(request):
     ray.shutdown()
 
 
-def _fill_object_store_and_get(obj, succeed=True, object_MiB=40,
+def _fill_object_store_and_get(obj, succeed=True, object_MiB=20,
                                num_objects=5):
     for _ in range(num_objects):
         ray.put(np.zeros(object_MiB * 1024 * 1024, dtype=np.uint8))
@@ -235,12 +235,12 @@ def test_pending_task_dependency_pinning(one_worker_100MiB):
     # pending task dependencies aren't considered, it will be evicted before
     # the ray.get below due to the subsequent ray.puts that fill up the object
     # store.
-    np_array = np.zeros(40 * 1024 * 1024, dtype=np.uint8)
+    np_array = np.zeros(20 * 1024 * 1024, dtype=np.uint8)
     signal = SignalActor.remote()
     obj_ref = pending.remote(np_array, signal.wait.remote())
 
     for _ in range(2):
-        ray.put(np.zeros(40 * 1024 * 1024, dtype=np.uint8))
+        ray.put(np.zeros(20 * 1024 * 1024, dtype=np.uint8))
 
     ray.get(signal.send.remote())
     ray.get(obj_ref)
@@ -350,7 +350,7 @@ def test_basic_serialized_reference(one_worker_100MiB, use_ray_put, failure):
             os._exit(0)
 
     array_oid = put_object(
-        np.zeros(40 * 1024 * 1024, dtype=np.uint8), use_ray_put)
+        np.zeros(20 * 1024 * 1024, dtype=np.uint8), use_ray_put)
     signal = SignalActor.remote()
     obj_ref = pending.remote([array_oid], signal.wait.remote())
 
@@ -395,7 +395,7 @@ def test_recursive_serialized_reference(one_worker_100MiB, use_ray_put,
 
     max_depth = 5
     array_oid = put_object(
-        np.zeros(40 * 1024 * 1024, dtype=np.uint8), use_ray_put)
+        np.zeros(20 * 1024 * 1024, dtype=np.uint8), use_ray_put)
     head_oid = recursive.remote([array_oid], signal, max_depth)
 
     # Remove the local reference.
@@ -448,7 +448,7 @@ def test_actor_holding_serialized_reference(one_worker_100MiB, use_ray_put,
 
     # Test that the reference held by the actor isn't evicted.
     array_oid = put_object(
-        np.zeros(40 * 1024 * 1024, dtype=np.uint8), use_ray_put)
+        np.zeros(20 * 1024 * 1024, dtype=np.uint8), use_ray_put)
     actor = GreedyActor.remote()
     actor.set_ref1.remote([array_oid])
 
@@ -500,7 +500,7 @@ def test_worker_holding_serialized_reference(one_worker_100MiB, use_ray_put,
 
     # Test that the reference held by the actor isn't evicted.
     array_oid = put_object(
-        np.zeros(40 * 1024 * 1024, dtype=np.uint8), use_ray_put)
+        np.zeros(20 * 1024 * 1024, dtype=np.uint8), use_ray_put)
     child_return_id = ray.get(launch_pending_task.remote([array_oid], signal))
 
     # Remove the local reference.
@@ -523,7 +523,7 @@ def test_worker_holding_serialized_reference(one_worker_100MiB, use_ray_put,
 
 # Test that an object containing object refs within it pins the inner IDs.
 def test_basic_nested_ids(one_worker_100MiB):
-    inner_oid = ray.put(np.zeros(40 * 1024 * 1024, dtype=np.uint8))
+    inner_oid = ray.put(np.zeros(20 * 1024 * 1024, dtype=np.uint8))
     outer_oid = ray.put([inner_oid])
 
     # Remove the local reference to the inner object.

--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -34,7 +34,7 @@ def one_worker_100MiB(request):
     ray.shutdown()
 
 
-def _fill_object_store_and_get(obj, succeed=True, object_MiB=40,
+def _fill_object_store_and_get(obj, succeed=True, object_MiB=20,
                                num_objects=5):
     for _ in range(num_objects):
         ray.put(np.zeros(object_MiB * 1024 * 1024, dtype=np.uint8))
@@ -71,7 +71,7 @@ def test_recursively_nest_ids(one_worker_100MiB, use_ray_put, failure):
 
     max_depth = 5
     array_oid = put_object(
-        np.zeros(40 * 1024 * 1024, dtype=np.uint8), use_ray_put)
+        np.zeros(20 * 1024 * 1024, dtype=np.uint8), use_ray_put)
     nested_oid = array_oid
     for _ in range(max_depth):
         nested_oid = ray.put([nested_oid])
@@ -110,7 +110,7 @@ def test_return_object_ref(one_worker_100MiB, use_ray_put, failure):
     def return_an_id():
         return [
             put_object(
-                np.zeros(40 * 1024 * 1024, dtype=np.uint8), use_ray_put)
+                np.zeros(20 * 1024 * 1024, dtype=np.uint8), use_ray_put)
         ]
 
     @ray.remote(max_retries=1)
@@ -150,7 +150,7 @@ def test_pass_returned_object_ref(one_worker_100MiB, use_ray_put, failure):
     def return_an_id():
         return [
             put_object(
-                np.zeros(40 * 1024 * 1024, dtype=np.uint8), use_ray_put)
+                np.zeros(20 * 1024 * 1024, dtype=np.uint8), use_ray_put)
         ]
 
     # TODO(edoakes): this fails with an ActorError with max_retries=1.
@@ -198,7 +198,7 @@ def test_recursively_pass_returned_object_ref(one_worker_100MiB, use_ray_put,
     @ray.remote
     def return_an_id():
         return put_object(
-            np.zeros(40 * 1024 * 1024, dtype=np.uint8), use_ray_put)
+            np.zeros(20 * 1024 * 1024, dtype=np.uint8), use_ray_put)
 
     @ray.remote(max_retries=1)
     def recursive(ref, signal, max_depth, depth=0):
@@ -261,7 +261,7 @@ def test_recursively_return_borrowed_object_ref(one_worker_100MiB, use_ray_put,
     def recursive(num_tasks_left):
         if num_tasks_left == 0:
             return put_object(
-                np.zeros(40 * 1024 * 1024, dtype=np.uint8),
+                np.zeros(20 * 1024 * 1024, dtype=np.uint8),
                 use_ray_put), os.getpid()
 
         return ray.get(recursive.remote(num_tasks_left - 1))
@@ -327,7 +327,7 @@ def test_borrowed_id_failure(one_worker_100MiB, failure):
     borrower = Borrower.remote()
     ray.get(borrower.ping.remote())
 
-    obj = ray.put(np.zeros(40 * 1024 * 1024, dtype=np.uint8))
+    obj = ray.put(np.zeros(20 * 1024 * 1024, dtype=np.uint8))
     if failure:
         with pytest.raises(ray.exceptions.RayActorError):
             ray.get(parent.pass_ref.remote([obj], borrower))

--- a/src/ray/object_manager/plasma/dlmalloc.cc
+++ b/src/ray/object_manager/plasma/dlmalloc.cc
@@ -136,7 +136,7 @@ void create_and_mmap_buffer(int64_t size, void **pointer, int *fd) {
 
 void *fake_mmap(size_t size) {
   if (allocated_once) {
-    RAY_LOG(INFO) << "fake_mmap called once already, refusing to allocate more";
+    RAY_LOG(INFO) << "fake_mmap called once already, refusing to allocate: " << size;
     return MFAIL;
   }
   allocated_once = true;
@@ -164,7 +164,6 @@ void *fake_mmap(size_t size) {
 }
 
 int fake_munmap(void *addr, int64_t size) {
-  RAY_LOG(INFO) << "fake_munmap(" << addr << ", " << size << ")";
   addr = pointer_retreat(addr, kMmapRegionsGap);
   size += kMmapRegionsGap;
 
@@ -175,6 +174,7 @@ int fake_munmap(void *addr, int64_t size) {
     // calls to mmap, to prevent dlmalloc from trimming.
     return -1;
   }
+  RAY_LOG(INFO) << "fake_munmap(" << addr << ", " << size << ")";
 
   int r;
 #ifdef _WIN32

--- a/src/ray/object_manager/plasma/dlmalloc.cc
+++ b/src/ray/object_manager/plasma/dlmalloc.cc
@@ -69,6 +69,8 @@ int fake_munmap(void *, int64_t);
 
 constexpr int GRANULARITY_MULTIPLIER = 2;
 
+// Ray allocates all plasma memory up-front at once to avoid runtime allocations.
+// Combined with MAP_PREPOPULATE, this can guarantee we never run into SIGBUS errors.
 static bool allocated_once = false;
 
 static void *pointer_advance(void *p, ptrdiff_t n) { return (unsigned char *)p + n; }
@@ -136,7 +138,7 @@ void create_and_mmap_buffer(int64_t size, void **pointer, int *fd) {
 
 void *fake_mmap(size_t size) {
   if (allocated_once) {
-    RAY_LOG(INFO) << "fake_mmap called once already, refusing to allocate: " << size;
+    RAY_LOG(DEBUG) << "fake_mmap called once already, refusing to allocate: " << size;
     return MFAIL;
   }
   allocated_once = true;

--- a/src/ray/object_manager/plasma/dlmalloc.cc
+++ b/src/ray/object_manager/plasma/dlmalloc.cc
@@ -69,6 +69,8 @@ int fake_munmap(void *, int64_t);
 
 constexpr int GRANULARITY_MULTIPLIER = 2;
 
+static bool allocated_once = false;
+
 static void *pointer_advance(void *p, ptrdiff_t n) { return (unsigned char *)p + n; }
 
 static void *pointer_retreat(void *p, ptrdiff_t n) { return (unsigned char *)p - n; }
@@ -133,6 +135,12 @@ void create_and_mmap_buffer(int64_t size, void **pointer, int *fd) {
 #endif
 
 void *fake_mmap(size_t size) {
+  if (allocated_once) {
+    RAY_LOG(INFO) << "fake_mmap called once already, refusing to allocate more";
+    return MFAIL;
+  }
+  allocated_once = true;
+
   // Add kMmapRegionsGap so that the returned pointer is deliberately not
   // page-aligned. This ensures that the segments of memory returned by
   // fake_mmap are never contiguous.
@@ -151,12 +159,12 @@ void *fake_mmap(size_t size) {
 
   // We lie to dlmalloc about where mapped memory actually lives.
   pointer = pointer_advance(pointer, kMmapRegionsGap);
-  RAY_LOG(DEBUG) << pointer << " = fake_mmap(" << size << ")";
+  RAY_LOG(INFO) << pointer << " = fake_mmap(" << size << ")";
   return pointer;
 }
 
 int fake_munmap(void *addr, int64_t size) {
-  RAY_LOG(DEBUG) << "fake_munmap(" << addr << ", " << size << ")";
+  RAY_LOG(INFO) << "fake_munmap(" << addr << ", " << size << ")";
   addr = pointer_retreat(addr, kMmapRegionsGap);
   size += kMmapRegionsGap;
 

--- a/src/ray/object_manager/plasma/dlmalloc.cc
+++ b/src/ray/object_manager/plasma/dlmalloc.cc
@@ -70,7 +70,7 @@ int fake_munmap(void *, int64_t);
 constexpr int GRANULARITY_MULTIPLIER = 2;
 
 // Ray allocates all plasma memory up-front at once to avoid runtime allocations.
-// Combined with MAP_PREPOPULATE, this can guarantee we never run into SIGBUS errors.
+// Combined with MAP_POPULATE, this can guarantee we never run into SIGBUS errors.
 static bool allocated_once = false;
 
 static void *pointer_advance(void *p, ptrdiff_t n) { return (unsigned char *)p + n; }

--- a/src/ray/object_manager/plasma/plasma_allocator.cc
+++ b/src/ray/object_manager/plasma/plasma_allocator.cc
@@ -35,7 +35,9 @@ void *PlasmaAllocator::Memalign(size_t alignment, size_t bytes) {
     return nullptr;
   }
   void *mem = dlmemalign(alignment, bytes);
-  RAY_CHECK(mem);
+  if (!mem) {
+    return nullptr;
+  }
   allocated_ += bytes;
   return mem;
 }

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -232,7 +232,9 @@ uint8_t *PlasmaStore::AllocateMemory(size_t size, MEMFD_TYPE *fd, int64_t *map_s
     int64_t space_needed = eviction_policy_.RequireSpace(size, &objects_to_evict);
     EvictObjects(objects_to_evict);
     // More space is still needed. Try to spill objects to external storage to
-    // make room.
+    // make room. NOTE(ekl) if we can't achieve this after a number of retries,
+    // it's because memory fragmentation in dlmalloc prevents us from allocating
+    // even if our footprint tracker here still says we have free space.
     if (space_needed > 0 || num_tries++ > 10) {
       *error = PlasmaError::OutOfMemory;
       break;

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -210,6 +210,7 @@ uint8_t *PlasmaStore::AllocateMemory(size_t size, MEMFD_TYPE *fd, int64_t *map_s
 
   // Try to evict objects until there is enough space.
   uint8_t *pointer = nullptr;
+  int num_tries = 0;
   while (true) {
     // Allocate space for the new object. We use memalign instead of malloc
     // in order to align the allocated region to a 64-byte boundary. This is not
@@ -232,7 +233,7 @@ uint8_t *PlasmaStore::AllocateMemory(size_t size, MEMFD_TYPE *fd, int64_t *map_s
     EvictObjects(objects_to_evict);
     // More space is still needed. Try to spill objects to external storage to
     // make room.
-    if (space_needed > 0) {
+    if (space_needed > 0 || num_tries++ > 10) {
       *error = PlasmaError::OutOfMemory;
       break;
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, we enforce the size of the plasma store at the server. However, dlmalloc can under the hood try to allocate more memory due to internal fragmentation. This disables these additional allocations, which can lead to SIGBUS if we run out of backing pages in /dev/shm.

Related to
https://github.com/ray-project/ray/issues/14182