### PR TITLE
[CI] Remove wheel renaming code path.

### DIFF
--- a/python/build-wheel-manylinux2014.sh
+++ b/python/build-wheel-manylinux2014.sh
@@ -91,13 +91,5 @@ for ((i=0; i<${#PYTHONS[@]}; ++i)); do
   popd
 done
 
-# Rename the wheels so that they can be uploaded to PyPI. TODO(rkn): This is a
-# hack, we should use auditwheel instead.
-for path in .whl/*.whl; do
-  if [ -f "${path}" ]; then
-    mv "${path}" "${path//linux/manylinux2014}"
-  fi
-done
-
 # Clean the build output so later operations is on a clean directory.
 git clean -f -f -x -d -e .whl -e python/ray/dashboard/client


### PR DESCRIPTION
This hotfix some wheel build issue.

pypa/manylinux2014_x86_64 was updated 05-20-2021 and the wheels
produced already have manylinux in them. So the renaming will
only change the name to `manymanylinux20142014`

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
