### PR TITLE
[serve] Fix some test sizes to avoid bazel warnings

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -11,7 +11,7 @@ serve_tests_srcs = glob(["tests/*.py"],
 
 py_test(
     name = "test_api",
-    size = "large",
+    size = "medium",
     srcs = serve_tests_srcs,
     tags = ["exclusive"],
     deps = [":serve_lib"],
@@ -19,7 +19,7 @@ py_test(
 
 py_test(
     name = "test_api_new",
-    size = "large",
+    size = "medium",
     srcs = serve_tests_srcs,
     tags = ["exclusive"],
     deps = [":serve_lib"],
@@ -59,7 +59,7 @@ py_test(
 
 py_test(
     name = "test_advanced",
-    size = "medium",
+    size = "small",
     srcs = serve_tests_srcs,
     tags = ["exclusive"],
     deps = [":serve_lib"],
@@ -75,7 +75,7 @@ py_test(
 
 py_test(
     name = "test_batching",
-    size = "medium",
+    size = "small",
     srcs = serve_tests_srcs,
     tags = ["exclusive"],
     deps = [":serve_lib"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There are more warnings on buildkite but these are the ones that also apply to travis.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
