### PR TITLE
[hotfix] Somehow the pong_plot_example is failing to gym.make("Pong-v0")

### DIFF
--- a/doc/BUILD
+++ b/doc/BUILD
@@ -17,12 +17,12 @@ py_test(
     tags = ["exclusive"]
 )
 
-py_test(
-    name = "plot_pong_example",
-    size = "large",
-    srcs = ["examples/plot_pong_example.py"],
-    tags = ["exclusive"]
-)
+#py_test(
+#    name = "plot_pong_example",
+#    size = "large",
+#    srcs = ["examples/plot_pong_example.py"],
+#    tags = ["exclusive"]
+#)
 
 py_test(
     name = "progress_bar",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

```



(pid=2324)   File "python/ray/_raylet.pyx", line 500, in ray._raylet.execute_task
&nbsp; | (pid=2324)   File "python/ray/_raylet.pyx", line 450, in ray._raylet.execute_task.function_executor
&nbsp; | (pid=2324)   File "/ray/python/ray/_private/function_manager.py", line 566, in actor_method_executor
&nbsp; | (pid=2324)     return method(__ray_actor, *args, **kwargs)
&nbsp; | (pid=2324)   File "/root/.cache/bazel/_bazel_root/5fe90af4e7d1ed9fcf52f59e39e126f5/execroot/com_github_ray_project_ray/bazel-out/k8-opt/bin/doc/plot_pong_example.runfiles/com_github_ray_project_ray/doc/examples/plot_pong_example.py", line 229, in __init__
&nbsp; | (pid=2324)     self.env = gym.make("Pong-v0")
&nbsp; | (pid=2324)   File "/opt/miniconda/lib/python3.6/site-packages/gym/envs/registration.py", line 145, in make
&nbsp; | (pid=2324)     return registry.make(id, **kwargs)
&nbsp; | (pid=2324)   File "/opt/miniconda/lib/python3.6/site-packages/gym/envs/registration.py", line 90, in make
&nbsp; | (pid=2324)     env = spec.make(**kwargs)
&nbsp; | (pid=2324)   File "/opt/miniconda/lib/python3.6/site-packages/gym/envs/registration.py", line 60, in make
&nbsp; | (pid=2324)     env = cls(**_kwargs)
&nbsp; | (pid=2324)   File "/opt/miniconda/lib/python3.6/site-packages/gym/envs/atari/atari_env.py", line 49, in __init__
&nbsp; | (pid=2324)     self.game_path = atari_py.get_game_path(game)
&nbsp; | (pid=2324)   File "/opt/miniconda/lib/python3.6/site-packages/atari_py/games.py", line 20, in get_game_path
&nbsp; | (pid=2324)     raise Exception('ROM is missing for %s, see https://github.com/openai/atari-py#roms for instructions' % (game_name,))
&nbsp; | (pid=2324) Exception: ROM is missing for pong, see https://github.com/openai/atari-py#roms for instructions
&nbsp;

<br class="Apple-interchange-newline">
```