### PR TITLE
[hotfix] Fix generated linux wheel name

### DIFF
--- a/python/build-wheel-manylinux2014.sh
+++ b/python/build-wheel-manylinux2014.sh
@@ -95,7 +95,10 @@ done
 # hack, we should use auditwheel instead.
 for path in .whl/*.whl; do
   if [ -f "${path}" ]; then
+    # We might have "linux" here or "manylinux2014" here.  We need the
+    # output to always be "manylinux2014".
     mv "${path}" "${path//linux/manylinux2014}"
+    mv "${path}" "${path//manymanylinux20142014/manylinux2014}"
   fi
 done
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
pypa/manylinux2014_x86_64 was updated 05-20-2021 and the wheel names  
produced already have manylinux2014 in them. However, sometimes the wheels only have "linux" instead of "manylinux2014". 

This PR ensures that in both cases, the wheel name we output has "manylinux2014", and it never has "manymanylinux20142014".


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
