### PR TITLE
Revert "Revert "[Core] minor refactor for usability of runtime_env (#15965)" (#15985)"

### DIFF
--- a/python/build-wheel-manylinux2014.sh
+++ b/python/build-wheel-manylinux2014.sh
@@ -95,7 +95,10 @@ done
 # hack, we should use auditwheel instead.
 for path in .whl/*.whl; do
   if [ -f "${path}" ]; then
-    mv "${path}" "${path//linux/manylinux2014}"
+    out="${path//-linux/-manylinux2014}"
+    if [ "$out" != "$path" ]; then
+        mv "${path}" "${out}"
+    fi
   fi
 done
 

--- a/python/ray/_private/runtime_env.py
+++ b/python/ray/_private/runtime_env.py
@@ -117,6 +117,13 @@ class RuntimeEnvDict:
             self._dict["working_dir"] = runtime_env_json["working_dir"]
         else:
             self._dict["working_dir"] = None
+
+        if "uris" in runtime_env_json:
+            self._dict["uris"] = runtime_env_json["uris"]
+
+        if "_ray_release" in runtime_env_json:
+            self._dict["_ray_release"] = runtime_env_json["_ray_release"]
+
         # TODO(ekl) we should have better schema validation here.
         # TODO(ekl) support py_modules
         # TODO(architkulkarni) support env_vars, docker


### PR DESCRIPTION
This reverts commit ec522a2d46d0a808b8af37140d5fb39c61e677bb.<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

The main change here is that the pypa wheel builder went from creating wheels in the format of 
`ray-2.0.0.dev0-cp37-cp37m-linux_x86_64.whl` to `ray-2.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl`.

The problem is that we've seen cases where both variants (just `linux` and `manylinux2014` are output in different runs). The new logic is to replace on **-linux** (proceeding dash) with **-manylinux2014**, meaning that output in either format will be canonicalized into `manylinux2014`.

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
