### PR TITLE
[kubernetes] Switch back to using "latest" tags.

### DIFF
--- a/deploy/charts/ray/Chart.yaml
+++ b/deploy/charts/ray/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # Ray version.
-appVersion: "1.3.0"
+appVersion: "latest"

--- a/deploy/charts/ray/values.yaml
+++ b/deploy/charts/ray/values.yaml
@@ -3,7 +3,7 @@
 # RayCluster settings:
 
 # image is Ray image to use for the head and workers of this Ray cluster.
-image: rayproject/ray:1.3.0
+image: rayproject/ray:latest
 # headPodType is the podType used for the Ray head node (as configured below).
 headPodType: rayHeadType
 # podTypes is the list of pod configurations available for use as Ray nodes.
@@ -70,7 +70,8 @@ namespacedOperator: false
 # in which to launch the operator.
 operatorNamespace: default
 # operatorImage - For best stability, it's currently recommended to use the nightly ray image in the operator Deployment.
-# For the latest ray release version, you can use rayproject/ray:1.3.0
-# You could also use a specific master commit, e.g. rayproject/ray:38b64e
+# For an official ray release version, use `rayproject/ray:1.x.y`.
+# For the latest ray release version, `rayproject/ray:latest`.
+# You could also use a specific master commit, e.g. `rayproject/ray:38b64e`.
 # The nightly operator image is compatible with all Ray versions since 1.2.0
 operatorImage: rayproject/ray:nightly

--- a/deploy/components/example_cluster.yaml
+++ b/deploy/components/example_cluster.yaml
@@ -52,7 +52,7 @@ spec:
         containers:
         - name: ray-node
           imagePullPolicy: Always
-          image: rayproject/ray:1.3.0
+          image: rayproject/ray:latest
           # Do not change this command - it keeps the pod alive until it is
           # explicitly killed.
           command: ["/bin/bash", "-c", "--"]
@@ -105,7 +105,7 @@ spec:
         containers:
         - name: ray-node
           imagePullPolicy: Always
-          image: rayproject/ray:1.3.0
+          image: rayproject/ray:latest
           command: ["/bin/bash", "-c", "--"]
           args: ["trap : TERM INT; sleep infinity & wait;"]
           # This volume allocates shared memory for Ray to use for its plasma

--- a/doc/kubernetes/job-example.yaml
+++ b/doc/kubernetes/job-example.yaml
@@ -9,7 +9,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: ray
-          image: rayproject/ray:1.3.0
+          image: rayproject/ray:latest
           imagePullPolicy: Always
           command: [ "/bin/bash", "-c", "--" ]
           args:

--- a/doc/kubernetes/ray-cluster.yaml
+++ b/doc/kubernetes/ray-cluster.yaml
@@ -53,7 +53,7 @@ spec:
           medium: Memory
       containers:
         - name: ray-head
-          image: rayproject/ray:1.3.0
+          image: rayproject/ray:latest
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "-c", "--" ]
           args:
@@ -107,7 +107,7 @@ spec:
           medium: Memory
       containers:
       - name: ray-worker
-        image: rayproject/ray:1.3.0
+        image: rayproject/ray:latest
         imagePullPolicy: IfNotPresent
         command: ["/bin/bash", "-c", "--"]
         args:

--- a/doc/source/cluster/kubernetes.rst
+++ b/doc/source/cluster/kubernetes.rst
@@ -154,7 +154,7 @@ on your Ray cluster. The Ray Client server runs on the Ray head node, on port ``
   Connecting with Ray client requires using matching minor versions of Python (for example 3.7)
   on the server and client end, that is, on the Ray head node and in the environment where
   ``ray.util.connect`` is invoked. Note that the default ``rayproject/ray`` images use Python 3.7.
-  The latest offical Ray release builds are available for Python 3.6 and 3.8 at the `Ray Docker Hub <https://hub.docker.com/r/rayproject/ray/tags?page=1&ordering=last_updated&name=1.3.0>`_.
+  The latest offical Ray release builds are available for Python 3.6 and 3.8 at the `Ray Docker Hub <https://hub.docker.com/r/rayproject/ray>`_.
 
   Connecting with Ray client also requires matching Ray versions. To connect from a local machine to a cluster running the examples in this document, the :ref:`latest release version<installation>` of Ray must be installed locally.
 

--- a/python/ray/autoscaler/kubernetes/defaults.yaml
+++ b/python/ray/autoscaler/kubernetes/defaults.yaml
@@ -115,7 +115,7 @@ available_node_types:
         containers:
         - name: ray-node
           imagePullPolicy: Always
-          image: rayproject/ray:1.3.0
+          image: rayproject/ray:latest
           command: ["/bin/bash", "-c", "--"]
           args: ["trap : TERM INT; sleep infinity & wait;"]
           # This volume allocates shared memory for Ray to use for its plasma
@@ -171,7 +171,7 @@ available_node_types:
         containers:
         - name: ray-node
           imagePullPolicy: Always
-          image: rayproject/ray:1.3.0
+          image: rayproject/ray:latest
           # Do not change this command - it keeps the pod alive until it is
           # explicitly killed.
           command: ["/bin/bash", "-c", "--"]

--- a/python/ray/autoscaler/kubernetes/example-full-legacy.yaml
+++ b/python/ray/autoscaler/kubernetes/example-full-legacy.yaml
@@ -131,7 +131,7 @@ head_node:
           #   - rsync (used for `ray rsync` commands and file mounts)
           #   - screen (used for `ray attach`)
           #   - kubectl (used by the autoscaler to manage worker pods)
-          image: rayproject/ray:1.3.0
+          image: rayproject/ray:latest
           # Do not change this command - it keeps the pod alive until it is
           # explicitly killed.
           command: ["/bin/bash", "-c", "--"]
@@ -194,7 +194,7 @@ worker_nodes:
           # You are free (and encouraged) to use your own container image,
           # but it should have the following installed:
           #   - rsync (used for `ray rsync` commands and file mounts)
-          image: rayproject/ray:1.3.0
+          image: rayproject/ray:latest
           # Do not change this command - it keeps the pod alive until it is
           # explicitly killed.
           command: ["/bin/bash", "-c", "--"]

--- a/python/ray/autoscaler/kubernetes/example-full.yaml
+++ b/python/ray/autoscaler/kubernetes/example-full.yaml
@@ -120,7 +120,7 @@ available_node_types:
         containers:
         - name: ray-node
           imagePullPolicy: Always
-          image: rayproject/ray:1.3.0
+          image: rayproject/ray:latest
           command: ["/bin/bash", "-c", "--"]
           args: ["trap : TERM INT; sleep infinity & wait;"]
           # This volume allocates shared memory for Ray to use for its plasma
@@ -176,7 +176,7 @@ available_node_types:
         containers:
         - name: ray-node
           imagePullPolicy: Always
-          image: rayproject/ray:1.3.0
+          image: rayproject/ray:latest
           # Do not change this command - it keeps the pod alive until it is
           # explicitly killed.
           command: ["/bin/bash", "-c", "--"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Switch back to using latest tags for K8s configs. 

This simplifies the release process and aligns with what we're currently doing with other autoscaling configs.

Properly versioned Ray/K8s will be released as a Helm repo starting with the upcoming release (1.4.0.)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
