### PR TITLE
Disable timeline events collection in Ray by default

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -134,7 +134,7 @@
       python/ray/tests/...
     - bazel test --config=ci $(./scripts/bazel_export_options)
       --test_tag_filters=-kubernetes,-jenkins_only,client_tests,-flaky
-      --test_env=RAY_CLIENT_MODE=1
+      --test_env=RAY_CLIENT_MODE=1 --test_env=RAY_PROFILING=1
       python/ray/tests/...
 - label: ":python: (Medium A-J)"
   conditions: ["RAY_CI_PYTHON_AFFECTED"]

--- a/doc/source/troubleshooting.rst
+++ b/doc/source/troubleshooting.rst
@@ -14,6 +14,9 @@ The most important tool is the timeline visualization tool. To visualize tasks
 in the Ray timeline, you can dump the timeline as a JSON file by running ``ray
 timeline`` from the command line or by using the following command.
 
+To use the timeline, Ray profiling must be enabled by setting the
+``RAY_PROFILING=1`` environment variable prior to starting Ray.
+
 .. code-block:: python
 
   ray.timeline(filename="/tmp/timeline.json")

--- a/doc/source/troubleshooting.rst
+++ b/doc/source/troubleshooting.rst
@@ -15,7 +15,7 @@ in the Ray timeline, you can dump the timeline as a JSON file by running ``ray
 timeline`` from the command line or by using the following command.
 
 To use the timeline, Ray profiling must be enabled by setting the
-``RAY_PROFILING=1`` environment variable prior to starting Ray.
+``RAY_PROFILING=1`` environment variable prior to starting Ray on every machine.
 
 .. code-block:: python
 

--- a/python/ray/profiling.py
+++ b/python/ray/profiling.py
@@ -12,7 +12,7 @@ class _NullLogSpan:
         pass
 
 
-PROFILING_ENABLED = "RAY_DISABLE_PROFILING" not in os.environ
+PROFILING_ENABLED = "RAY_PROFILING" in os.environ
 NULL_LOG_SPAN = _NullLogSpan()
 
 

--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -519,6 +519,11 @@ class GlobalState:
 
                 all_events.append(new_event)
 
+        if not all_events:
+            raise RuntimeError(
+                "No profiling events found. Ray profiling must be enabled "
+                "by setting RAY_PROFILING=1.")
+
         if filename is not None:
             with open(filename, "w") as outfile:
                 json.dump(all_events, outfile)
@@ -845,6 +850,9 @@ def objects(object_ref=None):
 @client_mode_hook
 def timeline(filename=None):
     """Return a list of profiling events that can viewed as a timeline.
+
+    Ray profiling must be enabled by setting the RAY_PROFILING=1 environment
+    variable prior to starting Ray.
 
     To view this information as a timeline, simply dump it as a json file by
     passing in "filename" or using using json.dump, and then load go to

--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -520,7 +520,7 @@ class GlobalState:
                 all_events.append(new_event)
 
         if not all_events:
-            raise RuntimeError(
+            logger.warning(
                 "No profiling events found. Ray profiling must be enabled "
                 "by setting RAY_PROFILING=1.")
 

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -243,7 +243,7 @@ py_test_module_list(
   name_suffix = "_client_mode",
   # TODO(barakmich): py_test will support env in Bazel 4.0.0...
   # Until then, we can use tags.
-  #env = {"RAY_CLIENT_MODE": "1"},
+  #env = {"RAY_CLIENT_MODE": "1", "RAY_PROFILING": "1"},
   tags = ["exclusive", "client_tests"],
   deps = ["//:ray_lib"],
 )

--- a/python/ray/tests/test_advanced.py
+++ b/python/ray/tests/test_advanced.py
@@ -7,6 +7,7 @@ import sys
 import threading
 import time
 
+import os
 import numpy as np
 import pytest
 
@@ -165,6 +166,9 @@ def test_running_function_on_all_workers(ray_start_regular):
     assert "fake_directory" not in ray.get(get_path2.remote())
 
 
+@pytest.mark.skipif(
+    "RAY_PROFILING" not in os.environ,
+    reason="Only tested in client/profiling build.")
 def test_profiling_api(ray_start_2_cpus):
     @ray.remote
     def f():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Profiling adds memory and CPU overhead, and is a central bottleneck in the GCS, so disable it by default. This significantly reduces the memory overhead in certain cases. For example, a worker using ray.get in a loop goes from 2GB->80MB heap usage after disabling profiling.

This only affects ray.timeline().