### PR TITLE
Remove unnecessary flaky block (no C++ tests are flaky)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,10 +98,10 @@ matrix:
       before_script:
         - . ./ci/travis/ci.sh build
       script:
-        - bazel test --config=ci $(./scripts/bazel_export_options)
-          --build_tests_only
-          --test_tag_filters=flaky
-          -- //:all -rllib/... -core_worker_test
+        # - bazel test --config=ci $(./scripts/bazel_export_options)
+        # --build_tests_only
+        # --test_tag_filters=flaky
+        # -- //:all -rllib/... -core_worker_test
         - bazel test --config=ci $(./scripts/bazel_export_options)
           --test_tag_filters=-kubernetes,-jenkins_only,flaky
           --test_env=CONDA_EXE


### PR DESCRIPTION
This is causing the OSX build to fail.