### PR TITLE
[Tracing] Add Otel to setup.py Observability

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -97,7 +97,11 @@ extras = {
     "default": ["colorful"],
     "serve": ["uvicorn", "requests", "starlette", "fastapi"],
     "tune": ["pandas", "tabulate", "tensorboardX"],
-    "k8s": ["kubernetes"]
+    "k8s": ["kubernetes"],
+    "observability": [
+        "opentelemetry-api==1.1.0", "opentelemetry-sdk==1.1.0",
+        "opentelemetry-exporter-otlp==1.1.0"
+    ]
 }
 
 extras["rllib"] = extras["tune"] + [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* Include `OTEL` in `ray[all]` (specifically `ray[observability]`.
* This is necessary for situations with Ray Client when the client side has OTEL making Ray include it in functions, but the server does not have OTEL, causing a deserialization error on the Server.  


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #16030
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
