### PR TITLE
[Client][Proxy] Track Num Clients in the proxy

### DIFF
--- a/python/ray/client_builder.py
+++ b/python/ray/client_builder.py
@@ -22,6 +22,7 @@ class ClientInfo:
     ray_version: str
     ray_commit: str
     protocol_version: str
+    _num_clients: int
 
 
 class ClientBuilder:
@@ -57,7 +58,8 @@ class ClientBuilder:
             python_version=client_info_dict["python_version"],
             ray_version=client_info_dict["ray_version"],
             ray_commit=client_info_dict["ray_commit"],
-            protocol_version=client_info_dict["protocol_version"])
+            protocol_version=client_info_dict["protocol_version"],
+            _num_clients=client_info_dict["num_clients"])
 
 
 class _LocalClientBuilder(ClientBuilder):

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -102,7 +102,6 @@ check_we_are_second = """
 import ray
 info = ray.client('localhost:25005').connect()
 assert info._num_clients == {num_clients}
-
 """
 
 
@@ -114,6 +113,10 @@ assert info._num_clients == {num_clients}
     ["ray start --head --ray-client-server-port 25005 --port 0"],
     indirect=True)
 def test_correct_num_clients(call_ray_start):
+    """
+    Checks that the returned value of `num_clients` correctly tracks clients
+    connecting and disconnecting.
+    """
     info = ray.client("localhost:25005").connect()
     assert info._num_clients == 1
     run_string_as_driver(check_we_are_second.format(num_clients=2))

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -8,6 +8,7 @@ import grpc
 import ray
 import ray.core.generated.ray_client_pb2 as ray_client_pb2
 from ray.job_config import JobConfig
+from ray.test_utils import run_string_as_driver
 import ray.util.client.server.proxier as proxier
 
 
@@ -95,6 +96,29 @@ def test_multiple_clients_use_different_drivers(call_ray_start):
 
     assert job_id_one != job_id_two
     assert namespace_one != namespace_two
+
+
+check_we_are_second = """
+import ray
+info = ray.client('localhost:25005').connect()
+assert info._num_clients == {num_clients}
+
+"""
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="PSUtil does not work the same on windows.")
+@pytest.mark.parametrize(
+    "call_ray_start",
+    ["ray start --head --ray-client-server-port 25005 --port 0"],
+    indirect=True)
+def test_correct_num_clients(call_ray_start):
+    info = ray.client("localhost:25005").connect()
+    assert info._num_clients == 1
+    run_string_as_driver(check_we_are_second.format(num_clients=2))
+    ray.util.disconnect()
+    run_string_as_driver(check_we_are_second.format(num_clients=1))
 
 
 def test_prepare_runtime_init_req_fails():

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -8,7 +8,7 @@ import json
 import psutil
 import socket
 import sys
-from threading import Thread, RLock
+from threading import Lock, Thread, RLock
 import time
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
 
@@ -314,7 +314,21 @@ def prepare_runtime_init_req(iterator: Iterator[ray_client_pb2.DataRequest]
 
 class DataServicerProxy(ray_client_pb2_grpc.RayletDataStreamerServicer):
     def __init__(self, proxy_manager: ProxyManager):
+        self.num_clients = 0
+        self.clients_lock = Lock()
         self.proxy_manager = proxy_manager
+
+    def modify_connection_info_resp(self,
+                                    init_resp: ray_client_pb2.DataResponse
+                                    ) -> ray_client_pb2.DataResponse:
+        init_type = init_resp.WhichOneof("type")
+        if init_type != "connection_info":
+            return init_resp
+        modified_resp = ray_client_pb2.DataResponse()
+        modified_resp.CopyFrom(init_resp)
+        with self.clients_lock:
+            modified_resp.num_clients = self.num_clients
+        return modified_resp
 
     def Datapath(self, request_iterator, context):
         client_id = _get_client_id_from_context(context)
@@ -337,11 +351,15 @@ class DataServicerProxy(ray_client_pb2_grpc.RayletDataStreamerServicer):
             context.set_code(grpc.StatusCode.NOT_FOUND)
             return None
         stub = ray_client_pb2_grpc.RayletDataStreamerStub(channel)
-        new_iter = chain([modified_init_req], request_iterator)
-        resp_stream = stub.Datapath(
-            new_iter, metadata=[("client_id", client_id)])
-        for resp in resp_stream:
-            yield resp
+        try:
+            new_iter = chain([modified_init_req], request_iterator)
+            resp_stream = stub.Datapath(
+                new_iter, metadata=[("client_id", client_id)])
+            for resp in resp_stream:
+                yield self.modify_connection_info_resp(resp)
+        finally:
+            with self.clients_lock:
+                self.num_clients -= 1
 
 
 class LogstreamServicerProxy(ray_client_pb2_grpc.RayletLogStreamerServicer):

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -327,7 +327,7 @@ class DataServicerProxy(ray_client_pb2_grpc.RayletDataStreamerServicer):
         modified_resp = ray_client_pb2.DataResponse()
         modified_resp.CopyFrom(init_resp)
         with self.clients_lock:
-            modified_resp.num_clients = self.num_clients
+            modified_resp.connection_info.num_clients = self.num_clients
         return modified_resp
 
     def Datapath(self, request_iterator, context):

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -321,6 +321,10 @@ class DataServicerProxy(ray_client_pb2_grpc.RayletDataStreamerServicer):
     def modify_connection_info_resp(self,
                                     init_resp: ray_client_pb2.DataResponse
                                     ) -> ray_client_pb2.DataResponse:
+        """
+        Modify the `num_clients` returned the ConnectionInfoResponse because
+        individual SpecificServers only have **one** client.
+        """
         init_type = init_resp.WhichOneof("type")
         if init_type != "connection_info":
             return init_resp
@@ -361,6 +365,7 @@ class DataServicerProxy(ray_client_pb2_grpc.RayletDataStreamerServicer):
                 yield self.modify_connection_info_resp(resp)
         finally:
             with self.clients_lock:
+                logger.debug(f"Client detached: {client_id}")
                 self.num_clients -= 1
 
 

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -352,6 +352,8 @@ class DataServicerProxy(ray_client_pb2_grpc.RayletDataStreamerServicer):
             return None
         stub = ray_client_pb2_grpc.RayletDataStreamerStub(channel)
         try:
+            with self.clients_lock:
+                self.num_clients += 1
             new_iter = chain([modified_init_req], request_iterator)
             resp_stream = stub.Datapath(
                 new_iter, metadata=[("client_id", client_id)])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* Fixes a bug where the `num_clients` corresponds to the `specificServer`. This is **always ONE**. This PR makes this proxy handle the num_clients.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
