### PR TITLE
[Serve] Remove global async thread: takes 2

### DIFF
--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -1,8 +1,7 @@
 import asyncio
 import concurrent.futures
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Union, Coroutine
-import threading
+from typing import Dict, List, Optional, Union
 from enum import Enum
 
 from ray.serve.common import EndpointTag
@@ -10,20 +9,6 @@ from ray.actor import ActorHandle
 from ray.serve.utils import get_random_letters
 from ray.serve.router import EndpointRouter, RequestMetadata
 from ray.util import metrics
-
-_global_async_loop = None
-
-
-def create_or_get_async_loop_in_thread():
-    global _global_async_loop
-    if _global_async_loop is None:
-        _global_async_loop = asyncio.new_event_loop()
-        thread = threading.Thread(
-            daemon=True,
-            target=_global_async_loop.run_forever,
-        )
-        thread.start()
-    return _global_async_loop
 
 
 @dataclass(frozen=True)
@@ -104,7 +89,6 @@ class RayServeHandle:
         return EndpointRouter(
             self.controller_handle,
             self.endpoint_name,
-            asyncio.get_event_loop(),
         )
 
     def options(
@@ -144,7 +128,7 @@ class RayServeHandle:
         )
 
     def _remote(self, endpoint_name, handle_options, args,
-                kwargs) -> Coroutine:
+                kwargs) -> concurrent.futures.Future:
         request_metadata = RequestMetadata(
             get_random_letters(10),  # Used for debugging.
             endpoint_name,
@@ -155,8 +139,8 @@ class RayServeHandle:
             use_serve_request=self._use_serve_request,
             http_arg_is_pickled=self._pickled_http_request,
         )
-        coro = self.router.assign_request(request_metadata, *args, **kwargs)
-        return coro
+        future = self.router.assign_request(request_metadata, *args, **kwargs)
+        return future
 
     async def remote(self, *args, **kwargs):
         """Issue an asynchronous request to the endpoint.
@@ -174,8 +158,9 @@ class RayServeHandle:
                 ``request.query_params``.
         """
         self.request_counter.inc()
-        return await self._remote(self.endpoint_name, self.handle_options,
-                                  args, kwargs)
+        return await asyncio.wrap_future(
+            self._remote(self.endpoint_name, self.handle_options, args,
+                         kwargs))
 
     def __repr__(self):
         return f"{self.__class__.__name__}(endpoint='{self.endpoint_name}')"
@@ -211,7 +196,6 @@ class RayServeSyncHandle(RayServeHandle):
         return EndpointRouter(
             self.controller_handle,
             self.endpoint_name,
-            create_or_get_async_loop_in_thread(),
         )
 
     def remote(self, *args, **kwargs):
@@ -232,10 +216,8 @@ class RayServeSyncHandle(RayServeHandle):
                 ``request.args``.
         """
         self.request_counter.inc()
-        coro = self._remote(self.endpoint_name, self.handle_options, args,
-                            kwargs)
-        future: concurrent.futures.Future = asyncio.run_coroutine_threadsafe(
-            coro, self.router._loop)
+        future: concurrent.futures.Future = self._remote(
+            self.endpoint_name, self.handle_options, args, kwargs)
         return future.result()
 
     def __reduce__(self):

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -139,7 +139,7 @@ class RayServeHandle:
             use_serve_request=self._use_serve_request,
             http_arg_is_pickled=self._pickled_http_request,
         )
-        future = self.router.assign_request(request_metadata, *args, **kwargs)
+        future = self.router.enqueue_request(request_metadata, *args, **kwargs)
         return future
 
     async def remote(self, *args, **kwargs):

--- a/python/ray/serve/router.py
+++ b/python/ray/serve/router.py
@@ -185,7 +185,8 @@ class ReplicaSet:
         tracker_refs: Set[ray.ObjectRef] = self.in_flight_queries.get(
             replica_handle, {})
         tracker_refs.discard(tracker_ref)
-        self._try_send_pending_queries()
+        if len(self.pending_requests):
+            self._try_send_pending_queries()
 
     def assign_replica(self, query: Query) -> concurrent.futures.Future:
         pending_query = PendingQuery(query)

--- a/python/ray/serve/router.py
+++ b/python/ray/serve/router.py
@@ -246,7 +246,7 @@ class EndpointRouter:
         if not self._pending_endpoint_registered.is_set():
             self._pending_endpoint_registered.set()
 
-    def assign_request(
+    def enqueue_request(
             self,
             request_meta: RequestMetadata,
             *request_args,

--- a/python/ray/serve/tests/test_router.py
+++ b/python/ray/serve/tests/test_router.py
@@ -3,6 +3,7 @@ Unit tests for the router class. Please don't add any test that will involve
 controller or the backend worker, use mock if necessary.
 """
 import asyncio
+import concurrent.futures
 from collections import defaultdict
 
 import pytest
@@ -65,7 +66,7 @@ def task_runner_mock_actor():
 
 async def test_simple_endpoint_backend_pair(ray_instance, mock_controller,
                                             task_runner_mock_actor):
-    q = ray.remote(EndpointRouter).remote(mock_controller, "svc")
+    q = EndpointRouter(mock_controller, "svc")
 
     # Propogate configs
     await mock_controller.set_traffic.remote(
@@ -76,8 +77,8 @@ async def test_simple_endpoint_backend_pair(ray_instance, mock_controller,
                                                  task_runner_mock_actor)
 
     # Make sure we get the request result back
-    ref = await q.assign_request.remote(
-        RequestMetadata(get_random_letters(10), "svc"), 1)
+    fut = q.assign_request(RequestMetadata(get_random_letters(10), "svc"), 1)
+    ref = fut.result()
     result = await ref
     assert result == "DONE"
 
@@ -89,7 +90,7 @@ async def test_simple_endpoint_backend_pair(ray_instance, mock_controller,
 
 async def test_changing_backend(ray_instance, mock_controller,
                                 task_runner_mock_actor):
-    q = ray.remote(EndpointRouter).remote(mock_controller, "svc")
+    q = EndpointRouter(mock_controller, "svc")
 
     await mock_controller.set_traffic.remote(
         "svc", TrafficPolicy({
@@ -98,8 +99,8 @@ async def test_changing_backend(ray_instance, mock_controller,
     await mock_controller.add_new_replica.remote("backend-alter",
                                                  task_runner_mock_actor)
 
-    await (await q.assign_request.remote(
-        RequestMetadata(get_random_letters(10), "svc"), 1))
+    await q.assign_request(RequestMetadata(get_random_letters(10), "svc"),
+                           1).result()
     got_work = await task_runner_mock_actor.get_recent_call.remote()
     assert got_work.args[0] == 1
 
@@ -109,15 +110,15 @@ async def test_changing_backend(ray_instance, mock_controller,
         }))
     await mock_controller.add_new_replica.remote("backend-alter-2",
                                                  task_runner_mock_actor)
-    await (await q.assign_request.remote(
-        RequestMetadata(get_random_letters(10), "svc"), 2))
+    await q.assign_request(RequestMetadata(get_random_letters(10), "svc"),
+                           2).result()
     got_work = await task_runner_mock_actor.get_recent_call.remote()
     assert got_work.args[0] == 2
 
 
 async def test_split_traffic_random(ray_instance, mock_controller,
                                     task_runner_mock_actor):
-    q = ray.remote(EndpointRouter).remote(mock_controller, "svc")
+    q = EndpointRouter(mock_controller, "svc")
 
     await mock_controller.set_traffic.remote(
         "svc", TrafficPolicy({
@@ -132,8 +133,8 @@ async def test_split_traffic_random(ray_instance, mock_controller,
     # single queue is 0.5^20 ~ 1-6
     object_refs = []
     for _ in range(20):
-        ref = await q.assign_request.remote(
-            RequestMetadata(get_random_letters(10), "svc"), 1)
+        ref = q.assign_request(
+            RequestMetadata(get_random_letters(10), "svc"), 1).result()
         object_refs.append(ref)
     ray.get(object_refs)
 
@@ -146,7 +147,7 @@ async def test_split_traffic_random(ray_instance, mock_controller,
 
 async def test_shard_key(ray_instance, mock_controller,
                          task_runner_mock_actor):
-    q = ray.remote(EndpointRouter).remote(mock_controller, "svc")
+    q = EndpointRouter(mock_controller, "svc")
 
     num_backends = 5
     traffic_dict = {}
@@ -161,10 +162,10 @@ async def test_shard_key(ray_instance, mock_controller,
     # Generate random shard keys and send one request for each.
     shard_keys = [get_random_letters() for _ in range(100)]
     for shard_key in shard_keys:
-        await (await q.assign_request.remote(
+        await q.assign_request(
             RequestMetadata(
                 get_random_letters(10), "svc", shard_key=shard_key),
-            shard_key))
+            shard_key).result()
 
     # Log the shard keys that were assigned to each backend.
     runner_shard_keys = defaultdict(set)
@@ -176,10 +177,10 @@ async def test_shard_key(ray_instance, mock_controller,
 
     # Send queries with the same shard keys a second time.
     for shard_key in shard_keys:
-        await (await q.assign_request.remote(
+        await q.assign_request(
             RequestMetadata(
                 get_random_letters(10), "svc", shard_key=shard_key),
-            shard_key))
+            shard_key).result()
 
     # Check that the requests were all mapped to the same backends.
     for i, runner in enumerate(runners):
@@ -208,7 +209,6 @@ async def test_replica_set(ray_instance, mock_controller_with_name):
     rs = ReplicaSet(
         mock_controller_with_name[1],
         "my_backend",
-        asyncio.get_event_loop(),
     )
     workers = [MockWorker.remote() for _ in range(2)]
     rs.set_max_concurrent_queries(BackendConfig(max_concurrent_queries=1))
@@ -217,8 +217,8 @@ async def test_replica_set(ray_instance, mock_controller_with_name):
     # Send two queries. They should go through the router but blocked by signal
     # actors.
     query = Query([], {}, RequestMetadata("request-id", "endpoint"))
-    first_ref = await rs.assign_replica(query)
-    second_ref = await rs.assign_replica(query)
+    first_ref = rs.assign_replica(query).result()
+    second_ref = rs.assign_replica(query).result()
 
     # These should be blocked by signal actor.
     with pytest.raises(ray.exceptions.GetTimeoutError):
@@ -231,12 +231,11 @@ async def test_replica_set(ray_instance, mock_controller_with_name):
             await asyncio.sleep(1)
 
     # Let's try to send another query.
-    third_ref_pending_task = asyncio.get_event_loop().create_task(
-        rs.assign_replica(query))
+    third_ref_pending_fut: concurrent.futures.Future = rs.assign_replica(query)
     # We should fail to assign a replica, so this coroutine should still be
     # pending after some time.
     await asyncio.sleep(0.2)
-    assert not third_ref_pending_task.done()
+    assert not third_ref_pending_fut.done()
 
     # Let's unblock the two workers
     await signal.send.remote()
@@ -244,8 +243,8 @@ async def test_replica_set(ray_instance, mock_controller_with_name):
     assert await second_ref == "DONE"
 
     # The third request should be unblocked and sent to first worker.
-    # This meas we should be able to get the object ref.
-    third_ref = await third_ref_pending_task
+    # This means we should be able to get the object ref.
+    third_ref = third_ref_pending_fut.result()
 
     # Now we got the object ref, let's get it result.
     await signal.send.remote()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Superseding #15379

Original comments:
This PR removes the background thread by using the _on_completed callback on the tracker_ref in ReplicaSet.

I think this is a nice state to be at for Serve v2 API. There are still difference between SyncHandle and AsyncHandle. But the underlying mechanism is much cleaner now and both uses the same callback based API.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
