### PR TITLE
[core] Fixes connect from worker node failed

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -286,7 +286,7 @@ def wait_for_node(redis_address,
             return
         else:
             time.sleep(0.1)
-    raise TimeoutError("Timed out while waiting for nodes to startup.")
+    raise TimeoutError("Timed out while waiting for node to startup.")
 
 
 def get_address_info_from_redis_helper(redis_address,

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -254,6 +254,41 @@ def find_redis_address_or_die():
     return redis_addresses.pop()
 
 
+def wait_for_node(redis_address,
+                  node_plasma_store_socket_name,
+                  redis_password=None,
+                  timeout=30):
+    """Wait until this node has appeared in the client table.
+
+    Args:
+        redis_address (str): The redis address.
+        node_plasma_store_socket_name (str): The
+            plasma_store_socket_name for the given node which we wait for.
+        redis_password (str): the redis password.
+        timeout: The amount of time in seconds to wait before raising an
+            exception.
+
+    Raises:
+        TimeoutError: An exception is raised if the timeout expires before
+            the node appears in the client table.
+    """
+    redis_ip_address, redis_port = redis_address.split(":")
+    wait_for_redis_to_start(redis_ip_address, redis_port, redis_password)
+    global_state = ray.state.GlobalState()
+    global_state._initialize_global_state(redis_address, redis_password)
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        clients = global_state.node_table()
+        object_store_socket_names = [
+            client["ObjectStoreSocketName"] for client in clients
+        ]
+        if node_plasma_store_socket_name in object_store_socket_names:
+            return
+        else:
+            time.sleep(0.1)
+    raise TimeoutError("Timed out while waiting for nodes to startup.")
+
+
 def get_address_info_from_redis_helper(redis_address,
                                        node_ip_address,
                                        redis_password=None):

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 import ray
+import ray._private.services
 from ray import ray_constants
 
 logger = logging.getLogger(__name__)
@@ -163,17 +164,9 @@ class Cluster:
             TimeoutError: An exception is raised if the timeout expires before
                 the node appears in the client table.
         """
-        start_time = time.time()
-        while time.time() - start_time < timeout:
-            clients = self.global_state.node_table()
-            object_store_socket_names = [
-                client["ObjectStoreSocketName"] for client in clients
-            ]
-            if node.plasma_store_socket_name in object_store_socket_names:
-                return
-            else:
-                time.sleep(0.1)
-        raise TimeoutError("Timed out while waiting for nodes to join.")
+        ray._private.services.wait_for_node(self.redis_address,
+                                            node.plasma_store_socket_name,
+                                            self.redis_password, timeout)
 
     def wait_for_nodes(self, timeout=30):
         """Waits for correct number of nodes to be registered.

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -240,6 +240,10 @@ class Node:
 
         if not connect_only:
             self.start_ray_processes()
+            # we should update the address info after the node has been started
+            ray._private.services.wait_for_node(self.redis_address,
+                                                self._plasma_store_socket_name,
+                                                self.redis_password)
             address_info = (ray._private.services.get_address_info_from_redis(
                 self.redis_address,
                 self._raylet_ip_address,

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -241,9 +241,15 @@ class Node:
         if not connect_only:
             self.start_ray_processes()
             # we should update the address info after the node has been started
-            ray._private.services.wait_for_node(self.redis_address,
-                                                self._plasma_store_socket_name,
-                                                self.redis_password)
+            try:
+                ray._private.services.wait_for_node(
+                    self.redis_address, self._plasma_store_socket_name,
+                    self.redis_password)
+            except TimeoutError:
+                raise Exception(
+                    "The current node has not been updated within 30 "
+                    "seconds, this could happen because of some of "
+                    "the Ray processes failed to startup.")
             address_info = (ray._private.services.get_address_info_from_redis(
                 self.redis_address,
                 self._raylet_ip_address,

--- a/python/ray/tests/test_failure_2.py
+++ b/python/ray/tests/test_failure_2.py
@@ -531,7 +531,8 @@ def test_raylet_node_manager_server_failure(ray_start_cluster_head,
     cluster = ray_start_cluster_head
     redis_port = int(cluster.address.split(":")[1])
     # Reuse redis port to make node manager grpc server fail to start.
-    cluster.add_node(wait=False, node_manager_port=redis_port)
+    with pytest.raises(TimeoutError):
+        cluster.add_node(wait=False, node_manager_port=redis_port)
     p = log_pubsub
     cnt = 0
     # wait for max 10 seconds.

--- a/python/ray/tests/test_failure_2.py
+++ b/python/ray/tests/test_failure_2.py
@@ -531,7 +531,7 @@ def test_raylet_node_manager_server_failure(ray_start_cluster_head,
     cluster = ray_start_cluster_head
     redis_port = int(cluster.address.split(":")[1])
     # Reuse redis port to make node manager grpc server fail to start.
-    with pytest.raises(TimeoutError):
+    with pytest.raises(Exception):
         cluster.add_node(wait=False, node_manager_port=redis_port)
     p = log_pubsub
     cnt = 0

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -1,4 +1,6 @@
 import os
+import sys
+
 import pytest
 import redis
 
@@ -121,6 +123,26 @@ def test_ports_assignment(ray_start_cluster):
     with pytest.raises(ValueError):
         head_node = cluster.add_node(
             **pre_selected_ports, min_worker_port=25000, max_worker_port=35000)
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="skip except linux")
+def test_ray_init_from_workers(ray_start_cluster):
+    cluster = ray_start_cluster
+    # add first node
+    node1 = cluster.add_node(node_ip_address="127.0.0.2")
+    # add second node
+    node2 = cluster.add_node(node_ip_address="127.0.0.3")
+    address = cluster.address
+    password = cluster.redis_password
+    assert address.split(":")[0] == "127.0.0.2"
+    assert node1.node_manager_port != node2.node_manager_port
+    info = ray.init(
+        address, _redis_password=password, _node_ip_address="127.0.0.3")
+    assert info["node_ip_address"] == "127.0.0.3"
+
+    address_info = ray._private.services.get_address_info_from_redis(
+        address, "127.0.0.3", redis_password=password, log_warning=False)
+    assert address_info["node_manager_port"] == node2.node_manager_port
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This patch fixes connect from worker node failed problem. When we connect to the ray cluster from the worker nodes(except the head node), we need to find out the given node address info (such as node_manager_port) with `ray._private.services.get_address_info_from_redis_helper`. In the current implementation, it will always return the head node address info. We will get failed because of the wrong address. We should connect to the `worker_node_ip + worker_node_manager_port` instead of `worker_node_ip + head_node_manager_port`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #16009

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
