### PR TITLE
[Placement group] Fix capturing child tasks doesn't work.

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -431,7 +431,7 @@ class ActorClass:
                 max_task_retries=None,
                 name=None,
                 lifetime=None,
-                placement_group=None,
+                placement_group=ray_constants.PLACEMENT_GROUP_DEFAULT_VAL,
                 placement_group_bundle_index=-1,
                 placement_group_capture_child_tasks=None,
                 runtime_env=None,
@@ -497,7 +497,7 @@ class ActorClass:
                 max_task_retries=None,
                 name=None,
                 lifetime=None,
-                placement_group=None,
+                placement_group=ray_constants.PLACEMENT_GROUP_DEFAULT_VAL,
                 placement_group_bundle_index=-1,
                 placement_group_capture_child_tasks=None,
                 runtime_env=None,
@@ -631,9 +631,11 @@ class ActorClass:
             placement_group_capture_child_tasks = (
                 worker.should_capture_child_tasks_in_placement_group)
 
-        if placement_group is None:
+        if placement_group == ray_constants.PLACEMENT_GROUP_DEFAULT_VAL:
             if placement_group_capture_child_tasks:
                 placement_group = get_current_placement_group()
+            else:
+                placement_group = PlacementGroup.empty()
 
         if not placement_group:
             placement_group = PlacementGroup.empty()

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -256,3 +256,7 @@ HEALTHCHECK_EXPIRATION_S = os.environ.get("RAY_HEALTHCHECK_EXPIRATION_S", 10)
 # Should be kept in sync with kSetupWorkerFilename in
 # src/ray/common/constants.h.
 SETUP_WORKER_FILENAME = "setup_worker.py"
+
+# The default value of the placement group. -1 is used so that None
+# argument can be used for a different purpose.
+PLACEMENT_GROUP_DEFAULT_VAL = -1

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -2,7 +2,7 @@ import logging
 import inspect
 from functools import wraps
 
-from ray import cloudpickle as pickle
+from ray import cloudpickle as pickle, ray_constants
 from ray._raylet import PythonFunctionDescriptor
 from ray import cross_language, Language
 from ray._private.client_mode_hook import client_mode_convert_function
@@ -128,7 +128,7 @@ class RemoteFunction:
                 accelerator_type=None,
                 resources=None,
                 max_retries=None,
-                placement_group=None,
+                placement_group=ray_constants.PLACEMENT_GROUP_DEFAULT_VAL,
                 placement_group_bundle_index=-1,
                 placement_group_capture_child_tasks=None,
                 runtime_env=None,
@@ -188,7 +188,7 @@ class RemoteFunction:
                 accelerator_type=None,
                 resources=None,
                 max_retries=None,
-                placement_group=None,
+                placement_group=ray_constants.PLACEMENT_GROUP_DEFAULT_VAL,
                 placement_group_bundle_index=-1,
                 placement_group_capture_child_tasks=None,
                 runtime_env=None,
@@ -253,9 +253,11 @@ class RemoteFunction:
             placement_group_capture_child_tasks = (
                 worker.should_capture_child_tasks_in_placement_group)
 
-        if placement_group is None:
+        if placement_group == ray_constants.PLACEMENT_GROUP_DEFAULT_VAL:
             if placement_group_capture_child_tasks:
                 placement_group = get_current_placement_group()
+            else:
+                placement_group = PlacementGroup.empty()
 
         if not placement_group:
             placement_group = PlacementGroup.empty()

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -958,8 +958,9 @@ def test_capture_child_actors(ray_start_cluster, connect_to_client):
         # (why? The placement group has STRICT_PACK strategy).
         node_id_set = set()
         for actor_info in ray.state.actors().values():
-            node_id = actor_info["Address"]["NodeID"]
-            node_id_set.add(node_id)
+            if actor_info["State"] == ray.gcs_utils.ActorTableData.ALIVE:
+                node_id = actor_info["Address"]["NodeID"]
+                node_id_set.add(node_id)
 
         # Since all node id should be identical, set should be equal to 1.
         assert len(node_id_set) == 1
@@ -982,8 +983,9 @@ def test_capture_child_actors(ray_start_cluster, connect_to_client):
         # placement group.
         node_id_set = set()
         for actor_info in ray.state.actors().values():
-            node_id = actor_info["Address"]["NodeID"]
-            node_id_set.add(node_id)
+            if actor_info["State"] == ray.gcs_utils.ActorTableData.ALIVE:
+                node_id = actor_info["Address"]["NodeID"]
+                node_id_set.add(node_id)
 
         assert len(node_id_set) == 2
 
@@ -1004,8 +1006,9 @@ def test_capture_child_actors(ray_start_cluster, connect_to_client):
         # placement group.
         node_id_set = set()
         for actor_info in ray.state.actors().values():
-            node_id = actor_info["Address"]["NodeID"]
-            node_id_set.add(node_id)
+            if actor_info["State"] == ray.gcs_utils.ActorTableData.ALIVE:
+                node_id = actor_info["Address"]["NodeID"]
+                node_id_set.add(node_id)
 
         assert len(node_id_set) == 2
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously, specifying `placement_group=None` didn't work for not capturing parent's placement group. It wasn't properly caught by tests because we checked all of actors within one test (we should've only considered alive actors). 

## Related issue number

https://github.com/ray-project/ray/issues/15944

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
