### PR TITLE
[Plasma store] Improve the OOM logging message.

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -718,12 +718,7 @@ cdef int64_t restore_spilled_objects_handler(
             exception_str = (
                 "An unexpected internal error occurred while the IO worker "
                 "was restoring spilled objects.")
-            logger.exception(exception_str)
-            ray._private.utils.push_error_to_driver(
-                ray.worker.global_worker,
-                "restore_spilled_objects_error",
-                traceback.format_exc() + exception_str,
-                job_id=None)
+            logger.exception(traceback.format_exc() + exception_str)
     return bytes_restored
 
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -718,7 +718,7 @@ cdef int64_t restore_spilled_objects_handler(
             exception_str = (
                 "An unexpected internal error occurred while the IO worker "
                 "was restoring spilled objects.")
-            logger.exception(traceback.format_exc() + exception_str)
+            logger.exception(exception_str)
     return bytes_restored
 
 

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -942,15 +942,15 @@ void PlasmaStore::ReplyToCreateClient(const std::shared_ptr<Client> &client,
   bool finished = create_request_queue_.GetRequestResult(req_id, &result, &error);
   if (error == PlasmaError::OutOfMemory) {
     // Logs are suppressed because there is only one OOM error per 10 seconds.
-    RAY_LOG(INFO)
-        << "Out of memory error is reported to the client. Object store current usage "
-        << (PlasmaAllocator::Allocated() / 1e9) << " / "
-        << (PlasmaAllocator::GetFootprintLimit() / 1e9)
-        << " GB. Pinned unevictable objects after spilling: "
-        << num_bytes_in_use_ / 1024 / 1024
-        << " MB. Unsealed objects: " << num_bytes_unsealed_ / 1024 / 1024
-        << " MB. Object size: " << (result.data_size + result.metadata_size) / 1024 / 1024
-        << " MB.";
+    RAY_LOG(INFO) << "Out of memory error is reported to the client for an object id "
+                  << object_id << ". Object store current usage "
+                  << (PlasmaAllocator::Allocated() / 1e9) << " / "
+                  << (PlasmaAllocator::GetFootprintLimit() / 1e9)
+                  << " GB. Pinned unevictable objects after spilling: "
+                  << num_bytes_in_use_ / 1024 / 1024
+                  << " MB. Unsealed objects: " << num_bytes_unsealed_ / 1024 / 1024
+                  << " MB. Object size: "
+                  << (result.data_size + result.metadata_size) / 1024 / 1024 << " MB.";
   }
   if (finished) {
     RAY_LOG(DEBUG) << "Finishing create object " << object_id << " request ID " << req_id;

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -949,7 +949,8 @@ void PlasmaStore::ReplyToCreateClient(const std::shared_ptr<Client> &client,
         << " GB. Pinned unevictable objects after spilling: "
         << num_bytes_in_use_ / 1024 / 1024
         << " MB. Unsealed objects: " << num_bytes_unsealed_ / 1024 / 1024
-        << " MB. Object size: " << (result.data_size + result.metadata_size) / 1024 / 1024 << " MB.";
+        << " MB. Object size: " << (result.data_size + result.metadata_size) / 1024 / 1024
+        << " MB.";
   }
   if (finished) {
     RAY_LOG(DEBUG) << "Finishing create object " << object_id << " request ID " << req_id;

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -940,6 +940,17 @@ void PlasmaStore::ReplyToCreateClient(const std::shared_ptr<Client> &client,
   PlasmaObject result = {};
   PlasmaError error;
   bool finished = create_request_queue_.GetRequestResult(req_id, &result, &error);
+  if (error == PlasmaError::OutOfMemory) {
+    // Logs are suppressed because there is only one OOM error per 10 seconds.
+    RAY_LOG(INFO)
+        << "Out of memory error is reported to the client. Object store current usage "
+        << (PlasmaAllocator::Allocated() / 1e9) << " / "
+        << (PlasmaAllocator::GetFootprintLimit() / 1e9)
+        << " GB. Pinned unevictable objects after spilling: "
+        << num_bytes_in_use_ / 1024 / 1024
+        << " MB. Unsealed objects: " << num_bytes_unsealed_ / 1024 / 1024
+        << " MB. Object size: " << (result.data_size + result.metadata_size) / 1024 / 1024 << " MB.";
+  }
   if (finished) {
     RAY_LOG(DEBUG) << "Finishing create object " << object_id << " request ID " << req_id;
     if (SendCreateReply(client, object_id, result, error).ok() &&


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add a better logging when OOM happens. The message will include more fine-grained stats of the plasma store, which will help us identifying more issues. 

It also removes the log pubsub for restore handler, which gives the false signal to users because those will be anyway retried.

Q: Any better way to improve error messages?

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
