### PR TITLE
[Refactor] Replace FractionalResourceQuantity with FixedPoint

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -330,12 +330,20 @@ cc_library(
         exclude = [
             "src/ray/common/**/*_test.cc",
         ],
-    ),
+    ) + [
+        "src/ray/raylet/scheduling/cluster_resource_data.cc",
+        "src/ray/raylet/scheduling/fixed_point.cc",
+        "src/ray/raylet/scheduling/scheduling_ids.cc",
+    ],
     hdrs = glob(
         [
             "src/ray/common/**/*.h",
         ],
-    ),
+    ) + [
+        "src/ray/raylet/scheduling/cluster_resource_data.h",
+        "src/ray/raylet/scheduling/fixed_point.h",
+        "src/ray/raylet/scheduling/scheduling_ids.h",
+    ],
     copts = COPTS,
     strip_include_prefix = "src",
     visibility = ["//visibility:public"],

--- a/python/ray/tests/test_basic_3.py
+++ b/python/ray/tests/test_basic_3.py
@@ -39,14 +39,18 @@ def test_many_fractional_resources(shutdown_only):
     result_ids = []
     for rand1, rand2, rand3 in np.random.uniform(size=(100, 3)):
         resource_set = {"CPU": int(rand1 * 10000) / 10000}
-        result_ids.append(f._remote([False, resource_set], num_cpus=rand1))
+        result_ids.append(
+            f._remote([False, resource_set], num_cpus=resource_set["CPU"]))
 
         resource_set = {"CPU": 1, "GPU": int(rand1 * 10000) / 10000}
-        result_ids.append(f._remote([False, resource_set], num_gpus=rand1))
+        result_ids.append(
+            f._remote([False, resource_set], num_gpus=resource_set["GPU"]))
 
         resource_set = {"CPU": 1, "Custom": int(rand1 * 10000) / 10000}
         result_ids.append(
-            f._remote([False, resource_set], resources={"Custom": rand1}))
+            f._remote(
+                [False, resource_set],
+                resources={"Custom": resource_set["Custom"]}))
 
         resource_set = {
             "CPU": int(rand1 * 10000) / 10000,
@@ -56,15 +60,15 @@ def test_many_fractional_resources(shutdown_only):
         result_ids.append(
             f._remote(
                 [False, resource_set],
-                num_cpus=rand1,
-                num_gpus=rand2,
-                resources={"Custom": rand3}))
+                num_cpus=resource_set["CPU"],
+                num_gpus=resource_set["GPU"],
+                resources={"Custom": resource_set["Custom"]}))
         result_ids.append(
             f._remote(
                 [True, resource_set],
-                num_cpus=rand1,
-                num_gpus=rand2,
-                resources={"Custom": rand3}))
+                num_cpus=resource_set["CPU"],
+                num_gpus=resource_set["GPU"],
+                resources={"Custom": resource_set["Custom"]}))
     assert all(ray.get(result_ids))
 
     # Check that the available resources at the end are the same as the

--- a/python/ray/tests/test_basic_3.py
+++ b/python/ray/tests/test_basic_3.py
@@ -39,18 +39,14 @@ def test_many_fractional_resources(shutdown_only):
     result_ids = []
     for rand1, rand2, rand3 in np.random.uniform(size=(100, 3)):
         resource_set = {"CPU": int(rand1 * 10000) / 10000}
-        result_ids.append(
-            f._remote([False, resource_set], num_cpus=resource_set["CPU"]))
+        result_ids.append(f._remote([False, resource_set], num_cpus=rand1))
 
         resource_set = {"CPU": 1, "GPU": int(rand1 * 10000) / 10000}
-        result_ids.append(
-            f._remote([False, resource_set], num_gpus=resource_set["GPU"]))
+        result_ids.append(f._remote([False, resource_set], num_gpus=rand1))
 
         resource_set = {"CPU": 1, "Custom": int(rand1 * 10000) / 10000}
         result_ids.append(
-            f._remote(
-                [False, resource_set],
-                resources={"Custom": resource_set["Custom"]}))
+            f._remote([False, resource_set], resources={"Custom": rand1}))
 
         resource_set = {
             "CPU": int(rand1 * 10000) / 10000,
@@ -60,15 +56,15 @@ def test_many_fractional_resources(shutdown_only):
         result_ids.append(
             f._remote(
                 [False, resource_set],
-                num_cpus=resource_set["CPU"],
-                num_gpus=resource_set["GPU"],
-                resources={"Custom": resource_set["Custom"]}))
+                num_cpus=rand1,
+                num_gpus=rand2,
+                resources={"Custom": rand3}))
         result_ids.append(
             f._remote(
                 [True, resource_set],
-                num_cpus=resource_set["CPU"],
-                num_gpus=resource_set["GPU"],
-                resources={"Custom": resource_set["Custom"]}))
+                num_cpus=rand1,
+                num_gpus=rand2,
+                resources={"Custom": rand3}))
     assert all(ray.get(result_ids))
 
     # Check that the available resources at the end are the same as the

--- a/src/ray/common/task/scheduling_resources.cc
+++ b/src/ray/common/task/scheduling_resources.cc
@@ -7,75 +7,9 @@
 #include "ray/util/logging.h"
 
 namespace ray {
-
-FractionalResourceQuantity::FractionalResourceQuantity() { resource_quantity_ = 0; }
-
-FractionalResourceQuantity::FractionalResourceQuantity(double resource_quantity) {
-  // We check for nonnegativeity due to the implicit conversion to
-  // FractionalResourceQuantity from ints/doubles when we do logical
-  // comparisons.
-  RAY_CHECK(resource_quantity >= 0)
-      << "Resource capacity, " << resource_quantity << ", should be nonnegative.";
-
-  resource_quantity_ =
-      static_cast<int64_t>(resource_quantity * kResourceConversionFactor);
-}
-
-const FractionalResourceQuantity FractionalResourceQuantity::operator+(
-    const FractionalResourceQuantity &rhs) const {
-  FractionalResourceQuantity result = *this;
-  result += rhs;
-  return result;
-}
-
-const FractionalResourceQuantity FractionalResourceQuantity::operator-(
-    const FractionalResourceQuantity &rhs) const {
-  FractionalResourceQuantity result = *this;
-  result -= rhs;
-  return result;
-}
-
-void FractionalResourceQuantity::operator+=(const FractionalResourceQuantity &rhs) {
-  resource_quantity_ += rhs.resource_quantity_;
-}
-
-void FractionalResourceQuantity::operator-=(const FractionalResourceQuantity &rhs) {
-  resource_quantity_ -= rhs.resource_quantity_;
-}
-
-bool FractionalResourceQuantity::operator==(const FractionalResourceQuantity &rhs) const {
-  return resource_quantity_ == rhs.resource_quantity_;
-}
-
-bool FractionalResourceQuantity::operator!=(const FractionalResourceQuantity &rhs) const {
-  return !(*this == rhs);
-}
-
-bool FractionalResourceQuantity::operator<(const FractionalResourceQuantity &rhs) const {
-  return resource_quantity_ < rhs.resource_quantity_;
-}
-
-bool FractionalResourceQuantity::operator>(const FractionalResourceQuantity &rhs) const {
-  return rhs < *this;
-}
-
-bool FractionalResourceQuantity::operator<=(const FractionalResourceQuantity &rhs) const {
-  return !(*this > rhs);
-}
-
-bool FractionalResourceQuantity::operator>=(const FractionalResourceQuantity &rhs) const {
-  bool result = !(*this < rhs);
-  return result;
-}
-
-double FractionalResourceQuantity::ToDouble() const {
-  return static_cast<double>(resource_quantity_) / kResourceConversionFactor;
-}
-
 ResourceSet::ResourceSet() {}
 
-ResourceSet::ResourceSet(
-    const std::unordered_map<std::string, FractionalResourceQuantity> &resource_map)
+ResourceSet::ResourceSet(const std::unordered_map<std::string, FixedPoint> &resource_map)
     : resource_capacity_(resource_map) {
   for (auto const &resource_pair : resource_map) {
     RAY_CHECK(resource_pair.second > 0);
@@ -85,8 +19,7 @@ ResourceSet::ResourceSet(
 ResourceSet::ResourceSet(const std::unordered_map<std::string, double> &resource_map) {
   for (auto const &resource_pair : resource_map) {
     RAY_CHECK(resource_pair.second > 0);
-    resource_capacity_[resource_pair.first] =
-        FractionalResourceQuantity(resource_pair.second);
+    resource_capacity_[resource_pair.first] = FixedPoint(resource_pair.second);
   }
 }
 
@@ -95,8 +28,7 @@ ResourceSet::ResourceSet(const std::vector<std::string> &resource_labels,
   RAY_CHECK(resource_labels.size() == resource_capacity.size());
   for (size_t i = 0; i < resource_labels.size(); i++) {
     RAY_CHECK(resource_capacity[i] > 0);
-    resource_capacity_[resource_labels[i]] =
-        FractionalResourceQuantity(resource_capacity[i]);
+    resource_capacity_[resource_labels[i]] = FixedPoint(resource_capacity[i]);
   }
 }
 
@@ -115,8 +47,8 @@ bool ResourceSet::IsSubset(const ResourceSet &other) const {
   // Check to make sure all keys of this are in other.
   for (const auto &resource_pair : resource_capacity_) {
     const auto &resource_name = resource_pair.first;
-    const FractionalResourceQuantity &lhs_quantity = resource_pair.second;
-    const FractionalResourceQuantity &rhs_quantity = other.GetResource(resource_name);
+    const FixedPoint &lhs_quantity = resource_pair.second;
+    const FixedPoint &rhs_quantity = other.GetResource(resource_name);
     if (lhs_quantity > rhs_quantity) {
       // Resource found in rhs, but lhs capacity exceeds rhs capacity.
       return false;
@@ -136,7 +68,7 @@ bool ResourceSet::IsEqual(const ResourceSet &rhs) const {
 }
 
 void ResourceSet::AddOrUpdateResource(const std::string &resource_name,
-                                      const FractionalResourceQuantity &capacity) {
+                                      const FixedPoint &capacity) {
   if (capacity > 0) {
     resource_capacity_[resource_name] = capacity;
   }
@@ -156,7 +88,7 @@ void ResourceSet::SubtractResources(const ResourceSet &other) {
   // is zero.
   for (const auto &resource_pair : other.GetResourceAmountMap()) {
     const std::string &resource_label = resource_pair.first;
-    const FractionalResourceQuantity &resource_capacity = resource_pair.second;
+    const FixedPoint &resource_capacity = resource_pair.second;
     if (resource_capacity_.count(resource_label) == 1) {
       resource_capacity_[resource_label] -= resource_capacity;
     }
@@ -171,17 +103,17 @@ void ResourceSet::SubtractResourcesStrict(const ResourceSet &other) {
   // is zero.
   for (const auto &resource_pair : other.GetResourceAmountMap()) {
     const std::string &resource_label = resource_pair.first;
-    const FractionalResourceQuantity &resource_capacity = resource_pair.second;
+    const FixedPoint &resource_capacity = resource_pair.second;
     RAY_CHECK(resource_capacity_.count(resource_label) == 1)
         << "Attempt to acquire unknown resource: " << resource_label << " capacity "
-        << resource_capacity.ToDouble();
+        << resource_capacity.Double();
     resource_capacity_[resource_label] -= resource_capacity;
 
     // Ensure that quantity is positive. Note, we have to have the check before
     // erasing the object to make sure that it doesn't get added back.
     RAY_CHECK(resource_capacity_[resource_label] >= 0)
         << "Capacity of resource after subtraction is negative, "
-        << resource_capacity_[resource_label].ToDouble() << ".";
+        << resource_capacity_[resource_label].Double() << ".";
 
     if (resource_capacity_[resource_label] == 0) {
       resource_capacity_.erase(resource_label);
@@ -193,17 +125,16 @@ void ResourceSet::SubtractResourcesStrict(const ResourceSet &other) {
 // capacity from the total_resource set
 void ResourceSet::AddResourcesCapacityConstrained(const ResourceSet &other,
                                                   const ResourceSet &total_resources) {
-  const std::unordered_map<std::string, FractionalResourceQuantity> &total_resource_map =
+  const std::unordered_map<std::string, FixedPoint> &total_resource_map =
       total_resources.GetResourceAmountMap();
   for (const auto &resource_pair : other.GetResourceAmountMap()) {
     const std::string &to_add_resource_label = resource_pair.first;
-    const FractionalResourceQuantity &to_add_resource_capacity = resource_pair.second;
+    const FixedPoint &to_add_resource_capacity = resource_pair.second;
     if (total_resource_map.count(to_add_resource_label) != 0) {
       // If resource exists in total map, add to the local capacity map.
       // If the new capacity is less than the total capacity, set the new capacity to
       // the local capacity (capping to the total).
-      const FractionalResourceQuantity &total_capacity =
-          total_resource_map.at(to_add_resource_label);
+      const FixedPoint &total_capacity = total_resource_map.at(to_add_resource_label);
       resource_capacity_[to_add_resource_label] =
           std::min(resource_capacity_[to_add_resource_label] + to_add_resource_capacity,
                    total_capacity);
@@ -222,23 +153,22 @@ void ResourceSet::AddResourcesCapacityConstrained(const ResourceSet &other,
 void ResourceSet::AddResources(const ResourceSet &other) {
   for (const auto &resource_pair : other.GetResourceAmountMap()) {
     const std::string &resource_label = resource_pair.first;
-    const FractionalResourceQuantity &resource_capacity = resource_pair.second;
+    const FixedPoint &resource_capacity = resource_pair.second;
     resource_capacity_[resource_label] += resource_capacity;
   }
 }
 
-FractionalResourceQuantity ResourceSet::GetResource(
-    const std::string &resource_name) const {
+FixedPoint ResourceSet::GetResource(const std::string &resource_name) const {
   if (resource_capacity_.count(resource_name) == 0) {
     return 0;
   }
-  const FractionalResourceQuantity &capacity = resource_capacity_.at(resource_name);
+  const FixedPoint &capacity = resource_capacity_.at(resource_name);
   return capacity;
 }
 
 const ResourceSet ResourceSet::GetNumCpus() const {
   ResourceSet cpu_resource_set;
-  const FractionalResourceQuantity cpu_quantity = GetResource(kCPU_ResourceLabel);
+  const FixedPoint cpu_quantity = GetResource(kCPU_ResourceLabel);
   if (cpu_quantity > 0) {
     cpu_resource_set.resource_capacity_[kCPU_ResourceLabel] = cpu_quantity;
   }
@@ -262,7 +192,7 @@ const std::string ResourceSet::ToString() const {
 
     // Convert the first element to a string.
     if (it != resource_capacity_.end()) {
-      double resource_amount = (it->second).ToDouble();
+      double resource_amount = (it->second).Double();
       return_string +=
           "{" + it->first + ": " + format_resource(it->first, resource_amount) + "}";
       it++;
@@ -270,7 +200,7 @@ const std::string ResourceSet::ToString() const {
 
     // Add the remaining elements to the string (along with a comma).
     for (; it != resource_capacity_.end(); ++it) {
-      double resource_amount = (it->second).ToDouble();
+      double resource_amount = (it->second).Double();
       return_string +=
           ", {" + it->first + ": " + format_resource(it->first, resource_amount) + "}";
     }
@@ -282,13 +212,13 @@ const std::string ResourceSet::ToString() const {
 const std::unordered_map<std::string, double> ResourceSet::GetResourceMap() const {
   std::unordered_map<std::string, double> result;
   for (const auto &resource_pair : resource_capacity_) {
-    result[resource_pair.first] = resource_pair.second.ToDouble();
+    result[resource_pair.first] = resource_pair.second.Double();
   }
   return result;
 };
 
-const std::unordered_map<std::string, FractionalResourceQuantity>
-    &ResourceSet::GetResourceAmountMap() const {
+const std::unordered_map<std::string, FixedPoint> &ResourceSet::GetResourceAmountMap()
+    const {
   return resource_capacity_;
 };
 
@@ -311,22 +241,22 @@ ResourceIds::ResourceIds(const std::vector<int64_t> &whole_ids)
     : whole_ids_(whole_ids), total_capacity_(whole_ids.size()), decrement_backlog_(0) {}
 
 ResourceIds::ResourceIds(
-    const std::vector<std::pair<int64_t, FractionalResourceQuantity>> &fractional_ids)
+    const std::vector<std::pair<int64_t, FixedPoint>> &fractional_ids)
     : fractional_ids_(fractional_ids),
       total_capacity_(TotalQuantity()),
       decrement_backlog_(0) {}
 
 ResourceIds::ResourceIds(
     const std::vector<int64_t> &whole_ids,
-    const std::vector<std::pair<int64_t, FractionalResourceQuantity>> &fractional_ids)
+    const std::vector<std::pair<int64_t, FixedPoint>> &fractional_ids)
     : whole_ids_(whole_ids),
       fractional_ids_(fractional_ids),
       total_capacity_(TotalQuantity()),
       decrement_backlog_(0) {}
 
-bool ResourceIds::Contains(const FractionalResourceQuantity &resource_quantity) const {
+bool ResourceIds::Contains(const FixedPoint &resource_quantity) const {
   if (resource_quantity >= 1) {
-    double whole_quantity = resource_quantity.ToDouble();
+    double whole_quantity = resource_quantity.Double();
     RAY_CHECK(IsWhole(whole_quantity));
     return whole_ids_.size() >= whole_quantity;
   } else {
@@ -343,10 +273,10 @@ bool ResourceIds::Contains(const FractionalResourceQuantity &resource_quantity) 
   }
 }
 
-ResourceIds ResourceIds::Acquire(const FractionalResourceQuantity &resource_quantity) {
+ResourceIds ResourceIds::Acquire(const FixedPoint &resource_quantity) {
   if (resource_quantity >= 1) {
     // Handle the whole case.
-    double whole_quantity = resource_quantity.ToDouble();
+    double whole_quantity = resource_quantity.Double();
     RAY_CHECK(IsWhole(whole_quantity));
     RAY_CHECK(static_cast<int64_t>(whole_ids_.size()) >=
               static_cast<int64_t>(whole_quantity));
@@ -383,9 +313,8 @@ ResourceIds ResourceIds::Acquire(const FractionalResourceQuantity &resource_quan
 
     auto return_pair = std::make_pair(whole_id, resource_quantity);
     // We cannot make use of the implicit conversion because ints have no
-    // operator-(const FractionalResourceQuantity&) function.
-    const FractionalResourceQuantity remaining_amount =
-        FractionalResourceQuantity(1) - resource_quantity;
+    // operator-(const FixedPoint&) function.
+    const FixedPoint remaining_amount = FixedPoint(1) - resource_quantity;
     fractional_ids_.push_back(std::make_pair(whole_id, remaining_amount));
     return ResourceIds({return_pair});
   }
@@ -411,18 +340,18 @@ void ResourceIds::Release(const ResourceIds &resource_ids) {
   auto const &fractional_ids_to_return = resource_ids.FractionalIds();
   for (auto const &fractional_pair_to_return : fractional_ids_to_return) {
     int64_t resource_id = fractional_pair_to_return.first;
-    auto const &fractional_pair_it = std::find_if(
-        fractional_ids_.begin(), fractional_ids_.end(),
-        [resource_id](std::pair<int64_t, FractionalResourceQuantity> &fractional_pair) {
-          return fractional_pair.first == resource_id;
-        });
+    auto const &fractional_pair_it =
+        std::find_if(fractional_ids_.begin(), fractional_ids_.end(),
+                     [resource_id](std::pair<int64_t, FixedPoint> &fractional_pair) {
+                       return fractional_pair.first == resource_id;
+                     });
     if (fractional_pair_it == fractional_ids_.end()) {
       fractional_ids_.push_back(fractional_pair_to_return);
     } else {
       fractional_pair_it->second += fractional_pair_to_return.second;
       RAY_CHECK(fractional_pair_it->second <= 1)
           << "Fractional Resource Id " << fractional_pair_it->first << " capacity is "
-          << fractional_pair_it->second.ToDouble() << ". Should have been less than one.";
+          << fractional_pair_it->second.Double() << ". Should have been less than one.";
       // If this makes the ID whole, then return it to the list of whole IDs.
       if (fractional_pair_it->second == 1) {
         if (decrement_backlog_ > 0) {
@@ -445,8 +374,7 @@ ResourceIds ResourceIds::Plus(const ResourceIds &resource_ids) const {
 
 const std::vector<int64_t> &ResourceIds::WholeIds() const { return whole_ids_; }
 
-const std::vector<std::pair<int64_t, FractionalResourceQuantity>>
-    &ResourceIds::FractionalIds() const {
+const std::vector<std::pair<int64_t, FixedPoint>> &ResourceIds::FractionalIds() const {
   return fractional_ids_;
 }
 
@@ -454,9 +382,8 @@ bool ResourceIds::TotalQuantityIsZero() const {
   return whole_ids_.empty() && fractional_ids_.empty();
 }
 
-FractionalResourceQuantity ResourceIds::TotalQuantity() const {
-  FractionalResourceQuantity total_quantity =
-      FractionalResourceQuantity(whole_ids_.size());
+FixedPoint ResourceIds::TotalQuantity() const {
+  FixedPoint total_quantity = FixedPoint(whole_ids_.size());
   for (auto const &fractional_pair : fractional_ids_) {
     total_quantity += fractional_pair.second;
   }
@@ -470,7 +397,7 @@ std::string ResourceIds::ToString() const {
   }
   return_string += "], Fractional IDs: ";
   for (auto const &fractional_pair : fractional_ids_) {
-    double fractional_amount = fractional_pair.second.ToDouble();
+    double fractional_amount = fractional_pair.second.Double();
     return_string += "(" + std::to_string(fractional_pair.first) + ", " +
                      std::to_string(fractional_amount) + "), ";
   }
@@ -481,7 +408,7 @@ std::string ResourceIds::ToString() const {
 void ResourceIds::UpdateCapacity(int64_t new_capacity) {
   // Assert the new capacity is positive for sanity
   RAY_CHECK(new_capacity >= 0);
-  int64_t capacity_delta = new_capacity - total_capacity_.ToDouble();
+  int64_t capacity_delta = new_capacity - total_capacity_.Double();
   if (capacity_delta < 0) {
     DecreaseCapacity(-1 * capacity_delta);
   } else {
@@ -507,7 +434,7 @@ void ResourceIds::IncreaseCapacity(int64_t increment_quantity) {
 void ResourceIds::DecreaseCapacity(int64_t decrement_quantity) {
   // Get total quantity, but casting to int to truncate any fractional resources. Updates
   // are supported only on whole resources.
-  int64_t available_quantity = TotalQuantity().ToDouble();
+  int64_t available_quantity = TotalQuantity().Double();
   RAY_LOG(DEBUG) << "[DecreaseCapacity] Available quantity: " << available_quantity;
 
   if (available_quantity < decrement_quantity) {
@@ -553,7 +480,7 @@ ResourceIdSet::ResourceIdSet(
 bool ResourceIdSet::Contains(const ResourceSet &resource_set) const {
   for (auto const &resource_pair : resource_set.GetResourceAmountMap()) {
     auto const &resource_name = resource_pair.first;
-    const FractionalResourceQuantity &resource_quantity = resource_pair.second;
+    const FixedPoint &resource_quantity = resource_pair.second;
 
     auto it = available_resources_.find(resource_name);
     if (it == available_resources_.end()) {
@@ -572,7 +499,7 @@ ResourceIdSet ResourceIdSet::Acquire(const ResourceSet &resource_set) {
 
   for (auto const &resource_pair : resource_set.GetResourceAmountMap()) {
     auto const &resource_name = resource_pair.first;
-    const FractionalResourceQuantity &resource_quantity = resource_pair.second;
+    const FixedPoint &resource_quantity = resource_pair.second;
 
     auto it = available_resources_.find(resource_name);
     RAY_CHECK(it != available_resources_.end());
@@ -661,7 +588,7 @@ ResourceIdSet ResourceIdSet::GetCpuResources() const {
 }
 
 ResourceSet ResourceIdSet::ToResourceSet() const {
-  std::unordered_map<std::string, FractionalResourceQuantity> resource_set;
+  std::unordered_map<std::string, FixedPoint> resource_set;
   for (auto const &resource_pair : available_resources_) {
     resource_set[resource_pair.first] = resource_pair.second.TotalQuantity();
   }
@@ -700,7 +627,7 @@ std::vector<flatbuffers::Offset<protocol::ResourceIdSetInfo>> ResourceIdSet::ToF
 
     for (auto const &fractional_pair : resource_pair.second.FractionalIds()) {
       resource_ids.push_back(fractional_pair.first);
-      resource_fractions.push_back(fractional_pair.second.ToDouble());
+      resource_fractions.push_back(fractional_pair.second.Double());
     }
 
     auto resource_id_set_message = protocol::CreateResourceIdSetInfo(
@@ -778,17 +705,14 @@ void SchedulingResources::AddResource(const ResourceSet &resources) {
 
 void SchedulingResources::UpdateResourceCapacity(const std::string &resource_name,
                                                  int64_t capacity) {
-  const FractionalResourceQuantity new_capacity = FractionalResourceQuantity(capacity);
-  const FractionalResourceQuantity &current_capacity =
-      resources_total_.GetResource(resource_name);
+  const FixedPoint new_capacity = FixedPoint(capacity);
+  const FixedPoint &current_capacity = resources_total_.GetResource(resource_name);
   if (current_capacity > 0) {
     // If the resource exists, add to total and available resources
-    const FractionalResourceQuantity capacity_difference =
-        new_capacity - current_capacity;
-    const FractionalResourceQuantity &current_available_capacity =
+    const FixedPoint capacity_difference = new_capacity - current_capacity;
+    const FixedPoint &current_available_capacity =
         resources_available_.GetResource(resource_name);
-    FractionalResourceQuantity new_available_capacity =
-        current_available_capacity + capacity_difference;
+    FixedPoint new_available_capacity = current_available_capacity + capacity_difference;
     if (new_available_capacity < 0) {
       new_available_capacity = 0;
     }

--- a/src/ray/common/task/scheduling_resources.cc
+++ b/src/ray/common/task/scheduling_resources.cc
@@ -238,7 +238,9 @@ ResourceIds::ResourceIds(double resource_quantity) {
 }
 
 ResourceIds::ResourceIds(const std::vector<int64_t> &whole_ids)
-    : whole_ids_(whole_ids), total_capacity_((uint64_t)whole_ids.size()), decrement_backlog_(0) {}
+    : whole_ids_(whole_ids),
+      total_capacity_((uint64_t)whole_ids.size()),
+      decrement_backlog_(0) {}
 
 ResourceIds::ResourceIds(
     const std::vector<std::pair<int64_t, FixedPoint>> &fractional_ids)

--- a/src/ray/common/task/scheduling_resources.cc
+++ b/src/ray/common/task/scheduling_resources.cc
@@ -238,7 +238,7 @@ ResourceIds::ResourceIds(double resource_quantity) {
 }
 
 ResourceIds::ResourceIds(const std::vector<int64_t> &whole_ids)
-    : whole_ids_(whole_ids), total_capacity_(whole_ids.size()), decrement_backlog_(0) {}
+    : whole_ids_(whole_ids), total_capacity_((uint64_t)whole_ids.size()), decrement_backlog_(0) {}
 
 ResourceIds::ResourceIds(
     const std::vector<std::pair<int64_t, FixedPoint>> &fractional_ids)
@@ -383,7 +383,7 @@ bool ResourceIds::TotalQuantityIsZero() const {
 }
 
 FixedPoint ResourceIds::TotalQuantity() const {
-  FixedPoint total_quantity = FixedPoint(whole_ids_.size());
+  FixedPoint total_quantity = FixedPoint((uint64_t)whole_ids_.size());
   for (auto const &fractional_pair : fractional_ids_) {
     total_quantity += fractional_pair.second;
   }

--- a/src/ray/common/task/scheduling_resources.h
+++ b/src/ray/common/task/scheduling_resources.h
@@ -7,11 +7,12 @@
 
 #include "ray/common/id.h"
 #include "ray/raylet/format/node_manager_generated.h"
+#include "ray/raylet/scheduling/cluster_resource_data.h"
 
 namespace ray {
 
 /// Conversion factor that is the amount in internal units is equivalent to
-/// one actual resource. Multiply to convert from actual to interal and
+/// one actual resource. Multiply to convert from actual to internal and
 /// divide to convert from internal to actual.
 constexpr double kResourceConversionFactor = 10000;
 
@@ -19,48 +20,6 @@ const std::string kCPU_ResourceLabel = "CPU";
 const std::string kGPU_ResourceLabel = "GPU";
 const std::string kObjectStoreMemory_ResourceLabel = "object_store_memory";
 const std::string kMemory_ResourceLabel = "memory";
-
-/// \class FractionalResourceQuantity
-/// \brief Converts the resource quantities to an internal representation to
-/// avoid machine precision errors.
-class FractionalResourceQuantity {
- public:
-  /// \brief Construct a FractionalResourceQuantity representing zero
-  /// resources. This constructor is used by std::unordered_map when we try
-  /// to add a new FractionalResourceQuantity in ResourceSets.
-  FractionalResourceQuantity();
-
-  /// \brief Construct a FractionalResourceQuantity representing
-  /// resource_quantity.
-  FractionalResourceQuantity(double resource_quantity);
-
-  /// \brief Addition of FractionalResourceQuantity.
-  const FractionalResourceQuantity operator+(const FractionalResourceQuantity &rhs) const;
-
-  /// \brief Subtraction of FractionalResourceQuantity.
-  const FractionalResourceQuantity operator-(const FractionalResourceQuantity &rhs) const;
-
-  /// \brief Addition and assignment of FractionalResourceQuantity.
-  void operator+=(const FractionalResourceQuantity &rhs);
-
-  /// \brief Subtraction and assignment of FractionalResourceQuantity.
-  void operator-=(const FractionalResourceQuantity &rhs);
-
-  bool operator==(const FractionalResourceQuantity &rhs) const;
-  bool operator!=(const FractionalResourceQuantity &rhs) const;
-  bool operator<(const FractionalResourceQuantity &rhs) const;
-  bool operator>(const FractionalResourceQuantity &rhs) const;
-  bool operator<=(const FractionalResourceQuantity &rhs) const;
-  bool operator>=(const FractionalResourceQuantity &rhs) const;
-
-  /// \brief Return actual resource amount as a double.
-  double ToDouble() const;
-
- private:
-  /// The resource quantity represented as 1/kResourceConversionFactor-th of a
-  /// unit.
-  int64_t resource_quantity_;
-};
 
 /// \class ResourceSet
 /// \brief Encapsulates and operates on a set of resources, including CPUs,
@@ -76,8 +35,7 @@ class ResourceSet {
   ResourceSet();
 
   /// \brief Constructs ResourceSet from the specified resource map.
-  ResourceSet(
-      const std::unordered_map<std::string, FractionalResourceQuantity> &resource_map);
+  ResourceSet(const std::unordered_map<std::string, FixedPoint> &resource_map);
 
   /// \brief Constructs ResourceSet from the specified resource map.
   ResourceSet(const std::unordered_map<std::string, double> &resource_map);
@@ -121,8 +79,7 @@ class ResourceSet {
   /// \param resource_name: name/label of the resource to add.
   /// \param capacity: numeric capacity value for the resource to add.
   /// \return True, if the resource was successfully added. False otherwise.
-  void AddOrUpdateResource(const std::string &resource_name,
-                           const FractionalResourceQuantity &capacity);
+  void AddOrUpdateResource(const std::string &resource_name, const FixedPoint &capacity);
 
   /// \brief Delete a resource from the resource set.
   ///
@@ -168,7 +125,7 @@ class ResourceSet {
   /// \param resource_name: Resource name for which capacity is requested.
   /// \return The capacity value associated with the specified resource, zero if resource
   /// does not exist.
-  FractionalResourceQuantity GetResource(const std::string &resource_name) const;
+  FixedPoint GetResource(const std::string &resource_name) const;
 
   /// Return the number of CPUs.
   ///
@@ -182,25 +139,24 @@ class ResourceSet {
 
   // TODO(atumanov): implement const_iterator class for the ResourceSet container.
   // TODO(williamma12): Make sure that everywhere we use doubles we don't
-  // convert it back to FractionalResourceQuantity.
+  // convert it back to FixedPoint.
   /// \brief Return a map of the resource and size in doubles. Note, size is in
   /// regular units and does not need to be multiplied by kResourceConversionFactor.
   ///
   /// \return map of resource in string to size in double.
   const std::unordered_map<std::string, double> GetResourceMap() const;
 
-  /// \brief Return a map of the resource and size in FractionalResourceQuantity. Note,
+  /// \brief Return a map of the resource and size in FixedPoint. Note,
   /// size is in kResourceConversionFactor of a unit.
   ///
-  /// \return map of resource in string to size in FractionalResourceQuantity.
-  const std::unordered_map<std::string, FractionalResourceQuantity>
-      &GetResourceAmountMap() const;
+  /// \return map of resource in string to size in FixedPoint.
+  const std::unordered_map<std::string, FixedPoint> &GetResourceAmountMap() const;
 
   const std::string ToString() const;
 
  private:
   /// Resource capacity map.
-  std::unordered_map<std::string, FractionalResourceQuantity> resource_capacity_;
+  std::unordered_map<std::string, FixedPoint> resource_capacity_;
 };
 
 /// \class ResourceIds
@@ -228,16 +184,14 @@ class ResourceIds {
   /// \brief Constructs ResourceIds with a given set of fractional IDs.
   ///
   /// \param fractional_ids: A vector of the resource IDs that are partially available.
-  explicit ResourceIds(
-      const std::vector<std::pair<int64_t, FractionalResourceQuantity>> &fractional_ids);
+  explicit ResourceIds(const std::vector<std::pair<int64_t, FixedPoint>> &fractional_ids);
 
   /// \brief Constructs ResourceIds with a given set of whole IDs and fractional IDs.
   ///
   /// \param whole_ids: A vector of the resource IDs that are completely available.
   /// \param fractional_ids: A vector of the resource IDs that are partially available.
-  ResourceIds(
-      const std::vector<int64_t> &whole_ids,
-      const std::vector<std::pair<int64_t, FractionalResourceQuantity>> &fractional_ids);
+  ResourceIds(const std::vector<int64_t> &whole_ids,
+              const std::vector<std::pair<int64_t, FixedPoint>> &fractional_ids);
 
   /// \brief Check if we have at least the requested amount.
   ///
@@ -249,14 +203,14 @@ class ResourceIds {
   ///
   /// \param resource_quantity Either a whole number or a fraction less than 1.
   /// \return True if there we have enough of the resource.
-  bool Contains(const FractionalResourceQuantity &resource_quantity) const;
+  bool Contains(const FixedPoint &resource_quantity) const;
 
   /// \brief Acquire the requested amount of the resource.
   ///
   /// \param resource_quantity The amount to acquire. Either a whole number or a
   /// fraction less than 1.
   /// \return A ResourceIds representing the specific acquired IDs.
-  ResourceIds Acquire(const FractionalResourceQuantity &resource_quantity);
+  ResourceIds Acquire(const FixedPoint &resource_quantity);
 
   /// \brief Return some resource IDs.
   ///
@@ -278,8 +232,7 @@ class ResourceIds {
   /// \brief Return just the fractional IDs.
   ///
   /// \return The fractional IDs.
-  const std::vector<std::pair<int64_t, FractionalResourceQuantity>> &FractionalIds()
-      const;
+  const std::vector<std::pair<int64_t, FixedPoint>> &FractionalIds() const;
 
   /// \brief Check if ResourceIds has any resources.
   ///
@@ -289,7 +242,7 @@ class ResourceIds {
   /// \brief Return the total quantity of resources, ignoring the specific IDs.
   ///
   /// \return The total quantity of the resource.
-  FractionalResourceQuantity TotalQuantity() const;
+  FixedPoint TotalQuantity() const;
 
   /// \brief Return a string representation of the object.
   ///
@@ -327,10 +280,10 @@ class ResourceIds {
   std::vector<int64_t> whole_ids_;
   /// A vector of pairs of resource ID and a fraction of that ID (the fraction
   /// is at least zero and strictly less than 1).
-  std::vector<std::pair<int64_t, FractionalResourceQuantity>> fractional_ids_;
+  std::vector<std::pair<int64_t, FixedPoint>> fractional_ids_;
   /// Quantity to track the total capacity of the resource, since the whole_ids_ vector
   /// keeps changing
-  FractionalResourceQuantity total_capacity_;
+  FixedPoint total_capacity_;
   /// Quantity to track any pending decrements in capacity that weren't executed because
   /// of insufficient available resources. This backlog in cleared in the release method.
   int64_t decrement_backlog_;

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -159,7 +159,7 @@ void GcsResourceManager::HandleGetAllAvailableResources(
     rpc::AvailableResources resource;
     resource.set_node_id(iter.first.Binary());
     for (const auto &res : iter.second.GetAvailableResources().GetResourceAmountMap()) {
-      (*resource.mutable_resources_available())[res.first] = res.second.ToDouble();
+      (*resource.mutable_resources_available())[res.first] = res.second.Double();
     }
     reply->add_resources_list()->CopyFrom(resource);
   }

--- a/src/ray/gcs/gcs_server/gcs_resource_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_scheduler.cc
@@ -42,14 +42,14 @@ double LeastResourceScorer::Score(const ResourceSet &required_resources,
   return node_score;
 }
 
-double LeastResourceScorer::Calculate(const FractionalResourceQuantity &requested,
-                                      const FractionalResourceQuantity &available) {
-  RAY_CHECK(available >= 0) << "Available resource " << available.ToDouble()
+double LeastResourceScorer::Calculate(const FixedPoint &requested,
+                                      const FixedPoint &available) {
+  RAY_CHECK(available >= 0) << "Available resource " << available.Double()
                             << " should be nonnegative.";
   if (requested > available) {
     return -1;
   }
-  return (available - requested).ToDouble() / available.ToDouble();
+  return (available - requested).Double() / available.Double();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/ray/gcs/gcs_server/gcs_resource_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_scheduler.h
@@ -66,8 +66,7 @@ class LeastResourceScorer : public NodeScorer {
   /// \param requested Quantity of one of the required resources.
   /// \param available Quantity of one of the available resources.
   /// \return Score of the node.
-  double Calculate(const FractionalResourceQuantity &requested,
-                   const FractionalResourceQuantity &available);
+  double Calculate(const FixedPoint &requested, const FixedPoint &available);
 };
 
 /// Gcs resource scheduler implementation.

--- a/src/ray/gcs/gcs_server/test/gcs_resource_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_resource_scheduler_test.cc
@@ -50,7 +50,7 @@ class GcsResourceSchedulerTest : public ::testing::Test {
     const auto &cluster_resource = gcs_resource_manager_->GetClusterResources();
     auto iter = cluster_resource.find(node_id);
     ASSERT_TRUE(iter != cluster_resource.end());
-    ASSERT_EQ(iter->second.GetAvailableResources().GetResource(resource_name).ToDouble(),
+    ASSERT_EQ(iter->second.GetAvailableResources().GetResource(resource_name).Double(),
               resource_value);
   }
 

--- a/src/ray/raylet/scheduling/cluster_resource_data.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_data.cc
@@ -1,4 +1,5 @@
 #include "ray/raylet/scheduling/cluster_resource_data.h"
+#include "ray/common/task/scheduling_resources.h"
 
 const std::string resource_labels[] = {
     ray::kCPU_ResourceLabel, ray::kMemory_ResourceLabel, ray::kGPU_ResourceLabel,

--- a/src/ray/raylet/scheduling/cluster_resource_data.h
+++ b/src/ray/raylet/scheduling/cluster_resource_data.h
@@ -20,7 +20,6 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
-#include "ray/common/task/scheduling_resources.h"
 #include "ray/raylet/scheduling/fixed_point.h"
 #include "ray/raylet/scheduling/scheduling_ids.h"
 #include "ray/util/logging.h"

--- a/src/ray/raylet/scheduling/fixed_point.cc
+++ b/src/ray/raylet/scheduling/fixed_point.cc
@@ -10,7 +10,7 @@ FixedPoint::FixedPoint(double d) {
 
 FixedPoint::FixedPoint(int i) { i_ = (i * RESOURCE_UNIT_SCALING); }
 
-FixedPoint::FixedPoint(unsigned long i) { i_ = (i * RESOURCE_UNIT_SCALING); }
+FixedPoint::FixedPoint(uint32_t i) { i_ = (i * RESOURCE_UNIT_SCALING); }
 
 FixedPoint::FixedPoint(int64_t i) : FixedPoint((double)i) {}
 

--- a/src/ray/raylet/scheduling/fixed_point.cc
+++ b/src/ray/raylet/scheduling/fixed_point.cc
@@ -10,7 +10,7 @@ FixedPoint::FixedPoint(double d) {
 
 FixedPoint::FixedPoint(int i) { i_ = (i * RESOURCE_UNIT_SCALING); }
 
-FixedPoint::FixedPoint(size_t i) { i_ = (i * RESOURCE_UNIT_SCALING); }
+FixedPoint::FixedPoint(unsigned long i) { i_ = (i * RESOURCE_UNIT_SCALING); }
 
 FixedPoint::FixedPoint(int64_t i) : FixedPoint((double)i) {}
 

--- a/src/ray/raylet/scheduling/fixed_point.cc
+++ b/src/ray/raylet/scheduling/fixed_point.cc
@@ -10,6 +10,8 @@ FixedPoint::FixedPoint(double d) {
 
 FixedPoint::FixedPoint(int i) { i_ = (i * RESOURCE_UNIT_SCALING); }
 
+FixedPoint::FixedPoint(size_t i) { i_ = (i * RESOURCE_UNIT_SCALING); }
+
 FixedPoint::FixedPoint(int64_t i) : FixedPoint((double)i) {}
 
 FixedPoint::FixedPoint(uint64_t i) : FixedPoint((double)i) {}

--- a/src/ray/raylet/scheduling/fixed_point.cc
+++ b/src/ray/raylet/scheduling/fixed_point.cc
@@ -10,7 +10,11 @@ FixedPoint::FixedPoint(double d) {
 
 FixedPoint::FixedPoint(int i) { i_ = (i * RESOURCE_UNIT_SCALING); }
 
-FixedPoint FixedPoint::operator+(FixedPoint const &ru) {
+FixedPoint::FixedPoint(int64_t i) : FixedPoint((double)i) {}
+
+FixedPoint::FixedPoint(uint64_t i) : FixedPoint((double)i) {}
+
+FixedPoint FixedPoint::operator+(FixedPoint const &ru) const {
   FixedPoint res;
   res.i_ = i_ + ru.i_;
   return res;
@@ -21,7 +25,7 @@ FixedPoint FixedPoint::operator+=(FixedPoint const &ru) {
   return *this;
 }
 
-FixedPoint FixedPoint::operator-(FixedPoint const &ru) {
+FixedPoint FixedPoint::operator-(FixedPoint const &ru) const {
   FixedPoint res;
   res.i_ = i_ - ru.i_;
   return res;
@@ -38,13 +42,13 @@ FixedPoint FixedPoint::operator-() const {
   return res;
 }
 
-FixedPoint FixedPoint::operator+(double const d) {
+FixedPoint FixedPoint::operator+(double const d) const {
   FixedPoint res;
   res.i_ = i_ + (int64_t)(d * RESOURCE_UNIT_SCALING);
   return res;
 }
 
-FixedPoint FixedPoint::operator-(double const d) {
+FixedPoint FixedPoint::operator-(double const d) const {
   FixedPoint res;
   res.i_ = i_ - (int64_t)(d * RESOURCE_UNIT_SCALING);
   return res;
@@ -52,6 +56,11 @@ FixedPoint FixedPoint::operator-(double const d) {
 
 FixedPoint FixedPoint::operator=(double const d) {
   i_ = (int64_t)(d * RESOURCE_UNIT_SCALING);
+  return *this;
+}
+
+FixedPoint FixedPoint::operator+=(int64_t const ru) {
+  *this += (double)ru;
   return *this;
 }
 

--- a/src/ray/raylet/scheduling/fixed_point.cc
+++ b/src/ray/raylet/scheduling/fixed_point.cc
@@ -59,6 +59,11 @@ FixedPoint FixedPoint::operator=(double const d) {
   return *this;
 }
 
+FixedPoint FixedPoint::operator+=(double const d) {
+  i_ += (int64_t)(d * RESOURCE_UNIT_SCALING);
+  return *this;
+}
+
 FixedPoint FixedPoint::operator+=(int64_t const ru) {
   *this += (double)ru;
   return *this;

--- a/src/ray/raylet/scheduling/fixed_point.cc
+++ b/src/ray/raylet/scheduling/fixed_point.cc
@@ -2,11 +2,7 @@
 
 #include <cmath>
 
-FixedPoint::FixedPoint(double d) {
-  // We need to round, not truncate because floating point multiplication can
-  // leave a number slightly smaller than the intended whole number.
-  i_ = (uint64_t)((d * RESOURCE_UNIT_SCALING) + 0.5);
-}
+FixedPoint::FixedPoint(double d) { i_ = (uint64_t)(d * RESOURCE_UNIT_SCALING); }
 
 FixedPoint::FixedPoint(int i) { i_ = (i * RESOURCE_UNIT_SCALING); }
 

--- a/src/ray/raylet/scheduling/fixed_point.h
+++ b/src/ray/raylet/scheduling/fixed_point.h
@@ -13,7 +13,7 @@ class FixedPoint {
  public:
   FixedPoint(double d = 0);
   FixedPoint(int i);
-  FixedPoint(size_t i);
+  FixedPoint(unsigned long i);
   FixedPoint(int64_t i);
   FixedPoint(uint64_t i);
 

--- a/src/ray/raylet/scheduling/fixed_point.h
+++ b/src/ray/raylet/scheduling/fixed_point.h
@@ -13,22 +13,26 @@ class FixedPoint {
  public:
   FixedPoint(double d = 0);
   FixedPoint(int i);
+  FixedPoint(int64_t i);
+  FixedPoint(uint64_t i);
 
-  FixedPoint operator+(FixedPoint const &ru);
+  FixedPoint operator+(FixedPoint const &ru) const;
 
   FixedPoint operator+=(FixedPoint const &ru);
 
-  FixedPoint operator-(FixedPoint const &ru);
+  FixedPoint operator-(FixedPoint const &ru) const;
 
   FixedPoint operator-=(FixedPoint const &ru);
 
   FixedPoint operator-() const;
 
-  FixedPoint operator+(double const d);
+  FixedPoint operator+(double const d) const;
 
-  FixedPoint operator-(double const d);
+  FixedPoint operator-(double const d) const;
 
   FixedPoint operator=(double const d);
+
+  FixedPoint operator+=(int64_t const ru);
 
   bool operator<(FixedPoint const &ru1) const;
   bool operator>(FixedPoint const &ru1) const;

--- a/src/ray/raylet/scheduling/fixed_point.h
+++ b/src/ray/raylet/scheduling/fixed_point.h
@@ -32,6 +32,8 @@ class FixedPoint {
 
   FixedPoint operator=(double const d);
 
+  FixedPoint operator+=(double const d);
+
   FixedPoint operator+=(int64_t const ru);
 
   bool operator<(FixedPoint const &ru1) const;

--- a/src/ray/raylet/scheduling/fixed_point.h
+++ b/src/ray/raylet/scheduling/fixed_point.h
@@ -13,6 +13,7 @@ class FixedPoint {
  public:
   FixedPoint(double d = 0);
   FixedPoint(int i);
+  FixedPoint(size_t i);
   FixedPoint(int64_t i);
   FixedPoint(uint64_t i);
 

--- a/src/ray/raylet/scheduling/fixed_point.h
+++ b/src/ray/raylet/scheduling/fixed_point.h
@@ -13,7 +13,7 @@ class FixedPoint {
  public:
   FixedPoint(double d = 0);
   FixedPoint(int i);
-  FixedPoint(unsigned long i);
+  FixedPoint(uint32_t i);
   FixedPoint(int64_t i);
   FixedPoint(uint64_t i);
 


### PR DESCRIPTION
## Why are these changes needed?

As mentioned in https://github.com/ray-project/ray/issues/15943#issuecomment-847657365 ,  we want to clean up some stale data structures in `scheduling_resources.h`. 

I'll split it into several PRs:

1. Replace `FractionalResourceQuantity` with `FixedPoint`
2. Reimplement `ResourceSet` in the style of new scheduler in`cluster_resource_data.h`.
3. Move `SchedulingResources` to `cluster_resource_data.h`.
4. Replace `ResourceIds` with `ResourceInstanceCapacities`
5. Replace `ResourceIdSet` with `NodeResourceInstances`


This is the first PR that replaces `FractionalResourceQuantity` with `FixedPoint`. Please have a look, thanks!

## Related issue number

https://github.com/ray-project/ray/issues/15943#issuecomment-847657365

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
