### PR TITLE
Add initialization for transport params for non s3 storage

### DIFF
--- a/python/ray/external_storage.py
+++ b/python/ray/external_storage.py
@@ -383,6 +383,9 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
             # This will lead us to call a Object.get when it is not necessary,
             # so defer seek and call seek before reading objects instead.
             self.transport_params = {"defer_seek": True, "resource": self.s3}
+        else:
+            self.transport_params = {}
+
         self.transport_params.update(self.override_transport_params)
 
     def spill_objects(self, object_refs, owner_addresses) -> List[str]:


### PR DESCRIPTION
## Why are these changes needed?

When using a spilling config of type smart_open with a non s3 bucket, the creation of the `ExternalStorageSmartOpenImpl` fails as the `transport_params` are not properly initialized.

I have run `scripts/format.sh` but it seemed to introduce changes in a few different places (not on the actual code update of the PR) so I chose to publish without running the script. I can update if necessary.

## Related issue number

None found

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
