### PR TITLE
remove id.h dependence for c++ worker headers

### DIFF
--- a/cpp/include/ray/api.h
+++ b/cpp/include/ray/api.h
@@ -78,7 +78,7 @@ class Ray {
   static std::once_flag is_inited_;
 
   template <typename T>
-  static std::vector<std::shared_ptr<T>> Get(const std::vector<ObjectID> &ids);
+  static std::vector<std::shared_ptr<T>> Get(const std::vector<std::string> &ids);
 
   template <typename FuncType>
   static TaskCaller<FuncType> TaskInternal(FuncType &func);
@@ -96,9 +96,9 @@ namespace ray {
 namespace api {
 
 template <typename T>
-inline static std::vector<ObjectID> ObjectRefsToObjectIDs(
+inline static std::vector<std::string> ObjectRefsToObjectIDs(
     const std::vector<ObjectRef<T>> &object_refs) {
-  std::vector<ObjectID> object_ids;
+  std::vector<std::string> object_ids;
   for (auto it = object_refs.begin(); it != object_refs.end(); it++) {
     object_ids.push_back(it->ID());
   }
@@ -118,7 +118,7 @@ inline std::shared_ptr<T> Ray::Get(const ObjectRef<T> &object) {
 }
 
 template <typename T>
-inline std::vector<std::shared_ptr<T>> Ray::Get(const std::vector<ObjectID> &ids) {
+inline std::vector<std::shared_ptr<T>> Ray::Get(const std::vector<std::string> &ids) {
   auto result = ray::internal::RayRuntime()->Get(ids);
   std::vector<std::shared_ptr<T>> return_objects;
   return_objects.reserve(result.size());

--- a/cpp/include/ray/api/actor_handle.h
+++ b/cpp/include/ray/api/actor_handle.h
@@ -21,10 +21,10 @@ class ActorHandle {
  public:
   ActorHandle();
 
-  ActorHandle(const ActorID &id);
+  ActorHandle(const std::string &id);
 
   /// Get a untyped ID of the actor
-  const ActorID &ID() const;
+  const std::string &ID() const;
 
   /// Include the `Call` methods for calling remote functions.
   template <typename F>
@@ -34,7 +34,7 @@ class ActorHandle {
   MSGPACK_DEFINE(id_);
 
  private:
-  ActorID id_;
+  std::string id_;
 };
 
 // ---------- implementation ----------
@@ -42,12 +42,12 @@ template <typename ActorType>
 ActorHandle<ActorType>::ActorHandle() {}
 
 template <typename ActorType>
-ActorHandle<ActorType>::ActorHandle(const ActorID &id) {
+ActorHandle<ActorType>::ActorHandle(const std::string &id) {
   id_ = id;
 }
 
 template <typename ActorType>
-const ActorID &ActorHandle<ActorType>::ID() const {
+const std::string &ActorHandle<ActorType>::ID() const {
   return id_;
 }
 

--- a/cpp/include/ray/api/actor_task_caller.h
+++ b/cpp/include/ray/api/actor_task_caller.h
@@ -14,7 +14,7 @@ class ActorTaskCaller {
  public:
   ActorTaskCaller() = default;
 
-  ActorTaskCaller(RayRuntime *runtime, ActorID id,
+  ActorTaskCaller(RayRuntime *runtime, std::string id,
                   RemoteFunctionHolder remote_function_holder)
       : runtime_(runtime), id_(id), remote_function_holder_(remote_function_holder) {}
 
@@ -23,7 +23,7 @@ class ActorTaskCaller {
 
  private:
   RayRuntime *runtime_;
-  ActorID id_;
+  std::string id_;
   RemoteFunctionHolder remote_function_holder_;
   std::vector<ray::api::TaskArg> args_;
 };

--- a/cpp/include/ray/api/common_types.h
+++ b/cpp/include/ray/api/common_types.h
@@ -41,7 +41,7 @@ struct TaskArg {
   /// If the buf is initialized shows it is a value argument.
   boost::optional<msgpack::sbuffer> buf;
   /// If the id is initialized shows it is a reference argument.
-  boost::optional<ObjectID> id;
+  boost::optional<std::string> id;
 };
 
 }  // namespace api

--- a/cpp/include/ray/api/object_ref.h
+++ b/cpp/include/ray/api/object_ref.h
@@ -28,12 +28,14 @@ inline void CheckResult(const std::shared_ptr<msgpack::sbuffer> &packed_object) 
   }
 }
 
-inline void CopyAndAddRefrence(ObjectID &dest_id, const ObjectID &id) {
+inline void CopyAndAddReference(std::string &dest_id, const std::string &id) {
   dest_id = id;
-  AddLocalReference(id);
+  ray::internal::RayRuntime()->AddLocalReference(id);
 }
 
-inline void SubRefrence(const ObjectID &id) { RemoveLocalReference(id); }
+inline void SubReference(const std::string &id) {
+  ray::internal::RayRuntime()->RemoveLocalReference(id);
+}
 
 /// Represents an object in the object store..
 /// \param T The type of object.
@@ -43,19 +45,19 @@ class ObjectRef {
   ObjectRef();
   ~ObjectRef();
 
-  ObjectRef(const ObjectRef &rhs) { CopyAndAddRefrence(id_, rhs.id_); }
+  ObjectRef(const ObjectRef &rhs) { CopyAndAddReference(id_, rhs.id_); }
 
   ObjectRef &operator=(const ObjectRef &rhs) {
-    CopyAndAddRefrence(id_, rhs.id_);
+    CopyAndAddReference(id_, rhs.id_);
     return *this;
   }
 
-  ObjectRef(const ObjectID &id);
+  ObjectRef(const std::string &id);
 
   bool operator==(const ObjectRef<T> &object) const;
 
   /// Get a untyped ID of the object
-  const ObjectID &ID() const;
+  const std::string &ID() const;
 
   /// Get the object from the object store.
   /// This method will be blocked until the object is ready.
@@ -67,7 +69,7 @@ class ObjectRef {
   MSGPACK_DEFINE(id_);
 
  private:
-  ObjectID id_;
+  std::string id_;
 };
 
 // ---------- implementation ----------
@@ -84,13 +86,13 @@ template <typename T>
 ObjectRef<T>::ObjectRef() {}
 
 template <typename T>
-ObjectRef<T>::ObjectRef(const ObjectID &id) {
-  CopyAndAddRefrence(id_, id);
+ObjectRef<T>::ObjectRef(const std::string &id) {
+  CopyAndAddReference(id_, id);
 }
 
 template <typename T>
 ObjectRef<T>::~ObjectRef() {
-  SubRefrence(id_);
+  SubReference(id_);
 }
 
 template <typename T>
@@ -99,7 +101,7 @@ inline bool ObjectRef<T>::operator==(const ObjectRef<T> &object) const {
 }
 
 template <typename T>
-const ObjectID &ObjectRef<T>::ID() const {
+const std::string &ObjectRef<T>::ID() const {
   return id_;
 }
 
@@ -112,21 +114,21 @@ template <>
 class ObjectRef<void> {
  public:
   ObjectRef() = default;
-  ~ObjectRef() { SubRefrence(id_); }
+  ~ObjectRef() { SubReference(id_); }
 
-  ObjectRef(const ObjectRef &rhs) { CopyAndAddRefrence(id_, rhs.id_); }
+  ObjectRef(const ObjectRef &rhs) { CopyAndAddReference(id_, rhs.id_); }
 
   ObjectRef &operator=(const ObjectRef &rhs) {
-    CopyAndAddRefrence(id_, rhs.id_);
+    CopyAndAddReference(id_, rhs.id_);
     return *this;
   }
 
-  ObjectRef(const ObjectID &id) { CopyAndAddRefrence(id_, id); }
+  ObjectRef(const std::string &id) { CopyAndAddReference(id_, id); }
 
   bool operator==(const ObjectRef<void> &object) const { return id_ == object.id_; }
 
   /// Get a untyped ID of the object
-  const ObjectID &ID() const { return id_; }
+  const std::string &ID() const { return id_; }
 
   /// Get the object from the object store.
   /// This method will be blocked until the object is ready.
@@ -141,7 +143,7 @@ class ObjectRef<void> {
   MSGPACK_DEFINE(id_);
 
  private:
-  ObjectID id_;
+  std::string id_;
 };
 }  // namespace api
 }  // namespace ray

--- a/cpp/include/ray/api/ray_runtime.h
+++ b/cpp/include/ray/api/ray_runtime.h
@@ -32,27 +32,24 @@ struct RemoteFunctionHolder {
 
 class RayRuntime {
  public:
-  virtual ObjectID Put(std::shared_ptr<msgpack::sbuffer> data) = 0;
-  virtual std::shared_ptr<msgpack::sbuffer> Get(const ObjectID &id) = 0;
+  virtual std::string Put(std::shared_ptr<msgpack::sbuffer> data) = 0;
+  virtual std::shared_ptr<msgpack::sbuffer> Get(const std::string &id) = 0;
 
   virtual std::vector<std::shared_ptr<msgpack::sbuffer>> Get(
-      const std::vector<ObjectID> &ids) = 0;
+      const std::vector<std::string> &ids) = 0;
 
-  virtual std::vector<bool> Wait(const std::vector<ObjectID> &ids, int num_objects,
+  virtual std::vector<bool> Wait(const std::vector<std::string> &ids, int num_objects,
                                  int timeout_ms) = 0;
 
-  virtual ObjectID Call(const RemoteFunctionHolder &remote_function_holder,
-                        std::vector<ray::api::TaskArg> &args) = 0;
-  virtual ActorID CreateActor(const RemoteFunctionHolder &remote_function_holder,
-                              std::vector<ray::api::TaskArg> &args) = 0;
-  virtual ObjectID CallActor(const RemoteFunctionHolder &remote_function_holder,
-                             const ActorID &actor,
-                             std::vector<ray::api::TaskArg> &args) = 0;
+  virtual std::string Call(const RemoteFunctionHolder &remote_function_holder,
+                           std::vector<ray::api::TaskArg> &args) = 0;
+  virtual std::string CreateActor(const RemoteFunctionHolder &remote_function_holder,
+                                  std::vector<ray::api::TaskArg> &args) = 0;
+  virtual std::string CallActor(const RemoteFunctionHolder &remote_function_holder,
+                                const std::string &actor,
+                                std::vector<ray::api::TaskArg> &args) = 0;
+  virtual void AddLocalReference(const std::string &id) = 0;
+  virtual void RemoveLocalReference(const std::string &id) = 0;
 };
-
-void AddLocalReference(const ObjectID &id);
-
-void RemoveLocalReference(const ObjectID &id);
-
 }  // namespace api
 }  // namespace ray

--- a/cpp/include/ray/core.h
+++ b/cpp/include/ray/core.h
@@ -3,7 +3,6 @@
 
 #include "ray/common/buffer.h"
 #include "ray/common/function_descriptor.h"
-#include "ray/common/id.h"
 #include "ray/common/status.h"
 #include "ray/common/task/task_common.h"
 #include "ray/common/task/task_spec.h"

--- a/cpp/src/ray/runtime/abstract_ray_runtime.h
+++ b/cpp/src/ray/runtime/abstract_ray_runtime.h
@@ -23,23 +23,27 @@ class AbstractRayRuntime : public RayRuntime {
 
   void Put(std::shared_ptr<msgpack::sbuffer> data, const ObjectID &object_id);
 
-  ObjectID Put(std::shared_ptr<msgpack::sbuffer> data);
+  std::string Put(std::shared_ptr<msgpack::sbuffer> data);
 
-  std::shared_ptr<msgpack::sbuffer> Get(const ObjectID &id);
+  std::shared_ptr<msgpack::sbuffer> Get(const std::string &id);
 
-  std::vector<std::shared_ptr<msgpack::sbuffer>> Get(const std::vector<ObjectID> &ids);
+  std::vector<std::shared_ptr<msgpack::sbuffer>> Get(const std::vector<std::string> &ids);
 
-  std::vector<bool> Wait(const std::vector<ObjectID> &ids, int num_objects,
+  std::vector<bool> Wait(const std::vector<std::string> &ids, int num_objects,
                          int timeout_ms);
 
-  ObjectID Call(const RemoteFunctionHolder &remote_function_holder,
-                std::vector<ray::api::TaskArg> &args);
+  std::string Call(const RemoteFunctionHolder &remote_function_holder,
+                   std::vector<ray::api::TaskArg> &args);
 
-  ActorID CreateActor(const RemoteFunctionHolder &remote_function_holder,
-                      std::vector<ray::api::TaskArg> &args);
+  std::string CreateActor(const RemoteFunctionHolder &remote_function_holder,
+                          std::vector<ray::api::TaskArg> &args);
 
-  ObjectID CallActor(const RemoteFunctionHolder &remote_function_holder,
-                     const ActorID &actor, std::vector<ray::api::TaskArg> &args);
+  std::string CallActor(const RemoteFunctionHolder &remote_function_holder,
+                        const std::string &actor, std::vector<ray::api::TaskArg> &args);
+
+  void AddLocalReference(const std::string &id);
+
+  void RemoveLocalReference(const std::string &id);
 
   const TaskID &GetCurrentTaskId();
 

--- a/cpp/src/ray/runtime/object/local_mode_object_store.cc
+++ b/cpp/src/ray/runtime/object/local_mode_object_store.cc
@@ -88,5 +88,9 @@ std::vector<bool> LocalModeObjectStore::Wait(const std::vector<ObjectID> &ids,
   }
   return result;
 }
+
+void LocalModeObjectStore::AddLocalReference(const std::string &id) { return; }
+
+void LocalModeObjectStore::RemoveLocalReference(const std::string &id) { return; }
 }  // namespace api
 }  // namespace ray

--- a/cpp/src/ray/runtime/object/local_mode_object_store.h
+++ b/cpp/src/ray/runtime/object/local_mode_object_store.h
@@ -17,6 +17,10 @@ class LocalModeObjectStore : public ObjectStore {
   std::vector<bool> Wait(const std::vector<ObjectID> &ids, int num_objects,
                          int timeout_ms);
 
+  void AddLocalReference(const std::string &id);
+
+  void RemoveLocalReference(const std::string &id);
+
  private:
   void PutRaw(std::shared_ptr<msgpack::sbuffer> data, ObjectID *object_id);
 

--- a/cpp/src/ray/runtime/object/native_object_store.cc
+++ b/cpp/src/ray/runtime/object/native_object_store.cc
@@ -83,5 +83,19 @@ std::vector<bool> NativeObjectStore::Wait(const std::vector<ObjectID> &ids,
   }
   return results;
 }
+
+void NativeObjectStore::AddLocalReference(const std::string &id) {
+  if (CoreWorkerProcess::IsInitialized()) {
+    auto &core_worker = CoreWorkerProcess::GetCoreWorker();
+    core_worker.AddLocalReference(ObjectID::FromBinary(id));
+  }
+}
+
+void NativeObjectStore::RemoveLocalReference(const std::string &id) {
+  if (CoreWorkerProcess::IsInitialized()) {
+    auto &core_worker = CoreWorkerProcess::GetCoreWorker();
+    core_worker.RemoveLocalReference(ObjectID::FromBinary(id));
+  }
+}
 }  // namespace api
 }  // namespace ray

--- a/cpp/src/ray/runtime/object/native_object_store.h
+++ b/cpp/src/ray/runtime/object/native_object_store.h
@@ -17,6 +17,10 @@ class NativeObjectStore : public ObjectStore {
   std::vector<bool> Wait(const std::vector<ObjectID> &ids, int num_objects,
                          int timeout_ms);
 
+  void AddLocalReference(const std::string &id);
+
+  void RemoveLocalReference(const std::string &id);
+
  private:
   void PutRaw(std::shared_ptr<msgpack::sbuffer> data, ObjectID *object_id);
 

--- a/cpp/src/ray/runtime/object/object_store.h
+++ b/cpp/src/ray/runtime/object/object_store.h
@@ -56,6 +56,19 @@ class ObjectStore {
   virtual std::vector<bool> Wait(const std::vector<ObjectID> &ids, int num_objects,
                                  int timeout_ms) = 0;
 
+  /// Increase the reference count for this object ID.
+  /// Increase the local reference count for this object ID. Should be called
+  /// by the language frontend when a new reference is created.
+  ///
+  /// \param[in] id The binary string ID to increase the reference count for.
+  virtual void AddLocalReference(const std::string &id) = 0;
+
+  /// Decrease the reference count for this object ID. Should be called
+  /// by the language frontend when a reference is destroyed.
+  ///
+  /// \param[in] id The binary string ID to decrease the reference count for.
+  virtual void RemoveLocalReference(const std::string &id) = 0;
+
  private:
   virtual void PutRaw(std::shared_ptr<msgpack::sbuffer> data, ObjectID *object_id) = 0;
 

--- a/cpp/src/ray/runtime/task/task_executor.cc
+++ b/cpp/src/ray/runtime/task/task_executor.cc
@@ -148,7 +148,7 @@ void TaskExecutor::Invoke(
   std::vector<msgpack::sbuffer> args_buffer;
   for (size_t i = 0; i < task_spec.NumArgs(); i++) {
     if (task_spec.ArgByRef(i)) {
-      auto arg = runtime->Get(task_spec.ArgId(i));
+      auto arg = runtime->Get(task_spec.ArgId(i).Binary());
       args_buffer.push_back(std::move(*arg));
     } else {
       msgpack::sbuffer sbuf;


### PR DESCRIPTION
## Why are these changes needed?

- remove id.h dependence for c++ worker headers