### PR TITLE
Reduce the pinned args threshold from 0.7 to 0.5 given recent memory fragmentation handling changes

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -412,7 +412,7 @@ RAY_CONFIG(int64_t, timeout_ms_task_wait_for_death_info, 1000)
 RAY_CONFIG(int64_t, asio_stats_print_interval_ms, -1)
 
 /// Maximum amount of memory that will be used by running tasks' args.
-RAY_CONFIG(float, max_task_args_memory_fraction, 0.7)
+RAY_CONFIG(float, max_task_args_memory_fraction, 0.5)
 
 /// The maximum number of objects to publish for each publish calls.
 RAY_CONFIG(int, publish_batch_size, 5000)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Now that we no longer overcommit object store pages, the effective memory fraction available is lower. Reduce the pinned args threshold proportionally to 0.5 to avoid OOMs.