### PR TITLE
[Release] Add back cluster config for microbenchmark release test.

### DIFF
--- a/release/microbenchmark/cluster.yaml
+++ b/release/microbenchmark/cluster.yaml
@@ -1,0 +1,33 @@
+cluster_name: ray-release-microbenchmark
+
+docker:
+    image: anyscale/ray:latest
+    container_name: ray_container
+    pull_before_run: False
+
+provider:
+    type: aws
+    region: us-west-2
+    availability_zone: us-west-2a, us-west-2b, us-west-2c
+
+
+available_node_types:
+    cpu_64_ondemand:
+        node_config:
+            InstanceType: m5.16xlarge
+
+        resources: {"CPU": 64}
+        min_workers: 0
+        max_workers: 0
+
+auth:
+    ssh_user: ubuntu
+
+head_node_type: cpu_64_ondemand
+
+
+setup_commands:
+    - pip install -U {{env["RAY_WHEEL"]}}
+
+head_start_ray_commands:
+    - ray stop


### PR DESCRIPTION
## Why are these changes needed?

Not having this cluster config breaks Releaser's validation of all test suites (which runs before running an individual test suite).
```
Traceback (most recent call last):
  File "cli.py", line 342, in <module>
    app()
  File "/home/ubuntu/.local/lib/python3.7/site-packages/typer/main.py", line 214, in __call__
    return get_command(self)(*args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/ubuntu/.local/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ubuntu/.local/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ubuntu/.local/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.7/site-packages/typer/main.py", line 497, in wrapper
    return callback(**use_params)  # type: ignore
  File "cli.py", line 253, in run_test
    validate_tests()
  File "cli.py", line 208, in validate_tests
    ), f"Validating {name} failed: cluster config file {os.path.abspath(cluster_file)} doesn't exist"
AssertionError: Validating microbenchmark failed: cluster config file /mnt/data/workspace/releaser/ray/release/microbenchmark/cluster.yaml doesn't exist
```
The cluster config is [expected](https://github.com/ray-project/releaser/blob/9a0e4effdae18075ff56bfb4243823f34df344fd/config.toml#L15-L18) by the Releaser in order for it to [start an Anyscale session](https://github.com/ray-project/releaser/blob/9a0e4effdae18075ff56bfb4243823f34df344fd/cli.py#L291).