### PR TITLE
[Core]Don't broadcast empty resources data

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -369,7 +369,10 @@ bool GcsResourceManager::ReleaseResources(const NodeID &node_id,
 void GcsResourceManager::GetResourceUsageBatchForBroadcast(
     rpc::ResourceUsageBatchData &buffer) {
   absl::MutexLock guard(&resource_buffer_mutex_);
-  GetResourceUsageBatchForBroadcast_Locked(buffer);
+  if (!resources_buffer_.empty()) {
+    GetResourceUsageBatchForBroadcast_Locked(buffer);
+    resources_buffer_.clear();
+  }
 }
 
 void GcsResourceManager::GetResourceUsageBatchForBroadcast_Locked(

--- a/src/ray/gcs/gcs_server/grpc_based_resource_broadcaster.cc
+++ b/src/ray/gcs/gcs_server/grpc_based_resource_broadcaster.cc
@@ -92,6 +92,10 @@ void GrpcBasedResourceBroadcaster::SendBroadcast() {
   rpc::ResourceUsageBatchData batch;
   get_resource_usage_batch_for_broadcast_(batch);
 
+  if (batch.batch_size() == 0) {
+    return;
+  }
+
   // Serializing is relatively expensive on large batches, so we should only do it once.
   std::string serialized_batch = batch.SerializeAsString();
   stats::OutboundHeartbeatSizeKB.Record((double)(batch.ByteSizeLong() / 1024.0));

--- a/src/ray/gcs/gcs_server/test/grpc_based_resource_broadcaster_test.cc
+++ b/src/ray/gcs/gcs_server/test/grpc_based_resource_broadcaster_test.cc
@@ -31,7 +31,12 @@ class GrpcBasedResourceBroadcasterTest : public ::testing::Test {
         broadcaster_(
             /*raylet_client_pool*/ nullptr,
             /*get_resource_usage_batch_for_broadcast*/
-            [](rpc::ResourceUsageBatchData &batch) {}
+            [](rpc::ResourceUsageBatchData &batch) {
+              rpc::ResourcesData data;
+              NodeID node_id = NodeID::FromRandom();
+              data.set_node_id(node_id.Binary());
+              batch.add_batch()->Swap(&data);
+            }
 
             ,
             /*send_batch*/


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This fix https://github.com/ray-project/ray/issues/16064 and avoid unnecessary empty broadcast.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/16064

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
