### PR TITLE
Revert "Fix tracing bug when actors are defined before connecting to …

### DIFF
--- a/doc/source/ray-tracing.rst
+++ b/doc/source/ray-tracing.rst
@@ -13,9 +13,8 @@ First, install OpenTelemetry.
 
 .. code-block:: shell
 
-    pip install opentelemetry-api==1.1.0
-    pip install opentelemetry-sdk==1.1.0
-    pip install opentelemetry-exporter-otlp==1.1.0
+    pip install opentelemetry-api==1.0.0rc1
+    pip install opentelemetry-sdk==1.0.0rc1
 
 Tracing Startup Hook
 --------------------
@@ -31,7 +30,7 @@ Below is an example tracing startup hook that sets up the default tracing provid
   from opentelemetry.sdk.trace import TracerProvider
   from opentelemetry.sdk.trace.export import (
       ConsoleSpanExporter,
-      SimpleSpanProcessor,
+      SimpleExportSpanProcessor,
   )
   
   
@@ -42,7 +41,7 @@ Below is an example tracing startup hook that sets up the default tracing provid
       # context and will log a warning if attempted multiple times.
       trace.set_tracer_provider(TracerProvider())
       trace.get_tracer_provider().add_span_processor(
-          SimpleSpanProcessor(
+          SimpleExportSpanProcessor(
               ConsoleSpanExporter(
                   out=open(f"/tmp/spans/{os.getpid()}.json", "a")
                   )

--- a/python/ray/tests/test_tracing.py
+++ b/python/ray/tests/test_tracing.py
@@ -40,17 +40,6 @@ def ray_start_cli_tracing(scope="function"):
 
 
 @pytest.fixture()
-def ray_start_cli_predefined_actor_tracing(scope="function"):
-    """Start ray with tracing-startup-hook, and clean up at end of test."""
-    check_call_ray(["stop", "--force"], )
-    check_call_ray(
-        ["start", "--head", "--tracing-startup-hook", setup_tracing_path], )
-    yield
-    ray.shutdown()
-    check_call_ray(["stop", "--force"])
-
-
-@pytest.fixture()
 def ray_start_init_tracing(scope="function"):
     """Call ray.init with tracing-startup-hook, and clean up at end of test."""
     ray.init(_tracing_startup_hook=setup_tracing_path)
@@ -102,7 +91,7 @@ def task_helper():
     }
 
 
-def sync_actor_helper(connect_to_cluster: bool = False):
+def sync_actor_helper():
     """Run a Ray sync actor and check the spans produced."""
 
     @ray.remote
@@ -113,9 +102,6 @@ def sync_actor_helper(connect_to_cluster: bool = False):
         def increment(self):
             self.value += 1
             return self.value
-
-    if connect_to_cluster:
-        ray.init(address="auto")
 
     # Create an actor from this class.
     counter = Counter.remote()
@@ -189,11 +175,6 @@ def test_tracing_async_actor_init_workflow(cleanup_dirs,
 def test_tracing_async_actor_start_workflow(cleanup_dirs,
                                             ray_start_cli_tracing):
     assert async_actor_helper()
-
-
-def test_tracing_predefined_actor(cleanup_dirs,
-                                  ray_start_cli_predefined_actor_tracing):
-    assert sync_actor_helper(connect_to_cluster=True)
 
 
 def test_wrapping(ray_start_init_tracing):

--- a/python/ray/util/tracing/tracing_helper.py
+++ b/python/ray/util/tracing/tracing_helper.py
@@ -145,7 +145,7 @@ def _function_hydrate_span_args(func: Callable[..., Any]):
     # We only get task ID for workers
     if ray.worker.global_worker.mode == ray.worker.WORKER_MODE:
         task_id = (runtime_context["task_id"].hex()
-                   if runtime_context.get("task_id") else None)
+                   if runtime_context["task_id"] else None)
         if task_id:
             span_args["ray.task_id"] = task_id
 
@@ -195,7 +195,7 @@ def _actor_hydrate_span_args(class_: _nameable, method: _nameable):
     # We only get actor ID for workers
     if ray.worker.global_worker.mode == ray.worker.WORKER_MODE:
         actor_id = (runtime_context["actor_id"].hex()
-                    if runtime_context.get("actor_id") else None)
+                    if runtime_context["actor_id"] else None)
 
         if actor_id:
             span_args["ray.actor_id"] = actor_id
@@ -313,7 +313,6 @@ def _tracing_actor_creation(method):
             kwargs = {}
         # If tracing feature flag is not on, perform a no-op
         if not is_tracing_enabled():
-            kwargs["_ray_trace_ctx"] = None
             return method(self, args, kwargs, *_args, **_kwargs)
 
         class_name = self.__ray_metadata__.class_name
@@ -465,7 +464,8 @@ def _inject_tracing_into_class(_cls):
         # Skip tracing for staticmethod or classmethod, because these method
         # might not be called directly by remote calls. Additionally, they are
         # tricky to get wrapped and unwrapped.
-        if (is_static_method(_cls, name) or is_class_method(method)):
+        if (is_static_method(_cls, name) or is_class_method(method)
+                or not is_tracing_enabled()):
             continue
 
         # Add _ray_trace_ctx to method signature


### PR DESCRIPTION
…cluster (#16069)"

This reverts commit 6c1ea6661180e656e83e7e5835d362428654ad8d.

```



File "/ray/python/ray/util/tracing/tracing_helper.py", line 279, in _function_with_tracing
&nbsp; | return function(*args, **kwargs)
&nbsp; | File "/tmp/ray_cross_language_test/test_cross_language_invocation.py", line 56, in py_func_call_java_actor
&nbsp; | java_actor = c.remote(b"Counter")
&nbsp; | File "/ray/python/ray/actor.py", line 418, in remote
&nbsp; | return self._remote(args=args, kwargs=kwargs)
&nbsp; | File "/ray/python/ray/util/tracing/tracing_helper.py", line 317, in _invocation_actor_class_remote_span
&nbsp; | return method(self, args, kwargs, *_args, **_kwargs)
&nbsp; | File "/ray/python/ray/actor.py", line 698, in _remote
&nbsp; | creation_args = cross_language.format_args(worker, args, kwargs)
&nbsp; | File "/ray/python/ray/cross_language.py", line 29, in format_args
&nbsp; | raise TypeError("Cross language remote functions "
&nbsp; | TypeError: Cross language remote functions does not support kwargs.
&nbsp;

<br class="Apple-interchange-newline">
```