### PR TITLE
[Core] Ignore psutil.AccessDenied when gathering per-process memory info upon an OOM

### DIFF
--- a/python/ray/_private/memory_monitor.py
+++ b/python/ray/_private/memory_monitor.py
@@ -47,6 +47,17 @@ class RayOutOfMemoryError(Exception):
                 # issue for more detail:
                 # https://github.com/ray-project/ray/issues/14929
                 continue
+            except psutil.AccessDenied:
+                # On MacOS, the proc_pidinfo call (used to get per-process
+                # memory info) fails with a permission denied error when used
+                # on a process that isn’t owned by the same user. For now, we
+                # drop the memory info of any such process, assuming that
+                # processes owned by other users (e.g. root) aren't Ray
+                # processes and will be of less interest when an OOM happens
+                # on a Ray node.
+                # See issue for more detail:
+                # https://github.com/ray-project/ray/issues/11845#issuecomment-849904019  # noqa: E501
+                continue
         proc_str = "PID\tMEM\tCOMMAND"
         for rss, pid, cmdline in sorted(proc_stats, reverse=True)[:10]:
             proc_str += "\n{}\t{}GiB\t{}".format(


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The MacOS `proc_pidinfo` call (used to get per-process memory info) fails with a `psutil.PermissionError` when used on [a process that isn’t owned by the same user](https://github.com/giampaolo/psutil/issues/883#issuecomment-256147899) (surfacing to the caller as a `psutil.AccessDenied` error), and there doesn't seem to be a clean `psutil`-based workaround for per-process memory info on MacOS.

This PR catches and ignores the exception, dropping the stats for that process under the assumption that processes owned by other users (e.g. root) aren't Ray processes and will be of less interest when an OOM happens on a Ray node.

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes particular error of #11845 and recent `test_actor_resources` [failures](https://travis-ci.com/github/ray-project/ray/jobs/508061559), although it doesn't fix the underlying OOM causes.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
