### PR TITLE
[Core, Flaky] Decrease the number of nodes and actors started on each node in test_actor_resources test.

### DIFF
--- a/python/ray/tests/test_actor_resources.py
+++ b/python/ray/tests/test_actor_resources.py
@@ -233,11 +233,11 @@ def test_actor_different_numbers_of_gpus(ray_start_cluster):
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_actor_multiple_gpus_from_multiple_tasks(ray_start_cluster):
     cluster = ray_start_cluster
-    num_nodes = 5
-    num_gpus_per_raylet = 5
+    num_nodes = 3
+    num_gpus_per_raylet = 2
     for i in range(num_nodes):
         cluster.add_node(
-            num_cpus=10 * num_gpus_per_raylet,
+            num_cpus=4 * num_gpus_per_raylet,
             num_gpus=num_gpus_per_raylet,
             _system_config={"num_heartbeats_timeout": 100} if i == 0 else {})
     ray.init(address=cluster.address)


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Test `test_actor_multiple_gpus_from_multiple_tasks` in `test_actor_resources.py` is [currently flaky on MacOS](https://flakey-tests.ray.io/), occasionally [failing with OOMs](https://travis-ci.com/github/ray-project/ray/jobs/508061559). This PR decreases the number of nodes and the number of actors started per node, assuming that is the cause of the OOMs. Before this PR, the pseudo-cluster had 5 nodes, each with 5 actors, totaling 25 actors; after this PR, the psuedo-cluster has 3 nodes, each with 2 actors, totaling 6 actors.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
