### PR TITLE
[tune] populate internal configs when creating Trainable through DistributedTrainableCreator

### DIFF
--- a/python/ray/tune/integration/horovod.py
+++ b/python/ray/tune/integration/horovod.py
@@ -14,6 +14,7 @@ from ray.tune.resources import Resources
 from ray.tune.utils.trainable import TrainableUtil
 from ray.tune.result import RESULT_DUPLICATE
 from ray.tune.logger import NoopLogger
+from ray.tune.trainable import DistributedTrainable
 
 from ray.tune.function_runner import wrap_function
 from horovod.ray import RayExecutor
@@ -73,7 +74,7 @@ def distributed_checkpoint_dir(step: int, disable: bool = False):
         shutil.rmtree(path)
 
 
-class _HorovodTrainable(tune.Trainable):
+class _HorovodTrainable(DistributedTrainable):
     """Abstract Trainable class for Horovod."""
     # Callable function for training.
     _function = None

--- a/python/ray/tune/integration/horovod.py
+++ b/python/ray/tune/integration/horovod.py
@@ -286,5 +286,5 @@ def _train_simple(config: Dict):
 def _train_validate_session(config: Dict):
     current_session = tune.session.get_session()
     assert current_session is not None
-    assert current_session._trial_id != "default"
-    assert current_session._trial_name != "default"
+    assert current_session.trial_id != "default"
+    assert current_session.trial_name != "default"

--- a/python/ray/tune/integration/horovod.py
+++ b/python/ray/tune/integration/horovod.py
@@ -117,7 +117,7 @@ class _HorovodTrainable(DistributedTrainable):
             num_hosts=self._num_hosts,
             num_slots=self._num_slots)
 
-        new_config = super().build_config(config)
+        new_config = DistributedTrainable.build_config(self, config)
 
         # We can't put `self` in the lambda closure, so we
         # resolve the variable ahead of time.

--- a/python/ray/tune/integration/horovod.py
+++ b/python/ray/tune/integration/horovod.py
@@ -116,6 +116,8 @@ class _HorovodTrainable(tune.Trainable):
             num_hosts=self._num_hosts,
             num_slots=self._num_slots)
 
+        new_config = super().build_config(config)
+
         # We can't put `self` in the lambda closure, so we
         # resolve the variable ahead of time.
         logdir_ = str(self.logdir)
@@ -124,7 +126,7 @@ class _HorovodTrainable(tune.Trainable):
         self.executor.start(
             executable_cls=trainable,
             executable_kwargs={
-                "config": config,
+                "config": new_config,
                 "logger_creator": lambda cfg: logger_creator(cfg, logdir_)
             })
 
@@ -278,3 +280,10 @@ def _train_simple(config: Dict):
                 with open(path, "wb") as f:
                     pickle.dump("hi", f)
         tune.report(test=1, rank=hvd.rank())
+
+
+def _train_validate_session(config: Dict):
+    current_session = tune.session.get_session()
+    assert current_session is not None
+    assert current_session._trial_id != "default"
+    assert current_session._trial_name != "default"

--- a/python/ray/tune/integration/tensorflow.py
+++ b/python/ray/tune/integration/tensorflow.py
@@ -70,7 +70,7 @@ class _TensorFlowTrainable(DistributedTrainable):
                 self._num_workers_per_host, self._timeout_s)
         remote_trainable = \
             remote_trainable.options(**remote_option)
-        new_config = super().build_config(config)
+        new_config = DistributedTrainable.build_config(self, config)
         self.workers = [
             remote_trainable.remote(config=new_config, )
             for _ in range(num_workers)

--- a/python/ray/tune/integration/tensorflow.py
+++ b/python/ray/tune/integration/tensorflow.py
@@ -70,8 +70,9 @@ class _TensorFlowTrainable(tune.Trainable):
                 self._num_workers_per_host, self._timeout_s)
         remote_trainable = \
             remote_trainable.options(**remote_option)
+        new_config = super().build_config(config)
         self.workers = [
-            remote_trainable.remote(config=config, )
+            remote_trainable.remote(config=new_config, )
             for _ in range(num_workers)
         ]
 

--- a/python/ray/tune/integration/tensorflow.py
+++ b/python/ray/tune/integration/tensorflow.py
@@ -3,7 +3,6 @@ import logging
 
 import ray
 import os
-from ray import tune
 from ray.tune.result import RESULT_DUPLICATE
 from ray.tune.function_runner import wrap_function
 from ray.tune.resources import Resources

--- a/python/ray/tune/integration/tensorflow.py
+++ b/python/ray/tune/integration/tensorflow.py
@@ -7,6 +7,7 @@ from ray import tune
 from ray.tune.result import RESULT_DUPLICATE
 from ray.tune.function_runner import wrap_function
 from ray.tune.resources import Resources
+from ray.tune.trainable import DistributedTrainable
 from ray.util.placement_group import remove_placement_group
 from ray.tune.utils.trainable import PlacementGroupUtil, TrainableUtil
 from ray.tune.utils import detect_checkpoint_function, find_free_port
@@ -40,7 +41,7 @@ def setup_address():
     return f"{ip}:{port}"
 
 
-class _TensorFlowTrainable(tune.Trainable):
+class _TensorFlowTrainable(DistributedTrainable):
     """Base class for distributed training on Tune."""
     _function = None
     _num_workers = None

--- a/python/ray/tune/integration/torch.py
+++ b/python/ray/tune/integration/torch.py
@@ -84,7 +84,7 @@ class _TorchTrainable(DistributedTrainable):
                 self._num_workers_per_host, self._timeout_s)
         remote_trainable = \
             remote_trainable.options(**remote_option)
-        new_config = super().build_config(config)
+        new_config = DistributedTrainable.build_config(self, config)
 
         self.workers = [
             remote_trainable.remote(

--- a/python/ray/tune/integration/torch.py
+++ b/python/ray/tune/integration/torch.py
@@ -323,5 +323,5 @@ def _train_validate_session(config: Dict,
     serializing within the test file."""
     current_session = tune.session.get_session()
     assert current_session is not None
-    assert current_session._trial_id != "default"
-    assert current_session._trial_name != "default"
+    assert current_session.trial_id != "default"
+    assert current_session.trial_name != "default"

--- a/python/ray/tune/integration/torch.py
+++ b/python/ray/tune/integration/torch.py
@@ -16,6 +16,7 @@ from ray.tune.result import RESULT_DUPLICATE
 from ray.tune.logger import NoopLogger
 from ray.tune.function_runner import wrap_function
 from ray.tune.resources import Resources
+from ray.tune.trainable import DistributedTrainable
 from ray.tune.utils.trainable import PlacementGroupUtil, TrainableUtil
 from ray.tune.utils import detect_checkpoint_function
 from ray.util.sgd.torch.utils import setup_process_group, setup_address
@@ -43,7 +44,7 @@ def logger_creator(log_config: Dict, logdir: str, rank: int) -> NoopLogger:
     return NoopLogger(log_config, worker_dir)
 
 
-class _TorchTrainable(tune.Trainable):
+class _TorchTrainable(DistributedTrainable):
     """Base class for distributed training on Tune.
 
     A wrapper class is needed to actually create a working

--- a/python/ray/tune/tests/test_horovod.py
+++ b/python/ray/tune/tests/test_horovod.py
@@ -96,7 +96,7 @@ def test_resource_tune(ray_connect_cluster, use_gpu):
     assert analysis.trials[0].last_result["training_iteration"] == 2
 
 
-def test_validate_session():
+def test_validate_session(ray_start_2_cpus):
     trainable_cls = DistributedTrainableCreator(_train_validate_session)
     tune.run(trainable_cls)
 

--- a/python/ray/tune/tests/test_horovod.py
+++ b/python/ray/tune/tests/test_horovod.py
@@ -6,8 +6,8 @@ from ray import tune
 pytest.importorskip("horovod")
 
 try:
-    from ray.tune.integration.horovod import (DistributedTrainableCreator,
-                                              _train_simple)
+    from ray.tune.integration.horovod import (
+        DistributedTrainableCreator, _train_simple, _train_validate_session)
 except ImportError:
     pass  # This shouldn't be reached - the test should be skipped.
 
@@ -94,6 +94,11 @@ def test_resource_tune(ray_connect_cluster, use_gpu):
     analysis = tune.run(
         trainable_cls, num_samples=2, stop={"training_iteration": 2})
     assert analysis.trials[0].last_result["training_iteration"] == 2
+
+
+def test_validate_session():
+    trainable_cls = DistributedTrainableCreator(_train_validate_session)
+    tune.run(trainable_cls)
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/tests/test_tensorflow_trainable.py
+++ b/python/ray/tune/tests/test_tensorflow_trainable.py
@@ -75,8 +75,8 @@ def _train_validate_session(config: Dict,
                             checkpoint_dir: Optional[str] = None):
     current_session = tune.session.get_session()
     assert current_session is not None
-    assert current_session._trial_id != "default"
-    assert current_session._trial_name != "default"
+    assert current_session.trial_id != "default"
+    assert current_session.trial_name != "default"
 
 
 def test_single_step(ray_start_2_cpus):  # noqa: F811
@@ -139,7 +139,7 @@ def test_colocated_gpu_double(ray_4_node_gpu):  # noqa: F811
     trainable.stop()
 
 
-def test_validate_session():
+def test_validate_session(ray_start_2_cpus):
     trainable_cls = DistributedTrainableCreator(_train_validate_session)
     tune.run(trainable_cls)
 

--- a/python/ray/tune/tests/test_tensorflow_trainable.py
+++ b/python/ray/tune/tests/test_tensorflow_trainable.py
@@ -71,6 +71,14 @@ def _train_check_global(config: Dict, checkpoint_dir: Optional[str] = None):
     tune.report(is_distributed=True)
 
 
+def _train_validate_session(config: Dict,
+                            checkpoint_dir: Optional[str] = None):
+    current_session = tune.session.get_session()
+    assert current_session is not None
+    assert current_session._trial_id != "default"
+    assert current_session._trial_name != "default"
+
+
 def test_single_step(ray_start_2_cpus):  # noqa: F811
     trainable_cls = DistributedTrainableCreator(train_mnist, num_workers=2)
     trainer = trainable_cls()
@@ -129,6 +137,11 @@ def test_colocated_gpu_double(ray_4_node_gpu):  # noqa: F811
     assert ray.available_resources().get("GPU", 0) == 0
     trainable.train()
     trainable.stop()
+
+
+def test_validate_session():
+    trainable_cls = DistributedTrainableCreator(_train_validate_session)
+    tune.run(trainable_cls)
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/tests/test_torch_trainable.py
+++ b/python/ray/tune/tests/test_torch_trainable.py
@@ -171,7 +171,7 @@ def test_colocated_gpu_double(ray_4_node_gpu):  # noqa: F811
     trainable.stop()
 
 
-def test_validate_session():
+def test_validate_session(ray_start_2_cpus):
     trainable_cls = DistributedTrainableCreator(_train_validate_session)
     tune.run(trainable_cls)
 

--- a/python/ray/tune/tests/test_torch_trainable.py
+++ b/python/ray/tune/tests/test_torch_trainable.py
@@ -7,9 +7,9 @@ import torch.distributed as dist
 import ray
 from ray import tune
 from ray.cluster_utils import Cluster
-from ray.tune.integration.torch import (DistributedTrainableCreator,
-                                        distributed_checkpoint_dir,
-                                        _train_simple, _train_check_global)
+from ray.tune.integration.torch import (
+    DistributedTrainableCreator, distributed_checkpoint_dir, _train_simple,
+    _train_check_global, _train_validate_session)
 
 
 @pytest.fixture
@@ -169,6 +169,11 @@ def test_colocated_gpu_double(ray_4_node_gpu):  # noqa: F811
     assert ray.available_resources().get("GPU", 0) == 0
     trainable.train()
     trainable.stop()
+
+
+def test_validate_session():
+    trainable_cls = DistributedTrainableCreator(_train_validate_session)
+    tune.run(trainable_cls)
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -822,7 +822,7 @@ class DistributedTrainable(Trainable):
         Builds a deep copy of the input config and populates it with
         metadata from this Trainable.
 
-        Useful for passing this Trainable's configs to each distributed 
+        Useful for passing this Trainable's configs to each distributed
         Trainable instance.
         """
         new_config = copy.deepcopy(config)

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -814,10 +814,12 @@ class Trainable:
 
 
 class DistributedTrainable(Trainable):
-    """Common class for a Trainable whose training should be performed in a distributed manner."""
+    """Common Trainable class for distributed training."""
 
     def build_config(self, config: Dict):
-        """Builds a deep copy of the input config and populates it with
+        """Builds config for disitrubted training.
+
+        Builds a deep copy of the input config and populates it with
         metadata from this Trainable.
 
         Useful for passing this Trainable's configs to each distributed 

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -93,6 +93,8 @@ class Trainable:
         self._iterations_since_restore = 0
         self._restored = False
         self._trial_info = trial_info
+        self._stdout_file = stdout_file
+        self._stderr_file = stderr_file
 
         start_time = time.time()
         self.setup(copy.deepcopy(self.config))
@@ -631,6 +633,16 @@ class Trainable:
     def get_config(self):
         """Returns configuration passed in by Tune."""
         return self.config
+
+    def build_config(self, config: Dict):
+        """Builds a deep copy of the input config and populates it with
+        metadata from this Trainable.
+        """
+        new_config = copy.deepcopy(config)
+        new_config[TRIAL_INFO] = self._trial_info
+        new_config[STDOUT_FILE] = self._stdout_file
+        new_config[STDERR_FILE] = self._stderr_file
+        return new_config
 
     def step(self):
         """Subclasses should override this to implement train().

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -634,16 +634,6 @@ class Trainable:
         """Returns configuration passed in by Tune."""
         return self.config
 
-    def build_config(self, config: Dict):
-        """Builds a deep copy of the input config and populates it with
-        metadata from this Trainable.
-        """
-        new_config = copy.deepcopy(config)
-        new_config[TRIAL_INFO] = self._trial_info
-        new_config[STDOUT_FILE] = self._stdout_file
-        new_config[STDERR_FILE] = self._stderr_file
-        return new_config
-
     def step(self):
         """Subclasses should override this to implement train().
 
@@ -821,3 +811,20 @@ class Trainable:
 
     def _implements_method(self, key):
         return hasattr(self, key) and callable(getattr(self, key))
+
+
+class DistributedTrainable(Trainable):
+    """Common class for a Trainable whose training should be performed in a distributed manner."""
+
+    def build_config(self, config: Dict):
+        """Builds a deep copy of the input config and populates it with
+        metadata from this Trainable.
+
+        Useful for passing this Trainable's configs to each distributed 
+        Trainable instance.
+        """
+        new_config = copy.deepcopy(config)
+        new_config[TRIAL_INFO] = self._trial_info
+        new_config[STDOUT_FILE] = self._stdout_file
+        new_config[STDERR_FILE] = self._stderr_file
+        return new_config

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -817,7 +817,7 @@ class DistributedTrainable(Trainable):
     """Common Trainable class for distributed training."""
 
     def build_config(self, config: Dict):
-        """Builds config for disitrubted training.
+        """Builds config for distributed training.
 
         Builds a deep copy of the input config and populates it with
         metadata from this Trainable.


### PR DESCRIPTION
## Why are these changes needed?

`DistributedTrainableCreator` creates a wrapper `Trainable` which is used to create an `ImplicitFunc`. The `ImplicitFunc` should be created with the same configs as the `Trainable`, but is currently not because `Trainable.__init__` clears out some of the internal configs (e.g. trial info). 

### Changes
1. Create a new `DistributedTrainable` class with a `build_config` method to populate internal configs.
2. Update {`horovod`, `tensorflow`, `torch`} integrations to inherit from `DistributedTrainable` and call `build_config`.

## Related issue number

Closes #15288

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
