### PR TITLE
Fix atof on the string bug + try removing load balance spillback scheduling policy

### DIFF
--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -118,10 +118,8 @@ def test_legacy_spillback_distribution(ray_start_cluster):
     cluster = ray_start_cluster
     # Create a head node and wait until it is up.
     cluster.add_node(
-        num_cpus=0,
-        _system_config={
-            "scheduler_loadbalance_spillback": True,
-            "scheduler_hybrid_scheduling": False
+        num_cpus=0, _system_config={
+            "scheduler_hybrid_threshold": 0,
         })
     ray.init(address=cluster.address)
     cluster.wait_for_nodes()

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -132,7 +132,7 @@ RAY_CONFIG(bool, scheduler_hybrid_scheduling,
 RAY_CONFIG(float, scheduler_hybrid_threshold,
            getenv("RAY_SCHEDULER_HYBRID_THRESHOLD") == nullptr
                ? 0.5
-               : std::stof("RAY_SCHEDULER_HYBRID_THRESHOLD"))
+               : std::stof(getenv("RAY_SCHEDULER_HYBRID_THRESHOLD")))
 
 // The max allowed size in bytes of a return object from direct actor calls.
 // Objects larger than this size will be spilled/promoted to plasma.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes the issues where atof was called on the string instead of values which causes some exception. 

It also tries to test if utilization score = 0 works in the same way as load balancing policy. Once it is confirmed, we can remove the whole policy and recommend utilization score = 0 for data processing workload. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
