### PR TITLE
[Test] Fix flaky global gc test

### DIFF
--- a/python/ray/tests/test_global_gc.py
+++ b/python/ray/tests/test_global_gc.py
@@ -54,8 +54,12 @@ def test_auto_local_gc(shutdown_only):
 
 def test_global_gc(shutdown_only):
     cluster = ray.cluster_utils.Cluster()
-    for _ in range(2):
-        cluster.add_node(num_cpus=1, num_gpus=0)
+    cluster.add_node(num_cpus=1, num_gpus=0, _system_config={
+        "local_gc_interval_s": 10,
+        "local_gc_min_interval_s": 5,
+        "global_gc_min_interval_s": 10
+    })
+    cluster.add_node(num_cpus=1, num_gpus=0)
     ray.init(address=cluster.address)
 
     class ObjectWithCyclicRef:

--- a/python/ray/tests/test_global_gc.py
+++ b/python/ray/tests/test_global_gc.py
@@ -54,11 +54,14 @@ def test_auto_local_gc(shutdown_only):
 
 def test_global_gc(shutdown_only):
     cluster = ray.cluster_utils.Cluster()
-    cluster.add_node(num_cpus=1, num_gpus=0, _system_config={
-        "local_gc_interval_s": 10,
-        "local_gc_min_interval_s": 5,
-        "global_gc_min_interval_s": 10
-    })
+    cluster.add_node(
+        num_cpus=1,
+        num_gpus=0,
+        _system_config={
+            "local_gc_interval_s": 10,
+            "local_gc_min_interval_s": 5,
+            "global_gc_min_interval_s": 10
+        })
     cluster.add_node(num_cpus=1, num_gpus=0)
     ray.init(address=cluster.address)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is purely based on my guess, and there's not enough evidence. But I think there's nothing to lose by doing this. 

Currently we are throttling the number of gc in the given time range, and it probably is the reason why it occasionally times out (since 30 seconds are not enough). This decreases the throttling parameters to fix that issue in the test. 

Status: Waiting for tests to see if it fixes the issue

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
