### PR TITLE
[kubernetes][helm][don't merge yet] Helm docs reference release version

### DIFF
--- a/doc/source/cluster/kubernetes-advanced.rst
+++ b/doc/source/cluster/kubernetes-advanced.rst
@@ -22,9 +22,9 @@ To configure Helm chart values, you can pass in a custom values ``yaml`` and/or 
 .. code-block:: shell
 
    # Pass in a custom values yaml.
-   $ helm install example-cluster -f custom_values.yaml ./ray
+   $ helm install example-cluster -f custom_values.yaml ray-charts/ray
    # Set custom values on the command line.
-   $ helm install example-cluster --set image=rayproject/ray:1.2.0 ./ray
+   $ helm install example-cluster --set image=rayproject/ray:1.2.0 ray-charts/ray
 
 Refer to the `Helm docs`_ for more information.
 
@@ -92,14 +92,14 @@ three separate Helm releases:
 .. code-block:: shell
 
   # Install the operator in its own Helm release.
-  $ helm install ray-operator --set operatorOnly=true ./ray
+  $ helm install ray-operator --set operatorOnly=true ray-charts/ray
 
   # Install a Ray cluster in a new namespace "ray".
-  $ helm -n ray install example-cluster --set clusterOnly=true ./ray --create-namespace
+  $ helm -n ray install example-cluster --set clusterOnly=true ray-charts/ray --create-namespace
 
   # Install a second Ray cluster. Launch the second cluster without any workers.
   $ helm -n ray install example-cluster2 \
-      --set podTypes.rayWorkerType.minWorkers=0 --set clusterOnly=true ./ray
+      --set podTypes.rayWorkerType.minWorkers=0 --set clusterOnly=true ray-charts/ray
 
   # Examine the pods in both clusters.
   $ kubectl -n ray get pods
@@ -119,7 +119,7 @@ Alternatively, the Operator and one of the Ray Clusters can be installed in the 
    # Start another Ray cluster.
    # The cluster will be managed by the operator created in the last command.
    $ helm -n ray install example-cluster2 \
-      --set podTypes.rayWorkerType.minWorkers=0 --set clusterOnly=true ./ray
+      --set podTypes.rayWorkerType.minWorkers=0 --set clusterOnly=true ray-charts/ray
 
 
 The Operator pod outputs autoscaling logs for all of the Ray clusters it manages.
@@ -198,6 +198,17 @@ The ``STATUS`` column reports the RayCluster's ``status.phase`` field. The follo
 
 The ``RESTARTS`` column reports the RayCluster's ``status.autoscalerRetries`` field. This tracks the number of times the cluster has restarted due to an autoscaling error.
 
+Installing the nightly chart
+----------------------------
+
+The latest development version of the Ray helm chart is available on the master branch of Ray's GitHub repo:
+
+.. code-block:: shell
+
+   $ git clone https://github.com/ray-project/ray
+   $ cd ray/deploy/charts
+   $ helm install ray-cluster ./ray
+
 Questions or Issues?
 --------------------
 
@@ -207,7 +218,7 @@ Questions or Issues?
 .. _`namespaced`: https://github.com/ray-project/ray/tree/master/deploy/components/operator_namespaced.yaml
 .. _`cluster-scoped`: https://github.com/ray-project/ray/tree/master/deploy/components/operator_cluster_scoped.yaml
 .. _`example`: https://github.com/ray-project/ray/tree/master/deploy/components/example_cluster.yaml
-.. _`values.yaml`: https://github.com/ray-project/ray/tree/master/deploy/charts/ray/values.yaml
+.. _`values.yaml`: https://github.com/ray-project/ray-helm-charts/blob/main/ray/values.yaml
 .. _`bug report`: https://github.com/ray-project/ray/issues/new?assignees=&labels=bug%2C+triage&template=bug_report.md&title=
 .. _`helm upgrade`: https://helm.sh/docs/helm/helm_upgrade/
 .. _`feature request`: https://github.com/ray-project/ray/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=

--- a/doc/source/cluster/kubernetes-advanced.rst
+++ b/doc/source/cluster/kubernetes-advanced.rst
@@ -26,7 +26,7 @@ To configure Helm chart values, you can pass in a custom values ``yaml`` and/or 
    # Set custom values on the command line.
    $ helm install example-cluster --set image=rayproject/ray:1.2.0 ray-charts/ray
 
-Refer to the `Helm docs`_ for more information.
+Refer to the `Helm docs`_ for more information on setting custom values.
 
 Ray cluster configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -148,17 +148,6 @@ to your Helm install command.
 .. warning::
    Do not simultaneously run namespaced and cluster-scoped Ray Operators within one Kubernetes cluster, as this will lead to unintended effects.
 
-.. _no-helm:
-
-Deploying without Helm
-----------------------
-It is possible to deploy the Ray Operator without Helm.
-The necessary configuration files are available on the `Ray GitHub`_.
-The following manifests should be installed in the order listed:
-
-- The `RayCluster CRD`_.
-- The Ray Operator, `namespaced`_ or `cluster-scoped`_.\Note that the cluster-scoped operator is configured to run in namespaced ``default``. Modify as needed.
-- A RayCluster custom resource: `example`_.
 
 Ray Cluster Lifecycle
 ---------------------
@@ -198,8 +187,15 @@ The ``STATUS`` column reports the RayCluster's ``status.phase`` field. The follo
 
 The ``RESTARTS`` column reports the RayCluster's ``status.autoscalerRetries`` field. This tracks the number of times the cluster has restarted due to an autoscaling error.
 
-Installing the nightly chart
-----------------------------
+Downloading the Helm chart
+--------------------------
+
+You can download the Ray Helm chart and customize it locally:
+
+.. code-block:: shell
+
+   $ helm pull ray-charts/ray --untar
+   $ helm install ray-cluster ./ray
 
 The latest development version of the Ray helm chart is available on the master branch of Ray's GitHub repo:
 
@@ -208,6 +204,18 @@ The latest development version of the Ray helm chart is available on the master 
    $ git clone https://github.com/ray-project/ray
    $ cd ray/deploy/charts
    $ helm install ray-cluster ./ray
+
+.. _no-helm:
+
+Deploying without Helm
+----------------------
+It is possible to deploy the Ray Operator without Helm.
+The necessary configuration files are available on the `Ray GitHub`_.
+The following manifests should be installed in the order listed:
+
+- The `RayCluster CRD`_.
+- The Ray Operator, `namespaced`_ or `cluster-scoped`_.\Note that the cluster-scoped operator is configured to run in namespaced ``default``. Modify as needed.
+- A RayCluster custom resource: `example`_.
 
 Questions or Issues?
 --------------------

--- a/doc/source/cluster/kubernetes.rst
+++ b/doc/source/cluster/kubernetes.rst
@@ -47,15 +47,20 @@ Installing the Ray Operator with Helm
 -------------------------------------
 Ray provides a `Helm`_ chart to simplify deployment of the Ray Operator and Ray clusters.
 
-Currently, the `Ray Helm chart`_ is available on the the master branch of the Ray GitHub repo.
-The chart will be published to a public Helm repo as part of each Ray release, starting with the upcoming Ray 1.4.0.
+The chart is developed in the `Ray GitHub repository`_.
+An official version is published to a `public Helm repo`_ with each Ray release.
 
 Preparation
 ~~~~~~~~~~~
 
 - Configure `kubectl`_ to access your Kubernetes cluster.
 - Install `Helm 3`_.
-- Download the `Ray Helm chart`_.
+- Download the latest release version of the chart:
+
+.. code-block:: shell
+
+  $ helm repo add ray-charts https://ray-project.github.io/ray-helm-charts/
+  $ helm repo update
 
 To run the default example in this document, make sure your Kubernetes cluster can accomodate
 additional resource requests of 4 CPU and 2.5Gi memory.
@@ -69,12 +74,9 @@ with scaling allowed up to three workers.
 
 .. code-block:: shell
 
-  # Navigate to the directory containing the chart
-  $ cd ray/deploy/charts
-
   # Install a small Ray cluster with the default configuration
   # in a new namespace called "ray". Let's name the Helm release "example-cluster."
-  $ helm -n ray install example-cluster --create-namespace ./ray
+  $ helm -n ray install example-cluster --create-namespace ray-charts/ray
   NAME: example-cluster
   LAST DEPLOYED: Fri May 14 11:44:06 2021
   NAMESPACE: ray
@@ -258,7 +260,8 @@ Questions or Issues?
 .. _`minikube`: https://minikube.sigs.k8s.io/docs/start/
 .. _`namespace`: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
 .. _`Deployment`: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
-.. _`Ray Helm chart`: https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
+.. _`Ray GitHub repository`: https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
+.. _`public Helm repo`: https://github.com/ray-project/ray-helm-charts
 .. _`kubectl`: https://kubernetes.io/docs/tasks/tools/
 .. _`Helm 3`: https://helm.sh/
 .. _`Helm`: https://helm.sh/


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR updates the Helm docs to reference the release version of the Ray helm chart.
To be merged soon after the Ray 1.4.0 release.

The Helm release is hosted here:
https://github.com/ray-project/ray-helm-charts

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/15222

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
