### PR TITLE
[Client] Make `dir()` work for ClientActorHandle

### DIFF
--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -974,5 +974,17 @@ def test_return_actor_handle_from_actor(ray_start_regular_shared):
     assert ray.get(inner.ping.remote()) == "pong"
 
 
+def test_actor_dir(ray_start_regular_shared):
+    @ray.remote
+    class Foo:
+        def method_one(self) -> None:
+            pass
+
+    f = Foo.remote()
+
+    methods = [fn for fn in dir(f) if not fn.startswith("__")]
+    assert methods == ["method_one"]
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -994,6 +994,9 @@ def test_actor_autocomplete(ray_start_regular_shared):
     methods = [fn for fn in dir(f) if not fn.startswith("_")]
     assert methods == ["method_one"]
 
+    all_methods = set(dir(f))
+    assert all_methods == {"__init__", "method_one", "__ray_terminate__"}
+
     method_options = [fn for fn in dir(f.method_one) if not fn.startswith("_")]
 
     assert set(method_options) == {"options", "remote"}

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -974,16 +974,29 @@ def test_return_actor_handle_from_actor(ray_start_regular_shared):
     assert ray.get(inner.ping.remote()) == "pong"
 
 
-def test_actor_dir(ray_start_regular_shared):
+def test_actor_autocomplete(ray_start_regular_shared):
+    """
+    Test that autocomplete works with actors by checking that the builtin dir()
+    function works as expected.
+    """
+
     @ray.remote
     class Foo:
         def method_one(self) -> None:
             pass
 
+    class_calls = [fn for fn in dir(Foo) if not fn.startswith("_")]
+
+    assert set(class_calls) == {"method_one", "options", "remote"}
+
     f = Foo.remote()
 
-    methods = [fn for fn in dir(f) if not fn.startswith("__")]
+    methods = [fn for fn in dir(f) if not fn.startswith("_")]
     assert methods == ["method_one"]
+
+    method_options = [fn for fn in dir(f.method_one) if not fn.startswith("_")]
+
+    assert set(method_options) == {"options", "remote"}
 
 
 if __name__ == "__main__":

--- a/python/ray/util/client/client_pickler.py
+++ b/python/ray/util/client/client_pickler.py
@@ -128,7 +128,7 @@ class ClientPickler(cloudpickle.CloudPickler):
             return PickleStub(
                 type="RemoteMethod",
                 client_id=self.client_id,
-                ref_id=obj.actor_handle.actor_ref.id,
+                ref_id=obj._actor_handle.actor_ref.id,
                 name=obj.method_name,
                 baseline_options=None,
             )

--- a/python/ray/util/client/client_pickler.py
+++ b/python/ray/util/client/client_pickler.py
@@ -129,7 +129,7 @@ class ClientPickler(cloudpickle.CloudPickler):
                 type="RemoteMethod",
                 client_id=self.client_id,
                 ref_id=obj._actor_handle.actor_ref.id,
-                name=obj.method_name,
+                name=obj._method_name,
                 baseline_options=None,
             )
         elif isinstance(obj, OptionWrapper):

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -205,10 +205,19 @@ class ClientActorHandle(ClientStub):
 
     def __init__(self, actor_ref: ClientActorRef):
         self.actor_ref = actor_ref
+        self._dir: Optional[List[str]] = None
 
     def __del__(self) -> None:
         if ray.is_connected():
             ray.call_release(self.actor_ref.id)
+
+    def __dir__(self) -> List[str]:
+        if self._dir:
+            return self._dir
+        if ray.is_connected():
+            self._dir = ray.get(ray.remote(lambda x: dir(x)).remote(self))
+            return self._dir
+        return super().__dir__()
 
     @property
     def _actor_id(self):

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -1,7 +1,6 @@
 import ray._raylet as raylet
 import ray.core.generated.ray_client_pb2 as ray_client_pb2
 import ray.core.generated.ray_client_pb2_grpc as ray_client_pb2_grpc
-from ray._private.client_mode_hook import client_mode_wrap
 from ray.util.client import ray
 from ray.util.client.options import validate_options
 
@@ -217,11 +216,11 @@ class ClientActorHandle(ClientStub):
             return self._dir
         if ray.is_connected():
 
-            @client_mode_wrap
+            @ray.remote(num_cpus=0)
             def get_dir(x):
                 return dir(x)
 
-            self._dir = get_dir(self)
+            self._dir = ray.get(get_dir.remote(self))
             return self._dir
         return super().__dir__()
 

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -9,7 +9,7 @@ import grpc
 import os
 import uuid
 import inspect
-from ray.util.inspect import is_cython
+from ray.util.inspect import is_cython, is_function_or_method
 import json
 import threading
 from typing import Any
@@ -161,7 +161,7 @@ class ClientActorClass(ClientStub):
         # Actually instantiate the actor
         ref_ids = ray.call_remote(self, *args, **kwargs)
         assert len(ref_ids) == 1
-        return ClientActorHandle(ClientActorRef(ref_ids[0]))
+        return ClientActorHandle(ClientActorRef(ref_ids[0]), actor_class=self)
 
     def options(self, **kwargs):
         return ActorOptionWrapper(self, kwargs)
@@ -203,16 +203,23 @@ class ClientActorHandle(ClientStub):
           is a serialized version of the actual handle as an opaque token.
     """
 
-    def __init__(self, actor_ref: ClientActorRef):
+    def __init__(self,
+                 actor_ref: ClientActorRef,
+                 actor_class: Optional[ClientActorClass] = None):
         self.actor_ref = actor_ref
         self._dir: Optional[List[str]] = None
+        if actor_class is not None:
+            self._dir = list(
+                dict(
+                    inspect.getmembers(actor_class.actor_cls,
+                                       is_function_or_method)).keys())
 
     def __del__(self) -> None:
         if ray.is_connected():
             ray.call_release(self.actor_ref.id)
 
     def __dir__(self) -> List[str]:
-        if self._dir:
+        if self._dir is not None:
             return self._dir
         if ray.is_connected():
 
@@ -300,7 +307,11 @@ class ActorOptionWrapper(OptionWrapper):
     def remote(self, *args, **kwargs):
         ref_ids = ray.call_remote(self, *args, **kwargs)
         assert len(ref_ids) == 1
-        return ClientActorHandle(ClientActorRef(ref_ids[0]))
+        actor_class = None
+        if isinstance(self.remote_stub, ClientActorClass):
+            actor_class = self.remote_stub
+        return ClientActorHandle(
+            ClientActorRef(ref_ids[0]), actor_class=actor_class)
 
 
 def set_task_options(task: ray_client_pb2.ClientTask,

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -1,6 +1,7 @@
 import ray._raylet as raylet
 import ray.core.generated.ray_client_pb2 as ray_client_pb2
 import ray.core.generated.ray_client_pb2_grpc as ray_client_pb2_grpc
+from ray._private.client_mode_hook import client_mode_wrap
 from ray.util.client import ray
 from ray.util.client.options import validate_options
 
@@ -215,7 +216,12 @@ class ClientActorHandle(ClientStub):
         if self._dir:
             return self._dir
         if ray.is_connected():
-            self._dir = ray.get(ray.remote(lambda x: dir(x)).remote(self))
+
+            @client_mode_wrap
+            def get_dir(x):
+                return dir(x)
+
+            self._dir = get_dir(self)
             return self._dir
         return super().__dir__()
 

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -242,8 +242,8 @@ class ClientRemoteMethod(ClientStub):
     """
 
     def __init__(self, actor_handle: ClientActorHandle, method_name: str):
-        self.actor_handle = actor_handle
-        self.method_name = method_name
+        self._actor_handle = actor_handle
+        self._method_name = method_name
 
     def __call__(self, *args, **kwargs):
         raise TypeError(f"Remote method cannot be called directly. "
@@ -253,8 +253,8 @@ class ClientRemoteMethod(ClientStub):
         return return_refs(ray.call_remote(self, *args, **kwargs))
 
     def __repr__(self):
-        return "ClientRemoteMethod(%s, %s)" % (self.method_name,
-                                               self.actor_handle)
+        return "ClientRemoteMethod(%s, %s)" % (self._method_name,
+                                               self._actor_handle)
 
     def options(self, **kwargs):
         return OptionWrapper(self, kwargs)
@@ -269,8 +269,8 @@ class ClientRemoteMethod(ClientStub):
     def _prepare_client_task(self) -> ray_client_pb2.ClientTask:
         task = ray_client_pb2.ClientTask()
         task.type = ray_client_pb2.ClientTask.METHOD
-        task.name = self.method_name
-        task.payload_id = self.actor_handle.actor_ref.id
+        task.name = self._method_name
+        task.payload_id = self._actor_handle.actor_ref.id
         return task
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* `dir()` on a ClientActorHandle does not properly show the methods of the actual Actor's class. It only shows the internal implementation details. This PR override the `__dir__()` function to return the expected value!

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
Tested for Client because `test_actor.py` is [run with client mode](https://github.com/ray-project/ray/blob/45d2331d5a6062e894725024e2a608830ac0b7ce/python/ray/tests/BUILD#L231).