### PR TITLE
[rllib] Remove bad spinlocks to allow pytorch GPU scheduler to interrupt.

### DIFF
--- a/python/ray/util/iter.py
+++ b/python/ray/util/iter.py
@@ -1221,9 +1221,11 @@ class _NextValueNotReady(Exception):
 
     This is used internally to implement the union() of multiple blocking
     local generators."""
+
     def __init__(self):
-        # many generators use the _NextValueNotReady in spin-locks which do not yeild threads to waiting processing such
-        # as pytorch GPU scheduling, this leads to problems such the following:
+        # many generators use the _NextValueNotReady in spin-locks which
+        # do not yeild threads to waiting processing such as pytorch GPU
+        # scheduling, this leads to problems such the following:
         # https://discuss.ray.io/t/very-slow-gradient-descent-on-remote-workers/1278/9
         time.sleep(0.001)
 

--- a/python/ray/util/iter.py
+++ b/python/ray/util/iter.py
@@ -1221,7 +1221,11 @@ class _NextValueNotReady(Exception):
 
     This is used internally to implement the union() of multiple blocking
     local generators."""
-    pass
+    def __init__(self):
+        # many generators use the _NextValueNotReady in spin-locks which do not yeild threads to waiting processing such
+        # as pytorch GPU scheduling, this leads to problems such the following:
+        # https://discuss.ray.io/t/very-slow-gradient-descent-on-remote-workers/1278/9
+        time.sleep(0.001)
 
 
 class _ActorSet(object):

--- a/rllib/execution/learner_thread.py
+++ b/rllib/execution/learner_thread.py
@@ -1,14 +1,15 @@
 import copy
-from six.moves import queue
 import threading
 from typing import Dict
 
 from ray.rllib.evaluation.metrics import get_learner_stats
+from ray.rllib.evaluation.rollout_worker import RolloutWorker
 from ray.rllib.execution.minibatch_buffer import MinibatchBuffer
 from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.utils.timer import TimerStat
 from ray.rllib.utils.window_stat import WindowStat
-from ray.rllib.evaluation.rollout_worker import RolloutWorker
+from ray.util.iter import _NextValueNotReady
+from six.moves import queue
 
 tf1, tf, tfv = try_import_tf()
 

--- a/rllib/execution/learner_thread.py
+++ b/rllib/execution/learner_thread.py
@@ -71,7 +71,7 @@ class LearnerThread(threading.Thread):
             try:
                 batch, _ = self.minibatch_buffer.get()
             except queue.Empty:
-                return
+                return _NextValueNotReady()
 
         with self.grad_timer:
             fetches = self.local_worker.learn_on_batch(batch)

--- a/rllib/execution/rollout_ops.py
+++ b/rllib/execution/rollout_ops.py
@@ -158,10 +158,12 @@ class ConcatBatches:
         self.buffer = []
         self.count = 0
         self.batch_start_time = None
+        print(f'Reset Concat')
 
     def _on_fetch_start(self):
         if self.batch_start_time is None:
             self.batch_start_time = time.perf_counter()
+            print(f'Batch Start Time {self.batch_start_time}')
 
     def __call__(self, batch: SampleBatchType) -> List[SampleBatchType]:
         _check_sample_batch_type(batch)
@@ -185,6 +187,7 @@ class ConcatBatches:
             out = SampleBatch.concat_samples(self.buffer)
             timer = _get_shared_metrics().timers[SAMPLE_TIMER]
             timer.push(time.perf_counter() - self.batch_start_time)
+            print(f'Sample Count: {self.count}')
             timer.push_units_processed(self.count)
             self.batch_start_time = None
             self.buffer = []

--- a/rllib/execution/rollout_ops.py
+++ b/rllib/execution/rollout_ops.py
@@ -158,12 +158,10 @@ class ConcatBatches:
         self.buffer = []
         self.count = 0
         self.batch_start_time = None
-        print(f'Reset Concat')
 
     def _on_fetch_start(self):
         if self.batch_start_time is None:
             self.batch_start_time = time.perf_counter()
-            print(f'Batch Start Time {self.batch_start_time}')
 
     def __call__(self, batch: SampleBatchType) -> List[SampleBatchType]:
         _check_sample_batch_type(batch)
@@ -187,7 +185,6 @@ class ConcatBatches:
             out = SampleBatch.concat_samples(self.buffer)
             timer = _get_shared_metrics().timers[SAMPLE_TIMER]
             timer.push(time.perf_counter() - self.batch_start_time)
-            print(f'Sample Count: {self.count}')
             timer.push_units_processed(self.count)
             self.batch_start_time = None
             self.buffer = []


### PR DESCRIPTION
## Why are these changes needed?

Discussion of this bug and the fix can be found here: 
https://discuss.ray.io/t/very-slow-gradient-descent-on-remote-workers/1278
and here:
https://discuss.ray.io/t/rllib-ray-trains-extremely-slow-when-learner-queue-is-full/289/6

Summary: pytorch GPU scheduler breaks and defaults to using CPU if sample queues in the IMPALA implementation are full.

When the sample queues are full, the worker threads spinlock which does not allow the [thread to be interrupted and used i the GPU scheduler](https://stackoverflow.com/questions/60086108/forward-pass-gets-10000x-slower-after-iterating-for-a-while).

Fix: Instead of spinlocking, introduce a small sleep (which allows the thread to be interrupted). This also stops wasting of CPU time spinning. By default if the `_NextValueNotReady(Exception)` class is used to mark queues that are full then a small sleep is executed.

This small wait fixes the bug and keeps the GPU running at full capacity!

@smorad I did try `sleep(0)` however this did not seem to solve the issue, I think the small wait is a good thing in this case as it allows CPU to rest and also at this point there are already 16 samples per queue ready to go which will not slow down learing at all.

@sven1977 Please note: This does actually introduce a bug that the "sample_throughput" calculation actually only calculates the throughput through the "ConcatBatches" part of the pipeline, which if there queues are full is tiny. Therefore sample throughput time is completely mis-calculated as it does not need to wait at all for new batches.

## Related issue number

Issues are in discuss.ray.io listed above.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
