### PR TITLE
[rllib] fixed import tensorflow when module not available

### DIFF
--- a/rllib/models/catalog.py
+++ b/rllib/models/catalog.py
@@ -738,8 +738,9 @@ class ModelCatalog:
             model_name (str): Name to register the model under.
             model_class (type): Python class of the model.
         """
-        if issubclass(model_class, tf.keras.Model):
-            deprecation_warning(old="register_custom_model", error=False)
+        if tf is not None:
+            if issubclass(model_class, tf.keras.Model):
+                deprecation_warning(old="register_custom_model", error=False)
         _global_registry.register(RLLIB_MODEL, model_name, model_class)
 
     @staticmethod


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When registering a Torch model and tensorflow is not installed in python environment, it will fail because the method `ModelCatalog.register_custom_model` checks `tf.keras.Model` to give `tf` related deprecation warning. Added check to only be made if tensorflow is loaded.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/. - nothing needed
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
