### PR TITLE
[Workflow] Inital workflow API implementation

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -299,6 +299,12 @@
     - bazel test --config=ci $(./scripts/bazel_export_options) --build_tests_only --test_tag_filters=client,-client_unit_tests python/ray/util/sgd/...
     - bazel test --config=ci $(./scripts/bazel_export_options) --build_tests_only --test_tag_filters=client,-flaky python/ray/util/xgboost/...
 
+- label: ":potable_water: Workflow tests and examples"
+  conditions: ["RAY_CI_PYTHON_AFFECTED"]
+  commands:
+    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
+    - bazel test --config=ci $(./scripts/bazel_export_options) python/ray/experimental/workflow/...
+
 - label: ":book: Doc tests and examples"
   conditions:
     ["RAY_CI_PYTHON_AFFECTED", "RAY_CI_TUNE_AFFECTED", "RAY_CI_DOC_AFFECTED"]

--- a/python/ray/experimental/workflow/BUILD
+++ b/python/ray/experimental/workflow/BUILD
@@ -1,0 +1,22 @@
+# --------------------------------------------------------------------
+# Tests from the python/ray/experimental/workflow/tests directory.
+# Covers all tests starting with `test_`.
+# Please keep these sorted alphabetically.
+# --------------------------------------------------------------------
+load("//bazel:python.bzl", "py_test_module_list")
+
+SRCS = [] + select({
+    "@bazel_tools//src/conditions:windows": glob([
+        # TODO(mehrdadn): This should be added for all platforms once resulting errors are fixed
+        "**/conftest.py",
+    ]),
+    "//conditions:default": [],
+})
+
+py_test_module_list(
+  files = glob(["tests/test_*.py"]),
+  size = "small",
+  extra_srcs = SRCS,
+  tags = ["exclusive"],
+  deps = ["//:ray_lib"],
+)

--- a/python/ray/experimental/workflow/__init__.py
+++ b/python/ray/experimental/workflow/__init__.py
@@ -1,0 +1,3 @@
+from ray.experimental.workflow.api import step, run
+
+__all__ = ("step", "run")

--- a/python/ray/experimental/workflow/api.py
+++ b/python/ray/experimental/workflow/api.py
@@ -1,0 +1,64 @@
+import logging
+import time
+import types
+import uuid
+
+import ray
+from ray.experimental.workflow.workflow_manager import (
+    WorkflowStepFunction, Workflow, resolve_object_ref)
+from ray.experimental.workflow import workflow_context
+
+logger = logging.getLogger(__name__)
+
+# TODO(suquark): This API is still not entirely consistent with our doc.
+# We need to fix 2 things:
+# 1. Resolve any workflow embedded in the argument of another workflow.
+# 2. Do not resolve ObjectRefs that does not come from a workflow.
+#    Only deref it once when it is a direct argument.
+
+
+def step(func) -> WorkflowStepFunction:
+    """
+    A decorator wraps over a function to turn it into a workflow step function.
+    """
+    if not isinstance(func, types.FunctionType):
+        raise TypeError("The @step decorator must wraps over a function.")
+    return WorkflowStepFunction(func)
+
+
+def run(entry_workflow: Workflow, workflow_root_dir=None,
+        workflow_id=None) -> ray.ObjectRef:
+    """
+    Run a workflow asynchronously.
+
+    Args:
+        entry_workflow: The workflow to run.
+        workflow_root_dir: The path of an external storage used for
+            checkpointing.
+        workflow_id: The ID of the workflow. The ID is used to identify
+            the workflow.
+
+    Returns:
+        The execution result of the workflow, represented by Ray ObjectRef.
+    """
+    if workflow_id is None:
+        # TODO(suquark): include the name of the workflow in the default ID,
+        # this makes the ID more readable.
+        workflow_id = uuid.uuid4().hex + "." + str(time.time())
+    logger.info(f"Workflow job {workflow_id} created.")
+    try:
+        workflow_context.init_workflow_step_context(workflow_id,
+                                                    workflow_root_dir)
+        rref = entry_workflow.execute()
+        logger.info(f"Workflow job {workflow_id} started.")
+        # TODO(suquark): although we do not return the resolved object to user,
+        # the object was resolved temporarily to the driver script.
+        # We may need a helper step for storing the resolved object
+        # instead later.
+        output = resolve_object_ref(rref)[1]
+    finally:
+        workflow_context.set_workflow_step_context(None)
+    return output
+
+
+__all__ = ("step", "run")

--- a/python/ray/experimental/workflow/tests/test_basic_workflows.py
+++ b/python/ray/experimental/workflow/tests/test_basic_workflows.py
@@ -1,0 +1,88 @@
+import ray
+from ray.experimental import workflow
+
+
+@workflow.step
+def identity(x):
+    return x
+
+
+@workflow.step
+def source1():
+    return "[source1]"
+
+
+@workflow.step
+def append1(x):
+    return x + "[append1]"
+
+
+@workflow.step
+def append2(x):
+    return x + "[append2]"
+
+
+@workflow.step
+def simple_sequential():
+    x = source1.step()
+    y = append1.step(x)
+    return append2.step(y)
+
+
+@workflow.step
+def simple_sequential_with_input(x):
+    y = append1.step(x)
+    return append2.step(y)
+
+
+@workflow.step
+def loop_sequential(n):
+    x = source1.step()
+    for _ in range(n):
+        x = append1.step(x)
+    return append2.step(x)
+
+
+@workflow.step
+def nested_step(x):
+    return append2.step(append1.step(x + "~[nested]~"))
+
+
+@workflow.step
+def nested(x):
+    return nested_step.step(x)
+
+
+@workflow.step
+def join(x, y):
+    return f"join({x}, {y})"
+
+
+@workflow.step
+def fork_join():
+    x = source1.step()
+    y = append1.step(x)
+    y = identity.step(y)
+    z = append2.step(x)
+    return join.step(y, z)
+
+
+def test_basic_workflows():
+    ray.init()
+
+    output = workflow.run(simple_sequential.step())
+    assert ray.get(output) == "[source1][append1][append2]"
+
+    output = workflow.run(simple_sequential_with_input.step("start:"))
+    assert ray.get(output) == "start:[append1][append2]"
+
+    output = workflow.run(loop_sequential.step(3))
+    assert ray.get(output) == "[source1]" + "[append1]" * 3 + "[append2]"
+
+    output = workflow.run(nested.step("nested:"))
+    assert ray.get(output) == "nested:~[nested]~[append1][append2]"
+
+    output = workflow.run(fork_join.step())
+    assert ray.get(output) == "join([source1][append1], [source1][append2])"
+
+    ray.shutdown()

--- a/python/ray/experimental/workflow/tests/test_large_intermediate.py
+++ b/python/ray/experimental/workflow/tests/test_large_intermediate.py
@@ -1,0 +1,39 @@
+import time
+
+import numpy as np
+from ray.experimental import workflow
+
+
+@workflow.step
+def large_input():
+    return np.arange(2**24)
+
+
+@workflow.step
+def identity(x):
+    return x
+
+
+@workflow.step
+def average(x):
+    return np.mean(x)
+
+
+@workflow.step
+def simple_large_intermediate():
+    x = large_input.step()
+    y = identity.step(x)
+    return average.step(y)
+
+
+def test_simple_large_intermediate():
+    import ray
+    ray.init()
+
+    start = time.time()
+    outputs = workflow.run(simple_large_intermediate.step())
+    outputs = ray.get(outputs)
+    print(f"duration = {time.time() - start}")
+
+    assert np.isclose(outputs, 8388607.5)
+    ray.shutdown()

--- a/python/ray/experimental/workflow/tests/test_recursion_factorial.py
+++ b/python/ray/experimental/workflow/tests/test_recursion_factorial.py
@@ -1,0 +1,28 @@
+from ray.experimental import workflow
+
+
+@workflow.step
+def mul(a, b):
+    return a * b
+
+
+@workflow.step
+def factorial(n):
+    if n == 1:
+        return 1
+    else:
+        return mul.step(n, factorial.step(n - 1))
+
+
+@workflow.step
+def recursion_factorial(n):
+    return factorial.step(n)
+
+
+def test_recursion_factorial():
+    import ray
+    ray.init()
+
+    outputs = workflow.run(recursion_factorial.step(10))
+    assert ray.get(outputs) == 3628800
+    ray.shutdown()

--- a/python/ray/experimental/workflow/tests/test_variable_mutable.py
+++ b/python/ray/experimental/workflow/tests/test_variable_mutable.py
@@ -1,0 +1,29 @@
+from ray.experimental import workflow
+
+
+@workflow.step
+def identity(x):
+    return x
+
+
+@workflow.step
+def projection(x, _):
+    return x
+
+
+@workflow.step
+def variable_mutable():
+    x = []
+    a = identity.step(x)
+    x.append(1)
+    b = identity.step(x)
+    return projection.step(a, b)
+
+
+def test_variable_mutable():
+    import ray
+    ray.init()
+
+    outputs = workflow.run(variable_mutable.step())
+    assert ray.get(outputs) == []
+    ray.shutdown()

--- a/python/ray/experimental/workflow/workflow_context.py
+++ b/python/ray/experimental/workflow/workflow_context.py
@@ -1,0 +1,61 @@
+import pathlib
+from typing import Optional
+
+
+class WorkflowStepContext:
+    # TODO(suquark): we have to skip some type hints here, because we are
+    # still not quite sure what should be the correct type. It will finalize
+    # we we receive enough feedback about the API.
+    def __init__(self,
+                 workflow_id=None,
+                 workflow_root_dir=None,
+                 workflow_scope=None):
+        """
+        The structure for saving workflow step context. The context provides
+        critical info (e.g. where to checkpoint, which is its parent step)
+        for the step to execute correctly.
+
+        Args:
+            workflow_id: The workflow job ID.
+            workflow_root_dir: The working directory of the workflow, used for
+                checkpointing etc.
+            workflow_scope: The "calling stack" of the current workflow step.
+                It describe the parent workflow steps.
+        """
+        self.workflow_id = workflow_id
+        self.workflow_root_dir = workflow_root_dir
+        self.workflow_scope = workflow_scope or []
+
+    def __reduce__(self):
+        return WorkflowStepContext, (self.workflow_id, self.workflow_root_dir,
+                                     self.workflow_scope)
+
+
+_context: Optional[WorkflowStepContext] = None
+
+
+def init_workflow_step_context(workflow_id, workflow_root_dir) -> None:
+    global _context
+    if workflow_root_dir is not None:
+        workflow_root_dir = pathlib.Path(workflow_root_dir)
+    else:
+        workflow_root_dir = pathlib.Path.cwd() / ".rayflow"
+    assert workflow_id is not None
+    _context = WorkflowStepContext(workflow_id, workflow_root_dir)
+
+
+def get_workflow_step_context() -> Optional[WorkflowStepContext]:
+    return _context
+
+
+def set_workflow_step_context(context: Optional[WorkflowStepContext]):
+    global _context
+    _context = context
+
+
+def get_scope():
+    return _context.workflow_scope
+
+
+def get_workflow_root_dir():
+    return _context.workflow_root_dir

--- a/python/ray/experimental/workflow/workflow_manager.py
+++ b/python/ray/experimental/workflow/workflow_manager.py
@@ -1,0 +1,187 @@
+import functools
+from typing import List, Tuple, Union, Any, Dict, Callable, Optional
+import uuid
+
+import ray
+
+from ray.experimental.workflow import workflow_context
+
+RRef = ray.ObjectRef  # Alias ObjectRef because it is too long in type hints.
+WorkflowOutputType = RRef  # Alias workflow output type.
+StepArgType = Union[RRef, Any]
+
+
+def resolve_object_ref(ref: RRef) -> Tuple[Any, RRef]:
+    """
+    Resolves the ObjectRef into the object instance.
+
+    Returns:
+        The object instance and the direct ObjectRef to the instance.
+    """
+    assert ray.is_initialized()
+    last_ref = ref
+    while True:
+        if isinstance(ref, RRef):
+            last_ref = ref
+        else:
+            break
+        ref = ray.get(last_ref)
+    return ref, last_ref
+
+
+def wrap_step_outputs(
+        outputs: WorkflowOutputType) -> Tuple[WorkflowOutputType, List[str]]:
+    """
+    This function converts returned object refs to workflow
+    step results. It also collects hex strings of these refs.
+
+    Args:
+        outputs: The outputs of a Ray remote call.
+
+    Returns:
+        Corresponding WorkflowStepResult objects and
+        related hex string.
+    """
+    if isinstance(outputs, RRef):
+        results = [outputs]
+    elif isinstance(outputs, tuple):
+        results = outputs
+    else:
+        raise TypeError("Unknown return type")
+    output_ids = [o.hex() for o in results]
+    return outputs, output_ids
+
+
+def resolve_step_inputs(args: List[RRef], kwargs: Dict[str, RRef]
+                        ) -> Tuple[List, Dict, List[RRef]]:
+    """
+    This function resolves the inputs for the code inside
+    a workflow step (works on the callee side).
+    For each ObjectRef argument, the function returns both the ObjectRef
+    and the object instance. If the ObjectRef is a chain of nested
+    ObjectRefs, then we resolve it recursively until we get the
+    object instance, and we return the *direct* ObjectRef of the
+    instance. This function does not resolve ObjectRef
+    inside another object (e.g. list of ObjectRefs) to give users some
+    flexibility.
+
+    Args:
+        args: List of workflow step input arguments.
+        kwargs: Dict of workflow step input arguments.
+
+    Returns:
+        Instances of arguments and resolved object refs.
+    """
+
+    resolved_object_refs = []
+    _args = []
+    _kwargs = {}
+    for a in args:
+        if isinstance(a, RRef):
+            obj, ref = resolve_object_ref(a)
+            _args.append(obj)
+            resolved_object_refs.append(ref)
+        else:
+            _args.append(a)
+    for k, v in kwargs:
+        if isinstance(v, RRef):
+            obj, ref = resolve_object_ref(v)
+            _kwargs[k] = obj
+            resolved_object_refs.append(ref)
+        else:
+            _kwargs[k] = v
+    return _args, _kwargs, resolved_object_refs
+
+
+class WorkflowStepFunction:
+    def __init__(self, func: Callable):
+        def _func(context, task_id, args, kwargs):
+            # NOTE: must use 'set_current_store_dir' to ensure that we are
+            # accessing the correct global variable.
+            workflow_context.set_workflow_step_context(context)
+            scope = workflow_context.get_scope()
+            scope.append(task_id)
+            args, kwargs, resolved_object_refs = resolve_step_inputs(
+                args, kwargs)
+            # free references to potentially save memory
+            del resolved_object_refs
+
+            output = func(*args, **kwargs)
+            if isinstance(output, Workflow):
+                output = output.execute()
+            return output
+
+        self.func = func
+        self._remote_function = ray.remote(_func)
+
+        # Override signature and docstring
+        @functools.wraps(func)
+        def _build_workflow(*args, **kwargs) -> Workflow:
+            # TODO(suquark): we can validate if the input arguments match
+            # the signature of the original function here.
+            return Workflow(self._run_step, args, kwargs)
+
+        self.step = _build_workflow
+
+    def _run_step(self, args, kwargs):
+        task_id = uuid.uuid4()
+        refs = self._remote_function.remote(
+            workflow_context.get_workflow_step_context(), task_id, args,
+            kwargs)
+        outputs, output_ids = wrap_step_outputs(refs)
+        return outputs
+
+
+class Workflow:
+    def __init__(self, step_func: Callable, args: Tuple,
+                 kwargs: Dict[str, Any]):
+        self.args: List[RRef] = []
+        self.kwargs: Dict[str, RRef] = {}
+        # NOTE: we must serialize the inputs here, so they cannot be
+        # mutable later.
+        for arg in args:
+            if isinstance(arg, (ray.ObjectRef, Workflow)):
+                self.args.append(arg)
+            else:
+                self.args.append(ray.put(arg))
+        for k, v in kwargs:
+            if isinstance(v, (ray.ObjectRef, Workflow)):
+                self.kwargs[k] = v
+            else:
+                self.kwargs[k] = ray.put(v)
+        self.step_func = step_func
+        self._executed = False
+        self._output: Optional[WorkflowOutputType] = None
+
+    @property
+    def executed(self) -> bool:
+        return self._executed
+
+    @property
+    def output(self):
+        if not self._executed:
+            raise Exception("The workflow has not been executed.")
+        return self._output
+
+    def execute(self) -> WorkflowOutputType:
+        """
+        Trigger workflow execution recursively.
+        """
+        if self.executed:
+            return self._output
+        input_args = []
+        input_kwargs = {}
+        for a in self.args:
+            if isinstance(a, Workflow):
+                input_args.append(a.execute())
+            else:
+                input_args.append(a)
+        for k, v in self.kwargs.items():
+            if isinstance(v, Workflow):
+                input_kwargs[k] = v.execute()
+            else:
+                input_kwargs[k] = v
+        output = self.step_func(input_args, input_kwargs)
+        if not isinstance(output, WorkflowOutputType):
+            raise TypeError("Unexpected return type of the workflow.")
+        return output


### PR DESCRIPTION
API design covered:

* Entrypoint of workflow. (The interface to launch a workflow)
* Workflow steps (use decorators to cover a function into a workflow step)
* Lazy submission (`workflow.step` returns a `Workflow` object that will be executed when returned from another step)
* Simplest nested workflow
 
API design limited:

* A workflow step only returns a single value (single `Workflow` object). Not sure if we need to implement multiple values later.
* When a workflow id is not specified, it comes from the timestamp. It may not be human readable.
* Some corner case checks (e.g. someone passes `WorkflowStepResult`enclosed in a python object to another workflow step)

API design excluded (too much for this PR):

* Resolve nested workflow objects (e.g. workflow in a list)

* Stuff related to storage

* Fault tolerance

* Workflow step retry

* Schedule

* ...
 
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
