### PR TITLE
[core] Record Plasma object sources and dump on out of memory

### DIFF
--- a/python/ray/_raylet.pxd
+++ b/python/ray/_raylet.pxd
@@ -104,6 +104,7 @@ cdef class CoreWorker:
                             size_t data_size, ObjectRef object_ref,
                             c_vector[CObjectID] contained_ids,
                             CObjectID *c_object_id, shared_ptr[CBuffer] *data,
+                            c_bool created_by_worker,
                             owner_address=*)
     cdef store_task_outputs(
             self, worker, outputs, const c_vector[CObjectID] return_ids,

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1010,6 +1010,7 @@ cdef class CoreWorker:
                             size_t data_size, ObjectRef object_ref,
                             c_vector[CObjectID] contained_ids,
                             CObjectID *c_object_id, shared_ptr[CBuffer] *data,
+                            c_bool created_by_worker,
                             owner_address=None):
         cdef:
             CAddress c_owner_address
@@ -1018,7 +1019,7 @@ cdef class CoreWorker:
             with nogil:
                 check_status(CCoreWorkerProcess.GetCoreWorker().CreateOwned(
                              metadata, data_size, contained_ids,
-                             c_object_id, data))
+                             c_object_id, data, created_by_worker))
         else:
             c_object_id[0] = object_ref.native()
             if owner_address is None:
@@ -1030,7 +1031,7 @@ cdef class CoreWorker:
             with nogil:
                 check_status(CCoreWorkerProcess.GetCoreWorker().CreateExisting(
                             metadata, data_size, c_object_id[0],
-                            c_owner_address, data))
+                            c_owner_address, data, created_by_worker))
 
         # If data is nullptr, that means the ObjectRef already existed,
         # which we ignore.
@@ -1065,7 +1066,7 @@ cdef class CoreWorker:
         object_already_exists = self._create_put_buffer(
             metadata_buf, data_size, object_ref,
             ObjectRefsToVector([]),
-            &c_object_id, &data_buf, owner_address)
+            &c_object_id, &data_buf, False, owner_address)
         if object_already_exists:
             logger.debug("Object already exists in 'put_file_like_object'.")
             return
@@ -1102,7 +1103,7 @@ cdef class CoreWorker:
         object_already_exists = self._create_put_buffer(
             metadata, total_bytes, object_ref,
             ObjectRefsToVector(serialized_object.contained_object_refs),
-            &c_object_id, &data)
+            &c_object_id, &data, True)
 
         if not object_already_exists:
             if total_bytes > 0:

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -184,12 +184,14 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         CRayStatus CreateOwned(const shared_ptr[CBuffer] &metadata,
                                const size_t data_size,
                                const c_vector[CObjectID] &contained_object_ids,
-                               CObjectID *object_id, shared_ptr[CBuffer] *data)
+                               CObjectID *object_id, shared_ptr[CBuffer] *data,
+                               c_bool created_by_worker)
         CRayStatus CreateExisting(const shared_ptr[CBuffer] &metadata,
                                   const size_t data_size,
                                   const CObjectID &object_id,
                                   const CAddress &owner_address,
-                                  shared_ptr[CBuffer] *data)
+                                  shared_ptr[CBuffer] *data,
+                                  c_bool created_by_worker)
         CRayStatus SealOwned(const CObjectID &object_id, c_bool pin_object)
         CRayStatus SealExisting(const CObjectID &object_id, c_bool pin_object)
         CRayStatus Get(const c_vector[CObjectID] &ids, int64_t timeout_ms,

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1099,9 +1099,9 @@ Status CoreWorker::CreateOwned(const std::shared_ptr<Buffer> &metadata,
        static_cast<int64_t>(data_size) < max_direct_call_object_size_)) {
     *data = std::make_shared<LocalMemoryBuffer>(data_size);
   } else {
-    auto status =
-        plasma_store_provider_->Create(metadata, data_size, *object_id,
-                                       /* owner_address = */ rpc_address_, data, created_by_worker);
+    auto status = plasma_store_provider_->Create(metadata, data_size, *object_id,
+                                                 /* owner_address = */ rpc_address_, data,
+                                                 created_by_worker);
     if (!status.ok() || !data) {
       reference_counter_->RemoveOwnedObject(*object_id);
       return status;
@@ -1113,8 +1113,7 @@ Status CoreWorker::CreateOwned(const std::shared_ptr<Buffer> &metadata,
 Status CoreWorker::CreateExisting(const std::shared_ptr<Buffer> &metadata,
                                   const size_t data_size, const ObjectID &object_id,
                                   const rpc::Address &owner_address,
-                                  std::shared_ptr<Buffer> *data,
-                                  bool created_by_worker) {
+                                  std::shared_ptr<Buffer> *data, bool created_by_worker) {
   if (options_.is_local_mode) {
     return Status::NotImplemented(
         "Creating an object with a pre-existing ObjectID is not supported in local "
@@ -1983,9 +1982,9 @@ Status CoreWorker::AllocateReturnObject(const ObjectID &object_id,
         static_cast<int64_t>(data_size) < max_direct_call_object_size_) {
       data_buffer = std::make_shared<LocalMemoryBuffer>(data_size);
     } else {
-      RAY_RETURN_NOT_OK(
-          CreateExisting(metadata, data_size, object_id, owner_address, &data_buffer,
-            /*created_by_worker=*/true));
+      RAY_RETURN_NOT_OK(CreateExisting(metadata, data_size, object_id, owner_address,
+                                       &data_buffer,
+                                       /*created_by_worker=*/true));
       object_already_exists = !data_buffer;
     }
   }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1086,7 +1086,8 @@ Status CoreWorker::Put(const RayObject &object,
 Status CoreWorker::CreateOwned(const std::shared_ptr<Buffer> &metadata,
                                const size_t data_size,
                                const std::vector<ObjectID> &contained_object_ids,
-                               ObjectID *object_id, std::shared_ptr<Buffer> *data) {
+                               ObjectID *object_id, std::shared_ptr<Buffer> *data,
+                               bool created_by_worker) {
   *object_id = ObjectID::FromIndex(worker_context_.GetCurrentTaskID(),
                                    worker_context_.GetNextPutIndex());
   reference_counter_->AddOwnedObject(*object_id, contained_object_ids, rpc_address_,
@@ -1100,7 +1101,7 @@ Status CoreWorker::CreateOwned(const std::shared_ptr<Buffer> &metadata,
   } else {
     auto status =
         plasma_store_provider_->Create(metadata, data_size, *object_id,
-                                       /* owner_address = */ rpc_address_, data);
+                                       /* owner_address = */ rpc_address_, data, created_by_worker);
     if (!status.ok() || !data) {
       reference_counter_->RemoveOwnedObject(*object_id);
       return status;
@@ -1112,14 +1113,15 @@ Status CoreWorker::CreateOwned(const std::shared_ptr<Buffer> &metadata,
 Status CoreWorker::CreateExisting(const std::shared_ptr<Buffer> &metadata,
                                   const size_t data_size, const ObjectID &object_id,
                                   const rpc::Address &owner_address,
-                                  std::shared_ptr<Buffer> *data) {
+                                  std::shared_ptr<Buffer> *data,
+                                  bool created_by_worker) {
   if (options_.is_local_mode) {
     return Status::NotImplemented(
         "Creating an object with a pre-existing ObjectID is not supported in local "
         "mode");
   } else {
     return plasma_store_provider_->Create(metadata, data_size, object_id, owner_address,
-                                          data);
+                                          data, created_by_worker);
   }
 }
 
@@ -1982,7 +1984,8 @@ Status CoreWorker::AllocateReturnObject(const ObjectID &object_id,
       data_buffer = std::make_shared<LocalMemoryBuffer>(data_size);
     } else {
       RAY_RETURN_NOT_OK(
-          CreateExisting(metadata, data_size, object_id, owner_address, &data_buffer));
+          CreateExisting(metadata, data_size, object_id, owner_address, &data_buffer,
+            /*created_by_worker=*/true));
       object_already_exists = !data_buffer;
     }
   }

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -538,7 +538,8 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \return Status.
   Status CreateOwned(const std::shared_ptr<Buffer> &metadata, const size_t data_size,
                      const std::vector<ObjectID> &contained_object_ids,
-                     ObjectID *object_id, std::shared_ptr<Buffer> *data);
+                     ObjectID *object_id, std::shared_ptr<Buffer> *data,
+                     bool created_by_worker);
 
   /// Create and return a buffer in the object store that can be directly written
   /// into, for an object ID that already exists. After writing to the buffer, the
@@ -554,7 +555,8 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \return Status.
   Status CreateExisting(const std::shared_ptr<Buffer> &metadata, const size_t data_size,
                         const ObjectID &object_id, const rpc::Address &owner_address,
-                        std::shared_ptr<Buffer> *data);
+                        std::shared_ptr<Buffer> *data,
+                        bool created_by_worker);
 
   /// Finalize placing an object into the object store. This should be called after
   /// a corresponding `CreateOwned()` call and then writing into the returned buffer.

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -555,8 +555,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \return Status.
   Status CreateExisting(const std::shared_ptr<Buffer> &metadata, const size_t data_size,
                         const ObjectID &object_id, const rpc::Address &owner_address,
-                        std::shared_ptr<Buffer> *data,
-                        bool created_by_worker);
+                        std::shared_ptr<Buffer> *data, bool created_by_worker);
 
   /// Finalize placing an object into the object store. This should be called after
   /// a corresponding `CreateOwned()` call and then writing into the returned buffer.

--- a/src/ray/core_worker/lib/java/io_ray_runtime_object_NativeObjectStore.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_object_NativeObjectStore.cc
@@ -35,11 +35,12 @@ ray::Status PutSerializedObject(JNIEnv *env, jobject obj, ray::ObjectID object_i
   if (object_id.IsNil()) {
     status = ray::CoreWorkerProcess::GetCoreWorker().CreateOwned(
         native_ray_object->GetMetadata(), data_size, native_ray_object->GetNestedIds(),
-        out_object_id, &data);
+        out_object_id, &data, /*created_by_worker=*/true);
   } else {
     status = ray::CoreWorkerProcess::GetCoreWorker().CreateExisting(
         native_ray_object->GetMetadata(), data_size, object_id,
-        ray::CoreWorkerProcess::GetCoreWorker().GetRpcAddress(), &data);
+        ray::CoreWorkerProcess::GetCoreWorker().GetRpcAddress(), &data,
+        /*created_by_worker=*/true);
     *out_object_id = object_id;
   }
   if (!status.ok()) {

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -90,7 +90,7 @@ Status CoreWorkerPlasmaStoreProvider::Put(const RayObject &object,
   std::shared_ptr<Buffer> data;
   RAY_RETURN_NOT_OK(Create(object.GetMetadata(),
                            object.HasData() ? object.GetData()->Size() : 0, object_id,
-                           owner_address, &data));
+                           owner_address, &data, /*created_by_worker=*/true));
   // data could be a nullptr if the ObjectID already existed, but this does
   // not throw an error.
   if (data != nullptr) {
@@ -111,11 +111,15 @@ Status CoreWorkerPlasmaStoreProvider::Create(const std::shared_ptr<Buffer> &meta
                                              const size_t data_size,
                                              const ObjectID &object_id,
                                              const rpc::Address &owner_address,
-                                             std::shared_ptr<Buffer> *data) {
+                                             std::shared_ptr<Buffer> *data, bool created_by_worker) {
   uint64_t retry_with_request_id = 0;
+  auto source = plasma::flatbuf::ObjectSource::CreatedByWorker;
+  if (!created_by_worker) {
+    source = plasma::flatbuf::ObjectSource::RestoredFromStorage;
+  }
   Status status = store_client_.Create(
       object_id, owner_address, data_size, metadata ? metadata->Data() : nullptr,
-      metadata ? metadata->Size() : 0, &retry_with_request_id, data,
+      metadata ? metadata->Size() : 0, &retry_with_request_id, data, source,
       /*device_num=*/0);
 
   while (retry_with_request_id > 0) {
@@ -436,7 +440,7 @@ void CoreWorkerPlasmaStoreProvider::WarnIfAttemptedTooManyTimes(
 Status CoreWorkerPlasmaStoreProvider::WarmupStore() {
   ObjectID object_id = ObjectID::FromRandom();
   std::shared_ptr<Buffer> data;
-  RAY_RETURN_NOT_OK(Create(nullptr, 8, object_id, rpc::Address(), &data));
+  RAY_RETURN_NOT_OK(Create(nullptr, 8, object_id, rpc::Address(), &data, /*created_by_worker=*/true));
   RAY_RETURN_NOT_OK(Seal(object_id));
   RAY_RETURN_NOT_OK(Release(object_id));
   RAY_RETURN_NOT_OK(Delete({object_id}, true));

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -111,7 +111,8 @@ Status CoreWorkerPlasmaStoreProvider::Create(const std::shared_ptr<Buffer> &meta
                                              const size_t data_size,
                                              const ObjectID &object_id,
                                              const rpc::Address &owner_address,
-                                             std::shared_ptr<Buffer> *data, bool created_by_worker) {
+                                             std::shared_ptr<Buffer> *data,
+                                             bool created_by_worker) {
   uint64_t retry_with_request_id = 0;
   auto source = plasma::flatbuf::ObjectSource::CreatedByWorker;
   if (!created_by_worker) {
@@ -440,7 +441,8 @@ void CoreWorkerPlasmaStoreProvider::WarnIfAttemptedTooManyTimes(
 Status CoreWorkerPlasmaStoreProvider::WarmupStore() {
   ObjectID object_id = ObjectID::FromRandom();
   std::shared_ptr<Buffer> data;
-  RAY_RETURN_NOT_OK(Create(nullptr, 8, object_id, rpc::Address(), &data, /*created_by_worker=*/true));
+  RAY_RETURN_NOT_OK(
+      Create(nullptr, 8, object_id, rpc::Address(), &data, /*created_by_worker=*/true));
   RAY_RETURN_NOT_OK(Seal(object_id));
   RAY_RETURN_NOT_OK(Release(object_id));
   RAY_RETURN_NOT_OK(Delete({object_id}, true));

--- a/src/ray/core_worker/store_provider/plasma_store_provider.h
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.h
@@ -119,7 +119,7 @@ class CoreWorkerPlasmaStoreProvider {
   /// \param[out] data The mutable object buffer in plasma that can be written to.
   Status Create(const std::shared_ptr<Buffer> &metadata, const size_t data_size,
                 const ObjectID &object_id, const rpc::Address &owner_address,
-                std::shared_ptr<Buffer> *data);
+                std::shared_ptr<Buffer> *data, bool created_by_worker);
 
   /// Seal an object buffer created with Create().
   ///

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -109,7 +109,7 @@ std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> ObjectBufferPool::Cr
     // Try to create shared buffer.
     std::shared_ptr<Buffer> data;
     Status s = store_client_.TryCreateImmediately(object_id, owner_address, object_size,
-                                                  NULL, metadata_size, &data);
+                                                  NULL, metadata_size, &data, plasma::flatbuf::ObjectSource::ReceivedFromRemoteRaylet);
     std::vector<boost::asio::mutable_buffer> buffer;
     if (!s.ok()) {
       // Create failed. The object may already exist locally. If something else went

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -108,8 +108,9 @@ std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> ObjectBufferPool::Cr
     int64_t object_size = data_size - metadata_size;
     // Try to create shared buffer.
     std::shared_ptr<Buffer> data;
-    Status s = store_client_.TryCreateImmediately(object_id, owner_address, object_size,
-                                                  NULL, metadata_size, &data, plasma::flatbuf::ObjectSource::ReceivedFromRemoteRaylet);
+    Status s = store_client_.TryCreateImmediately(
+        object_id, owner_address, object_size, NULL, metadata_size, &data,
+        plasma::flatbuf::ObjectSource::ReceivedFromRemoteRaylet);
     std::vector<boost::asio::mutable_buffer> buffer;
     if (!s.ok()) {
       // Create failed. The object may already exist locally. If something else went

--- a/src/ray/object_manager/plasma/client.cc
+++ b/src/ray/object_manager/plasma/client.cc
@@ -110,6 +110,7 @@ class PlasmaClient::Impl : public std::enable_shared_from_this<PlasmaClient::Imp
   Status Create(const ObjectID &object_id, const ray::rpc::Address &owner_address,
                 int64_t data_size, const uint8_t *metadata, int64_t metadata_size,
                 uint64_t *retry_with_request_id, std::shared_ptr<Buffer> *data,
+                fb::ObjectSource source,
                 int device_num = 0);
 
   Status RetryCreate(const ObjectID &object_id, uint64_t request_id,
@@ -119,7 +120,8 @@ class PlasmaClient::Impl : public std::enable_shared_from_this<PlasmaClient::Imp
   Status TryCreateImmediately(const ObjectID &object_id,
                               const ray::rpc::Address &owner_address, int64_t data_size,
                               const uint8_t *metadata, int64_t metadata_size,
-                              std::shared_ptr<Buffer> *data, int device_num);
+                              std::shared_ptr<Buffer> *data,
+                              fb::ObjectSource source, int device_num);
 
   Status Get(const std::vector<ObjectID> &object_ids, int64_t timeout_ms,
              std::vector<ObjectBuffer> *object_buffers, bool is_from_worker);
@@ -321,13 +323,13 @@ Status PlasmaClient::Impl::Create(const ObjectID &object_id,
                                   const ray::rpc::Address &owner_address,
                                   int64_t data_size, const uint8_t *metadata,
                                   int64_t metadata_size, uint64_t *retry_with_request_id,
-                                  std::shared_ptr<Buffer> *data, int device_num) {
+                                  std::shared_ptr<Buffer> *data, fb::ObjectSource source, int device_num) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
 
   RAY_LOG(DEBUG) << "called plasma_create on conn " << store_conn_ << " with size "
                  << data_size << " and metadata size " << metadata_size;
   RAY_RETURN_NOT_OK(SendCreateRequest(store_conn_, object_id, owner_address, data_size,
-                                      metadata_size, device_num,
+                                      metadata_size, source, device_num,
                                       /*try_immediately=*/false));
   return HandleCreateReply(object_id, metadata, retry_with_request_id, data);
 }
@@ -344,13 +346,14 @@ Status PlasmaClient::Impl::RetryCreate(const ObjectID &object_id, uint64_t reque
 Status PlasmaClient::Impl::TryCreateImmediately(
     const ObjectID &object_id, const ray::rpc::Address &owner_address, int64_t data_size,
     const uint8_t *metadata, int64_t metadata_size, std::shared_ptr<Buffer> *data,
+    fb::ObjectSource source,
     int device_num) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
 
   RAY_LOG(DEBUG) << "called plasma_create on conn " << store_conn_ << " with size "
                  << data_size << " and metadata size " << metadata_size;
   RAY_RETURN_NOT_OK(SendCreateRequest(store_conn_, object_id, owner_address, data_size,
-                                      metadata_size, device_num,
+                                      metadata_size, source, device_num,
                                       /*try_immediately=*/true));
   return HandleCreateReply(object_id, metadata, nullptr, data);
 }
@@ -724,9 +727,9 @@ Status PlasmaClient::Create(const ObjectID &object_id,
                             const ray::rpc::Address &owner_address, int64_t data_size,
                             const uint8_t *metadata, int64_t metadata_size,
                             uint64_t *retry_with_request_id,
-                            std::shared_ptr<Buffer> *data, int device_num) {
+                            std::shared_ptr<Buffer> *data, fb::ObjectSource source, int device_num) {
   return impl_->Create(object_id, owner_address, data_size, metadata, metadata_size,
-                       retry_with_request_id, data, device_num);
+                       retry_with_request_id, data, source, device_num);
 }
 
 Status PlasmaClient::RetryCreate(const ObjectID &object_id, uint64_t request_id,
@@ -739,9 +742,9 @@ Status PlasmaClient::TryCreateImmediately(const ObjectID &object_id,
                                           const ray::rpc::Address &owner_address,
                                           int64_t data_size, const uint8_t *metadata,
                                           int64_t metadata_size,
-                                          std::shared_ptr<Buffer> *data, int device_num) {
+                                          std::shared_ptr<Buffer> *data, fb::ObjectSource source, int device_num) {
   return impl_->TryCreateImmediately(object_id, owner_address, data_size, metadata,
-                                     metadata_size, data, device_num);
+                                     metadata_size, data, source, device_num);
 }
 
 Status PlasmaClient::Get(const std::vector<ObjectID> &object_ids, int64_t timeout_ms,

--- a/src/ray/object_manager/plasma/client.cc
+++ b/src/ray/object_manager/plasma/client.cc
@@ -110,8 +110,7 @@ class PlasmaClient::Impl : public std::enable_shared_from_this<PlasmaClient::Imp
   Status Create(const ObjectID &object_id, const ray::rpc::Address &owner_address,
                 int64_t data_size, const uint8_t *metadata, int64_t metadata_size,
                 uint64_t *retry_with_request_id, std::shared_ptr<Buffer> *data,
-                fb::ObjectSource source,
-                int device_num = 0);
+                fb::ObjectSource source, int device_num = 0);
 
   Status RetryCreate(const ObjectID &object_id, uint64_t request_id,
                      const uint8_t *metadata, uint64_t *retry_with_request_id,
@@ -120,8 +119,8 @@ class PlasmaClient::Impl : public std::enable_shared_from_this<PlasmaClient::Imp
   Status TryCreateImmediately(const ObjectID &object_id,
                               const ray::rpc::Address &owner_address, int64_t data_size,
                               const uint8_t *metadata, int64_t metadata_size,
-                              std::shared_ptr<Buffer> *data,
-                              fb::ObjectSource source, int device_num);
+                              std::shared_ptr<Buffer> *data, fb::ObjectSource source,
+                              int device_num);
 
   Status Get(const std::vector<ObjectID> &object_ids, int64_t timeout_ms,
              std::vector<ObjectBuffer> *object_buffers, bool is_from_worker);
@@ -323,7 +322,8 @@ Status PlasmaClient::Impl::Create(const ObjectID &object_id,
                                   const ray::rpc::Address &owner_address,
                                   int64_t data_size, const uint8_t *metadata,
                                   int64_t metadata_size, uint64_t *retry_with_request_id,
-                                  std::shared_ptr<Buffer> *data, fb::ObjectSource source, int device_num) {
+                                  std::shared_ptr<Buffer> *data, fb::ObjectSource source,
+                                  int device_num) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
 
   RAY_LOG(DEBUG) << "called plasma_create on conn " << store_conn_ << " with size "
@@ -346,8 +346,7 @@ Status PlasmaClient::Impl::RetryCreate(const ObjectID &object_id, uint64_t reque
 Status PlasmaClient::Impl::TryCreateImmediately(
     const ObjectID &object_id, const ray::rpc::Address &owner_address, int64_t data_size,
     const uint8_t *metadata, int64_t metadata_size, std::shared_ptr<Buffer> *data,
-    fb::ObjectSource source,
-    int device_num) {
+    fb::ObjectSource source, int device_num) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
 
   RAY_LOG(DEBUG) << "called plasma_create on conn " << store_conn_ << " with size "
@@ -727,7 +726,8 @@ Status PlasmaClient::Create(const ObjectID &object_id,
                             const ray::rpc::Address &owner_address, int64_t data_size,
                             const uint8_t *metadata, int64_t metadata_size,
                             uint64_t *retry_with_request_id,
-                            std::shared_ptr<Buffer> *data, fb::ObjectSource source, int device_num) {
+                            std::shared_ptr<Buffer> *data, fb::ObjectSource source,
+                            int device_num) {
   return impl_->Create(object_id, owner_address, data_size, metadata, metadata_size,
                        retry_with_request_id, data, source, device_num);
 }
@@ -742,7 +742,8 @@ Status PlasmaClient::TryCreateImmediately(const ObjectID &object_id,
                                           const ray::rpc::Address &owner_address,
                                           int64_t data_size, const uint8_t *metadata,
                                           int64_t metadata_size,
-                                          std::shared_ptr<Buffer> *data, fb::ObjectSource source, int device_num) {
+                                          std::shared_ptr<Buffer> *data,
+                                          fb::ObjectSource source, int device_num) {
   return impl_->TryCreateImmediately(object_id, owner_address, data_size, metadata,
                                      metadata_size, data, source, device_num);
 }

--- a/src/ray/object_manager/plasma/client.h
+++ b/src/ray/object_manager/plasma/client.h
@@ -102,6 +102,7 @@ class PlasmaClient {
   Status Create(const ObjectID &object_id, const ray::rpc::Address &owner_address,
                 int64_t data_size, const uint8_t *metadata, int64_t metadata_size,
                 uint64_t *retry_with_request_id, std::shared_ptr<Buffer> *data,
+                plasma::flatbuf::ObjectSource source,
                 int device_num = 0);
 
   /// Retry a previous Create call using the returned request ID.
@@ -146,7 +147,9 @@ class PlasmaClient {
   Status TryCreateImmediately(const ObjectID &object_id,
                               const ray::rpc::Address &owner_address, int64_t data_size,
                               const uint8_t *metadata, int64_t metadata_size,
-                              std::shared_ptr<Buffer> *data, int device_num = 0);
+                              std::shared_ptr<Buffer> *data,
+                              plasma::flatbuf::ObjectSource source,
+                              int device_num = 0);
 
   /// Get some objects from the Plasma Store. This function will block until the
   /// objects have all been created and sealed in the Plasma Store or the

--- a/src/ray/object_manager/plasma/client.h
+++ b/src/ray/object_manager/plasma/client.h
@@ -102,8 +102,7 @@ class PlasmaClient {
   Status Create(const ObjectID &object_id, const ray::rpc::Address &owner_address,
                 int64_t data_size, const uint8_t *metadata, int64_t metadata_size,
                 uint64_t *retry_with_request_id, std::shared_ptr<Buffer> *data,
-                plasma::flatbuf::ObjectSource source,
-                int device_num = 0);
+                plasma::flatbuf::ObjectSource source, int device_num = 0);
 
   /// Retry a previous Create call using the returned request ID.
   ///
@@ -148,8 +147,7 @@ class PlasmaClient {
                               const ray::rpc::Address &owner_address, int64_t data_size,
                               const uint8_t *metadata, int64_t metadata_size,
                               std::shared_ptr<Buffer> *data,
-                              plasma::flatbuf::ObjectSource source,
-                              int device_num = 0);
+                              plasma::flatbuf::ObjectSource source, int device_num = 0);
 
   /// Get some objects from the Plasma Store. This function will block until the
   /// objects have all been created and sealed in the Plasma Store or the

--- a/src/ray/object_manager/plasma/common.h
+++ b/src/ray/object_manager/plasma/common.h
@@ -25,6 +25,7 @@
 
 #include "ray/common/id.h"
 #include "ray/object_manager/plasma/compat.h"
+#include "ray/object_manager/plasma/plasma_generated.h"
 
 namespace plasma {
 
@@ -83,6 +84,8 @@ struct ObjectTableEntry {
   int64_t construct_duration;
   /// The state of the object, e.g., whether it is open or sealed.
   ObjectState state;
+  /// The source of the object. Used for debugging purposes.
+  plasma::flatbuf::ObjectSource source;
 };
 
 /// Mapping from ObjectIDs to information about the object.

--- a/src/ray/object_manager/plasma/create_request_queue.cc
+++ b/src/ray/object_manager/plasma/create_request_queue.cc
@@ -117,6 +117,11 @@ Status CreateRequestQueue::ProcessRequests() {
         // actually freeing up in the object store.
         return Status::ObjectStoreFull("Waiting for grace period.");
       } else {
+        std::string dump = "";
+        if (dump_debug_info_callback_) {
+          dump = dump_debug_info_callback_();
+        }
+        RAY_LOG(INFO) << "Failed to store object " << (*request_it)->object_id << "\n" << dump;
         // Raise OOM. In this case, the request will be marked as OOM.
         // We don't return so that we can process the next entry right away.
         FinishRequest(request_it);

--- a/src/ray/object_manager/plasma/create_request_queue.cc
+++ b/src/ray/object_manager/plasma/create_request_queue.cc
@@ -26,10 +26,12 @@ namespace plasma {
 
 uint64_t CreateRequestQueue::AddRequest(const ObjectID &object_id,
                                         const std::shared_ptr<ClientInterface> &client,
-                                        const CreateObjectCallback &create_callback) {
+                                        const CreateObjectCallback &create_callback,
+                                        size_t object_size) {
   auto req_id = next_req_id_++;
   fulfilled_requests_[req_id] = nullptr;
-  queue_.emplace_back(new CreateRequest(object_id, req_id, client, create_callback));
+  queue_.emplace_back(
+      new CreateRequest(object_id, req_id, client, create_callback, object_size));
   return req_id;
 }
 
@@ -57,7 +59,7 @@ bool CreateRequestQueue::GetRequestResult(uint64_t req_id, PlasmaObject *result,
 
 std::pair<PlasmaObject, PlasmaError> CreateRequestQueue::TryRequestImmediately(
     const ObjectID &object_id, const std::shared_ptr<ClientInterface> &client,
-    const CreateObjectCallback &create_callback) {
+    const CreateObjectCallback &create_callback, size_t object_size) {
   PlasmaObject result = {};
 
   if (!queue_.empty()) {
@@ -66,7 +68,7 @@ std::pair<PlasmaObject, PlasmaError> CreateRequestQueue::TryRequestImmediately(
     return {result, PlasmaError::OutOfMemory};
   }
 
-  auto req_id = AddRequest(object_id, client, create_callback);
+  auto req_id = AddRequest(object_id, client, create_callback, object_size);
   if (!ProcessRequests().ok()) {
     // If the request was not immediately fulfillable, finish it.
     if (!queue_.empty()) {
@@ -92,6 +94,8 @@ Status CreateRequestQueue::ProcessRequest(std::unique_ptr<CreateRequest> &reques
 }
 
 Status CreateRequestQueue::ProcessRequests() {
+  // Suppress OOM dump to once per grace period.
+  bool logged_oom = false;
   while (!queue_.empty()) {
     auto request_it = queue_.begin();
     auto status = ProcessRequest(*request_it);
@@ -118,10 +122,13 @@ Status CreateRequestQueue::ProcessRequests() {
         return Status::ObjectStoreFull("Waiting for grace period.");
       } else {
         std::string dump = "";
-        if (dump_debug_info_callback_) {
+        if (dump_debug_info_callback_ && !logged_oom) {
           dump = dump_debug_info_callback_();
+          logged_oom = true;
         }
-        RAY_LOG(INFO) << "Failed to store object " << (*request_it)->object_id << "\n"
+        RAY_LOG(INFO) << "Out-of-memory: Failed to create object "
+                      << (*request_it)->object_id << " of size "
+                      << (*request_it)->object_size / 1024 / 1024 << "MB\n"
                       << dump;
         // Raise OOM. In this case, the request will be marked as OOM.
         // We don't return so that we can process the next entry right away.

--- a/src/ray/object_manager/plasma/create_request_queue.cc
+++ b/src/ray/object_manager/plasma/create_request_queue.cc
@@ -121,7 +121,8 @@ Status CreateRequestQueue::ProcessRequests() {
         if (dump_debug_info_callback_) {
           dump = dump_debug_info_callback_();
         }
-        RAY_LOG(INFO) << "Failed to store object " << (*request_it)->object_id << "\n" << dump;
+        RAY_LOG(INFO) << "Failed to store object " << (*request_it)->object_id << "\n"
+                      << dump;
         // Raise OOM. In this case, the request will be marked as OOM.
         // We don't return so that we can process the next entry right away.
         FinishRequest(request_it);

--- a/src/ray/object_manager/plasma/create_request_queue.h
+++ b/src/ray/object_manager/plasma/create_request_queue.h
@@ -54,10 +54,12 @@ class CreateRequestQueue {
   /// \param client The client that sent the request. This is used as a key to
   /// drop this request if the client disconnects.
   /// \param create_callback A callback to attempt to create the object.
+  /// \param object_size Object size in bytes.
   /// \return A request ID that can be used to get the result.
   uint64_t AddRequest(const ObjectID &object_id,
                       const std::shared_ptr<ClientInterface> &client,
-                      const CreateObjectCallback &create_callback);
+                      const CreateObjectCallback &create_callback,
+                      const size_t object_size);
 
   /// Get the result of a request.
   ///
@@ -83,12 +85,13 @@ class CreateRequestQueue {
   /// \param client The client that sent the request. This is used as a key to
   /// drop this request if the client disconnects.
   /// \param create_callback A callback to attempt to create the object.
+  /// \param object_size Object size in bytes.
   /// \return The result of the call. This will return an out-of-memory error
   /// if there are other requests queued or there is not enough space left in
   /// the object store, this will return an out-of-memory error.
   std::pair<PlasmaObject, PlasmaError> TryRequestImmediately(
       const ObjectID &object_id, const std::shared_ptr<ClientInterface> &client,
-      const CreateObjectCallback &create_callback);
+      const CreateObjectCallback &create_callback, size_t object_size);
 
   /// Process requests in the queue.
   ///
@@ -109,11 +112,12 @@ class CreateRequestQueue {
   struct CreateRequest {
     CreateRequest(const ObjectID &object_id, uint64_t request_id,
                   const std::shared_ptr<ClientInterface> &client,
-                  CreateObjectCallback create_callback)
+                  CreateObjectCallback create_callback, size_t object_size)
         : object_id(object_id),
           request_id(request_id),
           client(client),
-          create_callback(create_callback) {}
+          create_callback(create_callback),
+          object_size(object_size) {}
 
     // The ObjectID to create.
     const ObjectID object_id;
@@ -128,6 +132,8 @@ class CreateRequestQueue {
 
     // A callback to attempt to create the object.
     const CreateObjectCallback create_callback;
+
+    const size_t object_size;
 
     // The results of the creation call. These should be sent back to the
     // client once ready.

--- a/src/ray/object_manager/plasma/create_request_queue.h
+++ b/src/ray/object_manager/plasma/create_request_queue.h
@@ -36,11 +36,13 @@ class CreateRequestQueue {
   CreateRequestQueue(int64_t oom_grace_period_s,
                      ray::SpillObjectsCallback spill_objects_callback,
                      std::function<void()> trigger_global_gc,
-                     std::function<int64_t()> get_time)
+                     std::function<int64_t()> get_time,
+                     std::function<std::string()> dump_debug_info_callback = nullptr)
       : oom_grace_period_ns_(oom_grace_period_s * 1e9),
         spill_objects_callback_(spill_objects_callback),
         trigger_global_gc_(trigger_global_gc),
-        get_time_(get_time) {}
+        get_time_(get_time),
+        dump_debug_info_callback_(dump_debug_info_callback) {}
 
   /// Add a request to the queue. The caller should use the returned request ID
   /// to later get the result of the request.
@@ -160,6 +162,8 @@ class CreateRequestQueue {
 
   /// A callback to return the current time.
   const std::function<int64_t()> get_time_;
+
+  const std::function<std::string()> dump_debug_info_callback_;
 
   /// Queue of object creation requests to respond to. Requests will be placed
   /// on this queue if the object store does not have enough room at the time

--- a/src/ray/object_manager/plasma/plasma.fbs
+++ b/src/ray/object_manager/plasma/plasma.fbs
@@ -18,6 +18,18 @@
 // Plasma protocol specification
 namespace plasma.flatbuf;
 
+enum ObjectSource:int {
+  // Object was created by a worker (either task returns or `ray.put`).
+  CreatedByWorker = 0,
+  // Object was spilled and restored from external storage.
+  RestoredFromStorage,
+  // Object was received from a remote raylet.
+  ReceivedFromRemoteRaylet,
+  // The object could not be created and the raylet stored an
+  // error as the value.
+  ErrorStoredByRaylet,
+}
+
 enum MessageType:long {
   // Message that gets send when a client hangs up.
   PlasmaDisconnectClient = 0,
@@ -131,6 +143,9 @@ table PlasmaCreateRequest {
   data_size: ulong;
   // The size of the object's metadata in bytes.
   metadata_size: ulong;
+  // The source of the object (worker, raylet, etc.). Used for
+  // debug purposes.
+  source: ObjectSource;
   // Device to create buffer on.
   device_num: int;
   // Try the creation request immediately. If this is not possible (due to

--- a/src/ray/object_manager/plasma/protocol.cc
+++ b/src/ray/object_manager/plasma/protocol.cc
@@ -226,23 +226,23 @@ Status SendCreateRetryRequest(const std::shared_ptr<StoreConn> &store_conn,
 
 Status SendCreateRequest(const std::shared_ptr<StoreConn> &store_conn, ObjectID object_id,
                          const ray::rpc::Address &owner_address, int64_t data_size,
-                         int64_t metadata_size, flatbuf::ObjectSource source, int device_num, bool try_immediately) {
+                         int64_t metadata_size, flatbuf::ObjectSource source,
+                         int device_num, bool try_immediately) {
   flatbuffers::FlatBufferBuilder fbb;
   auto message = fb::CreatePlasmaCreateRequest(
       fbb, fbb.CreateString(object_id.Binary()),
       fbb.CreateString(owner_address.raylet_id()),
       fbb.CreateString(owner_address.ip_address()), owner_address.port(),
-      fbb.CreateString(owner_address.worker_id()), data_size, metadata_size,
-      source,
-      device_num,
-      try_immediately);
+      fbb.CreateString(owner_address.worker_id()), data_size, metadata_size, source,
+      device_num, try_immediately);
   return PlasmaSend(store_conn, MessageType::PlasmaCreateRequest, &fbb, message);
 }
 
 void ReadCreateRequest(uint8_t *data, size_t size, ObjectID *object_id,
                        NodeID *owner_raylet_id, std::string *owner_ip_address,
                        int *owner_port, WorkerID *owner_worker_id, int64_t *data_size,
-                       int64_t *metadata_size, flatbuf::ObjectSource *source, int *device_num) {
+                       int64_t *metadata_size, flatbuf::ObjectSource *source,
+                       int *device_num) {
   RAY_DCHECK(data);
   auto message = flatbuffers::GetRoot<fb::PlasmaCreateRequest>(data);
   RAY_DCHECK(VerifyFlatbuffer(message, data, size));

--- a/src/ray/object_manager/plasma/protocol.cc
+++ b/src/ray/object_manager/plasma/protocol.cc
@@ -226,13 +226,15 @@ Status SendCreateRetryRequest(const std::shared_ptr<StoreConn> &store_conn,
 
 Status SendCreateRequest(const std::shared_ptr<StoreConn> &store_conn, ObjectID object_id,
                          const ray::rpc::Address &owner_address, int64_t data_size,
-                         int64_t metadata_size, int device_num, bool try_immediately) {
+                         int64_t metadata_size, flatbuf::ObjectSource source, int device_num, bool try_immediately) {
   flatbuffers::FlatBufferBuilder fbb;
   auto message = fb::CreatePlasmaCreateRequest(
       fbb, fbb.CreateString(object_id.Binary()),
       fbb.CreateString(owner_address.raylet_id()),
       fbb.CreateString(owner_address.ip_address()), owner_address.port(),
-      fbb.CreateString(owner_address.worker_id()), data_size, metadata_size, device_num,
+      fbb.CreateString(owner_address.worker_id()), data_size, metadata_size,
+      source,
+      device_num,
       try_immediately);
   return PlasmaSend(store_conn, MessageType::PlasmaCreateRequest, &fbb, message);
 }
@@ -240,7 +242,7 @@ Status SendCreateRequest(const std::shared_ptr<StoreConn> &store_conn, ObjectID 
 void ReadCreateRequest(uint8_t *data, size_t size, ObjectID *object_id,
                        NodeID *owner_raylet_id, std::string *owner_ip_address,
                        int *owner_port, WorkerID *owner_worker_id, int64_t *data_size,
-                       int64_t *metadata_size, int *device_num) {
+                       int64_t *metadata_size, flatbuf::ObjectSource *source, int *device_num) {
   RAY_DCHECK(data);
   auto message = flatbuffers::GetRoot<fb::PlasmaCreateRequest>(data);
   RAY_DCHECK(VerifyFlatbuffer(message, data, size));
@@ -251,6 +253,7 @@ void ReadCreateRequest(uint8_t *data, size_t size, ObjectID *object_id,
   *owner_ip_address = message->owner_ip_address()->str();
   *owner_port = message->owner_port();
   *owner_worker_id = WorkerID::FromBinary(message->owner_worker_id()->str());
+  *source = message->source();
   *device_num = message->device_num();
   return;
 }

--- a/src/ray/object_manager/plasma/protocol.h
+++ b/src/ray/object_manager/plasma/protocol.h
@@ -35,8 +35,8 @@ class StoreConn;
 using ray::Status;
 
 using flatbuf::MessageType;
-using flatbuf::PlasmaError;
 using flatbuf::ObjectSource;
+using flatbuf::PlasmaError;
 
 Status PlasmaErrorStatus(flatbuf::PlasmaError plasma_error);
 
@@ -90,12 +90,14 @@ Status SendCreateRetryRequest(const std::shared_ptr<StoreConn> &store_conn,
 
 Status SendCreateRequest(const std::shared_ptr<StoreConn> &store_conn, ObjectID object_id,
                          const ray::rpc::Address &owner_address, int64_t data_size,
-                         int64_t metadata_size, flatbuf::ObjectSource source, int device_num, bool try_immediately);
+                         int64_t metadata_size, flatbuf::ObjectSource source,
+                         int device_num, bool try_immediately);
 
 void ReadCreateRequest(uint8_t *data, size_t size, ObjectID *object_id,
                        NodeID *owner_raylet_id, std::string *owner_ip_address,
                        int *owner_port, WorkerID *owner_worker_id, int64_t *data_size,
-                       int64_t *metadata_size, flatbuf::ObjectSource *source, int *device_num);
+                       int64_t *metadata_size, flatbuf::ObjectSource *source,
+                       int *device_num);
 
 Status SendUnfinishedCreateReply(const std::shared_ptr<Client> &client,
                                  ObjectID object_id, uint64_t retry_with_request_id);

--- a/src/ray/object_manager/plasma/protocol.h
+++ b/src/ray/object_manager/plasma/protocol.h
@@ -36,6 +36,7 @@ using ray::Status;
 
 using flatbuf::MessageType;
 using flatbuf::PlasmaError;
+using flatbuf::ObjectSource;
 
 Status PlasmaErrorStatus(flatbuf::PlasmaError plasma_error);
 
@@ -89,12 +90,12 @@ Status SendCreateRetryRequest(const std::shared_ptr<StoreConn> &store_conn,
 
 Status SendCreateRequest(const std::shared_ptr<StoreConn> &store_conn, ObjectID object_id,
                          const ray::rpc::Address &owner_address, int64_t data_size,
-                         int64_t metadata_size, int device_num, bool try_immediately);
+                         int64_t metadata_size, flatbuf::ObjectSource source, int device_num, bool try_immediately);
 
 void ReadCreateRequest(uint8_t *data, size_t size, ObjectID *object_id,
                        NodeID *owner_raylet_id, std::string *owner_ip_address,
                        int *owner_port, WorkerID *owner_worker_id, int64_t *data_size,
-                       int64_t *metadata_size, int *device_num);
+                       int64_t *metadata_size, flatbuf::ObjectSource *source, int *device_num);
 
 Status SendUnfinishedCreateReply(const std::shared_ptr<Client> &client,
                                  ObjectID object_id, uint64_t retry_with_request_id);

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -290,10 +290,9 @@ PlasmaError PlasmaStore::HandleCreateObjectRequest(const std::shared_ptr<Client>
   ReadCreateRequest(input, input_size, &object_id, &owner_raylet_id, &owner_ip_address,
                     &owner_port, &owner_worker_id, &data_size, &metadata_size, &source,
                     &device_num);
-  auto error =
-      CreateObject(object_id, owner_raylet_id, owner_ip_address, owner_port,
-                   owner_worker_id, data_size, metadata_size, source, device_num,
-                   client, object);
+  auto error = CreateObject(object_id, owner_raylet_id, owner_ip_address, owner_port,
+                            owner_worker_id, data_size, metadata_size, source, device_num,
+                            client, object);
   if (error == PlasmaError::OutOfMemory) {
     RAY_LOG(DEBUG) << "Not enough memory to create the object " << object_id
                    << ", data_size=" << data_size << ", metadata_size=" << metadata_size;
@@ -301,14 +300,11 @@ PlasmaError PlasmaStore::HandleCreateObjectRequest(const std::shared_ptr<Client>
   return error;
 }
 
-PlasmaError PlasmaStore::CreateObject(const ObjectID &object_id,
-                                      const NodeID &owner_raylet_id,
-                                      const std::string &owner_ip_address, int owner_port,
-                                      const WorkerID &owner_worker_id, int64_t data_size,
-                                      int64_t metadata_size,
-                                      fb::ObjectSource source, int device_num,
-                                      const std::shared_ptr<Client> &client,
-                                      PlasmaObject *result) {
+PlasmaError PlasmaStore::CreateObject(
+    const ObjectID &object_id, const NodeID &owner_raylet_id,
+    const std::string &owner_ip_address, int owner_port, const WorkerID &owner_worker_id,
+    int64_t data_size, int64_t metadata_size, fb::ObjectSource source, int device_num,
+    const std::shared_ptr<Client> &client, PlasmaObject *result) {
   RAY_LOG(DEBUG) << "attempting to create object " << object_id << " size " << data_size;
 
   auto entry = GetObjectTableEntry(&store_info_, object_id);
@@ -1018,7 +1014,7 @@ std::string PlasmaStore::DumpDebugInfo() const {
   for (const auto &obj_entry : store_info_.objects) {
     const auto &obj = obj_entry.second;
     if (obj->state == ObjectState::PLASMA_CREATED) {
-      num_objects_unsealed ++;
+      num_objects_unsealed++;
       num_bytes_unsealed += obj->data_size;
     } else if (obj->ref_count == 1 && obj->source == fb::ObjectSource::CreatedByWorker) {
       num_objects_spillable++;
@@ -1047,7 +1043,7 @@ std::string PlasmaStore::DumpDebugInfo() const {
   }
 
   buffer << "- objects spillable: " << num_objects_spillable << "\n";
-  buffer << "- bytes spillable: " << num_bytes_spillable<< "\n";
+  buffer << "- bytes spillable: " << num_bytes_spillable << "\n";
   buffer << "- objects unsealed: " << num_objects_unsealed << "\n";
   buffer << "- bytes unsealed: " << num_bytes_unsealed << "\n";
   buffer << "- objects in use: " << num_objects_in_use << "\n";

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -97,7 +97,8 @@ class PlasmaStore {
   PlasmaError CreateObject(const ObjectID &object_id, const NodeID &owner_raylet_id,
                            const std::string &owner_ip_address, int owner_port,
                            const WorkerID &owner_worker_id, int64_t data_size,
-                           int64_t metadata_size, int device_num,
+                           int64_t metadata_size, plasma::flatbuf::ObjectSource source,
+                           int device_num,
                            const std::shared_ptr<Client> &client, PlasmaObject *result);
 
   /// Abort a created but unsealed object. If the client is not the
@@ -201,6 +202,10 @@ class PlasmaStore {
     size_t available = PlasmaAllocator::GetFootprintLimit() - num_bytes_in_use;
     callback(available);
   }
+
+  // NOTE(swang): This will iterate through all objects in the
+  // object store, so it should be called sparingly.
+  std::string DumpDebugInfo() const;
 
  private:
   PlasmaError HandleCreateObjectRequest(const std::shared_ptr<Client> &client,

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -98,8 +98,8 @@ class PlasmaStore {
                            const std::string &owner_ip_address, int owner_port,
                            const WorkerID &owner_worker_id, int64_t data_size,
                            int64_t metadata_size, plasma::flatbuf::ObjectSource source,
-                           int device_num,
-                           const std::shared_ptr<Client> &client, PlasmaObject *result);
+                           int device_num, const std::shared_ptr<Client> &client,
+                           PlasmaObject *result);
 
   /// Abort a created but unsealed object. If the client is not the
   /// creator, then the abort will fail.

--- a/src/ray/object_manager/test/create_request_queue_test.cc
+++ b/src/ray/object_manager/test/create_request_queue_test.cc
@@ -75,7 +75,7 @@ TEST_F(CreateRequestQueueTest, TestSimple) {
   // Advance the clock without processing objects. This shouldn't have an impact.
   current_time_ns_ += 10e9;
   auto client = std::make_shared<MockClient>();
-  auto req_id = queue_.AddRequest(ObjectID::Nil(), client, request);
+  auto req_id = queue_.AddRequest(ObjectID::Nil(), client, request, 1234);
   ASSERT_REQUEST_UNFINISHED(queue_, req_id);
 
   ASSERT_TRUE(queue_.ProcessRequests().ok());
@@ -84,9 +84,9 @@ TEST_F(CreateRequestQueueTest, TestSimple) {
   // Request gets cleaned up after we get it.
   ASSERT_REQUEST_FINISHED(queue_, req_id, PlasmaError::UnexpectedError);
 
-  auto req_id1 = queue_.AddRequest(ObjectID::Nil(), client, request);
-  auto req_id2 = queue_.AddRequest(ObjectID::Nil(), client, request);
-  auto req_id3 = queue_.AddRequest(ObjectID::Nil(), client, request);
+  auto req_id1 = queue_.AddRequest(ObjectID::Nil(), client, request, 1234);
+  auto req_id2 = queue_.AddRequest(ObjectID::Nil(), client, request, 1234);
+  auto req_id3 = queue_.AddRequest(ObjectID::Nil(), client, request, 1234);
   ASSERT_REQUEST_UNFINISHED(queue_, req_id1);
   ASSERT_REQUEST_UNFINISHED(queue_, req_id2);
   ASSERT_REQUEST_UNFINISHED(queue_, req_id3);
@@ -111,8 +111,8 @@ TEST_F(CreateRequestQueueTest, TestOom) {
   };
 
   auto client = std::make_shared<MockClient>();
-  auto req_id1 = queue_.AddRequest(ObjectID::Nil(), client, oom_request);
-  auto req_id2 = queue_.AddRequest(ObjectID::Nil(), client, blocked_request);
+  auto req_id1 = queue_.AddRequest(ObjectID::Nil(), client, oom_request, 1234);
+  auto req_id2 = queue_.AddRequest(ObjectID::Nil(), client, blocked_request, 1234);
 
   // Neither request was fulfilled.
   ASSERT_TRUE(queue_.ProcessRequests().IsObjectStoreFull());
@@ -151,8 +151,8 @@ TEST(CreateRequestQueueParameterTest, TestOomInfiniteRetry) {
   };
 
   auto client = std::make_shared<MockClient>();
-  auto req_id1 = queue.AddRequest(ObjectID::Nil(), client, oom_request);
-  auto req_id2 = queue.AddRequest(ObjectID::Nil(), client, blocked_request);
+  auto req_id1 = queue.AddRequest(ObjectID::Nil(), client, oom_request, 1234);
+  auto req_id2 = queue.AddRequest(ObjectID::Nil(), client, blocked_request, 1234);
 
   for (int i = 0; i < 10; i++) {
     // Advance 1 second.
@@ -186,8 +186,8 @@ TEST_F(CreateRequestQueueTest, TestTransientOom) {
   };
 
   auto client = std::make_shared<MockClient>();
-  auto req_id1 = queue.AddRequest(ObjectID::Nil(), client, oom_request);
-  auto req_id2 = queue.AddRequest(ObjectID::Nil(), client, blocked_request);
+  auto req_id1 = queue.AddRequest(ObjectID::Nil(), client, oom_request, 1234);
+  auto req_id2 = queue.AddRequest(ObjectID::Nil(), client, blocked_request, 1234);
 
   // Transient OOM should happen until the grace period.
   for (int i = 0; i < 9; i++) {
@@ -230,8 +230,8 @@ TEST_F(CreateRequestQueueTest, TestTransientOomFromCreateCallback) {
   };
 
   auto client = std::make_shared<MockClient>();
-  auto req_id1 = queue.AddRequest(ObjectID::Nil(), client, oom_request);
-  auto req_id2 = queue.AddRequest(ObjectID::Nil(), client, blocked_request);
+  auto req_id1 = queue.AddRequest(ObjectID::Nil(), client, oom_request, 1234);
+  auto req_id2 = queue.AddRequest(ObjectID::Nil(), client, blocked_request, 1234);
 
   // Transient OOM should happen until the grace period.
   for (int i = 0; i < 9; i++) {
@@ -276,8 +276,8 @@ TEST_F(CreateRequestQueueTest, TestOomTimerWithSpilling) {
   };
 
   auto client = std::make_shared<MockClient>();
-  auto req_id1 = queue.AddRequest(ObjectID::Nil(), client, oom_request);
-  auto req_id2 = queue.AddRequest(ObjectID::Nil(), client, blocked_request);
+  auto req_id1 = queue.AddRequest(ObjectID::Nil(), client, oom_request, 1234);
+  auto req_id2 = queue.AddRequest(ObjectID::Nil(), client, blocked_request, 1234);
 
   // Transient OOM should happen while spilling is in progress.
   for (int i = 0; i < 10; i++) {
@@ -333,8 +333,8 @@ TEST_F(CreateRequestQueueTest, TestTransientOomThenOom) {
   };
 
   auto client = std::make_shared<MockClient>();
-  auto req_id1 = queue.AddRequest(ObjectID::Nil(), client, oom_request);
-  auto req_id2 = queue.AddRequest(ObjectID::Nil(), client, blocked_request);
+  auto req_id1 = queue.AddRequest(ObjectID::Nil(), client, oom_request, 1234);
+  auto req_id2 = queue.AddRequest(ObjectID::Nil(), client, blocked_request, 1234);
 
   // Transient OOM should not use up any until grace period is done.
   for (int i = 0; i < 3; i++) {
@@ -376,7 +376,7 @@ TEST(CreateRequestQueueParameterTest, TestNoEvictIfFull) {
   auto oom_request = [&](PlasmaObject *result) { return PlasmaError::OutOfMemory; };
 
   auto client = std::make_shared<MockClient>();
-  static_cast<void>(queue.AddRequest(ObjectID::Nil(), client, oom_request));
+  static_cast<void>(queue.AddRequest(ObjectID::Nil(), client, oom_request, 1234));
   ASSERT_TRUE(queue.ProcessRequests().IsObjectStoreFull());
   current_time_ns += 1e8;
   ASSERT_TRUE(queue.ProcessRequests().IsObjectStoreFull());
@@ -391,13 +391,13 @@ TEST_F(CreateRequestQueueTest, TestClientDisconnected) {
   // Client makes two requests. One is processed, the other is still in the
   // queue.
   auto client = std::make_shared<MockClient>();
-  auto req_id1 = queue_.AddRequest(ObjectID::Nil(), client, request);
+  auto req_id1 = queue_.AddRequest(ObjectID::Nil(), client, request, 1234);
   ASSERT_TRUE(queue_.ProcessRequests().ok());
-  auto req_id2 = queue_.AddRequest(ObjectID::Nil(), client, request);
+  auto req_id2 = queue_.AddRequest(ObjectID::Nil(), client, request, 1234);
 
   // Another client makes a concurrent request.
   auto client2 = std::make_shared<MockClient>();
-  auto req_id3 = queue_.AddRequest(ObjectID::Nil(), client2, request);
+  auto req_id3 = queue_.AddRequest(ObjectID::Nil(), client2, request, 1234);
 
   // Client disconnects.
   queue_.RemoveDisconnectedClientRequests(client);
@@ -419,26 +419,26 @@ TEST_F(CreateRequestQueueTest, TestTryRequestImmediately) {
   auto client = std::make_shared<MockClient>();
 
   // Queue is empty, request can be fulfilled.
-  auto result = queue_.TryRequestImmediately(ObjectID::Nil(), client, request);
+  auto result = queue_.TryRequestImmediately(ObjectID::Nil(), client, request, 1234);
   ASSERT_EQ(result.first.data_size, 1234);
   ASSERT_EQ(result.second, PlasmaError::OK);
 
   // Request would block.
-  auto req_id = queue_.AddRequest(ObjectID::Nil(), client, request);
-  result = queue_.TryRequestImmediately(ObjectID::Nil(), client, request);
+  auto req_id = queue_.AddRequest(ObjectID::Nil(), client, request, 1234);
+  result = queue_.TryRequestImmediately(ObjectID::Nil(), client, request, 1234);
   ASSERT_EQ(result.first.data_size, 0);
   ASSERT_EQ(result.second, PlasmaError::OutOfMemory);
   ASSERT_TRUE(queue_.ProcessRequests().ok());
 
   // Queue is empty again, request can be fulfilled.
-  result = queue_.TryRequestImmediately(ObjectID::Nil(), client, request);
+  result = queue_.TryRequestImmediately(ObjectID::Nil(), client, request, 1234);
   ASSERT_EQ(result.first.data_size, 1234);
   ASSERT_EQ(result.second, PlasmaError::OK);
 
   // Queue is empty, but request would block. Check that we do not attempt to
   // retry the request.
   auto oom_request = [&](PlasmaObject *result) { return PlasmaError::OutOfMemory; };
-  result = queue_.TryRequestImmediately(ObjectID::Nil(), client, oom_request);
+  result = queue_.TryRequestImmediately(ObjectID::Nil(), client, oom_request, 1234);
   ASSERT_EQ(result.first.data_size, 0);
   ASSERT_EQ(result.second, PlasmaError::OutOfMemory);
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1675,7 +1675,7 @@ void NodeManager::MarkObjectsAsFailed(
     Status status;
     status = store_client_.TryCreateImmediately(
         object_id, ref.owner_address(), 0,
-        reinterpret_cast<const uint8_t *>(meta.c_str()), meta.length(), &data);
+        reinterpret_cast<const uint8_t *>(meta.c_str()), meta.length(), &data, plasma::flatbuf::ObjectSource::ErrorStoredByRaylet);
     if (status.ok()) {
       status = store_client_.Seal(object_id);
     }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1675,7 +1675,8 @@ void NodeManager::MarkObjectsAsFailed(
     Status status;
     status = store_client_.TryCreateImmediately(
         object_id, ref.owner_address(), 0,
-        reinterpret_cast<const uint8_t *>(meta.c_str()), meta.length(), &data, plasma::flatbuf::ObjectSource::ErrorStoredByRaylet);
+        reinterpret_cast<const uint8_t *>(meta.c_str()), meta.length(), &data,
+        plasma::flatbuf::ObjectSource::ErrorStoredByRaylet);
     if (status.ok()) {
       status = store_client_.Seal(object_id);
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds more detailed debug information when the plasma store runs out of memory. Lists objects based on how they were created (created by a task/actor, restored from storage, etc.).

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

No additional tests, but existing ones should be sufficient.
