### PR TITLE
[Client][Proxy] Prevent Logstream from Timing Out when Delays in DataClient

### DIFF
--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -140,7 +140,7 @@ def test_delay_in_rewriting_environment(shutdown_only):
     a Client connecting.
     """
     proxier.LOGSTREAM_RETRIES = 3
-    proxier.LOGSTREAM_RETRY_TIME = 1
+    proxier.LOGSTREAM_RETRY_INTERVAL_SEC = 1
     ray_instance = ray.init()
 
     def delay_in_rewrite(input: JobConfig):

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -40,7 +40,7 @@ def test_proxy_manager_lifecycle(shutdown_only):
     proc = pm._get_server_for_client(client)
     assert proc.port == 45000
 
-    proc.process_handle().process.wait(10)
+    proc.process_handle_future.result().process.wait(10)
     # Wait for reconcile loop
     time.sleep(2)
 

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -32,6 +32,7 @@ def test_proxy_manager_lifecycle(shutdown_only):
     pm._free_ports = [45000, 45001]
     client = "client1"
 
+    pm.create_specific_server(client)
     assert pm.start_specific_server(client, JobConfig())
     # Channel should be ready and corresponding to an existing server
     grpc.channel_ready_future(pm.get_channel(client)).result(timeout=5)
@@ -63,6 +64,7 @@ def test_proxy_manager_bad_startup(shutdown_only):
     pm._free_ports = [46000, 46001]
     client = "client1"
 
+    pm.create_specific_server(client)
     assert not pm.start_specific_server(
         client,
         JobConfig(

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -127,6 +127,7 @@ def test_correct_num_clients(call_ray_start):
 check_connection = """
 import ray
 ray.client("localhost:25010").connect()
+assert ray.util.client.ray.worker.log_client.log_thread.is_alive()
 """
 
 

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -32,7 +32,7 @@ MAX_SPECIFIC_SERVER_PORT = 24000
 CHECK_CHANNEL_TIMEOUT_S = 10
 
 LOGSTREAM_RETRIES = 5
-LOGSTREAM_RETRY_TIME = 2
+LOGSTREAM_RETRY_INTERVAL_SEC = 2
 
 
 def _get_client_id_from_context(context: Any) -> str:
@@ -432,10 +432,10 @@ class LogstreamServicerProxy(ray_client_pb2_grpc.RayletLogStreamerServicer):
                 break
             logger.warning(
                 f"Retrying Logstream connection. {i+1} attempts failed.")
-            time.sleep(LOGSTREAM_RETRY_TIME)
+            time.sleep(LOGSTREAM_RETRY_INTERVAL_SEC)
 
         if channel is None:
-            context.set_code(grpc.StatusCode.NOT_FOUND)
+            context.set_code(grpc.StatusCode.UNAVAILABLE)
             return None
 
         stub = ray_client_pb2_grpc.RayletLogStreamerStub(channel)

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -141,6 +141,8 @@ class ProxyManager():
 
     def create_specific_server(self, client_id: str) -> None:
         with self.server_lock:
+            assert self.servers.get(client_id) is None, (
+                f"Server already created for Client: {client_id}")
             port = self._get_unused_port()
             server = SpecificServer(
                 port=port,

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -341,8 +341,8 @@ class Worker:
         self.reference_count[id] += 1
 
     def close(self):
-        self.log_client.close()
         self.data_client.close()
+        self.log_client.close()
         if self.channel:
             self.channel.close()
             self.channel = None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This ensures that the `LogstreamServicer` does not time out fetching a channel when the DataStream initial connection takes a long time.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #16178

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
- Manually testing that connections still happen with `time.sleep(10)` in `rewrite_runtime_env_uris`.