### PR TITLE
[client] Fix ClientBuilder for Local Clusters

### DIFF
--- a/python/ray/client_builder.py
+++ b/python/ray/client_builder.py
@@ -119,7 +119,8 @@ class _LocalClientBuilder(ClientBuilder):
                 sys.version_info[0], sys.version_info[1], sys.version_info[2]),
             ray_version=ray.__version__,
             ray_commit=ray.__commit__,
-            protocol_version=None)
+            protocol_version=None,
+            _num_clients=1)
 
 
 def _split_address(address: str) -> Tuple[str, str]:

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -44,6 +44,7 @@ def test_client(address):
         assert builder.address == address.replace("ray://", "")
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
 def test_namespace():
     """
     Most of the "checks" in this test case rely on the fact that
@@ -108,6 +109,7 @@ def test_connect_to_cluster(ray_start_regular_shared):
     subprocess.check_output("ray stop --force", shell=True)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
 def test_local_clusters():
     """
     This tests the various behaviors of connecting to local clusters:
@@ -221,6 +223,8 @@ def test_module_lacks_client_builder():
         assert "does not have ClientBuilder" in str(exception)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="RC Proxy is Flaky on Windows.")
 def test_disconnect(call_ray_stop_only):
     subprocess.check_output(
         "ray start --head --ray-client-server-port=25555", shell=True)
@@ -254,6 +258,8 @@ def test_disconnect(call_ray_stop_only):
         ray.put(300)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="RC Proxy is Flaky on Windows.")
 def test_address_resolution(call_ray_stop_only):
     subprocess.check_output(
         "ray start --head --ray-client-server-port=50055", shell=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* It appears `client_builder` tests were not running properly in CI and thus this bug slipped through.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
* Fixes bug from https://github.com/ray-project/ray/pull/16021

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
