### PR TITLE
[Core] Make the the exit type explict for workers being killed TryKil…

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2824,7 +2824,7 @@ void CoreWorker::HandleExit(const rpc::ExitRequest &request, rpc::ExitReply *rep
                       [this, is_idle]() {
                         // If the worker is idle, we exit.
                         if (is_idle) {
-                          Exit(rpc::WorkerExitType::INTENDED_EXIT);
+                          Exit(rpc::WorkerExitType::IDLE_EXIT);
                         }
                       },
                       // We need to kill it regardless if the RPC failed.

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -478,6 +478,8 @@ enum WorkerExitType {
   PLACEMENT_GROUP_REMOVED = 3;
   // Worker exit due to exceptions in creation task.
   CREATION_TASK_ERROR = 4;
+  // Worker killed by raylet if it has been idle for too long.
+  IDLE_EXIT = 5;
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
…lingIdleWorkers

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We have seen the workers in our production cluster got killed for no reason(no sign of any error). After days of debugging, we finally located that this is related to `TryKillingIdleWorkers`, a mechanism added after Ray 1.0.

We hope we can have more information around exit type in logs, right now the log like this is of no use for debugging.
```
Exit signal received, this process will exit after all outstanding  tasks have finished, exit_type=INTENDED_EXIT.
```

Please comment if there is a better way to do this or if there are other exit types I can make they explicit add along with this PR.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://github.com/ray-project/ray/issues/16212

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
