### PR TITLE
[Core] Limit starting workers with maximum_startup_concurrency per worker type

### DIFF
--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -437,7 +437,9 @@ async def test_spill_during_get(object_spilling_config, shutdown_only,
         print(obj.shape)
         del obj
     duration = datetime.now() - start
-    assert duration <= timedelta(seconds=10), "Concurrent gets took too long. Maybe IO workers are not started properly."
+    assert duration <= timedelta(
+        seconds=10
+    ), "Concurrent gets took too long. Maybe IO workers are not started properly."  # noqa: E501
     assert_no_thrashing(address["redis_address"])
 
 

--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -400,6 +400,7 @@ async def test_spill_during_get(object_spilling_config, shutdown_only,
             "max_io_workers": 1,
             "object_spilling_config": object_spilling_config,
             "min_spilling_size": 0,
+            "worker_register_timeout_seconds": 600,
         },
     )
 
@@ -438,7 +439,7 @@ async def test_spill_during_get(object_spilling_config, shutdown_only,
         del obj
     duration = datetime.now() - start
     assert duration <= timedelta(
-        seconds=10
+        seconds=30
     ), "Concurrent gets took too long. Maybe IO workers are not started properly."  # noqa: E501
     assert_no_thrashing(address["redis_address"])
 

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -167,8 +167,9 @@ Process WorkerPool::StartWorkerProcess(
   // without starting more.
   int starting_workers = 0;
   for (auto &entry : state.starting_worker_processes) {
-    if (entry.second.worker_type == worker_type)
+    if (entry.second.worker_type == worker_type) {
       starting_workers += entry.second.num_starting_workers;
+    }
   }
 
   // Here we consider both task workers and I/O workers.

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -171,7 +171,8 @@ Process WorkerPool::StartWorkerProcess(
   }
 
   // Here we consider both task workers and I/O workers.
-  if (starting_workers >= maximum_startup_concurrency_) {
+  if (worker_type == rpc::WorkerType::WORKER &&
+      starting_workers >= maximum_startup_concurrency_) {
     // Workers have been started, but not registered. Force start disabled -- returning.
     RAY_LOG(DEBUG) << "Worker not started, " << starting_workers
                    << " workers of language type " << static_cast<int>(language)

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -426,6 +426,16 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
     int num_starting_io_workers = 0;
   };
 
+  /// Some basic information about the starting worker process.
+  struct StartingWorkerProcessInfo {
+    /// The number of workers in the worker process.
+    int num_workers;
+    /// The number of pending registration workers in the worker process.
+    int num_starting_workers;
+    /// The type of the worker.
+    rpc::WorkerType worker_type;
+  };
+
   /// An internal data structure that maintains the pool state per language.
   struct State {
     /// The commands and arguments used to start the worker process
@@ -451,7 +461,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
     std::unordered_set<std::shared_ptr<WorkerInterface>> pending_disconnection_workers;
     /// A map from the pids of starting worker processes
     /// to the number of their unregistered workers.
-    std::unordered_map<Process, int> starting_worker_processes;
+    std::unordered_map<Process, StartingWorkerProcessInfo> starting_worker_processes;
     /// A map for looking up the task with dynamic options by the pid of
     /// worker. Note that this is used for the dedicated worker processes.
     std::unordered_map<Process, TaskID> dedicated_workers_to_tasks;

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -459,8 +459,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
     /// All workers that have registered but is about to disconnect. They shouldn't be
     /// popped anymore.
     std::unordered_set<std::shared_ptr<WorkerInterface>> pending_disconnection_workers;
-    /// A map from the pids of starting worker processes
-    /// to the number of their unregistered workers.
+    /// A map from the pids of starting worker processes to the extra information
+    /// of the process.
     std::unordered_map<Process, StartingWorkerProcessInfo> starting_worker_processes;
     /// A map for looking up the task with dynamic options by the pid of
     /// worker. Note that this is used for the dedicated worker processes.

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -113,7 +113,7 @@ class WorkerPoolMock : public WorkerPool {
     int total = 0;
     for (auto &state_entry : states_by_lang_) {
       for (auto &process_entry : state_entry.second.starting_worker_processes) {
-        total += process_entry.second;
+        total += process_entry.second.num_starting_workers;
       }
     }
     return total;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We limit the number of starting workers with `maximum_startup_concurrency` to avoid creating too many workers in a short time.

If the object store is almost full and spilling is being triggered, spill workers may fail to start because there are other normal workers being started and the number of starting workers has reached `maximum_startup_concurrency`. However, the starting workers may hang on `WarmupStore` because the attempt to write a temporary small object into the object store won't succeed until there is enough space. A deadlock occurs.

However, we kill workers starting for too long (currently 30s). After 30s, a worker is killed and then there is a slot for one spill worker to start, finally, the deadlock is resolved.

This PR counts starting workers of the same worker type and compares it with `maximum_startup_concurrency`, so the number of starting normal workers doesn't impact starting IO workers.

## Related issue number

Closes #15940

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
