### PR TITLE
[Serve] Create default namespace when ray is not initialized

### DIFF
--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -375,6 +375,12 @@ def test_detached_namespace_warning(ray_shutdown):
     ray.shutdown()
 
 
+def test_detached_namespace_default_ray_init(ray_shutdown):
+    # Can start detached instance when ray is not initialized.
+    serve.start(detached=True)
+    ray.shutdown()
+
+
 def test_detached_instance_in_non_anonymous_namespace(ray_shutdown):
     # Can start detached instance in non-anonymous namespace.
     ray.init(namespace="foo")

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -378,7 +378,6 @@ def test_detached_namespace_warning(ray_shutdown):
 def test_detached_namespace_default_ray_init(ray_shutdown):
     # Can start detached instance when ray is not initialized.
     serve.start(detached=True)
-    ray.shutdown()
 
 
 def test_detached_instance_in_non_anonymous_namespace(ray_shutdown):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When users call `serve.start()` without `ray.init()` they still get the following error:
```
RuntimeError: serve.start(detached=True) should not be called in anonymous Ray namespaces because you won't be able to reconnect to the Serve instance after the script exits. If you want to start a long-lived Serve instance, provide a namespace when connecting to Ray. See the documentation for more details: https://docs.ray.io/en/master/namespaces.html?highlight=namespace#using-namespaces.
```

This makes the simple case of calling `serve.start()` error out the first time and is very confusing to users. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
