### PR TITLE
[Core] [runtime env] use ray instead of ray[all] when adding ray dependency

### DIFF
--- a/python/ray/workers/setup_runtime_env.py
+++ b/python/ray/workers/setup_runtime_env.py
@@ -140,7 +140,7 @@ def current_ray_pip_specifier() -> Optional[str]:
         # Wheels are at in the ray/.whl directory, and the present file is
         # at ray/python/ray/workers.  Use relative paths to allow for
         # testing locally if needed.
-        return "ray[all]@" + os.path.join(
+        return os.path.join(
             Path(__file__).resolve().parents[3], ".whl", get_wheel_filename())
     elif ray.__commit__ == "{{RAY_COMMIT_SHA}}":
         # Running on a version built from source locally.
@@ -153,9 +153,9 @@ def current_ray_pip_specifier() -> Optional[str]:
         return None
     elif "dev" in ray.__version__:
         # Running on a nightly wheel.
-        return f"ray[all]@{get_master_wheel_url()}"
+        return get_master_wheel_url()
     else:
-        return f"ray[all]=={ray.__version__}"
+        return f"ray=={ray.__version__}"
 
 
 def inject_dependencies(

--- a/python/ray/workers/setup_runtime_env.py
+++ b/python/ray/workers/setup_runtime_env.py
@@ -140,7 +140,7 @@ def current_ray_pip_specifier() -> Optional[str]:
         # Wheels are at in the ray/.whl directory, and the present file is
         # at ray/python/ray/workers.  Use relative paths to allow for
         # testing locally if needed.
-        return "ray[all]" + os.path.join(
+        return "ray[all]@" + os.path.join(
             Path(__file__).resolve().parents[3], ".whl", get_wheel_filename())
     elif ray.__commit__ == "{{RAY_COMMIT_SHA}}":
         # Running on a version built from source locally.

--- a/python/ray/workers/setup_runtime_env.py
+++ b/python/ray/workers/setup_runtime_env.py
@@ -140,7 +140,7 @@ def current_ray_pip_specifier() -> Optional[str]:
         # Wheels are at in the ray/.whl directory, and the present file is
         # at ray/python/ray/workers.  Use relative paths to allow for
         # testing locally if needed.
-        return os.path.join(
+        return "ray[all]" + os.path.join(
             Path(__file__).resolve().parents[3], ".whl", get_wheel_filename())
     elif ray.__commit__ == "{{RAY_COMMIT_SHA}}":
         # Running on a version built from source locally.
@@ -153,7 +153,7 @@ def current_ray_pip_specifier() -> Optional[str]:
         return None
     elif "dev" in ray.__version__:
         # Running on a nightly wheel.
-        return get_master_wheel_url()
+        return f"ray[all]@{get_master_wheel_url()}"
     else:
         return f"ray[all]=={ray.__version__}"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Previously, "ray[all]" would be injected by default into the runtime env. This PR changes it so that only `ray` is injected, in order to reduce the installation time.  To use libraries like Serve or Tune, the user will now need to include `ray[serve]`, etc. in the pip dependencies in their runtime env.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
