### PR TITLE
[core] Add object store debug information

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1557,6 +1557,7 @@ void CoreWorker::SubmitTask(const RayFunction &function,
                       debugger_breakpoint, task_options.serialized_runtime_env,
                       override_environment_variables);
   TaskSpecification task_spec = builder.Build();
+  RAY_LOG(DEBUG) << "Submit task " << task_spec.DebugString();
   if (options_.is_local_mode) {
     ExecuteTaskLocalMode(task_spec);
   } else {

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -185,6 +185,7 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
     const auto &return_object = reply.return_objects(i);
     ObjectID object_id = ObjectID::FromBinary(return_object.object_id());
     reference_counter_->UpdateObjectSize(object_id, return_object.size());
+    RAY_LOG(DEBUG) << "Task return object " << object_id << " has size " << return_object.size();
 
     if (return_object.in_plasma()) {
       const auto pinned_at_raylet_id = NodeID::FromBinary(worker_addr.raylet_id());

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -185,7 +185,8 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
     const auto &return_object = reply.return_objects(i);
     ObjectID object_id = ObjectID::FromBinary(return_object.object_id());
     reference_counter_->UpdateObjectSize(object_id, return_object.size());
-    RAY_LOG(DEBUG) << "Task return object " << object_id << " has size " << return_object.size();
+    RAY_LOG(DEBUG) << "Task return object " << object_id << " has size "
+                   << return_object.size();
 
     if (return_object.in_plasma()) {
       const auto pinned_at_raylet_id = NodeID::FromBinary(worker_addr.raylet_id());

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -62,8 +62,9 @@ std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> ObjectBufferPool::Ge
     if (object_buffer.data == nullptr) {
       RAY_LOG(INFO)
           << "Failed to get a chunk of the object: " << object_id
-          << ". It is mostly because the object is already evicted or spilled when the "
-             "pull request is received. The caller will retry the pull request again.";
+          << ". This is most likely because the object was evicted or spilled before the "
+             "pull request was received. The caller will retry the pull request after a "
+             "timeout.";
       return std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status>(
           errored_chunk_,
           ray::Status::IOError("Unable to obtain object chunk, object not local."));

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -500,10 +500,25 @@ class ObjectManager : public ObjectManagerInterface,
   int64_t used_memory_ = 0;
 
   /// Running total of received chunks.
-  int64_t num_chunks_received_total_ = 0;
+  size_t num_chunks_received_total_ = 0;
 
-  /// Running total of received chunks that failed (duplicated).
-  int64_t num_chunks_received_failed_ = 0;
+  /// Running total of received chunks that failed. A finer-grained breakdown
+  /// is recorded below.
+  size_t num_chunks_received_total_failed_ = 0;
+
+  /// The total number of chunks that we failed to receive because they were
+  /// no longer needed by any worker or task on this node.
+  size_t num_chunks_received_cancelled_ = 0;
+
+  /// The total number of chunks that we failed to receive because they are
+  /// still needed, but accepting them would put us over the pull manager's
+  /// threshold. The threshold is needed to throttle incoming objects.
+  size_t num_chunks_received_thrashed_ = 0;
+
+  /// The total number of chunks that we failed to receive because we could not
+  /// create the object in plasma. This is usually due to out-of-memory in
+  /// plasma.
+  size_t num_chunks_received_failed_due_to_plasma_ = 0;
 };
 
 }  // namespace ray

--- a/src/ray/object_manager/plasma/create_request_queue.cc
+++ b/src/ray/object_manager/plasma/create_request_queue.cc
@@ -32,6 +32,7 @@ uint64_t CreateRequestQueue::AddRequest(const ObjectID &object_id,
   fulfilled_requests_[req_id] = nullptr;
   queue_.emplace_back(
       new CreateRequest(object_id, req_id, client, create_callback, object_size));
+  num_bytes_pending_ += object_size;
   return req_id;
 }
 
@@ -147,6 +148,8 @@ void CreateRequestQueue::FinishRequest(
   RAY_CHECK(it != fulfilled_requests_.end());
   RAY_CHECK(it->second == nullptr);
   it->second = std::move(request);
+  RAY_CHECK(num_bytes_pending_ >= it->second->object_size);
+  num_bytes_pending_ -= it->second->object_size;
   queue_.erase(request_it);
 }
 
@@ -155,6 +158,8 @@ void CreateRequestQueue::RemoveDisconnectedClientRequests(
   for (auto it = queue_.begin(); it != queue_.end();) {
     if ((*it)->client == client) {
       fulfilled_requests_.erase((*it)->request_id);
+      RAY_CHECK(num_bytes_pending_ >= (*it)->object_size);
+      num_bytes_pending_ -= (*it)->object_size;
       it = queue_.erase(it);
     } else {
       it++;

--- a/src/ray/object_manager/plasma/create_request_queue.h
+++ b/src/ray/object_manager/plasma/create_request_queue.h
@@ -108,6 +108,10 @@ class CreateRequestQueue {
   /// \param client The client that was disconnected.
   void RemoveDisconnectedClientRequests(const std::shared_ptr<ClientInterface> &client);
 
+  size_t NumPendingRequests() const { return queue_.size(); }
+
+  size_t NumPendingBytes() const { return num_bytes_pending_; }
+
  private:
   struct CreateRequest {
     CreateRequest(const ObjectID &object_id, uint64_t request_id,
@@ -194,6 +198,8 @@ class CreateRequestQueue {
 
   /// The time OOM timer first starts. It becomes -1 upon every creation success.
   int64_t oom_start_time_ns_ = -1;
+
+  size_t num_bytes_pending_ = 0;
 
   friend class CreateRequestQueueTest;
 };

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -156,7 +156,10 @@ PlasmaStore::PlasmaStore(instrumented_io_context &main_service, std::string dire
           [this]() { return GetDebugDump(); }) {
   store_info_.directory = directory;
   store_info_.hugepages_enabled = hugepages_enabled;
-  if (RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
+  const auto asio_stats_print_interval_ms =
+      RayConfig::instance().asio_stats_print_interval_ms();
+  if (asio_stats_print_interval_ms > 0 &&
+      RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
     PrintDebugDump();
   }
 }

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -995,6 +995,7 @@ bool PlasmaStore::IsObjectSpillable(const ObjectID &object_id) {
 }
 
 std::string PlasmaStore::GetDebugDump() const {
+  // TODO(swang): We might want to optimize this if it gets called more often.
   std::stringstream buffer;
   buffer << "========== Plasma store: =================\n";
   size_t num_objects_spillable = 0;

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -375,6 +375,7 @@ PlasmaError PlasmaStore::CreateObject(
   AddToClientObjectIds(object_id, store_info_.objects[object_id].get(), client);
   num_objects_unsealed_++;
   num_bytes_unsealed_ += data_size + metadata_size;
+  num_bytes_created_total_ += data_size + metadata_size;
   return PlasmaError::OK;
 }
 
@@ -1057,6 +1058,7 @@ std::string PlasmaStore::GetDebugDump() const {
 
   buffer << "Current usage: " << (PlasmaAllocator::Allocated() / 1e9) << " / "
          << (PlasmaAllocator::GetFootprintLimit() / 1e9) << " GB\n";
+  buffer << "- num bytes created total: " << num_bytes_created_total_ << "\n";
   auto num_pending_requests = create_request_queue_.NumPendingRequests();
   auto num_pending_bytes = create_request_queue_.NumPendingBytes();
   buffer << num_pending_requests << " pending objects of total size "

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -833,7 +833,7 @@ Status PlasmaStore::ProcessMessage(const std::shared_ptr<Client> &client,
       auto req_id =
           create_request_queue_.AddRequest(object_id, client, handle_create, object_size);
       RAY_LOG(DEBUG) << "Received create request for object " << object_id
-                     << " assigned request ID " << req_id;
+                     << " assigned request ID " << req_id << ", " << object_size << " bytes";
       ProcessCreateRequests();
       ReplyToCreateClient(client, object_id, req_id);
     }

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -833,7 +833,8 @@ Status PlasmaStore::ProcessMessage(const std::shared_ptr<Client> &client,
       auto req_id =
           create_request_queue_.AddRequest(object_id, client, handle_create, object_size);
       RAY_LOG(DEBUG) << "Received create request for object " << object_id
-                     << " assigned request ID " << req_id << ", " << object_size << " bytes";
+                     << " assigned request ID " << req_id << ", " << object_size
+                     << " bytes";
       ProcessCreateRequests();
       ReplyToCreateClient(client, object_id, req_id);
     }

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -205,7 +205,7 @@ class PlasmaStore {
 
   // NOTE(swang): This will iterate through all objects in the
   // object store, so it should be called sparingly.
-  std::string DumpDebugInfo() const;
+  std::string GetDebugDump() const;
 
  private:
   PlasmaError HandleCreateObjectRequest(const std::shared_ptr<Client> &client,
@@ -322,6 +322,10 @@ class PlasmaStore {
 
   /// Total plasma object bytes that are consumed by core workers.
   int64_t total_consumed_bytes_ = 0;
+
+  /// Whether we have dumped debug information on OOM yet. This limits dump
+  /// (which can be expensive) to once per OOM event.
+  bool dumped_on_oom_ = false;
 };
 
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -331,6 +331,9 @@ class PlasmaStore {
   /// Whether we have dumped debug information on OOM yet. This limits dump
   /// (which can be expensive) to once per OOM event.
   bool dumped_on_oom_ = false;
+
+  /// A running total of the objects that have ever been created on this node.
+  size_t num_bytes_created_total_ = 0;
 };
 
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -203,6 +203,8 @@ class PlasmaStore {
     callback(available);
   }
 
+  void PrintDebugDump() const;
+
   // NOTE(swang): This will iterate through all objects in the
   // object store, so it should be called sparingly.
   std::string GetDebugDump() const;
@@ -296,6 +298,9 @@ class PlasmaStore {
   /// serviceable because there is not enough memory. The request will be
   /// retried when this timer expires.
   std::shared_ptr<boost::asio::deadline_timer> create_timer_;
+
+  /// Timer for printing debug information.
+  mutable std::shared_ptr<boost::asio::deadline_timer> stats_timer_;
 
   /// Queue of object creation requests.
   CreateRequestQueue create_request_queue_;

--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -513,7 +513,6 @@ void PullManager::ResetRetryTimer(const ObjectID &object_id) {
   auto it = object_pull_requests_.find(object_id);
   if (it != object_pull_requests_.end()) {
     it->second.next_pull_time = get_time_();
-    it->second.num_retries = 0;
   }
 }
 
@@ -521,6 +520,11 @@ void PullManager::UpdateRetryTimer(ObjectPullRequest &request) {
   const auto time = get_time_();
   auto retry_timeout_len = (pull_timeout_ms_ / 1000.) * (1UL << request.num_retries);
   request.next_pull_time = time + retry_timeout_len;
+
+  if (request.num_retries > 0) {
+    // We've tried this object before.
+    num_retries_total_++;
+  }
 
   // Bound the retry time at 10 * 1024 seconds.
   request.num_retries = std::min(request.num_retries + 1, 10);
@@ -536,7 +540,10 @@ void PullManager::Tick() {
 
 int PullManager::NumActiveRequests() const { return object_pull_requests_.size(); }
 
-bool PullManager::IsObjectActive(const ObjectID &object_id) const {
+bool PullManager::IsObjectActive(const ObjectID &object_id, bool *object_required) const {
+  if (object_required) {
+    *object_required = object_pull_requests_.count(object_id) == 1;
+  }
   absl::MutexLock lock(&active_objects_mu_);
   return active_object_pull_requests_.count(object_id) == 1;
 }
@@ -570,6 +577,7 @@ std::string PullManager::DebugString() const {
   result << "\n- num objects requested pull: " << object_pull_requests_.size();
   result << "\n- num objects actively being pulled: "
          << active_object_pull_requests_.size();
+  result << "\n- num pull retries: " << num_retries_total_;
   return result.str();
 }
 

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -106,7 +106,7 @@ class PullManager {
   /// Returns whether the object is actively being pulled. object_required
   /// returns whether the object is still needed by some pull request on this
   /// node (but may not be actively pulled due to throttling).
-  bool IsObjectActive(const ObjectID &object_id, bool *object_required) const;
+  bool IsObjectActive(const ObjectID &object_id, bool *object_required = nullptr) const;
 
   /// Check whether the pull request is currently active or waiting for object
   /// size information. If this returns false, then the pull request is most

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -103,7 +103,10 @@ class PullManager {
   /// The number of ongoing object pulls.
   int NumActiveRequests() const;
 
-  bool IsObjectActive(const ObjectID &object_id) const;
+  /// Returns whether the object is actively being pulled. object_required
+  /// returns whether the object is still needed by some pull request on this
+  /// node (but may not be actively pulled due to throttling).
+  bool IsObjectActive(const ObjectID &object_id, bool *object_required) const;
 
   /// Check whether the pull request is currently active or waiting for object
   /// size information. If this returns false, then the pull request is most
@@ -271,6 +274,8 @@ class PullManager {
 
   /// Internally maintained random number generator.
   std::mt19937_64 gen_;
+
+  size_t num_retries_total_ = 0;
 
   friend class PullManagerTest;
   friend class PullManagerTestWithCapacity;

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -369,6 +369,7 @@ bool ClusterTaskManager::PinTaskArgsIfMemoryAvailable(const TaskSpecification &s
   for (auto &arg : args) {
     task_arg_bytes += arg->GetSize();
   }
+  RAY_LOG(DEBUG) << "Task " << spec.TaskId() << " has args of size " << task_arg_bytes;
   PinTaskArgs(spec, std::move(args));
   RAY_LOG(DEBUG) << "Size of pinned task args is now " << pinned_task_arguments_bytes_;
   if (max_pinned_task_arguments_bytes_ == 0) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds more debug info. Adds information about why object chunks failed to be received. Also adds plasma store debug dumps once capacity is reached. Plasma store will periodically dump information if asio stats are turned on (should probably rename this config parameter at some point).

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
