### PR TITLE
[Core] [runtime env] Remove opentelemetry from pip dependencies in test

### DIFF
--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -239,12 +239,8 @@ def test_get_conda_env_dir(tmp_path):
 
 
 """
-Note(architkulkarni): For runtime_env tests that involve conda or pip installs,
-"opentelemetry-api==1.0.0rc1" and "opentelemetry-sdk==1.0.0rc1" must be
-included as dependencies, because they are installed in the CI's conda env but
-are not included in the Ray dependencies, so they cause an unpickling issue.
-
-Also, these tests only run on Buildkite in a special job that runs
+Note(architkulkarni):
+These tests only run on Buildkite in a special job that runs
 after the wheel is built, because the tests pass in the wheel as a dependency
 in the runtime env.  Buildkite only supports Linux for now.
 """
@@ -260,14 +256,9 @@ def test_conda_create_task(shutdown_only):
     ray.init()
     runtime_env = {
         "conda": {
-            "dependencies": [
-                "pip", {
-                    "pip": [
-                        "pip-install-test==0.5", "opentelemetry-api==1.0.0rc1",
-                        "opentelemetry-sdk==1.0.0rc1"
-                    ]
-                }
-            ]
+            "dependencies": ["pip", {
+                "pip": ["pip-install-test==0.5"]
+            }]
         }
     }
 
@@ -295,14 +286,9 @@ def test_conda_create_job_config(shutdown_only):
 
     runtime_env = {
         "conda": {
-            "dependencies": [
-                "pip", {
-                    "pip": [
-                        "pip-install-test==0.5", "opentelemetry-api==1.0.0rc1",
-                        "opentelemetry-sdk==1.0.0rc1"
-                    ]
-                }
-            ]
+            "dependencies": ["pip", {
+                "pip": ["pip-install-test==0.5"]
+            }]
         }
     }
     ray.init(job_config=JobConfig(runtime_env=runtime_env))
@@ -374,14 +360,9 @@ def test_conda_create_ray_client(call_ray_start):
 
     runtime_env = {
         "conda": {
-            "dependencies": [
-                "pip", {
-                    "pip": [
-                        "pip-install-test==0.5", "opentelemetry-api==1.0.0rc1",
-                        "opentelemetry-sdk==1.0.0rc1"
-                    ]
-                }
-            ]
+            "dependencies": ["pip", {
+                "pip": ["pip-install-test==0.5"]
+            }]
         }
     }
 
@@ -419,18 +400,11 @@ def test_pip_task(shutdown_only, pip_as_str, tmp_path):
         p = d / "requirements.txt"
         requirements_txt = """
         pip-install-test==0.5
-        opentelemetry-api==1.0.0rc1
-        opentelemetry-sdk==1.0.0rc1
         """
         p.write_text(requirements_txt)
         runtime_env = {"pip": str(p)}
     else:
-        runtime_env = {
-            "pip": [
-                "pip-install-test==0.5", "opentelemetry-api==1.0.0rc1",
-                "opentelemetry-sdk==1.0.0rc1"
-            ]
-        }
+        runtime_env = {"pip": ["pip-install-test==0.5"]}
 
     @ray.remote
     def f():
@@ -461,18 +435,11 @@ def test_pip_job_config(shutdown_only, pip_as_str, tmp_path):
         p = d / "requirements.txt"
         requirements_txt = """
         pip-install-test==0.5
-        opentelemetry-api==1.0.0rc1
-        opentelemetry-sdk==1.0.0rc1
         """
         p.write_text(requirements_txt)
         runtime_env = {"pip": str(p)}
     else:
-        runtime_env = {
-            "pip": [
-                "pip-install-test==0.5", "opentelemetry-api==1.0.0rc1",
-                "opentelemetry-sdk==1.0.0rc1"
-            ]
-        }
+        runtime_env = {"pip": ["pip-install-test==0.5"]}
 
     ray.init(job_config=JobConfig(runtime_env=runtime_env))
 
@@ -489,16 +456,7 @@ def test_pip_job_config(shutdown_only, pip_as_str, tmp_path):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Unsupported on Windows.")
 def test_conda_input_filepath(tmp_path):
-    conda_dict = {
-        "dependencies": [
-            "pip", {
-                "pip": [
-                    "pip-install-test==0.5", "opentelemetry-api==1.0.0rc1",
-                    "opentelemetry-sdk==1.0.0rc1"
-                ]
-            }
-        ]
-    }
+    conda_dict = {"dependencies": ["pip", {"pip": ["pip-install-test==0.5"]}]}
     d = tmp_path / "pip_requirements"
     d.mkdir()
     p = d / "environment.yml"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Thanks to https://github.com/ray-project/ray/pull/16177 we no longer need to manually include opentelemetry as a pip dependency when using runtime envs.  This PR removes these from the runtime env tests.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
