### PR TITLE
[Core] [runtime env] Fix test_get_master_wheel_url

### DIFF
--- a/python/ray/test_utils.py
+++ b/python/ray/test_utils.py
@@ -590,6 +590,9 @@ def get_master_wheel_url(
         py_version: str = f"{sys.version_info.major}{sys.version_info.minor}"
 ) -> str:
     """Return the URL for the wheel from a specific commit."""
-
+    filename = get_wheel_filename(
+        sys_platform=sys_platform,
+        ray_version=ray_version,
+        py_version=py_version)
     return (f"https://s3-us-west-2.amazonaws.com/ray-wheels/master/"
-            f"{ray_commit}/{get_wheel_filename()}")
+            f"{ray_commit}/{filename}")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Fixes a test for a function which generates the URL format for the wheels of Ray commits on master on S3.  The test was incorrectly passing in the current Ray version, causing it to fail on the release branch (because the release hasn't happened yet so the URL doesn't exist).
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
