### PR TITLE
Allow configuring internal config with RAY_{name} env vars.

### DIFF
--- a/src/ray/common/ray_config.h
+++ b/src/ray/common/ray_config.h
@@ -23,19 +23,27 @@
 #include "ray/util/logging.h"
 
 class RayConfig {
+  // Needed for the RAY_CONFIG macro below to work properly for strings.
+  typedef std::string string_type;
+#define TOSTRING0(x) #x
+#define TOSTRING(x) TOSTRING0(x)
+
 /// -----------Include ray_config_def.h to define config items.----------------
 /// A helper macro that defines a config item.
 /// In particular, this generates a private field called `name_` and a public getter
 /// method called `name()` for a given config item.
 ///
+/// Configs defined in this way can be overriden by setting the env variable
+/// RAY_{name}=value where {name} is the variable name.
+///
 /// \param type Type of the config item.
 /// \param name Name of the config item.
 /// \param default_value Default value of the config item.
-#define RAY_CONFIG(type, name, default_value) \
- private:                                     \
-  type name##_ = default_value;               \
-                                              \
- public:                                      \
+#define RAY_CONFIG(type, name, default_value)                      \
+ private:                                                          \
+  type name##_ = env_##type("RAY_" TOSTRING(name), default_value); \
+                                                                   \
+ public:                                                           \
   inline type name() { return name##_; }
 
 #include "ray/common/ray_config_def.h"
@@ -104,6 +112,78 @@ class RayConfig {
       return default_value;
     } else {
       return std::stof(value);
+    }
+  }
+
+  double env_double(const std::string &name, double default_value) {
+    auto value = getenv(name.c_str());
+    if (value == nullptr) {
+      return default_value;
+    } else {
+      return std::stod(value);
+    }
+  }
+
+  int env_int(const std::string &name, int default_value) {
+    auto value = getenv(name.c_str());
+    if (value == nullptr) {
+      return default_value;
+    } else {
+      return std::stoi(value);
+    }
+  }
+
+  std::string env_string_type(const std::string &name, std::string default_value) {
+    auto value = getenv(name.c_str());
+    if (value == nullptr) {
+      return default_value;
+    } else {
+      return value;
+    }
+  }
+
+  size_t env_size_t(const std::string &name, size_t default_value) {
+    auto value = getenv(name.c_str());
+    if (value == nullptr) {
+      return default_value;
+    } else {
+      return std::stoull(value);
+    }
+  }
+
+  int64_t env_int64_t(const std::string &name, int64_t default_value) {
+    auto value = getenv(name.c_str());
+    if (value == nullptr) {
+      return default_value;
+    } else {
+      return std::stoll(value);
+    }
+  }
+
+  uint64_t env_uint64_t(const std::string &name, uint64_t default_value) {
+    auto value = getenv(name.c_str());
+    if (value == nullptr) {
+      return default_value;
+    } else {
+      return std::stoull(value);
+    }
+  }
+
+  int32_t env_int32_t(const std::string &name, int32_t default_value) {
+    auto value = getenv(name.c_str());
+    if (value == nullptr) {
+      return default_value;
+    } else {
+      return std::stol(value);
+    }
+  }
+
+  uint32_t env_uint32_t(const std::string &name, uint32_t default_value) {
+    auto value = getenv(name.c_str());
+    if (value == nullptr) {
+      return default_value;
+    } else {
+      return std::stoul(value);
     }
   }
 /// ---------------------------------------------------------------------

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -365,7 +365,7 @@ RAY_CONFIG(int64_t, max_placement_group_load_report_size, 100)
 /// JSON configuration that describes the external storage. This is passed to
 /// Python IO workers to determine how to store/restore an object to/from
 /// external storage.
-RAY_CONFIG(std::string, object_spilling_config, "")
+RAY_CONFIG(string_type, object_spilling_config, "")
 
 /// Whether to enable automatic object spilling. If enabled, then
 /// Ray will choose objects to spill when the object store is out of


### PR DESCRIPTION
For example, to set the max files per spill file for testing shuffle, you can use `RAY_max_fused_object_count=50 python -m ray.experimental.shuffle --num-partitions=200 --partition-size=10e6`.

We should consider this a developer-only internal tool (not in public documentation).