### PR TITLE
[spilled object push optimization 1/3] create a SpilledObject that reads data in chunks.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -915,6 +915,20 @@ cc_test(
 )
 
 cc_test(
+    name = "spilled_object_test",
+    srcs = [
+        "src/ray/object_manager/test/spilled_object_test.cc",
+    ],
+    copts = COPTS,
+    deps = [
+        ":raylet_lib",
+        "@boost//:endian",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "create_request_queue_test",
     srcs = [
         "src/ray/object_manager/test/create_request_queue_test.cc",

--- a/src/ray/object_manager/spilled_object.cc
+++ b/src/ray/object_manager/spilled_object.cc
@@ -1,0 +1,196 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/object_manager/spilled_object.h"
+
+#include <fstream>
+#include <regex>
+
+#include "ray/util/logging.h"
+
+namespace ray {
+namespace {
+const size_t UINT64_size = sizeof(uint64_t);
+}
+
+/* static */ absl::optional<SpilledObject> SpilledObject::CreateSpilledObject(
+    const std::string &object_url, uint64_t chunk_size) {
+  if (chunk_size == 0) {
+    RAY_LOG(WARNING) << "chunk_size can't be 0.";
+    return absl::optional<SpilledObject>();
+  }
+
+  std::string file_path;
+  uint64_t object_offset = 0;
+  uint64_t object_size = 0;
+
+  if (!SpilledObject::ParseObjectURL(object_url, file_path, object_offset, object_size)) {
+    RAY_LOG(WARNING) << "Failed to parse spilled object url: " << object_url;
+    return absl::optional<SpilledObject>();
+  }
+
+  uint64_t data_offset = 0;
+  uint64_t data_size = 0;
+  uint64_t metadata_offset = 0;
+  uint64_t metadata_size = 0;
+  rpc::Address owner_address;
+
+  std::ifstream is(file_path, std::ios::binary);
+  if (!is ||
+      !SpilledObject::ParseObjectHeader(is, object_offset, data_offset, data_size,
+                                        metadata_offset, metadata_size, owner_address)) {
+    RAY_LOG(WARNING) << "Failed to parse object header for spilled object " << object_url;
+    return absl::optional<SpilledObject>();
+  }
+
+  return absl::optional<SpilledObject>(SpilledObject(
+      std::move(file_path), object_size, data_offset, data_size, metadata_offset,
+      metadata_size, std::move(owner_address), chunk_size));
+}
+
+uint64_t SpilledObject::GetDataSize() const { return data_size_; }
+
+uint64_t SpilledObject::GetMetadataSize() const { return metadata_size_; }
+
+const rpc::Address &SpilledObject::GetOwnerAddress() const { return owner_address_; }
+
+uint64_t SpilledObject::GetNumChunks() const {
+  // return ceil( (data_size + metadata_size) / chunk_size_)
+  return (data_size_ + metadata_size_ + chunk_size_ - 1) / chunk_size_;
+}
+
+absl::optional<std::string> SpilledObject::GetChunk(uint64_t chunk_index) const {
+  // The spilled file stores metadata before data. But the GetChunk needs to
+  // return data before metadata. We achieve by first read from data section,
+  // then read from metadata section.
+  const auto cur_chunk_offset = chunk_index * chunk_size_;
+  const auto cur_chunk_size =
+      std::min(chunk_size_, data_size_ + metadata_size_ - cur_chunk_offset);
+
+  std::string result(cur_chunk_size, '\0');
+  size_t result_offset = 0;
+
+  if (cur_chunk_offset < data_size_) {
+    // read from data section.
+    auto offset = cur_chunk_offset;
+    auto size = std::min(data_size_ - cur_chunk_offset, cur_chunk_size);
+    if (!ReadFromDataSection(offset, size, &result[result_offset])) {
+      return absl::optional<std::string>();
+    }
+    result_offset = size;
+  }
+
+  if (cur_chunk_offset + cur_chunk_size > data_size_) {
+    // read from metadata section.
+    auto offset = std::max(cur_chunk_offset, data_size_) - data_size_;
+    auto size = std::min(cur_chunk_offset + cur_chunk_size - data_size_, cur_chunk_size);
+    if (!ReadFromMetadataSection(offset, size, &result[result_offset])) {
+      return absl::optional<std::string>();
+    }
+  }
+  return absl::optional<std::string>(std::move(result));
+}
+
+SpilledObject::SpilledObject(std::string file_path, uint64_t object_size,
+                             uint64_t data_offset, uint64_t data_size,
+                             uint64_t metadata_offset, uint64_t metadata_size,
+                             rpc::Address owner_address, uint64_t chunk_size)
+    : file_path_(std::move(file_path)),
+      object_size_(object_size),
+      data_offset_(data_offset),
+      data_size_(data_size),
+      metadata_offset_(metadata_offset),
+      metadata_size_(metadata_size),
+      owner_address_(std::move(owner_address)),
+      chunk_size_(chunk_size) {}
+
+/* static */ bool SpilledObject::ParseObjectURL(const std::string &object_url,
+                                                std::string &file_path,
+                                                uint64_t &object_offset,
+                                                uint64_t &object_size) {
+  static const std::regex object_url_pattern("^(.*)\\?offset=(\\d+)&size=(\\d+)$");
+  std::smatch match_groups;
+  if (!std::regex_match(object_url, match_groups, object_url_pattern) ||
+      match_groups.size() != 4) {
+    return false;
+  }
+  file_path = match_groups[1].str();
+  try {
+    object_offset = std::stoi(match_groups[2].str());
+    object_size = std::stoi(match_groups[3].str());
+  } catch (...) {
+    return false;
+  }
+  return true;
+}
+
+/* static */
+bool SpilledObject::ParseObjectHeader(std::istream &is, uint64_t object_offset,
+                                      uint64_t &data_offset, uint64_t &data_size,
+                                      uint64_t &metadata_offset, uint64_t &metadata_size,
+                                      rpc::Address &owner_address) {
+  if (!is.seekg(object_offset)) {
+    return false;
+  }
+
+  uint64_t address_size = 0;
+  if (!ReadUINT64(is, address_size) || !ReadUINT64(is, metadata_size) ||
+      !ReadUINT64(is, data_size)) {
+    return false;
+  }
+
+  std::string address_str(address_size, '\0');
+  if (!is.read(&address_str[0], address_size) ||
+      !owner_address.ParseFromString(address_str)) {
+    return false;
+  }
+
+  metadata_offset = object_offset + UINT64_size * 3 + address_size;
+  data_offset = metadata_offset + metadata_size;
+  return true;
+}
+
+/* static */
+bool SpilledObject::ReadUINT64(std::istream &is, uint64_t &output) {
+  std::string buff(UINT64_size, '\0');
+  if (!is.read(&buff[0], UINT64_size)) {
+    return false;
+  }
+  output = SpilledObject::ToUINT64(buff);
+  return true;
+}
+
+/* static */
+uint64_t SpilledObject::ToUINT64(const std::string &s) {
+  RAY_CHECK(s.size() == UINT64_size);
+  uint64_t result = 0;
+  for (size_t i = 0; i < s.size(); i++) {
+    result = result << 8;
+    result += static_cast<unsigned char>(s.at(s.size() - i - 1));
+  }
+  return result;
+}
+
+bool SpilledObject::ReadFromDataSection(uint64_t offset, uint64_t size,
+                                        char *output) const {
+  std::ifstream is(file_path_, std::ios::binary);
+  return is.seekg(data_offset_ + offset) && is.read(output, size);
+}
+
+bool SpilledObject::ReadFromMetadataSection(uint64_t offset, uint64_t size,
+                                            char *output) const {
+  std::ifstream is(file_path_, std::ios::binary);
+  return is.seekg(metadata_offset_ + offset) && is.read(output, size);
+}
+}  // namespace ray

--- a/src/ray/object_manager/spilled_object.h
+++ b/src/ray/object_manager/spilled_object.h
@@ -1,0 +1,126 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <gtest/gtest_prod.h>
+
+#include <string>
+
+#include "absl/types/optional.h"
+#include "src/ray/protobuf/common.pb.h"
+
+namespace ray {
+
+/// Represent a local object spilled in the object_url.
+/// This class is thread safe.
+class SpilledObject {
+ public:
+  /// Create a Spilled Object. Returns an empty optional if any error happens, such as
+  /// malformed url; corrupted/deleted file; or 0 chunk_size.
+  ///
+  /// \param object_url the object url in the form of {path}?offset={offset}&size={size}
+  /// \param chunk_size the size of chunk for read.
+  static absl::optional<SpilledObject> CreateSpilledObject(const std::string &object_url,
+                                                           uint64_t chunk_size);
+
+  /// Return the size of data (exclusing metadata).
+  uint64_t GetDataSize() const;
+
+  /// Return the size of metadata.
+  uint64_t GetMetadataSize() const;
+
+  const rpc::Address &GetOwnerAddress() const;
+
+  uint64_t GetNumChunks() const;
+
+  /// Return the value in a given chunk, identified by chunk_index.
+  /// It migh return an empty optional if the file is deleted.
+  ///
+  /// \param chunk_index the index of chunk to return. index greater or
+  ///                    equal to GetNumChunks() yields undefined behavior.
+  absl::optional<std::string> GetChunk(uint64_t chunk_index) const;
+
+ private:
+  SpilledObject(std::string file_path, uint64_t total_size, uint64_t data_offset,
+                uint64_t data_size, uint64_t metadata_offset, uint64_t metadata_size,
+                rpc::Address owner_address, uint64_t chunk_size);
+
+  /// Parse the object url in the form of {path}?offset={offset}&size={size}.
+  /// Return false if parsing failed.
+  ///
+  /// \param[in] object_url url to parse from.
+  /// \param[out] file_path file stores the object.
+  /// \param[out] object_offset offset of the object stored in the file..
+  /// \param[out] total_size object size in the file.
+  /// \return bool.
+  static bool ParseObjectURL(const std::string &object_url, std::string &file_path,
+                             uint64_t &object_offset, uint64_t &total_size);
+
+  /// Read the istream, parse the object header according to the following format.
+  /// Return false if the input stream is deleted or corrupted.
+  ///     --- start of an object (at object_offset) ---
+  ///      address_size        (8 bytes),
+  ///      metadata_size       (8 bytes),
+  ///      data_size           (8 bytes),
+  ///      serialized_address  (address_size bytes),
+  ///      metadata_payload    (metadata_size bytes),
+  ///      data_payload        (data_size bytes)
+  ///    --- start of another object ---
+  ///      ...
+  ///
+  /// \param[in] is input stream to read from.
+  /// \param[in] object_offset offset of the object stored in the file.
+  /// \param[out] data_offset data payload offset in the file.
+  /// \param[out] data_size size of the data payload.
+  /// \param[out] metadata_offset metadata payload offset in the file.
+  /// \param[out] metadata_size size of the metadata payload.
+  /// \param[out] owner_address owner address.
+  /// \return bool.
+  static bool ParseObjectHeader(std::istream &is, uint64_t object_offset,
+                                uint64_t &data_offset, uint64_t &data_size,
+                                uint64_t &metadata_offset, uint64_t &metadata_size,
+                                rpc::Address &owner_address);
+
+  /// Read 8 bytes from inputstream and deserialize it as a little-endian
+  /// uint64_t. Return false if reach end of stream early.
+  static bool ReadUINT64(std::istream &is, uint64_t &output);
+
+  /// Deserialize 8 bytes string as a little-endian uint64_t.
+  static uint64_t ToUINT64(const std::string &s);
+
+  /// Helper functions read from data/metadata sections into output.
+  /// Return false if the file is corrupted.
+  bool ReadFromDataSection(uint64_t offset, uint64_t size, char *output) const;
+  bool ReadFromMetadataSection(uint64_t offset, uint64_t size, char *output) const;
+
+ private:
+  FRIEND_TEST(SpilledObjectTest, ParseObjectURL);
+  FRIEND_TEST(SpilledObjectTest, ToUINT64);
+  FRIEND_TEST(SpilledObjectTest, ReadUINT64);
+  FRIEND_TEST(SpilledObjectTest, ParseObjectHeader);
+  FRIEND_TEST(SpilledObjectTest, Getters);
+  FRIEND_TEST(SpilledObjectTest, GetNumChunks);
+
+  const std::string file_path_;
+  const uint64_t object_size_;
+  const uint64_t data_offset_;
+  const uint64_t data_size_;
+  const uint64_t metadata_offset_;
+  const uint64_t metadata_size_;
+  const rpc::Address owner_address_;
+  const uint64_t chunk_size_;
+};
+
+}  // namespace ray

--- a/src/ray/object_manager/test/spilled_object_test.cc
+++ b/src/ray/object_manager/test/spilled_object_test.cc
@@ -1,0 +1,296 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/object_manager/spilled_object.h"
+
+#include <boost/endian/conversion.hpp>
+#include <fstream>
+
+#include "absl/strings/str_format.h"
+#include "gtest/gtest.h"
+#include "ray/common/test_util.h"
+#include "ray/util/filesystem.h"
+
+namespace ray {
+
+TEST(SpilledObjectTest, ParseObjectURL) {
+  auto assert_parse_success =
+      [](const std::string &object_url, const std::string &expected_file_path,
+         uint64_t expected_object_offset, uint64_t expected_object_size) {
+        std::string actual_file_path;
+        uint64_t actual_offset = 0;
+        uint64_t actual_size = 0;
+        ASSERT_TRUE(SpilledObject::ParseObjectURL(object_url, actual_file_path,
+                                                  actual_offset, actual_size));
+        ASSERT_EQ(expected_file_path, actual_file_path);
+        ASSERT_EQ(expected_object_offset, actual_offset);
+        ASSERT_EQ(expected_object_size, actual_size);
+      };
+
+  auto assert_parse_fail = [](const std::string &object_url) {
+    std::string actual_file_path;
+    uint64_t actual_offset = 0;
+    uint64_t actual_size = 0;
+    ASSERT_FALSE(SpilledObject::ParseObjectURL(object_url, actual_file_path,
+                                               actual_offset, actual_size));
+  };
+
+  assert_parse_success("file://path/to/file?offset=123&size=456", "file://path/to/file",
+                       123, 456);
+  assert_parse_success("http://123?offset=123&size=456", "http://123", 123, 456);
+  assert_parse_success("file:///C:/Users/file.txt?offset=123&size=456",
+                       "file:///C:/Users/file.txt", 123, 456);
+  assert_parse_success("/tmp/file.txt?offset=123&size=456", "/tmp/file.txt", 123, 456);
+  assert_parse_success("C:\\file.txt?offset=123&size=456", "C:\\file.txt", 123, 456);
+
+  assert_parse_fail("file://path/to/file?offset=a&size=456");
+  assert_parse_fail("file://path/to/file?offset=0&size=bb");
+  assert_parse_fail("file://path/to/file?offset=123");
+  assert_parse_fail("file://path/to/file?offset=a&size=456&extra");
+}
+
+TEST(SpilledObjectTest, ToUINT64) {
+  ASSERT_EQ(0, SpilledObject::ToUINT64(
+                   {'\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00'}));
+  ASSERT_EQ(1, SpilledObject::ToUINT64(
+                   {'\x01', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00'}));
+  ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
+            SpilledObject::ToUINT64(
+                {'\xff', '\xff', '\xff', '\xff', '\xff', '\xff', '\xff', '\xff'}));
+}
+
+TEST(SpilledObjectTest, ReadUINT64) {
+  std::istringstream s1(std::string{
+      '\x00', '\x00', '\x00', '\x00', '\x00', '\x00',
+      '\x00', '\x00',  // little endian of 0
+      '\x01', '\x00', '\x00', '\x00', '\x00', '\x00',
+      '\x00', '\x00',  // little endian of 1
+      '\xff', '\xff', '\xff', '\xff', '\xff', '\xff',
+      '\xff', '\xff',                                 // little endian of 2^64 - 1
+      '\xff', '\xff', '\xff', '\xff', '\xff', '\xff'  // malformed
+  });
+  uint64_t output{100};
+  ASSERT_TRUE(SpilledObject::ReadUINT64(s1, output));
+  ASSERT_EQ(0, output);
+  ASSERT_TRUE(SpilledObject::ReadUINT64(s1, output));
+  ASSERT_EQ(1, output);
+  ASSERT_TRUE(SpilledObject::ReadUINT64(s1, output));
+  ASSERT_EQ(std::numeric_limits<uint64_t>::max(), output);
+  ASSERT_FALSE(SpilledObject::ReadUINT64(s1, output));
+}
+
+namespace {
+std::string ContructObjectString(uint64_t object_offset, std::string data,
+                                 std::string metadata, rpc::Address owner_address) {
+  std::string result(object_offset, '\0');
+  std::string address_str;
+  owner_address.SerializeToString(&address_str);
+  uint64_t address_size = boost::endian::native_to_little(address_str.size());
+  uint64_t data_size = boost::endian::native_to_little(data.size());
+  uint64_t metadata_size = boost::endian::native_to_little(metadata.size());
+
+  result.append((char *)(&address_size), 8);
+  result.append((char *)(&metadata_size), 8);
+  result.append((char *)(&data_size), 8);
+  result.append(address_str);
+  result.append(metadata);
+  result.append(data);
+  return result;
+}
+}  // namespace
+
+TEST(SpilledObjectTest, ParseObjectHeader) {
+  auto assert_parse_success = [](uint64_t object_offset, std::string data,
+                                 std::string metadata, std::string raylet_id) {
+    rpc::Address owner_address;
+    owner_address.set_raylet_id(raylet_id);
+    auto str = ContructObjectString(object_offset, data, metadata, owner_address);
+    uint64_t actual_data_offset = 0;
+    uint64_t actual_data_size = 0;
+    uint64_t actual_metadata_offset = 0;
+    uint64_t actual_metadata_size = 0;
+    rpc::Address actual_owner_address;
+    std::istringstream is(str);
+    ASSERT_TRUE(SpilledObject::ParseObjectHeader(
+        is, object_offset, actual_data_offset, actual_data_size, actual_metadata_offset,
+        actual_metadata_size, actual_owner_address));
+    std::string address_str;
+    owner_address.SerializeToString(&address_str);
+    ASSERT_EQ(object_offset + 24 + address_str.size(), actual_metadata_offset);
+    ASSERT_EQ(object_offset + 24 + address_str.size() + metadata.size(),
+              actual_data_offset);
+    ASSERT_EQ(data.size(), actual_data_size);
+    ASSERT_EQ(metadata.size(), actual_metadata_size);
+    ASSERT_EQ(owner_address.raylet_id(), actual_owner_address.raylet_id());
+    ASSERT_EQ(data, str.substr(actual_data_offset, actual_data_size));
+    ASSERT_EQ(metadata, str.substr(actual_metadata_offset, actual_metadata_size));
+  };
+  std::vector<uint64_t> offsets{0, 1, 100};
+  std::string large_data(10000, 'c');
+  std::vector<std::string> data_list{"", "somedata", large_data};
+  std::string large_metadata(10000, 'm');
+  std::vector<std::string> metadata_list{"", "somemetadata", large_metadata};
+  std::vector<std::string> raylet_ids{"", "yes", "laaaaaaaarrrrrggge"};
+
+  for (auto offset : offsets) {
+    for (auto &data : data_list) {
+      for (auto &metadata : metadata_list) {
+        for (auto &raylet_id : raylet_ids) {
+          assert_parse_success(offset, data, metadata, raylet_id);
+        }
+      }
+    }
+  }
+
+  auto assert_parse_failure = [](uint64_t object_offset, uint64_t truncate_size) {
+    std::string data("data");
+    std::string metadata("metadata");
+    rpc::Address owner_address;
+    auto str = ContructObjectString(object_offset, data, metadata, owner_address);
+    str = str.substr(0, truncate_size);
+    uint64_t actual_data_offset = 0;
+    uint64_t actual_data_size = 0;
+    uint64_t actual_metadata_offset = 0;
+    uint64_t actual_metadata_size = 0;
+    rpc::Address actual_owner_address;
+    std::istringstream is(str);
+    ASSERT_FALSE(SpilledObject::ParseObjectHeader(
+        is, object_offset, actual_data_offset, actual_data_size, actual_metadata_offset,
+        actual_metadata_size, actual_owner_address));
+  };
+
+  std::string address_str;
+  rpc::Address owner_address;
+  owner_address.SerializeToString(&address_str);
+  for (uint64_t truncate_len = 98; truncate_len < 124 + address_str.size();
+       truncate_len++) {
+    assert_parse_failure(100, truncate_len);
+  }
+}
+
+TEST(SpilledObjectTest, Getters) {
+  rpc::Address owner_address;
+  owner_address.set_raylet_id("nonsense");
+  SpilledObject obj("path", 8 /* object_size */, 2 /* data_offset */, 3 /* data_size */,
+                    4 /* metadata_offset */, 5 /* metadata_size */, owner_address,
+                    6 /* chunk_size */);
+  ASSERT_EQ(3, obj.GetDataSize());
+  ASSERT_EQ(5, obj.GetMetadataSize());
+  ASSERT_EQ(owner_address.raylet_id(), obj.GetOwnerAddress().raylet_id());
+  ASSERT_EQ(2, obj.GetNumChunks());
+}
+
+TEST(SpilledObjectTest, GetNumChunks) {
+  auto assert_get_num_chunks = [](uint64_t data_size, uint64_t chunk_size,
+                                  uint64_t expected_num_chunks) {
+    rpc::Address owner_address;
+    owner_address.set_raylet_id("nonsense");
+    SpilledObject obj("path", 100 /* object_size */, 2 /* data_offset */,
+                      data_size /* data_size */, 4 /* metadata_offset */,
+                      0 /* metadata_size */, owner_address, chunk_size /* chunk_size */);
+
+    ASSERT_EQ(expected_num_chunks, obj.GetNumChunks());
+  };
+
+  assert_get_num_chunks(11 /* data_size */, 1 /* chunk_size */,
+                        11 /* expected_num_chunks */);
+  assert_get_num_chunks(1 /* data_size */, 11 /* chunk_size */,
+                        1 /* expected_num_chunks */);
+  assert_get_num_chunks(0 /* data_size */, 11 /* chunk_size */,
+                        0 /* expected_num_chunks */);
+  assert_get_num_chunks(9 /* data_size */, 2 /* chunk_size */,
+                        5 /* expected_num_chunks */);
+  assert_get_num_chunks(10 /* data_size */, 2 /* chunk_size */,
+                        5 /* expected_num_chunks */);
+  assert_get_num_chunks(11 /* data_size */, 2 /* chunk_size */,
+                        6 /* expected_num_chunks */);
+}
+
+namespace {
+std::string CreateSpilledObjectOnTmp(uint64_t object_offset, std::string data,
+                                     std::string metadata, rpc::Address owner_address,
+                                     bool skip_write = false) {
+  auto str = ContructObjectString(object_offset, data, metadata, owner_address);
+  std::string tmp_file = ray::JoinPaths(
+      ray::GetUserTempDir(), "spilled_object_test" + ObjectID::FromRandom().Hex());
+
+  std::ofstream f(tmp_file, std::ios::binary);
+  if (!skip_write) {
+    RAY_CHECK(f.write(str.c_str(), str.size()));
+  }
+  f.close();
+  return absl::StrFormat("%s?offset=%d&size=%d", tmp_file, object_offset,
+                         str.size() - object_offset);
+}
+}  // namespace
+
+TEST(SpilledObjectTest, CreateSpilledObject) {
+  auto object_url = CreateSpilledObjectOnTmp(10 /* object_offset */, "data", "metadata",
+                                             ray::rpc::Address());
+  // 0 chunk_size.
+  ASSERT_FALSE(
+      SpilledObject::CreateSpilledObject(object_url, 0 /* chunk_size */).has_value());
+  ASSERT_FALSE(SpilledObject::CreateSpilledObject("malformatted_url", 1 /* chunk_size */)
+                   .has_value());
+  auto optional_object =
+      SpilledObject::CreateSpilledObject(object_url, 2 /* chunk_size */);
+  ASSERT_TRUE(optional_object.has_value());
+
+  auto object_url1 = CreateSpilledObjectOnTmp(10 /* object_offset */, "data", "metadata",
+                                              ray::rpc::Address(), true /* skip_write */);
+  // file corrupted.
+  ASSERT_FALSE(
+      SpilledObject::CreateSpilledObject(object_url1, 2 /* chunk_size */).has_value());
+}
+
+namespace {
+void AssertGetChunkWorks(std::string metadata, std::string data,
+                         std::vector<uint64_t> chunk_sizes) {
+  std::string expected_output = data + metadata;
+  chunk_sizes.push_back(expected_output.size());
+  auto object_url = CreateSpilledObjectOnTmp(10 /* object_offset */, data, metadata,
+                                             ray::rpc::Address());
+
+  // check that we can reconstruct the output by concatinating chunks with different
+  // chunk_size, and the size of chunk is expected.
+  for (auto chunk_size : chunk_sizes) {
+    auto optional_object = SpilledObject::CreateSpilledObject(object_url, chunk_size);
+    ASSERT_TRUE(optional_object.has_value());
+    std::string actual_output_by_chunks;
+    for (uint64_t i = 0; i < optional_object->GetNumChunks(); i++) {
+      auto chunk = optional_object->GetChunk(i);
+      ASSERT_TRUE(chunk.has_value());
+      ASSERT_GE(chunk_size, chunk->size());
+      if (i + 1 != optional_object->GetNumChunks()) {
+        ASSERT_EQ(chunk_size, chunk->size());
+      }
+      actual_output_by_chunks.append(chunk.value());
+    }
+    ASSERT_EQ(expected_output, actual_output_by_chunks);
+  }
+}
+}  // namespace
+
+TEST(SpilledObjectTest, GetChunk) {
+  AssertGetChunkWorks("meta", "alotofdata", {1, 2, 3, 5, 100});
+  AssertGetChunkWorks("alotofactualmeta", "meh", {1, 2, 3, 5, 100});
+  AssertGetChunkWorks("", "weonlyhavedata", {1, 2, 3, 5, 100});
+  AssertGetChunkWorks("weonlyhavemetadata", "", {1, 2, 3, 5, 100});
+}
+}  // namespace ray
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This is the a stacked PRs for bypassing local plasma store when restoring spilled object.

Basic Idea:

1. We created a thread safe SpilledObject which provide access to a locally spilled object. It exposes APIs for query ObjectInfo, as well as read it by chunks (see spilled_object.h header file, implementation is missing).
2. In ObjectManager::Push, depending on wether the object is spilled or not, we calls to either the spilled object or buffered_pool for pushing.

This is the 1 of 3 PRs which introduce a SpilledObject, which reads data in chunks.

[[pr1](https://github.com/ray-project/ray/pull/16248), [pr2](https://github.com/ray-project/ray/pull/16352), [pr3](https://github.com/ray-project/ray/pull/16364)]