### PR TITLE
[New Scheduler] Remove Useless Fields in Cluster Resource Data

### DIFF
--- a/src/ray/raylet/scheduling/cluster_resource_data.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_data.cc
@@ -124,7 +124,6 @@ TaskRequest TaskResourceInstances::ToTaskRequest() const {
   for (auto it = this->custom_resources.begin(); it != this->custom_resources.end();
        ++it) {
     task_req.custom_resources[i].id = it->first;
-    task_req.custom_resources[i].soft = false;
     task_req.custom_resources[i].demand = 0;
     for (size_t j = 0; j < it->second.size(); j++) {
       task_req.custom_resources[i].demand += it->second[j];
@@ -209,20 +208,18 @@ bool NodeResources::IsAvailable(const TaskRequest &task_req) const {
 
     const auto &resource = this->predefined_resources[i].available;
     const auto &demand = task_req.predefined_resources[i].demand;
-    bool is_soft = task_req.predefined_resources[i].soft;
 
-    if (resource < demand && !is_soft) {
+    if (resource < demand) {
       return false;
     }
   }
 
   // Now check custom resources.
   for (const auto &task_req_custom_resource : task_req.custom_resources) {
-    bool is_soft = task_req_custom_resource.soft;
     auto it = this->custom_resources.find(task_req_custom_resource.id);
-    if (it == this->custom_resources.end() && !is_soft) {
+    if (it == this->custom_resources.end()) {
       return false;
-    } else if (task_req_custom_resource.demand > it->second.available && !is_soft) {
+    } else if (task_req_custom_resource.demand > it->second.available) {
       return false;
     }
   }
@@ -240,20 +237,18 @@ bool NodeResources::IsFeasible(const TaskRequest &task_req) const {
     }
     const auto &resource = this->predefined_resources[i].total;
     const auto &demand = task_req.predefined_resources[i].demand;
-    bool is_soft = task_req.predefined_resources[i].soft;
 
-    if (resource < demand && !is_soft) {
+    if (resource < demand) {
       return false;
     }
   }
 
   // Now check custom resources.
   for (const auto &task_req_custom_resource : task_req.custom_resources) {
-    bool is_soft = task_req_custom_resource.soft;
     auto it = this->custom_resources.find(task_req_custom_resource.id);
-    if (it == this->custom_resources.end() && !is_soft) {
+    if (it == this->custom_resources.end()) {
       return false;
-    } else if (task_req_custom_resource.demand > it->second.total && !is_soft) {
+    } else if (task_req_custom_resource.demand > it->second.total) {
       return false;
     }
   }
@@ -487,16 +482,14 @@ std::string TaskRequest::DebugString() const {
   std::stringstream buffer;
   buffer << " {";
   for (size_t i = 0; i < this->predefined_resources.size(); i++) {
-    buffer << "(" << this->predefined_resources[i].demand << ":"
-           << this->predefined_resources[i].soft << ") ";
+    buffer << "(" << this->predefined_resources[i].demand << ") ";
   }
   buffer << "}";
 
   buffer << "  [";
   for (size_t i = 0; i < this->custom_resources.size(); i++) {
     buffer << this->custom_resources[i].id << ":"
-           << "(" << this->custom_resources[i].demand << ":"
-           << this->custom_resources[i].soft << ") ";
+           << "(" << this->custom_resources[i].demand << ") ";
   }
   buffer << "]" << std::endl;
   return buffer.str();

--- a/src/ray/raylet/scheduling/cluster_resource_data.h
+++ b/src/ray/raylet/scheduling/cluster_resource_data.h
@@ -56,11 +56,6 @@ struct ResourceInstanceCapacities {
 struct ResourceRequest {
   /// Amount of resource being requested.
   FixedPoint demand;
-  /// Specify whether the request is soft or hard.
-  /// If hard, the entire request is denied if the demand exceeds the resource
-  /// availability. Otherwise, the request can be still be granted.
-  /// Preferences are given to the nodes with the lowest number of violations.
-  bool soft = false;
 };
 
 /// Resource request, including resource ID. This is used for custom resources.
@@ -76,11 +71,6 @@ class TaskRequest {
   std::vector<ResourceRequest> predefined_resources;
   /// List of custom resources required by the task.
   std::vector<ResourceRequestWithId> custom_resources;
-  /// List of placement hints. A placement hint is a node on which
-  /// we desire to run this task. This is a soft constraint in that
-  /// the task will run on a different node in the cluster, if none of the
-  /// nodes in this list can schedule this task.
-  absl::flat_hash_set<int64_t> placement_hints;
   /// Check whether the request contains no resources.
   bool IsEmpty() const;
   /// Returns human-readable string for this task request.

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -277,15 +277,13 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
   /// (0., 0., 0., 0.)
   ///
   /// \param demand: The resource amount to be allocated.
-  /// \param soft: Specifies whether this demand has soft or hard constraints.
   /// \param available: List of available capacities of the instances of the resource.
   /// \param allocation: List of instance capacities allocated to satisfy the demand.
   /// This is a return parameter.
   ///
   /// \return true, if allocation successful. In this case, the sum of the elements in
   /// "allocation" is equal to "demand".
-  bool AllocateResourceInstances(FixedPoint demand, bool soft,
-                                 std::vector<FixedPoint> &available,
+  bool AllocateResourceInstances(FixedPoint demand, std::vector<FixedPoint> &available,
                                  std::vector<FixedPoint> *allocation);
 
   /// Allocate local resources to satisfy a given request (task_req).

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
@@ -52,20 +52,16 @@ vector<bool> EmptyBoolVector;
 vector<FixedPoint> EmptyFixedPointVector;
 
 void initTaskRequest(TaskRequest &tr, vector<FixedPoint> &pred_demands,
-                     vector<bool> &pred_soft, vector<int64_t> &cust_ids,
-                     vector<FixedPoint> &cust_demands, vector<bool> &cust_soft,
-                     vector<int64_t> &placement_hints) {
+                     vector<int64_t> &cust_ids, vector<FixedPoint> &cust_demands) {
   for (size_t i = 0; i < pred_demands.size(); i++) {
     ResourceRequest rq;
     rq.demand = pred_demands[i];
-    rq.soft = pred_soft[i];
     tr.predefined_resources.push_back(rq);
   }
 
   for (size_t i = pred_demands.size(); i < PredefinedResources_MAX; i++) {
     ResourceRequest rq;
     rq.demand = 0;
-    rq.soft = 0;
     tr.predefined_resources.push_back(rq);
   }
 
@@ -73,12 +69,7 @@ void initTaskRequest(TaskRequest &tr, vector<FixedPoint> &pred_demands,
     ResourceRequestWithId rq;
     rq.id = cust_ids[i];
     rq.demand = cust_demands[i];
-    rq.soft = cust_soft[i];
     tr.custom_resources.push_back(rq);
-  }
-
-  for (size_t i = 0; i < placement_hints.size(); i++) {
-    tr.placement_hints.insert(placement_hints[i]);
   }
 };
 
@@ -344,20 +335,17 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingUpdateAvailableResourcesTest) {
   {
     TaskRequest task_req;
 #define PRED_CUSTOM_LEN 2
-    vector<FixedPoint> pred_demands{7, 7};
-    vector<bool> pred_soft{false, true};
+    vector<FixedPoint> pred_demands{7, 5};
     vector<int64_t> cust_ids{1, 2};
-    vector<FixedPoint> cust_demands{3, 10};
-    vector<bool> cust_soft{false, true};
-    initTaskRequest(task_req, pred_demands, pred_soft, cust_ids, cust_demands, cust_soft,
-                    EmptyIntVector);
+    vector<FixedPoint> cust_demands{3, 5};
+    initTaskRequest(task_req, pred_demands, cust_ids, cust_demands);
     int64_t violations;
     bool is_infeasible;
     int64_t node_id = resource_scheduler.GetBestSchedulableNode(
         task_req, false, false, &violations, &is_infeasible);
     ASSERT_TRUE(node_id != -1);
     ASSERT_EQ(node_id, 1);
-    ASSERT_TRUE(violations > 0);
+    ASSERT_TRUE(violations == 0);
 
     NodeResources nr1, nr2;
     ASSERT_TRUE(resource_scheduler.GetNodeResources(node_id, &nr1));
@@ -447,37 +435,19 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingTaskRequestTest) {
   {
     TaskRequest task_req;
     vector<FixedPoint> pred_demands = {11};
-    vector<bool> pred_soft = {false};
-    initTaskRequest(task_req, pred_demands, pred_soft, EmptyIntVector,
-                    EmptyFixedPointVector, EmptyBoolVector, EmptyIntVector);
+    initTaskRequest(task_req, pred_demands, EmptyIntVector, EmptyFixedPointVector);
     int64_t violations;
     bool is_infeasible;
     int64_t node_id = resource_scheduler.GetBestSchedulableNode(
         task_req, false, false, &violations, &is_infeasible);
     ASSERT_EQ(node_id, -1);
   }
-  // Predefined resources, soft constraint violation
-  {
-    TaskRequest task_req;
-    vector<FixedPoint> pred_demands = {11};
-    vector<bool> pred_soft = {true};
-    initTaskRequest(task_req, pred_demands, pred_soft, EmptyIntVector,
-                    EmptyFixedPointVector, EmptyBoolVector, EmptyIntVector);
-    int64_t violations;
-    bool is_infeasible;
-    int64_t node_id = resource_scheduler.GetBestSchedulableNode(
-        task_req, false, false, &violations, &is_infeasible);
-    ASSERT_TRUE(node_id != -1);
-    ASSERT_TRUE(violations > 0);
-  }
 
   // Predefined resources, no constraint violation.
   {
     TaskRequest task_req;
     vector<FixedPoint> pred_demands = {5};
-    vector<bool> pred_soft = {false};
-    initTaskRequest(task_req, pred_demands, pred_soft, EmptyIntVector,
-                    EmptyFixedPointVector, EmptyBoolVector, EmptyIntVector);
+    initTaskRequest(task_req, pred_demands, EmptyIntVector, EmptyFixedPointVector);
     int64_t violations;
     bool is_infeasible;
     int64_t node_id = resource_scheduler.GetBestSchedulableNode(
@@ -489,45 +459,22 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingTaskRequestTest) {
   {
     TaskRequest task_req;
     vector<FixedPoint> pred_demands{5, 2};
-    vector<bool> pred_soft{false, true};
     vector<int64_t> cust_ids{1};
     vector<FixedPoint> cust_demands{11};
-    vector<bool> cust_soft{false};
-    initTaskRequest(task_req, pred_demands, pred_soft, cust_ids, cust_demands, cust_soft,
-                    EmptyIntVector);
+    initTaskRequest(task_req, pred_demands, cust_ids, cust_demands);
     int64_t violations;
     bool is_infeasible;
     int64_t node_id = resource_scheduler.GetBestSchedulableNode(
         task_req, false, false, &violations, &is_infeasible);
     ASSERT_TRUE(node_id == -1);
   }
-  // Custom resources, soft constraint violation.
-  {
-    TaskRequest task_req;
-    vector<FixedPoint> pred_demands{5, 2};
-    vector<bool> pred_soft{false, true};
-    vector<int64_t> cust_ids{1};
-    vector<FixedPoint> cust_demands{11};
-    vector<bool> cust_soft{true};
-    initTaskRequest(task_req, pred_demands, pred_soft, cust_ids, cust_demands, cust_soft,
-                    EmptyIntVector);
-    int64_t violations;
-    bool is_infeasible;
-    int64_t node_id = resource_scheduler.GetBestSchedulableNode(
-        task_req, false, false, &violations, &is_infeasible);
-    ASSERT_TRUE(node_id != -1);
-    ASSERT_TRUE(violations > 0);
-  }
   // Custom resources, no constraint violation.
   {
     TaskRequest task_req;
     vector<FixedPoint> pred_demands{5, 2};
-    vector<bool> pred_soft{false, true};
     vector<int64_t> cust_ids{1};
     vector<FixedPoint> cust_demands{5};
-    vector<bool> cust_soft{false};
-    initTaskRequest(task_req, pred_demands, pred_soft, cust_ids, cust_demands, cust_soft,
-                    EmptyIntVector);
+    initTaskRequest(task_req, pred_demands, cust_ids, cust_demands);
     int64_t violations;
     bool is_infeasible;
     int64_t node_id = resource_scheduler.GetBestSchedulableNode(
@@ -539,64 +486,22 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingTaskRequestTest) {
   {
     TaskRequest task_req;
     vector<FixedPoint> pred_demands{5, 2};
-    vector<bool> pred_soft{false, true};
     vector<int64_t> cust_ids{100};
     vector<FixedPoint> cust_demands{5};
-    vector<bool> cust_soft{false};
-    initTaskRequest(task_req, pred_demands, pred_soft, cust_ids, cust_demands, cust_soft,
-                    EmptyIntVector);
+    initTaskRequest(task_req, pred_demands, cust_ids, cust_demands);
     int64_t violations;
     bool is_infeasible;
     int64_t node_id = resource_scheduler.GetBestSchedulableNode(
         task_req, false, false, &violations, &is_infeasible);
     ASSERT_TRUE(node_id == -1);
   }
-  // Custom resource missing, soft constraint violation.
-  {
-    TaskRequest task_req;
-    vector<FixedPoint> pred_demands{5, 2};
-    vector<bool> pred_soft{false, true};
-    vector<int64_t> cust_ids{100};
-    vector<FixedPoint> cust_demands{5};
-    vector<bool> cust_soft{true};
-    initTaskRequest(task_req, pred_demands, pred_soft, cust_ids, cust_demands, cust_soft,
-                    EmptyIntVector);
-    int64_t violations;
-    bool is_infeasible;
-    int64_t node_id = resource_scheduler.GetBestSchedulableNode(
-        task_req, false, false, &violations, &is_infeasible);
-    ASSERT_TRUE(node_id != -1);
-    ASSERT_TRUE(violations > 0);
-  }
-  // Placement_hints, soft constraint violation.
-  {
-    TaskRequest task_req;
-    vector<FixedPoint> pred_demands{5, 2};
-    vector<bool> pred_soft{false, true};
-    vector<int64_t> cust_ids{1};
-    vector<FixedPoint> cust_demands{5};
-    vector<bool> cust_soft{true};
-    vector<int64_t> placement_hints{2, 3};
-    initTaskRequest(task_req, pred_demands, pred_soft, cust_ids, cust_demands, cust_soft,
-                    placement_hints);
-    int64_t violations;
-    bool is_infeasible;
-    int64_t node_id = resource_scheduler.GetBestSchedulableNode(
-        task_req, false, false, &violations, &is_infeasible);
-    ASSERT_TRUE(node_id != -1);
-    ASSERT_TRUE(violations > 0);
-  }
   // Placement hints, no constraint violation.
   {
     TaskRequest task_req;
     vector<FixedPoint> pred_demands{5, 2};
-    vector<bool> pred_soft{false, true};
     vector<int64_t> cust_ids{1};
     vector<FixedPoint> cust_demands{5};
-    vector<bool> cust_soft{true};
-    vector<int64_t> placement_hints{1, 2, 3};
-    initTaskRequest(task_req, pred_demands, pred_soft, cust_ids, cust_demands, cust_soft,
-                    placement_hints);
+    initTaskRequest(task_req, pred_demands, cust_ids, cust_demands);
     int64_t violations;
     bool is_infeasible;
     int64_t node_id = resource_scheduler.GetBestSchedulableNode(
@@ -684,9 +589,7 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesTest) {
 
     TaskRequest task_req;
     vector<FixedPoint> pred_demands = {3. /* CPU */, 2. /* MEM */, 1.5 /* GPU */};
-    vector<bool> pred_soft = {false, false, false};
-    initTaskRequest(task_req, pred_demands, pred_soft, EmptyIntVector,
-                    EmptyFixedPointVector, EmptyBoolVector, EmptyIntVector);
+    initTaskRequest(task_req, pred_demands, EmptyIntVector, EmptyFixedPointVector);
 
     NodeResourceInstances old_local_resources = resource_scheduler.GetLocalResources();
 
@@ -712,9 +615,7 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesTest) {
 
     TaskRequest task_req;
     vector<FixedPoint> pred_demands = {4. /* CPU */, 2. /* MEM */, 1.5 /* GPU */};
-    vector<bool> pred_soft = {false};  // Hard constrained resource.
-    initTaskRequest(task_req, pred_demands, pred_soft, EmptyIntVector,
-                    EmptyFixedPointVector, EmptyBoolVector, EmptyIntVector);
+    initTaskRequest(task_req, pred_demands, EmptyIntVector, EmptyFixedPointVector);
 
     NodeResourceInstances old_local_resources = resource_scheduler.GetLocalResources();
     std::shared_ptr<TaskResourceInstances> task_allocation =
@@ -724,38 +625,6 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesTest) {
 
     ASSERT_EQ(success, false);
     ASSERT_EQ((resource_scheduler.GetLocalResources() == old_local_resources), true);
-  }
-  // Allocate resources for a task request that overallocates a soft constrained resource.
-  {
-    NodeResources node_resources;
-    vector<FixedPoint> pred_capacities{3 /* CPU */, 4 /* MEM */, 5 /* GPU */};
-    initNodeResources(node_resources, pred_capacities, EmptyIntVector,
-                      EmptyFixedPointVector);
-    ClusterResourceScheduler resource_scheduler(0, node_resources);
-
-    TaskRequest task_req;
-    vector<FixedPoint> pred_demands = {4. /* CPU */, 2. /* MEM */, 1.5 /* GPU */};
-    vector<bool> pred_soft = {true};  // Soft constrained resource.
-    initTaskRequest(task_req, pred_demands, pred_soft, EmptyIntVector,
-                    EmptyFixedPointVector, EmptyBoolVector, EmptyIntVector);
-
-    NodeResourceInstances old_local_resources = resource_scheduler.GetLocalResources();
-    std::shared_ptr<TaskResourceInstances> task_allocation =
-        std::make_shared<TaskResourceInstances>();
-    bool success =
-        resource_scheduler.AllocateTaskResourceInstances(task_req, task_allocation);
-
-    ASSERT_EQ(success, true);
-
-    TaskResourceInstances expected_task_allocation;
-    addTaskResourceInstances(true, {0., 0., 0.}, CPU, &expected_task_allocation);
-    addTaskResourceInstances(true, {2.}, MEM, &expected_task_allocation);
-    addTaskResourceInstances(true, {0., 0.5, 1., 1., 1.}, GPU, &expected_task_allocation);
-
-    TaskResourceInstances local_available_resources =
-        resource_scheduler.GetLocalResources().GetAvailableResourceInstances();
-
-    ASSERT_EQ((local_available_resources == expected_task_allocation), true);
   }
   // Allocate resources for a task request specifying both predefined and custom
   // resources.
@@ -769,11 +638,8 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesTest) {
 
     TaskRequest task_req;
     vector<FixedPoint> pred_demands = {3. /* CPU */, 2. /* MEM */, 1.5 /* GPU */};
-    vector<bool> pred_soft = {false, false, false};
     vector<FixedPoint> cust_demands{3, 2};
-    vector<bool> cust_soft{false, false};
-    initTaskRequest(task_req, pred_demands, pred_soft, cust_ids, cust_demands, cust_soft,
-                    EmptyIntVector);
+    initTaskRequest(task_req, pred_demands, cust_ids, cust_demands);
 
     NodeResourceInstances old_local_resources = resource_scheduler.GetLocalResources();
     std::shared_ptr<TaskResourceInstances> task_allocation =
@@ -799,11 +665,8 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesTest) {
 
     TaskRequest task_req;
     vector<FixedPoint> pred_demands = {3. /* CPU */, 2. /* MEM */, 1.5 /* GPU */};
-    vector<bool> pred_soft = {false, false, false};
     vector<FixedPoint> cust_demands{3, 10};
-    vector<bool> cust_soft{false, false};
-    initTaskRequest(task_req, pred_demands, pred_soft, cust_ids, cust_demands, cust_soft,
-                    EmptyIntVector);
+    initTaskRequest(task_req, pred_demands, cust_ids, cust_demands);
 
     NodeResourceInstances old_local_resources = resource_scheduler.GetLocalResources();
     std::shared_ptr<TaskResourceInstances> task_allocation =
@@ -813,44 +676,6 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesTest) {
 
     ASSERT_EQ(success, false);
     ASSERT_EQ((resource_scheduler.GetLocalResources() == old_local_resources), true);
-  }
-  // Allocate resources for a task request specifying both predefined and custom
-  // resources, but overallocates a soft-constrained custom resource.
-  {
-    NodeResources node_resources;
-    vector<FixedPoint> pred_capacities{3 /* CPU */, 4 /* MEM */, 5 /* GPU */};
-    vector<int64_t> cust_ids{1, 2};
-    vector<FixedPoint> cust_capacities{4, 4};
-    initNodeResources(node_resources, pred_capacities, cust_ids, cust_capacities);
-    ClusterResourceScheduler resource_scheduler(0, node_resources);
-
-    TaskRequest task_req;
-    vector<FixedPoint> pred_demands = {3. /* CPU */, 2. /* MEM */, 1.5 /* GPU */};
-    vector<bool> pred_soft = {false, false, false};
-    vector<FixedPoint> cust_demands{3, 10};
-    vector<bool> cust_soft{false, true};
-    initTaskRequest(task_req, pred_demands, pred_soft, cust_ids, cust_demands, cust_soft,
-                    EmptyIntVector);
-
-    NodeResourceInstances old_local_resources = resource_scheduler.GetLocalResources();
-    std::shared_ptr<TaskResourceInstances> task_allocation =
-        std::make_shared<TaskResourceInstances>();
-    bool success =
-        resource_scheduler.AllocateTaskResourceInstances(task_req, task_allocation);
-
-    ASSERT_EQ(success, true);
-
-    TaskResourceInstances expected_task_allocation;
-    addTaskResourceInstances(true, {0., 0., 0.}, CPU, &expected_task_allocation);
-    addTaskResourceInstances(true, {2.}, MEM, &expected_task_allocation);
-    addTaskResourceInstances(true, {0., 0.5, 1., 1., 1.}, GPU, &expected_task_allocation);
-    addTaskResourceInstances(false, {1.}, 1, &expected_task_allocation);
-    addTaskResourceInstances(false, {0.}, 2, &expected_task_allocation);
-
-    TaskResourceInstances local_available_resources =
-        resource_scheduler.GetLocalResources().GetAvailableResourceInstances();
-
-    ASSERT_EQ((local_available_resources == expected_task_allocation), true);
   }
 }
 
@@ -865,11 +690,8 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesTest2) {
 
     TaskRequest task_req;
     vector<FixedPoint> pred_demands = {2. /* CPU */, 2. /* MEM */, 1.5 /* GPU */};
-    vector<bool> pred_soft = {false};
     vector<FixedPoint> cust_demands{3., 2.};
-    vector<bool> cust_soft{false, false};
-    initTaskRequest(task_req, pred_demands, pred_soft, cust_ids, cust_demands, cust_soft,
-                    EmptyIntVector);
+    initTaskRequest(task_req, pred_demands, cust_ids, cust_demands);
 
     std::shared_ptr<TaskResourceInstances> task_allocation =
         std::make_shared<TaskResourceInstances>();
@@ -996,9 +818,7 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstanceWithHardRequestTest) {
 
   TaskRequest task_req;
   vector<FixedPoint> pred_demands = {2. /* CPU */, 2. /* MEM */, 1.5 /* GPU */};
-  vector<bool> pred_soft = {false, false, true};
-  initTaskRequest(task_req, pred_demands, pred_soft, EmptyIntVector,
-                  EmptyFixedPointVector, EmptyBoolVector, EmptyIntVector);
+  initTaskRequest(task_req, pred_demands, EmptyIntVector, EmptyFixedPointVector);
 
   std::shared_ptr<TaskResourceInstances> task_allocation =
       std::make_shared<TaskResourceInstances>();


### PR DESCRIPTION
## Why are these changes needed?

As mentioned in https://github.com/ray-project/ray/pull/16155#issuecomment-854117322, the `soft` field in ResourceRequest and the `placement_hints` field in `TaskRequest` is not used. This PR removes them and modified all related codes and tests. Please have a look, thanks!

## Related issue number

https://github.com/ray-project/ray/pull/16155#issuecomment-854117322

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
