### PR TITLE
[Client] Auto-Run ray.client().connect()

### DIFF
--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -48,7 +48,7 @@ class GlobalState:
 
         # _really_init_global_state should have set self.global_state_accessor
         if self.global_state_accessor is None:
-            if os.environ.get("RAY_DISABLE_AUTO_CONNECT", "") != "1":
+            if os.environ.get("RAY_ENABLE_AUTO_CONNECT", "") == "1":
                 ray.client().connect()
                 # Retry connect!
                 return self._check_connected()

--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 import json
 import logging
+import os
 
 import ray
 
@@ -47,6 +48,10 @@ class GlobalState:
 
         # _really_init_global_state should have set self.global_state_accessor
         if self.global_state_accessor is None:
+            if not bool(os.environ.get("RAY_DISABLE_AUTO_CONNECT", "")):
+                ray.client().connect()
+                # Retry connect!
+                return self._check_connected()
             raise ray.exceptions.RaySystemError(
                 "Ray has not been started yet. You can start Ray with "
                 "'ray.init()'.")

--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -48,7 +48,7 @@ class GlobalState:
 
         # _really_init_global_state should have set self.global_state_accessor
         if self.global_state_accessor is None:
-            if not bool(os.environ.get("RAY_DISABLE_AUTO_CONNECT", "")):
+            if os.environ.get("RAY_DISABLE_AUTO_CONNECT", "") != "1":
                 ray.client().connect()
                 # Retry connect!
                 return self._check_connected()

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -224,12 +224,12 @@ def enable_pickle_debug():
 
 
 @pytest.fixture
-def set_disable_auto_connect(disable_auto_connect: str = "1"):
+def set_enable_auto_connect(enable_auto_connect: str = "0"):
     try:
-        os.environ["RAY_DISABLE_AUTO_CONNECT"] = disable_auto_connect
-        yield disable_auto_connect
+        os.environ["RAY_ENABLE_AUTO_CONNECT"] = enable_auto_connect
+        yield enable_auto_connect
     finally:
-        del os.environ["RAY_DISABLE_AUTO_CONNECT"]
+        del os.environ["RAY_ENABLE_AUTO_CONNECT"]
 
 
 @pytest.fixture()

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -223,6 +223,15 @@ def enable_pickle_debug():
     del os.environ["RAY_PICKLE_VERBOSE_DEBUG"]
 
 
+@pytest.fixture
+def set_disable_auto_connect(disable_auto_connect: str = "1"):
+    try:
+        os.environ["RAY_DISABLE_AUTO_CONNECT"] = disable_auto_connect
+        yield disable_auto_connect
+    finally:
+        del os.environ["RAY_DISABLE_AUTO_CONNECT"]
+
+
 @pytest.fixture()
 def two_node_cluster():
     system_config = {

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -22,8 +22,8 @@ import ray
 import setproctitle  # noqa
 
 
-@pytest.mark.parametrize("set_disable_auto_connect", ["1", "0"], indirect=True)
-def test_caching_actors(shutdown_only, set_disable_auto_connect):
+@pytest.mark.parametrize("set_enable_auto_connect", ["1", "0"], indirect=True)
+def test_caching_actors(shutdown_only, set_enable_auto_connect):
     # Test defining actors before ray.init() has been called.
 
     @ray.remote
@@ -34,7 +34,7 @@ def test_caching_actors(shutdown_only, set_disable_auto_connect):
         def get_val(self):
             return 3
 
-    if set_disable_auto_connect == "1":
+    if set_enable_auto_connect == "0":
         # Check that we can't actually create actors before ray.init() has
         # been called.
         with pytest.raises(Exception):

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -22,7 +22,8 @@ import ray
 import setproctitle  # noqa
 
 
-def test_caching_actors(shutdown_only):
+@pytest.mark.parametrize("disable_auto_connect", ["1", "0"])
+def test_caching_actors(shutdown_only, set_disable_auto_connect):
     # Test defining actors before ray.init() has been called.
 
     @ray.remote
@@ -33,12 +34,17 @@ def test_caching_actors(shutdown_only):
         def get_val(self):
             return 3
 
-    # Check that we can't actually create actors before ray.init() has been
-    # called.
-    with pytest.raises(Exception):
-        f = Foo.remote()
+    if set_disable_auto_connect == "1":
+        # Check that we can't actually create actors before ray.init() has
+        # been called.
+        with pytest.raises(Exception):
+            f = Foo.remote()
 
-    ray.init(num_cpus=1)
+        ray.init(num_cpus=1)
+    else:
+        # Actor creation should succeed here because ray.init() auto connection
+        # is (by default) enabled.
+        f = Foo.remote()
 
     f = Foo.remote()
 

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -22,7 +22,7 @@ import ray
 import setproctitle  # noqa
 
 
-@pytest.mark.parametrize("disable_auto_connect", ["1", "0"])
+@pytest.mark.parametrize("set_disable_auto_connect", ["1", "0"], indirect=True)
 def test_caching_actors(shutdown_only, set_disable_auto_connect):
     # Test defining actors before ray.init() has been called.
 

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -225,7 +225,7 @@ def test_module_lacks_client_builder():
 
 @pytest.mark.skipif(
     sys.platform == "win32", reason="RC Proxy is Flaky on Windows.")
-def test_disconnect(call_ray_stop_only):
+def test_disconnect(call_ray_stop_only, set_disable_auto_connect):
     subprocess.check_output(
         "ray start --head --ray-client-server-port=25555", shell=True)
     with ray.client("localhost:25555").namespace("n1").connect():

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -225,7 +225,7 @@ def test_module_lacks_client_builder():
 
 @pytest.mark.skipif(
     sys.platform == "win32", reason="RC Proxy is Flaky on Windows.")
-def test_disconnect(call_ray_stop_only, set_disable_auto_connect):
+def test_disconnect(call_ray_stop_only, set_enable_auto_connect):
     subprocess.check_output(
         "ray start --head --ray-client-server-port=25555", shell=True)
     with ray.client("localhost:25555").namespace("n1").connect():

--- a/python/ray/tests/test_error_ray_not_initialized.py
+++ b/python/ray/tests/test_error_ray_not_initialized.py
@@ -5,7 +5,7 @@ import pytest
 import ray
 
 
-def test_errors_before_initializing_ray(set_disable_auto_connect):
+def test_errors_before_initializing_ray(set_enable_auto_connect):
     @ray.remote
     def f():
         pass

--- a/python/ray/tests/test_error_ray_not_initialized.py
+++ b/python/ray/tests/test_error_ray_not_initialized.py
@@ -5,7 +5,7 @@ import pytest
 import ray
 
 
-def test_errors_before_initializing_ray():
+def test_errors_before_initializing_ray(set_disable_auto_connect):
     @ray.remote
     def f():
         pass

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -215,7 +215,7 @@ class Worker:
           Exception: An exception is raised if the worker is not connected.
         """
         if not self.connected:
-            if not bool(os.environ.get("RAY_DISABLE_AUTO_CONNECT", "")):
+            if os.environ.get("RAY_DISABLE_AUTO_CONNECT", "") != "1":
                 ray.client().connect()
                 return
             raise RaySystemError("Ray has not been started yet. You can "

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -215,7 +215,7 @@ class Worker:
           Exception: An exception is raised if the worker is not connected.
         """
         if not self.connected:
-            if os.environ.get("RAY_DISABLE_AUTO_CONNECT", "") != "1":
+            if os.environ.get("RAY_ENABLE_AUTO_CONNECT", "") == "1":
                 ray.client().connect()
                 return
             raise RaySystemError("Ray has not been started yet. You can "

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -215,6 +215,9 @@ class Worker:
           Exception: An exception is raised if the worker is not connected.
         """
         if not self.connected:
+            if not bool(os.environ.get("RAY_DISABLE_AUTO_CONNECT", "")):
+                ray.client().connect()
+                return
             raise RaySystemError("Ray has not been started yet. You can "
                                  "start Ray with 'ray.init()'.")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Enable ray auto-connecting to a cluster/starting up a cluster. This means no more `ray.init()` at the beginning of your code!
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
