### PR TITLE
[Core] [runtime_env] add get_release_wheel_url()

### DIFF
--- a/python/ray/test_utils.py
+++ b/python/ray/test_utils.py
@@ -596,3 +596,21 @@ def get_master_wheel_url(
         py_version=py_version)
     return (f"https://s3-us-west-2.amazonaws.com/ray-wheels/master/"
             f"{ray_commit}/{filename}")
+
+
+def get_release_wheel_url(
+        ray_commit: str = ray.__commit__,
+        sys_platform: str = sys.platform,
+        ray_version: str = ray.__version__,
+        py_version: str = f"{sys.version_info.major}{sys.version_info.minor}"
+) -> str:
+    """Return the URL for the wheel for a specific release."""
+    filename = get_wheel_filename(
+        sys_platform=sys_platform,
+        ray_version=ray_version,
+        py_version=py_version)
+    return (f"https://ray-wheels.s3-us-west-2.amazonaws.com/releases/"
+            f"{ray_version}/{ray_commit}/{filename}")
+    # e.g. https://ray-wheels.s3-us-west-2.amazonaws.com/releases/1.4.0rc1/e7c7
+    # f6371a69eb727fa469e4cd6f4fbefd143b4c/ray-1.4.0rc1-cp36-cp36m-manylinux201
+    # 4_x86_64.whl

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -7,9 +7,9 @@ import tempfile
 import requests
 from pathlib import Path
 import ray
-from ray.test_utils import (run_string_as_driver,
-                            run_string_as_driver_nonblocking,
-                            get_wheel_filename, get_master_wheel_url)
+from ray.test_utils import (
+    run_string_as_driver, run_string_as_driver_nonblocking, get_wheel_filename,
+    get_master_wheel_url, get_release_wheel_url)
 import ray.experimental.internal_kv as kv
 from time import sleep
 driver_script = """
@@ -675,7 +675,21 @@ def test_get_master_wheel_url():
         for py_version in ["36", "37", "38"]:
             url = get_master_wheel_url(test_commit, sys_platform, ray_version,
                                        py_version)
-            assert requests.head(url).status_code == 200
+            assert requests.head(url).status_code == 200, url
+
+
+def test_get_release_wheel_url():
+    test_commits = {
+        "1.4.0rc1": "e7c7f6371a69eb727fa469e4cd6f4fbefd143b4c",
+        "1.3.0": "0b4b444fadcdc23226e11fef066b982175804232",
+        "1.2.0": "1b1a2496ca51b745c07c79fb859946d3350d471b"
+    }
+    for sys_platform in ["darwin", "linux", "win32"]:
+        for py_version in ["36", "37", "38"]:
+            for version, commit in test_commits.items():
+                url = get_release_wheel_url(commit, sys_platform, version,
+                                            py_version)
+                assert requests.head(url).status_code == 200, url
 
 
 if __name__ == "__main__":

--- a/python/ray/workers/setup_runtime_env.py
+++ b/python/ray/workers/setup_runtime_env.py
@@ -14,7 +14,8 @@ import ray
 from ray._private.conda import (get_conda_activate_commands,
                                 get_or_create_conda_env)
 from ray._private.utils import try_to_create_directory
-from ray.test_utils import get_wheel_filename, get_master_wheel_url
+from ray.test_utils import (get_wheel_filename, get_master_wheel_url,
+                            get_release_wheel_url)
 logger = logging.getLogger(__name__)
 
 parser = argparse.ArgumentParser()
@@ -158,7 +159,7 @@ def current_ray_pip_specifier() -> Optional[str]:
         # Running on a nightly wheel.
         return get_master_wheel_url()
     else:
-        return f"ray=={ray.__version__}"
+        return get_release_wheel_url()
 
 
 def inject_dependencies(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Closes https://github.com/ray-project/ray/issues/16263
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Previously the Ray dependency was injected into the runtime env by adding the line "ray==1.4.0rc1" (for example) to the top of the pip requirements.txt.  However, if the user then supplies a pip dependency list such as `ray[serve]` to the runtime env, it results in the following requirements.txt:
```
ray==1.4.0rc1
ray[serve]
```

Running `pip install -r requirements.txt` on this results in an infinite loop for some reason (see https://github.com/ray-project/ray/issues/16263).  

If instead of `ray==1.4.0rc1` we use the URL for the wheel, the problem goes away.  This PR adds a function to generate the wheel link for a release and adds a unit test.
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
