### PR TITLE
Updated GPU Dockerfiles to CUDA 11.2

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -17,7 +17,7 @@ key="$1"
 case $key in
     --gpu)
     GPU="-gpu"
-    BASE_IMAGE="nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04"
+    BASE_IMAGE="nvidia/cuda:11.2.0-cudnn8-devel-ubuntu18.04"
     ;;
     --no-cache-build)
     NO_CACHE="--no-cache"

--- a/ci/travis/build-docker-images.py
+++ b/ci/travis/build-docker-images.py
@@ -120,7 +120,7 @@ def _build_cpu_gpu_images(image_name, no_cache=True) -> List[str]:
 
             if image_name == "base-deps":
                 build_args["BASE_IMAGE"] = (
-                    "nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04"
+                    "nvidia/cuda:11.2.0-cudnn8-devel-ubuntu18.04"
                     if gpu == "-gpu" else "ubuntu:focal")
             else:
                 # NOTE(ilr) This is a bit of an abuse of the name "GPU"

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -1,6 +1,6 @@
 # The base-deps Docker image installs main libraries needed to run Ray
 
-# The GPU option is nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04
+# The GPU option is nvidia/cuda:11.2.0-cudnn8-devel-ubuntu18.04
 ARG BASE_IMAGE="ubuntu:focal"
 FROM ${BASE_IMAGE}
 # FROM directive resets ARG


### PR DESCRIPTION
The TensorFlow 2.5.0 release is pre-compiled for CUDA 11.2. Using the current image, I was unable to interact with GPU devices through TensorFlow. Unfortunately, PyTorch is still on CUDA 11.1. However, CUDA should be backwards compatible with libraries built against older minor CUDA versions.