### PR TITLE
Revert "[Core] [runtime env] Inject ray[default] into pip dependencies"

### DIFF
--- a/python/ray/workers/setup_runtime_env.py
+++ b/python/ray/workers/setup_runtime_env.py
@@ -157,9 +157,9 @@ def current_ray_pip_specifier() -> Optional[str]:
         return None
     elif "dev" in ray.__version__:
         # Running on a nightly wheel.
-        return "ray[default]@" + get_master_wheel_url()
+        return get_master_wheel_url()
     else:
-        return "ray[default]@" + get_release_wheel_url()
+        return get_release_wheel_url()
 
 
 def inject_dependencies(


### PR DESCRIPTION
Reverts ray-project/ray#16268

Calling `pip install -r requirements.txt` with the following file:
```
ray[default]@https://ray-wheels.s3-us-west-2.amazonaws.com/releases/1.4.0rc1/e7c7f6371a69eb727fa469e4cd6f4fbefd143b4c/ray-1.4.0rc1-cp36-cp36m-macosx_10_13_intel.whl
ray[serve]
```
results in an infinite loop.  This breaks runtime envs if `ray[serve]` is added as a pip dependency.

Removing `ray[default]@`, the install succeeds.  