### PR TITLE
[Core] [runtime env] Fix injection of ray[default]

### DIFF
--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -427,7 +427,7 @@ def test_pip_task(shutdown_only, pip_as_str, tmp_path):
     sys.platform != "linux", reason="This test is only run on Buildkite.")
 def test_pip_ray_serve(shutdown_only):
     """Tests that ray[serve] can be included as a pip dependency."""
-
+    ray.init()
     runtime_env = {"pip": ["pip-install-test==0.5", "ray[serve]"]}
 
     @ray.remote

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -425,7 +425,7 @@ def test_pip_task(shutdown_only, pip_as_str, tmp_path):
     reason="This test is only run on CI because it uses the built Ray wheel.")
 @pytest.mark.skipif(
     sys.platform != "linux", reason="This test is only run on Buildkite.")
-def test_pip_ray_serve(shutdown_only, pip_as_str, tmp_path):
+def test_pip_ray_serve(shutdown_only):
     """Tests that ray[serve] can be included as a pip dependency."""
 
     runtime_env = {"pip": ["pip-install-test==0.5", "ray[serve]"]}

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -443,6 +443,7 @@ def test_pip_ray_serve(shutdown_only, pip_as_str, tmp_path):
     assert "ModuleNotFoundError" in str(excinfo.value)
     assert ray.get(f.options(runtime_env=runtime_env).remote())
 
+
 @pytest.mark.skipif(
     os.environ.get("CI") is None,
     reason="This test is only run on CI because it uses the built Ray wheel.")

--- a/python/ray/workers/setup_runtime_env.py
+++ b/python/ray/workers/setup_runtime_env.py
@@ -51,7 +51,7 @@ def setup(input_args):
                                       sys.version_info[:3]))  # like 3.6.10
             ray_pip = current_ray_pip_specifier()
             if ray_pip and not runtime_env.get("_skip_inject_ray"):
-                extra_pip_dependencies = [ray_pip]
+                extra_pip_dependencies = [ray_pip, "ray[default]"]
             else:
                 extra_pip_dependencies = []
             conda_dict = inject_dependencies(conda_dict, py_version,
@@ -157,9 +157,9 @@ def current_ray_pip_specifier() -> Optional[str]:
         return None
     elif "dev" in ray.__version__:
         # Running on a nightly wheel.
-        return "ray[default]@" + get_master_wheel_url()
+        return get_master_wheel_url()
     else:
-        return "ray[default]@" + get_release_wheel_url()
+        return get_release_wheel_url()
 
 
 def inject_dependencies(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`pip install -r requirements.txt` on the following `requirements.txt` file 

```
ray[default]@https://ray-wheels.s3-us-west-2.amazonaws.com/releases/1.4.0rc1/e7c7f6371a69eb727fa469e4cd6f4fbefd143b4c/ray-1.4.0rc1-cp36-cp36m-macosx_10_13_intel.whl
ray[serve]
```

results in an infinite loop (see https://github.com/ray-project/ray/issues/16263#issuecomment-855154555), but the following `requirements.txt` file

```
https://ray-wheels.s3-us-west-2.amazonaws.com/releases/1.4.0rc1/e7c7f6371a69eb727fa469e4cd6f4fbefd143b4c/ray-1.4.0rc1-cp36-cp36m-macosx_10_13_intel.whl
ray[default]
ray[serve]
```
works fine.  This PR changes the Ray dependency insertion to use the second approach rather than the first.  This will allow extras like `ray[serve]` to be specified by the user in their runtime env's pip requirements, while also preventing messages like
`FutureWarning: Not all Ray CLI dependencies were found. In Ray 1.4+, the Ray CLI, autoscaler, and dashboard will only be usable via pip install 'ray[default]'. Please update your install command.` that arise when the workers don't have `ray[default]`.

This PR also adds a test to ensure that `ray[serve]` can be added by the user as a dependency in a runtime env.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
