### PR TITLE
[core] Use function_actor_manager.lock when deserializing

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -296,6 +296,10 @@ class Worker:
             _unhandled_error_handler(e)
 
     def deserialize_objects(self, data_metadata_pairs, object_refs):
+        # FunctionActorManager may or the import thread may call pickle.loads
+        # at the same time which can lead to deadlock.
+        # TODO: We may be better off locking on imports or locking pickle.loads
+        # directly (Discussion at #16304)
         with self.function_actor_manager.lock:
             context = self.get_serialization_context()
             return context.deserialize_objects(data_metadata_pairs,

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -298,8 +298,8 @@ class Worker:
     def deserialize_objects(self, data_metadata_pairs, object_refs):
         # FunctionActorManager may or the import thread may call pickle.loads
         # at the same time which can lead to deadlock.
-        # TODO: We may be better off locking on imports or locking pickle.loads
-        # directly (Discussion at #16304)
+        # TODO: We may be better off locking on all imports or injecting a lock
+        # into pickle.loads (https://github.com/ray-project/ray/issues/16304)
         with self.function_actor_manager.lock:
             context = self.get_serialization_context()
             return context.deserialize_objects(data_metadata_pairs,

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -296,8 +296,8 @@ class Worker:
             _unhandled_error_handler(e)
 
     def deserialize_objects(self, data_metadata_pairs, object_refs):
-        # FunctionActorManager may or the import thread may call pickle.loads
-        # at the same time which can lead to deadlock.
+        # Function actor manager or the import thread may call pickle.loads
+        # at the same time which can lead to failed imports
         # TODO: We may be better off locking on all imports or injecting a lock
         # into pickle.loads (https://github.com/ray-project/ray/issues/16304)
         with self.function_actor_manager.lock:

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -289,16 +289,17 @@ class Worker:
                 serialized_value, object_ref=object_ref))
 
     def raise_errors(self, data_metadata_pairs, object_refs):
-        context = self.get_serialization_context()
-        out = context.deserialize_objects(data_metadata_pairs, object_refs)
+        out = self.deserialize_objects(data_metadata_pairs, object_refs)
         if "RAY_IGNORE_UNHANDLED_ERRORS" in os.environ:
             return
         for e in out:
             _unhandled_error_handler(e)
 
     def deserialize_objects(self, data_metadata_pairs, object_refs):
-        context = self.get_serialization_context()
-        return context.deserialize_objects(data_metadata_pairs, object_refs)
+        with self.function_actor_manager.lock:
+            context = self.get_serialization_context()
+            return context.deserialize_objects(data_metadata_pairs,
+                                               object_refs)
 
     def get_objects(self, object_refs, timeout=None):
         """Get the values in the object store associated with the IDs.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Addresses #7879 to some extent, and similar to #4718. Most of this is just speculation from what I've scraped together from various error messages, but it looks like there's a chance that worker.deserialize_objects is called at the same time as some other cloudpickle.loads call on a different thread. This can cause `importlib`'s [deadlock avoidance](https://github.com/python/cpython/blob/3.9/Lib/importlib/_bootstrap.py#L66-L67) to kick in, which prevents certain attributes from being imported correctly.

This PR just acquires the function_actor_manager lock before calling deserialize_objects (which eventually calls cloudpickle.loads). This is pretty much the same way #4718 handled the same issue but with the import_thread. 

## Testing

Motivated by some issues with trying to use ray client with Modin. It looks like we introduced a semi-hacky workaround sometime last year on the Modin repo to get around this problem using a private API, but for whatever reason it doesn't seem to work with client. I ran batches of some of the Modin unit tests on Github Actions with the following results:
- [Run 1](https://github.com/ckw017/modin-ci-testing/actions/runs/911216486): Without lock: 2/8 failures, with lock 0/8 failures
- [Run 2](https://github.com/ckw017/modin-ci-testing/actions/runs/911256934): Without lock: 3/8 failures, with lock 0/8 failures

Failures above were due to the `pandas.core` attribute not found error or some variant.

Not actually sure if this is the exact case as the original issue though which would require testing against the original reproducer mentioned, but the errors are identical.

## Further discussion

There's sort of a question here of whether we should introduce some kind of global import lock (can do some cursed stuff by reassigning `__builtins__.__import__`) or a lock on `pickle.loads` calls, since it looks like this problem can happen an ytime we have multiple threads importing stuff. An even spookier edge case is that if a task that a user submits involves unpickling something as part of a function they wrote it might also trigger this issue, although the case is pretty unlikely.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
