### PR TITLE
[autoscaler] Don't rsync cluster state with local node provider

### DIFF
--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -21,6 +21,9 @@ from ray.autoscaler.tags import (
     NODE_KIND_WORKER, NODE_KIND_UNMANAGED, NODE_KIND_HEAD)
 from ray.autoscaler._private.event_summarizer import EventSummarizer
 from ray.autoscaler._private.legacy_info_string import legacy_log_info_string
+from ray.autoscaler._private.local.node_provider import LocalNodeProvider
+from ray.autoscaler._private.local.node_provider import \
+    record_local_head_state_if_needed
 from ray.autoscaler._private.providers import _get_node_provider
 from ray.autoscaler._private.updater import NodeUpdaterThread
 from ray.autoscaler._private.node_launcher import NodeLauncher
@@ -520,6 +523,11 @@ class StandardAutoscaler:
             if not self.provider:
                 self.provider = _get_node_provider(self.config["provider"],
                                                    self.config["cluster_name"])
+
+            # If using the LocalNodeProvider, make sure the head node is marked
+            # non-terminated.
+            if isinstance(self.provider, LocalNodeProvider):
+                record_local_head_state_if_needed(self.provider)
 
             self.available_node_types = self.config["available_node_types"]
             upscaling_speed = self.config.get("upscaling_speed")

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -53,7 +53,6 @@ from ray.util.debug import log_once
 
 import ray.autoscaler._private.subprocess_output_util as cmd_output_util
 from ray.autoscaler._private.load_metrics import LoadMetricsSummary
-from ray.autoscaler._private.local.config import is_local_manual_node_provider
 from ray.autoscaler._private.autoscaler import AutoscalerSummary
 from ray.autoscaler._private.util import format_info_string, \
     format_info_string_no_node_types

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -695,17 +695,6 @@ def get_or_create_head_node(config: Dict[str, Any],
             setup_commands = config["head_setup_commands"]
             ray_start_commands = config["head_start_ray_commands"]
 
-        # If restarting Ray on a manually-managed on-prem cluster,
-        # we need to upload the local cluster state file to the head node.
-        # If we're not restarting the cluster (empty ray start cmds), don't
-        # sync to avoid breaking the currently running on-prem cluster
-        # autoscaler state.
-        restarting_ray = len(ray_start_commands) > 0
-        if restarting_ray and is_local_manual_node_provider(
-                config["provider"]):
-            # Add cluster state file to file mounts.
-            config = sync_state(config)
-
         if not no_restart:
             warn_about_bad_start_command(ray_start_commands,
                                          no_monitor_on_head)

--- a/python/ray/autoscaler/_private/local/config.py
+++ b/python/ray/autoscaler/_private/local/config.py
@@ -69,26 +69,6 @@ def prepare_manual(config: Dict[str, Any]) -> Dict[str, Any]:
     return config
 
 
-def is_local_manual_node_provider(provider_config: Dict[str, Any]) -> bool:
-    """Is this a LocalNodeProvider that has manually specified IPs?"""
-    return (provider_config["type"] == "local"
-            and "coordinator_address" not in provider_config)
-
-
-def sync_state(config: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    Adds cluster state file to file mounts.
-
-    Used to synchronize head and local cluster state files, mostly to let the
-    head node know that the head node itself is non-terminated.
-    """
-    config = copy.deepcopy(config)
-    cluster_name = config["cluster_name"]
-    state_path = get_state_path(cluster_name)
-    config["file_mounts"][state_path] = state_path
-    return config
-
-
 def get_lock_path(cluster_name: str) -> str:
     return "/tmp/cluster-{}.lock".format(cluster_name)
 

--- a/python/ray/autoscaler/_private/local/node_provider.py
+++ b/python/ray/autoscaler/_private/local/node_provider.py
@@ -264,18 +264,24 @@ def record_local_head_state_if_needed(
         local_provider: LocalNodeProvider) -> None:
     """This function is called on the Ray head from StandardAutoscaler.reset
     to record the head node's own existence in the cluster state file.
+
+    This is necessary because `provider.create_node` in
+    `commands.get_or_create_head_node` records the head state on the
+    cluster-launching machine but not on the head.
     """
     head_ip = local_provider.provider_config["head_ip"]
     cluster_name = local_provider.cluster_name
     # If the head node is not marked as created in the cluster state file,
     if head_ip not in local_provider.non_terminated_nodes({}):
+        # These tags are based on the ones in commands.get_or_create_head_node;
+        # keep in sync.
         head_tags = {
             TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
             TAG_RAY_USER_NODE_TYPE: LOCAL_CLUSTER_NODE_TYPE,
             TAG_RAY_NODE_NAME: "ray-{}-head".format(cluster_name),
             TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE
         }
-        # mark the head node as created in the cluster state file.
+        # Mark the head node as created in the cluster state file.
         local_provider.create_node(node_config={}, tags=head_tags, count=1)
 
         assert head_ip in local_provider.non_terminated_nodes({})

--- a/python/ray/autoscaler/_private/local/node_provider.py
+++ b/python/ray/autoscaler/_private/local/node_provider.py
@@ -4,16 +4,23 @@ import json
 import os
 import socket
 import logging
+from typing import Any
+from typing import Dict
 
 from ray.autoscaler.node_provider import NodeProvider
 from ray.autoscaler.tags import (
     TAG_RAY_NODE_KIND,
     NODE_KIND_WORKER,
     NODE_KIND_HEAD,
+    TAG_RAY_USER_NODE_TYPE,
+    TAG_RAY_NODE_NAME,
+    TAG_RAY_NODE_STATUS,
+    STATUS_UP_TO_DATE
 )
 from ray.autoscaler._private.local.config import bootstrap_local
 from ray.autoscaler._private.local.config import get_lock_path
 from ray.autoscaler._private.local.config import get_state_path
+from ray.autoscaler._private.local.config import LOCAL_CLUSTER_NODE_TYPE
 
 logger = logging.getLogger(__name__)
 
@@ -258,3 +265,24 @@ class LocalNodeProvider(NodeProvider):
     @staticmethod
     def bootstrap_config(cluster_config):
         return bootstrap_local(cluster_config)
+
+
+def record_local_head_state_if_needed(local_provider):
+    """This function is called on the Ray head from StandardAutoscaler.reset
+    to record the head node's own existence in the cluster state file.
+    """
+    head_ip = local_provider.provider_config["head_ip"]
+    cluster_name = local_provider.cluster_name
+    # If the head node is not marked as created in the cluster state file,
+    if head_ip not in local_provider.non_terminated_nodes({}):
+        head_tags = {
+            TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+            TAG_RAY_USER_NODE_TYPE: LOCAL_CLUSTER_NODE_TYPE,
+            TAG_RAY_NODE_NAME: "ray-{}-head".format(cluster_name),
+            TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE
+        }
+        # mark the head node as created in the cluster state file.
+        local_provider.create_node(node_config={}, tags=head_tags, count=1)
+
+        assert head_ip in local_provider.non_terminated_nodes({})
+

--- a/python/ray/tests/test_autoscaler_yaml.py
+++ b/python/ray/tests/test_autoscaler_yaml.py
@@ -248,9 +248,6 @@ class AutoscalingConfigTest(unittest.TestCase):
             self.fail("Failed to validate local/example-minimal-manual.yaml")
         expected_prepared = yaml.safe_load(EXPECTED_LOCAL_CONFIG_STR)
         assert prepared_config == expected_prepared
-        synced_config = local_config.sync_state(prepared_config)
-        state_path = "/tmp/cluster-minimal-manual.state"
-        assert (synced_config["file_mounts"] == {state_path: state_path})
 
         no_worker_config = copy.deepcopy(base_config)
         del no_worker_config["provider"]["worker_ips"]

--- a/python/ray/tests/test_autoscaler_yaml.py
+++ b/python/ray/tests/test_autoscaler_yaml.py
@@ -14,7 +14,6 @@ from click.exceptions import ClickException
 from ray.autoscaler._private.azure.config import (_configure_key_pair as
                                                   _azure_configure_key_pair)
 from ray.autoscaler._private.gcp import config as gcp_config
-from ray.autoscaler._private.local import config as local_config
 from ray.autoscaler._private.util import prepare_config, validate_config,\
     _get_default_config, merge_setup_commands
 from ray.autoscaler._private.providers import _NODE_PROVIDERS

--- a/python/ray/tests/test_coordinator_server.py
+++ b/python/ray/tests/test_coordinator_server.py
@@ -1,4 +1,5 @@
 import os
+import random
 import unittest
 import socket
 import json
@@ -51,14 +52,17 @@ class OnPremCoordinatorServerTest(unittest.TestCase):
 
         Test the general use case and if num_workers increase/decrease.
         """
-
+        # Use a random head_ip so that the state file is regenerated each time
+        # this test is run. (Otherwise the test will fail spuriously when run a
+        # second time.)
+        head_ip = ".".join(str(random.randint(0, 255)) for _ in range(4))
         cluster_config = {
             "cluster_name": "random_name",
             "min_workers": 0,
             "max_workers": 0,
             "provider": {
                 "type": "local",
-                "head_ip": "0.0.0.0:2",
+                "head_ip": head_ip,
                 "worker_ips": ["0.0.0.0:1"],
                 "external_head_ip": "0.0.0.0.3"
             },
@@ -66,7 +70,7 @@ class OnPremCoordinatorServerTest(unittest.TestCase):
         provider_config = cluster_config["provider"]
         node_provider = _get_node_provider(
             provider_config, cluster_config["cluster_name"], use_cache=False)
-        assert node_provider.external_ip("0.0.0.0:2") == "0.0.0.0.3"
+        assert node_provider.external_ip(head_ip) == "0.0.0.0.3"
         assert isinstance(node_provider, LocalNodeProvider)
         expected_workers = {}
         expected_workers[provider_config["head_ip"]] = {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Follow up to https://github.com/ray-project/ray/pull/16202
Closes https://github.com/ray-project/ray/issues/16279 by avoiding rsyncing cluster state and instead constructing it on the head, in StandardAutoscaler.reset.
-- rsyncing the state file looks like it can screw up permissions.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

Unit test testing the head state construction.
Tested by strategy described in https://github.com/ray-project/ray/pull/16202
Needs independent verification by using this PR branch to launch local cluster with setup commands
```
setup_commands:
    - if [ $(which ray) ]; then pip uninstall ray -y; fi
    - pip install -U "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl"
    - if [ -d ray ]; then rm -Rf ray; fi
    - git clone --single-branch --branch fix-attempt https://github.com/DmitriGekhtman/ray
    - pushd ray/python/ray && python setup-dev.py -y && popd
```
