### PR TITLE
[rllib] Fix AttributeError with None in observation shape

### DIFF
--- a/rllib/models/modelv2.py
+++ b/rllib/models/modelv2.py
@@ -415,7 +415,8 @@ def _unpack_obs(obs: TensorType, space: gym.Space,
         offset = 0
         if tensorlib == tf:
             batch_dims = [
-                v if isinstance(v, int) else v.value for v in obs.shape[:-1]
+                v if isinstance(v, int) or (v is None) else v.value
+                for v in obs.shape[:-1]
             ]
             batch_dims = [-1 if v is None else v for v in batch_dims]
         else:


### PR DESCRIPTION
## Why are these changes needed?
With some custom environments, values in obs.shape can be None (for instance:  (4800, None)). This leads to an AttributeError: 'NoneType' object has no attribute 'value' during rollout (not in training). The fix adds a None in first batch_dims, that will be changed to -1 in the second batch_dims:

```python
batch_dims = [
                v if isinstance(v, int) or (v is None) else v.value for v in obs.shape[:-1]
            ]
batch_dims = [-1 if v is None else v for v in batch_dims]

```

With that, there is no more error with observation shapes.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
