### PR TITLE
[New Scheduler]Simplify TaskRequest

### DIFF
--- a/src/ray/raylet/scheduling/cluster_resource_data.h
+++ b/src/ray/raylet/scheduling/cluster_resource_data.h
@@ -53,24 +53,13 @@ struct ResourceInstanceCapacities {
   std::vector<FixedPoint> available;
 };
 
-struct ResourceRequest {
-  /// Amount of resource being requested.
-  FixedPoint demand;
-};
-
-/// Resource request, including resource ID. This is used for custom resources.
-struct ResourceRequestWithId : ResourceRequest {
-  /// Resource ID.
-  int64_t id;
-};
-
 // Data structure specifying the capacity of each resource requested by a task.
 class TaskRequest {
  public:
   /// List of predefined resources required by the task.
-  std::vector<ResourceRequest> predefined_resources;
+  std::vector<FixedPoint> predefined_resources;
   /// List of custom resources required by the task.
-  std::vector<ResourceRequestWithId> custom_resources;
+  std::unordered_map<int64_t, FixedPoint> custom_resources;
   /// Check whether the request contains no resources.
   bool IsEmpty() const;
   /// Returns human-readable string for this task request.


### PR DESCRIPTION
## Why are these changes needed?

As mentioned in https://github.com/ray-project/ray/pull/16155#issuecomment-854651876, we want to simplify the TaskRequest struct. This PR does the following refactoration:

before:
```cpp
struct ResourceRequest {
  FixedPoint demand;
};

struct ResourceRequestWithId : ResourceRequest {
  int64_t id;
};

class TaskRequest {
  std::vector<ResourceRequest> predefined_resources;
  std::vector<ResourceRequestWithId> custom_resources;
};
```

after:
```cpp
class TaskRequest {
  std::vector<FixedPoint> predefined_resources;
  unordered_map<int64_t, FixedPoint> custom_resources;
};
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
