### PR TITLE
Batch the AddSpilledURLs RPC

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2778,18 +2778,20 @@ void CoreWorker::HandleSpillObjects(const rpc::SpillObjectsRequest &request,
 void CoreWorker::HandleAddSpilledUrl(const rpc::AddSpilledUrlRequest &request,
                                      rpc::AddSpilledUrlReply *reply,
                                      rpc::SendReplyCallback send_reply_callback) {
-  const ObjectID object_id = ObjectID::FromBinary(request.object_id());
-  const std::string &spilled_url = request.spilled_url();
-  const NodeID node_id = NodeID::FromBinary(request.spilled_node_id());
-  RAY_LOG(DEBUG) << "Received AddSpilledUrl request for object " << object_id
-                 << ", which has been spilled to " << spilled_url << " on node "
-                 << node_id;
-  auto reference_exists = reference_counter_->HandleObjectSpilled(
-      object_id, spilled_url, node_id, request.size(), /*release*/ false);
-  Status status =
-      reference_exists
-          ? Status::OK()
-          : Status::ObjectNotFound("Object " + object_id.Hex() + " not found");
+  Status status = Status::OK();
+  for (const auto &url : request.spilled_urls()) {
+    const ObjectID object_id = ObjectID::FromBinary(url.object_id());
+    const std::string &spilled_url = url.spilled_url();
+    const NodeID node_id = NodeID::FromBinary(url.spilled_node_id());
+    RAY_LOG(DEBUG) << "Received AddSpilledUrl request for object " << object_id
+                   << ", which has been spilled to " << spilled_url << " on node "
+                   << node_id;
+    auto reference_exists = reference_counter_->HandleObjectSpilled(
+        object_id, spilled_url, node_id, url.size(), /*release*/ false);
+    if (!reference_exists) {
+      status = Status::ObjectNotFound("Object " + object_id.Hex() + " not found");
+    }
+  }
   send_reply_callback(status, nullptr, nullptr);
 }
 

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -345,7 +345,7 @@ message DeleteSpilledObjectsRequest {
 message DeleteSpilledObjectsReply {
 }
 
-message AddSpilledUrlRequest {
+message SpilledURL {
   // Object that was spilled.
   bytes object_id = 1;
   // For objects that have been spilled to external storage, the URL from which
@@ -356,6 +356,11 @@ message AddSpilledUrlRequest {
   bytes spilled_node_id = 3;
   // The size of the object in bytes.
   int64 size = 4;
+}
+
+// Batched add spill URLs (add one or more URLs with the given attributes).
+message AddSpilledUrlRequest {
+  repeated SpilledURL spilled_urls = 1;
 }
 
 message AddSpilledUrlReply {

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -378,7 +378,7 @@ void LocalObjectManager::AddSpilledUrls(
 
   // Batch send the AddSpilledUrl RPCs.
   for (const auto &pair : requests_to_send) {
-    auto request = pair.second;
+    auto &request = pair.second;
     // Get the client connection for the batch.
     const ObjectID oid0 = ObjectID::FromBinary(request.spilled_urls(0).object_id());
     auto owner_client =

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -315,6 +315,9 @@ void LocalObjectManager::UnpinSpilledObjectCallback(
 void LocalObjectManager::AddSpilledUrls(
     const std::vector<ObjectID> &object_ids, const rpc::SpillObjectsReply &worker_reply,
     std::function<void(const ray::Status &)> callback) {
+  // Batch up RPC requests to the owner to avoid excess RPC traffic.
+  absl::flat_hash_map<WorkerID, rpc::AddSpilledUrlRequest> requests_to_send;
+
   auto num_remaining = std::make_shared<size_t>(object_ids.size());
   for (size_t i = 0; i < static_cast<size_t>(worker_reply.spilled_objects_url_size());
        ++i) {
@@ -333,9 +336,6 @@ void LocalObjectManager::AddSpilledUrls(
     // directory. By adding the spilled url "before" adding it to the object directory, we
     // can process the restore request before object directory replies.
     spilled_objects_url_.emplace(object_id, object_url);
-    auto unpin_callback =
-        std::bind(&LocalObjectManager::UnpinSpilledObjectCallback, this, object_id,
-                  object_url, num_remaining, callback, std::placeholders::_1);
 
     // Update the object_id -> url_ref_count to use it for deletion later.
     // We need to track the references here because a single file can contain
@@ -352,24 +352,21 @@ void LocalObjectManager::AddSpilledUrls(
     }
 
     if (RayConfig::instance().ownership_based_object_directory_enabled()) {
-      // TODO(Clark): Don't send RPC to owner if we're fulfilling an owner-initiated
-      // spill RPC.
-      rpc::AddSpilledUrlRequest request;
-      request.set_object_id(object_id.Binary());
-      request.set_spilled_url(object_url);
-      request.set_spilled_node_id(node_id_object_spilled.Binary());
-      request.set_size(it->second.first->GetSize());
+      auto owner_id = WorkerID::FromBinary(it->second.second.worker_id());
+      auto &request = requests_to_send[owner_id];
+      auto url = request.add_spilled_urls();
+      url->set_object_id(object_id.Binary());
+      url->set_spilled_url(object_url);
+      url->set_spilled_node_id(node_id_object_spilled.Binary());
+      url->set_size(it->second.first->GetSize());
 
-      auto owner_client = owner_client_pool_.GetOrConnect(it->second.second);
       RAY_LOG(DEBUG) << "Sending spilled URL " << object_url << " for object "
                      << object_id << " to owner "
                      << WorkerID::FromBinary(it->second.second.worker_id());
-      // Send spilled URL, spilled node ID, and object size to owner.
-      owner_client->AddSpilledUrl(
-          request, [unpin_callback](Status status, const rpc::AddSpilledUrlReply &reply) {
-            unpin_callback(status);
-          });
     } else {
+      auto unpin_callback =
+          std::bind(&LocalObjectManager::UnpinSpilledObjectCallback, this, object_id,
+                    object_url, num_remaining, callback, std::placeholders::_1);
       // Write to object directory. Wait for the write to finish before
       // releasing the object to make sure that the spilled object can
       // be retrieved by other raylets.
@@ -377,6 +374,26 @@ void LocalObjectManager::AddSpilledUrls(
           object_id, object_url, node_id_object_spilled, it->second.first->GetSize(),
           unpin_callback));
     }
+  }
+
+  // Batch send the AddSpilledUrl RPCs.
+  for (const auto &pair : requests_to_send) {
+    auto request = pair.second;
+    // Get the client connection for the batch.
+    const ObjectID oid0 = ObjectID::FromBinary(request.spilled_urls(0).object_id());
+    auto owner_client =
+        owner_client_pool_.GetOrConnect(objects_pending_spill_.find(oid0)->second.second);
+    // Send spilled URL, spilled node ID, and object size to owner.
+    owner_client->AddSpilledUrl(
+        request, [this, num_remaining, request, callback](
+                     Status status, const rpc::AddSpilledUrlReply &reply) {
+          for (const auto &url : request.spilled_urls()) {
+            const ObjectID object_id = ObjectID::FromBinary(url.object_id());
+            const std::string &spilled_url = url.spilled_url();
+            UnpinSpilledObjectCallback(object_id, spilled_url, num_remaining, callback,
+                                       status);
+          }
+        });
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This reduces the number of RPCs when spilling a large number of objects owned by the same process. It didn't fix the hang issue I was debugging but is a nice optimization to have anyways.