### PR TITLE
[Dashboard] Reorganize dashboard modules - snapshot

### DIFF
--- a/dashboard/modules/snapshot/tests/test_snapshot.py
+++ b/dashboard/modules/snapshot/tests/test_snapshot.py
@@ -1,0 +1,70 @@
+import os
+import json
+import jsonschema
+
+import pprint
+import requests
+
+from ray.test_utils import (
+    format_web_url,
+    run_string_as_driver,
+)
+from ray.new_dashboard import dashboard
+from ray.new_dashboard.tests.conftest import *  # noqa
+
+
+def test_snapshot(ray_start_with_dashboard):
+    driver_template = """
+import ray
+
+ray.init(address="{address}", namespace="my_namespace")
+
+@ray.remote
+class Pinger:
+    def ping(self):
+        return "pong"
+
+a = Pinger.options(lifetime={lifetime}, name={name}).remote()
+ray.get(a.ping.remote())
+    """
+
+    detached_driver = driver_template.format(
+        address=ray_start_with_dashboard["redis_address"],
+        lifetime="'detached'",
+        name="'abc'")
+    named_driver = driver_template.format(
+        address=ray_start_with_dashboard["redis_address"],
+        lifetime="None",
+        name="'xyz'")
+    unnamed_driver = driver_template.format(
+        address=ray_start_with_dashboard["redis_address"],
+        lifetime="None",
+        name="None")
+
+    run_string_as_driver(detached_driver)
+    run_string_as_driver(named_driver)
+    run_string_as_driver(unnamed_driver)
+
+    webui_url = ray_start_with_dashboard["webui_url"]
+    webui_url = format_web_url(webui_url)
+    response = requests.get(f"{webui_url}/api/snapshot")
+    response.raise_for_status()
+    data = response.json()
+    schema_path = os.path.join(
+        os.path.dirname(dashboard.__file__),
+        "modules/snapshot/snapshot_schema.json")
+    pprint.pprint(data)
+    jsonschema.validate(instance=data, schema=json.load(open(schema_path)))
+
+    assert len(data["data"]["snapshot"]["actors"]) == 3
+    assert len(data["data"]["snapshot"]["jobs"]) == 4
+
+    for actor_id, entry in data["data"]["snapshot"]["actors"].items():
+        assert entry["jobId"] in data["data"]["snapshot"]["jobs"]
+        assert entry["actorClass"] == "Pinger"
+        assert entry["startTime"] >= 0
+        if entry["isDetached"]:
+            assert entry["endTime"] == 0, entry
+        else:
+            assert entry["endTime"] > 0, entry
+        assert "runtimeEnv" in entry

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -2,7 +2,6 @@ import os
 import sys
 import copy
 import json
-import jsonschema
 import time
 import logging
 import asyncio
@@ -13,7 +12,6 @@ import collections
 import numpy as np
 import aiohttp.web
 import ray
-import pprint
 import psutil
 import pytest
 import redis
@@ -470,63 +468,6 @@ def test_get_cluster_status(ray_start_with_dashboard):
     assert response.json()["data"]["autoscalingError"] == "world"
     assert "clusterStatus" in response.json()["data"]
     assert "loadMetricsReport" in response.json()["data"]["clusterStatus"]
-
-
-def test_snapshot(ray_start_with_dashboard):
-    driver_template = """
-import ray
-
-ray.init(address="{address}", namespace="my_namespace")
-
-@ray.remote
-class Pinger:
-    def ping(self):
-        return "pong"
-
-a = Pinger.options(lifetime={lifetime}, name={name}).remote()
-ray.get(a.ping.remote())
-    """
-
-    detached_driver = driver_template.format(
-        address=ray_start_with_dashboard["redis_address"],
-        lifetime="'detached'",
-        name="'abc'")
-    named_driver = driver_template.format(
-        address=ray_start_with_dashboard["redis_address"],
-        lifetime="None",
-        name="'xyz'")
-    unnamed_driver = driver_template.format(
-        address=ray_start_with_dashboard["redis_address"],
-        lifetime="None",
-        name="None")
-
-    run_string_as_driver(detached_driver)
-    run_string_as_driver(named_driver)
-    run_string_as_driver(unnamed_driver)
-
-    webui_url = ray_start_with_dashboard["webui_url"]
-    webui_url = format_web_url(webui_url)
-    response = requests.get(f"{webui_url}/api/snapshot")
-    response.raise_for_status()
-    data = response.json()
-    schema_path = os.path.join(
-        os.path.dirname(dashboard.__file__),
-        "modules/snapshot/snapshot_schema.json")
-    pprint.pprint(data)
-    jsonschema.validate(instance=data, schema=json.load(open(schema_path)))
-
-    assert len(data["data"]["snapshot"]["actors"]) == 3
-    assert len(data["data"]["snapshot"]["jobs"]) == 4
-
-    for actor_id, entry in data["data"]["snapshot"]["actors"].items():
-        assert entry["jobId"] in data["data"]["snapshot"]["jobs"]
-        assert entry["actorClass"] == "Pinger"
-        assert entry["startTime"] >= 0
-        if entry["isDetached"]:
-            assert entry["endTime"] == 0, entry
-        else:
-            assert entry["endTime"] > 0, entry
-        assert "runtimeEnv" in entry
 
 
 def test_immutable_types():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- Move test_snapshot from test_dashboard.py to modules/snapshot/tests/test_snapshot.py. The test case should be in the module.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

#14766

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
