### PR TITLE
[RLlib] Fix PR 16162: Having added sleep to `_NextValueNotReady` causes TD3 tests to become flakey.

### DIFF
--- a/python/ray/util/iter.py
+++ b/python/ray/util/iter.py
@@ -1221,13 +1221,7 @@ class _NextValueNotReady(Exception):
 
     This is used internally to implement the union() of multiple blocking
     local generators."""
-
-    def __init__(self):
-        # Many generators use this class in spin-locks which
-        # do not yield threads to waiting processing such as pytorch GPU
-        # scheduling, this leads to problems such the following:
-        # https://discuss.ray.io/t/very-slow-gradient-descent-on-remote-workers/1278/9
-        time.sleep(0.000001)
+    pass
 
 
 class _ActorSet(object):

--- a/python/ray/util/iter.py
+++ b/python/ray/util/iter.py
@@ -1223,11 +1223,11 @@ class _NextValueNotReady(Exception):
     local generators."""
 
     def __init__(self):
-        # many generators use the _NextValueNotReady in spin-locks which
-        # do not yeild threads to waiting processing such as pytorch GPU
+        # Many generators use this class in spin-locks which
+        # do not yield threads to waiting processing such as pytorch GPU
         # scheduling, this leads to problems such the following:
         # https://discuss.ray.io/t/very-slow-gradient-descent-on-remote-workers/1278/9
-        time.sleep(0.001)
+        time.sleep(0.000001)
 
 
 class _ActorSet(object):

--- a/rllib/execution/learner_thread.py
+++ b/rllib/execution/learner_thread.py
@@ -1,6 +1,6 @@
 import copy
-import threading
 from six.moves import queue
+import threading
 import time
 from typing import Dict
 

--- a/rllib/execution/learner_thread.py
+++ b/rllib/execution/learner_thread.py
@@ -1,5 +1,7 @@
 import copy
 import threading
+from six.moves import queue
+import time
 from typing import Dict
 
 from ray.rllib.evaluation.metrics import get_learner_stats
@@ -9,7 +11,6 @@ from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.utils.timer import TimerStat
 from ray.rllib.utils.window_stat import WindowStat
 from ray.util.iter import _NextValueNotReady
-from six.moves import queue
 
 tf1, tf, tfv = try_import_tf()
 
@@ -72,6 +73,7 @@ class LearnerThread(threading.Thread):
             try:
                 batch, _ = self.minibatch_buffer.get()
             except queue.Empty:
+                time.sleep(0.001)
                 return _NextValueNotReady()
 
         with self.grad_timer:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

This PR offers a fix for PR 16162's problem with causing TD3 tests to fail/timeout often.
PR 16162 added a sleep to `_NextValueNotReady` causes TD3 tests to become flakey.
- This PR removes that sleep from the c'tor of _NextValueNotReady, but keeps the sleep in place inside IMPALA's learner_thread such that the original issue should remain fixed.
- See also this discussions here: https://discuss.ray.io/t/very-slow-gradient-descent-on-remote-workers/1278/9

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
