### PR TITLE
[core] Make object directory robust to out-of-order updates

### DIFF
--- a/src/ray/object_manager/ownership_based_object_directory.cc
+++ b/src/ray/object_manager/ownership_based_object_directory.cc
@@ -143,21 +143,22 @@ ray::Status OwnershipBasedObjectDirectory::ReportObjectAdded(
 
   metrics_num_object_locations_added_++;
 
-  auto operation = [this, rpc_client, request, worker_id, object_id, node_id](const SequencerDoneCallback &done_callback) {
-  rpc_client->AddObjectLocationOwner(
-      request, [worker_id, object_id, node_id, done_callback](
-                   Status status, const rpc::AddObjectLocationOwnerReply &reply) {
-        if (!status.ok()) {
-          RAY_LOG(DEBUG) << "Worker " << worker_id << " failed to add the location "
-                         << node_id << " for " << object_id
-                         << ", the object has most likely been freed: "
-                         << status.ToString();
-        } else {
-          RAY_LOG(DEBUG) << "Added location " << node_id << " for object " << object_id
-                         << " on owner " << worker_id;
-        }
-        done_callback();
-      });
+  auto operation = [rpc_client, request, worker_id, object_id,
+                    node_id](const SequencerDoneCallback &done_callback) {
+    rpc_client->AddObjectLocationOwner(
+        request, [worker_id, object_id, node_id, done_callback](
+                     Status status, const rpc::AddObjectLocationOwnerReply &reply) {
+          if (!status.ok()) {
+            RAY_LOG(DEBUG) << "Worker " << worker_id << " failed to add the location "
+                           << node_id << " for " << object_id
+                           << ", the object has most likely been freed: "
+                           << status.ToString();
+          } else {
+            RAY_LOG(DEBUG) << "Added location " << node_id << " for object " << object_id
+                           << " on owner " << worker_id;
+          }
+          done_callback();
+        });
   };
   sequencer_.Post(object_id, operation);
   return Status::OK();
@@ -182,21 +183,22 @@ ray::Status OwnershipBasedObjectDirectory::ReportObjectRemoved(
 
   metrics_num_object_locations_removed_++;
 
-  auto operation = [this, rpc_client, request, worker_id, object_id, node_id](const SequencerDoneCallback &done_callback) {
-  rpc_client->RemoveObjectLocationOwner(
-      request, [worker_id, object_id, node_id, done_callback](
-                   Status status, const rpc::RemoveObjectLocationOwnerReply &reply) {
-        if (!status.ok()) {
-          RAY_LOG(DEBUG) << "Worker " << worker_id << " failed to remove the location "
-                         << node_id << " for " << object_id
-                         << ", the object has most likely been freed: "
-                         << status.ToString();
-        } else {
-          RAY_LOG(DEBUG) << "Removed location " << node_id << " for object " << object_id
-                         << " on owner " << worker_id;
-        }
-        done_callback();
-      });
+  auto operation = [rpc_client, request, worker_id, object_id,
+                    node_id](const SequencerDoneCallback &done_callback) {
+    rpc_client->RemoveObjectLocationOwner(
+        request, [worker_id, object_id, node_id, done_callback](
+                     Status status, const rpc::RemoveObjectLocationOwnerReply &reply) {
+          if (!status.ok()) {
+            RAY_LOG(DEBUG) << "Worker " << worker_id << " failed to remove the location "
+                           << node_id << " for " << object_id
+                           << ", the object has most likely been freed: "
+                           << status.ToString();
+          } else {
+            RAY_LOG(DEBUG) << "Removed location " << node_id << " for object "
+                           << object_id << " on owner " << worker_id;
+          }
+          done_callback();
+        });
   };
   sequencer_.Post(object_id, operation);
   return Status::OK();

--- a/src/ray/object_manager/ownership_based_object_directory.cc
+++ b/src/ray/object_manager/ownership_based_object_directory.cc
@@ -143,7 +143,7 @@ ray::Status OwnershipBasedObjectDirectory::ReportObjectAdded(
 
   metrics_num_object_locations_added_++;
 
-  auto operation = [this, request, worker_id, object_id, node_id](const SequencerDoneCallback &done_callback) {
+  auto operation = [this, rpc_client, request, worker_id, object_id, node_id](const SequencerDoneCallback &done_callback) {
   rpc_client->AddObjectLocationOwner(
       request, [worker_id, object_id, node_id, done_callback](
                    Status status, const rpc::AddObjectLocationOwnerReply &reply) {
@@ -182,7 +182,7 @@ ray::Status OwnershipBasedObjectDirectory::ReportObjectRemoved(
 
   metrics_num_object_locations_removed_++;
 
-  auto operation = [this, request, worker_id, object_id, node_id](const SequencerDoneCallback &done_callback) {
+  auto operation = [this, rpc_client, request, worker_id, object_id, node_id](const SequencerDoneCallback &done_callback) {
   rpc_client->RemoveObjectLocationOwner(
       request, [worker_id, object_id, node_id, done_callback](
                    Status status, const rpc::RemoveObjectLocationOwnerReply &reply) {

--- a/src/ray/object_manager/ownership_based_object_directory.h
+++ b/src/ray/object_manager/ownership_based_object_directory.h
@@ -27,6 +27,7 @@
 #include "ray/gcs/gcs_client.h"
 #include "ray/object_manager/object_directory.h"
 #include "ray/rpc/worker/core_worker_client.h"
+#include "ray/util/sequencer.h"
 
 namespace ray {
 
@@ -79,6 +80,9 @@ class OwnershipBasedObjectDirectory : public ObjectDirectory {
   /// for any subsequent requests.
   absl::flat_hash_map<WorkerID, std::shared_ptr<rpc::CoreWorkerClient>>
       worker_rpc_clients_;
+  /// Used to order add/remove updates for a single ObjectID,
+  /// so we don't lose updates at the directory.
+  Sequencer sequencer_;
 
   /// Get or create the rpc client in the worker_rpc_clients.
   std::shared_ptr<rpc::CoreWorkerClient> GetClient(const rpc::Address &owner_address);

--- a/src/ray/object_manager/ownership_based_object_directory.h
+++ b/src/ray/object_manager/ownership_based_object_directory.h
@@ -82,7 +82,7 @@ class OwnershipBasedObjectDirectory : public ObjectDirectory {
       worker_rpc_clients_;
   /// Used to order add/remove updates for a single ObjectID,
   /// so we don't lose updates at the directory.
-  Sequencer sequencer_;
+  Sequencer<ObjectID> sequencer_;
 
   /// Get or create the rpc client in the worker_rpc_clients.
   std::shared_ptr<rpc::CoreWorkerClient> GetClient(const rpc::Address &owner_address);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The ownership-based object directory (OBOD) can lose updates if they arrive out of order. Under heavy load and especially if there's thrashing, this can lead to memory leaks (location that never gets deleted) and possibly hanging (the OBOD registers a location that doesn't actually exist). This fixes the issue by collecting all the updates as a per-location count instead of adding/removing the location entry from a set.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
