### PR TITLE
[Test] Use Ray client in XGBoost train_small release test

### DIFF
--- a/release/xgboost_tests/app_config.yaml
+++ b/release/xgboost_tests/app_config.yaml
@@ -1,4 +1,4 @@
-base_image: "anyscale/ray:1.2.0"
+base_image: "anyscale/ray-ml:pinned-nightly-py37"
 env_vars: {}
 debian_packages:
   - curl

--- a/release/xgboost_tests/workloads/train_small.py
+++ b/release/xgboost_tests/workloads/train_small.py
@@ -16,7 +16,12 @@ from xgboost_ray import RayParams
 from ray.util.xgboost.release_test_util import train_ray
 
 if __name__ == "__main__":
-    ray.client().job_name(os.environ["RAY_JOB_NAME"]).connect()
+    addr = os.environ.get("RAY_ADDRESS")
+    job_name = os.environ.get("RAY_JOB_NAME", "train_small")
+    if addr.startswith("anyscale://"):
+        ray.client(address=addr).job_name(job_name).connect()
+    else:
+        ray.init(address="auto")
 
     ray_params = RayParams(
         elastic_training=False,

--- a/release/xgboost_tests/xgboost_tests.yaml
+++ b/release/xgboost_tests/xgboost_tests.yaml
@@ -8,9 +8,10 @@
     compute_template: tpl_cpu_small.yaml
 
   run:
+    use_connect: True
     timeout: 600
     prepare: python wait_cluster.py 4 600
-    script: python workloads/train_small.py
+    script: workloads/train_small.py
 
 - name: train_moderate
   owner:

--- a/release/xgboost_tests/xgboost_tests.yaml
+++ b/release/xgboost_tests/xgboost_tests.yaml
@@ -11,7 +11,7 @@
     use_connect: True
     timeout: 600
     prepare: python wait_cluster.py 4 600
-    script: workloads/train_small.py
+    script: python workloads/train_small.py
 
 - name: train_moderate
   owner:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This is an example of using Anyscale connect for a Ray release test. The script is tested against latest release of Ray, Anyscale CLI, and releaser from head. The command to run is the same as running other release tests:
```
$ python releaser/e2e.py --test-config ray/release/xgboost_tests/xgboost_tests.yaml --test-name train_small
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
