### PR TITLE
[CI] Fix determine_tests_to_run logic

### DIFF
--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -122,8 +122,14 @@ if __name__ == "__main__":
                 RAY_CI_MACOS_WHEELS_AFFECTED = 1
             elif changed_file.startswith("python/ray/dashboard"):
                 RAY_CI_DASHBOARD_AFFECTED = 1
+                # https://github.com/ray-project/ray/pull/15981
+                RAY_CI_LINUX_WHEELS_AFFECTED = 1
+                RAY_CI_MACOS_WHEELS_AFFECTED = 1
             elif changed_file.startswith("dashboard"):
                 RAY_CI_DASHBOARD_AFFECTED = 1
+                # https://github.com/ray-project/ray/pull/15981
+                RAY_CI_LINUX_WHEELS_AFFECTED = 1
+                RAY_CI_MACOS_WHEELS_AFFECTED = 1
             elif changed_file.startswith("python/"):
                 RAY_CI_TUNE_AFFECTED = 1
                 RAY_CI_SGD_AFFECTED = 1
@@ -135,6 +141,9 @@ if __name__ == "__main__":
                 RAY_CI_MACOS_WHEELS_AFFECTED = 1
                 RAY_CI_STREAMING_PYTHON_AFFECTED = 1
                 RAY_CI_DOC_AFFECTED = 1
+                # Python changes might impact cross language stack in Java.
+                # Java also depends on Python CLI to manage processes.
+                RAY_CI_JAVA_AFFECTED = 1
                 if changed_file.startswith("python/setup.py") or re.match(
                         ".*requirements.*\.txt", changed_file):
                     RAY_CI_PYTHON_DEPENDENCIES_AFFECTED = 1


### PR DESCRIPTION
We recently had two master breakages due to determine_tests_to_run
script bug.
https://github.com/ray-project/ray/pull/16120
https://github.com/ray-project/ray/pull/15981

This PR fix both of them.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
