### PR TITLE
[Core] Revert "Fix concurrent actor starting too many threads. (#14927)"

### DIFF
--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -561,39 +561,6 @@ def test_actor_concurrent(ray_start_regular_shared):
     assert r1 == r2 == r3
 
 
-def test_actor_max_concurrency(ray_start_regular_shared):
-    """
-    Test that an actor of max_concurrency=N should only run
-    N tasks at most concurrently.
-    """
-    CONCURRENCY = 3
-
-    @ray.remote
-    class ConcurentActor:
-        def __init__(self):
-            self.threads = set()
-
-        def call(self):
-            # Record the current thread that runs this function.
-            self.threads.add(threading.current_thread())
-
-        def get_num_threads(self):
-            return len(self.threads)
-
-    @ray.remote
-    def call(actor):
-        for _ in range(CONCURRENCY * 100):
-            ray.get(actor.call.remote())
-        return
-
-    actor = ConcurentActor.options(max_concurrency=CONCURRENCY).remote()
-    # Start many concurrent tasks that will call the actor many times.
-    ray.get([call.remote(actor) for _ in range(CONCURRENCY * 10)])
-
-    # Check that the number of threads shouldn't be greater than CONCURRENCY.
-    assert ray.get(actor.get_num_threads.remote()) <= CONCURRENCY
-
-
 def test_wait(ray_start_regular_shared):
     @ray.remote
     def f(delay):

--- a/src/ray/core_worker/test/scheduling_queue_test.cc
+++ b/src/ray/core_worker/test/scheduling_queue_test.cc
@@ -39,7 +39,8 @@ class MockWaiter : public DependencyWaiter {
 TEST(SchedulingQueueTest, TestInOrder) {
   instrumented_io_context io_service;
   MockWaiter waiter;
-  ActorSchedulingQueue queue(io_service, waiter);
+  WorkerContext context(WorkerType::WORKER, WorkerID::FromRandom(), JobID::Nil());
+  ActorSchedulingQueue queue(io_service, waiter, context);
   int n_ok = 0;
   int n_rej = 0;
   auto fn_ok = [&n_ok](rpc::SendReplyCallback callback) { n_ok++; };
@@ -59,7 +60,8 @@ TEST(SchedulingQueueTest, TestWaitForObjects) {
   ObjectID obj3 = ObjectID::FromRandom();
   instrumented_io_context io_service;
   MockWaiter waiter;
-  ActorSchedulingQueue queue(io_service, waiter);
+  WorkerContext context(WorkerType::WORKER, WorkerID::FromRandom(), JobID::Nil());
+  ActorSchedulingQueue queue(io_service, waiter, context);
   int n_ok = 0;
   int n_rej = 0;
   auto fn_ok = [&n_ok](rpc::SendReplyCallback callback) { n_ok++; };
@@ -84,7 +86,8 @@ TEST(SchedulingQueueTest, TestWaitForObjectsNotSubjectToSeqTimeout) {
   ObjectID obj1 = ObjectID::FromRandom();
   instrumented_io_context io_service;
   MockWaiter waiter;
-  ActorSchedulingQueue queue(io_service, waiter);
+  WorkerContext context(WorkerType::WORKER, WorkerID::FromRandom(), JobID::Nil());
+  ActorSchedulingQueue queue(io_service, waiter, context);
   int n_ok = 0;
   int n_rej = 0;
   auto fn_ok = [&n_ok](rpc::SendReplyCallback callback) { n_ok++; };
@@ -101,7 +104,8 @@ TEST(SchedulingQueueTest, TestWaitForObjectsNotSubjectToSeqTimeout) {
 TEST(SchedulingQueueTest, TestOutOfOrder) {
   instrumented_io_context io_service;
   MockWaiter waiter;
-  ActorSchedulingQueue queue(io_service, waiter);
+  WorkerContext context(WorkerType::WORKER, WorkerID::FromRandom(), JobID::Nil());
+  ActorSchedulingQueue queue(io_service, waiter, context);
   int n_ok = 0;
   int n_rej = 0;
   auto fn_ok = [&n_ok](rpc::SendReplyCallback callback) { n_ok++; };
@@ -118,7 +122,8 @@ TEST(SchedulingQueueTest, TestOutOfOrder) {
 TEST(SchedulingQueueTest, TestSeqWaitTimeout) {
   instrumented_io_context io_service;
   MockWaiter waiter;
-  ActorSchedulingQueue queue(io_service, waiter);
+  WorkerContext context(WorkerType::WORKER, WorkerID::FromRandom(), JobID::Nil());
+  ActorSchedulingQueue queue(io_service, waiter, context);
   int n_ok = 0;
   int n_rej = 0;
   auto fn_ok = [&n_ok](rpc::SendReplyCallback callback) { n_ok++; };
@@ -140,7 +145,8 @@ TEST(SchedulingQueueTest, TestSeqWaitTimeout) {
 TEST(SchedulingQueueTest, TestSkipAlreadyProcessedByClient) {
   instrumented_io_context io_service;
   MockWaiter waiter;
-  ActorSchedulingQueue queue(io_service, waiter);
+  WorkerContext context(WorkerType::WORKER, WorkerID::FromRandom(), JobID::Nil());
+  ActorSchedulingQueue queue(io_service, waiter, context);
   int n_ok = 0;
   int n_rej = 0;
   auto fn_ok = [&n_ok](rpc::SendReplyCallback callback) { n_ok++; };

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -440,10 +440,6 @@ void CoreWorkerDirectTaskReceiver::HandleTask(
     return;
   }
 
-  if (task_spec.IsActorCreationTask()) {
-    SetMaxActorConcurrency(task_spec.IsAsyncioActor(), task_spec.MaxActorConcurrency());
-  }
-
   // Only assign resources for non-actor tasks. Actor tasks inherit the resources
   // assigned at initial actor creation time.
   std::shared_ptr<ResourceMappingType> resource_ids;
@@ -538,7 +534,7 @@ void CoreWorkerDirectTaskReceiver::HandleTask(
       auto result = actor_scheduling_queues_.emplace(
           task_spec.CallerWorkerId(),
           std::unique_ptr<SchedulingQueue>(new ActorSchedulingQueue(
-              task_main_io_service_, *waiter_, pool_, is_asyncio_, fiber_state_)));
+              task_main_io_service_, *waiter_, worker_context_)));
       it = result.first;
     }
 
@@ -568,27 +564,6 @@ bool CoreWorkerDirectTaskReceiver::CancelQueuedNormalTask(TaskID task_id) {
   // Look up the task to be canceled in the queue of normal tasks. If it is found and
   // removed successfully, return true.
   return normal_scheduling_queue_->CancelTaskIfFound(task_id);
-}
-
-void CoreWorkerDirectTaskReceiver::SetMaxActorConcurrency(bool is_asyncio,
-                                                          int max_concurrency) {
-  RAY_CHECK(max_concurrency_ == 0)
-      << "SetMaxActorConcurrency should only be called at most once.";
-  RAY_CHECK(fiber_state_ == nullptr);
-  RAY_CHECK(pool_ == nullptr);
-  RAY_CHECK(max_concurrency >= 1);
-  if (max_concurrency > 1) {
-    max_concurrency_ = max_concurrency;
-    is_asyncio_ = is_asyncio;
-    if (is_asyncio_) {
-      RAY_LOG(INFO) << "Creating new thread pool of size " << max_concurrency;
-      fiber_state_.reset(new FiberState(max_concurrency));
-    } else {
-      RAY_LOG(INFO) << "Setting actor as async with max_concurrency=" << max_concurrency
-                    << ", creating new fiber thread.";
-      pool_.reset(new BoundedExecutor(max_concurrency));
-    }
-  }
 }
 
 }  // namespace ray

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -391,17 +391,13 @@ class SchedulingQueue {
 class ActorSchedulingQueue : public SchedulingQueue {
  public:
   ActorSchedulingQueue(instrumented_io_context &main_io_service, DependencyWaiter &waiter,
-                       std::shared_ptr<BoundedExecutor> pool = nullptr,
-                       bool is_asyncio = false,
-                       std::shared_ptr<FiberState> fiber_state = nullptr,
+                       WorkerContext &worker_context,
                        int64_t reorder_wait_seconds = kMaxReorderWaitSeconds)
-      : reorder_wait_seconds_(reorder_wait_seconds),
+      : worker_context_(worker_context),
+        reorder_wait_seconds_(reorder_wait_seconds),
         wait_timer_(main_io_service),
         main_thread_id_(boost::this_thread::get_id()),
-        waiter_(waiter),
-        pool_(pool),
-        is_asyncio_(is_asyncio),
-        fiber_state_(fiber_state) {}
+        waiter_(waiter) {}
 
   bool TaskQueueEmpty() const { return pending_actor_tasks_.empty(); }
 
@@ -448,6 +444,24 @@ class ActorSchedulingQueue : public SchedulingQueue {
 
   /// Schedules as many requests as possible in sequence.
   void ScheduleRequests() {
+    // Only call SetMaxActorConcurrency to configure threadpool size when the
+    // actor is not async actor. Async actor is single threaded.
+    int max_concurrency = worker_context_.CurrentActorMaxConcurrency();
+    if (worker_context_.CurrentActorIsAsync()) {
+      // If this is an async actor, initialize the fiber state once.
+      if (!is_asyncio_) {
+        RAY_LOG(DEBUG) << "Setting direct actor as async, creating new fiber thread.";
+        fiber_state_.reset(new FiberState(max_concurrency));
+        is_asyncio_ = true;
+      }
+    } else {
+      // If this is a concurrency actor (not async), initialize the thread pool once.
+      if (max_concurrency != 1 && !pool_) {
+        RAY_LOG(INFO) << "Creating new thread pool of size " << max_concurrency;
+        pool_.reset(new BoundedExecutor(max_concurrency));
+      }
+    }
+
     // Cancel any stale requests that the client doesn't need any longer.
     while (!pending_actor_tasks_.empty() &&
            pending_actor_tasks_.begin()->first < next_seq_no_) {
@@ -468,7 +482,7 @@ class ActorSchedulingQueue : public SchedulingQueue {
       if (is_asyncio_) {
         // Process async actor task.
         fiber_state_->EnqueueFiber([request]() mutable { request.Accept(); });
-      } else if (pool_ != nullptr) {
+      } else if (pool_) {
         // Process concurrent actor task.
         pool_->PostBlocking([request]() mutable { request.Accept(); });
       } else {
@@ -511,6 +525,8 @@ class ActorSchedulingQueue : public SchedulingQueue {
     }
   }
 
+  // Worker context.
+  WorkerContext &worker_context_;
   /// Max time in seconds to wait for dependencies to show up.
   const int64_t reorder_wait_seconds_ = 0;
   /// Sorted map of (accept, rej) task callbacks keyed by their sequence number.
@@ -525,13 +541,13 @@ class ActorSchedulingQueue : public SchedulingQueue {
   /// Reference to the waiter owned by the task receiver.
   DependencyWaiter &waiter_;
   /// If concurrent calls are allowed, holds the pool for executing these tasks.
-  std::shared_ptr<BoundedExecutor> pool_;
+  std::unique_ptr<BoundedExecutor> pool_;
   /// Whether we should enqueue requests into asyncio pool. Setting this to true
   /// will instantiate all tasks as fibers that can be yielded.
   bool is_asyncio_ = false;
-  /// If is_asyncio_ is true, fiber_state_ contains the running state required
+  /// If use_asyncio_ is true, fiber_state_ contains the running state required
   /// to enable continuation and work together with python asyncio.
-  std::shared_ptr<FiberState> fiber_state_;
+  std::unique_ptr<FiberState> fiber_state_;
   friend class SchedulingQueueTest;
 };
 
@@ -660,20 +676,6 @@ class CoreWorkerDirectTaskReceiver {
   // Queue of pending normal (non-actor) tasks.
   std::unique_ptr<SchedulingQueue> normal_scheduling_queue_ =
       std::unique_ptr<SchedulingQueue>(new NormalSchedulingQueue());
-  /// The max number of concurrent calls to allow.
-  /// 0 indicates that the value is not set yet.
-  int max_concurrency_ = 0;
-  /// If concurrent calls are allowed, holds the pool for executing these tasks.
-  std::shared_ptr<BoundedExecutor> pool_;
-  /// Whether this actor use asyncio for concurrency.
-  bool is_asyncio_ = false;
-  /// If use_asyncio_ is true, fiber_state_ contains the running state required
-  /// to enable continuation and work together with python asyncio.
-  std::shared_ptr<FiberState> fiber_state_;
-
-  /// Set the max concurrency of an actor.
-  /// This should be called once for the actor creation task.
-  void SetMaxActorConcurrency(bool is_asyncio, int max_concurrency);
 };
 
 }  // namespace ray


### PR DESCRIPTION
This reverts commit 3e1a0439b791ab67a90d0a41e14c3cffcf49807b.

This fixes a lost object bug for a shuffling data loader workload. I'd prefer to merge a fix instead that doesn't revert us back to a fiber thread per caller and a thread pool per caller, this reverting PR is a last resort.

## Related issue number

Closes #16322 
