### PR TITLE
Fix active RPC tracking in event tracker

### DIFF
--- a/src/ray/common/asio/instrumented_io_context.h
+++ b/src/ray/common/asio/instrumented_io_context.h
@@ -78,6 +78,8 @@ struct StatsHandle {
         handler_stats(std::move(handler_stats_)),
         global_stats(std::move(global_stats_)) {}
 
+  void ZeroAccumulatedQueuingDelay() { start_time = absl::GetCurrentTimeNanos(); }
+
   ~StatsHandle() {
     if (!execution_recorded) {
       // If handler execution was never recorded, we need to clean up some queueing
@@ -103,6 +105,14 @@ class instrumented_io_context : public boost::asio::io_context {
   void post(std::function<void()> handler, const std::string name = "UNKNOWN")
       LOCKS_EXCLUDED(mutex_);
 
+  /// A proxy post function where the operation start is manually recorded. For example,
+  /// this is useful for tracking the number of active outbound RPC calls.
+  ///
+  /// \param handler The handler to be posted to the event loop.
+  /// \param handle The stats handle returned by RecordStart() previously.
+  void post(std::function<void()> handler, std::shared_ptr<StatsHandle> handle)
+      LOCKS_EXCLUDED(mutex_);
+
   /// Sets the queueing start time, increments the current and cumulative counts and
   /// returns an opaque handle for these stats. This is used in conjunction with
   /// RecordExecution() to manually instrument an event loop handler that doesn't call
@@ -112,11 +122,11 @@ class instrumented_io_context : public boost::asio::io_context {
   /// call.
   ///
   /// \param name A human-readable name to which collected stats will be associated.
-  /// \param pad_start_ns How much to pad the observed queueing start time, in
-  ///  nanoseconds.
+  /// \param expected_queueing_delay_ns How much to pad the observed queueing start time,
+  ///  in nanoseconds.
   /// \return An opaque stats handle, to be given to RecordExecution().
   std::shared_ptr<StatsHandle> RecordStart(const std::string &name,
-                                           int64_t pad_start_ns = 0);
+                                           int64_t expected_queueing_delay_ns = 0);
 
   /// Records stats about the provided function's execution. This is used in conjunction
   /// with RecordStart() to manually instrument an event loop handler that doesn't call


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Prior to this PR, we only tracked active "completion handlers" for outgoing client calls. Now we fully track all outstanding client RPCs, which enables visibility into pending outgoing RPC calls.

This enables hang debugging, for example `RAY_debug_dump_period_milliseconds=500 RAY_asio_event_loop_stats_collection_enabled=1 RAY_max_fused_object_count=2000 python -m ray.experimental.shuffle --num-partitions=200 --partition-size=10e6` will hang, and reading /tmp/ray/session_latest/debug_state.txt shows the smoking gun:

```
Handler stats:
	CoreWorkerService.grpc_client.AddObjectLocationOwner - 40006 total (6 active), CPU time: mean = 6.004 us, total = 240.180 ms
	CoreWorkerService.grpc_client.SubscribeForObjectEviction - 40000 total (13634 active), CPU time: mean = 8.162 us, total = 326.464 ms
```