### PR TITLE
[RFC] unify the push path for plasma/spilled objects.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -893,9 +893,9 @@ cc_test(
     copts = COPTS,
     deps = [
         ":raylet_lib",
+        "@boost//:endian",
         "@com_google_googletest//:gtest_main",
         "@com_google_absl//absl/strings:str_format",
-        "@boost//:endian",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -894,8 +894,8 @@ cc_test(
     deps = [
         ":raylet_lib",
         "@boost//:endian",
-        "@com_google_googletest//:gtest_main",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -894,6 +894,7 @@ cc_test(
     deps = [
         ":raylet_lib",
         "@com_google_googletest//:gtest_main",
+        "@com_google_absl//absl/strings:str_format",
         "@boost//:endian",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -886,6 +886,20 @@ cc_test(
 )
 
 cc_test(
+    name = "spilled_object_test",
+    srcs = [
+        "src/ray/object_manager/test/spilled_object_test.cc",
+    ],
+    copts = COPTS,
+    deps = [
+        ":raylet_lib",
+        "@com_google_googletest//:gtest_main",
+        "@boost//:endian",
+    ],
+)
+
+
+cc_test(
     name = "create_request_queue_test",
     srcs = [
         "src/ray/object_manager/test/create_request_queue_test.cc",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -899,7 +899,6 @@ cc_test(
     ],
 )
 
-
 cc_test(
     name = "create_request_queue_test",
     srcs = [

--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -57,40 +57,6 @@ class ObjectBufferPool {
   /// This object cannot be copied due to pool_mutex.
   RAY_DISALLOW_COPY_AND_ASSIGN(ObjectBufferPool);
 
-  /// Computes the number of chunks needed to transfer an object and its metadata.
-  ///
-  /// \param data_size The size of the object + metadata.
-  /// \return The number of chunks into which the object will be split.
-  uint64_t GetNumChunks(uint64_t data_size);
-
-  /// Computes the buffer length of a chunk of an object.
-  ///
-  /// \param chunk_index The chunk index for which to obtain the buffer length.
-  /// \param data_size The size of the object + metadata.
-  /// \return The buffer length of the chunk at chunk_index.
-  uint64_t GetBufferLength(uint64_t chunk_index, uint64_t data_size);
-
-  /// Returns a chunk of an object at the given chunk_index. The object chunk serves
-  /// as the data that is to be written to a connection as part of sending an object to
-  /// a remote node.
-  ///
-  /// \param object_id The ObjectID.
-  /// \param data_size The sum of the object size and metadata size.
-  /// \param metadata_size The size of the metadata.
-  /// \param chunk_index The index of the chunk.
-  /// \return A pair consisting of a ChunkInfo and status of invoking this method.
-  /// An IOError status is returned if the Get call on the plasma store fails.
-  std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> GetChunk(
-      const ObjectID &object_id, uint64_t data_size, uint64_t metadata_size,
-      uint64_t chunk_index);
-
-  /// When a chunk is done being used as part of a get, this method releases the chunk.
-  /// If all chunks of an object are released, the object buffer will be released.
-  ///
-  /// \param object_id The object_id of the buffer to release.
-  /// \param chunk_index The index of the chunk.
-  void ReleaseGetChunk(const ObjectID &object_id, uint64_t chunk_index);
-
   /// Returns a chunk of an empty object at the given chunk_index. The object chunk
   /// serves as the buffer that is to be written to by a connection receiving an object
   /// from a remote node. Only one thread is permitted to create the object chunk at
@@ -196,8 +162,6 @@ class ObjectBufferPool {
   mutable std::mutex pool_mutex_;
   /// Determines the maximum chunk size to be transferred by a single thread.
   const uint64_t default_chunk_size_;
-  /// The state of a buffer that's currently being used.
-  std::unordered_map<ray::ObjectID, GetBufferState> get_buffer_state_;
   /// The state of a buffer that's currently being used.
   std::unordered_map<ray::ObjectID, CreateBufferState> create_buffer_state_;
 

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -354,7 +354,7 @@ void ObjectManager::PushInternal(const ObjectID &object_id, const NodeID &node_i
     std::shared_ptr<SpilledObject> spilled_object;
     if (spilled_url.has_value()) {
       spilled_object =
-          std::make_shared<SpilledObject>(object_url, config_.object_chunk_size);
+          std::make_shared<SpilledObject>(spilled_url.value(), config_.object_chunk_size);
     }
 
     uint64_t data_size;
@@ -449,6 +449,7 @@ void ObjectManager::SendObjectChunk(const UniqueID &push_id, const ObjectID &obj
       return;
     }
 
+    RAY_CHECK(chunk_info.chunk_index == chunk_index);
     push_request.set_data(chunk_info.data, chunk_info.buffer_length);
   }
 
@@ -470,7 +471,7 @@ void ObjectManager::SendObjectChunk(const UniqueID &push_id, const ObjectID &obj
 
   if (!spilled_object) {
     // Do this regardless of whether it failed or succeeded.
-    buffer_pool_.ReleaseGetChunk(object_id, chunk_info.chunk_index);
+    buffer_pool_.ReleaseGetChunk(object_id, chunk_index);
   }
 }
 

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -340,15 +340,10 @@ void ObjectManager::Push(const ObjectID &object_id, const NodeID &node_id) {
   auto object_url = get_spilled_object_url_(object_id);
 
   if (!object_url.empty()) {
-    if (RayConfig::instance().enable_spilled_object_push_optimization()) {
-      // Push the object directly from spilled object, bypassing
-      // local store restoration.
-      PushInternal(object_id, node_id, std::optional<std::string>(object_url));
-      return;
-    }
-    // Issue a restore request if the object is on local disk. This is only relevant
-    // if the local filesystem storage type is being used.
-    restore_spilled_object_(object_id, object_url, nullptr);
+    // Push the object directly from spilled object, bypassing
+    // local store restoration.
+    PushInternal(object_id, node_id, std::optional<std::string>(object_url));
+    return;
   }
   // Avoid setting duplicated timer for the same object and node pair.
   auto &nodes = unfulfilled_push_requests_[object_id];
@@ -380,8 +375,8 @@ void ObjectManager::Push(const ObjectID &object_id, const NodeID &node_id) {
   }
 }
 
-void ObjectManager::PushObject(const ObjectID &object_id, const NodeID &node_id,
-                               std::optional<std::string> spilled_url) {
+void ObjectManager::PushInternal(const ObjectID &object_id, const NodeID &node_id,
+                                 std::optional<std::string> spilled_url) {
   auto rpc_client = GetRpcClient(node_id);
   if (rpc_client) {
     std::shared_ptr<SpilledObject> spilled_object;

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -412,7 +412,7 @@ class ObjectManager : public ObjectManagerInterface,
   /// \param spilled_url The optional spilled_url.
   /// \return Void
   void PushInternal(const ObjectID &object_id, const NodeID &node_id,
-                    std::optional<std::string> spilled_url);
+                    absl::optional<std::string> spilled_url);
 
   /// Send object to remote object manager. If spilled_object is not null, it pushes
   /// from the spilled objects. Otherwise it uses local object from buffer_pool_.

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -409,10 +409,10 @@ class ObjectManager : public ObjectManagerInterface,
   ///
   /// \param object_id The object's object id.
   /// \param node_id The remote node's id.
-  /// \param spilled_url The optional spilled_url.
+  /// \param object_reader TODO
   /// \return Void
   void PushInternal(const ObjectID &object_id, const NodeID &node_id,
-                    absl::optional<std::string> spilled_url);
+                    std::shared_ptr<ObjectReaderInterface> object_reader);
 
   /// Send object to remote object manager. If spilled_object is not null, it pushes
   /// from the spilled objects. Otherwise it uses local object from buffer_pool_.
@@ -421,19 +421,17 @@ class ObjectManager : public ObjectManagerInterface,
   /// contains only one chunk
   /// \param push_id Unique push id to indicate this push request
   /// \param object_id Object id
-  /// \param owner_address The address of the object's owner
   /// \param node_id The id of the receiver.
-  /// \param data_size Data size
-  /// \param metadata_size Metadata size
   /// \param chunk_index Chunk index of this object chunk, start with 0
+  /// TODO
   /// \param rpc_client Rpc client used to send message to remote object manager
   /// \param spilled_object The object in local spilled file.
   /// \param on_complete Callback to run on completion.
   void SendObjectChunk(const UniqueID &push_id, const ObjectID &object_id,
-                       const rpc::Address &owner_address, const NodeID &node_id,
-                       uint64_t data_size, uint64_t metadata_size, uint64_t chunk_index,
+                       const NodeID &node_id, uint64_t chunk_index,
+                       std::shared_ptr<ObjectReader> object_reader,
+                       std::shared_ptr<ChunkObjectReader> chunk_object_reader,
                        std::shared_ptr<rpc::ObjectManagerClient> rpc_client,
-                       std::shared_ptr<SpilledObject> spilled_object,
                        std::function<void(const Status &)> on_complete);
 
   /// Weak reference to main service. We ensure this object is destroyed before

--- a/src/ray/object_manager/object_reader.cc
+++ b/src/ray/object_manager/object_reader.cc
@@ -1,0 +1,63 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/rpc/object_manager/object_reader.h"
+
+namespace ray {
+
+ChunkReader::ChunkReader(std::shared_ptr<ObjectReaderInterface> object_reader,
+                         uint64_t chunk_size)
+    : object_reader_(std::move(object_reader)),
+      chunk_size_(chunk_size),
+      data_size_(object_reader_->GetDataSize()),
+      metadata_size_(object_reader_->GetMetadataSize()) {
+  RAY_CHECK(chunk_size > 0);
+}
+
+uint64_t ChunkReader::GetNumChunks() const {
+  return (data_size_ + metadata_size_ + chunk_size_ - 1) / chunk_size_;
+}
+
+uint64_t GetChunkSize() const { return chunk_size_; }
+
+Status ReadChunk(uint64_t chunk_index, std::string &output) const {
+  // first read from data section, then read from metadata section.
+  auto cur_chunk_offset = chunk_index * chunk_size_;
+  auto cur_chunk_size =
+      std::min(chunk_size_, data_size_ + metadata_size_ - cur_chunk_offset);
+
+  // increase the output size by cur_chunk_size
+  size_t output_offset = output.size();
+  output.resize(output.size() + cur_chunk_size, '\0');
+
+  if (cur_chunk_offset < data_size_) {
+    // read from data section.
+    auto offset = cur_chunk_offset;
+    auto size = std::min(data_size_ - cur_chunk_offset, cur_chunk_size);
+    RAY_CHECK_OK(
+        object_reader->ReadFromDataSection(offset, size, &output[output_offset]));
+    output_offset += size;
+  }
+
+  if (cur_chunk_offset + cur_chunk_size > data_size_) {
+    // read from metadata section.
+    auto offset = std::max(cur_chunk_offset, data_size_) - data_size_;
+    auto size = std::min(cur_chunk_offset + cur_chunk_size - data_size_, cur_chunk_size);
+    RAY_CHECK_OK(
+        object_reader->ReadFromMetadataSecton(offset, size, &output[output_offset]));
+  }
+  return Status::OK();
+}
+
+}  // namespace ray

--- a/src/ray/object_manager/object_reader.h
+++ b/src/ray/object_manager/object_reader.h
@@ -33,10 +33,9 @@ class ObjectReaderInterface {
                                         char *output) const = 0;
 };
 
-class ChunkObjectReader : ObjectReaderInterface {
+class ChunkObjectReader {
  public:
-  ChunkObjectReader(std::shared_ptr<ObjectReaderInterface> object_reader,
-                    uint64_t chunk_size);
+  ChunkReader(std::shared_ptr<ObjectReaderInterface> object_reader, uint64_t chunk_size);
   uint64_t GetNumChunks() const;
   uint64_t GetChunkSize() const;
   uint64_t GetTotalSize() const;

--- a/src/ray/object_manager/object_reader.h
+++ b/src/ray/object_manager/object_reader.h
@@ -1,0 +1,52 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "ray/common/status.h"
+#include "src/ray/protobuf/common.pb.h"
+
+namespace ray {
+
+class ObjectReaderInterface {
+ public:
+  virtual ~ObjectReaderInterface() = default;
+  virtual uint64_t GetDataSize() const = 0;
+  virtual uint64_t GetMetadataSize() const = 0;
+  virtual const rpc::Address &GetOwnerAddress() const = 0;
+  virtual Status ReadFromDataSection(uint64_t offset, uint64_t size,
+                                     char *output) const = 0;
+  virtual Status ReadFromMetadataSecton(uint64_t offset, uint64_t size,
+                                        char *output) const = 0;
+};
+
+class ChunkObjectReader : ObjectReaderInterface {
+ public:
+  ChunkObjectReader(std::shared_ptr<ObjectReaderInterface> object_reader,
+                    uint64_t chunk_size);
+  uint64_t GetNumChunks() const;
+  uint64_t GetChunkSize() const;
+  uint64_t GetTotalSize() const;
+  Status ReadChunk(uint64_t index, std::string &output) const;
+
+ private:
+  const std::shared_ptr<const ObjectReaderInterface> object_reader_;
+  const uint64_t chunk_size_;
+  const uint64_t data_size_;
+  const uint64_t metadata_size_;
+};
+
+}  // namespace ray

--- a/src/ray/object_manager/plasma_object_reader.cc
+++ b/src/ray/object_manager/plasma_object_reader.cc
@@ -1,0 +1,72 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/rpc/object_manager/plasma_object_reader.h"
+
+#include <cstring>
+
+#include "absl/strings/str_format.h"
+#include "ray/util/logging.h"
+
+namespace ray {
+
+PlasmaObjectReader::PlasmaObjectReader(ObjectID object_id, rpc::Address owner_address,
+                                       plasma::PlasmaClient &client)
+    : object_id_(object_id),
+      owner_address_(std::move(owner_address)),
+      client_(client),
+      object_buffer_() {
+  RAY_CHECK_OK(store_client_.Get(&object_id_, /*num_objects*/ 1, /*timeout_ms*/ 0,
+                                 &object_buffer_, /*is_from_worker*/ false));
+}
+
+PlasmaObjectReader::~PlasmaObjectReader() {
+  RAY_CHECK_OK(store_client_.Release(&object_id_));
+}
+
+uint64_t PlasmaObjectReader::GetDataSize() const override {
+  return object_buffer_.data->Size();
+}
+
+uint64_t PlasmaObjectReader::GetMetadataSize() const override {
+  return object_buffer_.metadata->Size();
+}
+
+const rpc::Address &PlasmaObjectReader::GetOwnerAddress() const override {
+  return owner_address_;
+}
+
+Status PlasmaObjectReader::ReadFromDataSection(uint64_t offset, uint64_t size,
+                                               char *output) const override {
+  if (offset + size > GetDataSize()) {
+    return Status::Invalid(absl::StrFormat(
+        "Read from data section failed: offset(%d) + size(%d) > data size (%d)", offset,
+        size, GetDataSize()));
+  }
+  std::memcpy(output, object_buffer_.data->Data() + offset, size);
+  return Status::OK();
+}
+
+Status PlasmaObjectReader::ReadFromMetadataSecton(uint64_t offset, uint64_t size,
+                                                  char *output) const override {
+  if (offset + size > GetMetadataSize()) {
+    return Status::Invalid(absl::StrFormat(
+        "Read from data section failed: offset(%d) + size(%d) > data size (%d)", offset,
+        size, GetMetadataSize()));
+  }
+  std::memcpy(output, object_buffer_.metadata->Data() + offset, size);
+  return Status::OK();
+}
+
+}  // namespace ray

--- a/src/ray/object_manager/plasma_object_reader.cc
+++ b/src/ray/object_manager/plasma_object_reader.cc
@@ -27,13 +27,11 @@ PlasmaObjectReader::PlasmaObjectReader(ObjectID object_id, rpc::Address owner_ad
       owner_address_(std::move(owner_address)),
       client_(client),
       object_buffer_() {
-  RAY_CHECK_OK(store_client_.Get(&object_id_, /*num_objects*/ 1, /*timeout_ms*/ 0,
-                                 &object_buffer_, /*is_from_worker*/ false));
+  RAY_CHECK_OK(client_.Get(&object_id_, /*num_objects*/ 1, /*timeout_ms*/ 0,
+                           &object_buffer_, /*is_from_worker*/ false));
 }
 
-PlasmaObjectReader::~PlasmaObjectReader() {
-  RAY_CHECK_OK(store_client_.Release(&object_id_));
-}
+PlasmaObjectReader::~PlasmaObjectReader() { RAY_CHECK_OK(client_.Release(&object_id_)); }
 
 uint64_t PlasmaObjectReader::GetDataSize() const override {
   return object_buffer_.data->Size();
@@ -51,7 +49,7 @@ Status PlasmaObjectReader::ReadFromDataSection(uint64_t offset, uint64_t size,
                                                char *output) const override {
   if (offset + size > GetDataSize()) {
     return Status::Invalid(absl::StrFormat(
-        "Read from data section failed: offset(%d) + size(%d) > data size (%d)", offset,
+        "Read from data section failed: offset(%d) + size(%d) > data size(%d)", offset,
         size, GetDataSize()));
   }
   std::memcpy(output, object_buffer_.data->Data() + offset, size);
@@ -62,8 +60,8 @@ Status PlasmaObjectReader::ReadFromMetadataSecton(uint64_t offset, uint64_t size
                                                   char *output) const override {
   if (offset + size > GetMetadataSize()) {
     return Status::Invalid(absl::StrFormat(
-        "Read from data section failed: offset(%d) + size(%d) > data size (%d)", offset,
-        size, GetMetadataSize()));
+        "Read from metadata section failed: offset(%d) + size(%d) > metadata size(%d)",
+        offset, size, GetMetadataSize()));
   }
   std::memcpy(output, object_buffer_.metadata->Data() + offset, size);
   return Status::OK();

--- a/src/ray/object_manager/plasma_object_reader.h
+++ b/src/ray/object_manager/plasma_object_reader.h
@@ -26,9 +26,7 @@ class PlasmaObjectReader : public ObjectReaderInterface {
   ~PlasmaObjectReader();
 
   uint64_t GetDataSize() const override;
-
   uint64_t GetMetadataSize() const override;
-
   const rpc::Address &GetOwnerAddress() const override;
   Status ReadFromDataSection(uint64_t offset, uint64_t size, char *output) const override;
   Status ReadFromMetadataSecton(uint64_t offset, uint64_t size,

--- a/src/ray/object_manager/plasma_object_reader.h
+++ b/src/ray/object_manager/plasma_object_reader.h
@@ -1,0 +1,43 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "ray/rpc/object_manager/object_reader.h"
+
+namespace ray {
+
+class PlasmaObjectReader : public ObjectReaderInterface {
+ public:
+  PlasmaObjectReader(ObjectID object_id, rpc::Address owner_address,
+                     plasma::PlasmaClient &client_);
+
+  ~PlasmaObjectReader();
+
+  uint64_t GetDataSize() const override;
+
+  uint64_t GetMetadataSize() const override;
+
+  const rpc::Address &GetOwnerAddress() const override;
+  Status ReadFromDataSection(uint64_t offset, uint64_t size, char *output) const override;
+  Status ReadFromMetadataSecton(uint64_t offset, uint64_t size,
+                                char *output) const override;
+
+ private:
+  const ObjectID object_id_;
+  const rpc::Address owner_address_;
+  plasma::PlasmaClient &client_;
+  plasma::ObjectBuffer object_buffer_;
+};
+}  // namespace ray

--- a/src/ray/object_manager/spilled_object.cc
+++ b/src/ray/object_manager/spilled_object.cc
@@ -17,6 +17,8 @@
 #include <fstream>
 #include <regex>
 
+#include "ray/util/logging.h"
+
 namespace ray {
 
 SpilledObject::SpilledObject(const std::string &object_url, uint64_t chunk_size) {
@@ -40,23 +42,23 @@ std::string SpilledObject::GetChunk(uint64_t chunk_index) const {
   auto length = std::min(chunk_size_, total_size_ - start_offset);
   if (start_offset + length <= data_size_) {
     // read from data section
-    return Read(data_offset_ + start_offset, length);
+    return ReadFromFile(data_offset_ + start_offset, length);
   }
-  if (start_offset >= data_size) {
+  if (start_offset >= data_size_) {
     // read from metadata section
-    return Read(metadata_offset_ + (start_offset - data_size), length);
+    return ReadFromFile(metadata_offset_ + (start_offset - data_size_), length);
   }
 
-  string result;
+  std::string result;
   result.append(ReadFromFile(data_offset_ + start_offset, data_size_ - start_offset));
-  result.append(ReadFromFile(metadata_offset, length - (data_size_ - start_offset)));
+  result.append(ReadFromFile(metadata_offset_, length - (data_size_ - start_offset)));
   return result;
 }
 
 void SpilledObject::ParseObjectURL(const std::string &object_url) {
   static const std::regex object_url_pattern("(.*)\\?offset=(\\d+)&size=(\\d+)");
   std::smatch match_groups;
-  RAY_DCHECK(std::regex_match(fname, match_groups, base_regex));
+  RAY_DCHECK(std::regex_match(object_url, match_groups, object_url_pattern));
   RAY_DCHECK(match_groups.size() == 4);
   file_path_ = match_groups[1].str();
   object_offset_ = std::stoi(match_groups[2].str());
@@ -65,19 +67,19 @@ void SpilledObject::ParseObjectURL(const std::string &object_url) {
 
 void SpilledObject::ReadObjectHeader() {
   auto offset = object_offset_;
-  auto address_size = ToUInt64(ReadFromFile(offset, 8));
+  auto address_size = ToUint64(ReadFromFile(offset, 8));
   offset += 8;
-  metadata_size_ = ToUInt64(ReadFromFile(offset, 8));
+  metadata_size_ = ToUint64(ReadFromFile(offset, 8));
   offset += 8;
-  data_size_ = ToUInt64(ReadFromFile(offset, 8));
+  data_size_ = ToUint64(ReadFromFile(offset, 8));
   offset += 8;
   owner_address_.ParseFromString(ReadFromFile(offset, address_size));
   metadata_offset_ = offset + address_size;
   data_offset_ = metadata_offset_ + metadata_size_;
 }
 
-uint64_t SpilledObject::ToUInt64(const std::string &s) const {
-  RAY_CHECK(s.size(), 8);
+uint64_t SpilledObject::ToUint64(const std::string &s) const {
+  RAY_CHECK(s.size() == 8);
   uint64_t result = 0;
   for (size_t i = 0; i < s.size(); i++) {
     result = result << 8;
@@ -86,7 +88,7 @@ uint64_t SpilledObject::ToUInt64(const std::string &s) const {
   return result;
 }
 
-std::string SpilledObject::ReadFromFile(int64_t offset, int64_t length) {
+std::string SpilledObject::ReadFromFile(int64_t offset, int64_t length) const {
   std::ifstream is(file_path_, std::ios::binary);
   is.seekg(offset);
   std::string str(length, '\0');

--- a/src/ray/object_manager/spilled_object.cc
+++ b/src/ray/object_manager/spilled_object.cc
@@ -111,7 +111,7 @@ SpilledObject::SpilledObject(std::string file_path, uint64_t total_size,
 /* static */ bool SpilledObject::ParseObjectURL(const std::string &object_url,
                                                 std::string &file_path,
                                                 uint64_t &object_offset,
-                                                uint64_t total_size) {
+                                                uint64_t &total_size) {
   static const std::regex object_url_pattern("(.*)\\?offset=(\\d+)&size=(\\d+)");
   std::smatch match_groups;
   if (!std::regex_match(object_url, match_groups, object_url_pattern) ||

--- a/src/ray/object_manager/spilled_object.cc
+++ b/src/ray/object_manager/spilled_object.cc
@@ -17,6 +17,7 @@
 #include <fstream>
 #include <regex>
 
+#include "absl/strings/str_format.h"
 #include "ray/util/logging.h"
 
 namespace ray {
@@ -24,11 +25,11 @@ namespace {
 const size_t UINT64_size = sizeof(uint64_t);
 }
 
-/* static */ absl::optional<SpilledObject> SpilledObject::CreateSpilledObject(
+/* static */ std::unique_ptr<SpilledObject> SpilledObject::CreateSpilledObject(
     const std::string &object_url, uint64_t chunk_size) {
   if (chunk_size == 0) {
     RAY_LOG(WARNING) << "chunk_size can't be 0.";
-    return absl::optional<SpilledObject>();
+    return {};
   }
 
   std::string file_path;
@@ -37,7 +38,7 @@ const size_t UINT64_size = sizeof(uint64_t);
 
   if (!SpilledObject::ParseObjectURL(object_url, file_path, object_offset, object_size)) {
     RAY_LOG(WARNING) << "Failed to parse spilled object url: " << object_url;
-    return absl::optional<SpilledObject>();
+    return {};
   }
 
   uint64_t data_offset = 0;
@@ -51,10 +52,10 @@ const size_t UINT64_size = sizeof(uint64_t);
       !SpilledObject::ParseObjectHeader(is, object_offset, data_offset, data_size,
                                         metadata_offset, metadata_size, owner_address)) {
     RAY_LOG(WARNING) << "Failed to parse object header for spilled object " << object_url;
-    return absl::optional<SpilledObject>();
+    return {};
   }
 
-  return absl::optional<SpilledObject>(SpilledObject(
+  return std::unique_ptr<SpilledObject>(SpilledObject(
       std::move(file_path), object_size, data_offset, data_size, metadata_offset,
       metadata_size, std::move(owner_address), chunk_size));
 }
@@ -65,54 +66,17 @@ uint64_t SpilledObject::GetMetadataSize() const { return metadata_size_; }
 
 const rpc::Address &SpilledObject::GetOwnerAddress() const { return owner_address_; }
 
-uint64_t SpilledObject::GetNumChunks() const {
-  return (data_size_ + metadata_size_ + chunk_size_ - 1) / chunk_size_;
-}
-
-absl::optional<std::string> SpilledObject::GetChunk(uint64_t chunk_index) const {
-  // The spilled file stores metadata before data. But the GetChunk needs to
-  // return data before metadata. We achieve by first read from data section,
-  // then read from metadata section.
-  auto cur_chunk_offset = chunk_index * chunk_size_;
-  auto cur_chunk_size =
-      std::min(chunk_size_, data_size_ + metadata_size_ - cur_chunk_offset);
-
-  std::string result(cur_chunk_size, '\0');
-  size_t result_offset = 0;
-
-  if (cur_chunk_offset < data_size_) {
-    // read from data section.
-    auto offset = cur_chunk_offset;
-    auto size = std::min(data_size_ - cur_chunk_offset, cur_chunk_size);
-    if (!ReadFromDataSection(offset, size, &result[result_offset])) {
-      return absl::optional<std::string>();
-    }
-    result_offset = size;
-  }
-
-  if (cur_chunk_offset + cur_chunk_size > data_size_) {
-    // read from metadata section.
-    auto offset = std::max(cur_chunk_offset, data_size_) - data_size_;
-    auto size = std::min(cur_chunk_offset + cur_chunk_size - data_size_, cur_chunk_size);
-    if (!ReadFromMetadataSection(offset, size, &result[result_offset])) {
-      return absl::optional<std::string>();
-    }
-  }
-  return absl::optional<std::string>(std::move(result));
-}
-
 SpilledObject::SpilledObject(std::string file_path, uint64_t object_size,
                              uint64_t data_offset, uint64_t data_size,
                              uint64_t metadata_offset, uint64_t metadata_size,
-                             rpc::Address owner_address, uint64_t chunk_size)
+                             rpc::Address owner_address)
     : file_path_(std::move(file_path)),
       object_size_(object_size),
       data_offset_(data_offset),
       data_size_(data_size),
       metadata_offset_(metadata_offset),
       metadata_size_(metadata_size),
-      owner_address_(std::move(owner_address)),
-      chunk_size_(chunk_size) {}
+      owner_address_(std::move(owner_address)) {}
 
 /* static */ bool SpilledObject::ParseObjectURL(const std::string &object_url,
                                                 std::string &file_path,
@@ -181,15 +145,23 @@ uint64_t SpilledObject::ToUINT64(const std::string &s) {
   return result;
 }
 
-bool SpilledObject::ReadFromDataSection(uint64_t offset, uint64_t size,
-                                        char *output) const {
+Status SpilledObject::ReadFromDataSection(uint64_t offset, uint64_t size,
+                                          char *output) const {
   std::ifstream is(file_path_, std::ios::binary);
-  return is.seekg(data_offset_ + offset) && is.read(output, size);
+  if (!is.seekg(data_offset_ + offset) || !is.read(output, size)) {
+    return Status::IOError(absl::StrFormat("Failed to read %s at offset %d with size %d",
+                                           file_path_, (data_offset_ + offset), size));
+  }
+  return Status::OK();
 }
 
-bool SpilledObject::ReadFromMetadataSection(uint64_t offset, uint64_t size,
-                                            char *output) const {
+Status SpilledObject::ReadFromMetadataSection(uint64_t offset, uint64_t size,
+                                              char *output) const {
   std::ifstream is(file_path_, std::ios::binary);
-  return is.seekg(metadata_offset_ + offset) && is.read(output, size);
+  if (!is.seekg(metadata_offset_ + offset) || !is.read(output, size)) {
+    return Status::IOError(absl::StrFormat("Failed to read %s at offset %d with size %d",
+                                           file_path_, (data_offset_ + offset), size));
+  }
+  return Status::OK();
 }
 }  // namespace ray

--- a/src/ray/object_manager/spilled_object.cc
+++ b/src/ray/object_manager/spilled_object.cc
@@ -1,0 +1,97 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/object_manager/spilled_object.h"
+
+#include <fstream>
+#include <regex>
+
+namespace ray {
+
+SpilledObject::SpilledObject(const std::string &object_url, uint64_t chunk_size) {
+  ParseObjectURL(object_url);
+  ReadObjectHeader();
+  chunk_size_ = chunk_size;
+}
+
+uint64_t SpilledObject::GetDataSize() const { return data_size_; }
+
+uint64_t SpilledObject::GetMetadataSize() const { return metadata_size_; }
+
+const rpc::Address &SpilledObject::GetOwnerAddress() const { return owner_address_; }
+
+uint64_t SpilledObject::GetNumChunks() const {
+  return (total_size_ + chunk_size_ - 1) / chunk_size_;
+}
+
+std::string SpilledObject::GetChunk(uint64_t chunk_index) const {
+  auto start_offset = chunk_index * chunk_size_;
+  auto length = std::min(chunk_size_, total_size_ - start_offset);
+  if (start_offset + length <= data_size_) {
+    // read from data section
+    return Read(data_offset_ + start_offset, length);
+  }
+  if (start_offset >= data_size) {
+    // read from metadata section
+    return Read(metadata_offset_ + (start_offset - data_size), length);
+  }
+
+  string result;
+  result.append(ReadFromFile(data_offset_ + start_offset, data_size_ - start_offset));
+  result.append(ReadFromFile(metadata_offset, length - (data_size_ - start_offset)));
+  return result;
+}
+
+void SpilledObject::ParseObjectURL(const std::string &object_url) {
+  static const std::regex object_url_pattern("(.*)\\?offset=(\\d+)&size=(\\d+)");
+  std::smatch match_groups;
+  RAY_DCHECK(std::regex_match(fname, match_groups, base_regex));
+  RAY_DCHECK(match_groups.size() == 4);
+  file_path_ = match_groups[1].str();
+  object_offset_ = std::stoi(match_groups[2].str());
+  total_size_ = std::stoi(match_groups[3].str());
+}
+
+void SpilledObject::ReadObjectHeader() {
+  auto offset = object_offset_;
+  auto address_size = ToUInt64(ReadFromFile(offset, 8));
+  offset += 8;
+  metadata_size_ = ToUInt64(ReadFromFile(offset, 8));
+  offset += 8;
+  data_size_ = ToUInt64(ReadFromFile(offset, 8));
+  offset += 8;
+  owner_address_.ParseFromString(ReadFromFile(offset, address_size));
+  metadata_offset_ = offset + address_size;
+  data_offset_ = metadata_offset_ + metadata_size_;
+}
+
+uint64_t SpilledObject::ToUInt64(const std::string &s) const {
+  RAY_CHECK(s.size(), 8);
+  uint64_t result = 0;
+  for (size_t i = 0; i < s.size(); i++) {
+    result = result << 8;
+    result += static_cast<unsigned char>(s.at(s.size() - i - 1));
+  }
+  return result;
+}
+
+std::string SpilledObject::ReadFromFile(int64_t offset, int64_t length) {
+  std::ifstream is(file_path_, std::ios::binary);
+  is.seekg(offset);
+  std::string str(length, '\0');
+  RAY_CHECK(is.read(&str[0], length));
+  return str;
+}
+
+}  // namespace ray

--- a/src/ray/object_manager/spilled_object.h
+++ b/src/ray/object_manager/spilled_object.h
@@ -25,37 +25,32 @@ namespace ray {
 
 /// Represent a local object spilled in the object_url.
 /// This class is thread safe.
-class SpilledObject {
+class SpilledObject : public ObjectReaderInterface {
  public:
   /// Create a Spilled Object. Returns an empty optional if any error happens, such as
-  /// malformed url; corrupted/deleted file; or 0 chunk_size.
+  /// malformed url; corrupted/deleted file.
   ///
   /// \param object_url the object url in the form of {path}?offset={offset}&size={size}
-  /// \param chunk_size the size of chunk for read.
-  static absl::optional<SpilledObject> CreateSpilledObject(const std::string &object_url,
-                                                           uint64_t chunk_size);
+  static std::unique_ptr<SpilledObject> CreateSpilledObject(
+      const std::string &object_url);
 
   /// Return the size of data (exclusing metadata).
-  uint64_t GetDataSize() const;
+  uint64_t GetDataSize() const override;
 
   /// Return the size of metadata.
-  uint64_t GetMetadataSize() const;
+  uint64_t GetMetadataSize() const override;
 
-  const rpc::Address &GetOwnerAddress() const;
+  const rpc::Address &GetOwnerAddress() const override;
 
-  uint64_t GetNumChunks() const;
+  Status ReadFromDataSection(uint64_t offset, uint64_t size, char *output) const override;
 
-  /// Return the value in a given chunk, identified by chunk_index.
-  /// It migh return an empty optional if the file is deleted.
-  ///
-  /// \param chunk_index the index of chunk to return. index greater or
-  ///                    equal to GetNumChunks() yields undefined behavior.
-  absl::optional<std::string> GetChunk(uint64_t chunk_index) const;
+  Status ReadFromMetadataSection(uint64_t offset, uint64_t size,
+                                 char *output) const override;
 
  private:
   SpilledObject(std::string file_path, uint64_t total_size, uint64_t data_offset,
                 uint64_t data_size, uint64_t metadata_offset, uint64_t metadata_size,
-                rpc::Address owner_address, uint64_t chunk_size);
+                rpc::Address owner_address);
 
   /// Parse the object url in the form of {path}?offset={offset}&size={size}.
   /// Return false if parsing failed.
@@ -100,11 +95,6 @@ class SpilledObject {
   /// Deserialize 8 bytes string as a little-endian uint64_t.
   static uint64_t ToUINT64(const std::string &s);
 
-  /// Helper functions read from data/metadata sections into output.
-  /// Return false if the file is corrupted.
-  bool ReadFromDataSection(uint64_t offset, uint64_t size, char *output) const;
-  bool ReadFromMetadataSection(uint64_t offset, uint64_t size, char *output) const;
-
  private:
   FRIEND_TEST(SpilledObjectTest, ParseObjectURL);
   FRIEND_TEST(SpilledObjectTest, ToUINT64);
@@ -120,7 +110,6 @@ class SpilledObject {
   const uint64_t metadata_offset_;
   const uint64_t metadata_size_;
   const rpc::Address owner_address_;
-  const uint64_t chunk_size_;
 };
 
 }  // namespace ray

--- a/src/ray/object_manager/spilled_object.h
+++ b/src/ray/object_manager/spilled_object.h
@@ -14,7 +14,9 @@
 
 #pragma once
 
-#include "ray/object_manager/common.h"
+#include <string>
+
+#include "src/ray/protobuf/common.pb.h"
 
 namespace ray {
 
@@ -23,9 +25,28 @@ namespace ray {
 class SpilledObject {
  public:
   SpilledObject(const std::string &object_url, uint64_t chunk_size);
-  const ObjectInfo &GetObjectInfo() const;
+  uint64_t GetDataSize() const;
+  uint64_t GetMetadataSize() const;
+  const rpc::Address &SpilledObject::GetOwnerAddress() const;
   uint64_t GetNumChunks() const;
   std::string GetChunk(uint64_t chunk_index) const;
+
+ private:
+  void ParseObjectURL(const std::string &object_url);
+  void ReadObjectHeader();
+  std::string ReadFromFile(int64_t offset, int64_t length);
+  uint64_t ToUint64(const std::string &s) const;
+
+ private:
+  std::string file_path_;
+  uint64_t object_offset_;
+  uint64_t total_size_;
+  uint64_t data_offset_;
+  uint64_t data_size_;
+  uint64_t metadata_offset_;
+  uint64_t metadata_size_;
+  rpc::Address owner_address_;
+  uint64_t chunk_size_;
 };
 
 }  // namespace ray

--- a/src/ray/object_manager/spilled_object.h
+++ b/src/ray/object_manager/spilled_object.h
@@ -27,14 +27,14 @@ class SpilledObject {
   SpilledObject(const std::string &object_url, uint64_t chunk_size);
   uint64_t GetDataSize() const;
   uint64_t GetMetadataSize() const;
-  const rpc::Address &SpilledObject::GetOwnerAddress() const;
+  const rpc::Address &GetOwnerAddress() const;
   uint64_t GetNumChunks() const;
   std::string GetChunk(uint64_t chunk_index) const;
 
  private:
   void ParseObjectURL(const std::string &object_url);
   void ReadObjectHeader();
-  std::string ReadFromFile(int64_t offset, int64_t length);
+  std::string ReadFromFile(int64_t offset, int64_t length) const;
   uint64_t ToUint64(const std::string &s) const;
 
  private:

--- a/src/ray/object_manager/spilled_object.h
+++ b/src/ray/object_manager/spilled_object.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <gtest/gtest_prod.h>
+
 #include <string>
 
 #include "absl/types/optional.h"
@@ -44,18 +46,24 @@ class SpilledObject {
   static bool ParseObjectURL(const std::string &object_url, std::string &file_path,
                              uint64_t &object_offset, uint64_t &total_size);
 
-  static bool ParseObjectHeader(const std::string &file_path, uint64_t object_offset,
+  static bool ParseObjectHeader(std::istream &is, uint64_t object_offset,
                                 uint64_t &data_offset, uint64_t &data_size,
                                 uint64_t &metadata_offset, uint64_t &metadata_size,
                                 rpc::Address &owner_address);
 
-  static bool ReadUINT64(std::ifstream &is, uint64_t &output);
+  static bool ReadUINT64(std::istream &is, uint64_t &output);
   static uint64_t ToUINT64(const std::string &s);
 
   bool ReadFromDataSection(uint64_t offset, uint64_t size, char *output) const;
   bool ReadFromMetadataSection(uint64_t offset, uint64_t size, char *output) const;
 
  private:
+  /// Test helper
+  FRIEND_TEST(SpilledObjectTest, ParseObjectURL);
+  FRIEND_TEST(SpilledObjectTest, ToUINT64);
+  FRIEND_TEST(SpilledObjectTest, ReadUINT64);
+  FRIEND_TEST(SpilledObjectTest, ParseObjectHeader);
+
   const std::string file_path_;
   const uint64_t total_size_;
   const uint64_t data_offset_;

--- a/src/ray/object_manager/spilled_object.h
+++ b/src/ray/object_manager/spilled_object.h
@@ -1,0 +1,31 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "ray/object_manager/common.h"
+
+namespace ray {
+
+/// Represent an object which is spilled in the object_url.
+/// This class is thread safe.
+class SpilledObject {
+ public:
+  SpilledObject(const std::string &object_url, uint64_t chunk_size);
+  const ObjectInfo &GetObjectInfo() const;
+  uint64_t GetNumChunks() const;
+  std::string GetChunk(uint64_t chunk_index) const;
+};
+
+}  // namespace ray

--- a/src/ray/object_manager/spilled_object.h
+++ b/src/ray/object_manager/spilled_object.h
@@ -23,49 +23,98 @@
 
 namespace ray {
 
-/// Represent an object which is spilled in the object_url.
+/// Represent a local object spilled in the object_url.
 /// This class is thread safe.
 class SpilledObject {
  public:
+  /// Create a Spilled Object. Returns an empty optional if any error happens, such as
+  /// malformed url; corrupted/deleted file; or 0 chunk_size.
+  ///
+  /// \param object_url the object url in the form of {path}?offset={offset}&size={size}
+  /// \param chunk_size the size of chunk for read.
   static absl::optional<SpilledObject> CreateSpilledObject(const std::string &object_url,
                                                            uint64_t chunk_size);
 
+  /// Return the size of data (exclusing metadata).
   uint64_t GetDataSize() const;
+
+  /// Return the size of metadata.
   uint64_t GetMetadataSize() const;
+
   const rpc::Address &GetOwnerAddress() const;
 
   uint64_t GetNumChunks() const;
+
+  /// Return the value in a given chunk, identified by chunk_index.
+  /// It migh return an empty optional if the file is deleted.
+  ///
+  /// \param chunk_index the index of chunk to return. index greater or
+  ///                    equal to GetNumChunks() yields undefined behavior.
   absl::optional<std::string> GetChunk(uint64_t chunk_index) const;
 
  private:
   SpilledObject(std::string file_path, uint64_t total_size, uint64_t data_offset,
-                const uint64_t data_size, const uint64_t metadata_offset,
-                const uint64_t metadata_size, const rpc::Address owner_address,
-                const uint64_t chunk_size);
+                uint64_t data_size, uint64_t metadata_offset, uint64_t metadata_size,
+                rpc::Address owner_address, uint64_t chunk_size);
 
+  /// Parse the object url in the form of {path}?offset={offset}&size={size}.
+  /// Return false if parsing failed.
+  ///
+  /// \param[in] object_url url to parse from.
+  /// \param[out] file_path file stores the object.
+  /// \param[out] object_offset offset of the object stored in the file..
+  /// \param[out] total_size object size in the file.
+  /// \return bool.
   static bool ParseObjectURL(const std::string &object_url, std::string &file_path,
                              uint64_t &object_offset, uint64_t &total_size);
 
+  /// Read the istream, parse the object header according to the following format.
+  /// Return false if the input stream is deleted or corrupted.
+  ///     --- start of an object (at object_offset) ---
+  ///      address_size        (8 bytes),
+  ///      metadata_size       (8 bytes),
+  ///      data_size           (8 bytes),
+  ///      serialized_address  (address_size bytes),
+  ///      metadata_payload    (metadata_size bytes),
+  ///      data_payload        (data_size bytes)
+  ///    --- start of another object ---
+  ///      ...
+  ///
+  /// \param[in] is input stream to read from.
+  /// \param[in] object_offset offset of the object stored in the file.
+  /// \param[out] data_offset data payload offset in the file.
+  /// \param[out] data_size size of the data payload.
+  /// \param[out] metadata_offset metadata payload offset in the file.
+  /// \param[out] metadata_size size of the metadata payload.
+  /// \param[out] owner_address owner address.
+  /// \return bool.
   static bool ParseObjectHeader(std::istream &is, uint64_t object_offset,
                                 uint64_t &data_offset, uint64_t &data_size,
                                 uint64_t &metadata_offset, uint64_t &metadata_size,
                                 rpc::Address &owner_address);
 
+  /// Read 8 bytes from inputstream and deserialize it as a little-endian
+  /// uint64_t. Return false if reach end of stream early.
   static bool ReadUINT64(std::istream &is, uint64_t &output);
+
+  /// Deserialize 8 bytes string as a little-endian uint64_t.
   static uint64_t ToUINT64(const std::string &s);
 
+  /// Helper functions read from data/metadata sections into output.
+  /// Return false if the file is corrupted.
   bool ReadFromDataSection(uint64_t offset, uint64_t size, char *output) const;
   bool ReadFromMetadataSection(uint64_t offset, uint64_t size, char *output) const;
 
  private:
-  /// Test helper
   FRIEND_TEST(SpilledObjectTest, ParseObjectURL);
   FRIEND_TEST(SpilledObjectTest, ToUINT64);
   FRIEND_TEST(SpilledObjectTest, ReadUINT64);
   FRIEND_TEST(SpilledObjectTest, ParseObjectHeader);
+  FRIEND_TEST(SpilledObjectTest, Getters);
+  FRIEND_TEST(SpilledObjectTest, GetNumChunks);
 
   const std::string file_path_;
-  const uint64_t total_size_;
+  const uint64_t object_size_;
   const uint64_t data_offset_;
   const uint64_t data_size_;
   const uint64_t metadata_offset_;

--- a/src/ray/object_manager/spilled_object.h
+++ b/src/ray/object_manager/spilled_object.h
@@ -42,15 +42,15 @@ class SpilledObject {
                 const uint64_t chunk_size);
 
   static bool ParseObjectURL(const std::string &object_url, std::string &file_path,
-                             uint64_t &object_offset, uint64_t total_size);
+                             uint64_t &object_offset, uint64_t &total_size);
 
   static bool ParseObjectHeader(const std::string &file_path, uint64_t object_offset,
                                 uint64_t &data_offset, uint64_t &data_size,
                                 uint64_t &metadata_offset, uint64_t &metadata_size,
                                 rpc::Address &owner_address);
 
-  static uint64_t ToUINT64(const std::string &s);
   static bool ReadUINT64(std::ifstream &is, uint64_t &output);
+  static uint64_t ToUINT64(const std::string &s);
 
   bool ReadFromDataSection(uint64_t offset, uint64_t size, char *output) const;
   bool ReadFromMetadataSection(uint64_t offset, uint64_t size, char *output) const;

--- a/src/ray/object_manager/test/spilled_object_test.cc
+++ b/src/ray/object_manager/test/spilled_object_test.cc
@@ -268,7 +268,7 @@ void AssertGetChunkWorks(std::string metadata, std::string data,
     auto optional_object = SpilledObject::CreateSpilledObject(object_url, chunk_size);
     ASSERT_TRUE(optional_object.has_value());
     std::string actual_output_by_chunks;
-    for (auto i = 0; i < optional_object->GetNumChunks(); i++) {
+    for (uint64_t i = 0; i < optional_object->GetNumChunks(); i++) {
       auto chunk = optional_object->GetChunk(i);
       ASSERT_TRUE(chunk.has_value());
       ASSERT_GE(chunk_size, chunk->size());

--- a/src/ray/object_manager/test/spilled_object_test.cc
+++ b/src/ray/object_manager/test/spilled_object_test.cc
@@ -1,0 +1,158 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/object_manager/spilled_object.h"
+
+#include <boost/endian/conversion.hpp>
+
+#include "gtest/gtest.h"
+#include "ray/common/test_util.h"
+
+namespace ray {
+
+TEST(SpilledObjectTest, ParseObjectURL) {
+  auto assert_parse_success =
+      [](const std::string &object_url, const std::string &expected_file_path,
+         uint64_t expected_object_offset, uint64_t expected_total_size) {
+        std::string actual_file_path;
+        uint64_t actual_offset = 0;
+        uint64_t actual_size = 0;
+        ASSERT_TRUE(SpilledObject::ParseObjectURL(object_url, actual_file_path,
+                                                  actual_offset, actual_size));
+        ASSERT_EQ(expected_file_path, actual_file_path);
+        ASSERT_EQ(expected_object_offset, actual_offset);
+        ASSERT_EQ(expected_total_size, actual_size);
+      };
+
+  auto assert_parse_fail = [](const std::string &object_url) {
+    std::string actual_file_path;
+    uint64_t actual_offset = 0;
+    uint64_t actual_size = 0;
+    ASSERT_FALSE(SpilledObject::ParseObjectURL(object_url, actual_file_path,
+                                               actual_offset, actual_size));
+  };
+
+  assert_parse_success("file://path/to/file?offset=123&size=456", "file://path/to/file",
+                       123, 456);
+  assert_parse_success("http://123?offset=123&size=456", "http://123", 123, 456);
+  assert_parse_success("file:///C:/Users/file.txt?offset=123&size=456",
+                       "file:///C:/Users/file.txt", 123, 456);
+  assert_parse_success("/tmp/file.txt?offset=123&size=456", "/tmp/file.txt", 123, 456);
+  assert_parse_success("C:\\file.txt?offset=123&size=456", "C:\\file.txt", 123, 456);
+
+  assert_parse_fail("file://path/to/file?offset=a&size=456");
+  assert_parse_fail("file://path/to/file?offset=0&size=bb");
+  assert_parse_fail("file://path/to/file?offset=123");
+  assert_parse_fail("file://path/to/file?offset=a&size=456&extra");
+}
+
+TEST(SpilledObjectTest, ToUINT64) {
+  ASSERT_EQ(0, SpilledObject::ToUINT64(
+                   {'\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00'}));
+  ASSERT_EQ(1, SpilledObject::ToUINT64(
+                   {'\x01', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00'}));
+  ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
+            SpilledObject::ToUINT64(
+                {'\xff', '\xff', '\xff', '\xff', '\xff', '\xff', '\xff', '\xff'}));
+}
+
+TEST(SpilledObjectTest, ReadUINT64) {
+  std::istringstream s1(std::string{
+      '\x00', '\x00', '\x00', '\x00', '\x00', '\x00',
+      '\x00', '\x00',  // little endian of 0
+      '\x01', '\x00', '\x00', '\x00', '\x00', '\x00',
+      '\x00', '\x00',  // little endian of 1
+      '\xff', '\xff', '\xff', '\xff', '\xff', '\xff',
+      '\xff', '\xff',                                 // little endian of 2^64 - 1
+      '\xff', '\xff', '\xff', '\xff', '\xff', '\xff'  // ill format
+  });
+  uint64_t output{100};
+  ASSERT_TRUE(SpilledObject::ReadUINT64(s1, output));
+  ASSERT_EQ(0, output);
+  ASSERT_TRUE(SpilledObject::ReadUINT64(s1, output));
+  ASSERT_EQ(1, output);
+  ASSERT_TRUE(SpilledObject::ReadUINT64(s1, output));
+  ASSERT_EQ(std::numeric_limits<uint64_t>::max(), output);
+  ASSERT_FALSE(SpilledObject::ReadUINT64(s1, output));
+}
+
+namespace {
+std::string ContructObjectString(uint64_t object_offset, std::string data,
+                                 std::string metadata, rpc::Address owner_address) {
+  std::string result(object_offset, '\0');
+  std::string address_str;
+  owner_address.SerializeToString(&address_str);
+  uint64_t address_size = boost::endian::native_to_little(address_str.size());
+  uint64_t data_size = boost::endian::native_to_little(data.size());
+  uint64_t metadata_size = boost::endian::native_to_little(metadata.size());
+
+  result.append((char *)(&address_size), 8);
+  result.append((char *)(&metadata_size), 8);
+  result.append((char *)(&data_size), 8);
+  result.append(address_str);
+  result.append(metadata);
+  result.append(data);
+  return result;
+}
+}  // namespace
+
+TEST(SpilledObjectTest, ParseObjectHeader) {
+  auto assert_parse_success = [](uint64_t object_offset, std::string data,
+                                 std::string metadata, std::string raylet_id) {
+    rpc::Address owner_address;
+    owner_address.set_raylet_id(raylet_id);
+    auto str = ContructObjectString(object_offset, data, metadata, owner_address);
+    uint64_t actual_data_offset = 0;
+    uint64_t actual_data_size = 0;
+    uint64_t actual_metadata_offset = 0;
+    uint64_t actual_metadata_size = 0;
+    rpc::Address actual_owner_address;
+    std::istringstream is(str);
+    SpilledObject::ParseObjectHeader(is, object_offset, actual_data_offset,
+                                     actual_data_size, actual_metadata_offset,
+                                     actual_metadata_size, actual_owner_address);
+    std::string address_str;
+    owner_address.SerializeToString(&address_str);
+    ASSERT_EQ(object_offset + 24 + address_str.size(), actual_metadata_offset);
+    ASSERT_EQ(object_offset + 24 + address_str.size() + metadata.size(),
+              actual_data_offset);
+    ASSERT_EQ(data.size(), actual_data_size);
+    ASSERT_EQ(metadata.size(), actual_metadata_size);
+    ASSERT_EQ(owner_address.raylet_id(), actual_owner_address.raylet_id());
+    ASSERT_EQ(data, str.substr(actual_data_offset, actual_data_size));
+    ASSERT_EQ(metadata, str.substr(actual_metadata_offset, actual_metadata_size));
+  };
+  std::vector<uint64_t> offsets{0, 1, 100};
+  std::string large_data(10000, 'c');
+  std::vector<std::string> data_list{"", "somedata", large_data};
+  std::string large_metadata(10000, 'm');
+  std::vector<std::string> metadata_list{"", "somemetadata", large_metadata};
+  std::vector<std::string> raylet_ids{"", "yes", "laaaaaaaarrrrrggge"};
+
+  for (auto offset : offsets) {
+    for (auto &data : data_list) {
+      for (auto &metadata : metadata_list) {
+        for (auto &raylet_id : raylet_ids) {
+          assert_parse_success(offset, data, metadata, raylet_id);
+        }
+      }
+    }
+  }
+}
+}  // namespace ray
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This is the attempt to unify the push path for both plasma and spilled objects.
This is achieved by 

1. introducing an ObjectReader interface which exposes ReadMetadataSection/ReadDataSection and Other Getter APIs
2. layer a ChunkReader over ObjectReader, which implements the ReadChunk call
3. have Plasma/Spilled ObjectReader implementation
4. plumbing ObjectReader/ChunkReader into object_manager
5. remove related code from ObjectBufferPool.

This is just a skeleton for early feedbacks; it is stacked over https://github.com/ray-project/ray/pull/16248