### PR TITLE
[Serve] Add tests for Serve quickstart with ray client

### DIFF
--- a/python/ray/serve/tests/test_ray_client.py
+++ b/python/ray/serve/tests/test_ray_client.py
@@ -102,6 +102,7 @@ A.deploy()
     ray.util.disconnect()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows")
 def test_quickstart_class(ray_client_instance):
     ray.util.connect(ray_client_instance, namespace="")
     assert ray.util.client.ray.is_connected()
@@ -123,6 +124,7 @@ def test_quickstart_class(ray_client_instance):
     ray.util.disconnect()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows")
 def test_quickstart_task(ray_client_instance):
     ray.util.connect(ray_client_instance, namespace="")
     assert ray.util.client.ray.is_connected()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR adds a test that runs the Serve "quickstart" examples from the front page of the docs using Ray Client.  
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
