### PR TITLE
[Build] Another attempt at building Python 3.9 MacOS wheels

### DIFF
--- a/ci/travis/test-wheels.sh
+++ b/ci/travis/test-wheels.sh
@@ -83,7 +83,7 @@ if [[ "$platform" == "linux" ]]; then
 
   # Check that the other wheels are present.
   NUMBER_OF_WHEELS="$(find "$ROOT_DIR"/../../.whl/ -mindepth 1 -maxdepth 1 -name "*.whl" | wc -l)"
-  if [[ "$NUMBER_OF_WHEELS" != "3" ]]; then
+  if [[ "$NUMBER_OF_WHEELS" != "4" ]]; then
     echo "Wrong number of wheels found."
     ls -l "$ROOT_DIR/../.whl/"
     exit 2
@@ -91,10 +91,11 @@ if [[ "$platform" == "linux" ]]; then
 
 elif [[ "$platform" == "macosx" ]]; then
   MACPYTHON_PY_PREFIX=/Library/Frameworks/Python.framework/Versions
-  PY_WHEEL_VERSIONS=("36" "37" "38")
+  PY_WHEEL_VERSIONS=("36" "37" "38" "39")
   PY_MMS=("3.6"
           "3.7"
-          "3.8")
+          "3.8"
+          "3.9")
 
   for ((i=0; i<${#PY_MMS[@]}; ++i)); do
     PY_MM="${PY_MMS[i]}"

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -32,19 +32,27 @@ You can install the nightly Ray wheels via the following links. These daily rele
 ===================  ===================  ======================
        Linux                MacOS         Windows (experimental)
 ===================  ===================  ======================
+`Linux Python 3.9`_  `MacOS Python 3.9`_  `Windows Python 3.9`_
 `Linux Python 3.8`_  `MacOS Python 3.8`_  `Windows Python 3.8`_
 `Linux Python 3.7`_  `MacOS Python 3.7`_  `Windows Python 3.7`_
 `Linux Python 3.6`_  `MacOS Python 3.6`_  `Windows Python 3.6`_
 ===================  ===================  ======================
 
+.. note::
+
+  Python 3.9 support is currently experimental.
+
+.. _`Linux Python 3.9`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
 .. _`Linux Python 3.8`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
 .. _`Linux Python 3.7`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
 .. _`Linux Python 3.6`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp36-cp36m-manylinux2014_x86_64.whl
 
+.. _`MacOS Python 3.9`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp39-cp39-macosx_10_13_x86_64.whl
 .. _`MacOS Python 3.8`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-macosx_10_13_x86_64.whl
 .. _`MacOS Python 3.7`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp37-cp37m-macosx_10_13_intel.whl
 .. _`MacOS Python 3.6`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp36-cp36m-macosx_10_13_intel.whl
 
+.. _`Windows Python 3.9`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp39-cp39-win_amd64.whl
 .. _`Windows Python 3.8`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-win_amd64.whl
 .. _`Windows Python 3.7`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp37-cp37m-win_amd64.whl
 .. _`Windows Python 3.6`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp36-cp36m-win_amd64.whl

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,2 +1,2 @@
-include ray/python/ray/autoscaler/ray-schema.json
-include ray/python/ray/py.typed
+include ray/autoscaler/ray-schema.json
+include ray/py.typed

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -16,19 +16,21 @@ DOWNLOAD_DIR=python_downloads
 NODE_VERSION="14"
 PY_VERSIONS=("3.6.2"
              "3.7.0"
-             "3.8.2")
+             "3.8.2"
+             "3.9.1")
 PY_INSTS=("python-3.6.2-macosx10.6.pkg"
           "python-3.7.0-macosx10.6.pkg"
-          "python-3.8.2-macosx10.9.pkg")
+          "python-3.8.2-macosx10.9.pkg"
+          "python-3.9.1-macosx10.9.pkg")
 PY_MMS=("3.6"
         "3.7"
-        "3.8")
+        "3.8"
+        "3.9")
 
-# The minimum supported numpy version is 1.14, see
-# https://issues.apache.org/jira/browse/ARROW-3141
 NUMPY_VERSIONS=("1.14.5"
                 "1.14.5"
-                "1.14.5")
+                "1.14.5"
+                "1.19.3")
 
 ./ci/travis/install-bazel.sh
 

--- a/python/build-wheel-manylinux2014.sh
+++ b/python/build-wheel-manylinux2014.sh
@@ -14,13 +14,13 @@ chmod +x /usr/bin/nproc
 NODE_VERSION="14"
 PYTHONS=("cp36-cp36m"
          "cp37-cp37m"
-         "cp38-cp38")
+         "cp38-cp38"
+         "cp39-cp39")
 
-# The minimum supported numpy version is 1.14, see
-# https://issues.apache.org/jira/browse/ARROW-3141
 NUMPY_VERSIONS=("1.14.5"
                 "1.14.5"
-                "1.14.5")
+                "1.14.5"
+                "1.19.3")
 
 yum -y install unzip zip sudo
 yum -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel xz

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -46,7 +46,7 @@ azure-common
 azure-mgmt-resource
 msrestazure
 boto3
-cython==0.29.0
+cython >= 0.29.15
 dataclasses; python_version < '3.7'
 dask[complete]
 feather-format

--- a/python/setup.py
+++ b/python/setup.py
@@ -269,7 +269,7 @@ def build(build_python, build_java):
     # that certain flags will not be passed along such as --user or sudo.
     # TODO(rkn): Fix this.
     if not os.getenv("SKIP_THIRDPARTY_INSTALL"):
-        pip_packages = ["psutil", "setproctitle==1.1.10"]
+        pip_packages = ["psutil", "setproctitle==1.2.2"]
         subprocess.check_call(
             [
                 sys.executable, "-m", "pip", "install", "-q",

--- a/python/setup.py
+++ b/python/setup.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 # before these files have been created, so we have to move the files
 # manually.
 
-SUPPORTED_PYTHONS = [(3, 6), (3, 7), (3, 8)]
+SUPPORTED_PYTHONS = [(3, 6), (3, 7), (3, 8), (3, 9)]
 SUPPORTED_BAZEL = (3, 2, 0)
 
 ROOT_DIR = os.path.dirname(__file__)
@@ -135,7 +135,8 @@ install_requires = [
     "grpcio >= 1.28.1",
     "jsonschema",
     "msgpack >= 1.0.0, < 2.0.0",
-    "numpy >= 1.16",
+    "numpy >= 1.16; python_version < '3.9'",
+    "numpy >= 1.19.3; python_version >= '3.9'",
     "protobuf >= 3.15.3",
     "py-spy >= 0.2.0",
     "pydantic >= 1.8",
@@ -436,6 +437,12 @@ setuptools.setup(
     url="https://github.com/ray-project/ray",
     keywords=("ray distributed parallel machine-learning hyperparameter-tuning"
               "reinforcement-learning deep-learning serving python"),
+    classifiers=[
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+    ],
     packages=setuptools.find_packages(),
     cmdclass={"build_ext": build_ext},
     # The BinaryDistribution argument triggers build_ext.

--- a/python/setup.py
+++ b/python/setup.py
@@ -448,7 +448,7 @@ setuptools.setup(
     # The BinaryDistribution argument triggers build_ext.
     distclass=BinaryDistribution,
     install_requires=install_requires,
-    setup_requires=["cython >= 0.29.14", "wheel"],
+    setup_requires=["cython >= 0.29.15", "wheel"],
     extras_require=extras,
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

I was able to reproduce the issue of Python 3.9 wheels missing `ray/python/ray/thirdparty_files` on my MacBook. IIUC, the file copying logic in `python/setup.py` is broken in some cases. Logic in `distutils.build_ext` actually copied the `psutil` and `setproctitle` files. This behavior could have changed on MacOS Python 3.9, for these types of files. Fixing the logic in `setup.py` seem to fix the issue. 

A more radical approach would be to not vendor `psutil` and `setproctitle` anymore, and require users to install themselves as Python dependencies. If Ray C++ uses these libraries, they could (might already?) be statically linked.

## Related issue number

<!-- For example: "Closes #1234" -->
#11287

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] CI tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
