### PR TITLE
[spilled object push optimization 2/3] Refactor ObjectManager's Push for integrating with SpilledObject

### DIFF
--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -142,25 +142,6 @@ class ObjectManager : public ObjectManagerInterface,
                          rpc::FreeObjectsReply *reply,
                          rpc::SendReplyCallback send_reply_callback) override;
 
-  /// Send object to remote object manager
-  ///
-  /// Object will be transfered as a sequence of chunks, small object(defined in config)
-  /// contains only one chunk
-  /// \param push_id Unique push id to indicate this push request
-  /// \param object_id Object id
-  /// \param owner_address The address of the object's owner
-  /// \param node_id The id of the receiver.
-  /// \param data_size Data size
-  /// \param metadata_size Metadata size
-  /// \param chunk_index Chunk index of this object chunk, start with 0
-  /// \param rpc_client Rpc client used to send message to remote object manager
-  /// \param on_complete Callback to run on completion.
-  void SendObjectChunk(const UniqueID &push_id, const ObjectID &object_id,
-                       const rpc::Address &owner_address, const NodeID &node_id,
-                       uint64_t data_size, uint64_t metadata_size, uint64_t chunk_index,
-                       std::shared_ptr<rpc::ObjectManagerClient> rpc_client,
-                       std::function<void(const Status &)> on_complete);
-
   /// Receive an object chunk from a remote object manager. Small object may
   /// fit in one chunk.
   ///
@@ -369,6 +350,50 @@ class ObjectManager : public ObjectManagerInterface,
   void SpreadFreeObjectsRequest(
       const std::vector<ObjectID> &object_ids,
       const std::vector<std::shared_ptr<rpc::ObjectManagerClient>> &rpc_clients);
+
+  /// Pushing a known local object to a remote object manager.
+  /// \param object_id The object's object id.
+  /// \param node_id The remote node's id.
+  /// \return Void.
+  void PushLocalObject(const ObjectID &object_id, const NodeID &node_id);
+
+  /// The internal implementation of pushing an object.
+  ///
+  /// \param chunk_reader Read the chunk into push_request's data fields; return
+  /// Status::OK() if the read succeeded.
+  /// \param release_chunk_callback Notify that a chunk is no longer needed.
+  void PushObjectInternal(
+      const ObjectID &object_id, const NodeID &node_id, uint64_t total_data_size,
+      uint64_t metadata_size, uint64_t num_chunks, rpc::Address owner_address,
+      std::function<ray::Status(uint64_t, rpc::PushRequest &)> chunk_reader,
+      std::function<void(uint64_t)> release_chunk_callback);
+
+  /// Send object to remote object manager
+  ///
+  /// Object will be transfered as a sequence of chunks, small object(defined in config)
+  /// contains only one chunk
+  /// \param push_id Unique push id to indicate this push request
+  /// \param object_id Object id
+  /// \param owner_address The address of the object's owner
+  /// \param node_id The id of the receiver.
+  /// \param data_size Data size
+  /// \param metadata_size Metadata size
+  /// \param chunk_index Chunk index of this object chunk, start with 0
+  /// \param rpc_client Rpc client used to send message to remote object manager
+  /// \param chunk_reader Read the chunk into push_request's data fields; return
+  /// Status::OK() if the read succeeded.
+  /// \param release_chunk_callback Notify that a chunk is no longer needed.
+  /// \param on_complete Callback to run on completion.
+  void SendObjectChunk(
+      const UniqueID &push_id, const ObjectID &object_id,
+      const rpc::Address &owner_address, const NodeID &node_id, uint64_t total_data_size,
+      uint64_t metadata_size, uint64_t chunk_index,
+      std::shared_ptr<rpc::ObjectManagerClient> rpc_client,
+      std::function<void(const Status &)> on_complete,
+      std::function<ray::Status(/*chunk_index*/ uint64_t,
+                                /*push_request*/ rpc::PushRequest &)>
+          chunk_reader,
+      std::function<void(/*chunk_index*/ uint64_t)> release_chunk_callback);
 
   /// Handle starting, running, and stopping asio rpc_service.
   void StartRpcService();

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -352,6 +352,7 @@ class ObjectManager : public ObjectManagerInterface,
       const std::vector<std::shared_ptr<rpc::ObjectManagerClient>> &rpc_clients);
 
   /// Pushing a known local object to a remote object manager.
+  ///
   /// \param object_id The object's object id.
   /// \param node_id The remote node's id.
   /// \return Void.
@@ -368,7 +369,7 @@ class ObjectManager : public ObjectManagerInterface,
       std::function<ray::Status(uint64_t, rpc::PushRequest &)> chunk_reader,
       std::function<void(uint64_t)> release_chunk_callback);
 
-  /// Send object to remote object manager
+  /// Send one chunk of the object to remote object manager
   ///
   /// Object will be transfered as a sequence of chunks, small object(defined in config)
   /// contains only one chunk


### PR DESCRIPTION
This the 2 of 3 PRs that implements spilled object push optimization. Please read https://github.com/ray-project/ray/pull/16248 for overall idea.

In this PR, we refactor `ObjectManager::Push` and `ObjectManager::SendObjectChunk`, so that we can integrate with SpilledObject easily in next PR. This PR shouldn't affect the behavior of existing code.

More specifically, 

- We refactor the `ObjectManager::Push` where it calls to `ObjectManager::PushLocalObject` if the object is local.
- we created `ObjectManager::PushLocalObject`, which read object information (data_size, owner address) and calls PushObjectInternal.
- `ObjectManager::PushObjectInternal` takes object size/location info, as well as two callback function: 
-- `chunk_reader`, which reads a specific chunk for the object
-- `release_chunk_callback`, which release the chunk when we are done reading a chunk
- `ObjectManager::SendObjectChunk` now doesn't interact with object_buffer_pool directly, but calls to the `chunk_reader` and `release_chunk_callback`


[[pr1](https://github.com/ray-project/ray/pull/16248), [pr2](https://github.com/ray-project/ray/pull/16352), [pr3](https://github.com/ray-project/ray/pull/16364)]