### PR TITLE
[Pubsub] Check if the reference_count_2 fails due to pubsub. 

### DIFF
--- a/src/ray/pubsub/subscriber.cc
+++ b/src/ray/pubsub/subscriber.cc
@@ -182,7 +182,7 @@ void Subscriber::MakeLongPollingPubsubConnection(const rpc::Address &publisher_a
   int64_t updated_commands = 0;
   while (!commands_.empty() && updated_commands < max_command_batch_size_) {
     auto &command = commands_.front();
-    auto *new_command = long_polling_request.add_commands();
+    auto new_command = long_polling_request.add_commands();
     new_command->Swap(command.get());
     commands_.pop();
     updated_commands += 1;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
