### PR TITLE
Make fallback directory for plasma configurable based on tempdir

### DIFF
--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -29,9 +29,9 @@ ObjectStoreRunner::ObjectStoreRunner(const ObjectManagerConfig &config,
                                      std::function<void()> object_store_full_callback,
                                      AddObjectCallback add_object_callback,
                                      DeleteObjectCallback delete_object_callback) {
-  plasma::plasma_store_runner.reset(
-      new plasma::PlasmaStoreRunner(config.store_socket_name, config.object_store_memory,
-                                    config.huge_pages, config.plasma_directory));
+  plasma::plasma_store_runner.reset(new plasma::PlasmaStoreRunner(
+      config.store_socket_name, config.object_store_memory, config.huge_pages,
+      config.plasma_directory, config.fallback_directory));
   // Initialize object store.
   store_thread_ =
       std::thread(&plasma::PlasmaStoreRunner::Start, plasma::plasma_store_runner.get(),

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -75,6 +75,8 @@ struct ObjectManagerConfig {
   int64_t object_store_memory = -1;
   /// The directory for shared memory files.
   std::string plasma_directory;
+  /// The directory for fallback allocation files.
+  std::string fallback_directory;
   /// Enable huge pages.
   bool huge_pages;
 };

--- a/src/ray/object_manager/plasma/dlmalloc.cc
+++ b/src/ray/object_manager/plasma/dlmalloc.cc
@@ -99,8 +99,7 @@ void create_and_mmap_buffer(int64_t size, void **pointer, int *fd) {
   // allocations will be run with dlmallopt(M_MMAP_THRESHOLD, 0) set by
   // plasma_allocator.cc.
   if (allocated_once && RayConfig::instance().plasma_unlimited()) {
-    // TODO(ekl) get this from the node manager config.
-    file_template = "/tmp";
+    file_template = plasma_config->fallback_directory;
   }
 
   file_template += "/plasmaXXXXXX";

--- a/src/ray/object_manager/plasma/plasma.h
+++ b/src/ray/object_manager/plasma/plasma.h
@@ -76,6 +76,9 @@ struct PlasmaStoreInfo {
   bool hugepages_enabled;
   /// A (platform-dependent) directory where to create the memory-backed file.
   std::string directory;
+  /// A (platform-dependent) directory where to create fallback files. This
+  /// should NOT be in /dev/shm.
+  std::string fallback_directory;
 };
 
 /// Get an entry from the object table and return NULL if the object_id

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -131,8 +131,8 @@ GetRequest::GetRequest(instrumented_io_context &io_context,
 }
 
 PlasmaStore::PlasmaStore(instrumented_io_context &main_service, std::string directory,
-                         bool hugepages_enabled, const std::string &socket_name,
-                         uint32_t delay_on_oom_ms,
+                         std::string fallback_directory, bool hugepages_enabled,
+                         const std::string &socket_name, uint32_t delay_on_oom_ms,
                          ray::SpillObjectsCallback spill_objects_callback,
                          std::function<void()> object_store_full_callback,
                          ray::AddObjectCallback add_object_callback,
@@ -155,6 +155,7 @@ PlasmaStore::PlasmaStore(instrumented_io_context &main_service, std::string dire
           []() { return absl::GetCurrentTimeNanos(); },
           [this]() { return GetDebugDump(); }) {
   store_info_.directory = directory;
+  store_info_.fallback_directory = fallback_directory;
   store_info_.hugepages_enabled = hugepages_enabled;
   const auto asio_stats_print_interval_ms =
       RayConfig::instance().asio_stats_print_interval_ms();

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -52,8 +52,9 @@ class PlasmaStore {
  public:
   // TODO: PascalCase PlasmaStore methods.
   PlasmaStore(instrumented_io_context &main_service, std::string directory,
-              bool hugepages_enabled, const std::string &socket_name,
-              uint32_t delay_on_oom_ms, ray::SpillObjectsCallback spill_objects_callback,
+              std::string fallback_directory, bool hugepages_enabled,
+              const std::string &socket_name, uint32_t delay_on_oom_ms,
+              ray::SpillObjectsCallback spill_objects_callback,
               std::function<void()> object_store_full_callback,
               ray::AddObjectCallback add_object_callback,
               ray::DeleteObjectCallback delete_object_callback);

--- a/src/ray/object_manager/plasma/store_runner.cc
+++ b/src/ray/object_manager/plasma/store_runner.cc
@@ -14,7 +14,8 @@ namespace plasma {
 void SetMallocGranularity(int value);
 
 PlasmaStoreRunner::PlasmaStoreRunner(std::string socket_name, int64_t system_memory,
-                                     bool hugepages_enabled, std::string plasma_directory)
+                                     bool hugepages_enabled, std::string plasma_directory,
+                                     std::string fallback_directory)
     : hugepages_enabled_(hugepages_enabled) {
   // Sanity check.
   if (socket_name.empty()) {
@@ -39,8 +40,11 @@ PlasmaStoreRunner::PlasmaStoreRunner(std::string socket_name, int64_t system_mem
     plasma_directory = "/tmp";
 #endif
   }
+  if (fallback_directory.empty()) {
+    fallback_directory = "/tmp";
+  }
   RAY_LOG(INFO) << "Starting object store with directory " << plasma_directory
-                << " and huge page support "
+                << ", fallback " << fallback_directory << ", and huge page support "
                 << (hugepages_enabled ? "enabled" : "disabled");
 #ifdef __linux__
   if (!hugepages_enabled) {
@@ -71,6 +75,7 @@ PlasmaStoreRunner::PlasmaStoreRunner(std::string socket_name, int64_t system_mem
 #endif
   system_memory_ = system_memory;
   plasma_directory_ = plasma_directory;
+  fallback_directory_ = fallback_directory;
 }
 
 void PlasmaStoreRunner::Start(ray::SpillObjectsCallback spill_objects_callback,
@@ -81,10 +86,11 @@ void PlasmaStoreRunner::Start(ray::SpillObjectsCallback spill_objects_callback,
   RAY_LOG(DEBUG) << "starting server listening on " << socket_name_;
   {
     absl::MutexLock lock(&store_runner_mutex_);
-    store_.reset(new PlasmaStore(
-        main_service_, plasma_directory_, hugepages_enabled_, socket_name_,
-        RayConfig::instance().object_store_full_delay_ms(), spill_objects_callback,
-        object_store_full_callback, add_object_callback, delete_object_callback));
+    store_.reset(new PlasmaStore(main_service_, plasma_directory_, fallback_directory_,
+                                 hugepages_enabled_, socket_name_,
+                                 RayConfig::instance().object_store_full_delay_ms(),
+                                 spill_objects_callback, object_store_full_callback,
+                                 add_object_callback, delete_object_callback));
     plasma_config = store_->GetPlasmaStoreInfo();
 
     // We are using a single memory-mapped file by mallocing and freeing a single

--- a/src/ray/object_manager/plasma/store_runner.h
+++ b/src/ray/object_manager/plasma/store_runner.h
@@ -35,6 +35,7 @@ class PlasmaStoreRunner {
   int64_t system_memory_;
   bool hugepages_enabled_;
   std::string plasma_directory_;
+  std::string fallback_directory_;
   mutable instrumented_io_context main_service_;
   std::unique_ptr<PlasmaStore> store_;
 };

--- a/src/ray/object_manager/plasma/store_runner.h
+++ b/src/ray/object_manager/plasma/store_runner.h
@@ -12,7 +12,8 @@ namespace plasma {
 class PlasmaStoreRunner {
  public:
   PlasmaStoreRunner(std::string socket_name, int64_t system_memory,
-                    bool hugepages_enabled, std::string plasma_directory);
+                    bool hugepages_enabled, std::string plasma_directory,
+                    std::string fallback_directory);
   void Start(ray::SpillObjectsCallback spill_objects_callback,
              std::function<void()> object_store_full_callback,
              ray::AddObjectCallback add_object_callback,

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -224,6 +224,7 @@ int main(int argc, char *argv[]) {
         object_manager_config.max_bytes_in_flight =
             RayConfig::instance().object_manager_max_bytes_in_flight();
         object_manager_config.plasma_directory = plasma_directory;
+        object_manager_config.fallback_directory = temp_dir;
         object_manager_config.huge_pages = huge_pages;
 
         object_manager_config.rpc_service_threads_number =


### PR DESCRIPTION
Currently, the fallback dir is hardcoded to /tmp instead of configurable.