### PR TITLE
[spilled object push optimization 3/3] ObjectManager Push from Spilled Object

### DIFF
--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -3,6 +3,8 @@ import json
 import random
 import platform
 import sys
+import shutil
+import zlib
 from datetime import datetime, timedelta
 
 import numpy as np
@@ -484,8 +486,10 @@ def test_spill_deadlock(object_spilling_config, shutdown_only):
 
 @pytest.mark.skipif(
     platform.system() == "Windows", reason="Failing on Windows.")
-def test_partial_retval_allocation():
-    ray.init(object_store_memory=100 * 1024 * 1024)
+def test_partial_retval_allocation(ray_start_cluster):
+    cluster = ray_start_cluster
+    cluster.add_node(object_store_memory=100 * 1024 * 1024)
+    ray.init(cluster.address)
 
     @ray.remote(num_returns=4)
     def f():
@@ -495,6 +499,110 @@ def test_partial_retval_allocation():
     for obj in ret:
         obj = ray.get(obj)
         print(obj.size)
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="Failing on Windows.")
+def test_pull_spilled_object(ray_start_cluster,
+                             multi_node_object_spilling_config, shutdown_only):
+    cluster = ray_start_cluster
+    object_spilling_config, _ = multi_node_object_spilling_config
+
+    # Head node.
+    cluster.add_node(
+        num_cpus=1,
+        resources={"custom": 0},
+        object_store_memory=75 * 1024 * 1024,
+        _system_config={
+            "max_io_workers": 2,
+            "min_spilling_size": 1 * 1024 * 1024,
+            "automatic_object_spilling_enabled": True,
+            "object_store_full_delay_ms": 100,
+            "object_spilling_config": object_spilling_config,
+        })
+    ray.init(cluster.address)
+
+    # add 1 worker node
+    cluster.add_node(
+        num_cpus=1,
+        resources={"custom": 1},
+        object_store_memory=75 * 1024 * 1024)
+    cluster.wait_for_nodes()
+
+    @ray.remote(num_cpus=1, resources={"custom": 1})
+    def create_objects():
+        results = []
+        for size in range(5):
+            arr = np.random.rand(size * 1024 * 1024)
+            hash_value = zlib.crc32(arr.tobytes())
+            results.append([ray.put(arr), hash_value])
+        # ensure the objects are spilled
+        arr = np.random.rand(5 * 1024 * 1024)
+        ray.get(ray.put(arr))
+        ray.get(ray.put(arr))
+        return results
+
+    @ray.remote(num_cpus=1, resources={"custom": 0})
+    def get_object(arr):
+        return zlib.crc32(arr.tobytes())
+
+    results = ray.get(create_objects.remote())
+    for value_ref, hash_value in results:
+        hash_value1 = ray.get(get_object.remote(value_ref))
+        assert hash_value == hash_value1
+
+
+# TODO(chenshen): fix error handling when spilled file
+# missing/corrupted
+@pytest.mark.skipif(True, reason="Currently hangs.")
+def test_pull_spilled_object_failure(object_spilling_config,
+                                     ray_start_cluster):
+    object_spilling_config, temp_folder = object_spilling_config
+    cluster = ray_start_cluster
+
+    # Head node.
+    cluster.add_node(
+        num_cpus=1,
+        resources={"custom": 0},
+        object_store_memory=75 * 1024 * 1024,
+        _system_config={
+            "max_io_workers": 2,
+            "min_spilling_size": 1 * 1024 * 1024,
+            "automatic_object_spilling_enabled": True,
+            "object_store_full_delay_ms": 100,
+            "object_spilling_config": object_spilling_config,
+        })
+    ray.init(cluster.address)
+
+    # add 1 worker node
+    cluster.add_node(
+        num_cpus=1,
+        resources={"custom": 1},
+        object_store_memory=75 * 1024 * 1024)
+    cluster.wait_for_nodes()
+
+    @ray.remote(num_cpus=1, resources={"custom": 1})
+    def create_objects():
+        arr = np.random.rand(5 * 1024 * 1024)
+        hash_value = zlib.crc32(arr.tobytes())
+        results = [ray.put(arr), hash_value]
+        # ensure the objects are spilled
+        arr = np.random.rand(5 * 1024 * 1024)
+        ray.get(ray.put(arr))
+        ray.get(ray.put(arr))
+        return results
+
+    @ray.remote(num_cpus=1, resources={"custom": 0})
+    def get_object(arr):
+        return zlib.crc32(arr.tobytes())
+
+    [ref, hash_value] = ray.get(create_objects.remote())
+
+    # remove spilled file
+    shutil.rmtree(temp_folder)
+
+    hash_value1 = ray.get(get_object.remote(ref))
+    assert hash_value == hash_value1
 
 
 if __name__ == "__main__":

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -366,8 +366,8 @@ class ObjectManager : public ObjectManagerInterface,
   /// \param node_id The remote node's id.
   /// \param spilled_url The url of the spilled object.
   /// \return Void.
-  void PushSpilledObject(const ObjectID &object_id, const NodeID &node_id,
-                         const std::string &spilled_url);
+  void PushFromFilesystem(const ObjectID &object_id, const NodeID &node_id,
+                          const std::string &spilled_url);
 
   /// The internal implementation of pushing an object.
   ///

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -40,6 +40,7 @@
 #include "ray/object_manager/plasma/store_runner.h"
 #include "ray/object_manager/pull_manager.h"
 #include "ray/object_manager/push_manager.h"
+#include "ray/object_manager/spilled_object.h"
 #include "ray/rpc/object_manager/object_manager_client.h"
 #include "ray/rpc/object_manager/object_manager_server.h"
 #include "src/ray/protobuf/common.pb.h"
@@ -359,6 +360,14 @@ class ObjectManager : public ObjectManagerInterface,
   /// \param node_id The remote node's id.
   /// \return Void.
   void PushLocalObject(const ObjectID &object_id, const NodeID &node_id);
+
+  /// Pushing a known spilled object to a remote object manager.
+  /// \param object_id The object's object id.
+  /// \param node_id The remote node's id.
+  /// \param spilled_url The url of the spilled object.
+  /// \return Void.
+  void PushSpilledObject(const ObjectID &object_id, const NodeID &node_id,
+                         const std::string &spilled_url);
 
   /// The internal implementation of pushing an object.
   ///


### PR DESCRIPTION
This the 3 of 3 PRs that implements spilled object push optimization. Please read ray-project#16248 for overall idea.

In this PR, we add a PushSpilledObject call which calls to PushObjectInternal with SpilledObject chunk reader.  As SpilledObject::CreateSpilledObject does synchronous IO; we schedule it off main thread.

[[pr1](https://github.com/ray-project/ray/pull/16248), [pr2](https://github.com/ray-project/ray/pull/16352), [pr3](https://github.com/ray-project/ray/pull/16364)]