### PR TITLE
[Core] Add container option in runtime env

### DIFF
--- a/python/ray/_private/runtime_env.py
+++ b/python/ray/_private/runtime_env.py
@@ -149,6 +149,9 @@ class RuntimeEnvDict:
         if "uris" in runtime_env_json:
             self._dict["uris"] = runtime_env_json["uris"]
 
+        if "container_option" in runtime_env_json:
+            self._dict["container_option"] = runtime_env_json["container_option"]
+
         self._dict["env_vars"] = None
         if "env_vars" in runtime_env_json:
             env_vars = runtime_env_json["env_vars"]

--- a/python/ray/_private/runtime_env.py
+++ b/python/ray/_private/runtime_env.py
@@ -59,12 +59,12 @@ class RuntimeEnvDict:
             Examples:
                 {"channels": ["defaults"], "dependencies": ["codecov"]}
                 "pytorch_p36"   # Found on DLAMIs
-        docker (dict): Require a given (Docker) container image. The Ray
-            dependency will be automatically installed into the docker image
-            to ensure compatibility with the cluster Ray. The `run_options`
-            dict spec is here: https://docs.docker.com/engine/reference/run/
+        container_option (dict): Require a given (Docker) container image. The Ray
+            worker process will run in a container with this image.
+            The `run_options` list spec is here:
+            https://docs.docker.com/engine/reference/run/
             Examples:
-                {"image": "anyscale/ray-ml:nightly-py38-cpu", **run_options}
+                {"image": "anyscale/ray-ml:nightly-py38-cpu", run_options}
         env_vars (dict): Environment variables to set.
             Examples:
                 {"OMP_NUM_THREADS": "32", "TF_WARNINGS": "none"}

--- a/python/ray/_private/runtime_env.py
+++ b/python/ray/_private/runtime_env.py
@@ -59,8 +59,8 @@ class RuntimeEnvDict:
             Examples:
                 {"channels": ["defaults"], "dependencies": ["codecov"]}
                 "pytorch_p36"   # Found on DLAMIs
-        container_option (dict): Require a given (Docker) container image. The Ray
-            worker process will run in a container with this image.
+        container_option (dict): Require a given (Docker) container image.
+            The Ray worker process will run in a container with this image.
             The `run_options` list spec is here:
             https://docs.docker.com/engine/reference/run/
             Examples:
@@ -150,7 +150,8 @@ class RuntimeEnvDict:
             self._dict["uris"] = runtime_env_json["uris"]
 
         if "container_option" in runtime_env_json:
-            self._dict["container_option"] = runtime_env_json["container_option"]
+            self._dict["container_option"] = runtime_env_json[
+                "container_option"]
 
         self._dict["env_vars"] = None
         if "env_vars" in runtime_env_json:

--- a/python/ray/job_config.py
+++ b/python/ray/job_config.py
@@ -125,7 +125,8 @@ class JobConfig:
         runtime_env = RuntimeEnvPB()
         runtime_env.uris[:] = self.get_runtime_env_uris()
         container_option_dict = self.get_runtime_env_container_options()
-        runtime_env.container_option.image = container_option_dict.get("image")
+        if container_option_dict.get("image"):
+            runtime_env.container_option.image = container_option_dict.get("image")
         if container_option_dict.get("run_options"):
             runtime_env.container_option.run_options. \
                 extend(container_option_dict.get("run_options"))

--- a/python/ray/job_config.py
+++ b/python/ray/job_config.py
@@ -4,7 +4,7 @@ import uuid
 import json
 
 from ray.core.generated.common_pb2 import RuntimeEnv as RuntimeEnvPB
-
+from ray.core.generated.common_pb2 import ContainerOption as ContainerOptionPB
 
 class JobConfig:
     """A class used to store the configurations of a job.
@@ -109,7 +109,9 @@ class JobConfig:
         return []
 
     def get_runtime_env_container_options(self):
-        return self.runtime_env.get("container_option")
+        if self.runtime_env.get("container_option"):
+            return self.runtime_env.get("container_option");
+        return dict()
 
     def set_runtime_env_uris(self, uris):
         self.runtime_env["uris"] = uris
@@ -122,6 +124,10 @@ class JobConfig:
     def _get_proto_runtime(self) -> RuntimeEnvPB:
         runtime_env = RuntimeEnvPB()
         runtime_env.uris[:] = self.get_runtime_env_uris()
-        runtime_env.container_option = self.get_runtime_env_container_options()
+        container_option_dict = self.get_runtime_env_container_options()
+        container_option = ContainerOptionPB()
+        container_option.image = container_option_dict.get("image")
+        container_option.run_options = container_option_dict.get("run_options")
+        runtime_env.container_option = container_option
         runtime_env.raw_json = json.dumps(self.runtime_env)
         return runtime_env

--- a/python/ray/job_config.py
+++ b/python/ray/job_config.py
@@ -125,9 +125,9 @@ class JobConfig:
         runtime_env = RuntimeEnvPB()
         runtime_env.uris[:] = self.get_runtime_env_uris()
         container_option_dict = self.get_runtime_env_container_options()
-        container_option = ContainerOptionPB()
-        container_option.image = container_option_dict.get("image")
-        container_option.run_options = container_option_dict.get("run_options")
-        runtime_env.container_option = container_option
+        runtime_env.container_option.image = container_option_dict.get("image")
+        if container_option_dict.get("run_options"):
+            runtime_env.container_option.run_options. \
+                extend(container_option_dict.get("run_options"))
         runtime_env.raw_json = json.dumps(self.runtime_env)
         return runtime_env

--- a/python/ray/job_config.py
+++ b/python/ray/job_config.py
@@ -108,6 +108,9 @@ class JobConfig:
             return self.runtime_env.get("uris")
         return []
 
+    def get_runtime_env_container_options(self):
+        return self.runtime_env.get("container_option")
+
     def set_runtime_env_uris(self, uris):
         self.runtime_env["uris"] = uris
         self._parsed_runtime_env.set_uris(uris)
@@ -119,5 +122,6 @@ class JobConfig:
     def _get_proto_runtime(self) -> RuntimeEnvPB:
         runtime_env = RuntimeEnvPB()
         runtime_env.uris[:] = self.get_runtime_env_uris()
+        runtime_env.container_option = self.get_runtime_env_container_options()
         runtime_env.raw_json = json.dumps(self.runtime_env)
         return runtime_env

--- a/python/ray/job_config.py
+++ b/python/ray/job_config.py
@@ -4,7 +4,7 @@ import uuid
 import json
 
 from ray.core.generated.common_pb2 import RuntimeEnv as RuntimeEnvPB
-from ray.core.generated.common_pb2 import ContainerOption as ContainerOptionPB
+
 
 class JobConfig:
     """A class used to store the configurations of a job.
@@ -110,7 +110,7 @@ class JobConfig:
 
     def get_runtime_env_container_options(self):
         if self.runtime_env.get("container_option"):
-            return self.runtime_env.get("container_option");
+            return self.runtime_env.get("container_option")
         return dict()
 
     def set_runtime_env_uris(self, uris):
@@ -126,7 +126,8 @@ class JobConfig:
         runtime_env.uris[:] = self.get_runtime_env_uris()
         container_option_dict = self.get_runtime_env_container_options()
         if container_option_dict.get("image"):
-            runtime_env.container_option.image = container_option_dict.get("image")
+            runtime_env.container_option.image = container_option_dict.get(
+                "image")
         if container_option_dict.get("run_options"):
             runtime_env.container_option.run_options. \
                 extend(container_option_dict.get("run_options"))

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -695,12 +695,12 @@ def test_container_option_serialize():
     runtime_env = {"container_option":{"image":"ray:latest","run_options":["--name=test"]}}
     job_config = ray.job_config.JobConfig(runtime_env=runtime_env)
     job_config_serialized = job_config.serialize()
-    assert job_config_serialized.count("--name=test") == 2
+    assert job_config_serialized.count(b'--name=test') == 3
 
     runtime_env1 = {"container_option":{"image":"ray:latest"}}
     job_config = ray.job_config.JobConfig(runtime_env=runtime_env1)
     job_config_serialized = job_config.serialize()
-    assert job_config_serialized.count("image") == 2
+    assert job_config_serialized.count(b'image') == 2
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -691,6 +691,18 @@ def test_get_release_wheel_url():
                 assert requests.head(url).status_code == 200, url
 
 
+def test_container_option_serialize():
+    runtime_env = {"container_option":{"image":"ray:latest","run_options":["--name=test"]}}
+    job_config = ray.job_config.JobConfig(runtime_env=runtime_env)
+    job_config_serialized = job_config.serialize()
+    assert job_config_serialized.count("--name=test") == 2
+
+    runtime_env1 = {"container_option":{"image":"ray:latest"}}
+    job_config = ray.job_config.JobConfig(runtime_env=runtime_env1)
+    job_config_serialized = job_config.serialize()
+    assert job_config_serialized.count("image") == 2
+
+
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -692,15 +692,20 @@ def test_get_release_wheel_url():
 
 
 def test_container_option_serialize():
-    runtime_env = {"container_option":{"image":"ray:latest","run_options":["--name=test"]}}
+    runtime_env = {
+        "container_option": {
+            "image": "ray:latest",
+            "run_options": ["--name=test"]
+        }
+    }
     job_config = ray.job_config.JobConfig(runtime_env=runtime_env)
     job_config_serialized = job_config.serialize()
-    assert job_config_serialized.count(b'--name=test') == 3
+    assert job_config_serialized.count(b"--name=test") == 3
 
-    runtime_env1 = {"container_option":{"image":"ray:latest"}}
+    runtime_env1 = {"container_option": {"image": "ray:latest"}}
     job_config = ray.job_config.JobConfig(runtime_env=runtime_env1)
     job_config_serialized = job_config.serialize()
-    assert job_config_serialized.count(b'image') == 2
+    assert job_config_serialized.count(b"image") == 2
 
 
 if __name__ == "__main__":

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -131,6 +131,13 @@ message RayException {
   string formatted_exception_string = 3;
 }
 
+message ContainerOption {
+  /// The worker process container image
+  string image = 1;
+  /// The worker process container run options
+  repeated string run_options = 2;
+}
+
 /// The runtime environment describes all the runtime packages needed to
 /// run some task or actor.
 message RuntimeEnv {
@@ -138,6 +145,8 @@ message RuntimeEnv {
   string raw_json = 1;
   /// Uris used in this runtime env
   repeated string uris = 2;
+  /// The option which is used for start worker process in container
+  ContainerOption container_option = 3;
 }
 
 /// The task specification encapsulates all immutable information about the


### PR DESCRIPTION
## Why are these changes needed?

We want to run ray worker process in individual container. Add container options in RuntimeEnv protobuf spec, so that we can specify container options in `runtime_env`.

This PR enable container_options in `job_config` runtime_env . I will implement container_options in `actor` runtime_env in next PR.

## Related issue number

https://github.com/ray-project/ray/issues/16333

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
