### PR TITLE
[Core] [runtime env] Merge actor/task's runtime env with JobConfig's runtime env

### DIFF
--- a/python/ray/_private/runtime_env.py
+++ b/python/ray/_private/runtime_env.py
@@ -118,7 +118,7 @@ class RuntimeEnvDict:
                                 "dict")
 
         self._dict["pip"] = None
-        if "pip" in runtime_env_json and runtime_env_json["pip"] is not None:
+        if "pip" in runtime_env_json:
             if sys.platform == "win32":
                 raise NotImplementedError("The 'pip' field in runtime_env "
                                           "is not currently supported on "
@@ -127,8 +127,10 @@ class RuntimeEnvDict:
                     and runtime_env_json["conda"] is not None):
                 raise ValueError(
                     "The 'pip' field and 'conda' field of "
-                    "runtime_env cannot both be specified.  To use "
-                    "pip with conda, please only set the 'conda' "
+                    "runtime_env cannot both be specified.\n"
+                    f"specified pip field: {runtime_env_json['pip']}\n"
+                    f"specified conda field: {runtime_env_json['conda']}\n"
+                    "To use pip with conda, please only set the 'conda' "
                     "field, and specify your pip dependencies "
                     "within the conda YAML config dict: see "
                     "https://conda.io/projects/conda/en/latest/"

--- a/python/ray/_private/runtime_env.py
+++ b/python/ray/_private/runtime_env.py
@@ -77,7 +77,7 @@ class RuntimeEnvDict:
     def __init__(self, runtime_env_json: dict):
         # Simple dictionary with all options validated. This will always
         # contain all supported keys; values will be set to None if
-        # unspecified.  However, if all values are None this is set to {}.
+        # unspecified.
         self._dict = dict()
 
         if "working_dir" in runtime_env_json:
@@ -118,12 +118,13 @@ class RuntimeEnvDict:
                                 "dict")
 
         self._dict["pip"] = None
-        if "pip" in runtime_env_json:
+        if "pip" in runtime_env_json and runtime_env_json["pip"] is not None:
             if sys.platform == "win32":
                 raise NotImplementedError("The 'pip' field in runtime_env "
                                           "is not currently supported on "
                                           "Windows.")
-            if "conda" in runtime_env_json:
+            if ("conda" in runtime_env_json
+                    and runtime_env_json["conda"] is not None):
                 raise ValueError(
                     "The 'pip' field and 'conda' field of "
                     "runtime_env cannot both be specified.  To use "
@@ -189,12 +190,6 @@ class RuntimeEnvDict:
         # TODO(ekl) we should have better schema validation here.
         # TODO(ekl) support py_modules
         # TODO(architkulkarni) support docker
-
-        # TODO(architkulkarni) This is to make it easy for the worker caching
-        # code in C++ to check if the env is empty without deserializing and
-        # parsing it.  We should use a less confusing approach here.
-        if all(val is None for val in self._dict.values()):
-            self._dict = {}
 
     def get_parsed_dict(self) -> dict:
         return self._dict

--- a/python/ray/_private/runtime_env.py
+++ b/python/ray/_private/runtime_env.py
@@ -192,7 +192,7 @@ class RuntimeEnvDict:
         # TODO(ekl) we should have better schema validation here.
         # TODO(ekl) support py_modules
         # TODO(architkulkarni) support docker
-        
+
         # TODO(architkulkarni) This is to make it easy for the worker caching
         # code in C++ to check if the env is empty without deserializing and
         # parsing it.  We should use a less confusing approach here.

--- a/python/ray/_private/runtime_env.py
+++ b/python/ray/_private/runtime_env.py
@@ -77,7 +77,7 @@ class RuntimeEnvDict:
     def __init__(self, runtime_env_json: dict):
         # Simple dictionary with all options validated. This will always
         # contain all supported keys; values will be set to None if
-        # unspecified.
+        # unspecified. However, if all values are None this is set to {}.
         self._dict = dict()
 
         if "working_dir" in runtime_env_json:
@@ -192,6 +192,12 @@ class RuntimeEnvDict:
         # TODO(ekl) we should have better schema validation here.
         # TODO(ekl) support py_modules
         # TODO(architkulkarni) support docker
+        
+        # TODO(architkulkarni) This is to make it easy for the worker caching
+        # code in C++ to check if the env is empty without deserializing and
+        # parsing it.  We should use a less confusing approach here.
+        if all(val is None for val in self._dict.values()):
+            self._dict = {}
 
     def get_parsed_dict(self) -> dict:
         return self._dict

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1731,11 +1731,15 @@ cdef class CoreWorker:
     def get_current_runtime_env_dict(self):
         # This should never change, so we can safely cache it to avoid ser/de
         if self.current_runtime_env_dict is None:
-            self.current_runtime_env_dict = json.loads(
-                CCoreWorkerProcess.GetCoreWorker()
-                .GetWorkerContext()
-                .GetCurrentSerializedRuntimeEnv()
-            )
+            if self.is_driver:
+                self.current_runtime_env_dict = \
+                    json.loads(self.get_job_config().serialized_runtime_env)
+            else:
+                self.current_runtime_env_dict = json.loads(
+                    CCoreWorkerProcess.GetCoreWorker()
+                    .GetWorkerContext()
+                    .GetCurrentSerializedRuntimeEnv()
+                )
         return self.current_runtime_env_dict
 
     def is_exiting(self):
@@ -1795,30 +1799,28 @@ cdef class CoreWorker:
         return self.job_config
 
     def prepare_runtime_env(self, runtime_env_dict: dict) -> str:
-        """Update parent's runtime env with new env via a simple dict update.
+        """Merge the given new runtime env with the current runtime env.
 
-        If the resulting runtime env is empty, fall back to the runtime env
-        set in the JobConfig.  Returns the JSON-serialized runtime env.
+        If running in a driver, the current runtime env comes from the
+        JobConfig.  Otherwise, we are running in a worker for an actor or
+        task, and the current runtime env comes from the current TaskSpec.
+
+        Args:
+            runtime_env_dict (dict): A runtime env for a child actor or task.
+        Returns:
+            The resulting merged JSON-serialized runtime env.
         """
 
         # Short-circuit in the common case.
-        if (runtime_env_dict == {}
-                and self.get_current_runtime_env_dict() == {}):
-            return self.get_job_config().serialized_runtime_env
+        if (runtime_env_dict == {}):
+            return self.current_runtime_env_dict
 
         result_dict = copy.deepcopy(self.get_current_runtime_env_dict())
         result_dict.update(runtime_env_dict)
 
-        # TODO(architkulkarni): remove once workers are cached by runtime env.
-        if all(val is None for val in result_dict.values()):
-            result_dict = {}
-
-        if result_dict == {}:
-            return self.get_job_config().serialized_runtime_env
-        else:
-            # TODO(architkulkarni): We should just use RuntimeEnvDict here
-            # so all the serialization and validation is done in one place
-            return json.dumps(result_dict, sort_keys=True)
+        # TODO(architkulkarni): We should just use RuntimeEnvDict here
+        # so all the serialization and validation is done in one place
+        return json.dumps(result_dict, sort_keys=True)
 
 cdef void async_callback(shared_ptr[CRayObject] obj,
                          CObjectID object_ref,

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1810,11 +1810,6 @@ cdef class CoreWorker:
         Returns:
             The resulting merged JSON-serialized runtime env.
         """
-
-        # Short-circuit in the common case.
-        if (runtime_env_dict == {}):
-            return self.current_runtime_env_dict
-
         result_dict = copy.deepcopy(self.get_current_runtime_env_dict())
         result_dict.update(runtime_env_dict)
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1813,6 +1813,11 @@ cdef class CoreWorker:
         result_dict = copy.deepcopy(self.get_current_runtime_env_dict())
         result_dict.update(runtime_env_dict)
 
+        # NOTE(architkulkarni): This allows worker caching code in C++ to
+        # check if a runtime env is empty without deserializing it.
+        if all(val is None for val in result_dict.values()):
+            result_dict = {}
+
         # TODO(architkulkarni): We should just use RuntimeEnvDict here
         # so all the serialization and validation is done in one place
         return json.dumps(result_dict, sort_keys=True)

--- a/python/ray/job_config.py
+++ b/python/ray/job_config.py
@@ -61,13 +61,8 @@ class JobConfig:
         # Lazily import this to avoid circular dependencies.
         import ray._private.runtime_env as runtime_support
         if runtime_env:
-            # Remove working_dir from the dict here, since that needs to be
-            # uploaded to the GCS after the job starts.
-            without_dir = dict(runtime_env)
-            if "working_dir" in without_dir:
-                del without_dir["working_dir"]
             self._parsed_runtime_env = runtime_support.RuntimeEnvDict(
-                without_dir)
+                runtime_env)
             self.worker_env.update(
                 self._parsed_runtime_env.get_parsed_dict().get("env_vars")
                 or {})

--- a/python/ray/job_config.py
+++ b/python/ray/job_config.py
@@ -61,8 +61,13 @@ class JobConfig:
         # Lazily import this to avoid circular dependencies.
         import ray._private.runtime_env as runtime_support
         if runtime_env:
+            # Remove working_dir from the dict here, since that needs to be
+            # uploaded to the GCS after the job starts.
+            without_dir = dict(runtime_env)
+            if "working_dir" in without_dir:
+                del without_dir["working_dir"]
             self._parsed_runtime_env = runtime_support.RuntimeEnvDict(
-                runtime_env)
+                without_dir)
             self.worker_env.update(
                 self._parsed_runtime_env.get_parsed_dict().get("env_vars")
                 or {})

--- a/python/ray/tests/test_runtime_env_env_vars.py
+++ b/python/ray/tests/test_runtime_env_env_vars.py
@@ -236,7 +236,7 @@ def test_override_environment_variables_complex(shutdown_only,
 
 @pytest.mark.parametrize("use_runtime_env", [True, False])
 def test_override_environment_variables_reuse(shutdown_only, use_runtime_env):
-    """Test that previously set env vars don't pollute newer calls."""
+    """Test that new tasks don't incorrectly reuse previous environments."""
     ray.init()
 
     env_var_name = "TEST123"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Previously, the runtime env specified per-task or per-actor would override the one specified in the JobConfig.  This PR makes it so that the runtime env is merged instead.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/16294
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
