### PR TITLE
[tune] get_checkpoints_paths .tune_metadata file search bug fixed

### DIFF
--- a/python/ray/tune/utils/trainable.py
+++ b/python/ray/tune/utils/trainable.py
@@ -160,6 +160,7 @@ class TrainableUtil:
             # that are not matched by '*' and '?' patterns.
             metadata_file += glob.glob(
                 os.path.join(glob.escape(chkpt_dir), ".tune_metadata"))
+            metadata_file = list(set(metadata_file))  # avoid duplication
             if len(metadata_file) != 1:
                 raise ValueError(
                     "{} has zero or more than one tune_metadata.".format(

--- a/python/ray/tune/utils/trainable.py
+++ b/python/ray/tune/utils/trainable.py
@@ -156,6 +156,9 @@ class TrainableUtil:
             chkpt_dir = os.path.dirname(marker_path)
             metadata_file = glob.glob(
                 os.path.join(glob.escape(chkpt_dir), "*.tune_metadata"))
+            if os.name == 'posix':  # https://bugs.python.org/issue44380
+                metadata_file += glob.glob(
+                    os.path.join(glob.escape(chkpt_dir), ".tune_metadata"))
             if len(metadata_file) != 1:
                 raise ValueError(
                     "{} has zero or more than one tune_metadata.".format(

--- a/python/ray/tune/utils/trainable.py
+++ b/python/ray/tune/utils/trainable.py
@@ -156,9 +156,10 @@ class TrainableUtil:
             chkpt_dir = os.path.dirname(marker_path)
             metadata_file = glob.glob(
                 os.path.join(glob.escape(chkpt_dir), "*.tune_metadata"))
-            if os.name == "posix":  # https://bugs.python.org/issue44380
-                metadata_file += glob.glob(
-                    os.path.join(glob.escape(chkpt_dir), ".tune_metadata"))
+            # glob.glob: filenames starting with a dot are special cases
+            # that are not matched by '*' and '?' patterns.
+            metadata_file += glob.glob(
+                os.path.join(glob.escape(chkpt_dir), ".tune_metadata"))
             if len(metadata_file) != 1:
                 raise ValueError(
                     "{} has zero or more than one tune_metadata.".format(

--- a/python/ray/tune/utils/trainable.py
+++ b/python/ray/tune/utils/trainable.py
@@ -156,7 +156,7 @@ class TrainableUtil:
             chkpt_dir = os.path.dirname(marker_path)
             metadata_file = glob.glob(
                 os.path.join(glob.escape(chkpt_dir), "*.tune_metadata"))
-            if os.name == 'posix':  # https://bugs.python.org/issue44380
+            if os.name == "posix":  # https://bugs.python.org/issue44380
                 metadata_file += glob.glob(
                     os.path.join(glob.escape(chkpt_dir), ".tune_metadata"))
             if len(metadata_file) != 1:


### PR DESCRIPTION
## Why are these changes needed?

`Analysis.get_best_checkpoint` bug fix.

## Related issue number

#16356 @richardliaw

## Checks

I tested by tuning my neural net and then using `Analysis` to load all trials' results and their best checkpoints. Functions exercised:

* `ray.tune.checkpoint_dir`
* `ray.tune.report`
* `ray.tune.Analysis.get_best_checkpoint` (was broken before)

tbd

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
