### PR TITLE
[sgd] Use target label count as training batch size

### DIFF
--- a/python/ray/util/sgd/torch/training_operator.py
+++ b/python/ray/util/sgd/torch/training_operator.py
@@ -600,7 +600,7 @@ class TrainingOperator:
         with self.timers.record("apply"):
             optimizer.step()
 
-        return {"train_loss": loss.item(), NUM_SAMPLES: features[0].size(0)}
+        return {"train_loss": loss.item(), NUM_SAMPLES: target.size(0)}
 
     def validate(self, val_iterator, info):
         """Runs one standard validation pass over the val_iterator.


### PR DESCRIPTION
Please take a look if this makes sense.  

Reason I think this change is better:
1) In my use case of graph learning model, I am having feature input as a sub-graph, which is a class object where feature[0] does not fit. And in fact, num of training label should reflect the number of samples. 
2) The validation part is already using target.size(0) for NUM_SAMPLE.  See line 693.

Tested on my own model, would like to double check this makes sense first, I  will do more tests if going forward (pointers would be much appreciated) 

## Related issue number
n/a

## Checks

- [ X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ X] Unit tests (manually tested on my own model)
   - [ ] Release tests
   - [ ] This PR is not tested :(
