### PR TITLE
Make it much simpler to turn on event stats

### DIFF
--- a/doc/source/debugging.rst
+++ b/doc/source/debugging.rst
@@ -109,15 +109,15 @@ If it worked, you should see as the first line in ``raylet.err``:
 Backend event stats
 -------------------
 The ``raylet`` process also periodically dumps event stats to the ``debug_state.txt`` log
-file if the ``RAY_EVENT_STATS=1`` environment variable is set. To also enable regular
-printing of the stats to log files, you can additional set ``RAY_EVENT_STATS_INTERVAL_MS=1000``.
+file if the ``RAY_event_stats=1`` environment variable is set. To also enable regular
+printing of the stats to log files, you can additional set ``RAY_event_stats_print_interval_ms=1000``.
 
 Event stats include ASIO event handlers, periodic timers, and RPC handlers. Here is a sample
 of what the event stats look like:
 
 .. code-block:: shell
 
-  Event loop stats:
+  Event stats:
   Global stats: 739128 total (27 active)
   Queueing time: mean = 47.402 ms, max = 1372.219 s, min = -0.000 s, total = 35035.892 s
   Execution time:  mean = 36.943 us, total = 27.306 s

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -104,12 +104,12 @@ def test_log_rotation(shutdown_only):
             f"backup count {backup_count}, file count: {file_cnt}")
 
 
-def test_periodic_asio_stats(shutdown_only):
+def test_periodic_event_stats(shutdown_only):
     ray.init(
         num_cpus=1,
         _system_config={
-            "asio_stats_print_interval_ms": 100,
-            "asio_event_loop_stats_collection_enabled": True
+            "event_stats_print_interval_ms": 100,
+            "event_stats": True
         })
     session_dir = ray.worker.global_worker.node.address_info["session_dir"]
     session_path = Path(session_dir)
@@ -127,7 +127,7 @@ def test_periodic_asio_stats(shutdown_only):
     def is_event_loop_stats_found(path):
         found = False
         with open(path) as f:
-            event_loop_stats_identifier = "Event loop stats"
+            event_loop_stats_identifier = "Event stats"
             for line in f.readlines():
                 if event_loop_stats_identifier in line:
                     found = True

--- a/release/data_processing_tests/dask_on_ray.yaml
+++ b/release/data_processing_tests/dask_on_ray.yaml
@@ -139,7 +139,7 @@ setup_commands:
 # Command to start ray on the head node. You don't need to change this.
 head_start_ray_commands:
     - ray stop
-    - ray start --head --port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml --system-config='{"asio_event_loop_stats_collection_enabled":true}'
+    - ray start --head --port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml --system-config='{"event_stats":true}'
 
 # Command to start ray on worker nodes. You don't need to change this.
 worker_start_ray_commands:

--- a/src/ray/common/asio/instrumented_io_context.cc
+++ b/src/ray/common/asio/instrumented_io_context.cc
@@ -57,7 +57,7 @@ std::string to_human_readable(int64_t duration) {
 
 void instrumented_io_context::post(std::function<void()> handler,
                                    const std::string name) {
-  if (!RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
+  if (!RayConfig::instance().event_stats()) {
     return boost::asio::io_context::post(std::move(handler));
   }
   const auto stats_handle = RecordStart(name);
@@ -74,7 +74,7 @@ void instrumented_io_context::post(std::function<void()> handler,
 
 void instrumented_io_context::post(std::function<void()> handler,
                                    std::shared_ptr<StatsHandle> stats_handle) {
-  if (!RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
+  if (!RayConfig::instance().event_stats()) {
     return boost::asio::io_context::post(std::move(handler));
   }
   // Reset the handle start time, so that we effectively measure the queueing
@@ -191,9 +191,9 @@ instrumented_io_context::get_handler_stats() const {
 }
 
 std::string instrumented_io_context::StatsString() const {
-  if (!RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
+  if (!RayConfig::instance().event_stats()) {
     return "Stats collection disabled, turn on "
-           "asio_event_loop_stats_collection_enabled "
+           "event_stats "
            "flag to enable event loop stats collection";
   }
   auto stats = get_handler_stats();

--- a/src/ray/common/asio/periodical_runner.cc
+++ b/src/ray/common/asio/periodical_runner.cc
@@ -34,7 +34,7 @@ void PeriodicalRunner::RunFnPeriodically(std::function<void()> fn, uint64_t peri
   if (period_ms > 0) {
     auto timer = std::make_shared<boost::asio::deadline_timer>(io_service_);
     timers_.push_back(timer);
-    if (RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
+    if (RayConfig::instance().event_stats()) {
       DoRunFnPeriodicallyInstrumented(fn, boost::posix_time::milliseconds(period_ms),
                                       *timer, name);
     } else {

--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -107,7 +107,7 @@ void ServerConnection::WriteBufferAsync(
     const std::vector<boost::asio::const_buffer> &buffer,
     const std::function<void(const ray::Status &)> &handler) {
   // Wait for the message to be written.
-  if (RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
+  if (RayConfig::instance().event_stats()) {
     auto &io_context =
         static_cast<instrumented_io_context &>(socket_.get_executor().context());
     const auto stats_handle =
@@ -155,7 +155,7 @@ void ServerConnection::ReadBufferAsync(
     const std::vector<boost::asio::mutable_buffer> &buffer,
     const std::function<void(const ray::Status &)> &handler) {
   // Wait for the message to be read.
-  if (RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
+  if (RayConfig::instance().event_stats()) {
     auto &io_context =
         static_cast<instrumented_io_context &>(socket_.get_executor().context());
     const auto stats_handle =
@@ -287,7 +287,7 @@ void ServerConnection::DoAsyncWrites() {
     return;
   }
   auto this_ptr = this->shared_from_this();
-  if (RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
+  if (RayConfig::instance().event_stats()) {
     auto &io_context =
         static_cast<instrumented_io_context &>(socket_.get_executor().context());
     const auto stats_handle =
@@ -378,7 +378,7 @@ void ClientConnection::ProcessMessages() {
       boost::asio::buffer(&read_type_, sizeof(read_type_)),
       boost::asio::buffer(&read_length_, sizeof(read_length_)),
   };
-  if (RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
+  if (RayConfig::instance().event_stats()) {
     auto this_ptr = shared_ClientConnection_from_this();
     auto &io_context = static_cast<instrumented_io_context &>(
         ServerConnection::socket_.get_executor().context());
@@ -419,7 +419,7 @@ void ClientConnection::ProcessMessageHeader(const boost::system::error_code &err
   read_message_.resize(read_length_);
   ServerConnection::bytes_read_ += read_length_;
   // Wait for the message to be read.
-  if (RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
+  if (RayConfig::instance().event_stats()) {
     auto this_ptr = shared_ClientConnection_from_this();
     auto &io_context = static_cast<instrumented_io_context &>(
         ServerConnection::socket_.get_executor().context());

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -18,6 +18,19 @@
 // Macro definition format: RAY_CONFIG(type, name, default_value).
 // NOTE: This file should NOT be included in any file other than ray_config.h.
 
+/// The duration between dumping debug info to logs, or 0 to disable.
+RAY_CONFIG(uint64_t, debug_dump_period_milliseconds, 10000)
+
+/// Whether to enable Ray event stats collection.
+/// TODO(ekl) this seems to segfault Java unit tests when on by default?
+RAY_CONFIG(bool, event_stats, false)
+
+/// The interval of periodic event loop stats print.
+/// -1 means the feature is disabled. In this case, stats are only available to
+/// debug_state.txt for raylets.
+/// NOTE: This requires event_stats=1.
+RAY_CONFIG(int64_t, event_stats_print_interval_ms, -1)
+
 /// In theory, this is used to detect Ray cookie mismatches.
 /// This magic number (hex for "RAY") is used instead of zero, rationale is
 /// that it could still be possible that some random program sends an int64_t
@@ -46,14 +59,6 @@ RAY_CONFIG(uint64_t, raylet_report_resources_period_milliseconds, 100)
 /// report periods ago, then a warning will be logged that the report
 /// handler is drifting.
 RAY_CONFIG(uint64_t, num_resource_report_periods_warning, 5)
-
-/// The duration between dumping debug info to logs, or 0 to disable.
-RAY_CONFIG(uint64_t, debug_dump_period_milliseconds, 10000)
-
-/// Whether to enable Ray event stats collection.
-/// TODO(ekl) this seems to segfault Java unit tests when on by default?
-RAY_CONFIG(bool, asio_event_loop_stats_collection_enabled,
-           env_bool("RAY_EVENT_STATS", false))
 
 /// Whether to record the creation sites of object references. This adds more
 /// information to `ray memstat`, but introduces a little extra overhead when
@@ -383,13 +388,6 @@ RAY_CONFIG(int64_t, log_rotation_backup_count, 5)
 /// notification, in this case we'll wait for a fixed timeout value and then mark it
 /// as failed.
 RAY_CONFIG(int64_t, timeout_ms_task_wait_for_death_info, 1000)
-
-/// The interval of periodic asio event loop stats print.
-/// -1 means the feature is disabled. In this case, stats are only available to
-/// debug_state.txt for raylets.
-/// NOTE: This requires asio_event_loop_stats_collection_enabled to be true.
-RAY_CONFIG(int64_t, asio_stats_print_interval_ms,
-           env_int64_t("RAY_EVENT_STATS_INTERVAL_MS", -1))
 
 /// Maximum amount of memory that will be used by running tasks' args.
 RAY_CONFIG(float, max_task_args_memory_fraction, 0.7)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -29,7 +29,7 @@ RAY_CONFIG(bool, event_stats, false)
 /// -1 means the feature is disabled. In this case, stats are only available to
 /// debug_state.txt for raylets.
 /// NOTE: This requires event_stats=1.
-RAY_CONFIG(int64_t, event_stats_print_interval_ms, -1)
+RAY_CONFIG(int64_t, event_stats_print_interval_ms, 10000)
 
 /// In theory, this is used to detect Ray cookie mismatches.
 /// This magic number (hex for "RAY") is used instead of zero, rationale is

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -702,15 +702,14 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
   max_direct_call_object_size_ = RayConfig::instance().max_direct_call_object_size();
 
   /// If periodic asio stats print is enabled, it will print it.
-  const auto asio_stats_print_interval_ms =
-      RayConfig::instance().asio_stats_print_interval_ms();
-  if (asio_stats_print_interval_ms != -1 &&
-      RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
+  const auto event_stats_print_interval_ms =
+      RayConfig::instance().event_stats_print_interval_ms();
+  if (event_stats_print_interval_ms != -1 && RayConfig::instance().event_stats()) {
     periodical_runner_.RunFnPeriodically(
         [this] {
-          RAY_LOG(INFO) << "Event loop stats:\n\n" << io_service_.StatsString() << "\n\n";
+          RAY_LOG(INFO) << "Event stats:\n\n" << io_service_.StatsString() << "\n\n";
         },
-        asio_stats_print_interval_ms);
+        event_stats_print_interval_ms);
   }
 }
 

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -488,13 +488,12 @@ void GcsServer::PrintDebugInfo() {
 
 void GcsServer::PrintAsioStats() {
   /// If periodic asio stats print is enabled, it will print it.
-  const auto asio_stats_print_interval_ms =
-      RayConfig::instance().asio_stats_print_interval_ms();
-  if (asio_stats_print_interval_ms != -1 &&
-      RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
-    RAY_LOG(INFO) << "Event loop stats:\n\n" << main_service_.StatsString() << "\n\n";
+  const auto event_stats_print_interval_ms =
+      RayConfig::instance().event_stats_print_interval_ms();
+  if (event_stats_print_interval_ms != -1 && RayConfig::instance().event_stats()) {
+    RAY_LOG(INFO) << "Event stats:\n\n" << main_service_.StatsString() << "\n\n";
     execute_after(main_service_, [this] { PrintAsioStats(); },
-                  asio_stats_print_interval_ms /* milliseconds */);
+                  event_stats_print_interval_ms /* milliseconds */);
   }
 }
 

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -943,7 +943,7 @@ std::string ObjectManager::DebugString() const {
   result << "\n  - num chunks received thrashed: " << num_chunks_received_thrashed_;
   result << "\n  - num chunks received, plasma error : "
          << num_chunks_received_failed_due_to_plasma_;
-  result << "\nEvent loop stats:" << rpc_service_.StatsString();
+  result << "\nEvent stats:" << rpc_service_.StatsString();
   result << "\n" << push_manager_->DebugString();
   result << "\n" << object_directory_->DebugString();
   result << "\n" << buffer_pool_.DebugString();

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -157,10 +157,9 @@ PlasmaStore::PlasmaStore(instrumented_io_context &main_service, std::string dire
   store_info_.directory = directory;
   store_info_.fallback_directory = fallback_directory;
   store_info_.hugepages_enabled = hugepages_enabled;
-  const auto asio_stats_print_interval_ms =
-      RayConfig::instance().asio_stats_print_interval_ms();
-  if (asio_stats_print_interval_ms > 0 &&
-      RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
+  const auto event_stats_print_interval_ms =
+      RayConfig::instance().event_stats_print_interval_ms();
+  if (event_stats_print_interval_ms > 0 && RayConfig::instance().event_stats()) {
     PrintDebugDump();
   }
 }
@@ -999,7 +998,7 @@ void PlasmaStore::PrintDebugDump() const {
   RAY_LOG(INFO) << GetDebugDump();
 
   stats_timer_ = execute_after(io_context_, [this]() { PrintDebugDump(); },
-                               RayConfig::instance().asio_stats_print_interval_ms());
+                               RayConfig::instance().event_stats_print_interval_ms());
 }
 
 std::string PlasmaStore::GetDebugDump() const {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -436,15 +436,14 @@ ray::Status NodeManager::RegisterGcs() {
       "NodeManager.deadline_timer.object_manager_profiling");
 
   /// If periodic asio stats print is enabled, it will print it.
-  const auto asio_stats_print_interval_ms =
-      RayConfig::instance().asio_stats_print_interval_ms();
-  if (asio_stats_print_interval_ms != -1 &&
-      RayConfig::instance().asio_event_loop_stats_collection_enabled()) {
+  const auto event_stats_print_interval_ms =
+      RayConfig::instance().event_stats_print_interval_ms();
+  if (event_stats_print_interval_ms != -1 && RayConfig::instance().event_stats()) {
     periodical_runner_.RunFnPeriodically(
         [this] {
-          RAY_LOG(INFO) << "Event loop stats:\n\n" << io_service_.StatsString() << "\n\n";
+          RAY_LOG(INFO) << "Event stats:\n\n" << io_service_.StatsString() << "\n\n";
         },
-        asio_stats_print_interval_ms,
+        event_stats_print_interval_ms,
         "NodeManager.deadline_timer.print_event_loop_stats");
   }
 
@@ -2014,8 +2013,8 @@ std::string NodeManager::DebugString() const {
     result << "\n" << entry.first;
   }
 
-  // Event loop stats.
-  result << "\nEvent loop stats:" << io_service_.StatsString();
+  // Event stats.
+  result << "\nEvent stats:" << io_service_.StatsString();
 
   result << "\nDebugString() time ms: " << (current_time_ms() - now_ms);
   return result.str();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Now just setting `RAY_event_stats=1` is all you need for event debugging.