### PR TITLE
Yield plasma lock to other threads during long-running gets

### DIFF
--- a/python/ray/experimental/shuffle.py
+++ b/python/ray/experimental/shuffle.py
@@ -209,20 +209,29 @@ def build_cluster(num_nodes, num_cpus, object_store_memory):
     return cluster
 
 
-def main():
+def main(ray_address=None,
+         object_store_memory=1e9,
+         num_partitions=5,
+         partition_size=200e6,
+         num_nodes=None,
+         num_cpus=8,
+         no_streaming=False,
+         use_wait=False):
     import argparse
     import numpy as np
     import time
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--ray-address", type=str, default=None)
-    parser.add_argument("--object-store-memory", type=float, default=1e9)
-    parser.add_argument("--num-partitions", type=int, default=5)
-    parser.add_argument("--partition-size", type=float, default=200e6)
-    parser.add_argument("--num-nodes", type=int, default=None)
-    parser.add_argument("--num-cpus", type=int, default=8)
-    parser.add_argument("--no-streaming", action="store_true", default=False)
-    parser.add_argument("--use-wait", action="store_true", default=False)
+    parser.add_argument("--ray-address", type=str, default=ray_address)
+    parser.add_argument(
+        "--object-store-memory", type=float, default=object_store_memory)
+    parser.add_argument("--num-partitions", type=int, default=num_partitions)
+    parser.add_argument("--partition-size", type=float, default=partition_size)
+    parser.add_argument("--num-nodes", type=int, default=num_nodes)
+    parser.add_argument("--num-cpus", type=int, default=num_cpus)
+    parser.add_argument(
+        "--no-streaming", action="store_true", default=no_streaming)
+    parser.add_argument("--use-wait", action="store_true", default=use_wait)
     args = parser.parse_args()
 
     is_multi_node = args.num_nodes

--- a/python/ray/tests/test_shuffle.py
+++ b/python/ray/tests/test_shuffle.py
@@ -1,3 +1,4 @@
+import ray
 import pytest
 import sys
 
@@ -5,7 +6,19 @@ from ray.experimental import shuffle
 
 
 def test_shuffle():
-    shuffle.main()
+    try:
+        shuffle.main()
+    finally:
+        ray.shutdown()
+
+
+# https://github.com/ray-project/ray/pull/16408
+def test_shuffle_hang():
+    try:
+        shuffle.main(
+            object_store_size=1e9, num_partitions=200, partition_size=10e6)
+    finally:
+        ray.shutdown()
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_shuffle.py
+++ b/python/ray/tests/test_shuffle.py
@@ -16,7 +16,7 @@ def test_shuffle():
 def test_shuffle_hang():
     try:
         shuffle.main(
-            object_store_size=1e9, num_partitions=200, partition_size=10e6)
+            object_store_memory=1e9, num_partitions=200, partition_size=10e6)
     finally:
         ray.shutdown()
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -148,6 +148,9 @@ RAY_CONFIG(int64_t, get_timeout_milliseconds, 1000)
 RAY_CONFIG(int64_t, worker_get_request_size, 10000)
 RAY_CONFIG(int64_t, worker_fetch_request_size, 10000)
 
+/// Temporary workaround for https://github.com/ray-project/ray/pull/16402.
+RAY_CONFIG(bool, yield_plasma_lock_workaround, true)
+
 // Whether to inline object status in serialized references.
 // See https://github.com/ray-project/ray/issues/16025 for more details.
 RAY_CONFIG(bool, inline_object_status_in_refs, true)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently plasma client Gets() hold the global plasma client mutex. During blocking PlasmaStoreProvider::Get(), this effectively starves other operations such as Release(), which can lead to deadlock.

As a workaround for now add a yield after a failed batch get. This allows other operations to run. The proper long term fix is to make the plasma client Get async, so it doesn't block other operations at all.

Verified `python -m ray.experimental.shuffle --num-partitions=200 --partition-size=10e6` no longer hangs after this.