### PR TITLE
[Core] Stopgap fix for async actor lost object bug, and adds reproduction as test.

### DIFF
--- a/python/ray/test_utils.py
+++ b/python/ray/test_utils.py
@@ -655,7 +655,8 @@ class _BatchQueueActor(_QueueActor):
                         first_timeout=None):
         start = timeit.default_timer()
         try:
-            batch = [await asyncio.wait_for(self.queue.get(), first_timeout)]
+            first = await asyncio.wait_for(self.queue.get(), first_timeout)
+            batch = [first]
             if total_timeout:
                 end = timeit.default_timer()
                 total_timeout = max(total_timeout - (end - start), 0)

--- a/python/ray/tests/test_queue.py
+++ b/python/ray/tests/test_queue.py
@@ -1,9 +1,10 @@
 import pytest
+import time
 
 import ray
 from ray.exceptions import GetTimeoutError, RayActorError
 from ray.util.queue import Queue, Empty, Full
-from ray.test_utils import wait_for_condition
+from ray.test_utils import wait_for_condition, BatchQueue
 
 
 # Remote helper functions for testing concurrency
@@ -212,6 +213,64 @@ def test_custom_resources(ray_start_regular_shared):
 
     wait_for_condition(no_cpu_in_resources)
     q.shutdown()
+
+
+def test_pull_from_streaming_batch_queue(ray_start_regular_shared):
+    class QueueBatchPuller:
+        def __init__(self, batch_size, queue):
+            self.batch_size = batch_size
+            self.queue = queue
+
+        def __iter__(self):
+            pending = []
+            is_done = False
+            while True:
+                if not pending:
+                    print("Getting a batch")
+                    for item in self.queue.get_batch(
+                            self.batch_size, total_timeout=0):
+                        if item is None:
+                            is_done = True
+                            break
+                        else:
+                            pending.append(item)
+                    if is_done:
+                        break
+                ready, pending = ray.wait(pending, num_returns=1)
+                yield ray.get(ready[0])
+
+    @ray.remote
+    class QueueConsumer:
+        def __init__(self, batch_size, queue):
+            self.batch_puller = QueueBatchPuller(batch_size, queue)
+            self.data = []
+
+        def consume(self):
+            for item in self.batch_puller:
+                self.data.append(item)
+                time.sleep(0.3)
+
+        def get_data(self):
+            return self.data
+
+    @ray.remote
+    def dummy(x):
+        return x
+
+    q = BatchQueue()
+    num_batches = 5
+    batch_size = 4
+    consumer = QueueConsumer.remote(batch_size, q)
+    consumer.consume.remote()
+    data = list(range(batch_size * num_batches))
+    for idx in range(0, len(data), batch_size):
+        time.sleep(1)
+        q.put_nowait_batch([
+            dummy.remote(item) for item in data[idx:idx + batch_size]])
+    q.put_nowait(None)
+    consumed_data = ray.get(consumer.get_data.remote())
+    assert len(consumed_data) == len(data)
+    assert set(consumed_data) == set(data)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_queue.py
+++ b/python/ray/tests/test_queue.py
@@ -265,8 +265,8 @@ def test_pull_from_streaming_batch_queue(ray_start_regular_shared):
     data = list(range(batch_size * num_batches))
     for idx in range(0, len(data), batch_size):
         time.sleep(1)
-        q.put_nowait_batch([
-            dummy.remote(item) for item in data[idx:idx + batch_size]])
+        q.put_nowait_batch(
+            [dummy.remote(item) for item in data[idx:idx + batch_size]])
     q.put_nowait(None)
     consumed_data = ray.get(consumer.get_data.remote())
     assert len(consumed_data) == len(data)

--- a/python/ray/tests/test_queue.py
+++ b/python/ray/tests/test_queue.py
@@ -226,7 +226,6 @@ def test_pull_from_streaming_batch_queue(ray_start_regular_shared):
             is_done = False
             while True:
                 if not pending:
-                    print("Getting a batch")
                     for item in self.queue.get_batch(
                             self.batch_size, total_timeout=0):
                         if item is None:

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -577,17 +577,15 @@ void CoreWorkerDirectTaskReceiver::SetMaxActorConcurrency(bool is_asyncio,
   RAY_CHECK(fiber_state_ == nullptr);
   RAY_CHECK(pool_ == nullptr);
   RAY_CHECK(max_concurrency >= 1);
-  if (max_concurrency > 1) {
-    max_concurrency_ = max_concurrency;
-    is_asyncio_ = is_asyncio;
-    if (is_asyncio_) {
-      RAY_LOG(INFO) << "Creating new thread pool of size " << max_concurrency;
-      fiber_state_.reset(new FiberState(max_concurrency));
-    } else {
-      RAY_LOG(INFO) << "Setting actor as async with max_concurrency=" << max_concurrency
-                    << ", creating new fiber thread.";
-      pool_.reset(new BoundedExecutor(max_concurrency));
-    }
+  max_concurrency_ = max_concurrency;
+  is_asyncio_ = is_asyncio;
+  if (is_asyncio_) {
+    RAY_LOG(INFO) << "Setting actor as async with max_concurrency=" << max_concurrency_
+                  << ", creating new fiber thread.";
+    fiber_state_.reset(new FiberState(max_concurrency_));
+  } else if (max_concurrency_ > 1) {
+    RAY_LOG(INFO) << "Creating new thread pool of size " << max_concurrency_;
+    pool_.reset(new BoundedExecutor(max_concurrency_));
   }
 }
 

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -667,7 +667,7 @@ class CoreWorkerDirectTaskReceiver {
   std::shared_ptr<BoundedExecutor> pool_;
   /// Whether this actor use asyncio for concurrency.
   bool is_asyncio_ = false;
-  /// If use_asyncio_ is true, fiber_state_ contains the running state required
+  /// If is_asyncio_ is true, fiber_state_ contains the running state required
   /// to enable continuation and work together with python asyncio.
   std::shared_ptr<FiberState> fiber_state_;
 


### PR DESCRIPTION
## Why are these changes needed?

Stopgap fix for async actor lost object bug, and also adds a reproduction as a test. The stopgap fix consists of reverting back to having a fiber thread per caller instead of a single fiber thread shared among all callers. This indicates that there's a thread-safety bug, where we’re implicitly relying on there being a fiber thread per caller instead of a single shared fiber thread.

## Related issue number

Closes #16322

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
