### PR TITLE
[tune] Fix `ConcurrencyLimiter` batch mode never finishing if searcher limits concurrency itself

### DIFF
--- a/python/ray/tune/suggest/ax.py
+++ b/python/ray/tune/suggest/ax.py
@@ -73,7 +73,7 @@ class AxSearch(Searcher):
             `parameter_constraints`, `outcome_constraints`.
         use_early_stopped_trials: Deprecated.
         max_concurrent (int): Deprecated.
-        **kwargs: Passed to AxClient instance. Ignored if `AxClient` is not
+        **ax_kwargs: Passed to AxClient instance. Ignored if `AxClient` is not
             None.
 
     Tune automatically converts search spaces to Ax's format:
@@ -132,7 +132,7 @@ class AxSearch(Searcher):
                  ax_client: Optional[AxClient] = None,
                  use_early_stopped_trials: Optional[bool] = None,
                  max_concurrent: Optional[int] = None,
-                 **kwargs):
+                 **ax_kwargs):
         assert ax is not None, """Ax must be installed!
             You can install AxSearch with the command:
             `pip install ax-platform sqlalchemy`."""
@@ -147,7 +147,7 @@ class AxSearch(Searcher):
             use_early_stopped_trials=use_early_stopped_trials)
 
         self._ax = ax_client
-        self._ax_kwargs = kwargs or {}
+        self._ax_kwargs = ax_kwargs or {}
 
         if isinstance(space, dict) and space:
             resolved_vars, domain_vars, grid_vars = parse_spec_vars(space)

--- a/python/ray/tune/suggest/ax.py
+++ b/python/ray/tune/suggest/ax.py
@@ -73,6 +73,8 @@ class AxSearch(Searcher):
             `parameter_constraints`, `outcome_constraints`.
         use_early_stopped_trials: Deprecated.
         max_concurrent (int): Deprecated.
+        **kwargs: Passed to AxClient instance. Ignored if `AxClient` is not
+            None.
 
     Tune automatically converts search spaces to Ax's format:
 
@@ -129,7 +131,8 @@ class AxSearch(Searcher):
                  outcome_constraints: Optional[List] = None,
                  ax_client: Optional[AxClient] = None,
                  use_early_stopped_trials: Optional[bool] = None,
-                 max_concurrent: Optional[int] = None):
+                 max_concurrent: Optional[int] = None,
+                 **kwargs):
         assert ax is not None, """Ax must be installed!
             You can install AxSearch with the command:
             `pip install ax-platform sqlalchemy`."""
@@ -144,6 +147,7 @@ class AxSearch(Searcher):
             use_early_stopped_trials=use_early_stopped_trials)
 
         self._ax = ax_client
+        self._ax_kwargs = kwargs or {}
 
         if isinstance(space, dict) and space:
             resolved_vars, domain_vars, grid_vars = parse_spec_vars(space)
@@ -173,7 +177,7 @@ class AxSearch(Searcher):
             self._metric = DEFAULT_METRIC
 
         if not self._ax:
-            self._ax = AxClient()
+            self._ax = AxClient(**self._ax_kwargs)
 
         try:
             exp = self._ax.experiment

--- a/python/ray/tune/suggest/suggestion.py
+++ b/python/ray/tune/suggest/suggestion.py
@@ -341,6 +341,7 @@ class ConcurrencyLimiter(Searcher):
         self.max_concurrent = max_concurrent
         self.batch = batch
         self.live_trials = set()
+        self.num_unfinished_live_trials = 0
         self.cached_results = {}
 
         if not isinstance(searcher, Searcher):
@@ -365,6 +366,7 @@ class ConcurrencyLimiter(Searcher):
         suggestion = self.searcher.suggest(trial_id)
         if suggestion not in (None, Searcher.FINISHED):
             self.live_trials.add(trial_id)
+            self.num_unfinished_live_trials += 1
         return suggestion
 
     def on_trial_complete(self,
@@ -375,7 +377,8 @@ class ConcurrencyLimiter(Searcher):
             return
         elif self.batch:
             self.cached_results[trial_id] = (result, error)
-            if len(self.cached_results) == self.max_concurrent:
+            self.num_unfinished_live_trials -= 1
+            if self.num_unfinished_live_trials <= 0:
                 # Update the underlying searcher once the
                 # full batch is completed.
                 for trial_id, (result, error) in self.cached_results.items():
@@ -383,12 +386,15 @@ class ConcurrencyLimiter(Searcher):
                         trial_id, result=result, error=error)
                     self.live_trials.remove(trial_id)
                 self.cached_results = {}
+                self.num_unfinished_live_trials = 0
+                self.max_concurrent = self.max_concurrent
             else:
                 return
         else:
             self.searcher.on_trial_complete(
                 trial_id, result=result, error=error)
             self.live_trials.remove(trial_id)
+            self.num_unfinished_live_trials -= 1
 
     def get_state(self) -> Dict:
         state = self.__dict__.copy()

--- a/python/ray/tune/suggest/suggestion.py
+++ b/python/ray/tune/suggest/suggestion.py
@@ -387,7 +387,6 @@ class ConcurrencyLimiter(Searcher):
                     self.live_trials.remove(trial_id)
                 self.cached_results = {}
                 self.num_unfinished_live_trials = 0
-                self.max_concurrent = self.max_concurrent
             else:
                 return
         else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If a searcher (like `AxSearcher`) wrapped in `ConcurrencyLimiter` limits concurrency internally, it is possible for a batch to be never filled, thus leading to an infinite loop. This PR fixes that and adds convenience kwargs passed to `AxClient` in `AxSearcher`. 

## Related issue number

Closes #15880.

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
