### PR TITLE
Properly call UnblockIfNeeded in Get() even if all objects are present

### DIFF
--- a/python/ray/internal/internal_api.py
+++ b/python/ray/internal/internal_api.py
@@ -105,12 +105,18 @@ def node_stats(node_manager_address=None,
 def store_stats_summary(reply):
     """Returns formatted string describing object store stats in all nodes."""
     store_summary = "--- Aggregate object store stats across all nodes ---\n"
+    # TODO(ekl) it would be nice if we could provide a full memory usage
+    # breakdown by type (e.g., pinned by worker, primary, etc.)
     store_summary += (
-        "Plasma memory usage {} MiB, {} objects, {}% full\n".format(
+        "Plasma memory usage {} MiB, {} objects, {}% full, {}% "
+        "needed\n".format(
             int(reply.store_stats.object_store_bytes_used / (1024 * 1024)),
             reply.store_stats.num_local_objects,
             round(
                 100 * reply.store_stats.object_store_bytes_used /
+                reply.store_stats.object_store_bytes_avail, 2),
+            round(
+                100 * reply.store_stats.object_store_bytes_primary_copy /
                 reply.store_stats.object_store_bytes_avail, 2)))
     if reply.store_stats.object_store_bytes_fallback > 0:
         store_summary += ("Plasma filesystem mmap usage: {} MiB\n".format(

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -264,7 +264,8 @@ RAY_CONFIG(uint64_t, local_gc_interval_s, 10 * 60)
 /// The min amount of time between local GCs (whether auto or mem pressure triggered).
 RAY_CONFIG(uint64_t, local_gc_min_interval_s, 10)
 
-/// The min amount of time between triggering global_gc in raylet
+/// The min amount of time between triggering global_gc in raylet. This only applies
+/// to global GCs triggered due to high_plasma_storage_usage.
 RAY_CONFIG(uint64_t, global_gc_min_interval_s, 30)
 
 /// Duration to wait between retries for failed tasks.

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -280,9 +280,10 @@ Status CoreWorkerPlasmaStoreProvider::Get(
                                    ctx.GetCurrentTaskID(), results, got_exception));
   }
 
-  // If all objects were fetched already, return.
+  // If all objects were fetched already, return. Note that we always need to
+  // call UnblockIfNeeded() to cancel the get request.
   if (remaining.empty() || *got_exception) {
-    return Status::OK();
+    return UnblockIfNeeded(raylet_client_, ctx);
   }
 
   // If not all objects were successfully fetched, repeatedly call FetchOrReconstruct

--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -583,6 +583,17 @@ bool PullManager::PullRequestActiveOrWaitingForMetadata(uint64_t request_id) con
   return bundle_it->second.num_object_sizes_missing > 0;
 }
 
+std::string PullManager::BundleInfo(const Queue &bundles) const {
+  auto it = bundles.begin();
+  if (it == bundles.end()) {
+    return "N/A";
+  }
+  auto bundle = it->second;
+  std::stringstream result;
+  result << bundle.num_bytes_needed << " bytes, " << bundle.objects.size() << " objects";
+  return result.str();
+}
+
 std::string PullManager::DebugString() const {
   absl::MutexLock lock(&active_objects_mu_);
   std::stringstream result;
@@ -592,6 +603,9 @@ std::string PullManager::DebugString() const {
   result << "\n- num get request bundles: " << get_request_bundles_.size();
   result << "\n- num wait request bundles: " << wait_request_bundles_.size();
   result << "\n- num task request bundles: " << task_argument_bundles_.size();
+  result << "\n- first get request bundle size: " << BundleInfo(get_request_bundles_);
+  result << "\n- first wait request bundle size: " << BundleInfo(wait_request_bundles_);
+  result << "\n- first task request bundle size: " << BundleInfo(task_argument_bundles_);
   result << "\n- num objects requested pull: " << object_pull_requests_.size();
   result << "\n- num objects actively being pulled: "
          << active_object_pull_requests_.size();

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -217,6 +217,9 @@ class PullManager {
   /// request.
   void TriggerOutOfMemoryHandlingIfNeeded();
 
+  /// Return debug info about this bundle queue.
+  std::string BundleInfo(const Queue &bundles) const;
+
   /// See the constructor's arguments.
   NodeID self_node_id_;
   const std::function<bool(const ObjectID &)> object_is_local_;

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -137,12 +137,14 @@ message ObjectStoreStats {
   int64 object_store_bytes_used = 7;
   // The max capacity of the object store.
   int64 object_store_bytes_avail = 8;
+  // The number of bytes pinned as the primary copy of objects.
+  int64 object_store_bytes_primary_copy = 9;
   // The number of bytes allocated from the filesystem (fallback allocs).
-  int64 object_store_bytes_fallback = 9;
+  int64 object_store_bytes_fallback = 10;
   // The number of local objects total.
-  int64 num_local_objects = 10;
+  int64 num_local_objects = 11;
   // The number of plasma object bytes that are consumed by core workers.
-  int64 consumed_bytes = 11;
+  int64 consumed_bytes = 12;
 }
 
 message GetNodeStatsReply {

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -491,6 +491,7 @@ void LocalObjectManager::FillObjectSpillingStats(rpc::GetNodeStatsReply *reply) 
   stats->set_restore_time_total_s(restore_time_total_s_);
   stats->set_restored_bytes_total(restored_bytes_total_);
   stats->set_restored_objects_total(restored_objects_total_);
+  stats->set_object_store_bytes_primary_copy(pinned_objects_size_);
 }
 
 void LocalObjectManager::RecordObjectSpillingStats() const {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2210,6 +2210,9 @@ rpc::ObjectStoreStats AccumulateStoreStats(
                                             cur_store.object_store_bytes_used());
     store_stats.set_object_store_bytes_avail(store_stats.object_store_bytes_avail() +
                                              cur_store.object_store_bytes_avail());
+    store_stats.set_object_store_bytes_primary_copy(
+        store_stats.object_store_bytes_primary_copy() +
+        cur_store.object_store_bytes_primary_copy());
     store_stats.set_object_store_bytes_fallback(
         store_stats.object_store_bytes_fallback() +
         cur_store.object_store_bytes_fallback());


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Properly call UnblockIfNeeded in Get() even if all objects are present. This avoids the get request from getting infinitely large if we try to get a large number of objects that are already local.

Split out this and metrics code from https://github.com/ray-project/ray/pull/16394/files