### PR TITLE
Fix fd reuse errors with plasma fallback allocation

### DIFF
--- a/src/ray/object_manager/plasma/client.cc
+++ b/src/ray/object_manager/plasma/client.cc
@@ -37,6 +37,8 @@
 #include "ray/object_manager/plasma/protocol.h"
 #include "ray/object_manager/plasma/shared_memory.h"
 
+#include "absl/container/flat_hash_map.h"
+
 namespace fb = plasma::flatbuf;
 
 namespace plasma {
@@ -186,10 +188,10 @@ class PlasmaClient::Impl : public std::enable_shared_from_this<PlasmaClient::Imp
   /// Table of dlmalloc buffer files that have been memory mapped so far. This
   /// is a hash table mapping a file descriptor to a struct containing the
   /// address of the corresponding memory-mapped file.
-  std::unordered_map<MEMFD_TYPE, std::unique_ptr<ClientMmapTableEntry>> mmap_table_;
+  absl::flat_hash_map<MEMFD_TYPE, std::unique_ptr<ClientMmapTableEntry>> mmap_table_;
   /// A hash table of the object IDs that are currently being used by this
   /// client.
-  std::unordered_map<ObjectID, std::unique_ptr<ObjectInUseEntry>> objects_in_use_;
+  absl::flat_hash_map<ObjectID, std::unique_ptr<ObjectInUseEntry>> objects_in_use_;
   /// The amount of memory available to the Plasma store. The client needs this
   /// information to make sure that it does not delay in releasing so much
   /// memory that the store is unable to evict enough objects to free up space.
@@ -216,7 +218,8 @@ uint8_t *PlasmaClient::Impl::GetStoreFdAndMmap(MEMFD_TYPE store_fd_val,
     return entry->second->pointer();
   } else {
     MEMFD_TYPE fd;
-    RAY_CHECK_OK(store_conn_->RecvFd(&fd));
+    RAY_CHECK_OK(store_conn_->RecvFd(&fd.first));
+    fd.second = store_fd_val.second;
     mmap_table_[store_fd_val] = std::make_unique<ClientMmapTableEntry>(fd, map_size);
     return mmap_table_[store_fd_val]->pointer();
   }

--- a/src/ray/object_manager/plasma/client.cc
+++ b/src/ray/object_manager/plasma/client.cc
@@ -189,6 +189,10 @@ class PlasmaClient::Impl : public std::enable_shared_from_this<PlasmaClient::Imp
   /// is a hash table mapping a file descriptor to a struct containing the
   /// address of the corresponding memory-mapped file.
   absl::flat_hash_map<MEMFD_TYPE, std::unique_ptr<ClientMmapTableEntry>> mmap_table_;
+  /// Used to clean up old fd entries in mmap_table_ that are no longer needed,
+  /// since their fd has been reused. TODO(ekl) we should be more proactive about
+  /// unmapping unused segments.
+  absl::flat_hash_map<MEMFD_TYPE_NON_UNIQUE, MEMFD_TYPE> dedup_fd_table_;
   /// A hash table of the object IDs that are currently being used by this
   /// client.
   absl::flat_hash_map<ObjectID, std::unique_ptr<ObjectInUseEntry>> objects_in_use_;
@@ -220,6 +224,12 @@ uint8_t *PlasmaClient::Impl::GetStoreFdAndMmap(MEMFD_TYPE store_fd_val,
     MEMFD_TYPE fd;
     RAY_CHECK_OK(store_conn_->RecvFd(&fd.first));
     fd.second = store_fd_val.second;
+    // Close and erase the old duplicated fd entry that is no longer needed.
+    if (dedup_fd_table_.find(store_fd_val.first) != dedup_fd_table_.end()) {
+      RAY_LOG(INFO) << "Erasing re-used mmap entry for fd " << store_fd_val.first;
+      mmap_table_.erase(dedup_fd_table_[store_fd_val.first]);
+    }
+    dedup_fd_table_[store_fd_val.first] = store_fd_val;
     mmap_table_[store_fd_val] = std::make_unique<ClientMmapTableEntry>(fd, map_size);
     return mmap_table_[store_fd_val]->pointer();
   }

--- a/src/ray/object_manager/plasma/compat.h
+++ b/src/ray/object_manager/plasma/compat.h
@@ -27,6 +27,7 @@
 #include <sys/_types.h> /* __darwin_mach_port_t */
 typedef __darwin_mach_port_t mach_port_t;
 #include <pthread.h>
+#include <utility>
 mach_port_t pthread_mach_thread_np(pthread_t);
 #endif /* _MACH_PORT_T */
 #endif /* __APPLE__ */
@@ -40,14 +41,17 @@ mach_port_t pthread_mach_thread_np(pthread_t);
 #endif                       // #ifndef WIN32_LEAN_AND_MEAN
 #include <Windows.h>         // Force inclusion of WinGDI here to resolve name conflict
 #endif                       // #ifndef _WINDOWS_
-#define MEMFD_TYPE HANDLE
+#define MEMFD_TYPE_NON_UNIQUE HANDLE
 #define INVALID_FD NULL
 // https://docs.microsoft.com/en-us/windows/win32/winauto/32-bit-and-64-bit-interoperability
 #define FD2INT(x) (static_cast<int>(reinterpret_cast<std::uintptr_t>(x)))
 #define INT2FD(x) (reinterpret_cast<HANDLE>(static_cast<std::uintptr_t>(x)))
 #else
-#define MEMFD_TYPE int
+#define MEMFD_TYPE_NON_UNIQUE int
 #define INVALID_FD -1
 #define FD2INT(x) (x)
 #define INT2FD(x) (x)
 #endif  // #ifndef _WIN32
+
+// Pair of (fd, unique_id).
+#define MEMFD_TYPE std::pair<MEMFD_TYPE_NON_UNIQUE, int64_t>

--- a/src/ray/object_manager/plasma/compat.h
+++ b/src/ray/object_manager/plasma/compat.h
@@ -56,3 +56,4 @@ mach_port_t pthread_mach_thread_np(pthread_t);
 // Pair of (fd, unique_id). We need to separately track a unique id here
 // since fd values can get re-used by the operating system.
 #define MEMFD_TYPE std::pair<MEMFD_TYPE_NON_UNIQUE, int64_t>
+#define INVALID_UNIQUE_FD_ID 0

--- a/src/ray/object_manager/plasma/compat.h
+++ b/src/ray/object_manager/plasma/compat.h
@@ -53,5 +53,6 @@ mach_port_t pthread_mach_thread_np(pthread_t);
 #define INT2FD(x) (x)
 #endif  // #ifndef _WIN32
 
-// Pair of (fd, unique_id).
+// Pair of (fd, unique_id). We need to separately track a unique id here
+// since fd values can get re-used by the operating system.
 #define MEMFD_TYPE std::pair<MEMFD_TYPE_NON_UNIQUE, int64_t>

--- a/src/ray/object_manager/plasma/connection.cc
+++ b/src/ray/object_manager/plasma/connection.cc
@@ -112,7 +112,7 @@ Status Client::SendFd(MEMFD_TYPE fd) {
     }
     CloseHandle(target_process);
 #else
-    auto ec = send_fd(GetNativeHandle(), fd);
+    auto ec = send_fd(GetNativeHandle(), fd.first);
     if (ec <= 0) {
       if (ec == 0) {
         return Status::IOError("Encountered unexpected EOF");
@@ -129,7 +129,7 @@ Status Client::SendFd(MEMFD_TYPE fd) {
 StoreConn::StoreConn(ray::local_stream_socket &&socket)
     : ray::ServerConnection(std::move(socket)) {}
 
-Status StoreConn::RecvFd(MEMFD_TYPE *fd) {
+Status StoreConn::RecvFd(MEMFD_TYPE_NON_UNIQUE *fd) {
 #ifdef _WIN32
   DWORD pid = GetCurrentProcessId();
   Status s = WriteBuffer({boost::asio::buffer(&pid, sizeof(pid))});

--- a/src/ray/object_manager/plasma/connection.cc
+++ b/src/ray/object_manager/plasma/connection.cc
@@ -92,7 +92,7 @@ Status Client::SendFd(MEMFD_TYPE fd) {
       return Status::Invalid("Cannot open PID = " + std::to_string(target_pid));
     }
     HANDLE target_handle = NULL;
-    bool success = DuplicateHandle(GetCurrentProcess(), fd, target_process,
+    bool success = DuplicateHandle(GetCurrentProcess(), fd.first, target_process,
                                    &target_handle, 0, TRUE, DUPLICATE_SAME_ACCESS);
     if (!success) {
       // TODO(suquark): Define better error type.
@@ -103,8 +103,8 @@ Status Client::SendFd(MEMFD_TYPE fd) {
     if (!s.ok()) {
       /* we failed to send the handle, and it needs cleaning up! */
       HANDLE duplicated_back = NULL;
-      if (DuplicateHandle(target_process, fd, GetCurrentProcess(), &duplicated_back, 0,
-                          FALSE, DUPLICATE_CLOSE_SOURCE)) {
+      if (DuplicateHandle(target_process, fd.first, GetCurrentProcess(), &duplicated_back,
+                          0, FALSE, DUPLICATE_CLOSE_SOURCE)) {
         CloseHandle(duplicated_back);
       }
       CloseHandle(target_process);

--- a/src/ray/object_manager/plasma/connection.h
+++ b/src/ray/object_manager/plasma/connection.h
@@ -5,6 +5,8 @@
 #include "ray/common/status.h"
 #include "ray/object_manager/plasma/compat.h"
 
+#include "absl/container/flat_hash_set.h"
+
 namespace plasma {
 
 namespace flatbuf {
@@ -37,7 +39,8 @@ class Client : public ray::ClientConnection, public ClientInterface {
  private:
   Client(ray::MessageHandler &message_handler, ray::local_stream_socket &&socket);
   /// File descriptors that are used by this client.
-  std::unordered_set<MEMFD_TYPE> used_fds_;
+  /// TODO(ekl) we should also clean up old fds that are removed.
+  absl::flat_hash_set<MEMFD_TYPE> used_fds_;
 };
 
 std::ostream &operator<<(std::ostream &os, const std::shared_ptr<Client> &client);
@@ -50,7 +53,7 @@ class StoreConn : public ray::ServerConnection {
   /// Receive a file descriptor for the store.
   ///
   /// \return A file descriptor.
-  ray::Status RecvFd(MEMFD_TYPE *fd);
+  ray::Status RecvFd(MEMFD_TYPE_NON_UNIQUE *fd);
 };
 
 std::ostream &operator<<(std::ostream &os, const std::shared_ptr<StoreConn> &store_conn);

--- a/src/ray/object_manager/plasma/create_request_queue.cc
+++ b/src/ray/object_manager/plasma/create_request_queue.cc
@@ -63,12 +63,6 @@ std::pair<PlasmaObject, PlasmaError> CreateRequestQueue::TryRequestImmediately(
     const CreateObjectCallback &create_callback, size_t object_size) {
   PlasmaObject result = {};
 
-  // Immediately fulfill it using the fallback allocator.
-  if (RayConfig::instance().plasma_unlimited()) {
-    PlasmaError error = create_callback(&result, /*fallback_allocator=*/true);
-    return {result, error};
-  }
-
   if (!queue_.empty()) {
     // There are other requests queued. Return an out-of-memory error
     // immediately because this request cannot be served.

--- a/src/ray/object_manager/plasma/create_request_queue.cc
+++ b/src/ray/object_manager/plasma/create_request_queue.cc
@@ -66,7 +66,8 @@ std::pair<PlasmaObject, PlasmaError> CreateRequestQueue::TryRequestImmediately(
   // Immediately fulfill it using the fallback allocator.
   if (RayConfig::instance().plasma_unlimited()) {
     PlasmaError error = create_callback(&result, /*fallback_allocator=*/true);
-    RAY_CHECK(error == PlasmaError::OK || error == PlasmaError::ObjectExists);  // DO NOT MERGE
+    RAY_CHECK(error == PlasmaError::OK ||
+              error == PlasmaError::ObjectExists);  // DO NOT MERGE
     return {result, error};
   }
 

--- a/src/ray/object_manager/plasma/create_request_queue.cc
+++ b/src/ray/object_manager/plasma/create_request_queue.cc
@@ -63,6 +63,13 @@ std::pair<PlasmaObject, PlasmaError> CreateRequestQueue::TryRequestImmediately(
     const CreateObjectCallback &create_callback, size_t object_size) {
   PlasmaObject result = {};
 
+  // Immediately fulfill it using the fallback allocator.
+  if (RayConfig::instance().plasma_unlimited()) {
+    PlasmaError error = create_callback(&result, /*fallback_allocator=*/true);
+    RAY_CHECK(error == PlasmaError::OK);  // DO NOT MERGE
+    return {result, error};
+  }
+
   if (!queue_.empty()) {
     // There are other requests queued. Return an out-of-memory error
     // immediately because this request cannot be served.

--- a/src/ray/object_manager/plasma/create_request_queue.cc
+++ b/src/ray/object_manager/plasma/create_request_queue.cc
@@ -66,8 +66,6 @@ std::pair<PlasmaObject, PlasmaError> CreateRequestQueue::TryRequestImmediately(
   // Immediately fulfill it using the fallback allocator.
   if (RayConfig::instance().plasma_unlimited()) {
     PlasmaError error = create_callback(&result, /*fallback_allocator=*/true);
-    RAY_CHECK(error == PlasmaError::OK ||
-              error == PlasmaError::ObjectExists);  // DO NOT MERGE
     return {result, error};
   }
 

--- a/src/ray/object_manager/plasma/create_request_queue.cc
+++ b/src/ray/object_manager/plasma/create_request_queue.cc
@@ -66,7 +66,7 @@ std::pair<PlasmaObject, PlasmaError> CreateRequestQueue::TryRequestImmediately(
   // Immediately fulfill it using the fallback allocator.
   if (RayConfig::instance().plasma_unlimited()) {
     PlasmaError error = create_callback(&result, /*fallback_allocator=*/true);
-    RAY_CHECK(error == PlasmaError::OK);  // DO NOT MERGE
+    RAY_CHECK(error == PlasmaError::OK || error == PlasmaError::ObjectExists);  // DO NOT MERGE
     return {result, error};
   }
 

--- a/src/ray/object_manager/plasma/dlmalloc.cc
+++ b/src/ray/object_manager/plasma/dlmalloc.cc
@@ -74,7 +74,7 @@ constexpr int GRANULARITY_MULTIPLIER = 2;
 static bool allocated_once = false;
 
 // Give each mmap record a unique id, so we can disambiguate fd reuse.
-static int64_t next_mmap_unique_id = 1;
+static int64_t next_mmap_unique_id = INVALID_UNIQUE_FD_ID + 1;
 
 // Populated on the first allocation so we can track which allocations fall within
 // the initial region vs outside.

--- a/src/ray/object_manager/plasma/dlmalloc.cc
+++ b/src/ray/object_manager/plasma/dlmalloc.cc
@@ -74,7 +74,7 @@ constexpr int GRANULARITY_MULTIPLIER = 2;
 static bool allocated_once = false;
 
 // Give each mmap record a unique id, so we can disambiguate fd reuse.
-static int64_t next_mmap_unique_id = 1000;
+static int64_t next_mmap_unique_id = 1;
 
 // Populated on the first allocation so we can track which allocations fall within
 // the initial region vs outside.

--- a/src/ray/object_manager/plasma/dlmalloc.cc
+++ b/src/ray/object_manager/plasma/dlmalloc.cc
@@ -73,6 +73,9 @@ constexpr int GRANULARITY_MULTIPLIER = 2;
 // Combined with MAP_POPULATE, this can guarantee we never run into SIGBUS errors.
 static bool allocated_once = false;
 
+// Give each mmap record a unique id, so we can disambiguate fd reuse.
+static int64_t next_mmap_unique_id = 1000;
+
 // Populated on the first allocation so we can track which allocations fall within
 // the initial region vs outside.
 static char *initial_region_ptr = nullptr;
@@ -171,7 +174,7 @@ void *fake_mmap(size_t size) {
   size += kMmapRegionsGap;
 
   void *pointer;
-  MEMFD_TYPE fd;
+  MEMFD_TYPE_NON_UNIQUE fd;
   create_and_mmap_buffer(size, &pointer, &fd);
   allocated_once = true;
 
@@ -179,7 +182,7 @@ void *fake_mmap(size_t size) {
   mparams.granularity *= GRANULARITY_MULTIPLIER;
 
   MmapRecord &record = mmap_records[pointer];
-  record.fd = fd;
+  record.fd = {fd, next_mmap_unique_id++};
   record.size = size;
 
   // We lie to dlmalloc about where mapped memory actually lives.
@@ -205,12 +208,12 @@ int fake_munmap(void *addr, int64_t size) {
 #ifdef _WIN32
   r = UnmapViewOfFile(addr) ? 0 : -1;
   if (r == 0) {
-    CloseHandle(entry->second.fd);
+    CloseHandle(entry->second.fd.first);
   }
 #else
   r = munmap(addr, size);
   if (r == 0) {
-    close(entry->second.fd);
+    close(entry->second.fd.first);
   }
 #endif
 

--- a/src/ray/object_manager/plasma/malloc.cc
+++ b/src/ray/object_manager/plasma/malloc.cc
@@ -36,13 +36,15 @@ void GetMallocMapinfo(void *addr, MEMFD_TYPE *fd, int64_t *map_size, ptrdiff_t *
   // TODO(rshin): Implement a more efficient search through mmap_records.
   for (const auto &entry : mmap_records) {
     if (addr >= entry.first && addr < pointer_advance(entry.first, entry.second.size)) {
-      *fd = entry.second.fd;
+      fd->first = entry.second.fd.first;
+      fd->second = entry.second.fd.second;
       *map_size = entry.second.size;
       *offset = pointer_distance(entry.first, addr);
       return;
     }
   }
-  *fd = INVALID_FD;
+  fd->first = INVALID_FD;
+  fd->second = 0;
   *map_size = 0;
   *offset = 0;
 }
@@ -53,7 +55,8 @@ int64_t GetMmapSize(MEMFD_TYPE fd) {
       return entry.second.size;
     }
   }
-  RAY_LOG(FATAL) << "failed to find entry in mmap_records for fd " << fd;
+  RAY_LOG(FATAL) << "failed to find entry in mmap_records for fd " << fd.first << " "
+                 << fd.second;
   return -1;  // This code is never reached.
 }
 

--- a/src/ray/object_manager/plasma/malloc.cc
+++ b/src/ray/object_manager/plasma/malloc.cc
@@ -44,7 +44,7 @@ void GetMallocMapinfo(void *addr, MEMFD_TYPE *fd, int64_t *map_size, ptrdiff_t *
     }
   }
   fd->first = INVALID_FD;
-  fd->second = 0;
+  fd->second = INVALID_UNIQUE_FD_ID;
   *map_size = 0;
   *offset = 0;
 }

--- a/src/ray/object_manager/plasma/plasma.fbs
+++ b/src/ray/object_manager/plasma/plasma.fbs
@@ -180,7 +180,7 @@ table PlasmaCreateReply {
   // being sent to the client right after this message.
   store_fd: int;
   // The unique id of the store file descriptor in case of fd reuse.
-  unique_fd_id: int;
+  unique_fd_id: long;
   // The size in bytes of the segment for the store file descriptor (needed to
   // call mmap).
   mmap_size: long;

--- a/src/ray/object_manager/plasma/plasma.fbs
+++ b/src/ray/object_manager/plasma/plasma.fbs
@@ -96,6 +96,8 @@ struct PlasmaObjectSpec {
   // Index of the memory segment (= memory mapped file) that
   // this object is allocated in.
   segment_index: int;
+  // The unique id of the segment fd in case of fd reuse.
+  unique_fd_id: long;
   // The offset in bytes in the memory mapped file of the data.
   data_offset: ulong;
   // The size in bytes of the data.
@@ -177,6 +179,8 @@ table PlasmaCreateReply {
   // The file descriptor in the store that corresponds to the file descriptor
   // being sent to the client right after this message.
   store_fd: int;
+  // The unique id of the store file descriptor in case of fd reuse.
+  unique_fd_id: int;
   // The size in bytes of the segment for the store file descriptor (needed to
   // call mmap).
   mmap_size: long;
@@ -229,6 +233,8 @@ table PlasmaGetReply {
   // of file descriptors that the store will send to the client after this
   // message.
   store_fds: [int];
+  // List of the unique ids for store_fds above.
+  unique_fd_ids: [long];
   // Size in bytes of the segment for each store file descriptor (needed to call
   // mmap). This list must have the same length as store_fds.
   mmap_sizes: [long];

--- a/src/ray/object_manager/plasma/protocol.cc
+++ b/src/ray/object_manager/plasma/protocol.cc
@@ -272,16 +272,17 @@ Status SendUnfinishedCreateReply(const std::shared_ptr<Client> &client,
 Status SendCreateReply(const std::shared_ptr<Client> &client, ObjectID object_id,
                        const PlasmaObject &object, PlasmaError error_code) {
   flatbuffers::FlatBufferBuilder fbb;
-  PlasmaObjectSpec plasma_object(FD2INT(object.store_fd), object.data_offset,
-                                 object.data_size, object.metadata_offset,
-                                 object.metadata_size, object.device_num);
+  PlasmaObjectSpec plasma_object(
+      FD2INT(object.store_fd.first), object.store_fd.second, object.data_offset,
+      object.data_size, object.metadata_offset, object.metadata_size, object.device_num);
   auto object_string = fbb.CreateString(object_id.Binary());
   fb::PlasmaCreateReplyBuilder crb(fbb);
   crb.add_error(static_cast<PlasmaError>(error_code));
   crb.add_plasma_object(&plasma_object);
   crb.add_object_id(object_string);
   crb.add_retry_with_request_id(0);
-  crb.add_store_fd(FD2INT(object.store_fd));
+  crb.add_store_fd(FD2INT(object.store_fd.first));
+  crb.add_unique_fd_id(object.store_fd.second);
   crb.add_mmap_size(object.mmap_size);
   if (object.device_num != 0) {
     RAY_LOG(FATAL) << "This should be unreachable.";
@@ -303,13 +304,15 @@ Status ReadCreateReply(uint8_t *data, size_t size, ObjectID *object_id,
     return Status::OK();
   }
 
-  object->store_fd = INT2FD(message->plasma_object()->segment_index());
+  object->store_fd.first = INT2FD(message->plasma_object()->segment_index());
+  object->store_fd.second = message->plasma_object()->unique_fd_id();
   object->data_offset = message->plasma_object()->data_offset();
   object->data_size = message->plasma_object()->data_size();
   object->metadata_offset = message->plasma_object()->metadata_offset();
   object->metadata_size = message->plasma_object()->metadata_size();
 
-  *store_fd = INT2FD(message->store_fd());
+  store_fd->first = INT2FD(message->store_fd());
+  store_fd->second = message->unique_fd_id();
   *mmap_size = message->mmap_size();
 
   object->device_num = message->plasma_object()->device_num();
@@ -591,18 +594,22 @@ Status SendGetReply(const std::shared_ptr<Client> &client, ObjectID object_ids[]
   std::vector<flatbuffers::Offset<fb::CudaHandle>> handles;
   for (int64_t i = 0; i < num_objects; ++i) {
     const PlasmaObject &object = plasma_objects[object_ids[i]];
-    objects.push_back(PlasmaObjectSpec(FD2INT(object.store_fd), object.data_offset,
+    objects.push_back(PlasmaObjectSpec(FD2INT(object.store_fd.first),
+                                       object.store_fd.second, object.data_offset,
                                        object.data_size, object.metadata_offset,
                                        object.metadata_size, object.device_num));
   }
   std::vector<int> store_fds_as_int;
+  std::vector<long> unique_fd_ids;
   for (MEMFD_TYPE store_fd : store_fds) {
-    store_fds_as_int.push_back(FD2INT(store_fd));
+    store_fds_as_int.push_back(FD2INT(store_fd.first));
+    unique_fd_ids.push_back(store_fd.second);
   }
   auto message = fb::CreatePlasmaGetReply(
       fbb, ToFlatbuffer(&fbb, object_ids, num_objects),
       fbb.CreateVectorOfStructs(MakeNonNull(objects.data()), num_objects),
       fbb.CreateVector(MakeNonNull(store_fds_as_int.data()), store_fds_as_int.size()),
+      fbb.CreateVector(MakeNonNull(unique_fd_ids.data()), unique_fd_ids.size()),
       fbb.CreateVector(MakeNonNull(mmap_sizes.data()), mmap_sizes.size()),
       fbb.CreateVector(MakeNonNull(handles.data()), handles.size()));
   return PlasmaSend(client, MessageType::PlasmaGetReply, &fbb, message);
@@ -620,7 +627,8 @@ Status ReadGetReply(uint8_t *data, size_t size, ObjectID object_ids[],
   }
   for (uoffset_t i = 0; i < num_objects; ++i) {
     const PlasmaObjectSpec *object = message->plasma_objects()->Get(i);
-    plasma_objects[i].store_fd = INT2FD(object->segment_index());
+    plasma_objects[i].store_fd.first = INT2FD(object->segment_index());
+    plasma_objects[i].store_fd.second = object->unique_fd_id();
     plasma_objects[i].data_offset = object->data_offset();
     plasma_objects[i].data_size = object->data_size();
     plasma_objects[i].metadata_offset = object->metadata_offset();
@@ -629,7 +637,8 @@ Status ReadGetReply(uint8_t *data, size_t size, ObjectID object_ids[],
   }
   RAY_CHECK(message->store_fds()->size() == message->mmap_sizes()->size());
   for (uoffset_t i = 0; i < message->store_fds()->size(); i++) {
-    store_fds.push_back(INT2FD(message->store_fds()->Get(i)));
+    store_fds.push_back(
+        {INT2FD(message->store_fds()->Get(i)), message->unique_fd_ids()->Get(i)});
     mmap_sizes.push_back(message->mmap_sizes()->Get(i));
   }
   return Status::OK();

--- a/src/ray/object_manager/plasma/protocol.cc
+++ b/src/ray/object_manager/plasma/protocol.cc
@@ -600,7 +600,7 @@ Status SendGetReply(const std::shared_ptr<Client> &client, ObjectID object_ids[]
                                        object.metadata_size, object.device_num));
   }
   std::vector<int> store_fds_as_int;
-  std::vector<long> unique_fd_ids;
+  std::vector<int64_t> unique_fd_ids;
   for (MEMFD_TYPE store_fd : store_fds) {
     store_fds_as_int.push_back(FD2INT(store_fd.first));
     unique_fd_ids.push_back(store_fd.second);

--- a/src/ray/object_manager/plasma/shared_memory.cc
+++ b/src/ray/object_manager/plasma/shared_memory.cc
@@ -18,8 +18,8 @@ ClientMmapTableEntry::ClientMmapTableEntry(MEMFD_TYPE fd, int64_t map_size)
   // in fake_mmap in malloc.h, to make map_size page-aligned again.
   length_ = map_size - kMmapRegionsGap;
 #ifdef _WIN32
-  pointer_ =
-      reinterpret_cast<uint8_t *>(MapViewOfFile(fd.first, FILE_MAP_ALL_ACCESS, 0, 0, length_));
+  pointer_ = reinterpret_cast<uint8_t *>(
+      MapViewOfFile(fd.first, FILE_MAP_ALL_ACCESS, 0, 0, length_));
   // TODO(pcm): Don't fail here, instead return a Status.
   if (pointer_ == NULL) {
     RAY_LOG(FATAL) << "mmap failed";

--- a/src/ray/object_manager/plasma/shared_memory.cc
+++ b/src/ray/object_manager/plasma/shared_memory.cc
@@ -19,7 +19,7 @@ ClientMmapTableEntry::ClientMmapTableEntry(MEMFD_TYPE fd, int64_t map_size)
   length_ = map_size - kMmapRegionsGap;
 #ifdef _WIN32
   pointer_ =
-      reinterpret_cast<uint8_t *>(MapViewOfFile(fd, FILE_MAP_ALL_ACCESS, 0, 0, length_));
+      reinterpret_cast<uint8_t *>(MapViewOfFile(fd.first, FILE_MAP_ALL_ACCESS, 0, 0, length_));
   // TODO(pcm): Don't fail here, instead return a Status.
   if (pointer_ == NULL) {
     RAY_LOG(FATAL) << "mmap failed";

--- a/src/ray/object_manager/plasma/shared_memory.cc
+++ b/src/ray/object_manager/plasma/shared_memory.cc
@@ -24,15 +24,15 @@ ClientMmapTableEntry::ClientMmapTableEntry(MEMFD_TYPE fd, int64_t map_size)
   if (pointer_ == NULL) {
     RAY_LOG(FATAL) << "mmap failed";
   }
-  CloseHandle(fd);  // Closing this fd has an effect on performance.
+  CloseHandle(fd.first);  // Closing this fd has an effect on performance.
 #else
   pointer_ = reinterpret_cast<uint8_t *>(
-      mmap(NULL, length_, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
+      mmap(NULL, length_, PROT_READ | PROT_WRITE, MAP_SHARED, fd.first, 0));
   // TODO(pcm): Don't fail here, instead return a Status.
   if (pointer_ == MAP_FAILED) {
     RAY_LOG(FATAL) << "mmap failed";
   }
-  close(fd);  // Closing this fd has an effect on performance.
+  close(fd.first);  // Closing this fd has an effect on performance.
 #endif
 }
 

--- a/src/ray/object_manager/plasma/shared_memory.h
+++ b/src/ray/object_manager/plasma/shared_memory.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <utility>
 
 #include "ray/object_manager/plasma/compat.h"
 #include "ray/util/macros.h"

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -267,7 +267,7 @@ uint8_t *PlasmaStore::AllocateMemory(size_t size, MEMFD_TYPE *fd, int64_t *map_s
   // Fallback to allocating from the filesystem.
   if (pointer == nullptr && RayConfig::instance().plasma_unlimited() &&
       fallback_allocator) {
-    RAY_LOG(INFO)
+    RAY_LOG(ERROR)
         << "Shared memory store full, falling back to allocating from filesystem: "
         << size;
     pointer = reinterpret_cast<uint8_t *>(

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -282,7 +282,7 @@ uint8_t *PlasmaStore::AllocateMemory(size_t size, MEMFD_TYPE *fd, int64_t *map_s
   if (pointer != nullptr) {
     GetMallocMapinfo(pointer, fd, map_size, offset);
     RAY_CHECK(fd->first != INVALID_FD);
-    RAY_CHECK(fd->second != 0);
+    RAY_CHECK(fd->second != INVALID_UNIQUE_FD_ID);
     *error = PlasmaError::OK;
   }
 

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -269,7 +269,7 @@ uint8_t *PlasmaStore::AllocateMemory(size_t size, MEMFD_TYPE *fd, int64_t *map_s
   // Fallback to allocating from the filesystem.
   if (pointer == nullptr && RayConfig::instance().plasma_unlimited() &&
       fallback_allocator) {
-    RAY_LOG(ERROR)
+    RAY_LOG(INFO)
         << "Shared memory store full, falling back to allocating from filesystem: "
         << size;
     pointer = reinterpret_cast<uint8_t *>(

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -51,6 +51,8 @@
 #include "ray/object_manager/plasma/protocol.h"
 #include "ray/util/util.h"
 
+#include "absl/container/flat_hash_set.h"
+
 namespace fb = plasma::flatbuf;
 
 namespace {
@@ -279,7 +281,8 @@ uint8_t *PlasmaStore::AllocateMemory(size_t size, MEMFD_TYPE *fd, int64_t *map_s
 
   if (pointer != nullptr) {
     GetMallocMapinfo(pointer, fd, map_size, offset);
-    RAY_CHECK(*fd != INVALID_FD);
+    RAY_CHECK(fd->first != INVALID_FD);
+    RAY_CHECK(fd->second != 0);
     *error = PlasmaError::OK;
   }
 
@@ -338,7 +341,7 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID &object_id,
     return PlasmaError::ObjectExists;
   }
 
-  MEMFD_TYPE fd = INVALID_FD;
+  MEMFD_TYPE fd{INVALID_FD, 0};
   int64_t map_size = 0;
   ptrdiff_t offset = 0;
   uint8_t *pointer = nullptr;
@@ -460,13 +463,13 @@ void PlasmaStore::ReturnFromGet(const std::shared_ptr<GetRequest> &get_req) {
   }
 
   // Figure out how many file descriptors we need to send.
-  std::unordered_set<MEMFD_TYPE> fds_to_send;
+  absl::flat_hash_set<MEMFD_TYPE> fds_to_send;
   std::vector<MEMFD_TYPE> store_fds;
   std::vector<int64_t> mmap_sizes;
   for (const auto &object_id : get_req->object_ids) {
     PlasmaObject &object = get_req->objects[object_id];
     MEMFD_TYPE fd = object.store_fd;
-    if (object.data_size != -1 && fds_to_send.count(fd) == 0 && fd != INVALID_FD) {
+    if (object.data_size != -1 && fds_to_send.count(fd) == 0 && fd.first != INVALID_FD) {
       fds_to_send.insert(fd);
       store_fds.push_back(fd);
       mmap_sizes.push_back(GetMmapSize(fd));

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -341,7 +341,7 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID &object_id,
     return PlasmaError::ObjectExists;
   }
 
-  MEMFD_TYPE fd{INVALID_FD, 0};
+  MEMFD_TYPE fd{INVALID_FD, INVALID_UNIQUE_FD_ID};
   int64_t map_size = 0;
   ptrdiff_t offset = 0;
   uint8_t *pointer = nullptr;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

With RAY_plasma_unlimited mode, allocations that can't fit in /dev/shm get placed in separate filesystem files. These files are removed by dlmalloc once the object is deallocated. However, this deallocation causes fd ids to get re-used, which wasn't handled properly in plasma.

It is desirable to deallocate these filesystem files in order to prevent allocations from going to the filesystem instead of /dev/shm once memory becomes available.

This fixes https://github.com/ray-project/ray/issues/16460