### PR TITLE
[tune] Add `add_evaluated_point` method

### DIFF
--- a/python/ray/tune/suggest/hebo.py
+++ b/python/ray/tune/suggest/hebo.py
@@ -278,6 +278,17 @@ class HEBOSearch(Searcher):
             self._opt.observe(
                 trial_info, np.array([self._metric_op * result[self._metric]]))
 
+    def add_evaluated_point(self,
+                            parameters: Dict,
+                            value: float,
+                            error: bool = False,
+                            pruned: bool = False,
+                            intermediate_values: Optional[List[float]] = None):
+        if not error and not pruned:
+            self._opt.observe(
+                pd.DataFrame([parameters]),
+                np.array([value]) * self._metric_op)
+
     def save(self, checkpoint_path: str):
         """Storing current optimizer state."""
         if self._random_state_seed is not None:

--- a/python/ray/tune/suggest/hebo.py
+++ b/python/ray/tune/suggest/hebo.py
@@ -284,10 +284,15 @@ class HEBOSearch(Searcher):
                             error: bool = False,
                             pruned: bool = False,
                             intermediate_values: Optional[List[float]] = None):
+        if intermediate_values:
+            logger.warning("HEBO doesn't use intermediate_values. Ignoring.")
         if not error and not pruned:
             self._opt.observe(
                 pd.DataFrame([parameters]),
                 np.array([value]) * self._metric_op)
+        else:
+            logger.warning("Only non errored and non pruned points"
+                           " can be added to HEBO.")
 
     def save(self, checkpoint_path: str):
         """Storing current optimizer state."""

--- a/python/ray/tune/suggest/optuna.py
+++ b/python/ray/tune/suggest/optuna.py
@@ -8,7 +8,8 @@ from ray.tune.sample import Categorical, Domain, Float, Integer, LogUniform, \
 from ray.tune.suggest.suggestion import UNRESOLVED_SEARCH_SPACE, \
     UNDEFINED_METRIC_MODE, UNDEFINED_SEARCH_SPACE
 from ray.tune.suggest.variant_generator import parse_spec_vars
-from ray.tune.utils.util import flatten_dict, unflatten_dict
+from ray.tune.utils.util import flatten_dict, unflatten_dict, \
+    validate_warmstart
 
 try:
     import optuna as ot
@@ -74,6 +75,12 @@ class OptunaSearch(Searcher):
         seed (int): Seed to initialize sampler with. This parameter is only
             used when ``sampler=None``. In all other cases, the sampler
             you pass should be initialized with the seed already.
+        evaluated_rewards (list): If you have previously evaluated the
+            parameters passed in as points_to_evaluate you can avoid
+            re-running those trials by passing in the reward attributes
+            as a list so the optimiser can be told the results without
+            needing to re-compute the trial. Must be the same length as
+            points_to_evaluate.
 
     Tune automatically converts search spaces to Optuna's format:
 
@@ -122,7 +129,8 @@ class OptunaSearch(Searcher):
                  mode: Optional[str] = None,
                  points_to_evaluate: Optional[List[Dict]] = None,
                  sampler: Optional[BaseSampler] = None,
-                 seed: Optional[int] = None):
+                 seed: Optional[int] = None,
+                 evaluated_rewards: Optional[List] = None):
         assert ot is not None, (
             "Optuna must be installed! Run `pip install optuna`.")
         super(OptunaSearch, self).__init__(
@@ -153,6 +161,7 @@ class OptunaSearch(Searcher):
         self._space = space
 
         self._points_to_evaluate = points_to_evaluate or []
+        self._evaluated_rewards = evaluated_rewards
 
         self._study_name = "optuna"  # Fixed study name for in-memory storage
 
@@ -189,8 +198,16 @@ class OptunaSearch(Searcher):
             direction="minimize" if mode == "min" else "maximize",
             load_if_exists=True)
 
-        for point in self._points_to_evaluate:
-            self._ot_study.enqueue_trial(point)
+        if self._points_to_evaluate:
+            validate_warmstart(self._space, self._points_to_evaluate,
+                               self._evaluated_rewards)
+            if self._evaluated_rewards:
+                for point, reward in zip(self._points_to_evaluate,
+                                         self._evaluated_rewards):
+                    self.add_evaluated_point(point, reward)
+            else:
+                for point in self._points_to_evaluate:
+                    self._ot_study.enqueue_trial(point)
 
     def set_search_properties(self, metric: Optional[str], mode: Optional[str],
                               config: Dict) -> bool:
@@ -266,17 +283,62 @@ class OptunaSearch(Searcher):
         except ValueError as exc:
             logger.warning(exc)  # E.g. if NaN was reported
 
+    def add_evaluated_point(self,
+                            parameters: Dict,
+                            value: float,
+                            error: bool = False,
+                            pruned: bool = False,
+                            intermediate_values: Optional[List[float]] = None):
+        if not self._space:
+            raise RuntimeError(
+                UNDEFINED_SEARCH_SPACE.format(
+                    cls=self.__class__.__name__, space="space"))
+        if not self._metric or not self._mode:
+            raise RuntimeError(
+                UNDEFINED_METRIC_MODE.format(
+                    cls=self.__class__.__name__,
+                    metric=self._metric,
+                    mode=self._mode))
+
+        ot_trial_state = OptunaTrialState.COMPLETE
+        if error:
+            ot_trial_state = OptunaTrialState.FAIL
+        elif pruned:
+            ot_trial_state = OptunaTrialState.PRUNED
+
+        if intermediate_values:
+            intermediate_values_dict = {
+                i: value
+                for i, value in enumerate(intermediate_values)
+            }
+        else:
+            intermediate_values_dict = None
+
+        trial = ot.trial.create_trial(
+            state=ot_trial_state,
+            value=value,
+            params=parameters,
+            distributions=self._space,
+            intermediate_values=intermediate_values_dict)
+
+        self._ot_study.add_trial(trial)
+
     def save(self, checkpoint_path: str):
         save_object = (self._sampler, self._ot_trials, self._ot_study,
-                       self._points_to_evaluate)
+                       self._points_to_evaluate, self._evaluated_rewards)
         with open(checkpoint_path, "wb") as outputFile:
             pickle.dump(save_object, outputFile)
 
     def restore(self, checkpoint_path: str):
         with open(checkpoint_path, "rb") as inputFile:
             save_object = pickle.load(inputFile)
-        self._sampler, self._ot_trials, self._ot_study, \
-            self._points_to_evaluate = save_object
+        if len(save_object) == 5:
+            self._sampler, self._ot_trials, self._ot_study, \
+                self._points_to_evaluate, self._evaluated_rewards = save_object
+        else:
+            # Backwards compatibility
+            self._sampler, self._ot_trials, self._ot_study, \
+                self._points_to_evaluate = save_object
 
     @staticmethod
     def convert_search_space(spec: Dict) -> Dict[str, Any]:

--- a/python/ray/tune/tests/test_searchers.py
+++ b/python/ray/tune/tests/test_searchers.py
@@ -240,6 +240,97 @@ class InvalidValuesTest(unittest.TestCase):
         self.assertLessEqual(best_trial.config["report"], 2.0)
 
 
+class AddEvaluatedPointTest(unittest.TestCase):
+    """
+    Test add_evaluated_point method in searchers that support it.
+    """
+
+    def setUp(self):
+        self.param_name = "report"
+        self.valid_value = 1.0
+        self.space = {self.param_name: tune.uniform(0.0, 5.0)}
+
+    def tearDown(self):
+        pass
+
+    @classmethod
+    def setUpClass(cls):
+        ray.init(num_cpus=4, num_gpus=0, include_dashboard=False)
+
+    @classmethod
+    def tearDownClass(cls):
+        ray.shutdown()
+
+    def testOptuna(self):
+        from ray.tune.suggest.optuna import OptunaSearch
+        from optuna.trial import TrialState
+
+        searcher = OptunaSearch(
+            space=self.space,
+            metric="metric",
+            mode="max",
+            points_to_evaluate=[{
+                self.param_name: self.valid_value
+            }],
+            evaluated_rewards=[1.0])
+
+        self.assertGreater(len(searcher._ot_study.trials), 0)
+
+        searcher = OptunaSearch(
+            space=self.space,
+            metric="metric",
+            mode="max",
+        )
+
+        point = {
+            self.param_name: self.valid_value,
+        }
+
+        self.assertEqual(len(searcher._ot_study.trials), 0)
+
+        searcher.add_evaluated_point(
+            point, 1.0, intermediate_values=[0.8, 0.9])
+        self.assertEqual(len(searcher._ot_study.trials), 1)
+        self.assertTrue(
+            searcher._ot_study.trials[-1].state == TrialState.COMPLETE)
+
+        searcher.add_evaluated_point(
+            point, 1.0, intermediate_values=[0.8, 0.9], error=True)
+        self.assertEqual(len(searcher._ot_study.trials), 2)
+        self.assertTrue(searcher._ot_study.trials[-1].state == TrialState.FAIL)
+
+        searcher.add_evaluated_point(
+            point, 1.0, intermediate_values=[0.8, 0.9], pruned=True)
+        self.assertEqual(len(searcher._ot_study.trials), 3)
+        self.assertTrue(
+            searcher._ot_study.trials[-1].state == TrialState.PRUNED)
+
+    def testHEBO(self):
+        from ray.tune.suggest.hebo import HEBOSearch
+
+        searcher = HEBOSearch(
+            space=self.space,
+            metric="metric",
+            mode="max",
+        )
+
+        point = {
+            self.param_name: self.valid_value,
+        }
+
+        len_X = len(searcher._opt.X)
+        len_y = len(searcher._opt.y)
+        self.assertEqual(len_X, 0)
+        self.assertEqual(len_y, 0)
+
+        searcher.add_evaluated_point(point, 1.0)
+
+        len_X = len(searcher._opt.X)
+        len_y = len(searcher._opt.y)
+        self.assertEqual(len_X, 1)
+        self.assertEqual(len_y, 1)
+
+
 if __name__ == "__main__":
     import pytest
     import sys


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is an API change to the `Searcher` class, adding an `add_evaluated_point` method, allowing the user to pass information about parameter configurations that have been evaluated separately to search algorithms that support it. Potential use cases include warm starting, meta-Searchers that use multiple Searchers internally which share information between themselves and combining information from multiple runs.

Additionally, the implementation of the new method has been added to Optuna and HEBO Searchers. Implementation for other searchers is left for the future. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
