### PR TITLE
[WIP] [Core] partition task dispatch queues by runtime env hash

### DIFF
--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -3,6 +3,9 @@
 #include <sstream>
 
 #include "ray/util/logging.h"
+// the below line gives "src/ray/common/task/task_spec.cc:6:10:
+// fatal error: 'ray/raylet/worker_pool.h' file not found"
+// #include "ray/raylet/worker_pool.h"
 
 namespace ray {
 
@@ -117,6 +120,12 @@ std::string TaskSpecification::SerializedRuntimeEnv() const {
 
 bool TaskSpecification::HasRuntimeEnv() const {
   return !(SerializedRuntimeEnv() == "{}" || SerializedRuntimeEnv() == "");
+}
+
+int TaskSpecification::GetRuntimeEnvHash() const {
+  // WorkerCacheKey env = {OverrideEnvironmentVariables(), SerializedRuntimeEnv()};
+  // return env.IntHash();
+  return 0;
 }
 
 const SchedulingClass TaskSpecification::GetSchedulingClass() const {

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -79,6 +79,8 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
 
   bool HasRuntimeEnv() const;
 
+  int GetRuntimeEnvHash() const;
+
   size_t NumArgs() const;
 
   size_t NumReturns() const;

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -235,4 +235,49 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   static int next_sched_id_ GUARDED_BY(mutex_);
 };
 
+/// \class WorkerCacheKey
+///
+/// Class used to cache workers, keyed by runtime_env.
+class WorkerCacheKey {
+ public:
+  /// Create a cache key with the given environment variable overrides and serialized
+  /// runtime_env.
+  ///
+  /// \param override_environment_variables The environment variable overrides set in this
+  /// worker. \param serialized_runtime_env The JSON-serialized runtime env for this
+  /// worker.
+  WorkerCacheKey(
+      const std::unordered_map<std::string, std::string> override_environment_variables,
+      const std::string serialized_runtime_env);
+
+  bool operator==(const WorkerCacheKey &k) const;
+
+  /// Check if this worker's environment is empty (the default).
+  ///
+  /// \return true if there are no environment variables set and the runtime env is the
+  /// empty string (protobuf default) or a JSON-serialized empty dict.
+  bool EnvIsEmpty() const;
+
+  /// Get the hash for this worker's environment.
+  ///
+  /// \return The hash of the override_environment_variables and the serialized
+  /// runtime_env.
+  std::size_t Hash() const;
+
+  /// Get the int-valued hash for this worker's environment, useful for portability in
+  /// flatbuffers.
+  ///
+  /// \return The hash truncated to an int.
+  int IntHash() const;
+
+ private:
+  /// The environment variable overrides for this worker.
+  const std::unordered_map<std::string, std::string> override_environment_variables;
+  /// The JSON-serialized runtime env for this worker.
+  const std::string serialized_runtime_env;
+  /// The cached hash of the worker's environment.  This is set to 0
+  /// for unspecified or empty environments.
+  mutable std::size_t hash_ = 0;
+};
+
 }  // namespace ray

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -243,8 +243,8 @@ void ClusterTaskManager::DispatchScheduledTasksToWorkers(
             ReleaseTaskArgs(task_id);
             // It may be that a worker isn't available with the runtime env of this task.
             // While the worker is starting up and installing this runtime env, we should
-            // continue to the next runtime env, because we may be able to start another task
-            // with a different runtime env.
+            // continue to the next runtime env, because we may be able to start another
+            // task with a different runtime env.
             break;
           }
 

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -241,7 +241,11 @@ void ClusterTaskManager::DispatchScheduledTasksToWorkers(
             // Worker processes spin up pretty quickly, so it's not worth trying to spill
             // this task.
             ReleaseTaskArgs(task_id);
-            return;
+            // It may be that a worker isn't available with the runtime env of this task.
+            // While the worker is starting up and installing this runtime env, we should
+            // continue in this iteration, because we may be able to start another task
+            // with a different runtime env.
+            continue;
           }
 
           RAY_LOG(DEBUG) << "Dispatching task " << task_id << " to worker "

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -243,10 +243,9 @@ void ClusterTaskManager::DispatchScheduledTasksToWorkers(
             ReleaseTaskArgs(task_id);
             // It may be that a worker isn't available with the runtime env of this task.
             // While the worker is starting up and installing this runtime env, we should
-            // continue in this iteration, because we may be able to start another task
+            // continue to the next runtime env, because we may be able to start another task
             // with a different runtime env.
-            runtime_env_hash_it++;
-            continue;
+            break;
           }
 
           RAY_LOG(DEBUG) << "Dispatching task " << task_id << " to worker "

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -245,6 +245,7 @@ void ClusterTaskManager::DispatchScheduledTasksToWorkers(
             // While the worker is starting up and installing this runtime env, we should
             // continue in this iteration, because we may be able to start another task
             // with a different runtime env.
+            runtime_env_hash_it++;
             continue;
           }
 

--- a/src/ray/raylet/scheduling/cluster_task_manager.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager.h
@@ -235,7 +235,9 @@ class ClusterTaskManager : public ClusterTaskManagerInterface {
   /// All tasks in this map that have dependencies should be registered with
   /// the dependency manager, in case a dependency gets evicted while the task
   /// is still queued.
-  std::unordered_map<SchedulingClass, std::deque<Work>> tasks_to_dispatch_;
+  /// The tasks are also keyed by their runtime_env_hash (int).
+  std::unordered_map<SchedulingClass, std::unordered_map<int, std::deque<Work>>>
+      tasks_to_dispatch_;
 
   /// Tasks waiting for arguments to be transferred locally.
   /// Tasks move from waiting -> dispatch.

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -1272,6 +1272,9 @@ std::size_t WorkerCacheKey::Hash() const {
       // either.  Sort the variables so different permutations yield the same hash.
       std::sort(env_vars.begin(), env_vars.end());
       for (auto &pair : env_vars) {
+        // TODO(architkulkarni): boost::hash_combine isn't guaranteed to be equal during
+        // separate runs of a program, which may cause problems if these hashes are
+        // communicated between different Raylets and compared.
         boost::hash_combine(hash_, pair.first);
         boost::hash_combine(hash_, pair.second);
       }

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -18,7 +18,6 @@
 
 #include <algorithm>
 #include <boost/asio/io_service.hpp>
-#include <boost/functional/hash.hpp>
 #include <queue>
 #include <unordered_map>
 #include <unordered_set>
@@ -40,51 +39,6 @@ namespace raylet {
 
 using WorkerCommandMap =
     std::unordered_map<Language, std::vector<std::string>, std::hash<int>>;
-
-/// \class WorkerCacheKey
-///
-/// Class used to cache workers, keyed by runtime_env.
-class WorkerCacheKey {
- public:
-  /// Create a cache key with the given environment variable overrides and serialized
-  /// runtime_env.
-  ///
-  /// \param override_environment_variables The environment variable overrides set in this
-  /// worker. \param serialized_runtime_env The JSON-serialized runtime env for this
-  /// worker.
-  WorkerCacheKey(
-      const std::unordered_map<std::string, std::string> override_environment_variables,
-      const std::string serialized_runtime_env);
-
-  bool operator==(const WorkerCacheKey &k) const;
-
-  /// Check if this worker's environment is empty (the default).
-  ///
-  /// \return true if there are no environment variables set and the runtime env is the
-  /// empty string (protobuf default) or a JSON-serialized empty dict.
-  bool EnvIsEmpty() const;
-
-  /// Get the hash for this worker's environment.
-  ///
-  /// \return The hash of the override_environment_variables and the serialized
-  /// runtime_env.
-  std::size_t Hash() const;
-
-  /// Get the int-valued hash for this worker's environment, useful for portability in
-  /// flatbuffers.
-  ///
-  /// \return The hash truncated to an int.
-  int IntHash() const;
-
- private:
-  /// The environment variable overrides for this worker.
-  const std::unordered_map<std::string, std::string> override_environment_variables;
-  /// The JSON-serialized runtime env for this worker.
-  const std::string serialized_runtime_env;
-  /// The cached hash of the worker's environment.  This is set to 0
-  /// for unspecified or empty environments.
-  mutable std::size_t hash_ = 0;
-};
 
 /// \class WorkerPoolInterface
 ///


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Tasks with the same "shape" (num_cpus, etc) are placed in the same queue.  If two tasks are in the same queue, and the one at the head of the queue requires a runtime env to be installed, the second task will not get scheduled while the runtime env is installing.  The reason is that `DispatchScheduledTasksToWorkers()` iterates through the queue and returns immediately if the worker for the task is not ready yet (https://github.com/ray-project/ray/blob/master/src/ray/raylet/scheduling/cluster_task_manager.cc#L238).

To fix this, we break up the task dispatch queue into one queue for each runtime_env_hash using an unordered map, so that tasks with different runtime env hashes don't block each other.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #16226 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
