### PR TITLE
[tune] Add option to keep random values constant over grid search

### DIFF
--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -1562,6 +1562,10 @@ class SearchSpaceTest(unittest.TestCase):
             self.assertEqual(sub_configs[0]["rand"], sub_configs[1]["rand"])
             self.assertEqual(sub_configs[0]["rand"], sub_configs[2]["rand"])
 
+        # Also, for different samples the random variables should differ
+        self.assertEqual(configs[0]["grid"], configs[3]["grid"])
+        self.assertNotEqual(configs[0]["rand"], configs[3]["rand"])
+
 
 if __name__ == "__main__":
     import pytest

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -1539,7 +1539,7 @@ class SearchSpaceTest(unittest.TestCase):
             self.assertNotEqual(sub_configs[0]["rand"], sub_configs[1]["rand"])
             self.assertNotEqual(sub_configs[0]["rand"], sub_configs[2]["rand"])
 
-        # First, keep random variables constant
+        # Second, keep random variables constant
         searcher = BasicVariantGenerator(constant_grid_search=True)
         exp = Experiment(
             run=_mock_objective,

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -1502,6 +1502,66 @@ class SearchSpaceTest(unittest.TestCase):
         self.assertTrue(configs[8]["nested"]["random"] == 8.0)
         self.assertTrue(configs[8]["nested"]["dependent"] == -8.0)
 
+    def testConstantGridSearchBasicVariant(self):
+        config = {
+            "grid": tune.grid_search([1, 2, 3]),
+            "rand": tune.uniform(0, 1000),
+            "dependent_rand": tune.sample_from(
+                lambda spec: spec.config.rand / 10),
+            "dependent_grid": tune.sample_from(
+                lambda spec: spec.config.grid / 10)
+        }
+
+        num_samples = 6
+
+        from ray.tune.suggest.basic_variant import BasicVariantGenerator
+
+        # First, do not keep random variables constant
+        searcher = BasicVariantGenerator(constant_grid_search=False)
+        exp = Experiment(
+            run=_mock_objective,
+            name="test",
+            config=config,
+            num_samples=num_samples)
+        searcher.add_configurations(exp)
+
+        configs = []
+        while not searcher.is_finished():
+            trial = searcher.next_trial()
+            if not trial:
+                break
+            configs.append(trial.config)
+
+        for i in range(num_samples):
+            sub_configs = configs[i * 3:i * 3 + 3]
+            # These should not be equal, because we sample randomly for
+            # each grid search value
+            self.assertNotEqual(sub_configs[0]["rand"], sub_configs[1]["rand"])
+            self.assertNotEqual(sub_configs[0]["rand"], sub_configs[2]["rand"])
+
+        # First, keep random variables constant
+        searcher = BasicVariantGenerator(constant_grid_search=True)
+        exp = Experiment(
+            run=_mock_objective,
+            name="test",
+            config=config,
+            num_samples=num_samples)
+        searcher.add_configurations(exp)
+
+        configs = []
+        while not searcher.is_finished():
+            trial = searcher.next_trial()
+            if not trial:
+                break
+            configs.append(trial.config)
+
+        for i in range(num_samples):
+            sub_configs = configs[i * 3:i * 3 + 3]
+            # These should be equal, because we sample randomly first and
+            # then keep the random values constant
+            self.assertEqual(sub_configs[0]["rand"], sub_configs[1]["rand"])
+            self.assertEqual(sub_configs[0]["rand"], sub_configs[2]["rand"])
+
 
 if __name__ == "__main__":
     import pytest


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This introduces a new option to the BasicVariantGenerator to allow us to sample random variables before applying grid search. This will keep random variables constant across grid search categories.

Also cc @Yard1 who might be working on this code soon.

## Related issue number

Closes #15126

See https://discuss.ray.io/t/tune-feature-request-using-ray-tune-for-k-fold-with-repeated-grid-sampling/2541

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
