### PR TITLE
[tune] Use unbuffered training when checkpoint_at_end is used.

### DIFF
--- a/doc/source/tune/user-guide.rst
+++ b/doc/source/tune/user-guide.rst
@@ -831,7 +831,8 @@ These are the environment variables Ray Tune currently considers:
   is not set, ``~/ray_results`` will be used.
 * **TUNE_RESULT_BUFFER_LENGTH**: Ray Tune can buffer results from trainables before they are passed
   to the driver. Enabling this might delay scheduling decisions, as trainables are speculatively
-  continued. Setting this to ``0`` disables result buffering. Defaults to 1000 (results).
+  continued. Setting this to ``0`` disables result buffering. Defaults to 1000 (results), or to 1 (no buffering)
+  if used with ``checkpoint_at_end``.
 * **TUNE_RESULT_BUFFER_MAX_TIME_S**: Similarly, Ray Tune buffers results up to ``number_of_trial/10`` seconds,
   but never longer than this value. Defaults to 100 (seconds).
 * **TUNE_RESULT_BUFFER_MIN_TIME_S**: Additionally, you can specify a minimum time to buffer results. Defaults to 0.

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -393,7 +393,7 @@ class RayTrialExecutor(TrialExecutor):
             # If buffer length has not been explicitly set, we determine
             # it automatically
             if buffer_length is None:
-                if trial.checkpoint_at_end or trial.checkpoint_freq:
+                if trial.checkpoint_at_end:
                     # If a trial checkpoint can be triggered externally,
                     # it is not safe to buffer results.
                     buffer_length = 1

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -25,6 +25,7 @@ from ray.tune.utils.trainable import TrainableUtil
 from ray.tune.trial import Trial, Checkpoint, Location, TrialInfo
 from ray.tune.trial_executor import TrialExecutor
 from ray.tune.utils import warn_if_slow
+from ray.util import log_once
 
 logger = logging.getLogger(__name__)
 
@@ -185,8 +186,10 @@ class RayTrialExecutor(TrialExecutor):
         self.pg_recon_interval = float(
             os.environ.get("TUNE_PLACEMENT_GROUP_RECON_INTERVAL", "5"))
 
-        self._buffer_length = result_buffer_length or int(
+        self._default_buffer_length = result_buffer_length or int(
             os.getenv("TUNE_RESULT_BUFFER_LENGTH", 1000))
+        self._buffer_length = result_buffer_length
+
         self._buffer_min_time_s = float(
             os.getenv("TUNE_RESULT_BUFFER_MIN_TIME_S", 0.))
         self._buffer_max_time_s = float(
@@ -385,8 +388,28 @@ class RayTrialExecutor(TrialExecutor):
             min(self._buffer_max_time_s,
                 len(self._running) // 10))
         with self._change_working_directory(trial):
-            if self._buffer_length > 1:
-                buffer_length = self._buffer_length
+            buffer_length = self._buffer_length
+
+            # If buffer length has not been explicitly set, we determine
+            # it automatically
+            if buffer_length is None:
+                if trial.checkpoint_at_end or trial.checkpoint_freq:
+                    # If a trial checkpoint can be triggered externally,
+                    # it is not safe to buffer results.
+                    buffer_length = 1
+                else:
+                    # Else, use the default buffer length
+                    buffer_length = self._default_buffer_length
+            else:
+                if trial.checkpoint_at_end:
+                    if log_once("trial_executor_buffer_checkpoint"):
+                        logger.warning(
+                            "You passed `checkpoint_at_end` to `tune.run()`, "
+                            "but still requested buffered training. "
+                            "If used with a custom stopper or early stopping, "
+                            "checkpoints may be created later than desired.")
+
+            if buffer_length > 1:
                 if trial.checkpoint_freq > 0:
                     buffer_length = min(buffer_length, trial.checkpoint_freq)
                 remote = trial.runner.train_buffered.remote(

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -729,12 +729,16 @@ class TrialRunner:
                         # non-training future (e.g. a save) was scheduled.
                         # We do not allow processing more results then.
                         if i < len(results) - 1:
-                            raise RuntimeError(
-                                f"Trial {trial} has a non-training future "
-                                f"scheduled but {len(results)-i} results "
-                                f"left to process. This should never "
-                                f"happen - please file an issue at "
-                                f"https://github.com/ray-project/ray/issues")
+                            if log_once("trial_runner_buffer_checkpoint"):
+                                logger.warning(
+                                    f"Trial {trial} has a non-training future "
+                                    f"scheduled but {len(results)-i} results "
+                                    f"left to process. This means that a "
+                                    f"checkpoint was requested, but buffered "
+                                    f"training was continued before it was "
+                                    f"saved. Consider using non-buffered "
+                                    f"training by setting the env variable "
+                                    f"`TUNE_RESULT_BUFFER_LENGTH=1`.")
                     elif decision == TrialScheduler.STOP:
                         # If the decision is to stop the trial,
                         # ignore all results that came after that.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray Tune uses buffered training to speculatively evaluate training functions. This speeds up training in the case when a single training iteration takes only a short amount of time.

However, this is inherently incompatible with external events such as custom stoppers and checkpoint. Specifically, when we combine a custom stopper (e.g. metrics or iteration based, or early stopping) with `checkpoint_at_end`, the Trainable might already speculatively evaluate future training steps, even though the control loop would like to stop training and save a checkpoint.

This particular combination previously lead to errors. This PR introduce two changes. First, if `checkpoint_at_end` is set, buffered training is disabled per default and has to be deliberately enabled. Second, instead of raising an error, a warning is raised instead.

## Related issue number

Closes #16013

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
