### PR TITLE
[Client] Add separate error message if dataclient has disconnected before a request is sent

### DIFF
--- a/python/ray/util/client/dataclient.py
+++ b/python/ray/util/client/dataclient.py
@@ -110,9 +110,10 @@ class DataClient:
                        ) -> ray_client_pb2.DataResponse:
         if self._in_shutdown:
             raise ConnectionError(
-                "Request can't be sent because the data channel terminated. "
-                "This is likely because the server disconnected from the data "
-                "channel at some point before this request was prepared.")
+                "Request can't be sent because the data channel is "
+                "terminated. This is likely because the data channel "
+                "disconnected at some point before this request was "
+                "prepared.")
         req_id = self._next_id()
         req.req_id = req_id
         self.request_queue.put(req)
@@ -134,9 +135,10 @@ class DataClient:
                     callback: Optional[ResponseCallable] = None) -> None:
         if self._in_shutdown:
             raise ConnectionError(
-                "Request can't be sent because the data channel terminated. "
-                "This is likely because the server disconnected from the data "
-                "channel at some point before this request was prepared.")
+                "Request can't be sent because the data channel is "
+                "terminated. This is likely because the data channel "
+                "disconnected at some point before this request was "
+                "prepared.")
         req_id = self._next_id()
         req.req_id = req_id
         if callback:

--- a/python/ray/util/client/dataclient.py
+++ b/python/ray/util/client/dataclient.py
@@ -108,6 +108,11 @@ class DataClient:
 
     def _blocking_send(self, req: ray_client_pb2.DataRequest
                        ) -> ray_client_pb2.DataResponse:
+        if self._in_shutdown:
+            raise ConnectionError(
+                "Request can't be sent because the data channel terminated. "
+                "This is likely because the server disconnected from the data "
+                "channel at some point before this request was prepared.")
         req_id = self._next_id()
         req.req_id = req_id
         self.request_queue.put(req)
@@ -127,6 +132,11 @@ class DataClient:
     def _async_send(self,
                     req: ray_client_pb2.DataRequest,
                     callback: Optional[ResponseCallable] = None) -> None:
+        if self._in_shutdown:
+            raise ConnectionError(
+                "Request can't be sent because the data channel terminated. "
+                "This is likely because the server disconnected from the data "
+                "channel at some point before this request was prepared.")
         req_id = self._next_id()
         req.req_id = req_id
         if callback:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The existing error message suggests that the request sent may have caused the data channel to shut down, but in some cases the data channel may have been shut down long before the request was prepared (for example, in a session where the user leaves for a long stretch of time, the server disconnects the data channel, and then the user attempts another remote task that requires the data channel). This gives a different error message in the case that the channel was already shut down before the request was made.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
