### PR TITLE
[serve] Fix ray serve shutdown to properly go through controller

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -134,7 +134,9 @@ class Client:
         instance.
         """
         if (not self._shutdown) and ray.is_initialized():
-            ray.get(self._controller.shutdown.remote())
+            for goal_id in ray.get(self._controller.shutdown.remote()):
+                self._wait_for_goal(goal_id)
+
             ray.kill(self._controller, no_restart=True)
 
             # Wait for the named actor entry gets removed as well.

--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -530,7 +530,7 @@ class BackendState:
             shutdown_goals.append(
                 self.delete_backend(backend_tag, force_kill=True))
 
-        # TODO(jiaodong): This might not be 100% safe since we deleted 
+        # TODO(jiaodong): This might not be 100% safe since we deleted
         # everything without ensuring all shutdown goals are completed
         # yet. Need to address in follow-up PRs.
         self._kv_store.delete(CHECKPOINT_KEY)

--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -516,7 +516,7 @@ class BackendState:
     def shutdown(self) -> List[Optional[GoalId]]:
         """
         Shutdown all running replicas by notifying the controller, and leave 
-        it to  the controller event loop to take actions afterwards.
+        it to the controller event loop to take actions afterwards.
 
         Once shutdown signal is received, it will also prevent any new 
         deployments or replicas from being created.
@@ -530,8 +530,13 @@ class BackendState:
             shutdown_goals.append(
                 self.delete_backend(backend_tag, force_kill=True))
 
-        # self._kv_store.delete(CHECKPOINT_KEY)
+        # TODO(jiaodong): This might not be 100% safe since we deleted 
+        # everything without ensuring all shutdown goals are completed
+        # yet. Need to address in follow-up PRs.
+        self._kv_store.delete(CHECKPOINT_KEY)
 
+        # TODO(jiaodong): Need to add some logic to prevent new replicas
+        # from being created once shutdown signal is sent.
         return shutdown_goals
 
     def _checkpoint(self) -> None:
@@ -669,7 +674,6 @@ class BackendState:
 
         new_goal_id, existing_goal_id = self._set_backend_goal(
             backend_tag, None)
-        print(f"---- {new_goal_id}, {existing_goal_id}")
         if force_kill:
             self._backend_metadata[
                 backend_tag].backend_config.\

--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -513,12 +513,26 @@ class BackendState:
         self._notify_backend_configs_changed()
         self._notify_replica_handles_changed()
 
-    def shutdown(self) -> None:
-        for replica_dict in self.get_running_replica_handles().values():
-            for replica in replica_dict.values():
-                ray.kill(replica, no_restart=True)
+    def shutdown(self) -> List[Optional[GoalId]]:
+        """
+        Shutdown all running replicas by notifying the controller, and leave 
+        it to  the controller event loop to take actions afterwards.
 
-        self._kv_store.delete(CHECKPOINT_KEY)
+        Once shutdown signal is received, it will also prevent any new 
+        deployments or replicas from being created.
+
+        One can send multiple shutdown signals but won't effectively make any 
+        difference compare to calling it once.
+        """
+
+        shutdown_goals = []
+        for backend_tag, _ in self._replicas.items():
+            shutdown_goals.append(
+                self.delete_backend(backend_tag, force_kill=True))
+
+        # self._kv_store.delete(CHECKPOINT_KEY)
+
+        return shutdown_goals
 
     def _checkpoint(self) -> None:
         self._kv_store.put(
@@ -572,6 +586,15 @@ class BackendState:
 
     def _set_backend_goal(self, backend_tag: BackendTag,
                           backend_info: Optional[BackendInfo]) -> None:
+        """
+        Set desirable state for a given backend, identified by tag.
+
+        Args:
+            backend_tag (BackendTag): Identifier of a backend
+            backend_info (Optional[BackendInfo]): Contains backend and 
+                replica config, if passed in as None, we're marking 
+                target backend as shutting down.
+        """
         existing_goal_id = self._backend_goals.get(backend_tag)
         new_goal_id = self._goal_manager.create_goal()
 
@@ -646,6 +669,7 @@ class BackendState:
 
         new_goal_id, existing_goal_id = self._set_backend_goal(
             backend_tag, None)
+        print(f"---- {new_goal_id}, {existing_goal_id}")
         if force_kill:
             self._backend_metadata[
                 backend_tag].backend_config.\

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -264,12 +264,14 @@ class ServeController:
         """Return the HTTP proxy configuration."""
         return self.http_state.get_config()
 
-    async def shutdown(self) -> None:
+    async def shutdown(self) -> List[GoalId]:
         """Shuts down the serve instance completely."""
         async with self.write_lock:
-            self.backend_state.shutdown()
+            goal_ids = self.backend_state.shutdown()
             self.endpoint_state.shutdown()
             self.http_state.shutdown()
+
+            return goal_ids
 
     async def deploy(
             self, name: str, backend_config: BackendConfig,

--- a/python/ray/serve/tests/test_backend_state.py
+++ b/python/ray/serve/tests/test_backend_state.py
@@ -1423,10 +1423,10 @@ def test_health_check(mock_backend_state):
     check_counts(backend_state, total=2, by_state=[(ReplicaState.RUNNING, 2)])
 
 
-def test_shutdown_through_controller(mock_backend_state):
+def test_shutdown(mock_backend_state):
     """
-    Test to ensure a shutdown action goes through controller's backend 
-    state change and handled by controller's main event loop.
+    Test that shutdown waits for all backends to be deleted and the backends
+    are force-killed without a grace period.
     """
     backend_state, timer, goal_manager = mock_backend_state
 
@@ -1451,6 +1451,8 @@ def test_shutdown_through_controller(mock_backend_state):
 
     check_counts(backend_state, total=1, by_state=[(ReplicaState.STOPPING, 1)])
     assert backend_state._replicas[TEST_TAG].get()[0]._actor.stopped
+    assert backend_state._replicas[TEST_TAG].get()[
+        0]._actor.force_stopped_counter == 1
     assert not backend_state._replicas[TEST_TAG].get()[0]._actor.cleaned_up
     assert not goal_manager.check_complete(shutdown_goal)
 

--- a/python/ray/serve/tests/test_backend_state.py
+++ b/python/ray/serve/tests/test_backend_state.py
@@ -394,7 +394,7 @@ def test_create_delete_single_replica(mock_backend_state):
     backend_state.update()
     assert len(backend_state._replicas) == 0
     assert goal_manager.check_complete(delete_goal)
-    replica._actor.cleaned_up
+    assert replica._actor.cleaned_up
 
 
 def test_force_kill(mock_backend_state):
@@ -1430,46 +1430,42 @@ def test_shutdown_through_controller(mock_backend_state):
     """
     backend_state, timer, goal_manager = mock_backend_state
 
-    assert len(backend_state._replicas) == 0
-
     b_info_1 = backend_info()
     create_goal, updating = backend_state.deploy_backend(TEST_TAG, b_info_1)
-    assert updating
 
     # Single replica should be created.
     backend_state.update()
     check_counts(backend_state, total=1, by_state=[(ReplicaState.STARTING, 1)])
-
-    # update() should not transition the state if the replica isn't ready.
-    backend_state.update()
-    check_counts(backend_state, total=1, by_state=[(ReplicaState.STARTING, 1)])
     backend_state._replicas[TEST_TAG].get()[0]._actor.set_ready()
-    assert not goal_manager.check_complete(create_goal)
 
     # Now the replica should be marked running.
     backend_state.update()
     check_counts(backend_state, total=1, by_state=[(ReplicaState.RUNNING, 1)])
 
+    # Test shutdown flow
     assert not backend_state._replicas[TEST_TAG].get()[0]._actor.stopped
 
-    shutdown_goals = backend_state.shutdown()
-    print(shutdown_goals)
+    shutdown_goal = backend_state.shutdown()[0]
+
     backend_state.update()
 
+    check_counts(backend_state, total=1, by_state=[(ReplicaState.STOPPING, 1)])
     assert backend_state._replicas[TEST_TAG].get()[0]._actor.stopped
+    assert not backend_state._replicas[TEST_TAG].get()[0]._actor.cleaned_up
+    assert not goal_manager.check_complete(shutdown_goal)
 
-    for goal in shutdown_goals:
-        print(goal)
-        print("AAAA")
-        print(goal_manager._pending_goals)
+    # Once it's done stopping, replica should be removed.
+    replica = backend_state._replicas[TEST_TAG].get()[0]
+    replica._actor.set_done_stopping()
+    backend_state.update()
+    check_counts(backend_state, total=0)
 
+    # TODO(edoakes): can we remove this extra update period for completing it?
+    backend_state.update()
+    assert len(backend_state._replicas) == 0
+    assert goal_manager.check_complete(shutdown_goal)
+    assert replica._actor.cleaned_up
 
-# def test_no_new_replica_after_shutdown(mock_backend_state):
-#     """
-#     Test to ensure no new deployments can be made if the controller receives
-#     a shutdown request but haven't completely finish yet.
-#     """
-#     pass
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
## Why are these changes needed?

Currently ray serve's shutdown() logic directly calls ray.kill that bypasses everything in ray serve .. which is not ideal. We want to send a signal to the controller marking our desire to shutdown all existing replicas (and also prevent new replicas from being created) and let the controller's main event loop to take over the rest. 

TODO: 
   1) Fix the goal manager state in unit test with mocks, not sure why actor is shut down but goal manager don't think so
   2) Add an actual ray cluster test 
   3) Add logic to prevent new replicas from being scheduled.

   4) (stretch) i felt an urge to refactor files / functions I read along with this task. Won't do it in this diff but probably later ones. 

## Related issue number

Closes #16115

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
