### PR TITLE
[C++ Worker]Remove unused boost sub libs for the generated template project

### DIFF
--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -83,10 +83,34 @@ genrule(
         cp -f $(locations libray_api.so) "$$WORK_DIR/python/ray/core/src/ray/cpp/" &&
         TEMP_DIR="$$WORK_DIR/cpp/example" &&
         rm -rf $$TEMP_DIR/thirdparty &&
-        mkdir -p "$$TEMP_DIR/thirdparty/include/" &&
+        mkdir -p "$$TEMP_DIR/thirdparty/include/boost" &&
         mkdir -p "$$TEMP_DIR/thirdparty/lib/" &&
         cp -f -r $$WORK_DIR/external/msgpack/include/* "$$TEMP_DIR/thirdparty/include" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/" "$$TEMP_DIR/thirdparty/include" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/archive" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/bind" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/callable_traits" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/concept" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/config" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/container" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/container_hash" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/core" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/detail" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/dll" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/exception" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/filesystem" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/functional" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/io" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/iterator" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/lexical_cast" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/move" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/mpl" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/optional" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/parameter" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/preprocessor" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/system" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/type_traits" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/utility" "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r $$WORK_DIR/external/boost/boost/*.hpp "$$TEMP_DIR/thirdparty/include/boost/" &&
         cp -f $(locations libray_api.so) "$$TEMP_DIR/thirdparty/lib/" &&
         cp -f -r "$$WORK_DIR/cpp/include/ray/" "$$TEMP_DIR/thirdparty/include" &&        
         echo "$$WORK_DIR" > $@

--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -83,34 +83,35 @@ genrule(
         cp -f $(locations libray_api.so) "$$WORK_DIR/python/ray/core/src/ray/cpp/" &&
         TEMP_DIR="$$WORK_DIR/cpp/example" &&
         rm -rf $$TEMP_DIR/thirdparty &&
-        mkdir -p "$$TEMP_DIR/thirdparty/include/boost" &&
+        BOOST_DIR="$$TEMP_DIR/thirdparty/include/boost/" &&
+        mkdir -p "$$BOOST_DIR" &&
         mkdir -p "$$TEMP_DIR/thirdparty/lib/" &&
         cp -f -r $$WORK_DIR/external/msgpack/include/* "$$TEMP_DIR/thirdparty/include" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/archive" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/bind" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/callable_traits" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/concept" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/config" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/container" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/container_hash" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/core" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/detail" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/dll" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/exception" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/filesystem" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/functional" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/io" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/iterator" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/lexical_cast" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/move" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/mpl" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/optional" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/parameter" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/preprocessor" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/system" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/type_traits" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r "$$WORK_DIR/external/boost/boost/utility" "$$TEMP_DIR/thirdparty/include/boost/" &&
-        cp -f -r $$WORK_DIR/external/boost/boost/*.hpp "$$TEMP_DIR/thirdparty/include/boost/" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/archive" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/bind" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/callable_traits" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/concept" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/config" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/container" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/container_hash" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/core" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/detail" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/dll" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/exception" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/filesystem" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/functional" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/io" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/iterator" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/lexical_cast" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/move" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/mpl" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/optional" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/parameter" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/preprocessor" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/system" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/type_traits" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/utility" "$$BOOST_DIR" &&
+        cp -f -r $$WORK_DIR/external/boost/boost/*.hpp "$$BOOST_DIR" &&
         cp -f $(locations libray_api.so) "$$TEMP_DIR/thirdparty/lib/" &&
         cp -f -r "$$WORK_DIR/cpp/include/ray/" "$$TEMP_DIR/thirdparty/include" &&        
         echo "$$WORK_DIR" > $@


### PR DESCRIPTION
## Why are these changes needed?
We have provided [a template project](https://github.com/ray-project/ray/pull/16337) for a c++ worker user, the template project contains all boost libraries, however we just use some of it, so we can remove most unused libraries to make it more smaller.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
