### PR TITLE
[Connect] Separate Specific Server logs into different files

### DIFF
--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -1,3 +1,4 @@
+from glob import glob
 import os
 import pickle
 import pytest
@@ -22,7 +23,7 @@ def test_proxy_manager_lifecycle(shutdown_only):
     Creates a ProxyManager and tests basic handling of the lifetime of a
     specific RayClient Server. It checks the following properties:
     1. The SpecificServer is created using the first port.
-    2. The SpecificServer comes alive.
+    2. The SpecificServer comes alive and has a log associated with it.
     3. The SpecificServer destructs itself when no client connects.
     4. The ProxyManager returns the port of the destructed SpecificServer.
     """
@@ -44,6 +45,11 @@ def test_proxy_manager_lifecycle(shutdown_only):
 
     proc = pm._get_server_for_client(client)
     assert proc.port == port_one
+
+    log_files_path = os.path.join(pm.node.get_session_dir_path(), "logs",
+                                  "ray_client_server*")
+    files = glob.glob(log_files_path)
+    assert any(port_one in f for f in files)
 
     proc.process_handle_future.result().process.wait(10)
     # Wait for reconcile loop

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -48,7 +48,7 @@ def test_proxy_manager_lifecycle(shutdown_only):
 
     log_files_path = os.path.join(pm.node.get_session_dir_path(), "logs",
                                   "ray_client_server*")
-    files = glob.glob(log_files_path)
+    files = glob(log_files_path)
     assert any(port_one in f for f in files)
 
     proc.process_handle_future.result().process.wait(10)

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -44,12 +44,12 @@ def test_proxy_manager_lifecycle(shutdown_only):
     grpc.channel_ready_future(pm.get_channel(client)).result(timeout=5)
 
     proc = pm._get_server_for_client(client)
-    assert proc.port == port_one
+    assert proc.port == port_one, f"Free Ports are: [{port_one}, {port_two}]"
 
     log_files_path = os.path.join(pm.node.get_session_dir_path(), "logs",
                                   "ray_client_server*")
     files = glob(log_files_path)
-    assert any(port_one in f for f in files)
+    assert any(str(port_one) in f for f in files)
 
     proc.process_handle_future.result().process.wait(10)
     # Wait for reconcile loop

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -117,7 +117,7 @@ class ProxyManager():
         self._check_thread.start()
 
         self.fate_share = bool(detect_fate_sharing_support())
-        self._node: Optional[Any] = None
+        self._node: Optional[ray.node.Node] = None
         atexit.register(self._cleanup)
 
     def _get_unused_port(self) -> int:
@@ -153,7 +153,7 @@ class ProxyManager():
         return self._redis_address
 
     @property
-    def node(self) -> Any:
+    def node(self) -> ray.node.Node:
         """
         Gets the session_dir of this running Ray session. This usually
         looks like /tmp/ray/session_<timestamp>.

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -154,9 +154,8 @@ class ProxyManager():
 
     @property
     def node(self) -> ray.node.Node:
-        """
-        Gets the session_dir of this running Ray session. This usually
-        looks like /tmp/ray/session_<timestamp>.
+        """Gets a 'ray.Node' object for this node (the head node).
+        If it does not already exist, one is created using the redis_address.
         """
         if self._node:
             return self._node

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -208,7 +208,7 @@ class ProxyManager():
             fate_share=self.fate_share,
             server_type="specific-server",
             serialized_runtime_env=serialized_runtime_env,
-            session_dir=self.node._session_dir)
+            session_dir=self.node.get_session_dir_path())
 
         # Wait for the process being run transitions from the shim process
         # to the actual RayClient Server.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Instead of all logs being written to `ray_client_server.err`, logs for a specific server running on **port X** will be written to `ray_client_server_X.err`! This makes it easier to debug issues!

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
