### PR TITLE
[Core][Minor]Remove the hard check when disconnect gcs client

### DIFF
--- a/src/ray/gcs/gcs_client/service_based_gcs_client.cc
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.cc
@@ -116,7 +116,10 @@ Status ServiceBasedGcsClient::Connect(instrumented_io_context &io_service) {
 }
 
 void ServiceBasedGcsClient::Disconnect() {
-  RAY_CHECK(is_connected_);
+  if (!is_connected_) {
+    RAY_LOG(WARNING) << "ServiceBasedGcsClient has been disconnected.";
+    return;
+  }
   is_connected_ = false;
   periodical_runner_.reset();
   gcs_pub_sub_.reset();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There's a hard flag check when we close the gcs client but sometimes we would disconnect the gcs client for more than one time because the gcs client may be shared between different objects(now in accessor and core worker).
In case of unwanted FATAL error and exit, I'd like to remove the hard check and rephrase it to a warning log.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
