### PR TITLE
[Client] Disconnect on dataclient error

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -128,6 +128,7 @@ py_test_module_list(
     "test_command_runner.py",
     "test_component_failures.py",
     "test_coordinator_server.py",
+    "test_dataclient_disconnect.py",
     "test_debug_tools.py",
     "test_distributed_sort.py",
     "test_job.py",

--- a/python/ray/tests/test_dataclient_disconnect.py
+++ b/python/ray/tests/test_dataclient_disconnect.py
@@ -1,0 +1,53 @@
+from ray.util.client.ray_client_helpers import ray_start_client_server
+from unittest.mock import Mock
+import pytest
+
+
+def test_dataclient_disconnect_on_request():
+    with ray_start_client_server() as ray:
+        assert ray.is_connected()
+
+        @ray.remote
+        def f():
+            return 42
+
+        assert ray.get(f.remote()) == 42
+        # Force grpc to error by sending garbage request
+        with pytest.raises(ConnectionError):
+            ray.worker.data_client._blocking_send(Mock())
+
+        # Client should be disconnected
+        assert not ray.is_connected()
+
+        # Test that a new connection can be made
+        connection_data = ray.connect("localhost:50051")
+        assert connection_data["num_clients"] == 1
+        assert ray.get(f.remote()) == 42
+
+
+def test_dataclient_disconnect_before_request():
+    with ray_start_client_server() as ray:
+        assert ray.is_connected()
+
+        @ray.remote
+        def f():
+            return 42
+
+        assert ray.get(f.remote()) == 42
+        # Force grpc to error by queueing garbage request. This simulates
+        # the data channel shutting down for connection issues between
+        # different remote calls.
+        ray.worker.data_client.request_queue.put(Mock())
+
+        # The next remote call should error since the data channel has shut
+        # down, which should also disconnect the client.
+        with pytest.raises(ConnectionError):
+            ray.get(f.remote())
+
+        # Client should be disconnected
+        assert not ray.is_connected()
+
+        # Test that a new connection can be made
+        connection_data = ray.connect("localhost:50051")
+        assert connection_data["num_clients"] == 1
+        assert ray.get(f.remote()) == 42

--- a/python/ray/tests/test_dataclient_disconnect.py
+++ b/python/ray/tests/test_dataclient_disconnect.py
@@ -51,3 +51,8 @@ def test_dataclient_disconnect_before_request():
         connection_data = ray.connect("localhost:50051")
         assert connection_data["num_clients"] == 1
         assert ray.get(f.remote()) == 42
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/util/client/dataclient.py
+++ b/python/ray/util/client/dataclient.py
@@ -19,8 +19,6 @@ INT32_MAX = (2**31) - 1
 
 ResponseCallable = Callable[[ray_client_pb2.DataResponse], None]
 
-i = 0
-
 
 class DataClient:
     def __init__(self, channel: "grpc._channel.Channel", client_id: str,

--- a/python/ray/util/client/dataclient.py
+++ b/python/ray/util/client/dataclient.py
@@ -109,8 +109,8 @@ class DataClient:
     def _blocking_send(self, req: ray_client_pb2.DataRequest
                        ) -> ray_client_pb2.DataResponse:
         if self._in_shutdown:
-            import ray
-            ray.util.disconnect()
+            from ray.util import disconnect
+            disconnect()
             raise ConnectionError(
                 "Request can't be sent because the data channel is "
                 "terminated. This is likely because the data channel "
@@ -124,8 +124,8 @@ class DataClient:
             self.cv.wait_for(
                 lambda: req_id in self.ready_data or self._in_shutdown)
             if self._in_shutdown:
-                import ray
-                ray.util.disconnect()
+                from ray.util import disconnect
+                disconnect()
                 raise ConnectionError(
                     "Sending request failed because the data channel "
                     "terminated. This is usually due to an error "
@@ -139,8 +139,8 @@ class DataClient:
                     req: ray_client_pb2.DataRequest,
                     callback: Optional[ResponseCallable] = None) -> None:
         if self._in_shutdown:
-            import ray
-            ray.util.disconnect()
+            from ray.util import disconnect
+            disconnect()
             raise ConnectionError(
                 "Request can't be sent because the data channel is "
                 "terminated. This is likely because the data channel "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When the data client's grpc channel disconnects (either for connection issues, or for a bad request) client is left in a state where it can't perform any remote functionality, but is still technically connected (client_ray.is_connected() is True).Since is_connected() still returns True, this causes errors if the user tries to start a new connection. This PR disconnects the client when the data client is found to be shut down by the main thread so that the user can cleanly try to reconnect.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
