### PR TITLE
[Client] Extra Step to Avoid RPC call on `get_actor`

### DIFF
--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -136,7 +136,7 @@ class ClientActorClass(ClientStub):
         _ref: The ClientObjectRef of the pickled `actor_cls`
     """
 
-    def __init__(self, actor_cls, options=None):
+    def __init__(self, actor_cls: type, options=None):
         self.actor_cls = actor_cls
         self._lock = threading.Lock()
         self._name = actor_cls.__name__
@@ -202,12 +202,14 @@ class ClientActorHandle(ClientStub):
 
     Args:
         actor_ref: A reference to the running actor given to the client. This
-          is a serialized version of the actual handle as an opaque token.
+            is a serialized version of the actual handle as an opaque token.
+        actor_class: Either the class of the actor represented or the list of
+            methods of that actor (received from the server).
     """
 
     def __init__(self,
                  actor_ref: ClientActorRef,
-                 actor_class: Optional[Union[Any, List[str]]] = None):
+                 actor_class: Optional[Union[type, List[str]]] = None):
         self.actor_ref = actor_ref
         if inspect.isclass(actor_class):
             self._dir = list(

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -482,8 +482,10 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
         self.actor_refs[bin_actor_id] = actor
         self.actor_owners[task.client_id].add(bin_actor_id)
         self.named_actors.add(bin_actor_id)
-        return ray_client_pb2.ClientTaskTicket(
-            return_ids=[actor._actor_id.binary()])
+        return ray_client_pb2.ClientTaskTicket(return_ids=[
+            actor._actor_id.binary(),
+            cloudpickle.dumps(dir(actor))
+        ])
 
     def _convert_args(self, arg_list, kwarg_map):
         argout = []

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -546,7 +546,7 @@ class Worker:
         """Register a ClientActorClass for the ActorClass and return a UUID"""
         key = uuid.uuid4().hex
         md = actor.__ray_metadata__
-        cls = md.modified_class
+        cls: type = md.modified_class
         self._converted[key] = ClientActorClass(
             cls,
             options={

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -406,8 +406,13 @@ class Worker:
         task.type = ray_client_pb2.ClientTask.NAMED_ACTOR
         task.name = name
         ids = self._call_schedule_for_task(task)
-        assert len(ids) == 1
-        return ClientActorHandle(ClientActorRef(ids[0]))
+        if len(ids) == 1:
+            return ClientActorHandle(ClientActorRef(ids[0]))
+        elif len(ids) == 2:
+            return ClientActorHandle(
+                ClientActorRef(ids[0]), actor_class=cloudpickle.loads(ids[1]))
+        else:
+            assert False, "Incorrect number of return ids"
 
     def terminate_actor(self, actor: ClientActorHandle,
                         no_restart: bool) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* Ensures that the main way that other codepath where we get a  `ClientActorHandle` (via `ray.get_actor()`) pre-populates the internal list of methods. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
