### PR TITLE
[tune] move to local parameter registry for `tune.with_parameters()`

### DIFF
--- a/python/ray/tune/registry.py
+++ b/python/ray/tune/registry.py
@@ -170,7 +170,3 @@ class _ParameterRegistry:
         for k, v in self.to_flush.items():
             self.references[k] = ray.put(v)
         self.to_flush.clear()
-
-
-parameter_registry = _ParameterRegistry()
-ray.worker._post_init_hooks.append(parameter_registry.flush)

--- a/python/ray/tune/utils/trainable.py
+++ b/python/ray/tune/utils/trainable.py
@@ -11,7 +11,7 @@ import ray.cloudpickle as pickle
 import os
 
 import ray
-from ray.tune.registry import parameter_registry
+from ray.tune.registry import _ParameterRegistry
 from ray.tune.utils import detect_checkpoint_function
 from ray.util import placement_group
 from six import string_types
@@ -295,6 +295,9 @@ def with_parameters(trainable, **kwargs):
             f"`tune.with_parameters() only works with function trainables "
             f"or classes that inherit from `tune.Trainable()`. Got type: "
             f"{type(trainable)}.")
+
+    parameter_registry = _ParameterRegistry()
+    ray.worker._post_init_hooks.append(parameter_registry.flush)
 
     # Objects are moved into the object store
     prefix = f"{str(trainable)}_"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

See #16609 - running `tune.with_parameters()` twice in the same script but different ray sessions crashes.

cc @amogkam 

## Related issue number

Closes #16609

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
