### PR TITLE
SIGSEGV during concurrent object receives due to mis-use of references

### DIFF
--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -51,7 +51,7 @@ uint64_t ObjectBufferPool::GetBufferLength(uint64_t chunk_index, uint64_t data_s
              : default_chunk_size_;
 }
 
-std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> ObjectBufferPool::GetChunk(
+std::pair<const ObjectBufferPool::ChunkInfo, ray::Status> ObjectBufferPool::GetChunk(
     const ObjectID &object_id, uint64_t data_size, uint64_t metadata_size,
     uint64_t chunk_index) {
   std::lock_guard<std::mutex> lock(pool_mutex_);
@@ -65,7 +65,7 @@ std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> ObjectBufferPool::Ge
           << ". This is most likely because the object was evicted or spilled before the "
              "pull request was received. The caller will retry the pull request after a "
              "timeout.";
-      return std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status>(
+      return std::pair<const ObjectBufferPool::ChunkInfo, ray::Status>(
           errored_chunk_,
           ray::Status::IOError("Unable to obtain object chunk, object not local."));
     }
@@ -75,13 +75,13 @@ std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> ObjectBufferPool::Ge
                                                  object_buffer.metadata->Size()));
     auto *data = object_buffer.data->Data();
     uint64_t num_chunks = GetNumChunks(data_size);
-    get_buffer_state_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(object_id),
-        std::forward_as_tuple(BuildChunks(object_id, data, data_size)));
+    get_buffer_state_.emplace(std::piecewise_construct, std::forward_as_tuple(object_id),
+                              std::forward_as_tuple(BuildChunks(
+                                  object_id, data, data_size, object_buffer.data)));
     RAY_CHECK(get_buffer_state_[object_id].chunk_info.size() == num_chunks);
   }
   get_buffer_state_[object_id].references++;
-  return std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status>(
+  return std::pair<const ObjectBufferPool::ChunkInfo, ray::Status>(
       get_buffer_state_[object_id].chunk_info[chunk_index], ray::Status::OK());
 }
 
@@ -101,7 +101,7 @@ void ObjectBufferPool::AbortGet(const ObjectID &object_id) {
   get_buffer_state_.erase(object_id);
 }
 
-std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> ObjectBufferPool::CreateChunk(
+std::pair<const ObjectBufferPool::ChunkInfo, ray::Status> ObjectBufferPool::CreateChunk(
     const ObjectID &object_id, const rpc::Address &owner_address, uint64_t data_size,
     uint64_t metadata_size, uint64_t chunk_index) {
   std::unique_lock<std::mutex> lock(pool_mutex_);
@@ -125,7 +125,7 @@ std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> ObjectBufferPool::Cr
         // Create failed. The object may already exist locally. If something else went
         // wrong, another chunk will succeed in creating the buffer, and this
         // chunk will eventually make it here via pull requests.
-        return std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status>(
+        return std::pair<const ObjectBufferPool::ChunkInfo, ray::Status>(
             errored_chunk_, ray::Status::IOError(s.message()));
       }
       // Read object into store.
@@ -133,7 +133,7 @@ std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> ObjectBufferPool::Cr
       uint64_t num_chunks = GetNumChunks(data_size);
       create_buffer_state_.emplace(
           std::piecewise_construct, std::forward_as_tuple(object_id),
-          std::forward_as_tuple(BuildChunks(object_id, mutable_data, data_size)));
+          std::forward_as_tuple(BuildChunks(object_id, mutable_data, data_size, data)));
       RAY_LOG(DEBUG) << "Created object " << object_id
                      << " in plasma store, number of chunks: " << num_chunks
                      << ", chunk index: " << chunk_index;
@@ -143,12 +143,12 @@ std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> ObjectBufferPool::Cr
   if (create_buffer_state_[object_id].chunk_state[chunk_index] !=
       CreateChunkState::AVAILABLE) {
     // There can be only one reference to this chunk at any given time.
-    return std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status>(
+    return std::pair<const ObjectBufferPool::ChunkInfo, ray::Status>(
         errored_chunk_,
         ray::Status::IOError("Chunk already received by a different thread."));
   }
   create_buffer_state_[object_id].chunk_state[chunk_index] = CreateChunkState::REFERENCED;
-  return std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status>(
+  return std::pair<const ObjectBufferPool::ChunkInfo, ray::Status>(
       create_buffer_state_[object_id].chunk_info[chunk_index], ray::Status::OK());
 }
 
@@ -206,17 +206,19 @@ void ObjectBufferPool::AbortCreate(const ObjectID &object_id) {
 }
 
 std::vector<ObjectBufferPool::ChunkInfo> ObjectBufferPool::BuildChunks(
-    const ObjectID &object_id, uint8_t *data, uint64_t data_size) {
+    const ObjectID &object_id, uint8_t *data, uint64_t data_size,
+    std::shared_ptr<Buffer> buffer_ref) {
   uint64_t space_remaining = data_size;
   std::vector<ChunkInfo> chunks;
   int64_t position = 0;
   while (space_remaining) {
     position = data_size - space_remaining;
     if (space_remaining < default_chunk_size_) {
-      chunks.emplace_back(chunks.size(), data + position, space_remaining);
+      chunks.emplace_back(chunks.size(), data + position, space_remaining, buffer_ref);
       space_remaining = 0;
     } else {
-      chunks.emplace_back(chunks.size(), data + position, default_chunk_size_);
+      chunks.emplace_back(chunks.size(), data + position, default_chunk_size_,
+                          buffer_ref);
       space_remaining -= default_chunk_size_;
     }
   }

--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -35,14 +35,20 @@ class ObjectBufferPool {
   /// This is the structure returned whenever an object chunk is
   /// accessed via Get and Create.
   struct ChunkInfo {
-    ChunkInfo(uint64_t chunk_index, uint8_t *data, uint64_t buffer_length)
-        : chunk_index(chunk_index), data(data), buffer_length(buffer_length){};
+    ChunkInfo(uint64_t chunk_index, uint8_t *data, uint64_t buffer_length,
+              std::shared_ptr<Buffer> buffer_ref)
+        : chunk_index(chunk_index),
+          data(data),
+          buffer_length(buffer_length),
+          buffer_ref(buffer_ref){};
     /// A pointer to the start position of this object chunk.
     uint64_t chunk_index;
     /// A pointer to the start position of this object chunk.
     uint8_t *data;
     /// The size of this object chunk.
     uint64_t buffer_length;
+    /// A shared reference to the underlying buffer, keeping it alive.
+    std::shared_ptr<Buffer> buffer_ref;
   };
 
   /// Constructor.
@@ -80,7 +86,7 @@ class ObjectBufferPool {
   /// \param chunk_index The index of the chunk.
   /// \return A pair consisting of a ChunkInfo and status of invoking this method.
   /// An IOError status is returned if the Get call on the plasma store fails.
-  std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> GetChunk(
+  std::pair<const ObjectBufferPool::ChunkInfo, ray::Status> GetChunk(
       const ObjectID &object_id, uint64_t data_size, uint64_t metadata_size,
       uint64_t chunk_index);
 
@@ -108,7 +114,7 @@ class ObjectBufferPool {
   /// An IOError status is returned if object creation on the store client fails,
   /// or if create is invoked consecutively on the same chunk
   /// (with no intermediate AbortCreateChunk).
-  std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> CreateChunk(
+  std::pair<const ObjectBufferPool::ChunkInfo, ray::Status> CreateChunk(
       const ObjectID &object_id, const rpc::Address &owner_address, uint64_t data_size,
       uint64_t metadata_size, uint64_t chunk_index);
 
@@ -153,7 +159,8 @@ class ObjectBufferPool {
   /// Splits an object into ceil(data_size/chunk_size) chunks, which will
   /// either be read or written to in parallel.
   std::vector<ChunkInfo> BuildChunks(const ObjectID &object_id, uint8_t *data,
-                                     uint64_t data_size);
+                                     uint64_t data_size,
+                                     std::shared_ptr<Buffer> buffer_ref);
 
   /// Holds the state of a get buffer.
   struct GetBufferState {
@@ -189,7 +196,7 @@ class ObjectBufferPool {
   };
 
   /// Returned when GetChunk or CreateChunk fails.
-  const ChunkInfo errored_chunk_ = {0, nullptr, 0};
+  const ChunkInfo errored_chunk_ = {0, nullptr, 0, nullptr};
 
   /// Mutex on public methods for thread-safe operations on
   /// get_buffer_state_, create_buffer_state_, and store_client_.

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -388,7 +388,7 @@ void ObjectManager::PushLocalObject(const ObjectID &object_id, const NodeID &nod
   auto local_chunk_reader = [this, object_id, total_data_size, metadata_size](
                                 uint64_t chunk_index,
                                 rpc::PushRequest &push_request) -> Status {
-    std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> chunk_status =
+    std::pair<const ObjectBufferPool::ChunkInfo, ray::Status> chunk_status =
         buffer_pool_.GetChunk(object_id, total_data_size, metadata_size, chunk_index);
     // Fail on status not okay. The object is local, and there is
     // no other anticipated error here.
@@ -789,7 +789,7 @@ bool ObjectManager::ReceiveObjectChunk(const NodeID &node_id, const ObjectID &ob
     // This object is no longer being actively pulled. Do not create the object.
     return false;
   }
-  std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> chunk_status =
+  std::pair<const ObjectBufferPool::ChunkInfo, ray::Status> chunk_status =
       buffer_pool_.CreateChunk(object_id, owner_address, data_size, metadata_size,
                                chunk_index);
   if (!pull_manager_->IsObjectActive(object_id, &still_required)) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes a memory ownership issue (probably long outstanding) that can cause segfault under heavy object receive workloads. There is a race between receiving a chunk and another thread deleting the underlying object since the object manager was holding a raw ptr to the buffer instead of a shared_ptr.

Reproducible by running `test_object_manager.py::test_pull_bundles_admission_control_dynamic` with `num_objects = num_tasks = 20` on https://github.com/ray-project/ray/pull/16394.