### PR TITLE
Fix Darwin ARM64 build (macOS/M1 support)

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -155,10 +155,9 @@ def ray_deps_setup():
     auto_http_archive(
         name = "com_github_nelhage_rules_boost",
         # If you update the Boost version, remember to update the 'boost' rule.
-		url = "https://github.com/nelhage/rules_boost/archive/652b21e35e4eeed5579e696da0facbe8dba52b1f.tar.gz",
-		sha256 = "c1b8b2adc3b4201683cf94dda7eef3fc0f4f4c0ea5caa3ed3feffe07e1fb5b15",
+        url = "https://github.com/nelhage/rules_boost/archive/652b21e35e4eeed5579e696da0facbe8dba52b1f.tar.gz",
+        sha256 = "c1b8b2adc3b4201683cf94dda7eef3fc0f4f4c0ea5caa3ed3feffe07e1fb5b15",
         patches = [
-            # "//thirdparty/patches:rules_boost-undefine-boost_fallthrough.patch",
             "//thirdparty/patches:rules_boost-windows-linkopts.patch",
         ],
     )
@@ -239,6 +238,8 @@ def ray_deps_setup():
         patches = [
             "//thirdparty/patches:grpc-cython-copts.patch",
             "//thirdparty/patches:grpc-python.patch",
+            # The "fix-cares-build" patch is only required until the gRPC version is upgraded
+            "//thirdparty/patches:grpc-fix-cares-build.patch",
         ],
     )
 

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -155,10 +155,10 @@ def ray_deps_setup():
     auto_http_archive(
         name = "com_github_nelhage_rules_boost",
         # If you update the Boost version, remember to update the 'boost' rule.
-        url = "https://github.com/nelhage/rules_boost/archive/2613d04ab3d22dfc4543ea0a083d9adeaa0daf09.tar.gz",
-        sha256 = "512f913240e026099d4ca4a98b1ce8048c99de77fdc8e8584e9e2539ee119ca2",
+		url = "https://github.com/nelhage/rules_boost/archive/652b21e35e4eeed5579e696da0facbe8dba52b1f.tar.gz",
+		sha256 = "c1b8b2adc3b4201683cf94dda7eef3fc0f4f4c0ea5caa3ed3feffe07e1fb5b15",
         patches = [
-            "//thirdparty/patches:rules_boost-undefine-boost_fallthrough.patch",
+            # "//thirdparty/patches:rules_boost-undefine-boost_fallthrough.patch",
             "//thirdparty/patches:rules_boost-windows-linkopts.patch",
         ],
     )

--- a/thirdparty/patches/grpc-fix-cares-build.patch
+++ b/thirdparty/patches/grpc-fix-cares-build.patch
@@ -1,0 +1,30 @@
+diff --git third_party/cares/cares.BUILD third_party/cares/cares.BUILD
+--- third_party/cares/cares.BUILD
++++ third_party/cares/cares.BUILD
+@@ -13,6 +13,16 @@ config_setting(
+     values = {"cpu": "x64_windows"},
+ )
+ 
++config_setting(
++    name = "darwin_arm64",
++    values = {"cpu": "darwin_arm64"},
++)
++
++config_setting(
++    name = "darwin_arm64e",
++    values = {"cpu": "darwin_arm64e"},
++)
++
+ # Android is not officially supported through C++.
+ # This just helps with the build for now.
+ config_setting(
+@@ -98,6 +108,8 @@ genrule(
+         ":watchos_arm64_32": ["@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h"],
+         ":darwin": ["@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h"],
+         ":darwin_x86_64": ["@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h"],
++        ":darwin_arm64": ["@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h"],
++        ":darwin_arm64e": ["@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h"],
+         ":windows": ["@com_github_grpc_grpc//third_party/cares:config_windows/ares_config.h"],
+         ":android": ["@com_github_grpc_grpc//third_party/cares:config_android/ares_config.h"],
+         "//conditions:default": ["@com_github_grpc_grpc//third_party/cares:config_linux/ares_config.h"],
+-- 

--- a/thirdparty/patches/rules_boost-undefine-boost_fallthrough.patch
+++ b/thirdparty/patches/rules_boost-undefine-boost_fallthrough.patch
@@ -1,8 +1,0 @@
-diff --git BUILD.boost BUILD.boost
---- BUILD.boost
-+++ BUILD.boost
-@@ -1356,3 +1356,2 @@ boost_library(
-     defines = [
--        "BOOST_FALLTHROUGH",
-     ],
--- 

--- a/thirdparty/patches/rules_boost-windows-linkopts.patch
+++ b/thirdparty/patches/rules_boost-windows-linkopts.patch
@@ -5,7 +5,7 @@ diff --git BUILD.boost BUILD.boost
      }),
      linkopts = select({
          ":android": [],
-+		":windows": [],
++        ":windows": [],
          "//conditions:default": ["-lpthread"],
      }),
      deps = [

--- a/thirdparty/patches/rules_boost-windows-linkopts.patch
+++ b/thirdparty/patches/rules_boost-windows-linkopts.patch
@@ -1,15 +1,12 @@
 diff --git BUILD.boost BUILD.boost
 --- BUILD.boost
 +++ BUILD.boost
-@@ -313,1 +313,9 @@ boost_library(name = "asio",
--    linkopts = ["-lpthread"],
-+    linkopts = select({
-+        ":linux": [
-+            "-lpthread",
-+        ],
-+        ":osx_x86_64": [
-+            "-lpthread",
-+        ],
-+        "//conditions:default": [],
-+    }),
--- 
+@@ -428,6 +428,7 @@ boost_library(
+     }),
+     linkopts = select({
+         ":android": [],
++		":windows": [],
+         "//conditions:default": ["-lpthread"],
+     }),
+     deps = [
+--


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes the wheel build for platform "darwin_arm64" to support Macs with Apple's M1 chipset.

1. Fix Bazel
	- Toolchain detection bug: https://github.com/bazelbuild/bazel/issues/13514
	- Will be fixed in Bazel 4.2.0 (June 2021): https://github.com/bazelbuild/bazel/issues/13558
	- For now use Bazel built from source (HEAD at `0ad9fac9b3d24e78f91c831c393520787022e2a1`, branch `4.1.0-unix-toolchain-fix-for-darwin-arm64`)
2. Upgrade @com_github_nelhage_rules_boost version
	- Fallthrough patch is obsolete
3. Patch @com_github_cares_cares build in @com_github_grpc_grpc dependency
	- See https://github.com/grpc/grpc/pull/24872
	- Directly upgrading @com_github_grpc_grpc or @com_github_cares_cares breaks the build

## Related issue number

Fixes #14697
Note that until Bazel 4.2.0 is released, Bazel must either be built from source or the toolchain must be manually configured.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
