### PR TITLE
FetchOrReconstruct message can get re-ordered until after task finishes, leaking get bundles

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1405,7 +1405,9 @@ void NodeManager::ProcessFetchOrReconstructMessage(
     if (!worker) {
       worker = worker_pool_.GetRegisteredDriver(client);
     }
-    if (worker) {
+    // Fetch requests can get re-ordered after the worker finishes, so make sure to
+    // check the worker is still assigned a task to avoid leaks.
+    if (worker && !worker->GetAssignedTaskId().IsNil()) {
       // This will start a fetch for the objects that gets canceled once the
       // objects are local, or if the worker dies.
       dependency_manager_.StartOrUpdateWaitRequest(worker->WorkerId(), refs);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The typical execution of a task fetching args looks as follows:
1. Worker calls async FetchOrReconstruct on its args using raylet client
2. Worker synchronously fetches its args from plasma store
3. Worker returns from the get, cancelling the get bundle created by step (1).

Under rare circumstances, the call in step (1) can get re-ordered until after step (3), since it's async. This can lead to a "leaked" get bundle in the raylet, which won't be cancelled until the worker processes another task and finishes that.

This issue can be reproduced by running pytest -v -s test_object_manager.py::test_pull_bundles_admission_control in a loop, after a few dozen times it will hang with an active get bundle but seemingly no active tasks.