### PR TITLE
[Core] Rename TaskRequest to ResourceRequest

### DIFF
--- a/src/ray/raylet/scheduling/cluster_resource_data.h
+++ b/src/ray/raylet/scheduling/cluster_resource_data.h
@@ -54,7 +54,7 @@ struct ResourceInstanceCapacities {
 };
 
 // Data structure specifying the capacity of each resource requested by a task.
-class TaskRequest {
+class ResourceRequest {
  public:
   /// List of predefined resources required by the task.
   std::vector<FixedPoint> predefined_resources;
@@ -79,7 +79,7 @@ class TaskResourceInstances {
   const std::vector<FixedPoint> &Get(const std::string &resource_name,
                                      const StringIdMap &string_id_map) const;
   /// For each resource of this request aggregate its instances.
-  TaskRequest ToTaskRequest() const;
+  ResourceRequest ToResourceRequest() const;
   /// Get CPU instances only.
   std::vector<FixedPoint> GetCPUInstances() const {
     if (!this->predefined_resources.empty()) {
@@ -150,10 +150,10 @@ class NodeResources {
   float CalculateCriticalResourceUtilization() const;
   /// Returns true if the node has the available resources to run the task.
   /// Note: This doesn't account for the binpacking of unit resources.
-  bool IsAvailable(const TaskRequest &task_req) const;
+  bool IsAvailable(const ResourceRequest &resource_request) const;
   /// Returns true if the node's total resources are enough to run the task.
   /// Note: This doesn't account for the binpacking of unit resources.
-  bool IsFeasible(const TaskRequest &task_req) const;
+  bool IsFeasible(const ResourceRequest &resource_request) const;
   /// Returns if this equals another node resources.
   bool operator==(const NodeResources &other);
   bool operator!=(const NodeResources &other);
@@ -206,13 +206,13 @@ struct Node {
   NodeResources local_view_;
 };
 
-/// \request Conversion result to a TaskRequest data structure.
+/// \request Conversion result to a ResourceRequest data structure.
 NodeResources ResourceMapToNodeResources(
     StringIdMap &string_to_int_map,
     const std::unordered_map<std::string, double> &resource_map_total,
     const std::unordered_map<std::string, double> &resource_map_available);
 
-/// Convert a map of resources to a TaskRequest data structure.
-TaskRequest ResourceMapToTaskRequest(
+/// Convert a map of resources to a ResourceRequest data structure.
+ResourceRequest ResourceMapToResourceRequest(
     StringIdMap &string_to_int_map,
     const std::unordered_map<std::string, double> &resource_map);

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -133,24 +133,26 @@ bool ClusterResourceScheduler::RemoveNode(const std::string &node_id_string) {
 
 bool ClusterResourceScheduler::IsLocallyFeasible(
     const std::unordered_map<std::string, double> shape) {
-  const TaskRequest task_req = ResourceMapToTaskRequest(string_to_int_map_, shape);
+  const ResourceRequest resource_request =
+      ResourceMapToResourceRequest(string_to_int_map_, shape);
   RAY_CHECK(nodes_.contains(local_node_id_));
   const auto &it = nodes_.find(local_node_id_);
   RAY_CHECK(it != nodes_.end());
-  return IsFeasible(task_req, it->second.GetLocalView());
+  return IsFeasible(resource_request, it->second.GetLocalView());
 }
 
-bool ClusterResourceScheduler::IsFeasible(const TaskRequest &task_req,
+bool ClusterResourceScheduler::IsFeasible(const ResourceRequest &resource_request,
                                           const NodeResources &resources) const {
   // First, check predefined resources.
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
-    if (task_req.predefined_resources[i] > resources.predefined_resources[i].total) {
+    if (resource_request.predefined_resources[i] >
+        resources.predefined_resources[i].total) {
       return false;
     }
   }
 
   // Now check custom resources.
-  for (const auto &task_req_custom_resource : task_req.custom_resources) {
+  for (const auto &task_req_custom_resource : resource_request.custom_resources) {
     auto it = resources.custom_resources.find(task_req_custom_resource.first);
 
     if (it == resources.custom_resources.end()) {
@@ -164,27 +166,28 @@ bool ClusterResourceScheduler::IsFeasible(const TaskRequest &task_req,
   return true;
 }
 
-int64_t ClusterResourceScheduler::IsSchedulable(const TaskRequest &task_req,
+int64_t ClusterResourceScheduler::IsSchedulable(const ResourceRequest &resource_request,
                                                 int64_t node_id,
                                                 const NodeResources &resources) const {
   int violations = 0;
 
   // First, check predefined resources.
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
-    if (task_req.predefined_resources[i] > resources.predefined_resources[i].available) {
+    if (resource_request.predefined_resources[i] >
+        resources.predefined_resources[i].available) {
       // A hard constraint has been violated, so we cannot schedule
-      // this task request.
+      // this resource request.
       return -1;
     }
   }
 
   // Now check custom resources.
-  for (const auto &task_req_custom_resource : task_req.custom_resources) {
+  for (const auto &task_req_custom_resource : resource_request.custom_resources) {
     auto it = resources.custom_resources.find(task_req_custom_resource.first);
 
     if (it == resources.custom_resources.end()) {
       // Requested resource doesn't exist at this node.
-      // This is a hard constraint so cannot schedule this task request.
+      // This is a hard constraint so cannot schedule this resource request.
       return -1;
     } else {
       if (task_req_custom_resource.second > it->second.available) {
@@ -198,7 +201,7 @@ int64_t ClusterResourceScheduler::IsSchedulable(const TaskRequest &task_req,
 }
 
 int64_t ClusterResourceScheduler::GetBestSchedulableNodeSimpleBinPack(
-    const TaskRequest &task_req, bool actor_creation, bool force_spillback,
+    const ResourceRequest &resource_request, bool actor_creation, bool force_spillback,
     int64_t *total_violations, bool *is_infeasible) {
   // NOTE: We need to set `is_infeasible` to false in advance to avoid `is_infeasible` not
   // being set.
@@ -216,22 +219,24 @@ int64_t ClusterResourceScheduler::GetBestSchedulableNodeSimpleBinPack(
   const auto local_node_it = nodes_.find(local_node_id_);
   if (!force_spillback) {
     if (local_node_it != nodes_.end()) {
-      if (IsSchedulable(task_req, local_node_it->first,
+      if (IsSchedulable(resource_request, local_node_it->first,
                         local_node_it->second.GetLocalView()) == 0) {
         return local_node_id_;
       }
     }
   }
 
-  bool local_node_feasible = IsFeasible(task_req, local_node_it->second.GetLocalView());
+  bool local_node_feasible =
+      IsFeasible(resource_request, local_node_it->second.GetLocalView());
 
   for (const auto &node : nodes_) {
     // Return -1 if node not schedulable. otherwise return the number
     // of soft constraint violations.
-    int64_t violations = IsSchedulable(task_req, node.first, node.second.GetLocalView());
+    int64_t violations =
+        IsSchedulable(resource_request, node.first, node.second.GetLocalView());
     if (violations == -1) {
       if (!local_node_feasible && best_nodes.empty() &&
-          IsFeasible(task_req, node.second.GetLocalView())) {
+          IsFeasible(resource_request, node.second.GetLocalView())) {
         // If the local node is not feasible, and a better node has not yet
         // been found, and this node does not currently have the resources
         // available but is feasible, then schedule to this node.
@@ -273,14 +278,12 @@ int64_t ClusterResourceScheduler::GetBestSchedulableNodeSimpleBinPack(
   return best_node;
 }
 
-int64_t ClusterResourceScheduler::GetBestSchedulableNode(const TaskRequest &task_req,
-                                                         bool actor_creation,
-                                                         bool force_spillback,
-                                                         int64_t *total_violations,
-                                                         bool *is_infeasible) {
+int64_t ClusterResourceScheduler::GetBestSchedulableNode(
+    const ResourceRequest &resource_request, bool actor_creation, bool force_spillback,
+    int64_t *total_violations, bool *is_infeasible) {
   // The zero cpu actor is a special case that must be handled the same way by all
   // scheduling policies.
-  if (actor_creation && task_req.IsEmpty()) {
+  if (actor_creation && resource_request.IsEmpty()) {
     int64_t best_node = -1;
     // This is an actor which requires no resources.
     // Pick a random node to to avoid scheduling all actors on the local node.
@@ -291,19 +294,20 @@ int64_t ClusterResourceScheduler::GetBestSchedulableNode(const TaskRequest &task
     }
     RAY_LOG(DEBUG) << "GetBestSchedulableNode, best_node = " << best_node
                    << ", # nodes = " << nodes_.size()
-                   << ", task_req = " << task_req.DebugString();
+                   << ", resource_request = " << resource_request.DebugString();
     return best_node;
   }
 
   if (!hybrid_spillback_) {
-    return GetBestSchedulableNodeSimpleBinPack(task_req, actor_creation, force_spillback,
-                                               total_violations, is_infeasible);
+    return GetBestSchedulableNodeSimpleBinPack(resource_request, actor_creation,
+                                               force_spillback, total_violations,
+                                               is_infeasible);
   }
 
   // TODO (Alex): Setting require_available == force_spillback is a hack in order to
   // remain bug compatible with the legacy scheduling algorithms.
   int64_t best_node_id = raylet_scheduling_policy::HybridPolicy(
-      task_req, local_node_id_, nodes_, spread_threshold_, force_spillback,
+      resource_request, local_node_id_, nodes_, spread_threshold_, force_spillback,
       force_spillback);
   *is_infeasible = best_node_id == -1 ? true : false;
   if (!*is_infeasible) {
@@ -321,9 +325,10 @@ int64_t ClusterResourceScheduler::GetBestSchedulableNode(const TaskRequest &task
 std::string ClusterResourceScheduler::GetBestSchedulableNode(
     const std::unordered_map<std::string, double> &task_resources, bool actor_creation,
     bool force_spillback, int64_t *total_violations, bool *is_infeasible) {
-  TaskRequest task_request = ResourceMapToTaskRequest(string_to_int_map_, task_resources);
-  int64_t node_id = GetBestSchedulableNode(task_request, actor_creation, force_spillback,
-                                           total_violations, is_infeasible);
+  ResourceRequest resource_request =
+      ResourceMapToResourceRequest(string_to_int_map_, task_resources);
+  int64_t node_id = GetBestSchedulableNode(
+      resource_request, actor_creation, force_spillback, total_violations, is_infeasible);
 
   std::string id_string;
   if (node_id == -1) {
@@ -335,7 +340,7 @@ std::string ClusterResourceScheduler::GetBestSchedulableNode(
 }
 
 bool ClusterResourceScheduler::SubtractRemoteNodeAvailableResources(
-    int64_t node_id, const TaskRequest &task_req) {
+    int64_t node_id, const ResourceRequest &resource_request) {
   RAY_CHECK(node_id != local_node_id_);
 
   auto it = nodes_.find(node_id);
@@ -344,8 +349,8 @@ bool ClusterResourceScheduler::SubtractRemoteNodeAvailableResources(
   }
   NodeResources *resources = it->second.GetMutableLocalView();
 
-  // Just double check this node can still schedule the task request.
-  if (IsSchedulable(task_req, node_id, *resources) == -1) {
+  // Just double check this node can still schedule the resource request.
+  if (IsSchedulable(resource_request, node_id, *resources) == -1) {
     return false;
   }
 
@@ -354,10 +359,10 @@ bool ClusterResourceScheduler::SubtractRemoteNodeAvailableResources(
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
     resources->predefined_resources[i].available =
         std::max(FixedPoint(0), resources->predefined_resources[i].available -
-                                    task_req.predefined_resources[i]);
+                                    resource_request.predefined_resources[i]);
   }
 
-  for (const auto &task_req_custom_resource : task_req.custom_resources) {
+  for (const auto &task_req_custom_resource : resource_request.custom_resources) {
     auto it = resources->custom_resources.find(task_req_custom_resource.first);
     if (it != resources->custom_resources.end()) {
       it->second.available =
@@ -731,7 +736,8 @@ bool ClusterResourceScheduler::AllocateResourceInstances(
 }
 
 bool ClusterResourceScheduler::AllocateTaskResourceInstances(
-    const TaskRequest &task_req, std::shared_ptr<TaskResourceInstances> task_allocation) {
+    const ResourceRequest &resource_request,
+    std::shared_ptr<TaskResourceInstances> task_allocation) {
   RAY_CHECK(task_allocation != nullptr);
   if (nodes_.find(local_node_id_) == nodes_.end()) {
     return false;
@@ -739,8 +745,8 @@ bool ClusterResourceScheduler::AllocateTaskResourceInstances(
 
   task_allocation->predefined_resources.resize(PredefinedResources_MAX);
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
-    if (task_req.predefined_resources[i] > 0) {
-      if (!AllocateResourceInstances(task_req.predefined_resources[i],
+    if (resource_request.predefined_resources[i] > 0) {
+      if (!AllocateResourceInstances(resource_request.predefined_resources[i],
                                      local_resources_.predefined_resources[i].available,
                                      &task_allocation->predefined_resources[i])) {
         // Allocation failed. Restore node's local resources by freeing the resources
@@ -751,7 +757,7 @@ bool ClusterResourceScheduler::AllocateTaskResourceInstances(
     }
   }
 
-  for (const auto &task_req_custom_resource : task_req.custom_resources) {
+  for (const auto &task_req_custom_resource : resource_request.custom_resources) {
     auto it = local_resources_.custom_resources.find(task_req_custom_resource.first);
     if (it != local_resources_.custom_resources.end()) {
       if (task_req_custom_resource.second > 0) {
@@ -890,9 +896,9 @@ std::vector<double> ClusterResourceScheduler::SubtractGPUResourceInstances(
 }
 
 bool ClusterResourceScheduler::AllocateLocalTaskResources(
-    const TaskRequest &task_request,
+    const ResourceRequest &resource_request,
     std::shared_ptr<TaskResourceInstances> task_allocation) {
-  if (AllocateTaskResourceInstances(task_request, task_allocation)) {
+  if (AllocateTaskResourceInstances(resource_request, task_allocation)) {
     UpdateLocalAvailableResourcesFromResourceInstances();
     return true;
   }
@@ -903,8 +909,9 @@ bool ClusterResourceScheduler::AllocateLocalTaskResources(
     const std::unordered_map<std::string, double> &task_resources,
     std::shared_ptr<TaskResourceInstances> task_allocation) {
   RAY_CHECK(task_allocation != nullptr);
-  TaskRequest task_request = ResourceMapToTaskRequest(string_to_int_map_, task_resources);
-  return AllocateLocalTaskResources(task_request, task_allocation);
+  ResourceRequest resource_request =
+      ResourceMapToResourceRequest(string_to_int_map_, task_resources);
+  return AllocateLocalTaskResources(resource_request, task_allocation);
 }
 
 std::string ClusterResourceScheduler::GetResourceNameFromIndex(int64_t res_idx) {
@@ -924,10 +931,11 @@ std::string ClusterResourceScheduler::GetResourceNameFromIndex(int64_t res_idx) 
 bool ClusterResourceScheduler::AllocateRemoteTaskResources(
     const std::string &node_string,
     const std::unordered_map<std::string, double> &task_resources) {
-  TaskRequest task_request = ResourceMapToTaskRequest(string_to_int_map_, task_resources);
+  ResourceRequest resource_request =
+      ResourceMapToResourceRequest(string_to_int_map_, task_resources);
   auto node_id = string_to_int_map_.Insert(node_string);
   RAY_CHECK(node_id != local_node_id_);
-  return SubtractRemoteNodeAvailableResources(node_id, task_request);
+  return SubtractRemoteNodeAvailableResources(node_id, resource_request);
 }
 
 void ClusterResourceScheduler::ReleaseWorkerResources(

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -1116,14 +1116,14 @@ ResourceSet ClusterTaskManager::CalcNormalTaskResources() const {
     }
 
     if (auto allocated_instances = worker->GetAllocatedInstances()) {
-      auto task_request = allocated_instances->ToTaskRequest();
-      for (size_t i = 0; i < task_request.predefined_resources.size(); i++) {
-        if (task_request.predefined_resources[i] > 0) {
+      auto resource_request = allocated_instances->ToResourceRequest();
+      for (size_t i = 0; i < resource_request.predefined_resources.size(); i++) {
+        if (resource_request.predefined_resources[i] > 0) {
           total_normal_task_resources[ResourceEnumToString(PredefinedResources(i))] +=
-              task_request.predefined_resources[i];
+              resource_request.predefined_resources[i];
         }
       }
-      for (auto &entry : task_request.custom_resources) {
+      for (auto &entry : resource_request.custom_resources) {
         if (entry.second > 0) {
           total_normal_task_resources[string_id_map.Get(entry.first)] += entry.second;
         }

--- a/src/ray/raylet/scheduling/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/scheduling_policy.cc
@@ -4,7 +4,7 @@ namespace ray {
 
 namespace raylet_scheduling_policy {
 
-int64_t HybridPolicy(const TaskRequest &task_request, const int64_t local_node_id,
+int64_t HybridPolicy(const ResourceRequest &resource_request, const int64_t local_node_id,
                      const absl::flat_hash_map<int64_t, Node> &nodes,
                      float spread_threshold, bool force_spillback,
                      bool require_available) {
@@ -40,11 +40,11 @@ int64_t HybridPolicy(const TaskRequest &task_request, const int64_t local_node_i
     const auto &it = nodes.find(node_id);
     RAY_CHECK(it != nodes.end());
     const auto &node = it->second;
-    if (!node.GetLocalView().IsFeasible(task_request)) {
+    if (!node.GetLocalView().IsFeasible(resource_request)) {
       continue;
     }
 
-    bool is_available = node.GetLocalView().IsAvailable(task_request);
+    bool is_available = node.GetLocalView().IsAvailable(resource_request);
     float critical_resource_utilization =
         node.GetLocalView().CalculateCriticalResourceUtilization();
     if (critical_resource_utilization < spread_threshold) {

--- a/src/ray/raylet/scheduling/scheduling_policy.h
+++ b/src/ray/raylet/scheduling/scheduling_policy.h
@@ -30,7 +30,7 @@ namespace raylet_scheduling_policy {
 /// properties will lead to packing of nodes. Above the threshold, the policy will act
 /// like a traditional weighted round robin.
 ///
-/// \param task_request: The task request we're attempting to schedule.
+/// \param resource_request: The resource request we're attempting to schedule.
 /// \param local_node_id: The id of the local node, which is needed for traversal order.
 /// \param nodes: The summary view of all the nodes that can be scheduled on.
 /// \param spread_threshold: Below this threshold, critical resource utilization will be
@@ -38,7 +38,7 @@ namespace raylet_scheduling_policy {
 ///
 /// \return -1 if the task is infeasible, otherwise the node id (key in `nodes`) to
 /// schedule on.
-int64_t HybridPolicy(const TaskRequest &task_request, const int64_t local_node_id,
+int64_t HybridPolicy(const ResourceRequest &resource_request, const int64_t local_node_id,
                      const absl::flat_hash_map<int64_t, Node> &nodes,
                      float spread_threshold, bool force_spillback,
                      bool require_available);

--- a/src/ray/raylet/scheduling/scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/scheduling_policy_test.cc
@@ -24,8 +24,8 @@ class SchedulingPolicyTest : public ::testing::Test {};
 TEST_F(SchedulingPolicyTest, FeasibleDefinitionTest) {
   StringIdMap map;
   auto task_req1 =
-      ResourceMapToTaskRequest(map, {{"CPU", 1}, {"object_store_memory", 1}});
-  auto task_req2 = ResourceMapToTaskRequest(map, {{"CPU", 1}});
+      ResourceMapToResourceRequest(map, {{"CPU", 1}, {"object_store_memory", 1}});
+  auto task_req2 = ResourceMapToResourceRequest(map, {{"CPU", 1}});
   {
     // Don't break with a non-resized predefined resources array.
     NodeResources resources;
@@ -47,8 +47,8 @@ TEST_F(SchedulingPolicyTest, FeasibleDefinitionTest) {
 TEST_F(SchedulingPolicyTest, AvailableDefinitionTest) {
   StringIdMap map;
   auto task_req1 =
-      ResourceMapToTaskRequest(map, {{"CPU", 1}, {"object_store_memory", 1}});
-  auto task_req2 = ResourceMapToTaskRequest(map, {{"CPU", 1}});
+      ResourceMapToResourceRequest(map, {{"CPU", 1}, {"object_store_memory", 1}});
+  auto task_req2 = ResourceMapToResourceRequest(map, {{"CPU", 1}});
   {
     // Don't break with a non-resized predefined resources array.
     NodeResources resources;
@@ -111,7 +111,7 @@ TEST_F(SchedulingPolicyTest, AvailableTruncationTest) {
   // has a lower critical resource utilization, but they're both truncated to 0, so we
   // should still pick the local node (due to traversal order).
   StringIdMap map;
-  TaskRequest req = ResourceMapToTaskRequest(map, {{"CPU", 1}});
+  ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}});
   int64_t local_node = 0;
   int64_t remote_node = 1;
 
@@ -128,7 +128,7 @@ TEST_F(SchedulingPolicyTest, AvailableTieBreakTest) {
   // In this test, the local node and a remote node are both available. The remote node
   // has a lower critical resource utilization so we schedule on it.
   StringIdMap map;
-  TaskRequest req = ResourceMapToTaskRequest(map, {{"CPU", 1}});
+  ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}});
   int64_t local_node = 0;
   int64_t remote_node = 1;
 
@@ -146,7 +146,7 @@ TEST_F(SchedulingPolicyTest, AvailableOverFeasibleTest) {
   // utilization, but the remote node can run the task immediately, so we pick the remote
   // node.
   StringIdMap map;
-  TaskRequest req = ResourceMapToTaskRequest(map, {{"CPU", 1}, {"GPU", 1}});
+  ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}});
   int64_t local_node = 0;
   int64_t remote_node = 1;
 
@@ -162,7 +162,7 @@ TEST_F(SchedulingPolicyTest, AvailableOverFeasibleTest) {
 TEST_F(SchedulingPolicyTest, InfeasibleTest) {
   // All the nodes are infeasible, so we return -1.
   StringIdMap map;
-  TaskRequest req = ResourceMapToTaskRequest(map, {{"CPU", 1}, {"GPU", 1}});
+  ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}});
   int64_t local_node = 0;
   int64_t remote_node = 1;
 
@@ -179,7 +179,7 @@ TEST_F(SchedulingPolicyTest, BarelyFeasibleTest) {
   // Test the edge case where a task requires all of a node's resources, and the node is
   // fully utilized.
   StringIdMap map;
-  TaskRequest req = ResourceMapToTaskRequest(map, {{"CPU", 1}, {"GPU", 1}});
+  ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}});
   int64_t local_node = 0;
 
   absl::flat_hash_map<int64_t, Node> nodes;
@@ -194,7 +194,7 @@ TEST_F(SchedulingPolicyTest, TruncationAcrossFeasibleNodesTest) {
   // Same as AvailableTruncationTest except now none of the nodes are available, but the
   // tie break logic should apply to feasible nodes too.
   StringIdMap map;
-  TaskRequest req = ResourceMapToTaskRequest(map, {{"CPU", 1}, {"GPU", 1}});
+  ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}});
   int64_t local_node = 0;
   int64_t remote_node = 1;
 
@@ -211,7 +211,7 @@ TEST_F(SchedulingPolicyTest, ForceSpillbackIfAvailableTest) {
   // The local node is better, but we force spillback, so we'll schedule on a non-local
   // node anyways.
   StringIdMap map;
-  TaskRequest req = ResourceMapToTaskRequest(map, {{"CPU", 1}, {"GPU", 1}});
+  ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}});
   int64_t local_node = 0;
   int64_t remote_node = 1;
 
@@ -227,7 +227,7 @@ TEST_F(SchedulingPolicyTest, ForceSpillbackIfAvailableTest) {
 TEST_F(SchedulingPolicyTest, ForceSpillbackTest) {
   // The local node is available but disqualified.
   StringIdMap map;
-  TaskRequest req = ResourceMapToTaskRequest(map, {{"CPU", 1}, {"GPU", 1}});
+  ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}});
   int64_t local_node = 0;
   int64_t remote_node = 1;
 
@@ -244,7 +244,7 @@ TEST_F(SchedulingPolicyTest, ForceSpillbackOnlyFeasibleLocallyTest) {
   // The local node is better, but we force spillback, so we'll schedule on a non-local
   // node anyways.
   StringIdMap map;
-  TaskRequest req = ResourceMapToTaskRequest(map, {{"CPU", 1}, {"GPU", 1}});
+  ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}});
   int64_t local_node = 0;
   int64_t remote_node = 1;
 


### PR DESCRIPTION
## Why are these changes needed?

After discussion with @wuisawesome, we think ResourceRequest is a better name. Because this struct will be used as a resource container of the placement group bundle. 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
