### PR TITLE
[tune] Fix Tee utility class properties

### DIFF
--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -169,6 +169,10 @@ class Tee(object):
         self.stream1 = stream1
         self.stream2 = stream2
 
+    def seek(self, *args, **kwargs):
+        self.stream1.seek(*args, **kwargs)
+        self.stream2.seek(*args, **kwargs)
+
     def write(self, *args, **kwargs):
         self.stream1.write(*args, **kwargs)
         self.stream2.write(*args, **kwargs)
@@ -194,6 +198,18 @@ class Tee(object):
         if hasattr(self.stream1, "newlines"):
             return self.stream1.newlines
         return self.stream2.newlines
+
+    def detach(self):
+        raise NotImplementedError
+
+    def read(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def readline(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def tell(self, *args, **kwargs):
+        raise NotImplementedError
 
 
 def date_str():

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -177,6 +177,24 @@ class Tee(object):
         self.stream1.flush(*args, **kwargs)
         self.stream2.flush(*args, **kwargs)
 
+    @property
+    def encoding(self):
+        if hasattr(self.stream1, "encoding"):
+            return self.stream1.encoding
+        return self.stream2.encoding
+
+    @property
+    def error(self):
+        if hasattr(self.stream1, "error"):
+            return self.stream1.error
+        return self.stream2.error
+
+    @property
+    def newlines(self):
+        if hasattr(self.stream1, "newlines"):
+            return self.stream1.newlines
+        return self.stream2.newlines
+
 
 def date_str():
     return datetime.today().strftime("%Y-%m-%d_%H-%M-%S")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Tune redirects stdout/stderr by replacing the steam with a `Tee` object, writing both to stdout/stderr and a file. However, we currently don't implement the full `io.TextIOBase` API. This PR adds full API compatibility, although we don't implement read functions (as they don't make sense here).

Fixes e.g. this problem with Weights and Biases:

```
(pid=655) Traceback (most recent call last):
(pid=655)   File "/usr/local/lib/python3.7/dist-packages/wandb/sdk/wandb_init.py", line 757, in init
(pid=655)     run = wi.init()
(pid=655)   File "/usr/local/lib/python3.7/dist-packages/wandb/sdk/wandb_init.py", line 551, in init
(pid=655)     run._on_start()
(pid=655)   File "/usr/local/lib/python3.7/dist-packages/wandb/sdk/wandb_run.py", line 1658, in _on_start
(pid=655)     self._display_run()
(pid=655)   File "/usr/local/lib/python3.7/dist-packages/wandb/sdk/wandb_run.py", line 1463, in _display_run
(pid=655)     if platform.system() != "Windows" and sys.stdout.encoding == "UTF-8":
(pid=655) AttributeError: 'Tee' object has no attribute 'encoding'
```


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
