### PR TITLE
[tune] Use fork for wandb, disable ipython in trainables

### DIFF
--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -194,6 +194,7 @@ class _WandbLoggingProcess(Process):
         self.kwargs = kwargs
 
     def run(self):
+        os.environ["WANDB_START_METHOD"] = "fork"
         wandb.init(*self.args, **self.kwargs)
         while True:
             result = self.queue.get()
@@ -559,6 +560,7 @@ class WandbTrainableMixin:
             config=_config)
         wandb_init_kwargs.update(wandb_config)
 
+        os.environ["WANDB_START_METHOD"] = "fork"
         self.wandb = self._wandb.init(**wandb_init_kwargs)
 
     def stop(self):

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -22,6 +22,7 @@ from ray.tune.result import (
 from ray.tune.utils import UtilMonitor
 from ray.tune.utils.placement_groups import PlacementGroupFactory
 from ray.tune.utils.trainable import TrainableUtil
+from ray.tune.utils.log import disable_ipython
 from ray.tune.utils.util import Tee
 from ray.util.debug import log_once
 
@@ -73,7 +74,7 @@ class Trainable:
         self.config = config or {}
         trial_info = self.config.pop(TRIAL_INFO, None)
 
-        self._disable_ipython()
+        disable_ipython()
 
         self._result_logger = self._logdir = None
         self._create_logger(self.config, logger_creator)
@@ -493,14 +494,6 @@ class Trainable:
             True if reset was successful else False.
         """
         return False
-
-    def _disable_ipython(self):
-        """Disable output of IPython HTML objects."""
-        try:
-            from IPython.core.interactiveshell import InteractiveShell
-            InteractiveShell.clear_instance()
-        except Exception:
-            pass
 
     def _create_logger(self, config, logger_creator=None):
         """Create logger from logger creator.

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -76,6 +76,8 @@ class Trainable:
         self._result_logger = self._logdir = None
         self._create_logger(self.config, logger_creator)
 
+        self._disable_ipython()
+
         self._stdout_context = self._stdout_fp = self._stdout_stream = None
         self._stderr_context = self._stderr_fp = self._stderr_stream = None
         self._stderr_logging_handler = None
@@ -491,6 +493,14 @@ class Trainable:
             True if reset was successful else False.
         """
         return False
+
+    def _disable_ipython(self):
+        """Disable output of IPython HTML objects."""
+        try:
+            from IPython.core.interactiveshell import InteractiveShell
+            InteractiveShell.clear_instance()
+        except Exception:
+            pass
 
     def _create_logger(self, config, logger_creator=None):
         """Create logger from logger creator.

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -73,10 +73,10 @@ class Trainable:
         self.config = config or {}
         trial_info = self.config.pop(TRIAL_INFO, None)
 
+        self._disable_ipython()
+
         self._result_logger = self._logdir = None
         self._create_logger(self.config, logger_creator)
-
-        self._disable_ipython()
 
         self._stdout_context = self._stdout_fp = self._stdout_stream = None
         self._stderr_context = self._stderr_fp = self._stderr_stream = None

--- a/python/ray/tune/utils/log.py
+++ b/python/ray/tune/utils/log.py
@@ -32,3 +32,12 @@ def has_verbosity(level: Union[int, Verbosity]) -> bool:
     verbosity_level = int(verbosity)
 
     return verbosity_level >= log_level
+
+
+def disable_ipython():
+    """Disable output of IPython HTML objects."""
+    try:
+        from IPython.core.interactiveshell import InteractiveShell
+        InteractiveShell.clear_instance()
+    except Exception:
+        pass


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Some environments (e.g. Google colab) also instantiate IPython environments in remote processes (e.g. Trainables). This leads to faulty outputs (non-rendered HTML containers). 

## Related issue number

Closes #16197

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
