### PR TITLE
Force spillback in TrySpillback()

### DIFF
--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -117,7 +117,6 @@ bool ClusterResourceScheduler::RemoveNode(int64_t node_id) {
     return false;
   } else {
     nodes_.erase(it);
-    string_to_int_map_.Remove(node_id);
     return true;
   }
 }
@@ -553,7 +552,6 @@ void ClusterResourceScheduler::DeleteResource(const std::string &node_id_string,
     int64_t resource_id = string_to_int_map_.Get(resource_name);
     auto itr = local_view->custom_resources.find(resource_id);
     if (itr != local_view->custom_resources.end()) {
-      string_to_int_map_.Remove(resource_id);
       local_view->custom_resources.erase(itr);
     }
 

--- a/src/ray/raylet/scheduling/scheduling_ids.cc
+++ b/src/ray/raylet/scheduling/scheduling_ids.cc
@@ -60,20 +60,4 @@ int64_t StringIdMap::Insert(const std::string &string_id, uint8_t max_id) {
   }
 };
 
-void StringIdMap::Remove(const std::string &string_id) {
-  auto sit = string_to_int_.find(string_id);
-  if (sit != string_to_int_.end()) {
-    int_to_string_.erase(string_to_int_[string_id]);
-    string_to_int_.erase(sit);
-  }
-};
-
-void StringIdMap::Remove(int64_t id) {
-  auto it = int_to_string_.find(id);
-  if (it != int_to_string_.end()) {
-    string_to_int_.erase(int_to_string_[id]);
-    int_to_string_.erase(it);
-  }
-};
-
 int64_t StringIdMap::Count() { return string_to_int_.size(); }

--- a/src/ray/raylet/scheduling/scheduling_ids.h
+++ b/src/ray/raylet/scheduling/scheduling_ids.h
@@ -52,15 +52,8 @@ class StringIdMap {
   /// \return The integer ID associated with string ID string_id.
   int64_t Insert(const std::string &string_id, uint8_t num_ids = 0);
 
-  /// Delete an ID identified by its string format.
-  ///
-  /// \param ID to be deleted.
-  void Remove(const std::string &string_id);
-
-  /// Delete an ID identified by its integer format.
-  ///
-  /// \param ID to be deleted.
-  void Remove(int64_t id);
+  /// Removing an ID is unsupported, because it is prone to erroneously
+  /// deleting an ID still in use.
 
   /// Get number of identifiers.
   int64_t Count();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I believe `GetBestSchedulableNode()` should not return a local node when called by `TrySpillback()` in the spillback codepath. Since `TrySpillback()` is called after a task failed to schedule locally, this issue may not matter but just a bit confusing. However, I'm seeing `local_resources_` becoming out of sync with `nodes_[local_node_id_]` in `ClusterResourceScheduler`. An infinite loop can happen:
- A task fails to schedule locally, based on `local_resources_`
- `GetBestSchedulableNode()` returns the local node (when spillback is not forced), based on `nodes_`.
- The returned local node is ignored in `TrySpillback()`

Please advise on testing strategy, if needed.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
