### PR TITLE
[core] porting abseil::StatusOr

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1059,6 +1059,16 @@ cc_test(
 )
 
 cc_test(
+    name = "statusor_test",
+    srcs = ["src/ray/common/test/statusor_test.cc"],
+    copts = COPTS,
+    deps = [
+        ":ray_common",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "publisher_test",
     srcs = ["src/ray/pubsub/test/publisher_test.cc"],
     copts = COPTS,

--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -252,6 +252,10 @@ class RAY_EXPORT Status {
 
   std::string message() const { return ok() ? "" : state_->msg; }
 
+  bool operator==(const Status &other) const {
+    return code() == other.code() && message() == other.message();
+  }
+
  private:
   struct State {
     StatusCode code;

--- a/src/ray/common/statusor.h
+++ b/src/ray/common/statusor.h
@@ -1,0 +1,272 @@
+// Copyright 2021 The Google Research Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <new>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include "ray/common/status.h"
+
+namespace ray {
+
+template <typename T>
+class StatusOr {
+  template <typename U>
+  friend class StatusOr;
+
+ public:
+  // Construct a new StatusOr with Status::UNKNOWN status
+  StatusOr();
+
+  // Construct a new StatusOr with the given non-ok status. After calling
+  // this constructor, calls to value() will crash.
+  //
+  // NOTE: Not explicit - we want to use StatusOr<T> as a return
+  // value, so it is convenient and sensible to be able to do 'return
+  // Status()' when the return type is StatusOr<T>.
+  //
+  // REQUIRES: status != StatusCode::kOk. This requirement is RAY_CHECKed.
+  StatusOr(const Status &status);
+
+  // Construct a new StatusOr with the given value. If T is a plain pointer,
+  // value must not be NULL. After calling this constructor, calls to
+  // ValueOrDie() will succeed, and calls to status() will return OK.
+  //
+  // NOTE: Not explicit - we want to use StatusOr<T> as a return type
+  // so it is convenient and sensible to be able to do 'return T()'
+  // when when the return type is StatusOr<T>.
+  //
+  // REQUIRES: if T is a plain pointer, value != nullptr. This requirement is
+  // RAY_CHECKED.
+  StatusOr(const T &value);
+
+  // Copy constructor.
+  StatusOr(const StatusOr &other) = default;
+
+  // Conversion copy constructor, T must be copy constructible from U
+  template <typename U>
+  StatusOr(const StatusOr<U> &other);
+
+  // Assignment operator.
+  StatusOr &operator=(const StatusOr &other) = default;
+
+  // Conversion assignment operator, T must be assignable from U
+  template <typename U>
+  StatusOr &operator=(const StatusOr<U> &other);
+
+  // Move constructor and move-assignment operator.
+  StatusOr(StatusOr &&other) = default;
+  StatusOr &operator=(StatusOr &&other) = default;
+
+  // Rvalue-reference overloads of the other constructors and assignment
+  // operators, to support move-only types and avoid unnecessary copying.
+  StatusOr(T &&value);
+  template <typename U>
+  StatusOr(StatusOr<U> &&other);
+  template <typename U>
+  StatusOr &operator=(StatusOr<U> &&other);
+
+  // Returns a reference to our status. If this contains a T, then
+  // returns StatusCode::kOk.
+  const Status &status() const;
+
+  // Returns this->status().ok()
+  bool ok() const;
+
+  // StatusOr<T>:: operator*()
+  //
+  // Returns a reference to the current value.
+  //
+  // REQUIRES: `this->ok() == true`, otherwise it crashes.
+  const T &value() const &;
+  T &value() &;
+  const T &&value() const &&;
+  T &&value() &&;
+
+  // StatusOr<T>:: operator*()
+  //
+  // Returns a pointer to the current value.
+  //
+  // REQUIRES: `this->ok() == true`, otherwise it crashes.
+  const T &operator*() const &;
+  T &operator*() &;
+  const T &&operator*() const &&;
+  T &&operator*() &&;
+
+  // StatusOr<T>::operator->()
+  //
+  // Returns a pointer to the current value.
+  //
+  // REQUIRES: `this->ok() == true`, otherwise it crashes.
+  const T *operator->() const;
+  T *operator->();
+
+ private:
+  void EnsureOK() const;
+  Status status_;
+  T value_;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Implementation details for StatusOr<T>
+
+namespace internal {
+
+class StatusOrHelper {
+ public:
+  // Customized behavior for StatusOr<T> vs. StatusOr<T*>
+  template <typename T>
+  struct Specialize;
+};
+
+template <typename T>
+struct StatusOrHelper::Specialize {
+  // For non-pointer T, a reference can never be NULL.
+  static inline bool IsValueNull(const T &t) { return false; }
+};
+
+template <typename T>
+struct StatusOrHelper::Specialize<T *> {
+  static inline bool IsValueNull(const T *t) { return t == nullptr; }
+};
+
+}  // namespace internal
+
+template <typename T>
+inline StatusOr<T>::StatusOr() : status_(Status::UnknownError("")), value_() {}
+
+template <typename T>
+inline StatusOr<T>::StatusOr(const Status &status) : status_(status), value_() {
+  RAY_CHECK(!status_.ok())
+      << "Status::OK is not a valid constructor argument to StatusOr<T>";
+}
+
+template <typename T>
+inline StatusOr<T>::StatusOr(const T &value) : status_(Status::OK()), value_(value) {
+  RAY_CHECK(!internal::StatusOrHelper::Specialize<T>::IsValueNull(value_))
+      << "nullptr is not a valid constructor argument to StatusOr<T*>";
+}
+
+template <typename T>
+template <typename U>
+inline StatusOr<T>::StatusOr(const StatusOr<U> &other)
+    : status_(other.status_), value_(other.value_) {}
+
+template <typename T>
+template <typename U>
+inline StatusOr<T> &StatusOr<T>::operator=(const StatusOr<U> &other) {
+  status_ = other.status_;
+  value_ = other.value_;
+  return *this;
+}
+
+template <typename T>
+inline StatusOr<T>::StatusOr(T &&value)
+    : status_(Status::OK()), value_(std::move(value)) {
+  RAY_CHECK(!internal::StatusOrHelper::Specialize<T>::IsValueNull(value_))
+      << "nullptr is not a valid constructor argument to StatusOr<T*>";
+}
+
+template <typename T>
+template <typename U>
+inline StatusOr<T>::StatusOr(StatusOr<U> &&other)
+    : status_(other.status_), value_(std::move(other.value_)) {}
+
+template <typename T>
+template <typename U>
+inline StatusOr<T> &StatusOr<T>::operator=(StatusOr<U> &&other) {
+  status_ = other.status_;
+  value_ = std::move(other.value_);
+  return *this;
+}
+
+template <typename T>
+inline const Status &StatusOr<T>::status() const {
+  return status_;
+}
+
+template <typename T>
+inline bool StatusOr<T>::ok() const {
+  return status_.ok();
+}
+
+template <typename T>
+const T &StatusOr<T>::value() const & {
+  this->EnsureOK();
+  return this->value_;
+}
+
+template <typename T>
+T &StatusOr<T>::value() & {
+  this->EnsureOK();
+  return this->value_;
+}
+
+template <typename T>
+const T &&StatusOr<T>::value() const && {
+  this->EnsureOK();
+  return std::move(this->value_);
+}
+
+template <typename T>
+T &&StatusOr<T>::value() && {
+  this->EnsureOK();
+  return std::move(this->value_);
+}
+
+template <typename T>
+const T &StatusOr<T>::operator*() const & {
+  this->EnsureOK();
+  return this->value_;
+}
+
+template <typename T>
+T &StatusOr<T>::operator*() & {
+  this->EnsureOK();
+  return this->value_;
+}
+
+template <typename T>
+const T &&StatusOr<T>::operator*() const && {
+  this->EnsureOK();
+  return std::move(this->value_);
+}
+
+template <typename T>
+T &&StatusOr<T>::operator*() && {
+  this->EnsureOK();
+  return std::move(this->value_);
+}
+
+template <typename T>
+const T *StatusOr<T>::operator->() const {
+  this->EnsureOK();
+  return &this->value_;
+}
+
+template <typename T>
+T *StatusOr<T>::operator->() {
+  this->EnsureOK();
+  return &this->value_;
+}
+
+template <typename T>
+void StatusOr<T>::EnsureOK() const {
+  RAY_CHECK(status_.ok()) << "Attempting to fetch value instead of handling error status";
+}
+
+}  // namespace ray

--- a/src/ray/common/test/statusor_test.cc
+++ b/src/ray/common/test/statusor_test.cc
@@ -1,0 +1,244 @@
+// Copyright 2020 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/common/statusor.h"
+
+#include "gtest/gtest.h"
+
+namespace ray {
+namespace {
+
+class Base1 {
+ public:
+  virtual ~Base1() {}
+  int pad;
+};
+
+class Base2 {
+ public:
+  virtual ~Base2() {}
+  int yetotherpad;
+};
+
+class Derived : public Base1, public Base2 {
+ public:
+  virtual ~Derived() {}
+  int evenmorepad;
+};
+
+TEST(StatusOr, TestDefaultCtor) {
+  StatusOr<int> thing;
+  EXPECT_FALSE(thing.ok());
+  EXPECT_EQ(Status::UnknownError(""), thing.status());
+}
+
+TEST(StatusOr, TestStatusCtor) {
+  StatusOr<int> thing(Status::Invalid(""));
+  EXPECT_FALSE(thing.ok());
+  EXPECT_EQ(Status::Invalid(""), thing.status());
+}
+
+TEST(StatusOr, TestValueCtor) {
+  const int kI = 4;
+  StatusOr<int> thing(kI);
+  EXPECT_TRUE(thing.ok());
+  EXPECT_EQ(kI, thing.value());
+}
+
+TEST(StatusOr, TestCopyCtorStatusOk) {
+  const int kI = 4;
+  StatusOr<int> original(kI);
+  StatusOr<int> copy(original);
+  EXPECT_EQ(original.status(), copy.status());
+  EXPECT_EQ(original.value(), copy.value());
+}
+
+TEST(StatusOr, TestCopyCtorStatusNotOk) {
+  StatusOr<int> original(Status::Invalid(""));
+  StatusOr<int> copy(original);
+  EXPECT_EQ(original.status(), copy.status());
+}
+
+TEST(StatusOr, TestCopyCtorStatusOKConverting) {
+  const int kI = 4;
+  StatusOr<int>    original(kI);
+  StatusOr<double> copy(original);
+  EXPECT_EQ(original.status(), copy.status());
+  EXPECT_EQ(original.value(), copy.value());
+}
+
+TEST(StatusOr, TestCopyCtorStatusNotOkConverting) {
+  StatusOr<int> original(Status::Invalid(""));
+  StatusOr<double> copy(original);
+  EXPECT_EQ(original.status(), copy.status());
+}
+
+TEST(StatusOr, TestAssignmentStatusOk) {
+  const int kI = 4;
+  StatusOr<int> source(kI);
+  StatusOr<int> target;
+  target = source;
+  EXPECT_EQ(source.status(), target.status());
+  EXPECT_EQ(source.value(), target.value());
+}
+
+TEST(StatusOr, TestAssignmentStatusNotOk) {
+  StatusOr<int> source(Status::Invalid(""));
+  StatusOr<int> target;
+  target = source;
+  EXPECT_EQ(source.status(), target.status());
+}
+
+TEST(StatusOr, TestAssignmentStatusOKConverting) {
+  const int kI = 4;
+  StatusOr<int>    source(kI);
+  StatusOr<double> target;
+  target = source;
+  EXPECT_EQ(source.status(), target.status());
+  EXPECT_DOUBLE_EQ(source.value(), target.value());
+}
+
+TEST(StatusOr, TestAssignmentStatusNotOkConverting) {
+  StatusOr<int> source(Status::Invalid(""));
+  StatusOr<double> target;
+  target = source;
+  EXPECT_EQ(source.status(), target.status());
+}
+
+TEST(StatusOr, TestStatus) {
+  StatusOr<int> good(4);
+  EXPECT_TRUE(good.ok());
+  StatusOr<int> bad(Status::Invalid(""));
+  EXPECT_FALSE(bad.ok());
+  EXPECT_EQ(Status::Invalid(""), bad.status());
+}
+
+TEST(StatusOr, TestValue) {
+  const int kI = 4;
+  StatusOr<int> thing(kI);
+  EXPECT_EQ(kI, thing.value());
+}
+
+TEST(StatusOr, TestValueConst) {
+  const int kI = 4;
+  const StatusOr<int> thing(kI);
+  EXPECT_EQ(kI, thing.value());
+}
+
+TEST(StatusOr, TestPointerDefaultCtor) {
+  StatusOr<int*> thing;
+  EXPECT_FALSE(thing.ok());
+  EXPECT_EQ(Status::UnknownError(""), thing.status());
+}
+
+TEST(StatusOr, TestPointerStatusCtor) {
+  StatusOr<int*> thing(Status::Invalid(""));
+  EXPECT_FALSE(thing.ok());
+  EXPECT_EQ(Status::Invalid(""), thing.status());
+}
+
+TEST(StatusOr, TestPointerValueCtor) {
+  const int kI = 4;
+  StatusOr<const int*> thing(&kI);
+  EXPECT_TRUE(thing.ok());
+  EXPECT_EQ(&kI, thing.value());
+}
+
+TEST(StatusOr, TestPointerCopyCtorStatusOk) {
+  const int kI = 0;
+  StatusOr<const int*> original(&kI);
+  StatusOr<const int*> copy(original);
+  EXPECT_EQ(original.status(), copy.status());
+  EXPECT_EQ(original.value(), copy.value());
+}
+
+TEST(StatusOr, TestPointerCopyCtorStatusNotOk) {
+  StatusOr<int*> original(Status::Invalid(""));
+  StatusOr<int*> copy(original);
+  EXPECT_EQ(original.status(), copy.status());
+}
+
+TEST(StatusOr, TestPointerCopyCtorStatusOKConverting) {
+  Derived derived;
+  StatusOr<Derived*> original(&derived);
+  StatusOr<Base2*>   copy(original);
+  EXPECT_EQ(original.status(), copy.status());
+  EXPECT_EQ(static_cast<const Base2*>(original.value()), copy.value());
+}
+
+TEST(StatusOr, TestPointerCopyCtorStatusNotOkConverting) {
+  StatusOr<Derived*> original(Status::Invalid(""));
+  StatusOr<Base2*>   copy(original);
+  EXPECT_EQ(original.status(), copy.status());
+}
+
+TEST(StatusOr, TestPointerAssignmentStatusOk) {
+  const int kI = 0;
+  StatusOr<const int*> source(&kI);
+  StatusOr<const int*> target;
+  target = source;
+  EXPECT_EQ(source.status(), target.status());
+  EXPECT_EQ(source.value(), target.value());
+}
+
+TEST(StatusOr, TestPointerAssignmentStatusNotOk) {
+  StatusOr<int*> source(Status::Invalid(""));
+  StatusOr<int*> target;
+  target = source;
+  EXPECT_EQ(source.status(), target.status());
+}
+
+TEST(StatusOr, TestPointerAssignmentStatusOKConverting) {
+  Derived derived;
+  StatusOr<Derived*> source(&derived);
+  StatusOr<Base2*>   target;
+  target = source;
+  EXPECT_EQ(source.status(), target.status());
+  EXPECT_EQ(static_cast<const Base2*>(source.value()), target.value());
+}
+
+TEST(StatusOr, TestPointerAssignmentStatusNotOkConverting) {
+  StatusOr<Derived*> source(Status::Invalid(""));
+  StatusOr<Base2*>   target;
+  target = source;
+  EXPECT_EQ(source.status(), target.status());
+}
+
+TEST(StatusOr, TestPointerStatus) {
+  const int kI = 0;
+  StatusOr<const int*> good(&kI);
+  EXPECT_TRUE(good.ok());
+  StatusOr<const int*> bad(Status::Invalid(""));
+  EXPECT_EQ(Status::Invalid(""), bad.status());
+}
+
+TEST(StatusOr, TestPointerValue) {
+  const int kI = 0;
+  StatusOr<const int*> thing(&kI);
+  EXPECT_EQ(&kI, thing.value());
+}
+
+TEST(StatusOr, TestPointerValueConst) {
+  const int kI = 0;
+  const StatusOr<const int*> thing(&kI);
+  EXPECT_EQ(&kI, thing.value());
+}
+
+}  // namespace
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
abseil::StatusOr allows us return a result which is either a value or a status. This would simplify our code where we used to return status and result separately.  For more details see: https://abseil.io/docs/cpp/guides/status#returning-a-status-or-a-value

This PR introduce an earlier version of StatusOr with out fancy inner type conversion. from https://github.com/google-research/google-research/blob/master/eeg_modelling/edf/base/statusor.h

More unit tests needed for testing value().