### PR TITLE
[Client][Test] Avoid Port-Reuse to DeFlake

### DIFF
--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -31,6 +31,8 @@ def test_proxy_manager_lifecycle(shutdown_only):
     os.environ["TIMEOUT_FOR_SPECIFIC_SERVER_S"] = "5"
     pm = proxier.ProxyManager(ray_instance["redis_address"],
                               ray_instance["session_dir"])
+	# NOTE: We use different ports between runs because sometimes the port is
+    # not released, introducing flakiness.
     port_one, port_two = random.choices(range(45000, 45100), k=2)
     pm._free_ports = [port_one, port_two]
     client = "client1"

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -1,6 +1,7 @@
 import os
 import pickle
 import pytest
+import random
 import sys
 import time
 from unittest.mock import patch
@@ -30,7 +31,8 @@ def test_proxy_manager_lifecycle(shutdown_only):
     os.environ["TIMEOUT_FOR_SPECIFIC_SERVER_S"] = "5"
     pm = proxier.ProxyManager(ray_instance["redis_address"],
                               ray_instance["session_dir"])
-    pm._free_ports = [45000, 45001]
+    port_one, port_two =  random.choices(range(45000, 45100), k=2)
+    pm._free_ports = [port_one, port_two]
     client = "client1"
 
     pm.create_specific_server(client)
@@ -39,14 +41,14 @@ def test_proxy_manager_lifecycle(shutdown_only):
     grpc.channel_ready_future(pm.get_channel(client)).result(timeout=5)
 
     proc = pm._get_server_for_client(client)
-    assert proc.port == 45000
+    assert proc.port == port_one
 
     proc.process_handle_future.result().process.wait(10)
     # Wait for reconcile loop
     time.sleep(2)
 
     assert len(pm._free_ports) == 2
-    assert pm._get_unused_port() == 45001
+    assert pm._get_unused_port() == port_two
 
 
 @pytest.mark.skipif(

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -31,7 +31,7 @@ def test_proxy_manager_lifecycle(shutdown_only):
     os.environ["TIMEOUT_FOR_SPECIFIC_SERVER_S"] = "5"
     pm = proxier.ProxyManager(ray_instance["redis_address"],
                               ray_instance["session_dir"])
-    port_one, port_two =  random.choices(range(45000, 45100), k=2)
+    port_one, port_two = random.choices(range(45000, 45100), k=2)
     pm._free_ports = [port_one, port_two]
     client = "client1"
 

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -31,7 +31,7 @@ def test_proxy_manager_lifecycle(shutdown_only):
     os.environ["TIMEOUT_FOR_SPECIFIC_SERVER_S"] = "5"
     pm = proxier.ProxyManager(ray_instance["redis_address"],
                               ray_instance["session_dir"])
-	# NOTE: We use different ports between runs because sometimes the port is
+    # NOTE: We use different ports between runs because sometimes the port is
     # not released, introducing flakiness.
     port_one, port_two = random.choices(range(45000, 45100), k=2)
     pm._free_ports = [port_one, port_two]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes one of the failures that happened in the following 2 runs:
* Here: https://buildkite.com/ray-project/ray-builders-branch/builds/2025#6ce952fc-c98f-4ee3-b19f-110174b9cff9
* Here: https://buildkite.com/ray-project/ray-builders-branch/builds/2026#359a02df-7179-4302-a909-2c5ef00c7a39
* Avoids using the same port between tests!

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
