### PR TITLE
[kubernetes] Adding cpu limit to make ray helm chart working in environments which require set resource limits

### DIFF
--- a/deploy/charts/ray/templates/operator_cluster_scoped.yaml
+++ b/deploy/charts/ray/templates/operator_cluster_scoped.yaml
@@ -61,5 +61,5 @@ spec:
             memory: 1Gi
           limits:
             memory: 2Gi
-            cpu: 2
+            cpu: 1.1
 {{- end }}

--- a/deploy/charts/ray/templates/operator_cluster_scoped.yaml
+++ b/deploy/charts/ray/templates/operator_cluster_scoped.yaml
@@ -61,4 +61,5 @@ spec:
             memory: 1Gi
           limits:
             memory: 2Gi
+            cpu: 2
 {{- end }}

--- a/deploy/charts/ray/templates/operator_cluster_scoped.yaml
+++ b/deploy/charts/ray/templates/operator_cluster_scoped.yaml
@@ -61,5 +61,5 @@ spec:
             memory: 1Gi
           limits:
             memory: 2Gi
-            cpu: 1.1
+            cpu: 1
 {{- end }}

--- a/deploy/charts/ray/templates/operator_namespaced.yaml
+++ b/deploy/charts/ray/templates/operator_namespaced.yaml
@@ -62,6 +62,6 @@ spec:
             memory: 1Gi
           limits:
             memory: 2Gi
-            cpu: 2
+            cpu: 1.1
 {{- end }}
 

--- a/deploy/charts/ray/templates/operator_namespaced.yaml
+++ b/deploy/charts/ray/templates/operator_namespaced.yaml
@@ -62,6 +62,6 @@ spec:
             memory: 1Gi
           limits:
             memory: 2Gi
-            cpu: 1.1
+            cpu: 1
 {{- end }}
 

--- a/deploy/charts/ray/templates/operator_namespaced.yaml
+++ b/deploy/charts/ray/templates/operator_namespaced.yaml
@@ -62,5 +62,6 @@ spec:
             memory: 1Gi
           limits:
             memory: 2Gi
+            cpu: 2
 {{- end }}
 

--- a/deploy/components/operator_cluster_scoped.yaml
+++ b/deploy/components/operator_cluster_scoped.yaml
@@ -60,5 +60,5 @@ spec:
             memory: 1Gi
           limits:
             memory: 2Gi
-            cpu: 1.1
+            cpu: 1
 

--- a/deploy/components/operator_cluster_scoped.yaml
+++ b/deploy/components/operator_cluster_scoped.yaml
@@ -60,4 +60,5 @@ spec:
             memory: 1Gi
           limits:
             memory: 2Gi
+            cpu: 1.1
 

--- a/deploy/components/operator_namespaced.yaml
+++ b/deploy/components/operator_namespaced.yaml
@@ -61,5 +61,5 @@ spec:
             memory: 1Gi
           limits:
             memory: 2Gi
-            cpu: 1.1
+            cpu: 1
 

--- a/deploy/components/operator_namespaced.yaml
+++ b/deploy/components/operator_namespaced.yaml
@@ -61,4 +61,5 @@ spec:
             memory: 1Gi
           limits:
             memory: 2Gi
+            cpu: 1.1
 


### PR DESCRIPTION
## Why are these changes needed?
Adding cpu limit to make ray helm chart working in environments which require set resource limits. Otherwise the operator pod does not start.