### PR TITLE
Same worker id in python and c++ (try #2) 

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -991,6 +991,10 @@ cdef class CoreWorker:
             CCoreWorkerProcess.GetCoreWorker()
             .GetCurrentPlacementGroupId().Binary())
 
+    def get_worker_id(self):
+        return WorkerID(
+            CCoreWorkerProcess.GetCoreWorker().GetWorkerID().Binary())
+
     def should_capture_child_tasks_in_placement_group(self):
         return CCoreWorkerProcess.GetCoreWorker(
             ).ShouldCaptureChildTasksInPlacementGroup()

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -146,6 +146,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         CTaskID GetCurrentTaskId()
         CNodeID GetCurrentNodeId()
         CPlacementGroupID GetCurrentPlacementGroupId()
+        CWorkerID GetWorkerID()
         c_bool ShouldCaptureChildTasksInPlacementGroup()
         const CActorID &GetActorId()
         void SetActorTitle(const c_string &title)

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -1,6 +1,7 @@
 import os
-from collections import defaultdict
+from collections import defaultdict, Counter
 from pathlib import Path
+import re
 
 import ray
 from ray import ray_constants
@@ -141,6 +142,43 @@ def test_periodic_event_stats(shutdown_only):
             wait_for_condition(lambda: is_event_loop_stats_found(path))
         if "gcs_server.out" in str(path):
             wait_for_condition(lambda: is_event_loop_stats_found(path))
+
+
+def test_worker_id_names(shutdown_only):
+    ray.init(
+        num_cpus=1,
+        _system_config={
+            "event_stats_print_interval_ms": 100,
+            "event_stats": True
+        })
+    session_dir = ray.worker.global_worker.node.address_info["session_dir"]
+    session_path = Path(session_dir)
+    log_dir_path = session_path / "logs"
+
+    # Run the basic workload.
+    @ray.remote
+    def f():
+        print("hello")
+
+    ray.get(f.remote())
+
+    paths = list(log_dir_path.iterdir())
+
+    ids = []
+    for path in paths:
+        if "python-core-worker" in str(path):
+            pattern = ".*-([a-f0-9]*).*"
+        elif "worker" in str(path):
+            pattern = ".*worker-([a-f0-9]*)-.*-.*"
+        else:
+            continue
+        worker_id = re.match(pattern, str(path)).group(1)
+        ids.append(worker_id)
+    counts = Counter(ids).values()
+    for count in counts:
+        # There should be a "python-core-.*.log", "worker-.*.out",
+        # and "worker-.*.err"
+        assert count == 3
 
 
 if __name__ == "__main__":

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -52,7 +52,7 @@ from ray.exceptions import (
 from ray._private.function_manager import FunctionActorManager
 from ray._private.ray_logging import setup_logger
 from ray._private.ray_logging import global_worker_stdstream_dispatcher
-from ray._private.utils import _random_string, check_oversized_pickle
+from ray._private.utils import check_oversized_pickle
 from ray.util.inspect import is_cython
 from ray.experimental.internal_kv import _internal_kv_get, \
     _internal_kv_initialized
@@ -168,6 +168,10 @@ class Worker:
     @property
     def placement_group_id(self):
         return self.core_worker.get_placement_group_id()
+
+    @property
+    def worker_id(self):
+        return self.core_worker.get_worker_id().binary()
 
     @property
     def should_capture_child_tasks_in_placement_group(self):
@@ -1190,18 +1194,10 @@ def connect(node,
         # We should not specify the job_id if it's `WORKER_MODE`.
         assert job_id is None
         job_id = JobID.nil()
-        # TODO(qwang): Rename this to `worker_id_str` or type to `WorkerID`
-        worker.worker_id = _random_string()
     else:
         # This is the code path of driver mode.
         if job_id is None:
             job_id = ray.state.next_job_id()
-        # When tasks are executed on remote workers in the context of multiple
-        # drivers, the current job ID is used to keep track of which job is
-        # responsible for the task so that error messages will be propagated to
-        # the correct driver.
-        worker.worker_id = ray._private.utils.compute_driver_id_from_job(
-            job_id).binary()
 
     if mode is not SCRIPT_MODE and mode is not LOCAL_MODE and setproctitle:
         process_name = ray_constants.WORKER_PROCESS_TYPE_IDLE_WORKER


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR makes the log files for the C++ core worker, and corresponding python worker consistent. It makes the c++ worker the only place that generates worker ids. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #16127 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
