### PR TITLE
[Dataset] Adds JSON, CSV, Pandas, and Dask IO layers, and adds the write side of the Parquet IO layer.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -330,6 +330,7 @@
   conditions: ["RAY_CI_PYTHON_AFFECTED"]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
+    - DATA_PROCESSING_TESTING=1 ./ci/travis/install-dependencies.sh
     - bazel test --config=ci $(./scripts/bazel_export_options) python/ray/experimental/workflow/... python/ray/experimental/data/...
 
 - label: ":book: Doc tests and examples"

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -342,6 +342,11 @@ install_dependencies() {
     pip install -r "${WORKSPACE_DIR}"/python/requirements/tune/requirements_upstream.txt
   fi
 
+  # Data processing test dependencies.
+  if [ "${DATA_PROCESSING_TESTING-}" = 1 ] || [ "${DOC_TESTING-}" = 1 ]; then
+    pip install -r "${WORKSPACE_DIR}"/python/requirements/data_processing/requirements.txt
+  fi
+
   # Remove this entire section once Serve dependencies are fixed.
   if [ "${DOC_TESTING-}" != 1 ] && [ "${SGD_TESTING-}" != 1 ] && [ "${TUNE_TESTING-}" != 1 ] && [ "${RLLIB_TESTING-}" != 1 ]; then
     # If CI has deemed that a different version of Torch

--- a/python/ray/experimental/data/dataset.py
+++ b/python/ray/experimental/data/dataset.py
@@ -441,36 +441,6 @@ class Dataset(Generic[T]):
         # Block until writing is done.
         ray.get(refs)
 
-    def write_parquet_partitions(
-            self,
-            path: str,
-            partition_cols: List[str],
-            filesystem: Optional["pyarrow.fs.FileSystem"] = None) -> None:
-        """Write the dataset to parquet as a partitioned dataset, consisting of
-        multiple files.
-
-        This is only supported for datasets convertible to Arrow records.
-
-        Examples:
-            >>> ds.write_parquet_partitions(
-                    "s3://bucket/path", partition_cols=["foo", "bar"]))
-
-        Time complexity: O(dataset size / parallelism)
-
-        Args:
-            path: The root path to the parent directory in the filesystem to
-                write to.
-            partition_cols: Column names by which to partition the dataset.
-            filesystem: The filesystem implementation to write to.
-        """
-        import pyarrow as pa
-        import pyarrow.parquet as pq
-
-        table = pa.concat_tables(
-            [block._table for block in ray.get(self._blocks)])
-        pq.write_to_dataset(
-            table, path, partition_cols=partition_cols, filesystem=filesystem)
-
     def write_json(
             self,
             paths: Union[str, List[str]],

--- a/python/ray/experimental/data/dataset.py
+++ b/python/ray/experimental/data/dataset.py
@@ -440,6 +440,36 @@ class Dataset(Generic[T]):
         # Block until writing is done.
         ray.get(refs)
 
+    def write_parquet_partitions(
+            self, path: str, partition_cols: List[str],
+            filesystem: Optional["pyarrow.fs.FileSystem"] = None
+            ) -> None:
+        """Write the dataset to parquet as a partitioned dataset, consisting of
+        multiple files.
+
+        This is only supported for datasets convertible to Arrow records.
+
+        Examples:
+            >>> ds.write_parquet_partitions(
+                    "s3://bucket/path", partition_cols=["foo", "bar"]))
+
+        Time complexity: O(dataset size / parallelism)
+
+        Args:
+            path: The root path to the parent directory in the filesystem to
+                write to.
+            partition_cols: Column names by which to partition the dataset.
+            filesystem: The filesystem implementation to write to.
+        """
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        table = pa.concat_tables([
+            block._table for block in ray.get(self._blocks)])
+        pq.write_to_dataset(
+            table, path, partition_cols=partition_cols,
+            filesystem=filesystem)
+
     def write_json(self, paths: Union[str, List[str]],
                    filesystem: Optional["pyarrow.fs.FileSystem"] = None
                    ) -> None:

--- a/python/ray/experimental/data/dataset.py
+++ b/python/ray/experimental/data/dataset.py
@@ -435,48 +435,30 @@ class Dataset(Generic[T]):
 
     def write_json(
             self,
-            paths: Union[str, List[str]],
-            filesystem: Optional["pyarrow.fs.FileSystem"] = None) -> None:
+            path: str) -> None:
         """Write the dataset to json.
 
         This is only supported for datasets convertible to Arrow records.
 
         Examples:
-            # Write to a single file.
             >>> ds.write_json("s3://bucket/path")
-
-            # Write to multiple files.
-            >>> ds.write_json(["/path/to/file1", "/path/to/file2"])
 
         Time complexity: O(dataset size / parallelism)
 
         Args:
-            paths: A single file path or a list of file paths (or directories).
-            filesystem: The filesystem implementation to write to.
+            path: The path to the destination root directory, where Parquet
+                files will be written to..
         """
-        import pandas as pd
-        import numpy as np
-
-        if isinstance(paths, str):
-            paths = [paths]
-        elif (not isinstance(paths, list)
-              or any(not isinstance(p, str) for p in paths)):
-            raise ValueError(
-                "paths must be a path string or a list of path strings.")
-
         @ray.remote
-        def json_write(writer_path: str, *blocks: List[ArrowBlock]):
-            logger.debug(f"Writing {len(blocks)} blocks to {writer_path}.")
-            dfs = []
-            for block in blocks:
-                dfs.append(block.to_pandas())
-            pd.concat(dfs).to_json(writer_path, orient="records")
+        def json_write(write_path: str, block: ArrowBlock):
+            logger.debug(
+                f"Writing {block.num_rows()} records to {write_path}.")
+            block.to_pandas().to_json(write_path, orient="records")
 
         refs = [
-            json_write.remote(writer_path, *blocks)
-            for writer_path, blocks in zip(
-                paths, np.array_split(self._blocks, len(paths)))
-            if len(blocks) > 0
+            json_write.remote(
+                os.path.join(path, f"data{block_idx}.json"), block)
+            for block_idx, block in enumerate(self._blocks)
         ]
 
         # Block until writing is done.

--- a/python/ray/experimental/data/dataset.py
+++ b/python/ray/experimental/data/dataset.py
@@ -394,10 +394,10 @@ class Dataset(Generic[T]):
         """
         raise NotImplementedError  # P0
 
-    def write_parquet(
-            self,
-            path: str,
-            filesystem: Optional["pyarrow.fs.FileSystem"] = None) -> None:
+    def write_parquet(self,
+                      path: str,
+                      filesystem: Optional["pyarrow.fs.FileSystem"] = None
+                      ) -> None:
         """Write the dataset to parquet.
 
         This is only supported for datasets convertible to Arrow records.
@@ -417,8 +417,7 @@ class Dataset(Generic[T]):
         @ray.remote
         def parquet_write(write_path, block):
             print(f"Writing {block.num_rows()} records to {write_path}.")
-            with pq.ParquetWriter(write_path,
-                                  block._table.schema) as writer:
+            with pq.ParquetWriter(write_path, block._table.schema) as writer:
                 writer.write_table(block._table)
 
         refs = [

--- a/python/ray/experimental/data/dataset.py
+++ b/python/ray/experimental/data/dataset.py
@@ -1,6 +1,8 @@
 from typing import List, Any, Callable, Iterator, Generic, TypeVar, \
     Generator, Optional, Union, TYPE_CHECKING
 
+import os
+
 if TYPE_CHECKING:
     import pyarrow
     import pandas
@@ -394,48 +396,35 @@ class Dataset(Generic[T]):
 
     def write_parquet(
             self,
-            paths: Union[str, List[str]],
+            path: str,
             filesystem: Optional["pyarrow.fs.FileSystem"] = None) -> None:
         """Write the dataset to parquet.
 
         This is only supported for datasets convertible to Arrow records.
 
         Examples:
-            # Write to a single file.
             >>> ds.write_parquet("s3://bucket/path")
-
-            # Write to multiple files.
-            >>> ds.write_parquet(["/path/to/file1", "/path/to/file2"])
 
         Time complexity: O(dataset size / parallelism)
 
         Args:
-            paths: A single file path or a list of file paths (or directories).
+            path: The path to the destination root directory, where Parquet
+                files will be written to..
             filesystem: The filesystem implementation to write to.
         """
         import pyarrow.parquet as pq
-        import numpy as np
-
-        if isinstance(paths, str):
-            paths = [paths]
-        elif (not isinstance(paths, list)
-              or any(not isinstance(p, str) for p in paths)):
-            raise ValueError(
-                "paths must be a path string or a list of path strings.")
 
         @ray.remote
-        def parquet_write(writer_path, *blocks):
-            print(f"Writing {len(blocks)} blocks to {writer_path}.")
-            with pq.ParquetWriter(writer_path,
-                                  blocks[0]._table.schema) as writer:
-                for block in blocks:
-                    writer.write_table(block._table)
+        def parquet_write(write_path, block):
+            print(f"Writing {block.num_rows()} records to {write_path}.")
+            with pq.ParquetWriter(write_path,
+                                  block._table.schema) as writer:
+                writer.write_table(block._table)
 
         refs = [
-            parquet_write.remote(writer_path, *blocks)
-            for writer_path, blocks in zip(
-                paths, np.array_split(self._blocks, len(paths)))
-            if len(blocks) > 0
+            parquet_write.remote(
+                os.path.join(path, f"data{block_idx}.parquet"), block)
+            for block_idx, block in enumerate(self._blocks)
         ]
 
         # Block until writing is done.

--- a/python/ray/experimental/data/dataset.py
+++ b/python/ray/experimental/data/dataset.py
@@ -433,9 +433,7 @@ class Dataset(Generic[T]):
         # Block until writing is done.
         ray.get(refs)
 
-    def write_json(
-            self,
-            path: str) -> None:
+    def write_json(self, path: str) -> None:
         """Write the dataset to json.
 
         This is only supported for datasets convertible to Arrow records.
@@ -449,6 +447,7 @@ class Dataset(Generic[T]):
             path: The path to the destination root directory, where Parquet
                 files will be written to..
         """
+
         @ray.remote
         def json_write(write_path: str, block: ArrowBlock):
             logger.debug(
@@ -464,9 +463,7 @@ class Dataset(Generic[T]):
         # Block until writing is done.
         ray.get(refs)
 
-    def write_csv(
-            self,
-            path: str) -> None:
+    def write_csv(self, path: str) -> None:
         """Write the dataset to csv.
 
         This is only supported for datasets convertible to Arrow records.
@@ -480,6 +477,7 @@ class Dataset(Generic[T]):
             path: The path to the destination root directory, where Parquet
                 files will be written to..
         """
+
         @ray.remote
         def csv_write(write_path: str, block: ArrowBlock):
             logger.debug(

--- a/python/ray/experimental/data/dataset.py
+++ b/python/ray/experimental/data/dataset.py
@@ -685,7 +685,11 @@ class Dataset(Generic[T]):
         Returns:
             A list of remote Pandas dataframes created from this dataset.
         """
-        raise NotImplementedError  # P1
+        @ray.remote
+        def block_to_df(block):
+            return block._table.to_pandas()
+
+        return [block_to_df.remote(block) for block in self._blocks]
 
     def to_spark(self) -> "pyspark.sql.DataFrame":
         """Convert this dataset into a Spark dataframe.

--- a/python/ray/experimental/data/dataset.py
+++ b/python/ray/experimental/data/dataset.py
@@ -444,7 +444,7 @@ class Dataset(Generic[T]):
         Time complexity: O(dataset size / parallelism)
 
         Args:
-            path: The path to the destination root directory, where Parquet
+            path: The path to the destination root directory, where json
                 files will be written to..
         """
 
@@ -474,7 +474,7 @@ class Dataset(Generic[T]):
         Time complexity: O(dataset size / parallelism)
 
         Args:
-            path: The path to the destination root directory, where Parquet
+            path: The path to the destination root directory, where csv
                 files will be written to..
         """
 

--- a/python/ray/experimental/data/dataset.py
+++ b/python/ray/experimental/data/dataset.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Any, Callable, Iterator, Generic, TypeVar, \
     Generator, Optional, Union, TYPE_CHECKING
 
@@ -17,6 +18,8 @@ from ray.experimental.data.impl.shuffle import simple_shuffle
 from ray.experimental.data.impl.block import ObjectRef, Block, ListBlock
 from ray.experimental.data.impl.arrow_block import (
     DelegatingArrowBlockBuilder, ArrowBlock)
+
+logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -416,7 +419,8 @@ class Dataset(Generic[T]):
 
         @ray.remote
         def parquet_write(write_path, block):
-            print(f"Writing {block.num_rows()} records to {write_path}.")
+            logger.debug(
+                f"Writing {block.num_rows()} records to {write_path}.")
             with pq.ParquetWriter(write_path, block._table.schema) as writer:
                 writer.write_table(block._table)
 
@@ -462,7 +466,7 @@ class Dataset(Generic[T]):
 
         @ray.remote
         def json_write(writer_path: str, *blocks: List[ArrowBlock]):
-            print(f"Writing {len(blocks)} blocks to {writer_path}.")
+            logger.debug(f"Writing {len(blocks)} blocks to {writer_path}.")
             dfs = []
             for block in blocks:
                 dfs.append(block.to_pandas())
@@ -510,7 +514,7 @@ class Dataset(Generic[T]):
 
         @ray.remote
         def csv_write(writer_path: str, *blocks: List[ArrowBlock]):
-            print(f"Writing {len(blocks)} blocks to {writer_path}.")
+            logger.debug(f"Writing {len(blocks)} blocks to {writer_path}.")
             include_header = True
             for block in blocks:
                 block.to_pandas().to_csv(

--- a/python/ray/experimental/data/dataset.py
+++ b/python/ray/experimental/data/dataset.py
@@ -392,9 +392,10 @@ class Dataset(Generic[T]):
         """
         raise NotImplementedError  # P0
 
-    def write_parquet(self, paths: Union[str, List[str]],
-                      filesystem: Optional["pyarrow.fs.FileSystem"] = None
-                      ) -> None:
+    def write_parquet(
+            self,
+            paths: Union[str, List[str]],
+            filesystem: Optional["pyarrow.fs.FileSystem"] = None) -> None:
         """Write the dataset to parquet.
 
         This is only supported for datasets convertible to Arrow records.
@@ -417,17 +418,16 @@ class Dataset(Generic[T]):
 
         if isinstance(paths, str):
             paths = [paths]
-        elif (
-                not isinstance(paths, list) or
-                any(not isinstance(p, str) for p in paths)):
+        elif (not isinstance(paths, list)
+              or any(not isinstance(p, str) for p in paths)):
             raise ValueError(
                 "paths must be a path string or a list of path strings.")
 
         @ray.remote
         def parquet_write(writer_path, *blocks):
             print(f"Writing {len(blocks)} blocks to {writer_path}.")
-            with pq.ParquetWriter(
-                    writer_path, blocks[0]._table.schema) as writer:
+            with pq.ParquetWriter(writer_path,
+                                  blocks[0]._table.schema) as writer:
                 for block in blocks:
                     writer.write_table(block._table)
 
@@ -435,15 +435,17 @@ class Dataset(Generic[T]):
             parquet_write.remote(writer_path, *blocks)
             for writer_path, blocks in zip(
                 paths, np.array_split(self._blocks, len(paths)))
-            if len(blocks) > 0]
+            if len(blocks) > 0
+        ]
 
         # Block until writing is done.
         ray.get(refs)
 
     def write_parquet_partitions(
-            self, path: str, partition_cols: List[str],
-            filesystem: Optional["pyarrow.fs.FileSystem"] = None
-            ) -> None:
+            self,
+            path: str,
+            partition_cols: List[str],
+            filesystem: Optional["pyarrow.fs.FileSystem"] = None) -> None:
         """Write the dataset to parquet as a partitioned dataset, consisting of
         multiple files.
 
@@ -464,15 +466,15 @@ class Dataset(Generic[T]):
         import pyarrow as pa
         import pyarrow.parquet as pq
 
-        table = pa.concat_tables([
-            block._table for block in ray.get(self._blocks)])
+        table = pa.concat_tables(
+            [block._table for block in ray.get(self._blocks)])
         pq.write_to_dataset(
-            table, path, partition_cols=partition_cols,
-            filesystem=filesystem)
+            table, path, partition_cols=partition_cols, filesystem=filesystem)
 
-    def write_json(self, paths: Union[str, List[str]],
-                   filesystem: Optional["pyarrow.fs.FileSystem"] = None
-                   ) -> None:
+    def write_json(
+            self,
+            paths: Union[str, List[str]],
+            filesystem: Optional["pyarrow.fs.FileSystem"] = None) -> None:
         """Write the dataset to json.
 
         This is only supported for datasets convertible to Arrow records.
@@ -495,9 +497,8 @@ class Dataset(Generic[T]):
 
         if isinstance(paths, str):
             paths = [paths]
-        elif (
-                not isinstance(paths, list) or
-                any(not isinstance(p, str) for p in paths)):
+        elif (not isinstance(paths, list)
+              or any(not isinstance(p, str) for p in paths)):
             raise ValueError(
                 "paths must be a path string or a list of path strings.")
 
@@ -513,14 +514,16 @@ class Dataset(Generic[T]):
             json_write.remote(writer_path, *blocks)
             for writer_path, blocks in zip(
                 paths, np.array_split(self._blocks, len(paths)))
-            if len(blocks) > 0]
+            if len(blocks) > 0
+        ]
 
         # Block until writing is done.
         ray.get(refs)
 
-    def write_csv(self, paths: Union[str, List[str]],
-                  filesystem: Optional["pyarrow.fs.FileSystem"] = None
-                  ) -> None:
+    def write_csv(
+            self,
+            paths: Union[str, List[str]],
+            filesystem: Optional["pyarrow.fs.FileSystem"] = None) -> None:
         """Write the dataset to csv.
 
         This is only supported for datasets convertible to Arrow records.
@@ -542,9 +545,8 @@ class Dataset(Generic[T]):
 
         if isinstance(paths, str):
             paths = [paths]
-        elif (
-                not isinstance(paths, list) or
-                any(not isinstance(p, str) for p in paths)):
+        elif (not isinstance(paths, list)
+              or any(not isinstance(p, str) for p in paths)):
             raise ValueError(
                 "paths must be a path string or a list of path strings.")
 
@@ -561,7 +563,8 @@ class Dataset(Generic[T]):
             csv_write.remote(writer_path, *blocks)
             for writer_path, blocks in zip(
                 paths, np.array_split(self._blocks, len(paths)))
-            if len(blocks) > 0]
+            if len(blocks) > 0
+        ]
 
         # Block until writing is done.
         ray.get(refs)
@@ -685,6 +688,7 @@ class Dataset(Generic[T]):
         Returns:
             A list of remote Pandas dataframes created from this dataset.
         """
+
         @ray.remote
         def block_to_df(block):
             return block._table.to_pandas()

--- a/python/ray/experimental/data/dataset.py
+++ b/python/ray/experimental/data/dataset.py
@@ -595,6 +595,8 @@ class Dataset(Generic[T]):
     def to_dask(self) -> "dask.DataFrame":
         """Convert this dataset into a Dask DataFrame.
 
+        This is only supported for datasets convertible to Arrow records.
+
         Note that this function will set the Dask scheduler to Dask-on-Ray
         globally, via the config.
 
@@ -637,6 +639,8 @@ class Dataset(Generic[T]):
     def to_pandas(self) -> Iterator[ObjectRef["pandas.DataFrame"]]:
         """Convert this dataset into a set of Pandas dataframes.
 
+        This is only supported for datasets convertible to Arrow records.
+
         Time complexity: O(1)
 
         Returns:
@@ -644,7 +648,7 @@ class Dataset(Generic[T]):
         """
 
         @ray.remote
-        def block_to_df(block):
+        def block_to_df(block: ArrowBlock):
             return block._table.to_pandas()
 
         return [block_to_df.remote(block) for block in self._blocks]

--- a/python/ray/experimental/data/dataset.py
+++ b/python/ray/experimental/data/dataset.py
@@ -515,7 +515,7 @@ class Dataset(Generic[T]):
             include_header = True
             for block in blocks:
                 block.to_pandas().to_csv(
-                    writer_path, mode="a", header=include_header)
+                    writer_path, mode="a", header=include_header, index=False)
                 include_header = False
 
         refs = [

--- a/python/ray/experimental/data/read_api.py
+++ b/python/ray/experimental/data/read_api.py
@@ -26,9 +26,8 @@ def autoinit_ray(f):
     return wrapped
 
 
-def _resolve_paths_and_filesystem(
-        paths: Union[str, List[str]],
-        filesystem: "pyarrow.fs.FileSystem" = None):
+def _resolve_paths_and_filesystem(paths: Union[str, List[str]],
+                                  filesystem: "pyarrow.fs.FileSystem" = None):
     from pyarrow.fs import (FileType, FileSelector,
                             _resolve_filesystem_and_path)
 

--- a/python/ray/experimental/data/read_api.py
+++ b/python/ray/experimental/data/read_api.py
@@ -1,4 +1,5 @@
 import builtins
+import logging
 from typing import List, Any, Union, Optional, Tuple, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -12,6 +13,8 @@ import ray
 from ray.experimental.data.dataset import Dataset
 from ray.experimental.data.impl.block import ObjectRef, ListBlock, Block
 from ray.experimental.data.impl.arrow_block import ArrowBlock, ArrowRow
+
+logger = logging.getLogger(__name__)
 
 
 def autoinit_ray(f):
@@ -167,7 +170,7 @@ def read_parquet(paths: Union[str, List[str]],
 
     @ray.remote
     def gen_read(pieces: List[pq.ParquetDatasetPiece]):
-        print("Reading {} parquet pieces".format(len(pieces)))
+        logger.debug("Reading {} parquet pieces".format(len(pieces)))
         table = piece.read(
             columns=columns, use_threads=False, partitions=partitions)
         return ArrowBlock(table)
@@ -211,7 +214,7 @@ def read_json(paths: Union[str, List[str]],
 
     @ray.remote
     def json_read(reader_paths: List[str]):
-        print(f"Reading {len(reader_paths)} files.")
+        logger.debug(f"Reading {len(reader_paths)} files.")
         tables = []
         for p in reader_paths:
             tables.append(
@@ -264,7 +267,7 @@ def read_csv(paths: Union[str, List[str]],
 
     @ray.remote
     def csv_read(reader_paths: List[str]):
-        print(f"Reading {len(reader_paths)} files.")
+        logger.debug(f"Reading {len(reader_paths)} files.")
         tables = []
         for p in reader_paths:
             tables.append(

--- a/python/ray/experimental/data/read_api.py
+++ b/python/ray/experimental/data/read_api.py
@@ -358,7 +358,13 @@ def from_pandas(dfs: List[ObjectRef["pandas.DataFrame"]],
     Returns:
         Dataset holding Arrow records read from the dataframes.
     """
-    raise NotImplementedError  # P1
+    import pyarrow as pa
+
+    @ray.remote
+    def df_to_block(df):
+        return ArrowBlock(pa.table(df))
+
+    return Dataset([df_to_block.remote(df) for df in dfs])
 
 
 def from_spark(df: "pyspark.sql.DataFrame",

--- a/python/ray/experimental/data/read_api.py
+++ b/python/ray/experimental/data/read_api.py
@@ -210,7 +210,7 @@ def read_json(paths: Union[str, List[str]],
             "paths must be a path string or a list of path strings.")
 
     @ray.remote
-    def json_read(reader_paths):
+    def json_read(reader_paths: List[str]):
         print(f"Reading {len(reader_paths)} files.")
         tables = []
         for p in reader_paths:
@@ -263,7 +263,7 @@ def read_csv(paths: Union[str, List[str]],
             "paths must be a path string or a list of path strings.")
 
     @ray.remote
-    def csv_read(reader_paths):
+    def csv_read(reader_paths: List[str]):
         print(f"Reading {len(reader_paths)} files.")
         tables = []
         for p in reader_paths:
@@ -356,7 +356,7 @@ def from_pandas(dfs: List[ObjectRef["pandas.DataFrame"]],
     import pyarrow as pa
 
     @ray.remote
-    def df_to_block(df):
+    def df_to_block(df: "pandas.DataFrame"):
         return ArrowBlock(pa.table(df))
 
     return Dataset([df_to_block.remote(df) for df in dfs])

--- a/python/ray/experimental/data/read_api.py
+++ b/python/ray/experimental/data/read_api.py
@@ -202,8 +202,8 @@ def read_json(paths: Union[str, List[str]],
         Dataset holding Arrow records read from the specified paths.
     """
     import pyarrow as pa
-    from pyarrow.fs import (
-        FileType, FileSelector, _resolve_filesystem_and_path)
+    from pyarrow.fs import (FileType, FileSelector,
+                            _resolve_filesystem_and_path)
     from pyarrow import json
     import numpy as np
 
@@ -221,9 +221,8 @@ def read_json(paths: Union[str, List[str]],
     for path in paths:
         resolved_filesystem, resolved_path = _resolve_filesystem_and_path(
             path, filesystem)
-        if (
-                filesystem is not None and
-                type(resolved_filesystem) != type(filesystem)):
+        if (filesystem is not None
+                and type(resolved_filesystem) != type(filesystem)):
             raise ValueError("All paths must use same filesystem.")
         filesystem = resolved_filesystem
         resolved_path = filesystem.normalize_path(resolved_path)
@@ -295,8 +294,8 @@ def read_csv(paths: Union[str, List[str]],
         Dataset holding Arrow records read from the specified paths.
     """
     import pyarrow as pa
-    from pyarrow.fs import (
-        FileType, FileSelector, _resolve_filesystem_and_path)
+    from pyarrow.fs import (FileType, FileSelector,
+                            _resolve_filesystem_and_path)
     from pyarrow import csv
     import numpy as np
 
@@ -314,9 +313,8 @@ def read_csv(paths: Union[str, List[str]],
     for path in paths:
         resolved_filesystem, resolved_path = _resolve_filesystem_and_path(
             path, filesystem)
-        if (
-                filesystem is not None and
-                type(resolved_filesystem) != type(filesystem)):
+        if (filesystem is not None
+                and type(resolved_filesystem) != type(filesystem)):
             raise ValueError("All paths must use same filesystem.")
         filesystem = resolved_filesystem
         resolved_path = filesystem.normalize_path(resolved_path)

--- a/python/ray/experimental/data/read_api.py
+++ b/python/ray/experimental/data/read_api.py
@@ -198,7 +198,33 @@ def read_json(paths: Union[str, List[str]],
     Returns:
         Dataset holding Arrow records read from the specified paths.
     """
-    raise NotImplementedError  # P0
+    import pyarrow as pa
+    from pyarrow import json
+    import numpy as np
+
+    if isinstance(paths, str):
+        paths = [paths]
+    elif (
+            not isinstance(paths, list) or
+            any(not isinstance(p, str) for p in paths)):
+        raise ValueError(
+            "paths must be a path string or a list of path strings.")
+
+    @ray.remote
+    def json_read(reader_paths):
+        print(f"Reading {len(reader_paths)} files.")
+        tables = []
+        for p in reader_paths:
+            tables.append(
+                json.read_json(
+                    p, read_options=json.ReadOptions(use_threads=False),
+                    **arrow_json_args))
+        return ArrowBlock(pa.concat_tables(tables))
+
+    return Dataset([
+        json_read.remote(reader_paths)
+        for reader_paths in np.array_split(paths, parallelism)
+        if len(reader_paths) > 0])
 
 
 @autoinit_ray

--- a/python/ray/experimental/data/read_api.py
+++ b/python/ray/experimental/data/read_api.py
@@ -204,9 +204,8 @@ def read_json(paths: Union[str, List[str]],
 
     if isinstance(paths, str):
         paths = [paths]
-    elif (
-            not isinstance(paths, list) or
-            any(not isinstance(p, str) for p in paths)):
+    elif (not isinstance(paths, list)
+          or any(not isinstance(p, str) for p in paths)):
         raise ValueError(
             "paths must be a path string or a list of path strings.")
 
@@ -217,14 +216,16 @@ def read_json(paths: Union[str, List[str]],
         for p in reader_paths:
             tables.append(
                 json.read_json(
-                    p, read_options=json.ReadOptions(use_threads=False),
+                    p,
+                    read_options=json.ReadOptions(use_threads=False),
                     **arrow_json_args))
         return ArrowBlock(pa.concat_tables(tables))
 
     return Dataset([
         json_read.remote(reader_paths)
         for reader_paths in np.array_split(paths, parallelism)
-        if len(reader_paths) > 0])
+        if len(reader_paths) > 0
+    ])
 
 
 @autoinit_ray
@@ -256,9 +257,8 @@ def read_csv(paths: Union[str, List[str]],
 
     if isinstance(paths, str):
         paths = [paths]
-    elif (
-            not isinstance(paths, list) or
-            any(not isinstance(p, str) for p in paths)):
+    elif (not isinstance(paths, list)
+          or any(not isinstance(p, str) for p in paths)):
         raise ValueError(
             "paths must be a path string or a list of path strings.")
 
@@ -269,14 +269,16 @@ def read_csv(paths: Union[str, List[str]],
         for p in reader_paths:
             tables.append(
                 csv.read_csv(
-                    p, read_options=csv.ReadOptions(use_threads=False),
+                    p,
+                    read_options=csv.ReadOptions(use_threads=False),
                     **arrow_csv_args))
         return ArrowBlock(pa.concat_tables(tables))
 
     return Dataset([
         csv_read.remote(reader_paths)
         for reader_paths in np.array_split(paths, parallelism)
-        if len(reader_paths) > 0])
+        if len(reader_paths) > 0
+    ])
 
 
 @autoinit_ray
@@ -322,8 +324,8 @@ def from_dask(df: "dask.DataFrame") -> Dataset[ArrowRow]:
 
     partitions = df.to_delayed()
     persisted_partitions = dask.persist(*partitions, scheduler=ray_dask_get)
-    return from_pandas([
-        next(iter(part.dask.values())) for part in persisted_partitions])
+    return from_pandas(
+        [next(iter(part.dask.values())) for part in persisted_partitions])
 
 
 def from_modin(df: "modin.DataFrame",

--- a/python/ray/experimental/data/tests/test_dataset.py
+++ b/python/ray/experimental/data/tests/test_dataset.py
@@ -228,6 +228,21 @@ def test_to_dask(ray_start_regular_shared):
 
 
 def test_json_read(ray_start_regular_shared, tmp_path):
+    # Directory, two files.
+    path = os.path.join(tmp_path, "test_json_dir")
+    os.mkdir(path)
+    df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    path1 = os.path.join(path, "data0.json")
+    df1.to_json(path1, orient="records", lines=True)
+    df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
+    path2 = os.path.join(path, "data1.json")
+    df2.to_json(path2, orient="records", lines=True)
+    ds = ray.experimental.data.read_json(path)
+    df = pd.concat([df1, df2])
+    dsdf = pd.concat(ray.get(ds.to_pandas()))
+    assert df.equals(dsdf)
+    shutil.rmtree(path)
+
     # Single file.
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
     path1 = os.path.join(tmp_path, "test1.json")
@@ -278,6 +293,21 @@ def test_json_write(ray_start_regular_shared, tmp_path):
 
 
 def test_csv_read(ray_start_regular_shared, tmp_path):
+    # Directory, two files.
+    path = os.path.join(tmp_path, "test_csv_dir")
+    os.mkdir(path)
+    df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    path1 = os.path.join(path, "data0.csv")
+    df1.to_csv(path1, index=False)
+    df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
+    path2 = os.path.join(path, "data1.csv")
+    df2.to_csv(path2, index=False)
+    ds = ray.experimental.data.read_csv(path)
+    df = pd.concat([df1, df2])
+    dsdf = pd.concat(ray.get(ds.to_pandas()))
+    assert df.equals(dsdf)
+    shutil.rmtree(path)
+
     # Single file.
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
     path1 = os.path.join(tmp_path, "test1.csv")

--- a/python/ray/experimental/data/tests/test_dataset.py
+++ b/python/ray/experimental/data/tests/test_dataset.py
@@ -266,21 +266,21 @@ def test_json_write(ray_start_regular_shared, tmp_path):
     ds = ray.experimental.data.from_pandas([ray.put(df1), ray.put(df2)])
     path2 = os.path.join(tmp_path, "test2.json")
     ds.write_json([path1, path2])
-    assert pd.concat([
-        df1, df2]).equals(
-            pd.concat([pd.read_json(path1), pd.read_json(path2)]))
+    assert pd.concat([df1, df2]).equals(
+        pd.concat([pd.read_json(path1),
+                   pd.read_json(path2)]))
     os.remove(path1)
     os.remove(path2)
 
     # Three blocks, two files.
     df3 = pd.DataFrame({"one": [7, 8, 9], "two": ["h", "i", "j"]})
-    ds = ray.experimental.data.from_pandas([
-        ray.put(df1), ray.put(df2), ray.put(df3)])
+    ds = ray.experimental.data.from_pandas(
+        [ray.put(df1), ray.put(df2), ray.put(df3)])
     ds.write_json([path1, path2])
-    assert pd.concat([
-        df1, df2, df3], ignore_index=True).equals(
-            pd.concat([pd.read_json(path1), pd.read_json(path2)],
-                      ignore_index=True))
+    assert pd.concat(
+        [df1, df2, df3], ignore_index=True).equals(
+            pd.concat(
+                [pd.read_json(path1), pd.read_json(path2)], ignore_index=True))
     os.remove(path1)
     os.remove(path2)
 
@@ -291,10 +291,9 @@ def test_json_write(ray_start_regular_shared, tmp_path):
     # path3 should never be written since there are only 2 blocks.
     with pytest.raises(ValueError):
         pd.read_json(path3)
-    assert pd.concat([
-        df1, df2]).equals(
-            pd.concat([
-                pd.read_json(path1), pd.read_json(path2)]))
+    assert pd.concat([df1, df2]).equals(
+        pd.concat([pd.read_json(path1),
+                   pd.read_json(path2)]))
     os.remove(path1)
     os.remove(path2)
 
@@ -350,8 +349,8 @@ def test_csv_write(ray_start_regular_shared, tmp_path):
 
     # Three blocks, two files.
     df3 = pd.DataFrame({"one": [7, 8, 9], "two": ["h", "i", "j"]})
-    ds = ray.experimental.data.from_pandas([
-        ray.put(df1), ray.put(df2), ray.put(df3)])
+    ds = ray.experimental.data.from_pandas(
+        [ray.put(df1), ray.put(df2), ray.put(df3)])
     ds.write_csv([path1, path2])
     df = pd.concat([df1, df2, df3], ignore_index=True)
     dsdf = pd.concat(

--- a/python/ray/experimental/data/tests/test_dataset.py
+++ b/python/ray/experimental/data/tests/test_dataset.py
@@ -228,21 +228,6 @@ def test_to_dask(ray_start_regular_shared):
 
 
 def test_json_read(ray_start_regular_shared, tmp_path):
-    # Directory, two files.
-    path = os.path.join(tmp_path, "test_json_dir")
-    os.mkdir(path)
-    df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
-    path1 = os.path.join(path, "data0.json")
-    df1.to_json(path1, orient="records", lines=True)
-    df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
-    path2 = os.path.join(path, "data1.json")
-    df2.to_json(path2, orient="records", lines=True)
-    ds = ray.experimental.data.read_json(path)
-    df = pd.concat([df1, df2])
-    dsdf = pd.concat(ray.get(ds.to_pandas()))
-    assert df.equals(dsdf)
-    shutil.rmtree(path)
-
     # Single file.
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
     path1 = os.path.join(tmp_path, "test1.json")
@@ -266,6 +251,57 @@ def test_json_read(ray_start_regular_shared, tmp_path):
     ds = ray.experimental.data.read_json([path1, path2, path3], parallelism=2)
     dsdf = pd.concat(ray.get(ds.to_pandas()), ignore_index=True)
     assert df.equals(dsdf)
+
+    # Directory, two files.
+    path = os.path.join(tmp_path, "test_json_dir")
+    os.mkdir(path)
+    df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    path1 = os.path.join(path, "data0.json")
+    df1.to_json(path1, orient="records", lines=True)
+    df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
+    path2 = os.path.join(path, "data1.json")
+    df2.to_json(path2, orient="records", lines=True)
+    ds = ray.experimental.data.read_json(path)
+    df = pd.concat([df1, df2])
+    dsdf = pd.concat(ray.get(ds.to_pandas()))
+    assert df.equals(dsdf)
+    shutil.rmtree(path)
+
+    # Two directories, three files.
+    path1 = os.path.join(tmp_path, "test_json_dir1")
+    path2 = os.path.join(tmp_path, "test_json_dir2")
+    os.mkdir(path1)
+    os.mkdir(path2)
+    df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    file_path1 = os.path.join(path1, "data0.json")
+    df1.to_json(file_path1, orient="records", lines=True)
+    df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
+    file_path2 = os.path.join(path2, "data1.json")
+    df2.to_json(file_path2, orient="records", lines=True)
+    df3 = pd.DataFrame({"one": [7, 8, 9], "two": ["h", "i", "j"]})
+    file_path3 = os.path.join(path2, "data2.json")
+    df3.to_json(file_path3, orient="records", lines=True)
+    ds = ray.experimental.data.read_json([path1, path2])
+    df = pd.concat([df1, df2, df3])
+    dsdf = pd.concat(ray.get(ds.to_pandas()))
+    assert df.equals(dsdf)
+    shutil.rmtree(path1)
+    shutil.rmtree(path2)
+
+    # Directory and file, two files.
+    dir_path = os.path.join(tmp_path, "test_json_dir")
+    os.mkdir(dir_path)
+    df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    path1 = os.path.join(dir_path, "data0.json")
+    df1.to_json(path1, orient="records", lines=True)
+    df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
+    path2 = os.path.join(tmp_path, "data1.json")
+    df2.to_json(path2, orient="records", lines=True)
+    ds = ray.experimental.data.read_json([dir_path, path2])
+    df = pd.concat([df1, df2])
+    dsdf = pd.concat(ray.get(ds.to_pandas()))
+    assert df.equals(dsdf)
+    shutil.rmtree(dir_path)
 
 
 def test_json_write(ray_start_regular_shared, tmp_path):
@@ -293,21 +329,6 @@ def test_json_write(ray_start_regular_shared, tmp_path):
 
 
 def test_csv_read(ray_start_regular_shared, tmp_path):
-    # Directory, two files.
-    path = os.path.join(tmp_path, "test_csv_dir")
-    os.mkdir(path)
-    df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
-    path1 = os.path.join(path, "data0.csv")
-    df1.to_csv(path1, index=False)
-    df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
-    path2 = os.path.join(path, "data1.csv")
-    df2.to_csv(path2, index=False)
-    ds = ray.experimental.data.read_csv(path)
-    df = pd.concat([df1, df2])
-    dsdf = pd.concat(ray.get(ds.to_pandas()))
-    assert df.equals(dsdf)
-    shutil.rmtree(path)
-
     # Single file.
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
     path1 = os.path.join(tmp_path, "test1.csv")
@@ -333,6 +354,57 @@ def test_csv_read(ray_start_regular_shared, tmp_path):
     df = pd.concat([df1, df2, df3], ignore_index=True)
     dsdf = pd.concat(ray.get(ds.to_pandas()), ignore_index=True)
     assert df.equals(dsdf)
+
+    # Directory, two files.
+    path = os.path.join(tmp_path, "test_csv_dir")
+    os.mkdir(path)
+    df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    path1 = os.path.join(path, "data0.csv")
+    df1.to_csv(path1, index=False)
+    df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
+    path2 = os.path.join(path, "data1.csv")
+    df2.to_csv(path2, index=False)
+    ds = ray.experimental.data.read_csv(path)
+    df = pd.concat([df1, df2])
+    dsdf = pd.concat(ray.get(ds.to_pandas()))
+    assert df.equals(dsdf)
+    shutil.rmtree(path)
+
+    # Two directories, three files.
+    path1 = os.path.join(tmp_path, "test_csv_dir1")
+    path2 = os.path.join(tmp_path, "test_csv_dir2")
+    os.mkdir(path1)
+    os.mkdir(path2)
+    df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    file_path1 = os.path.join(path1, "data0.csv")
+    df1.to_csv(file_path1, index=False)
+    df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
+    file_path2 = os.path.join(path2, "data1.csv")
+    df2.to_csv(file_path2, index=False)
+    df3 = pd.DataFrame({"one": [7, 8, 9], "two": ["h", "i", "j"]})
+    file_path3 = os.path.join(path2, "data2.csv")
+    df3.to_csv(file_path3, index=False)
+    ds = ray.experimental.data.read_csv([path1, path2])
+    df = pd.concat([df1, df2, df3])
+    dsdf = pd.concat(ray.get(ds.to_pandas()))
+    assert df.equals(dsdf)
+    shutil.rmtree(path1)
+    shutil.rmtree(path2)
+
+    # Directory and file, two files.
+    dir_path = os.path.join(tmp_path, "test_csv_dir")
+    os.mkdir(dir_path)
+    df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    path1 = os.path.join(dir_path, "data0.csv")
+    df1.to_csv(path1, index=False)
+    df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
+    path2 = os.path.join(tmp_path, "data1.csv")
+    df2.to_csv(path2, index=False)
+    ds = ray.experimental.data.read_csv([dir_path, path2])
+    df = pd.concat([df1, df2])
+    dsdf = pd.concat(ray.get(ds.to_pandas()))
+    assert df.equals(dsdf)
+    shutil.rmtree(dir_path)
 
 
 def test_csv_write(ray_start_regular_shared, tmp_path):

--- a/python/requirements/data_processing/requirements.txt
+++ b/python/requirements/data_processing/requirements.txt
@@ -1,0 +1,2 @@
+dask[complete]==2021.03.0; python_version < '3.7'
+dask[complete]==2021.06.1; python_version >= '3.7'


### PR DESCRIPTION
Adds read/write APIs for JSON, CSV, Pandas, and Dask, and adds write and write_partitions APIs for Parquet. Opted for simplicity over performance for the MVP, so there are sure to be a few spots of needless memory hogging that we can optimize away later.

## TODOs

- [x] Add tests to test suite.
- [x] Decide whether or not to keep `write_parquet_partitions`.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
