### PR TITLE
[Dataset] Miscellaneous hotfixes.

### DIFF
--- a/python/ray/experimental/data/impl/arrow_block.py
+++ b/python/ray/experimental/data/impl/arrow_block.py
@@ -29,7 +29,7 @@ class ArrowRow:
         return self.as_pydict().values()
 
     def items(self) -> Iterator[Tuple[str, Any]]:
-        return self.as_pydict().keys()
+        return self.as_pydict().items()
 
     def __getitem__(self, key: str) -> Any:
         return self._row[key][0].as_py()

--- a/python/ray/experimental/data/impl/block.py
+++ b/python/ray/experimental/data/impl/block.py
@@ -60,7 +60,7 @@ class ListBlock(Block):
         return len(self._items)
 
     def iter_rows(self) -> Iterator[T]:
-        return self._items.__iter__()
+        return iter(self._items)
 
     def slice(self, start: int, end: int) -> "ListBlock[T]":
         return ListBlock(self._items[start:end])

--- a/python/ray/experimental/data/read_api.py
+++ b/python/ray/experimental/data/read_api.py
@@ -17,7 +17,7 @@ from ray.experimental.data.impl.arrow_block import ArrowBlock, ArrowRow
 def autoinit_ray(f):
     def wrapped(*a, **kw):
         if not ray.is_initialized():
-            ray.client.connect()
+            ray.client().connect()
         return f(*a, **kw)
 
     return wrapped

--- a/python/ray/experimental/data/read_api.py
+++ b/python/ray/experimental/data/read_api.py
@@ -146,6 +146,7 @@ def read_parquet(paths: Union[str, List[str]],
         Dataset holding Arrow records read from the specified paths.
     """
     import pyarrow.parquet as pq
+    import numpy as np
 
     pq_ds = pq.ParquetDataset(paths, **arrow_parquet_args)
     pieces = pq_ds.pieces
@@ -159,10 +160,6 @@ def read_parquet(paths: Union[str, List[str]],
                                        piece.file_options, i,
                                        piece.partition_keys))
 
-    read_tasks = [[] for _ in builtins.range(parallelism)]
-    for i, piece in enumerate(pieces):
-        read_tasks[i].append(piece)
-    nonempty_tasks = [r for r in read_tasks if r]
     partitions = pq_ds.partitions
 
     @ray.remote
@@ -172,7 +169,10 @@ def read_parquet(paths: Union[str, List[str]],
             columns=columns, use_threads=False, partitions=partitions)
         return ArrowBlock(table)
 
-    return Dataset([gen_read.remote(ps) for ps in nonempty_tasks])
+    return Dataset([
+        gen_read.remote(ps)
+        for ps in np.array_split(pieces, parallelism)
+        if len(ps) > 0])
 
 
 @autoinit_ray

--- a/python/ray/experimental/data/read_api.py
+++ b/python/ray/experimental/data/read_api.py
@@ -170,9 +170,9 @@ def read_parquet(paths: Union[str, List[str]],
         return ArrowBlock(table)
 
     return Dataset([
-        gen_read.remote(ps)
-        for ps in np.array_split(pieces, parallelism)
-        if len(ps) > 0])
+        gen_read.remote(ps) for ps in np.array_split(pieces, parallelism)
+        if len(ps) > 0
+    ])
 
 
 @autoinit_ray


### PR DESCRIPTION
Some minor misc. hotfixes:

- Fix Ray Client autoinit hook (`ray.client.connect()` --> `ray.client().connect()`).
- Fix `parallelism > len(pieces)` case in `read_parquet`.
- Fix `ArrowRow.items()` so it returns `.items()` instead of `.keys()`.
- `foo.__iter__()` --> `iter(foo)`.