### PR TITLE
[Client] Keep client_mode for `dumps_from_client`

### DIFF
--- a/python/ray/util/client/client_pickler.py
+++ b/python/ray/util/client/client_pickler.py
@@ -150,11 +150,10 @@ class ServerUnpickler(pickle.Unpickler):
 
 
 def dumps_from_client(obj: Any, client_id: str, protocol=None) -> bytes:
-    with disable_client_hook():
-        with io.BytesIO() as file:
-            cp = ClientPickler(client_id, file, protocol=protocol)
-            cp.dump(obj)
-            return file.getvalue()
+    with io.BytesIO() as file:
+        cp = ClientPickler(client_id, file, protocol=protocol)
+        cp.dump(obj)
+        return file.getvalue()
 
 
 def loads_from_server(data: bytes,

--- a/python/ray/util/client/client_pickler.py
+++ b/python/ray/util/client/client_pickler.py
@@ -40,7 +40,6 @@ from ray.util.client.common import ClientRemoteMethod
 from ray.util.client.common import OptionWrapper
 from ray.util.client.common import InProgressSentinel
 import ray.core.generated.ray_client_pb2 as ray_client_pb2
-from ray._private.client_mode_hook import disable_client_hook
 
 if sys.version_info < (3, 8):
     try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* If libraries use the Ray API in a serialization hook, it will fail because it is run without client mode (meaning that Ray is not initialized). This is specifically a problem for serializing something on the client side.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/16733

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
