### PR TITLE
[cli] use shutil.move in `ray cluster-dump` and allow passing of tempfile

### DIFF
--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import random
+import shutil
 import sys
 import subprocess
 import tempfile
@@ -1175,7 +1176,8 @@ def get_local_dump_archive(stream: bool = False,
                            debug_state: bool = True,
                            pip: bool = True,
                            processes: bool = True,
-                           processes_verbose: bool = False) -> Optional[str]:
+                           processes_verbose: bool = False,
+                           tempfile: Optional[str] = None) -> Optional[str]:
     if stream and output:
         raise ValueError(
             "You can only use either `--output` or `--stream`, but not both.")
@@ -1187,7 +1189,7 @@ def get_local_dump_archive(stream: bool = False,
         processes=processes,
         processes_verbose=processes_verbose)
 
-    with Archive() as archive:
+    with Archive(file=tempfile) as archive:
         get_all_local_data(archive, parameters)
 
     tmp = archive.file
@@ -1199,7 +1201,7 @@ def get_local_dump_archive(stream: bool = False,
         return None
 
     target = output or os.path.join(os.getcwd(), os.path.basename(tmp))
-    os.rename(tmp, target)
+    shutil.move(tmp, target)
     cli_logger.print(f"Created local data archive at {target}")
 
     return target
@@ -1216,7 +1218,8 @@ def get_cluster_dump_archive(cluster_config_file: Optional[str] = None,
                              debug_state: bool = True,
                              pip: bool = True,
                              processes: bool = True,
-                             processes_verbose: bool = False) -> Optional[str]:
+                             processes_verbose: bool = False,
+                             tempfile: Optional[str] = None) -> Optional[str]:
 
     # Inform the user what kind of logs are collected (before actually
     # collecting, so they can abort)
@@ -1281,7 +1284,7 @@ def get_cluster_dump_archive(cluster_config_file: Optional[str] = None,
         processes=processes,
         processes_verbose=processes_verbose)
 
-    with Archive() as archive:
+    with Archive(file=tempfile) as archive:
         if local:
             create_archive_for_local_and_remote_nodes(
                 archive, remote_nodes=nodes, parameters=parameters)
@@ -1300,7 +1303,7 @@ def get_cluster_dump_archive(cluster_config_file: Optional[str] = None,
     else:
         output = os.path.expanduser(output)
 
-    os.rename(archive.file, output)
+    shutil.move(archive.file, output)
     return output
 
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1510,13 +1510,21 @@ def status(address, redis_password):
     is_flag=True,
     default=True,
     help="Increase process information verbosity")
+@click.option(
+    "--tempfile",
+    "-T",
+    required=False,
+    type=str,
+    default=None,
+    help="Temporary file to use")
 def local_dump(stream: bool = False,
                output: Optional[str] = None,
                logs: bool = True,
                debug_state: bool = True,
                pip: bool = True,
                processes: bool = True,
-               processes_verbose: bool = False):
+               processes_verbose: bool = False,
+               tempfile: Optional[str] = None):
     """Collect local data and package into an archive.
 
     Usage:
@@ -1533,7 +1541,8 @@ def local_dump(stream: bool = False,
         debug_state=debug_state,
         pip=pip,
         processes=processes,
-        processes_verbose=processes_verbose)
+        processes_verbose=processes_verbose,
+        tempfile=tempfile)
 
 
 @cli.command()
@@ -1605,6 +1614,13 @@ def local_dump(stream: bool = False,
     is_flag=True,
     default=True,
     help="Increase process information verbosity")
+@click.option(
+    "--tempfile",
+    "-T",
+    required=False,
+    type=str,
+    default=None,
+    help="Temporary file to use")
 def cluster_dump(cluster_config_file: Optional[str] = None,
                  host: Optional[str] = None,
                  ssh_user: Optional[str] = None,
@@ -1616,7 +1632,8 @@ def cluster_dump(cluster_config_file: Optional[str] = None,
                  debug_state: bool = True,
                  pip: bool = True,
                  processes: bool = True,
-                 processes_verbose: bool = False):
+                 processes_verbose: bool = False,
+                 tempfile: Optional[str] = None):
     """Get log data from one or more nodes.
 
     Best used with Ray cluster configs:
@@ -1643,7 +1660,8 @@ def cluster_dump(cluster_config_file: Optional[str] = None,
         debug_state=debug_state,
         pip=pip,
         processes=processes,
-        processes_verbose=processes_verbose)
+        processes_verbose=processes_verbose,
+        tempfile=tempfile)
     if archive_path:
         click.echo(f"Created archive: {archive_path}")
     else:


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When directories are on different devices (e.g. `/tmp` on local hard disk and the current working directory on NFS), `cluster-dump` can run into this problem:

```
OSError: [Errno 18] Invalid cross-device link: '/tmp/ray_logs_0tcd81or.tar.gz' -> '/home/user/ray_config/collected_logs_2021-06-28_08-19-47.tar.gz
```

This is due to usage of `os.rename()`. This PR replaces `os.rename()` by `shutil.move()` (which checks for devices and uses copy/remove for cross file renames). Also, this PR allows specifying a temporary file to use.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
