### PR TITLE
[Serve] Copy FastAPI ResponseModel field

### DIFF
--- a/python/ray/serve/http_util.py
+++ b/python/ray/serve/http_util.py
@@ -173,6 +173,17 @@ def make_fastapi_class_based_view(fastapi_app, cls: Type) -> None:
         if isinstance(route, APIRoute) and route.endpoint in member_methods
     ]
 
+    # If there is a response model, FastAPI creates a copy of the fields.
+    # But FastAPI creates the field incorrectly by missing the outer_type_.
+    for route in fastapi_app.routes:
+        if isinstance(route, APIRoute) and route.response_model:
+            original_resp_fields = (
+                route.response_field.outer_type_.__fields__)
+            cloned_resp_fields = (
+                route.secure_cloned_response_field.outer_type_.__fields__)
+            for key, field in cloned_resp_fields.items():
+                field.outer_type_ = original_resp_fields[key].outer_type_
+
     # Modify these routes and mount it to a new APIRouter.
     # We need to to this (instead of modifying in place) because we want to use
     # the laster fastapi_app.include_router to re-run the dependency analysis

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -5,6 +5,7 @@ import tempfile
 
 import pytest
 import inspect
+from ray.serve.utils import ensure_serialization_context
 import requests
 from fastapi import (Cookie, Depends, FastAPI, Header, Query, Request,
                      APIRouter, BackgroundTasks, Response)
@@ -465,6 +466,29 @@ def test_fastapi_multiple_headers(serve_instance):
 
     resp = requests.get("http://localhost:8000/f")
     assert resp.cookies.get_dict() == {"a": "b", "c": "d"}
+
+
+def test_fastapi_nested_field_in_response_model(serve_instance):
+    # https://github.com/ray-project/ray/issues/16757
+    class TestModel(BaseModel):
+        a: str
+        b: List[str]
+
+    app = FastAPI()
+
+    @app.get("/", response_model=TestModel)
+    def test_endpoint():
+        test_model = TestModel(a="a", b=["b"])
+        return test_model
+
+    @serve.deployment(route_prefix="/")
+    @serve.ingress(app)
+    class TestDeployment:
+        pass
+
+    TestDeployment.deploy()
+    resp = requests.get("http://localhost:8000/")
+    assert resp.json() == {"a": "a", "b": ["b"]}
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -5,7 +5,6 @@ import tempfile
 
 import pytest
 import inspect
-from ray.serve.utils import ensure_serialization_context
 import requests
 from fastapi import (Cookie, Depends, FastAPI, Header, Query, Request,
                      APIRouter, BackgroundTasks, Response)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
It turns out when you specify a response model for FastAPI, FastAPI [makes a copy](https://github.com/tiangolo/fastapi/blob/fa7e3c996edf2d5482fff8f9d890ac2390dede4d/fastapi/routing.py#L332-L349
) of that pydantic model. But when it's copying it, it [missed](https://github.com/tiangolo/fastapi/blob/fa7e3c996edf2d5482fff8f9d890ac2390dede4d/fastapi/utils.py#L72) the outer_type_ parameter. The missed parameter has no effect when you are using it in process but it is not compatible with how we serialize and copy pydantic fields in the serialization addons.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #16757
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
