### PR TITLE
[autoscaler] GPU=0 resource tweak

### DIFF
--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -11,7 +11,7 @@ import copy
 import numpy as np
 import logging
 import collections
-from numbers import Number
+from numbers import Real
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -37,7 +37,7 @@ NodeType = str
 NodeTypeConfigDict = str
 
 # e.g., {"GPU": 1}.
-ResourceDict = Dict[str, Number]
+ResourceDict = Dict[str, Real]
 
 # e.g., "node-1".
 NodeID = str
@@ -737,7 +737,7 @@ def get_nodes_for(node_types: Dict[NodeType, NodeTypeConfigDict],
 def _utilization_score(node_resources: ResourceDict,
                        resources: List[ResourceDict]) -> Optional[float]:
     remaining = copy.deepcopy(node_resources)
-    is_gpu_node = "GPU" in node_resources and node_resources["GPU"] != 0
+    is_gpu_node = "GPU" in node_resources and node_resources["GPU"] > 0
     any_gpu_task = any("GPU" in r for r in resources)
 
     # Avoid launching GPU nodes if there aren't any GPU tasks at all. Note that

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -737,7 +737,7 @@ def get_nodes_for(node_types: Dict[NodeType, NodeTypeConfigDict],
 def _utilization_score(node_resources: ResourceDict,
                        resources: List[ResourceDict]) -> Optional[float]:
     remaining = copy.deepcopy(node_resources)
-    is_gpu_node = "GPU" in node_resources
+    is_gpu_node = "GPU" in node_resources and node_resources["GPU"] != 0
     any_gpu_task = any("GPU" in r for r in resources)
 
     # Avoid launching GPU nodes if there aren't any GPU tasks at all. Note that


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Kind of a follow-up to https://github.com/ray-project/ray/pull/14024.
If a user supplies a GPU=0 ray resource annotation, in cluster config or helm chart, we shouldn't consider the node to be a GPU node in the resource demand scheduler.

Fixes the configuration/scaling bug described in bullet 1 here:
https://github.com/ray-project/ray/issues/16549#issue-925165455

Did a quick manual check on k8s to verify the fix.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
