### PR TITLE
[docs] Note that ordering of objects returned is preserved for ray.get.

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1447,6 +1447,10 @@ def get(object_refs, *, timeout=None):
     object has been created). If object_refs is a list, then the objects
     corresponding to each object in the list will be returned.
 
+    Ordering for an input list of object refs is preserved for each object
+    returned. That is, if an object ref to A precedes an object ref to B in the
+    input list, then A will precede B in the returned list.
+
     This method will issue a warning if it's running inside async context,
     you can use ``await object_ref`` instead of ``ray.get(object_ref)``. For
     a list of object refs, you can use ``await asyncio.gather(*object_refs)``.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The order of objects returned by `ray.get` can be critical for ensuring the proper functionality of applications that depend on it, but is not currently noted in its documentation. This PR updates the `ray.get` docs to let users know that they can count on the order or returned objects matching the order of input object references as part of its implementation contract (i.e. any observed deviation from this behavior should be considered a critical bug).

## Related issue number

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
