### PR TITLE
[Core] [runtime env] Add RuntimeEnvHash and JobID to SchedulingKey

### DIFF
--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -600,7 +600,7 @@ def test_client_working_dir_filepath(call_ray_start, tmp_path):
     reason="This test is only run on CI because it uses the built Ray wheel.")
 @pytest.mark.skipif(
     sys.platform != "linux", reason="This test is only run on Buildkite.")
-def test_env_installation_nonblocking():
+def test_env_installation_nonblocking(shutdown_only):
     """Test fix for https://github.com/ray-project/ray/issues/16226."""
     env = {"env_vars": {"TEST_123": "123"}}
     job_config = ray.job_config.JobConfig(runtime_env=env)

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -635,11 +635,11 @@ def test_env_installation_nonblocking(shutdown_only):
         for i in range(int(total_sleep_s / gap_s)):
             start = time.time()
             ray.get(f.remote())
-            time.sleep(gap_s)
             # Env installation takes around 10 to 60 seconds.  If we fail the
             # below assert, we can be pretty sure an env installation blocked
             # the task.
             assert time.time() - start < 0.1
+            time.sleep(gap_s)
 
     assert_tasks_finish_quickly()
 

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -600,8 +600,6 @@ def test_client_working_dir_filepath(call_ray_start, tmp_path):
     reason="This test is only run on CI because it uses the built Ray wheel.")
 @pytest.mark.skipif(
     sys.platform != "linux", reason="This test is only run on Buildkite.")
-@pytest.mark.parametrize(
-    "call_ray_start", ["ray start --head --num-cpus=4"], indirect=True)
 def test_env_installation_nonblocking():
     """Test fix for https://github.com/ray-project/ray/issues/16226."""
     env = {"env_vars": {"TEST_123": "123"}}

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -2,6 +2,7 @@
 
 #include <sstream>
 
+#include <boost/functional/hash.hpp>
 #include "ray/util/logging.h"
 
 namespace ray {
@@ -117,6 +118,11 @@ std::string TaskSpecification::SerializedRuntimeEnv() const {
 
 bool TaskSpecification::HasRuntimeEnv() const {
   return !(SerializedRuntimeEnv() == "{}" || SerializedRuntimeEnv() == "");
+}
+
+int TaskSpecification::GetRuntimeEnvHash() const {
+  WorkerCacheKey env = {OverrideEnvironmentVariables(), SerializedRuntimeEnv()};
+  return env.IntHash();
 }
 
 const SchedulingClass TaskSpecification::GetSchedulingClass() const {
@@ -358,5 +364,49 @@ std::string TaskSpecification::CallSiteString() const {
   stream << FunctionDescriptor()->CallSiteString();
   return stream.str();
 }
+
+WorkerCacheKey::WorkerCacheKey(
+    const std::unordered_map<std::string, std::string> override_environment_variables,
+    const std::string serialized_runtime_env)
+    : override_environment_variables(override_environment_variables),
+      serialized_runtime_env(serialized_runtime_env) {}
+
+bool WorkerCacheKey::operator==(const WorkerCacheKey &k) const {
+  return Hash() == k.Hash();
+}
+
+bool WorkerCacheKey::EnvIsEmpty() const {
+  return override_environment_variables.size() == 0 &&
+         (serialized_runtime_env == "" || serialized_runtime_env == "{}");
+}
+
+std::size_t WorkerCacheKey::Hash() const {
+  // Cache the hash value.
+  if (!hash_) {
+    if (EnvIsEmpty()) {
+      // It's useful to have the same predetermined value for both unspecified and empty
+      // runtime envs.
+      hash_ = 0;
+    } else {
+      std::vector<std::pair<std::string, std::string>> env_vars(
+          override_environment_variables.begin(), override_environment_variables.end());
+      // The environment doesn't depend the order of the variables, so the hash should not
+      // either.  Sort the variables so different permutations yield the same hash.
+      std::sort(env_vars.begin(), env_vars.end());
+      for (auto &pair : env_vars) {
+        // TODO(architkulkarni): boost::hash_combine isn't guaranteed to be equal during
+        // separate runs of a program, which may cause problems if these hashes are
+        // communicated between different Raylets and compared.
+        boost::hash_combine(hash_, pair.first);
+        boost::hash_combine(hash_, pair.second);
+      }
+
+      boost::hash_combine(hash_, serialized_runtime_env);
+    }
+  }
+  return hash_;
+}
+
+int WorkerCacheKey::IntHash() const { return (int)Hash(); }
 
 }  // namespace ray

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -74,7 +74,8 @@ Status CoreWorkerDirectTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
         const SchedulingKey scheduling_key(
             task_spec.GetSchedulingClass(), task_spec.GetDependencyIds(),
             task_spec.IsActorCreationTask() ? task_spec.ActorCreationId()
-                                            : ActorID::Nil());
+                                            : ActorID::Nil(),
+            task_spec.GetRuntimeEnvHash(), task_spec.JobId());
         auto &scheduling_key_entry = scheduling_key_entries_[scheduling_key];
         scheduling_key_entry.task_queue.push_back(task_spec);
         scheduling_key_entry.resource_spec = task_spec;

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -75,7 +75,7 @@ Status CoreWorkerDirectTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
             task_spec.GetSchedulingClass(), task_spec.GetDependencyIds(),
             task_spec.IsActorCreationTask() ? task_spec.ActorCreationId()
                                             : ActorID::Nil(),
-            task_spec.GetRuntimeEnvHash(), task_spec.JobId());
+            task_spec.GetRuntimeEnvHash());
         auto &scheduling_key_entry = scheduling_key_entries_[scheduling_key];
         scheduling_key_entry.task_queue.push_back(task_spec);
         scheduling_key_entry.resource_spec = task_spec;
@@ -628,7 +628,8 @@ Status CoreWorkerDirectTaskSubmitter::CancelTask(TaskSpecification task_spec,
   RAY_LOG(INFO) << "Killing task: " << task_spec.TaskId();
   const SchedulingKey scheduling_key(
       task_spec.GetSchedulingClass(), task_spec.GetDependencyIds(),
-      task_spec.IsActorCreationTask() ? task_spec.ActorCreationId() : ActorID::Nil());
+      task_spec.IsActorCreationTask() ? task_spec.ActorCreationId() : ActorID::Nil(),
+      task_spec.GetRuntimeEnvHash());
   std::shared_ptr<rpc::CoreWorkerClientInterface> client = nullptr;
   {
     absl::MutexLock lock(&mu_);

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -46,11 +46,11 @@ typedef std::function<std::shared_ptr<WorkerLeaseInterface>(const std::string &i
 // direct actor creation task, and reconstruct the actor if it dies. Otherwise if
 // the actor creation task just reuses an existing worker, then raylet will not
 // be aware of the actor and is not able to manage it.  It is also keyed on
-// RuntimeEnvHash and JobID, because a worker can only run a task if the
-// worker's RuntimeEnvHash and assigned JobID match those in the task spec.
+// RuntimeEnvHash, because a worker can only run a task if the worker's RuntimeEnvHash
+// matches the RuntimeEnvHash required by the task spec.
 typedef int RuntimeEnvHash;
 using SchedulingKey =
-    std::tuple<SchedulingClass, std::vector<ObjectID>, ActorID, RuntimeEnvHash, JobID>;
+    std::tuple<SchedulingClass, std::vector<ObjectID>, ActorID, RuntimeEnvHash>;
 
 // This class is thread-safe.
 class CoreWorkerDirectTaskSubmitter {
@@ -250,7 +250,7 @@ class CoreWorkerDirectTaskSubmitter {
         google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry> assigned_resources =
             google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry>(),
         SchedulingKey scheduling_key = std::make_tuple(0, std::vector<ObjectID>(),
-                                                       ActorID::Nil(), 0, JobID::Nil()))
+                                                       ActorID::Nil(), 0))
         : lease_client(lease_client),
           lease_expiration_time(lease_expiration_time),
           assigned_resources(assigned_resources),

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -45,8 +45,12 @@ typedef std::function<std::shared_ptr<WorkerLeaseInterface>(const std::string &i
 // would always request a new worker lease. We need this to let raylet know about
 // direct actor creation task, and reconstruct the actor if it dies. Otherwise if
 // the actor creation task just reuses an existing worker, then raylet will not
-// be aware of the actor and is not able to manage it.
-using SchedulingKey = std::tuple<SchedulingClass, std::vector<ObjectID>, ActorID>;
+// be aware of the actor and is not able to manage it.  It is also keyed on
+// RuntimeEnvHash and JobID, because a worker can only run a task if the
+// worker's RuntimeEnvHash and assigned JobID match those in the task spec.
+typedef int RuntimeEnvHash;
+using SchedulingKey =
+    std::tuple<SchedulingClass, std::vector<ObjectID>, ActorID, RuntimeEnvHash, JobID>;
 
 // This class is thread-safe.
 class CoreWorkerDirectTaskSubmitter {
@@ -246,7 +250,7 @@ class CoreWorkerDirectTaskSubmitter {
         google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry> assigned_resources =
             google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry>(),
         SchedulingKey scheduling_key = std::make_tuple(0, std::vector<ObjectID>(),
-                                                       ActorID::Nil()))
+                                                       ActorID::Nil(), 0, JobID::Nil()))
         : lease_client(lease_client),
           lease_expiration_time(lease_expiration_time),
           assigned_resources(assigned_resources),

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -22,6 +22,7 @@
 #include "ray/common/network_util.h"
 #include "ray/common/ray_config.h"
 #include "ray/common/status.h"
+#include "ray/common/task/task_spec.h"
 #include "ray/core_worker/common.h"
 #include "ray/gcs/pb_util.h"
 #include "ray/stats/stats.h"
@@ -1264,46 +1265,6 @@ WorkerPool::IOWorkerState &WorkerPool::GetIOWorkerStateFromWorkerType(
   UNREACHABLE;
 }
 
-WorkerCacheKey::WorkerCacheKey(
-    const std::unordered_map<std::string, std::string> override_environment_variables,
-    const std::string serialized_runtime_env)
-    : override_environment_variables(override_environment_variables),
-      serialized_runtime_env(serialized_runtime_env) {}
-
-bool WorkerCacheKey::operator==(const WorkerCacheKey &k) const {
-  return Hash() == k.Hash();
-}
-
-bool WorkerCacheKey::EnvIsEmpty() const {
-  return override_environment_variables.size() == 0 &&
-         (serialized_runtime_env == "" || serialized_runtime_env == "{}");
-}
-
-std::size_t WorkerCacheKey::Hash() const {
-  // Cache the hash value.
-  if (!hash_) {
-    if (EnvIsEmpty()) {
-      // It's useful to have the same predetermined value for both unspecified and empty
-      // runtime envs.
-      hash_ = 0;
-    } else {
-      std::vector<std::pair<std::string, std::string>> env_vars(
-          override_environment_variables.begin(), override_environment_variables.end());
-      // The environment doesn't depend the order of the variables, so the hash should not
-      // either.  Sort the variables so different permutations yield the same hash.
-      std::sort(env_vars.begin(), env_vars.end());
-      for (auto &pair : env_vars) {
-        boost::hash_combine(hash_, pair.first);
-        boost::hash_combine(hash_, pair.second);
-      }
-
-      boost::hash_combine(hash_, serialized_runtime_env);
-    }
-  }
-  return hash_;
-}
-
-int WorkerCacheKey::IntHash() const { return (int)Hash(); }
 
 }  // namespace raylet
 

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -1265,7 +1265,6 @@ WorkerPool::IOWorkerState &WorkerPool::GetIOWorkerStateFromWorkerType(
   UNREACHABLE;
 }
 
-
 }  // namespace raylet
 
 }  // namespace ray

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -40,7 +40,6 @@ namespace raylet {
 using WorkerCommandMap =
     std::unordered_map<Language, std::vector<std::string>, std::hash<int>>;
 
-
 /// \class WorkerPoolInterface
 ///
 /// Used for new scheduler unit tests.

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -18,7 +18,6 @@
 
 #include <algorithm>
 #include <boost/asio/io_service.hpp>
-#include <boost/functional/hash.hpp>
 #include <queue>
 #include <unordered_map>
 #include <unordered_set>
@@ -41,50 +40,6 @@ namespace raylet {
 using WorkerCommandMap =
     std::unordered_map<Language, std::vector<std::string>, std::hash<int>>;
 
-/// \class WorkerCacheKey
-///
-/// Class used to cache workers, keyed by runtime_env.
-class WorkerCacheKey {
- public:
-  /// Create a cache key with the given environment variable overrides and serialized
-  /// runtime_env.
-  ///
-  /// \param override_environment_variables The environment variable overrides set in this
-  /// worker. \param serialized_runtime_env The JSON-serialized runtime env for this
-  /// worker.
-  WorkerCacheKey(
-      const std::unordered_map<std::string, std::string> override_environment_variables,
-      const std::string serialized_runtime_env);
-
-  bool operator==(const WorkerCacheKey &k) const;
-
-  /// Check if this worker's environment is empty (the default).
-  ///
-  /// \return true if there are no environment variables set and the runtime env is the
-  /// empty string (protobuf default) or a JSON-serialized empty dict.
-  bool EnvIsEmpty() const;
-
-  /// Get the hash for this worker's environment.
-  ///
-  /// \return The hash of the override_environment_variables and the serialized
-  /// runtime_env.
-  std::size_t Hash() const;
-
-  /// Get the int-valued hash for this worker's environment, useful for portability in
-  /// flatbuffers.
-  ///
-  /// \return The hash truncated to an int.
-  int IntHash() const;
-
- private:
-  /// The environment variable overrides for this worker.
-  const std::unordered_map<std::string, std::string> override_environment_variables;
-  /// The JSON-serialized runtime env for this worker.
-  const std::string serialized_runtime_env;
-  /// The cached hash of the worker's environment.  This is set to 0
-  /// for unspecified or empty environments.
-  mutable std::size_t hash_ = 0;
-};
 
 /// \class WorkerPoolInterface
 ///


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
A worker can only be assigned to a task if its runtime env hash matches the one in the task spec. (https://github.com/ray-project/ray/blob/master/src/ray/raylet/worker_pool.cc#L929-L942)

If a remote task called that requires a runtime env to be installed, the worker lease request will remain unfulfilled for the duration of the installation, which can take ~50 seconds.  This blocks other worker lease requests, because we ratelimit to a single lease request per SchedulingKey. (https://sourcegraph.com/github.com/ray-project/ray/-/blob/src/ray/core_worker/transport/direct_task_transport.cc?L441)

The issue is if we subsequently call another remote task with a different runtime env (or the same runtime env), it won't be scheduled until the first worker lease request is fulfilled:

```python
# Start a remote task with a new env, will take ~50s to install and start the worker
f.options(runtime_env={"pip": ["pip-install-test==0.5"]}).remote()
start = time.time()
ray.get(f.remote()) # Empty env, should return nearly instantaneously...
print(time.time() - start) # ...but this returns ~50
```

The fix is to add RuntimeEnvHash to the SchedulingKey, which this PR does.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/16226. 
Closes #16537 by adding a test which fails before this PR, but passes with the fix in this PR.  The test is a single-driver version of the reproduction in https://github.com/ray-project/ray/issues/16226, which required two drivers.
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
