### PR TITLE
[C++ API] rename 'ray_redis_address' to 'ray_address'

### DIFF
--- a/cpp/src/ray/config_internal.cc
+++ b/cpp/src/ray/config_internal.cc
@@ -3,7 +3,7 @@
 
 #include "config_internal.h"
 
-DEFINE_string(ray_redis_address, "", "The address of the Redis server to connect to.");
+DEFINE_string(ray_address, "", "The address of the Ray cluster to connect to.");
 
 DEFINE_string(ray_redis_password, "",
               "Prevents external clients without the password from connecting to Redis "
@@ -49,8 +49,8 @@ void ConfigInternal::Init(RayConfig &config, int *argc, char ***argv) {
     if (!FLAGS_ray_dynamic_library_path.empty()) {
       dynamic_library_path = FLAGS_ray_dynamic_library_path;
     }
-    if (!FLAGS_ray_redis_address.empty()) {
-      SetRedisAddress(FLAGS_ray_redis_address);
+    if (!FLAGS_ray_address.empty()) {
+      SetRedisAddress(FLAGS_ray_address);
     }
     google::CommandLineFlagInfo info;
     // Don't rewrite `ray_redis_password` when it is not set in the command line.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -139,7 +139,7 @@ Ray provides Python, Java, and *EXPERIMENTAL* C++ API. And Ray uses Tasks (funct
 
       ray stop
       ray start --head --port 6379 --redis-password 5241590000000000 --node-manager-port 62665
-      ./bazel-bin/cpp/example/example --ray-dynamic-library-path=bazel-bin/cpp/example/example.so --ray-redis-address=127.0.0.1:6379
+      ./bazel-bin/cpp/example/example --ray-dynamic-library-path=bazel-bin/cpp/example/example.so --ray-address=127.0.0.1:6379
 
     .. literalinclude:: ../../cpp/example/example.cc
        :language: cpp

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1726,7 +1726,7 @@ def build_cpp_worker_command(cpp_worker_options, redis_address,
         f"--ray-plasma-store-socket-name={plasma_store_name}",
         f"--ray-raylet-socket-name={raylet_name}",
         "--ray-node-manager-port=RAY_NODE_MANAGER_PORT_PLACEHOLDER",
-        f"--ray-redis-address={redis_address}",
+        f"--ray-address={redis_address}",
         f"--ray-redis-password={redis_password}",
         f"--ray-session-dir={session_dir}", f"--ray-logs-dir={log_dir}",
         f"--ray-node-ip-address={node_ip_address}"


### PR DESCRIPTION
We need to rename to 'ray_address' to make it more clearer.
