### PR TITLE
[Test] Create a wait_for_num_nodes() function, and use it in `train_small`

### DIFF
--- a/release/xgboost_tests/workloads/train_small.py
+++ b/release/xgboost_tests/workloads/train_small.py
@@ -11,6 +11,7 @@ import os
 import time
 
 import ray
+from ray.test_utils import wait_for_num_nodes
 from xgboost_ray import RayParams
 
 from ray.util.xgboost.release_test_util import train_ray
@@ -22,6 +23,9 @@ if __name__ == "__main__":
         ray.client(address=addr).job_name(job_name).connect()
     else:
         ray.init(address="auto")
+
+    wait_for_num_nodes(
+        int(os.environ.get("RAY_RELEASE_MIN_WORKERS", 0)) + 1, 600)
 
     output = os.environ["TEST_OUTPUT_JSON"]
     state = os.environ["TEST_STATE_JSON"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This would avoid the race condition between scheduling and cluster starting up.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
