### PR TITLE
[WIP][Serve] Attempt to provide exponential retry & termination for failures happened in deployment constructor

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -62,7 +62,7 @@ class ReplicaContext:
     backend_tag: BackendTag
     replica_tag: ReplicaTag
     _internal_controller_name: str
-    constructor_retry_remaining: int 
+    constructor_retry_remaining: int
     servable_object: Callable
 
 
@@ -75,7 +75,8 @@ def _set_internal_replica_context(
 ):
     global _INTERNAL_REPLICA_CONTEXT
     _INTERNAL_REPLICA_CONTEXT = ReplicaContext(
-        backend_tag, replica_tag, controller_name, constructor_retry_remaining, servable_object)
+        backend_tag, replica_tag, controller_name, constructor_retry_remaining,
+        servable_object)
 
 
 def _ensure_connected(f: Callable) -> Callable:
@@ -408,12 +409,16 @@ class Client:
                                                      inspect.isfunction):
                 python_methods.append(method_name)
 
-        print("   [DEBUG][api.py] Calling deploy -> ray.get(controller.deploy.remote())")
+        print(
+            "   [DEBUG][api.py] Calling deploy -> ray.get(controller.deploy.remote())"
+        )
         goal_id, updating = ray.get(
             self._controller.deploy.remote(
                 name, backend_config, replica_config, python_methods, version,
                 prev_version, route_prefix))
-        print("   [DEBUG][api.py] Returning api.deploy -> ray.get(controller.deploy.remote())")
+        print(
+            "   [DEBUG][api.py] Returning api.deploy -> ray.get(controller.deploy.remote())"
+        )
         if updating:
             msg = f"Updating deployment '{name}'"
             if version is not None:

--- a/python/ray/serve/async_goal_manager.py
+++ b/python/ray/serve/async_goal_manager.py
@@ -31,7 +31,8 @@ class AsyncGoalManager:
         return goal_id not in self._pending_goals
 
     async def wait_for_goal(self, goal_id: GoalId) -> None:
-        print(f"   [DEBUG][async_goal_manager.py] Waiting for goal_id {goal_id}")
+        print(
+            f"   [DEBUG][async_goal_manager.py] Waiting for goal_id {goal_id}")
         start = time.time()
         if goal_id not in self._pending_goals:
             logger.debug(f"Goal {goal_id} not found")
@@ -41,4 +42,6 @@ class AsyncGoalManager:
         await event.wait()
         logger.debug(
             f"Waiting for goal {goal_id} took {time.time() - start} seconds")
-        print(f"   [DEBUG][async_goal_manager.py] Waiting for goal {goal_id} took {time.time() - start} seconds")
+        print(
+            f"   [DEBUG][async_goal_manager.py] Waiting for goal {goal_id} took {time.time() - start} seconds"
+        )

--- a/python/ray/serve/async_goal_manager.py
+++ b/python/ray/serve/async_goal_manager.py
@@ -15,13 +15,14 @@ class AsyncGoalManager:
         return len(self._pending_goals)
 
     def create_goal(self, goal_id: Optional[GoalId] = None) -> GoalId:
+        print("   [DEBUG][async_goal_manager.py] Creating goal_id")
         if goal_id is None:
             goal_id = uuid4()
         self._pending_goals[goal_id] = asyncio.Event()
         return goal_id
 
     def complete_goal(self, goal_id: GoalId) -> None:
-        logger.debug(f"Completing goal {goal_id}")
+        print(f"   [DEBUG][async_goal_manager.py] Completing goal {goal_id}")
         event = self._pending_goals.pop(goal_id, None)
         if event:
             event.set()
@@ -30,6 +31,7 @@ class AsyncGoalManager:
         return goal_id not in self._pending_goals
 
     async def wait_for_goal(self, goal_id: GoalId) -> None:
+        print(f"   [DEBUG][async_goal_manager.py] Waiting for goal_id {goal_id}")
         start = time.time()
         if goal_id not in self._pending_goals:
             logger.debug(f"Goal {goal_id} not found")
@@ -39,3 +41,4 @@ class AsyncGoalManager:
         await event.wait()
         logger.debug(
             f"Waiting for goal {goal_id} took {time.time() - start} seconds")
+        print(f"   [DEBUG][async_goal_manager.py] Waiting for goal {goal_id} took {time.time() - start} seconds")

--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -25,7 +25,7 @@ SLOW_STARTUP_WARNING_PERIOD_S = 30
 
 
 class ReplicaState(Enum):
-    # started the actor that 
+    # started the actor that
     SHOULD_START = 1
 
     STARTING = 2

--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -44,7 +44,9 @@ def create_backend_replica(name: str, serialized_backend_def: bytes):
         async def __init__(self, backend_tag, replica_tag, init_args,
                            backend_config: BackendConfig,
                            controller_name: str):
-            print("   [DEBUG][backend_worker.py] Executing RayServeWrappedReplica.__init__")
+            print(
+                "   [DEBUG][backend_worker.py] Executing RayServeWrappedReplica.__init__"
+            )
             backend_def = cloudpickle.loads(serialized_backend_def)
             if isinstance(backend_def, str):
                 backend = import_attr(backend_def)
@@ -62,7 +64,8 @@ def create_backend_replica(name: str, serialized_backend_def: bytes):
             # Set the controller name so that serve.connect() in the user's
             # backend code will connect to the instance that this backend is
             # running in.
-            print("   [DEBUG][backend_worker.py] Setting first replica_context")
+            print(
+                "   [DEBUG][backend_worker.py] Setting first replica_context")
 
             context = ray.serve.api.get_replica_context()
             if context == None:
@@ -80,27 +83,38 @@ def create_backend_replica(name: str, serialized_backend_def: bytes):
                 # (required for FastAPI backend definition).
                 _callable = backend.__new__(backend)
                 try:
-                    print("   [DEBUG][backend_worker.py] Trying to execute callable.__init__")
+                    print(
+                        "   [DEBUG][backend_worker.py] Trying to execute callable.__init__"
+                    )
                     await sync_to_async(_callable.__init__)(*init_args)
                 except Exception as e:
-                    print("   [DEBUG][backend_worker.py] Exception during callable.__init__")
-                    constructor_retry_remaining = ray.serve.api.get_replica_context().constructor_retry_remaining
+                    print(
+                        "   [DEBUG][backend_worker.py] Exception during callable.__init__"
+                    )
+                    constructor_retry_remaining = ray.serve.api.get_replica_context(
+                    ).constructor_retry_remaining
                     if constructor_retry_remaining <= 0:
-                        # TODO: Add termination logic that marks the goal_id as failed, ideally surface 
-                        # exception message too 
-                        print("   [DEBUG][backend_worker.py] All constructor retries exhausted. TODO abort")
+                        # TODO: Add termination logic that marks the goal_id as failed, ideally surface
+                        # exception message too
+                        print(
+                            "   [DEBUG][backend_worker.py] All constructor retries exhausted. TODO abort"
+                        )
                     else:
                         # TODO: Add proper retry here (maybe by a retry decorator that works for async func ?)
-                        print(f"   [DEBUG][backend_worker.py] {constructor_retry_remaining - 1} retry left.")
+                        print(
+                            f"   [DEBUG][backend_worker.py] {constructor_retry_remaining - 1} retry left."
+                        )
                         ray.serve.api._set_internal_replica_context(
                             backend_tag,
                             replica_tag,
                             controller_name,
-                            constructor_retry_remaining=constructor_retry_remaining - 1,
+                            constructor_retry_remaining=
+                            constructor_retry_remaining - 1,
                             servable_object=None)
             # Setting the context again to update the servable_object.
 
-            print("   [DEBUG][backend_worker.py] Setting second replica_context")
+            print(
+                "   [DEBUG][backend_worker.py] Setting second replica_context")
             ray.serve.api._set_internal_replica_context(
                 backend_tag,
                 replica_tag,
@@ -113,7 +127,9 @@ def create_backend_replica(name: str, serialized_backend_def: bytes):
             print("   [DEBUG][backend_worker.py] Creating RayServeReplica ..")
             self.backend = RayServeReplica(_callable, backend_config,
                                            is_function, controller_handle)
-            print("   [DEBUG][backend_worker.py] Finished creating RayServeReplica.")
+            print(
+                "   [DEBUG][backend_worker.py] Finished creating RayServeReplica."
+            )
 
         @ray.method(num_returns=2)
         async def handle_request(

--- a/python/ray/serve/http_proxy.py
+++ b/python/ray/serve/http_proxy.py
@@ -208,7 +208,7 @@ class HTTPProxy:
         # Set the controller name so that serve will connect to the
         # controller instance this proxy is running in.
         ray.serve.api._set_internal_replica_context(None, None,
-                                                    controller_name, None)
+                                                    controller_name, constructor_retry_remaining=3, servable_object=None)
 
         # Used only for displaying the route table.
         self.route_info: Dict[str, Tuple[EndpointTag, List[str]]] = dict()

--- a/python/ray/serve/http_proxy.py
+++ b/python/ray/serve/http_proxy.py
@@ -207,8 +207,12 @@ class HTTPProxy:
     def __init__(self, controller_name: str):
         # Set the controller name so that serve will connect to the
         # controller instance this proxy is running in.
-        ray.serve.api._set_internal_replica_context(None, None,
-                                                    controller_name, constructor_retry_remaining=3, servable_object=None)
+        ray.serve.api._set_internal_replica_context(
+            None,
+            None,
+            controller_name,
+            constructor_retry_remaining=3,
+            servable_object=None)
 
         # Used only for displaying the route table.
         self.route_info: Dict[str, Tuple[EndpointTag, List[str]]] = dict()

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -415,10 +415,12 @@ class Worker:
 
         def sigterm_handler(signum, frame):
             shutdown(True)
+            print("-----XXXXX worker main_loop() exit with 1.")
             sys.exit(1)
 
         ray._private.utils.set_sigterm_handler(sigterm_handler)
         self.core_worker.run_task_loop()
+        print("-----XXXXX worker main_loop() exit with 0.")
         sys.exit(0)
 
     def print_logs(self):


### PR DESCRIPTION
Apparently not ready for review, just putting up initial PR to get it rolling, there's still quite some context to read and try out with current ray serve codebase.

All changes so far attempts to let RayServeWrappedReplica retries on its own async constructor via its replica context. An alternative is to update backend_state metadata + controll logic but so far I think it might be simpler to keep it as simple as 

(1) We set a goal_id to have the replica running and wait for its state to reach "RUNNING"
(2) Replica just takes care of logic needed to bring it to that state 

If exception happens in (2), as long as it haven't reached termination condition (out of retries), controller at (1) doesn't need to know what happened, thus don't need to change any existing logic.  Ideally (1) should be able to get the precise exception message from (2) when it reaches termination state and threw exception.


TODO: 
 - When all retries are exhausted, we should correctly exit and mark this replica in terminal state. 
 - Be able to retry async init with exponential backoff.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
