### PR TITLE
[tune/wandb] Fix parameter lookup for sequences

### DIFF
--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -1,6 +1,6 @@
 import os
 import pickle
-from collections.abc import Iterable
+from collections.abc import Sequence
 from multiprocessing import Process, Queue
 from numbers import Number
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -31,7 +31,7 @@ def _is_allowed_type(obj):
     """Return True if type is allowed for logging to wandb"""
     if isinstance(obj, np.ndarray) and obj.size == 1:
         return isinstance(obj.item(), Number)
-    if isinstance(obj, Iterable) and len(obj) > 0:
+    if isinstance(obj, Sequence) and len(obj) > 0:
         return isinstance(obj[0], _VALID_ITERABLE_TYPES)
     return isinstance(obj, _VALID_TYPES)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`__len__` is requires a `Sequence`, not an `Iterable`, as per https://docs.python.org/3/library/collections.abc.html

## Related issue number

Closes #16681

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
