### PR TITLE
[Autoscaler] Use NetworkInterfaces parameter to launch instances.

### DIFF
--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -372,9 +372,10 @@ class AWSNodeProvider(NodeProvider):
                     }],
                     "TagSpecifications": tag_specs
                 })
-                maybe_security_group_ids = conf.pop("SecurityGroupIds", None)
-                if maybe_security_group_ids is not None:
-                    conf["NetworkInterface"]["Groups"] = maybe_security_group_ids
+                _ = conf.pop("SubnetId", None)
+                security_group_ids = conf.pop("SecurityGroupIds", None)
+                if security_group_ids is not None:
+                    conf["NetworkInterfaces"][0]["Groups"] = maybe_security_group_ids
 
                 created = self.ec2_fail_fast.create_instances(**conf)
                 created_nodes_dict = {n.id: n for n in created}

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -375,7 +375,7 @@ class AWSNodeProvider(NodeProvider):
                 _ = conf.pop("SubnetId", None)
                 security_group_ids = conf.pop("SecurityGroupIds", None)
                 if security_group_ids is not None:
-                    conf["NetworkInterfaces"][0]["Groups"] = maybe_security_group_ids
+                    conf["NetworkInterfaces"][0]["Groups"] = security_group_ids
 
                 created = self.ec2_fail_fast.create_instances(**conf)
                 created_nodes_dict = {n.id: n for n in created}

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -365,9 +365,17 @@ class AWSNodeProvider(NodeProvider):
                 conf.update({
                     "MinCount": 1,
                     "MaxCount": count,
-                    "SubnetId": subnet_id,
+                    "NetworkInterfaces": [{
+                        "AssociatePublicIpAddress": True,
+                        "DeviceIndex": 0,
+                        "SubnetId": subnet_id,
+                    }],
                     "TagSpecifications": tag_specs
                 })
+                maybe_security_group_ids = conf.pop("SecurityGroupIds", None)
+                if maybe_security_group_ids is not None:
+                    conf["NetworkInterface"]["Groups"] = maybe_security_group_ids
+
                 created = self.ec2_fail_fast.create_instances(**conf)
                 created_nodes_dict = {n.id: n for n in created}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR allows launching in subnets where public IP assignments are enabled but off by default.

It does this by:

- Specifying NetworkInterfaces.AssociatePublicIpAddress = True
- Moving SubnetId, SecurityGroupIds into NetworkInterfaces (required by boto when using NetworkInterfaces)

## Related issue number

Partial resolution to #16815.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
