### PR TITLE
[windows] correct symlinks for files (node.py)

### DIFF
--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -20,7 +20,7 @@ def do_link(package, force=False, local_path=None):
     local_home = os.path.abspath(os.path.join(__file__, local_path))
     # If installed package dir does not exist, continue either way. We'll
     # remove it/create a link from there anyways.
-    if not os.path.isdir(package_home):
+    if not os.path.isdir(package_home) and not os.path.isfile(package_home):
         print(f"{package_home} does not exist. Continuing to link.")
     # Make sure the path we are linking to does exist.
     assert os.path.exists(local_home), local_home
@@ -39,8 +39,17 @@ def do_link(package, force=False, local_path=None):
             pass
         except OSError:
             os.remove(package_home)
-        subprocess.check_call(
-            ["mklink", "/J", package_home, local_home], shell=True)
+
+        # create symlink for directory or file
+        if os.path.isdir(local_home):
+            subprocess.check_call(
+                ["mklink", "/J", package_home, local_home], shell=True)
+        elif os.path.isfile(local_home):
+            subprocess.check_call(
+                ["mklink", "/H", package_home, local_home], shell=True)
+        else:
+            print(f"{local_home} is neither directory nor file. Link failed.")
+
     # Posix: Use `ln -s` to create softlink.
     else:
         sudo = []


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Fix `setup-dev.py` for Windows, which consistently leads to errors because it linked files incorrectly, e.g., `node.py`. 
This breaks the [recommended dev setup](https://docs.ray.io/en/master/development.html#building-ray-python-only).

In detail:

Previously, always `mklink /j` was used for symlink for both directories and files ([mklink docs](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/mklink)).
Apparently, this does not work as intended for files; just for directories (at least for me under Windows 10).
`setup-dev.py` finishes without errors but afterwards, `import ray` fails:

```
import ray

C:\Users\Stefan\git-repos\work\ray\venv\lib\site-packages\ray\autoscaler\_private\cli_logger.py:57: FutureWarning: Not all Ray CLI dependencies were found. In Ray 1.4+, the Ray CLI, autoscaler, and dashboard will only be usable via `pip install 'ray[default]'`. Please update your install command.
  warnings.warn(
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "C:\Program Files\JetBrains\PyCharm 2018.3.3\plugins\python\helpers\pydev\_pydev_bundle\pydev_import_hook.py", line 21, in do_import
    module = self._system_import(name, *args, **kwargs)
  File "C:\Users\Stefan\git-repos\work\ray\venv\lib\site-packages\ray\__init__.py", line 89, in <module>
    from ray.worker import (  # noqa: E402,F401
  File "C:\Program Files\JetBrains\PyCharm 2018.3.3\plugins\python\helpers\pydev\_pydev_bundle\pydev_import_hook.py", line 21, in do_import
    module = self._system_import(name, *args, **kwargs)
  File "C:\Users\Stefan\git-repos\work\ray\venv\lib\site-packages\ray\worker.py", line 24, in <module>
    import ray.node
  File "C:\Program Files\JetBrains\PyCharm 2018.3.3\plugins\python\helpers\pydev\_pydev_bundle\pydev_import_hook.py", line 21, in do_import
    module = self._system_import(name, *args, **kwargs)
ModuleNotFoundError: No module named 'ray.node'
```

Replacing `mklink /j` with `mklink /h` for files (not dirs) consistently resolves the issue for me.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] Just tested manually/locally.
