### PR TITLE
[WIP] Fix serve constructor failure

### DIFF
--- a/python/ray/serve/backend_state_manager.py
+++ b/python/ray/serve/backend_state_manager.py
@@ -42,7 +42,7 @@ class ActorReplicaWrapper:
     This is primarily defined so that we can mock out actual Ray operations
     for unit testing.
 
-    *All Ray API calls should be made here, not in BackendState.*
+    *All Ray API calls should be made here, not in BackendStateManager.*
     """
 
     def __init__(self, actor_name: str, detached: bool, controller_name: str,
@@ -151,7 +151,13 @@ class ActorReplicaWrapper:
             self._health_check_ref = self._actor_handle.run_forever.remote()
 
         ready, _ = ray.wait([self._health_check_ref], timeout=0)
-        return len(ready) == 0
+
+        rst = len(ready) == 0
+        print(f"check_health -> {rst}")
+        print(f"ready: {ready}")
+        print(f"==== ray.get: {ray.get(ready)}")
+    
+        return rst
 
     def force_stop(self):
         """Force the actor to exit without shutting down gracefully."""
@@ -516,7 +522,7 @@ class ReplicaStateContainer:
         return repr(self._replicas)
 
 
-class BackendState:
+class BackendStateManager:
     """Manages all state for backends in the system.
 
     This class is *not* thread safe, so any state-modifying methods should be
@@ -853,6 +859,9 @@ class BackendState:
             ReplicaState.SHOULD_START, ReplicaState.STARTING_OR_UPDATING,
             ReplicaState.RUNNING
         ])
+        print(f"current replicas: {current_replicas}")
+        print(f"target_replicas replicas: {target_replicas}")
+        print(f"current replica states: {self._replicas[backend_tag]}")
 
         delta_replicas = target_replicas - current_replicas
         if delta_replicas == 0:
@@ -874,6 +883,7 @@ class BackendState:
                     ReplicaState.SHOULD_START,
                     BackendReplica(self._controller_name, self._detached,
                                    replica_tag, backend_tag, target_version))
+                print(f"Adding SHOULD_START to replica_tag: {replica_tag}, backend_tag: {backend_tag}")
 
         elif delta_replicas < 0:
             to_remove = -delta_replicas
@@ -887,6 +897,7 @@ class BackendState:
                 max_replicas=to_remove)
 
             for replica in replicas_to_stop:
+                print(f"Adding SHOULD_STOP to replica_tag: {replica}, backend_tag: {backend_tag}")
                 replica.set_should_stop(graceful_shutdown_timeout_s)
                 self._replicas[backend_tag].add(ReplicaState.SHOULD_STOP,
                                                 replica)

--- a/python/ray/serve/backend_state_manager.py
+++ b/python/ray/serve/backend_state_manager.py
@@ -156,7 +156,7 @@ class ActorReplicaWrapper:
         print(f"check_health -> {rst}")
         print(f"ready: {ready}")
         print(f"==== ray.get: {ray.get(ready)}")
-    
+
         return rst
 
     def force_stop(self):
@@ -883,7 +883,9 @@ class BackendStateManager:
                     ReplicaState.SHOULD_START,
                     BackendReplica(self._controller_name, self._detached,
                                    replica_tag, backend_tag, target_version))
-                print(f"Adding SHOULD_START to replica_tag: {replica_tag}, backend_tag: {backend_tag}")
+                print(
+                    f"Adding SHOULD_START to replica_tag: {replica_tag}, backend_tag: {backend_tag}"
+                )
 
         elif delta_replicas < 0:
             to_remove = -delta_replicas
@@ -897,7 +899,9 @@ class BackendStateManager:
                 max_replicas=to_remove)
 
             for replica in replicas_to_stop:
-                print(f"Adding SHOULD_STOP to replica_tag: {replica}, backend_tag: {backend_tag}")
+                print(
+                    f"Adding SHOULD_STOP to replica_tag: {replica}, backend_tag: {backend_tag}"
+                )
                 replica.set_should_stop(graceful_shutdown_timeout_s)
                 self._replicas[backend_tag].add(ReplicaState.SHOULD_STOP,
                                                 replica)

--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -25,7 +25,7 @@ from ray.serve.router import Query, RequestMetadata
 from ray.serve.constants import (
     BACKEND_RECONFIGURE_METHOD,
     DEFAULT_LATENCY_BUCKET_MS,
-    REPLICA_CONSTRUCTOR_RETRY_COUNT,
+    REPLICA_CONSTRUCTOR_TRY_COUNT,
 )
 from ray.exceptions import RayTaskError
 
@@ -70,22 +70,22 @@ def create_backend_replica(name: str, serialized_backend_def: bytes):
             if is_function:
                 _callable = backend
             else:
-                # This allows backends to define an async __init__ method
-                # (required for FastAPI backend definition).
-                _callable = backend.__new__(backend)
                 # Retry with exponential backoff if ran into transient
                 # failures; Will throw and notify backend_state if
                 # constructor failed with no retries left
-                for current_retry in range(REPLICA_CONSTRUCTOR_RETRY_COUNT):
+                for current_try in range(REPLICA_CONSTRUCTOR_TRY_COUNT):
+                    # This allows backends to define an async __init__ method
+                    # (required for FastAPI backend definition).
+                    _callable = backend.__new__(backend)
                     try:
                         await sync_to_async(_callable.__init__)(*init_args)
                     except Exception as e:
                         logger.error(
                             f"Exception while running deployment class "
                             f"__init__: {e}")
-                        if current_retry < REPLICA_CONSTRUCTOR_RETRY_COUNT - 1:
+                        if current_try < REPLICA_CONSTRUCTOR_TRY_COUNT - 1:
                             delay_secs = round(
-                                (2**current_retry + random.uniform(0, 1)), 2)
+                                (2**current_try + random.uniform(0, 1)), 2)
                             logger.info(
                                 f"Waiting for {delay_secs} secs to retry ..")
                             await asyncio.sleep(delay_secs)

--- a/python/ray/serve/constants.py
+++ b/python/ray/serve/constants.py
@@ -16,11 +16,14 @@ DEFAULT_HTTP_PORT = 8000
 #: Max concurrency
 ASYNC_CONCURRENCY = int(1e6)
 
+# How often to call the control loop on the controller.
+CONTROL_LOOP_PERIOD_S = 0.1
+
 #: Max time to wait for HTTP proxy in `serve.start()`.
 HTTP_PROXY_TIMEOUT = 60
 
-#: Default retry count for allowing failures in replica constructor.
-REPLICA_CONSTRUCTOR_RETRY_COUNT = 4
+#: Default try count for allowing failures in replica constructor.
+REPLICA_CONSTRUCTOR_TRY_COUNT = 4
 
 #: Default histogram buckets for latency tracker.
 DEFAULT_LATENCY_BUCKET_MS = [

--- a/python/ray/serve/constants.py
+++ b/python/ray/serve/constants.py
@@ -19,6 +19,9 @@ ASYNC_CONCURRENCY = int(1e6)
 #: Max time to wait for HTTP proxy in `serve.start()`.
 HTTP_PROXY_TIMEOUT = 60
 
+#: Default retry count for allowing failures in replica constructor.
+REPLICA_CONSTRUCTOR_RETRY_COUNT = 4
+
 #: Default histogram buckets for latency tracker.
 DEFAULT_LATENCY_BUCKET_MS = [
     1,

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 import ray
 from ray.actor import ActorHandle
 from ray.serve.async_goal_manager import AsyncGoalManager
-from ray.serve.backend_state import BackendState
+from ray.serve.backend_state_manager import BackendStateManager
 from ray.serve.backend_worker import create_backend_replica
 from ray.serve.common import (
     BackendInfo,
@@ -20,9 +20,10 @@ from ray.serve.common import (
 from ray.serve.config import BackendConfig, HTTPOptions, ReplicaConfig
 from ray.serve.constants import (
     ALL_HTTP_METHODS,
+    CONTROL_LOOP_PERIOD_S,
     RESERVED_VERSION_TAG,
 )
-from ray.serve.endpoint_state import EndpointState
+from ray.serve.endpoint_state_manager import EndpointStateManager
 from ray.serve.http_state import HTTPState
 from ray.serve.kv_store import RayInternalKVStore
 from ray.serve.long_poll import LongPollHost
@@ -31,9 +32,6 @@ from ray.serve.utils import logger
 # Used for testing purposes only. If this is set, the controller will crash
 # after writing each checkpoint with the specified probability.
 _CRASH_AFTER_CHECKPOINT_PROBABILITY = 0
-
-# How often to call the control loop on the controller.
-CONTROL_LOOP_PERIOD_S = 0.1
 
 
 @ray.remote(num_cpus=0)
@@ -80,10 +78,11 @@ class ServeController:
 
         self.goal_manager = AsyncGoalManager()
         self.http_state = HTTPState(controller_name, detached, http_config)
-        self.endpoint_state = EndpointState(self.kv_store, self.long_poll_host)
-        self.backend_state = BackendState(controller_name, detached,
-                                          self.kv_store, self.long_poll_host,
-                                          self.goal_manager)
+        self.endpoint_state_manager = EndpointStateManager(
+            self.kv_store, self.long_poll_host)
+        self.backend_state_manager = BackendStateManager(
+            controller_name, detached, self.kv_store, self.long_poll_host,
+            self.goal_manager)
 
         asyncio.get_event_loop().create_task(self.run_control_loop())
 
@@ -116,7 +115,7 @@ class ServeController:
                 except Exception as e:
                     logger.error(f"Exception updating HTTP state: {e}")
                 try:
-                    self.backend_state.update()
+                    self.backend_state_manager.update()
                 except Exception as e:
                     logger.error(f"Exception updating backend state: {e}")
 
@@ -125,19 +124,19 @@ class ServeController:
     def _all_replica_handles(
             self) -> Dict[BackendTag, Dict[ReplicaTag, ActorHandle]]:
         """Used for testing."""
-        return self.backend_state.get_running_replica_handles()
+        return self.backend_state_manager.get_running_replica_handles()
 
     def get_all_backends(self) -> Dict[BackendTag, BackendConfig]:
         """Returns a dictionary of backend tag to backend config."""
-        return self.backend_state.get_backend_configs()
+        return self.backend_state_manager.get_backend_configs()
 
     def get_all_endpoints(self) -> Dict[EndpointTag, Dict[BackendTag, Any]]:
         """Returns a dictionary of backend tag to backend config."""
-        return self.endpoint_state.get_endpoints()
+        return self.endpoint_state_manager.get_endpoints()
 
     def _validate_traffic_dict(self, traffic_dict: Dict[str, float]):
         for backend in traffic_dict:
-            if self.backend_state.get_backend(backend) is None:
+            if self.backend_state_manager.get_backend(backend) is None:
                 raise ValueError(
                     "Attempted to assign traffic to a backend '{}' that "
                     "is not registered.".format(backend))
@@ -151,14 +150,14 @@ class ServeController:
             logger.info("Setting traffic for endpoint "
                         f"'{endpoint}' to '{traffic_dict}'.")
 
-            self.endpoint_state.set_traffic_policy(endpoint,
-                                                   TrafficPolicy(traffic_dict))
+            self.endpoint_state_manager.set_traffic_policy(
+                endpoint, TrafficPolicy(traffic_dict))
 
     async def shadow_traffic(self, endpoint_name: str, backend_tag: BackendTag,
                              proportion: float) -> None:
         """Shadow traffic from the endpoint to the backend."""
         async with self.write_lock:
-            if self.backend_state.get_backend(backend_tag) is None:
+            if self.backend_state_manager.get_backend(backend_tag) is None:
                 raise ValueError(
                     "Attempted to shadow traffic to a backend '{}' that "
                     "is not registered.".format(backend_tag))
@@ -167,8 +166,8 @@ class ServeController:
                 "Shadowing '{}' of traffic to endpoint '{}' to backend '{}'.".
                 format(proportion, endpoint_name, backend_tag))
 
-            self.endpoint_state.shadow_traffic(endpoint_name, backend_tag,
-                                               proportion)
+            self.endpoint_state_manager.shadow_traffic(endpoint_name,
+                                                       backend_tag, proportion)
 
     async def create_endpoint(
             self,
@@ -189,7 +188,7 @@ class ServeController:
                 "Registering route '{}' to endpoint '{}' with methods '{}'.".
                 format(route, endpoint, methods))
 
-            self.endpoint_state.create_endpoint(
+            self.endpoint_state_manager.create_endpoint(
                 endpoint, EndpointInfo(methods, route=route),
                 TrafficPolicy(traffic_dict))
 
@@ -204,7 +203,7 @@ class ServeController:
         """
         logger.info("Deleting endpoint '{}'".format(endpoint))
         async with self.write_lock:
-            self.endpoint_state.delete_endpoint(endpoint)
+            self.endpoint_state_manager.delete_endpoint(endpoint)
 
     async def create_backend(
             self, backend_tag: BackendTag, backend_config: BackendConfig,
@@ -218,7 +217,7 @@ class ServeController:
                 version=RESERVED_VERSION_TAG,
                 backend_config=backend_config,
                 replica_config=replica_config)
-            goal_id, _ = self.backend_state.deploy_backend(
+            goal_id, _ = self.backend_state_manager.deploy_backend(
                 backend_tag, backend_info)
             return goal_id
 
@@ -227,20 +226,22 @@ class ServeController:
                              force_kill: bool = False) -> Optional[GoalId]:
         async with self.write_lock:
             # Check that the specified backend isn't used by any endpoints.
-            for endpoint, info in self.endpoint_state.get_endpoints().items():
+            for endpoint, info in self.endpoint_state_manager.get_endpoints(
+            ).items():
                 if (backend_tag in info["traffic"]
                         or backend_tag in info["shadows"]):
                     raise ValueError(f"Backend '{backend_tag}' is used by "
                                      f"endpoint '{endpoint}' and cannot be "
                                      "deleted. Please remove the backend "
                                      "from all endpoints and try again.")
-            return self.backend_state.delete_backend(backend_tag, force_kill)
+            return self.backend_state_manager.delete_backend(
+                backend_tag, force_kill)
 
     async def update_backend_config(self, backend_tag: BackendTag,
                                     config_options: BackendConfig) -> GoalId:
         """Set the config for the specified backend."""
         async with self.write_lock:
-            existing_info = self.backend_state.get_backend(backend_tag)
+            existing_info = self.backend_state_manager.get_backend(backend_tag)
             if existing_info is None:
                 raise ValueError(f"Backend {backend_tag} is not registered.")
 
@@ -250,15 +251,16 @@ class ServeController:
                 backend_config=existing_info.backend_config.copy(
                     update=config_options.dict(exclude_unset=True)),
                 replica_config=existing_info.replica_config)
-            goal_id, _ = self.backend_state.deploy_backend(
+            goal_id, _ = self.backend_state_manager.deploy_backend(
                 backend_tag, backend_info)
             return goal_id
 
     def get_backend_config(self, backend_tag: BackendTag) -> BackendConfig:
         """Get the current config for the specified backend."""
-        if self.backend_state.get_backend(backend_tag) is None:
+        if self.backend_state_manager.get_backend(backend_tag) is None:
             raise ValueError(f"Backend {backend_tag} is not registered.")
-        return self.backend_state.get_backend(backend_tag).backend_config
+        return self.backend_state_manager.get_backend(
+            backend_tag).backend_config
 
     def get_http_config(self):
         """Return the HTTP proxy configuration."""
@@ -267,8 +269,8 @@ class ServeController:
     async def shutdown(self) -> List[GoalId]:
         """Shuts down the serve instance completely."""
         async with self.write_lock:
-            goal_ids = self.backend_state.shutdown()
-            self.endpoint_state.shutdown()
+            goal_ids = self.backend_state_manager.shutdown()
+            self.endpoint_state_manager.shutdown()
             self.http_state.shutdown()
 
             return goal_ids
@@ -283,7 +285,8 @@ class ServeController:
 
         async with self.write_lock:
             if prev_version is not None:
-                existing_backend_info = self.backend_state.get_backend(name)
+                existing_backend_info = self.backend_state_manager.get_backend(
+                    name)
                 if (existing_backend_info is None
                         or not existing_backend_info.version):
                     raise ValueError(
@@ -303,22 +306,23 @@ class ServeController:
                 backend_config=backend_config,
                 replica_config=replica_config)
 
-            goal_id, updating = self.backend_state.deploy_backend(
+            goal_id, updating = self.backend_state_manager.deploy_backend(
                 name, backend_info)
             endpoint_info = EndpointInfo(
                 ALL_HTTP_METHODS,
                 route=route_prefix,
                 python_methods=python_methods,
                 legacy=False)
-            self.endpoint_state.update_endpoint(name, endpoint_info,
-                                                TrafficPolicy({
-                                                    name: 1.0
-                                                }))
+            self.endpoint_state_manager.update_endpoint(
+                name, endpoint_info, TrafficPolicy({
+                    name: 1.0
+                }))
             return goal_id, updating
 
     def delete_deployment(self, name: str) -> Optional[GoalId]:
-        self.endpoint_state.delete_endpoint(name)
-        return self.backend_state.delete_backend(name, force_kill=False)
+        self.endpoint_state_manager.delete_endpoint(name)
+        return self.backend_state_manager.delete_backend(
+            name, force_kill=False)
 
     def get_deployment_info(self, name: str) -> Tuple[BackendInfo, str]:
         """Get the current information about a deployment.
@@ -332,18 +336,19 @@ class ServeController:
         Raises:
             KeyError if the deployment doesn't exist.
         """
-        backend_info: BackendInfo = self.backend_state.get_backend(name)
+        backend_info: BackendInfo = self.backend_state_manager.get_backend(
+            name)
         if backend_info is None:
             raise KeyError(f"Deployment {name} does not exist.")
 
-        route = self.endpoint_state.get_endpoint_route(name)
+        route = self.endpoint_state_manager.get_endpoint_route(name)
 
         return backend_info, route
 
     def list_deployments(self) -> Dict[str, Tuple[BackendInfo, str]]:
         """Gets the current information about all active deployments."""
         return {
-            name: (self.backend_state.get_backend(name),
-                   self.endpoint_state.get_endpoint_route(name))
-            for name in self.backend_state.get_backend_configs()
+            name: (self.backend_state_manager.get_backend(name),
+                   self.endpoint_state_manager.get_endpoint_route(name))
+            for name in self.backend_state_manager.get_backend_configs()
         }

--- a/python/ray/serve/endpoint_state_manager.py
+++ b/python/ray/serve/endpoint_state_manager.py
@@ -10,7 +10,7 @@ from ray.serve.long_poll import LongPollHost
 CHECKPOINT_KEY = "serve-endpoint-state-checkpoint"
 
 
-class EndpointState:
+class EndpointStateManager:
     """Manages all state for endpoints in the system.
 
     This class is *not* thread safe, so any state-modifying methods should be


### PR DESCRIPTION
## Why are these changes needed?

Currently when exception is thrown in deployment constructor, which is expected to happen in case of transient failures, it's not retrying with backoff or be able to correctly indicate its status to ray controller.

## Changes In this PR

- Added deployment constructor retry with exponential backoff, and will raise exception if out of retries
- [TODO] Add needed changes in backend_state or controller to handle this
- [TODO] Tests ?

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
