### PR TITLE
[core] use fallocate for fallback allocation to avoid SIGBUS

### DIFF
--- a/src/ray/object_manager/plasma/dlmalloc.cc
+++ b/src/ray/object_manager/plasma/dlmalloc.cc
@@ -20,7 +20,7 @@
 #include <assert.h>
 
 #ifdef __linux__
-#define _GNU_SOURCE
+#define _GNU_SOURCE  /* Turns on fallocate() definition */
 #include <fcntl.h>
 #endif
 

--- a/src/ray/object_manager/plasma/dlmalloc.cc
+++ b/src/ray/object_manager/plasma/dlmalloc.cc
@@ -157,7 +157,7 @@ void create_and_mmap_buffer(int64_t size, void **pointer, int *fd) {
   if (allocated_once && RayConfig::instance().plasma_unlimited()) {
     RAY_LOG(DEBUG) << "Preallocating fallback allocation using fallocate";
     int ret = fallocate(*fd, /*mode*/ 0, /*offset*/ 0, size);
-    if (!ret) {
+    if (ret != 0) {
       if (ret == EOPNOTSUPP || ret == ENOSYS) {
         // in case that fallocate is not supported by current filesystem or kernel,
         // we continue to mmap

--- a/src/ray/object_manager/plasma/dlmalloc.cc
+++ b/src/ray/object_manager/plasma/dlmalloc.cc
@@ -21,8 +21,8 @@
 
 #ifdef __linux__
 #ifndef _GNU_SOURCE
-#define _GNU_SOURCE  /* Turns on fallocate() definition */
-#endif /* _GNU_SOURCE */
+#define _GNU_SOURCE /* Turns on fallocate() definition */
+#endif              /* _GNU_SOURCE */
 #include <fcntl.h>
 #endif /* __linux__ */
 
@@ -164,7 +164,8 @@ void create_and_mmap_buffer(int64_t size, void **pointer, int *fd) {
         RAY_LOG(DEBUG) << "fallocate is not supported: " << std::strerror(errno);
       } else {
         // otherwise we short circuit the allocation with OOM error.
-        RAY_LOG(ERROR) << "Out of disk space with fallocate error: " << std::strerror(errno);
+        RAY_LOG(ERROR) << "Out of disk space with fallocate error: "
+                       << std::strerror(errno);
         *pointer = MAP_FAILED;
         return;
       }

--- a/src/ray/object_manager/plasma/dlmalloc.cc
+++ b/src/ray/object_manager/plasma/dlmalloc.cc
@@ -166,7 +166,7 @@ void create_and_mmap_buffer(int64_t size, void **pointer, int *fd) {
         // otherwise we short circuit the allocation with OOM error.
         RAY_LOG(ERROR) << "Out of disk space with fallocate error: "
                        << std::strerror(errno);
-        *pointer = MAP_FAILED;
+        *pointer = MFAIL;
         return;
       }
     }
@@ -207,6 +207,9 @@ void *fake_mmap(size_t size) {
   void *pointer;
   MEMFD_TYPE_NON_UNIQUE fd;
   create_and_mmap_buffer(size, &pointer, &fd);
+  if (pointer == MFAIL) {
+    return MFAIL;
+  }
   allocated_once = true;
 
   // Increase dlmalloc's allocation granularity directly.

--- a/src/ray/object_manager/plasma/dlmalloc.cc
+++ b/src/ray/object_manager/plasma/dlmalloc.cc
@@ -18,7 +18,12 @@
 #include "ray/object_manager/plasma/malloc.h"
 
 #include <assert.h>
+
+#ifdef __linux__
+#define _GNU_SOURCE
 #include <fcntl.h>
+#endif
+
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -144,7 +149,7 @@ void create_and_mmap_buffer(int64_t size, void **pointer, int *fd) {
     flags |= MAP_POPULATE;
   }
 
-#ifdef _GNU_SOURCE
+#ifdef __linux__
   // For fallback allocation, use fallocate to ensure follow up access to this
   // mmaped file doesn't cause SIGBUS. Only supported on Linux.
   if (allocated_once && RayConfig::instance().plasma_unlimited()) {
@@ -157,7 +162,7 @@ void create_and_mmap_buffer(int64_t size, void **pointer, int *fd) {
         RAY_LOG(DEBUG) << "fallocate is not supported: " << std::strerror(errno);
       } else {
         // otherwise we short circuit the allocation with OOM error.
-        RAY_LOG(ERROR) << "Out of memory with fallocate error: " << std::strerror(errno);
+        RAY_LOG(ERROR) << "Out of disk space with fallocate error: " << std::strerror(errno);
         *pointer = MAP_FAILED;
         return;
       }

--- a/src/ray/object_manager/plasma/dlmalloc.cc
+++ b/src/ray/object_manager/plasma/dlmalloc.cc
@@ -20,9 +20,11 @@
 #include <assert.h>
 
 #ifdef __linux__
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE  /* Turns on fallocate() definition */
+#endif /* _GNU_SOURCE */
 #include <fcntl.h>
-#endif
+#endif /* __linux__ */
 
 #include <stddef.h>
 #include <stdio.h>
@@ -168,7 +170,7 @@ void create_and_mmap_buffer(int64_t size, void **pointer, int *fd) {
       }
     }
   }
-#endif
+#endif /* __linux__ */
 
   *pointer = mmap(NULL, size, PROT_READ | PROT_WRITE, flags, *fd, 0);
   if (*pointer == MAP_FAILED) {


### PR DESCRIPTION
Recently we had a SIGBUS bug that fallback allocation crashes with SIGBUS error when /tmp is full. Ideally we'd like to throw some OOM error instead of SIGBUS. 

To address the problem, this PR uses [fallocate](https://man7.org/linux/man-pages/man2/fallocate.2.html) which guarantees that the follow up write access won't fail if fallocate call succeed. Note that this only works for linux. 

Another note is there is a [posix_fallocate](https://man7.org/linux/man-pages/man3/posix_fallocate.3.html) which falls back to emulation on non-linux systems. This is also worth considering but it may ends up with different performance behavior when fallocate/emulation is used. There is some additional caveat:

>        In the glibc implementation, posix_fallocate() is implemented
>        using the fallocate(2) system call, which is MT-safe.  If the
>        underlying filesystem does not support fallocate(2), then the
>        operation is emulated with the following caveats:
> 
>        * The emulation is inefficient.
> 
>        * There is a race condition where concurrent writes from another
>          thread or process could be overwritten with null bytes.
> 
>        * There is a race condition where concurrent file size increases
>          by another thread or process could result in a file whose size
>          is smaller than expected.
> 
>        * If fd has been opened with the O_APPEND or O_WRONLY flags, the
>          function fails with the error EBADF.

Test with shuffler:
```
(pid=36628) Epoch 0 done on consumer 1.
(pid=36628) Starting epoch 1 on consumer 1.
2021-07-06 03:37:57,350	ERROR worker.py:79 -- Unhandled error (suppress with RAY_IGNORE_UNHANDLED_ERRORS=1): ray::Consumer.consume() (pid=36616, ip=172.31.10.69)
  File "python/ray/_raylet.pyx", line 493, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 514, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 384, in ray._raylet.raise_if_dependency_failed
ray.exceptions.RayTaskError: ray::shuffle_reduce() (pid=38802, ip=172.31.10.69)
  File "python/ray/_raylet.pyx", line 563, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 564, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 1670, in ray._raylet.CoreWorker.store_task_outputs
  File "python/ray/_raylet.pyx", line 152, in ray._raylet.check_status
ray.exceptions.ObjectStoreFullError: Failed to put object 31ffddd68e69d833ffffffffffffffffffffffff0100000001000000 in object store because it is full. Object size is 1466584036 bytes.
The local object store is full of objects that are still in scope and cannot be evicted. Tip: Use the `ray memory` command to list active objects in the cluster.
(pid=36616) Epoch 0 done on consumer 3.
(pid=36616) Starting epoch 1 on consumer 3.
2021-07-06 03:38:02,257	ERROR worker.py:79 -- Unhandled error (suppress with RAY_IGNORE_UNHANDLED_ERRORS=1): ray::Consumer.consume() (pid=36625, ip=172.31.10.69)
  File "python/ray/_raylet.pyx", line 493, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 514, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 384, in ray._raylet.raise_if_dependency_failed
ray.exceptions.RayTaskError: ray::shuffle_reduce() (pid=38830, ip=172.31.10.69)
  File "python/ray/_raylet.pyx", line 563, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 564, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 1670, in ray._raylet.CoreWorker.store_task_outputs
  File "python/ray/_raylet.pyx", line 152, in ray._raylet.check_status
ray.exceptions.ObjectStoreFullError: Failed to put object 0fb939667ee64409ffffffffffffffffffffffff0100000001000000 in object store because it is full. Object size is 1466027204 bytes.
The local object store is full of objects that are still in scope and cannot be evicted. Tip: Use the `ray memory` command to list active objects in the cluster.
(pid=36625) Consuming batch on consumer 2 for epoch 0.
```

in raylet.out log:
```
[2021-07-06 03:37:33,758 I 36462 36479] dlmalloc.cc:122: create_and_mmap_buffer(1466028040, /tmp/ray/plasmaXXXXXX)
[2021-07-06 03:37:33,758 D 36462 36479] dlmalloc.cc:158: Preallocating fallback allocation using fallocate
[2021-07-06 03:37:34,540 E 36462 36479] dlmalloc.cc:167: Out of disk space with fallocate error: No space left on device
```