### PR TITLE
[release] write output for golden notebook tests

### DIFF
--- a/release/golden_notebook_tests/workloads/dask_xgboost_test.py
+++ b/release/golden_notebook_tests/workloads/dask_xgboost_test.py
@@ -1,4 +1,7 @@
 import argparse
+import json
+import os
+import time
 
 import dask
 import dask.dataframe as dd
@@ -52,4 +55,15 @@ def main():
 
 
 if __name__ == "__main__":
+    start = time.time()
     main()
+    taken = time.time() - start
+    result = {
+        "time_taken": taken,
+    }
+    test_output_json = os.environ.get("TEST_OUTPUT_JSON",
+                                      "/tmp/dask_xgboost_test.json")
+    with open(test_output_json, "wt") as f:
+        json.dump(result, f)
+
+    print("Test Successful!")

--- a/release/golden_notebook_tests/workloads/modin_xgboost_test.py
+++ b/release/golden_notebook_tests/workloads/modin_xgboost_test.py
@@ -1,4 +1,7 @@
 import argparse
+import json
+import os
+import time
 
 import modin.pandas as pd
 import ray
@@ -49,4 +52,15 @@ def main():
 
 
 if __name__ == "__main__":
+    start = time.time()
     main()
+    taken = time.time() - start
+    result = {
+        "time_taken": taken,
+    }
+    test_output_json = os.environ.get("TEST_OUTPUT_JSON",
+                                      "/tmp/modin_xgboost_test.json")
+    with open(test_output_json, "wt") as f:
+        json.dump(result, f)
+
+    print("Test Successful!")

--- a/release/golden_notebook_tests/workloads/torch_tune_serve_test.py
+++ b/release/golden_notebook_tests/workloads/torch_tune_serve_test.py
@@ -1,4 +1,7 @@
 import argparse
+import json
+import os
+import time
 
 import ray
 import requests
@@ -167,6 +170,8 @@ def test_predictions(test_mode=False):
     print("Labels = {}. Predictions = {}. {} out of {} are correct.".format(
         list(labels), predictions, correct, num_to_test))
 
+    return correct / float(num_to_test)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -176,6 +181,8 @@ if __name__ == "__main__":
         default=False,
         help="Finish quickly for testing.")
     args = parser.parse_args()
+
+    start = time.time()
 
     ray.client("anyscale://").connect()
     num_workers = 2
@@ -192,6 +199,16 @@ if __name__ == "__main__":
     setup_serve(model_id)
 
     print("Testing Prediction Service.")
-    test_predictions(args.smoke_test)
+    accuracy = test_predictions(args.smoke_test)
+
+    taken = time.time() - start
+    result = {
+        "time_taken": taken,
+        "accuracy": accuracy,
+    }
+    test_output_json = os.environ.get("TEST_OUTPUT_JSON",
+                                      "/tmp/torch_tune_serve_test.json")
+    with open(test_output_json, "wt") as f:
+        json.dump(result, f)
 
     print("Test Successful!")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Release tests expect `/tmp/release_test_out.json` to be written for each test. For now, we store basic metrics such as time taken for all tests and the accuracy of the model for `torch_tune_serve_test`. 

Example failure: https://buildkite.com/ray-project/periodic-ci/builds/492

## Related issue number

<!-- For example: "Closes #1234" -->
n/a

## Checks

Ran `e2e` successfully: [session](https://beta.anyscale.com/o/anyscale-internal/projects/prj_6ql9vRLldtxt3yKyLDTdCo/clusters/ses_LbyrtcLgCE9URhX7UbNg5jjr)

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
