### PR TITLE
[rllib] Fix to allow input strings that are not file paths

### DIFF
--- a/rllib/train.py
+++ b/rllib/train.py
@@ -182,10 +182,15 @@ def run(args, parser):
             inputs = force_list(input_)
             # This script runs in the ray/rllib dir.
             rllib_dir = Path(__file__).parent
-            abs_inputs = [
-                str(rllib_dir.absolute().joinpath(i))
-                if not os.path.exists(i) else i for i in inputs
-            ]
+
+            def patch_path(path):
+                if os.path.exists(path):
+                    return path
+                else:
+                    abs_path = str(rllib_dir.absolute().joinpath(path))
+                    return abs_path if os.path.exists(abs_path) else path
+
+            abs_inputs = list(map(patch_path, inputs))
             if not isinstance(input_, list):
                 abs_inputs = abs_inputs[0]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This change allows the `input` config option to take values that are not file paths (for example, d4rl).
The logic is, if the string is not already a valid path, check if the absolute rllib path prepended to it is a valid one, and otherwise just use the original string.

## Related issue number

<!-- For example: "Closes #1234" -->
Fixes #16829

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
