### PR TITLE
[tune] Allow the logging of wandb.Image in tune.integration.wandb

### DIFF
--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -23,8 +23,8 @@ except ImportError:
 
 WANDB_ENV_VAR = "WANDB_API_KEY"
 _WANDB_QUEUE_END = (None, )
-_VALID_TYPES = (Number, wandb.data_types.Video)
-_VALID_ITERABLE_TYPES = (wandb.data_types.Video)
+_VALID_TYPES = (Number, wandb.data_types.Video, wandb.data_types.Image)
+_VALID_ITERABLE_TYPES = (wandb.data_types.Video, wandb.data_types.Image)
 
 
 def _is_allowed_type(obj):


### PR DESCRIPTION

## Why are these changes needed?

Allow the logging of wandb.Image in tune.integration.wandb

## Related issue number

Closes #16837 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
