### PR TITLE
Deflake test_failure_3

### DIFF
--- a/python/ray/test_utils.py
+++ b/python/ray/test_utils.py
@@ -375,6 +375,7 @@ def generate_system_config_map(**kwargs):
 class SignalActor:
     def __init__(self):
         self.ready_event = asyncio.Event()
+        self.num_waiters = 0
 
     def send(self, clear=False):
         self.ready_event.set()
@@ -383,7 +384,12 @@ class SignalActor:
 
     async def wait(self, should_wait=True):
         if should_wait:
+            self.num_waiters += 1
             await self.ready_event.wait()
+            self.num_waiters -= 1
+
+    async def cur_num_waiters(self):
+        return self.num_waiters
 
 
 @ray.remote(num_cpus=0)

--- a/python/ray/tests/test_failure_3.py
+++ b/python/ray/tests/test_failure_3.py
@@ -90,6 +90,7 @@ def test_async_actor_task_retries(ray_start_regular):
         if ray.get(signal.cur_num_waiters.remote()) > 0:
             break
         time.sleep(.1)
+    assert ray.get(signal.cur_num_waiters.remote()) > 0
     # seqno 2
     ref_2 = dying.set_should_exit.remote()
     assert ray.get(ref_2) is None

--- a/python/ray/tests/test_failure_3.py
+++ b/python/ray/tests/test_failure_3.py
@@ -5,6 +5,7 @@ import ray
 
 import numpy as np
 import pytest
+import time
 
 from ray.test_utils import SignalActor
 
@@ -83,6 +84,12 @@ def test_async_actor_task_retries(ray_start_regular):
     assert ray.get(ref_0) == 0
     # seqno 1
     ref_1 = dying.get.remote(1, wait=True)
+    # Need a barrier here to ensure ordering between the async and sync call.
+    # Otherwise ref2 could be executed prior to ref1.
+    for i in range(100):
+        if ray.get(signal.cur_num_waiters.remote()) > 0:
+            break
+        time.sleep(.1)
     # seqno 2
     ref_2 = dying.set_should_exit.remote()
     assert ray.get(ref_2) is None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This test was flaky due to an incorrect ordering assumption between async and non-async tasks.