### PR TITLE
[docs] Cleanup workflow api.py pydoc and spell out ObjectRef for clarity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,6 @@ project-id
 # release test related
 .anyscale.yaml
 test_state.json
+
+# workflow storage
+workflow_data/

--- a/python/ray/experimental/workflow/api.py
+++ b/python/ray/experimental/workflow/api.py
@@ -14,30 +14,58 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def step(func) -> WorkflowStepFunction:
-    """
-    A decorator wraps over a function to turn it into a workflow step function.
+def step(func: types.FunctionType) -> WorkflowStepFunction:
+    """A decorator used for creating workflow steps.
+
+    Examples:
+        >>> @workflow.step
+        ... def book_flight(origin: str, dest: str) -> Flight:
+        ...    ...
+
+    Args:
+        func: The function to turn into a workflow step.
     """
     if not isinstance(func, types.FunctionType):
-        raise TypeError("The @step decorator must wraps over a function.")
+        raise TypeError(
+            "The @workflow.step decorator can only wrap a function.")
     return WorkflowStepFunction(func)
 
 
 def run(entry_workflow: "Workflow",
         storage: "Optional[Union[str, Storage]]" = None,
         workflow_id: Optional[str] = None) -> ray.ObjectRef:
-    """
-    Run a workflow asynchronously.
+    """Run a workflow asynchronously.
+
+    Examples:
+        >>> @workflow.step
+        ... def book_flight(origin: str, dest: str) -> Flight:
+        ...    ...
+
+        >>> @workflow.step
+        ... def book_hotel(location: str) -> Reservation:
+        ...    ...
+
+        >>> @workflow.step
+        ... def finalize_trip(bookings: List[Any]) -> Trip:
+        ...    ...
+
+        >>> flight1 = book_flight.step("OAK", "SAN")
+        >>> flight2 = book_flight.step("SAN", "OAK")
+        >>> hotel = book_hotel.step("SAN")
+        >>> trip = finalize_trip.step([flight1, flight2, hotel])
+        >>> ray.get(workflow.run(trip))
 
     Args:
-        entry_workflow: The workflow to run.
-        storage: The storage or the URL of an external storage used for
-            checkpointing.
-        workflow_id: The ID of the workflow. The ID is used to identify
-            the workflow.
+        entry_workflow: The output step of the workflow to run. The return
+            type of the workflow will be ObjectRef[T] if the output step is
+            a workflow step returning type T.
+        storage: The external storage URL or a custom storage class. If not
+            specified, ``$(pwd)/workflow_data`` will be used.
+        workflow_id: A unique identifier that can be used to resume the
+            workflow. If not specified, a random id will be generated.
 
     Returns:
-        The execution result of the workflow, represented by Ray ObjectRef.
+        An object reference that can be used to retrieve the workflow result.
     """
     assert ray.is_initialized()
     return execution.run(entry_workflow, storage, workflow_id)
@@ -45,17 +73,24 @@ def run(entry_workflow: "Workflow",
 
 def resume(workflow_id: str,
            storage: "Optional[Union[str, Storage]]" = None) -> ray.ObjectRef:
-    """
-    Resume a workflow asynchronously. This workflow maybe fail previously.
+    """Resume a workflow.
+
+    Resume a workflow and retrieve its output. If the workflow was incomplete,
+    it will be re-executed from its checkpointed outputs. If the workflow was
+    complete, returns the result immediately.
+
+    Examples:
+        >>> res1 = workflow.run(trip, workflow_id="trip1")
+        >>> res2 = workflow.resume("trip1")
+        >>> assert ray.get(res1) == ray.get(res2)
 
     Args:
-        workflow_id: The ID of the workflow. The ID is used to identify
-            the workflow.
-        storage: The storage or the URL of an external storage used for
-            checkpointing.
+        workflow_id: The id of the workflow to resume.
+        storage: The external storage URL or a custom storage class. If not
+            specified, ``$(pwd)/workflow_data`` will be used.
 
     Returns:
-        The execution result of the workflow, represented by Ray ObjectRef.
+        An object reference that can be used to retrieve the workflow result.
     """
     assert ray.is_initialized()
     return execution.resume(workflow_id, storage)

--- a/python/ray/experimental/workflow/api.py
+++ b/python/ray/experimental/workflow/api.py
@@ -20,7 +20,7 @@ def step(func: types.FunctionType) -> WorkflowStepFunction:
     Examples:
         >>> @workflow.step
         ... def book_flight(origin: str, dest: str) -> Flight:
-        ...    ...
+        ...    return Flight(...)
 
     Args:
         func: The function to turn into a workflow step.
@@ -39,15 +39,15 @@ def run(entry_workflow: "Workflow",
     Examples:
         >>> @workflow.step
         ... def book_flight(origin: str, dest: str) -> Flight:
-        ...    ...
+        ...    return Flight(...)
 
         >>> @workflow.step
         ... def book_hotel(location: str) -> Reservation:
-        ...    ...
+        ...    return Reservation(...)
 
         >>> @workflow.step
         ... def finalize_trip(bookings: List[Any]) -> Trip:
-        ...    ...
+        ...    return Trip(...)
 
         >>> flight1 = book_flight.step("OAK", "SAN")
         >>> flight2 = book_flight.step("SAN", "OAK")

--- a/python/ray/experimental/workflow/common.py
+++ b/python/ray/experimental/workflow/common.py
@@ -6,13 +6,12 @@ import uuid
 
 from dataclasses import dataclass
 
-import ray
+from ray import ObjectRef
 
 # Alias types
-RRef = ray.ObjectRef  # Alias ObjectRef because it is too long in type hints.
 StepID = str
-WorkflowOutputType = RRef
-WorkflowInputTuple = Tuple[RRef, List["Workflow"], List[RRef]]
+WorkflowOutputType = ObjectRef
+WorkflowInputTuple = Tuple[ObjectRef, List["Workflow"], List[ObjectRef]]
 StepExecutionFunction = Callable[
     [StepID, WorkflowInputTuple, Optional[StepID]], WorkflowOutputType]
 SerializedStepFunction = str
@@ -23,7 +22,7 @@ class WorkflowInputs:
     # The workflow step function body.
     func_body: Callable
     # The object ref of the input arguments.
-    args: RRef
+    args: ObjectRef
     # The hex string of object refs in the arguments.
     object_refs: List[str]
     # The ID of workflows in the arguments.
@@ -50,11 +49,12 @@ def slugify(value: str, allow_unicode=False):
 class Workflow:
     def __init__(self, original_function: Callable,
                  step_execution_function: StepExecutionFunction,
-                 input_placeholder: RRef, input_workflows: List["Workflow"],
-                 input_object_refs: List[RRef]):
-        self._input_placeholder: RRef = input_placeholder
+                 input_placeholder: ObjectRef,
+                 input_workflows: List["Workflow"],
+                 input_object_refs: List[ObjectRef]):
+        self._input_placeholder: ObjectRef = input_placeholder
         self._input_workflows: List[Workflow] = input_workflows
-        self._input_object_refs: List[RRef] = input_object_refs
+        self._input_object_refs: List[ObjectRef] = input_object_refs
         # we need the original function for checkpointing
         self._original_function: Callable = original_function
         self._step_execution_function: StepExecutionFunction = (
@@ -79,7 +79,8 @@ class Workflow:
     def id(self) -> StepID:
         return self._step_id
 
-    def execute(self, outer_most_step_id: Optional[StepID] = None) -> RRef:
+    def execute(self,
+                outer_most_step_id: Optional[StepID] = None) -> ObjectRef:
         """Trigger workflow execution recursively.
 
         Args:

--- a/python/ray/experimental/workflow/recovery.py
+++ b/python/ray/experimental/workflow/recovery.py
@@ -125,8 +125,8 @@ def resume_workflow_job(workflow_id: str,
         try:
             workflow_context.init_workflow_step_context(
                 workflow_id, store.storage_url)
-            rref = execute_workflow(r)
-            return flatten_workflow_output(workflow_id, rref)
+            obj_ref = execute_workflow(r)
+            return flatten_workflow_output(workflow_id, obj_ref)
         finally:
             workflow_context.set_workflow_step_context(None)
 

--- a/python/ray/experimental/workflow/serialization_context.py
+++ b/python/ray/experimental/workflow/serialization_context.py
@@ -62,12 +62,12 @@ def workflow_args_serialization_context(
         serializer=workflow_serializer,
         deserializer=_resolve_workflow_outputs)
 
-    def objectref_serializer(rref):
-        if rref in objectref_deduplicator:
-            return objectref_deduplicator[rref]
+    def objectref_serializer(obj_ref):
+        if obj_ref in objectref_deduplicator:
+            return objectref_deduplicator[obj_ref]
         i = len(object_refs)
-        object_refs.append(rref)
-        objectref_deduplicator[rref] = i
+        object_refs.append(obj_ref)
+        objectref_deduplicator[obj_ref] = i
         return i
 
     # override the default ObjectRef serializer

--- a/python/ray/experimental/workflow/step_function.py
+++ b/python/ray/experimental/workflow/step_function.py
@@ -4,12 +4,13 @@ from typing import List, Tuple, Callable, Optional
 
 import ray
 
+from ray import ObjectRef
 from ray.experimental.workflow import serialization_context
 from ray.experimental.workflow.common import (
-    RRef, Workflow, StepID, WorkflowOutputType, WorkflowInputTuple)
+    Workflow, StepID, WorkflowOutputType, WorkflowInputTuple)
 from ray.experimental.workflow.step_executor import execute_workflow_step
 
-StepInputTupleToResolve = Tuple[RRef, List[RRef], List[RRef]]
+StepInputTupleToResolve = Tuple[ObjectRef, List[ObjectRef], List[ObjectRef]]
 
 
 class WorkflowStepFunction:
@@ -32,7 +33,7 @@ class WorkflowStepFunction:
             except TypeError as exc:  # capture a friendlier stacktrace
                 raise TypeError(str(exc)) from None
             workflows: List[Workflow] = []
-            object_refs: List[RRef] = []
+            object_refs: List[ObjectRef] = []
             with serialization_context.workflow_args_serialization_context(
                     workflows, object_refs):
                 # NOTE: When calling 'ray.put', we trigger python object
@@ -43,7 +44,7 @@ class WorkflowStepFunction:
                 # so it won't be mutated later. This guarantees correct
                 # semantics. See "tests/test_variable_mutable.py" as
                 # an example.
-                input_placeholder: RRef = ray.put((args, kwargs))
+                input_placeholder: ObjectRef = ray.put((args, kwargs))
                 if object_refs:
                     raise ValueError(
                         "There are ObjectRefs in workflow inputs. However "

--- a/python/ray/experimental/workflow/storage/__init__.py
+++ b/python/ray/experimental/workflow/storage/__init__.py
@@ -22,7 +22,7 @@ def create_storage(storage_url: str) -> Storage:
 
 
 # the default storage is a local filesystem storage with a hidden directory
-_global_storage = create_storage(os.path.join(os.path.curdir, ".rayflow"))
+_global_storage = create_storage(os.path.join(os.path.curdir, "workflow_data"))
 
 
 def get_global_storage() -> Storage:

--- a/python/ray/experimental/workflow/storage/base.py
+++ b/python/ray/experimental/workflow/storage/base.py
@@ -204,12 +204,13 @@ class Storage(metaclass=abc.ABCMeta):
         """
 
     @abstractmethod
-    def save_object_ref(self, workflow_id: str, rref: ray.ObjectRef) -> None:
+    def save_object_ref(self, workflow_id: str,
+                        obj_ref: ray.ObjectRef) -> None:
         """Save the input object ref.
 
         Args:
             workflow_id: ID of the workflow job.
-            rref: The ObjectRef to be saved.
+            obj_ref: The ObjectRef to be saved.
 
         Raises:
             DataSaveError: if we fail to save the object ref.

--- a/python/ray/experimental/workflow/storage/filesystem.py
+++ b/python/ray/experimental/workflow/storage/filesystem.py
@@ -230,11 +230,12 @@ class FilesystemStorageImpl(Storage):
         except Exception as e:
             raise DataLoadError from e
 
-    def save_object_ref(self, workflow_id: str, rref: ray.ObjectRef) -> None:
+    def save_object_ref(self, workflow_id: str,
+                        obj_ref: ray.ObjectRef) -> None:
         objects_dir = self._workflow_root_dir / workflow_id / OBJECTS_DIR
         try:
-            obj = ray.get(rref)
-            with _open_atomic(objects_dir / rref.hex(), "wb") as f:
+            obj = ray.get(obj_ref)
+            with _open_atomic(objects_dir / obj_ref.hex(), "wb") as f:
                 ray.cloudpickle.dump(obj, f)
         except Exception as e:
             raise DataSaveError from e

--- a/python/ray/experimental/workflow/tests/test_object_deref.py
+++ b/python/ray/experimental/workflow/tests/test_object_deref.py
@@ -3,11 +3,10 @@ from typing import List, Dict
 import pytest
 
 import numpy as np
-import ray
-from ray.experimental import workflow
 
-# alias because the original type is too long
-RRef = ray.ObjectRef
+import ray
+from ray import ObjectRef
+from ray.experimental import workflow
 
 
 @ray.remote
@@ -24,8 +23,9 @@ def nested_workflow(n: int):
 
 
 @workflow.step
-def deref_check(u: int, v: "RRef[int]", w: "List[RRef[RRef[int]]]", x: str,
-                y: List[str], z: List[Dict[str, str]]):
+def deref_check(u: int, v: "ObjectRef[int]",
+                w: "List[ObjectRef[ObjectRef[int]]]", x: str, y: List[str],
+                z: List[Dict[str, str]]):
     try:
         return (u == 42 and ray.get(v) == 42 and ray.get(ray.get(w[0])) == 42
                 and x == "nested" and y[0] == "nested"

--- a/python/ray/experimental/workflow/tests/test_storage.py
+++ b/python/ray/experimental/workflow/tests/test_storage.py
@@ -21,13 +21,13 @@ def test_raw_storage():
     args = ([1, "2"], {"k": b"543"})
     output = ["the_answer"]
     object_resolved = 42
-    rref = ray.put(object_resolved)
+    obj_ref = ray.put(object_resolved)
 
     # test creating normal objects
     raw_storage.save_step_input_metadata(workflow_id, step_id, input_metadata)
     raw_storage.save_step_func_body(workflow_id, step_id, some_func)
     raw_storage.save_step_args(workflow_id, step_id, args)
-    raw_storage.save_object_ref(workflow_id, rref)
+    raw_storage.save_object_ref(workflow_id, obj_ref)
     raw_storage.save_step_output_metadata(workflow_id, step_id,
                                           output_metadata)
     raw_storage.save_step_output(workflow_id, step_id, output)
@@ -43,8 +43,8 @@ def test_raw_storage():
                                                 step_id) == input_metadata
     assert raw_storage.load_step_func_body(workflow_id, step_id)(33) == 34
     assert raw_storage.load_step_args(workflow_id, step_id) == args
-    assert ray.get(raw_storage.load_object_ref(workflow_id,
-                                               rref.hex())) == object_resolved
+    assert ray.get(raw_storage.load_object_ref(
+        workflow_id, obj_ref.hex())) == object_resolved
     assert raw_storage.load_step_output_metadata(workflow_id,
                                                  step_id) == output_metadata
     assert raw_storage.load_step_output(workflow_id, step_id) == output
@@ -55,12 +55,12 @@ def test_raw_storage():
     args = (args, "overwrite")
     output = (output, "overwrite")
     object_resolved = (object_resolved, "overwrite")
-    rref = ray.put(object_resolved)
+    obj_ref = ray.put(object_resolved)
 
     raw_storage.save_step_input_metadata(workflow_id, step_id, input_metadata)
     raw_storage.save_step_func_body(workflow_id, step_id, some_func2)
     raw_storage.save_step_args(workflow_id, step_id, args)
-    raw_storage.save_object_ref(workflow_id, rref)
+    raw_storage.save_object_ref(workflow_id, obj_ref)
     raw_storage.save_step_output_metadata(workflow_id, step_id,
                                           output_metadata)
     raw_storage.save_step_output(workflow_id, step_id, output)
@@ -68,8 +68,8 @@ def test_raw_storage():
                                                 step_id) == input_metadata
     assert raw_storage.load_step_func_body(workflow_id, step_id)(33) == 32
     assert raw_storage.load_step_args(workflow_id, step_id) == args
-    assert ray.get(raw_storage.load_object_ref(workflow_id,
-                                               rref.hex())) == object_resolved
+    assert ray.get(raw_storage.load_object_ref(
+        workflow_id, obj_ref.hex())) == object_resolved
     assert raw_storage.load_step_output_metadata(workflow_id,
                                                  step_id) == output_metadata
     assert raw_storage.load_step_output(workflow_id, step_id) == output
@@ -94,13 +94,13 @@ def test_workflow_storage():
     args = ([1, "2"], {"k": b"543"})
     output = ["the_answer"]
     object_resolved = 42
-    rref = ray.put(object_resolved)
+    obj_ref = ray.put(object_resolved)
 
     # test basics
     raw_storage.save_step_input_metadata(workflow_id, step_id, input_metadata)
     raw_storage.save_step_func_body(workflow_id, step_id, some_func)
     raw_storage.save_step_args(workflow_id, step_id, args)
-    raw_storage.save_object_ref(workflow_id, rref)
+    raw_storage.save_object_ref(workflow_id, obj_ref)
     raw_storage.save_step_output_metadata(workflow_id, step_id,
                                           output_metadata)
     raw_storage.save_step_output(workflow_id, step_id, output)
@@ -109,7 +109,8 @@ def test_workflow_storage():
     assert wf_storage.load_step_output(step_id) == output
     assert wf_storage.load_step_args(step_id, [], []) == args
     assert wf_storage.load_step_func_body(step_id)(33) == 34
-    assert ray.get(wf_storage.load_object_ref(rref.hex())) == object_resolved
+    assert ray.get(wf_storage.load_object_ref(
+        obj_ref.hex())) == object_resolved
 
     # test "inspect_step"
     inspect_result = wf_storage.inspect_step(step_id)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- Rename RRef => ObjectRef
- Cleans up api.py pydoc and adds examples
- Renames storage directory from .rayflow/ to workflow_data/