### PR TITLE
[Core] fix typo in DispatchScheduledTasksToWorkers

### DIFF
--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -243,7 +243,7 @@ void ClusterTaskManager::DispatchScheduledTasksToWorkers(
                        << worker->WorkerId();
         auto reply = std::get<1>(*work_it);
         auto callback = std::get<2>(*work_it);
-        Dispatch(worker, leased_workers_, allocated_instances, task, reply, callback);
+        Dispatch(worker, leased_workers, allocated_instances, task, reply, callback);
       }
 
       if (!spec.GetDependencies().empty()) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

We passed `leased_workers_` into method `ClusterTaskManager::DispatchScheduledTasksToWorkers`, but use the class field `leased_workers_` directly instead of the parameter `leased_workers` in this method.  The parameter `leased_workers` is useless. It makes me confused. I think it is just a typo?

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
