### PR TITLE
[Client][Proxy] Handle Non-Default Redis Password

### DIFF
--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -120,8 +120,9 @@ assert info._num_clients == {num_clients}
     sys.platform == "win32",
     reason="PSUtil does not work the same on windows.")
 @pytest.mark.parametrize(
-    "call_ray_start",
-    ["ray start --head --ray-client-server-port 25005 --port 0"],
+    "call_ray_start", [
+        "ray start --head --ray-client-server-port 25005 --port 0 --redis-password=password"
+    ],
     indirect=True)
 def test_correct_num_clients(call_ray_start):
     """

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -121,7 +121,8 @@ assert info._num_clients == {num_clients}
     reason="PSUtil does not work the same on windows.")
 @pytest.mark.parametrize(
     "call_ray_start", [
-        "ray start --head --ray-client-server-port 25005 --port 0 --redis-password=password"
+        "ray start --head --ray-client-server-port 25005 "
+        "--port 0 --redis-password=password"
     ],
     indirect=True)
 def test_correct_num_clients(call_ray_start):

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -30,8 +30,8 @@ def test_proxy_manager_lifecycle(shutdown_only):
     ray_instance = ray.init()
     proxier.CHECK_PROCESS_INTERVAL_S = 1
     os.environ["TIMEOUT_FOR_SPECIFIC_SERVER_S"] = "5"
-    pm = proxier.ProxyManager(ray_instance["redis_address"],
-                              ray_instance["session_dir"])
+    pm = proxier.ProxyManager(
+        ray_instance["redis_address"], session_dir=ray_instance["session_dir"])
     # NOTE: We use different ports between runs because sometimes the port is
     # not released, introducing flakiness.
     port_one, port_two = random.choices(range(45000, 45100), k=2)
@@ -70,8 +70,8 @@ def test_proxy_manager_bad_startup(shutdown_only):
     ray_instance = ray.init()
     proxier.CHECK_PROCESS_INTERVAL_S = 1
     proxier.CHECK_CHANNEL_TIMEOUT_S = 1
-    pm = proxier.ProxyManager(ray_instance["redis_address"],
-                              ray_instance["session_dir"])
+    pm = proxier.ProxyManager(
+        ray_instance["redis_address"], session_dir=ray_instance["session_dir"])
     pm._free_ports = [46000, 46001]
     client = "client1"
 
@@ -159,9 +159,10 @@ def test_delay_in_rewriting_environment(shutdown_only):
         time.sleep(6)
         return input
 
-    server = proxier.serve_proxier("localhost:25010",
-                                   ray_instance["redis_address"],
-                                   session_dir=ray_instance["session_dir"])
+    server = proxier.serve_proxier(
+        "localhost:25010",
+        ray_instance["redis_address"],
+        session_dir=ray_instance["session_dir"])
 
     with patch.object(proxier, "ray_client_server_env_prep", delay_in_rewrite):
         run_string_as_driver(check_connection)
@@ -195,9 +196,10 @@ def test_startup_error_yields_clean_result(shutdown_only):
     def raise_not_rewrite(input: JobConfig):
         raise RuntimeError("WEIRD_ERROR")
 
-    server = proxier.serve_proxier("localhost:25030",
-                                   ray_instance["redis_address"],
-                                   session_dir=ray_instance["session_dir"])
+    server = proxier.serve_proxier(
+        "localhost:25030",
+        ray_instance["redis_address"],
+        session_dir=ray_instance["session_dir"])
 
     with patch.object(proxier, "ray_client_server_env_prep",
                       raise_not_rewrite):

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -161,7 +161,7 @@ def test_delay_in_rewriting_environment(shutdown_only):
 
     server = proxier.serve_proxier("localhost:25010",
                                    ray_instance["redis_address"],
-                                   ray_instance["session_dir"])
+                                   session_dir=ray_instance["session_dir"])
 
     with patch.object(proxier, "ray_client_server_env_prep", delay_in_rewrite):
         run_string_as_driver(check_connection)
@@ -197,7 +197,7 @@ def test_startup_error_yields_clean_result(shutdown_only):
 
     server = proxier.serve_proxier("localhost:25030",
                                    ray_instance["redis_address"],
-                                   ray_instance["session_dir"])
+                                   session_dir=ray_instance["session_dir"])
 
     with patch.object(proxier, "ray_client_server_env_prep",
                       raise_not_rewrite):

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -106,10 +106,12 @@ def _match_running_client_server(command: List[str]) -> bool:
 class ProxyManager():
     def __init__(self,
                  redis_address: Optional[str],
-                 session_dir: Optional[str] = None):
+                 session_dir: Optional[str] = None,
+                 redis_password: Optional[str] = None):
         self.servers: Dict[str, SpecificServer] = dict()
         self.server_lock = RLock()
         self._redis_address = redis_address
+        self._redis_password = redis_password
         self._free_ports: List[int] = list(
             range(MIN_SPECIFIC_SERVER_PORT, MAX_SPECIFIC_SERVER_PORT))
 
@@ -160,8 +162,12 @@ class ProxyManager():
         if self._node:
             return self._node
 
+        ray_params = RayParams(redis_address=self.redis_address)
+        if self._redis_password:
+            ray_params.redis_password = self._redis_password
+
         self._node = ray.node.Node(
-            RayParams(redis_address=self.redis_address),
+            ray_params,
             head=False,
             shutdown_at_exit=False,
             spawn_reaper=False,
@@ -208,7 +214,8 @@ class ProxyManager():
             fate_share=self.fate_share,
             server_type="specific-server",
             serialized_runtime_env=serialized_runtime_env,
-            session_dir=self.node.get_session_dir_path())
+            session_dir=self.node.get_session_dir_path(),
+            redis_password=self._redis_password)
 
         # Wait for the process being run transitions from the shim process
         # to the actual RayClient Server.
@@ -499,11 +506,13 @@ class LogstreamServicerProxy(ray_client_pb2_grpc.RayletLogStreamerServicer):
 
 def serve_proxier(connection_str: str,
                   redis_address: str,
+                  *,
+                  redis_password: Optional[str] = None,
                   session_dir: Optional[str] = None):
     server = grpc.server(
         futures.ThreadPoolExecutor(max_workers=CLIENT_SERVER_MAX_THREADS),
         options=GRPC_OPTIONS)
-    proxy_manager = ProxyManager(redis_address, session_dir)
+    proxy_manager = ProxyManager(redis_address, redis_password, session_dir)
     task_servicer = RayletServicerProxy(None, proxy_manager)
     data_servicer = DataServicerProxy(proxy_manager)
     logs_servicer = LogstreamServicerProxy(proxy_manager)

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -106,6 +106,7 @@ def _match_running_client_server(command: List[str]) -> bool:
 class ProxyManager():
     def __init__(self,
                  redis_address: Optional[str],
+                 *,
                  session_dir: Optional[str] = None,
                  redis_password: Optional[str] = None):
         self.servers: Dict[str, SpecificServer] = dict()
@@ -512,7 +513,8 @@ def serve_proxier(connection_str: str,
     server = grpc.server(
         futures.ThreadPoolExecutor(max_workers=CLIENT_SERVER_MAX_THREADS),
         options=GRPC_OPTIONS)
-    proxy_manager = ProxyManager(redis_address, redis_password, session_dir)
+    proxy_manager = ProxyManager(
+        redis_address, session_dir=session_dir, redis_password=redis_password)
     task_servicer = RayletServicerProxy(None, proxy_manager)
     data_servicer = DataServicerProxy(proxy_manager)
     logs_servicer = LogstreamServicerProxy(proxy_manager)

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -700,8 +700,8 @@ def main():
     hostport = "%s:%d" % (args.host, args.port)
     logger.info(f"Starting Ray Client server on {hostport}")
     if args.mode == "proxy":
-        server = serve_proxier(hostport, args.redis_address,
-                               args.redis_password)
+        server = serve_proxier(
+            hostport, args.redis_address, redis_password=args.redis_password)
     else:
         server = serve(hostport, ray_connect_handler)
 

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -700,7 +700,8 @@ def main():
     hostport = "%s:%d" % (args.host, args.port)
     logger.info(f"Starting Ray Client server on {hostport}")
     if args.mode == "proxy":
-        server = serve_proxier(hostport, args.redis_address)
+        server = serve_proxier(hostport, args.redis_address,
+                               args.redis_password)
     else:
         server = serve(hostport, ray_connect_handler)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* The ClientServer proxy did not previously pipe redis password in.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/16776

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
