### PR TITLE
Revert the gRPC-based resource broadcast due to check failures during cluster autoscaling

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -253,7 +253,8 @@ RAY_CONFIG(uint64_t, gcs_max_concurrent_resource_pulls, 100)
 // mutually exlusive.
 RAY_CONFIG(bool, pull_based_resource_reporting, true)
 // Feature flag to use grpc instead of redis for resource broadcast.
-RAY_CONFIG(bool, grpc_based_resource_broadcast, true)
+// TODO(ekl) broken as of https://github.com/ray-project/ray/issues/16858
+RAY_CONFIG(bool, grpc_based_resource_broadcast, false)
 // Feature flag to enable grpc based pubsub in GCS.
 RAY_CONFIG(bool, gcs_grpc_based_pubsub, false)
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -252,6 +252,8 @@ RAY_CONFIG(uint64_t, gcs_max_concurrent_resource_pulls, 100)
 // Feature flag to turn on resource report polling. Polling and raylet pushing are
 // mutually exlusive.
 RAY_CONFIG(bool, pull_based_resource_reporting, true)
+// Feature flag to use grpc instead of redis for resource broadcast.
+RAY_CONFIG(bool, grpc_based_resource_broadcast, true)
 // Feature flag to enable grpc based pubsub in GCS.
 RAY_CONFIG(bool, gcs_grpc_based_pubsub, false)
 

--- a/src/ray/gcs/accessor.h
+++ b/src/ray/gcs/accessor.h
@@ -87,6 +87,17 @@ class ActorInfoAccessor {
   virtual Status AsyncCreateActor(const TaskSpecification &task_spec,
                                   const StatusCallback &callback) = 0;
 
+  /// Subscribe to any register or update operations of actors.
+  ///
+  /// \param subscribe Callback that will be called each time when an actor is registered
+  /// or updated.
+  /// \param done Callback that will be called when subscription is complete and we
+  /// are ready to receive notification.
+  /// \return Status
+  virtual Status AsyncSubscribeAll(
+      const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
+      const StatusCallback &done) = 0;
+
   /// Subscribe to any update operations of an actor.
   ///
   /// \param actor_id The ID of actor to be subscribed to.
@@ -180,6 +191,96 @@ class JobInfoAccessor {
 
  protected:
   JobInfoAccessor() = default;
+};
+
+/// \class TaskInfoAccessor
+/// `TaskInfoAccessor` is a sub-interface of `GcsClient`.
+/// This class includes all the methods that are related to accessing
+/// task information in the GCS.
+class TaskInfoAccessor {
+ public:
+  virtual ~TaskInfoAccessor() {}
+
+  /// Add a task to GCS asynchronously.
+  ///
+  /// \param data_ptr The task that will be added to GCS.
+  /// \param callback Callback that will be called after task has been added
+  /// to GCS.
+  /// \return Status
+  virtual Status AsyncAdd(const std::shared_ptr<rpc::TaskTableData> &data_ptr,
+                          const StatusCallback &callback) = 0;
+
+  /// Get task information from GCS asynchronously.
+  ///
+  /// \param task_id The ID of the task to look up in GCS.
+  /// \param callback Callback that is called after lookup finished.
+  /// \return Status
+  virtual Status AsyncGet(const TaskID &task_id,
+                          const OptionalItemCallback<rpc::TaskTableData> &callback) = 0;
+
+  /// Add a task lease to GCS asynchronously.
+  ///
+  /// \param data_ptr The task lease that will be added to GCS.
+  /// \param callback Callback that will be called after task lease has been added
+  /// to GCS.
+  /// \return Status
+  virtual Status AsyncAddTaskLease(const std::shared_ptr<rpc::TaskLeaseData> &data_ptr,
+                                   const StatusCallback &callback) = 0;
+
+  /// Get task lease information from GCS asynchronously.
+  ///
+  /// \param task_id The ID of the task to look up in GCS.
+  /// \param callback Callback that is called after lookup finished.
+  /// \return Status
+  virtual Status AsyncGetTaskLease(
+      const TaskID &task_id,
+      const OptionalItemCallback<rpc::TaskLeaseData> &callback) = 0;
+
+  /// Subscribe asynchronously to the event that the given task lease is added in GCS.
+  ///
+  /// \param task_id The ID of the task to be subscribed to.
+  /// \param subscribe Callback that will be called each time when the task lease is
+  /// updated or the task lease is empty currently.
+  /// \param done Callback that will be called when subscription is complete.
+  /// \return Status
+  virtual Status AsyncSubscribeTaskLease(
+      const TaskID &task_id,
+      const SubscribeCallback<TaskID, boost::optional<rpc::TaskLeaseData>> &subscribe,
+      const StatusCallback &done) = 0;
+
+  /// Cancel subscription to a task lease asynchronously.
+  ///
+  /// \param task_id The ID of the task to be unsubscribed to.
+  /// \return Status
+  virtual Status AsyncUnsubscribeTaskLease(const TaskID &task_id) = 0;
+
+  /// Attempt task reconstruction to GCS asynchronously.
+  ///
+  /// \param data_ptr The task reconstruction that will be added to GCS.
+  /// \param callback Callback that will be called after task reconstruction
+  /// has been added to GCS.
+  /// \return Status
+  virtual Status AttemptTaskReconstruction(
+      const std::shared_ptr<rpc::TaskReconstructionData> &data_ptr,
+      const StatusCallback &callback) = 0;
+
+  /// Reestablish subscription.
+  /// This should be called when GCS server restarts from a failure.
+  /// PubSub server restart will cause GCS server restart. In this case, we need to
+  /// resubscribe from PubSub server, otherwise we only need to fetch data from GCS
+  /// server.
+  ///
+  /// \param is_pubsub_server_restarted Whether pubsub server is restarted.
+  virtual void AsyncResubscribe(bool is_pubsub_server_restarted) = 0;
+
+  /// Check if the specified task lease is unsubscribed.
+  ///
+  /// \param task_id The ID of the task.
+  /// \return Whether the specified task lease is unsubscribed.
+  virtual bool IsTaskLeaseUnsubscribed(const TaskID &task_id) = 0;
+
+ protected:
+  TaskInfoAccessor() = default;
 };
 
 /// `ObjectInfoAccessor` is a sub-interface of `GcsClient`.

--- a/src/ray/gcs/gcs_client.h
+++ b/src/ray/gcs/gcs_client.h
@@ -123,6 +123,13 @@ class GcsClient : public std::enable_shared_from_this<GcsClient> {
     return *node_resource_accessor_;
   }
 
+  /// Get the sub-interface for accessing task information in GCS.
+  /// This function is thread safe.
+  TaskInfoAccessor &Tasks() {
+    RAY_CHECK(task_accessor_ != nullptr);
+    return *task_accessor_;
+  }
+
   /// Get the sub-interface for accessing error information in GCS.
   /// This function is thread safe.
   ErrorInfoAccessor &Errors() {
@@ -171,6 +178,7 @@ class GcsClient : public std::enable_shared_from_this<GcsClient> {
   std::unique_ptr<ObjectInfoAccessor> object_accessor_;
   std::unique_ptr<NodeInfoAccessor> node_accessor_;
   std::unique_ptr<NodeResourceInfoAccessor> node_resource_accessor_;
+  std::unique_ptr<TaskInfoAccessor> task_accessor_;
   std::unique_ptr<ErrorInfoAccessor> error_accessor_;
   std::unique_ptr<StatsInfoAccessor> stats_accessor_;
   std::unique_ptr<WorkerInfoAccessor> worker_accessor_;

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -252,6 +252,37 @@ Status ServiceBasedActorInfoAccessor::AsyncCreateActor(
   return Status::OK();
 }
 
+Status ServiceBasedActorInfoAccessor::AsyncSubscribeAll(
+    const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
+    const StatusCallback &done) {
+  RAY_CHECK(subscribe != nullptr);
+  fetch_all_data_operation_ = [this, subscribe](const StatusCallback &done) {
+    auto callback = [subscribe, done](
+                        const Status &status,
+                        const std::vector<rpc::ActorTableData> &actor_info_list) {
+      for (auto &actor_info : actor_info_list) {
+        subscribe(ActorID::FromBinary(actor_info.actor_id()), actor_info);
+      }
+      if (done) {
+        done(status);
+      }
+    };
+    RAY_CHECK_OK(AsyncGetAll(callback));
+  };
+
+  subscribe_all_operation_ = [this, subscribe](const StatusCallback &done) {
+    auto on_subscribe = [subscribe](const std::string &id, const std::string &data) {
+      ActorTableData actor_data;
+      actor_data.ParseFromString(data);
+      subscribe(ActorID::FromBinary(actor_data.actor_id()), actor_data);
+    };
+    return client_impl_->GetGcsPubSub().SubscribeAll(ACTOR_CHANNEL, on_subscribe, done);
+  };
+
+  return subscribe_all_operation_(
+      [this, done](const Status &status) { fetch_all_data_operation_(done); });
+}
+
 Status ServiceBasedActorInfoAccessor::AsyncSubscribe(
     const ActorID &actor_id,
     const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
@@ -833,6 +864,189 @@ Status ServiceBasedNodeResourceInfoAccessor::AsyncGetAllResourceUsage(
                        << status;
       });
   return Status::OK();
+}
+
+ServiceBasedTaskInfoAccessor::ServiceBasedTaskInfoAccessor(
+    ServiceBasedGcsClient *client_impl)
+    : client_impl_(client_impl) {}
+
+Status ServiceBasedTaskInfoAccessor::AsyncAdd(
+    const std::shared_ptr<rpc::TaskTableData> &data_ptr, const StatusCallback &callback) {
+  TaskID task_id = TaskID::FromBinary(data_ptr->task().task_spec().task_id());
+  JobID job_id = JobID::FromBinary(data_ptr->task().task_spec().job_id());
+  RAY_LOG(DEBUG) << "Adding task, task id = " << task_id << ", job id = " << job_id;
+  rpc::AddTaskRequest request;
+  request.mutable_task_data()->CopyFrom(*data_ptr);
+  client_impl_->GetGcsRpcClient().AddTask(
+      request,
+      [task_id, job_id, callback](const Status &status, const rpc::AddTaskReply &reply) {
+        if (callback) {
+          callback(status);
+        }
+        RAY_LOG(DEBUG) << "Finished adding task, status = " << status
+                       << ", task id = " << task_id << ", job id = " << job_id;
+      });
+  return Status::OK();
+}
+
+Status ServiceBasedTaskInfoAccessor::AsyncGet(
+    const TaskID &task_id, const OptionalItemCallback<rpc::TaskTableData> &callback) {
+  RAY_LOG(DEBUG) << "Getting task, task id = " << task_id
+                 << ", job id = " << task_id.JobId();
+  rpc::GetTaskRequest request;
+  request.set_task_id(task_id.Binary());
+  client_impl_->GetGcsRpcClient().GetTask(
+      request, [task_id, callback](const Status &status, const rpc::GetTaskReply &reply) {
+        if (reply.has_task_data()) {
+          callback(status, reply.task_data());
+        } else {
+          callback(status, boost::none);
+        }
+        RAY_LOG(DEBUG) << "Finished getting task, status = " << status
+                       << ", task id = " << task_id << ", job id = " << task_id.JobId();
+      });
+  return Status::OK();
+}
+
+Status ServiceBasedTaskInfoAccessor::AsyncAddTaskLease(
+    const std::shared_ptr<rpc::TaskLeaseData> &data_ptr, const StatusCallback &callback) {
+  TaskID task_id = TaskID::FromBinary(data_ptr->task_id());
+  NodeID node_id = NodeID::FromBinary(data_ptr->node_manager_id());
+  RAY_LOG(DEBUG) << "Adding task lease, task id = " << task_id
+                 << ", node id = " << node_id << ", job id = " << task_id.JobId();
+  rpc::AddTaskLeaseRequest request;
+  request.mutable_task_lease_data()->CopyFrom(*data_ptr);
+  client_impl_->GetGcsRpcClient().AddTaskLease(
+      request, [task_id, node_id, callback](const Status &status,
+                                            const rpc::AddTaskLeaseReply &reply) {
+        if (callback) {
+          callback(status);
+        }
+        RAY_LOG(DEBUG) << "Finished adding task lease, status = " << status
+                       << ", task id = " << task_id << ", node id = " << node_id
+                       << ", job id = " << task_id.JobId();
+      });
+  return Status::OK();
+}
+
+Status ServiceBasedTaskInfoAccessor::AsyncGetTaskLease(
+    const TaskID &task_id, const OptionalItemCallback<rpc::TaskLeaseData> &callback) {
+  RAY_LOG(DEBUG) << "Getting task lease, task id = " << task_id
+                 << ", job id = " << task_id.JobId();
+  rpc::GetTaskLeaseRequest request;
+  request.set_task_id(task_id.Binary());
+  client_impl_->GetGcsRpcClient().GetTaskLease(
+      request,
+      [task_id, callback](const Status &status, const rpc::GetTaskLeaseReply &reply) {
+        if (reply.has_task_lease_data()) {
+          callback(status, reply.task_lease_data());
+        } else {
+          callback(status, boost::none);
+        }
+        RAY_LOG(DEBUG) << "Finished getting task lease, status = " << status
+                       << ", task id = " << task_id << ", job id = " << task_id.JobId();
+      });
+  return Status::OK();
+}
+
+Status ServiceBasedTaskInfoAccessor::AsyncSubscribeTaskLease(
+    const TaskID &task_id,
+    const SubscribeCallback<TaskID, boost::optional<rpc::TaskLeaseData>> &subscribe,
+    const StatusCallback &done) {
+  RAY_CHECK(subscribe != nullptr)
+      << "Failed to subscribe task lease, task id = " << task_id
+      << ", job id = " << task_id.JobId();
+
+  auto fetch_data_operation = [this, task_id,
+                               subscribe](const StatusCallback &fetch_done) {
+    auto callback = [task_id, subscribe, fetch_done](
+                        const Status &status,
+                        const boost::optional<rpc::TaskLeaseData> &result) {
+      subscribe(task_id, result);
+      if (fetch_done) {
+        fetch_done(status);
+      }
+    };
+    RAY_CHECK_OK(AsyncGetTaskLease(task_id, callback));
+  };
+
+  auto subscribe_operation = [this, task_id,
+                              subscribe](const StatusCallback &subscribe_done) {
+    auto on_subscribe = [task_id, subscribe](const std::string &id,
+                                             const std::string &data) {
+      TaskLeaseData task_lease_data;
+      task_lease_data.ParseFromString(data);
+      subscribe(task_id, task_lease_data);
+    };
+    return client_impl_->GetGcsPubSub().Subscribe(TASK_LEASE_CHANNEL, task_id.Hex(),
+                                                  on_subscribe, subscribe_done);
+  };
+
+  subscribe_task_lease_operations_[task_id] = subscribe_operation;
+  fetch_task_lease_data_operations_[task_id] = fetch_data_operation;
+  return subscribe_operation(
+      [fetch_data_operation, done](const Status &status) { fetch_data_operation(done); });
+}
+
+Status ServiceBasedTaskInfoAccessor::AsyncUnsubscribeTaskLease(const TaskID &task_id) {
+  RAY_LOG(DEBUG) << "Unsubscribing task lease, task id = " << task_id
+                 << ", job id = " << task_id.JobId();
+  auto status =
+      client_impl_->GetGcsPubSub().Unsubscribe(TASK_LEASE_CHANNEL, task_id.Hex());
+  subscribe_task_lease_operations_.erase(task_id);
+  fetch_task_lease_data_operations_.erase(task_id);
+  RAY_LOG(DEBUG) << "Finished unsubscribing task lease, task id = " << task_id
+                 << ", job id = " << task_id.JobId();
+  return status;
+}
+
+Status ServiceBasedTaskInfoAccessor::AttemptTaskReconstruction(
+    const std::shared_ptr<rpc::TaskReconstructionData> &data_ptr,
+    const StatusCallback &callback) {
+  auto num_reconstructions = data_ptr->num_reconstructions();
+  NodeID node_id = NodeID::FromBinary(data_ptr->node_manager_id());
+  TaskID task_id = TaskID::FromBinary(data_ptr->task_id());
+  RAY_LOG(DEBUG) << "Reconstructing task, reconstructions num = " << num_reconstructions
+                 << ", node id = " << node_id << ", task id = " << task_id
+                 << ", job id = " << task_id.JobId();
+  rpc::AttemptTaskReconstructionRequest request;
+  request.mutable_task_reconstruction()->CopyFrom(*data_ptr);
+  client_impl_->GetGcsRpcClient().AttemptTaskReconstruction(
+      request,
+      [num_reconstructions, node_id, task_id, callback](
+          const Status &status, const rpc::AttemptTaskReconstructionReply &reply) {
+        if (callback) {
+          callback(status);
+        }
+        RAY_LOG(DEBUG) << "Finished reconstructing task, status = " << status
+                       << ", reconstructions num = " << num_reconstructions
+                       << ", node id = " << node_id << ", task id = " << task_id
+                       << ", job id = " << task_id.JobId();
+      });
+  return Status::OK();
+}
+
+void ServiceBasedTaskInfoAccessor::AsyncResubscribe(bool is_pubsub_server_restarted) {
+  RAY_LOG(DEBUG) << "Reestablishing subscription for task info.";
+  // If only the GCS sever has restarted, we only need to fetch data from the GCS server.
+  // If the pub-sub server has also restarted, we need to resubscribe to the pub-sub
+  // server first, then fetch data from the GCS server.
+  if (is_pubsub_server_restarted) {
+    for (auto &item : subscribe_task_lease_operations_) {
+      auto &task_id = item.first;
+      RAY_CHECK_OK(item.second([this, task_id](const Status &status) {
+        fetch_task_lease_data_operations_[task_id](nullptr);
+      }));
+    }
+  } else {
+    for (auto &item : fetch_task_lease_data_operations_) {
+      item.second(nullptr);
+    }
+  }
+}
+
+bool ServiceBasedTaskInfoAccessor::IsTaskLeaseUnsubscribed(const TaskID &task_id) {
+  return client_impl_->GetGcsPubSub().IsUnsubscribed(TASK_LEASE_CHANNEL, task_id.Hex());
 }
 
 ServiceBasedObjectInfoAccessor::ServiceBasedObjectInfoAccessor(

--- a/src/ray/gcs/gcs_client/service_based_accessor.h
+++ b/src/ray/gcs/gcs_client/service_based_accessor.h
@@ -90,6 +90,10 @@ class ServiceBasedActorInfoAccessor : public ActorInfoAccessor {
   Status AsyncKillActor(const ActorID &actor_id, bool force_kill, bool no_restart,
                         const StatusCallback &callback) override;
 
+  Status AsyncSubscribeAll(
+      const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
+      const StatusCallback &done) override;
+
   Status AsyncSubscribe(const ActorID &actor_id,
                         const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
                         const StatusCallback &done) override;
@@ -253,6 +257,55 @@ class ServiceBasedNodeResourceInfoAccessor : public NodeResourceInfoAccessor {
   ServiceBasedGcsClient *client_impl_;
 
   Sequencer<NodeID> sequencer_;
+};
+
+/// \class ServiceBasedTaskInfoAccessor
+/// ServiceBasedTaskInfoAccessor is an implementation of `TaskInfoAccessor`
+/// that uses GCS service as the backend.
+class ServiceBasedTaskInfoAccessor : public TaskInfoAccessor {
+ public:
+  explicit ServiceBasedTaskInfoAccessor(ServiceBasedGcsClient *client_impl);
+
+  virtual ~ServiceBasedTaskInfoAccessor() = default;
+
+  Status AsyncAdd(const std::shared_ptr<rpc::TaskTableData> &data_ptr,
+                  const StatusCallback &callback) override;
+
+  Status AsyncGet(const TaskID &task_id,
+                  const OptionalItemCallback<rpc::TaskTableData> &callback) override;
+
+  Status AsyncAddTaskLease(const std::shared_ptr<rpc::TaskLeaseData> &data_ptr,
+                           const StatusCallback &callback) override;
+
+  Status AsyncGetTaskLease(
+      const TaskID &task_id,
+      const OptionalItemCallback<rpc::TaskLeaseData> &callback) override;
+
+  Status AsyncSubscribeTaskLease(
+      const TaskID &task_id,
+      const SubscribeCallback<TaskID, boost::optional<rpc::TaskLeaseData>> &subscribe,
+      const StatusCallback &done) override;
+
+  Status AsyncUnsubscribeTaskLease(const TaskID &task_id) override;
+
+  Status AttemptTaskReconstruction(
+      const std::shared_ptr<rpc::TaskReconstructionData> &data_ptr,
+      const StatusCallback &callback) override;
+
+  void AsyncResubscribe(bool is_pubsub_server_restarted) override;
+
+  bool IsTaskLeaseUnsubscribed(const TaskID &task_id) override;
+
+ private:
+  /// Save the subscribe operations, so we can call them again when PubSub
+  /// server restarts from a failure.
+  std::unordered_map<TaskID, SubscribeOperation> subscribe_task_lease_operations_;
+
+  /// Save the fetch data operation in this function, so we can call it again when GCS
+  /// server restarts from a failure.
+  std::unordered_map<TaskID, FetchDataOperation> fetch_task_lease_data_operations_;
+
+  ServiceBasedGcsClient *client_impl_;
 };
 
 /// \class ServiceBasedObjectInfoAccessor

--- a/src/ray/gcs/gcs_client/service_based_gcs_client.cc
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.cc
@@ -80,6 +80,7 @@ Status ServiceBasedGcsClient::Connect(instrumented_io_context &io_service) {
     actor_accessor_->AsyncResubscribe(is_pubsub_server_restarted);
     node_accessor_->AsyncResubscribe(is_pubsub_server_restarted);
     node_resource_accessor_->AsyncResubscribe(is_pubsub_server_restarted);
+    task_accessor_->AsyncResubscribe(is_pubsub_server_restarted);
     object_accessor_->AsyncResubscribe(is_pubsub_server_restarted);
     worker_accessor_->AsyncResubscribe(is_pubsub_server_restarted);
   };
@@ -94,6 +95,7 @@ Status ServiceBasedGcsClient::Connect(instrumented_io_context &io_service) {
   actor_accessor_.reset(new ServiceBasedActorInfoAccessor(this));
   node_accessor_.reset(new ServiceBasedNodeInfoAccessor(this));
   node_resource_accessor_.reset(new ServiceBasedNodeResourceInfoAccessor(this));
+  task_accessor_.reset(new ServiceBasedTaskInfoAccessor(this));
   object_accessor_.reset(new ServiceBasedObjectInfoAccessor(this));
   stats_accessor_.reset(new ServiceBasedStatsInfoAccessor(this));
   error_accessor_.reset(new ServiceBasedErrorInfoAccessor(this));

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -29,13 +29,9 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
  public:
   ServiceBasedGcsClientTest() {
     RayConfig::instance().initialize(
-        R"(
-{
-  "ping_gcs_rpc_server_max_retries": 60,
-  "maximum_gcs_destroyed_actor_cached_count": 10,
-  "maximum_gcs_dead_node_cached_count": 10
-}
-  )");
+        "ping_gcs_rpc_server_max_retries,60;maximum_gcs_destroyed_actor_cached_count,10;"
+        "maximum_gcs_dead_node_cached_count,10;"
+        "grpc_based_resource_broadcast,false");
     TestSetupUtil::StartUpRedisServers(std::vector<int>());
   }
 
@@ -52,6 +48,7 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     // Tests legacy code paths. The poller and broadcaster have their own dedicated unit
     // test targets.
     config_.pull_based_resource_reporting = false;
+    config_.grpc_based_resource_broadcast = false;
 
     client_io_service_.reset(new instrumented_io_context());
     client_io_service_thread_.reset(new std::thread([this] {
@@ -171,6 +168,14 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
       return gcs_client_->Actors().IsActorUnsubscribed(actor_id);
     };
     EXPECT_TRUE(WaitForCondition(condition, timeout_ms_.count()));
+  }
+
+  bool SubscribeAllActors(
+      const gcs::SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe) {
+    std::promise<bool> promise;
+    RAY_CHECK_OK(gcs_client_->Actors().AsyncSubscribeAll(
+        subscribe, [&promise](Status status) { promise.set_value(status.ok()); }));
+    return WaitReady(promise.get_future(), timeout_ms_);
   }
 
   bool RegisterActor(const std::shared_ptr<rpc::ActorTableData> &actor_table_data,
@@ -297,6 +302,13 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
+  bool SubscribeToResources(const gcs::ItemCallback<rpc::NodeResourceChange> &subscribe) {
+    std::promise<bool> promise;
+    RAY_CHECK_OK(gcs_client_->NodeResources().AsyncSubscribeToResources(
+        subscribe, [&promise](Status status) { promise.set_value(status.ok()); }));
+    return WaitReady(promise.get_future(), timeout_ms_);
+  }
+
   gcs::NodeResourceInfoAccessor::ResourceMap GetResources(const NodeID &node_id) {
     gcs::NodeResourceInfoAccessor::ResourceMap resource_map;
     std::promise<bool> promise;
@@ -335,6 +347,14 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
+  bool SubscribeBatchResourceUsage(
+      const gcs::ItemCallback<rpc::ResourceUsageBatchData> &subscribe) {
+    std::promise<bool> promise;
+    RAY_CHECK_OK(gcs_client_->NodeResources().AsyncSubscribeBatchedResourceUsage(
+        subscribe, [&promise](Status status) { promise.set_value(status.ok()); }));
+    return WaitReady(promise.get_future(), timeout_ms_);
+  }
+
   bool ReportHeartbeat(const std::shared_ptr<rpc::HeartbeatTableData> heartbeat) {
     std::promise<bool> promise;
     RAY_CHECK_OK(gcs_client_->Nodes().AsyncReportHeartbeat(
@@ -361,6 +381,66 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
         }));
     EXPECT_TRUE(WaitReady(promise.get_future(), timeout_ms_));
     return resources;
+  }
+
+  void WaitForTaskLeaseUnsubscribed(const TaskID &task_id) {
+    auto condition = [this, task_id]() {
+      return gcs_client_->Tasks().IsTaskLeaseUnsubscribed(task_id);
+    };
+    EXPECT_TRUE(WaitForCondition(condition, timeout_ms_.count()));
+  }
+
+  bool AddTask(const std::shared_ptr<rpc::TaskTableData> task) {
+    std::promise<bool> promise;
+    RAY_CHECK_OK(gcs_client_->Tasks().AsyncAdd(
+        task, [&promise](Status status) { promise.set_value(status.ok()); }));
+    return WaitReady(promise.get_future(), timeout_ms_);
+  }
+
+  rpc::TaskTableData GetTask(const TaskID &task_id) {
+    std::promise<bool> promise;
+    rpc::TaskTableData task_table_data;
+    RAY_CHECK_OK(gcs_client_->Tasks().AsyncGet(
+        task_id, [&task_table_data, &promise](
+                     Status status, const boost::optional<rpc::TaskTableData> &result) {
+          if (result) {
+            task_table_data.CopyFrom(*result);
+          }
+          promise.set_value(status.ok());
+        }));
+    EXPECT_TRUE(WaitReady(promise.get_future(), timeout_ms_));
+    return task_table_data;
+  }
+
+  bool SubscribeTaskLease(
+      const TaskID &task_id,
+      const gcs::SubscribeCallback<TaskID, boost::optional<rpc::TaskLeaseData>>
+          &subscribe) {
+    std::promise<bool> promise;
+    RAY_CHECK_OK(gcs_client_->Tasks().AsyncSubscribeTaskLease(
+        task_id, subscribe,
+        [&promise](Status status) { promise.set_value(status.ok()); }));
+    return WaitReady(promise.get_future(), timeout_ms_);
+  }
+
+  void UnsubscribeTaskLease(const TaskID &task_id) {
+    RAY_CHECK_OK(gcs_client_->Tasks().AsyncUnsubscribeTaskLease(task_id));
+  }
+
+  bool AddTaskLease(const std::shared_ptr<rpc::TaskLeaseData> task_lease) {
+    std::promise<bool> promise;
+    RAY_CHECK_OK(gcs_client_->Tasks().AsyncAddTaskLease(
+        task_lease, [&promise](Status status) { promise.set_value(status.ok()); }));
+    return WaitReady(promise.get_future(), timeout_ms_);
+  }
+
+  bool AttemptTaskReconstruction(
+      const std::shared_ptr<rpc::TaskReconstructionData> task_reconstruction_data) {
+    std::promise<bool> promise;
+    RAY_CHECK_OK(gcs_client_->Tasks().AttemptTaskReconstruction(
+        task_reconstruction_data,
+        [&promise](Status status) { promise.set_value(status.ok()); }));
+    return WaitReady(promise.get_future(), timeout_ms_);
   }
 
   bool SubscribeToLocations(
@@ -511,6 +591,36 @@ TEST_F(ServiceBasedGcsClientTest, TestGetNextJobID) {
   ASSERT_TRUE(job_id1.ToInt() + 1 == job_id2.ToInt());
 }
 
+TEST_F(ServiceBasedGcsClientTest, TestActorSubscribeAll) {
+  // NOTE: `TestActorSubscribeAll` will subscribe to all actor messages, so we need to
+  // execute it before `TestActorInfo`, otherwise `TestActorSubscribeAll` will receive
+  // messages from `TestActorInfo`.
+  // Create actor table data.
+  JobID job_id = JobID::FromInt(1);
+  AddJob(job_id);
+  auto actor_table_data1 = Mocker::GenActorTableData(job_id);
+  auto actor_table_data2 = Mocker::GenActorTableData(job_id);
+
+  // Subscribe to any register or update operations of actors.
+  std::atomic<int> actor_update_count(0);
+  auto on_subscribe = [&actor_update_count](const ActorID &actor_id,
+                                            const gcs::ActorTableData &data) {
+    ++actor_update_count;
+  };
+  ASSERT_TRUE(SubscribeAllActors(on_subscribe));
+
+  // Register an actor to GCS.
+  RegisterActor(actor_table_data1, false);
+  RegisterActor(actor_table_data2, false);
+
+  // NOTE: In the process of actor registration, if the callback function of
+  // `WaitForActorOutOfScope` is executed first, and then the callback function of
+  // `ActorTable().Put` is executed, GCS will publish once; otherwise, GCS will publish
+  // twice. So we assert `actor_update_count >= 2`.
+  auto condition = [&actor_update_count]() { return actor_update_count >= 2; };
+  EXPECT_TRUE(WaitForCondition(condition, timeout_ms_.count()));
+}
+
 TEST_F(ServiceBasedGcsClientTest, TestActorInfo) {
   // Create actor table data.
   JobID job_id = JobID::FromInt(1);
@@ -587,6 +697,214 @@ TEST_F(ServiceBasedGcsClientTest, TestNodeInfo) {
   EXPECT_EQ(node_list[1].state(),
             rpc::GcsNodeInfo_GcsNodeState::GcsNodeInfo_GcsNodeState_DEAD);
   ASSERT_TRUE(gcs_client_->Nodes().IsRemoved(node2_id));
+}
+
+TEST_F(ServiceBasedGcsClientTest, TestNodeResources) {
+  // Subscribe to node resource changes.
+  std::atomic<int> add_count(0);
+  std::atomic<int> remove_count(0);
+  auto on_subscribe = [&add_count,
+                       &remove_count](const rpc::NodeResourceChange &notification) {
+    if (0 == notification.deleted_resources_size()) {
+      ++add_count;
+    } else {
+      ++remove_count;
+    }
+  };
+  ASSERT_TRUE(SubscribeToResources(on_subscribe));
+
+  // Register node.
+  auto node_info = Mocker::GenNodeInfo();
+  RAY_CHECK(RegisterNode(*node_info));
+
+  // Update resources of node in GCS.
+  NodeID node_id = NodeID::FromBinary(node_info->node_id());
+  std::string key = "CPU";
+  ASSERT_TRUE(UpdateResources(node_id, key));
+  WaitForExpectedCount(add_count, 1);
+  ASSERT_TRUE(GetResources(node_id).count(key));
+
+  // Delete resources of a node from GCS.
+  ASSERT_TRUE(DeleteResources(node_id, {key}));
+  WaitForExpectedCount(remove_count, 1);
+  ASSERT_TRUE(GetResources(node_id).empty());
+}
+
+TEST_F(ServiceBasedGcsClientTest, TestNodeResourceUsage) {
+  // Subscribe batched state of all nodes from GCS.
+  std::atomic<int> resource_batch_count(0);
+  auto on_subscribe = [&resource_batch_count](const gcs::ResourceUsageBatchData &result) {
+    ++resource_batch_count;
+  };
+  ASSERT_TRUE(SubscribeBatchResourceUsage(on_subscribe));
+
+  // Register node.
+  auto node_info = Mocker::GenNodeInfo();
+  RAY_CHECK(RegisterNode(*node_info));
+
+  // Report resource usage of a node to GCS.
+  NodeID node_id = NodeID::FromBinary(node_info->node_id());
+  auto resource = std::make_shared<rpc::ResourcesData>();
+  resource->set_node_id(node_id.Binary());
+  resource->set_should_global_gc(true);
+  std::string resource_name = "CPU";
+  double resource_value = 1.0;
+  (*resource->mutable_resources_total())[resource_name] = resource_value;
+  ASSERT_TRUE(ReportResourceUsage(resource));
+  WaitForExpectedCount(resource_batch_count, 1);
+
+  // Get and check last report resource usage.
+  auto last_resource_usage = gcs_client_->NodeResources().GetLastResourceUsage();
+  ASSERT_EQ(last_resource_usage->GetTotalResources().GetResource(resource_name),
+            resource_value);
+}
+
+TEST_F(ServiceBasedGcsClientTest, TestNodeResourceUsageWithLightResourceUsageReport) {
+  // Subscribe batched state of all nodes from GCS.
+  std::atomic<int> resource_batch_count(0);
+  auto on_subscribe = [&resource_batch_count](const gcs::ResourceUsageBatchData &result) {
+    ++resource_batch_count;
+  };
+  ASSERT_TRUE(SubscribeBatchResourceUsage(on_subscribe));
+
+  // Register node.
+  auto node_info = Mocker::GenNodeInfo();
+  RAY_CHECK(RegisterNode(*node_info));
+
+  // Report unchanged resource usage of a node to GCS.
+  NodeID node_id = NodeID::FromBinary(node_info->node_id());
+  auto resource = std::make_shared<rpc::ResourcesData>();
+  resource->set_node_id(node_id.Binary());
+  ASSERT_TRUE(ReportResourceUsage(resource));
+  WaitForExpectedCount(resource_batch_count, 0);
+
+  // Report changed resource usage of a node to GCS.
+  auto resource1 = std::make_shared<rpc::ResourcesData>();
+  resource1->set_node_id(node_id.Binary());
+  resource1->set_resources_available_changed(true);
+  ASSERT_TRUE(ReportResourceUsage(resource1));
+  WaitForExpectedCount(resource_batch_count, 1);
+}
+
+TEST_F(ServiceBasedGcsClientTest, TestGetAllAvailableResources) {
+  // Subscribe batched state of all nodes from GCS.
+  std::atomic<int> resource_batch_count(0);
+  auto on_subscribe = [&resource_batch_count](const gcs::ResourceUsageBatchData &result) {
+    ++resource_batch_count;
+  };
+  ASSERT_TRUE(SubscribeBatchResourceUsage(on_subscribe));
+
+  // Register node.
+  auto node_info = Mocker::GenNodeInfo();
+  RAY_CHECK(RegisterNode(*node_info));
+
+  // Report resource usage of a node to GCS.
+  NodeID node_id = NodeID::FromBinary(node_info->node_id());
+  auto resource = std::make_shared<rpc::ResourcesData>();
+  resource->set_node_id(node_id.Binary());
+  // Set this flag to indicate resources has changed.
+  resource->set_resources_available_changed(true);
+  (*resource->mutable_resources_available())["CPU"] = 1.0;
+  (*resource->mutable_resources_available())["GPU"] = 10.0;
+  ASSERT_TRUE(ReportResourceUsage(resource));
+  WaitForExpectedCount(resource_batch_count, 1);
+
+  // Assert get all available resources right.
+  std::vector<rpc::AvailableResources> resources = GetAllAvailableResources();
+  EXPECT_EQ(resources.size(), 1);
+  EXPECT_EQ(resources[0].resources_available_size(), 2);
+  EXPECT_EQ((*resources[0].mutable_resources_available())["CPU"], 1.0);
+  EXPECT_EQ((*resources[0].mutable_resources_available())["GPU"], 10.0);
+}
+
+TEST_F(ServiceBasedGcsClientTest,
+       TestGetAllAvailableResourcesWithLightResourceUsageReport) {
+  // Subscribe batched state of all nodes from GCS.
+  std::atomic<int> resource_batch_count(0);
+  auto on_subscribe = [&resource_batch_count](const gcs::ResourceUsageBatchData &result) {
+    ++resource_batch_count;
+  };
+  ASSERT_TRUE(SubscribeBatchResourceUsage(on_subscribe));
+
+  // Register node.
+  auto node_info = Mocker::GenNodeInfo();
+  RAY_CHECK(RegisterNode(*node_info));
+
+  // Report resource usage of a node to GCS.
+  NodeID node_id = NodeID::FromBinary(node_info->node_id());
+  auto resource = std::make_shared<rpc::ResourcesData>();
+  resource->set_node_id(node_id.Binary());
+  resource->set_resources_available_changed(true);
+  (*resource->mutable_resources_available())["CPU"] = 1.0;
+  (*resource->mutable_resources_available())["GPU"] = 10.0;
+  ASSERT_TRUE(ReportResourceUsage(resource));
+  WaitForExpectedCount(resource_batch_count, 1);
+
+  // Assert get all available resources right.
+  std::vector<rpc::AvailableResources> resources = GetAllAvailableResources();
+  EXPECT_EQ(resources.size(), 1);
+  EXPECT_EQ(resources[0].resources_available_size(), 2);
+  EXPECT_EQ((*resources[0].mutable_resources_available())["CPU"], 1.0);
+  EXPECT_EQ((*resources[0].mutable_resources_available())["GPU"], 10.0);
+
+  // Report unchanged resource usage of a node to GCS.
+  auto resource1 = std::make_shared<rpc::ResourcesData>();
+  resource1->set_node_id(node_id.Binary());
+  (*resource1->mutable_resources_available())["GPU"] = 8.0;
+  ASSERT_TRUE(ReportResourceUsage(resource1));
+  WaitForExpectedCount(resource_batch_count, 1);
+
+  // The value would remain unchanged.
+  std::vector<rpc::AvailableResources> resources1 = GetAllAvailableResources();
+  EXPECT_EQ(resources1.size(), 1);
+  EXPECT_EQ(resources1[0].resources_available_size(), 2);
+  EXPECT_EQ((*resources1[0].mutable_resources_available())["CPU"], 1.0);
+  EXPECT_EQ((*resources1[0].mutable_resources_available())["GPU"], 10.0);
+}
+
+TEST_F(ServiceBasedGcsClientTest, TestTaskInfo) {
+  JobID job_id = JobID::FromInt(1);
+  AddJob(job_id);
+  TaskID task_id = TaskID::ForDriverTask(job_id);
+  auto task_table_data = Mocker::GenTaskTableData(job_id.Binary(), task_id.Binary());
+
+  // Add a task to GCS.
+  ASSERT_TRUE(AddTask(task_table_data));
+  auto get_task_result = GetTask(task_id);
+  ASSERT_TRUE(get_task_result.task().task_spec().task_id() == task_id.Binary());
+  ASSERT_TRUE(get_task_result.task().task_spec().job_id() == job_id.Binary());
+
+  // Subscribe to the event that the given task lease is added in GCS.
+  std::atomic<int> task_lease_count(0);
+  auto task_lease_subscribe = [&task_lease_count](
+                                  const TaskID &id,
+                                  const boost::optional<rpc::TaskLeaseData> &result) {
+    ++task_lease_count;
+  };
+  ASSERT_TRUE(SubscribeTaskLease(task_id, task_lease_subscribe));
+
+  // Add a task lease to GCS.
+  NodeID node_id = NodeID::FromRandom();
+  auto task_lease = Mocker::GenTaskLeaseData(task_id.Binary(), node_id.Binary());
+  ASSERT_TRUE(AddTaskLease(task_lease));
+  WaitForExpectedCount(task_lease_count, 2);
+
+  // Cancel subscription to a task lease.
+  UnsubscribeTaskLease(task_id);
+  WaitForTaskLeaseUnsubscribed(task_id);
+
+  // Add a task lease to GCS again.
+  ASSERT_TRUE(AddTaskLease(task_lease));
+
+  // Assert unsubscribe succeeded.
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  EXPECT_EQ(task_lease_count, 2);
+
+  // Attempt task reconstruction to GCS.
+  auto task_reconstruction_data = std::make_shared<rpc::TaskReconstructionData>();
+  task_reconstruction_data->set_task_id(task_id.Binary());
+  task_reconstruction_data->set_num_reconstructions(0);
+  ASSERT_TRUE(AttemptTaskReconstruction(task_reconstruction_data));
 }
 
 TEST_F(ServiceBasedGcsClientTest, TestObjectInfo) {
@@ -695,6 +1013,99 @@ TEST_F(ServiceBasedGcsClientTest, TestJobTableResubscribe) {
   WaitForExpectedCount(job_update_count, 3);
 }
 
+TEST_F(ServiceBasedGcsClientTest, TestActorTableResubscribe) {
+  // Test that subscription of the actor table can still work when GCS server restarts.
+  JobID job_id = JobID::FromInt(1);
+  AddJob(job_id);
+  auto actor_table_data = Mocker::GenActorTableData(job_id);
+  auto actor_id = ActorID::FromBinary(actor_table_data->actor_id());
+
+  // Number of notifications for the following `SubscribeAllActors` operation.
+  std::atomic<int> num_subscribe_all_notifications(0);
+  // All the notifications for the following `SubscribeAllActors` operation.
+  std::vector<gcs::ActorTableData> subscribe_all_notifications;
+  auto subscribe_all = [&num_subscribe_all_notifications, &subscribe_all_notifications](
+                           const ActorID &id, const rpc::ActorTableData &data) {
+    subscribe_all_notifications.emplace_back(data);
+    ++num_subscribe_all_notifications;
+    RAY_LOG(INFO) << "The number of actors subscription messages received is "
+                  << num_subscribe_all_notifications;
+  };
+  // Subscribe to updates of all actors.
+  ASSERT_TRUE(SubscribeAllActors(subscribe_all));
+
+  // Number of notifications for the following `SubscribeActor` operation.
+  std::atomic<int> num_subscribe_one_notifications(0);
+  // All the notifications for the following `SubscribeActor` operation.
+  std::vector<gcs::ActorTableData> subscribe_one_notifications;
+  auto actor_subscribe = [&num_subscribe_one_notifications, &subscribe_one_notifications](
+                             const ActorID &actor_id, const gcs::ActorTableData &data) {
+    subscribe_one_notifications.emplace_back(data);
+    ++num_subscribe_one_notifications;
+    RAY_LOG(INFO) << "The number of actor subscription messages received is "
+                  << num_subscribe_one_notifications;
+  };
+  // Subscribe to updates for this actor.
+  ASSERT_TRUE(SubscribeActor(actor_id, actor_subscribe));
+
+  // In order to prevent receiving the message of other test case publish, we get the
+  // expected number of actor subscription messages before registering actor.
+  auto expected_num_subscribe_all_notifications = num_subscribe_all_notifications + 1;
+  auto expected_num_subscribe_one_notifications = num_subscribe_one_notifications + 1;
+
+  // NOTE: In the process of actor registration, if the callback function of
+  // `WaitForActorOutOfScope` is executed first, and then the callback function of
+  // `ActorTable().Put` is executed, the actor registration fails, we will receive one
+  // notification message; otherwise, the actor registration succeeds, we will receive
+  // two notification messages. So we can't assert whether the actor is registered
+  // successfully.
+  RegisterActor(actor_table_data, false);
+
+  // We should receive new notification from the subscribe channel.
+  auto condition_subscribe_all = [&num_subscribe_all_notifications,
+                                  expected_num_subscribe_all_notifications]() {
+    return num_subscribe_all_notifications >= expected_num_subscribe_all_notifications;
+  };
+  EXPECT_TRUE(WaitForCondition(condition_subscribe_all, timeout_ms_.count()));
+  auto condition_subscribe_one = [&num_subscribe_one_notifications,
+                                  expected_num_subscribe_one_notifications]() {
+    return num_subscribe_one_notifications >= expected_num_subscribe_one_notifications;
+  };
+  EXPECT_TRUE(WaitForCondition(condition_subscribe_one, timeout_ms_.count()));
+
+  // Restart GCS server.
+  RestartGcsServer();
+
+  // When GCS client detects that GCS server has restarted, but the pub-sub server
+  // didn't restart, it will fetch data again from the GCS server. The GCS will destroy
+  // the actor because it finds that the actor is out of scope, so we'll receive another
+  // notification of DEAD state.
+  expected_num_subscribe_one_notifications += 2;
+  auto condition_subscribe_one_restart = [&num_subscribe_one_notifications,
+                                          expected_num_subscribe_one_notifications]() {
+    return num_subscribe_one_notifications >= expected_num_subscribe_one_notifications;
+  };
+  EXPECT_TRUE(WaitForCondition(condition_subscribe_one_restart, timeout_ms_.count()));
+
+  // NOTE: GCS will not reply when actor registration fails, so when GCS restarts, gcs
+  // client will register the actor again. When an actor is registered, the status in GCS
+  // is `DEPENDENCIES_UNREADY`. When GCS finds that the owner of an actor is nil, it will
+  // destroy the actor and the status of the actor will change to `DEAD`. The GCS client
+  // fetch actor info from the GCS server, and the status of the actor may be
+  // `DEPENDENCIES_UNREADY` or `DEAD`, so we do not assert the actor status here any
+  // more.
+  // If the status of the actor is `DEPENDENCIES_UNREADY`, we will fetch two records, so
+  // `num_subscribe_all_notifications` will increase by 3. If the status of the actor is
+  // `DEAD`, we will fetch one record, so `num_subscribe_all_notifications` will increase
+  // by 2.
+  expected_num_subscribe_all_notifications += 2;
+  auto condition_subscribe_all_restart = [&num_subscribe_all_notifications,
+                                          expected_num_subscribe_all_notifications]() {
+    return num_subscribe_all_notifications >= expected_num_subscribe_all_notifications;
+  };
+  EXPECT_TRUE(WaitForCondition(condition_subscribe_all_restart, timeout_ms_.count()));
+}
+
 TEST_F(ServiceBasedGcsClientTest, TestObjectTableResubscribe) {
   ObjectID object1_id = ObjectID::FromRandom();
   ObjectID object2_id = ObjectID::FromRandom();
@@ -753,6 +1164,22 @@ TEST_F(ServiceBasedGcsClientTest, TestNodeTableResubscribe) {
   };
   ASSERT_TRUE(SubscribeToNodeChange(node_subscribe));
 
+  // Subscribe to node resource changes.
+  std::atomic<int> resource_change_count(0);
+  auto resource_subscribe =
+      [&resource_change_count](const rpc::NodeResourceChange &result) {
+        ++resource_change_count;
+      };
+  ASSERT_TRUE(SubscribeToResources(resource_subscribe));
+
+  // Subscribe batched state of all nodes from GCS.
+  std::atomic<int> batch_resource_usage_count(0);
+  auto batch_resource_usage_subscribe =
+      [&batch_resource_usage_count](const rpc::ResourceUsageBatchData &result) {
+        ++batch_resource_usage_count;
+      };
+  ASSERT_TRUE(SubscribeBatchResourceUsage(batch_resource_usage_subscribe));
+
   auto node_info = Mocker::GenNodeInfo(1);
   ASSERT_TRUE(RegisterNode(*node_info));
   NodeID node_id = NodeID::FromBinary(node_info->node_id());
@@ -760,6 +1187,10 @@ TEST_F(ServiceBasedGcsClientTest, TestNodeTableResubscribe) {
   ASSERT_TRUE(UpdateResources(node_id, key));
   auto resources = std::make_shared<rpc::ResourcesData>();
   resources->set_node_id(node_info->node_id());
+  // Set this flag because GCS won't publish unchanged resources.
+  resources->set_should_global_gc(true);
+  ASSERT_TRUE(ReportResourceUsage(resources));
+  WaitForExpectedCount(batch_resource_usage_count, 1);
 
   RestartGcsServer();
 
@@ -771,6 +1202,60 @@ TEST_F(ServiceBasedGcsClientTest, TestNodeTableResubscribe) {
   ASSERT_TRUE(ReportResourceUsage(resources));
 
   WaitForExpectedCount(node_change_count, 2);
+  WaitForExpectedCount(resource_change_count, 2);
+  WaitForExpectedCount(batch_resource_usage_count, 2);
+}
+
+TEST_F(ServiceBasedGcsClientTest, TestTaskTableResubscribe) {
+  JobID job_id = JobID::FromInt(6);
+  AddJob(job_id);
+  TaskID task_id = TaskID::ForDriverTask(job_id);
+  auto task_table_data = Mocker::GenTaskTableData(job_id.Binary(), task_id.Binary());
+
+  // Subscribe to the event that the given task lease is added in GCS.
+  std::atomic<int> task_lease_count(0);
+  auto task_lease_subscribe = [&task_lease_count](
+                                  const TaskID &task_id,
+                                  const boost::optional<rpc::TaskLeaseData> &data) {
+    if (data) {
+      ++task_lease_count;
+    }
+  };
+  ASSERT_TRUE(SubscribeTaskLease(task_id, task_lease_subscribe));
+
+  ASSERT_TRUE(AddTask(task_table_data));
+  NodeID node_id = NodeID::FromRandom();
+  auto task_lease = Mocker::GenTaskLeaseData(task_id.Binary(), node_id.Binary());
+  ASSERT_TRUE(AddTaskLease(task_lease));
+  WaitForExpectedCount(task_lease_count, 1);
+
+  RestartGcsServer();
+
+  node_id = NodeID::FromRandom();
+  task_lease = Mocker::GenTaskLeaseData(task_id.Binary(), node_id.Binary());
+  ASSERT_TRUE(AddTaskLease(task_lease));
+  WaitForExpectedCount(task_lease_count, 3);
+}
+
+TEST_F(ServiceBasedGcsClientTest, TestWorkerTableResubscribe) {
+  // Subscribe to all unexpected failure of workers from GCS.
+  std::atomic<int> worker_failure_count(0);
+  auto on_subscribe = [&worker_failure_count](const rpc::WorkerDeltaData &result) {
+    ++worker_failure_count;
+  };
+  ASSERT_TRUE(SubscribeToWorkerFailures(on_subscribe));
+
+  // Restart GCS
+  RestartGcsServer();
+
+  // Add a worker before report worker failure to GCS.
+  auto worker_data = Mocker::GenWorkerTableData();
+  worker_data->mutable_worker_address()->set_worker_id(WorkerID::FromRandom().Binary());
+  ASSERT_TRUE(AddWorker(worker_data));
+
+  // Report a worker failure to GCS and check if resubscribe works.
+  ASSERT_TRUE(ReportWorkerFailure(worker_data));
+  WaitForExpectedCount(worker_failure_count, 1);
 }
 
 TEST_F(ServiceBasedGcsClientTest, TestGcsTableReload) {

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -29,9 +29,13 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
  public:
   ServiceBasedGcsClientTest() {
     RayConfig::instance().initialize(
-        "ping_gcs_rpc_server_max_retries,60;maximum_gcs_destroyed_actor_cached_count,10;"
-        "maximum_gcs_dead_node_cached_count,10;"
-        "grpc_based_resource_broadcast,false");
+        R"(
+{
+  "ping_gcs_rpc_server_max_retries": 60,
+  "maximum_gcs_destroyed_actor_cached_count": 10,
+  "maximum_gcs_dead_node_cached_count": 10
+}
+  )");
     TestSetupUtil::StartUpRedisServers(std::vector<int>());
   }
 

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -20,8 +20,19 @@ namespace ray {
 namespace gcs {
 
 GcsResourceManager::GcsResourceManager(
-    std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage)
-    : gcs_table_storage_(gcs_table_storage) {}
+    instrumented_io_context &main_io_service, std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub,
+    std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage, bool redis_broadcast_enabled)
+    : periodical_runner_(main_io_service),
+      gcs_pub_sub_(gcs_pub_sub),
+      gcs_table_storage_(gcs_table_storage),
+      redis_broadcast_enabled_(redis_broadcast_enabled) {
+  if (redis_broadcast_enabled_) {
+    periodical_runner_.RunFnPeriodically(
+        [this] { SendBatchedResourceUsage(); },
+        RayConfig::instance().raylet_report_resources_period_milliseconds(),
+        "GcsResourceManager.deadline_timer.send_batched_resource_usage");
+  }
+}
 
 void GcsResourceManager::HandleGetResources(const rpc::GetResourcesRequest &request,
                                             rpc::GetResourcesReply *reply,
@@ -74,7 +85,11 @@ void GcsResourceManager::HandleUpdateResources(
       node_resource_change.set_node_id(node_id.Binary());
       node_resource_change.mutable_updated_resources()->insert(changed_resources->begin(),
                                                                changed_resources->end());
-      {
+      if (redis_broadcast_enabled_) {
+        RAY_CHECK_OK(gcs_pub_sub_->Publish(NODE_RESOURCE_CHANNEL, node_id.Hex(),
+                                           node_resource_change.SerializeAsString(),
+                                           nullptr));
+      } else {
         absl::MutexLock guard(&resource_buffer_mutex_);
         resources_buffer_proto_.add_batch()->mutable_change()->Swap(
             &node_resource_change);
@@ -126,7 +141,11 @@ void GcsResourceManager::HandleDeleteResources(
       for (const auto &resource_name : resource_names) {
         node_resource_change.add_deleted_resources(resource_name);
       }
-      {
+      if (redis_broadcast_enabled_) {
+        RAY_CHECK_OK(gcs_pub_sub_->Publish(NODE_RESOURCE_CHANNEL, node_id.Hex(),
+                                           node_resource_change.SerializeAsString(),
+                                           nullptr));
+      } else {
         absl::MutexLock guard(&resource_buffer_mutex_);
         resources_buffer_proto_.add_batch()->mutable_change()->Swap(
             &node_resource_change);
@@ -379,6 +398,18 @@ void GcsResourceManager::GetResourceUsageBatchForBroadcast_Locked(
     rpc::ResourceUsageBatchData &buffer) {
   for (auto &resources : resources_buffer_) {
     buffer.add_batch()->Swap(&resources.second);
+  }
+}
+
+void GcsResourceManager::SendBatchedResourceUsage() {
+  absl::MutexLock guard(&resource_buffer_mutex_);
+  if (!resources_buffer_.empty()) {
+    auto batch = std::make_shared<rpc::ResourceUsageBatchData>();
+    GetResourceUsageBatchForBroadcast_Locked(*batch);
+    stats::OutboundHeartbeatSizeKB.Record((double)(batch->ByteSizeLong() / 1024.0));
+    RAY_CHECK_OK(gcs_pub_sub_->Publish(RESOURCES_BATCH_CHANNEL, "",
+                                       batch->SerializeAsString(), nullptr));
+    resources_buffer_.clear();
   }
 }
 

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -16,12 +16,14 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "ray/common/asio/instrumented_io_context.h"
+#include "ray/common/asio/periodical_runner.h"
 #include "ray/common/id.h"
 #include "ray/common/task/scheduling_resources.h"
 #include "ray/gcs/accessor.h"
 #include "ray/gcs/gcs_server/gcs_init_data.h"
 #include "ray/gcs/gcs_server/gcs_resource_manager.h"
 #include "ray/gcs/gcs_server/gcs_table_storage.h"
+#include "ray/gcs/pubsub/gcs_pub_sub.h"
 #include "ray/rpc/client_call.h"
 #include "ray/rpc/gcs_server/gcs_rpc_server.h"
 #include "src/ray/protobuf/gcs.pb.h"
@@ -40,7 +42,10 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler {
   /// \param main_io_service The main event loop.
   /// \param gcs_pub_sub GCS message publisher.
   /// \param gcs_table_storage GCS table external storage accessor.
-  explicit GcsResourceManager(std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage);
+  explicit GcsResourceManager(instrumented_io_context &main_io_service,
+                              std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub,
+                              std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
+                              bool redis_broadcast_enabled);
 
   virtual ~GcsResourceManager() {}
 
@@ -167,11 +172,16 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler {
   void DeleteResources(const NodeID &node_id,
                        const std::vector<std::string> &deleted_resources);
 
+  /// Send any buffered resource usage as a single publish.
+  void SendBatchedResourceUsage();
+
   /// Prelocked version of GetResourceUsageBatchForBroadcast. This is necessary for need
   /// the functionality as part of a larger transaction.
   void GetResourceUsageBatchForBroadcast_Locked(rpc::ResourceUsageBatchData &buffer)
       EXCLUSIVE_LOCKS_REQUIRED(resource_buffer_mutex_);
 
+  /// The runner to run function periodically.
+  PeriodicalRunner periodical_runner_;
   /// Newest resource usage of all nodes.
   absl::flat_hash_map<NodeID, rpc::ResourcesData> node_resource_usages_;
 
@@ -185,8 +195,12 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler {
   rpc::ResourceUsageBroadcastData resources_buffer_proto_
       GUARDED_BY(resource_buffer_mutex_);
 
+  /// A publisher for publishing gcs messages.
+  std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub_;
   /// Storage for GCS tables.
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
+  /// Whether or not to broadcast resource usage via redis.
+  const bool redis_broadcast_enabled_;
   /// Map from node id to the scheduling resources of the node.
   absl::flat_hash_map<NodeID, SchedulingResources> cluster_scheduling_resources_;
   /// Placement group load information that is used for autoscaler.

--- a/src/ray/gcs/gcs_server/gcs_resource_report_poller.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_report_poller.h
@@ -1,5 +1,4 @@
 #include "ray/common/asio/instrumented_io_context.h"
-#include "ray/common/asio/periodical_runner.h"
 #include "ray/gcs/gcs_server/gcs_resource_manager.h"
 #include "ray/rpc/node_manager/node_manager_client_pool.h"
 

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -25,6 +25,7 @@
 #include "ray/gcs/gcs_server/gcs_placement_group_manager.h"
 #include "ray/gcs/gcs_server/gcs_worker_manager.h"
 #include "ray/gcs/gcs_server/stats_handler_impl.h"
+#include "ray/gcs/gcs_server/task_info_handler_impl.h"
 
 namespace ray {
 namespace gcs {
@@ -111,6 +112,9 @@ void GcsServer::DoStart(const GcsInitData &gcs_init_data) {
   // Init gcs worker manager.
   InitGcsWorkerManager();
 
+  // Init task info handler.
+  InitTaskInfoHandler();
+
   // Init stats handler.
   InitStatsHandler();
 
@@ -158,7 +162,9 @@ void GcsServer::Stop() {
       gcs_resource_report_poller_->Stop();
     }
 
-    grpc_based_resource_broadcaster_->Stop();
+    if (config_.grpc_based_resource_broadcast) {
+      grpc_based_resource_broadcaster_->Stop();
+    }
 
     is_stopped_ = true;
     RAY_LOG(INFO) << "GCS server stopped.";
@@ -195,7 +201,9 @@ void GcsServer::InitGcsHeartbeatManager(const GcsInitData &gcs_init_data) {
 
 void GcsServer::InitGcsResourceManager(const GcsInitData &gcs_init_data) {
   RAY_CHECK(gcs_table_storage_ && gcs_pub_sub_);
-  gcs_resource_manager_ = std::make_shared<GcsResourceManager>(gcs_table_storage_);
+  gcs_resource_manager_ = std::make_shared<GcsResourceManager>(
+      main_service_, gcs_pub_sub_, gcs_table_storage_,
+      !config_.grpc_based_resource_broadcast);
   // Initialize by gcs tables data.
   gcs_resource_manager_->Initialize(gcs_init_data);
   // Register service.
@@ -318,6 +326,16 @@ void GcsServer::StoreGcsServerAddressInRedis() {
   RAY_LOG(INFO) << "Finished setting gcs server address: " << address;
 }
 
+void GcsServer::InitTaskInfoHandler() {
+  RAY_CHECK(gcs_table_storage_ && gcs_pub_sub_);
+  task_info_handler_.reset(
+      new rpc::DefaultTaskInfoHandler(gcs_table_storage_, gcs_pub_sub_));
+  // Register service.
+  task_info_service_.reset(
+      new rpc::TaskInfoGrpcService(main_service_, *task_info_handler_));
+  rpc_server_.RegisterService(*task_info_service_);
+}
+
 void GcsServer::InitResourceReportPolling(const GcsInitData &gcs_init_data) {
   if (config_.pull_based_resource_reporting) {
     gcs_resource_report_poller_.reset(new GcsResourceReportPoller(
@@ -331,16 +349,18 @@ void GcsServer::InitResourceReportPolling(const GcsInitData &gcs_init_data) {
 }
 
 void GcsServer::InitResourceReportBroadcasting(const GcsInitData &gcs_init_data) {
-  grpc_based_resource_broadcaster_.reset(new GrpcBasedResourceBroadcaster(
-      raylet_client_pool_,
-      [this](rpc::ResourceUsageBroadcastData &buffer) {
-        gcs_resource_manager_->GetResourceUsageBatchForBroadcast(buffer);
-      }
+  if (config_.grpc_based_resource_broadcast) {
+    grpc_based_resource_broadcaster_.reset(new GrpcBasedResourceBroadcaster(
+        raylet_client_pool_,
+        [this](rpc::ResourceUsageBroadcastData &buffer) {
+          gcs_resource_manager_->GetResourceUsageBatchForBroadcast(buffer);
+        }
 
-      ));
+        ));
 
-  grpc_based_resource_broadcaster_->Initialize(gcs_init_data);
-  grpc_based_resource_broadcaster_->Start();
+    grpc_based_resource_broadcaster_->Initialize(gcs_init_data);
+    grpc_based_resource_broadcaster_->Start();
+  }
 }
 
 void GcsServer::InitStatsHandler() {
@@ -405,7 +425,9 @@ void GcsServer::InstallEventListeners() {
     if (config_.pull_based_resource_reporting) {
       gcs_resource_report_poller_->HandleNodeAdded(*node);
     }
-    grpc_based_resource_broadcaster_->HandleNodeAdded(*node);
+    if (config_.grpc_based_resource_broadcast) {
+      grpc_based_resource_broadcaster_->HandleNodeAdded(*node);
+    }
   });
   gcs_node_manager_->AddNodeRemovedListener(
       [this](std::shared_ptr<rpc::GcsNodeInfo> node) {
@@ -419,7 +441,9 @@ void GcsServer::InstallEventListeners() {
         if (config_.pull_based_resource_reporting) {
           gcs_resource_report_poller_->HandleNodeRemoved(*node);
         }
-        grpc_based_resource_broadcaster_->HandleNodeRemoved(*node);
+        if (config_.grpc_based_resource_broadcast) {
+          grpc_based_resource_broadcaster_->HandleNodeRemoved(*node);
+        }
       });
 
   // Install worker event listener.
@@ -460,7 +484,11 @@ void GcsServer::PrintDebugInfo() {
          << gcs_object_manager_->DebugString() << "\n"
          << gcs_placement_group_manager_->DebugString() << "\n"
          << gcs_pub_sub_->DebugString() << "\n"
-         << grpc_based_resource_broadcaster_->DebugString();
+         << ((rpc::DefaultTaskInfoHandler *)task_info_handler_.get())->DebugString();
+
+  if (config_.grpc_based_resource_broadcast) {
+    stream << "\n" << grpc_based_resource_broadcaster_->DebugString();
+  }
   // TODO(ffbin): We will get the session_dir in the next PR, and write the log to
   // gcs_debug_state.txt.
   RAY_LOG(INFO) << stream.str();

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -47,6 +47,7 @@ struct GcsServerConfig {
   bool enable_sharding_conn = true;
   std::string node_ip_address;
   bool pull_based_resource_reporting;
+  bool grpc_based_resource_broadcast;
   bool grpc_pubsub_enabled;
 };
 
@@ -112,6 +113,9 @@ class GcsServer {
 
   /// Initialize gcs worker manager.
   void InitGcsWorkerManager();
+
+  /// Initialize task info handler.
+  void InitTaskInfoHandler();
 
   /// Initialize stats handler.
   void InitStatsHandler();
@@ -189,6 +193,9 @@ class GcsServer {
   /// Object info handler and service.
   std::unique_ptr<gcs::GcsObjectManager> gcs_object_manager_;
   std::unique_ptr<rpc::ObjectInfoGrpcService> object_info_service_;
+  /// Task info handler and service.
+  std::unique_ptr<rpc::TaskInfoHandler> task_info_handler_;
+  std::unique_ptr<rpc::TaskInfoGrpcService> task_info_service_;
   /// Stats handler and service.
   std::unique_ptr<rpc::StatsHandler> stats_handler_;
   std::unique_ptr<rpc::StatsGrpcService> stats_service_;

--- a/src/ray/gcs/gcs_server/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server/gcs_server_main.cc
@@ -105,6 +105,8 @@ int main(int argc, char *argv[]) {
   gcs_server_config.node_ip_address = node_ip_address;
   gcs_server_config.pull_based_resource_reporting =
       RayConfig::instance().pull_based_resource_reporting();
+  gcs_server_config.grpc_based_resource_broadcast =
+      RayConfig::instance().grpc_based_resource_broadcast();
   gcs_server_config.grpc_pubsub_enabled = RayConfig::instance().gcs_grpc_based_pubsub();
   ray::gcs::GcsServer gcs_server(gcs_server_config, main_service);
 

--- a/src/ray/gcs/gcs_server/grpc_based_resource_broadcaster.h
+++ b/src/ray/gcs/gcs_server/grpc_based_resource_broadcaster.h
@@ -1,5 +1,4 @@
 #include "ray/common/asio/instrumented_io_context.h"
-#include "ray/common/asio/periodical_runner.h"
 #include "ray/gcs/gcs_server/gcs_resource_manager.h"
 #include "ray/rpc/node_manager/node_manager_client_pool.h"
 

--- a/src/ray/gcs/gcs_server/task_info_handler_impl.cc
+++ b/src/ray/gcs/gcs_server/task_info_handler_impl.cc
@@ -1,0 +1,167 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/gcs/gcs_server/task_info_handler_impl.h"
+
+namespace ray {
+namespace rpc {
+
+void DefaultTaskInfoHandler::HandleAddTask(const AddTaskRequest &request,
+                                           AddTaskReply *reply,
+                                           SendReplyCallback send_reply_callback) {
+  JobID job_id = JobID::FromBinary(request.task_data().task().task_spec().job_id());
+  TaskID task_id = TaskID::FromBinary(request.task_data().task().task_spec().task_id());
+  RAY_LOG(DEBUG) << "Adding task, job id = " << job_id << ", task id = " << task_id;
+  auto on_done = [job_id, task_id, reply, send_reply_callback](const Status &status) {
+    if (!status.ok()) {
+      RAY_LOG(ERROR) << "Failed to add task, job id = " << job_id
+                     << ", task id = " << task_id;
+    } else {
+      RAY_LOG(DEBUG) << "Finished adding task, job id = " << job_id
+                     << ", task id = " << task_id;
+      GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
+    }
+  };
+
+  Status status =
+      gcs_table_storage_->TaskTable().Put(task_id, request.task_data(), on_done);
+  if (!status.ok()) {
+    on_done(status);
+  }
+  ++counts_[CountType::ADD_TASK_REQUEST];
+}
+
+void DefaultTaskInfoHandler::HandleGetTask(const GetTaskRequest &request,
+                                           GetTaskReply *reply,
+                                           SendReplyCallback send_reply_callback) {
+  TaskID task_id = TaskID::FromBinary(request.task_id());
+  RAY_LOG(DEBUG) << "Getting task, job id = " << task_id.JobId()
+                 << ", task id = " << task_id;
+  auto on_done = [task_id, request, reply, send_reply_callback](
+                     const Status &status, const boost::optional<TaskTableData> &result) {
+    if (status.ok() && result) {
+      reply->mutable_task_data()->CopyFrom(*result);
+    }
+    RAY_LOG(DEBUG) << "Finished getting task, job id = " << task_id.JobId()
+                   << ", task id = " << task_id << ", status = " << status.ToString();
+    GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+  };
+
+  Status status = gcs_table_storage_->TaskTable().Get(task_id, on_done);
+  if (!status.ok()) {
+    on_done(status, boost::none);
+  }
+  ++counts_[CountType::GET_TASK_REQUEST];
+}
+
+void DefaultTaskInfoHandler::HandleAddTaskLease(const AddTaskLeaseRequest &request,
+                                                AddTaskLeaseReply *reply,
+                                                SendReplyCallback send_reply_callback) {
+  TaskID task_id = TaskID::FromBinary(request.task_lease_data().task_id());
+  NodeID node_id = NodeID::FromBinary(request.task_lease_data().node_manager_id());
+  RAY_LOG(DEBUG) << "Adding task lease, job id = " << task_id.JobId()
+                 << ", task id = " << task_id << ", node id = " << node_id;
+  auto on_done = [this, task_id, node_id, request, reply,
+                  send_reply_callback](const Status &status) {
+    if (!status.ok()) {
+      RAY_LOG(ERROR) << "Failed to add task lease, job id = " << task_id.JobId()
+                     << ", task id = " << task_id << ", node id = " << node_id;
+    } else {
+      RAY_CHECK_OK(gcs_pub_sub_->Publish(TASK_LEASE_CHANNEL, task_id.Hex(),
+                                         request.task_lease_data().SerializeAsString(),
+                                         nullptr));
+      RAY_LOG(DEBUG) << "Finished adding task lease, job id = " << task_id.JobId()
+                     << ", task id = " << task_id << ", node id = " << node_id;
+    }
+    GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
+  };
+
+  Status status = gcs_table_storage_->TaskLeaseTable().Put(
+      task_id, request.task_lease_data(), on_done);
+  if (!status.ok()) {
+    on_done(status);
+  }
+  ++counts_[CountType::ADD_TASK_LEASE_REQUEST];
+}
+
+void DefaultTaskInfoHandler::HandleGetTaskLease(const GetTaskLeaseRequest &request,
+                                                GetTaskLeaseReply *reply,
+                                                SendReplyCallback send_reply_callback) {
+  TaskID task_id = TaskID::FromBinary(request.task_id());
+  RAY_LOG(DEBUG) << "Getting task lease, job id = " << task_id.JobId()
+                 << ", task id = " << task_id;
+  auto on_done = [task_id, request, reply, send_reply_callback](
+                     const Status &status, const boost::optional<TaskLeaseData> &result) {
+    if (status.ok() && result) {
+      reply->mutable_task_lease_data()->CopyFrom(*result);
+    }
+    RAY_LOG(DEBUG) << "Finished getting task lease, job id = " << task_id.JobId()
+                   << ", task id = " << task_id << ", status = " << status.ToString();
+    GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+  };
+
+  Status status = gcs_table_storage_->TaskLeaseTable().Get(task_id, on_done);
+  if (!status.ok()) {
+    on_done(status, boost::none);
+  }
+  ++counts_[CountType::GET_TASK_LEASE_REQUEST];
+}
+
+void DefaultTaskInfoHandler::HandleAttemptTaskReconstruction(
+    const AttemptTaskReconstructionRequest &request,
+    AttemptTaskReconstructionReply *reply, SendReplyCallback send_reply_callback) {
+  TaskID task_id = TaskID::FromBinary(request.task_reconstruction().task_id());
+  NodeID node_id = NodeID::FromBinary(request.task_reconstruction().node_manager_id());
+  RAY_LOG(DEBUG) << "Reconstructing task, job id = " << task_id.JobId()
+                 << ", task id = " << task_id << ", reconstructions num = "
+                 << request.task_reconstruction().num_reconstructions()
+                 << ", node id = " << node_id;
+  auto on_done = [task_id, node_id, request, reply,
+                  send_reply_callback](const Status &status) {
+    if (!status.ok()) {
+      RAY_LOG(ERROR) << "Failed to reconstruct task, job id = " << task_id.JobId()
+                     << ", task id = " << task_id << ", reconstructions num = "
+                     << request.task_reconstruction().num_reconstructions()
+                     << ", node id = " << node_id;
+    } else {
+      RAY_LOG(DEBUG) << "Finished reconstructing task, job id = " << task_id.JobId()
+                     << ", task id = " << task_id << ", reconstructions num = "
+                     << request.task_reconstruction().num_reconstructions()
+                     << ", node id = " << node_id;
+    }
+    GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
+  };
+
+  Status status = gcs_table_storage_->TaskReconstructionTable().Put(
+      task_id, request.task_reconstruction(), on_done);
+  if (!status.ok()) {
+    on_done(status);
+  }
+  ++counts_[CountType::ATTEMPT_TASK_RECONSTRUCTION_REQUEST];
+}
+
+std::string DefaultTaskInfoHandler::DebugString() const {
+  std::ostringstream stream;
+  stream << "DefaultTaskInfoHandler: {AddTask request count: "
+         << counts_[CountType::ADD_TASK_REQUEST]
+         << ", GetTask request count: " << counts_[CountType::GET_TASK_REQUEST]
+         << ", AddTaskLease request count: " << counts_[CountType::ADD_TASK_LEASE_REQUEST]
+         << ", GetTaskLease request count: " << counts_[CountType::GET_TASK_LEASE_REQUEST]
+         << ", AttemptTaskReconstruction request count: "
+         << counts_[CountType::ATTEMPT_TASK_RECONSTRUCTION_REQUEST] << "}";
+  return stream.str();
+}
+
+}  // namespace rpc
+}  // namespace ray

--- a/src/ray/gcs/gcs_server/task_info_handler_impl.h
+++ b/src/ray/gcs/gcs_server/task_info_handler_impl.h
@@ -1,0 +1,66 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "ray/gcs/gcs_server/gcs_table_storage.h"
+#include "ray/gcs/pubsub/gcs_pub_sub.h"
+#include "ray/rpc/gcs_server/gcs_rpc_server.h"
+
+namespace ray {
+namespace rpc {
+
+/// This implementation class of `TaskInfoHandler`.
+class DefaultTaskInfoHandler : public rpc::TaskInfoHandler {
+ public:
+  explicit DefaultTaskInfoHandler(std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
+                                  std::shared_ptr<gcs::GcsPubSub> &gcs_pub_sub)
+      : gcs_table_storage_(gcs_table_storage), gcs_pub_sub_(gcs_pub_sub) {}
+
+  void HandleAddTask(const AddTaskRequest &request, AddTaskReply *reply,
+                     SendReplyCallback send_reply_callback) override;
+
+  void HandleGetTask(const GetTaskRequest &request, GetTaskReply *reply,
+                     SendReplyCallback send_reply_callback) override;
+
+  void HandleAddTaskLease(const AddTaskLeaseRequest &request, AddTaskLeaseReply *reply,
+                          SendReplyCallback send_reply_callback) override;
+
+  void HandleGetTaskLease(const GetTaskLeaseRequest &request, GetTaskLeaseReply *reply,
+                          SendReplyCallback send_reply_callback) override;
+
+  void HandleAttemptTaskReconstruction(const AttemptTaskReconstructionRequest &request,
+                                       AttemptTaskReconstructionReply *reply,
+                                       SendReplyCallback send_reply_callback) override;
+
+  std::string DebugString() const;
+
+ private:
+  std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
+  std::shared_ptr<gcs::GcsPubSub> &gcs_pub_sub_;
+
+  // Debug info.
+  enum CountType {
+    ADD_TASK_REQUEST = 0,
+    GET_TASK_REQUEST = 1,
+    ADD_TASK_LEASE_REQUEST = 3,
+    GET_TASK_LEASE_REQUEST = 4,
+    ATTEMPT_TASK_RECONSTRUCTION_REQUEST = 5,
+    CountType_MAX = 6,
+  };
+  uint64_t counts_[CountType::CountType_MAX] = {0};
+};
+
+}  // namespace rpc
+}  // namespace ray

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
@@ -70,7 +70,8 @@ class GcsPlacementGroupManagerTest : public ::testing::Test {
       : mock_placement_group_scheduler_(new MockPlacementGroupScheduler()) {
     gcs_pub_sub_ = std::make_shared<GcsServerMocker::MockGcsPubSub>(redis_client_);
     gcs_table_storage_ = std::make_shared<gcs::InMemoryGcsTableStorage>(io_service_);
-    gcs_resource_manager_ = std::make_shared<gcs::GcsResourceManager>(nullptr);
+    gcs_resource_manager_ =
+        std::make_shared<gcs::GcsResourceManager>(io_service_, nullptr, nullptr, true);
     gcs_placement_group_manager_.reset(new gcs::GcsPlacementGroupManager(
         io_service_, mock_placement_group_scheduler_, gcs_table_storage_,
         *gcs_resource_manager_,

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -40,7 +40,8 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     }
     gcs_table_storage_ = std::make_shared<gcs::InMemoryGcsTableStorage>(io_service_);
     gcs_pub_sub_ = std::make_shared<GcsServerMocker::MockGcsPubSub>(redis_client_);
-    gcs_resource_manager_ = std::make_shared<gcs::GcsResourceManager>(nullptr);
+    gcs_resource_manager_ =
+        std::make_shared<gcs::GcsResourceManager>(io_service_, nullptr, nullptr, true);
     gcs_resource_scheduler_ =
         std::make_shared<gcs::GcsResourceScheduler>(*gcs_resource_manager_);
     gcs_node_manager_ =

--- a/src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc
@@ -26,9 +26,11 @@ using ::testing::_;
 class GcsResourceManagerTest : public ::testing::Test {
  public:
   GcsResourceManagerTest() {
-    gcs_resource_manager_ = std::make_shared<gcs::GcsResourceManager>(nullptr);
+    gcs_resource_manager_ =
+        std::make_shared<gcs::GcsResourceManager>(io_service_, nullptr, nullptr, true);
   }
 
+  instrumented_io_context io_service_;
   std::shared_ptr<gcs::GcsResourceManager> gcs_resource_manager_;
 };
 

--- a/src/ray/gcs/gcs_server/test/gcs_resource_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_resource_scheduler_test.cc
@@ -26,7 +26,8 @@ using ::testing::_;
 class GcsResourceSchedulerTest : public ::testing::Test {
  public:
   void SetUp() override {
-    gcs_resource_manager_ = std::make_shared<gcs::GcsResourceManager>(nullptr);
+    gcs_resource_manager_ =
+        std::make_shared<gcs::GcsResourceManager>(io_service_, nullptr, nullptr, true);
     gcs_resource_scheduler_ =
         std::make_shared<gcs::GcsResourceScheduler>(*gcs_resource_manager_);
   }

--- a/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
@@ -231,6 +231,56 @@ class GcsServerTest : public ::testing::Test {
     return object_locations;
   }
 
+  bool AddTask(const rpc::AddTaskRequest &request) {
+    std::promise<bool> promise;
+    client_->AddTask(request,
+                     [&promise](const Status &status, const rpc::AddTaskReply &reply) {
+                       RAY_CHECK_OK(status);
+                       promise.set_value(true);
+                     });
+    return WaitReady(promise.get_future(), timeout_ms_);
+  }
+
+  rpc::TaskTableData GetTask(const std::string &task_id) {
+    rpc::TaskTableData task_data;
+    rpc::GetTaskRequest request;
+    request.set_task_id(task_id);
+    std::promise<bool> promise;
+    client_->GetTask(request, [&task_data, &promise](const Status &status,
+                                                     const rpc::GetTaskReply &reply) {
+      if (status.ok()) {
+        if (reply.has_task_data()) {
+          task_data.CopyFrom(reply.task_data());
+        }
+      }
+      promise.set_value(true);
+    });
+
+    EXPECT_TRUE(WaitReady(promise.get_future(), timeout_ms_));
+    return task_data;
+  }
+
+  bool AddTaskLease(const rpc::AddTaskLeaseRequest &request) {
+    std::promise<bool> promise;
+    client_->AddTaskLease(
+        request, [&promise](const Status &status, const rpc::AddTaskLeaseReply &reply) {
+          RAY_CHECK_OK(status);
+          promise.set_value(true);
+        });
+    return WaitReady(promise.get_future(), timeout_ms_);
+  }
+
+  bool AttemptTaskReconstruction(const rpc::AttemptTaskReconstructionRequest &request) {
+    std::promise<bool> promise;
+    client_->AttemptTaskReconstruction(
+        request, [&promise](const Status &status,
+                            const rpc::AttemptTaskReconstructionReply &reply) {
+          RAY_CHECK_OK(status);
+          promise.set_value(true);
+        });
+    return WaitReady(promise.get_future(), timeout_ms_);
+  }
+
   bool AddProfileData(const rpc::AddProfileDataRequest &request) {
     std::promise<bool> promise;
     client_->AddProfileData(
@@ -479,6 +529,37 @@ TEST_F(GcsServerTest, TestObjectInfo) {
   object_locations = GetObjectLocations(object_id.Binary());
   ASSERT_TRUE(object_locations.size() == 1);
   ASSERT_TRUE(object_locations[0].manager() == node2_id.Binary());
+}
+
+TEST_F(GcsServerTest, TestTaskInfo) {
+  // Create task_table_data
+  JobID job_id = JobID::FromInt(1);
+  TaskID task_id = TaskID::ForDriverTask(job_id);
+  auto job_table_data = Mocker::GenTaskTableData(job_id.Binary(), task_id.Binary());
+
+  // Add task
+  rpc::AddTaskRequest add_task_request;
+  add_task_request.mutable_task_data()->CopyFrom(*job_table_data);
+  ASSERT_TRUE(AddTask(add_task_request));
+  rpc::TaskTableData result = GetTask(task_id.Binary());
+  ASSERT_TRUE(result.task().task_spec().job_id() == job_id.Binary());
+
+  // Add task lease
+  NodeID node_id = NodeID::FromRandom();
+  auto task_lease_data = Mocker::GenTaskLeaseData(task_id.Binary(), node_id.Binary());
+  rpc::AddTaskLeaseRequest add_task_lease_request;
+  add_task_lease_request.mutable_task_lease_data()->CopyFrom(*task_lease_data);
+  ASSERT_TRUE(AddTaskLease(add_task_lease_request));
+
+  // Attempt task reconstruction
+  rpc::AttemptTaskReconstructionRequest attempt_task_reconstruction_request;
+  rpc::TaskReconstructionData task_reconstruction_data;
+  task_reconstruction_data.set_task_id(task_id.Binary());
+  task_reconstruction_data.set_node_manager_id(node_id.Binary());
+  task_reconstruction_data.set_num_reconstructions(0);
+  attempt_task_reconstruction_request.mutable_task_reconstruction()->CopyFrom(
+      task_reconstruction_data);
+  ASSERT_TRUE(AttemptTaskReconstruction(attempt_task_reconstruction_request));
 }
 
 TEST_F(GcsServerTest, TestStats) {

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -312,6 +312,63 @@ service ObjectInfoGcsService {
       returns (RemoveObjectLocationReply);
 }
 
+message AddTaskRequest {
+  TaskTableData task_data = 1;
+}
+
+message AddTaskReply {
+  GcsStatus status = 1;
+}
+
+message GetTaskRequest {
+  bytes task_id = 1;
+}
+
+message GetTaskReply {
+  GcsStatus status = 1;
+  TaskTableData task_data = 2;
+}
+
+message AddTaskLeaseRequest {
+  TaskLeaseData task_lease_data = 1;
+}
+
+message AddTaskLeaseReply {
+  GcsStatus status = 1;
+}
+
+message GetTaskLeaseRequest {
+  bytes task_id = 1;
+}
+
+message GetTaskLeaseReply {
+  GcsStatus status = 1;
+  TaskLeaseData task_lease_data = 2;
+}
+
+message AttemptTaskReconstructionRequest {
+  TaskReconstructionData task_reconstruction = 1;
+}
+
+message AttemptTaskReconstructionReply {
+  GcsStatus status = 1;
+}
+
+// Service for task info access.
+service TaskInfoGcsService {
+  // Add a task to GCS Service.
+  rpc AddTask(AddTaskRequest) returns (AddTaskReply);
+  // Get task information from GCS Service.
+  rpc GetTask(GetTaskRequest) returns (GetTaskReply);
+  // Add a task lease to GCS Service.
+  rpc AddTaskLease(AddTaskLeaseRequest) returns (AddTaskLeaseReply);
+  // Get task lease information from GCS Service.
+  rpc GetTaskLease(GetTaskLeaseRequest) returns (GetTaskLeaseReply);
+  // Attempt task reconstruction to GCS Service.
+  rpc AttemptTaskReconstruction(AttemptTaskReconstructionRequest)
+      returns (AttemptTaskReconstructionReply);
+}
+
 message AddProfileDataRequest {
   ProfileTableData profile_data = 1;
 }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -407,6 +407,14 @@ ray::Status NodeManager::RegisterGcs() {
   RAY_RETURN_NOT_OK(
       gcs_client_->Nodes().AsyncSubscribeToNodeChange(on_node_change, on_done));
 
+  // Subscribe to resource usage batches from the monitor.
+  const auto &resource_usage_batch_added =
+      [this](const ResourceUsageBatchData &resource_usage_batch) {
+        ResourceUsageBatchReceived(resource_usage_batch);
+      };
+  RAY_RETURN_NOT_OK(gcs_client_->NodeResources().AsyncSubscribeBatchedResourceUsage(
+      resource_usage_batch_added, /*done*/ nullptr));
+
   // Subscribe to all unexpected failure notifications from the local and
   // remote raylets. Note that this does not include workers that failed due to
   // node failure. These workers can be identified by comparing the raylet_id
@@ -1628,6 +1636,7 @@ void NodeManager::HandleRequestWorkerLease(const rpc::RequestWorkerLeaseRequest 
     std::shared_ptr<rpc::TaskTableData> data = std::make_shared<rpc::TaskTableData>();
     data->mutable_task()->mutable_task_spec()->CopyFrom(
         task.GetTaskSpecification().GetMessage());
+    RAY_CHECK_OK(gcs_client_->Tasks().AsyncAdd(data, nullptr));
   }
 
   if (RayConfig::instance().enable_worker_prestart()) {

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -104,6 +104,8 @@ class GcsRpcClient {
         address, port, client_call_manager);
     object_info_grpc_client_ = std::make_unique<GrpcClient<ObjectInfoGcsService>>(
         address, port, client_call_manager);
+    task_info_grpc_client_ = std::make_unique<GrpcClient<TaskInfoGcsService>>(
+        address, port, client_call_manager);
     stats_grpc_client_ =
         std::make_unique<GrpcClient<StatsGcsService>>(address, port, client_call_manager);
     worker_info_grpc_client_ = std::make_unique<GrpcClient<WorkerInfoGcsService>>(
@@ -209,6 +211,22 @@ class GcsRpcClient {
   VOID_GCS_RPC_CLIENT_METHOD(ObjectInfoGcsService, RemoveObjectLocation,
                              object_info_grpc_client_, )
 
+  /// Add a task to GCS Service.
+  VOID_GCS_RPC_CLIENT_METHOD(TaskInfoGcsService, AddTask, task_info_grpc_client_, )
+
+  /// Get task information from GCS Service.
+  VOID_GCS_RPC_CLIENT_METHOD(TaskInfoGcsService, GetTask, task_info_grpc_client_, )
+
+  /// Add a task lease to GCS Service.
+  VOID_GCS_RPC_CLIENT_METHOD(TaskInfoGcsService, AddTaskLease, task_info_grpc_client_, )
+
+  /// Get task lease information from GCS Service.
+  VOID_GCS_RPC_CLIENT_METHOD(TaskInfoGcsService, GetTaskLease, task_info_grpc_client_, )
+
+  /// Attempt task reconstruction to GCS Service.
+  VOID_GCS_RPC_CLIENT_METHOD(TaskInfoGcsService, AttemptTaskReconstruction,
+                             task_info_grpc_client_, )
+
   /// Add profile data to GCS Service.
   VOID_GCS_RPC_CLIENT_METHOD(StatsGcsService, AddProfileData, stats_grpc_client_, )
 
@@ -276,6 +294,7 @@ class GcsRpcClient {
   std::unique_ptr<GrpcClient<NodeResourceInfoGcsService>> node_resource_info_grpc_client_;
   std::unique_ptr<GrpcClient<HeartbeatInfoGcsService>> heartbeat_info_grpc_client_;
   std::unique_ptr<GrpcClient<ObjectInfoGcsService>> object_info_grpc_client_;
+  std::unique_ptr<GrpcClient<TaskInfoGcsService>> task_info_grpc_client_;
   std::unique_ptr<GrpcClient<StatsGcsService>> stats_grpc_client_;
   std::unique_ptr<GrpcClient<WorkerInfoGcsService>> worker_info_grpc_client_;
   std::unique_ptr<GrpcClient<PlacementGroupInfoGcsService>>

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -41,6 +41,9 @@ namespace rpc {
 #define OBJECT_INFO_SERVICE_RPC_HANDLER(HANDLER) \
   RPC_SERVICE_HANDLER(ObjectInfoGcsService, HANDLER)
 
+#define TASK_INFO_SERVICE_RPC_HANDLER(HANDLER) \
+  RPC_SERVICE_HANDLER(TaskInfoGcsService, HANDLER)
+
 #define STATS_SERVICE_RPC_HANDLER(HANDLER) RPC_SERVICE_HANDLER(StatsGcsService, HANDLER)
 
 #define WORKER_INFO_SERVICE_RPC_HANDLER(HANDLER) \
@@ -367,6 +370,59 @@ class ObjectInfoGrpcService : public GrpcService {
   ObjectInfoGcsServiceHandler &service_handler_;
 };
 
+class TaskInfoGcsServiceHandler {
+ public:
+  virtual ~TaskInfoGcsServiceHandler() = default;
+
+  virtual void HandleAddTask(const AddTaskRequest &request, AddTaskReply *reply,
+                             SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleGetTask(const GetTaskRequest &request, GetTaskReply *reply,
+                             SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleAddTaskLease(const AddTaskLeaseRequest &request,
+                                  AddTaskLeaseReply *reply,
+                                  SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleGetTaskLease(const GetTaskLeaseRequest &request,
+                                  GetTaskLeaseReply *reply,
+                                  SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleAttemptTaskReconstruction(
+      const AttemptTaskReconstructionRequest &request,
+      AttemptTaskReconstructionReply *reply, SendReplyCallback send_reply_callback) = 0;
+};
+
+/// The `GrpcService` for `TaskInfoGcsService`.
+class TaskInfoGrpcService : public GrpcService {
+ public:
+  /// Constructor.
+  ///
+  /// \param[in] handler The service handler that actually handle the requests.
+  explicit TaskInfoGrpcService(instrumented_io_context &io_service,
+                               TaskInfoGcsServiceHandler &handler)
+      : GrpcService(io_service), service_handler_(handler){};
+
+ protected:
+  grpc::Service &GetGrpcService() override { return service_; }
+
+  void InitServerCallFactories(
+      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
+      std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories) override {
+    TASK_INFO_SERVICE_RPC_HANDLER(AddTask);
+    TASK_INFO_SERVICE_RPC_HANDLER(GetTask);
+    TASK_INFO_SERVICE_RPC_HANDLER(AddTaskLease);
+    TASK_INFO_SERVICE_RPC_HANDLER(GetTaskLease);
+    TASK_INFO_SERVICE_RPC_HANDLER(AttemptTaskReconstruction);
+  }
+
+ private:
+  /// The grpc async service object.
+  TaskInfoGcsService::AsyncService service_;
+  /// The service handler that actually handle the requests.
+  TaskInfoGcsServiceHandler &service_handler_;
+};
+
 class StatsGcsServiceHandler {
  public:
   virtual ~StatsGcsServiceHandler() = default;
@@ -571,6 +627,7 @@ using NodeInfoHandler = NodeInfoGcsServiceHandler;
 using NodeResourceInfoHandler = NodeResourceInfoGcsServiceHandler;
 using HeartbeatInfoHandler = HeartbeatInfoGcsServiceHandler;
 using ObjectInfoHandler = ObjectInfoGcsServiceHandler;
+using TaskInfoHandler = TaskInfoGcsServiceHandler;
 using StatsHandler = StatsGcsServiceHandler;
 using WorkerInfoHandler = WorkerInfoGcsServiceHandler;
 using PlacementGroupInfoHandler = PlacementGroupInfoGcsServiceHandler;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR:
- Reverts the PR removing the redis-based broadcaster
- Flips the flag to revert Ray to using the redis-based broadcaster by default

## Related issue number

https://github.com/ray-project/ray/issues/16858