### PR TITLE
[Core][RFC] Fix potential eviction bug

### DIFF
--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -611,6 +611,7 @@ int PlasmaStore::RemoveFromClientObjectIds(const ObjectID &object_id,
         // Above code does not really delete an object. Instead, it just put an
         // object to LRU cache which will be cleaned when the memory is not enough.
         deletion_cache_.erase(object_id);
+        eviction_policy_.RemoveObject(object_id);
         EvictObjects({object_id});
       }
     }


### PR DESCRIPTION
Reading the code it seems to me we always remove those objects to be evicited from eviction_policy before calling `EvictObjects`. 
This is usually achieved by calling `eviction_policy_.ChooseObjectsToEvict/RequireSpace` which will remove the objects from eviction_policy.  
https://github.com/ray-project/ray/blob/9b17c35bee6a28b4b09ede36fdb9fdced3929f55/src/ray/object_manager/plasma/store.cc#L243
https://github.com/ray-project/ray/blob/9b17c35bee6a28b4b09ede36fdb9fdced3929f55/src/ray/object_manager/plasma/store.cc#L914
However in this case the object is not removed from `eviction_policy_`, which might lead to potential bugs.

Let me know if this makes sense. TBD: add tests.