### PR TITLE
[doc] Allows xgboost_ray documentation to be rendered

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -97,10 +97,19 @@ for mod_name in MOCK_MODULES:
 sys.modules["tensorflow"].VERSION = "9.9.9"
 sys.modules["tensorflow.keras.callbacks"] = ChildClassMock()
 sys.modules["pytorch_lightning"] = ChildClassMock()
-sys.modules["xgboost"] = ChildClassMock()
-sys.modules["xgboost.core"] = ChildClassMock()
-sys.modules["xgboost.callback"] = ChildClassMock()
-sys.modules["xgboost_ray"] = ChildClassMock()
+
+
+def import_or_mock(module):
+    try:
+        # Same as `import module`
+        __import__(module, globals(), locals(), [], 0)
+    except ImportError:
+        sys.modules[module] = ChildClassMock()
+
+
+xgb_modules = ["xgboost", "xgboost.core", "xgboost.callback", "xgboost_ray"]
+for xgb_mod in xgb_modules:
+    import_or_mock(xgb_mod)
 
 
 class SimpleClass(object):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
If `xgboost` + `xgboost_ray` is available when building the docs, `conf.py` will import it otherwise it is mocked. This enables sphinx to see the docstring when building the API docs for `xgboost` at: https://docs.ray.io/en/master/xgboost-ray.html#api-reference

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/xgboost_ray/issues/95

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
