### PR TITLE
[Serve] Call FastAPIWrapper class constructor before startup hooks

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1057,6 +1057,8 @@ def ingress(app: Union["FastAPI", "APIRouter"]):
 
         class FastAPIWrapper(cls):
             async def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
                 self.app = frozen_app
 
                 # Use uvicorn's lifespan handling code to properly deal with
@@ -1069,10 +1071,6 @@ def ingress(app: Union["FastAPI", "APIRouter"]):
                 with LoggingContext(
                         self.lifespan.logger, level=logging.WARNING):
                     await self.lifespan.startup()
-
-                # TODO(edoakes): should the startup_hook run before or after
-                # the constructor?
-                super().__init__(*args, **kwargs)
 
             async def __call__(self, request: Request):
                 sender = ASGIHTTPSender()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Call the class constructor in the `FastAPIWrapper` before the startup hooks are run. This allows users to specify any setup commands that need to be run before the app is started before deploying the actor in the `__init__` method.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   Verified the unit test fails without this change
   - [ ] Release tests
   - [ ] This PR is not tested :(
