### PR TITLE
[Core]Align storage of session_dir in java/python so it can be accessed u…

### DIFF
--- a/cpp/src/ray/util/process_helper.cc
+++ b/cpp/src/ray/util/process_helper.cc
@@ -17,7 +17,7 @@ static std::string GetSessionDir(std::string redis_ip, int port, std::string pas
     RAY_CHECK(auth_reply->type != REDIS_REPLY_ERROR);
     freeReplyObject(auth_reply);
   }
-  auto reply = (redisReply *)redisCommand(context, "GET session_dir");
+  auto reply = (redisReply *)redisCommand(context, "HGET session_dir value");
   RAY_CHECK(reply->type != REDIS_REPLY_ERROR);
   std::string session_dir(reply->str);
   freeReplyObject(reply);

--- a/java/runtime/src/main/java/io/ray/runtime/RayNativeRuntime.java
+++ b/java/runtime/src/main/java/io/ray/runtime/RayNativeRuntime.java
@@ -51,7 +51,7 @@ public final class RayNativeRuntime extends AbstractRayRuntime {
     if (rayConfig.workerMode == WorkerType.DRIVER) {
       // Fetch session dir from GCS if this is a driver.
       RedisClient client = new RedisClient(rayConfig.getRedisAddress(), rayConfig.redisPassword);
-      final String sessionDir = client.get("session_dir", null);
+      final String sessionDir = client.get("session_dir", "value");
       Preconditions.checkNotNull(sessionDir);
       rayConfig.setSessionDir(sessionDir);
     }


### PR DESCRIPTION
…sing internal kv manager

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We wanna remove redis dependency in java/python lang with move the get/set logic to internal kv manager. 
The kv manager now use hset/hget to manage values of keys so we first need to change the storage type of `session_dir` to hash type.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
preorder of https://github.com/ray-project/ray/pull/16773
substitution of https://github.com/ray-project/ray/pull/16834
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
