### PR TITLE
Never convert trial_id to float when loading progress.csv.

### DIFF
--- a/python/ray/tune/analysis/experiment_analysis.py
+++ b/python/ray/tune/analysis/experiment_analysis.py
@@ -206,8 +206,9 @@ class Analysis:
                         json_list = [json.loads(line) for line in f if line]
                     df = pd.json_normalize(json_list, sep="/")
                 elif self._file_type == "csv":
-                    df = pd.read_csv(os.path.join(path, EXPR_PROGRESS_FILE),
-                                     dtype=force_dtype)
+                    df = pd.read_csv(
+                        os.path.join(path, EXPR_PROGRESS_FILE),
+                        dtype=force_dtype)
                 self.trial_dataframes[path] = df
             except Exception:
                 fail_count += 1

--- a/python/ray/tune/analysis/experiment_analysis.py
+++ b/python/ray/tune/analysis/experiment_analysis.py
@@ -198,6 +198,7 @@ class Analysis:
             A dictionary containing "trial dir" to Dataframe.
         """
         fail_count = 0
+        force_dtype = {"trial_id": str}  # Never convert trial_id to float.
         for path in self._get_trial_paths():
             try:
                 if self._file_type == "json":
@@ -205,7 +206,8 @@ class Analysis:
                         json_list = [json.loads(line) for line in f if line]
                     df = pd.json_normalize(json_list, sep="/")
                 elif self._file_type == "csv":
-                    df = pd.read_csv(os.path.join(path, EXPR_PROGRESS_FILE))
+                    df = pd.read_csv(os.path.join(path, EXPR_PROGRESS_FILE),
+                                     dtype=force_dtype)
                 self.trial_dataframes[path] = df
             except Exception:
                 fail_count += 1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When `ray.tune.Analysis` loads `progess.csv` files it incorrectly converts trial ids which look like `float` in scientific notation, e.g. `"5381e182"`, to `float`. This change prevents this conversion.

## Related issue number

No issue was created. @richardliaw 

## Checks

I checked that accidental `float` conversion no longer happens when a trial_id can be interpreted as a `float` in scientific notation.

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
