### PR TITLE
[Workflow] Readonly Virtual Actor

### DIFF
--- a/python/ray/experimental/workflow/__init__.py
+++ b/python/ray/experimental/workflow/__init__.py
@@ -1,4 +1,6 @@
-from ray.experimental.workflow.api import step, run, resume, get_output
+from ray.experimental.workflow.api import (step, actor, run, resume,
+                                           get_output, get_actor)
 from ray.experimental.workflow.workflow_access import WorkflowExecutionError
 
-__all__ = ("step", "run", "resume", "get_output", "WorkflowExecutionError")
+__all__ = ("step", "actor", "run", "resume", "get_output", "get_actor",
+           "WorkflowExecutionError")

--- a/python/ray/experimental/workflow/api.pyi
+++ b/python/ray/experimental/workflow/api.pyi
@@ -3,6 +3,7 @@ from typing import Callable, Generic, Optional, TypeVar, Union, overload
 
 from ray._raylet import ObjectRef
 from ray.experimental.workflow.storage import Storage
+from ray.experimental.workflow.virtual_actor import VirtualActorClass, VirtualActor
 
 T0 = TypeVar("T0")
 T1 = TypeVar("T1")
@@ -86,4 +87,8 @@ def resume(workflow_id: str) -> ObjectRef: ...
 @overload
 def resume(workflow_id: str, storage: Optional[Union[str, Storage]]) -> ObjectRef: ...
 
+def actor(cls: type) -> VirtualActorClass: ...
+
 def get_output(workflow_id: str) -> ObjectRef: ...
+
+def get_actor(actor_id: str, storage: "Optional[Union[str, Storage]]" = None, readonly=False) -> VirtualActor: ...

--- a/python/ray/experimental/workflow/common.py
+++ b/python/ray/experimental/workflow/common.py
@@ -29,7 +29,7 @@ class WorkflowInputs:
     workflows: List[str]
 
 
-def slugify(value: str, allow_unicode=False):
+def slugify(value: str, allow_unicode=False) -> str:
     """Adopted from
     https://github.com/django/django/blob/master/django/utils/text.py
     Convert to ASCII if 'allow_unicode' is False. Convert spaces or repeated
@@ -44,6 +44,18 @@ def slugify(value: str, allow_unicode=False):
             "ascii", "ignore").decode("ascii")
     value = re.sub(r"[^\w.\-]", "", value).strip()
     return re.sub(r"[-\s]+", "-", value)
+
+
+def actor_id_to_workflow_id(actor_id: str) -> str:
+    """Get the workflow ID from actor ID.
+
+    Args:
+        actor_id: The ID of a virtual actor.
+
+    Returns:
+        Workflow ID.
+    """
+    return "__actor__." + actor_id
 
 
 class Workflow:

--- a/python/ray/experimental/workflow/storage/base.py
+++ b/python/ray/experimental/workflow/storage/base.py
@@ -235,3 +235,30 @@ class Storage(metaclass=abc.ABCMeta):
     @abstractmethod
     def storage_url(self) -> str:
         """Get the URL of the storage."""
+
+    @abstractmethod
+    async def load_actor_class_body(self, workflow_id: str) -> type:
+        """Load the class body of the virtual actor.
+
+        Args:
+            workflow_id: ID of the workflow job.
+
+        Raises:
+            DataLoadError: if we fail to load the class body.
+        """
+
+    @abstractmethod
+    async def save_actor_class_body(self, workflow_id: str, cls: type) -> None:
+        """Save the class body of the virtual actor.
+
+        Args:
+            workflow_id: ID of the workflow job.
+            cls: The class body used by the virtual actor.
+
+        Raises:
+            DataSaveError: if we fail to save the class body.
+        """
+
+    @abstractmethod
+    def __reduce__(self):
+        """Reduce the storage to a serializable object."""

--- a/python/ray/experimental/workflow/storage/s3.py
+++ b/python/ray/experimental/workflow/storage/s3.py
@@ -17,6 +17,7 @@ STEP_OUTPUTS_METADATA = "outputs.json"
 STEP_ARGS = "args.pkl"
 STEP_OUTPUT = "output.pkl"
 STEP_FUNC_BODY = "func_body.pkl"
+CLASS_BODY = "class_body.pkl"
 
 MAX_RECEIVED_DATA_MEMORY_SIZE = 25 * 1024 * 1024  # 25MB
 
@@ -231,3 +232,20 @@ class S3StorageImpl(Storage):
 
     def _get_s3_path(self, *args) -> str:
         return "/".join(itertools.chain([self._s3_path], args))
+
+    @data_load_error
+    async def load_actor_class_body(self, workflow_id: str) -> type:
+        path = self._get_s3_path(workflow_id, CLASS_BODY)
+        data = await self._get_object(path)
+        return data
+
+    @data_save_error
+    async def save_actor_class_body(self, workflow_id: str, cls: type) -> None:
+        path = self._get_s3_path(workflow_id, CLASS_BODY)
+        await self._put_object(path, cls)
+
+    def __reduce__(self):
+        return S3StorageImpl, (self._bucket, self._s3_path, self._region_name,
+                               self._endpoint_url, self._aws_access_key_id,
+                               self._aws_secret_access_key,
+                               self._aws_session_token, self._config)

--- a/python/ray/experimental/workflow/tests/test_virtual_actor.py
+++ b/python/ray/experimental/workflow/tests/test_virtual_actor.py
@@ -1,0 +1,83 @@
+import time
+
+import pytest
+
+import ray
+
+from ray.experimental import workflow
+from ray.experimental.workflow import virtual_actor
+
+
+@workflow.actor
+class Counter:
+    def __init__(self, x: int):
+        self.x = x
+
+    def get(self):
+        return self.x
+
+    def incr(self):
+        self.x += 1
+        return self.x
+
+    def workload(self):
+        # simulate a workload
+        time.sleep(1)
+
+    def __getstate__(self):
+        return self.x
+
+    def __setstate__(self, state):
+        self.x = state
+
+
+@workflow.step
+def init_virtual_actor(x):
+    return x
+
+
+def test_readonly_actor():
+    ray.init(namespace="workflow")
+    actor = Counter.options(actor_id="Counter").create(42)
+    ray.get(actor.ready())
+    assert ray.get(actor.get.options(readonly=True).run()) == 42
+    assert ray.get(actor.incr.options(readonly=True).run()) == 43
+    assert ray.get(actor.get.options(readonly=True).run()) == 42
+
+    # test get actor
+    readonly_actor = workflow.get_actor("Counter", readonly=True)
+    # test concurrency
+    assert ray.get([readonly_actor.get.run() for _ in range(10)]) == [42] * 10
+    assert ray.get([readonly_actor.incr.run() for _ in range(10)]) == [43] * 10
+    assert ray.get([readonly_actor.get.run() for _ in range(10)]) == [42] * 10
+    start = time.time()
+    ray.get([readonly_actor.workload.run() for _ in range(10)])
+    end = time.time()
+    assert end - start < 5
+    ray.shutdown()
+
+
+@workflow.actor
+class SlowInit:
+    def __init__(self, x: int):
+        time.sleep(5)
+        self.x = x
+
+    def get(self):
+        return self.x
+
+    def __getstate__(self):
+        return self.x
+
+    def __setstate__(self, state):
+        self.x = state
+
+
+def test_actor_ready():
+    ray.init(namespace="workflow")
+    actor = SlowInit.options(actor_id="SlowInit").create(42)
+    with pytest.raises(virtual_actor.VirtualActorNotInitializedError):
+        ray.get(actor.get.options(readonly=True).run())
+    ray.get(actor.ready())
+    assert ray.get(actor.get.options(readonly=True).run()) == 42
+    ray.shutdown()

--- a/python/ray/experimental/workflow/virtual_actor.py
+++ b/python/ray/experimental/workflow/virtual_actor.py
@@ -1,0 +1,448 @@
+import abc
+import inspect
+import logging
+from typing import Optional, List, TYPE_CHECKING, Any, Tuple, Dict
+import uuid
+import weakref
+
+import ray
+from ray.util.inspect import (is_function_or_method, is_class_method,
+                              is_static_method)
+from ray._private import signature
+from ray.experimental.workflow.common import slugify, actor_id_to_workflow_id
+from ray.experimental.workflow.storage import Storage, get_global_storage
+from ray.experimental.workflow.workflow_storage import WorkflowStorage
+from ray.experimental.workflow.recovery import get_latest_output
+from ray.experimental.workflow.workflow_access import (
+    get_or_create_management_actor)
+from ray.experimental.workflow.step_function import WorkflowStepFunction
+
+if TYPE_CHECKING:
+    from ray import ObjectRef
+
+logger = logging.getLogger(__name__)
+
+
+class VirtualActorNotInitializedError(Exception):
+    def __init__(self, message):
+        self.message = message
+        super().__init__(message)
+
+
+@ray.remote
+def _readonly_method_executor(actor_id: str, storage: Storage, cls: type,
+                              method_name: str, flattened_args: List):
+    workflow_id = actor_id_to_workflow_id(actor_id)
+    instance = cls.__new__(cls)
+    try:
+        state = get_latest_output(workflow_id, storage)
+    except Exception as e:
+        raise VirtualActorNotInitializedError(
+            f"Virtual actor '{actor_id}' has not been initialized. "
+            "We cannot get the latest state for the "
+            "readonly virtual actor.") from e
+    instance.__setstate__(state)
+    args, kwargs = signature.recover_args(flattened_args)
+    method = getattr(instance, method_name)
+    return method(*args, **kwargs)
+
+
+# TODO(suquark): This is just a temporary solution. A virtual actor writer
+# should take place of this solution later.
+@WorkflowStepFunction
+def _virtual_actor_init(cls: type, flattened_args: List) -> Any:
+    instance = cls.__new__(cls)
+    args, kwargs = signature.recover_args(flattened_args)
+    instance.__init__(*args, **kwargs)
+    return instance.__getstate__()
+
+
+class ActorMethodBase(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def run(self, *args, **kwargs) -> "ObjectRef":
+        """Execute the actor method.
+
+        Returns:
+            A future object represents the result.
+        """
+
+
+# Create objects to wrap method invocations. This is done so that we can
+# invoke methods with actor.method.run() instead of actor.method().
+class ActorMethod(ActorMethodBase):
+    """A class used to invoke an actor method.
+
+    Note: This class only keeps a weak ref to the actor, unless it has been
+    passed to a remote function. This avoids delays in GC of the actor.
+
+    Attributes:
+        _actor_ref: A weakref handle to the actor.
+        _method_name: The name of the actor method.
+    """
+
+    def __init__(self, actor, method_name):
+        self._actor_ref = weakref.ref(actor)
+        self._method_name = method_name
+
+    def __call__(self, *args, **kwargs):
+        raise TypeError("Actor methods cannot be called directly. Instead "
+                        f"of running 'object.{self._method_name}()', try "
+                        f"'object.{self._method_name}.remote()'.")
+
+    def run(self, *args, **kwargs) -> "ObjectRef":
+        """Execute the actor method.
+
+        Returns:
+            A future object represents the result.
+        """
+        return self._run(args, kwargs)
+
+    def options(self, **options) -> ActorMethodBase:
+        """Convenience method for executing an actor method call with options.
+
+        Same arguments as func._run(), but returns a wrapped function
+        that a non-underscore .run() can be called on.
+
+        Examples:
+            # The following two calls are equivalent.
+            >>> actor.my_method._run(args=[x, y], readonly=False)
+            >>> actor.my_method.options(readonly=False).run(x, y)
+        """
+
+        func_cls = self
+
+        class FuncWrapper(ActorMethodBase):
+            def run(self, *args, **kwargs):
+                return func_cls._run(args=args, kwargs=kwargs, **options)
+
+        return FuncWrapper()
+
+    def _run(self,
+             args: Tuple[Any],
+             kwargs: Dict[str, Any],
+             readonly: Optional[bool] = None) -> "ObjectRef":
+        actor = self._actor_ref()
+        if actor is None:
+            raise RuntimeError("Lost reference to actor")
+        try:
+            return actor._actor_method_call(
+                self._method_name, args=args, kwargs=kwargs, readonly=readonly)
+        except TypeError as exc:  # capture a friendlier stacktrace
+            raise TypeError(
+                "Invalid input arguments for virtual actor "
+                f"method '{self._method_name}': {str(exc)}") from None
+
+    def __getstate__(self):
+        return {
+            "actor": self._actor_ref(),
+            "method_name": self._method_name,
+        }
+
+    def __setstate__(self, state):
+        self.__init__(state["actor"], state["method_name"])
+
+
+class VirtualActorMetadata:
+    """Recording the metadata of a virtual actor class, including
+    the signatures of its methods etc."""
+
+    def __init__(self, original_class: type):
+        actor_methods = inspect.getmembers(original_class,
+                                           is_function_or_method)
+        self.cls = original_class
+        self.module = original_class.__module__
+        self.name = original_class.__name__
+        self.qualname = original_class.__qualname__
+        self.methods = dict(actor_methods)
+
+        # Extract the signatures of each of the methods. This will be used
+        # to catch some errors if the methods are called with inappropriate
+        # arguments.
+        self.signatures = {}
+        for method_name, method in actor_methods:
+            # Whether or not this method requires binding of its first
+            # argument. For class and static methods, we do not want to bind
+            # the first argument, but we do for instance methods
+            method = inspect.unwrap(method)
+            is_bound = (is_class_method(method)
+                        or is_static_method(original_class, method_name))
+
+            # Print a warning message if the method signature is not
+            # supported. We don't raise an exception because if the actor
+            # inherits from a class that has a method whose signature we
+            # don't support, there may not be much the user can do about it.
+            self.signatures[method_name] = signature.extract_signature(
+                method, ignore_first=not is_bound)
+
+    def generate_random_actor_id(self) -> str:
+        """Generate random actor ID."""
+        return f"{slugify(self.qualname)}.{uuid.uuid4()}"
+
+    def flatten_args(self, method_name: str, args: Tuple[Any],
+                     kwargs: Dict[str, Any]) -> List[Any]:
+        """Check and flatten arguments of the actor method.
+
+        Args:
+            method_name: The name of the actor method in the actor class.
+            args: Positional arguments.
+            kwargs: Keywords arguments.
+
+        Returns:
+            Flattened arguments.
+        """
+        return signature.flatten_args(self.signatures[method_name], args,
+                                      kwargs)
+
+
+class VirtualActorClassBase(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def create(self, *args, **kwargs) -> "VirtualActor":
+        """Create a virtual actor.
+
+        Args:
+            args: These arguments are forwarded directly to the actor
+                constructor.
+            kwargs: These arguments are forwarded directly to the actor
+                constructor.
+
+        Returns:
+            A handle to the newly created actor.
+        """
+
+
+class VirtualActorClass(VirtualActorClassBase):
+    """The virtual actor class used to create a virtual actor."""
+    _metadata: VirtualActorMetadata
+
+    def __init__(self):
+        # This shouldn't be reached because one of the base classes must be
+        # an actor class if this was meant to be subclassed.
+        assert False, (
+            "VirtualActorClass.__init__ should not be called. Please use "
+            "the @workflow.actor decorator instead.")
+
+    def __call__(self, *args, **kwargs):
+        """Prevents users from directly instantiating an ActorClass.
+
+        This will be called instead of __init__ when 'VirtualActorClass()' is
+        executed because an is an object rather than a metaobject. To properly
+        instantiated a virtual actor, use 'VirtualActorClass.create()' or
+        'VirtualActorClass.get()'.
+
+        Raises:
+            Exception: Always.
+        """
+        raise TypeError("Actors cannot be instantiated directly. "
+                        f"Instead of '{self._metadata.name}()', "
+                        f"use '{self._metadata.name}.create()'.")
+
+    @classmethod
+    def _from_class(cls, base_class: type) -> "VirtualActorClass":
+        """Construct the virtual actor class from a base class."""
+        for attribute in [
+                "create",
+                "_create",
+                "option",
+                "get",
+                "_get",
+                "_from_class",
+        ]:
+            if hasattr(base_class, attribute):
+                logger.warning("Creating an actor from class "
+                               f"{base_class.__name__} overwrites "
+                               f"attribute {attribute} of that class")
+
+        if not is_function_or_method(getattr(base_class, "__init__", None)):
+            # Add __init__ if it does not exist.
+            # Actor creation will be executed with __init__ together.
+
+            # Assign an __init__ function will avoid many checks later on.
+            def __init__(self):
+                pass
+
+            base_class.__init__ = __init__
+
+        # Make sure the actor class we are constructing inherits from the
+        # original class so it retains all class properties.
+        class DerivedActorClass(cls, base_class):
+            pass
+
+        metadata = VirtualActorMetadata(base_class)
+        if "__getstate__" not in metadata.methods:
+            raise ValueError("The class does not have '__getstate__' method")
+        if "__setstate__" not in metadata.methods:
+            raise ValueError("The class does not have '__setstate__' method")
+
+        DerivedActorClass.__module__ = metadata.module
+        name = f"VirtualActorClass({metadata.name})"
+        DerivedActorClass.__name__ = name
+        DerivedActorClass.__qualname__ = name
+        # Construct the base object.
+        self = DerivedActorClass.__new__(DerivedActorClass)
+
+        self._metadata = metadata
+        return self
+
+    def create(self, *args, **kwargs) -> "VirtualActor":
+        """Create an actor. See `VirtualActorClassBase.create()`."""
+        return self._create(
+            args=args,
+            kwargs=kwargs,
+            actor_id=None,
+            storage=None,
+            readonly=False)
+
+    # TODO(suquark): remove get()
+    def get(self, actor_id: str, storage: Storage):
+        """Get an existing virtual actor by inheriting its state."""
+        return self._construct(
+            actor_id=actor_id, storage=storage, readonly=False)
+
+    # TODO(suquark): support num_cpu etc in options
+    def options(self,
+                actor_id: str,
+                storage: Optional[Storage] = None,
+                readonly: bool = False) -> VirtualActorClassBase:
+        """Configures and overrides the actor instantiation parameters.
+
+        Examples:
+
+        .. code-block:: python
+
+            @workflow.actor
+            class Foo:
+                def method(self):
+                    return 1
+            # By default class Foo will not be running in the readonly mode,
+            # and will use a randomly generated 'actor_id'.
+            # You can specify 'readonly' and 'actor_id' by
+            Bar = Foo.options(actor_id="my_actor_id", readonly=True)
+        """
+
+        actor_cls = self
+
+        class ActorOptionWrapper(VirtualActorClassBase):
+            def create(self, *args, **kwargs):
+                return actor_cls._create(
+                    args=args,
+                    kwargs=kwargs,
+                    actor_id=actor_id,
+                    storage=storage,
+                    readonly=readonly)
+
+            def get(self):
+                return actor_cls._construct(
+                    actor_id=actor_id, storage=storage, readonly=readonly)
+
+        return ActorOptionWrapper()
+
+    def _create(self, args, kwargs, actor_id: Optional[str],
+                storage: Optional[Storage], readonly: bool) -> "VirtualActor":
+        """Create a new virtual actor"""
+        if actor_id is None:
+            actor_id = self._metadata.generate_random_actor_id()
+        if storage is None:
+            storage = get_global_storage()
+        instance = self._construct(actor_id, storage, readonly)
+        instance._create(args, kwargs)
+        return instance
+
+    def _construct(self, actor_id: str, storage: Storage,
+                   readonly: bool) -> "VirtualActor":
+        """Construct a blank virtual actor."""
+        return VirtualActor(self._metadata, actor_id, storage, readonly)
+
+
+class VirtualActor:
+    """The instance of a virtual actor class."""
+
+    def __init__(self, metadata: VirtualActorMetadata, actor_id: str,
+                 storage: Storage, readonly: bool):
+        self._metadata = metadata
+        self._actor_id = actor_id
+        self._storage = storage
+        self._readonly = readonly
+        for method_name in metadata.signatures:
+            # TODO(suquark): Maybe we should avoid overriding class fields.
+            # However, we did not do it in ActorHandle.
+            method = ActorMethod(self, method_name)
+            setattr(self, method_name, method)
+
+    def _create(self, args: Tuple[Any], kwargs: Dict[str, Any]):
+        workflow_storage = WorkflowStorage(self.workflow_id, self._storage)
+        workflow_storage.save_actor_class_body(self._metadata.cls)
+        # TODO(suquark): This is just a temporary solution.
+        # A virtual actor writer should take place of this solution later.
+        from ray.experimental.workflow import run
+        arg_list = self._metadata.flatten_args("__init__", args, kwargs)
+        init_step = _virtual_actor_init.step(self._metadata.cls, arg_list)
+        init_step._step_id = self._metadata.cls.__init__.__name__
+        ref = run(
+            init_step, storage=self._storage, workflow_id=self.workflow_id)
+        actor = get_or_create_management_actor()
+        # keep the ref in a list to prevent dereference
+        ray.get(actor.init_actor.remote(self._actor_id, [ref]))
+
+    @property
+    def actor_id(self) -> str:
+        """The actor ID of the virtual actor."""
+        return self._actor_id
+
+    @property
+    def workflow_id(self) -> str:
+        """The workflow ID associated with the actor."""
+        return actor_id_to_workflow_id(self._actor_id)
+
+    @property
+    def readonly(self) -> bool:
+        """If the actor is readonly or not."""
+        return self._readonly
+
+    def ready(self) -> "ObjectRef":
+        """Return a future. If 'ray.get()' it successfully, then the actor
+        is fully initialized."""
+        # TODO(suquark): should ray.get(xxx.ready()) always be true?
+        actor = get_or_create_management_actor()
+        return ray.get(
+            actor.actor_ready.remote(self._actor_id,
+                                     self._storage.storage_url))
+
+    def __getattr__(self, item):
+        if item in self._methods_metadata.signatures:
+            return ActorMethod(self, item)
+        raise AttributeError(f"No method with name '{item}'")
+
+    def _actor_method_call(self, method_name: str, args, kwargs,
+                           readonly: Optional[bool]) -> "ObjectRef":
+        flatten_args = self._metadata.flatten_args(method_name, args, kwargs)
+        if readonly is None:
+            # inherit the class setting by default
+            readonly = self._readonly
+        if readonly:
+            cls = self._metadata.cls
+            return _readonly_method_executor.remote(
+                self._actor_id, self._storage, cls, method_name, flatten_args)
+        raise NotImplementedError("Virtual actor writer mode has not been "
+                                  "supported yet.")
+
+
+def decorate_actor(cls: type):
+    """Decorate and convert a class to virtual actor class."""
+    return VirtualActorClass._from_class(cls)
+
+
+def get_actor(actor_id: str, storage: Storage, readonly) -> VirtualActor:
+    """Get an virtual actor.
+
+    Args:
+        actor_id: The ID of the actor.
+        storage: The storage of the actor.
+        readonly: Turn the actor into readonly actor or not.
+
+    Returns:
+        A virtual actor.
+    """
+    ws = WorkflowStorage(actor_id_to_workflow_id(actor_id), storage)
+    cls = ws.load_actor_class_body()
+    v_cls = VirtualActorClass._from_class(cls)
+    return v_cls._construct(actor_id, storage, readonly=readonly)

--- a/python/ray/experimental/workflow/workflow_access.py
+++ b/python/ray/experimental/workflow/workflow_access.py
@@ -1,9 +1,15 @@
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, List, TYPE_CHECKING
 
 import ray
+from ray.experimental.workflow import common
 from ray.experimental.workflow import recovery
 from ray.experimental.workflow import storage
+from ray.experimental.workflow import workflow_storage
+
+if TYPE_CHECKING:
+    from ray.actor import ActorHandle
+
 logger = logging.getLogger(__name__)
 
 MANAGEMENT_ACTOR_NAME = "WorkflowManagementActor"
@@ -88,6 +94,7 @@ class WorkflowManagementActor:
 
     def __init__(self):
         self._workflow_outputs: Dict[str, ray.ObjectRef] = {}
+        self._actor_initialized: Dict[str, ray.ObjectRef] = {}
 
     def run_or_resume(self, workflow_id: str,
                       storage_url: str) -> ray.ObjectRef:
@@ -109,6 +116,47 @@ class WorkflowManagementActor:
         self._workflow_outputs[workflow_id] = output
         logger.info(f"Workflow job [id={workflow_id}] started.")
         return output
+
+    def init_actor(self, actor_id: str,
+                   init_marker: List[ray.ObjectRef]) -> None:
+        """Initialize a workflow virtual actor.
+
+        Args:
+            actor_id: The ID of a workflow virtual actor.
+            init_marker: A future object (wrapped in a list) that represents
+                the state of the actor. "ray.get" the object successfully
+                indicates the actor is initialized successfully.
+        """
+        # TODO(suquark): Maybe we should raise an error if the actor_id
+        # already exists?
+        self._actor_initialized[actor_id] = init_marker[0]
+
+    def actor_ready(self, actor_id: str, storage_url: str) -> ray.ObjectRef:
+        """Check if a workflow virtual actor is fully initialized.
+
+        Args:
+            actor_id: The ID of a workflow virtual actor.
+            storage_url: A string that represents the storage.
+
+        Returns:
+            A future object that represents the state of the actor.
+            "ray.get" the object successfully indicates the actor is
+            initialized successfully.
+        """
+        store = storage.create_storage(storage_url)
+        workflow_id = common.actor_id_to_workflow_id(actor_id)
+        ws = workflow_storage.WorkflowStorage(workflow_id, store)
+        try:
+            step_id = ws.get_entrypoint_step_id()
+            output_exists = ws.inspect_step(step_id).output_object_valid
+            if output_exists:
+                return ray.put(None)
+        except Exception:
+            pass
+        if actor_id not in self._actor_initialized:
+            raise ValueError(f"Actor '{actor_id}' has not been created, or "
+                             "it has failed before initialization.")
+        return self._actor_initialized[actor_id]
 
     def get_output(self, workflow_id: str) -> ray.ObjectRef:
         """Get the output of a running workflow.
@@ -144,3 +192,14 @@ class WorkflowManagementActor:
         """
         logger.info(f"Workflow job [id={workflow_id}] succeeded.")
         self._workflow_outputs.pop(workflow_id, None)
+
+
+def get_or_create_management_actor() -> "ActorHandle":
+    """Get or create WorkflowManagementActor"""
+    try:
+        actor = ray.get_actor(MANAGEMENT_ACTOR_NAME)
+    except ValueError:
+        # the actor does not exist
+        actor = WorkflowManagementActor.options(
+            name=MANAGEMENT_ACTOR_NAME, lifetime="detached").remote()
+    return actor

--- a/python/ray/experimental/workflow/workflow_access.py
+++ b/python/ray/experimental/workflow/workflow_access.py
@@ -196,6 +196,10 @@ class WorkflowManagementActor:
 
 def get_or_create_management_actor() -> "ActorHandle":
     """Get or create WorkflowManagementActor"""
+    # TODO(suquark): We should not get the actor everytime. We also need to
+    # resume the actor if it failed. Using a global variable to cache the
+    # actor seems not enough to resume the actor, because there is no
+    # aliveness detection for an actor.
     try:
         actor = ray.get_actor(MANAGEMENT_ACTOR_NAME)
     except ValueError:

--- a/python/ray/experimental/workflow/workflow_storage.py
+++ b/python/ray/experimental/workflow/workflow_storage.py
@@ -275,3 +275,24 @@ class WorkflowStorage:
             for w in workflow.iter_workflows_in_dag()
         ]
         asyncio_run(asyncio.gather(*tasks))
+
+    def load_actor_class_body(self) -> type:
+        """Load the class body of the virtual actor.
+
+        Raises:
+            DataLoadError: if we fail to load the class body.
+        """
+        return asyncio_run(
+            self._storage.load_actor_class_body(self._workflow_id))
+
+    def save_actor_class_body(self, cls: type) -> None:
+        """Save the class body of the virtual actor.
+
+        Args:
+            cls: The class body used by the virtual actor.
+
+        Raises:
+            DataSaveError: if we fail to save the class body.
+        """
+        asyncio_run(
+            self._storage.save_actor_class_body(self._workflow_id, cls))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The initial API for virtual actor + readonly virtual actor.

There are still 2 things not clear to me:

1. What is the relationship between "virtual actor id" and "workflow_id"? Currently I just treat them as the same, because a workflow could just be a virtual actor.
2. Is `Actor.create(xxx)` reasonable if the actor is based on an existing workflow(since its state is initialized from the workflow)? I use `get()` in the code to express this. However, `Actor.create(xxx)` is useful if we consider the initialization when we cannot find the output of a workflow.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
