### PR TITLE
[serve] Bump timeouts on test_deploy and re-enable

### DIFF
--- a/python/ray/serve/tests/test_deploy.py
+++ b/python/ray/serve/tests/test_deploy.py
@@ -315,7 +315,7 @@ def test_redeploy_single_replica(serve_instance, use_handle):
     start = time.time()
     new_version_ref = None
     while time.time() - start < 30:
-        ready, not_ready = ray.wait([call.remote(block=False)], timeout=0.5)
+        ready, not_ready = ray.wait([call.remote(block=False)], timeout=5)
         if len(ready) == 1:
             # If the request doesn't block, it must have been the old version.
             val, pid = ray.get(ready[0])
@@ -325,7 +325,6 @@ def test_redeploy_single_replica(serve_instance, use_handle):
             # If the request blocks, it must have been the new version.
             new_version_ref = not_ready[0]
             break
-        time.sleep(0.1)
     else:
         assert False, "Timed out waiting for new version to be called."
 
@@ -342,10 +341,7 @@ def test_redeploy_single_replica(serve_instance, use_handle):
     assert new_version_pid != pid2
 
 
-@pytest.mark.skipif(
-    sys.platform in ["win32", "darwin"],
-    reason="Failing on "
-    "Windows and OSX.")
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize("use_handle", [True, False])
 def test_redeploy_multiple_replicas(serve_instance, use_handle):
     # Tests that redeploying a deployment with multiple replicas performs
@@ -396,7 +392,7 @@ def test_redeploy_multiple_replicas(serve_instance, use_handle):
         start = time.time()
         while time.time() - start < 30:
             refs = [call.remote(block=False) for _ in range(10)]
-            ready, not_ready = ray.wait(refs, timeout=0.5)
+            ready, not_ready = ray.wait(refs, timeout=5)
             for ref in ready:
                 val, pid = ray.get(ref)
                 responses[val].add(pid)
@@ -408,7 +404,6 @@ def test_redeploy_multiple_replicas(serve_instance, use_handle):
                     for val, num in expected.items())
                     and (expect_blocking is False or len(blocking) > 0)):
                 break
-            time.sleep(0.1)
         else:
             assert False, f"Timed out, responses: {responses}."
 
@@ -449,10 +444,7 @@ def test_redeploy_multiple_replicas(serve_instance, use_handle):
     make_nonblocking_calls({"2": 2})
 
 
-@pytest.mark.skipif(
-    sys.platform in ["win32", "darwin"],
-    reason="Failing on "
-    "Windows and OSX.")
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize("use_handle", [True, False])
 def test_reconfigure_multiple_replicas(serve_instance, use_handle):
     # Tests that updating the user_config with multiple replicas performs a
@@ -499,7 +491,7 @@ def test_reconfigure_multiple_replicas(serve_instance, use_handle):
         start = time.time()
         while time.time() - start < 30:
             refs = [call.remote() for _ in range(10)]
-            ready, not_ready = ray.wait(refs, timeout=0.5)
+            ready, not_ready = ray.wait(refs, timeout=5)
             for ref in ready:
                 val, pid = ray.get(ref)
                 responses[val].add(pid)
@@ -511,7 +503,6 @@ def test_reconfigure_multiple_replicas(serve_instance, use_handle):
                     for val, num in expected.items())
                     and (expect_blocking is False or len(blocking) > 0)):
                 break
-            time.sleep(0.1)
         else:
             assert False, f"Timed out, responses: {responses}."
 
@@ -537,10 +528,7 @@ def test_reconfigure_multiple_replicas(serve_instance, use_handle):
     make_nonblocking_calls({"2": 2})
 
 
-@pytest.mark.skipif(
-    sys.platform in ["win32", "darwin"],
-    reason="Failing on "
-    "Windows and OSX.")
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize("use_handle", [True, False])
 def test_redeploy_scale_down(serve_instance, use_handle):
     # Tests redeploying with a new version and lower num_replicas.
@@ -566,7 +554,7 @@ def test_redeploy_scale_down(serve_instance, use_handle):
         start = time.time()
         while time.time() - start < 30:
             refs = [call.remote() for _ in range(10)]
-            ready, not_ready = ray.wait(refs, timeout=0.5)
+            ready, not_ready = ray.wait(refs, timeout=5)
             for ref in ready:
                 val, pid = ray.get(ref)
                 responses[val].add(pid)
@@ -575,7 +563,6 @@ def test_redeploy_scale_down(serve_instance, use_handle):
                     len(responses[val]) == num
                     for val, num in expected.items()):
                 break
-            time.sleep(0.1)
         else:
             assert False, f"Timed out, responses: {responses}."
 
@@ -594,10 +581,7 @@ def test_redeploy_scale_down(serve_instance, use_handle):
     assert all(pid not in pids1 for pid in responses2["2"])
 
 
-@pytest.mark.skipif(
-    sys.platform in ["win32", "darwin"],
-    reason="Failing on "
-    "Windows and OSX.")
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize("use_handle", [True, False])
 def test_redeploy_scale_up(serve_instance, use_handle):
     # Tests redeploying with a new version and higher num_replicas.
@@ -623,7 +607,7 @@ def test_redeploy_scale_up(serve_instance, use_handle):
         start = time.time()
         while time.time() - start < 30:
             refs = [call.remote() for _ in range(10)]
-            ready, not_ready = ray.wait(refs, timeout=0.5)
+            ready, not_ready = ray.wait(refs, timeout=5)
             for ref in ready:
                 val, pid = ray.get(ref)
                 responses[val].add(pid)
@@ -632,7 +616,6 @@ def test_redeploy_scale_up(serve_instance, use_handle):
                     len(responses[val]) == num
                     for val, num in expected.items()):
                 break
-            time.sleep(0.1)
         else:
             assert False, f"Timed out, responses: {responses}."
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Became very flaky on mac, trying to re-enable.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
