### PR TITLE
[rllib] Added missing **model_config in rllib/models/catalog.py

### DIFF
--- a/rllib/examples/models/modelv3.py
+++ b/rllib/examples/models/modelv3.py
@@ -17,7 +17,8 @@ class RNNModel(tf.keras.models.Model if tf else object):
                  *,
                  name="",
                  hiddens_size=256,
-                 cell_size=64):
+                 cell_size=64,
+                 **kwargs):
         super().__init__(name=name)
 
         self.cell_size = cell_size

--- a/rllib/models/catalog.py
+++ b/rllib/models/catalog.py
@@ -458,6 +458,7 @@ class ModelCatalog:
                             action_space=action_space,
                             num_outputs=num_outputs,
                             name=name,
+                            **model_config,
                             **customized_model_kwargs,
                         )
                     else:


### PR DESCRIPTION
## Why are these changes needed?

When using a custom tf.keras.Model, the dictionary model_config is not passed to the constructor in rllib/models/catalog.py.

## Related issue number

Closes #16884

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
