### PR TITLE
[RFC] Fix object size inconsistency caused by object-marked-failed.

### DIFF
--- a/src/ray/object_manager/chunk_object_reader.cc
+++ b/src/ray/object_manager/chunk_object_reader.cc
@@ -1,0 +1,65 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/object_manager/chunk_object_reader.h"
+#include "ray/util/logging.h"
+
+namespace ray {
+
+ChunkObjectReader::ChunkObjectReader(std::shared_ptr<IObjectReader> object,
+                                     uint64_t chunk_size)
+    : object_(std::move(object)), chunk_size_(chunk_size) {
+  RAY_CHECK(chunk_size_ > 0) << "chunk_size shouldn't be 0";
+}
+
+uint64_t ChunkObjectReader::GetNumChunks() const {
+  return (object_->GetDataSize() + object_->GetMetadataSize() + chunk_size_ - 1) /
+         chunk_size_;
+}
+
+absl::optional<std::string> ChunkObjectReader::GetChunk(uint64_t chunk_index) const {
+  // The spilled file stores metadata before data. But the GetChunk needs to
+  // return data before metadata. We achieve by first read from data section,
+  // then read from metadata section.
+  const auto cur_chunk_offset = chunk_index * chunk_size_;
+  const auto cur_chunk_size =
+      std::min(chunk_size_,
+               object_->GetDataSize() + object_->GetMetadataSize() - cur_chunk_offset);
+
+  std::string result(cur_chunk_size, '\0');
+  size_t result_offset = 0;
+
+  if (cur_chunk_offset < object_->GetDataSize()) {
+    // read from data section.
+    auto offset = cur_chunk_offset;
+    auto size = std::min(object_->GetDataSize() - cur_chunk_offset, cur_chunk_size);
+    if (!object_->ReadFromDataSection(offset, size, &result[result_offset])) {
+      return absl::optional<std::string>();
+    }
+    result_offset = size;
+  }
+
+  if (cur_chunk_offset + cur_chunk_size > object_->GetDataSize()) {
+    // read from metadata section.
+    auto offset =
+        std::max(cur_chunk_offset, object_->GetDataSize()) - object_->GetDataSize();
+    auto size = std::min(cur_chunk_offset + cur_chunk_size - object_->GetDataSize(),
+                         cur_chunk_size);
+    if (!object_->ReadFromMetadataSection(offset, size, &result[result_offset])) {
+      return absl::optional<std::string>();
+    }
+  }
+  return absl::optional<std::string>(std::move(result));
+}
+};  // namespace ray

--- a/src/ray/object_manager/chunk_object_reader.h
+++ b/src/ray/object_manager/chunk_object_reader.h
@@ -1,0 +1,46 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "ray/object_manager/spilled_object.h"
+
+namespace ray {
+
+/// Read object in chunks.
+class ChunkObjectReader {
+ public:
+  /// Create a ChunkObjectReader.
+  ///
+  /// \param object_url the underlying object to read from.
+  /// \param chunk_size the size of chunk for read
+  ChunkObjectReader(std::shared_ptr<IObjectReader> object, uint64_t chunk_size);
+
+  uint64_t GetNumChunks() const;
+
+  /// Return the value in a given chunk, identified by chunk_index.
+  /// It migh return an empty optional if the file is deleted.
+  ///
+  /// \param chunk_index the index of chunk to return. index greater or
+  ///                    equal to GetNumChunks() yields undefined behavior.
+  absl::optional<std::string> GetChunk(uint64_t chunk_index) const;
+
+  const IObjectReader &GetObject() const { return *object_; }
+
+ private:
+  const std::shared_ptr<IObjectReader> object_;
+  const uint64_t chunk_size_;
+};
+
+}  // namespace ray

--- a/src/ray/object_manager/chunk_object_reader.h
+++ b/src/ray/object_manager/chunk_object_reader.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include "ray/object_manager/spilled_object.h"
+#include "ray/object_manager/spilled_object_reader.h"
 
 namespace ray {
 

--- a/src/ray/object_manager/memory_object_reader.cc
+++ b/src/ray/object_manager/memory_object_reader.cc
@@ -1,0 +1,51 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/object_manager/memory_object_reader.h"
+#include <cstring>
+
+namespace ray {
+
+MemoryObjectReader::MemoryObjectReader(plasma::ObjectBuffer object_buffer,
+                                       rpc::Address owner_address)
+    : object_buffer_(std::move(object_buffer)),
+      owner_address_(std::move(owner_address)) {}
+
+uint64_t MemoryObjectReader::GetDataSize() const { return object_buffer_.data->Size(); }
+
+uint64_t MemoryObjectReader::GetMetadataSize() const {
+  return object_buffer_.metadata->Size();
+}
+
+const rpc::Address &MemoryObjectReader::GetOwnerAddress() const { return owner_address_; }
+
+bool MemoryObjectReader::ReadFromDataSection(uint64_t offset, uint64_t size,
+                                             char *output) const {
+  if (offset + size > GetDataSize()) {
+    return false;
+  }
+  std::memcpy(output, object_buffer_.data->Data() + offset, size);
+  return true;
+}
+
+bool MemoryObjectReader::ReadFromMetadataSection(uint64_t offset, uint64_t size,
+                                                 char *output) const {
+  if (offset + size > GetMetadataSize()) {
+    return false;
+  }
+  std::memcpy(output, object_buffer_.metadata->Data() + offset, size);
+  return true;
+}
+
+}  // namespace ray

--- a/src/ray/object_manager/memory_object_reader.h
+++ b/src/ray/object_manager/memory_object_reader.h
@@ -1,0 +1,43 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "ray/object_manager/plasma/client.h"
+#include "ray/object_manager/spilled_object.h"
+
+namespace ray {
+
+/// A wrapper over plasma object.
+/// This class is thread safe.
+class MemoryObjectReader : public IObjectReader {
+ public:
+  MemoryObjectReader(plasma::ObjectBuffer object_buffer, rpc::Address owner_address);
+
+  uint64_t GetDataSize() const override;
+
+  uint64_t GetMetadataSize() const override;
+
+  const rpc::Address &GetOwnerAddress() const override;
+
+  bool ReadFromDataSection(uint64_t offset, uint64_t size, char *output) const override;
+  bool ReadFromMetadataSection(uint64_t offset, uint64_t size,
+                               char *output) const override;
+
+ private:
+  const plasma::ObjectBuffer object_buffer_;
+  const rpc::Address owner_address_;
+};
+
+}  // namespace ray

--- a/src/ray/object_manager/memory_object_reader.h
+++ b/src/ray/object_manager/memory_object_reader.h
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include "ray/object_manager/object_reader.h"
 #include "ray/object_manager/plasma/client.h"
-#include "ray/object_manager/spilled_object.h"
 
 namespace ray {
 
-/// A wrapper over plasma object.
-/// This class is thread safe.
+/// A wrapper over plasma object. Please reader ray/object_manager/object_reader.h
+/// for interface guanrantees. This class is thread safe.
 class MemoryObjectReader : public IObjectReader {
  public:
   MemoryObjectReader(plasma::ObjectBuffer object_buffer, rpc::Address owner_address);

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -70,14 +70,13 @@ std::pair<const ObjectBufferPool::ChunkInfo, ray::Status> ObjectBufferPool::GetC
           ray::Status::IOError("Unable to obtain object chunk, object not local."));
     }
     if (object_buffer.data->Size() == 0 && object_buffer.metadata->Size() == 1) {
-      RAY_LOG(INFO)
-          << "Failed to get a chunk of the object: " << object_id
-          << ". This is most likely because the object was evicted or spilled before the "
-             "pull request was received. The caller will retry the pull request after a "
-             "timeout.";
+      RAY_LOG(INFO) << object_id << " is marked as failed with error_type: "
+                    << std::string(static_cast<char *>(object_buffer.metadata->Data()),
+                                   object_buffer.metadata->Size());
       return std::pair<const ObjectBufferPool::ChunkInfo, ray::Status>(
           errored_chunk_,
-          ray::Status::IOError("Unable to obtain object chunk, object not local."));
+          ray::Status::IOError(
+              "Unable to obtain object chunk, object is marked as failed."));
     }
     RAY_CHECK(object_buffer.metadata->Data() ==
               object_buffer.data->Data() + object_buffer.data->Size());

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -71,7 +71,7 @@ std::pair<const ObjectBufferPool::ChunkInfo, ray::Status> ObjectBufferPool::GetC
     }
     if (object_buffer.data->Size() == 0 && object_buffer.metadata->Size() == 1) {
       RAY_LOG(INFO) << object_id << " is marked as failed with error_type: "
-                    << std::string(static_cast<char *>(object_buffer.metadata->Data()),
+                    << std::string(reinterpret_cast<char *>(object_buffer.metadata->Data()),
                                    object_buffer.metadata->Size());
       return std::pair<const ObjectBufferPool::ChunkInfo, ray::Status>(
           errored_chunk_,

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -73,7 +73,8 @@ std::pair<const ObjectBufferPool::ChunkInfo, ray::Status> ObjectBufferPool::GetC
               object_buffer.data->Data() + object_buffer.data->Size());
     RAY_CHECK(data_size == static_cast<uint64_t>(object_buffer.data->Size() +
                                                  object_buffer.metadata->Size()))
-        << "Total size: " << data_size << ", data size: " << object_buffer.data->Size()
+        << "Object id:" << object_id << "Total size: " << data_size
+        << ", data size: " << object_buffer.data->Size()
         << ", metadata size: " << object_buffer.metadata->Size();
     auto *data = object_buffer.data->Data();
     uint64_t num_chunks = GetNumChunks(data_size);

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -28,15 +28,10 @@ ObjectBufferPool::ObjectBufferPool(const std::string &store_socket_name,
 
 ObjectBufferPool::~ObjectBufferPool() {
   // Abort everything in progress.
-  auto get_buf_state_copy = get_buffer_state_;
-  for (const auto &pair : get_buf_state_copy) {
-    AbortGet(pair.first);
-  }
   auto create_buf_state_copy = create_buffer_state_;
   for (const auto &pair : create_buf_state_copy) {
     AbortCreate(pair.first);
   }
-  RAY_CHECK(get_buffer_state_.empty());
   RAY_CHECK(create_buffer_state_.empty());
   RAY_CHECK_OK(store_client_.Disconnect());
 }
@@ -51,66 +46,30 @@ uint64_t ObjectBufferPool::GetBufferLength(uint64_t chunk_index, uint64_t data_s
              : default_chunk_size_;
 }
 
-std::pair<const ObjectBufferPool::ChunkInfo, ray::Status> ObjectBufferPool::GetChunk(
-    const ObjectID &object_id, uint64_t data_size, uint64_t metadata_size,
-    uint64_t chunk_index) {
+std::pair<std::shared_ptr<MemoryObjectReader>, ray::Status>
+ObjectBufferPool::CreateObjectReader(const ObjectID &object_id,
+                                     rpc::Address owner_address) {
   std::lock_guard<std::mutex> lock(pool_mutex_);
-  if (get_buffer_state_.count(object_id) == 0) {
-    plasma::ObjectBuffer object_buffer;
-    RAY_CHECK_OK(
-        store_client_.Get(&object_id, 1, 0, &object_buffer, /*is_from_worker=*/false));
-    if (object_buffer.data == nullptr) {
-      RAY_LOG(INFO)
-          << "Failed to get a chunk of the object: " << object_id
-          << ". This is most likely because the object was evicted or spilled before the "
-             "pull request was received. The caller will retry the pull request after a "
-             "timeout.";
-      return std::pair<const ObjectBufferPool::ChunkInfo, ray::Status>(
-          errored_chunk_,
-          ray::Status::IOError("Unable to obtain object chunk, object not local."));
-    }
-    if (object_buffer.data->Size() == 0 && object_buffer.metadata->Size() == 1) {
-      RAY_LOG(INFO) << object_id << " is marked as failed with error_type: "
-                    << std::string(reinterpret_cast<char *>(object_buffer.metadata->Data()),
-                                   object_buffer.metadata->Size());
-      return std::pair<const ObjectBufferPool::ChunkInfo, ray::Status>(
-          errored_chunk_,
-          ray::Status::IOError(
-              "Unable to obtain object chunk, object is marked as failed."));
-    }
-    RAY_CHECK(object_buffer.metadata->Data() ==
-              object_buffer.data->Data() + object_buffer.data->Size());
-    RAY_CHECK(data_size == static_cast<uint64_t>(object_buffer.data->Size() +
-                                                 object_buffer.metadata->Size()))
-        << "Object id:" << object_id << "Total size: " << data_size
-        << ", data size: " << object_buffer.data->Size()
-        << ", metadata size: " << object_buffer.metadata->Size();
-    auto *data = object_buffer.data->Data();
-    uint64_t num_chunks = GetNumChunks(data_size);
-    get_buffer_state_.emplace(std::piecewise_construct, std::forward_as_tuple(object_id),
-                              std::forward_as_tuple(BuildChunks(
-                                  object_id, data, data_size, object_buffer.data)));
-    RAY_CHECK(get_buffer_state_[object_id].chunk_info.size() == num_chunks);
-  }
-  get_buffer_state_[object_id].references++;
-  return std::pair<const ObjectBufferPool::ChunkInfo, ray::Status>(
-      get_buffer_state_[object_id].chunk_info[chunk_index], ray::Status::OK());
-}
 
-void ObjectBufferPool::ReleaseGetChunk(const ObjectID &object_id, uint64_t chunk_index) {
-  std::lock_guard<std::mutex> lock(pool_mutex_);
-  GetBufferState &buffer_state = get_buffer_state_[object_id];
-  buffer_state.references--;
-  if (buffer_state.references == 0) {
-    RAY_CHECK_OK(store_client_.Release(object_id));
-    get_buffer_state_.erase(object_id);
+  std::vector<ObjectID> object_ids{object_id};
+  std::vector<plasma::ObjectBuffer> object_buffers(1);
+  RAY_CHECK_OK(
+      store_client_.Get(object_ids, 0, &object_buffers, /*is_from_worker=*/false));
+  if (object_buffers[0].data == nullptr) {
+    RAY_LOG(INFO)
+        << "Failed to get a chunk of the object: " << object_id
+        << ". This is most likely because the object was evicted or spilled before the "
+           "pull request was received. The caller will retry the pull request after a "
+           "timeout.";
+    return std::pair<std::shared_ptr<MemoryObjectReader>, ray::Status>(
+        nullptr,
+        ray::Status::IOError("Unable to obtain object chunk, object not local."));
   }
-}
 
-void ObjectBufferPool::AbortGet(const ObjectID &object_id) {
-  std::lock_guard<std::mutex> lock(pool_mutex_);
-  RAY_CHECK_OK(store_client_.Release(object_id));
-  get_buffer_state_.erase(object_id);
+  return std::pair<std::shared_ptr<MemoryObjectReader>, ray::Status>(
+      std::make_shared<MemoryObjectReader>(std::move(object_buffers[0]),
+                                           std::move(owner_address)),
+      ray::Status::OK());
 }
 
 std::pair<const ObjectBufferPool::ChunkInfo, ray::Status> ObjectBufferPool::CreateChunk(
@@ -246,7 +205,6 @@ std::string ObjectBufferPool::DebugString() const {
   std::lock_guard<std::mutex> lock(pool_mutex_);
   std::stringstream result;
   result << "BufferPool:";
-  result << "\n- get buffer state map size: " << get_buffer_state_.size();
   result << "\n- create buffer state map size: " << create_buffer_state_.size();
   return result.str();
 }

--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -24,6 +24,7 @@
 
 #include "ray/common/id.h"
 #include "ray/common/status.h"
+#include "ray/object_manager/memory_object_reader.h"
 #include "ray/object_manager/plasma/client.h"
 
 namespace ray {
@@ -76,34 +77,23 @@ class ObjectBufferPool {
   /// \return The buffer length of the chunk at chunk_index.
   uint64_t GetBufferLength(uint64_t chunk_index, uint64_t data_size);
 
-  /// Returns a chunk of an object at the given chunk_index. The object chunk serves
-  /// as the data that is to be written to a connection as part of sending an object to
-  /// a remote node.
+  /// Returns an object reader for read.
   ///
   /// \param object_id The ObjectID.
-  /// \param data_size The sum of the object size and metadata size.
-  /// \param metadata_size The size of the metadata.
-  /// \param chunk_index The index of the chunk.
-  /// \return A pair consisting of a ChunkInfo and status of invoking this method.
-  /// An IOError status is returned if the Get call on the plasma store fails.
-  std::pair<const ObjectBufferPool::ChunkInfo, ray::Status> GetChunk(
-      const ObjectID &object_id, uint64_t data_size, uint64_t metadata_size,
-      uint64_t chunk_index);
-
-  /// When a chunk is done being used as part of a get, this method releases the chunk.
-  /// If all chunks of an object are released, the object buffer will be released.
-  ///
-  /// \param object_id The object_id of the buffer to release.
-  /// \param chunk_index The index of the chunk.
-  void ReleaseGetChunk(const ObjectID &object_id, uint64_t chunk_index);
+  /// \param owner_address The address of the object's owner.
+  /// \return A pair consisting of a MemoryObjectReader and status of invoking
+  /// this method. An IOError status is returned if the Get call on the plasma store
+  /// fails, and the MemoryObjectReader will be empty.
+  std::pair<std::shared_ptr<MemoryObjectReader>, ray::Status> CreateObjectReader(
+      const ObjectID &object_id, rpc::Address owner_address);
 
   /// Returns a chunk of an empty object at the given chunk_index. The object chunk
-  /// serves as the buffer that is to be written to by a connection receiving an object
-  /// from a remote node. Only one thread is permitted to create the object chunk at
-  /// chunk_index. Multiple threads attempting to create the same object chunk will
-  /// result in one succeeding. The ObjectManager is responsible for handling
-  /// create failures. This method will fail if it's invoked on a chunk_index on which
-  /// SealChunk has already been invoked.
+  /// serves as the buffer that is to be written to by a connection receiving an
+  /// object from a remote node. Only one thread is permitted to create the object
+  /// chunk at chunk_index. Multiple threads attempting to create the same object
+  /// chunk will result in one succeeding. The ObjectManager is responsible for
+  /// handling create failures. This method will fail if it's invoked on a chunk_index
+  /// on which SealChunk has already been invoked.
   ///
   /// \param object_id The ObjectID.
   /// \param owner_address The address of the object's owner.
@@ -153,27 +143,11 @@ class ObjectBufferPool {
   std::string DebugString() const;
 
  private:
-  /// Abort the get operation associated with an object.
-  void AbortGet(const ObjectID &object_id);
-
   /// Splits an object into ceil(data_size/chunk_size) chunks, which will
   /// either be read or written to in parallel.
   std::vector<ChunkInfo> BuildChunks(const ObjectID &object_id, uint8_t *data,
                                      uint64_t data_size,
                                      std::shared_ptr<Buffer> buffer_ref);
-
-  /// Holds the state of a get buffer.
-  struct GetBufferState {
-    GetBufferState() {}
-    GetBufferState(std::vector<ChunkInfo> chunk_info) : chunk_info(chunk_info) {}
-    /// A vector maintaining information about the chunks which comprise
-    /// an object.
-    std::vector<ChunkInfo> chunk_info;
-    /// The number of references that currently rely on this buffer.
-    /// Once this reaches 0, the buffer is released and this object is erased
-    /// from get_buffer_state_.
-    uint64_t references = 0;
-  };
 
   /// The state of a chunk associated with a create operation.
   enum class CreateChunkState : unsigned int { AVAILABLE = 0, REFERENCED, SEALED };
@@ -203,8 +177,6 @@ class ObjectBufferPool {
   mutable std::mutex pool_mutex_;
   /// Determines the maximum chunk size to be transferred by a single thread.
   const uint64_t default_chunk_size_;
-  /// The state of a buffer that's currently being used.
-  std::unordered_map<ray::ObjectID, GetBufferState> get_buffer_state_;
   /// The state of a buffer that's currently being used.
   std::unordered_map<ray::ObjectID, CreateBufferState> create_buffer_state_;
 

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -402,12 +402,13 @@ void ObjectManager::PushLocalObject(const ObjectID &object_id, const NodeID &nod
   if (object_reader->GetDataSize() != data_size ||
       object_reader->GetMetadataSize() != metadata_size) {
     if (object_reader->GetDataSize() == 0 && object_reader->GetMetadataSize() == 1) {
+      // TODO(scv119): handle object size changes in a more graceful way.
       RAY_LOG(WARNING) << object_id
                        << " is marked as failed but object_manager has stale info "
                        << " with data size: " << data_size
                        << ", metadata size: " << metadata_size
                        << ". This is likely due to race condition."
-                       << " Update the info and procceed sending failed object.";
+                       << " Update the info and proceed sending failed object.";
       local_objects_[object_id].object_info.data_size = 0;
       local_objects_[object_id].object_info.metadata_size = 1;
     } else {
@@ -510,8 +511,7 @@ void ObjectManager::SendObjectChunk(const UniqueID &push_id, const ObjectID &obj
   auto optional_chunk = chunk_reader->GetChunk(chunk_index);
   if (!optional_chunk.has_value()) {
     RAY_LOG(ERROR) << "Read chunk " << chunk_index << " of object " << object_id
-                   << " failed. "
-                   << " It may have been evicted.";
+                   << " failed. It may have been evicted.";
     on_complete(Status::IOError("Failed to read spilled object"));
     return;
   }

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -378,10 +378,8 @@ void ObjectManager::Push(const ObjectID &object_id, const NodeID &node_id) {
 
 void ObjectManager::PushLocalObject(const ObjectID &object_id, const NodeID &node_id) {
   const ObjectInfo &object_info = local_objects_[object_id].object_info;
-  uint64_t total_data_size =
-      static_cast<uint64_t>(object_info.data_size + object_info.metadata_size);
+  uint64_t data_size = static_cast<uint64_t>(object_info.data_size);
   uint64_t metadata_size = static_cast<uint64_t>(object_info.metadata_size);
-  uint64_t num_chunks = buffer_pool_.GetNumChunks(total_data_size);
 
   rpc::Address owner_address;
   owner_address.set_raylet_id(object_info.owner_raylet_id.Binary());
@@ -389,28 +387,41 @@ void ObjectManager::PushLocalObject(const ObjectID &object_id, const NodeID &nod
   owner_address.set_port(object_info.owner_port);
   owner_address.set_worker_id(object_info.owner_worker_id.Binary());
 
-  auto local_chunk_reader = [this, object_id, total_data_size, metadata_size](
-                                uint64_t chunk_index,
-                                rpc::PushRequest &push_request) -> Status {
-    std::pair<const ObjectBufferPool::ChunkInfo, ray::Status> chunk_status =
-        buffer_pool_.GetChunk(object_id, total_data_size, metadata_size, chunk_index);
-    // Fail on status not okay. The object is local, and there is
-    // no other anticipated error here.
-    Status status = chunk_status.second;
-    if (status.ok()) {
-      ObjectBufferPool::ChunkInfo chunk_info = chunk_status.first;
-      push_request.set_data(chunk_info.data, chunk_info.buffer_length);
+  std::pair<std::shared_ptr<MemoryObjectReader>, ray::Status> reader_status =
+      buffer_pool_.CreateObjectReader(object_id, owner_address);
+  Status status = reader_status.second;
+  if (!status.ok()) {
+    RAY_LOG(ERROR) << "Failed to read object " << object_id
+                   << ". It may have been evicted.";
+    return;
+  }
+
+  std::shared_ptr<MemoryObjectReader> object_reader = std::move(reader_status.first);
+  RAY_CHECK(object_reader) << "object_reader can't be null";
+
+  if (object_reader->GetDataSize() != data_size ||
+      object_reader->GetMetadataSize() != metadata_size) {
+    if (object_reader->GetDataSize() == 0 && object_reader->GetMetadataSize() == 1) {
+      RAY_LOG(WARNING) << object_id
+                       << " is marked as failed but object_manager has stale info "
+                       << " with data size: " << data_size
+                       << ", metadata size: " << metadata_size
+                       << ". This is likely due to race condition."
+                       << " Update the info and procceed sending failed object.";
+      local_objects_[object_id].object_info.data_size = 0;
+      local_objects_[object_id].object_info.metadata_size = 1;
+    } else {
+      RAY_LOG(FATAL) << "Object id:" << object_id
+                     << "'s size mismatches our record. Expected data size: " << data_size
+                     << ", expected metadata size: " << metadata_size
+                     << ", actual data size: " << object_reader->GetDataSize()
+                     << ", actual metadata size: " << object_reader->GetMetadataSize();
     }
-    return status;
-  };
+  }
 
-  auto release_chunk_callback = [this, object_id](uint64_t chunk_index) {
-    buffer_pool_.ReleaseGetChunk(object_id, chunk_index);
-  };
-
-  PushObjectInternal(object_id, node_id, total_data_size, metadata_size, num_chunks,
-                     std::move(owner_address), std::move(local_chunk_reader),
-                     std::move(release_chunk_callback));
+  PushObjectInternal(object_id, node_id,
+                     std::make_shared<ChunkObjectReader>(std::move(object_reader),
+                                                         config_.object_chunk_size));
 }
 
 void ObjectManager::PushFromFilesystem(const ObjectID &object_id, const NodeID &node_id,
@@ -419,57 +430,30 @@ void ObjectManager::PushFromFilesystem(const ObjectID &object_id, const NodeID &
   // main thread.
   rpc_service_.post(
       [this, object_id, node_id, spilled_url, chunk_size = config_.object_chunk_size]() {
-        auto optional_spilled_object =
-            SpilledObject::CreateSpilledObject(spilled_url, chunk_size);
+        auto optional_spilled_object = SpilledObject::CreateSpilledObject(spilled_url);
         if (!optional_spilled_object.has_value()) {
           RAY_LOG(ERROR) << "Failed to load spilled object " << object_id
                          << ". It may have been evicted.";
           return;
         }
-
-        auto spilled_object =
-            std::make_shared<SpilledObject>(std::move(optional_spilled_object.value()));
-
-        uint64_t total_data_size =
-            spilled_object->GetDataSize() + spilled_object->GetMetadataSize();
-        uint64_t metadata_size = spilled_object->GetMetadataSize();
-        uint64_t num_chunks = spilled_object->GetNumChunks();
-        rpc::Address owner_address = spilled_object->GetOwnerAddress();
-
-        auto spilled_object_chunk_reader = [object_id, spilled_object](
-                                               uint64_t chunk_index,
-                                               rpc::PushRequest &push_request) -> Status {
-          auto optional_chunk = spilled_object->GetChunk(chunk_index);
-          if (!optional_chunk.has_value()) {
-            RAY_LOG(DEBUG) << "Read chunk " << chunk_index << " of spilled object "
-                           << object_id << " failed. It may have already been deleted.";
-            return Status::IOError("Failed to read spilled object");
-          }
-          push_request.set_data(std::move(optional_chunk.value()));
-          return Status::OK();
-        };
+        auto chunk_object_reader = std::make_shared<ChunkObjectReader>(
+            std::make_shared<SpilledObject>(std::move(optional_spilled_object.value())),
+            chunk_size);
 
         // Schedule PushObjectInternal back to main_service as PushObjectInternal access
         // thread unsafe datastructure.
         main_service_->post(
-            [this, object_id, node_id, total_data_size, metadata_size, num_chunks,
-             owner_address = std::move(owner_address),
-             spilled_object_chunk_reader = std::move(spilled_object_chunk_reader)]() {
-              PushObjectInternal(object_id, node_id, total_data_size, metadata_size,
-                                 num_chunks, std::move(owner_address),
-                                 std::move(spilled_object_chunk_reader),
-                                 [](uint64_t) { /* do nothing to release chunk */ });
+            [this, object_id, node_id,
+             chunk_object_reader = std::move(chunk_object_reader)]() {
+              PushObjectInternal(object_id, node_id, std::move(chunk_object_reader));
             },
             "ObjectManager.PushLocalSpilledObjectInternal");
       },
       "ObjectManager.CreateSpilledObject");
 }
 
-void ObjectManager::PushObjectInternal(
-    const ObjectID &object_id, const NodeID &node_id, uint64_t total_data_size,
-    uint64_t metadata_size, uint64_t num_chunks, rpc::Address owner_address,
-    std::function<ray::Status(uint64_t, rpc::PushRequest &)> chunk_reader,
-    std::function<void(uint64_t)> release_chunk_callback) {
+void ObjectManager::PushObjectInternal(const ObjectID &object_id, const NodeID &node_id,
+                                       std::shared_ptr<ChunkObjectReader> chunk_reader) {
   auto rpc_client = GetRpcClient(node_id);
   if (!rpc_client) {
     // Push is best effort, so do nothing here.
@@ -479,63 +463,64 @@ void ObjectManager::PushObjectInternal(
   }
 
   RAY_LOG(DEBUG) << "Sending object chunks of " << object_id << " to node " << node_id
-                 << ", number of chunks: " << num_chunks
-                 << ", total data size: " << total_data_size;
+                 << ", number of chunks: " << chunk_reader->GetNumChunks()
+                 << ", total data size: " << chunk_reader->GetObject().GetObjectSize();
 
   auto push_id = UniqueID::FromRandom();
-  push_manager_->StartPush(node_id, object_id, num_chunks, [=](int64_t chunk_id) {
-    rpc_service_.post(
-        [=]() {
-          // Post to the multithreaded RPC event loop so that data is copied
-          // off of the main thread.
-          SendObjectChunk(push_id, object_id, owner_address, node_id, total_data_size,
-                          metadata_size, chunk_id, rpc_client,
-                          [=](const Status &status) {
-                            // Post back to the main event loop because the
-                            // PushManager is thread-safe.
-                            main_service_->post(
-                                [this, node_id, object_id]() {
-                                  push_manager_->OnChunkComplete(node_id, object_id);
-                                },
-                                "ObjectManager.Push");
-                          },
-                          std::move(chunk_reader), std::move(release_chunk_callback));
-        },
-        "ObjectManager.Push");
-  });
+  push_manager_->StartPush(
+      node_id, object_id, chunk_reader->GetNumChunks(), [=](int64_t chunk_id) {
+        rpc_service_.post(
+            [=]() {
+              // Post to the multithreaded RPC event loop so that data is copied
+              // off of the main thread.
+              SendObjectChunk(push_id, object_id, node_id, chunk_id, rpc_client,
+                              [=](const Status &status) {
+                                // Post back to the main event loop because the
+                                // PushManager is thread-safe.
+                                main_service_->post(
+                                    [this, node_id, object_id]() {
+                                      push_manager_->OnChunkComplete(node_id, object_id);
+                                    },
+                                    "ObjectManager.Push");
+                              },
+                              std::move(chunk_reader));
+            },
+            "ObjectManager.Push");
+      });
 }
 
-void ObjectManager::SendObjectChunk(
-    const UniqueID &push_id, const ObjectID &object_id, const rpc::Address &owner_address,
-    const NodeID &node_id, uint64_t total_data_size, uint64_t metadata_size,
-    uint64_t chunk_index, std::shared_ptr<rpc::ObjectManagerClient> rpc_client,
-    std::function<void(const Status &)> on_complete,
-    std::function<ray::Status(uint64_t, rpc::PushRequest &)> chunk_reader,
-    std::function<void(uint64_t)> release_chunk_callback) {
+void ObjectManager::SendObjectChunk(const UniqueID &push_id, const ObjectID &object_id,
+                                    const NodeID &node_id, uint64_t chunk_index,
+                                    std::shared_ptr<rpc::ObjectManagerClient> rpc_client,
+                                    std::function<void(const Status &)> on_complete,
+                                    std::shared_ptr<ChunkObjectReader> chunk_reader) {
   double start_time = absl::GetCurrentTimeNanos() / 1e9;
   rpc::PushRequest push_request;
   // Set request header
   push_request.set_push_id(push_id.Binary());
   push_request.set_object_id(object_id.Binary());
-  push_request.mutable_owner_address()->CopyFrom(owner_address);
+  push_request.mutable_owner_address()->CopyFrom(
+      chunk_reader->GetObject().GetOwnerAddress());
   push_request.set_node_id(self_node_id_.Binary());
-  push_request.set_data_size(total_data_size);
-  push_request.set_metadata_size(metadata_size);
+  push_request.set_data_size(chunk_reader->GetObject().GetObjectSize());
+  push_request.set_metadata_size(chunk_reader->GetObject().GetMetadataSize());
   push_request.set_chunk_index(chunk_index);
 
   // read a chunk into push_request and handle errors.
-  auto status = chunk_reader(chunk_index, push_request);
-  if (!status.ok()) {
-    RAY_LOG(WARNING) << "Attempting to push object " << object_id
-                     << " which is not local. It may have been evicted.";
-    on_complete(status);
+  auto optional_chunk = chunk_reader->GetChunk(chunk_index);
+  if (!optional_chunk.has_value()) {
+    RAY_LOG(ERROR) << "Read chunk " << chunk_index << " of object " << object_id
+                   << " failed. "
+                   << " It may have been evicted.";
+    on_complete(Status::IOError("Failed to read spilled object"));
     return;
   }
+  push_request.set_data(std::move(optional_chunk.value()));
 
   // record the time cost between send chunk and receive reply
   rpc::ClientCallback<rpc::PushReply> callback =
-      [this, start_time, object_id, node_id, chunk_index, owner_address, rpc_client,
-       on_complete](const Status &status, const rpc::PushReply &reply) {
+      [this, start_time, object_id, node_id, chunk_index, on_complete](
+          const Status &status, const rpc::PushReply &reply) {
         // TODO: Just print warning here, should we try to resend this chunk?
         if (!status.ok()) {
           RAY_LOG(WARNING) << "Send object " << object_id << " chunk to node " << node_id
@@ -548,8 +533,6 @@ void ObjectManager::SendObjectChunk(
       };
 
   rpc_client->Push(push_request, callback);
-
-  release_chunk_callback(chunk_index);
 }
 
 ray::Status ObjectManager::Wait(

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -369,6 +369,8 @@ class ObjectManager : public ObjectManagerInterface,
 
   /// The internal implementation of pushing an object.
   ///
+  /// \param object_id The object's id.
+  /// \param node_id The remote node's id.
   /// \param chunk_reader Chunk reader used to read a chunk of the object
   /// Status::OK() if the read succeeded.
   void PushObjectInternal(const ObjectID &object_id, const NodeID &node_id,

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -33,6 +33,7 @@
 #include "ray/common/id.h"
 #include "ray/common/ray_config.h"
 #include "ray/common/status.h"
+#include "ray/object_manager/chunk_object_reader.h"
 #include "ray/object_manager/common.h"
 #include "ray/object_manager/object_buffer_pool.h"
 #include "ray/object_manager/object_directory.h"
@@ -40,7 +41,6 @@
 #include "ray/object_manager/plasma/store_runner.h"
 #include "ray/object_manager/pull_manager.h"
 #include "ray/object_manager/push_manager.h"
-#include "ray/object_manager/spilled_object.h"
 #include "ray/rpc/object_manager/object_manager_client.h"
 #include "ray/rpc/object_manager/object_manager_server.h"
 #include "src/ray/protobuf/common.pb.h"
@@ -369,14 +369,10 @@ class ObjectManager : public ObjectManagerInterface,
 
   /// The internal implementation of pushing an object.
   ///
-  /// \param chunk_reader Read the chunk into push_request's data fields; return
+  /// \param chunk_reader Chunk reader used to read a chunk of the object
   /// Status::OK() if the read succeeded.
-  /// \param release_chunk_callback Notify that a chunk is no longer needed.
-  void PushObjectInternal(
-      const ObjectID &object_id, const NodeID &node_id, uint64_t total_data_size,
-      uint64_t metadata_size, uint64_t num_chunks, rpc::Address owner_address,
-      std::function<ray::Status(uint64_t, rpc::PushRequest &)> chunk_reader,
-      std::function<void(uint64_t)> release_chunk_callback);
+  void PushObjectInternal(const ObjectID &object_id, const NodeID &node_id,
+                          std::shared_ptr<ChunkObjectReader> chunk_reader);
 
   /// Send one chunk of the object to remote object manager
   ///
@@ -384,26 +380,16 @@ class ObjectManager : public ObjectManagerInterface,
   /// contains only one chunk
   /// \param push_id Unique push id to indicate this push request
   /// \param object_id Object id
-  /// \param owner_address The address of the object's owner
   /// \param node_id The id of the receiver.
-  /// \param data_size Data size
-  /// \param metadata_size Metadata size
   /// \param chunk_index Chunk index of this object chunk, start with 0
   /// \param rpc_client Rpc client used to send message to remote object manager
-  /// \param chunk_reader Read the chunk into push_request's data fields; return
-  /// Status::OK() if the read succeeded.
-  /// \param release_chunk_callback Notify that a chunk is no longer needed.
-  /// \param on_complete Callback to run on completion.
-  void SendObjectChunk(
-      const UniqueID &push_id, const ObjectID &object_id,
-      const rpc::Address &owner_address, const NodeID &node_id, uint64_t total_data_size,
-      uint64_t metadata_size, uint64_t chunk_index,
-      std::shared_ptr<rpc::ObjectManagerClient> rpc_client,
-      std::function<void(const Status &)> on_complete,
-      std::function<ray::Status(/*chunk_index*/ uint64_t,
-                                /*push_request*/ rpc::PushRequest &)>
-          chunk_reader,
-      std::function<void(/*chunk_index*/ uint64_t)> release_chunk_callback);
+  /// \param on_complete Callback when the chunk is sent
+  /// \param chunk_reader Chunk reader used to read a chunk of the object
+  void SendObjectChunk(const UniqueID &push_id, const ObjectID &object_id,
+                       const NodeID &node_id, uint64_t chunk_index,
+                       std::shared_ptr<rpc::ObjectManagerClient> rpc_client,
+                       std::function<void(const Status &)> on_complete,
+                       std::shared_ptr<ChunkObjectReader> chunk_reader);
 
   /// Handle starting, running, and stopping asio rpc_service.
   void StartRpcService();

--- a/src/ray/object_manager/object_reader.h
+++ b/src/ray/object_manager/object_reader.h
@@ -1,0 +1,55 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "src/ray/protobuf/common.pb.h"
+
+namespace ray {
+
+/// Reader over an immutable Ray object.
+class IObjectReader {
+ public:
+  virtual ~IObjectReader() = default;
+
+  /// Return the size of data (exclusing metadata).
+  virtual uint64_t GetDataSize() const = 0;
+
+  /// Return the size of metadata.
+  virtual uint64_t GetMetadataSize() const = 0;
+
+  uint64_t GetObjectSize() const { return GetDataSize() + GetMetadataSize(); }
+
+  virtual const rpc::Address &GetOwnerAddress() const = 0;
+
+  /// Read from data sections into output.
+  /// Return false if the object is corrupted or size/offset is invalid.
+  ///
+  /// \param offset offset to the data secton to copy from.
+  /// \param size number of bytes to copy.
+  /// \param output pointer to the memory location to copy to.
+  /// \return bool.
+  virtual bool ReadFromDataSection(uint64_t offset, uint64_t size,
+                                   char *output) const = 0;
+  /// Read from metadata sections into output.
+  /// Return false if the object is corrupted or size/offset is invalid.
+  ///
+  /// \param offset offset to the metadata secton to copy from.
+  /// \param size number of bytes to copy.
+  /// \param output pointer to the memory location to copy to.
+  /// \return bool.
+  virtual bool ReadFromMetadataSection(uint64_t offset, uint64_t size,
+                                       char *output) const = 0;
+};
+}  // namespace ray

--- a/src/ray/object_manager/plasma/client.cc
+++ b/src/ray/object_manager/plasma/client.cc
@@ -512,17 +512,6 @@ Status PlasmaClient::Impl::Get(const std::vector<ObjectID> &object_ids,
                     is_from_worker);
 }
 
-Status PlasmaClient::Impl::Get(const ObjectID *object_ids, int64_t num_objects,
-                               int64_t timeout_ms, ObjectBuffer *out,
-                               bool is_from_worker) {
-  std::lock_guard<std::recursive_mutex> guard(client_mutex_);
-
-  const auto wrap_buffer = [](const ObjectID &object_id,
-                              const std::shared_ptr<Buffer> &buffer) { return buffer; };
-  return GetBuffers(object_ids, num_objects, timeout_ms, wrap_buffer, out,
-                    is_from_worker);
-}
-
 Status PlasmaClient::Impl::MarkObjectUnused(const ObjectID &object_id) {
   auto object_entry = objects_in_use_.find(object_id);
   RAY_CHECK(object_entry != objects_in_use_.end());
@@ -758,12 +747,6 @@ Status PlasmaClient::TryCreateImmediately(const ObjectID &object_id,
 Status PlasmaClient::Get(const std::vector<ObjectID> &object_ids, int64_t timeout_ms,
                          std::vector<ObjectBuffer> *object_buffers, bool is_from_worker) {
   return impl_->Get(object_ids, timeout_ms, object_buffers, is_from_worker);
-}
-
-Status PlasmaClient::Get(const ObjectID *object_ids, int64_t num_objects,
-                         int64_t timeout_ms, ObjectBuffer *object_buffers,
-                         bool is_from_worker) {
-  return impl_->Get(object_ids, num_objects, timeout_ms, object_buffers, is_from_worker);
 }
 
 Status PlasmaClient::Release(const ObjectID &object_id) {

--- a/src/ray/object_manager/plasma/client.h
+++ b/src/ray/object_manager/plasma/client.h
@@ -147,22 +147,6 @@ class PlasmaClient {
   Status Get(const std::vector<ObjectID> &object_ids, int64_t timeout_ms,
              std::vector<ObjectBuffer> *object_buffers, bool is_from_worker);
 
-  /// Deprecated variant of Get() that doesn't automatically release buffers
-  /// when they get out of scope.
-  ///
-  /// \param object_ids The IDs of the objects to get.
-  /// \param num_objects The number of object IDs to get.
-  /// \param timeout_ms The amount of time in milliseconds to wait before this
-  ///        request times out. If this value is -1, then no timeout is set.
-  /// \param object_buffers An array where the results will be stored.
-  /// \param is_from_worker Whether or not if the Get request comes from a Ray workers.
-  /// \return The return status.
-  ///
-  /// The caller is responsible for releasing any retrieved objects, but it
-  /// should not release objects that were not retrieved.
-  Status Get(const ObjectID *object_ids, int64_t num_objects, int64_t timeout_ms,
-             ObjectBuffer *object_buffers, bool is_from_worker);
-
   /// Tell Plasma that the client no longer needs the object. This should be
   /// called after Get() or Create() when the client is done with the object.
   /// After this call, the buffer returned by Get() is no longer valid.

--- a/src/ray/object_manager/plasma/protocol.cc
+++ b/src/ray/object_manager/plasma/protocol.cc
@@ -557,6 +557,9 @@ Status SendGetReply(const std::shared_ptr<Client> &client, ObjectID object_ids[]
   std::vector<flatbuffers::Offset<fb::CudaHandle>> handles;
   for (int64_t i = 0; i < num_objects; ++i) {
     const PlasmaObject &object = plasma_objects[object_ids[i]];
+    RAY_LOG(DEBUG) << "Sending object info, id: " << object_ids[i]
+                   << " data_size: " << object.data_size
+                   << " metadata_size: " << object.metadata_size;
     objects.push_back(PlasmaObjectSpec(FD2INT(object.store_fd.first),
                                        object.store_fd.second, object.data_offset,
                                        object.data_size, object.metadata_offset,

--- a/src/ray/object_manager/spilled_object.cc
+++ b/src/ray/object_manager/spilled_object.cc
@@ -25,12 +25,7 @@ const size_t UINT64_size = sizeof(uint64_t);
 }
 
 /* static */ absl::optional<SpilledObject> SpilledObject::CreateSpilledObject(
-    const std::string &object_url, uint64_t chunk_size) {
-  if (chunk_size == 0) {
-    RAY_LOG(WARNING) << "chunk_size can't be 0.";
-    return absl::optional<SpilledObject>();
-  }
-
+    const std::string &object_url) {
   std::string file_path;
   uint64_t object_offset = 0;
   uint64_t object_size = 0;
@@ -54,9 +49,9 @@ const size_t UINT64_size = sizeof(uint64_t);
     return absl::optional<SpilledObject>();
   }
 
-  return absl::optional<SpilledObject>(SpilledObject(
-      std::move(file_path), object_size, data_offset, data_size, metadata_offset,
-      metadata_size, std::move(owner_address), chunk_size));
+  return absl::optional<SpilledObject>(
+      SpilledObject(std::move(file_path), object_size, data_offset, data_size,
+                    metadata_offset, metadata_size, std::move(owner_address)));
 }
 
 uint64_t SpilledObject::GetDataSize() const { return data_size_; }
@@ -65,55 +60,17 @@ uint64_t SpilledObject::GetMetadataSize() const { return metadata_size_; }
 
 const rpc::Address &SpilledObject::GetOwnerAddress() const { return owner_address_; }
 
-uint64_t SpilledObject::GetNumChunks() const {
-  // return ceil( (data_size + metadata_size) / chunk_size_)
-  return (data_size_ + metadata_size_ + chunk_size_ - 1) / chunk_size_;
-}
-
-absl::optional<std::string> SpilledObject::GetChunk(uint64_t chunk_index) const {
-  // The spilled file stores metadata before data. But the GetChunk needs to
-  // return data before metadata. We achieve by first read from data section,
-  // then read from metadata section.
-  const auto cur_chunk_offset = chunk_index * chunk_size_;
-  const auto cur_chunk_size =
-      std::min(chunk_size_, data_size_ + metadata_size_ - cur_chunk_offset);
-
-  std::string result(cur_chunk_size, '\0');
-  size_t result_offset = 0;
-
-  if (cur_chunk_offset < data_size_) {
-    // read from data section.
-    auto offset = cur_chunk_offset;
-    auto size = std::min(data_size_ - cur_chunk_offset, cur_chunk_size);
-    if (!ReadFromDataSection(offset, size, &result[result_offset])) {
-      return absl::optional<std::string>();
-    }
-    result_offset = size;
-  }
-
-  if (cur_chunk_offset + cur_chunk_size > data_size_) {
-    // read from metadata section.
-    auto offset = std::max(cur_chunk_offset, data_size_) - data_size_;
-    auto size = std::min(cur_chunk_offset + cur_chunk_size - data_size_, cur_chunk_size);
-    if (!ReadFromMetadataSection(offset, size, &result[result_offset])) {
-      return absl::optional<std::string>();
-    }
-  }
-  return absl::optional<std::string>(std::move(result));
-}
-
 SpilledObject::SpilledObject(std::string file_path, uint64_t object_size,
                              uint64_t data_offset, uint64_t data_size,
                              uint64_t metadata_offset, uint64_t metadata_size,
-                             rpc::Address owner_address, uint64_t chunk_size)
+                             rpc::Address owner_address)
     : file_path_(std::move(file_path)),
       object_size_(object_size),
       data_offset_(data_offset),
       data_size_(data_size),
       metadata_offset_(metadata_offset),
       metadata_size_(metadata_size),
-      owner_address_(std::move(owner_address)),
-      chunk_size_(chunk_size) {}
+      owner_address_(std::move(owner_address)) {}
 
 /* static */ bool SpilledObject::ParseObjectURL(const std::string &object_url,
                                                 std::string &file_path,

--- a/src/ray/object_manager/spilled_object.h
+++ b/src/ray/object_manager/spilled_object.h
@@ -23,39 +23,54 @@
 
 namespace ray {
 
-/// Represent a local object spilled in the object_url.
-/// This class is thread safe.
-class SpilledObject {
+/// Reader over an immutable Ray object.
+class IObjectReader {
  public:
-  /// Create a Spilled Object. Returns an empty optional if any error happens, such as
-  /// malformed url; corrupted/deleted file; or 0 chunk_size.
-  ///
-  /// \param object_url the object url in the form of {path}?offset={offset}&size={size}
-  /// \param chunk_size the size of chunk for read.
-  static absl::optional<SpilledObject> CreateSpilledObject(const std::string &object_url,
-                                                           uint64_t chunk_size);
+  virtual ~IObjectReader() = default;
 
   /// Return the size of data (exclusing metadata).
-  uint64_t GetDataSize() const;
+  virtual uint64_t GetDataSize() const = 0;
 
   /// Return the size of metadata.
-  uint64_t GetMetadataSize() const;
+  virtual uint64_t GetMetadataSize() const = 0;
 
-  const rpc::Address &GetOwnerAddress() const;
+  uint64_t GetObjectSize() const { return GetDataSize() + GetMetadataSize(); }
 
-  uint64_t GetNumChunks() const;
+  virtual const rpc::Address &GetOwnerAddress() const = 0;
 
-  /// Return the value in a given chunk, identified by chunk_index.
-  /// It migh return an empty optional if the file is deleted.
+  /// Read from data/metadata sections into output.
+  /// Return false if the object is corrupted or size/offset is invalid.
+  virtual bool ReadFromDataSection(uint64_t offset, uint64_t size,
+                                   char *output) const = 0;
+  virtual bool ReadFromMetadataSection(uint64_t offset, uint64_t size,
+                                       char *output) const = 0;
+};
+
+/// Reader for a local object spilled in the object_url.
+/// This class is thread safe.
+/// TODO(chenshen): rename it to SpilledObjectReader
+class SpilledObject : public IObjectReader {
+ public:
+  /// Create a Spilled Object. Returns an empty optional if any error happens, such as
+  /// malformed url; corrupted/deleted file.
   ///
-  /// \param chunk_index the index of chunk to return. index greater or
-  ///                    equal to GetNumChunks() yields undefined behavior.
-  absl::optional<std::string> GetChunk(uint64_t chunk_index) const;
+  /// \param object_url the object url in the form of {path}?offset={offset}&size={size}
+  static absl::optional<SpilledObject> CreateSpilledObject(const std::string &object_url);
+
+  uint64_t GetDataSize() const override;
+
+  uint64_t GetMetadataSize() const override;
+
+  const rpc::Address &GetOwnerAddress() const override;
+
+  bool ReadFromDataSection(uint64_t offset, uint64_t size, char *output) const override;
+  bool ReadFromMetadataSection(uint64_t offset, uint64_t size,
+                               char *output) const override;
 
  private:
   SpilledObject(std::string file_path, uint64_t total_size, uint64_t data_offset,
                 uint64_t data_size, uint64_t metadata_offset, uint64_t metadata_size,
-                rpc::Address owner_address, uint64_t chunk_size);
+                rpc::Address owner_address);
 
   /// Parse the object url in the form of {path}?offset={offset}&size={size}.
   /// Return false if parsing failed.
@@ -100,18 +115,13 @@ class SpilledObject {
   /// Deserialize 8 bytes string as a little-endian uint64_t.
   static uint64_t ToUINT64(const std::string &s);
 
-  /// Helper functions read from data/metadata sections into output.
-  /// Return false if the file is corrupted.
-  bool ReadFromDataSection(uint64_t offset, uint64_t size, char *output) const;
-  bool ReadFromMetadataSection(uint64_t offset, uint64_t size, char *output) const;
-
  private:
   FRIEND_TEST(SpilledObjectTest, ParseObjectURL);
   FRIEND_TEST(SpilledObjectTest, ToUINT64);
   FRIEND_TEST(SpilledObjectTest, ReadUINT64);
   FRIEND_TEST(SpilledObjectTest, ParseObjectHeader);
   FRIEND_TEST(SpilledObjectTest, Getters);
-  FRIEND_TEST(SpilledObjectTest, GetNumChunks);
+  FRIEND_TEST(ChunkObjectReaderTest, GetNumChunks);
 
   const std::string file_path_;
   const uint64_t object_size_;
@@ -120,7 +130,6 @@ class SpilledObject {
   const uint64_t metadata_offset_;
   const uint64_t metadata_size_;
   const rpc::Address owner_address_;
-  const uint64_t chunk_size_;
 };
 
 }  // namespace ray

--- a/src/ray/object_manager/spilled_object.h
+++ b/src/ray/object_manager/spilled_object.h
@@ -38,17 +38,29 @@ class IObjectReader {
 
   virtual const rpc::Address &GetOwnerAddress() const = 0;
 
-  /// Read from data/metadata sections into output.
+  /// Read from data sections into output.
   /// Return false if the object is corrupted or size/offset is invalid.
+  ///
+  /// \param offset offset to the data secton to copy from.
+  /// \param size number of bytes to copy.
+  /// \param output pointer to the memory location to copy to.
+  /// \return bool.
   virtual bool ReadFromDataSection(uint64_t offset, uint64_t size,
                                    char *output) const = 0;
+  /// Read from metadata sections into output.
+  /// Return false if the object is corrupted or size/offset is invalid.
+  ///
+  /// \param offset offset to the metadata secton to copy from.
+  /// \param size number of bytes to copy.
+  /// \param output pointer to the memory location to copy to.
+  /// \return bool.
   virtual bool ReadFromMetadataSection(uint64_t offset, uint64_t size,
                                        char *output) const = 0;
 };
 
 /// Reader for a local object spilled in the object_url.
 /// This class is thread safe.
-/// TODO(chenshen): rename it to SpilledObjectReader
+/// TODO(scv119): rename it to SpilledObjectReader
 class SpilledObject : public IObjectReader {
  public:
   /// Create a Spilled Object. Returns an empty optional if any error happens, such as

--- a/src/ray/object_manager/test/spilled_object_test.cc
+++ b/src/ray/object_manager/test/spilled_object_test.cc
@@ -374,7 +374,7 @@ TYPED_TEST(ObjectReaderTest, GetChunk) {
 }
 
 TEST(StringAllocationTest, TestNoCopyWhenStringMoved) {
-  // Since protobuf allways allocate string on heap,
+  // Since protobuf always allocate string on heap,
   // move assign a string field doesn't copy the data.
   std::string s(1000, '\0');
   auto allocation_address = s.c_str();

--- a/src/ray/object_manager/test/spilled_object_test.cc
+++ b/src/ray/object_manager/test/spilled_object_test.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ray/object_manager/spilled_object.h"
 #include "ray/object_manager/chunk_object_reader.h"
 #include "ray/object_manager/memory_object_reader.h"
+#include "ray/object_manager/spilled_object_reader.h"
 
 #include <boost/endian/conversion.hpp>
 #include <fstream>
@@ -26,15 +26,15 @@
 
 namespace ray {
 
-TEST(SpilledObjectTest, ParseObjectURL) {
+TEST(SpilledObjectReaderTest, ParseObjectURL) {
   auto assert_parse_success =
       [](const std::string &object_url, const std::string &expected_file_path,
          uint64_t expected_object_offset, uint64_t expected_object_size) {
         std::string actual_file_path;
         uint64_t actual_offset = 0;
         uint64_t actual_size = 0;
-        ASSERT_TRUE(SpilledObject::ParseObjectURL(object_url, actual_file_path,
-                                                  actual_offset, actual_size));
+        ASSERT_TRUE(SpilledObjectReader::ParseObjectURL(object_url, actual_file_path,
+                                                        actual_offset, actual_size));
         ASSERT_EQ(expected_file_path, actual_file_path);
         ASSERT_EQ(expected_object_offset, actual_offset);
         ASSERT_EQ(expected_object_size, actual_size);
@@ -44,8 +44,8 @@ TEST(SpilledObjectTest, ParseObjectURL) {
     std::string actual_file_path;
     uint64_t actual_offset = 0;
     uint64_t actual_size = 0;
-    ASSERT_FALSE(SpilledObject::ParseObjectURL(object_url, actual_file_path,
-                                               actual_offset, actual_size));
+    ASSERT_FALSE(SpilledObjectReader::ParseObjectURL(object_url, actual_file_path,
+                                                     actual_offset, actual_size));
   };
 
   assert_parse_success("file://path/to/file?offset=123&size=456", "file://path/to/file",
@@ -62,17 +62,17 @@ TEST(SpilledObjectTest, ParseObjectURL) {
   assert_parse_fail("file://path/to/file?offset=a&size=456&extra");
 }
 
-TEST(SpilledObjectTest, ToUINT64) {
-  ASSERT_EQ(0, SpilledObject::ToUINT64(
+TEST(SpilledObjectReaderTest, ToUINT64) {
+  ASSERT_EQ(0, SpilledObjectReader::ToUINT64(
                    {'\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00'}));
-  ASSERT_EQ(1, SpilledObject::ToUINT64(
+  ASSERT_EQ(1, SpilledObjectReader::ToUINT64(
                    {'\x01', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00'}));
   ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
-            SpilledObject::ToUINT64(
+            SpilledObjectReader::ToUINT64(
                 {'\xff', '\xff', '\xff', '\xff', '\xff', '\xff', '\xff', '\xff'}));
 }
 
-TEST(SpilledObjectTest, ReadUINT64) {
+TEST(SpilledObjectReaderTest, ReadUINT64) {
   std::istringstream s1(std::string{
       '\x00', '\x00', '\x00', '\x00', '\x00', '\x00',
       '\x00', '\x00',  // little endian of 0
@@ -83,13 +83,13 @@ TEST(SpilledObjectTest, ReadUINT64) {
       '\xff', '\xff', '\xff', '\xff', '\xff', '\xff'  // malformed
   });
   uint64_t output{100};
-  ASSERT_TRUE(SpilledObject::ReadUINT64(s1, output));
+  ASSERT_TRUE(SpilledObjectReader::ReadUINT64(s1, output));
   ASSERT_EQ(0, output);
-  ASSERT_TRUE(SpilledObject::ReadUINT64(s1, output));
+  ASSERT_TRUE(SpilledObjectReader::ReadUINT64(s1, output));
   ASSERT_EQ(1, output);
-  ASSERT_TRUE(SpilledObject::ReadUINT64(s1, output));
+  ASSERT_TRUE(SpilledObjectReader::ReadUINT64(s1, output));
   ASSERT_EQ(std::numeric_limits<uint64_t>::max(), output);
-  ASSERT_FALSE(SpilledObject::ReadUINT64(s1, output));
+  ASSERT_FALSE(SpilledObjectReader::ReadUINT64(s1, output));
 }
 
 namespace {
@@ -112,7 +112,7 @@ std::string ContructObjectString(uint64_t object_offset, std::string data,
 }
 }  // namespace
 
-TEST(SpilledObjectTest, ParseObjectHeader) {
+TEST(SpilledObjectReaderTest, ParseObjectHeader) {
   auto assert_parse_success = [](uint64_t object_offset, std::string data,
                                  std::string metadata, std::string raylet_id) {
     rpc::Address owner_address;
@@ -124,7 +124,7 @@ TEST(SpilledObjectTest, ParseObjectHeader) {
     uint64_t actual_metadata_size = 0;
     rpc::Address actual_owner_address;
     std::istringstream is(str);
-    ASSERT_TRUE(SpilledObject::ParseObjectHeader(
+    ASSERT_TRUE(SpilledObjectReader::ParseObjectHeader(
         is, object_offset, actual_data_offset, actual_data_size, actual_metadata_offset,
         actual_metadata_size, actual_owner_address));
     std::string address_str;
@@ -167,7 +167,7 @@ TEST(SpilledObjectTest, ParseObjectHeader) {
     uint64_t actual_metadata_size = 0;
     rpc::Address actual_owner_address;
     std::istringstream is(str);
-    ASSERT_FALSE(SpilledObject::ParseObjectHeader(
+    ASSERT_FALSE(SpilledObjectReader::ParseObjectHeader(
         is, object_offset, actual_data_offset, actual_data_size, actual_metadata_offset,
         actual_metadata_size, actual_owner_address));
   };
@@ -182,9 +182,10 @@ TEST(SpilledObjectTest, ParseObjectHeader) {
 }
 
 namespace {
-std::string CreateSpilledObjectOnTmp(uint64_t object_offset, std::string data,
-                                     std::string metadata, rpc::Address owner_address,
-                                     bool skip_write = false) {
+std::string CreateSpilledObjectReaderOnTmp(uint64_t object_offset, std::string data,
+                                           std::string metadata,
+                                           rpc::Address owner_address,
+                                           bool skip_write = false) {
   auto str = ContructObjectString(object_offset, data, metadata, owner_address);
   std::string tmp_file = ray::JoinPaths(
       ray::GetUserTempDir(), "spilled_object_test" + ObjectID::FromRandom().Hex());
@@ -210,24 +211,13 @@ MemoryObjectReader CreateMemoryObjectReader(std::string &data, std::string &meta
 }
 }  // namespace
 
-TEST(SpilledObjectTest, Getters) {
-  rpc::Address owner_address;
-  owner_address.set_raylet_id("nonsense");
-  SpilledObject obj("path", 8 /* object_size */, 2 /* data_offset */, 3 /* data_size */,
-                    4 /* metadata_offset */, 5 /* metadata_size */, owner_address);
-  ASSERT_EQ(3, obj.GetDataSize());
-  ASSERT_EQ(5, obj.GetMetadataSize());
-  ASSERT_EQ(8, obj.GetObjectSize());
-  ASSERT_EQ(owner_address.raylet_id(), obj.GetOwnerAddress().raylet_id());
-}
-
 TEST(ChunkObjectReaderTest, GetNumChunks) {
   auto assert_get_num_chunks = [](uint64_t data_size, uint64_t chunk_size,
                                   uint64_t expected_num_chunks) {
     rpc::Address owner_address;
     owner_address.set_raylet_id("nonsense");
     ChunkObjectReader reader(
-        std::make_shared<SpilledObject>(SpilledObject(
+        std::make_shared<SpilledObjectReader>(SpilledObjectReader(
             "path", 100 /* object_size */, 2 /* data_offset */, data_size /* data_size */,
             4 /* metadata_offset */, 0 /* metadata_size */, owner_address)),
         chunk_size /* chunk_size */);
@@ -250,81 +240,137 @@ TEST(ChunkObjectReaderTest, GetNumChunks) {
                         6 /* expected_num_chunks */);
 }
 
-TEST(SpilledObjectTest, CreateSpilledObject) {
-  auto object_url = CreateSpilledObjectOnTmp(10 /* object_offset */, "data", "metadata",
-                                             ray::rpc::Address());
-  ASSERT_TRUE(SpilledObject::CreateSpilledObject(object_url).has_value());
-  ASSERT_FALSE(SpilledObject::CreateSpilledObject("malformatted_url").has_value());
-  auto optional_object = SpilledObject::CreateSpilledObject(object_url);
+TEST(SpilledObjectReaderTest, CreateSpilledObjectReader) {
+  auto object_url = CreateSpilledObjectReaderOnTmp(10 /* object_offset */, "data",
+                                                   "metadata", ray::rpc::Address());
+  ASSERT_TRUE(SpilledObjectReader::CreateSpilledObjectReader(object_url).has_value());
+  ASSERT_FALSE(
+      SpilledObjectReader::CreateSpilledObjectReader("malformatted_url").has_value());
+  auto optional_object = SpilledObjectReader::CreateSpilledObjectReader(object_url);
   ASSERT_TRUE(optional_object.has_value());
 
-  auto object_url1 = CreateSpilledObjectOnTmp(10 /* object_offset */, "data", "metadata",
-                                              ray::rpc::Address(), true /* skip_write */);
+  auto object_url1 =
+      CreateSpilledObjectReaderOnTmp(10 /* object_offset */, "data", "metadata",
+                                     ray::rpc::Address(), true /* skip_write */);
   // file corrupted.
-  ASSERT_FALSE(SpilledObject::CreateSpilledObject(object_url1).has_value());
+  ASSERT_FALSE(SpilledObjectReader::CreateSpilledObjectReader(object_url1).has_value());
 }
 
-TEST(MemoryObjectReaderTeset, Getters) {
-  rpc::Address owner_address;
-  owner_address.set_raylet_id("nonsense");
-  std::string data("ata");
-  std::string metadata("metadata");
-  auto obj = CreateMemoryObjectReader(data, metadata, owner_address);
-  ASSERT_EQ(data.size(), obj.GetDataSize());
-  ASSERT_EQ(metadata.size(), obj.GetMetadataSize());
-  ASSERT_EQ(data.size() + metadata.size(), obj.GetObjectSize());
-  ASSERT_EQ(owner_address.raylet_id(), obj.GetOwnerAddress().raylet_id());
+template <class T>
+std::shared_ptr<T> CreateObjectReader(std::string &data, std::string &metadata,
+                                      rpc::Address owner_address);
+
+template <>
+std::shared_ptr<SpilledObjectReader> CreateObjectReader<SpilledObjectReader>(
+    std::string &data, std::string &metadata, rpc::Address owner_address) {
+  auto object_url = CreateSpilledObjectReaderOnTmp(0 /* object_offset */, data, metadata,
+                                                   owner_address);
+  auto optional_object = SpilledObjectReader::CreateSpilledObjectReader(object_url);
+  return std::make_shared<SpilledObjectReader>(std::move(optional_object.value()));
 }
 
-namespace {
-void AssertGetChunkWorks(std::string metadata, std::string data,
-                         std::vector<uint64_t> chunk_sizes) {
-  rpc::Address owner_address;
-  owner_address.set_raylet_id("nonsense");
+template <>
+std::shared_ptr<MemoryObjectReader> CreateObjectReader<MemoryObjectReader>(
+    std::string &data, std::string &metadata, rpc::Address owner_address) {
+  return std::make_shared<MemoryObjectReader>(
+      CreateMemoryObjectReader(data, metadata, owner_address));
+}
 
-  std::string expected_output = data + metadata;
-  if (expected_output.size() != 0) {
-    chunk_sizes.push_back(expected_output.size());
+template <typename T>
+struct ObjectReaderTest : public ::testing::Test {
+  static std::shared_ptr<T> CreateObjectReader_(std::string &data, std::string &metadata,
+                                                rpc::Address owner_address) {
+    return CreateObjectReader<T>(data, metadata, owner_address);
   }
-  auto object_url = CreateSpilledObjectOnTmp(10 /* object_offset */, data, metadata,
-                                             ray::rpc::Address());
+};
 
-  // check that we can reconstruct the output by concatinating chunks with different
-  // chunk_size, and the size of chunk is expected.
-  for (auto chunk_size : chunk_sizes) {
-    auto optional_object = SpilledObject::CreateSpilledObject(object_url);
-    ASSERT_TRUE(optional_object.has_value());
+typedef ::testing::Types<SpilledObjectReader, MemoryObjectReader> Implementations;
 
-    std::vector<ChunkObjectReader> readers{
-        {std::make_shared<SpilledObject>(std::move(optional_object.value())), chunk_size},
-        {std::make_shared<MemoryObjectReader>(
-             CreateMemoryObjectReader(data, metadata, owner_address)),
-         chunk_size}};
+TYPED_TEST_CASE(ObjectReaderTest, Implementations);
 
-    for (auto &reader : readers) {
-      std::string actual_output_by_chunks;
-      for (uint64_t i = 0; i < reader.GetNumChunks(); i++) {
-        auto chunk = reader.GetChunk(i);
-        ASSERT_TRUE(chunk.has_value());
-        ASSERT_GE(chunk_size, chunk->size());
-        if (i + 1 != reader.GetNumChunks()) {
-          ASSERT_EQ(chunk_size, chunk->size());
+TYPED_TEST(ObjectReaderTest, Getters) {
+  std::string data("data");
+  std::string metadata("metadata");
+  rpc::Address owner_address;
+  owner_address.set_raylet_id("nonsense");
+  auto obj_reader = this->CreateObjectReader_(data, metadata, owner_address);
+  ASSERT_EQ(data.size(), obj_reader->GetDataSize());
+  ASSERT_EQ(metadata.size(), obj_reader->GetMetadataSize());
+  ASSERT_EQ(data.size() + metadata.size(), obj_reader->GetObjectSize());
+  ASSERT_EQ(owner_address.raylet_id(), obj_reader->GetOwnerAddress().raylet_id());
+}
+
+TYPED_TEST(ObjectReaderTest, GetDataAndMetadata) {
+  std::vector<std::string> list_data{"", "alotofdata", "da", "data"};
+  std::vector<std::string> list_metadata{"", "meta", "metadata", "alotofmetadata"};
+  for (auto &data : list_data) {
+    for (auto &metadata : list_metadata) {
+      std::vector<uint64_t> chunk_sizes{1, 2, 3, 5, 100};
+      rpc::Address owner_address;
+
+      auto reader = TestFixture::CreateObjectReader_(data, metadata, owner_address);
+
+      for (size_t offset = 0; offset <= data.size(); offset++) {
+        for (size_t size = offset; size <= data.size() - offset; size++) {
+          std::string result(size, '\0');
+          if (offset + size <= data.size()) {
+            ASSERT_TRUE(reader->ReadFromDataSection(offset, size, &result[0]));
+            ASSERT_EQ(data.substr(offset, size), result);
+          } else {
+            ASSERT_FALSE(reader->ReadFromDataSection(offset, size, &result[0]));
+          }
         }
-        actual_output_by_chunks.append(chunk.value());
       }
-      ASSERT_EQ(expected_output, actual_output_by_chunks);
+
+      for (size_t offset = 0; offset <= metadata.size(); offset++) {
+        for (size_t size = offset; size <= metadata.size() - offset; size++) {
+          std::string result(size, '\0');
+          if (offset + size <= metadata.size()) {
+            ASSERT_TRUE(reader->ReadFromMetadataSection(offset, size, &result[0]));
+            ASSERT_EQ(metadata.substr(offset, size), result);
+          } else {
+            ASSERT_FALSE(reader->ReadFromMetadataSection(offset, size, &result[0]));
+          }
+        }
+      }
     }
   }
 }
-}  // namespace
 
-TEST(SpilledObjectTest, GetChunk) {
-  AssertGetChunkWorks("meta", "alotofdata", {1, 2, 3, 5, 100});
-  AssertGetChunkWorks("", "weonlyhavedata", {1, 2, 3, 5, 100});
-  AssertGetChunkWorks("weonlyhavemetadata", "", {1, 2, 3, 5, 100});
-  AssertGetChunkWorks("1", "", {1, 2, 3, 5, 100});
-  AssertGetChunkWorks("alotofactualmeta", "meh", {1, 2, 3, 5, 100});
-  AssertGetChunkWorks("", "", {1, 2, 3, 5, 100});
+TYPED_TEST(ObjectReaderTest, GetChunk) {
+  std::vector<std::string> list_data{"", "alotofdata", "da", "data"};
+  std::vector<std::string> list_metadata{"", "meta", "metadata", "alotofmetadata"};
+  for (auto &data : list_data) {
+    for (auto &metadata : list_metadata) {
+      std::vector<uint64_t> chunk_sizes{1, 2, 3, 5, 100};
+      rpc::Address owner_address;
+      owner_address.set_raylet_id("nonsense");
+
+      std::string expected_output = data + metadata;
+      if (expected_output.size() != 0) {
+        chunk_sizes.push_back(expected_output.size());
+      }
+
+      // check that we can reconstruct the output by concatinating chunks with different
+      // chunk_size, and the size of chunk is expected.
+      for (auto chunk_size : chunk_sizes) {
+        auto reader = ChunkObjectReader(
+            TestFixture::CreateObjectReader_(data, metadata, owner_address), chunk_size);
+
+        std::string actual_output_by_chunks;
+        for (uint64_t i = 0; i < reader.GetNumChunks(); i++) {
+          auto chunk = reader.GetChunk(i);
+          ASSERT_TRUE(chunk.has_value());
+          ASSERT_GE(chunk_size, chunk->size());
+          if (i + 1 != reader.GetNumChunks()) {
+            ASSERT_EQ(chunk_size, chunk->size());
+          }
+          actual_output_by_chunks.append(chunk.value());
+        }
+        ASSERT_EQ(expected_output, actual_output_by_chunks);
+      }
+    }
+  }
 }
 }  // namespace ray
 

--- a/src/ray/object_manager/test/spilled_object_test.cc
+++ b/src/ray/object_manager/test/spilled_object_test.cc
@@ -372,6 +372,26 @@ TYPED_TEST(ObjectReaderTest, GetChunk) {
     }
   }
 }
+
+TEST(StringAllocationTest, TestNoCopyWhenStringMoved) {
+  // Since protobuf allways allocate string on heap,
+  // move assign a string field doesn't copy the data.
+  std::string s(1000, '\0');
+  auto allocation_address = s.c_str();
+  rpc::Address address;
+  address.set_raylet_id(std::move(s));
+  EXPECT_EQ(allocation_address, address.raylet_id().c_str());
+}
+
+TEST(StringAllocationTest, TestCopyWhenPassByPointer) {
+  // Construct a string field by pointer and length
+  // always copy the data.
+  char arr[1000];
+  auto allocation_address = &arr[0];
+  rpc::Address address;
+  address.set_raylet_id(allocation_address, 1000);
+  EXPECT_NE(allocation_address, address.raylet_id().c_str());
+}
 }  // namespace ray
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
the bug in #16923 demonstrated as object metadata/data size mismatches in object_pull_manager. After investigation we figured it's turned out to be because a sequence of following events:
1. the object was first created and being GCed.
2. node_manager mark the object as failed, by setting datasize to 0 and metadata to error_type
3. the push manager still has stale information of this object, where it thought the data_size should be 329227, then failed the request.
4. 
See https://github.com/ray-project/ray/issues/16923#issuecomment-877712079 for detailed log.

In this PR we fix the issue by updating the staled info and proceed sending the object.

To fix the PR, we actually did following refactor:
1. refactor the SpilledObject into SpilledObject(Reader) and ChunkObjectReader.
2. create a MemoryObjectReader similar to SpilledObject, but wraps from plasma::ObjectBuffer.
3. Update object_buffer_pool to return a MemoryObjectReader directly on CreateObjectReader call.
4. In ObjectManager, call CreateObjectReader for pushing local object, and detect if the MemoryObjectReader is marked ad deleted, update the ObjectManager's local_object_info and continue the push.


TBD: 

- [x] add unittest for MemoryObjectReader
- [x] verify the bug is fixed by stress testing:
- run stress test `decision_tree_autoscaling_20_runs`  3 times successfully without issue, 1 times with object lost error (unrelated to this PR)