### PR TITLE
Disable runtime envs in scalability envelope

### DIFF
--- a/benchmarks/distributed/test_distributed.py
+++ b/benchmarks/distributed/test_distributed.py
@@ -140,7 +140,7 @@ def test_many_placement_groups():
         remove_placement_group(pg)
 
 
-ray.init(address="auto")
+ray.client().env({}).connect()
 
 scale_to(TEST_NUM_NODES)
 assert num_alive_nodes(

--- a/benchmarks/object_store/test_object_store.py
+++ b/benchmarks/object_store/test_object_store.py
@@ -56,7 +56,7 @@ def test_object_broadcast():
         assert result == OBJECT_SIZE
 
 
-ray.init(address="auto")
+ray.client().env({}).connect()
 start = perf_counter()
 test_object_broadcast()
 end = perf_counter()

--- a/benchmarks/single_node/test_single_node.py
+++ b/benchmarks/single_node/test_single_node.py
@@ -137,7 +137,7 @@ def test_large_object():
     assert big_obj[-1] == 0
 
 
-ray.init(address="auto")
+ray.client().env({}).connect()
 
 args_start = perf_counter()
 test_many_args()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Runtime envs seem to be unstable. Until they stabilize, unfortunately we need to turn them off in the scalability envelope

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
