### PR TITLE
[tune] Add information about environment variables to `tune.run` docstring

### DIFF
--- a/doc/source/tune/user-guide.rst
+++ b/doc/source/tune/user-guide.rst
@@ -769,6 +769,8 @@ By default, ``tune.run`` will continue executing until all trials have terminate
 
 This is useful when you are trying to setup a large hyperparameter experiment.
 
+.. _tune-env-vars:
+
 Environment variables
 ---------------------
 Some of Ray Tune's behavior can be configured using environment variables.

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -116,6 +116,11 @@ def run(
     will gracefully shut down and checkpoint the latest experiment state.
     Sending SIGINT again (or SIGKILL/SIGTERM instead) will skip this step.
 
+    Many aspects of Tune, such as the frequency of global checkpointing,
+    maximum pending placement group trials and the path of the result
+    directory be configured through environment variables. Refer to
+    :ref:`tune-env-vars` for a list of environment variables available.
+
     Examples:
 
     .. code-block:: python


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The fact that Tune can be configured through environment variables is not obvious, especially to first-time users. This PR adds a mention of that to `tune.run` docstring.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
