### PR TITLE
Allows users of the helm chart to set a nodeLabel for the operator pod

### DIFF
--- a/deploy/charts/ray/templates/operator_cluster_scoped.yaml
+++ b/deploy/charts/ray/templates/operator_cluster_scoped.yaml
@@ -47,6 +47,9 @@ spec:
         cluster.ray.io/component: operator
     spec:
       serviceAccountName: ray-operator-serviceaccount
+{{- if .Values.nodeSelector }}
+      nodeSelector: {{- .Values.nodeSelector | toYaml | nindent 8 }}
+{{- end }}
       containers:
       - name: ray
         imagePullPolicy: Always

--- a/deploy/charts/ray/templates/operator_cluster_scoped.yaml
+++ b/deploy/charts/ray/templates/operator_cluster_scoped.yaml
@@ -47,9 +47,10 @@ spec:
         cluster.ray.io/component: operator
     spec:
       serviceAccountName: ray-operator-serviceaccount
-{{- if .Values.nodeSelector }}
-      nodeSelector: {{- .Values.nodeSelector | toYaml | nindent 8 }}
-{{- end }}
+{{ if .Values.nodeSelector }}
+      nodeSelector:
+        {{ .Values.nodeSelector | toYaml }}
+{{ end }}
       containers:
       - name: ray
         imagePullPolicy: Always

--- a/deploy/charts/ray/templates/operator_namespaced.yaml
+++ b/deploy/charts/ray/templates/operator_namespaced.yaml
@@ -44,6 +44,10 @@ spec:
         cluster.ray.io/component: operator
     spec:
       serviceAccountName: ray-operator-serviceaccount
+{{ if .Values.nodeSelector }}
+      nodeSelector:
+        {{ .Values.nodeSelector | toYaml }}
+{{ end }}
       containers:
       - name: ray
         imagePullPolicy: Always


### PR DESCRIPTION
## Why are these changes needed?

This PR allows users of the helm chart to set a nodeLabel for the operator pod so for instance it can be scheduled on a on-demand instance instead of a spot instance.