### PR TITLE
[Docs] Add Ray Client Server Port to  Docs

### DIFF
--- a/doc/source/configure.rst
+++ b/doc/source/configure.rst
@@ -131,7 +131,7 @@ The node manager and object manager run as separate processes with their own por
 
 The following options specify the range of ports used by worker processes across machines. All ports in the range should be open.
 
-- ``--min-worker-port``: Minimum port number worker can be bound to. Default: 10000.
+- ``--min-worker-port``: Minimum port number worker can be bound to. Default: 10002.
 - ``--max-worker-port``: Maximum port number worker can be bound to. Default: 10999.
 
 Port numbers are how Ray disambiguates input and output to and from multiple workers on a single node. Each worker will take input and give output on a single port number. Thus, for example, by default, there is a maximum of 1,000 workers on each node, irrespective of number of CPUs.
@@ -143,6 +143,7 @@ Head Node
 In addition to ports specified above, the head node needs to open several more ports.
 
 - ``--port``: Port of Redis. If `--address` is not specified, the head node will start a redis instance listening on this port. Default: 6379.
+- ``--ray-client-server-port``: Listening port for Ray Client Server. Default: 10001.
 - ``--redis-shard-ports``: Comma-separated list of ports for non-primary Redis shards. Default: Random values.
 - ``--gcs-server-port``: GCS Server port. GCS server is a stateless service that is in charge of communicating with the GCS. Default: Random value.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Clarify that worker ports start at `10002`.
* Mention that `10001` is defaulted.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/16643

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
