### PR TITLE
Fix flaky test_plasma_unlimited::test_fallback_allocation_failure

### DIFF
--- a/python/ray/external_storage.py
+++ b/python/ray/external_storage.py
@@ -133,15 +133,11 @@ class ExternalStorage(metaclass=abc.ABCMeta):
             # 24 bytes to store owner address, metadata, and buffer lengths.
             assert self.HEADER_LENGTH + address_len + metadata_len + buf_len \
                 == len(payload)
-            # TODO (yic): Considering add retry here to avoid transient issue
-            try:
-                written_bytes = f.write(payload)
-                url_with_offset = create_url_with_offset(
-                    url=url, offset=offset, size=written_bytes)
-                keys.append(url_with_offset.encode())
-                offset = f.tell()
-            except IOError:
-                return keys
+            written_bytes = f.write(payload)
+            url_with_offset = create_url_with_offset(
+                url=url, offset=offset, size=written_bytes)
+            keys.append(url_with_offset.encode())
+            offset = f.tell()
         return keys
 
     def _size_check(self, address_len, metadata_len, buffer_len,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This test was flaky since (1) we didn't pin the objects, which caused them to get spilled, (2) the spill directory was also /dev/shm, which filled up.