### PR TITLE
Allow using `breakpoint()` to drop into Ray debugger

### DIFF
--- a/doc/source/ray-debugging.rst
+++ b/doc/source/ray-debugging.rst
@@ -106,8 +106,8 @@ following recursive function as an example:
         if n == 1:
             return n
         else:
-            n_id = fact.remote(n - 1)
-            return n * ray.get(n_id)
+            n_ref = fact.remote(n - 1)
+            return n * ray.get(n_ref)
 
     breakpoint()
     result_ref = fact.remote(5)
@@ -144,8 +144,8 @@ the following output:
       7  	    if n == 1:
       8  	        return n
       9  	    else:
-     10  	        n_id = fact.remote(n - 1)
-     11  	        return n * ray.get(n_id)
+     10  	        n_ref = fact.remote(n - 1)
+     11  	        return n * ray.get(n_ref)
     (Pdb) p(n)
     5
     (Pdb)

--- a/doc/source/ray-debugging.rst
+++ b/doc/source/ray-debugging.rst
@@ -25,7 +25,7 @@ Take the following example:
 
     @ray.remote
     def f(x):
-        ray.util.pdb.set_trace()
+        breakpoint()
         return x * x
 
     futures = [f.remote(i) for i in range(2)]
@@ -39,7 +39,7 @@ Put the program into a file named ``debugging.py`` and execute it using:
 
 
 Each of the 4 executed tasks will drop into a breakpoint when the line
-``ray.util.pdb.set_trace()`` is executed. You can attach to the debugger by running
+``breakpoint()`` is executed. You can attach to the debugger by running
 the following command on the head node of the cluster:
 
 .. code-block:: bash
@@ -109,7 +109,7 @@ following recursive function as an example:
             n_id = fact.remote(n - 1)
             return n * ray.get(n_id)
 
-    ray.util.pdb.set_trace()
+    breakpoint()
     result_ref = fact.remote(5)
     result = ray.get(result_ref)
 

--- a/doc/source/ray-debugging.rst
+++ b/doc/source/ray-debugging.rst
@@ -16,6 +16,11 @@ drop into a PDB session that you can then use to:
 Getting Started
 ---------------
 
+.. note::
+
+    On Python 3.6, the ``breakpoint()`` function is not supported and you need to use
+    ``ray.util.pdb.set_trace()`` instead.
+
 Take the following example:
 
 .. code-block:: python

--- a/python/ray/tests/test_ray_debugger.py
+++ b/python/ray/tests/test_ray_debugger.py
@@ -14,7 +14,7 @@ def test_ray_debugger_breakpoint(shutdown_only):
 
     @ray.remote
     def f():
-        breakpoint()
+        ray.util.pdb.set_trace()
         return 1
 
     result = f.remote()
@@ -45,7 +45,7 @@ def test_ray_debugger_commands(shutdown_only):
     @ray.remote
     def f():
         """We support unicode too: 🐛"""
-        breakpoint()
+        ray.util.pdb.set_trace()
 
     result1 = f.remote()
     result2 = f.remote()
@@ -55,7 +55,7 @@ def test_ray_debugger_commands(shutdown_only):
     p = pexpect.spawn("ray debug")
     p.expect("Enter breakpoint index or press enter to refresh: ")
     p.sendline("0")
-    p.expect("-> breakpoint()")
+    p.expect("-> ray.util.pdb.set_trace()")
     p.sendline("ll")
     # Cannot use the 🐛 symbol here because pexpect doesn't support
     # unicode, but this test also does nicely:
@@ -63,7 +63,7 @@ def test_ray_debugger_commands(shutdown_only):
     p.sendline("c")
     p.expect("Enter breakpoint index or press enter to refresh: ")
     p.sendline("0")
-    p.expect("-> breakpoint()")
+    p.expect("-> ray.util.pdb.set_trace()")
     p.sendline("c")
 
     ray.get([result1, result2])
@@ -80,7 +80,7 @@ def test_ray_debugger_stepping(shutdown_only):
 
     @ray.remote
     def f():
-        breakpoint()
+        ray.util.pdb.set_trace()
         x = g.remote()
         return ray.get(x)
 
@@ -109,7 +109,7 @@ def test_ray_debugger_recursive(shutdown_only):
     def fact(n):
         if n < 1:
             return n
-        breakpoint()
+        ray.util.pdb.set_trace()
         n_id = fact.remote(n - 1)
         return n * ray.get(n_id)
 

--- a/python/ray/tests/test_ray_debugger.py
+++ b/python/ray/tests/test_ray_debugger.py
@@ -55,7 +55,7 @@ def test_ray_debugger_commands(shutdown_only):
     p = pexpect.spawn("ray debug")
     p.expect("Enter breakpoint index or press enter to refresh: ")
     p.sendline("0")
-    p.expect("-> ray.util.pdb.set_trace()")
+    p.expect("-> breakpoint()")
     p.sendline("ll")
     # Cannot use the 🐛 symbol here because pexpect doesn't support
     # unicode, but this test also does nicely:
@@ -63,7 +63,7 @@ def test_ray_debugger_commands(shutdown_only):
     p.sendline("c")
     p.expect("Enter breakpoint index or press enter to refresh: ")
     p.sendline("0")
-    p.expect("-> ray.util.pdb.set_trace()")
+    p.expect("-> breakpoint()")
     p.sendline("c")
 
     ray.get([result1, result2])

--- a/python/ray/tests/test_ray_debugger.py
+++ b/python/ray/tests/test_ray_debugger.py
@@ -14,7 +14,7 @@ def test_ray_debugger_breakpoint(shutdown_only):
 
     @ray.remote
     def f():
-        ray.util.pdb.set_trace()
+        breakpoint()
         return 1
 
     result = f.remote()
@@ -45,7 +45,7 @@ def test_ray_debugger_commands(shutdown_only):
     @ray.remote
     def f():
         """We support unicode too: 🐛"""
-        ray.util.pdb.set_trace()
+        breakpoint()
 
     result1 = f.remote()
     result2 = f.remote()
@@ -80,7 +80,7 @@ def test_ray_debugger_stepping(shutdown_only):
 
     @ray.remote
     def f():
-        ray.util.pdb.set_trace()
+        breakpoint()
         x = g.remote()
         return ray.get(x)
 
@@ -109,7 +109,7 @@ def test_ray_debugger_recursive(shutdown_only):
     def fact(n):
         if n < 1:
             return n
-        ray.util.pdb.set_trace()
+        breakpoint()
         n_id = fact.remote(n - 1)
         return n * ray.get(n_id)
 

--- a/python/ray/util/rpdb.py
+++ b/python/ray/util/rpdb.py
@@ -97,7 +97,10 @@ class RemotePdb(Pdb):
             cry("RemotePdb accepted connection from %s." % repr(address))
         self.handle = LF2CRLF_FileWrapper(connection)
         Pdb.__init__(
-            self, completekey="tab", stdin=self.handle, stdout=self.handle,
+            self,
+            completekey="tab",
+            stdin=self.handle,
+            stdout=self.handle,
             skip=["ray.*"])
         self.backup = []
         if self._patch_stdstreams:

--- a/python/ray/util/rpdb.py
+++ b/python/ray/util/rpdb.py
@@ -97,7 +97,8 @@ class RemotePdb(Pdb):
             cry("RemotePdb accepted connection from %s." % repr(address))
         self.handle = LF2CRLF_FileWrapper(connection)
         Pdb.__init__(
-            self, completekey="tab", stdin=self.handle, stdout=self.handle)
+            self, completekey="tab", stdin=self.handle, stdout=self.handle,
+            skip=["ray.*"])
         self.backup = []
         if self._patch_stdstreams:
             for name in (

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1260,7 +1260,8 @@ def connect(node,
         # paths such as the client.
         job_config.set_ray_namespace(namespace)
 
-    # Make sure breakpoint() in the user's code will always invoke the Ray debugger.
+    # Make sure breakpoint() in the user's code will
+    # always invoke the Ray debugger.
     os.environ["PYTHONBREAKPOINT"] = "ray.util.rpdb.set_trace"
 
     serialized_job_config = job_config.serialize()

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1260,6 +1260,9 @@ def connect(node,
         # paths such as the client.
         job_config.set_ray_namespace(namespace)
 
+    # Make sure breakpoint() in the user's code will always invoke the Ray debugger.
+    os.environ["PYTHONBREAKPOINT"] = "ray.util.rpdb.set_trace"
+
     serialized_job_config = job_config.serialize()
     worker.core_worker = ray._raylet.CoreWorker(
         mode, node.plasma_store_socket_name, node.raylet_socket_name, job_id,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/17023

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
