### PR TITLE
[GCP] Allow Head Node to Launch Workers with IAM Role

### DIFF
--- a/python/ray/autoscaler/_private/gcp/config.py
+++ b/python/ray/autoscaler/_private/gcp/config.py
@@ -26,7 +26,7 @@ DEFAULT_SERVICE_ACCOUNT_CONFIG = {
     "displayName": "Ray Autoscaler Service Account ({})".format(VERSION),
 }
 DEFAULT_SERVICE_ACCOUNT_ROLES = ("roles/storage.objectAdmin",
-                                 "roles/compute.admin", 
+                                 "roles/compute.admin",
                                  "roles/iam.serviceAccountUser")
 # NOTE: iam.serviceAccountUser allows the Head Node to create worker nodes
 # with ServiceAccounts.

--- a/python/ray/autoscaler/_private/gcp/config.py
+++ b/python/ray/autoscaler/_private/gcp/config.py
@@ -28,6 +28,8 @@ DEFAULT_SERVICE_ACCOUNT_CONFIG = {
 DEFAULT_SERVICE_ACCOUNT_ROLES = ("roles/storage.objectAdmin",
                                  "roles/compute.admin", 
                                  "roles/iam.serviceAccountUser")
+# NOTE: iam.serviceAccountUser allows the Head Node to create worker nodes
+# with ServiceAccounts.
 
 MAX_POLLS = 12
 POLL_INTERVAL = 5

--- a/python/ray/autoscaler/_private/gcp/config.py
+++ b/python/ray/autoscaler/_private/gcp/config.py
@@ -26,7 +26,8 @@ DEFAULT_SERVICE_ACCOUNT_CONFIG = {
     "displayName": "Ray Autoscaler Service Account ({})".format(VERSION),
 }
 DEFAULT_SERVICE_ACCOUNT_ROLES = ("roles/storage.objectAdmin",
-                                 "roles/compute.admin")
+                                 "roles/compute.admin", 
+                                 "roles/iam.serviceAccountUser")
 
 MAX_POLLS = 12
 POLL_INTERVAL = 5
@@ -478,7 +479,6 @@ def _add_iam_policy_binding(service_account, roles, crm):
         resource=project_id, body={}).execute()
 
     already_configured = True
-
     for role in roles:
         role_exists = False
         for binding in policy["bindings"]:

--- a/python/ray/autoscaler/gcp/example-full.yaml
+++ b/python/ray/autoscaler/gcp/example-full.yaml
@@ -116,6 +116,7 @@ available_node_types:
             scheduling:
               - preemptible: true
             # Un-Comment this to launch workers with the Service Account of the Head Node
+            # serviceAccounts:
             # - email: ray-autoscaler-sa-v1@<project_id>.iam.gserviceaccount.com
             #   scopes:
             #   - https://www.googleapis.com/auth/cloud-platform

--- a/python/ray/autoscaler/gcp/example-full.yaml
+++ b/python/ray/autoscaler/gcp/example-full.yaml
@@ -115,6 +115,10 @@ available_node_types:
             # Comment this out to use on-demand.
             scheduling:
               - preemptible: true
+            # Un-Comment this to launch workers with the Service Account of the Head Node
+            # - email: ray-autoscaler-sa-v1@<project_id>.iam.gserviceaccount.com
+            #   scopes:
+            #   - https://www.googleapis.com/auth/cloud-platform
 
     # Additional options can be found in in the compute docs at
     # https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* This makes it possible to launch worker nodes with the `ray-autoscaler-sa-v1@<project_id>.iam.gserviceaccount.com` Account. This makes it possible for workers to leverage the same permissions as the head ndoe:

<!-- Please give a short summary of the change and the problem this solves. -->

Example of a NodeConfig that is now allowed:
```
        node_config:
            serviceAccounts:
            - email: ray-autoscaler-sa-v1@anyscale-dev.iam.gserviceaccount.com
              scopes:
              - https://www.googleapis.com/auth/cloud-platform
```

## Related issue number

<!-- For example: "Closes #1234" -->
* Closes https://github.com/ray-project/ray/issues/13799

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
