### PR TITLE
[flaky test] Fix a bad test related to reference counting.

### DIFF
--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -121,9 +121,6 @@ def test_return_object_ref(one_worker_100MiB, use_ray_put, failure):
     outer_oid = return_an_id.remote()
     inner_oid_binary = ray.get(outer_oid)[0].binary()
 
-    # Check that the inner ID is pinned by the outer ID.
-    _fill_object_store_and_get(inner_oid_binary)
-
     # Check that taking a reference to the inner ID and removing the outer ID
     # doesn't unpin the object.
     inner_oid = ray.get(outer_oid)[0]  # noqa: F841


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This line of the test is wrong actually. Since WaitForRefRemoved can come before/after task return, it'll introduce issues when it comes after the task return.

But it's totally fine since we'll get the request of WaitForRefRemoved eventually.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #16688 
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
