### PR TITLE
[Core] use shim process in dedicated_workers_to_tasks

### DIFF
--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -683,7 +683,7 @@ void WorkerPool::PushWorker(const std::shared_ptr<WorkerInterface> &worker) {
   RAY_CHECK(worker->GetAssignedTaskId().IsNil())
       << "Idle workers cannot have an assigned task ID";
   auto &state = GetStateForLanguage(worker->GetLanguage());
-  auto it = state.dedicated_workers_to_tasks.find(worker->GetProcess());
+  auto it = state.dedicated_workers_to_tasks.find(worker->GetShimProcess());
   if (it != state.dedicated_workers_to_tasks.end()) {
     // The worker is used for the actor creation task with dynamic options.
     // Put it into idle dedicated worker pool.

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -1218,8 +1218,8 @@ TEST_F(WorkerPoolTest, StartWorkWithDifferentShimPid) {
       {"-Dmy-actor.hello=foo", "-Dmy-actor.world=bar", "-Xmx2g", "-Xms1g"});
   auto task_id = TaskID::ForDriverTask(JOB_ID);
   auto actor_id = ActorID::Of(JOB_ID, task_id, 1);
-  TaskSpecification java_task_spec = ExampleTaskSpec(ActorID::Nil(), Language::JAVA, JOB_ID,
-                                                actor_id, actor_jvm_options, task_id);
+  TaskSpecification java_task_spec = ExampleTaskSpec(
+      ActorID::Nil(), Language::JAVA, JOB_ID, actor_id, actor_jvm_options, task_id);
   ASSERT_EQ(worker_pool_->PopWorker(java_task_spec), nullptr);
   last_process = worker_pool_->LastStartedWorkerProcess();
   pid_t java_shim_pid = last_process.GetId();

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -1210,6 +1210,26 @@ TEST_F(WorkerPoolTest, StartWorkWithDifferentShimPid) {
   // After worker finished starting, starting_worker_processes will erase this process.
   worker_pool_->OnWorkerStarted(worker);
   ASSERT_EQ(0, worker_pool_->NumWorkerProcessesStarting());
+
+  // test dedicated workers with different shim pid
+  std::vector<std::string> actor_jvm_options;
+  actor_jvm_options.insert(
+      actor_jvm_options.end(),
+      {"-Dmy-actor.hello=foo", "-Dmy-actor.world=bar", "-Xmx2g", "-Xms1g"});
+  auto task_id = TaskID::ForDriverTask(JOB_ID);
+  auto actor_id = ActorID::Of(JOB_ID, task_id, 1);
+  TaskSpecification java_task_spec = ExampleTaskSpec(ActorID::Nil(), Language::JAVA, JOB_ID,
+                                                actor_id, actor_jvm_options, task_id);
+  ASSERT_EQ(worker_pool_->PopWorker(java_task_spec), nullptr);
+  last_process = worker_pool_->LastStartedWorkerProcess();
+  pid_t java_shim_pid = last_process.GetId();
+  pid_t java_pid = java_shim_pid + 1000;
+  auto java_worker = CreateWorker(Process(), Language::JAVA);
+  RAY_CHECK_OK(worker_pool_->RegisterWorker(java_worker, java_pid, java_shim_pid,
+                                            [](Status, int) {}));
+  // Add the workers to the pool.
+  worker_pool_->PushWorker(java_worker);
+  ASSERT_TRUE(worker_pool_->PopWorker(java_task_spec) != nullptr);
 }
 
 }  // namespace raylet


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Start ray dedicated worker which has different shim pid from worker pid, the idle_dedicated_workers key is shim process, in WorkerPool::PushWorker cann't get the worker by the worker process, so the idle_dedicated_workers is always empty.




## Related issue number

Closes https://github.com/ray-project/ray/issues/17075

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
