### PR TITLE
[tune] `ResourceChangingScheduler` improvements

### DIFF
--- a/doc/source/tune/api_docs/schedulers.rst
+++ b/doc/source/tune/api_docs/schedulers.rst
@@ -246,6 +246,11 @@ evenly_distribute_cpus_gpus
 
 .. autofunction:: ray.tune.schedulers.resource_changing_scheduler.evenly_distribute_cpus_gpus
 
+evenly_distribute_cpus_gpus_distributed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: ray.tune.schedulers.resource_changing_scheduler.evenly_distribute_cpus_gpus_distributed
+
 FIFOScheduler
 -------------
 

--- a/doc/source/tune/api_docs/schedulers.rst
+++ b/doc/source/tune/api_docs/schedulers.rst
@@ -247,7 +247,7 @@ evenly_distribute_cpus_gpus
 .. autofunction:: ray.tune.schedulers.resource_changing_scheduler.evenly_distribute_cpus_gpus
 
 evenly_distribute_cpus_gpus_distributed
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: ray.tune.schedulers.resource_changing_scheduler.evenly_distribute_cpus_gpus_distributed
 

--- a/python/ray/tune/examples/xgboost_dynamic_resources_example.py
+++ b/python/ray/tune/examples/xgboost_dynamic_resources_example.py
@@ -112,8 +112,7 @@ def tune_xgboost():
 
     def example_resources_allocation_function(
             trial_runner: "trial_runner.TrialRunner", trial: Trial,
-            result: Dict[str, Any],
-            base_trial_resource: Union[PlacementGroupFactory, Resources]
+            result: Dict[str, Any], scheduler: "ResourceChangingScheduler"
     ) -> Union[None, PlacementGroupFactory, Resources]:
         """This is a basic example of a resource allocating function.
 
@@ -133,10 +132,13 @@ def tune_xgboost():
                 Can be used to obtain information about other trials.
             trial (Trial): The trial to allocate new resources to.
             result (Dict[str, Any]): The latest results of trial.
-            base_trial_resource (Union[PlacementGroupFactory, Resources]):
-                Base trial resources as defined in
-                ``tune.run(resources_per_trial)``
+            scheduler (ResourceChangingScheduler): The scheduler calling
+                the function.
         """
+
+        # Get base trial resources as defined in
+        # ``tune.run(resources_per_trial)``
+        base_trial_resource = scheduler._base_trial_resources
 
         # Don't bother if this is just the first iteration
         if result["training_iteration"] < 1:

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -451,8 +451,8 @@ class RayTrialExecutor(TrialExecutor):
             if not runner:
                 return False
         trial.set_runner(runner)
-        self.restore(trial, checkpoint)
         self._notify_trainable_of_new_resources_if_needed(trial)
+        self.restore(trial, checkpoint)
         self.set_status(trial, Trial.RUNNING)
 
         if trial in self._staged_trials:

--- a/python/ray/tune/schedulers/resource_changing_scheduler.py
+++ b/python/ray/tune/schedulers/resource_changing_scheduler.py
@@ -78,13 +78,17 @@ def evenly_distribute_cpus_gpus(
         upper_cpu_limit = 0
     else:
         upper_cpu_limit = math.ceil(total_available_cpus / num_running_trials)
-        upper_cpu_limit = max(min_cpu, upper_cpu_limit)
+        upper_cpu_limit = math.ceil(upper_cpu_limit / min_cpu) * min_cpu
+        upper_cpu_limit = max(min_cpu,
+                              min(upper_cpu_limit, total_available_cpus))
 
     if min_gpu == 0:
         upper_gpu_limit = 0
     else:
         upper_gpu_limit = math.ceil(total_available_gpus / num_running_trials)
-        upper_gpu_limit = max(min_gpu, upper_gpu_limit)
+        upper_gpu_limit = math.ceil(upper_gpu_limit / min_gpu) * min_gpu
+        upper_gpu_limit = max(min_gpu,
+                              min(upper_gpu_limit, total_available_gpus))
 
     # Function to check how many CPUs and GPUs a trial is using currently
     def get_used_cpus_and_gpus(t: Trial):
@@ -109,6 +113,10 @@ def evenly_distribute_cpus_gpus(
     # Add free CPUs and GPUs enforcing upper and lower limits
     new_cpu = min(upper_cpu_limit, max(trial_used_cpus + free_cpus, min_cpu))
     new_gpu = min(upper_gpu_limit, max(trial_used_gpus + free_gpus, min_gpu))
+
+    print(
+        f"total_available_cpus:{total_available_cpus} min_cpu:{min_cpu} num_running_trials:{num_running_trials} upper_cpu_limit:{upper_cpu_limit} trial_used_cpus:{trial_used_cpus} used_cpus:{used_cpus} free_cpus:{free_cpus} new_cpu:{new_cpu}"
+    )
 
     # Assign new CPUs and GPUs to the trial in a PlacementGroupFactory
     return PlacementGroupFactory([{"CPU": new_cpu, "GPU": new_gpu}])

--- a/python/ray/tune/schedulers/resource_changing_scheduler.py
+++ b/python/ray/tune/schedulers/resource_changing_scheduler.py
@@ -14,19 +14,20 @@ from ray.tune.utils.placement_groups import PlacementGroupFactory
 logger = logging.getLogger(__name__)
 
 
-def evenly_distribute_cpus_gpus(
-        trial_runner: "trial_runner.TrialRunner", trial: Trial,
-        result: Dict[str, Any], scheduler: "ResourceChangingScheduler"
-) -> Union[None, PlacementGroupFactory, Resources]:
+def evenly_distribute_cpus_gpus(trial_runner: "trial_runner.TrialRunner",
+                                trial: Trial, result: Dict[str, Any],
+                                scheduler: "ResourceChangingScheduler"
+                                ) -> Union[None, PlacementGroupFactory]:
     """This is a basic resource allocating function.
 
     This function is used by default in ``ResourceChangingScheduler``.
 
     The function naively balances free resources (CPUs and GPUs) between
     trials, giving them all equal priority, ensuring that all resources
-    are always being used. If for some reason a trial ends up with
-    more resources than there are free ones, it will adjust downwards.
+    are always being used. All of the resources will be placed in one bundle.
 
+    If for some reason a trial ends up with
+    more resources than there are free ones, it will adjust downwards.
     It will also ensure that trial as at least as many resources as
     it started with (``base_trial_resource``).
 

--- a/python/ray/tune/schedulers/resource_changing_scheduler.py
+++ b/python/ray/tune/schedulers/resource_changing_scheduler.py
@@ -278,11 +278,16 @@ class ResourceChangingScheduler(TrialScheduler):
 
         any_resources_changed = False
 
+        new_trials_to_reallocate = {}
         for trial, new_resources in self._trials_to_reallocate.items():
+            if trial.status == Trial.RUNNING:
+                new_trials_to_reallocate[trial] = new_resources
+                logger.debug(f"{trial} is still running, skipping for now")
+                continue
             any_resources_changed = (any_resources_changed
                                      or self.set_trial_resources(
                                          trial, new_resources))
-        self._trials_to_reallocate.clear()
+        self._trials_to_reallocate = new_trials_to_reallocate
 
         if any_resources_changed:
             # force reconcilation to ensure resource changes

--- a/python/ray/tune/schedulers/resource_changing_scheduler.py
+++ b/python/ray/tune/schedulers/resource_changing_scheduler.py
@@ -73,18 +73,19 @@ def evenly_distribute_cpus_gpus(
     # Set upper limits for resources based on number of live trials
     # to ensure that the trial cannot get more resources that it's
     # possible to run
+    len_running_trials_minus_this = len(trial_runner.get_live_trials()) - 1
     if min_cpu == 0:
         upper_cpu_limit = 0
     else:
-        upper_cpu_limit = math.ceil(total_available_cpus / len(
-            trial_runner.get_live_trials()) / min_cpu)
+        upper_cpu_limit = math.ceil(total_available_cpus / max(
+            1, (len_running_trials_minus_this * min_cpu)))
         upper_cpu_limit = max(min_cpu, upper_cpu_limit)
 
     if min_gpu == 0:
         upper_gpu_limit = 0
     else:
-        upper_gpu_limit = math.ceil(total_available_gpus / len(
-            trial_runner.get_live_trials()) / min_gpu)
+        upper_gpu_limit = math.ceil(total_available_gpus / max(
+            1, (len_running_trials_minus_this * min_gpu)))
         upper_gpu_limit = max(min_gpu, upper_gpu_limit)
 
     # Function to check how many CPUs and GPUs a trial is using currently

--- a/python/ray/tune/schedulers/resource_changing_scheduler.py
+++ b/python/ray/tune/schedulers/resource_changing_scheduler.py
@@ -78,12 +78,14 @@ def evenly_distribute_cpus_gpus(
     else:
         upper_cpu_limit = math.ceil(total_available_cpus / len(
             trial_runner.get_live_trials()) / min_cpu)
+        upper_cpu_limit = max(min_cpu, upper_cpu_limit)
 
     if min_gpu == 0:
         upper_gpu_limit = 0
     else:
         upper_gpu_limit = math.ceil(total_available_gpus / len(
             trial_runner.get_live_trials()) / min_gpu)
+        upper_gpu_limit = max(min_gpu, upper_gpu_limit)
 
     # Function to check how many CPUs and GPUs a trial is using currently
     def get_used_cpus_and_gpus(t: Trial):

--- a/python/ray/tune/schedulers/resource_changing_scheduler.py
+++ b/python/ray/tune/schedulers/resource_changing_scheduler.py
@@ -27,7 +27,7 @@ class _DistributeResources:
                  ) -> Union[None, PlacementGroupFactory]:
         # Get base trial resources as defined in
         # ``tune.run(resources_per_trial)``
-        base_trial_resource = scheduler._base_trial_resources
+        base_trial_resource = scheduler.base_trial_resources
 
         if not isinstance(base_trial_resource, PlacementGroupFactory):
             raise ValueError("evenly_distribute_cpus_gpus only supports"
@@ -298,6 +298,11 @@ class ResourceChangingScheduler(TrialScheduler):
     @property
     def metric(self):
         return self._base_scheduler._metric
+
+    @property
+    def base_trial_resources(
+            self) -> Optional[Union[Resources, PlacementGroupFactory]]:
+        return self._base_trial_resources
 
     def set_search_properties(self, metric: Optional[str],
                               mode: Optional[str]) -> bool:

--- a/python/ray/tune/schedulers/resource_changing_scheduler.py
+++ b/python/ray/tune/schedulers/resource_changing_scheduler.py
@@ -73,19 +73,17 @@ def evenly_distribute_cpus_gpus(
     # Set upper limits for resources based on number of live trials
     # to ensure that the trial cannot get more resources that it's
     # possible to run
-    len_running_trials_minus_this = len(trial_runner.get_live_trials()) - 1
+    num_running_trials = len(trial_runner.get_live_trials())
     if min_cpu == 0:
         upper_cpu_limit = 0
     else:
-        upper_cpu_limit = math.ceil(total_available_cpus / max(
-            1, (len_running_trials_minus_this * min_cpu)))
+        upper_cpu_limit = math.ceil(total_available_cpus / num_running_trials)
         upper_cpu_limit = max(min_cpu, upper_cpu_limit)
 
     if min_gpu == 0:
         upper_gpu_limit = 0
     else:
-        upper_gpu_limit = math.ceil(total_available_gpus / max(
-            1, (len_running_trials_minus_this * min_gpu)))
+        upper_gpu_limit = math.ceil(total_available_gpus / num_running_trials)
         upper_gpu_limit = max(min_gpu, upper_gpu_limit)
 
     # Function to check how many CPUs and GPUs a trial is using currently

--- a/python/ray/tune/schedulers/resource_changing_scheduler.py
+++ b/python/ray/tune/schedulers/resource_changing_scheduler.py
@@ -78,17 +78,13 @@ def evenly_distribute_cpus_gpus(
         upper_cpu_limit = 0
     else:
         upper_cpu_limit = math.ceil(total_available_cpus / num_running_trials)
-        upper_cpu_limit = math.ceil(upper_cpu_limit / min_cpu) * min_cpu
-        upper_cpu_limit = max(min_cpu,
-                              min(upper_cpu_limit, total_available_cpus))
+        upper_cpu_limit = max(min_cpu, upper_cpu_limit)
 
     if min_gpu == 0:
         upper_gpu_limit = 0
     else:
         upper_gpu_limit = math.ceil(total_available_gpus / num_running_trials)
-        upper_gpu_limit = math.ceil(upper_gpu_limit / min_gpu) * min_gpu
-        upper_gpu_limit = max(min_gpu,
-                              min(upper_gpu_limit, total_available_gpus))
+        upper_gpu_limit = max(min_gpu, upper_gpu_limit)
 
     # Function to check how many CPUs and GPUs a trial is using currently
     def get_used_cpus_and_gpus(t: Trial):

--- a/python/ray/tune/schedulers/resource_changing_scheduler.py
+++ b/python/ray/tune/schedulers/resource_changing_scheduler.py
@@ -110,10 +110,6 @@ def evenly_distribute_cpus_gpus(
     new_cpu = min(upper_cpu_limit, max(trial_used_cpus + free_cpus, min_cpu))
     new_gpu = min(upper_gpu_limit, max(trial_used_gpus + free_gpus, min_gpu))
 
-    print(
-        f"total_available_cpus:{total_available_cpus} min_cpu:{min_cpu} num_running_trials:{num_running_trials} upper_cpu_limit:{upper_cpu_limit} trial_used_cpus:{trial_used_cpus} used_cpus:{used_cpus} free_cpus:{free_cpus} new_cpu:{new_cpu}"
-    )
-
     # Assign new CPUs and GPUs to the trial in a PlacementGroupFactory
     return PlacementGroupFactory([{"CPU": new_cpu, "GPU": new_gpu}])
 

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -499,6 +499,8 @@ class Trainable:
             self, new_resources: Union[PlacementGroupFactory, Resources]):
         """Fires whenever Trainable resources are changed.
 
+        This method will be called before the checkpoint is loaded.
+
         Args:
             new_resources (PlacementGroupFactory|Resources):
                 Updated resources. Will be a PlacementGroupFactory if


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Instead of passing the `base_trial_resources`, we should pass the entire `ResourceChangingScheduler` to the `resources_allocation_function`. That way, users can access all of its attributes in the function.

A secondary built-in resources allocation function is provided, which adds new resource bundles (intended for distributed training jobs).

This PR also changes the order of execution so that the Trainable is notified of new resources *before* loading from checkpoint, and fixes an exception if the resources were changed in a trial that wasn't paused yet.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
