### PR TITLE
[Dataset] Fix S3FileSystem subsystem initialization on deserialization.

### DIFF
--- a/python/ray/experimental/data/datasource/__init__.py
+++ b/python/ray/experimental/data/datasource/__init__.py
@@ -3,12 +3,13 @@ from ray.experimental.data.datasource.datasource import (
 from ray.experimental.data.datasource.json_datasource import JSONDatasource
 from ray.experimental.data.datasource.csv_datasource import CSVDatasource
 from ray.experimental.data.datasource.file_based_datasource import (
-    FileBasedDatasource)
+    FileBasedDatasource, _S3FileSystemWrapper)
 
 __all__ = [
     "JSONDatasource",
     "CSVDatasource",
     "FileBasedDatasource",
+    "_S3FileSystemWrapper",
     "Datasource",
     "RangeDatasource",
     "DummyOutputDatasource",

--- a/python/ray/experimental/data/impl/reader.py
+++ b/python/ray/experimental/data/impl/reader.py
@@ -1,5 +1,7 @@
 from typing import Any, Union, Optional, Tuple, TYPE_CHECKING
 
+from ray.experimental.data.datasource import _S3FileSystemWrapper
+
 if TYPE_CHECKING:
     import pyarrow
 
@@ -15,6 +17,8 @@ def read_file(path: str,
       the path and the contents of the file.
     """
     if filesystem:
+        if isinstance(filesystem, _S3FileSystemWrapper):
+            filesystem = filesystem.unwrap()
         contents = filesystem.open_input_stream(path).readall()
     else:
         contents = open(path, "rb").read()

--- a/python/ray/experimental/data/read_api.py
+++ b/python/ray/experimental/data/read_api.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 import ray
 from ray.experimental.data.dataset import Dataset
 from ray.experimental.data.datasource import Datasource, RangeDatasource, \
-    JSONDatasource, CSVDatasource, ReadTask
+    JSONDatasource, CSVDatasource, ReadTask, _S3FileSystemWrapper
 from ray.experimental.data.impl import reader as _reader
 from ray.experimental.data.impl.arrow_block import ArrowBlock, ArrowRow
 from ray.experimental.data.impl.block import ObjectRef, SimpleBlock, Block, \
@@ -322,7 +322,11 @@ def read_binary_files(
     Returns:
         Dataset holding Arrow records read from the specified paths.
     """
+    import pyarrow as pa
+
     dataset = from_items(paths, parallelism=parallelism)
+    if isinstance(filesystem, pa.fs.S3FileSystem):
+        filesystem = _S3FileSystemWrapper(filesystem)
     return dataset.map(
         lambda path: _reader.read_file(
             path,


### PR DESCRIPTION
Fixes S3FileSystem subsystem initialization on deserialization by creating an `_S3FileSystemWrapper` class that wraps `S3FileSystem` with a deserialization hook that imports `pyarrow.fs`, implicitly triggering the S3 subsystem initialization. So far this has been applied to the file-based datasource readers (JSON and CSV) and to `read_binary_files`.

## TODOs

- [ ] (Optional) Test coverage with an `S3FileSystem` fixture. This could wait until a future PR since the fix is a P1 but test coverage is a P2.

## Related issue number

Closes #17085

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
