### PR TITLE
[data] Fix the ObjectRef type in the dataset docs

### DIFF
--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -187,11 +187,11 @@ Datasets can be written to local or remote storage using ``.write_csv()``, ``.wr
 .. code-block:: python
 
     # Write to csv files in /tmp/output.
-    ds = ray.data.range(10000).write_csv("/tmp/output")
+    ray.data.range(10000).write_csv("/tmp/output")
     # -> /tmp/output/data0.csv, /tmp/output/data1.csv, ...
 
     # Use repartition to control the number of output files:
-    ds = ray.data.range(10000).repartition(1).write_csv("/tmp/output2")
+    ray.data.range(10000).repartition(1).write_csv("/tmp/output2")
     # -> /tmp/output2/data0.csv
 
 Transforming Datasets
@@ -220,7 +220,7 @@ To take advantage of vectorized functions, use ``.map_batches()``. Note that you
 
 .. code-block:: python
 
-    ds = ray.data.range(10000)
+    ds = ray.data.range_arrow(10000)
     ds = ds.map_batches(lambda df: df.applymap(lambda x: x * 2), batch_format="pandas")
     # -> Map Progress: 100%|█████████████████████████| 200/200 [00:00<00:00, 1927.62it/s]
     ds.take(5)

--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -173,7 +173,7 @@ Finally, you can create a Dataset from existing data in the Ray object store or 
 
     # Create a Dataset from a list of Pandas DataFrame objects.
     pdf = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
-    ds = ray.experimental.data.from_pandas([ray.put(pdf)])
+    ds = ray.data.from_pandas([ray.put(pdf)])
 
     # Create a Dataset from a Dask-on-Ray DataFrame.
     dask_df = dd.from_pandas(pdf, npartitions=10)

--- a/doc/source/data/package-ref.rst
+++ b/doc/source/data/package-ref.rst
@@ -3,33 +3,33 @@ Datasets API Reference
 
 Creating a Dataset
 ------------------
-.. autofunction:: ray.experimental.data.range
-.. autofunction:: ray.experimental.data.range_arrow
-.. autofunction:: ray.experimental.data.read_csv
-.. autofunction:: ray.experimental.data.read_json
-.. autofunction:: ray.experimental.data.read_parquet
-.. autofunction:: ray.experimental.data.read_binary_files
-.. autofunction:: ray.experimental.data.read_datasource
-.. autofunction:: ray.experimental.data.from_spark
-.. autofunction:: ray.experimental.data.from_dask
-.. autofunction:: ray.experimental.data.from_modin
-.. autofunction:: ray.experimental.data.from_mars
-.. autofunction:: ray.experimental.data.from_pandas
+.. autofunction:: ray.data.range
+.. autofunction:: ray.data.range_arrow
+.. autofunction:: ray.data.read_csv
+.. autofunction:: ray.data.read_json
+.. autofunction:: ray.data.read_parquet
+.. autofunction:: ray.data.read_binary_files
+.. autofunction:: ray.data.read_datasource
+.. autofunction:: ray.data.from_spark
+.. autofunction:: ray.data.from_dask
+.. autofunction:: ray.data.from_modin
+.. autofunction:: ray.data.from_mars
+.. autofunction:: ray.data.from_pandas
 
 Dataset API
 -----------
 
-.. autoclass:: ray.experimental.data.Dataset
+.. autoclass:: ray.data.Dataset
     :members:
 
 Custom Datasource API
 ---------------------
 
-.. autoclass:: ray.experimental.data.Datasource
+.. autoclass:: ray.data.Datasource
     :members:
 
-.. autoclass:: ray.experimental.data.ReadTask
+.. autoclass:: ray.data.ReadTask
     :members:
 
-.. autoclass:: ray.experimental.data.WriteTask
+.. autoclass:: ray.data.WriteTask
     :members:

--- a/python/ray/experimental/data/block.py
+++ b/python/ray/experimental/data/block.py
@@ -6,8 +6,6 @@ if TYPE_CHECKING:
     import pyarrow
     from ray.experimental.data.impl.block_builder import BlockBuilder
 
-# TODO(ekl) shouldn't Ray provide an ObjectRef type natively?
-ObjectRef = List
 T = TypeVar("T")
 
 

--- a/python/ray/experimental/data/dataset.py
+++ b/python/ray/experimental/data/dataset.py
@@ -20,7 +20,8 @@ import itertools
 import numpy as np
 
 import ray
-from ray.experimental.data.block import ObjectRef, Block, BlockMetadata
+from ray.types import ObjectRef
+from ray.experimental.data.block import Block, BlockMetadata
 from ray.experimental.data.datasource import Datasource, WriteTask
 from ray.experimental.data.impl.batcher import Batcher
 from ray.experimental.data.impl.compute import get_compute

--- a/python/ray/experimental/data/datasource/datasource.py
+++ b/python/ray/experimental/data/datasource/datasource.py
@@ -4,7 +4,8 @@ from typing import Any, Generic, List, Callable, Union
 import numpy as np
 
 import ray
-from ray.experimental.data.block import Block, BlockMetadata, ObjectRef, T
+from ray.types import ObjectRef
+from ray.experimental.data.block import Block, BlockMetadata, T
 from ray.experimental.data.impl.block_builder import SimpleBlock
 from ray.experimental.data.impl.arrow_block import ArrowRow, ArrowBlock
 

--- a/python/ray/experimental/data/impl/block_list.py
+++ b/python/ray/experimental/data/impl/block_list.py
@@ -1,6 +1,7 @@
 from typing import Iterable, List
 
-from ray.experimental.data.block import Block, BlockMetadata, ObjectRef, T
+from ray.types import ObjectRef
+from ray.experimental.data.block import Block, BlockMetadata, T
 
 
 class BlockList(Iterable[ObjectRef[Block[T]]]):

--- a/python/ray/experimental/data/impl/compute.py
+++ b/python/ray/experimental/data/impl/compute.py
@@ -1,7 +1,8 @@
 from typing import TypeVar, Iterable, Any, Union
 
 import ray
-from ray.experimental.data.block import Block, BlockMetadata, ObjectRef
+from ray.types import ObjectRef
+from ray.experimental.data.block import Block, BlockMetadata
 from ray.experimental.data.impl.block_list import BlockList
 from ray.experimental.data.impl.progress_bar import ProgressBar
 

--- a/python/ray/experimental/data/impl/lazy_block_list.py
+++ b/python/ray/experimental/data/impl/lazy_block_list.py
@@ -1,6 +1,7 @@
 from typing import Callable, List
 
-from ray.experimental.data.block import Block, BlockMetadata, ObjectRef, T
+from ray.types import ObjectRef
+from ray.experimental.data.block import Block, BlockMetadata, T
 from ray.experimental.data.impl.block_list import BlockList
 
 

--- a/python/ray/experimental/data/impl/progress_bar.py
+++ b/python/ray/experimental/data/impl/progress_bar.py
@@ -1,7 +1,7 @@
 from typing import List
 
 import ray
-from ray.experimental.data.block import ObjectRef
+from ray.types import ObjectRef
 
 try:
     import tqdm

--- a/python/ray/experimental/data/read_api.py
+++ b/python/ray/experimental/data/read_api.py
@@ -13,7 +13,8 @@ if TYPE_CHECKING:
     import pyspark
 
 import ray
-from ray.experimental.data.block import ObjectRef, Block, BlockMetadata
+from ray.types import ObjectRef
+from ray.experimental.data.block import Block, BlockMetadata
 from ray.experimental.data.dataset import Dataset
 from ray.experimental.data.datasource import Datasource, RangeDatasource, \
     JSONDatasource, CSVDatasource, ReadTask

--- a/python/ray/types.py
+++ b/python/ray/types.py
@@ -1,0 +1,9 @@
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+# TODO(ekl) this is a dummy generic ref type for documentation purposes only.
+# We should try to make the Cython ray.ObjectRef properly generic.
+class ObjectRef(Generic[T]):
+    pass


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Replace the bad placeholder type (List) with a proper ObjectRef class. Would be nice to figure out how to make the Cython type generic so we can use `ray.ObjectRef[T]` directly, but I couldn't figure it out.