### PR TITLE
[CI] Fix share volume file leak

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -338,6 +338,7 @@ build_wheels() {
         docker run --rm -w /ray -v "${PWD}":/ray "${MOUNT_BAZEL_CACHE[@]}" \
         quay.io/pypa/manylinux2014_x86_64 /ray/python/build-wheel-manylinux2014.sh
       else
+        rm -rf /ray-mount/*
         cp -rT /ray /ray-mount
         ls /ray-mount
         docker run --rm -v /ray:/ray-mounted ubuntu:focal ls /


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In any buildkite CI job, it will start dind on demand and start buildkite-job container. And the dind container's `/ray` is shared with buildkite-job container's `/ray-mount`.

The buildkite-job container will copy its `/ray` to `/ray-mount`, so the dind container's `/ray` will contains all source files, but the buildkite-job does not clean these files after job finished.

When a new buildkite-job container started in the same node, it will try to build Ray by `docker run --rm -w /ray -v /ray:/ray quay.io/pypa/manylinux2014_x86_64 /ray/python/build-wheel-manylinux2014.sh`, but the `/ray` in dind container still contains some files which belong to last buildkite-job.


## Related issue number

Closes https://github.com/ray-project/ray/issues/17121

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
