### PR TITLE
[nightly-test] increase timeout to 1 hour

### DIFF
--- a/benchmarks/benchmark_tests.yaml
+++ b/benchmarks/benchmark_tests.yaml
@@ -22,7 +22,7 @@
     compute_template: object_store.yaml
 
   run:
-    timeout: 600
+    timeout: 3600
     prepare: sleep 0
     script: python object_store/test_object_store.py
 


### PR DESCRIPTION
autoscaler takes while to scale the cluster to 50 nodes. (The latest run takes 30+ minutes). We increase it to 1 hour.

Test plan
- [x] Trigger a new run with this new timeout to verify it [worked](https://beta.anyscale.com/o/anyscale-internal/projects/prj_SVFGM5yBqK6DHCfLtRMryXHM/clusters/ses_4a1jxvBciJCQQRxb7NUiu4a7)