### PR TITLE
fix GcsServerAddressUpdater shutdown order

### DIFF
--- a/src/ray/core_worker/gcs_server_address_updater.cc
+++ b/src/ray/core_worker/gcs_server_address_updater.cc
@@ -41,12 +41,12 @@ GcsServerAddressUpdater::GcsServerAddressUpdater(
 
 GcsServerAddressUpdater::~GcsServerAddressUpdater() {
   updater_runner_.reset();
-  raylet_client_.reset();
   updater_io_service_.stop();
   if (updater_thread_->joinable()) {
     updater_thread_->join();
   }
   updater_thread_.reset();
+  raylet_client_.reset();
 }
 
 void GcsServerAddressUpdater::UpdateGcsServerAddress() {


### PR DESCRIPTION
There is a race condition on core worker destruction: specifically, during shutdown the ray::GcsServerAddressUpdater::UpdateGcsServerAddress is called on an released raylet_client_.

Changing the destruction order should fix this issue.

```
4966 [2021-07-15 21:09:34,193 D 101501 101860] gcs_server_address_updater.cc:53: Getting gcs server address from raylet.
4967 [2021-07-15 21:09:34,331 D 101501 101896] service_based_accessor.cc:1305: Adding profile data, component type = worker, node id = d97629eda9d89d8e4618b434dfeb3cfe340902c5acf8ba87729bf124
4968 [2021-07-15 21:09:34,331 D 101501 101896] profiling.cc:84: Pushed 3 events to GCS.
4969 [2021-07-15 21:09:34,332 D 101501 101896] service_based_accessor.cc:1315: Finished adding profile data, status = OK, component type = worker, node id = d97629eda9d89d8e4618b434dfeb3cfe340902c5acf8ba87729bf124
4970 [2021-07-15 21:09:35,186 I 101501 101896] core_worker.cc:756: Exit signal received, this process will exit after all outstanding tasks have finished, exit_type=IDLE_EXIT
4971 [2021-07-15 21:09:35,186 D 101501 101501] redis_client.cc:196: RedisClient disconnected.
4972 [2021-07-15 21:09:35,186 D 101501 101501] redis_context.cc:277: Redis async context disconnected. Status: 0
4973 [2021-07-15 21:09:35,186 D 101501 101501] service_based_gcs_client.cc:128: ServiceBasedGcsClient Disconnected.
4974 [2021-07-15 21:09:35,186 I 101501 101501] core_worker.cc:325: Removed worker d97629eda9d89d8e4618b434dfeb3cfe340902c5acf8ba87729bf124
4975 [2021-07-15 21:09:35,193 D 101501 101860] gcs_server_address_updater.cc:53: Getting gcs server address from raylet.
4976 [2021-07-15 21:09:35,220 E 101501 101860] logging.cc:299: *** SIGSEGV received at time=1626383375 on cpu 9 ***
4977 [2021-07-15 21:09:35,220 E 101501 101860] logging.cc:299: PC: @     0x7f74a1145f47  (unknown)  ray::GcsServerAddressUpdater::UpdateGcsServerAddress()
4978 [2021-07-15 21:09:35,222 E 101501 101860] logging.cc:299:     @     0x7f74a27b53c0       1568  (unknown)
4979 [2021-07-15 21:09:35,222 E 101501 101860] logging.cc:299:     @     0x7f74a1503399        192  ray::PeriodicalRunner::DoRunFnPeriodically()
4980 [2021-07-15 21:09:35,222 E 101501 101860] logging.cc:299:     @     0x7f74a1504b02        192  boost::asio::detail::executor_function<>::do_complete()
4981 [2021-07-15 21:09:35,222 E 101501 101860] logging.cc:299:     @     0x7f74a10ab350         80  boost::asio::io_context::executor_type::dispatch<>()
4982 [2021-07-15 21:09:35,222 E 101501 101860] logging.cc:299:     @     0x7f74a1504311        336  boost::asio::detail::wait_handler<>::do_complete()
4983 [2021-07-15 21:09:35,222 E 101501 101860] logging.cc:299:     @     0x7f74a1618321        112  boost::asio::detail::scheduler::do_run_one()
4984 [2021-07-15 21:09:35,222 E 101501 101860] logging.cc:299:     @     0x7f74a1618459        176  boost::asio::detail::scheduler::run()
4985 [2021-07-15 21:09:35,222 E 101501 101860] logging.cc:299:     @     0x7f74a161a184         64  boost::asio::io_context::run()
4986 [2021-07-15 21:09:35,222 E 101501 101860] logging.cc:299:     @     0x7f74a1144b09        128  std::thread::_State_impl<>::_M_run()
4987 [2021-07-15 21:09:35,222 E 101501 101860] logging.cc:299:     @     0x7f74a0b1e19d  (unknown)  execute_native_thread_routine
4988 [2021-07-15 21:09:35,224 E 101501 101860] logging.cc:299:     @     0x561034313bb0  1832497568  (unknown)
4989 [2021-07-15 21:09:35,227 E 101501 101860] logging.cc:299:     @     0x7f74a1144510  (unknown)  (unknown)
4990 [2021-07-15 21:09:35,229 E 101501 101860] logging.cc:299:     @ 0xcde907894800a39e  (unknown)  (unknown)

```

TODO:
- [ ] How to test this?