### PR TITLE
[core] Fix SIGABRT on erase call

### DIFF
--- a/src/ray/object_manager/plasma/plasma_allocator.cc
+++ b/src/ray/object_manager/plasma/plasma_allocator.cc
@@ -49,7 +49,9 @@ void *PlasmaAllocator::Memalign(size_t alignment, size_t bytes) {
       return nullptr;
     }
   }
+  RAY_LOG(DEBUG) << "allocating " << bytes;
   void *mem = dlmemalign(alignment, bytes);
+  RAY_LOG(DEBUG) << "allocated " << bytes << " at " << mem;
   if (!mem) {
     return nullptr;
   }
@@ -75,6 +77,7 @@ void *PlasmaAllocator::DiskMemalignUnlimited(size_t alignment, size_t bytes) {
 }
 
 void PlasmaAllocator::Free(void *mem, size_t bytes) {
+  RAY_LOG(DEBUG) << "deallocating " << bytes << " at " << mem;
   dlfree(mem);
   allocated_ -= bytes;
   if (RayConfig::instance().plasma_unlimited() && IsOutsideInitialAllocation(mem)) {

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -623,9 +623,15 @@ int PlasmaStore::RemoveFromClientObjectIds(const ObjectID &object_id,
 }
 
 void PlasmaStore::EraseFromObjectTable(const ObjectID &object_id) {
-  auto &object = store_info_.objects[object_id];
+  auto object = GetObjectTableEntry(&store_info_, object_id);
+  if (object == nullptr) {
+    RAY_LOG(WARNING) << object_id << " has already been deleted.";
+    return;
+  }
   auto buff_size = object->data_size + object->metadata_size;
   if (object->device_num == 0) {
+    RAY_LOG(DEBUG) << "Erasing object: " << object_id << ", address: " << object->pointer
+                   << ", size:" << buff_size;
     PlasmaAllocator::Free(object->pointer, buff_size);
   }
   if (object->state == ObjectState::PLASMA_CREATED) {

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -630,7 +630,8 @@ void PlasmaStore::EraseFromObjectTable(const ObjectID &object_id) {
   }
   auto buff_size = object->data_size + object->metadata_size;
   if (object->device_num == 0) {
-    RAY_LOG(DEBUG) << "Erasing object: " << object_id << ", address: " << object->pointer
+    RAY_LOG(DEBUG) << "Erasing object: " << object_id
+                   << ", address: " << static_cast<void *>(object->pointer)
                    << ", size:" << buff_size;
     PlasmaAllocator::Free(object->pointer, buff_size);
   }


### PR DESCRIPTION
we've seen SIGABRT EraseFromObjectTable call, which is most likely caused by `auto &object = store_info_.objects[object_id];` which creates an empty object entry if the object_id doesn't exist. This fixes the behavior.

also per dlmalloc's [documents](http://gee.cs.oswego.edu/pub/misc/malloc-2.8.4.c):

```
/*
  free(void* p)
  Releases the chunk of memory pointed to by p, that had been previously
  allocated using malloc or a related routine such as realloc.
  It has no effect if p is null. If p was not malloced or already
  freed, free(p) will by default cause the current program to abort.
*/
```


```
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299: *** SIGABRT received at time=1626467718 on cpu 7 ***
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299: PC: @     0x7fd426e7018b  (unknown)  raise
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @     0x7fd4273873c0       3936  (unknown)
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @     0x55854f4ab9e2         32  plasma::PlasmaAllocator::Free()
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @     0x55854f4b5fb4         96  plasma::PlasmaStore::EraseFromObjectTable()
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @     0x55854f4b6111         48  plasma::PlasmaStore::DeleteObject()
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @     0x55854f4bb925        448  plasma::PlasmaStore::ProcessMessage()
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @     0x55854f4ad2ff         32  std::_Function_handler<>::_M_invoke()
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @     0x55854f4ce966        160  std::_Function_handler<>::_M_invoke()
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @     0x55854f7650f2        128  ray::ClientConnection::ProcessMessage()
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @     0x55854f761c78        128  boost::asio::detail::read_op<>::operator()()
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @     0x55854f76202b        128  boost::asio::detail::executor_function<>::do_complete()
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @     0x55854f357880         80  boost::asio::io_context::executor_type::dispatch<>()
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @     0x55854f762973        192  boost::asio::executor::dispatch<>()
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @     0x55854f762b68        224  boost::asio::detail::reactive_socket_recv_op<>::do_complete()
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @     0x55854fb7d351        112  boost::asio::detail::scheduler::do_run_one()
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @     0x55854fb7d481        176  boost::asio::detail::scheduler::run()
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @     0x55854fb7f680         64  boost::asio::io_context::run()
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @     0x55854f4ac41b        304  plasma::PlasmaStoreRunner::Start()
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @     0x55854f43ef67        208  std::thread::_State_impl<>::_M_run()
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @     0x55854fbc0960  (unknown)  execute_native_thread_routine
[2021-07-16 13:35:18,484 E 96 123] logging.cc:299:     @ ... and at least 3 more frames
```