### PR TITLE
[C++ API] support get ray address from env

### DIFF
--- a/cpp/include/ray/api/ray_config.h
+++ b/cpp/include/ray/api/ray_config.h
@@ -12,6 +12,8 @@ namespace api {
 class RayConfig {
  public:
   // The address of the Ray cluster to connect to.
+  // If not provided, it will be initialized from environment variable "RAY_ADDRESS" by
+  // default.
   std::string address = "";
 
   // Whether or not to run this application in a local mode. This is used for debugging.

--- a/cpp/src/ray/config_internal.cc
+++ b/cpp/src/ray/config_internal.cc
@@ -85,6 +85,14 @@ void ConfigInternal::Init(RayConfig &config, int *argc, char ***argv) {
     gflags::ShutDownCommandLineFlags();
   }
   if (worker_type == WorkerType::DRIVER && run_mode == RunMode::CLUSTER) {
+    if (redis_ip.empty()) {
+      auto ray_address_env = std::getenv("RAY_ADDRESS");
+      if (ray_address_env) {
+        RAY_LOG(INFO) << "Initialize Ray cluster address to \"" << ray_address_env
+                      << "\" from environment variable \"RAY_ADDRESS\".";
+        SetRedisAddress(ray_address_env);
+      }
+    }
     if (code_search_path.empty()) {
       auto program_path = boost::dll::program_location().parent_path();
       RAY_LOG(INFO) << "No code search path found yet. "

--- a/cpp/src/ray/config_internal.cc
+++ b/cpp/src/ray/config_internal.cc
@@ -88,8 +88,8 @@ void ConfigInternal::Init(RayConfig &config, int *argc, char ***argv) {
     if (redis_ip.empty()) {
       auto ray_address_env = std::getenv("RAY_ADDRESS");
       if (ray_address_env) {
-        RAY_LOG(INFO) << "Initialize Ray cluster address to \"" << ray_address_env
-                      << "\" from environment variable \"RAY_ADDRESS\".";
+        RAY_LOG(DEBUG) << "Initialize Ray cluster address to \"" << ray_address_env
+                       << "\" from environment variable \"RAY_ADDRESS\".";
         SetRedisAddress(ray_address_env);
       }
     }

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -138,7 +138,7 @@ Ray provides Python, Java, and *EXPERIMENTAL* C++ API. And Ray uses Tasks (funct
 
       ray stop
       ray start --head
-      ./bazel-bin/example --ray-address=127.0.0.1:6379
+      RAY_ADDRESS=127.0.0.1:6379 ./bazel-bin/example
 
     .. literalinclude:: ../../cpp/example/example.cc
        :language: cpp


### PR DESCRIPTION
## Why are these changes needed?
- If you want to run C++ example and connect an existing cluster, you should run like this now:
./bazel-bin/example --ray-address=127.0.0.1:6379
- In this way of Gflags, you should use Ray::Init with argc and argv, like:
Ray::Init(config, argc, argv)
- We should also support initialize ray address by env, which is an easy-to-use in some scenes. 
 RAY_ADDRESS=127.0.0.1:6379 ./bazel-bin/example