### PR TITLE
Revert "ray ignores TMPDIR variable"

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -43,9 +43,7 @@ win32_AssignProcessToJobObject = None
 
 
 def get_user_temp_dir():
-    if "TMPDIR" in os.environ:
-        return os.environ["TMPDIR"]
-    elif sys.platform.startswith("darwin") or sys.platform.startswith("linux"):
+    if sys.platform.startswith("darwin") or sys.platform.startswith("linux"):
         # Ideally we wouldn't need this fallback, but keep it for now for
         # for compatibility
         tempdir = os.path.join(os.sep, "tmp")

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -9,7 +9,6 @@ import ray._private.services
 from ray.util.client.ray_client_helpers import ray_start_client_server
 from ray.client_builder import ClientContext
 from ray.cluster_utils import Cluster
-from ray.test_utils import run_string_as_driver
 
 
 @pytest.fixture
@@ -92,18 +91,6 @@ def test_shutdown_and_reset_global_worker(shutdown_only):
 
     a = A.remote()
     ray.get(a.f.remote())
-
-
-def test_tmpdir_env_var(shutdown_only):
-    result = run_string_as_driver(
-        """
-import ray
-context = ray.init()
-assert context["session_dir"].startswith("/tmp/qqq/"), context
-print("passed")
-""",
-        env={"TMPDIR": "/tmp/qqq"})
-    assert "passed" in result, result
 
 
 def test_ports_assignment(ray_start_cluster):

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -120,9 +120,7 @@ def test_raylet_tempfiles(shutdown_only):
 
 
 def test_tempdir_privilege(shutdown_only):
-    tmp_dir = ray._private.utils.get_ray_temp_dir()
-    os.makedirs(tmp_dir, exist_ok=True)
-    os.chmod(tmp_dir, 0o000)
+    os.chmod(ray._private.utils.get_ray_temp_dir(), 0o000)
     ray.init(num_cpus=1)
     session_dir = ray.worker._global_node.get_session_dir_path()
     assert os.path.exists(session_dir), "Specified socket path not found."


### PR DESCRIPTION
Reverts ray-project/ray#17130

This commit broke macOS because $TMPDIR by default is a long fully qualified path
```
➜  ~ echo $TMPDIR
/var/folders/vv/v17lwmd95j797hl_wlmt03cw0000gn/T/
```

This long path can break ray.init
```
In [2]: ray.init()                                                                                                                      
---------------------------------------------------------------------------
OSError                                   Traceback (most recent call last)
<ipython-input-2-3f68a533b944> in <module>
----> 1 ray.init()

~/Desktop/ray/ray/python/ray/_private/client_mode_hook.py in wrapper(*args, **kwargs)
     80         if client_mode_should_convert():
     81             return getattr(ray, func.__name__)(*args, **kwargs)
---> 82         return func(*args, **kwargs)
     83 
     84     return wrapper

~/Desktop/ray/ray/python/ray/worker.py in init(address, num_cpus, num_gpus, resources, object_store_memory, local_mode, ignore_reinit_error, include_dashboard, dashboard_host, dashboard_port, job_config, configure_logging, logging_level, logging_format, log_to_driver, namespace, runtime_env, internal_config, _enable_object_reconstruction, _redis_max_memory, _plasma_directory, _node_ip_address, _driver_object_store_memory, _memory, _redis_password, _temp_dir, _lru_evict, _metrics_export_port, _system_config, _tracing_startup_hook, **kwargs)
    869             shutdown_at_exit=False,
    870             spawn_reaper=True,
--> 871             ray_params=ray_params)
    872     else:
    873         # In this case, we are connecting to an existing cluster.

~/Desktop/ray/ray/python/ray/node.py in __init__(self, ray_params, head, shutdown_at_exit, spawn_reaper, connect_only)
    215             self._plasma_store_socket_name = self._prepare_socket_file(
    216                 self._ray_params.plasma_store_socket_name,
--> 217                 default_prefix="plasma_store")
    218             self._raylet_socket_name = self._prepare_socket_file(
    219                 self._ray_params.raylet_socket_name, default_prefix="raylet")

~/Desktop/ray/ray/python/ray/node.py in _prepare_socket_file(self, socket_path, default_prefix)
    628             if len(result.split("://", 1)[-1].encode("utf-8")) > maxlen:
    629                 raise OSError("AF_UNIX path length cannot exceed "
--> 630                               "{} bytes: {!r}".format(maxlen, result))
    631         return result
    632 

OSError: AF_UNIX path length cannot exceed 103 bytes: '/var/folders/vv/v17lwmd95j797hl_wlmt03cw0000gn/T/ray/session_2021-07-16_17-10-20_531793_5832/sockets/plasma_store'
```