### PR TITLE
[Ray debugger] Set breakpoint() hook only for tasks and actors

### DIFF
--- a/doc/source/ray-debugging.rst
+++ b/doc/source/ray-debugging.rst
@@ -114,9 +114,13 @@ following recursive function as an example:
             n_ref = fact.remote(n - 1)
             return n * ray.get(n_ref)
 
-    breakpoint()
-    result_ref = fact.remote(5)
-    result = ray.get(result_ref)
+    @ray.remote
+    def compute():
+        breakpoint()
+        result_ref = fact.remote(5)
+        result = ray.get(result_ref)
+
+    ray.get(compute.remote())
 
 
 After running the program by executing the Python file and calling
@@ -126,7 +130,7 @@ enter. This will result in the following output:
 .. code-block:: python
 
     Enter breakpoint index or press enter to refresh: 0
-    > /home/ubuntu/tmp/stepping.py(14)<module>()
+    > /home/ubuntu/tmp/stepping.py(16)<module>()
     -> result_ref = fact.remote(5)
     (Pdb)
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1322,8 +1322,10 @@ def connect(node,
         job_config.set_ray_namespace(namespace)
 
     # Make sure breakpoint() in the user's code will
-    # always invoke the Ray debugger.
-    os.environ["PYTHONBREAKPOINT"] = "ray.util.rpdb.set_trace"
+    # invoke the Ray debugger if we are in a worker or actor process
+    # (but not on the driver).
+    if mode == WORKER_MODE:
+        os.environ["PYTHONBREAKPOINT"] = "ray.util.rpdb.set_trace"
 
     serialized_job_config = job_config.serialize()
     worker.core_worker = ray._raylet.CoreWorker(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For the driver, people typically want to keep the normal debugger and interact directly with it through the terminal instead having to call `ray debug` in a different terminal.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
