### PR TITLE
[Workflow] Fix recovery storage mismatch issue

### DIFF
--- a/python/ray/experimental/workflow/api.py
+++ b/python/ray/experimental/workflow/api.py
@@ -16,6 +16,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# TODO(suquark): Update the storage interface (e.g., passing it through
+# context instead of argument).
+
 
 def step(func: types.FunctionType) -> WorkflowStepFunction:
     """A decorator used for creating workflow steps.

--- a/python/ray/experimental/workflow/common.py
+++ b/python/ray/experimental/workflow/common.py
@@ -205,6 +205,6 @@ class Workflow:
             storage: The external storage URL or a custom storage class. If not
                 specified, ``/tmp/ray/workflow_data`` will be used.
         """
-        # avoid cyclic importing
+        # TODO(suquark): avoid cyclic importing
         from ray.experimental.workflow.execution import run
         return run(self, storage, workflow_id)

--- a/python/ray/experimental/workflow/execution.py
+++ b/python/ray/experimental/workflow/execution.py
@@ -5,11 +5,10 @@ from typing import Union, Optional
 
 import ray
 
-from ray.experimental.workflow import workflow_context
+from ray.experimental.workflow import workflow_storage
 from ray.experimental.workflow.common import Workflow
-from ray.experimental.workflow.step_executor import commit_step
-from ray.experimental.workflow.storage import (
-    Storage, create_storage, get_global_storage, set_global_storage)
+from ray.experimental.workflow.storage import (Storage, create_storage,
+                                               get_global_storage)
 from ray.experimental.workflow.workflow_access import (
     MANAGEMENT_ACTOR_NAME, flatten_workflow_output,
     get_or_create_management_actor)
@@ -26,6 +25,28 @@ def _is_anonymous_namespace():
     return bool(match)
 
 
+def _get_storage(storage: Optional[Union[str, Storage]]) -> Storage:
+    if storage is None:
+        return get_global_storage()
+    elif isinstance(storage, str):
+        return create_storage(storage)
+    elif isinstance(storage, Storage):
+        return storage
+    else:
+        raise TypeError("'storage' should be None, str, or Storage type.")
+
+
+def _get_storage_url(storage: Optional[Union[str, Storage]]) -> str:
+    if storage is None:
+        return get_global_storage().storage_url
+    elif isinstance(storage, str):
+        return storage
+    elif isinstance(storage, Storage):
+        return storage.storage_url
+    else:
+        raise TypeError("'storage' should be None, str, or Storage type.")
+
+
 def run(entry_workflow: Workflow,
         storage: Optional[Union[str, Storage]] = None,
         workflow_id: Optional[str] = None) -> ray.ObjectRef:
@@ -38,28 +59,23 @@ def run(entry_workflow: Workflow,
     if workflow_id is None:
         # Workflow ID format: {Entry workflow UUID}.{Unix time to nanoseconds}
         workflow_id = f"{entry_workflow.id}.{time.time():.9f}"
-    if isinstance(storage, str):
-        set_global_storage(create_storage(storage))
-    elif isinstance(storage, Storage):
-        set_global_storage(storage)
-    elif storage is not None:
-        raise TypeError("'storage' should be None, str, or Storage type.")
-    storage_url = get_global_storage().storage_url
+    store = _get_storage(storage)
     logger.info(f"Workflow job created. [id=\"{workflow_id}\", storage_url="
-                f"\"{storage_url}\"].")
-    try:
-        workflow_context.init_workflow_step_context(workflow_id, storage_url)
-        commit_step(entry_workflow)
-        actor = get_or_create_management_actor()
-        # NOTE: It is important to 'ray.get' the returned output. This
-        # ensures caller of 'run()' holds the reference to the workflow
-        # result. Otherwise if the actor removes the reference of the
-        # workflow output, the caller may fail to resolve the result.
-        output = ray.get(actor.run_or_resume.remote(workflow_id, storage_url))
-        direct_output = flatten_workflow_output(workflow_id, output)
-    finally:
-        workflow_context.set_workflow_step_context(None)
-    return direct_output
+                f"\"{store.storage_url}\"].")
+
+    # checkpoint the workflow
+    ws = workflow_storage.WorkflowStorage(workflow_id, store)
+    ws.save_subworkflow(entry_workflow)
+    ws.save_step_output("", entry_workflow, None)
+
+    actor = get_or_create_management_actor()
+    # NOTE: It is important to 'ray.get' the returned output. This
+    # ensures caller of 'run()' holds the reference to the workflow
+    # result. Otherwise if the actor removes the reference of the
+    # workflow output, the caller may fail to resolve the result.
+    output = ray.get(
+        actor.run_or_resume.remote(workflow_id, store.storage_url))
+    return flatten_workflow_output(workflow_id, output)
 
 
 # TODO(suquark): support recovery with ObjectRef inputs.
@@ -74,23 +90,15 @@ def resume(workflow_id: str,
         raise ValueError("Must use a namespace in 'ray.init()' to access "
                          "workflows properly. Current namespace seems to "
                          "be anonymous.")
-    if isinstance(storage, str):
-        store = create_storage(storage)
-    elif isinstance(storage, Storage):
-        store = storage
-    elif storage is None:
-        store = get_global_storage()
-    else:
-        raise TypeError("'storage' should be None, str, or Storage type.")
+    storage_url = _get_storage_url(storage)
     logger.info(f"Resuming workflow [id=\"{workflow_id}\", storage_url="
-                f"\"{store.storage_url}\"].")
+                f"\"{storage_url}\"].")
     actor = get_or_create_management_actor()
     # NOTE: It is important to 'ray.get' the returned output. This
     # ensures caller of 'run()' holds the reference to the workflow
     # result. Otherwise if the actor removes the reference of the
     # workflow output, the caller may fail to resolve the result.
-    output = ray.get(
-        actor.run_or_resume.remote(workflow_id, store.storage_url))
+    output = ray.get(actor.run_or_resume.remote(workflow_id, storage_url))
     direct_output = flatten_workflow_output(workflow_id, output)
     logger.info(f"Workflow job {workflow_id} resumed.")
     return direct_output

--- a/python/ray/experimental/workflow/execution.py
+++ b/python/ray/experimental/workflow/execution.py
@@ -68,13 +68,13 @@ def run(entry_workflow: Workflow,
     ws.save_subworkflow(entry_workflow)
     ws.save_step_output("", entry_workflow, None)
 
-    actor = get_or_create_management_actor()
+    workflow_manager = get_or_create_management_actor()
     # NOTE: It is important to 'ray.get' the returned output. This
     # ensures caller of 'run()' holds the reference to the workflow
     # result. Otherwise if the actor removes the reference of the
     # workflow output, the caller may fail to resolve the result.
     output = ray.get(
-        actor.run_or_resume.remote(workflow_id, store.storage_url))
+        workflow_manager.run_or_resume.remote(workflow_id, store.storage_url))
     return flatten_workflow_output(workflow_id, output)
 
 
@@ -93,12 +93,13 @@ def resume(workflow_id: str,
     storage_url = _get_storage_url(storage)
     logger.info(f"Resuming workflow [id=\"{workflow_id}\", storage_url="
                 f"\"{storage_url}\"].")
-    actor = get_or_create_management_actor()
+    workflow_manager = get_or_create_management_actor()
     # NOTE: It is important to 'ray.get' the returned output. This
     # ensures caller of 'run()' holds the reference to the workflow
     # result. Otherwise if the actor removes the reference of the
     # workflow output, the caller may fail to resolve the result.
-    output = ray.get(actor.run_or_resume.remote(workflow_id, storage_url))
+    output = ray.get(
+        workflow_manager.run_or_resume.remote(workflow_id, storage_url))
     direct_output = flatten_workflow_output(workflow_id, output)
     logger.info(f"Workflow job {workflow_id} resumed.")
     return direct_output

--- a/python/ray/experimental/workflow/execution.py
+++ b/python/ray/experimental/workflow/execution.py
@@ -12,6 +12,7 @@ from ray.experimental.workflow.storage import (Storage, create_storage,
 from ray.experimental.workflow.workflow_access import (
     MANAGEMENT_ACTOR_NAME, flatten_workflow_output,
     get_or_create_management_actor)
+from ray.experimental.workflow.step_executor import commit_step
 
 logger = logging.getLogger(__name__)
 
@@ -65,9 +66,7 @@ def run(entry_workflow: Workflow,
 
     # checkpoint the workflow
     ws = workflow_storage.WorkflowStorage(workflow_id, store)
-    ws.save_subworkflow(entry_workflow)
-    ws.save_step_output("", entry_workflow, None)
-
+    commit_step(ws, "", entry_workflow)
     workflow_manager = get_or_create_management_actor()
     # NOTE: It is important to 'ray.get' the returned output. This
     # ensures caller of 'run()' holds the reference to the workflow

--- a/python/ray/experimental/workflow/step_executor.py
+++ b/python/ray/experimental/workflow/step_executor.py
@@ -1,5 +1,4 @@
-from typing import (List, Tuple, Union, Any, Dict, Callable, Optional,
-                    TYPE_CHECKING)
+from typing import (List, Tuple, Any, Dict, Callable, Optional, TYPE_CHECKING)
 
 import ray
 from ray import ObjectRef
@@ -9,7 +8,6 @@ from ray.experimental.workflow.common import Workflow
 from ray.experimental.workflow import workflow_storage
 
 if TYPE_CHECKING:
-    from ray.experimental.workflow.storage import Storage
     from ray.experimental.workflow.common import (StepID, WorkflowOutputType,
                                                   WorkflowInputTuple)
 
@@ -125,26 +123,6 @@ def execute_workflow(workflow: Workflow,
     # Passing down outer most step so inner nested steps would
     # access the same outer most step.
     return workflow.execute(outer_most_step_id)
-
-
-def commit_step(workflow_id: str,
-                step_id: "StepID",
-                storage: "Storage",
-                ret: Union[Workflow, Any],
-                outer_most_step_id: Optional[str] = None):
-    """Checkpoint the step output.
-
-    Args:
-        workflow_id: The ID of the workflow
-        ret: The returned object of the workflow step.
-        outer_most_step_id: The ID of the outer most workflow. None if it
-            does not exists. See "step_executor.execute_workflow" for detailed
-            explanation.
-    """
-    store = workflow_storage.WorkflowStorage(workflow_id, storage)
-    if isinstance(ret, Workflow):
-        store.save_subworkflow(ret)
-    store.save_step_output(step_id, ret, outer_most_step_id)
 
 
 @ray.remote

--- a/python/ray/experimental/workflow/virtual_actor_class.py
+++ b/python/ray/experimental/workflow/virtual_actor_class.py
@@ -366,10 +366,10 @@ class VirtualActor:
         """Return a future. If 'ray.get()' it successfully, then the actor
         is fully initialized."""
         # TODO(suquark): should ray.get(xxx.ready()) always be true?
-        actor = get_or_create_management_actor()
+        workflow_manager = get_or_create_management_actor()
         return ray.get(
-            actor.actor_ready.remote(self._actor_id,
-                                     self._storage.storage_url))
+            workflow_manager.actor_ready.remote(self._actor_id,
+                                                self._storage.storage_url))
 
     def __getattr__(self, item):
         if item in self._metadata.signatures:

--- a/python/ray/experimental/workflow/workflow_context.py
+++ b/python/ray/experimental/workflow/workflow_context.py
@@ -55,6 +55,11 @@ def update_workflow_step_context(context: Optional[WorkflowStepContext],
     global _context
     _context = context
     _context.workflow_scope.append(step_id)
+    # avoid cyclic import
+    from ray.experimental.workflow import storage
+    # TODO(suquark): [optimization] if the original storage has the same URL,
+    # skip creating the new one
+    storage.set_global_storage(storage.create_storage(context.storage_url))
 
 
 def get_current_step_id() -> str:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Originally, the workflow would fail if we use a storage different from the current global storage.

This happens mainly because the we  did not setup the store in `update_workflow_step_context`.

I also feel the original code is too "messy", so I cleaned them up.

## Related issue number

Closes https://github.com/ray-project/ray/issues/17097

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
