### PR TITLE
Fix memory leak in JNI.

### DIFF
--- a/src/ray/core_worker/lib/java/jni_utils.h
+++ b/src/ray/core_worker/lib/java/jni_utils.h
@@ -523,6 +523,7 @@ inline std::shared_ptr<ray::RayObject> JavaNativeRayObjectToNativeRayObject(
       env, java_contained_ids, &contained_object_ids, [](JNIEnv *env, jobject id) {
         return JavaByteArrayToId<ray::ObjectID>(env, static_cast<jbyteArray>(id));
       });
+  env->DeleteLocalRef(java_contained_ids);
   return std::make_shared<ray::RayObject>(data_buffer, metadata_buffer,
                                           contained_object_ids);
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
`java_contained_ids` is leaked in every task.

Generally, it's unnecessary to release local references in native JNI functions because it will be deleted when the native function returns to JVM from native.

But in TaskExecutor, we have a native callback with a `while(true)` loop executing every task, that means it has no chance to return to JVM from native. So we should release the local references manually.

```
pseudo

/// in native function:

while(true) {
    // 1. Invoke the java method of the task and allocate the java_contained_ids.
    // 2. Increase a count of local reference
   java_contained_ids = env->GetField();  // no chance to return to JVM.
}

```


## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
