### PR TITLE
[Core] Add worker resource limit

### DIFF
--- a/docker/ray-worker-container/Dockerfile
+++ b/docker/ray-worker-container/Dockerfile
@@ -74,7 +74,7 @@ RUN apt-get update -y \
     && echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list \
     && curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | apt-key add - \
     && apt-get update \
-    && apt-get -y install podman \
+    && apt-get -y install podman runc \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 

--- a/python/ray/tests/mock_setup_worker.py
+++ b/python/ray/tests/mock_setup_worker.py
@@ -21,6 +21,11 @@ parser.add_argument(
     type=str,
     help="the serialized runtime env context")
 
+parser.add_argument(
+    "--allocated-instances-serialized-json",
+    type=str,
+    help="the worker allocated resource")
+
 # The worker is not set up yet, so we can't get session_dir from the worker.
 parser.add_argument(
     "--session-dir", type=str, help="the directory for the current session")

--- a/python/ray/tests/test_actor_in_container.py
+++ b/python/ray/tests/test_actor_in_container.py
@@ -67,6 +67,78 @@ def test_actor_in_heterogeneous_image():
     ray.shutdown()
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="Only works on linux.")
+def test_actor_in_container_with_resource_limit():
+    job_config = ray.job_config.JobConfig(
+        runtime_env={
+            "container": {
+                "image": "rayproject/ray-worker-container:nightly-py36-cpu",
+                # Currently runc will mount individual cgroupfs
+                # issue: https://github.com/containers/podman/issues/10989
+                "run_options": [
+                    "--runtime", "/usr/sbin/runc", "--security-opt",
+                    "seccomp=unconfined"
+                ],
+            }
+        })
+    ray.init(
+        job_config=job_config,
+        _system_config={"worker_resource_limits_enabled": True})
+
+    @ray.remote
+    class Counter(object):
+        def __init__(self):
+            self.value = 0
+
+        def get_memory_limit(self):
+            f = open("/sys/fs/cgroup/memory/memory.limit_in_bytes", "r")
+            return f.readline().strip("\n")
+
+        def get_cpu_share(self):
+            f = open("/sys/fs/cgroup/cpu/cpu.shares", "r")
+            return f.readline().strip("\n")
+
+    a1 = Counter.options(num_cpus=2, memory=100 * 1024 * 1024).remote()
+    cpu_share = ray.get(a1.get_cpu_share.remote())
+    assert cpu_share == "2048"
+    memory_limit = ray.get(a1.get_memory_limit.remote())
+    assert memory_limit == "104857600"
+    ray.shutdown()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Only works on linux.")
+def test_reuse_worker_with_resource_limit():
+    runtime_env = {
+        "container": {
+            "image": "rayproject/ray-worker-container:nightly-py36-cpu",
+        }
+    }
+    job_config = ray.job_config.JobConfig()
+    ray.init(
+        job_config=job_config,
+        _system_config={"worker_resource_limits_enabled": True})
+
+    @ray.remote
+    def get_pid():
+        import os
+        return os.getpid()
+
+    obj_ref = get_pid.options(
+        runtime_env=runtime_env, num_cpus=1,
+        memory=100 * 1024 * 1024).remote()
+    pid = ray.get(obj_ref)
+    obj_ref1 = get_pid.options(
+        runtime_env=runtime_env, num_cpus=1,
+        memory=100 * 1024 * 1024).remote()
+    pid1 = ray.get(obj_ref1)
+    assert pid == pid1
+    obj_ref2 = get_pid.options(
+        runtime_env=runtime_env, num_cpus=1, memory=50 * 1024 * 1024).remote()
+    pid2 = ray.get(obj_ref2)
+    assert pid != pid2
+    ray.shutdown()
+
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main(["-v", __file__, "-s"]))

--- a/python/ray/tests/test_setup_worker.py
+++ b/python/ray/tests/test_setup_worker.py
@@ -1,0 +1,22 @@
+# coding: utf-8
+import sys
+
+import pytest
+
+import ray
+import ray.workers.setup_worker
+
+
+def test_parse_allocated_resource():
+    cpu_share = ray.workers.setup_worker.parse_allocated_resource(
+        r'{"CPU":20000,"memory":10737418240000}')
+    assert cpu_share == ["--cpu-shares=2048", "--memory=1073741824"]
+    cpu_set = ray.workers.setup_worker.parse_allocated_resource(
+        r'{"CPU":[10000,0,10000],"memory":10737418240000}')
+    assert cpu_set == [
+        "--cpu-shares=2048", "--cpuset-cpus=0,2", "--memory=1073741824"
+    ]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/workers/setup_worker.py
+++ b/python/ray/workers/setup_worker.py
@@ -4,6 +4,7 @@ import logging
 import os
 
 from ray._private.utils import import_attr
+
 logger = logging.getLogger(__name__)
 
 parser = argparse.ArgumentParser(
@@ -21,12 +22,45 @@ parser.add_argument(
     type=str,
     help="the serialized parsed runtime env dict")
 
+parser.add_argument(
+    "--allocated-instances-serialized-json",
+    type=str,
+    help="the worker allocated resource")
+
 
 def get_tmp_dir(remaining_args):
     for arg in remaining_args:
         if arg.startswith("--temp-dir="):
             return arg[11:]
     return None
+
+
+def parse_allocated_resource(allocated_instances_serialized_json):
+    container_resource_args = []
+    allocated_resource = json.loads(allocated_instances_serialized_json)
+    if "CPU" in allocated_resource.keys():
+        cpu_resource = allocated_resource["CPU"]
+        if isinstance(cpu_resource, list):
+            # cpuset: because we may split one cpu core into some pieces,
+            # we need set cpuset.cpu_exclusive=0 and set cpuset-cpus
+            cpu_ids = []
+            cpu_shares = 0
+            for idx, val in enumerate(cpu_resource):
+                if val > 0:
+                    cpu_ids.append(idx)
+                    cpu_shares += val
+            container_resource_args.append("--cpu-shares=" +
+                                           str(int(cpu_shares / 10000 * 1024)))
+            container_resource_args.append("--cpuset-cpus=" + ",".join(
+                str(e) for e in cpu_ids))
+        else:
+            # cpushare
+            container_resource_args.append(
+                "--cpu-shares=" + str(int(cpu_resource / 10000 * 1024)))
+    if "memory" in allocated_resource.keys():
+        container_resource_args.append(
+            "--memory=" + str(int(allocated_resource["memory"] / 10000)))
+    return container_resource_args
 
 
 def start_worker_in_container(container_option, args, remaining_args):
@@ -65,6 +99,8 @@ def start_worker_in_container(container_option, args, remaining_args):
     container_command.append("RAY_RAYLET_PID=" + str(os.getppid()))
     if container_option.get("run_options"):
         container_command.extend(container_option.get("run_options"))
+    container_command.extend(
+        parse_allocated_resource(args.allocated_instances_serialized_json))
 
     container_command.append("--entrypoint")
     container_command.append("python")

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -456,3 +456,7 @@ RAY_CONFIG(std::string, custom_unit_instance_resources, "")
 
 // Maximum size of the batch size when broadcasting resources to raylet.
 RAY_CONFIG(uint64_t, resource_broadcast_batch_size_bytes, 1024 * 1024 * 5);
+
+// If enabled and worker stated in container, the container will add
+// resource limit.
+RAY_CONFIG(bool, worker_resource_limits_enabled, false)

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -1,8 +1,9 @@
 #include "ray/common/task/task_spec.h"
 
+#include <boost/functional/hash.hpp>
 #include <sstream>
 
-#include <boost/functional/hash.hpp>
+#include "ray/common/ray_config.h"
 #include "ray/util/logging.h"
 
 namespace ray {
@@ -126,7 +127,12 @@ bool TaskSpecification::HasRuntimeEnv() const {
 }
 
 int TaskSpecification::GetRuntimeEnvHash() const {
-  WorkerCacheKey env = {OverrideEnvironmentVariables(), SerializedRuntimeEnv()};
+  std::unordered_map<std::string, double> required_resource{};
+  if (RayConfig::instance().worker_resource_limits_enabled()) {
+    required_resource = GetRequiredResources().GetResourceMap();
+  }
+  WorkerCacheKey env = {OverrideEnvironmentVariables(), SerializedRuntimeEnv(),
+                        required_resource};
   return env.IntHash();
 }
 
@@ -372,17 +378,21 @@ std::string TaskSpecification::CallSiteString() const {
 
 WorkerCacheKey::WorkerCacheKey(
     const std::unordered_map<std::string, std::string> override_environment_variables,
-    const std::string serialized_runtime_env)
+    const std::string serialized_runtime_env,
+    const std::unordered_map<std::string, double> required_resources)
     : override_environment_variables(override_environment_variables),
-      serialized_runtime_env(serialized_runtime_env) {}
+      serialized_runtime_env(serialized_runtime_env),
+      required_resources(std::move(required_resources)) {}
 
 bool WorkerCacheKey::operator==(const WorkerCacheKey &k) const {
+  // FIXME we should compare fields
   return Hash() == k.Hash();
 }
 
 bool WorkerCacheKey::EnvIsEmpty() const {
   return override_environment_variables.size() == 0 &&
-         (serialized_runtime_env == "" || serialized_runtime_env == "{}");
+         (serialized_runtime_env == "" || serialized_runtime_env == "{}") &&
+         required_resources.empty();
 }
 
 std::size_t WorkerCacheKey::Hash() const {
@@ -407,6 +417,15 @@ std::size_t WorkerCacheKey::Hash() const {
       }
 
       boost::hash_combine(hash_, serialized_runtime_env);
+
+      std::vector<std::pair<std::string, double>> resource_vars(
+          required_resources.begin(), required_resources.end());
+      // Sort the variables so different permutations yield the same hash.
+      std::sort(resource_vars.begin(), resource_vars.end());
+      for (auto &pair : resource_vars) {
+        boost::hash_combine(hash_, pair.first);
+        boost::hash_combine(hash_, pair.second);
+      }
     }
   }
   return hash_;

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -247,10 +247,11 @@ class WorkerCacheKey {
   ///
   /// \param override_environment_variables The environment variable overrides set in this
   /// worker. \param serialized_runtime_env The JSON-serialized runtime env for this
-  /// worker.
+  /// worker. \param required_resources The required resouce.
   WorkerCacheKey(
       const std::unordered_map<std::string, std::string> override_environment_variables,
-      const std::string serialized_runtime_env);
+      const std::string serialized_runtime_env,
+      const std::unordered_map<std::string, double> required_resources);
 
   bool operator==(const WorkerCacheKey &k) const;
 
@@ -277,6 +278,8 @@ class WorkerCacheKey {
   const std::unordered_map<std::string, std::string> override_environment_variables;
   /// The JSON-serialized runtime env for this worker.
   const std::string serialized_runtime_env;
+  /// The required resources for this worker.
+  const std::unordered_map<std::string, double> required_resources;
   /// The cached hash of the worker's environment.  This is set to 0
   /// for unspecified or empty environments.
   mutable std::size_t hash_ = 0;

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -601,6 +601,42 @@ void ClusterResourceScheduler::DeleteResource(const std::string &node_id_string,
   }
 }
 
+std::string ClusterResourceScheduler::SerializedTaskResourceInstances(
+    std::shared_ptr<TaskResourceInstances> task_allocation) const {
+  bool has_added_resource = false;
+  std::stringstream buffer;
+  buffer << "{";
+  for (size_t i = 0; i < PredefinedResources_MAX; i++) {
+    std::vector<FixedPoint> resource = task_allocation->predefined_resources[i];
+    if (resource.empty()) {
+      continue;
+    }
+    if (has_added_resource) {
+      buffer << ",";
+    }
+    std::string resource_name = ResourceEnumToString(static_cast<PredefinedResources>(i));
+    buffer << "\"" << resource_name << "\":";
+    bool is_unit_instance = predefined_unit_instance_resources_.find(i) !=
+                            predefined_unit_instance_resources_.end();
+    if (!is_unit_instance) {
+      buffer << resource[0];
+    } else {
+      buffer << "[";
+      for (size_t i = 0; i < resource.size(); i++) {
+        buffer << resource[i];
+        if (i < resource.size() - 1) {
+          buffer << ", ";
+        }
+      }
+      buffer << "]";
+    }
+    has_added_resource = true;
+  }
+  // TODO (chenk008): add custom_resources
+  buffer << "}";
+  return buffer.str();
+}
+
 std::string ClusterResourceScheduler::DebugString(void) const {
   std::stringstream buffer;
   buffer << "\nLocal id: " << local_node_id_;

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -414,6 +414,13 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
   void UpdateLastResourceUsage(
       const std::shared_ptr<SchedulingResources> gcs_resources) override;
 
+  /// Serialize task resource instances to json string.
+  ///
+  /// \param task_allocation Allocated resource instances for a task.
+  /// \return The task resource instances json string
+  std::string SerializedTaskResourceInstances(
+      std::shared_ptr<TaskResourceInstances> task_allocation) const;
+
   /// Return human-readable string for this scheduler state.
   std::string DebugString() const;
 

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -242,7 +242,14 @@ void ClusterTaskManager::DispatchScheduledTasksToWorkers(
       } else {
         // The local node has the available resources to run the task, so we should run
         // it.
-        std::shared_ptr<WorkerInterface> worker = worker_pool_.PopWorker(spec);
+        std::string allocated_instances_serialized_json = "{}";
+        if (RayConfig::instance().worker_resource_limits_enabled()) {
+          allocated_instances_serialized_json =
+              cluster_resource_scheduler_->SerializedTaskResourceInstances(
+                  allocated_instances);
+        }
+        std::shared_ptr<WorkerInterface> worker =
+            worker_pool_.PopWorker(spec, allocated_instances_serialized_json);
         if (!worker) {
           RAY_LOG(DEBUG) << "This node has available resources, but no worker processes "
                             "to grant the lease.";

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -50,7 +50,7 @@ class MockWorkerPool : public WorkerPoolInterface {
       const std::string &allocated_instances_serialized_json) {
     num_pops++;
     const WorkerCacheKey env = {
-        task_spec.OverrideEnvironmentVariables(),task_spec.SerializedRuntimeEnv(), {}};
+        task_spec.OverrideEnvironmentVariables(), task_spec.SerializedRuntimeEnv(), {}};
     const int runtime_env_hash = env.IntHash();
     std::shared_ptr<WorkerInterface> worker = nullptr;
 
@@ -325,7 +325,7 @@ TEST_F(ClusterTaskManagerTest, DispatchQueueNonBlockingTest) {
 
   // Push a worker that can only run task A.
   const WorkerCacheKey env_A = {
-      /*override_environment_variables=*/{},serialized_runtime_env_A, {}};
+      /*override_environment_variables=*/{}, serialized_runtime_env_A, {}};
   const int runtime_env_hash_A = env_A.IntHash();
   std::shared_ptr<MockWorker> worker_A =
       std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234, runtime_env_hash_A);

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -45,7 +45,9 @@ class MockWorkerPool : public WorkerPoolInterface {
  public:
   MockWorkerPool() : num_pops(0) {}
 
-  std::shared_ptr<WorkerInterface> PopWorker(const TaskSpecification &task_spec) {
+  std::shared_ptr<WorkerInterface> PopWorker(
+      const TaskSpecification &task_spec,
+      const std::string &allocated_instances_serialized_json) {
     num_pops++;
     const WorkerCacheKey env = {task_spec.OverrideEnvironmentVariables(),
                                 task_spec.SerializedRuntimeEnv()};

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -50,7 +50,7 @@ class MockWorkerPool : public WorkerPoolInterface {
       const std::string &allocated_instances_serialized_json) {
     num_pops++;
     const WorkerCacheKey env = {task_spec.OverrideEnvironmentVariables(),
-                                task_spec.SerializedRuntimeEnv()};
+                                task_spec.SerializedRuntimeEnv(), {}};
     const int runtime_env_hash = env.IntHash();
     std::shared_ptr<WorkerInterface> worker = nullptr;
 
@@ -325,7 +325,7 @@ TEST_F(ClusterTaskManagerTest, DispatchQueueNonBlockingTest) {
 
   // Push a worker that can only run task A.
   const WorkerCacheKey env_A = {/*override_environment_variables=*/{},
-                                serialized_runtime_env_A};
+                                serialized_runtime_env_A, {}};
   const int runtime_env_hash_A = env_A.IntHash();
   std::shared_ptr<MockWorker> worker_A =
       std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234, runtime_env_hash_A);

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -49,8 +49,8 @@ class MockWorkerPool : public WorkerPoolInterface {
       const TaskSpecification &task_spec,
       const std::string &allocated_instances_serialized_json) {
     num_pops++;
-    const WorkerCacheKey env = {task_spec.OverrideEnvironmentVariables(),
-                                task_spec.SerializedRuntimeEnv(), {}};
+    const WorkerCacheKey env = {
+        task_spec.OverrideEnvironmentVariables(),task_spec.SerializedRuntimeEnv(), {}};
     const int runtime_env_hash = env.IntHash();
     std::shared_ptr<WorkerInterface> worker = nullptr;
 
@@ -324,8 +324,8 @@ TEST_F(ClusterTaskManagerTest, DispatchQueueNonBlockingTest) {
   task_manager_.QueueAndScheduleTask(task_B_2, &reply_B_2, empty_callback);
 
   // Push a worker that can only run task A.
-  const WorkerCacheKey env_A = {/*override_environment_variables=*/{},
-                                serialized_runtime_env_A, {}};
+  const WorkerCacheKey env_A = {
+      /*override_environment_variables=*/{},serialized_runtime_env_A, {}};
   const int runtime_env_hash_A = env_A.IntHash();
   std::shared_ptr<MockWorker> worker_A =
       std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234, runtime_env_hash_A);

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -156,7 +156,8 @@ Process WorkerPool::StartWorkerProcess(
     const std::vector<std::string> &dynamic_options, const int runtime_env_hash,
     const std::string &serialized_runtime_env,
     std::unordered_map<std::string, std::string> override_environment_variables,
-    const std::string &serialized_runtime_env_context) {
+    const std::string &serialized_runtime_env_context,
+    const std::string &allocated_instances_serialized_json) {
   rpc::JobConfig *job_config = nullptr;
   if (!IsIOWorkerType(worker_type)) {
     RAY_CHECK(!job_id.IsNil());
@@ -300,6 +301,9 @@ Process WorkerPool::StartWorkerProcess(
   if (language == Language::PYTHON) {
     if (serialized_runtime_env != "{}" && serialized_runtime_env != "") {
       worker_command_args.push_back("--serialized-runtime-env=" + serialized_runtime_env);
+      // Allocated_resource_json is only used in "shim process".
+      worker_command_args.push_back("--allocated-instances-serialized-json=" +
+                                    allocated_instances_serialized_json);
     } else {
       // The "shim process" setup worker is not needed, so do not run it.
       // Check that the arg really is the path to the setup worker before erasing it, to
@@ -857,26 +861,35 @@ void WorkerPool::TryKillingIdleWorkers() {
 }
 
 int GetRuntimeEnvHash(const TaskSpecification &task_spec) {
+  // We add required_resource instead of allocated_instances because allocated_instances
+  // may contains resource ID.
+  std::unordered_map<std::string, double> required_resource{};
+  if (RayConfig::instance().worker_resource_limits_enabled()) {
+    required_resource = task_spec.GetRequiredResources().GetResourceMap();
+  }
   const WorkerCacheKey env = {task_spec.OverrideEnvironmentVariables(),
-                              task_spec.SerializedRuntimeEnv()};
+                              task_spec.SerializedRuntimeEnv(), required_resource};
   return env.IntHash();
 }
 
 std::shared_ptr<WorkerInterface> WorkerPool::PopWorker(
-    const TaskSpecification &task_spec) {
+    const TaskSpecification &task_spec,
+    const std::string &allocated_instances_serialized_json) {
   auto &state = GetStateForLanguage(task_spec.GetLanguage());
 
   std::shared_ptr<WorkerInterface> worker = nullptr;
   Process proc;
   auto start_worker_process_fn =
-      [this](const TaskSpecification &task_spec, State &state,
-             std::vector<std::string> dynamic_options, bool dedicated,
-             const int runtime_env_hash, const std::string &serialized_runtime_env,
-             const std::string &serialized_runtime_env_context) -> Process {
+      [this, allocated_instances_serialized_json](
+          const TaskSpecification &task_spec, State &state,
+          std::vector<std::string> dynamic_options, bool dedicated,
+          const int runtime_env_hash, const std::string &serialized_runtime_env,
+          const std::string &serialized_runtime_env_context) -> Process {
     Process proc = StartWorkerProcess(
         task_spec.GetLanguage(), rpc::WorkerType::WORKER, task_spec.JobId(),
         dynamic_options, runtime_env_hash, serialized_runtime_env,
-        task_spec.OverrideEnvironmentVariables(), serialized_runtime_env_context);
+        task_spec.OverrideEnvironmentVariables(), serialized_runtime_env_context,
+        allocated_instances_serialized_json);
     if (proc.IsValid()) {
       WarnAboutSize();
       if (dedicated) {
@@ -890,8 +903,8 @@ std::shared_ptr<WorkerInterface> WorkerPool::PopWorker(
   if (task_spec.IsActorTask()) {
     // Code path of actor task.
     RAY_CHECK(false) << "Direct call shouldn't reach here.";
-  } else if ((task_spec.IsActorCreationTask() &&
-              !task_spec.DynamicWorkerOptions().empty())) {
+  } else if (task_spec.IsActorCreationTask() &&
+             !task_spec.DynamicWorkerOptions().empty()) {
     // Code path of task that needs a dedicated worker: an actor creation task with
     // dynamic worker options.
     // Try to pop it from idle dedicated pool.
@@ -917,7 +930,8 @@ std::shared_ptr<WorkerInterface> WorkerPool::PopWorker(
         state.tasks_with_pending_runtime_envs.emplace(task_spec.TaskId());
         agent_manager_->CreateRuntimeEnv(
             task_spec.SerializedRuntimeEnv(),
-            [start_worker_process_fn, &state, task_spec, dynamic_options](
+            [start_worker_process_fn, &state, task_spec, dynamic_options,
+             allocated_instances_serialized_json](
                 bool done, const std::string &serialized_runtime_env_context) {
               state.tasks_with_pending_runtime_envs.erase(task_spec.TaskId());
               if (!done) {

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -49,10 +49,15 @@ class WorkerPoolInterface {
   /// the worker back onto the pool once the worker has completed its work.
   ///
   /// \param task_spec The returned worker must be able to execute this task.
-  /// \return An idle worker with the requested task spec. Returns nullptr if no
+  /// \param allocated_instances_serialized_json The allocated resouce instances
+  /// json string, it contains resource ID which assigned to this worker.
+  /// Instance resource value will be like {"GPU":[10000,0,10000]}, non-instance
+  /// resource value will be {"CPU":20000}.
+  /// \return An idle worker with tit he requested task spec. Returns nullptr if no
   /// such worker exists.
   virtual std::shared_ptr<WorkerInterface> PopWorker(
-      const TaskSpecification &task_spec) = 0;
+      const TaskSpecification &task_spec,
+      const std::string &allocated_instances_serialized_json = "{}") = 0;
   /// Add an idle worker to the pool.
   ///
   /// \param The idle worker to add.
@@ -275,9 +280,13 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// the worker back onto the pool once the worker has completed its work.
   ///
   /// \param task_spec The returned worker must be able to execute this task.
+  /// \param allocated_instances_serialized_json The allocated resouce instances
+  /// json string.
   /// \return An idle worker with the requested task spec. Returns nullptr if no
   /// such worker exists.
-  std::shared_ptr<WorkerInterface> PopWorker(const TaskSpecification &task_spec);
+  std::shared_ptr<WorkerInterface> PopWorker(
+      const TaskSpecification &task_spec,
+      const std::string &allocated_instances_serialized_json = "{}");
 
   /// Try to prestart a number of workers suitable the given task spec. Prestarting
   /// is needed since core workers request one lease at a time, if starting is slow,
@@ -352,6 +361,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// \param job_id The ID of the job to which the started worker process belongs.
   /// \param dynamic_options The dynamic options that we should add for worker command.
   /// \param serialized_runtime_env The runtime environment for the started worker
+  /// \param allocated_instances_serialized_json The allocated resource instances
+  //  json string.
   /// process. \return The id of the process that we started if it's positive, otherwise
   /// it means we didn't start a process.
   Process StartWorkerProcess(
@@ -359,7 +370,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
       const std::vector<std::string> &dynamic_options = {},
       const int runtime_env_hash = 0, const std::string &serialized_runtime_env = "{}",
       std::unordered_map<std::string, std::string> override_environment_variables = {},
-      const std::string &serialized_runtime_env_context = "{}");
+      const std::string &serialized_runtime_env_context = "{}",
+      const std::string &allocated_instances_serialized_json = "{}");
 
   /// The implementation of how to start a new worker process with command arguments.
   /// The lifetime of the process is tied to that of the returned object,

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -1159,8 +1159,8 @@ TEST_F(WorkerPoolTest, CacheWorkersByRuntimeEnvHash) {
       ExampleTaskSpec(ActorID::Nil(), Language::PYTHON, JOB_ID, ActorID::Nil(),
                       /*dynamic_options=*/{}, TaskID::Nil(), "mock_runtime_env_2");
 
-  const WorkerCacheKey env1 = {/*override_environment_variables=*/{},
-                               "mock_runtime_env_1"};
+  const WorkerCacheKey env1 = {
+      /*override_environment_variables=*/{}, "mock_runtime_env_1", {}};
   const int runtime_env_hash_1 = env1.IntHash();
 
   // Try to pop worker for task with runtime env 1.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When ray worker started in container, we add cpushare limit, cpuset, memory limit when enable `worker_resource_restricted`

We can also use enviroment ` CUDA_VISIBLE_DEVICES` to add nvidia limit in next PR


## Related issue number

https://github.com/ray-project/ray/issues/16871

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
