### PR TITLE
[Core] fix the bug where we failed to read spilled object whose size is greater than max(int32_t)

### DIFF
--- a/src/ray/object_manager/spilled_object_reader.cc
+++ b/src/ray/object_manager/spilled_object_reader.cc
@@ -87,9 +87,18 @@ SpilledObjectReader::SpilledObjectReader(std::string file_path, uint64_t object_
   }
   file_path = match_groups[1].str();
   try {
-    object_offset = std::stoi(match_groups[2].str());
-    object_size = std::stoi(match_groups[3].str());
+    auto offset = std::stoll(match_groups[2].str());
+    auto size = std::stoll(match_groups[3].str());
+    if (offset < 0 || size < 0) {
+      RAY_LOG(ERROR) << "Offset and size can't be negative. offset: " << offset
+                     << ", size: " << size;
+      return false;
+    }
+    object_offset = offset;
+    object_size = size;
   } catch (...) {
+    RAY_LOG(ERROR) << "Failed to parse offset: " << match_groups[2].str()
+                   << " and size: " << match_groups[3].str();
     return false;
   }
   return true;

--- a/src/ray/object_manager/test/spilled_object_test.cc
+++ b/src/ray/object_manager/test/spilled_object_test.cc
@@ -55,7 +55,18 @@ TEST(SpilledObjectReaderTest, ParseObjectURL) {
                        "file:///C:/Users/file.txt", 123, 456);
   assert_parse_success("/tmp/file.txt?offset=123&size=456", "/tmp/file.txt", 123, 456);
   assert_parse_success("C:\\file.txt?offset=123&size=456", "C:\\file.txt", 123, 456);
+  assert_parse_success(
+      "/tmp/ray/session_2021-07-19_09-50-58_115365_119/ray_spillled_objects/"
+      "2f81e7cfcc578f4effffffffffffffffffffffff0200000001000000-multi-1?offset=0&size="
+      "2199437144",
+      "/tmp/ray/session_2021-07-19_09-50-58_115365_119/ray_spillled_objects/"
+      "2f81e7cfcc578f4effffffffffffffffffffffff0200000001000000-multi-1",
+      0, 2199437144);
+  assert_parse_success("/tmp/123?offset=0&size=9223372036854775807", "/tmp/123", 0,
+                       9223372036854775807);
 
+  assert_parse_fail("/tmp/123?offset=-1&size=1");
+  assert_parse_fail("/tmp/123?offset=0&size=9223372036854775808");
   assert_parse_fail("file://path/to/file?offset=a&size=456");
   assert_parse_fail("file://path/to/file?offset=0&size=bb");
   assert_parse_fail("file://path/to/file?offset=123");


### PR DESCRIPTION
we use `stoi` to parse spilled url which only handles int32_t. change it to `stoll` which handles long long, which is at least int64_t in C++11.
https://en.cppreference.com/w/cpp/string/basic_string/stol
https://en.cppreference.com/w/cpp/language/types

Test plan: 
- [x] added unit test.