### PR TITLE
Re-merge TMPDIR support, but only for Linux. OSX requires RAY_TMPDIR

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -46,7 +46,9 @@ win32_AssignProcessToJobObject = None
 
 
 def get_user_temp_dir():
-    if sys.platform.startswith("darwin") or sys.platform.startswith("linux"):
+    if "TMPDIR" in os.environ:
+        return os.environ["TMPDIR"]
+    elif sys.platform.startswith("darwin") or sys.platform.startswith("linux"):
         # Ideally we wouldn't need this fallback, but keep it for now for
         # for compatibility
         tempdir = os.path.join(os.sep, "tmp")

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -46,7 +46,9 @@ win32_AssignProcessToJobObject = None
 
 
 def get_user_temp_dir():
-    if "TMPDIR" in os.environ:
+    if "RAY_TMPDIR" in os.environ:
+        return os.environ["RAY_TMPDIR"]
+    elif sys.platform.startswith("linux") and "TMPDIR" in os.environ:
         return os.environ["TMPDIR"]
     elif sys.platform.startswith("darwin") or sys.platform.startswith("linux"):
         # Ideally we wouldn't need this fallback, but keep it for now for

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -9,6 +9,7 @@ import ray._private.services
 from ray.util.client.ray_client_helpers import ray_start_client_server
 from ray.client_builder import ClientContext
 from ray.cluster_utils import Cluster
+from ray.test_utils import run_string_as_driver
 
 
 @pytest.fixture
@@ -91,6 +92,18 @@ def test_shutdown_and_reset_global_worker(shutdown_only):
 
     a = A.remote()
     ray.get(a.f.remote())
+
+
+def test_tmpdir_env_var(shutdown_only):
+    result = run_string_as_driver(
+        """
+import ray
+context = ray.init()
+assert context["session_dir"].startswith("/tmp/qqq/"), context
+print("passed")
+""",
+        env={"TMPDIR": "/tmp/qqq"})
+    assert "passed" in result, result
 
 
 def test_ports_assignment(ray_start_cluster):

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -102,7 +102,7 @@ context = ray.init()
 assert context["session_dir"].startswith("/tmp/qqq/"), context
 print("passed")
 """,
-        env={"TMPDIR": "/tmp/qqq"})
+        env={"RAY_TMPDIR": "/tmp/qqq"})
     assert "passed" in result, result
 
 

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -120,7 +120,9 @@ def test_raylet_tempfiles(shutdown_only):
 
 
 def test_tempdir_privilege(shutdown_only):
-    os.chmod(ray._private.utils.get_ray_temp_dir(), 0o000)
+    tmp_dir = ray._private.utils.get_ray_temp_dir()
+    os.makedirs(tmp_dir, exist_ok=True)
+    os.chmod(tmp_dir, 0o000)
     ray.init(num_cpus=1)
     session_dir = ray.worker._global_node.get_session_dir_path()
     assert os.path.exists(session_dir), "Specified socket path not found."


### PR DESCRIPTION
Followup from the reverted https://github.com/ray-project/ray/pull/17130/files

Closes https://github.com/ray-project/ray/issues/13606