### PR TITLE
[data] Enable zero-copy access to underlying Arrow tables

### DIFF
--- a/python/ray/experimental/data/block.py
+++ b/python/ray/experimental/data/block.py
@@ -13,7 +13,7 @@ class Block(Generic[T]):
     """Represents a batch of rows to be stored in the Ray object store.
 
     Blocks can be accessed in a uniform way via ``BlockAccessors`` such as
-    ``ListBlockAccessor`` and ``ArrowBlockAccessor``.
+    ``SimpleBlockAccessor`` and ``ArrowBlockAccessor``.
 
     This class is a dummy type that cannot be constructed. It stands in for the
     real type ``Union[pyarrow.Table, List[T]] (Generic[T])`` which cannot be
@@ -51,7 +51,7 @@ class BlockAccessor(Generic[T]):
     this is needed if we want to support storing ``pyarrow.Table`` directly
     as a top-level Ray object, without a wrapping class (issue #17186).
 
-    There are two types of block accessors: ``ListBlockAccessor``, which
+    There are two types of block accessors: ``SimpleBlockAccessor``, which
     operates over a plain Python list, and ``ArrowBlockAccessor``, for
     ``pyarrow.Table`` type blocks.
     """

--- a/python/ray/experimental/data/block.py
+++ b/python/ray/experimental/data/block.py
@@ -11,18 +11,14 @@ from ray.util.annotations import DeveloperAPI
 T = TypeVar("T")
 
 
-@DeveloperAPI
-class Block(Generic[T]):
-    """Represents a batch of rows to be stored in the Ray object store.
-
-    Blocks can be accessed in a uniform way via ``BlockAccessors`` such as
-    ``SimpleBlockAccessor`` and ``ArrowBlockAccessor``.
-
-    This class is a dummy type that cannot be constructed. It stands in for the
-    real type ``Union[pyarrow.Table, List[T]] (Generic[T])`` which cannot be
-    expressed with the current Python type rules.
-    """
+# TODO(ekl) this is a dummy generic ref type for documentation purposes only.
+# It adds Generic[T] to pyarrow.Table so we can define Block[T] below.
+class ArrowTable(Generic[T]):
     pass
+
+
+# Represents a batch of rows to be stored in the Ray object store.
+Block = Union[List[T], ArrowTable[T]]
 
 
 @DeveloperAPI

--- a/python/ray/experimental/data/block.py
+++ b/python/ray/experimental/data/block.py
@@ -6,9 +6,12 @@ if TYPE_CHECKING:
     import pyarrow
     from ray.experimental.data.impl.block_builder import BlockBuilder
 
+from ray.util.annotations import DeveloperAPI
+
 T = TypeVar("T")
 
 
+@DeveloperAPI
 class Block(Generic[T]):
     """Represents a batch of rows to be stored in the Ray object store.
 
@@ -22,6 +25,7 @@ class Block(Generic[T]):
     pass
 
 
+@DeveloperAPI
 class BlockMetadata:
     """Metadata about the block.
 
@@ -44,6 +48,7 @@ class BlockMetadata:
         self.input_files: List[str] = input_files
 
 
+@DeveloperAPI
 class BlockAccessor(Generic[T]):
     """Provides accessor methods for a specific block.
 

--- a/python/ray/experimental/data/block.py
+++ b/python/ray/experimental/data/block.py
@@ -18,7 +18,10 @@ class ArrowTable(Generic[T]):
 
 
 # Represents a batch of rows to be stored in the Ray object store.
-Block = Union[List[T], ArrowTable[T]]
+#
+# Block data can be accessed in a uniform way via ``BlockAccessors`` such as
+# ``SimpleBlockAccessor`` and ``ArrowBlockAccessor``.
+Block = Union[List[T], arrowTable[T]]
 
 
 @DeveloperAPI

--- a/python/ray/experimental/data/block.py
+++ b/python/ray/experimental/data/block.py
@@ -13,7 +13,7 @@ T = TypeVar("T")
 
 # TODO(ekl) this is a dummy generic ref type for documentation purposes only.
 # It adds Generic[T] to pyarrow.Table so we can define Block[T] below.
-class ArrowTable(Generic[T]):
+class _ArrowTable(Generic[T]):
     pass
 
 
@@ -21,7 +21,7 @@ class ArrowTable(Generic[T]):
 #
 # Block data can be accessed in a uniform way via ``BlockAccessors`` such as
 # ``SimpleBlockAccessor`` and ``ArrowBlockAccessor``.
-Block = Union[List[T], arrowTable[T]]
+Block = Union[List[T], _ArrowTable[T]]
 
 
 @DeveloperAPI

--- a/python/ray/experimental/data/dataset.py
+++ b/python/ray/experimental/data/dataset.py
@@ -21,6 +21,7 @@ import numpy as np
 
 import ray
 from ray.types import ObjectRef
+from ray.util.annotations import DeveloperAPI, PublicAPI
 from ray.experimental.data.block import Block, BlockAccessor, BlockMetadata
 from ray.experimental.data.datasource import Datasource, WriteTask
 from ray.experimental.data.impl.batcher import Batcher
@@ -40,6 +41,7 @@ BatchType = Union["pandas.DataFrame", "pyarrow.Table", list]
 logger = logging.getLogger(__name__)
 
 
+@PublicAPI(stability="beta")
 class Dataset(Generic[T]):
     """Implements a distributed Arrow dataset.
 
@@ -1152,6 +1154,7 @@ class Dataset(Generic[T]):
 
         return [block_to_df.remote(block) for block in self._blocks]
 
+    @DeveloperAPI
     def get_blocks(self) -> List[ObjectRef["Block"]]:
         """Get a list of references to the underlying blocks of this dataset.
 

--- a/python/ray/experimental/data/dataset.py
+++ b/python/ray/experimental/data/dataset.py
@@ -45,8 +45,7 @@ class Dataset(Generic[T]):
 
     Datasets are implemented as a list of ``ObjectRef[Block[T]]``. The block
     also determines the unit of parallelism. The default block type is the
-    ``ArrowBlock``, which is backed by a ``pyarrow.Table`` object. Other
-    Python objects are represented with ``SimpleBlock`` (a plain Python list).
+    ``pyarrow.Table``. Arrow-incompatible objects are held in ``list`` blocks.
 
     Since Datasets are just lists of Ray object refs, they can be passed
     between Ray tasks and actors just like any other object. Datasets support

--- a/python/ray/experimental/data/datasource/datasource.py
+++ b/python/ray/experimental/data/datasource/datasource.py
@@ -7,10 +7,12 @@ import ray
 from ray.types import ObjectRef
 from ray.experimental.data.block import Block, BlockAccessor, BlockMetadata, T
 from ray.experimental.data.impl.arrow_block import ArrowRow
+from ray.util.annotations import PublicAPI
 
 WriteResult = Any
 
 
+@PublicAPI(stability="beta")
 class Datasource(Generic[T]):
     """Interface for defining a custom ``ray.data.Dataset`` datasource.
 
@@ -83,6 +85,7 @@ class Datasource(Generic[T]):
         pass
 
 
+@PublicAPI(stability="beta")
 class ReadTask(Callable[[], Block[T]]):
     """A function used to read a block of a dataset.
 
@@ -105,6 +108,7 @@ class ReadTask(Callable[[], Block[T]]):
         return self._read_fn()
 
 
+@PublicAPI(stability="beta")
 class WriteTask(Callable[[], WriteResult]):
     """A function used to write a chunk of a dataset.
 

--- a/python/ray/experimental/data/datasource/datasource.py
+++ b/python/ray/experimental/data/datasource/datasource.py
@@ -5,9 +5,8 @@ import numpy as np
 
 import ray
 from ray.types import ObjectRef
-from ray.experimental.data.block import Block, BlockMetadata, T
-from ray.experimental.data.impl.block_builder import SimpleBlock
-from ray.experimental.data.impl.arrow_block import ArrowRow, ArrowBlock
+from ray.experimental.data.block import Block, BlockAccessor, BlockMetadata, T
+from ray.experimental.data.impl.arrow_block import ArrowRow
 
 WriteResult = Any
 
@@ -141,11 +140,10 @@ class RangeDatasource(Datasource[Union[ArrowRow, int]]):
         # from an external system instead of generating dummy data.
         def make_block(start: int, count: int) -> Block[Union[ArrowRow, int]]:
             if use_arrow:
-                return ArrowBlock(
-                    pyarrow.Table.from_arrays(
-                        [np.arange(start, start + count)], names=["value"]))
+                return pyarrow.Table.from_arrays(
+                    [np.arange(start, start + count)], names=["value"])
             else:
-                return SimpleBlock(list(builtins.range(start, start + count)))
+                return list(builtins.range(start, start + count))
 
         i = 0
         while i < n:
@@ -187,6 +185,7 @@ class DummyOutputDatasource(Datasource[Union[ArrowRow, int]]):
                 self.enabled = True
 
             def write(self, block: Block[T]) -> str:
+                block = BlockAccessor.for_block(block)
                 if not self.enabled:
                     raise ValueError("disabled")
                 self.rows_written += block.num_rows()

--- a/python/ray/experimental/data/datasource/file_based_datasource.py
+++ b/python/ray/experimental/data/datasource/file_based_datasource.py
@@ -4,7 +4,7 @@ from typing import Optional, List, Tuple, Union, TYPE_CHECKING
 if TYPE_CHECKING:
     import pyarrow
 
-from ray.experimental.data.impl.arrow_block import ArrowRow, ArrowBlock
+from ray.experimental.data.impl.arrow_block import ArrowRow
 from ray.experimental.data.impl.block_list import BlockMetadata
 from ray.experimental.data.datasource.datasource import (Datasource, ReadTask)
 
@@ -50,7 +50,7 @@ class FileBasedDatasource(Datasource[Union[ArrowRow, int]]):
             for read_path in read_paths:
                 with fs.open_input_file(read_path) as f:
                     tables.append(read_file(f, **reader_args))
-            return ArrowBlock(pa.concat_tables(tables))
+            return pa.concat_tables(tables)
 
         read_tasks = [
             ReadTask(

--- a/python/ray/experimental/data/datasource/file_based_datasource.py
+++ b/python/ray/experimental/data/datasource/file_based_datasource.py
@@ -7,10 +7,12 @@ if TYPE_CHECKING:
 from ray.experimental.data.impl.arrow_block import ArrowRow
 from ray.experimental.data.impl.block_list import BlockMetadata
 from ray.experimental.data.datasource.datasource import (Datasource, ReadTask)
+from ray.util.annotations import DeveloperAPI
 
 logger = logging.getLogger(__name__)
 
 
+@DeveloperAPI
 class FileBasedDatasource(Datasource[Union[ArrowRow, int]]):
     """File-based datasource, for reading and writing files.
 

--- a/python/ray/experimental/data/impl/arrow_block.py
+++ b/python/ray/experimental/data/impl/arrow_block.py
@@ -96,7 +96,7 @@ class ArrowBlockBuilder(BlockBuilder[T]):
             self._columns[key].append(value)
         self._num_rows += 1
 
-    def add_block(self, block: pyarrow.Table) -> None:
+    def add_block(self, block: "pyarrow.Table") -> None:
         assert isinstance(block, pyarrow.Table), block
         self._tables.append(block)
         self._num_rows += block.num_rows

--- a/python/ray/experimental/data/impl/arrow_block.py
+++ b/python/ray/experimental/data/impl/arrow_block.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     pyarrow = None
 
-from ray.experimental.data.block import Block
+from ray.experimental.data.block import Block, BlockAccessor
 from ray.experimental.data.impl.block_builder import BlockBuilder, \
     SimpleBlockBuilder
 
@@ -65,7 +65,7 @@ class DelegatingArrowBlockBuilder(BlockBuilder[T]):
 
     def add_block(self, block: Block[T]) -> None:
         if self._builder is None:
-            self._builder = block.builder()
+            self._builder = BlockAccessor.for_block(block).builder()
         self._builder.add_block(block)
 
     def build(self) -> Block[T]:
@@ -96,28 +96,29 @@ class ArrowBlockBuilder(BlockBuilder[T]):
             self._columns[key].append(value)
         self._num_rows += 1
 
-    def add_block(self, block: "ArrowBlock[T]") -> None:
-        self._tables.append(block._table)
-        self._num_rows += block.num_rows()
+    def add_block(self, block: pyarrow.Table) -> None:
+        assert isinstance(block, pyarrow.Table), block
+        self._tables.append(block)
+        self._num_rows += block.num_rows
 
-    def build(self) -> "ArrowBlock[T]":
+    def build(self) -> Block[T]:
         if self._columns:
             tables = [pyarrow.Table.from_pydict(self._columns)]
         else:
             tables = []
         tables.extend(self._tables)
         if len(tables) > 1:
-            return ArrowBlock(pyarrow.concat_tables(tables))
+            return pyarrow.concat_tables(tables)
         elif len(tables) > 0:
-            return ArrowBlock(tables[0])
+            return tables[0]
         else:
-            return ArrowBlock(pyarrow.Table.from_pydict({}))
+            return pyarrow.Table.from_pydict({})
 
     def num_rows(self) -> int:
         return self._num_rows
 
 
-class ArrowBlock(Block):
+class ArrowBlockAccessor(BlockAccessor):
     def __init__(self, table: "pyarrow.Table"):
         if pyarrow is None:
             raise ImportError("Run `pip install pyarrow` for Arrow support")
@@ -142,15 +143,15 @@ class ArrowBlock(Block):
 
         return Iter()
 
-    def slice(self, start: int, end: int, copy: bool) -> "ArrowBlock[T]":
+    def slice(self, start: int, end: int,
+              copy: bool) -> "ArrowBlockAccessor[T]":
         view = self._table.slice(start, end - start)
         if copy:
             # TODO(ekl) there must be a cleaner way to force a copy of a table.
             copy = [c.to_pandas() for c in view.itercolumns()]
-            return ArrowBlock(
-                pyarrow.Table.from_arrays(copy, schema=self._table.schema))
+            return pyarrow.Table.from_arrays(copy, schema=self._table.schema)
         else:
-            return ArrowBlock(view)
+            return view
 
     def schema(self) -> "pyarrow.lib.Schema":
         return self._table.schema

--- a/python/ray/experimental/data/impl/batcher.py
+++ b/python/ray/experimental/data/impl/batcher.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from ray.experimental.data.block import Block
+from ray.experimental.data.block import Block, BlockAccessor
 from ray.experimental.data.impl.arrow_block import DelegatingArrowBlockBuilder
 
 
@@ -32,7 +32,8 @@ class Batcher:
         """Whether this Batcher has any full batches.
         """
         return self._buffer and (self._batch_size is None or sum(
-            b.num_rows() for b in self._buffer) >= self._batch_size)
+            BlockAccessor.for_block(b).num_rows()
+            for b in self._buffer) >= self._batch_size)
 
     def has_any(self) -> bool:
         """Whether this Batcher has any data.

--- a/python/ray/experimental/data/impl/batcher.py
+++ b/python/ray/experimental/data/impl/batcher.py
@@ -38,7 +38,8 @@ class Batcher:
     def has_any(self) -> bool:
         """Whether this Batcher has any data.
         """
-        return any(b.num_rows() > 0 for b in self._buffer)
+        return any(
+            BlockAccessor.for_block(b).num_rows() > 0 for b in self._buffer)
 
     def next_batch(self) -> Block:
         """Get the next batch from the block buffer.
@@ -56,20 +57,21 @@ class Batcher:
         leftover = []
         needed = self._batch_size
         for block in self._buffer:
+            accessor = BlockAccessor.for_block(block)
             if needed <= 0:
                 # We already have a full batch, so add this block to
                 # the leftovers.
                 leftover.append(block)
-            elif block.num_rows() <= needed:
+            elif accessor.num_rows() <= needed:
                 # We need this entire block to fill out a batch.
                 output.add_block(block)
-                needed -= block.num_rows()
+                needed -= accessor.num_rows()
             else:
                 # We only need part of the block to fill out a batch.
-                output.add_block(block.slice(0, needed, copy=False))
+                output.add_block(accessor.slice(0, needed, copy=False))
                 # Add the rest of the block to the leftovers.
                 leftover.append(
-                    block.slice(needed, block.num_rows(), copy=False))
+                    accessor.slice(needed, accessor.num_rows(), copy=False))
                 needed = 0
 
         # Move the leftovers into the block buffer so they're the first

--- a/python/ray/experimental/data/impl/block_builder.py
+++ b/python/ray/experimental/data/impl/block_builder.py
@@ -1,11 +1,11 @@
 import sys
-from typing import Iterator, Generic, Any, TYPE_CHECKING
+from typing import Iterator, List, Generic, Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
     import pandas
     import pyarrow
 
-from ray.experimental.data.block import Block, T
+from ray.experimental.data.block import Block, BlockAccessor, T
 
 
 class BlockBuilder(Generic[T]):
@@ -31,14 +31,15 @@ class SimpleBlockBuilder(BlockBuilder[T]):
     def add(self, item: T) -> None:
         self._items.append(item)
 
-    def add_block(self, block: "SimpleBlock[T]") -> None:
-        self._items.extend(block._items)
+    def add_block(self, block: List[T]) -> None:
+        assert isinstance(block, list), block
+        self._items.extend(block)
 
-    def build(self) -> "SimpleBlock[T]":
-        return SimpleBlock(self._items)
+    def build(self) -> "Block[T]":
+        return list(self._items)
 
 
-class SimpleBlock(Block):
+class SimpleBlockAccessor(BlockAccessor):
     def __init__(self, items):
         self._items = items
 
@@ -48,11 +49,12 @@ class SimpleBlock(Block):
     def iter_rows(self) -> Iterator[T]:
         return iter(self._items)
 
-    def slice(self, start: int, end: int, copy: bool) -> "SimpleBlock[T]":
+    def slice(self, start: int, end: int,
+              copy: bool) -> "SimpleBlockAccessor[T]":
         view = self._items[start:end]
         if copy:
             view = view.copy()
-        return SimpleBlock(view)
+        return view
 
     def to_pandas(self) -> "pandas.DataFrame":
         import pandas

--- a/python/ray/experimental/data/impl/compute.py
+++ b/python/ray/experimental/data/impl/compute.py
@@ -2,7 +2,7 @@ from typing import TypeVar, Iterable, Any, Union, Callable
 
 import ray
 from ray.types import ObjectRef
-from ray.experimental.data.block import Block, BlockMetadata
+from ray.experimental.data.block import Block, BlockAccessor, BlockMetadata
 from ray.experimental.data.impl.block_list import BlockList
 from ray.experimental.data.impl.progress_bar import ProgressBar
 
@@ -30,10 +30,11 @@ class TaskPool(ComputeStrategy):
         @ray.remote(**kwargs)
         def wrapped_fn(block: Block, meta: BlockMetadata):
             new_block = fn(block)
+            accessor = BlockAccessor.for_block(new_block)
             new_meta = BlockMetadata(
-                num_rows=new_block.num_rows(),
-                size_bytes=new_block.size_bytes(),
-                schema=new_block.schema(),
+                num_rows=accessor.num_rows(),
+                size_bytes=accessor.size_bytes(),
+                schema=accessor.schema(),
                 input_files=meta.input_files)
             return new_block, new_meta
 
@@ -62,10 +63,11 @@ class ActorPool(ComputeStrategy):
             def process_block(self, block: Block[T], meta: BlockMetadata
                               ) -> (Block[U], BlockMetadata):
                 new_block = fn(block)
+                accessor = BlockAccessor.for_block(new_block)
                 new_metadata = BlockMetadata(
-                    num_rows=new_block.num_rows(),
-                    size_bytes=new_block.size_bytes(),
-                    schema=new_block.schema(),
+                    num_rows=accessor.num_rows(),
+                    size_bytes=accessor.size_bytes(),
+                    schema=accessor.schema(),
                     input_files=meta.input_files)
                 return new_block, new_metadata
 

--- a/python/ray/experimental/data/impl/shuffle.py
+++ b/python/ray/experimental/data/impl/shuffle.py
@@ -2,7 +2,7 @@ import math
 from typing import TypeVar, List
 
 import ray
-from ray.experimental.data.block import Block, BlockMetadata
+from ray.experimental.data.block import Block, BlockAccessor, BlockMetadata
 from ray.experimental.data.impl.progress_bar import ProgressBar
 from ray.experimental.data.impl.block_list import BlockList
 from ray.experimental.data.impl.arrow_block import DelegatingArrowBlockBuilder
@@ -16,12 +16,13 @@ def simple_shuffle(input_blocks: BlockList[T],
 
     @ray.remote(num_returns=output_num_blocks)
     def shuffle_map(block: Block[T]) -> List[Block[T]]:
+        block = BlockAccessor.for_block(block)
         slice_sz = max(1, math.ceil(block.num_rows() / output_num_blocks))
         slices = []
         for i in range(output_num_blocks):
             slices.append(
                 block.slice(i * slice_sz, (i + 1) * slice_sz, copy=True))
-        num_rows = sum(s.num_rows() for s in slices)
+        num_rows = sum(BlockAccessor.for_block(s).num_rows() for s in slices)
         assert num_rows == block.num_rows(), (num_rows, block.num_rows())
         # Needed to handle num_returns=1 edge case in Ray API.
         if len(slices) == 1:
@@ -37,10 +38,11 @@ def simple_shuffle(input_blocks: BlockList[T],
         for block in mapper_outputs:
             builder.add_block(block)
         new_block = builder.build()
+        accessor = BlockAccessor.for_block(new_block)
         new_metadata = BlockMetadata(
-            num_rows=new_block.num_rows(),
-            size_bytes=new_block.size_bytes(),
-            schema=new_block.schema(),
+            num_rows=accessor.num_rows(),
+            size_bytes=accessor.size_bytes(),
+            schema=accessor.schema(),
             input_files=None)
         return new_block, new_metadata
 

--- a/python/ray/experimental/data/tests/test_dataset.py
+++ b/python/ray/experimental/data/tests/test_dataset.py
@@ -258,8 +258,17 @@ def test_to_pandas(ray_start_regular_shared):
 
 def test_to_arrow(ray_start_regular_shared):
     n = 5
+
+    # Zero-copy.
     df = pd.DataFrame({"value": list(range(n))})
     ds = ray.experimental.data.range_arrow(n)
+    dfds = pd.concat(
+        [t.to_pandas() for t in ray.get(ds.to_arrow())], ignore_index=True)
+    assert df.equals(dfds)
+
+    # Conversion.
+    df = pd.DataFrame({0: list(range(n))})
+    ds = ray.experimental.data.range(n)
     dfds = pd.concat(
         [t.to_pandas() for t in ray.get(ds.to_arrow())], ignore_index=True)
     assert df.equals(dfds)

--- a/python/ray/experimental/data/tests/test_dataset.py
+++ b/python/ray/experimental/data/tests/test_dataset.py
@@ -16,7 +16,7 @@ import ray
 
 from ray.tests.conftest import *  # noqa
 from ray.experimental.data.datasource import DummyOutputDatasource
-from ray.experimental.data.block import Block
+from ray.experimental.data.block import Block, BlockAccessor
 import ray.experimental.data.tests.util as util
 
 
@@ -270,7 +270,7 @@ def test_get_blocks(ray_start_regular_shared):
     assert len(blocks) == 10
     out = []
     for b in ray.get(blocks):
-        out.extend(list(b.iter_rows()))
+        out.extend(list(BlockAccessor.for_block(b).iter_rows()))
     out = sorted(out)
     assert out == list(range(10)), out
 

--- a/python/ray/experimental/data/tests/test_dataset.py
+++ b/python/ray/experimental/data/tests/test_dataset.py
@@ -16,7 +16,7 @@ import ray
 
 from ray.tests.conftest import *  # noqa
 from ray.experimental.data.datasource import DummyOutputDatasource
-from ray.experimental.data.block import Block, BlockAccessor
+from ray.experimental.data.block import BlockAccessor
 import ray.experimental.data.tests.util as util
 
 
@@ -352,31 +352,6 @@ def test_pyarrow(ray_start_regular_shared):
         .take() == [{"b": 2}, {"b": 20}]
 
 
-def test_uri_parser():
-    from ray.experimental.data.read_api import _parse_paths
-    fs, path = _parse_paths("/local/path")
-    assert path == "/local/path"
-    assert fs.type_name == "local"
-
-    fs, path = _parse_paths("./")
-    assert path == "./"
-    assert fs.type_name == "local"
-
-    fs, path = _parse_paths("s3://bucket/dir")
-    assert path == "bucket/dir"
-    assert fs.type_name == "s3"
-
-    fs, path = _parse_paths(["s3://bucket/dir_1", "s3://bucket/dir_2"])
-    assert path == ["bucket/dir_1", "bucket/dir_2"]
-    assert fs.type_name == "s3"
-
-    with pytest.raises(ValueError):
-        _parse_paths(["s3://bucket/dir_1", "/path/local"])
-
-    with pytest.raises(ValueError):
-        _parse_paths([])
-
-
 def test_read_binary_files(ray_start_regular_shared):
     with util.gen_bin_files(10) as (_, paths):
         ds = ray.experimental.data.read_binary_files(paths, parallelism=10)
@@ -442,7 +417,6 @@ def test_iter_batches_basic(ray_start_regular_shared):
 
     # blocks format.
     for batch, df in zip(ds.iter_batches(batch_format="_blocks"), dfs):
-        assert isinstance(batch, Block)
         assert batch.to_pandas().equals(df)
 
     # Batch size.
@@ -945,7 +919,7 @@ def test_json_read(ray_start_regular_shared, tmp_path):
     assert pd.concat([df1, df2]).equals(dsdf)
     # Test metadata ops.
     for block, meta in zip(ds._blocks, ds._blocks.get_metadata()):
-        ray.get(block).size_bytes() == meta.size_bytes
+        BlockAccessor.for_block(ray.get(block)).size_bytes() == meta.size_bytes
 
     # Three files, parallelism=2.
     df3 = pd.DataFrame({"one": [7, 8, 9], "two": ["h", "i", "j"]})
@@ -1055,7 +1029,7 @@ def test_csv_read(ray_start_regular_shared, tmp_path):
     assert df.equals(dsdf)
     # Test metadata ops.
     for block, meta in zip(ds._blocks, ds._blocks.get_metadata()):
-        ray.get(block).size_bytes() == meta.size_bytes
+        BlockAccessor.for_block(ray.get(block)).size_bytes() == meta.size_bytes
 
     # Three files, parallelism=2.
     df3 = pd.DataFrame({"one": [7, 8, 9], "two": ["h", "i", "j"]})
@@ -1140,6 +1114,32 @@ def test_csv_write(ray_start_regular_shared, tmp_path):
         pd.concat([pd.read_csv(file_path),
                    pd.read_csv(file_path2)]))
     shutil.rmtree(path)
+
+
+# TODO: this shouldn't be making network calls
+def test_uri_parser():
+    from ray.experimental.data.read_api import _parse_paths
+    fs, path = _parse_paths("/local/path")
+    assert path == "/local/path"
+    assert fs.type_name == "local"
+
+    fs, path = _parse_paths("./")
+    assert path == "./"
+    assert fs.type_name == "local"
+
+    fs, path = _parse_paths("s3://bucket/dir")
+    assert path == "bucket/dir"
+    assert fs.type_name == "s3"
+
+    fs, path = _parse_paths(["s3://bucket/dir_1", "s3://bucket/dir_2"])
+    assert path == ["bucket/dir_1", "bucket/dir_2"]
+    assert fs.type_name == "s3"
+
+    with pytest.raises(ValueError):
+        _parse_paths(["s3://bucket/dir_1", "/path/local"])
+
+    with pytest.raises(ValueError):
+        _parse_paths([])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Due to Ray limitations, we cannot create references to portions of an existing Ray object with zero-copy semantics. Hence, in Dataset we have to store Arrow tables as top-level Ray objects. This means we have to add a wrapper class to access different block types in a uniform way.

After this PR, calls to `ds.to_arrow()` and `ds.from_arrow()` are zero copy.

Possible design alternatives:
- Rename Block to something like BlockData (can still do this in the future, but didn't do this in this PR since it changes a lot of code)
- Require all block accesses to be done via static methods (e.g., `Block.num_rows(block_data)`. This is a bit clunky and potentially slower since we have check the Python type of the data each time.
- Support zero-copy sub-object references in Ray.

Closes https://github.com/ray-project/ray/issues/17186
Related issue https://github.com/oap-project/raydp/pull/166