### PR TITLE
[Streaming] Fix illegal cast when rollbacking.

### DIFF
--- a/streaming/java/streaming-api/src/main/java/io/ray/streaming/operator/chain/ChainedOperator.java
+++ b/streaming/java/streaming-api/src/main/java/io/ray/streaming/operator/chain/ChainedOperator.java
@@ -87,7 +87,7 @@ public abstract class ChainedOperator extends StreamOperator<Function> {
 
   @Override
   public Serializable saveCheckpoint() {
-    Object[] checkpoints = new Object[operators.size()];
+    Serializable[] checkpoints = new Serializable[operators.size()];
     for (int i = 0; i < operators.size(); ++i) {
       checkpoints[i] = operators.get(i).saveCheckpoint();
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
When rolling back, I met an error which said it was illegal to cast object[] to Serializable[] in loadcheckpoint(). To make the returned value of savecheckpoint adapt to loadcheckpoint(), I changed the type of checkpoints.
## Related issue number

<!-- For example: "Closes #1234" -->
Closes #13056
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
