### PR TITLE
[Core] fix erase iterator while iterating over a map.

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -572,6 +572,8 @@ void GcsPlacementGroupManager::OnNodeDead(const NodeID &node_id) {
 
 void GcsPlacementGroupManager::CleanPlacementGroupIfNeededWhenJobDead(
     const JobID &job_id) {
+  std::vector<PlacementGroupID> groups_to_remove;
+
   for (const auto &it : registered_placement_groups_) {
     auto &placement_group = it.second;
     if (placement_group->GetCreatorJobId() != job_id) {
@@ -579,13 +581,19 @@ void GcsPlacementGroupManager::CleanPlacementGroupIfNeededWhenJobDead(
     }
     placement_group->MarkCreatorJobDead();
     if (placement_group->IsPlacementGroupLifetimeDone()) {
-      RemovePlacementGroup(placement_group->GetPlacementGroupID(), [](Status status) {});
+      groups_to_remove.push_back(placement_group->GetPlacementGroupID());
     }
+  }
+
+  for (const auto &group : groups_to_remove) {
+    RemovePlacementGroup(group, [](Status status) {});
   }
 }
 
 void GcsPlacementGroupManager::CleanPlacementGroupIfNeededWhenActorDead(
     const ActorID &actor_id) {
+  std::vector<PlacementGroupID> groups_to_remove;
+
   for (const auto &it : registered_placement_groups_) {
     auto &placement_group = it.second;
     if (placement_group->GetCreatorActorId() != actor_id) {
@@ -593,8 +601,12 @@ void GcsPlacementGroupManager::CleanPlacementGroupIfNeededWhenActorDead(
     }
     placement_group->MarkCreatorActorDead();
     if (placement_group->IsPlacementGroupLifetimeDone()) {
-      RemovePlacementGroup(placement_group->GetPlacementGroupID(), [](Status status) {});
+      groups_to_remove.push_back(placement_group->GetPlacementGroupID());
     }
+  }
+
+  for (const auto &group : groups_to_remove) {
+    RemovePlacementGroup(group, [](Status status) {});
   }
 }
 

--- a/src/ray/object_manager/plasma/create_request_queue.cc
+++ b/src/ray/object_manager/plasma/create_request_queue.cc
@@ -190,9 +190,10 @@ void CreateRequestQueue::RemoveDisconnectedClientRequests(
 
   for (auto it = fulfilled_requests_.begin(); it != fulfilled_requests_.end();) {
     if (it->second && it->second->client == client) {
-      fulfilled_requests_.erase(it);
+      fulfilled_requests_.erase(it++);
+    } else {
+      it++;
     }
-    it++;
   }
 }
 

--- a/src/ray/pubsub/publisher.cc
+++ b/src/ray/pubsub/publisher.cc
@@ -300,6 +300,8 @@ bool Publisher::UnregisterSubscriberInternal(const SubscriberID &subscriber_id) 
 
 void Publisher::CheckDeadSubscribers() {
   absl::MutexLock lock(&mutex_);
+  std::vector<SubscriberID> dead_subscribers;
+
   for (const auto &it : subscribers_) {
     const auto &subscriber = it.second;
 
@@ -308,12 +310,15 @@ void Publisher::CheckDeadSubscribers() {
     RAY_CHECK(!(disconnected && active_connection_timed_out));
 
     if (disconnected) {
-      const auto &subscriber_id = it.first;
-      UnregisterSubscriberInternal(subscriber_id);
+      dead_subscribers.push_back(it.first);
     } else if (active_connection_timed_out) {
       // Refresh the long polling connection. The subscriber will send it again.
       subscriber->PublishIfPossible(/*force*/ true);
     }
+  }
+
+  for (const auto &subscriber_id : dead_subscribers) {
+    UnregisterSubscriberInternal(subscriber_id);
   }
 }
 


### PR DESCRIPTION
erasing an [absl](https://github.com/abseil/abseil-cpp/blob/master/absl/container/internal/raw_hash_set.h#L1248)/[std](https://en.cppreference.com/w/cpp/container/map/erase) map iterator invalidates the iterator. 

this leads to SIGABRT when I running debug build wheels. ([one of the crash stack got from core dump](https://gist.github.com/scv119/db8e9837dcb45c3abd86f551e29f0871))

instead, we should use _Post-increment_  i.e., ```map.erase(iterator++)``` for absl::flat_hash_map, where

> Post-increment and post-decrement creates a copy of the object, increments or decrements the value of the object and returns the copy from before the increment or decrement.

https://en.cppreference.com/w/cpp/language/operator_incdec

basically ```map.erase(iterator++)``` equals to
```
auto copy = iterator;
iterator++;
map.erase(copy);
```
Note as @clarkzinzow points out 
```
it = map.erase(it)
```
is more idiomatic code, but unfortunately absl::flat_has_map.erase returns void :( 




