### PR TITLE
change default expiration to 2 days in order to prevent custodian kil…

### DIFF
--- a/release/long_running_tests/app_config.yaml
+++ b/release/long_running_tests/app_config.yaml
@@ -9,9 +9,9 @@ python:
   conda_packages: []
 
 post_build_cmds:
+  - 'rm -r wrk || true && git clone https://github.com/wg/wrk.git /tmp/wrk && cd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin'
   - pip uninstall -y numpy ray || true
   - sudo rm -rf /home/ray/anaconda3/lib/python3.7/site-packages/numpy
   - pip3 install numpy || true
   - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install -U ray[all] gym[atari]
-  - 'rm -r wrk || true && git clone https://github.com/wg/wrk.git /tmp/wrk && cd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin'

--- a/release/long_running_tests/tpl_cpu_1.yaml
+++ b/release/long_running_tests/tpl_cpu_1.yaml
@@ -21,4 +21,4 @@ aws:
         - Key: anyscale-user
           Value: '{{env["ANYSCALE_USER"]}}'
         - Key: anyscale-expiration
-          Value: '{{env["EXPIRATION_1D"]}}'
+          Value: '{{env["EXPIRATION_2D"]}}'

--- a/release/long_running_tests/tpl_cpu_2.yaml
+++ b/release/long_running_tests/tpl_cpu_2.yaml
@@ -21,4 +21,4 @@ aws:
         - Key: anyscale-user
           Value: '{{env["ANYSCALE_USER"]}}'
         - Key: anyscale-expiration
-          Value: '{{env["EXPIRATION_1D"]}}'
+          Value: '{{env["EXPIRATION_2D"]}}'

--- a/release/long_running_tests/tpl_cpu_3.yaml
+++ b/release/long_running_tests/tpl_cpu_3.yaml
@@ -21,4 +21,4 @@ aws:
         - Key: anyscale-user
           Value: '{{env["ANYSCALE_USER"]}}'
         - Key: anyscale-expiration
-          Value: '{{env["EXPIRATION_1D"]}}'
+          Value: '{{env["EXPIRATION_2D"]}}'


### PR DESCRIPTION
## Why are these changes needed?

We observed our aws custodian will kill a job in the early morning automatically based on its interpretation of a "2021-07-15". But for long running tests that indent to run for 24hrs, if kicked off during morning / afternoon on 2021-07-14, it will never successfully finish due to flakiness. Thus this PR changes it to two days so e2e.py will still finish for long running tests, also letting custodian to be able to clean it up.


## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
