### PR TITLE
change placement group report size to 1k

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -352,7 +352,7 @@ RAY_CONFIG(bool, enable_timeline, true)
 
 /// The maximum number of pending placement group entries that are reported to monitor to
 /// autoscale the cluster.
-RAY_CONFIG(int64_t, max_placement_group_load_report_size, 100)
+RAY_CONFIG(int64_t, max_placement_group_load_report_size, 1000)
 
 /* Configuration parameters for object spilling. */
 /// JSON configuration that describes the external storage. This is passed to


### PR DESCRIPTION
## Why are these changes needed?

We're adding nightly tests for ray serve at 1k replica. We noticed that it took ~22 mins for autoscaler to reach 1k replicas, from auto scaler log it shows we're adding replicas in a batch of 100. If there's no other concerns we can raise this config to 1000 so autoscaler can get 1 placement group request and process faster.

cc: @simon-mo 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
