### PR TITLE
[Datasets] Allow for Parquet metadata file to be missing.

### DIFF
--- a/python/ray/experimental/data/read_api.py
+++ b/python/ray/experimental/data/read_api.py
@@ -211,19 +211,15 @@ def read_parquet(paths: Union[str, List[str]],
     metadata: List[BlockMetadata] = []
     for pieces in nonempty_tasks:
         calls.append(lambda pieces=pieces: gen_read.remote(pieces))
-        input_files = [p.path for p in pieces]
         piece_metadata = []
         for p in pieces:
             try:
                 piece_metadata.append(p.metadata)
             except AttributeError:
-                block_metadata = BlockMetadata(
-                    num_rows=None,
-                    size_bytes=None,
-                    schema=None,
-                    input_files=input_files)
                 break
-        else:
+        input_files = [p.path for p in pieces]
+        if len(piece_metadata) == len(pieces):
+            # Piece metadata was available, constructo a normal BlockMetadata.
             block_metadata = BlockMetadata(
                 num_rows=sum(m.num_rows for m in piece_metadata),
                 size_bytes=sum(
@@ -232,7 +228,15 @@ def read_parquet(paths: Union[str, List[str]],
                         for i in builtins.range(m.num_row_groups))
                     for m in piece_metadata),
                 schema=piece_metadata[0].schema.to_arrow_schema(),
-                input_files=[p.path for p in pieces])
+                input_files=input_files)
+        else:
+            # Piece metadata was not available, construct an empty
+            # BlockMetadata.
+            block_metadata = BlockMetadata(
+                num_rows=None,
+                size_bytes=None,
+                schema=None,
+                input_files=input_files)
         metadata.append(block_metadata)
 
     return Dataset(LazyBlockList(calls, metadata))


### PR DESCRIPTION
We shouldn't fail when the Parquet metadata file is missing since that's considered an optional part of the Parquet spec.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
