### PR TITLE
[Datasets] Port read_parquet to Datasource API.

### DIFF
--- a/python/ray/experimental/data/datasource/__init__.py
+++ b/python/ray/experimental/data/datasource/__init__.py
@@ -2,12 +2,15 @@ from ray.experimental.data.datasource.datasource import (
     Datasource, RangeDatasource, DummyOutputDatasource, ReadTask, WriteTask)
 from ray.experimental.data.datasource.json_datasource import JSONDatasource
 from ray.experimental.data.datasource.csv_datasource import CSVDatasource
+from ray.experimental.data.datasource.parquet_datasource import (
+    ParquetDatasource)
 from ray.experimental.data.datasource.file_based_datasource import (
     FileBasedDatasource, _S3FileSystemWrapper)
 
 __all__ = [
     "JSONDatasource",
     "CSVDatasource",
+    "ParquetDatasource",
     "FileBasedDatasource",
     "_S3FileSystemWrapper",
     "Datasource",

--- a/python/ray/experimental/data/datasource/file_based_datasource.py
+++ b/python/ray/experimental/data/datasource/file_based_datasource.py
@@ -118,6 +118,7 @@ def _expand_directory(path: str,
 
 # TODO(Clark): Add unit test coverage of _resolve_paths_and_filesystem.
 
+
 def _resolve_paths_and_filesystem(
         paths: Union[str, List[str]],
         filesystem: "pyarrow.fs.FileSystem" = None

--- a/python/ray/experimental/data/datasource/file_based_datasource.py
+++ b/python/ray/experimental/data/datasource/file_based_datasource.py
@@ -116,6 +116,8 @@ def _expand_directory(path: str,
     return zip(*sorted(filtered_paths, key=lambda x: x[0]))
 
 
+# TODO(Clark): Add unit test coverage of _resolve_paths_and_filesystem.
+
 def _resolve_paths_and_filesystem(
         paths: Union[str, List[str]],
         filesystem: "pyarrow.fs.FileSystem" = None

--- a/python/ray/experimental/data/datasource/parquet_datasource.py
+++ b/python/ray/experimental/data/datasource/parquet_datasource.py
@@ -4,7 +4,7 @@ from typing import Optional, List, Union, TYPE_CHECKING
 if TYPE_CHECKING:
     import pyarrow
 
-from ray.experimental.data.impl.arrow_block import ArrowRow, ArrowBlock
+from ray.experimental.data.impl.arrow_block import ArrowRow
 from ray.experimental.data.impl.block_list import BlockMetadata
 from ray.experimental.data.datasource.datasource import Datasource, ReadTask
 from ray.experimental.data.datasource.file_based_datasource import (
@@ -47,7 +47,7 @@ class ParquetDatasource(Datasource[ArrowRow]):
                 table = pa.concat_tables(tables)
             else:
                 table = tables[0]
-            return ArrowBlock(table)
+            return table
 
         read_tasks = [
             ReadTask(

--- a/python/ray/experimental/data/datasource/parquet_datasource.py
+++ b/python/ray/experimental/data/datasource/parquet_datasource.py
@@ -1,0 +1,94 @@
+import logging
+from typing import Optional, List, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pyarrow
+
+from ray.experimental.data.impl.arrow_block import ArrowRow, ArrowBlock
+from ray.experimental.data.impl.block_list import BlockMetadata
+from ray.experimental.data.datasource.datasource import Datasource, ReadTask
+from ray.experimental.data.datasource.file_based_datasource import (
+    _resolve_paths_and_filesystem)
+
+logger = logging.getLogger(__name__)
+
+
+class ParquetDatasource(Datasource[ArrowRow]):
+    """Parquet datasource, for reading and writing Parquet files.
+
+    Examples:
+        >>> source = ParquetDatasource()
+        >>> ray.data.read_datasource(source, paths="/path/to/dir").take()
+        ... {"a": 1, "b": "foo"}
+    """
+    def prepare_read(self,
+                     parallelism: int,
+                     paths: Union[str, List[str]],
+                     filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+                     **reader_args) -> List[ReadTask]:
+        """Creates and returns read tasks for a file-based datasource.
+        """
+        import pyarrow.parquet as pq
+        import numpy as np
+
+        paths, file_infos, filesystem = _resolve_paths_and_filesystem(
+            paths, filesystem)
+        file_sizes = [file_info.size for file_info in file_infos]
+
+        pq_ds = pq.ParquetDataset(
+            paths, **reader_args, filesystem=filesystem)
+        pieces = pq_ds.pieces
+
+        def read_pieces(pieces: List["pyarrow._dataset.ParquetFileFragment"]):
+            import pyarrow as pa
+            logger.debug(f"Reading {len(pieces)} parquet pieces")
+            tables = [piece.to_table() for piece in pieces]
+            if len(tables) > 1:
+                table = pa.concat_tables(tables)
+            else:
+                table = tables[0]
+            return ArrowBlock(table)
+
+        read_tasks = [
+            ReadTask(
+                lambda pieces=pieces: read_pieces(pieces),
+                _get_metadata(pieces, file_sizes))
+            for pieces, file_sizes in zip(
+                    np.array_split(pieces, parallelism),
+                    np.array_split(file_sizes, parallelism))
+            if len(pieces) > 0]
+
+        return read_tasks
+
+
+def _get_metadata(
+        pieces: List["pyarrow._dataset.ParquetFileFragment"],
+        file_sizes: List[int]):
+    piece_metadata = []
+    for p in pieces:
+        try:
+            piece_metadata.append(p.metadata)
+        except AttributeError:
+            break
+    input_files = [p.path for p in pieces]
+    if len(piece_metadata) == len(pieces):
+        # Piece metadata was available, constructo a normal
+        # BlockMetadata.
+        block_metadata = BlockMetadata(
+            num_rows=sum(m.num_rows for m in piece_metadata),
+            size_bytes=sum(
+                sum(
+                    m.row_group(i).total_byte_size
+                    for i in range(m.num_row_groups))
+                for m in piece_metadata),
+            schema=piece_metadata[0].schema.to_arrow_schema(),
+            input_files=input_files)
+    else:
+        # Piece metadata was not available, construct an empty
+        # BlockMetadata.
+        block_metadata = BlockMetadata(
+            num_rows=None,
+            size_bytes=sum(file_sizes),
+            schema=None,
+            input_files=input_files)
+    return block_metadata

--- a/python/ray/experimental/data/read_api.py
+++ b/python/ray/experimental/data/read_api.py
@@ -1,6 +1,5 @@
 import logging
 from pathlib import Path
-import builtins
 from typing import List, Any, Union, Optional, Tuple, Callable, TypeVar, \
     TYPE_CHECKING
 
@@ -18,7 +17,8 @@ from ray.util.annotations import PublicAPI
 from ray.experimental.data.block import Block, BlockAccessor, BlockMetadata
 from ray.experimental.data.dataset import Dataset
 from ray.experimental.data.datasource import Datasource, RangeDatasource, \
-    JSONDatasource, CSVDatasource, ReadTask, _S3FileSystemWrapper
+    JSONDatasource, CSVDatasource, ParquetDatasource, ReadTask, \
+    _S3FileSystemWrapper
 from ray.experimental.data.impl import reader as _reader
 from ray.experimental.data.impl.arrow_block import ArrowRow, \
     DelegatingArrowBlockBuilder
@@ -136,7 +136,6 @@ def read_datasource(datasource: Datasource[T],
 @PublicAPI(stability="beta")
 def read_parquet(paths: Union[str, List[str]],
                  filesystem: Optional["pyarrow.fs.FileSystem"] = None,
-                 columns: Optional[List[str]] = None,
                  parallelism: int = 200,
                  **arrow_parquet_args) -> Dataset[ArrowRow]:
     """Create an Arrow dataset from parquet files.
@@ -151,71 +150,18 @@ def read_parquet(paths: Union[str, List[str]],
     Args:
         paths: A single file path or a list of file paths (or directories).
         filesystem: The filesystem implementation to read from.
-        columns: A list of column names to read.
         parallelism: The amount of parallelism to use for the dataset.
         arrow_parquet_args: Other parquet read options to pass to pyarrow.
 
     Returns:
         Dataset holding Arrow records read from the specified paths.
     """
-    import pyarrow.parquet as pq
-
-    if filesystem is None:
-        filesystem, paths = _parse_paths(paths)
-    pq_ds = pq.ParquetDataset(
-        paths, **arrow_parquet_args, filesystem=filesystem)
-    pieces = pq_ds.pieces
-
-    read_tasks = [[] for _ in builtins.range(parallelism)]
-    # TODO(ekl) support reading row groups (maybe as an option)
-    for i, piece in enumerate(pq_ds.pieces):
-        read_tasks[i % len(read_tasks)].append(piece)
-    nonempty_tasks = [r for r in read_tasks if r]
-
-    @ray.remote
-    def gen_read(pieces: List["pyarrow._dataset.ParquetFileFragment"]):
-        import pyarrow
-        logger.debug("Reading {} parquet pieces".format(len(pieces)))
-        tables = [piece.to_table() for piece in pieces]
-        if len(tables) > 1:
-            table = pyarrow.concat_tables(tables)
-        else:
-            table = tables[0]
-        return table
-
-    calls: List[Callable[[], ObjectRef[Block]]] = []
-    metadata: List[BlockMetadata] = []
-    for pieces in nonempty_tasks:
-        calls.append(lambda pieces=pieces: gen_read.remote(pieces))
-        piece_metadata = []
-        for p in pieces:
-            try:
-                piece_metadata.append(p.metadata)
-            except AttributeError:
-                break
-        input_files = [p.path for p in pieces]
-        if len(piece_metadata) == len(pieces):
-            # Piece metadata was available, constructo a normal BlockMetadata.
-            block_metadata = BlockMetadata(
-                num_rows=sum(m.num_rows for m in piece_metadata),
-                size_bytes=sum(
-                    sum(
-                        m.row_group(i).total_byte_size
-                        for i in builtins.range(m.num_row_groups))
-                    for m in piece_metadata),
-                schema=piece_metadata[0].schema.to_arrow_schema(),
-                input_files=input_files)
-        else:
-            # Piece metadata was not available, construct an empty
-            # BlockMetadata.
-            block_metadata = BlockMetadata(
-                num_rows=None,
-                size_bytes=None,
-                schema=None,
-                input_files=input_files)
-        metadata.append(block_metadata)
-
-    return Dataset(LazyBlockList(calls, metadata))
+    return read_datasource(
+        ParquetDatasource(),
+        parallelism=parallelism,
+        paths=paths,
+        filesystem=filesystem,
+        **arrow_parquet_args)
 
 
 @PublicAPI(stability="beta")

--- a/python/ray/experimental/data/read_api.py
+++ b/python/ray/experimental/data/read_api.py
@@ -135,6 +135,7 @@ def read_datasource(datasource: Datasource[T],
 @PublicAPI(stability="beta")
 def read_parquet(paths: Union[str, List[str]],
                  filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+                 columns: Optional[List[str]] = None,
                  parallelism: int = 200,
                  **arrow_parquet_args) -> Dataset[ArrowRow]:
     """Create an Arrow dataset from parquet files.
@@ -149,6 +150,7 @@ def read_parquet(paths: Union[str, List[str]],
     Args:
         paths: A single file path or a list of file paths (or directories).
         filesystem: The filesystem implementation to read from.
+        columns: A list of column names to read.
         parallelism: The amount of parallelism to use for the dataset.
         arrow_parquet_args: Other parquet read options to pass to pyarrow.
 
@@ -160,6 +162,7 @@ def read_parquet(paths: Union[str, List[str]],
         parallelism=parallelism,
         paths=paths,
         filesystem=filesystem,
+        columns=columns,
         **arrow_parquet_args)
 
 

--- a/python/ray/experimental/data/read_api.py
+++ b/python/ray/experimental/data/read_api.py
@@ -1,5 +1,4 @@
 import logging
-from pathlib import Path
 from typing import List, Any, Union, Optional, Tuple, Callable, TypeVar, \
     TYPE_CHECKING
 
@@ -384,34 +383,3 @@ def from_spark(df: "pyspark.sql.DataFrame",
         Dataset holding Arrow records read from the dataframe.
     """
     raise NotImplementedError  # P2
-
-
-def _parse_paths(paths: Union[str, List[str]]
-                 ) -> Tuple["pyarrow.fs.FileSystem", Union[str, List[str]]]:
-    from pyarrow import fs
-
-    def parse_single_path(path: str):
-        if Path(path).exists():
-            return fs.LocalFileSystem(), path
-        else:
-            return fs.FileSystem.from_uri(path)
-
-    if isinstance(paths, str):
-        return parse_single_path(paths)
-
-    if not isinstance(paths, list) or any(not isinstance(p, str)
-                                          for p in paths):
-        raise ValueError(
-            "paths must be a path string or a list of path strings.")
-    else:
-        if len(paths) == 0:
-            raise ValueError("No data provided")
-
-        parsed_results = [parse_single_path(path) for path in paths]
-        fses, paths = zip(*parsed_results)
-        unique_fses = set(map(type, fses))
-        if len(unique_fses) > 1:
-            raise ValueError(
-                f"When specifying multiple paths, each path must have the "
-                f"same filesystem, but found: {unique_fses}")
-        return fses[0], list(paths)

--- a/python/ray/experimental/data/tests/test_dataset.py
+++ b/python/ray/experimental/data/tests/test_dataset.py
@@ -325,6 +325,11 @@ def test_parquet_read(ray_start_regular_shared, tmp_path):
     assert sorted(values) == [[1, "a"], [2, "b"], [3, "c"], [4, "e"], [5, "f"],
                               [6, "g"]]
 
+    # Test column selection.
+    ds = ray.experimental.data.read_parquet(str(tmp_path), columns=["one"])
+    values = [s["one"] for s in ds.take()]
+    assert sorted(values) == [1, 2, 3, 4, 5, 6]
+
 
 def test_parquet_write(ray_start_regular_shared, tmp_path):
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})

--- a/python/ray/experimental/data/tests/test_dataset.py
+++ b/python/ray/experimental/data/tests/test_dataset.py
@@ -1089,32 +1089,6 @@ def test_csv_write(ray_start_regular_shared, tmp_path):
     shutil.rmtree(path)
 
 
-# TODO: this shouldn't be making network calls
-def test_uri_parser():
-    from ray.experimental.data.read_api import _parse_paths
-    fs, path = _parse_paths("/local/path")
-    assert path == "/local/path"
-    assert fs.type_name == "local"
-
-    fs, path = _parse_paths("./")
-    assert path == "./"
-    assert fs.type_name == "local"
-
-    fs, path = _parse_paths("s3://bucket/dir")
-    assert path == "bucket/dir"
-    assert fs.type_name == "s3"
-
-    fs, path = _parse_paths(["s3://bucket/dir_1", "s3://bucket/dir_2"])
-    assert path == ["bucket/dir_1", "bucket/dir_2"]
-    assert fs.type_name == "s3"
-
-    with pytest.raises(ValueError):
-        _parse_paths(["s3://bucket/dir_1", "/path/local"])
-
-    with pytest.raises(ValueError):
-        _parse_paths([])
-
-
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Ports `read_parquet` to `Datasource` API.

I initially went with a much simpler version that didn't use `ParquetDataset` and was able to reuse `FileBasedDatasource`, but we'd lose out on being able extract the block metadata from the `ParquetDataset` fragments. Future work could involve hooking in a `_get_metadata(paths, filesystem)` API on `FileBasedDatasource` that subclasses can optionally implement for pre-reading metadata gathering, which in the Parquet case would involve reading the metadata from the footer of each Parquet file.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
