### PR TITLE
[core][rfc] Fix race condition between write chunk and abort object.

### DIFF
--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -151,6 +151,7 @@ void ObjectBufferPool::WriteChunk(const ObjectID &object_id, const uint64_t chun
                    << chunk_index << " could be sealed";
     return;
   }
+  RAY_CHECK(it->second.chunk_info.size() >= chunk_index);
   auto &chunk_info = it->second.chunk_info.at(chunk_index);
   RAY_CHECK(data.size() == chunk_info.buffer_length)
       << "size mismatch!  data size: " << data.size()

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -144,16 +144,22 @@ void ObjectBufferPool::AbortCreateChunk(const ObjectID &object_id,
   }
 }
 
-void ObjectBufferPool::SealChunk(const ObjectID &object_id, const uint64_t chunk_index) {
+void ObjectBufferPool::WriteChunk(const ObjectID &object_id, const uint64_t chunk_index,
+                                  const std::string &data) {
   std::lock_guard<std::mutex> lock(pool_mutex_);
   auto it = create_buffer_state_.find(object_id);
   if (it == create_buffer_state_.end() ||
-      it->second.chunk_state[chunk_index] != CreateChunkState::REFERENCED) {
+      it->second.chunk_state.at(chunk_index) != CreateChunkState::REFERENCED) {
     RAY_LOG(DEBUG) << "Object " << object_id << " aborted due to OOM before chunk "
                    << chunk_index << " could be sealed";
     return;
   }
-  it->second.chunk_state[chunk_index] = CreateChunkState::SEALED;
+  auto &chunk_info = it->second.chunk_info.at(chunk_index);
+  RAY_CHECK(data.size() == chunk_info.buffer_length)
+      << "size mismatch!  data size: " << data.size()
+      << " chunk size: " << chunk_info.buffer_length;
+  std::memcpy(chunk_info.data, data.data(), chunk_info.buffer_length);
+  it->second.chunk_state.at(chunk_index) = CreateChunkState::SEALED;
   it->second.num_seals_remaining--;
   if (it->second.num_seals_remaining == 0) {
     RAY_CHECK_OK(store_client_.Seal(object_id));

--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -100,13 +100,13 @@ class ObjectBufferPool {
   /// \param data_size The sum of the object size and metadata size.
   /// \param metadata_size The size of the metadata.
   /// \param chunk_index The index of the chunk.
-  /// \return A pair consisting of ChunkInfo and status of invoking this method.
+  /// \return status of invoking this method.
   /// An IOError status is returned if object creation on the store client fails,
   /// or if create is invoked consecutively on the same chunk
   /// (with no intermediate AbortCreateChunk).
-  std::pair<const ObjectBufferPool::ChunkInfo, ray::Status> CreateChunk(
-      const ObjectID &object_id, const rpc::Address &owner_address, uint64_t data_size,
-      uint64_t metadata_size, uint64_t chunk_index);
+  ray::Status CreateChunk(const ObjectID &object_id, const rpc::Address &owner_address,
+                          uint64_t data_size, uint64_t metadata_size,
+                          uint64_t chunk_index);
 
   /// Abort the create operation associated with a chunk at chunk_index.
   /// This method will fail if it's invoked on a chunk_index on which
@@ -117,7 +117,8 @@ class ObjectBufferPool {
   /// \param chunk_index The index of the chunk.
   void AbortCreateChunk(const ObjectID &object_id, uint64_t chunk_index);
 
-  /// Write to a Chunk of an object.
+  /// Write to a Chunk of an object. If all chunks of an object is written,
+  /// it seals the object.
   ///
   /// This method will fail if it's invoked on a chunk_index on which
   /// CreateChunk was not first invoked, or a chunk_index on which

--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -93,7 +93,7 @@ class ObjectBufferPool {
   /// chunk at chunk_index. Multiple threads attempting to create the same object
   /// chunk will result in one succeeding. The ObjectManager is responsible for
   /// handling create failures. This method will fail if it's invoked on a chunk_index
-  /// on which SealChunk has already been invoked.
+  /// on which WriteChunk has already been invoked.
   ///
   /// \param object_id The ObjectID.
   /// \param owner_address The address of the object's owner.
@@ -117,15 +117,17 @@ class ObjectBufferPool {
   /// \param chunk_index The index of the chunk.
   void AbortCreateChunk(const ObjectID &object_id, uint64_t chunk_index);
 
-  /// Seal the object associated with a create operation. This is invoked whenever
-  /// a chunk is successfully written to.
+  /// Write to a Chunk of an object.
+  ///
   /// This method will fail if it's invoked on a chunk_index on which
   /// CreateChunk was not first invoked, or a chunk_index on which
-  /// SealChunk or AbortCreateChunk has already been invoked.
+  /// WriteChunk has already been invoked.
   ///
   /// \param object_id The ObjectID.
   /// \param chunk_index The index of the chunk.
-  void SealChunk(const ObjectID &object_id, uint64_t chunk_index);
+  /// \param data The data to write into the chunk.
+  void WriteChunk(const ObjectID &object_id, uint64_t chunk_index,
+                  const std::string &data);
 
   /// Free a list of objects from object store.
   ///

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -788,8 +788,7 @@ bool ObjectManager::ReceiveObjectChunk(const NodeID &node_id, const ObjectID &ob
   ObjectBufferPool::ChunkInfo chunk_info = chunk_status.first;
   if (chunk_status.second.ok()) {
     // Avoid handling this chunk if it's already being handled by another process.
-    std::memcpy(chunk_info.data, data.data(), chunk_info.buffer_length);
-    buffer_pool_.SealChunk(object_id, chunk_index);
+    buffer_pool_.WriteChunk(object_id, chunk_index, data);
     return true;
   } else {
     num_chunks_received_failed_due_to_plasma_++;

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -772,9 +772,8 @@ bool ObjectManager::ReceiveObjectChunk(const NodeID &node_id, const ObjectID &ob
     // This object is no longer being actively pulled. Do not create the object.
     return false;
   }
-  std::pair<const ObjectBufferPool::ChunkInfo, ray::Status> chunk_status =
-      buffer_pool_.CreateChunk(object_id, owner_address, data_size, metadata_size,
-                               chunk_index);
+  auto chunk_status = buffer_pool_.CreateChunk(object_id, owner_address, data_size,
+                                               metadata_size, chunk_index);
   if (!pull_manager_->IsObjectActive(object_id)) {
     num_chunks_received_cancelled_++;
     // This object is no longer being actively pulled. Abort the object. We
@@ -785,14 +784,13 @@ bool ObjectManager::ReceiveObjectChunk(const NodeID &node_id, const ObjectID &ob
     return false;
   }
 
-  ObjectBufferPool::ChunkInfo chunk_info = chunk_status.first;
-  if (chunk_status.second.ok()) {
+  if (chunk_status.ok()) {
     // Avoid handling this chunk if it's already being handled by another process.
     buffer_pool_.WriteChunk(object_id, chunk_index, data);
     return true;
   } else {
     num_chunks_received_failed_due_to_plasma_++;
-    RAY_LOG(INFO) << "Error receiving chunk:" << chunk_status.second.message();
+    RAY_LOG(INFO) << "Error receiving chunk:" << chunk_status.message();
     return false;
   }
 }


### PR DESCRIPTION
TL;DR: there is a race condition between writing a chunk (of the object) vs abort the object creation. This could lead to memory corruption when an object is first removed(aborted) then the address being written.

We still seeing low frequency segfault in stress tests after fixing few issues: #17204, #17140. 
By examining the core dump, we were able to confirm that mmaped addesses in dlmalloc are corrupted, as SIGSEGV happens at [dlmalloc/unlink_chunk](https://github.com/ray-project/ray/blob/35ec91c4e04c67adc7123aa8461cf50923a316b4/src/ray/thirdparty/dlmalloc.c#L4729).

Given dlmalloc itself is very stable and we don't double-free , the only possible cause for this corruption is that we write to unallocated address. The current implementation of handlePush in object manager could have cause this. as chunks creating and abortion are handled by multiple threads, it could happen that one thread aborted the object creation where another thread still trying to write to that aborted chunk.  

The proposed solution in this PR is to synchronize the object abortion with chunk mutation by a mutex. 
If we think this is a bottleneck, we could create a lock for each object or shard locks by object_id.


```
187386 [2021-07-20 21:42:05,924 E 4550 4575] logging.cc:299: *** SIGSEGV received at time=1626817325 on cpu 3 ***
187387 [2021-07-20 21:42:05,924 E 4550 4575] logging.cc:299: PC: @     0x5614428e5b62  (unknown)  dlfree
187388 [2021-07-20 21:42:05,924 E 4550 4575] logging.cc:299:     @     0x561442d6927b         64  absl::lts_20210324::WriteFailureInfo()
187389 [2021-07-20 21:42:05,936 E 4550 4575] logging.cc:299:     @     0x561442d69452         96  absl::lts_20210324::AbslFailureSignalHandler()
187390 [2021-07-20 21:42:05,937 E 4550 4575] logging.cc:299:     @     0x7f21249e5890       1792  (unknown)
187391 [2021-07-20 21:42:05,937 E 4550 4575] logging.cc:299:     @     0x5614428b499c         80  plasma::PlasmaAllocator::Free()
187392 [2021-07-20 21:42:05,937 E 4550 4575] logging.cc:299:     @     0x5614428b92f9        112  plasma::PlasmaStore::EraseFromObjectTable()
```
```
(gdb) info line* 0x5614428e5b62
Line 4729 of "bazel-out/k8-dbg/bin/_virtual_includes/plasma_store_server_lib/ray/thirdparty/dlmalloc.c" starts at address 0x5614428e5870 <plasma::dlfree(void*)+448>
   and ends at 0x5614428e5f01 <plasma::dlfree(void*)+2129>.
(gdb) info line* 0x7f21249e5890
Line 28 of "../sysdeps/pthread/flockfile.c" starts at address 0x7f21249e5881 <__flockfile+17> and ends at 0x7f21249e58c2 <__flockfile+82>.
(gdb) info line* 0x5614428b499c
Line 82 of "src/ray/object_manager/plasma/plasma_allocator.cc" starts at address 0x5614428b499c <plasma::PlasmaAllocator::Free(void*, unsigned long)+154>
   and ends at 0x5614428b49c0 <plasma::PlasmaAllocator::Free(void*, unsigned long)+190>.
```

Test plan:
- [x] existing unit tests
- [x] stress test it.
