### PR TITLE
[autoscaler] Add support for EC2 launch templates.

### DIFF
--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -867,7 +867,7 @@ def _configure_from_network_interfaces(config: Dict[str, Any]) \
         available node types. If no network interfaces are found, then the
         config is returned unchanged.
     Raises:
-        ValueError: If [1] subnet and security group IDs exists at both the
+        ValueError: If [1] subnet and security group IDs exist at both the
         node config and network interface levels, [2] any network interface
         doesn't have a subnet defined, or [3] any network interface doesn't
         have a security group defined.
@@ -893,7 +893,7 @@ def _configure_node_type_from_network_interface(
         given node type. If no network interfaces are found, then the
         config is returned unchanged.
     Raises:
-        ValueError: If [1] subnet and security group IDs exists at both the
+        ValueError: If [1] subnet and security group IDs exist at both the
         node config and network interface levels, [2] any network interface
         doesn't have a subnet defined, or [3] any network interface doesn't
         have a security group defined.
@@ -914,7 +914,7 @@ def _configure_subnets_and_groups_from_network_interfaces(
     Args:
         node_cfg (Dict[str, Any]): node config to bootstrap
     Raises:
-        ValueError: If [1] subnet and security group IDs exists at both the
+        ValueError: If [1] subnet and security group IDs exist at both the
         node config and network interface levels, [2] any network interface
         doesn't have a subnet defined, or [3] any network interface doesn't
         have a security group defined.
@@ -943,7 +943,7 @@ def _configure_subnets_and_groups_from_network_interfaces(
 
 def _subnets_in_network_config(config: Dict[str, Any]) -> List[str]:
     """
-    Returns all subnet IDs found in the given node config.
+    Returns all subnet IDs found in the given node config's network interfaces.
 
     Args:
         config: node config
@@ -960,7 +960,8 @@ def _subnets_in_network_config(config: Dict[str, Any]) -> List[str]:
 def _security_groups_in_network_config(config: Dict[str, Any]) \
         -> List[List[str]]:
     """
-    Returns all security group IDs found in the given node config.
+    Returns all security group IDs found in the given node config's network
+    interfaces.
 
     Args:
         config: node config

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -1,7 +1,7 @@
 import random
 import copy
 import threading
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 import logging
 import time
 from typing import Any, Dict, List
@@ -241,7 +241,8 @@ class AWSNodeProvider(NodeProvider):
         Returns dict mapping instance id to ec2.Instance object for the created
         instances.
         """
-        tags = copy.deepcopy(tags)
+        # sort tags by key to support deterministic unit test stubbing
+        tags = OrderedDict(sorted(copy.deepcopy(tags).items()))
 
         reused_nodes_dict = {}
         # Try to reuse previously stopped nodes with compatible configs
@@ -311,11 +312,11 @@ class AWSNodeProvider(NodeProvider):
         return all_created_nodes
 
     @staticmethod
-    def _merge_tag_specs(tag_specs: Dict[str, Any],
-                         user_tag_specs: Dict[str, Any]) -> None:
+    def _merge_tag_specs(tag_specs: List[Dict[str, Any]],
+                         user_tag_specs: List[Dict[str, Any]]) -> None:
         """
         Merges user-provided node config tag specifications into a base
-        dictionary of node provider tag specifications. The base dictionary of
+        list of node provider tag specifications. The base list of
         node provider tag specs is modified in-place.
 
         This allows users to add tags and override values of existing
@@ -324,8 +325,8 @@ class AWSNodeProvider(NodeProvider):
         tag specs.
 
         Args:
-            tag_specs (Dict[str, Any]): base node provider tag specs to modify
-            user_tag_specs (Dict[str, Any]): user's node config tag specs
+            tag_specs (List[Dict[str, Any]]): base node provider tag specs
+            user_tag_specs (List[Dict[str, Any]]): user's node config tag specs
         """
 
         for user_tag_spec in user_tag_specs:

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -310,6 +310,38 @@ class AWSNodeProvider(NodeProvider):
         all_created_nodes.update(created_nodes_dict)
         return all_created_nodes
 
+    @staticmethod
+    def _merge_tag_specs(tag_specs: Dict[str, Any],
+                         user_tag_specs: Dict[str, Any]) -> None:
+        """
+        Merges user-provided node config tag specifications into a base
+        dictionary of node provider tag specifications. The base dictionary of
+        node provider tag specs is modified in-place.
+
+        This allows users to add tags and override values of existing
+        tags with their own, and only applies to the resource type
+        "instance". All other resource types are appended to the list of
+        tag specs.
+
+        Args:
+            tag_specs (Dict[str, Any]): base node provider tag specs to modify
+            user_tag_specs (Dict[str, Any]): user's node config tag specs
+        """
+
+        for user_tag_spec in user_tag_specs:
+            if user_tag_spec["ResourceType"] == "instance":
+                for user_tag in user_tag_spec["Tags"]:
+                    exists = False
+                    for tag in tag_specs[0]["Tags"]:
+                        if user_tag["Key"] == tag["Key"]:
+                            exists = True
+                            tag["Value"] = user_tag["Value"]
+                            break
+                    if not exists:
+                        tag_specs[0]["Tags"] += [user_tag]
+            else:
+                tag_specs += [user_tag_spec]
+
     def _create_node(self, node_config, tags, count):
         created_nodes_dict = {}
 
@@ -330,23 +362,7 @@ class AWSNodeProvider(NodeProvider):
             "Tags": tag_pairs,
         }]
         user_tag_specs = conf.get("TagSpecifications", [])
-        # Allow users to add tags and override values of existing
-        # tags with their own. This only applies to the resource type
-        # "instance". All other resource types are appended to the list of
-        # tag specs.
-        for user_tag_spec in user_tag_specs:
-            if user_tag_spec["ResourceType"] == "instance":
-                for user_tag in user_tag_spec["Tags"]:
-                    exists = False
-                    for tag in tag_specs[0]["Tags"]:
-                        if user_tag["Key"] == tag["Key"]:
-                            exists = True
-                            tag["Value"] = user_tag["Value"]
-                            break
-                    if not exists:
-                        tag_specs[0]["Tags"] += [user_tag]
-            else:
-                tag_specs += [user_tag_spec]
+        AWSNodeProvider._merge_tag_specs(tag_specs, user_tag_specs)
 
         # SubnetIds is not a real config key: we must resolve to a
         # single SubnetId before invoking the AWS API.

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -326,7 +326,8 @@ def _bootstrap_config(config: Dict[str, Any],
         with open(cache_key, "w") as f:
             config_cache = {
                 "_version": CONFIG_CACHE_VERSION,
-                "provider_log_info": try_get_log_state(config["provider"]),
+                "provider_log_info": try_get_log_state(
+                    resolved_config["provider"]),
                 "config": resolved_config
             }
             f.write(json.dumps(config_cache))

--- a/python/ray/autoscaler/aws/example-launch-templates.yaml
+++ b/python/ray/autoscaler/aws/example-launch-templates.yaml
@@ -1,0 +1,60 @@
+cluster_name: launch_templates
+
+max_workers: 2
+
+provider:
+    type: aws
+    region: us-west-2
+
+    # Note that availability zones can be omitted when using custom launch
+    # templates that contain either pre-configured availability zones or custom
+    # network interfaces for all node types, since each node will always be
+    # launched in either the launch template's AZ or the AZ shared by its
+    # network interface subnets.
+    # If some of your node types have launch templates binding them to AZs and
+    # others do not, then node types without AZ bindings will be limited to
+    # launching only in subnets available in the below availability zones:
+    availability_zone: us-west-2a, us-west-2b, us-west-2c
+
+auth:
+    ssh_user: ubuntu
+
+# You can use EC2 launch templates to consolidate, re-use, and version common
+# node configurations.
+
+# For more information, see the documentation on EC2 Launch Templates at:
+# https://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchTemplates.html
+
+available_node_types:
+  ray.head.default:
+    max_workers: 0
+    resources: {}
+    node_config:
+      # The launch template to use to launch the instances. Any parameters that
+      # you specify in node_config override the same parameters in the launch
+      # template. Tags will be merged by key, with node_config values overriding
+      # launch template values for the same key. You can specify either the name
+      # or ID of a launch template, but not both.
+      LaunchTemplate:
+        LaunchTemplateId: lt-00000000000000000,
+        # Launch template versions can be set to a version number, "$Default"
+        # for the default launch template version, or "$Latest" for the latest
+        # launch template version.
+        Version: $Latest
+
+      ImageId: latest_dlami
+      InstanceType: m5.large
+
+  ray.worker.default:
+    min_workers: 0
+    max_workers: 1
+    resources: {}
+    node_config:
+      LaunchTemplate:
+        LaunchTemplateName: ExampleLaunchTemplate,
+        Version: 2
+
+      ImageId: latest_dlami
+      InstanceType: m5.large
+
+head_node_type: ray.head.default

--- a/python/ray/autoscaler/aws/example-launch-templates.yaml
+++ b/python/ray/autoscaler/aws/example-launch-templates.yaml
@@ -36,10 +36,11 @@ available_node_types:
       # launch template values for the same key. You can specify either the name
       # or ID of a launch template, but not both.
       LaunchTemplate:
-        LaunchTemplateId: lt-00000000000000000,
+        LaunchTemplateId: lt-00000000000000000
         # Launch template versions can be set to a version number, "$Default"
         # for the default launch template version, or "$Latest" for the latest
-        # launch template version.
+        # launch template version. If the version is omitted, it will
+        # automatically resolve to the launch template's default version.
         Version: $Latest
 
       ImageId: latest_dlami
@@ -51,7 +52,7 @@ available_node_types:
     resources: {}
     node_config:
       LaunchTemplate:
-        LaunchTemplateName: ExampleLaunchTemplate,
+        LaunchTemplateName: ExampleLaunchTemplate
         Version: 2
 
       ImageId: latest_dlami

--- a/python/ray/tests/aws/test_autoscaler_aws.py
+++ b/python/ray/tests/aws/test_autoscaler_aws.py
@@ -227,19 +227,19 @@ def test_fills_out_amis_and_iam(iam_client_stub, ec2_client_stub):
 
     defaults_filled = bootstrap_aws(config)
 
-    ami = DEFAULT_AMI.get(config.get("provider", {}).get("region"))
+    ami = DEFAULT_AMI.get(defaults_filled.get("provider", {}).get("region"))
 
     for node_type in defaults_filled["available_node_types"].values():
         node_config = node_type["node_config"]
         assert node_config.get("ImageId") == ami
 
     # Correctly configured IAM role
-    assert (config["head_node"]["IamInstanceProfile"] == {
+    assert (defaults_filled["head_node"]["IamInstanceProfile"] == {
         "Arn": DEFAULT_INSTANCE_PROFILE["Arn"]
     })
     # Workers of the head's type do not get the IAM role.
     head_type = config["head_node_type"]
-    assert "IamInstanceProfile" not in config["available_node_types"][
+    assert "IamInstanceProfile" not in defaults_filled["available_node_types"][
         head_type]
 
     iam_client_stub.assert_no_pending_responses()
@@ -361,7 +361,7 @@ def test_create_sg_multinode(iam_client_stub, ec2_client_stub):
     # name and in bound rules
     assert bootstrapped_config["provider"]["security_group"][
         "GroupName"] == DEFAULT_SG_WITH_NAME_AND_RULES["GroupName"]
-    assert config["provider"]["security_group"][
+    assert bootstrapped_config["provider"]["security_group"][
         "IpPermissions"] == CUSTOM_IN_BOUND_RULES
 
     # Confirming correct security group got filled for head and workers

--- a/python/ray/tests/aws/utils/constants.py
+++ b/python/ray/tests/aws/utils/constants.py
@@ -168,3 +168,39 @@ CUSTOM_IN_BOUND_RULES = [{
 DEFAULT_SG_WITH_NAME_AND_RULES = copy.deepcopy(DEFAULT_SG_WITH_NAME)
 DEFAULT_SG_WITH_NAME_AND_RULES[
     "IpPermissions"] = DEFAULT_IN_BOUND_RULES + CUSTOM_IN_BOUND_RULES
+
+# Default launch template to expose to tests.
+DEFAULT_LT = {
+    "LaunchTemplateId": "lt-00000000000000000",
+    "LaunchTemplateName": "ExampleLaunchTemplate",
+    "VersionNumber": 2,
+    "CreateTime": datetime(2020, 8, 17, 23, 30, 3),
+    "CreatedBy": DEFAULT_INSTANCE_PROFILE["Roles"][0]["Arn"],
+    "DefaultVersion": True,
+    "LaunchTemplateData": {
+        "EbsOptimized": False,
+        "IamInstanceProfile": {
+            "Arn": DEFAULT_INSTANCE_PROFILE["Arn"]
+        },
+        "NetworkInterfaces": [{
+            "DeviceIndex": 0,
+            "Groups": [DEFAULT_SG["GroupId"]],
+            "SubnetId": DEFAULT_SUBNET["SubnetId"]
+        }],
+        "ImageId": "ami-00000000000000000",
+        "InstanceType": "m5.large",
+        "TagSpecifications": [{
+            "ResourceType": "instance",
+            "Tags": [{
+                "Key": "test-key",
+                "Value": "test-value"
+            }]
+        }, {
+            "ResourceType": "volume",
+            "Tags": [{
+                "Key": "test-key",
+                "Value": "test-value"
+            }]
+        }]
+    }
+}

--- a/python/ray/tests/aws/utils/constants.py
+++ b/python/ray/tests/aws/utils/constants.py
@@ -2,6 +2,9 @@ import copy
 import ray
 from datetime import datetime
 
+from ray.autoscaler.tags import TAG_RAY_LAUNCH_CONFIG, TAG_RAY_NODE_KIND, \
+    NODE_KIND_HEAD, TAG_RAY_USER_NODE_TYPE
+
 # Override global constants used in AWS autoscaler config artifact names.
 # This helps ensure that any unmocked test doesn't alter non-test artifacts.
 ray.autoscaler._private.aws.config.RAY = \
@@ -203,4 +206,11 @@ DEFAULT_LT = {
             }]
         }]
     }
+}
+
+# Default node provider tags to expose to tests.
+DEFAULT_NODE_PROVIDER_INSTANCE_TAGS = {
+    TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+    TAG_RAY_LAUNCH_CONFIG: "test-ray-launch-config",
+    TAG_RAY_USER_NODE_TYPE: "ray.head.default",
 }

--- a/python/ray/tests/aws/utils/helpers.py
+++ b/python/ray/tests/aws/utils/helpers.py
@@ -58,7 +58,7 @@ def apply_node_provider_config_updates(config, node_cfg, node_type_name,
                                        max_count):
     """
     Applies default updates made by AWSNodeProvider to node_cfg during node
-    creation.
+    creation. This should only be used for testing purposes.
 
     Args:
         config: autoscaler config

--- a/python/ray/tests/aws/utils/helpers.py
+++ b/python/ray/tests/aws/utils/helpers.py
@@ -1,9 +1,14 @@
 import os
 import yaml
 import ray
+import copy
 
+from ray.autoscaler._private.aws.node_provider import AWSNodeProvider
+from ray.autoscaler.tags import TAG_RAY_NODE_KIND, NODE_KIND_HEAD, \
+    NODE_KIND_WORKER, TAG_RAY_USER_NODE_TYPE, TAG_RAY_CLUSTER_NAME
 from ray.autoscaler._private.commands import prepare_config, validate_config
-from ray.tests.aws.utils.constants import DEFAULT_CLUSTER_NAME
+from ray.tests.aws.utils.constants import DEFAULT_CLUSTER_NAME, \
+    DEFAULT_NODE_PROVIDER_INSTANCE_TAGS
 
 
 def get_aws_example_config_file_path(file_name):
@@ -27,3 +32,56 @@ def bootstrap_aws_config(config):
 def bootstrap_aws_example_config_file(file_name):
     config = load_aws_example_config_file(file_name)
     return bootstrap_aws_config(config)
+
+
+def node_provider_tags(config, type_name):
+    """
+    Returns a copy of DEFAULT_NODE_PROVIDER_INSTANCE_TAGS with the Ray node
+    kind and Ray user node type filled in from the input config and node type
+    name.
+
+    Args:
+        config: autoscaler config
+        type_name: node type name
+    Returns:
+        tags: node provider tags
+    """
+    tags = copy.copy(DEFAULT_NODE_PROVIDER_INSTANCE_TAGS)
+    head_name = config["head_node_type"]
+    node_kind = NODE_KIND_HEAD if type_name is head_name else NODE_KIND_WORKER
+    tags[TAG_RAY_NODE_KIND] = node_kind
+    tags[TAG_RAY_USER_NODE_TYPE] = type_name
+    return tags
+
+
+def apply_node_provider_config_updates(config, node_cfg, node_type_name,
+                                       max_count):
+    """
+    Applies default updates made by AWSNodeProvider to node_cfg during node
+    creation.
+
+    Args:
+        config: autoscaler config
+        node_cfg: node config
+        node_type_name: node type name
+        max_count: max nodes of the given type to launch
+    """
+    tags = node_provider_tags(config, node_type_name)
+    tags[TAG_RAY_CLUSTER_NAME] = DEFAULT_CLUSTER_NAME
+    user_tag_specs = node_cfg.get("TagSpecifications", [])
+    tag_specs = [{
+        "ResourceType": "instance",
+        "Tags": [{
+            "Key": k,
+            "Value": v
+        } for k, v in sorted(tags.items())]
+    }]
+    node_provider_cfg_updates = {
+        "MinCount": 1,
+        "MaxCount": max_count,
+        "TagSpecifications": tag_specs,
+    }
+    tags.pop(TAG_RAY_CLUSTER_NAME)
+    node_cfg.update(node_provider_cfg_updates)
+    # merge node provider tag specs with user overrides
+    AWSNodeProvider._merge_tag_specs(tag_specs, user_tag_specs)

--- a/python/ray/tests/aws/utils/stubs.py
+++ b/python/ray/tests/aws/utils/stubs.py
@@ -1,7 +1,11 @@
 import ray
+import copy
+
+from ray.autoscaler._private.aws.node_provider import AWSNodeProvider
 from ray.tests.aws.utils.mocks import mock_path_exists_key_pair
 from ray.tests.aws.utils.constants import DEFAULT_INSTANCE_PROFILE, \
-    DEFAULT_KEY_PAIR, DEFAULT_SUBNET, A_THOUSAND_SUBNETS_IN_DIFFERENT_VPCS
+    DEFAULT_KEY_PAIR, DEFAULT_SUBNET, A_THOUSAND_SUBNETS_IN_DIFFERENT_VPCS, \
+    DEFAULT_LT
 
 from unittest import mock
 
@@ -163,8 +167,51 @@ def run_instances_with_network_interfaces_consumer(ec2_client_stub,
         service_response={})
 
 
+def run_instances_with_launch_template_consumer(
+        ec2_client_stub, node_cfg, lt_data, node_provider_cfg_updates):
+    # create a copy of both node config and launch template data to modify
+    lt_data_cp = copy.deepcopy(lt_data)
+    node_cfg_cp = copy.deepcopy(node_cfg)
+    # override launch template parameters with explicit node config parameters
+    lt_data_cp.update(node_cfg_cp)
+    # copy all launch template parameters back to node config
+    node_cfg_cp.update(lt_data_cp)
+    # copy all default node provider config updates to node config
+    node_cfg_cp.update(node_provider_cfg_updates)
+    # merge node provider tag specs with user overrides
+    user_tag_specs = node_cfg.get("TagSpecifications", [])
+    tag_specs = node_provider_cfg_updates["TagSpecifications"]
+    AWSNodeProvider._merge_tag_specs(tag_specs, user_tag_specs)
+    # remove any security group and subet IDs copied from network interfaces
+    node_cfg_cp.pop("SecurityGroupIds", [])
+    node_cfg_cp.pop("SubnetIds", [])
+    ec2_client_stub.add_response(
+        "run_instances", expected_params=node_cfg_cp, service_response={})
+
+
 def describe_instances_with_any_filter_consumer(ec2_client_stub):
     ec2_client_stub.add_response(
         "describe_instances",
         expected_params={"Filters": ANY},
         service_response={})
+
+
+def describe_launch_template_versions_by_id_default(ec2_client_stub, versions):
+    ec2_client_stub.add_response(
+        "describe_launch_template_versions",
+        expected_params={
+            "LaunchTemplateId": DEFAULT_LT["LaunchTemplateId"],
+            "Versions": versions
+        },
+        service_response={"LaunchTemplateVersions": [DEFAULT_LT]})
+
+
+def describe_launch_template_versions_by_name_default(ec2_client_stub,
+                                                      versions):
+    ec2_client_stub.add_response(
+        "describe_launch_template_versions",
+        expected_params={
+            "LaunchTemplateName": DEFAULT_LT["LaunchTemplateName"],
+            "Versions": versions
+        },
+        service_response={"LaunchTemplateVersions": [DEFAULT_LT]})


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

These changes add support for EC2 Launch Templates as part of a user's AWS Autoscaler node config. Any parameters specified in node_config override the same parameters in the launch template, in compliance with the behavior of EC2's [create_instances](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances) API. These changes were previously proposed in: https://github.com/ray-project/ray/pull/9336.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/9334
Resolves milestone [8] of https://github.com/ray-project/ray/issues/8420. 

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
