### PR TITLE
[Datasets] Fix S3FileSystem import

### DIFF
--- a/python/ray/experimental/data/read_api.py
+++ b/python/ray/experimental/data/read_api.py
@@ -315,12 +315,13 @@ def read_binary_files(
         Dataset holding Arrow records read from the specified paths.
     """
     import pyarrow as pa
+    from pyarrow.fs import S3FileSystem
 
     if isinstance(paths, str):
         paths = _reader.list_objects(paths)
 
     dataset = from_items(paths, parallelism=parallelism)
-    if isinstance(filesystem, pa.fs.S3FileSystem):
+    if isinstance(filesystem, S3FileSystem):
         filesystem = _S3FileSystemWrapper(filesystem)
 
     return dataset.map(


### PR DESCRIPTION
Hotfix for S3FileSystem import, not sure how the `read_binary_files` tests didn't hit this.
