### PR TITLE
Revert "[core] remove opencensus/prometheus_exporter dependencies"

### DIFF
--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -3,7 +3,9 @@ import sys
 try:
     import aiohttp.web
     import aiohttp
+except ImportError:
     import aiohttp_cors  # noqa: F401
+    print("The dashboard requires aiohttp to run.")
     import aioredis  # noqa: F401
 except (ModuleNotFoundError, ImportError):
     print("Not all Ray Dashboard dependencies were found. "

--- a/python/ray/_private/prometheus_exporter.py
+++ b/python/ray/_private/prometheus_exporter.py
@@ -5,27 +5,19 @@
 
 import re
 
-try:
-    from prometheus_client import start_http_server
-    from prometheus_client.core import (
-        REGISTRY,
-        CollectorRegistry,
-        CounterMetricFamily,
-        GaugeMetricFamily,
-        HistogramMetricFamily,
-        UnknownMetricFamily,
-    )
+from prometheus_client import start_http_server
+from prometheus_client.core import (
+    REGISTRY,
+    CollectorRegistry,
+    CounterMetricFamily,
+    GaugeMetricFamily,
+    HistogramMetricFamily,
+    UnknownMetricFamily,
+)
 
-    from opencensus.common.transports import sync
-    from opencensus.stats import aggregation_data as aggregation_data_module
-    from opencensus.stats import base_exporter
-except ImportError:
-    warning_message = (
-        "Not all Ray Dashboard dependencies were found. "
-        "In Ray 1.4+, the Ray CLI, autoscaler, and dashboard will "
-        "only be usable via `pip install 'ray[default]'`. Please "
-        "update your install command.")
-    raise ImportError(warning_message)
+from opencensus.common.transports import sync
+from opencensus.stats import aggregation_data as aggregation_data_module
+from opencensus.stats import base_exporter
 
 
 class Options(object):

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1174,11 +1174,6 @@ def start_dashboard(require_dashboard,
 
         # Make sure the process can start.
         try:
-            # These checks have to come first because aiohttp looks
-            # for opencensus, too, and raises a different error otherwise.
-            import opencensus  # noqa: F401
-            import prometheus_client  # noqa: F401
-
             import aiohttp  # noqa: F401
             import aioredis  # noqa: F401
             import aiohttp_cors  # noqa: F401

--- a/python/requirements/requirements_default.txt
+++ b/python/requirements/requirements_default.txt
@@ -2,5 +2,3 @@ aiohttp
 aiohttp_cors
 aioredis
 colorful
-opencensus
-prometheus_client>=0.7.1

--- a/python/setup.py
+++ b/python/setup.py
@@ -157,8 +157,6 @@ if setup_spec.type == SetupType.RAY:
             "jsonschema",  # noqa
             "requests",  # noqa
             "gpustat",  # noqa
-            "opencensus",  # noqa
-            "prometheus_client >= 0.7.1",  # noqa
         ],
         "serve": ["uvicorn", "requests", "starlette", "fastapi"],
         "tune": ["pandas", "tabulate", "tensorboardX>=1.9", "requests"],
@@ -200,6 +198,8 @@ if setup_spec.type == SetupType.RAY:
         "protobuf >= 3.15.3",
         "pyyaml",
         "redis >= 3.5.0",
+        "opencensus",
+        "prometheus_client >= 0.7.1",
     ]
 
 


### PR DESCRIPTION
Reverts ray-project/ray#17182
broke macOS wheel build

https://app.travis-ci.com/github/ray-project/ray/builds/233370303#L1496 getting
```
+/Library/Frameworks/Python.framework/Versions/3.6/bin/python3.6 /Users/travis/build/ray-project/ray/python/ray/tests/test_microbenchmarks.py
ImportError while loading conftest '/Users/travis/build/ray-project/ray/python/ray/tests/conftest.py'.
python/ray/tests/conftest.py:12: in <module>
    from ray.test_utils import init_error_pubsub
/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/ray/test_utils.py:22: in <module>
    from prometheus_client.parser import text_string_to_metric_families
E   ModuleNotFoundError: No module named 'prometheus_client'
```