### PR TITLE
[Core] Update locality protocol comment.

### DIFF
--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -1059,14 +1059,10 @@ absl::optional<LocalityData> ReferenceCounter::GetLocalityData(
   }
 
   // The locations of this object.
-  // - If we own this object and the ownership-based object directory is enabled, this
-  // will contain the complete up-to-date set of object locations.
-  // - If we don't own this object and the ownership-based object directory is enabled,
-  // this will contain a snapshot of the object locations at future resolution time.
-  // - If we own this object and the ownership-based object directory is disabled, this
-  // will only contain the pinned location, if known.
-  // - If we don't own this object and the ownership-based object directory is disabled,
-  // this will be empty.
+  // - If we own this object, this will contain the complete up-to-date set of object
+  //   locations.
+  // - If we don't own this object, this will contain a snapshot of the object locations
+  //   at future resolution time.
   const auto &node_ids = it->second.locations;
 
   // We should only reach here if we have valid locality data to return.

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -1061,9 +1061,12 @@ absl::optional<LocalityData> ReferenceCounter::GetLocalityData(
   // The locations of this object.
   // - If we own this object and the ownership-based object directory is enabled, this
   // will contain the complete up-to-date set of object locations.
+  // - If we don't own this object and the ownership-based object directory is enabled,
+  // this will contain a snapshot of the object locations at future resolution time.
   // - If we own this object and the ownership-based object directory is disabled, this
   // will only contain the pinned location, if known.
-  // - If we don't own this object, this will be empty.
+  // - If we don't own this object and the ownership-based object directory is disabled,
+  // this will be empty.
   const auto &node_ids = it->second.locations;
 
   // We should only reach here if we have valid locality data to return.


### PR DESCRIPTION
This was never updated in the PR that added locality-aware scheduling support for borrowed refs. This PR updates the comment to properly document the locality data protocol.
