### PR TITLE
[autoscaler] GCP TPU VM autoscaler

### DIFF
--- a/python/ray/autoscaler/_private/gcp/config.py
+++ b/python/ray/autoscaler/_private/gcp/config.py
@@ -64,6 +64,12 @@ def get_node_type(node: dict) -> GCPNodeType:
             "is required.")
 
     if "machineType" not in node and "acceleratorType" in node:
+        # remove after TPU support is added!
+        if node["acceleratorType"] not in ("v2-8", "v3-8"):
+            raise ValueError(
+                "For now, only v2-8' and 'v3-8' accelerator types are "
+                "supported. Support for TPU pods will be added in the future.")
+
         return GCPNodeType.TPU
     return GCPNodeType.COMPUTE
 

--- a/python/ray/autoscaler/_private/gcp/config.py
+++ b/python/ray/autoscaler/_private/gcp/config.py
@@ -17,6 +17,7 @@ from ray.autoscaler._private.util import check_legacy_fields
 logger = logging.getLogger(__name__)
 
 VERSION = "v1"
+TPU_VERSION = "v2alpha"  # change once v2 is stable
 
 RAY = "ray-autoscaler"
 DEFAULT_SERVICE_ACCOUNT_ID = RAY + "-sa-" + VERSION
@@ -128,6 +129,15 @@ def _create_compute(gcp_credentials=None):
         "compute", "v1", credentials=gcp_credentials, cache_discovery=False)
 
 
+def _create_tpu(gcp_credentials=None):
+    return discovery.build(
+        "tpu",
+        TPU_VERSION,
+        credentials=gcp_credentials,
+        cache_discovery=False,
+        discoveryServiceUrl="https://tpu.googleapis.com/$discovery/rest")
+
+
 def construct_clients_from_provider_config(provider_config):
     """
     Attempt to fetch and parse the JSON GCP credentials from the provider
@@ -142,7 +152,8 @@ def construct_clients_from_provider_config(provider_config):
         # credentials in the local environment.
         return _create_crm(), \
             _create_iam(), \
-            _create_compute()
+            _create_compute(), \
+            _create_tpu()
 
     assert ("type" in gcp_credentials), \
         "gcp_credentials cluster yaml field missing 'type' field."
@@ -169,7 +180,8 @@ def construct_clients_from_provider_config(provider_config):
 
     return _create_crm(credentials), \
         _create_iam(credentials), \
-        _create_compute(credentials)
+        _create_compute(credentials), \
+        _create_tpu(credentials)
 
 
 def bootstrap_gcp(config):
@@ -178,7 +190,7 @@ def bootstrap_gcp(config):
     # Used internally to store head IAM role.
     config["head_node"] = {}
 
-    crm, iam, compute = \
+    crm, iam, compute, tpu = \
         construct_clients_from_provider_config(config["provider"])
 
     config = _configure_project(config, crm)

--- a/python/ray/autoscaler/_private/gcp/config.py
+++ b/python/ray/autoscaler/_private/gcp/config.py
@@ -419,7 +419,7 @@ def _configure_subnet(config, compute):
         # TPU
         if "networkConfig" not in node_config:
             node_config["networkConfig"] = copy.deepcopy(
-                default_interfaces)
+                default_interfaces)[0]
             node_config["networkConfig"].pop("accessConfigs")
 
     return config

--- a/python/ray/autoscaler/_private/gcp/config.py
+++ b/python/ray/autoscaler/_private/gcp/config.py
@@ -387,7 +387,9 @@ def _configure_subnet(config, compute):
     ]
     # Rationale: avoid subnet lookup if the network is already
     # completely manually configured
-    if all("networkInterfaces" in node_config for node_config in node_configs):
+
+    # networkInterfaces is compute, networkConfig is TPU
+    if all("networkInterfaces" in node_config or "networkConfig" in node_config for node_config in node_configs):
         return config
 
     subnets = _list_subnets(config, compute)
@@ -409,9 +411,16 @@ def _configure_subnet(config, compute):
     }]
 
     for node_config in node_configs:
+        # The one not applicable for the instance will be removed during creation
+        # compute
         if "networkInterfaces" not in node_config:
             node_config["networkInterfaces"] = copy.deepcopy(
                 default_interfaces)
+        # TPU
+        if "networkConfig" not in node_config:
+            node_config["networkConfig"] = copy.deepcopy(
+                default_interfaces)
+            node_config["networkConfig"].pop("accessConfigs")
 
     return config
 

--- a/python/ray/autoscaler/_private/gcp/config.py
+++ b/python/ray/autoscaler/_private/gcp/config.py
@@ -28,6 +28,7 @@ DEFAULT_SERVICE_ACCOUNT_CONFIG = {
 }
 DEFAULT_SERVICE_ACCOUNT_ROLES = ("roles/storage.objectAdmin",
                                  "roles/compute.admin",
+                                 "roles/tpu.admin",
                                  "roles/iam.serviceAccountUser")
 # NOTE: iam.serviceAccountUser allows the Head Node to create worker nodes
 # with ServiceAccounts.

--- a/python/ray/autoscaler/_private/gcp/config.py
+++ b/python/ray/autoscaler/_private/gcp/config.py
@@ -27,8 +27,7 @@ DEFAULT_SERVICE_ACCOUNT_CONFIG = {
     "displayName": "Ray Autoscaler Service Account ({})".format(VERSION),
 }
 DEFAULT_SERVICE_ACCOUNT_ROLES = ("roles/storage.objectAdmin",
-                                 "roles/compute.admin",
-                                 "roles/tpu.admin",
+                                 "roles/compute.admin", "roles/tpu.admin",
                                  "roles/iam.serviceAccountUser")
 # NOTE: iam.serviceAccountUser allows the Head Node to create worker nodes
 # with ServiceAccounts.
@@ -389,7 +388,8 @@ def _configure_subnet(config, compute):
     # completely manually configured
 
     # networkInterfaces is compute, networkConfig is TPU
-    if all("networkInterfaces" in node_config or "networkConfig" in node_config for node_config in node_configs):
+    if all("networkInterfaces" in node_config or "networkConfig" in node_config
+           for node_config in node_configs):
         return config
 
     subnets = _list_subnets(config, compute)
@@ -411,15 +411,14 @@ def _configure_subnet(config, compute):
     }]
 
     for node_config in node_configs:
-        # The one not applicable for the instance will be removed during creation
+        # The not applicable key will be removed during creation
         # compute
         if "networkInterfaces" not in node_config:
             node_config["networkInterfaces"] = copy.deepcopy(
                 default_interfaces)
         # TPU
         if "networkConfig" not in node_config:
-            node_config["networkConfig"] = copy.deepcopy(
-                default_interfaces)[0]
+            node_config["networkConfig"] = copy.deepcopy(default_interfaces)[0]
             node_config["networkConfig"].pop("accessConfigs")
 
     return config

--- a/python/ray/autoscaler/_private/gcp/config.py
+++ b/python/ray/autoscaler/_private/gcp/config.py
@@ -13,6 +13,8 @@ from google.oauth2 import service_account
 from google.oauth2.credentials import Credentials as OAuthCredentials
 
 from ray.autoscaler._private.util import check_legacy_fields
+from ray.autoscaler._private.gcp.node import (GCPNodeType, MAX_POLLS,
+                                              POLL_INTERVAL)
 
 logger = logging.getLogger(__name__)
 
@@ -26,14 +28,44 @@ SERVICE_ACCOUNT_EMAIL_TEMPLATE = (
 DEFAULT_SERVICE_ACCOUNT_CONFIG = {
     "displayName": "Ray Autoscaler Service Account ({})".format(VERSION),
 }
-DEFAULT_SERVICE_ACCOUNT_ROLES = ("roles/storage.objectAdmin",
-                                 "roles/compute.admin", "roles/tpu.admin",
-                                 "roles/iam.serviceAccountUser")
+
+# Those roles will be always added.
+DEFAULT_SERVICE_ACCOUNT_ROLES = [
+    "roles/storage.objectAdmin", "roles/compute.admin",
+    "roles/iam.serviceAccountUser"
+]
+# Those roles will only be added if there are TPU nodes defined in config.
+TPU_SERVICE_ACCOUNT_ROLES = ["roles/tpu.admin"]
+
+# If there are TPU nodes in config, this field will be set
+# to True in config["provider"].
+HAS_TPU_PROVIDER_FIELD = "_has_tpus"
+
 # NOTE: iam.serviceAccountUser allows the Head Node to create worker nodes
 # with ServiceAccounts.
 
-MAX_POLLS = 12
-POLL_INTERVAL = 5
+
+def get_node_type(node: dict) -> GCPNodeType:
+    """Returns node type based on the keys in ``node``.
+
+    This is a very simple check. If we have a ``machineType`` key,
+    this is a Compute instance. If we don't have a ``machineType`` key,
+    but we have ``acceleratorType``, this is a TPU. Otherwise, it's
+    invalid and an exception is raised.
+
+    This works for both node configs and API returned nodes.
+    """
+
+    if "machineType" not in node and "acceleratorType" not in node:
+        raise ValueError(
+            "Invalid node. For a Compute instance, 'machineType' is "
+            "required."
+            "For a TPU instance, 'acceleratorType' and no 'machineType' "
+            "is required.")
+
+    if "machineType" not in node and "acceleratorType" in node:
+        return GCPNodeType.TPU
+    return GCPNodeType.COMPUTE
 
 
 def wait_for_crm_operation(operation, crm):
@@ -111,6 +143,15 @@ def generate_rsa_key_pair():
     return public_key, pem
 
 
+def _has_tpus_in_node_configs(config: dict) -> bool:
+    """Check if any nodes in config are TPUs."""
+    node_configs = [
+        node_type["node_config"]
+        for node_type in config["available_node_types"].values()
+    ]
+    return any(get_node_type(node) == GCPNodeType.TPU for node in node_configs)
+
+
 def _create_crm(gcp_credentials=None):
     return discovery.build(
         "cloudresourcemanager",
@@ -142,18 +183,23 @@ def construct_clients_from_provider_config(provider_config):
     """
     Attempt to fetch and parse the JSON GCP credentials from the provider
     config yaml file.
+
+    tpu resource (the last element of the tuple) will be None if
+    `_has_tpus` in provider config is not set or False.
     """
     gcp_credentials = provider_config.get("gcp_credentials")
     if gcp_credentials is None:
         logger.debug("gcp_credentials not found in cluster yaml file. "
                      "Falling back to GOOGLE_APPLICATION_CREDENTIALS "
                      "environment variable.")
+        tpu = _create_tpu() if provider_config.get(HAS_TPU_PROVIDER_FIELD,
+                                                   False) else None
         # If gcp_credentials is None, then discovery.build will search for
         # credentials in the local environment.
         return _create_crm(), \
             _create_iam(), \
             _create_compute(), \
-            _create_tpu()
+            tpu
 
     assert ("type" in gcp_credentials), \
         "gcp_credentials cluster yaml field missing 'type' field."
@@ -178,10 +224,13 @@ def construct_clients_from_provider_config(provider_config):
         # Otherwise the credentials type must be credentials_token.
         credentials = OAuthCredentials(credentials_field)
 
+    tpu = _create_tpu(credentials) if provider_config.get(
+        HAS_TPU_PROVIDER_FIELD, False) else None
+
     return _create_crm(credentials), \
         _create_iam(credentials), \
         _create_compute(credentials), \
-        _create_tpu(credentials)
+        tpu
 
 
 def bootstrap_gcp(config):
@@ -189,6 +238,11 @@ def bootstrap_gcp(config):
     check_legacy_fields(config)
     # Used internally to store head IAM role.
     config["head_node"] = {}
+
+    # Check if we have any TPUs defined, and if so,
+    # insert that information into the provider config
+    if _has_tpus_in_node_configs(config):
+        config["provider"][HAS_TPU_PROVIDER_FIELD] = True
 
     crm, iam, compute, tpu = \
         construct_clients_from_provider_config(config["provider"])
@@ -259,8 +313,12 @@ def _configure_iam_role(config, crm, iam):
 
     assert service_account is not None, "Failed to create service account"
 
-    _add_iam_policy_binding(service_account, DEFAULT_SERVICE_ACCOUNT_ROLES,
-                            crm)
+    if config["provider"].get(HAS_TPU_PROVIDER_FIELD, False):
+        roles = DEFAULT_SERVICE_ACCOUNT_ROLES + TPU_SERVICE_ACCOUNT_ROLES
+    else:
+        roles = DEFAULT_SERVICE_ACCOUNT_ROLES
+
+    _add_iam_policy_binding(service_account, roles, crm)
 
     config["head_node"]["serviceAccounts"] = [{
         "email": service_account["email"],

--- a/python/ray/autoscaler/_private/gcp/node.py
+++ b/python/ray/autoscaler/_private/gcp/node.py
@@ -511,12 +511,10 @@ class GCPTPU(GCPResource):
         })
 
         if "networkConfig" not in config:
-            config.update({
-                # this is required for SSH to work, per google documentation
-                "networkConfig": {
-                    "enableExternalIps": True
-                }
-            })
+            config["networkConfig"] = {}
+        if "enableExternalIps" not in config["networkConfig"]:
+            # this is required for SSH to work, per google documentation
+            config["networkConfig"]["enableExternalIps"] = True
 
         operation = self.resource.projects().locations().nodes().create(
             parent=self.path,

--- a/python/ray/autoscaler/_private/gcp/node.py
+++ b/python/ray/autoscaler/_private/gcp/node.py
@@ -299,6 +299,8 @@ class GCPCompute(GCPResource):
                         wait_for_operation: bool = True) -> Tuple[dict, str]:
 
         config = base_config.copy()
+        # removing TPU-specific default key set in config.py
+        config.pop("networkConfig", None)
         name = _generate_node_name(labels, GCPNodeType.COMPUTE.value)
 
         machine_type = ("zones/{zone}/machineTypes/{machine_type}"
@@ -431,6 +433,8 @@ class GCPTPU(GCPResource):
                         labels: dict,
                         wait_for_operation: bool = True) -> Tuple[dict, str]:
         config = base_config.copy()
+        # removing Compute-specific default key set in config.py
+        config.pop("networkInterfaces", None)
         name = _generate_node_name(labels, GCPNodeType.TPU.value)
 
         labels = dict(config.get("labels", {}), **labels)

--- a/python/ray/autoscaler/_private/gcp/node.py
+++ b/python/ray/autoscaler/_private/gcp/node.py
@@ -61,7 +61,12 @@ def _retry_on_exception(exception: Union[Exception, Tuple[Exception]],
 def _generate_node_name(labels: dict, node_suffix: str) -> str:
     """Generate node name from labels and suffix.
 
-    The suffix is expected to be one of 'compute' or 'tpu'."""
+    This is required so that the correct resource can be selected
+    when the only information autoscaler has is the name of the node.
+
+    The suffix is expected to be one of 'compute' or 'tpu'
+    (as in ``GCPNodeType``).
+    """
     name_label = labels[TAG_RAY_NODE_NAME]
     assert (len(name_label) <=
             (INSTANCE_NAME_MAX_LEN - INSTANCE_NAME_UUID_LEN - 1)), (

--- a/python/ray/autoscaler/_private/gcp/node.py
+++ b/python/ray/autoscaler/_private/gcp/node.py
@@ -508,11 +508,15 @@ class GCPTPU(GCPResource):
         config.update({
             "labels": dict(labels,
                            **{TAG_RAY_CLUSTER_NAME: self.cluster_name}),
-            # this is required for SSH to work, per google documentation
-            "networkConfig": {
-                "enableExternalIps": True
-            }
         })
+
+        if "networkConfig" not in config:
+            config.update({
+                # this is required for SSH to work, per google documentation
+                "networkConfig": {
+                    "enableExternalIps": True
+                }
+            })
 
         operation = self.resource.projects().locations().nodes().create(
             parent=self.path,

--- a/python/ray/autoscaler/_private/gcp/node.py
+++ b/python/ray/autoscaler/_private/gcp/node.py
@@ -427,7 +427,7 @@ class GCPTPU(GCPResource):
         body = {
             "labels": dict(node["labels"], **labels),
         }
-        update_mask = ",".join(_flatten_dict(body, delimiter=".").keys())
+        update_mask = "labels"
         logger.info(f"tpu set_labels update_mask {update_mask}")
         logger.info(f"tpu set_labels body {body}")
         operation = self.resource.projects().locations().nodes().patch(

--- a/python/ray/autoscaler/_private/gcp/node.py
+++ b/python/ray/autoscaler/_private/gcp/node.py
@@ -388,8 +388,6 @@ class GCPTPU(GCPResource):
         instances = response.get("nodes", [])
         instances = [GCPTPUNode(i, self) for i in instances]
 
-        logger.info(f"tpu list_instances: {instances}")
-
         # filter_expr cannot be passed directly to API
         # so we need to filter the results ourselves
 
@@ -410,8 +408,6 @@ class GCPTPU(GCPResource):
 
         instances = list(filter(filter_instance, instances))
 
-        logger.info(f"tpu list_instances after filter: {instances}")
-
         return instances
 
     def get_instance(self, node_id: str) -> "GCPTPUNode":
@@ -428,8 +424,7 @@ class GCPTPU(GCPResource):
             "labels": dict(node["labels"], **labels),
         }
         update_mask = "labels"
-        logger.info(f"tpu set_labels update_mask {update_mask}")
-        logger.info(f"tpu set_labels body {body}")
+
         operation = self.resource.projects().locations().nodes().patch(
             name=node["name"],
             updateMask=update_mask,

--- a/python/ray/autoscaler/_private/gcp/node.py
+++ b/python/ray/autoscaler/_private/gcp/node.py
@@ -25,6 +25,8 @@ def _retry_on_exception(exception: Union[Exception, Tuple[Exception]],
                         regex: Optional[str] = None,
                         max_retries: int = MAX_POLLS,
                         retry_interval: int = POLL_INTERVAL):
+    """Retry a function call n-times for as long as it throws an exception."""
+
     def dec(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
@@ -458,8 +460,9 @@ class GCPTPU(GCPResource):
 
         return GCPTPUNode(instance, self)
 
-    @_retry_on_exception(HttpError, "unable to queue the operation",
-                         MAX_POLLS * 8)
+    # this sometimes fails without a clear reason, so we retry it
+    # MAX_POLLS times
+    @_retry_on_exception(HttpError, "unable to queue the operation")
     def set_labels(self,
                    node: GCPNode,
                    labels: dict,

--- a/python/ray/autoscaler/_private/gcp/node.py
+++ b/python/ray/autoscaler/_private/gcp/node.py
@@ -349,6 +349,9 @@ class GCPCompute(GCPResource):
 class GCPTPU(GCPResource):
     """Abstraction around GCP TPU resource"""
 
+    # node names already contain the path, but this is required for `parent`
+    # arguments
+
     @property
     def path(self):
         return f"projects/{self.project_id}/locations/{self.availability_zone}"
@@ -425,6 +428,8 @@ class GCPTPU(GCPResource):
             "labels": dict(node["labels"], **labels),
         }
         update_mask = ",".join(_flatten_dict(body, delimiter=".").keys())
+        logger.info(f"tpu set_labels update_mask {update_mask}")
+        logger.info(f"tpu set_labels body {body}")
         operation = self.resource.projects().locations().nodes().patch(
             name=node["name"],
             updateMask=update_mask,

--- a/python/ray/autoscaler/_private/gcp/node.py
+++ b/python/ray/autoscaler/_private/gcp/node.py
@@ -415,7 +415,7 @@ class GCPTPU(GCPResource):
                            max_polls: int = MAX_POLLS_TPU,
                            poll_interval: int = POLL_INTERVAL) -> dict:
         """Poll for TPU operation until finished."""
-        logger.info("wait_for_tpu_zone_operation: "
+        logger.info("wait_for_tpu_operation: "
                     f"Waiting for operation {operation['name']} to finish...")
 
         for _ in range(max_polls):
@@ -425,7 +425,7 @@ class GCPTPU(GCPResource):
                 raise Exception(result["error"])
 
             if "response" in result:
-                logger.info("wait_for_tpu_zone_operation: "
+                logger.info("wait_for_tpu_operation: "
                             f"Operation {operation['name']} finished.")
                 break
 

--- a/python/ray/autoscaler/_private/gcp/node.py
+++ b/python/ray/autoscaler/_private/gcp/node.py
@@ -355,7 +355,10 @@ class GCPTPU(GCPResource):
         logger.info("wait_for_tpu_zone_operation: "
                     f"Waiting for operation {operation['name']} to finish...")
 
-        for _ in range(MAX_POLLS):
+        # TPUs take a long while to start, so we increase the MAX_POLLS
+        max_polls = MAX_POLLS * 8
+
+        for _ in range(max_polls):
             result = self.resource.projects().locations().operations().get(
                 name=f"{operation['name']}").execute()
             if "error" in result:

--- a/python/ray/autoscaler/_private/gcp/node.py
+++ b/python/ray/autoscaler/_private/gcp/node.py
@@ -9,12 +9,13 @@ from enum import Enum
 from googleapiclient.discovery import Resource
 
 from ray.autoscaler.tags import TAG_RAY_CLUSTER_NAME, TAG_RAY_NODE_NAME
-from ray.autoscaler._private.gcp.config import MAX_POLLS, POLL_INTERVAL
 
 logger = logging.getLogger(__name__)
 
 INSTANCE_NAME_MAX_LEN = 64
 INSTANCE_NAME_UUID_LEN = 8
+MAX_POLLS = 12
+POLL_INTERVAL = 5
 
 
 def _generate_node_name(labels: dict, node_suffix: str) -> str:

--- a/python/ray/autoscaler/_private/gcp/node.py
+++ b/python/ray/autoscaler/_private/gcp/node.py
@@ -1,0 +1,460 @@
+from typing import List, Optional, Tuple
+import logging
+import abc
+import time
+from uuid import uuid4
+from collections import UserDict
+from enum import Enum, auto
+
+from googleapiclient.discovery import Resource
+
+from ray.autoscaler.tags import TAG_RAY_CLUSTER_NAME, TAG_RAY_NODE_NAME
+from ray.autoscaler._private.gcp.config import MAX_POLLS, POLL_INTERVAL
+from ray.tune.utils.util import flatten_dict
+
+logger = logging.getLogger(__name__)
+
+INSTANCE_NAME_MAX_LEN = 64
+INSTANCE_NAME_UUID_LEN = 8
+
+
+def _generate_node_name(labels: dict, node_suffix: str) -> str:
+    name_label = labels[TAG_RAY_NODE_NAME]
+    assert (len(name_label) <=
+            (INSTANCE_NAME_MAX_LEN - INSTANCE_NAME_UUID_LEN - 1)), (
+                name_label, len(name_label))
+    return f"{name_label}-{uuid4().hex[:INSTANCE_NAME_UUID_LEN]}-{node_suffix}"
+
+
+class GCPNodeType(Enum):
+    COMPUTE = "compute"
+    TPU = "tpu"
+
+    @staticmethod
+    def from_gcp_node(node: "GCPNode"):
+        if isinstance(node, GCPTPUNode):
+            return GCPNodeType.TPU
+        if isinstance(node, GCPComputeNode):
+            return GCPNodeType.COMPUTE
+        raise TypeError(f"Wrong GCPNode type {type(node)}.")
+
+    @staticmethod
+    def name_to_type(name: str):
+        return GCPNodeType(name.split("-")[-1])
+
+
+class GCPNode(UserDict, metaclass=abc.ABCMeta):
+    """Abstraction around compute and tpu nodes"""
+
+    NON_TERMINATED_STATUSES = None
+    RUNNING_STATUSES = None
+    STATUS_FIELD = None
+
+    def __init__(self, dict: dict, resource: "GCPResource", **kwargs) -> None:
+        super().__init__(dict, **kwargs)
+        self.resource = resource
+        assert isinstance(self.resource, GCPResource)
+
+    def is_running(self) -> bool:
+        return self.get(self.STATUS_FIELD) in self.RUNNING_STATUSES
+
+    def is_terminated(self) -> bool:
+        return self.get(self.STATUS_FIELD) not in self.NON_TERMINATED_STATUSES
+
+    @abc.abstractmethod
+    def get_tags(self) -> dict:
+        return
+
+    @abc.abstractmethod
+    def get_external_ip(self) -> str:
+        return
+
+    @abc.abstractmethod
+    def get_internal_ip(self) -> str:
+        return
+
+
+class GCPComputeNode(GCPNode):
+    """Abstraction around compute nodes"""
+
+    NON_TERMINATED_STATUSES = {"PROVISIONING", "STAGING", "RUNNING"}
+    RUNNING_STATUSES = {"RUNNING"}
+    STATUS_FIELD = "status"
+
+    def get_tags(self) -> dict:
+        return self.get("labels", {})
+
+    def get_external_ip(self) -> str:
+        return self.get("networkInterfaces", [{}])[0].get(
+            "accessConfigs", [{}])[0].get("natIP", None)
+
+    def get_internal_ip(self) -> str:
+        return self.get("networkInterfaces", [{}])[0].get("networkIP")
+
+
+class GCPTPUNode(GCPNode):
+    """Abstraction around tpu nodes"""
+    # https://cloud.google.com/tpu/docs/reference/rest/v2alpha1/projects.locations.nodes#State
+
+    NON_TERMINATED_STATUSES = {"CREATING", "STARTING", "RESTARTING", "READY"}
+    RUNNING_STATUSES = {"READY"}
+    STATUS_FIELD = "state"
+
+    def get_tags(self) -> dict:
+        return self.get("labels", {})
+
+    def get_external_ip(self) -> str:
+        return self.get("networkEndpoints",
+                        [{}])[0].get("accessConfig", {}).get(
+                            "externalIp", None)
+
+    def get_internal_ip(self) -> str:
+        return self.get("networkEndpoints", [{}])[0].get("ipAddress", None)
+
+
+class GCPResource(metaclass=abc.ABCMeta):
+    """Abstraction around compute and tpu resources"""
+
+    def __init__(self, resource: Resource, project_id: str,
+                 availability_zone: str, cluster_name: str) -> None:
+        self.resource = resource
+        self.project_id = project_id
+        self.availability_zone = availability_zone
+        self.cluster_name = cluster_name
+
+    @abc.abstractmethod
+    def wait_for_operation(self, operation: dict) -> dict:
+        """Waits a preset amount of time for operation to complete"""
+        return None
+
+    @abc.abstractmethod
+    def list_instances(self,
+                       tag_filters: Optional[dict] = None) -> List["GCPNode"]:
+        """Returns a list of instances"""
+        return
+
+    @abc.abstractmethod
+    def get_instance(self, node_id: str) -> "GCPNode":
+        """Returns a single instance"""
+        return
+
+    @abc.abstractmethod
+    def set_labels(self,
+                   node: GCPNode,
+                   labels: dict,
+                   wait_for_operation: bool = True) -> dict:
+        """Sets labels on an instance and returns result"""
+        return
+
+    @abc.abstractmethod
+    def create_instance(self,
+                        base_config: dict,
+                        labels: dict,
+                        wait_for_operation: bool = True) -> Tuple[dict, str]:
+        """Creates a single instance and returns result.
+        
+        Returns a tuple of (result, node_name)."""
+        return
+
+    def create_instances(
+            self,
+            base_config: dict,
+            labels: dict,
+            count: int,
+            wait_for_operation: bool = True) -> List[Tuple[dict, str]]:
+        """Creates multiple instances and returns result.
+        
+        Returns a list of tuples of (result, node_name)."""
+        operations = [
+            self.create_instance(
+                base_config, labels, wait_for_operation=False)
+            for i in range(count)
+        ]
+
+        if wait_for_operation:
+            results = [(self.wait_for_operation(operation), node_name)
+                       for operation, node_name in operations]
+        else:
+            results = operations
+
+        return results
+
+    @abc.abstractmethod
+    def delete_instance(self, node_id: str,
+                        wait_for_operation: bool = True) -> dict:
+        """Deletes an instance and returns result"""
+        return
+
+
+class GCPCompute(GCPResource):
+    """Abstraction around GCP compute resource"""
+
+    def wait_for_operation(self, operation: dict) -> dict:
+        """Poll for compute zone operation until finished."""
+        logger.info("wait_for_compute_zone_operation: "
+                    f"Waiting for operation {operation['name']} to finish...")
+
+        for _ in range(MAX_POLLS):
+            result = self.resource.zoneOperations().get(
+                project=self.project_id,
+                operation=operation["name"],
+                zone=self.availability_zone).execute()
+            if "error" in result:
+                raise Exception(result["error"])
+
+            if result["status"] == "DONE":
+                logger.info("wait_for_compute_zone_operation: "
+                            f"Operation {operation['name']} finished.")
+                break
+
+            time.sleep(POLL_INTERVAL)
+
+        return result
+
+    def list_instances(self, tag_filters: Optional[dict] = None
+                       ) -> List["GCPComputeNode"]:
+        tag_filters = tag_filters or {}
+
+        if tag_filters:
+            label_filter_expr = "(" + " AND ".join([
+                "(labels.{key} = {value})".format(key=key, value=value)
+                for key, value in tag_filters.items()
+            ]) + ")"
+        else:
+            label_filter_expr = ""
+
+        instance_state_filter_expr = "(" + " OR ".join([
+            "(status = {status})".format(status=status)
+            for status in GCPComputeNode.NON_TERMINATED_STATUSES
+        ]) + ")"
+
+        cluster_name_filter_expr = ("(labels.{key} = {value})"
+                                    "".format(
+                                        key=TAG_RAY_CLUSTER_NAME,
+                                        value=self.cluster_name))
+
+        not_empty_filters = [
+            f for f in [
+                label_filter_expr,
+                instance_state_filter_expr,
+                cluster_name_filter_expr,
+            ] if f
+        ]
+
+        filter_expr = " AND ".join(not_empty_filters)
+
+        response = self.resource.instances().list(
+            project=self.project_id,
+            zone=self.availability_zone,
+            filter=filter_expr,
+        ).execute()
+
+        instances = response.get("items", [])
+        return [GCPComputeNode(i, self) for i in instances]
+
+    def get_instance(self, node_id: str) -> "GCPComputeNode":
+        instance = self.resource.instances().get(
+            project=self.project_id,
+            zone=self.availability_zone,
+            instance=node_id,
+        ).execute()
+
+        return GCPComputeNode(instance, self)
+
+    def set_labels(self,
+                   node: GCPComputeNode,
+                   labels: dict,
+                   wait_for_operation: bool = True) -> dict:
+        body = {
+            "labels": dict(node["labels"], **labels),
+            "labelFingerprint": node["labelFingerprint"]
+        }
+        node_id = node["name"]
+        operation = self.resource.instances().setLabels(
+            project=self.project_id,
+            zone=self.availability_zone,
+            instance=node_id,
+            body=body).execute()
+
+        if wait_for_operation:
+            result = self.wait_for_operation(operation)
+        else:
+            result = operation
+
+        return result
+
+    def create_instance(self,
+                        base_config: dict,
+                        labels: dict,
+                        wait_for_operation: bool = True) -> Tuple[dict, str]:
+
+        config = base_config.copy()
+        name = _generate_node_name(labels, GCPNodeType.COMPUTE.value)
+
+        machine_type = ("zones/{zone}/machineTypes/{machine_type}"
+                        "".format(
+                            zone=self.availability_zone,
+                            machine_type=base_config["machineType"]))
+        labels = dict(config.get("labels", {}), **labels)
+
+        config.update({
+            "machineType": machine_type,
+            "labels": dict(labels,
+                           **{TAG_RAY_CLUSTER_NAME: self.cluster_name}),
+            "name": name
+        })
+
+        operation = self.resource.instances().insert(
+            project=self.project_id, zone=self.availability_zone,
+            body=config).execute()
+
+        if wait_for_operation:
+            result = self.wait_for_operation(operation)
+        else:
+            result = operation
+
+        return result, name
+
+    def delete_instance(self, node_id: str,
+                        wait_for_operation: bool = True) -> dict:
+        operation = self.resource.instances().delete(
+            project=self.project_id,
+            zone=self.availability_zone,
+            instance=node_id,
+        ).execute()
+
+        if wait_for_operation:
+            result = self.wait_for_operation(operation)
+        else:
+            result = operation
+
+        return result
+
+
+class GCPTPU(GCPResource):
+    """Abstraction around GCP TPU resource"""
+
+    @property
+    def path(self):
+        return f"projects/{self.project_id}/locations/{self.availability_zone}"
+
+    def wait_for_operation(self, operation: dict) -> dict:
+        """Poll for TPU operation until finished."""
+        logger.info("wait_for_tpu_zone_operation: "
+                    f"Waiting for operation {operation['name']} to finish...")
+
+        for _ in range(MAX_POLLS):
+            result = self.resource.projects().locations().operations().get(
+                name=f"{self.path}/{operation['name']}").execute()
+            if "error" in result:
+                raise Exception(result["error"])
+
+            if "response" in result:
+                logger.info("wait_for_tpu_zone_operation: "
+                            f"Operation {operation['name']} finished.")
+                break
+
+            time.sleep(POLL_INTERVAL)
+
+        return result
+
+    def list_instances(
+            self, tag_filters: Optional[dict] = None) -> List["GCPTPUNode"]:
+        response = self.resource.projects().locations().nodes().list(
+            parent=self.path).execute()
+
+        instances = response.get("nodes", [])
+        instances = [GCPTPUNode(i, self) for i in instances]
+
+        # filter_expr cannot be passed directly to API
+        # so we need to filter the results ourselves
+
+        # same logic as for GCPCompute
+        def filter_instance(instance: GCPTPUNode) -> bool:
+            if instance.is_terminated:
+                return False
+
+            labels = instance.get_tags()
+
+            if tag_filters:
+                for key, value in tag_filters.items():
+                    if key not in labels:
+                        return False
+                    if value != labels[key]:
+                        return False
+
+            return True
+
+        instances = list(filter(filter_instance, instances))
+
+        return instances
+
+    def get_instance(self, node_id: str) -> "GCPTPUNode":
+        instance = self.resource.projects().locations().nodes().get(
+            name=f"{self.path}/nodes/{node_id}").execute()
+
+        return GCPTPUNode(instance, self)
+
+    def set_labels(self,
+                   node: GCPNode,
+                   labels: dict,
+                   wait_for_operation: bool = True) -> dict:
+        body = {
+            "labels": dict(node["labels"], **labels),
+        }
+        update_mask = ",".join(flatten_dict(body, delimiter=".").keys())
+        operation = self.resource.projects().locations().nodes().patch(
+            name=node["name"],
+            updateMask=update_mask,
+            body=body,
+        ).execute()
+
+        if wait_for_operation:
+            result = self.wait_for_operation(operation)
+        else:
+            result = operation
+
+        return result
+
+    def create_instance(self,
+                        base_config: dict,
+                        labels: dict,
+                        wait_for_operation: bool = True) -> Tuple[dict, str]:
+        config = base_config.copy()
+        name = _generate_node_name(labels, GCPNodeType.TPU.value)
+
+        labels = dict(config.get("labels", {}), **labels)
+
+        config.update({
+            "labels": dict(labels,
+                           **{TAG_RAY_CLUSTER_NAME: self.cluster_name}),
+            # this is required for SSH to work
+            "networkConfig": {
+                "enableExternalIps": True
+            }
+        })
+
+        operation = self.resource.projects().locations().nodes().create(
+            parent=self.path,
+            body=config,
+            nodeId=name,
+        ).execute()
+
+        if wait_for_operation:
+            result = self.wait_for_operation(operation)
+        else:
+            result = operation
+
+        return result, name
+
+    def delete_instance(self, node_id: str,
+                        wait_for_operation: bool = True) -> dict:
+        operation = self.resource.projects().locations().nodes().delete(
+            name=f"{self.path}/nodes/{node_id}").execute()
+
+        if wait_for_operation:
+            result = self.wait_for_operation(operation)
+        else:
+            result = operation
+
+        return result

--- a/python/ray/autoscaler/_private/gcp/node.py
+++ b/python/ray/autoscaler/_private/gcp/node.py
@@ -357,7 +357,7 @@ class GCPTPU(GCPResource):
 
         for _ in range(MAX_POLLS):
             result = self.resource.projects().locations().operations().get(
-                name=f"{self.path}/{operation['name']}").execute()
+                name=f"{operation['name']}").execute()
             if "error" in result:
                 raise Exception(result["error"])
 

--- a/python/ray/autoscaler/_private/gcp/node.py
+++ b/python/ray/autoscaler/_private/gcp/node.py
@@ -514,6 +514,7 @@ class GCPTPU(GCPResource):
             config["networkConfig"] = {}
         if "enableExternalIps" not in config["networkConfig"]:
             # this is required for SSH to work, per google documentation
+            # https://cloud.google.com/tpu/docs/users-guide-tpu-vm#create-curl
             config["networkConfig"]["enableExternalIps"] = True
 
         operation = self.resource.projects().locations().nodes().create(

--- a/python/ray/autoscaler/_private/gcp/node_provider.py
+++ b/python/ray/autoscaler/_private/gcp/node_provider.py
@@ -92,7 +92,6 @@ class GCPNodeProvider(NodeProvider):
 
             for resource in self.resources.values():
                 node_instances = resource.list_instances(tag_filters)
-                logger.info(f"{type(resource)}: {node_instances}")
                 instances += node_instances
 
             # Note: All the operations use "name" as the unique instance id

--- a/python/ray/autoscaler/_private/gcp/node_provider.py
+++ b/python/ray/autoscaler/_private/gcp/node_provider.py
@@ -1,3 +1,4 @@
+from typing import Dict, Set
 from functools import wraps
 from uuid import uuid4
 from threading import RLock
@@ -10,33 +11,24 @@ from ray.autoscaler._private.gcp.config import bootstrap_gcp
 from ray.autoscaler._private.gcp.config import MAX_POLLS, POLL_INTERVAL, \
     construct_clients_from_provider_config
 
+from ray.autoscaler._private.gcp.node import (
+    GCPResource, GCPNode, GCPCompute, GCPComputeNode, GCPTPU, GCPTPUNode,
+    GCPNodeType, INSTANCE_NAME_MAX_LEN, INSTANCE_NAME_UUID_LEN)
+
 logger = logging.getLogger(__name__)
 
-INSTANCE_NAME_MAX_LEN = 64
-INSTANCE_NAME_UUID_LEN = 8
 
-
-def wait_for_compute_zone_operation(compute, project_name, operation, zone):
-    """Poll for compute zone operation until finished."""
-    logger.info("wait_for_compute_zone_operation: "
-                "Waiting for operation {} to finish...".format(
-                    operation["name"]))
-
-    for _ in range(MAX_POLLS):
-        result = compute.zoneOperations().get(
-            project=project_name, operation=operation["name"],
-            zone=zone).execute()
-        if "error" in result:
-            raise Exception(result["error"])
-
-        if result["status"] == "DONE":
-            logger.info("wait_for_compute_zone_operation: "
-                        "Operation {} finished.".format(operation["name"]))
-            break
-
-        time.sleep(POLL_INTERVAL)
-
-    return result
+def _get_node_type(node: dict) -> GCPNodeType:
+    """Returns True if node is a TPU, false if Compute"""
+    if "machineType" not in node and "acceleratorType" not in node:
+        raise ValueError(
+            "Invalid node. For a Compute instance, 'machineType' is "
+            "required."
+            "For a TPU instance, 'acceleratorType' and no 'machineType' "
+            "is required.")
+    if "machineType" not in node and "acceleratorType" in node:
+        return GCPNodeType.TPU
+    return GCPNodeType.COMPUTE
 
 
 def _retry(method, max_tries=5, backoff_s=1):
@@ -70,96 +62,66 @@ def _retry(method, max_tries=5, backoff_s=1):
 class GCPNodeProvider(NodeProvider):
     def __init__(self, provider_config, cluster_name):
         NodeProvider.__init__(self, provider_config, cluster_name)
-
         self.lock = RLock()
         self._construct_clients()
 
         # Cache of node objects from the last nodes() call. This avoids
         # excessive DescribeInstances requests.
-        self.cached_nodes = {}
+        self.cached_nodes: Dict[str, GCPNode] = {}
 
     def _construct_clients(self):
-        _, _, self.compute = construct_clients_from_provider_config(
+        _, _, compute, tpu = construct_clients_from_provider_config(
             self.provider_config)
+        self.resources: Dict[GCPNodeType, GCPResource] = {}
+
+        self.resources[GCPNodeType.COMPUTE] = GCPCompute(
+            compute, self.provider_config["project_id"],
+            self.provider_config["availability_zone"], self.cluster_name)
+        self.resources[GCPNodeType.TPU] = GCPTPU(
+            tpu, self.provider_config["project_id"],
+            self.provider_config["availability_zone"], self.cluster_name)
+
+    def _get_resource_depending_on_node_name(self,
+                                             node_name: str) -> GCPResource:
+        return self.resources[GCPNodeType.name_to_type(node_name)]
 
     @_retry
     def non_terminated_nodes(self, tag_filters):
         with self.lock:
-            if tag_filters:
-                label_filter_expr = "(" + " AND ".join([
-                    "(labels.{key} = {value})".format(key=key, value=value)
-                    for key, value in tag_filters.items()
-                ]) + ")"
-            else:
-                label_filter_expr = ""
+            instances = []
 
-            instance_state_filter_expr = "(" + " OR ".join([
-                "(status = {status})".format(status=status)
-                for status in {"PROVISIONING", "STAGING", "RUNNING"}
-            ]) + ")"
+            for resource in self.resources.values():
+                node_instances = resource.list_instances(tag_filters)
+                instances += node_instances
 
-            cluster_name_filter_expr = ("(labels.{key} = {value})"
-                                        "".format(
-                                            key=TAG_RAY_CLUSTER_NAME,
-                                            value=self.cluster_name))
-
-            not_empty_filters = [
-                f for f in [
-                    label_filter_expr,
-                    instance_state_filter_expr,
-                    cluster_name_filter_expr,
-                ] if f
-            ]
-
-            filter_expr = " AND ".join(not_empty_filters)
-
-            response = self.compute.instances().list(
-                project=self.provider_config["project_id"],
-                zone=self.provider_config["availability_zone"],
-                filter=filter_expr,
-            ).execute()
-
-            instances = response.get("items", [])
             # Note: All the operations use "name" as the unique instance id
             self.cached_nodes = {i["name"]: i for i in instances}
-
             return [i["name"] for i in instances]
 
     def is_running(self, node_id):
         with self.lock:
             node = self._get_cached_node(node_id)
-            return node["status"] == "RUNNING"
+            return node.is_running()
 
     def is_terminated(self, node_id):
         with self.lock:
             node = self._get_cached_node(node_id)
-            return node["status"] not in {"PROVISIONING", "STAGING", "RUNNING"}
+            return node.is_terminated()
 
     def node_tags(self, node_id):
         with self.lock:
             node = self._get_cached_node(node_id)
-            labels = node.get("labels", {})
-            return labels
+            return node.get_tags()
 
     @_retry
     def set_node_tags(self, node_id, tags):
         with self.lock:
             labels = tags
-            project_id = self.provider_config["project_id"]
-            availability_zone = self.provider_config["availability_zone"]
-
             node = self._get_node(node_id)
-            operation = self.compute.instances().setLabels(
-                project=project_id,
-                zone=availability_zone,
-                instance=node_id,
-                body={
-                    "labels": dict(node["labels"], **labels),
-                    "labelFingerprint": node["labelFingerprint"]
-                }).execute()
 
-            result = wait_for_compute_zone_operation(
-                self.compute, project_id, operation, availability_zone)
+            resource = self._get_resource_depending_on_node_name(node_id)
+
+            result = resource.set_labels(node=node, labels=labels)
 
             return result
 
@@ -167,14 +129,10 @@ class GCPNodeProvider(NodeProvider):
         with self.lock:
             node = self._get_cached_node(node_id)
 
-            def get_external_ip(node):
-                return node.get("networkInterfaces", [{}])[0].get(
-                    "accessConfigs", [{}])[0].get("natIP", None)
-
-            ip = get_external_ip(node)
+            ip = node.get_external_ip()
             if ip is None:
                 node = self._get_node(node_id)
-                ip = get_external_ip(node)
+                ip = node.get_external_ip()
 
             return ip
 
@@ -182,13 +140,10 @@ class GCPNodeProvider(NodeProvider):
         with self.lock:
             node = self._get_cached_node(node_id)
 
-            def get_internal_ip(node):
-                return node.get("networkInterfaces", [{}])[0].get("networkIP")
-
-            ip = get_internal_ip(node)
+            ip = node.get_internal_ip()
             if ip is None:
                 node = self._get_node(node_id)
-                ip = get_internal_ip(node)
+                ip = node.get_internal_ip()
 
             return ip
 
@@ -196,78 +151,33 @@ class GCPNodeProvider(NodeProvider):
     def create_node(self, base_config, tags, count) -> None:
         with self.lock:
             labels = tags  # gcp uses "labels" instead of aws "tags"
-            project_id = self.provider_config["project_id"]
-            availability_zone = self.provider_config["availability_zone"]
 
-            config = base_config.copy()
+            node_type = _get_node_type(base_config)
+            resource = self.resources[node_type]
 
-            name_label = labels[TAG_RAY_NODE_NAME]
-            assert (len(name_label) <=
-                    (INSTANCE_NAME_MAX_LEN - INSTANCE_NAME_UUID_LEN - 1)), (
-                        name_label, len(name_label))
-
-            machine_type = ("zones/{zone}/machineTypes/{machine_type}"
-                            "".format(
-                                zone=availability_zone,
-                                machine_type=base_config["machineType"]))
-            labels = dict(config.get("labels", {}), **labels)
-
-            config.update({
-                "machineType": machine_type,
-                "labels": dict(labels,
-                               **{TAG_RAY_CLUSTER_NAME: self.cluster_name}),
-            })
-
-            operations = [
-                self.compute.instances().insert(
-                    project=project_id,
-                    zone=availability_zone,
-                    body=dict(
-                        config, **{
-                            "name": ("{name_label}-{uuid}".format(
-                                name_label=name_label,
-                                uuid=uuid4().hex[:INSTANCE_NAME_UUID_LEN]))
-                        })).execute() for i in range(count)
-            ]
-
-            for operation in operations:
-                wait_for_compute_zone_operation(self.compute, project_id,
-                                                operation, availability_zone)
+            resource.create_instances(base_config, labels, count)
 
     @_retry
     def terminate_node(self, node_id):
         with self.lock:
-            project_id = self.provider_config["project_id"]
-            availability_zone = self.provider_config["availability_zone"]
-
-            operation = self.compute.instances().delete(
-                project=project_id,
-                zone=availability_zone,
-                instance=node_id,
-            ).execute()
-
-            result = wait_for_compute_zone_operation(
-                self.compute, project_id, operation, availability_zone)
-
+            resource = self._get_resource_depending_on_node_name(node_id)
+            result = resource.delete_instance(node_id=node_id, )
             return result
 
     @_retry
-    def _get_node(self, node_id):
+    def _get_node(self, node_id: str) -> GCPNode:
         self.non_terminated_nodes({})  # Side effect: updates cache
 
         with self.lock:
             if node_id in self.cached_nodes:
                 return self.cached_nodes[node_id]
 
-            instance = self.compute.instances().get(
-                project=self.provider_config["project_id"],
-                zone=self.provider_config["availability_zone"],
-                instance=node_id,
-            ).execute()
+            resource = self._get_resource_depending_on_node_name(node_id)
+            instance = resource.get_instance(node_id=node_id)
 
             return instance
 
-    def _get_cached_node(self, node_id):
+    def _get_cached_node(self, node_id: str) -> GCPNode:
         if node_id in self.cached_nodes:
             return self.cached_nodes[node_id]
 

--- a/python/ray/autoscaler/_private/gcp/node_provider.py
+++ b/python/ray/autoscaler/_private/gcp/node_provider.py
@@ -7,6 +7,10 @@ import logging
 from ray.autoscaler.node_provider import NodeProvider
 from ray.autoscaler._private.gcp.config import (
     bootstrap_gcp, construct_clients_from_provider_config, get_node_type)
+
+# The logic has been abstracted away here to allow for different GCP resources
+# (API endpoints), which can differ widely, making it impossible to use
+# the same logic for everything.
 from ray.autoscaler._private.gcp.node import (  # noqa
     GCPResource, GCPNode, GCPCompute, GCPTPU, GCPNodeType,
     INSTANCE_NAME_MAX_LEN, INSTANCE_NAME_UUID_LEN)

--- a/python/ray/autoscaler/_private/gcp/node_provider.py
+++ b/python/ray/autoscaler/_private/gcp/node_provider.py
@@ -92,6 +92,7 @@ class GCPNodeProvider(NodeProvider):
 
             for resource in self.resources.values():
                 node_instances = resource.list_instances(tag_filters)
+                logger.info(f"{type(resource)}: {node_instances}")
                 instances += node_instances
 
             # Note: All the operations use "name" as the unique instance id

--- a/python/ray/autoscaler/_private/gcp/node_provider.py
+++ b/python/ray/autoscaler/_private/gcp/node_provider.py
@@ -1,31 +1,38 @@
-from typing import Dict, Set
+from typing import Dict
 from functools import wraps
-from uuid import uuid4
 from threading import RLock
 import time
 import logging
 
 from ray.autoscaler.node_provider import NodeProvider
-from ray.autoscaler.tags import TAG_RAY_CLUSTER_NAME, TAG_RAY_NODE_NAME
 from ray.autoscaler._private.gcp.config import bootstrap_gcp
-from ray.autoscaler._private.gcp.config import MAX_POLLS, POLL_INTERVAL, \
+from ray.autoscaler._private.gcp.config import \
     construct_clients_from_provider_config
-
-from ray.autoscaler._private.gcp.node import (
-    GCPResource, GCPNode, GCPCompute, GCPComputeNode, GCPTPU, GCPTPUNode,
-    GCPNodeType, INSTANCE_NAME_MAX_LEN, INSTANCE_NAME_UUID_LEN)
+from ray.autoscaler._private.gcp.node import (  # noqa
+    GCPResource, GCPNode, GCPCompute, GCPTPU, GCPNodeType,
+    INSTANCE_NAME_MAX_LEN, INSTANCE_NAME_UUID_LEN)
 
 logger = logging.getLogger(__name__)
 
 
 def _get_node_type(node: dict) -> GCPNodeType:
-    """Returns True if node is a TPU, false if Compute"""
+    """Returns node type based on the keys in ``node``.
+
+    This is a very simple check. If we have a ``machineType`` key,
+    this is a Compute instance. If we don't have a ``machineType`` key,
+    but we have ``acceleratorType``, this is a TPU. Otherwise, it's
+    invalid and an exception is raised.
+
+    This works for both configs and nodes.
+    """
+
     if "machineType" not in node and "acceleratorType" not in node:
         raise ValueError(
             "Invalid node. For a Compute instance, 'machineType' is "
             "required."
             "For a TPU instance, 'acceleratorType' and no 'machineType' "
             "is required.")
+
     if "machineType" not in node and "acceleratorType" in node:
         return GCPNodeType.TPU
     return GCPNodeType.COMPUTE
@@ -60,7 +67,7 @@ def _retry(method, max_tries=5, backoff_s=1):
 
 
 class GCPNodeProvider(NodeProvider):
-    def __init__(self, provider_config, cluster_name):
+    def __init__(self, provider_config: dict, cluster_name: str):
         NodeProvider.__init__(self, provider_config, cluster_name)
         self.lock = RLock()
         self._construct_clients()
@@ -72,6 +79,9 @@ class GCPNodeProvider(NodeProvider):
     def _construct_clients(self):
         _, _, compute, tpu = construct_clients_from_provider_config(
             self.provider_config)
+
+        # Dict of different resources provided by GCP.
+        # At this moment - Compute and TPUs
         self.resources: Dict[GCPNodeType, GCPResource] = {}
 
         self.resources[GCPNodeType.COMPUTE] = GCPCompute(
@@ -83,10 +93,15 @@ class GCPNodeProvider(NodeProvider):
 
     def _get_resource_depending_on_node_name(self,
                                              node_name: str) -> GCPResource:
+        """Return the resource responsible for the node, based on node_name.
+
+        This expects the name to be in format '[NAME]-[UUID]-[TYPE]',
+        where [TYPE] is either 'compute' or 'tpu'.
+        """
         return self.resources[GCPNodeType.name_to_type(node_name)]
 
     @_retry
-    def non_terminated_nodes(self, tag_filters):
+    def non_terminated_nodes(self, tag_filters: dict):
         with self.lock:
             instances = []
 
@@ -98,23 +113,23 @@ class GCPNodeProvider(NodeProvider):
             self.cached_nodes = {i["name"]: i for i in instances}
             return [i["name"] for i in instances]
 
-    def is_running(self, node_id):
+    def is_running(self, node_id: str):
         with self.lock:
             node = self._get_cached_node(node_id)
             return node.is_running()
 
-    def is_terminated(self, node_id):
+    def is_terminated(self, node_id: str):
         with self.lock:
             node = self._get_cached_node(node_id)
             return node.is_terminated()
 
-    def node_tags(self, node_id):
+    def node_tags(self, node_id: str):
         with self.lock:
             node = self._get_cached_node(node_id)
-            return node.get_tags()
+            return node.get_labels()
 
     @_retry
-    def set_node_tags(self, node_id, tags):
+    def set_node_tags(self, node_id: str, tags: dict):
         with self.lock:
             labels = tags
             node = self._get_node(node_id)
@@ -125,7 +140,7 @@ class GCPNodeProvider(NodeProvider):
 
             return result
 
-    def external_ip(self, node_id):
+    def external_ip(self, node_id: str):
         with self.lock:
             node = self._get_cached_node(node_id)
 
@@ -136,7 +151,7 @@ class GCPNodeProvider(NodeProvider):
 
             return ip
 
-    def internal_ip(self, node_id):
+    def internal_ip(self, node_id: str):
         with self.lock:
             node = self._get_cached_node(node_id)
 
@@ -148,7 +163,7 @@ class GCPNodeProvider(NodeProvider):
             return ip
 
     @_retry
-    def create_node(self, base_config, tags, count) -> None:
+    def create_node(self, base_config: dict, tags: dict, count: int) -> None:
         with self.lock:
             labels = tags  # gcp uses "labels" instead of aws "tags"
 
@@ -158,7 +173,7 @@ class GCPNodeProvider(NodeProvider):
             resource.create_instances(base_config, labels, count)
 
     @_retry
-    def terminate_node(self, node_id):
+    def terminate_node(self, node_id: str):
         with self.lock:
             resource = self._get_resource_depending_on_node_name(node_id)
             result = resource.delete_instance(node_id=node_id, )

--- a/python/ray/autoscaler/gcp/tpu.yaml
+++ b/python/ray/autoscaler/gcp/tpu.yaml
@@ -30,6 +30,8 @@ available_node_types:
         min_workers: 7
         resources: {"TPU": 1}  # use TPU custom resource in your code
         node_config:
+            # Only v2-8 and v3-8 accelerator types are currently supported.
+            # Support for TPU pods will be added in the future.
             acceleratorType: v2-8
             runtimeVersion: v2-alpha
             # Uncomment to use preemptible TPUs

--- a/python/ray/autoscaler/gcp/tpu.yaml
+++ b/python/ray/autoscaler/gcp/tpu.yaml
@@ -1,9 +1,12 @@
+# This config is an example TPU config allowing you to run
+# https://github.com/Yard1/swarm-jax on GCP TPUs
+
 # A unique identifier for the head node and workers of this cluster.
 cluster_name: tputest
 
 # The maximum number of worker nodes to launch in addition to the head
 # node. min_workers default to 0.
-max_workers: 1
+max_workers: 4
 
 available_node_types:
     ray_head_default:
@@ -11,23 +14,24 @@ available_node_types:
         max_workers: 0
         resources: {"CPU": 2}
         node_config:
-            machineType: n1-standard-2
+            machineType: n2-standard-2
             disks:
               - boot: true
                 autoDelete: true
                 type: PERSISTENT
                 initializeParams:
-                  diskSizeGb: 50
+                  diskSizeGb: 100
                   # See https://cloud.google.com/compute/docs/images for more images
                   sourceImage: projects/deeplearning-platform-release/global/images/family/common-cpu
     ray_tpu:
-        min_workers: 1
+        min_workers: 4
         resources: {"TPU": 1}
         node_config:
             acceleratorType: v2-8
             runtimeVersion: v2-alpha
-            schedulingConfig:
-                preemptible: True
+            # Uncomment to use preemptible TPUs
+            # schedulingConfig:
+            #     preemptible: true
 
 provider:
     type: gcp
@@ -37,13 +41,22 @@ provider:
 
 setup_commands: []
 
+# Specify the node type of the head node (as configured above).
+head_node_type: ray_head_default
 
 # Compute instances have python 3.7, but TPUs have 3.8 - need to update
 head_setup_commands:
-  - sleep 2 && sudo apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev curl libbz2-dev && curl -O https://www.python.org/ftp/python/3.8.5/Python-3.8.5.tar.xz && tar -xf Python-3.8.5.tar.xz && cd Python-3.8.5 && ./configure && make -j 4 && sudo make install
-  - python3.8 -m pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl && wget https://raw.githubusercontent.com/Yard1/ray/gcp_tpu_autoscaler/python/ray/autoscaler/_private/gcp/config.py && wget https://raw.githubusercontent.com/Yard1/ray/gcp_tpu_autoscaler/python/ray/autoscaler/_private/gcp/node.py && wget https://raw.githubusercontent.com/Yard1/ray/gcp_tpu_autoscaler/python/ray/autoscaler/_private/gcp/node_provider.py && cp -f config.py ~/.local/lib/python3.8/site-packages/ray/autoscaler/_private/gcp/ && cp -f node.py ~/.local/lib/python3.8/site-packages/ray/autoscaler/_private/gcp/ && cp -f node_provider.py ~/.local/lib/python3.8/site-packages/ray/autoscaler/_private/gcp/
-  - python3.8 -m pip install google-api-python-client==1.7.8 cryptography
+  - until sudo apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev curl libbz2-dev; do echo "Try again"; sleep 2; done && curl -O https://www.python.org/ftp/python/3.8.5/Python-3.8.5.tar.xz && tar -xf Python-3.8.5.tar.xz && cd Python-3.8.5 && ./configure && make -j 4 && sudo make install
+  - python3.8 -m pip install --upgrade "jax[cpu]==0.2.14" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+  - python3.8 -m pip install --upgrade fabric dataclasses optax==0.0.6 git+https://github.com/deepmind/dm-haiku google-api-python-client cryptography tensorboardX ray[default]
+  - python3.8 -m pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
+  - git clone --branch test https://github.com/Yard1/swarm-jax.git && cd swarm-jax && python3.8 -m pip install .
+  - sudo update-alternatives --install /opt/conda/bin/python python /usr/local/bin/python3.8 10 && sudo update-alternatives --install /opt/conda/bin/pip pip /usr/local/bin/pip3.8 10
 
+# Install Jax and other dependencies on TPU
 worker_setup_commands:
+  - pip3 install --upgrade "jax[tpu]==0.2.14" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+  - pip3 install --upgrade fabric dataclasses optax==0.0.6 git+https://github.com/deepmind/dm-haiku tensorboardX ray[default]
+  - python3 -c "import jax; jax.device_count(); jax.numpy.add(1, 1)"
   - pip3 install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
-  - pip3 install google-api-python-client==1.7.8
+  - git clone --branch test https://github.com/Yard1/swarm-jax.git && cd swarm-jax && sudo pip3 install .

--- a/python/ray/autoscaler/gcp/tpu.yaml
+++ b/python/ray/autoscaler/gcp/tpu.yaml
@@ -1,11 +1,12 @@
 # This config is an example TPU config allowing you to run
 # https://github.com/Yard1/swarm-jax on GCP TPUs
+# Replace provider.project_id with your GCP project id
 
 # A unique identifier for the head node and workers of this cluster.
 cluster_name: tputest
 
 # The maximum number of worker nodes to launch in addition to the head
-# node. min_workers default to 0.
+# node.
 max_workers: 4
 
 available_node_types:
@@ -20,12 +21,12 @@ available_node_types:
                 autoDelete: true
                 type: PERSISTENT
                 initializeParams:
-                  diskSizeGb: 100
+                  diskSizeGb: 50
                   # See https://cloud.google.com/compute/docs/images for more images
                   sourceImage: projects/deeplearning-platform-release/global/images/family/common-cpu
     ray_tpu:
         min_workers: 4
-        resources: {"TPU": 1}
+        resources: {"TPU": 1}  # use TPU custom resource in your code
         node_config:
             acceleratorType: v2-8
             runtimeVersion: v2-alpha
@@ -37,26 +38,28 @@ provider:
     type: gcp
     region: us-central1
     availability_zone: us-central1-f
-    project_id: tpu-test-320314
+    project_id: null
 
 setup_commands: []
 
 # Specify the node type of the head node (as configured above).
+# TPUs cannot be head nodes (will raise an exception).
 head_node_type: ray_head_default
 
 # Compute instances have python 3.7, but TPUs have 3.8 - need to update
+# Install Jax and other dependencies on the Compute head node
 head_setup_commands:
-  - until sudo apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev curl libbz2-dev; do echo "Try again"; sleep 2; done && curl -O https://www.python.org/ftp/python/3.8.5/Python-3.8.5.tar.xz && tar -xf Python-3.8.5.tar.xz && cd Python-3.8.5 && ./configure && make -j 4 && sudo make install
-  - python3.8 -m pip install --upgrade "jax[cpu]==0.2.14" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
-  - python3.8 -m pip install --upgrade fabric dataclasses optax==0.0.6 git+https://github.com/deepmind/dm-haiku google-api-python-client cryptography tensorboardX ray[default]
-  - python3.8 -m pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
-  - git clone --branch test https://github.com/Yard1/swarm-jax.git && cd swarm-jax && python3.8 -m pip install .
-  - sudo update-alternatives --install /opt/conda/bin/python python /usr/local/bin/python3.8 10 && sudo update-alternatives --install /opt/conda/bin/pip pip /usr/local/bin/pip3.8 10
+  - conda create -y -n "ray" python=3.8.5 && sudo update-alternatives --install /opt/conda/bin/python python /opt/conda/envs/ray/bin/python 10 && sudo update-alternatives --install /opt/conda/bin/pip pip /opt/conda/envs/ray/bin/pip 10
+  - export PATH="$PATH:/opt/conda/envs/ray/bin" && echo 'export PATH="$PATH:/opt/conda/envs/ray/bin"' >> ~/.bashrc
+  - python -m pip install --upgrade "jax[cpu]==0.2.14" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+  - python -m pip install --upgrade fabric dataclasses optax==0.0.6 git+https://github.com/deepmind/dm-haiku google-api-python-client cryptography tensorboardX ray[default]
+  - python -m pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
+  - git clone --branch test https://github.com/Yard1/swarm-jax.git && cd swarm-jax && python -m pip install .
 
 # Install Jax and other dependencies on TPU
 worker_setup_commands:
   - pip3 install --upgrade "jax[tpu]==0.2.14" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
   - pip3 install --upgrade fabric dataclasses optax==0.0.6 git+https://github.com/deepmind/dm-haiku tensorboardX ray[default]
-  - python3 -c "import jax; jax.device_count(); jax.numpy.add(1, 1)"
+  - python3 -c "import jax; jax.device_count(); jax.numpy.add(1, 1)"  # test if Jax has been installed correctly
   - pip3 install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
   - git clone --branch test https://github.com/Yard1/swarm-jax.git && cd swarm-jax && sudo pip3 install .

--- a/python/ray/autoscaler/gcp/tpu.yaml
+++ b/python/ray/autoscaler/gcp/tpu.yaml
@@ -1,13 +1,15 @@
 # This config is an example TPU config allowing you to run
 # https://github.com/Yard1/swarm-jax on GCP TPUs
 # Replace provider.project_id with your GCP project id
+# After the nodes are up, run:
+#   ray attach tpu.yaml swarm_tpu_jax.py swarm-jax/data/enwik8 [NUM_TPUS] [EPOCHS]
 
 # A unique identifier for the head node and workers of this cluster.
 cluster_name: tputest
 
 # The maximum number of worker nodes to launch in addition to the head
 # node.
-max_workers: 4
+max_workers: 7
 
 available_node_types:
     ray_head_default:
@@ -25,7 +27,7 @@ available_node_types:
                   # See https://cloud.google.com/compute/docs/images for more images
                   sourceImage: projects/deeplearning-platform-release/global/images/family/common-cpu
     ray_tpu:
-        min_workers: 4
+        min_workers: 7
         resources: {"TPU": 1}  # use TPU custom resource in your code
         node_config:
             acceleratorType: v2-8
@@ -38,7 +40,7 @@ provider:
     type: gcp
     region: us-central1
     availability_zone: us-central1-f
-    project_id: null
+    project_id: null  # replace with your GCP project id
 
 setup_commands: []
 
@@ -54,7 +56,7 @@ head_setup_commands:
   - python -m pip install --upgrade "jax[cpu]==0.2.14" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
   - python -m pip install --upgrade fabric dataclasses optax==0.0.6 git+https://github.com/deepmind/dm-haiku google-api-python-client cryptography tensorboardX ray[default]
   - python -m pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
-  - git clone --branch test https://github.com/Yard1/swarm-jax.git && cd swarm-jax && python -m pip install .
+  - git clone https://github.com/Yard1/swarm-jax.git && cd swarm-jax && python -m pip install .
 
 # Install Jax and other dependencies on TPU
 worker_setup_commands:
@@ -62,4 +64,4 @@ worker_setup_commands:
   - pip3 install --upgrade fabric dataclasses optax==0.0.6 git+https://github.com/deepmind/dm-haiku tensorboardX ray[default]
   - python3 -c "import jax; jax.device_count(); jax.numpy.add(1, 1)"  # test if Jax has been installed correctly
   - pip3 install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
-  - git clone --branch test https://github.com/Yard1/swarm-jax.git && cd swarm-jax && sudo pip3 install .
+  - git clone https://github.com/Yard1/swarm-jax.git && cd swarm-jax && sudo pip3 install .

--- a/python/ray/autoscaler/gcp/tpu.yaml
+++ b/python/ray/autoscaler/gcp/tpu.yaml
@@ -1,0 +1,49 @@
+# A unique identifier for the head node and workers of this cluster.
+cluster_name: tputest
+
+# The maximum number of worker nodes to launch in addition to the head
+# node. min_workers default to 0.
+max_workers: 1
+
+available_node_types:
+    ray_head_default:
+        min_workers: 0
+        max_workers: 0
+        resources: {"CPU": 2}
+        node_config:
+            machineType: n1-standard-2
+            disks:
+              - boot: true
+                autoDelete: true
+                type: PERSISTENT
+                initializeParams:
+                  diskSizeGb: 50
+                  # See https://cloud.google.com/compute/docs/images for more images
+                  sourceImage: projects/deeplearning-platform-release/global/images/family/common-cpu
+    ray_tpu:
+        min_workers: 1
+        resources: {"TPU": 1}
+        node_config:
+            acceleratorType: v2-8
+            runtimeVersion: v2-alpha
+            schedulingConfig:
+                preemptible: True
+
+provider:
+    type: gcp
+    region: us-central1
+    availability_zone: us-central1-f
+    project_id: tpu-test-320314
+
+setup_commands: []
+
+
+# Compute instances have python 3.7, but TPUs have 3.8 - need to update
+head_setup_commands:
+  - sleep 2 && sudo apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev curl libbz2-dev && curl -O https://www.python.org/ftp/python/3.8.5/Python-3.8.5.tar.xz && tar -xf Python-3.8.5.tar.xz && cd Python-3.8.5 && ./configure && make -j 4 && sudo make install
+  - python3.8 -m pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl && wget https://raw.githubusercontent.com/Yard1/ray/gcp_tpu_autoscaler/python/ray/autoscaler/_private/gcp/config.py && wget https://raw.githubusercontent.com/Yard1/ray/gcp_tpu_autoscaler/python/ray/autoscaler/_private/gcp/node.py && wget https://raw.githubusercontent.com/Yard1/ray/gcp_tpu_autoscaler/python/ray/autoscaler/_private/gcp/node_provider.py && cp -f config.py ~/.local/lib/python3.8/site-packages/ray/autoscaler/_private/gcp/ && cp -f node.py ~/.local/lib/python3.8/site-packages/ray/autoscaler/_private/gcp/ && cp -f node_provider.py ~/.local/lib/python3.8/site-packages/ray/autoscaler/_private/gcp/
+  - python3.8 -m pip install google-api-python-client==1.7.8 cryptography
+
+worker_setup_commands:
+  - pip3 install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
+  - pip3 install google-api-python-client==1.7.8


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

WIP!

This PR adds support for [GCP TPU VMs](https://cloud.google.com/tpu/docs/users-guide-tpu-vm#creating_a_cloud_tpu_vm_with_gcloud) in autoscaler. This is achieved by refactoring and abstracting the current GCP autoscaler code to allow for different types of resources, with different APIs (Compute and TPU).

This will allow for users to take advantage of GCP TPUs without having to hack support for them themselves, making projects such as https://github.com/kingoflolz/swarm-jax/tree/master/swarm_jax much simpler.

TPU pods are not yet supported (only v2-8 and v3-8 instances are supported).

Requires further testing. Not all functionality may work with TPUs. The existing (compute) functionality *should* be unaffected, unless by mistake. The provided config is very WIP.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
