### PR TITLE
[Java] Filter error log for intentional system exit.

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
@@ -129,7 +129,13 @@ public abstract class TaskExecutor<T extends TaskExecutor.ActorContext> {
           result = rayFunction.getConstructor().newInstance(args);
         }
       } catch (InvocationTargetException e) {
-        LOGGER.error("Execute rayFunction {} failed. actor {}, args {}", rayFunction, actor, args);
+        final boolean isIntentionalSystemExit =
+            e.getCause() != null && e.getCause() instanceof RayIntentionalSystemExitException;
+        if (!isIntentionalSystemExit) {
+          LOGGER.error(
+              "Execute rayFunction {} failed. actor {}, args {}", rayFunction, actor, args);
+        }
+
         if (e.getCause() != null) {
           throw e.getCause();
         } else {

--- a/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
@@ -16,8 +16,10 @@ import io.ray.runtime.object.ObjectSerializer;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -132,8 +134,15 @@ public abstract class TaskExecutor<T extends TaskExecutor.ActorContext> {
         final boolean isIntentionalSystemExit =
             e.getCause() != null && e.getCause() instanceof RayIntentionalSystemExitException;
         if (!isIntentionalSystemExit) {
+          final List<Class<?>> argTypes =
+              Arrays.stream(args)
+                  .map(arg -> arg == null ? null : arg.getClass())
+                  .collect(Collectors.toList());
           LOGGER.error(
-              "Execute rayFunction {} failed. actor {}, args {}", rayFunction, actor, args);
+              "Execute rayFunction {} failed. actor {}, argument types {}",
+              rayFunction,
+              actor,
+              argTypes);
         }
 
         if (e.getCause() != null) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
For an intentional system exit, we shouldn't print the invocation error log.

Q: Why don't  I combine this log to `LOGGER.error("Error executing task " + taskId, e);`
A:  There is no function context.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
