### PR TITLE
[object store refactor 1/n] Introduce IAllocator and PlasmaAllocator

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -295,7 +295,6 @@ cc_library(
         ],
     }),
     hdrs = [
-        "src/ray/object_manager/plasma/allocator.h",
         "src/ray/object_manager/plasma/client.h",
         "src/ray/object_manager/plasma/common.h",
         "src/ray/object_manager/plasma/compat.h",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -295,6 +295,7 @@ cc_library(
         ],
     }),
     hdrs = [
+        "src/ray/object_manager/plasma/allocator.h",
         "src/ray/object_manager/plasma/client.h",
         "src/ray/object_manager/plasma/common.h",
         "src/ray/object_manager/plasma/compat.h",
@@ -339,6 +340,7 @@ cc_library(
     ],
     hdrs = [
         "src/ray/object_manager/common.h",
+        "src/ray/object_manager/plasma/allocator.h",
         "src/ray/object_manager/plasma/create_request_queue.h",
         "src/ray/object_manager/plasma/eviction_policy.h",
         "src/ray/object_manager/plasma/plasma_allocator.h",

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -930,7 +930,9 @@ std::string ObjectManager::DebugString() const {
 void ObjectManager::RecordMetrics() const {
   stats::ObjectStoreAvailableMemory().Record(config_.object_store_memory - used_memory_);
   stats::ObjectStoreUsedMemory().Record(used_memory_);
-  stats::ObjectStoreFallbackMemory().Record(plasma::PlasmaAllocator::FallbackAllocated());
+  stats::ObjectStoreFallbackMemory().Record(
+      // TODO(scv119): this is not thread safe.
+      plasma::PlasmaAllocator::GetInstance().FallbackAllocated());
   stats::ObjectStoreLocalObjects().Record(local_objects_.size());
   stats::ObjectManagerPullRequests().Record(pull_manager_->NumActiveRequests());
 }
@@ -938,7 +940,9 @@ void ObjectManager::RecordMetrics() const {
 void ObjectManager::FillObjectStoreStats(rpc::GetNodeStatsReply *reply) const {
   auto stats = reply->mutable_store_stats();
   stats->set_object_store_bytes_used(used_memory_);
-  stats->set_object_store_bytes_fallback(plasma::PlasmaAllocator::FallbackAllocated());
+  stats->set_object_store_bytes_fallback(
+      // TODO(scv119): this is not thread safe.
+      plasma::PlasmaAllocator::GetInstance().FallbackAllocated());
   stats->set_object_store_bytes_avail(config_.object_store_memory);
   stats->set_num_local_objects(local_objects_.size());
   stats->set_consumed_bytes(plasma::plasma_store_runner->GetConsumedBytes());

--- a/src/ray/object_manager/plasma/allocator.h
+++ b/src/ray/object_manager/plasma/allocator.h
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+#pragma once
+
+#include "absl/types/optional.h"
+#include "ray/object_manager/plasma/common.h"
+#include "ray/object_manager/plasma/compat.h"
+
+namespace plasma {
+
+// IAllocator is responsible for allocating/deallocating memories.
+// This class is not thread safe.
+class IAllocator {
+ public:
+  virtual ~IAllocator() = default;
+
+  /// Allocates size bytes and returns allocated memory.
+  ///
+  /// \param bytes Number of bytes.
+  /// \return allocated memory. returns empty if not enough space.
+  virtual absl::optional<Allocation> Allocate(size_t bytes) = 0;
+
+  // Same as Allocate, but allocates pages from the filesystem. The footprint limit
+  // is not enforced for these allocations, but allocations here are still tracked
+  // and count towards the limit.
+  //
+  // TODO(scv119) ideally we should have mem/disk allocator implementations
+  // so we don't need FallbackAllocate. However the dlmalloc has some limitation
+  // prevents us from doing so.
+  virtual absl::optional<Allocation> FallbackAllocate(size_t bytes) = 0;
+
+  /// Frees the memory space pointed to by mem, which must have been returned by
+  /// a previous call to Allocate/FallbackAllocate or it yield undefined behavior.
+  ///
+  /// \param allocation allocation to free.
+  virtual void Free(const Allocation &allocation) = 0;
+
+  /// Sets the memory footprint limit for this allocator.
+  ///
+  /// \param bytes memory footprint limit in bytes.
+  virtual void SetFootprintLimit(size_t bytes) = 0;
+
+  /// Get the memory footprint limit for this allocator.
+  ///
+  /// \return memory footprint limit in bytes.
+  virtual int64_t GetFootprintLimit() const = 0;
+
+  /// Get the number of bytes allocated so far.
+  /// \return Number of bytes allocated so far.
+  virtual int64_t Allocated() const = 0;
+
+  /// Get the number of bytes fallback allocated so far.
+  /// \return Number of bytes fallback allocated so far.
+  virtual int64_t FallbackAllocated() const = 0;
+};
+
+}  // namespace plasma

--- a/src/ray/object_manager/plasma/common.h
+++ b/src/ray/object_manager/plasma/common.h
@@ -45,23 +45,38 @@ enum class ObjectState : int {
   PLASMA_SEALED = 2,
 };
 
+// Represents a chunk of allocated memory.
+struct Allocation {
+  /// Pointer to the allocated memory.
+  void *address;
+  /// Num bytes of the allocated memory.
+  int64_t size;
+  /// The file descriptor of the memory mapped file where the memory allocated.
+  MEMFD_TYPE fd;
+  /// The offset in bytes in the memory mapped file of the allocated memory.
+  ptrdiff_t offset;
+  /// Device number of the allocated memory.
+  int device_num;
+  /// the total size of this mapped memory.
+  int64_t mmap_size;
+
+  Allocation(void *address, int64_t size, MEMFD_TYPE fd, ptrdiff_t offset, int device_num,
+             int64_t mmap_size)
+      : address(address),
+        size(size),
+        fd(std::move(fd)),
+        offset(offset),
+        device_num(device_num),
+        mmap_size(mmap_size) {}
+};
+
 /// This type is used by the Plasma store. It is here because it is exposed to
 /// the eviction policy.
 struct ObjectTableEntry {
-  ObjectTableEntry();
+  ObjectTableEntry(Allocation allocation);
 
-  ~ObjectTableEntry();
-
-  /// Memory mapped file containing the object.
-  MEMFD_TYPE fd;
-  /// Device number.
-  int device_num;
-  /// Size of the underlying map.
-  int64_t map_size;
-  /// Offset from the base of the mmap.
-  ptrdiff_t offset;
-  /// Pointer to the object data. Needed to free the object.
-  uint8_t *pointer;
+  /// Allocation Info;
+  Allocation allocation;
   /// Size of the object in bytes.
   int64_t data_size;
   /// Size of the object metadata in bytes.

--- a/src/ray/object_manager/plasma/eviction_policy.cc
+++ b/src/ray/object_manager/plasma/eviction_policy.cc
@@ -90,7 +90,7 @@ int64_t LRUCache::ChooseObjectsToEvict(int64_t num_bytes_required,
   return bytes_evicted;
 }
 
-EvictionPolicy::EvictionPolicy(PlasmaStoreInfo *store_info, IAllocator &allocator)
+EvictionPolicy::EvictionPolicy(PlasmaStoreInfo *store_info, const IAllocator &allocator)
     : pinned_memory_bytes_(0),
       store_info_(store_info),
       allocator_(allocator),

--- a/src/ray/object_manager/plasma/eviction_policy.cc
+++ b/src/ray/object_manager/plasma/eviction_policy.cc
@@ -90,8 +90,11 @@ int64_t LRUCache::ChooseObjectsToEvict(int64_t num_bytes_required,
   return bytes_evicted;
 }
 
-EvictionPolicy::EvictionPolicy(PlasmaStoreInfo *store_info, int64_t max_size)
-    : pinned_memory_bytes_(0), store_info_(store_info), cache_("global lru", max_size) {}
+EvictionPolicy::EvictionPolicy(PlasmaStoreInfo *store_info, IAllocator &allocator)
+    : pinned_memory_bytes_(0),
+      store_info_(store_info),
+      allocator_(allocator),
+      cache_("global lru", allocator_.GetFootprintLimit()) {}
 
 int64_t EvictionPolicy::ChooseObjectsToEvict(int64_t num_bytes_required,
                                              std::vector<ObjectID> *objects_to_evict) {
@@ -111,18 +114,16 @@ void EvictionPolicy::ObjectCreated(const ObjectID &object_id, bool is_create) {
 int64_t EvictionPolicy::RequireSpace(int64_t size,
                                      std::vector<ObjectID> *objects_to_evict) {
   // Check if there is enough space to create the object.
-  int64_t required_space =
-      PlasmaAllocator::Allocated() + size - PlasmaAllocator::GetFootprintLimit();
+  int64_t required_space = allocator_.Allocated() + size - allocator_.GetFootprintLimit();
   // Try to free up at least as much space as we need right now but ideally
   // up to 20% of the total capacity.
-  int64_t space_to_free =
-      std::max(required_space, PlasmaAllocator::GetFootprintLimit() / 5);
+  int64_t space_to_free = std::max(required_space, allocator_.GetFootprintLimit() / 5);
   // Choose some objects to evict, and update the return pointers.
   int64_t num_bytes_evicted = ChooseObjectsToEvict(space_to_free, objects_to_evict);
   RAY_LOG(DEBUG) << "There is not enough space to create this object, so evicting "
                  << objects_to_evict->size() << " objects to free up "
                  << num_bytes_evicted << " bytes. The number of bytes in use (before "
-                 << "this eviction) is " << PlasmaAllocator::Allocated() << ".";
+                 << "this eviction) is " << allocator_.Allocated() << ".";
   return required_space - num_bytes_evicted;
 }
 

--- a/src/ray/object_manager/plasma/eviction_policy.h
+++ b/src/ray/object_manager/plasma/eviction_policy.h
@@ -98,7 +98,7 @@ class EvictionPolicy {
   /// \param store_info Information about the Plasma store that is exposed
   ///        to the eviction policy.
   /// \param allocator Memory allocator.
-  explicit EvictionPolicy(PlasmaStoreInfo *store_info, IAllocator &allocator);
+  explicit EvictionPolicy(PlasmaStoreInfo *store_info, const IAllocator &allocator);
 
   /// Destroy an eviction policy.
   virtual ~EvictionPolicy() {}
@@ -175,7 +175,7 @@ class EvictionPolicy {
   /// Pointer to the plasma store info.
   PlasmaStoreInfo *store_info_;
 
-  IAllocator &allocator_;
+  const IAllocator &allocator_;
 
   /// Datastructure for the LRU cache.
   LRUCache cache_;

--- a/src/ray/object_manager/plasma/eviction_policy.h
+++ b/src/ray/object_manager/plasma/eviction_policy.h
@@ -24,6 +24,7 @@
 #include <utility>
 #include <vector>
 
+#include "ray/object_manager/plasma/allocator.h"
 #include "ray/object_manager/plasma/common.h"
 #include "ray/object_manager/plasma/plasma.h"
 
@@ -96,8 +97,8 @@ class EvictionPolicy {
   ///
   /// \param store_info Information about the Plasma store that is exposed
   ///        to the eviction policy.
-  /// \param max_size Max size in bytes total of objects to store.
-  explicit EvictionPolicy(PlasmaStoreInfo *store_info, int64_t max_size);
+  /// \param allocator Memory allocator.
+  explicit EvictionPolicy(PlasmaStoreInfo *store_info, IAllocator &allocator);
 
   /// Destroy an eviction policy.
   virtual ~EvictionPolicy() {}
@@ -173,6 +174,9 @@ class EvictionPolicy {
 
   /// Pointer to the plasma store info.
   PlasmaStoreInfo *store_info_;
+
+  IAllocator &allocator_;
+
   /// Datastructure for the LRU cache.
   LRUCache cache_;
 };

--- a/src/ray/object_manager/plasma/malloc.cc
+++ b/src/ray/object_manager/plasma/malloc.cc
@@ -32,7 +32,8 @@ static ptrdiff_t pointer_distance(void const *pfrom, void const *pto) {
   return (unsigned char const *)pto - (unsigned char const *)pfrom;
 }
 
-bool GetMallocMapinfo(void *addr, MEMFD_TYPE *fd, int64_t *map_size, ptrdiff_t *offset) {
+bool GetMallocMapinfo(const void *const addr, MEMFD_TYPE *fd, int64_t *map_size,
+                      ptrdiff_t *offset) {
   // TODO(rshin): Implement a more efficient search through mmap_records.
   for (const auto &entry : mmap_records) {
     if (addr >= entry.first && addr < pointer_advance(entry.first, entry.second.size)) {

--- a/src/ray/object_manager/plasma/malloc.cc
+++ b/src/ray/object_manager/plasma/malloc.cc
@@ -32,7 +32,7 @@ static ptrdiff_t pointer_distance(void const *pfrom, void const *pto) {
   return (unsigned char const *)pto - (unsigned char const *)pfrom;
 }
 
-void GetMallocMapinfo(void *addr, MEMFD_TYPE *fd, int64_t *map_size, ptrdiff_t *offset) {
+bool GetMallocMapinfo(void *addr, MEMFD_TYPE *fd, int64_t *map_size, ptrdiff_t *offset) {
   // TODO(rshin): Implement a more efficient search through mmap_records.
   for (const auto &entry : mmap_records) {
     if (addr >= entry.first && addr < pointer_advance(entry.first, entry.second.size)) {
@@ -40,24 +40,16 @@ void GetMallocMapinfo(void *addr, MEMFD_TYPE *fd, int64_t *map_size, ptrdiff_t *
       fd->second = entry.second.fd.second;
       *map_size = entry.second.size;
       *offset = pointer_distance(entry.first, addr);
-      return;
+      return true;
     }
   }
+
   fd->first = INVALID_FD;
   fd->second = INVALID_UNIQUE_FD_ID;
   *map_size = 0;
   *offset = 0;
-}
 
-int64_t GetMmapSize(MEMFD_TYPE fd) {
-  for (const auto &entry : mmap_records) {
-    if (entry.second.fd == fd) {
-      return entry.second.size;
-    }
-  }
-  RAY_LOG(FATAL) << "failed to find entry in mmap_records for fd " << fd.first << " "
-                 << fd.second;
-  return -1;  // This code is never reached.
+  return false;
 }
 
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/malloc.h
+++ b/src/ray/object_manager/plasma/malloc.h
@@ -41,6 +41,11 @@ struct MmapRecord {
 /// and size.
 extern std::unordered_map<void *, MmapRecord> mmap_records;
 
-/// private function, only used by PlasmaAllocator
-bool GetMallocMapinfo(void *addr, MEMFD_TYPE *fd, int64_t *map_length, ptrdiff_t *offset);
+/// private function, only used by PlasmaAllocator to look up Mmap information
+/// given an address allocated by dlmalloc.
+///
+/// \return true if look up succeed. false means the address is not allocated
+/// by dlmalloc.
+bool GetMallocMapinfo(const void *const addr, MEMFD_TYPE *fd, int64_t *map_length,
+                      ptrdiff_t *offset);
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/malloc.h
+++ b/src/ray/object_manager/plasma/malloc.h
@@ -31,14 +31,6 @@ namespace plasma {
 /// (in the client we cannot guarantee that these mmaps are contiguous).
 constexpr int64_t kMmapRegionsGap = sizeof(size_t);
 
-void GetMallocMapinfo(void *addr, MEMFD_TYPE *fd, int64_t *map_length, ptrdiff_t *offset);
-
-/// Get the mmap size corresponding to a specific file descriptor.
-///
-/// \param fd The file descriptor to look up.
-/// \return The size of the corresponding memory-mapped file.
-int64_t GetMmapSize(MEMFD_TYPE fd);
-
 struct MmapRecord {
   MEMFD_TYPE fd;
   int64_t size;
@@ -49,4 +41,6 @@ struct MmapRecord {
 /// and size.
 extern std::unordered_map<void *, MmapRecord> mmap_records;
 
+/// private function, only used by PlasmaAllocator
+bool GetMallocMapinfo(void *addr, MEMFD_TYPE *fd, int64_t *map_length, ptrdiff_t *offset);
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/plasma.cc
+++ b/src/ray/object_manager/plasma/plasma.cc
@@ -21,15 +21,14 @@
 
 namespace plasma {
 
-ObjectTableEntry::ObjectTableEntry() : pointer(nullptr), ref_count(0) {}
-
-ObjectTableEntry::~ObjectTableEntry() { pointer = nullptr; }
+ObjectTableEntry::ObjectTableEntry(Allocation allocation)
+    : allocation(std::move(allocation)), ref_count(0) {}
 
 ObjectTableEntry *GetObjectTableEntry(PlasmaStoreInfo *store_info,
                                       const ObjectID &object_id) {
   auto it = store_info->objects.find(object_id);
   if (it == store_info->objects.end()) {
-    return NULL;
+    return nullptr;
   }
   return it->second.get();
 }

--- a/src/ray/object_manager/plasma/plasma_allocator.cc
+++ b/src/ray/object_manager/plasma/plasma_allocator.cc
@@ -111,7 +111,7 @@ absl::optional<Allocation> PlasmaAllocator::FallbackAllocate(size_t bytes) {
 }
 
 void PlasmaAllocator::Free(const Allocation &allocation) {
-  RAY_CHECK(allocation.address != nullptr);
+  RAY_CHECK(allocation.address != nullptr) << "Cannot free the nullptr";
   RAY_LOG(DEBUG) << "deallocating " << allocation.size << " at " << allocation.address;
   dlfree(allocation.address);
   allocated_ -= allocation.size;

--- a/src/ray/object_manager/plasma/plasma_allocator.cc
+++ b/src/ray/object_manager/plasma/plasma_allocator.cc
@@ -31,57 +31,93 @@ void dlfree(void *mem);
 int dlmallopt(int param_number, int value);
 }
 
+namespace {
 /* Copied from dlmalloc.c; make sure to keep in sync */
 size_t MAX_SIZE_T = (size_t)-1;
 const int M_MMAP_THRESHOLD = -3;
 
-int64_t PlasmaAllocator::footprint_limit_ = 0;
-int64_t PlasmaAllocator::allocated_ = 0;
-int64_t PlasmaAllocator::fallback_allocated_ = 0;
+// We align the allocated region to a 64-byte boundary. This is not
+// strictly necessary, but it is an optimization that could speed up the
+// computation of a hash of the data (see compute_object_hash_parallel in
+// plasma_client.cc). Note that even though this pointer is 64-byte aligned,
+// it is not guaranteed that the corresponding pointer in the client will be
+// 64-byte aligned, but in practice it often will be.
+const size_t kAllocationAlignment = 64;
 
-void *PlasmaAllocator::Memalign(size_t alignment, size_t bytes) {
+absl::optional<Allocation> BuildAllocation(void *addr, size_t size) {
+  if (addr == nullptr) {
+    return absl::nullopt;
+  }
+  MEMFD_TYPE fd;
+  int64_t mmap_size;
+  ptrdiff_t offset;
+
+  if (GetMallocMapinfo(addr, &fd, &mmap_size, &offset)) {
+    return Allocation(addr, static_cast<int64_t>(size), std::move(fd), offset,
+                      0 /* device_number*/, mmap_size);
+  }
+  return absl::nullopt;
+}
+
+}  // namespace
+
+/* static */ PlasmaAllocator &PlasmaAllocator::GetInstance() {
+  static PlasmaAllocator instance(kAllocationAlignment);
+  return instance;
+}
+
+PlasmaAllocator::PlasmaAllocator(size_t alignment)
+    : kAlignment(alignment), allocated_(0), fallback_allocated_(0), footprint_limit_(0) {}
+
+absl::optional<Allocation> PlasmaAllocator::Allocate(size_t bytes) {
   if (!RayConfig::instance().plasma_unlimited()) {
     // We only check against the footprint limit in limited allocation mode.
     // In limited mode: the check is done here; dlmemalign never returns nullptr.
     // In unlimited mode: dlmemalign returns nullptr once the initial /dev/shm block
     // fills.
     if (allocated_ + static_cast<int64_t>(bytes) > footprint_limit_) {
-      return nullptr;
+      return absl::nullopt;
     }
   }
   RAY_LOG(DEBUG) << "allocating " << bytes;
-  void *mem = dlmemalign(alignment, bytes);
+  void *mem = dlmemalign(kAlignment, bytes);
   RAY_LOG(DEBUG) << "allocated " << bytes << " at " << mem;
   if (!mem) {
-    return nullptr;
+    return absl::nullopt;
   }
   allocated_ += bytes;
-  return mem;
+  return BuildAllocation(mem, bytes);
 }
 
-void *PlasmaAllocator::DiskMemalignUnlimited(size_t alignment, size_t bytes) {
+absl::optional<Allocation> PlasmaAllocator::FallbackAllocate(size_t bytes) {
   // Forces allocation as a separate file.
   RAY_CHECK(dlmallopt(M_MMAP_THRESHOLD, 0));
-  void *mem = dlmemalign(alignment, bytes);
+  RAY_LOG(DEBUG) << "fallback allocating " << bytes;
+  void *mem = dlmemalign(kAlignment, bytes);
+  RAY_LOG(DEBUG) << "allocated " << bytes << " at " << mem;
   // Reset to the default value.
   RAY_CHECK(dlmallopt(M_MMAP_THRESHOLD, MAX_SIZE_T));
+
   if (!mem) {
-    return nullptr;
+    return absl::nullopt;
   }
+
   allocated_ += bytes;
   // The allocation was servicable using the initial region, no need to fallback.
   if (IsOutsideInitialAllocation(mem)) {
     fallback_allocated_ += bytes;
   }
-  return mem;
+  return BuildAllocation(mem, bytes);
 }
 
-void PlasmaAllocator::Free(void *mem, size_t bytes) {
-  RAY_LOG(DEBUG) << "deallocating " << bytes << " at " << mem;
-  dlfree(mem);
-  allocated_ -= bytes;
-  if (RayConfig::instance().plasma_unlimited() && IsOutsideInitialAllocation(mem)) {
-    fallback_allocated_ -= bytes;
+void PlasmaAllocator::Free(const Allocation &allocation) {
+  RAY_CHECK(allocation.address != nullptr);
+  RAY_LOG(DEBUG) << "deallocating " << allocation.size << " at " << allocation.address;
+  dlfree(allocation.address);
+  allocated_ -= allocation.size;
+  if (RayConfig::instance().plasma_unlimited() &&
+      IsOutsideInitialAllocation(allocation.address)) {
+    fallback_allocated_ -= allocation.size;
   }
 }
 
@@ -89,10 +125,10 @@ void PlasmaAllocator::SetFootprintLimit(size_t bytes) {
   footprint_limit_ = static_cast<int64_t>(bytes);
 }
 
-int64_t PlasmaAllocator::GetFootprintLimit() { return footprint_limit_; }
+int64_t PlasmaAllocator::GetFootprintLimit() const { return footprint_limit_; }
 
-int64_t PlasmaAllocator::Allocated() { return allocated_; }
+int64_t PlasmaAllocator::Allocated() const { return allocated_; }
 
-int64_t PlasmaAllocator::FallbackAllocated() { return fallback_allocated_; }
+int64_t PlasmaAllocator::FallbackAllocated() const { return fallback_allocated_; }
 
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -358,8 +358,10 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID &object_id,
   }
 
   RAY_LOG(DEBUG) << "create object " << object_id << " succeeded";
-  auto ptr = std::make_unique<ObjectTableEntry>(std::move(allocation.value()));
-  entry = store_info_.objects.emplace(object_id, std::move(ptr)).first->second.get();
+  auto object_table_entry =
+      std::make_unique<ObjectTableEntry>(std::move(allocation.value()));
+  entry = store_info_.objects.emplace(object_id, std::move(object_table_entry))
+              .first->second.get();
   entry->data_size = data_size;
   entry->metadata_size = metadata_size;
   entry->state = ObjectState::PLASMA_CREATED;

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -54,6 +54,7 @@
 
 namespace fb = plasma::flatbuf;
 
+namespace plasma {
 namespace {
 
 ray::ObjectID GetCreateRequestObjectId(const std::vector<uint8_t> &message) {
@@ -64,9 +65,21 @@ ray::ObjectID GetCreateRequestObjectId(const std::vector<uint8_t> &message) {
   return ray::ObjectID::FromBinary(request->object_id()->str());
 }
 
+void ToPlasmaObject(const ObjectTableEntry &entry, PlasmaObject *object,
+                    bool check_sealed) {
+  RAY_DCHECK(object != nullptr);
+  if (check_sealed) {
+    RAY_DCHECK(entry.state == ObjectState::PLASMA_SEALED);
+  }
+  object->store_fd = entry.allocation.fd;
+  object->data_offset = entry.allocation.offset;
+  object->metadata_offset = entry.allocation.offset + entry.data_size;
+  object->data_size = entry.data_size;
+  object->metadata_size = entry.metadata_size;
+  object->device_num = entry.allocation.device_num;
+  object->mmap_size = entry.allocation.mmap_size;
+}
 }  // namespace
-
-namespace plasma {
 
 struct GetRequest {
   GetRequest(instrumented_io_context &io_context, const std::shared_ptr<Client> &client,
@@ -143,7 +156,8 @@ PlasmaStore::PlasmaStore(instrumented_io_context &main_service, std::string dire
       socket_name_(socket_name),
       acceptor_(main_service, ParseUrlEndpoint(socket_name)),
       socket_(main_service),
-      eviction_policy_(&store_info_, PlasmaAllocator::GetFootprintLimit()),
+      allocator_(PlasmaAllocator::GetInstance()),
+      eviction_policy_(&store_info_, allocator_),
       spill_objects_callback_(spill_objects_callback),
       add_object_callback_(add_object_callback),
       delete_object_callback_(delete_object_callback),
@@ -204,24 +218,15 @@ void PlasmaStore::AddToClientObjectIds(const ObjectID &object_id, ObjectTableEnt
 }
 
 // Allocate memory
-uint8_t *PlasmaStore::AllocateMemory(size_t size, MEMFD_TYPE *fd, int64_t *map_size,
-                                     ptrdiff_t *offset,
-                                     const std::shared_ptr<Client> &client,
-                                     bool is_create, bool fallback_allocator,
-                                     PlasmaError *error) {
+absl::optional<Allocation> PlasmaStore::AllocateMemory(size_t size, bool is_create,
+                                                       bool fallback_allocator,
+                                                       PlasmaError *error) {
   // Try to evict objects until there is enough space.
-  uint8_t *pointer = nullptr;
+  absl::optional<Allocation> allocation;
   int num_tries = 0;
   while (true) {
-    // Allocate space for the new object. We use memalign instead of malloc
-    // in order to align the allocated region to a 64-byte boundary. This is not
-    // strictly necessary, but it is an optimization that could speed up the
-    // computation of a hash of the data (see compute_object_hash_parallel in
-    // plasma_client.cc). Note that even though this pointer is 64-byte aligned,
-    // it is not guaranteed that the corresponding pointer in the client will be
-    // 64-byte aligned, but in practice it often will be.
-    pointer = reinterpret_cast<uint8_t *>(PlasmaAllocator::Memalign(kBlockSize, size));
-    if (pointer) {
+    allocation = allocator_.Allocate(size);
+    if (allocation.has_value()) {
       // If we manage to allocate the memory, return the pointer.
       *error = PlasmaError::OK;
       break;
@@ -248,34 +253,32 @@ uint8_t *PlasmaStore::AllocateMemory(size_t size, MEMFD_TYPE *fd, int64_t *map_s
   }
 
   // Fallback to allocating from the filesystem.
-  if (pointer == nullptr && RayConfig::instance().plasma_unlimited() &&
+  if (!allocation.has_value() && RayConfig::instance().plasma_unlimited() &&
       fallback_allocator) {
     RAY_LOG(INFO)
         << "Shared memory store full, falling back to allocating from filesystem: "
         << size;
-    pointer = reinterpret_cast<uint8_t *>(
-        PlasmaAllocator::DiskMemalignUnlimited(kBlockSize, size));
-    if (pointer == nullptr) {
+    allocation = allocator_.FallbackAllocate(size);
+    if (!allocation.has_value()) {
       RAY_LOG(ERROR) << "Plasma fallback allocator failed, likely out of disk space.";
     }
   } else if (!fallback_allocator) {
     RAY_LOG(DEBUG) << "Fallback allocation not enabled for this request.";
   }
 
-  if (pointer != nullptr) {
-    GetMallocMapinfo(pointer, fd, map_size, offset);
-    RAY_CHECK(fd->first != INVALID_FD);
-    RAY_CHECK(fd->second != INVALID_UNIQUE_FD_ID);
+  if (allocation.has_value()) {
+    RAY_CHECK(allocation->fd.first != INVALID_FD);
+    RAY_CHECK(allocation->fd.second != INVALID_UNIQUE_FD_ID);
     *error = PlasmaError::OK;
   }
 
   auto now = absl::GetCurrentTimeNanos();
   if (now - last_usage_log_ns_ > usage_log_interval_ns_) {
-    RAY_LOG(INFO) << "Object store current usage " << (PlasmaAllocator::Allocated() / 1e9)
-                  << " / " << (PlasmaAllocator::GetFootprintLimit() / 1e9) << " GB.";
+    RAY_LOG(INFO) << "Object store current usage " << (allocator_.Allocated() / 1e9)
+                  << " / " << (allocator_.GetFootprintLimit() / 1e9) << " GB.";
     last_usage_log_ns_ = now;
   }
-  return pointer;
+  return allocation;
 }
 
 PlasmaError PlasmaStore::HandleCreateObjectRequest(const std::shared_ptr<Client> &client,
@@ -308,10 +311,10 @@ PlasmaError PlasmaStore::HandleCreateObjectRequest(const std::shared_ptr<Client>
 
   // Trigger object spilling if current usage is above the specified threshold.
   if (spilling_required != nullptr) {
-    const int64_t footprint_limit = PlasmaAllocator::GetFootprintLimit();
+    const int64_t footprint_limit = allocator_.GetFootprintLimit();
     if (footprint_limit != 0) {
       const float allocated_percentage =
-          static_cast<float>(PlasmaAllocator::Allocated()) / footprint_limit;
+          static_cast<float>(allocator_.Allocated()) / footprint_limit;
       if (allocated_percentage > object_spilling_threshold_) {
         RAY_LOG(DEBUG) << "Triggering object spilling because current usage "
                        << allocated_percentage << "% is above threshold "
@@ -340,36 +343,26 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID &object_id,
     return PlasmaError::ObjectExists;
   }
 
-  MEMFD_TYPE fd{INVALID_FD, INVALID_UNIQUE_FD_ID};
-  int64_t map_size = 0;
-  ptrdiff_t offset = 0;
-  uint8_t *pointer = nullptr;
   auto total_size = data_size + metadata_size;
 
-  if (device_num == 0) {
-    PlasmaError error = PlasmaError::OK;
-    pointer = AllocateMemory(total_size, &fd, &map_size, &offset, client,
-                             /*is_create=*/true, fallback_allocator, &error);
-    if (!pointer) {
-      return error;
-    }
-  } else {
+  if (device_num != 0) {
     RAY_LOG(ERROR) << "device_num != 0 but CUDA not enabled";
     return PlasmaError::OutOfMemory;
   }
 
+  PlasmaError error = PlasmaError::OK;
+  auto allocation = AllocateMemory(total_size,
+                                   /*is_create=*/true, fallback_allocator, &error);
+  if (!allocation.has_value()) {
+    return error;
+  }
+
   RAY_LOG(DEBUG) << "create object " << object_id << " succeeded";
-  auto ptr = std::make_unique<ObjectTableEntry>();
+  auto ptr = std::make_unique<ObjectTableEntry>(std::move(allocation.value()));
   entry = store_info_.objects.emplace(object_id, std::move(ptr)).first->second.get();
   entry->data_size = data_size;
   entry->metadata_size = metadata_size;
-  entry->pointer = pointer;
-  // TODO(pcm): Set the other fields.
-  entry->fd = fd;
-  entry->map_size = map_size;
-  entry->offset = offset;
   entry->state = ObjectState::PLASMA_CREATED;
-  entry->device_num = device_num;
   entry->owner_raylet_id = owner_raylet_id;
   entry->owner_ip_address = owner_ip_address;
   entry->owner_port = owner_port;
@@ -378,15 +371,7 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID &object_id,
   entry->construct_duration = -1;
   entry->source = source;
 
-  result->store_fd = fd;
-  result->data_offset = offset;
-  result->metadata_offset = offset + data_size;
-  result->data_size = data_size;
-  result->metadata_size = metadata_size;
-  result->device_num = device_num;
-  if (device_num == 0) {
-    result->mmap_size = GetMmapSize(fd);
-  }
+  ToPlasmaObject(*entry, result, /* check sealed */ false);
 
   // Notify the eviction policy that this object was created. This must be done
   // immediately before the call to AddToClientObjectIds so that the
@@ -398,18 +383,6 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID &object_id,
   num_bytes_unsealed_ += data_size + metadata_size;
   num_bytes_created_total_ += data_size + metadata_size;
   return PlasmaError::OK;
-}
-
-void PlasmaObject_init(PlasmaObject *object, ObjectTableEntry *entry) {
-  RAY_DCHECK(object != nullptr);
-  RAY_DCHECK(entry != nullptr);
-  RAY_DCHECK(entry->state == ObjectState::PLASMA_SEALED);
-  object->store_fd = entry->fd;
-  object->data_offset = entry->offset;
-  object->metadata_offset = entry->offset + entry->data_size;
-  object->data_size = entry->data_size;
-  object->metadata_size = entry->metadata_size;
-  object->device_num = entry->device_num;
 }
 
 void PlasmaStore::RemoveGetRequest(const std::shared_ptr<GetRequest> &get_request) {
@@ -471,7 +444,7 @@ void PlasmaStore::ReturnFromGet(const std::shared_ptr<GetRequest> &get_req) {
     if (object.data_size != -1 && fds_to_send.count(fd) == 0 && fd.first != INVALID_FD) {
       fds_to_send.insert(fd);
       store_fds.push_back(fd);
-      mmap_sizes.push_back(GetMmapSize(fd));
+      mmap_sizes.push_back(object.mmap_size);
       if (get_req->is_from_worker) {
         total_consumed_bytes_ += object.data_size + object.metadata_size;
       }
@@ -518,8 +491,7 @@ void PlasmaStore::UpdateObjectGetRequests(const ObjectID &object_id) {
     auto get_req = get_requests[index];
     auto entry = GetObjectTableEntry(&store_info_, object_id);
     RAY_CHECK(entry != nullptr);
-
-    PlasmaObject_init(&get_req->objects[object_id], entry);
+    ToPlasmaObject(*entry, &get_req->objects[object_id], /* check sealed */ true);
     get_req->num_satisfied += 1;
     // Record the fact that this client will be using this object and will
     // be responsible for releasing this object.
@@ -557,7 +529,7 @@ void PlasmaStore::ProcessGetRequest(const std::shared_ptr<Client> &client,
     auto entry = GetObjectTableEntry(&store_info_, object_id);
     if (entry && entry->state == ObjectState::PLASMA_SEALED) {
       // Update the get request to take into account the present object.
-      PlasmaObject_init(&get_req->objects[object_id], entry);
+      ToPlasmaObject(*entry, &get_req->objects[object_id], /* checksealed */ true);
       get_req->num_satisfied += 1;
       // If necessary, record that this client is using this object. In the case
       // where entry == NULL, this will be called from SealObject.
@@ -629,11 +601,11 @@ void PlasmaStore::EraseFromObjectTable(const ObjectID &object_id) {
     return;
   }
   auto buff_size = object->data_size + object->metadata_size;
-  if (object->device_num == 0) {
+  if (object->allocation.device_num == 0) {
     RAY_LOG(DEBUG) << "Erasing object: " << object_id
-                   << ", address: " << static_cast<void *>(object->pointer)
+                   << ", address: " << static_cast<void *>(object->allocation.address)
                    << ", size:" << buff_size;
-    PlasmaAllocator::Free(object->pointer, buff_size);
+    allocator_.Free(object->allocation);
   }
   if (object->state == ObjectState::PLASMA_CREATED) {
     num_bytes_unsealed_ -= object->data_size + object->metadata_size;
@@ -910,7 +882,7 @@ Status PlasmaStore::ProcessMessage(const std::shared_ptr<Client> &client,
     RAY_RETURN_NOT_OK(SendEvictReply(client, num_bytes_evicted));
   } break;
   case fb::MessageType::PlasmaConnectRequest: {
-    RAY_RETURN_NOT_OK(SendConnectReply(client, PlasmaAllocator::GetFootprintLimit()));
+    RAY_RETURN_NOT_OK(SendConnectReply(client, allocator_.GetFootprintLimit()));
   } break;
   case fb::MessageType::PlasmaDisconnectClient:
     RAY_LOG(DEBUG) << "Disconnecting client on fd " << client;
@@ -1054,8 +1026,8 @@ std::string PlasmaStore::GetDebugDump() const {
     }
   }
 
-  buffer << "Current usage: " << (PlasmaAllocator::Allocated() / 1e9) << " / "
-         << (PlasmaAllocator::GetFootprintLimit() / 1e9) << " GB\n";
+  buffer << "Current usage: " << (allocator_.Allocated() / 1e9) << " / "
+         << (allocator_.GetFootprintLimit() / 1e9) << " GB\n";
   buffer << "- num bytes created total: " << num_bytes_created_total_ << "\n";
   auto num_pending_requests = create_request_queue_.NumPendingRequests();
   auto num_pending_bytes = create_request_queue_.NumPendingBytes();

--- a/src/ray/object_manager/plasma/store_runner.cc
+++ b/src/ray/object_manager/plasma/store_runner.cc
@@ -101,7 +101,9 @@ void PlasmaStoreRunner::Start(ray::SpillObjectsCallback spill_objects_callback,
     // should be part of PlasmaAllocator contruction.
     auto allocation = PlasmaAllocator::GetInstance().Allocate(
         PlasmaAllocator::GetInstance().GetFootprintLimit() - 256 * sizeof(size_t));
-    RAY_CHECK(allocation.has_value());
+    RAY_CHECK(allocation.has_value())
+        << "Plasma store initial allocation failed. Probably not enough space in "
+        << plasma_directory_;
     // This will unmap the file, but the next one created will be as large
     // as this one (this is an implementation detail of dlmalloc).
     PlasmaAllocator::GetInstance().Free(allocation.value());

--- a/src/ray/object_manager/plasma/store_runner.cc
+++ b/src/ray/object_manager/plasma/store_runner.cc
@@ -26,7 +26,7 @@ PlasmaStoreRunner::PlasmaStoreRunner(std::string socket_name, int64_t system_mem
     RAY_LOG(FATAL) << "please specify the amount of system memory with -m switch";
   }
   // Set system memory capacity
-  PlasmaAllocator::SetFootprintLimit(static_cast<size_t>(system_memory));
+  PlasmaAllocator::GetInstance().SetFootprintLimit(static_cast<size_t>(system_memory));
   RAY_LOG(INFO) << "Allowing the Plasma store to use up to "
                 << static_cast<double>(system_memory) / 1000000000 << "GB of memory.";
   if (hugepages_enabled && plasma_directory.empty()) {
@@ -97,13 +97,14 @@ void PlasmaStoreRunner::Start(ray::SpillObjectsCallback spill_objects_callback,
     // large amount of space up front. According to the documentation,
     // dlmalloc might need up to 128*sizeof(size_t) bytes for internal
     // bookkeeping.
-    void *pointer = PlasmaAllocator::Memalign(
-        kBlockSize, PlasmaAllocator::GetFootprintLimit() - 256 * sizeof(size_t));
-    RAY_CHECK(pointer != nullptr);
+    // TODO(scv119): this leaks details of PlasmaAlloctor,
+    // should be part of PlasmaAllocator contruction.
+    auto allocation = PlasmaAllocator::GetInstance().Allocate(
+        PlasmaAllocator::GetInstance().GetFootprintLimit() - 256 * sizeof(size_t));
+    RAY_CHECK(allocation.has_value());
     // This will unmap the file, but the next one created will be as large
     // as this one (this is an implementation detail of dlmalloc).
-    PlasmaAllocator::Free(pointer,
-                          PlasmaAllocator::GetFootprintLimit() - 256 * sizeof(size_t));
+    PlasmaAllocator::GetInstance().Free(allocation.value());
 
     store_->Start();
   }


### PR DESCRIPTION
## Problem
There are two major issues with plasma store:
- Lack of unit/integration tests.
- Complicate interactions between components. 
Which makes the IO layer unstable & vulnerable to race conditions & slow to develop. 

## Goal
The goal is to make local object management unit testable, easy to extend, and hide implementation detail from the upper layer.
### Phase 1: Unit test all major components: 
- Refactor current plasma store into following unit testable components: MmapAllocator / GarbageCollector / ObjectLifetimeManager/GetRequestQueue /CreateRequestQueue/Object Transfer Manager
- Refactor object transfer code path (object manager unit-testable), add unit test and integration test (in cpp).

This is the first PR that refactors object store.  Next PR #17313

Specifically in this PR, we creates IAllocator interface thats allocates mmaped memories, and refactor the PlasmaAllocator to implement this interface. 

## Test Plan
-[x] existing tests
-[ ] [on demand stress tests ](https://buildkite.com/ray-project/periodic-ci/builds/642)
-[x] more unit test coming in follow up PR #17313 


Note: I'm trying out stack PRs in ray-project/test-wheels branch so that we can get signals from CI, so we need merge PRs in sequence.


