### PR TITLE
Multi & single deployment large scale test

### DIFF
--- a/release/serve_tests/compute_tpl_8_cpu.yaml
+++ b/release/serve_tests/compute_tpl_8_cpu.yaml
@@ -2,7 +2,7 @@ cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
 # 1k max replicas (1000 / 8 = 125 containers needed)
-max_workers: 20
+max_workers: 130
 
 head_node_type:
     name: head_node
@@ -13,9 +13,9 @@ worker_node_types:
     - name: worker_node
       # 8 cpus, x86, 32G mem, 10Gb NIC, $0.384/hr on demand
       instance_type: m5.2xlarge
-      min_workers: 20
+      min_workers: 130
       # 1k max replicas
-      max_workers: 20
+      max_workers: 130
       use_spot: false
 
 aws:

--- a/release/serve_tests/compute_tpl_8_cpu.yaml
+++ b/release/serve_tests/compute_tpl_8_cpu.yaml
@@ -2,7 +2,7 @@ cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
 # 1k max replicas (1000 / 8 = 125 containers needed)
-max_workers: 130
+max_workers: 20
 
 head_node_type:
     name: head_node
@@ -13,9 +13,9 @@ worker_node_types:
     - name: worker_node
       # 8 cpus, x86, 32G mem, 10Gb NIC, $0.384/hr on demand
       instance_type: m5.2xlarge
-      min_workers: 130
+      min_workers: 20
       # 1k max replicas
-      max_workers: 130
+      max_workers: 20
       use_spot: false
 
 aws:

--- a/release/serve_tests/compute_tpl_8_cpu.yaml
+++ b/release/serve_tests/compute_tpl_8_cpu.yaml
@@ -1,18 +1,18 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
-# 1k max replicas
+# 1k max replicas (1000 / 8 = 125 containers needed)
 max_workers: 130
 
 head_node_type:
     name: head_node
-    # 8 cpus, x86, 32G mem, 10Gb NIC, $0.384/hr on demand
-    instance_type: m5.2xlarge
+    # 8 cpus, x86, 32G mem, 300 GB disk, 15Gb NIC, $0.544/hr on demand
+    instance_type: m5dn.2xlarge
 
 worker_node_types:
     - name: worker_node
-    # 8 cpus, x86, 32G mem, 10Gb NIC, $0.384/hr on demand
-      instance_type: m5.2xlarge
+    # 8 cpus, x86, 32G mem, 300 GB disk, 15Gb NIC, $0.544/hr on demand
+      instance_type: m5dn.2xlarge
       min_workers: 130
       # 1k max replicas
       max_workers: 130

--- a/release/serve_tests/compute_tpl_8_cpu.yaml
+++ b/release/serve_tests/compute_tpl_8_cpu.yaml
@@ -6,13 +6,13 @@ max_workers: 130
 
 head_node_type:
     name: head_node
-    # 8 cpus, x86, 32G mem, 300 GB disk, 15Gb NIC, $0.544/hr on demand
-    instance_type: m5dn.2xlarge
+    # 8 cpus, x86, 32G mem, 10Gb NIC, $0.384/hr on demand
+    instance_type: m5.2xlarge
 
 worker_node_types:
     - name: worker_node
-    # 8 cpus, x86, 32G mem, 300 GB disk, 15Gb NIC, $0.544/hr on demand
-      instance_type: m5dn.2xlarge
+      # 8 cpus, x86, 32G mem, 10Gb NIC, $0.384/hr on demand
+      instance_type: m5.2xlarge
       min_workers: 130
       # 1k max replicas
       max_workers: 130

--- a/release/serve_tests/serve_tests.yaml
+++ b/release/serve_tests/serve_tests.yaml
@@ -4,9 +4,22 @@
     compute_template: compute_tpl_8_cpu.yaml
 
   run:
-    timeout: 10800
+    timeout: 7200
     long_running: False
-    script: python workloads/single_deployment_1k_noop_replica.py --run-locally=False
+    script: python workloads/single_deployment_1k_noop_replica.py
+  
+  smoke_test:
+    timeout: 600
+
+- name: multi_deployment_1k_noop_replica
+  cluster:
+    app_config: app_config.yaml
+    compute_template: compute_tpl_8_cpu.yaml
+
+  run:
+    timeout: 7200
+    long_running: False
+    script: python workloads/multi_deployment_1k_noop_replica.py
   
   smoke_test:
     timeout: 600

--- a/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
@@ -29,8 +29,6 @@ import click
 import math
 import os
 import random
-import requests
-import time
 
 from ray import serve
 from ray.serve.utils import logger
@@ -65,6 +63,7 @@ DEFAULT_FULL_TEST_TRIAL_LENGTH = "10m"
 def setup_multi_deployment_replicas(num_replicas, num_deployments):
     num_replica_per_deployment = num_replicas // num_deployments
     all_deployment_names = [f"Echo_{i+1}" for i in range(num_deployments)]
+
     @serve.deployment(num_replicas=num_replica_per_deployment)
     class Echo:
         def __init__(self):

--- a/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
@@ -42,6 +42,7 @@ from serve_test_cluster_utils import (
     setup_anyscale_cluster,
     warm_up_cluster,
     NUM_CPU_PER_NODE,
+    NUM_CONNECTIONS,
 )
 from typing import Optional
 
@@ -52,12 +53,12 @@ DEFAULT_SMOKE_TEST_NUM_DEPLOYMENTS = 4  # 2 replicas each
 # TODO:(jiaodong) We should investigate and change this back to 1k
 # for now, we won't get valid latency numbers from wrk at 1k replica
 # likely due to request timeout.
-DEFAULT_FULL_TEST_NUM_REPLICA = 1000
-DEFAULT_FULL_TEST_NUM_DEPLOYMENTS = 100  # 10 replicas each
+DEFAULT_FULL_TEST_NUM_REPLICA = 100
+DEFAULT_FULL_TEST_NUM_DEPLOYMENTS = 10  # 10 replicas each
 
 # Experiment configs - wrk specific
 DEFAULT_SMOKE_TEST_TRIAL_LENGTH = "5s"
-DEFAULT_FULL_TEST_TRIAL_LENGTH = "10m"
+DEFAULT_FULL_TEST_TRIAL_LENGTH = "1m"
 
 
 def setup_multi_deployment_replicas(num_replicas, num_deployments):
@@ -141,12 +142,10 @@ def main(num_replicas: Optional[int], num_deployments: Optional[int],
     logger.info(f"Starting wrk trial for {trial_length} ....\n")
     # For detailed discussion, see https://github.com/wg/wrk/issues/205
     # TODO:(jiaodong) What's the best number to use here ?
-    num_connections = int(num_replicas * NUM_CPU_PER_NODE * 0.75)
-
     all_endpoints = list(serve.list_endpoints().keys())
     all_metrics, all_wrk_stdout = run_wrk_on_all_nodes(
         trial_length,
-        num_connections,
+        NUM_CONNECTIONS,
         http_host,
         http_port,
         all_endpoints=all_endpoints)

--- a/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """
-Benchmark test for single deployment at 1k no-op replica scale.
+Benchmark test for multi deployment at 1k no-op replica scale.
 
 1) Start with a single head node.
-2) Scale to 1k no-op replicas over N nodes.
+2) Start 1000 deployments each with 10 no-op replicas
 3) Launch wrk in each running node to simulate load balanced request
+4) Recursively send queries to random deployments, up to depth=5
 5) Run a 10-minute wrk trial on each node, aggregate results.
 
 Report:
@@ -25,9 +26,9 @@ Report:
 """
 
 import click
-import json
 import math
 import os
+import random
 
 from ray import serve
 from ray.serve.utils import logger
@@ -46,63 +47,85 @@ from typing import Optional
 
 # Experiment configs
 DEFAULT_SMOKE_TEST_NUM_REPLICA = 8
-DEFAULT_FULL_TEST_NUM_REPLICA = 1000
+DEFAULT_SMOKE_TEST_NUM_DEPLOYMENTS = 4  # 2 replicas each
 
-# Deployment configs
-DEFAULT_MAX_BATCH_SIZE = 16
+# TODO:(jiaodong) We should investigate and change this back to 1k
+# for now, we won't get valid latency numbers from wrk at 1k replica
+# likely due to request timeout.
+DEFAULT_FULL_TEST_NUM_REPLICA = 1000
+DEFAULT_FULL_TEST_NUM_DEPLOYMENTS = 100  # 10 replicas each
 
 # Experiment configs - wrk specific
 DEFAULT_SMOKE_TEST_TRIAL_LENGTH = "5s"
 DEFAULT_FULL_TEST_TRIAL_LENGTH = "10m"
 
 
-def deploy_replicas(num_replicas, max_batch_size):
-    @serve.deployment(name="echo", num_replicas=num_replicas)
+def setup_multi_deployment_replicas(num_replicas, num_deployments):
+    num_replica_per_deployment = num_replicas // num_deployments
+    all_deployment_names = [f"Echo_{i+1}" for i in range(num_deployments)]
+
+    @serve.deployment(num_replicas=num_replica_per_deployment)
     class Echo:
-        @serve.batch(max_batch_size=max_batch_size)
-        async def handle_batch(self, requests):
-            return ["hi" for _ in range(len(requests))]
+        def __init__(self):
+            self.all_deployment_handles = []
+
+        def get_random_deployment_handle(self):
+            # sync get_handle() and expected to be called only a few times
+            # during deployment warmup so each deployment has reference to
+            # all other handles to send recursive inference call
+            if len(self.all_deployment_handles) < len(all_deployment_names):
+                deployments = list(serve.list_deployments().values())
+                self.all_deployment_handles = [
+                    deployment.get_handle() for deployment in deployments
+                ]
+
+            return random.choice(self.all_deployment_handles)
+
+        async def handle_request(self, request, depth: int):
+            # Max recursive call depth reached
+            if depth >= 4:
+                return "hi"
+
+            next_deployment_handle = self.get_random_deployment_handle()
+            return await next_deployment_handle.handle_request.remote(
+                request, depth + 1)
 
         async def __call__(self, request):
-            return await self.handle_batch(request)
+            return await self.handle_request(request, 0)
 
-    Echo.deploy()
-
-
-def save_results(final_result, default_name):
-    test_output_json = os.environ.get(
-        "TEST_OUTPUT_JSON", "/tmp/single_deployment_1k_noop_replica.json")
-    with open(test_output_json, "wt") as f:
-        json.dump(final_result, f)
+    for deployment in all_deployment_names:
+        Echo.options(name=deployment).deploy()
 
 
 @click.command()
 @click.option("--num-replicas", type=int)
+@click.option("--num-deployments", type=int)
 @click.option("--trial-length", type=str)
-@click.option("--max-batch-size", type=int, default=DEFAULT_MAX_BATCH_SIZE)
-def main(num_replicas: Optional[int], trial_length: Optional[str],
-         max_batch_size: Optional[int]):
+def main(num_replicas: Optional[int], num_deployments: Optional[int],
+         trial_length: Optional[str]):
     # Give default cluster parameter values based on smoke_test config
     # if user provided values explicitly, use them instead.
     # IS_SMOKE_TEST is set by args of releaser's e2e.py
     smoke_test = os.environ.get("IS_SMOKE_TEST", "1")
     if smoke_test == "1":
         num_replicas = num_replicas or DEFAULT_SMOKE_TEST_NUM_REPLICA
+        num_deployments = num_deployments or DEFAULT_SMOKE_TEST_NUM_DEPLOYMENTS
         trial_length = trial_length or DEFAULT_SMOKE_TEST_TRIAL_LENGTH
-        logger.info(
-            f"Running local / smoke test with {num_replicas} replicas ..\n")
-
+        logger.info(f"Running smoke test with {num_replicas} replicas, "
+                    f"{num_deployments} deployments .. \n")
         # Choose cluster setup based on user config. Local test uses Cluster()
         # to mock actors that requires # of nodes to be specified, but ray
         # client doesn't need to
         num_nodes = int(math.ceil(num_replicas / NUM_CPU_PER_NODE))
         logger.info(
-            f"Setting up local ray cluster with {num_nodes} nodes ..\n")
+            f"Setting up local ray cluster with {num_nodes} nodes .. \n")
         serve_client = setup_local_single_node_cluster(num_nodes)
     else:
         num_replicas = num_replicas or DEFAULT_FULL_TEST_NUM_REPLICA
+        num_deployments = num_deployments or DEFAULT_FULL_TEST_NUM_DEPLOYMENTS
         trial_length = trial_length or DEFAULT_FULL_TEST_TRIAL_LENGTH
-        logger.info(f"Running full test with {num_replicas} replicas ..\n")
+        logger.info(f"Running full test with {num_replicas} replicas, "
+                    f"{num_deployments} deployments .. \n")
         logger.info("Setting up anyscale ray cluster .. \n")
         serve_client = setup_anyscale_cluster()
 
@@ -111,7 +134,7 @@ def main(num_replicas: Optional[int], trial_length: Optional[str],
     logger.info(f"Ray serve http_host: {http_host}, http_port: {http_port}")
 
     logger.info(f"Deploying with {num_replicas} target replicas ....\n")
-    deploy_replicas(num_replicas, max_batch_size)
+    setup_multi_deployment_replicas(num_replicas, num_deployments)
 
     logger.info("Warming up cluster ....\n")
     warm_up_cluster(5, http_host, http_port)
@@ -119,7 +142,8 @@ def main(num_replicas: Optional[int], trial_length: Optional[str],
     logger.info(f"Starting wrk trial for {trial_length} ....\n")
     # For detailed discussion, see https://github.com/wg/wrk/issues/205
     # TODO:(jiaodong) What's the best number to use here ?
-    num_connections = int(num_replicas * DEFAULT_MAX_BATCH_SIZE * 0.75)
+    num_connections = int(num_replicas * NUM_CPU_PER_NODE * 0.75)
+
     all_endpoints = list(serve.list_endpoints().keys())
     all_metrics, all_wrk_stdout = run_wrk_on_all_nodes(
         trial_length,
@@ -137,7 +161,7 @@ def main(num_replicas: Optional[int], trial_length: Optional[str],
         logger.info(f"{key}: {val}")
     save_test_results(
         aggregated_metrics,
-        default_output_file="/tmp/single_deployment_1k_noop_replica.json")
+        default_output_file="/tmp/multi_deployment_1k_noop_replica.json")
 
 
 if __name__ == "__main__":

--- a/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
@@ -53,12 +53,12 @@ DEFAULT_SMOKE_TEST_NUM_DEPLOYMENTS = 4  # 2 replicas each
 # TODO:(jiaodong) We should investigate and change this back to 1k
 # for now, we won't get valid latency numbers from wrk at 1k replica
 # likely due to request timeout.
-DEFAULT_FULL_TEST_NUM_REPLICA = 100
-DEFAULT_FULL_TEST_NUM_DEPLOYMENTS = 10  # 10 replicas each
+DEFAULT_FULL_TEST_NUM_REPLICA = 1000
+DEFAULT_FULL_TEST_NUM_DEPLOYMENTS = 100  # 10 replicas each
 
 # Experiment configs - wrk specific
 DEFAULT_SMOKE_TEST_TRIAL_LENGTH = "5s"
-DEFAULT_FULL_TEST_TRIAL_LENGTH = "1m"
+DEFAULT_FULL_TEST_TRIAL_LENGTH = "10m"
 
 
 def setup_multi_deployment_replicas(num_replicas, num_deployments):
@@ -83,7 +83,7 @@ def setup_multi_deployment_replicas(num_replicas, num_deployments):
 
         async def handle_request(self, request, depth: int):
             # Max recursive call depth reached
-            if depth >= 4:
+            if depth > 4:
                 return "hi"
 
             next_deployment_handle = self.get_random_deployment_handle()

--- a/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
@@ -29,6 +29,8 @@ import click
 import math
 import os
 import random
+import requests
+import time
 
 from ray import serve
 from ray.serve.utils import logger
@@ -63,7 +65,6 @@ DEFAULT_FULL_TEST_TRIAL_LENGTH = "10m"
 def setup_multi_deployment_replicas(num_replicas, num_deployments):
     num_replica_per_deployment = num_replicas // num_deployments
     all_deployment_names = [f"Echo_{i+1}" for i in range(num_deployments)]
-
     @serve.deployment(num_replicas=num_replica_per_deployment)
     class Echo:
         def __init__(self):
@@ -78,7 +79,6 @@ def setup_multi_deployment_replicas(num_replicas, num_deployments):
                 self.all_deployment_handles = [
                     deployment.get_handle() for deployment in deployments
                 ]
-
             return random.choice(self.all_deployment_handles)
 
         async def handle_request(self, request, depth: int):

--- a/release/serve_tests/workloads/serve_test_cluster_utils.py
+++ b/release/serve_tests/workloads/serve_test_cluster_utils.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+import ray
+import requests
+import time
+
+from ray import serve
+from ray.cluster_utils import Cluster
+from ray.serve.utils import logger
+from ray.serve.config import DeploymentMode
+
+# Cluster setup configs
+NUM_CPU_PER_NODE = 8
+
+
+def setup_local_single_node_cluster(num_nodes):
+    """Setup ray cluster locally via ray.init() and Cluster()
+
+    Each actor is simulated in local process on single node,
+    thus smaller scale by default.
+    """
+    cluster = Cluster()
+    for i in range(num_nodes):
+        cluster.add_node(
+            redis_port=6379 if i == 0 else None,
+            num_cpus=NUM_CPU_PER_NODE,
+            num_gpus=0,
+            resources={str(i): 2},
+        )
+    ray.init(address=cluster.address, dashboard_host="0.0.0.0")
+    serve_client = serve.start(
+        http_options={"location": DeploymentMode.EveryNode})
+
+    return serve_client
+
+
+def setup_anyscale_cluster():
+    """Setup ray cluster at anyscale via ray.client()
+
+    Note this is by default large scale and should be kicked off
+    less frequently.
+    """
+    # TODO: Ray client didn't work with releaser script yet because
+    # we cannot connect to anyscale cluster from its headnode
+    # ray.client().env({}).connect()
+    ray.init(address="auto")
+    serve_client = serve.start(
+        http_options={"location": DeploymentMode.EveryNode})
+
+    return serve_client
+
+
+def warm_up_cluster(
+        num_warmup_iterations: int,
+        http_host: str,
+        http_port: str,
+) -> None:
+    for endpoint in serve.list_endpoints().keys():
+        logger.info(f"Warming up {endpoint} ..")
+        for _ in range(num_warmup_iterations):
+            resp = requests.get(
+                f"http://{http_host}:{http_port}/{endpoint}").text
+            logger.info(resp)
+            time.sleep(0.1)

--- a/release/serve_tests/workloads/serve_test_cluster_utils.py
+++ b/release/serve_tests/workloads/serve_test_cluster_utils.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import ray
 import requests
-import time
 
 from ray import serve
 from ray.cluster_utils import Cluster
@@ -50,15 +49,15 @@ def setup_anyscale_cluster():
     return serve_client
 
 
-def warm_up_cluster(
+@ray.remote
+def warm_up_one_cluster(
         num_warmup_iterations: int,
         http_host: str,
         http_port: str,
+        endpoint: str,
 ) -> None:
-    for endpoint in serve.list_endpoints().keys():
-        logger.info(f"Warming up {endpoint} ..")
-        for _ in range(num_warmup_iterations):
-            resp = requests.get(
-                f"http://{http_host}:{http_port}/{endpoint}").text
-            logger.info(resp)
-            time.sleep(1)
+    logger.info(f"Warming up {endpoint} ..")
+    for _ in range(num_warmup_iterations):
+        resp = requests.get(f"http://{http_host}:{http_port}/{endpoint}").text
+        logger.info(resp)
+    return endpoint

--- a/release/serve_tests/workloads/serve_test_cluster_utils.py
+++ b/release/serve_tests/workloads/serve_test_cluster_utils.py
@@ -10,6 +10,7 @@ from ray.serve.config import DeploymentMode
 
 # Cluster setup configs
 NUM_CPU_PER_NODE = 8
+NUM_CONNECTIONS = 100
 
 
 def setup_local_single_node_cluster(num_nodes):

--- a/release/serve_tests/workloads/serve_test_cluster_utils.py
+++ b/release/serve_tests/workloads/serve_test_cluster_utils.py
@@ -9,7 +9,7 @@ from ray.serve.utils import logger
 from ray.serve.config import DeploymentMode
 
 # Cluster setup configs
-NUM_CPU_PER_NODE = 8
+NUM_CPU_PER_NODE = 10
 NUM_CONNECTIONS = 100
 
 
@@ -61,4 +61,4 @@ def warm_up_cluster(
             resp = requests.get(
                 f"http://{http_host}:{http_port}/{endpoint}").text
             logger.info(resp)
-            time.sleep(0.1)
+            time.sleep(1)

--- a/release/serve_tests/workloads/serve_test_utils.py
+++ b/release/serve_tests/workloads/serve_test_utils.py
@@ -254,7 +254,11 @@ def run_wrk_on_all_nodes(trial_length: str,
                          http_port: str,
                          all_endpoints: List[str] = None):
     """
+<<<<<<< HEAD
     Use ray task to run one wrk trial on each node alive, picked randomly
+=======
+    Use ray task to run one wrk trial on each node alive, picked randomly 
+>>>>>>> f1dd93c07 (make functions cleaner)
     from all available deployments.
 
     Returns:

--- a/release/serve_tests/workloads/serve_test_utils.py
+++ b/release/serve_tests/workloads/serve_test_utils.py
@@ -169,7 +169,9 @@ def parse_wrk_decoded_stdout(decoded_out):
                 parsed[4])
         # Socket errors: connect 0, read 0, write 0, timeout 100
         elif parsed[0] == "Socket" and parsed[1] == "errors:":
-            metrics_dict["per_node_total_timeout_requests"] = parse_metric_to_base(parsed[-1])
+            metrics_dict[
+                "per_node_total_timeout_requests"] = parse_metric_to_base(
+                    parsed[-1])
         # Summary section
         # Requests/sec:   1317.73
         # Transfer/sec:    198.19KB
@@ -241,8 +243,7 @@ def aggregate_all_metrics(
         "cluster_total_transfer_KB": sum(
             metrics_from_all_nodes["per_node_total_transfer_KB"]),
         "cluster_total_timeout_requests": sum(
-            metrics_from_all_nodes["per_node_total_timeout_requests"]
-        ),
+            metrics_from_all_nodes["per_node_total_timeout_requests"]),
         "cluster_max_P50_latency_ms": max(
             metrics_from_all_nodes["P50_latency_ms"]),
         "cluster_max_P75_latency_ms": max(

--- a/release/serve_tests/workloads/serve_test_utils.py
+++ b/release/serve_tests/workloads/serve_test_utils.py
@@ -1,5 +1,16 @@
 #!/usr/bin/env python3
+import json
+import os
+import random
+import ray
 import re
+import subprocess
+from collections import defaultdict
+
+from serve_test_cluster_utils import NUM_CPU_PER_NODE
+from ray.serve.utils import logger
+from subprocess import PIPE
+from typing import Dict, List, Union
 
 
 def parse_time_to_ms(time_string: str) -> float:
@@ -75,7 +86,7 @@ def parse_metric_to_base(metric_string: str) -> float:
             "1.5M" -> 1500000
     """
 
-    parsed = re.split(r"(\d+.?\d+)(\w+)", metric_string)
+    parsed = re.split(r"(\d+.?\d+)(\w*)", metric_string)
     values = [val for val in parsed if val]
 
     if len(values) == 1:
@@ -126,15 +137,14 @@ def parse_wrk_decoded_stdout(decoded_out):
         #   Latency    72.32ms    6.00ms 139.00ms   91.60%
         #   Req/Sec   165.99     34.84   242.00     57.20%
         if parsed[0] == "Latency" and len(parsed) == 5:
-            metrics_dict["latency_avg_ms"] = parse_time_to_ms(parsed[1])
-            metrics_dict["latency_stdev_ms"] = parse_time_to_ms(parsed[2])
-            metrics_dict["latency_max_ms"] = parse_time_to_ms(parsed[3])
-            metrics_dict["latency_+/-_stdev %"] = float(parsed[4][:-1])
+            metrics_dict["per_thread_latency_avg_ms"] = parse_time_to_ms(
+                parsed[1])
+            metrics_dict["per_thread_latency_max_ms"] = parse_time_to_ms(
+                parsed[3])
         elif parsed[0] == "Req/Sec" and len(parsed) == 5:
-            metrics_dict["req/sec_avg"] = parse_metric_to_base(parsed[1])
-            metrics_dict["req/sec_stdev"] = parse_metric_to_base(parsed[2])
-            metrics_dict["req/sec_max"] = parse_metric_to_base(parsed[3])
-            metrics_dict["req/sec_+/-_stdev %"] = float(parsed[4][:-1])
+            metrics_dict["per_thread_tps"] = parse_metric_to_base(parsed[1])
+            metrics_dict["per_thread_max_tps"] = parse_metric_to_base(
+                parsed[3])
         # Latency Distribution header, ignored
         elif parsed[0] == "Latency" and parsed[1] == "Distribution":
             continue
@@ -151,12 +161,155 @@ def parse_wrk_decoded_stdout(decoded_out):
             metrics_dict["P90_latency_ms"] = parse_time_to_ms(parsed[1])
         elif parsed[0] == "99%":
             metrics_dict["P99_latency_ms"] = parse_time_to_ms(parsed[1])
+        # Total requests and transfer (might have timeout too)
+        elif len(parsed) >= 6 and parsed[1] == "requests":
+            metrics_dict["per_node_total_thoughput"] = int(parsed[0])
+            metrics_dict["per_node_total_transfer_KB"] = parse_size_to_KB(
+                parsed[4])
+        # 13306 requests in 10.10s, 1.95MB read
         # Summary section
         # Requests/sec:   1317.73
         # Transfer/sec:    198.19KB
         elif parsed[0] == "Requests/sec:":
-            metrics_dict["requests/sec"] = parse_metric_to_base(parsed[1])
+            metrics_dict["per_nodel_tps"] = parse_metric_to_base(parsed[1])
         elif parsed[0] == "Transfer/sec:":
-            metrics_dict["transfer/sec_KB"] = parse_size_to_KB(parsed[1])
+            metrics_dict["per_node_transfer_per_sec_KB"] = parse_size_to_KB(
+                parsed[1])
 
     return metrics_dict
+
+
+@ray.remote
+def run_one_wrk_trial(trial_length: str,
+                      num_connections: int,
+                      http_host: str,
+                      http_port: str,
+                      endpoint: str = "") -> None:
+    proc = subprocess.Popen(
+        [
+            "wrk",
+            "-c",
+            str(num_connections),
+            "-t",
+            str(NUM_CPU_PER_NODE),
+            "-d",
+            trial_length,
+            "--latency",
+            "--timeout=5s",
+            f"http://{http_host}:{http_port}/{endpoint}",
+        ],
+        stdout=PIPE,
+        stderr=PIPE,
+    )
+    proc.wait()
+    out, err = proc.communicate()
+
+    if err.decode() != "":
+        logger.error(err.decode())
+
+    return out.decode()
+
+
+def aggregate_all_metrics(
+        metrics_from_all_nodes: Dict[str, List[Union[float, int]]]):
+    num_nodes = len(metrics_from_all_nodes["per_nodel_tps"])
+    return {
+        # Per thread metrics
+        "per_thread_latency_avg_ms": round(
+            sum(metrics_from_all_nodes["per_thread_latency_avg_ms"]) /
+            num_nodes, 2),
+        "per_thread_latency_max_ms": max(
+            metrics_from_all_nodes["per_thread_latency_max_ms"]),
+        "per_thread_avg_tps": round(
+            sum(metrics_from_all_nodes["per_thread_tps"]) / num_nodes, 2),
+        "per_thread_max_tps": max(
+            metrics_from_all_nodes["per_thread_max_tps"]),
+
+        # Per wrk node metrics
+        "per_node_avg_tps": round(
+            sum(metrics_from_all_nodes["per_nodel_tps"]) / num_nodes, 2),
+        "per_node_avg_transfer_per_sec_KB": round(
+            sum(metrics_from_all_nodes["per_node_transfer_per_sec_KB"]) /
+            num_nodes, 2),
+
+        # Cluster metrics
+        "cluster_total_thoughput": sum(
+            metrics_from_all_nodes["per_node_total_thoughput"]),
+        "cluster_total_transfer_KB": sum(
+            metrics_from_all_nodes["per_node_total_transfer_KB"]),
+        "cluster_max_P50_latency_ms": max(
+            metrics_from_all_nodes["P50_latency_ms"]),
+        "cluster_max_P75_latency_ms": max(
+            metrics_from_all_nodes["P75_latency_ms"]),
+        "cluster_max_P90_latency_ms": max(
+            metrics_from_all_nodes["P90_latency_ms"]),
+        "cluster_max_P99_latency_ms": max(
+            metrics_from_all_nodes["P99_latency_ms"]),
+    }
+
+
+def run_wrk_on_all_nodes(trial_length: str,
+                         num_connections: int,
+                         http_host: str,
+                         http_port: str,
+                         all_endpoints: List[str] = None):
+    """
+    Use ray task to run one wrk trial on each node alive, picked randomly
+    from all available deployments.
+
+    Returns:
+        all_metrics: (Dict[str, List[Union[float, int]]]) Parsed wrk metrics
+            from each wrk on each running node
+        all_wrk_stdout: (List[str]) decoded stdout of each wrk trial for per
+            node checks at the end of experiment
+    """
+    all_metrics = defaultdict(list)
+    all_wrk_stdout = []
+    rst_ray_refs = []
+    for node in ray.nodes():
+        if node["Alive"]:
+            node_resource = f"node:{node['NodeManagerAddress']}"
+            # Randomly pick one from all available endpoints in ray cluster
+            endpoint = random.choice(all_endpoints)
+            rst_ray_refs.append(
+                run_one_wrk_trial.options(
+                    num_cpus=0, resources={
+                        node_resource: 0.01
+                    }).remote(trial_length, num_connections, http_host,
+                              http_port, endpoint))
+    for decoded_output in ray.get(rst_ray_refs):
+        all_wrk_stdout.append(decoded_output)
+        parsed_metrics = parse_wrk_decoded_stdout(decoded_output)
+
+        # Per thread metrics
+        all_metrics["per_thread_latency_avg_ms"].append(
+            parsed_metrics["per_thread_latency_avg_ms"])
+        all_metrics["per_thread_latency_max_ms"].append(
+            parsed_metrics["per_thread_latency_max_ms"])
+        all_metrics["per_thread_tps"].append(parsed_metrics["per_thread_tps"])
+        all_metrics["per_thread_max_tps"].append(
+            parsed_metrics["per_thread_max_tps"])
+
+        # Per node metrics
+        all_metrics["P50_latency_ms"].append(parsed_metrics["P50_latency_ms"])
+        all_metrics["P75_latency_ms"].append(parsed_metrics["P75_latency_ms"])
+        all_metrics["P90_latency_ms"].append(parsed_metrics["P90_latency_ms"])
+        all_metrics["P99_latency_ms"].append(parsed_metrics["P99_latency_ms"])
+
+        all_metrics["per_node_total_thoughput"].append(
+            parsed_metrics["per_node_total_thoughput"])
+        all_metrics["per_node_total_transfer_KB"].append(
+            parsed_metrics["per_node_total_transfer_KB"])
+
+        all_metrics["per_nodel_tps"].append(parsed_metrics["per_nodel_tps"])
+        all_metrics["per_node_transfer_per_sec_KB"].append(
+            parsed_metrics["per_node_transfer_per_sec_KB"])
+
+    return all_metrics, all_wrk_stdout
+
+
+def save_test_results(final_result,
+                      default_output_file="/tmp/release_test_out.json"):
+    test_output_json = os.environ.get("TEST_OUTPUT_JSON", default_output_file)
+    with open(test_output_json, "wt") as f:
+        json.dump(final_result, f)

--- a/release/serve_tests/workloads/serve_test_utils.py
+++ b/release/serve_tests/workloads/serve_test_utils.py
@@ -254,11 +254,7 @@ def run_wrk_on_all_nodes(trial_length: str,
                          http_port: str,
                          all_endpoints: List[str] = None):
     """
-<<<<<<< HEAD
     Use ray task to run one wrk trial on each node alive, picked randomly
-=======
-    Use ray task to run one wrk trial on each node alive, picked randomly 
->>>>>>> f1dd93c07 (make functions cleaner)
     from all available deployments.
 
     Returns:

--- a/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
@@ -24,12 +24,10 @@ Report:
     cluster_max_P99_latency_ms
 """
 
-from logging import shutdown
 import click
 import json
 import math
 import os
-import pprint 
 
 from ray import serve
 from ray.serve.utils import logger

--- a/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
@@ -66,9 +66,7 @@ def deploy_replicas(num_replicas, max_batch_size):
         async def __call__(self, request):
             return await self.handle_batch(request)
 
-    deployment_handle = Echo.deploy()
-    return deployment_handle
-
+    Echo.deploy()
 
 def save_results(final_result, default_name):
     test_output_json = os.environ.get(
@@ -112,10 +110,10 @@ def main(num_replicas: Optional[int], trial_length: Optional[str],
     logger.info(f"Ray serve http_host: {http_host}, http_port: {http_port}")
 
     logger.info(f"Deploying with {num_replicas} target replicas ....\n")
-    deployment_handle = deploy_replicas(num_replicas, max_batch_size)
+    deploy_replicas(num_replicas, max_batch_size)
 
     logger.info("Warming up cluster ....\n")
-    warm_up_cluster(5, deployment_handle, http_host, http_port)
+    warm_up_cluster(5, http_host, http_port)
 
     logger.info(f"Starting wrk trial for {trial_length} ....\n")
     # For detailed discussion, see https://github.com/wg/wrk/issues/205

--- a/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
@@ -57,7 +57,6 @@ DEFAULT_SMOKE_TEST_TRIAL_LENGTH = "5s"
 DEFAULT_FULL_TEST_TRIAL_LENGTH = "1m"
 
 
-
 def deploy_replicas(num_replicas, max_batch_size):
     @serve.deployment(name="echo", num_replicas=num_replicas)
     class Echo:

--- a/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
@@ -24,10 +24,12 @@ Report:
     cluster_max_P99_latency_ms
 """
 
+from logging import shutdown
 import click
 import json
 import math
 import os
+import pprint 
 
 from ray import serve
 from ray.serve.utils import logger

--- a/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
@@ -68,6 +68,7 @@ def deploy_replicas(num_replicas, max_batch_size):
 
     Echo.deploy()
 
+
 def save_results(final_result, default_name):
     test_output_json = os.environ.get(
         "TEST_OUTPUT_JSON", "/tmp/single_deployment_1k_noop_replica.json")

--- a/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
@@ -41,19 +41,21 @@ from serve_test_cluster_utils import (
     setup_anyscale_cluster,
     warm_up_cluster,
     NUM_CPU_PER_NODE,
+    NUM_CONNECTIONS,
 )
 from typing import Optional
 
 # Experiment configs
 DEFAULT_SMOKE_TEST_NUM_REPLICA = 8
-DEFAULT_FULL_TEST_NUM_REPLICA = 1000
+DEFAULT_FULL_TEST_NUM_REPLICA = 100
 
 # Deployment configs
 DEFAULT_MAX_BATCH_SIZE = 16
 
 # Experiment configs - wrk specific
 DEFAULT_SMOKE_TEST_TRIAL_LENGTH = "5s"
-DEFAULT_FULL_TEST_TRIAL_LENGTH = "10m"
+DEFAULT_FULL_TEST_TRIAL_LENGTH = "1m"
+
 
 
 def deploy_replicas(num_replicas, max_batch_size):
@@ -66,7 +68,8 @@ def deploy_replicas(num_replicas, max_batch_size):
         async def __call__(self, request):
             return await self.handle_batch(request)
 
-    Echo.deploy()
+    deployment_handle = Echo.deploy()
+    return deployment_handle
 
 
 def save_results(final_result, default_name):
@@ -119,25 +122,13 @@ def main(num_replicas: Optional[int], trial_length: Optional[str],
     logger.info(f"Starting wrk trial for {trial_length} ....\n")
     # For detailed discussion, see https://github.com/wg/wrk/issues/205
     # TODO:(jiaodong) What's the best number to use here ?
-    num_connections = int(num_replicas * DEFAULT_MAX_BATCH_SIZE * 0.75)
     all_endpoints = list(serve.list_endpoints().keys())
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 941b57c6e (travis)
     all_metrics, all_wrk_stdout = run_wrk_on_all_nodes(
         trial_length,
-        num_connections,
+        NUM_CONNECTIONS,
         http_host,
         http_port,
         all_endpoints=all_endpoints)
-<<<<<<< HEAD
-=======
-    all_metrics, all_wrk_stdout = run_wrk_on_all_nodes(trial_length, num_connections, http_host,
-                                                       http_port, all_endpoints=all_endpoints)
->>>>>>> 97756611c (both multi and single working locally)
-=======
->>>>>>> 941b57c6e (travis)
 
     aggregated_metrics = aggregate_all_metrics(all_metrics)
     logger.info("Wrk stdout on each node: ")
@@ -147,17 +138,8 @@ def main(num_replicas: Optional[int], trial_length: Optional[str],
     for key, val in aggregated_metrics.items():
         logger.info(f"{key}: {val}")
     save_test_results(
-<<<<<<< HEAD
-<<<<<<< HEAD
         aggregated_metrics,
         default_output_file="/tmp/single_deployment_1k_noop_replica.json")
-=======
-        aggregated_metrics, default_output_file="/tmp/single_deployment_1k_noop_replica.json")
->>>>>>> 97756611c (both multi and single working locally)
-=======
-        aggregated_metrics,
-        default_output_file="/tmp/single_deployment_1k_noop_replica.json")
->>>>>>> 941b57c6e (travis)
 
 
 if __name__ == "__main__":

--- a/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
@@ -69,6 +69,7 @@ def deploy_replicas(num_replicas, max_batch_size):
     deployment_handle = Echo.deploy()
     return deployment_handle
 
+
 def save_results(final_result, default_name):
     test_output_json = os.environ.get(
         "TEST_OUTPUT_JSON", "/tmp/single_deployment_1k_noop_replica.json")
@@ -121,12 +122,17 @@ def main(num_replicas: Optional[int], trial_length: Optional[str],
     # TODO:(jiaodong) What's the best number to use here ?
     num_connections = int(num_replicas * DEFAULT_MAX_BATCH_SIZE * 0.75)
     all_endpoints = list(serve.list_endpoints().keys())
+<<<<<<< HEAD
     all_metrics, all_wrk_stdout = run_wrk_on_all_nodes(
         trial_length,
         num_connections,
         http_host,
         http_port,
         all_endpoints=all_endpoints)
+=======
+    all_metrics, all_wrk_stdout = run_wrk_on_all_nodes(trial_length, num_connections, http_host,
+                                                       http_port, all_endpoints=all_endpoints)
+>>>>>>> 97756611c (both multi and single working locally)
 
     aggregated_metrics = aggregate_all_metrics(all_metrics)
     logger.info("Wrk stdout on each node: ")
@@ -136,8 +142,12 @@ def main(num_replicas: Optional[int], trial_length: Optional[str],
     for key, val in aggregated_metrics.items():
         logger.info(f"{key}: {val}")
     save_test_results(
+<<<<<<< HEAD
         aggregated_metrics,
         default_output_file="/tmp/single_deployment_1k_noop_replica.json")
+=======
+        aggregated_metrics, default_output_file="/tmp/single_deployment_1k_noop_replica.json")
+>>>>>>> 97756611c (both multi and single working locally)
 
 
 if __name__ == "__main__":

--- a/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
@@ -115,9 +115,9 @@ def main(num_replicas: Optional[int], trial_length: Optional[str],
     deploy_replicas(num_replicas, max_batch_size)
 
     logger.info("Warming up cluster ....\n")
-    warm_up_cluster(5, http_host, http_port)
+    warm_up_cluster(10, http_host, http_port)
 
-    logger.info(f"Starting wrk trial for {trial_length} ....\n")
+    logger.info(f"Starting wrk trial on all nodes for {trial_length} ....\n")
     # For detailed discussion, see https://github.com/wg/wrk/issues/205
     # TODO:(jiaodong) What's the best number to use here ?
     all_endpoints = list(serve.list_endpoints().keys())

--- a/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
@@ -69,6 +69,7 @@ def deploy_replicas(num_replicas, max_batch_size):
 
     Echo.deploy()
 
+
 def save_results(final_result, default_name):
     test_output_json = os.environ.get(
         "TEST_OUTPUT_JSON", "/tmp/single_deployment_1k_noop_replica.json")

--- a/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
@@ -123,16 +123,22 @@ def main(num_replicas: Optional[int], trial_length: Optional[str],
     num_connections = int(num_replicas * DEFAULT_MAX_BATCH_SIZE * 0.75)
     all_endpoints = list(serve.list_endpoints().keys())
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 941b57c6e (travis)
     all_metrics, all_wrk_stdout = run_wrk_on_all_nodes(
         trial_length,
         num_connections,
         http_host,
         http_port,
         all_endpoints=all_endpoints)
+<<<<<<< HEAD
 =======
     all_metrics, all_wrk_stdout = run_wrk_on_all_nodes(trial_length, num_connections, http_host,
                                                        http_port, all_endpoints=all_endpoints)
 >>>>>>> 97756611c (both multi and single working locally)
+=======
+>>>>>>> 941b57c6e (travis)
 
     aggregated_metrics = aggregate_all_metrics(all_metrics)
     logger.info("Wrk stdout on each node: ")
@@ -143,11 +149,16 @@ def main(num_replicas: Optional[int], trial_length: Optional[str],
         logger.info(f"{key}: {val}")
     save_test_results(
 <<<<<<< HEAD
+<<<<<<< HEAD
         aggregated_metrics,
         default_output_file="/tmp/single_deployment_1k_noop_replica.json")
 =======
         aggregated_metrics, default_output_file="/tmp/single_deployment_1k_noop_replica.json")
 >>>>>>> 97756611c (both multi and single working locally)
+=======
+        aggregated_metrics,
+        default_output_file="/tmp/single_deployment_1k_noop_replica.json")
+>>>>>>> 941b57c6e (travis)
 
 
 if __name__ == "__main__":

--- a/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
@@ -66,8 +66,8 @@ def deploy_replicas(num_replicas, max_batch_size):
         async def __call__(self, request):
             return await self.handle_batch(request)
 
-    Echo.deploy()
-
+    deployment_handle = Echo.deploy()
+    return deployment_handle
 
 def save_results(final_result, default_name):
     test_output_json = os.environ.get(
@@ -111,10 +111,10 @@ def main(num_replicas: Optional[int], trial_length: Optional[str],
     logger.info(f"Ray serve http_host: {http_host}, http_port: {http_port}")
 
     logger.info(f"Deploying with {num_replicas} target replicas ....\n")
-    deploy_replicas(num_replicas, max_batch_size)
+    deployment_handle = deploy_replicas(num_replicas, max_batch_size)
 
     logger.info("Warming up cluster ....\n")
-    warm_up_cluster(5, http_host, http_port)
+    warm_up_cluster(5, deployment_handle, http_host, http_port)
 
     logger.info(f"Starting wrk trial for {trial_length} ....\n")
     # For detailed discussion, see https://github.com/wg/wrk/issues/205

--- a/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
@@ -47,14 +47,14 @@ from typing import Optional
 
 # Experiment configs
 DEFAULT_SMOKE_TEST_NUM_REPLICA = 8
-DEFAULT_FULL_TEST_NUM_REPLICA = 100
+DEFAULT_FULL_TEST_NUM_REPLICA = 1000
 
 # Deployment configs
 DEFAULT_MAX_BATCH_SIZE = 16
 
 # Experiment configs - wrk specific
 DEFAULT_SMOKE_TEST_TRIAL_LENGTH = "5s"
-DEFAULT_FULL_TEST_TRIAL_LENGTH = "1m"
+DEFAULT_FULL_TEST_TRIAL_LENGTH = "10m"
 
 
 def deploy_replicas(num_replicas, max_batch_size):
@@ -67,9 +67,7 @@ def deploy_replicas(num_replicas, max_batch_size):
         async def __call__(self, request):
             return await self.handle_batch(request)
 
-    deployment_handle = Echo.deploy()
-    return deployment_handle
-
+    Echo.deploy()
 
 def save_results(final_result, default_name):
     test_output_json = os.environ.get(


### PR DESCRIPTION
## Summary

 - Added multi deployment test with 1k replica and 100 deployments
 - Multi deployment will randomly pick next endpoint from all 100 existing ones, include self, and stop at depth of 5
 - Warmup at each endpoint / deployment has its own ray remote task and executed in parallel
 - Each node has its own HTTP Proxy as well as wrk job simulating load balanced traffic
 - Metrics are parsed and aggregated as one, and shows per thread/node/cluster level
 - A bunch of refactoring

## Test plan

1 deployment, 1k replicas, 10 cpu per node, 100 connections per wrk:

https://beta.anyscale.com/o/anyscale-internal/projects/prj_UgMsAz5Rqk2iuvHmyrBH3S4E/clusters/ses_TQztbsGqe6rauG23JdaJihgi?command-history-section=command_history

100 deployments, 1k replicas, 10 cpu per node, 100 connections per wrk:

https://beta.anyscale.com/o/anyscale-internal/projects/prj_UgMsAz5Rqk2iuvHmyrBH3S4E/clusters/ses_89uwNQunRpcDsiBZ73y8BRYi

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
