### PR TITLE
[object store refactor 2/n] More refactor on PlasmaAllocator, and add unit tests

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -959,6 +959,34 @@ cc_test(
 )
 
 cc_test(
+    name = "allocator_test",
+    srcs = [
+        "src/ray/object_manager/plasma/test/allocator_test.cc",
+    ],
+    copts = COPTS,
+    deps = [
+        ":plasma_store_server_lib",
+        "@boost//:filesystem",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "fallback_allocator_test",
+    srcs = [
+        "src/ray/object_manager/plasma/test/fallback_allocator_test.cc",
+    ],
+    copts = COPTS,
+    deps = [
+        ":plasma_store_server_lib",
+        "@boost//:filesystem",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "create_request_queue_test",
     size = "small",
     srcs = [

--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -55,7 +55,7 @@ def get_commit_range():
         base = event["pull_request"]["base"]["sha"]
         commit_range = "{}...{}".format(base, event.get("after", ""))
     elif os.environ.get("BUILDKITE"):
-        commit_range = "{}...{}".format(
+        commit_range = "origin/{}...{}".format(
             os.environ["BUILDKITE_PULL_REQUEST_BASE_BRANCH"],
             os.environ["BUILDKITE_COMMIT"],
         )

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -931,8 +931,7 @@ void ObjectManager::RecordMetrics() const {
   stats::ObjectStoreAvailableMemory().Record(config_.object_store_memory - used_memory_);
   stats::ObjectStoreUsedMemory().Record(used_memory_);
   stats::ObjectStoreFallbackMemory().Record(
-      // TODO(scv119): this is not thread safe.
-      plasma::PlasmaAllocator::GetInstance().FallbackAllocated());
+      plasma::plasma_store_runner->GetFallbackAllocated());
   stats::ObjectStoreLocalObjects().Record(local_objects_.size());
   stats::ObjectManagerPullRequests().Record(pull_manager_->NumActiveRequests());
 }
@@ -941,8 +940,7 @@ void ObjectManager::FillObjectStoreStats(rpc::GetNodeStatsReply *reply) const {
   auto stats = reply->mutable_store_stats();
   stats->set_object_store_bytes_used(used_memory_);
   stats->set_object_store_bytes_fallback(
-      // TODO(scv119): this is not thread safe.
-      plasma::PlasmaAllocator::GetInstance().FallbackAllocated());
+      plasma::plasma_store_runner->GetFallbackAllocated());
   stats->set_object_store_bytes_avail(config_.object_store_memory);
   stats->set_num_local_objects(local_objects_.size());
   stats->set_consumed_bytes(plasma::plasma_store_runner->GetConsumedBytes());

--- a/src/ray/object_manager/plasma/allocator.h
+++ b/src/ray/object_manager/plasma/allocator.h
@@ -47,12 +47,7 @@ class IAllocator {
   /// a previous call to Allocate/FallbackAllocate or it yield undefined behavior.
   ///
   /// \param allocation allocation to free.
-  virtual void Free(const Allocation &allocation) = 0;
-
-  /// Sets the memory footprint limit for this allocator.
-  ///
-  /// \param bytes memory footprint limit in bytes.
-  virtual void SetFootprintLimit(size_t bytes) = 0;
+  virtual void Free(Allocation allocation) = 0;
 
   /// Get the memory footprint limit for this allocator.
   ///
@@ -60,11 +55,9 @@ class IAllocator {
   virtual int64_t GetFootprintLimit() const = 0;
 
   /// Get the number of bytes allocated so far.
-  /// \return Number of bytes allocated so far.
   virtual int64_t Allocated() const = 0;
 
   /// Get the number of bytes fallback allocated so far.
-  /// \return Number of bytes fallback allocated so far.
   virtual int64_t FallbackAllocated() const = 0;
 };
 

--- a/src/ray/object_manager/plasma/common.h
+++ b/src/ray/object_manager/plasma/common.h
@@ -26,6 +26,7 @@
 #include "ray/common/id.h"
 #include "ray/object_manager/plasma/compat.h"
 #include "ray/object_manager/plasma/plasma_generated.h"
+#include "ray/util/macros.h"
 
 namespace plasma {
 
@@ -68,6 +69,11 @@ struct Allocation {
         offset(offset),
         device_num(device_num),
         mmap_size(mmap_size) {}
+
+  // only allow moves.
+  RAY_DISALLOW_COPY_AND_ASSIGN(Allocation);
+  Allocation(Allocation &&) noexcept = default;
+  Allocation &operator=(Allocation &&) noexcept = default;
 };
 
 /// This type is used by the Plasma store. It is here because it is exposed to

--- a/src/ray/object_manager/plasma/dlmalloc.cc
+++ b/src/ray/object_manager/plasma/dlmalloc.cc
@@ -77,45 +77,68 @@ int fake_munmap(void *, int64_t);
 
 constexpr int GRANULARITY_MULTIPLIER = 2;
 
+namespace {
 // Ray allocates all plasma memory up-front at once to avoid runtime allocations.
 // Combined with MAP_POPULATE, this can guarantee we never run into SIGBUS errors.
-static bool allocated_once = false;
+bool allocated_once = false;
 
 // Give each mmap record a unique id, so we can disambiguate fd reuse.
-static int64_t next_mmap_unique_id = INVALID_UNIQUE_FD_ID + 1;
+int64_t next_mmap_unique_id = INVALID_UNIQUE_FD_ID + 1;
 
 // Populated on the first allocation so we can track which allocations fall within
 // the initial region vs outside.
-static char *initial_region_ptr = nullptr;
-static size_t initial_region_size = 0;
+char *initial_region_ptr = nullptr;
+size_t initial_region_size = 0;
 
-static void *pointer_advance(void *p, ptrdiff_t n) { return (unsigned char *)p + n; }
+void *pointer_advance(void *p, ptrdiff_t n) { return (unsigned char *)p + n; }
 
-static void *pointer_retreat(void *p, ptrdiff_t n) { return (unsigned char *)p - n; }
+void *pointer_retreat(void *p, ptrdiff_t n) { return (unsigned char *)p - n; }
+
+struct DLMallocConfig {
+  /// Boolean flag indicating whether to start the object store with hugepages
+  /// support enabled. Huge pages are substantially larger than normal memory
+  /// pages (e.g. 2MB or 1GB instead of 4KB) and using them can reduce
+  /// bookkeeping overhead from the OS.
+  bool hugepages_enabled = false;
+  /// A (platform-dependent) directory where to create the memory-backed file.
+  std::string directory = "";
+  /// A (platform-dependent) directory where to create fallback files. This
+  /// should NOT be in /dev/shm.
+  std::string fallback_directory = "";
+  /// Boolean flag indicating whether fallback allocation is enabled.
+  bool fallback_enabled = false;
+};
+
+DLMallocConfig dlmalloc_config;
+}  // namespace
 
 #ifdef _WIN32
 void create_and_mmap_buffer(int64_t size, void **pointer, HANDLE *handle) {
   *handle = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE,
                               (DWORD)((uint64_t)size >> (CHAR_BIT * sizeof(DWORD))),
                               (DWORD)(uint64_t)size, NULL);
-  RAY_CHECK(*handle != NULL) << "CreateFileMapping() failed. GetLastError() = "
-                             << GetLastError();
+  RAY_CHECK(*handle != nullptr)
+      << "CreateFileMapping() failed. GetLastError() = " << GetLastError();
   *pointer = MapViewOfFile(*handle, FILE_MAP_ALL_ACCESS, 0, 0, (size_t)size);
-  if (*pointer == NULL) {
+  if (*pointer == nullptr) {
     RAY_LOG(ERROR) << "MapViewOfFile() failed. GetLastError() = " << GetLastError();
+  }
+  if (!allocated_once) {
+    initial_region_ptr = static_cast<char *>(*pointer);
+    initial_region_size = size;
   }
 }
 #else
 void create_and_mmap_buffer(int64_t size, void **pointer, int *fd) {
   // Create a buffer. This is creating a temporary file and then
   // immediately unlinking it so we do not leave traces in the system.
-  std::string file_template = plasma_config->directory;
+  std::string file_template = dlmalloc_config.directory;
 
   // In never-OOM mode, fallback to allocating from the filesystem. Note that these
   // allocations will be run with dlmallopt(M_MMAP_THRESHOLD, 0) set by
   // plasma_allocator.cc.
-  if (allocated_once && RayConfig::instance().plasma_unlimited()) {
-    file_template = plasma_config->fallback_directory;
+  if (allocated_once && dlmalloc_config.fallback_enabled) {
+    file_template = dlmalloc_config.fallback_directory;
   }
 
   file_template += "/plasmaXXXXXX";
@@ -130,7 +153,7 @@ void create_and_mmap_buffer(int64_t size, void **pointer, int *fd) {
   if (unlink(&file_name[0]) != 0) {
     RAY_LOG(FATAL) << "failed to unlink file " << &file_name[0];
   }
-  if (!plasma_config->hugepages_enabled) {
+  if (!dlmalloc_config.hugepages_enabled) {
     // Increase the size of the file to the desired size. This seems not to be
     // needed for files that are backed by the huge page fs, see also
     // http://www.mail-archive.com/kvm-devel@lists.sourceforge.net/msg14737.html
@@ -154,7 +177,7 @@ void create_and_mmap_buffer(int64_t size, void **pointer, int *fd) {
 #ifdef __linux__
   // For fallback allocation, use fallocate to ensure follow up access to this
   // mmaped file doesn't cause SIGBUS. Only supported on Linux.
-  if (allocated_once && RayConfig::instance().plasma_unlimited()) {
+  if (allocated_once && dlmalloc_config.fallback_enabled) {
     RAY_LOG(DEBUG) << "Preallocating fallback allocation using fallocate";
     int ret = fallocate(*fd, /*mode*/ 0, /*offset*/ 0, size);
     if (ret != 0) {
@@ -176,7 +199,7 @@ void create_and_mmap_buffer(int64_t size, void **pointer, int *fd) {
   *pointer = mmap(NULL, size, PROT_READ | PROT_WRITE, flags, *fd, 0);
   if (*pointer == MAP_FAILED) {
     RAY_LOG(ERROR) << "mmap failed with error: " << std::strerror(errno);
-    if (errno == ENOMEM && plasma_config->hugepages_enabled) {
+    if (errno == ENOMEM && dlmalloc_config.hugepages_enabled) {
       RAY_LOG(ERROR)
           << "  (this probably means you have to increase /proc/sys/vm/nr_hugepages)";
     }
@@ -189,12 +212,11 @@ void create_and_mmap_buffer(int64_t size, void **pointer, int *fd) {
 #endif
 
 void *fake_mmap(size_t size) {
-  // In unlimited allocation mode, fail allocations done by PlasmaAllocator::Memalign()
+  // In unlimited allocation mode, fail allocations done by PlasmaAllocator::Allocate()
   // after the initial allocation. Allow allocations done by
-  // PlasmaAllocator::DiskMemalignUnlimited(), which sets mmap_threshold to zero prior to
+  // PlasmaAllocator::FallbackAllocate(), which sets mmap_threshold to zero prior to
   // calling dlmemalign().
-  if (RayConfig::instance().plasma_unlimited() && allocated_once &&
-      mparams.mmap_threshold > 0) {
+  if (dlmalloc_config.fallback_enabled && allocated_once && mparams.mmap_threshold > 0) {
     RAY_LOG(DEBUG) << "fake_mmap called once already, refusing to overcommit: " << size;
     return MFAIL;
   }
@@ -255,6 +277,7 @@ int fake_munmap(void *addr, int64_t size) {
   return r;
 }
 
+namespace internal {
 void SetMallocGranularity(int value) { change_mparam(M_GRANULARITY, value); }
 
 // Returns whether the given pointer is outside the initially allocated region.
@@ -265,6 +288,13 @@ bool IsOutsideInitialAllocation(void *p) {
   return (p < initial_region_ptr) || (p >= (initial_region_ptr + initial_region_size));
 }
 
-const PlasmaStoreInfo *plasma_config;
-
+void SetDLMallocConfig(const std::string &plasma_directory,
+                       const std::string &fallback_directory, bool hugepage_enabled,
+                       bool fallback_enabled) {
+  dlmalloc_config.hugepages_enabled = hugepage_enabled;
+  dlmalloc_config.directory = plasma_directory;
+  dlmalloc_config.fallback_directory = fallback_directory;
+  dlmalloc_config.fallback_enabled = fallback_enabled;
+}
+}  // namespace internal
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/plasma.h
+++ b/src/ray/object_manager/plasma/plasma.h
@@ -69,16 +69,6 @@ enum class ObjectStatus : int {
 struct PlasmaStoreInfo {
   /// Objects that are in the Plasma store.
   ObjectTable objects;
-  /// Boolean flag indicating whether to start the object store with hugepages
-  /// support enabled. Huge pages are substantially larger than normal memory
-  /// pages (e.g. 2MB or 1GB instead of 4KB) and using them can reduce
-  /// bookkeeping overhead from the OS.
-  bool hugepages_enabled;
-  /// A (platform-dependent) directory where to create the memory-backed file.
-  std::string directory;
-  /// A (platform-dependent) directory where to create fallback files. This
-  /// should NOT be in /dev/shm.
-  std::string fallback_directory;
 };
 
 /// Get an entry from the object table and return NULL if the object_id
@@ -90,8 +80,4 @@ struct PlasmaStoreInfo {
 ///         is not present.
 ObjectTableEntry *GetObjectTableEntry(PlasmaStoreInfo *store_info,
                                       const ObjectID &object_id);
-
-/// Globally accessible reference to plasma store configuration.
-extern const PlasmaStoreInfo *plasma_config;
-
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -51,8 +51,7 @@ struct GetRequest;
 class PlasmaStore {
  public:
   // TODO: PascalCase PlasmaStore methods.
-  PlasmaStore(instrumented_io_context &main_service, std::string directory,
-              std::string fallback_directory, bool hugepages_enabled,
+  PlasmaStore(instrumented_io_context &main_service, IAllocator &allocator,
               const std::string &socket_name, uint32_t delay_on_oom_ms,
               float object_spilling_threshold,
               ray::SpillObjectsCallback spill_objects_callback,
@@ -67,9 +66,6 @@ class PlasmaStore {
 
   /// Stop this store.
   void Stop();
-
-  /// Get a const pointer to the internal PlasmaStoreInfo object.
-  const PlasmaStoreInfo *GetPlasmaStoreInfo();
 
   /// Create a new object. The client must do a call to release_object to tell
   /// the store when it is done with the object.

--- a/src/ray/object_manager/plasma/test/allocator_test.cc
+++ b/src/ray/object_manager/plasma/test/allocator_test.cc
@@ -1,0 +1,89 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <boost/filesystem.hpp>
+#include "gtest/gtest.h"
+#include "ray/object_manager/plasma/plasma_allocator.h"
+
+using namespace boost::filesystem;
+
+namespace plasma {
+namespace {
+const int64_t kMB = 1024 * 1024;
+std::string CreateTestDir() {
+  path directory = temp_directory_path() / unique_path();
+  create_directories(directory);
+  return directory.string();
+}
+};  // namespace
+
+TEST(PlasmaAllocatorTest, NoFallbackPassThroughTest) {
+  auto plasma_directory = CreateTestDir();
+  auto fallback_directory = CreateTestDir();
+  int64_t kLimit = 256 * sizeof(size_t) + 10 * kMB;
+  PlasmaAllocator allocator(plasma_directory, fallback_directory,
+                            /* hugepage_enabled */ false, kLimit,
+                            /* fallback_enabled */ false);
+
+  EXPECT_EQ(kLimit, allocator.GetFootprintLimit());
+
+  int64_t expect_allocated = 0;
+  std::vector<Allocation> allocations;
+  for (int i = 0; i < 10; i++) {
+    auto allocation = allocator.Allocate(kMB);
+    expect_allocated += kMB;
+    EXPECT_TRUE(allocation.has_value());
+    EXPECT_EQ(expect_allocated, allocator.Allocated());
+    EXPECT_EQ(0, allocator.FallbackAllocated());
+    allocations.push_back(std::move(allocation.value()));
+  }
+
+  // over allocation yields failure.
+  {
+    auto allocation = allocator.Allocate(kMB);
+    // allocation failure.
+    EXPECT_FALSE(allocation.has_value());
+    EXPECT_EQ(0, allocator.FallbackAllocated());
+    EXPECT_EQ(expect_allocated, allocator.Allocated());
+  }
+
+  // fallback allocation fails when fallback allocation disabled
+  {
+    auto allocation = allocator.FallbackAllocate(kMB);
+    // allocation failure.
+    EXPECT_FALSE(allocation.has_value());
+    EXPECT_EQ(0, allocator.FallbackAllocated());
+    EXPECT_EQ(expect_allocated, allocator.Allocated());
+  }
+
+  {
+    // free up space.
+    auto allocation = std::move(allocations.back());
+    allocations.pop_back();
+    allocator.Free(std::move(allocation));
+    EXPECT_EQ(9 * kMB, allocator.Allocated());
+
+    // now that we can allocate another entry.
+    auto new_allocation = allocator.Allocate(kMB);
+    EXPECT_TRUE(new_allocation.has_value());
+    EXPECT_EQ(10 * kMB, allocator.Allocated());
+    allocations.push_back(std::move(new_allocation.value()));
+  }
+}
+}  // namespace plasma
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/ray/object_manager/plasma/test/fallback_allocator_test.cc
+++ b/src/ray/object_manager/plasma/test/fallback_allocator_test.cc
@@ -1,0 +1,106 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <boost/filesystem.hpp>
+#include "gtest/gtest.h"
+#include "ray/object_manager/plasma/plasma_allocator.h"
+
+using namespace boost::filesystem;
+
+namespace plasma {
+namespace {
+const int64_t kMB = 1024 * 1024;
+std::string CreateTestDir() {
+  path directory = temp_directory_path() / unique_path();
+  create_directories(directory);
+  return directory.string();
+}
+};  // namespace
+
+TEST(FallbackPlasmaAllocatorTest, FallbackPassThroughTest) {
+  auto plasma_directory = CreateTestDir();
+  auto fallback_directory = CreateTestDir();
+  int64_t kLimit = 256 * sizeof(size_t) + 2 * kMB;
+  PlasmaAllocator allocator(plasma_directory, fallback_directory,
+                            /* hugepage_enabled */ false, kLimit,
+                            /* fallback_enabled */ true);
+
+  EXPECT_EQ(kLimit, allocator.GetFootprintLimit());
+
+  int64_t expect_allocated = 0;
+  int64_t expect_fallback_allocated = 0;
+  std::vector<Allocation> allocations;
+  std::vector<Allocation> fallback_allocations;
+  for (int i = 0; i < 2; i++) {
+    auto allocation = allocator.Allocate(kMB);
+    expect_allocated += kMB;
+    EXPECT_TRUE(allocation.has_value());
+    EXPECT_EQ(expect_allocated, allocator.Allocated());
+    EXPECT_EQ(0, allocator.FallbackAllocated());
+    allocations.push_back(std::move(allocation.value()));
+  }
+
+  // over allocation yields failure.
+  {
+    auto allocation = allocator.Allocate(kMB);
+    // allocation failure.
+    EXPECT_FALSE(allocation.has_value());
+    EXPECT_EQ(0, allocator.FallbackAllocated());
+    EXPECT_EQ(expect_allocated, allocator.Allocated());
+  }
+
+  // fallback allocation succeeds when fallback allocation enabled.
+  {
+    for (int i = 0; i < 2; i++) {
+      auto allocation = allocator.FallbackAllocate(kMB);
+      expect_allocated += kMB;
+      expect_fallback_allocated += kMB;
+      EXPECT_TRUE(allocation.has_value());
+      EXPECT_EQ(expect_allocated, allocator.Allocated());
+      EXPECT_EQ(expect_fallback_allocated, allocator.FallbackAllocated());
+      fallback_allocations.push_back(std::move(allocation.value()));
+    }
+  }
+
+  {
+    // free up 1 fallback allocation.
+    auto allocation = std::move(fallback_allocations.back());
+    fallback_allocations.pop_back();
+    allocator.Free(std::move(allocation));
+    EXPECT_EQ(3 * kMB, allocator.Allocated());
+    EXPECT_EQ(1 * kMB, allocator.FallbackAllocated());
+  }
+
+  {
+    // free up 1 allocation from primary mmap.
+    auto allocation = std::move(allocations.back());
+    allocations.pop_back();
+    allocator.Free(std::move(allocation));
+    EXPECT_EQ(2 * kMB, allocator.Allocated());
+    EXPECT_EQ(1 * kMB, allocator.FallbackAllocated());
+
+    // now we can allocate from primary.
+    auto new_allocation = allocator.Allocate(kMB);
+    EXPECT_TRUE(new_allocation.has_value());
+    EXPECT_EQ(3 * kMB, allocator.Allocated());
+    EXPECT_EQ(1 * kMB, allocator.FallbackAllocated());
+  }
+}
+
+}  // namespace plasma
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This the 2nd PR that refactor PlasmaStore for modularization and testability.  Previous PR: #17307 , Next PR: #17332 

In this PR, we further refactor PlasmaAllocator for better testability. Specifically 
- we move  the initial mmap/unmmap call into PlasmaAllocator constructor
- we move the dlmalloc setting into PlasmaAllocator constructor, so that we "almost" hide dlmalloc fully into PlasmaAllocator (except for one outstanding SetMallocGranularity call in store_runner.cc/and dlmalloc.cc reads RayConfig::instance().preallocate_plasma_memory()).
- Fix a concurrency issue where object_manager reads fallback allocated bytes without synchronization
- Added unit tests for basic behavior of PlasmaStoreAllocator. (note we have to separate them into different files as we can't reset dlmalloc for now).


## Test Plan
-[x] existing tests
-[x] added unit tests