### PR TITLE
[rllib] CLI: refactor if __name__ == "__main__" into main() method

### DIFF
--- a/rllib/rollout.py
+++ b/rllib/rollout.py
@@ -506,7 +506,7 @@ def rollout(agent,
             episodes += 1
 
 
-if __name__ == "__main__":
+def main():
     parser = create_parser()
     args = parser.parse_args()
 
@@ -522,3 +522,7 @@ if __name__ == "__main__":
             "--out as well!")
 
     run(args, parser)
+
+
+if __name__ == "__main__":
+    main()

--- a/rllib/train.py
+++ b/rllib/train.py
@@ -257,7 +257,11 @@ def run(args, parser):
     ray.shutdown()
 
 
-if __name__ == "__main__":
+def main():
     parser = create_parser()
     args = parser.parse_args()
     run(args, parser)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This would allow users to extend the default training script without copying code:
```python
from ray.rllib.train import main as rllib_main

def main():
    # do imports and preprocessing steps
    rllib_main()

if __name__ == "__main__":
    main()
```

For example, one can use the ray registry as an API to pass constructor functions (for custom models, input, environments, etc...).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
