### PR TITLE
[docs] update docs with pip requirements

### DIFF
--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -19,6 +19,8 @@ Building Ray (Python Only)
 
 RLlib, Tune, Autoscaler, and most Python files do not require you to build and compile Ray. Follow these instructions to develop Ray's Python files locally without building Ray.
 
+0. (Optional) To setup an isolated Anaconda environment, see :ref:`ray_anaconda`.
+
 1. Pip install the **latest Ray wheels.** See :ref:`install-nightlies` for instructions.
 
 .. code-block:: shell
@@ -37,14 +39,19 @@ RLlib, Tune, Autoscaler, and most Python files do not require you to build and c
 3. Replace Python files in the installed package with your local editable copy. We provide a simple script to help you do this: ``python python/ray/setup-dev.py``.
 Running the script will remove the  ``ray/tune``, ``ray/rllib``, ``ray/autoscaler`` dir (among other directories) bundled with the ``ray`` pip package, and replace them with links to your local code. This way, changing files in your git clone will directly affect the behavior of your installed ray.
 
+.. code-block:: shell
+
+    # This replaces `<package path>/site-packages/ray/<package>`
+    # with your local `ray/python/ray/<package>`.
+    python python/ray/setup-dev.py
+
 .. warning:: Do not run ``pip uninstall ray`` or ``pip install -U`` (for Ray or Ray wheels) if setting up your environment this way. To uninstall or upgrade, you must first ``rm -rf`` the pip-installation site (usually a ``site-packages/ray`` location), then do a pip reinstall (see 1. above), and finally run the above `setup-dev.py` script again.
 
 .. code-block:: shell
 
-    cd ray
-    python python/ray/setup-dev.py
-    # This replaces miniconda3/lib/python3.7/site-packages/ray/tune
-    # with your local `ray/python/ray/tune`.
+    # To uninstall, delete the symlinks first.
+    rm -rf <package path>/site-packages/ray # Path will be in the output of `setup-dev.py`.
+    pip uninstall ray # or `pip install -U <wheel>`
 
 Building Ray on Linux & MacOS (full)
 ------------------------------------

--- a/doc/source/getting-involved.rst
+++ b/doc/source/getting-involved.rst
@@ -85,10 +85,17 @@ Even though we have hooks to run unit tests automatically for each pull request,
 we recommend you to run unit tests locally beforehand to reduce reviewers’
 burden and speedup review process.
 
+If you are running tests for the first time, you can install the required dependencies with:
 
 .. code-block:: shell
 
-    pytest ray/python/ray/tests/
+    pip install -r python/requirements.txt
+
+To run all Python tests:
+
+.. code-block:: shell
+
+    pytest python/ray/tests/
 
 Documentation should be documented in `Google style <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html>`__ format.
 
@@ -143,11 +150,13 @@ Lint and Formatting
 .. note:: Python 3.7 is recommended. You will run into flake8 `issues <https://github.com/ray-project/ray/pull/11588>`_ with Python 3.8.
 
 We also have tests for code formatting and linting that need to pass before merge.
-Install ``yapf==0.23, flake8, flake8-quotes``.
 
-* `yapf <https://github.com/google/yapf>`_ version ``0.23.0`` (``pip install yapf==0.23.0``)
-* `flake8 <https://flake8.pycqa.org/en/latest/>`_ version ``3.7.7`` (``pip install flake8==3.7.7``)
-* `flake8-quotes <https://github.com/zheller/flake8-quotes>`_ (``pip install flake8-quotes``)
+* For Python formatting, install the `required dependencies <https://github.com/ray-project/ray/blob/master/python/requirements_linters.txt>`_ first with:
+
+.. code-block:: shell
+
+  pip install -r python/requirements_linters.txt
+
 * If developing for C++, you will need `clang-format <https://www.kernel.org/doc/html/latest/process/clang-format.html>`_ version ``7.0.0`` (download this version of Clang from `here <http://releases.llvm.org/download.html>`_)
 
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -193,12 +193,12 @@ on the AUR page of ``python-ray`` `here`_.
 .. _`yay`: https://aur.archlinux.org/packages/yay
 .. _`here`: https://aur.archlinux.org/packages/python-ray
 
-
+.. _ray_anaconda:
 
 Installing Ray with Anaconda
 ----------------------------
 
-If you use `Anaconda`_ and want to use Ray in a defined environment, e.g, ``ray``, use these commands:
+If you use `Anaconda`_ (`installation instructions`_) and want to use Ray in a defined environment, e.g, ``ray``, use these commands:
 
 .. code-block:: bash
 
@@ -210,6 +210,7 @@ If you use `Anaconda`_ and want to use Ray in a defined environment, e.g, ``ray`
 Use ``pip list`` to confirm that ``ray`` is installed.
 
 .. _`Anaconda`: https://www.anaconda.com/
+.. _`installation instructions`: https://docs.anaconda.com/anaconda/install/index.html
 
 
 


### PR DESCRIPTION
## Why are these changes needed?

Update Ray Docs with easy to follow steps to install pip dependencies where needed.
1. Add `requirements.txt` to **Testing**.
2. Replace (outdated) dependency list in **Lint and Formatting** with `requirements_linters.txt`.

Also cleaned up local development docs slightly.

## Related issue number

Closes #16160

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
