### PR TITLE
[autoscaler] Avoid race in no-updaters logic

### DIFF
--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -681,6 +681,12 @@ class StandardAutoscaler:
             # nodes with pending or failed status:
             if not node_status == STATUS_UP_TO_DATE:
                 continue
+            # This node is up-to-date. If it hasn't had the chance to produce
+            # a heartbeat, fake the heartbeat now (cf. logic for completed node
+            # updaters).
+            ip = self.provider.internal_ip(node_id)
+            if ip not in self.load_metrics.last_heartbeat_time_by_ip:
+                self.load_metrics.mark_active(ip)
             # Heartbeat indicates node is healthy:
             if self.heartbeat_on_time(node_id, now):
                 continue

--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -682,7 +682,7 @@ class StandardAutoscaler:
             if not node_status == STATUS_UP_TO_DATE:
                 continue
             # This node is up-to-date. If it hasn't had the chance to produce
-            # a heartbeat, fake the heartbeat now (cf. logic for completed node
+            # a heartbeat, fake the heartbeat now (see logic for completed node
             # updaters).
             ip = self.provider.internal_ip(node_id)
             if ip not in self.load_metrics.last_heartbeat_time_by_ip:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Follow up to https://github.com/ray-project/ray/pull/17194
Mark newly up-to-date nodes active when not using updaters, mirroring current completed update logic. Avoids termination of newly created nodes.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
