### PR TITLE
[object store refactor 3/n] introduce object_store

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -295,6 +295,7 @@ cc_library(
         ],
     }),
     hdrs = [
+        "src/ray/object_manager/common.h",
         "src/ray/object_manager/plasma/client.h",
         "src/ray/object_manager/plasma/common.h",
         "src/ray/object_manager/plasma/compat.h",
@@ -333,6 +334,7 @@ cc_library(
         "src/ray/object_manager/plasma/create_request_queue.cc",
         "src/ray/object_manager/plasma/dlmalloc.cc",
         "src/ray/object_manager/plasma/eviction_policy.cc",
+        "src/ray/object_manager/plasma/object_store.cc",
         "src/ray/object_manager/plasma/plasma_allocator.cc",
         "src/ray/object_manager/plasma/store.cc",
         "src/ray/object_manager/plasma/store_runner.cc",
@@ -342,6 +344,7 @@ cc_library(
         "src/ray/object_manager/plasma/allocator.h",
         "src/ray/object_manager/plasma/create_request_queue.h",
         "src/ray/object_manager/plasma/eviction_policy.h",
+        "src/ray/object_manager/plasma/object_store.h",
         "src/ray/object_manager/plasma/plasma_allocator.h",
         "src/ray/object_manager/plasma/store.h",
         "src/ray/object_manager/plasma/store_runner.h",
@@ -982,6 +985,20 @@ cc_test(
     deps = [
         ":plasma_store_server_lib",
         "@boost//:filesystem",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "object_store_test",
+    srcs = [
+        "src/ray/object_manager/plasma/test/object_store_test.cc",
+    ],
+    copts = COPTS,
+    deps = [
+        ":plasma_store_server_lib",
+        "@com_google_absl//absl/random",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_googletest//:gtest_main",
     ],

--- a/src/ray/object_manager/common.h
+++ b/src/ray/object_manager/common.h
@@ -18,6 +18,7 @@
 #include <functional>
 
 #include "ray/common/id.h"
+#include "ray/common/status.h"
 
 namespace ray {
 
@@ -45,6 +46,17 @@ struct ObjectInfo {
   int owner_port;
   /// Owner's worker ID.
   WorkerID owner_worker_id;
+
+  int64_t GetObjectSize() const { return data_size + metadata_size; }
+
+  bool operator==(const ObjectInfo &other) const {
+    return ((object_id == other.object_id) && (data_size == other.data_size) &&
+            (metadata_size == other.metadata_size) &&
+            (owner_raylet_id == other.owner_raylet_id) &&
+            (owner_ip_address == other.owner_ip_address) &&
+            (owner_port == other.owner_port) &&
+            (owner_worker_id == other.owner_worker_id));
+  }
 };
 
 // A callback to call when an object is added to the shared memory store.

--- a/src/ray/object_manager/plasma/common.h
+++ b/src/ray/object_manager/plasma/common.h
@@ -24,6 +24,7 @@
 #include <unordered_map>
 
 #include "ray/common/id.h"
+#include "ray/object_manager/common.h"
 #include "ray/object_manager/plasma/compat.h"
 #include "ray/object_manager/plasma/plasma_generated.h"
 #include "ray/util/macros.h"
@@ -78,25 +79,19 @@ struct Allocation {
 
 /// This type is used by the Plasma store. It is here because it is exposed to
 /// the eviction policy.
-struct ObjectTableEntry {
-  ObjectTableEntry(Allocation allocation);
+struct LocalObject {
+  LocalObject(Allocation allocation);
+
+  RAY_DISALLOW_COPY_AND_ASSIGN(LocalObject);
+
+  int64_t GetObjectSize() const { return object_info.GetObjectSize(); }
 
   /// Allocation Info;
   Allocation allocation;
-  /// Size of the object in bytes.
-  int64_t data_size;
-  /// Size of the object metadata in bytes.
-  int64_t metadata_size;
+  /// Ray object info;
+  ray::ObjectInfo object_info;
   /// Number of clients currently using this object.
-  int ref_count;
-  /// Owner's raylet ID.
-  NodeID owner_raylet_id;
-  /// Owner's IP address.
-  std::string owner_ip_address;
-  /// Owner's port.
-  int owner_port;
-  /// Owner's worker ID.
-  WorkerID owner_worker_id;
+  mutable int ref_count;
   /// Unix epoch of when this object was created.
   int64_t create_time;
   /// How long creation of this object took.
@@ -106,8 +101,4 @@ struct ObjectTableEntry {
   /// The source of the object. Used for debugging purposes.
   plasma::flatbuf::ObjectSource source;
 };
-
-/// Mapping from ObjectIDs to information about the object.
-typedef std::unordered_map<ObjectID, std::unique_ptr<ObjectTableEntry>> ObjectTable;
-
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/eviction_policy.cc
+++ b/src/ray/object_manager/plasma/eviction_policy.cc
@@ -90,11 +90,12 @@ int64_t LRUCache::ChooseObjectsToEvict(int64_t num_bytes_required,
   return bytes_evicted;
 }
 
-EvictionPolicy::EvictionPolicy(PlasmaStoreInfo *store_info, const IAllocator &allocator)
+EvictionPolicy::EvictionPolicy(const ObjectStore &object_store,
+                               const IAllocator &allocator)
     : pinned_memory_bytes_(0),
-      store_info_(store_info),
-      allocator_(allocator),
-      cache_("global lru", allocator_.GetFootprintLimit()) {}
+      cache_("global lru", allocator.GetFootprintLimit()),
+      object_store_(object_store),
+      allocator_(allocator) {}
 
 int64_t EvictionPolicy::ChooseObjectsToEvict(int64_t num_bytes_required,
                                              std::vector<ObjectID> *objects_to_evict) {
@@ -146,10 +147,8 @@ void EvictionPolicy::RemoveObject(const ObjectID &object_id) {
 }
 
 int64_t EvictionPolicy::GetObjectSize(const ObjectID &object_id) const {
-  auto entry = store_info_->objects[object_id].get();
-  return entry->data_size + entry->metadata_size;
+  return object_store_.GetObject(object_id)->GetObjectSize();
 }
 
 std::string EvictionPolicy::DebugString() const { return cache_.DebugString(); }
-
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/eviction_policy.h
+++ b/src/ray/object_manager/plasma/eviction_policy.h
@@ -24,9 +24,10 @@
 #include <utility>
 #include <vector>
 
-#include "ray/object_manager/plasma/allocator.h"
 #include "ray/object_manager/plasma/common.h"
+#include "ray/object_manager/plasma/object_store.h"
 #include "ray/object_manager/plasma/plasma.h"
+#include "ray/object_manager/plasma/plasma_allocator.h"
 
 namespace plasma {
 
@@ -95,10 +96,9 @@ class EvictionPolicy {
  public:
   /// Construct an eviction policy.
   ///
-  /// \param store_info Information about the Plasma store that is exposed
-  ///        to the eviction policy.
-  /// \param allocator Memory allocator.
-  explicit EvictionPolicy(PlasmaStoreInfo *store_info, const IAllocator &allocator);
+  /// \param object_store Reference to the object_store
+  /// \param allocator Reference to the allocator
+  EvictionPolicy(const ObjectStore &object_store, const IAllocator &allocator);
 
   /// Destroy an eviction policy.
   virtual ~EvictionPolicy() {}
@@ -172,13 +172,12 @@ class EvictionPolicy {
   /// The number of bytes pinned by applications.
   int64_t pinned_memory_bytes_;
 
-  /// Pointer to the plasma store info.
-  PlasmaStoreInfo *store_info_;
-
-  const IAllocator &allocator_;
-
   /// Datastructure for the LRU cache.
   LRUCache cache_;
+
+  const ObjectStore &object_store_;
+
+  const IAllocator &allocator_;
 };
 
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/object_store.cc
+++ b/src/ray/object_manager/plasma/object_store.cc
@@ -1,0 +1,172 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "ray/object_manager/plasma/object_store.h"
+
+namespace plasma {
+
+ObjectStore::ObjectStore(IAllocator &allocator)
+    : allocator_(allocator), object_table_() {}
+
+const LocalObject *ObjectStore::CreateObject(const ray::ObjectInfo &object_info,
+                                             plasma::flatbuf::ObjectSource source,
+                                             bool fallback_allocate) {
+  RAY_LOG(DEBUG) << "attempting to create object " << object_info.object_id << " size "
+                 << object_info.data_size;
+  RAY_CHECK(object_table_.count(object_info.object_id) == 0)
+      << object_info.object_id << " already exists!";
+  auto object_size = object_info.GetObjectSize();
+  auto allocation = fallback_allocate ? allocator_.FallbackAllocate(object_size)
+                                      : allocator_.Allocate(object_size);
+  if (!allocation.has_value()) {
+    return nullptr;
+  }
+  auto ptr = std::make_unique<LocalObject>(std::move(allocation.value()));
+  auto entry =
+      object_table_.emplace(object_info.object_id, std::move(ptr)).first->second.get();
+  entry->object_info = object_info;
+  entry->state = ObjectState::PLASMA_CREATED;
+  entry->create_time = std::time(nullptr);
+  entry->construct_duration = -1;
+  entry->source = source;
+
+  num_objects_unsealed_++;
+  num_bytes_unsealed_ += entry->GetObjectSize();
+  num_bytes_created_total_ += entry->GetObjectSize();
+  RAY_LOG(DEBUG) << "create object " << object_info.object_id << " succeeded";
+  return entry;
+}
+
+const LocalObject *ObjectStore::GetObject(const ObjectID &object_id) const {
+  auto it = object_table_.find(object_id);
+  if (it == object_table_.end()) {
+    return nullptr;
+  }
+  return it->second.get();
+}
+
+const LocalObject *ObjectStore::SealObject(const ObjectID &object_id) {
+  auto entry = GetMutableObject(object_id);
+  if (entry == nullptr || entry->state == ObjectState::PLASMA_SEALED) {
+    return nullptr;
+  }
+  entry->state = ObjectState::PLASMA_SEALED;
+  entry->construct_duration = std::time(nullptr) - entry->create_time;
+  num_objects_unsealed_--;
+  num_bytes_unsealed_ -= entry->GetObjectSize();
+  return entry;
+}
+
+bool ObjectStore::DeleteObject(const ObjectID &object_id) {
+  auto entry = GetMutableObject(object_id);
+  if (entry == nullptr) {
+    return false;
+  }
+  if (entry->state == ObjectState::PLASMA_CREATED) {
+    num_bytes_unsealed_ -= entry->GetObjectSize();
+    num_objects_unsealed_--;
+  }
+  allocator_.Free(std::move(entry->allocation));
+  object_table_.erase(object_id);
+  return true;
+}
+
+int64_t ObjectStore::GetNumBytesCreatedTotal() const { return num_bytes_created_total_; }
+
+int64_t ObjectStore::GetNumBytesUnsealed() const { return num_bytes_unsealed_; };
+
+int64_t ObjectStore::GetNumObjectsUnsealed() const { return num_objects_unsealed_; };
+
+void ObjectStore::GetDebugDump(std::stringstream &buffer) const {
+  size_t num_objects_spillable = 0;
+  size_t num_bytes_spillable = 0;
+  size_t num_objects_unsealed = 0;
+  size_t num_bytes_unsealed = 0;
+  size_t num_objects_in_use = 0;
+  size_t num_bytes_in_use = 0;
+  size_t num_objects_evictable = 0;
+  size_t num_bytes_evictable = 0;
+
+  size_t num_objects_created_by_worker = 0;
+  size_t num_bytes_created_by_worker = 0;
+  size_t num_objects_restored = 0;
+  size_t num_bytes_restored = 0;
+  size_t num_objects_received = 0;
+  size_t num_bytes_received = 0;
+  size_t num_objects_errored = 0;
+  size_t num_bytes_errored = 0;
+  // TODO(scv119): generate metrics eagerly.
+  for (const auto &obj_entry : object_table_) {
+    const auto &obj = obj_entry.second;
+    if (obj->state == ObjectState::PLASMA_CREATED) {
+      num_objects_unsealed++;
+      num_bytes_unsealed += obj->object_info.data_size;
+    } else if (obj->ref_count == 1 &&
+               obj->source == plasma::flatbuf::ObjectSource::CreatedByWorker) {
+      num_objects_spillable++;
+      num_bytes_spillable += obj->object_info.data_size;
+    } else if (obj->ref_count > 0) {
+      num_objects_in_use++;
+      num_bytes_in_use += obj->object_info.data_size;
+    } else {
+      num_bytes_evictable++;
+      num_bytes_evictable += obj->object_info.data_size;
+    }
+
+    if (obj->source == plasma::flatbuf::ObjectSource::CreatedByWorker) {
+      num_objects_created_by_worker++;
+      num_bytes_created_by_worker += obj->object_info.data_size;
+    } else if (obj->source == plasma::flatbuf::ObjectSource::RestoredFromStorage) {
+      num_objects_restored++;
+      num_bytes_restored += obj->object_info.data_size;
+    } else if (obj->source == plasma::flatbuf::ObjectSource::ReceivedFromRemoteRaylet) {
+      num_objects_received++;
+      num_bytes_received += obj->object_info.data_size;
+    } else if (obj->source == plasma::flatbuf::ObjectSource::ErrorStoredByRaylet) {
+      num_objects_errored++;
+      num_bytes_errored += obj->object_info.data_size;
+    }
+  }
+  buffer << "- objects spillable: " << num_objects_spillable << "\n";
+  buffer << "- bytes spillable: " << num_bytes_spillable << "\n";
+  buffer << "- objects unsealed: " << num_objects_unsealed << "\n";
+  buffer << "- bytes unsealed: " << num_bytes_unsealed << "\n";
+  buffer << "- objects in use: " << num_objects_in_use << "\n";
+  buffer << "- bytes in use: " << num_bytes_in_use << "\n";
+  buffer << "- objects evictable: " << num_objects_evictable << "\n";
+  buffer << "- bytes evictable: " << num_bytes_evictable << "\n";
+  buffer << "\n";
+
+  buffer << "- objects created by worker: " << num_objects_created_by_worker << "\n";
+  buffer << "- bytes created by worker: " << num_bytes_created_by_worker << "\n";
+  buffer << "- objects restored: " << num_objects_restored << "\n";
+  buffer << "- bytes restored: " << num_bytes_restored << "\n";
+  buffer << "- objects received: " << num_objects_received << "\n";
+  buffer << "- bytes received: " << num_bytes_received << "\n";
+  buffer << "- objects errored: " << num_objects_errored << "\n";
+  buffer << "- bytes errored: " << num_bytes_errored << "\n";
+}
+
+LocalObject *ObjectStore::GetMutableObject(const ObjectID &object_id) {
+  auto it = object_table_.find(object_id);
+  if (it == object_table_.end()) {
+    return nullptr;
+  }
+  return it->second.get();
+}
+
+}  // namespace plasma

--- a/src/ray/object_manager/plasma/object_store.h
+++ b/src/ray/object_manager/plasma/object_store.h
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "absl/container/flat_hash_map.h"
+#include "ray/object_manager/plasma/allocator.h"
+#include "ray/object_manager/plasma/common.h"
+#include "ray/object_manager/plasma/plasma.h"
+
+namespace plasma {
+
+// ObjectStore stores objects with unique object id. It uses IAllocator
+// to allocate memory for object creation.
+// ObjectStore is not thread safe.
+class ObjectStore {
+ public:
+  explicit ObjectStore(IAllocator &allocator);
+
+  /// Create a new object given object's info. Caller need to decide
+  /// to use primary allocation or fallback allocation by setting
+  /// fallback_allocate flag.
+  /// NOTE: It ABORT the program if an object with the same id already exists.
+  ///
+  /// \param object_info Plasma object info.
+  /// \param source From where the object is created.
+  /// \param fallback_allocate Whether to use fallback allocation.
+  /// \return
+  ///   - pointer to created object or nullptr when out of space.
+  const LocalObject *CreateObject(const ray::ObjectInfo &object_info,
+                                  plasma::flatbuf::ObjectSource source,
+                                  bool fallback_allocate);
+
+  /// Get object by id.
+  ///
+  /// \param object_id Object ID of the object to be sealed.
+  /// \return
+  ///   - nullptr if such object doesn't exist.
+  ///   - otherwise, pointer to the object.
+  const LocalObject *GetObject(const ObjectID &object_id) const;
+
+  /// Seal created object by id.
+  ///
+  /// \param object_id Object ID of the object to be sealed.
+  /// \return
+  ///   - nulltpr if such object doesn't exist, or the object has already been sealed.
+  ///   - otherise, pointer to the sealed object..
+  const LocalObject *SealObject(const ObjectID &object_id);
+
+  /// Delete an existing object.
+  ///
+  /// \param object_id Object ID of the object to be sealed.
+  /// \return
+  ///   - false if such object doesn't exist.
+  ///   - true if abort successfuly.
+  bool DeleteObject(const ObjectID &object_id);
+
+  int64_t GetNumBytesCreatedTotal() const;
+
+  int64_t GetNumBytesUnsealed() const;
+
+  int64_t GetNumObjectsUnsealed() const;
+
+  void GetDebugDump(std::stringstream &buffer) const;
+
+ private:
+  LocalObject *GetMutableObject(const ObjectID &object_id);
+
+  /// Allocator that allocates memory.
+  IAllocator &allocator_;
+
+  /// Mapping from ObjectIDs to information about the object.
+  absl::flat_hash_map<ObjectID, std::unique_ptr<LocalObject>> object_table_;
+
+  /// Total number of bytes allocated to objects that are created but not yet
+  /// sealed.
+  int64_t num_bytes_unsealed_ = 0;
+
+  /// Number of objects that are created but not sealed.
+  int64_t num_objects_unsealed_ = 0;
+
+  /// A running total of the objects that have ever been created on this node.
+  int64_t num_bytes_created_total_ = 0;
+};
+}  // namespace plasma

--- a/src/ray/object_manager/plasma/plasma.cc
+++ b/src/ray/object_manager/plasma/plasma.cc
@@ -21,16 +21,6 @@
 
 namespace plasma {
 
-ObjectTableEntry::ObjectTableEntry(Allocation allocation)
+LocalObject::LocalObject(Allocation allocation)
     : allocation(std::move(allocation)), ref_count(0) {}
-
-ObjectTableEntry *GetObjectTableEntry(PlasmaStoreInfo *store_info,
-                                      const ObjectID &object_id) {
-  auto it = store_info->objects.find(object_id);
-  if (it == store_info->objects.end()) {
-    return nullptr;
-  }
-  return it->second.get();
-}
-
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/plasma.h
+++ b/src/ray/object_manager/plasma/plasma.h
@@ -64,20 +64,4 @@ enum class ObjectStatus : int {
   /// The object was found.
   OBJECT_FOUND = 1
 };
-
-/// The plasma store information that is exposed to the eviction policy.
-struct PlasmaStoreInfo {
-  /// Objects that are in the Plasma store.
-  ObjectTable objects;
-};
-
-/// Get an entry from the object table and return NULL if the object_id
-/// is not present.
-///
-/// \param store_info The PlasmaStoreInfo that contains the object table.
-/// \param object_id The object_id of the entry we are looking for.
-/// \return The entry associated with the object_id or NULL if the object_id
-///         is not present.
-ObjectTableEntry *GetObjectTableEntry(PlasmaStoreInfo *store_info,
-                                      const ObjectID &object_id);
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/plasma_allocator.cc
+++ b/src/ray/object_manager/plasma/plasma_allocator.cc
@@ -89,7 +89,7 @@ PlasmaAllocator::PlasmaAllocator(const std::string &plasma_directory,
       << "PlasmaAllocator initialization failed."
       << " It's likely we don't have enought space in " << plasma_directory;
   // This will unmap the file, but the next one created will be as large
-  // as this one (this is an implementation internal of dlmalloc).
+  // as this one (this is an implementation detail of dlmalloc).
   Free(std::move(allocation.value()));
 }
 

--- a/src/ray/object_manager/plasma/protocol.cc
+++ b/src/ray/object_manager/plasma/protocol.cc
@@ -201,21 +201,18 @@ Status SendCreateRequest(const std::shared_ptr<StoreConn> &store_conn, ObjectID 
   return PlasmaSend(store_conn, MessageType::PlasmaCreateRequest, &fbb, message);
 }
 
-void ReadCreateRequest(uint8_t *data, size_t size, ObjectID *object_id,
-                       NodeID *owner_raylet_id, std::string *owner_ip_address,
-                       int *owner_port, WorkerID *owner_worker_id, int64_t *data_size,
-                       int64_t *metadata_size, flatbuf::ObjectSource *source,
-                       int *device_num) {
+void ReadCreateRequest(uint8_t *data, size_t size, ray::ObjectInfo *object_info,
+                       flatbuf::ObjectSource *source, int *device_num) {
   RAY_DCHECK(data);
   auto message = flatbuffers::GetRoot<fb::PlasmaCreateRequest>(data);
   RAY_DCHECK(VerifyFlatbuffer(message, data, size));
-  *data_size = message->data_size();
-  *metadata_size = message->metadata_size();
-  *object_id = ObjectID::FromBinary(message->object_id()->str());
-  *owner_raylet_id = NodeID::FromBinary(message->owner_raylet_id()->str());
-  *owner_ip_address = message->owner_ip_address()->str();
-  *owner_port = message->owner_port();
-  *owner_worker_id = WorkerID::FromBinary(message->owner_worker_id()->str());
+  object_info->data_size = message->data_size();
+  object_info->metadata_size = message->metadata_size();
+  object_info->object_id = ObjectID::FromBinary(message->object_id()->str());
+  object_info->owner_raylet_id = NodeID::FromBinary(message->owner_raylet_id()->str());
+  object_info->owner_ip_address = message->owner_ip_address()->str();
+  object_info->owner_port = message->owner_port();
+  object_info->owner_worker_id = WorkerID::FromBinary(message->owner_worker_id()->str());
   *source = message->source();
   *device_num = message->device_num();
   return;

--- a/src/ray/object_manager/plasma/protocol.h
+++ b/src/ray/object_manager/plasma/protocol.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "ray/common/status.h"
+#include "ray/object_manager/common.h"
 #include "ray/object_manager/plasma/plasma.h"
 #include "ray/object_manager/plasma/plasma_generated.h"
 #include "src/ray/protobuf/common.pb.h"
@@ -81,11 +82,8 @@ Status SendCreateRequest(const std::shared_ptr<StoreConn> &store_conn, ObjectID 
                          int64_t metadata_size, flatbuf::ObjectSource source,
                          int device_num, bool try_immediately);
 
-void ReadCreateRequest(uint8_t *data, size_t size, ObjectID *object_id,
-                       NodeID *owner_raylet_id, std::string *owner_ip_address,
-                       int *owner_port, WorkerID *owner_worker_id, int64_t *data_size,
-                       int64_t *metadata_size, flatbuf::ObjectSource *source,
-                       int *device_num);
+void ReadCreateRequest(uint8_t *data, size_t size, ray::ObjectInfo *object_info,
+                       flatbuf::ObjectSource *source, int *device_num);
 
 Status SendUnfinishedCreateReply(const std::shared_ptr<Client> &client,
                                  ObjectID object_id, uint64_t retry_with_request_id);

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -65,19 +65,18 @@ ray::ObjectID GetCreateRequestObjectId(const std::vector<uint8_t> &message) {
   return ray::ObjectID::FromBinary(request->object_id()->str());
 }
 
-void ToPlasmaObject(const ObjectTableEntry &entry, PlasmaObject *object,
-                    bool check_sealed) {
+void ToPlasmaObject(const LocalObject &entry, PlasmaObject *object, bool check_sealed) {
   RAY_DCHECK(object != nullptr);
   if (check_sealed) {
     RAY_DCHECK(entry.state == ObjectState::PLASMA_SEALED);
   }
   object->store_fd = entry.allocation.fd;
   object->data_offset = entry.allocation.offset;
-  object->metadata_offset = entry.allocation.offset + entry.data_size;
+  object->metadata_offset = entry.allocation.offset + entry.object_info.data_size;
+  object->data_size = entry.object_info.data_size;
+  object->metadata_size = entry.object_info.metadata_size;
   object->device_num = entry.allocation.device_num;
   object->mmap_size = entry.allocation.mmap_size;
-  object->data_size = entry.data_size;
-  object->metadata_size = entry.metadata_size;
 }
 }  // namespace
 
@@ -156,7 +155,8 @@ PlasmaStore::PlasmaStore(instrumented_io_context &main_service, IAllocator &allo
       acceptor_(main_service, ParseUrlEndpoint(socket_name)),
       socket_(main_service),
       allocator_(allocator),
-      eviction_policy_(&store_info_, allocator_),
+      object_store_(allocator_),
+      eviction_policy_(object_store_, allocator_),
       spill_objects_callback_(spill_objects_callback),
       add_object_callback_(add_object_callback),
       delete_object_callback_(delete_object_callback),
@@ -189,7 +189,8 @@ void PlasmaStore::Stop() { acceptor_.close(); }
 
 // If this client is not already using the object, add the client to the
 // object's list of clients, otherwise do nothing.
-void PlasmaStore::AddToClientObjectIds(const ObjectID &object_id, ObjectTableEntry *entry,
+void PlasmaStore::AddToClientObjectIds(const ObjectID &object_id,
+                                       const LocalObject *entry,
                                        const std::shared_ptr<Client> &client) {
   // Check if this client is already using the object.
   if (client->object_ids.find(object_id) != client->object_ids.end()) {
@@ -200,7 +201,7 @@ void PlasmaStore::AddToClientObjectIds(const ObjectID &object_id, ObjectTableEnt
   if (entry->ref_count == 0) {
     // Tell the eviction policy that this object is being used.
     eviction_policy_.BeginObjectAccess(object_id);
-    num_bytes_in_use_ += entry->data_size + entry->metadata_size;
+    num_bytes_in_use_ += entry->GetObjectSize();
   }
   // Increase reference count.
   entry->ref_count++;
@@ -211,68 +212,52 @@ void PlasmaStore::AddToClientObjectIds(const ObjectID &object_id, ObjectTableEnt
   client->object_ids.insert(object_id);
 }
 
-// Allocate memory
-absl::optional<Allocation> PlasmaStore::AllocateMemory(size_t size, bool is_create,
-                                                       bool fallback_allocator,
-                                                       PlasmaError *error) {
+const LocalObject *PlasmaStore::CreateObjectInternal(const ray::ObjectInfo &object_info,
+                                                     plasma::flatbuf::ObjectSource source,
+                                                     bool allow_fallback_allocation) {
   // Try to evict objects until there is enough space.
-  absl::optional<Allocation> allocation;
-  int num_tries = 0;
-  while (true) {
-    allocation = allocator_.Allocate(size);
-    if (allocation.has_value()) {
-      // If we manage to allocate the memory, return the pointer.
-      *error = PlasmaError::OK;
-      break;
+  // NOTE(ekl) if we can't achieve this after a number of retries, it's
+  // because memory fragmentation in dlmalloc prevents us from allocating
+  // even if our footprint tracker here still says we have free space.
+  for (int num_tries = 0; num_tries <= 10; num_tries++) {
+    auto result =
+        object_store_.CreateObject(object_info, source, /*fallback_allocate*/ false);
+    if (result != nullptr) {
+      return result;
     }
     // Tell the eviction policy how much space we need to create this object.
     std::vector<ObjectID> objects_to_evict;
-    int64_t space_needed = eviction_policy_.RequireSpace(size, &objects_to_evict);
+    int64_t space_needed =
+        eviction_policy_.RequireSpace(object_info.GetObjectSize(), &objects_to_evict);
     EvictObjects(objects_to_evict);
     // More space is still needed.
     if (space_needed > 0) {
-      RAY_LOG(DEBUG) << "attempt to allocate " << size << " failed, need "
-                     << space_needed;
-      *error = PlasmaError::OutOfMemory;
-      break;
-    }
-
-    // NOTE(ekl) if we can't achieve this after a number of retries, it's
-    // because memory fragmentation in dlmalloc prevents us from allocating
-    // even if our footprint tracker here still says we have free space.
-    if (num_tries++ > 10) {
-      *error = PlasmaError::OutOfMemory;
+      RAY_LOG(DEBUG) << "attempt to allocate " << object_info.GetObjectSize()
+                     << " failed, need " << space_needed;
       break;
     }
   }
 
-  // Fallback to allocating from the filesystem.
-  if (!allocation.has_value() && RayConfig::instance().plasma_unlimited() &&
-      fallback_allocator) {
-    RAY_LOG(INFO)
-        << "Shared memory store full, falling back to allocating from filesystem: "
-        << size;
-    allocation = allocator_.FallbackAllocate(size);
-    if (!allocation.has_value()) {
-      RAY_LOG(ERROR) << "Plasma fallback allocator failed, likely out of disk space.";
-    }
-  } else if (!fallback_allocator) {
+  if (!RayConfig::instance().plasma_unlimited()) {
+    RAY_LOG(DEBUG) << "Fallback allocation is not enabled.";
+    return nullptr;
+  }
+  if (!allow_fallback_allocation) {
     RAY_LOG(DEBUG) << "Fallback allocation not enabled for this request.";
+    return nullptr;
   }
 
-  if (allocation.has_value()) {
-    RAY_CHECK(allocation->fd.first != INVALID_FD);
-    RAY_CHECK(allocation->fd.second != INVALID_UNIQUE_FD_ID);
-    *error = PlasmaError::OK;
-  }
+  RAY_LOG(INFO)
+      << "Shared memory store full, falling back to allocating from filesystem: "
+      << object_info.GetObjectSize();
 
-  auto now = absl::GetCurrentTimeNanos();
-  if (now - last_usage_log_ns_ > usage_log_interval_ns_) {
-    RAY_LOG(INFO) << "Object store current usage " << (allocator_.Allocated() / 1e9)
-                  << " / " << (allocator_.GetFootprintLimit() / 1e9) << " GB.";
-    last_usage_log_ns_ = now;
+  auto result =
+      object_store_.CreateObject(object_info, source, /*fallback_allocate*/ true);
+
+  if (result == nullptr) {
+    RAY_LOG(ERROR) << "Plasma fallback allocator failed, likely out of disk space.";
   }
-  return allocation;
+  return result;
 }
 
 PlasmaError PlasmaStore::HandleCreateObjectRequest(const std::shared_ptr<Client> &client,
@@ -282,25 +267,21 @@ PlasmaError PlasmaStore::HandleCreateObjectRequest(const std::shared_ptr<Client>
                                                    bool *spilling_required) {
   uint8_t *input = (uint8_t *)message.data();
   size_t input_size = message.size();
-  ObjectID object_id;
-
-  NodeID owner_raylet_id;
-  std::string owner_ip_address;
-  int owner_port;
-  WorkerID owner_worker_id;
-  int64_t data_size;
-  int64_t metadata_size;
+  ray::ObjectInfo object_info;
   fb::ObjectSource source;
   int device_num;
-  ReadCreateRequest(input, input_size, &object_id, &owner_raylet_id, &owner_ip_address,
-                    &owner_port, &owner_worker_id, &data_size, &metadata_size, &source,
-                    &device_num);
-  auto error = CreateObject(object_id, owner_raylet_id, owner_ip_address, owner_port,
-                            owner_worker_id, data_size, metadata_size, source, device_num,
-                            client, fallback_allocator, object);
+  ReadCreateRequest(input, input_size, &object_info, &source, &device_num);
+
+  if (device_num != 0) {
+    RAY_LOG(ERROR) << "device_num != 0 but CUDA not enabled";
+    return PlasmaError::OutOfMemory;
+  }
+
+  auto error = CreateObject(object_info, source, client, fallback_allocator, object);
   if (error == PlasmaError::OutOfMemory) {
-    RAY_LOG(DEBUG) << "Not enough memory to create the object " << object_id
-                   << ", data_size=" << data_size << ", metadata_size=" << metadata_size;
+    RAY_LOG(DEBUG) << "Not enough memory to create the object " << object_info.object_id
+                   << ", data_size=" << object_info.data_size
+                   << ", metadata_size=" << object_info.metadata_size;
   }
 
   // Trigger object spilling if current usage is above the specified threshold.
@@ -320,64 +301,39 @@ PlasmaError PlasmaStore::HandleCreateObjectRequest(const std::shared_ptr<Client>
   return error;
 }
 
-PlasmaError PlasmaStore::CreateObject(const ObjectID &object_id,
-                                      const NodeID &owner_raylet_id,
-                                      const std::string &owner_ip_address, int owner_port,
-                                      const WorkerID &owner_worker_id, int64_t data_size,
-                                      int64_t metadata_size, fb::ObjectSource source,
-                                      int device_num,
+PlasmaError PlasmaStore::CreateObject(const ray::ObjectInfo &object_info,
+                                      fb::ObjectSource source,
                                       const std::shared_ptr<Client> &client,
                                       bool fallback_allocator, PlasmaObject *result) {
-  RAY_LOG(DEBUG) << "attempting to create object " << object_id << " size " << data_size;
+  RAY_LOG(DEBUG) << "attempting to create object " << object_info.object_id << " size "
+                 << object_info.data_size;
 
-  auto entry = GetObjectTableEntry(&store_info_, object_id);
-  if (entry != nullptr) {
-    // There is already an object with the same ID in the Plasma Store, so
-    // ignore this request.
+  if (object_store_.GetObject(object_info.object_id) != nullptr) {
     return PlasmaError::ObjectExists;
   }
-
-  auto total_size = data_size + metadata_size;
-
-  if (device_num != 0) {
-    RAY_LOG(ERROR) << "device_num != 0 but CUDA not enabled";
+  auto entry = CreateObjectInternal(object_info, source, fallback_allocator);
+  {
+    // TODO(scv119) use RAY_LOG_EVERY_MS
+    auto now = absl::GetCurrentTimeNanos();
+    if (now - last_usage_log_ns_ > usage_log_interval_ns_) {
+      RAY_LOG(INFO) << "Object store current usage " << (allocator_.Allocated() / 1e9)
+                    << " / " << (allocator_.GetFootprintLimit() / 1e9) << " GB.";
+      last_usage_log_ns_ = now;
+    }
+  }
+  if (entry == nullptr) {
     return PlasmaError::OutOfMemory;
   }
 
-  PlasmaError error = PlasmaError::OK;
-  auto allocation = AllocateMemory(total_size,
-                                   /*is_create=*/true, fallback_allocator, &error);
-  if (!allocation.has_value()) {
-    return error;
-  }
-
-  RAY_LOG(DEBUG) << "create object " << object_id << " succeeded";
-  auto object_table_entry =
-      std::make_unique<ObjectTableEntry>(std::move(allocation.value()));
-  entry = store_info_.objects.emplace(object_id, std::move(object_table_entry))
-              .first->second.get();
-  entry->data_size = data_size;
-  entry->metadata_size = metadata_size;
-  entry->state = ObjectState::PLASMA_CREATED;
-  entry->owner_raylet_id = owner_raylet_id;
-  entry->owner_ip_address = owner_ip_address;
-  entry->owner_port = owner_port;
-  entry->owner_worker_id = owner_worker_id;
-  entry->create_time = std::time(nullptr);
-  entry->construct_duration = -1;
-  entry->source = source;
-
+  RAY_LOG(DEBUG) << "create object " << object_info.object_id << " succeeded";
   ToPlasmaObject(*entry, result, /* check sealed */ false);
 
   // Notify the eviction policy that this object was created. This must be done
   // immediately before the call to AddToClientObjectIds so that the
   // eviction policy does not have an opportunity to evict the object.
-  eviction_policy_.ObjectCreated(object_id, true);
+  eviction_policy_.ObjectCreated(object_info.object_id, true);
   // Record that this client is using this object.
-  AddToClientObjectIds(object_id, store_info_.objects[object_id].get(), client);
-  num_objects_unsealed_++;
-  num_bytes_unsealed_ += data_size + metadata_size;
-  num_bytes_created_total_ += data_size + metadata_size;
+  AddToClientObjectIds(object_info.object_id, entry, client);
   return PlasmaError::OK;
 }
 
@@ -485,7 +441,7 @@ void PlasmaStore::UpdateObjectGetRequests(const ObjectID &object_id) {
   size_t num_requests = get_requests.size();
   for (size_t i = 0; i < num_requests; ++i) {
     auto get_req = get_requests[index];
-    auto entry = GetObjectTableEntry(&store_info_, object_id);
+    auto entry = object_store_.GetObject(object_id);
     RAY_CHECK(entry != nullptr);
     ToPlasmaObject(*entry, &get_req->objects[object_id], /* check sealed */ true);
     get_req->num_satisfied += 1;
@@ -522,7 +478,7 @@ void PlasmaStore::ProcessGetRequest(const std::shared_ptr<Client> &client,
   for (auto object_id : object_ids) {
     // Check if this object is already present
     // locally. If so, record that the object is being used and mark it as accounted for.
-    auto entry = GetObjectTableEntry(&store_info_, object_id);
+    auto entry = object_store_.GetObject(object_id);
     if (entry && entry->state == ObjectState::PLASMA_SEALED) {
       // Update the get request to take into account the present object.
       ToPlasmaObject(*entry, &get_req->objects[object_id], /* checksealed */ true);
@@ -557,7 +513,7 @@ void PlasmaStore::ProcessGetRequest(const std::shared_ptr<Client> &client,
 }
 
 int PlasmaStore::RemoveFromClientObjectIds(const ObjectID &object_id,
-                                           ObjectTableEntry *entry,
+                                           const LocalObject *entry,
                                            const std::shared_ptr<Client> &client) {
   auto it = client->object_ids.find(object_id);
   if (it != client->object_ids.end()) {
@@ -569,7 +525,7 @@ int PlasmaStore::RemoveFromClientObjectIds(const ObjectID &object_id,
     // If no more clients are using this object, notify the eviction policy
     // that the object is no longer being used.
     if (entry->ref_count == 0) {
-      num_bytes_in_use_ -= entry->data_size + entry->metadata_size;
+      num_bytes_in_use_ -= entry->GetObjectSize();
       RAY_LOG(DEBUG) << "Releasing object no longer in use " << object_id
                      << ", num bytes in use is now " << num_bytes_in_use_;
       if (deletion_cache_.count(object_id) == 0) {
@@ -591,34 +547,29 @@ int PlasmaStore::RemoveFromClientObjectIds(const ObjectID &object_id,
 }
 
 void PlasmaStore::EraseFromObjectTable(const ObjectID &object_id) {
-  auto object = GetObjectTableEntry(&store_info_, object_id);
+  auto object = object_store_.GetObject(object_id);
   if (object == nullptr) {
     RAY_LOG(WARNING) << object_id << " has already been deleted.";
     return;
   }
-  auto buff_size = object->data_size + object->metadata_size;
-  if (object->allocation.device_num == 0) {
-    RAY_LOG(DEBUG) << "Erasing object: " << object_id
-                   << ", address: " << static_cast<void *>(object->allocation.address)
-                   << ", size:" << buff_size;
-    allocator_.Free(std::move(object->allocation));
-  }
-  if (object->state == ObjectState::PLASMA_CREATED) {
-    num_bytes_unsealed_ -= object->data_size + object->metadata_size;
-    num_objects_unsealed_--;
-  }
+  RAY_CHECK(object->allocation.device_num == 0)
+      << object_id << "'s device_num is " << object->allocation.device_num
+      << "but CUDA not enabled";
+  RAY_LOG(DEBUG) << "Erasing object: " << object_id
+                 << ", address: " << static_cast<void *>(object->allocation.address)
+                 << ", size:" << object->GetObjectSize();
   if (object->ref_count > 0) {
     // A client was using this object.
-    num_bytes_in_use_ -= object->data_size + object->metadata_size;
+    num_bytes_in_use_ -= object->GetObjectSize();
     RAY_LOG(DEBUG) << "Erasing object " << object_id << " with nonzero ref count"
                    << object_id << ", num bytes in use is now " << num_bytes_in_use_;
   }
-  store_info_.objects.erase(object_id);
+  object_store_.DeleteObject(object_id);
 }
 
 void PlasmaStore::ReleaseObject(const ObjectID &object_id,
                                 const std::shared_ptr<Client> &client) {
-  auto entry = GetObjectTableEntry(&store_info_, object_id);
+  auto entry = object_store_.GetObject(object_id);
   RAY_CHECK(entry != nullptr);
   // Remove the client from the object's array of clients.
   RAY_CHECK(RemoveFromClientObjectIds(object_id, entry, client) == 1);
@@ -626,7 +577,7 @@ void PlasmaStore::ReleaseObject(const ObjectID &object_id,
 
 // Check if an object is present.
 ObjectStatus PlasmaStore::ContainsObject(const ObjectID &object_id) {
-  auto entry = GetObjectTableEntry(&store_info_, object_id);
+  auto entry = object_store_.GetObject(object_id);
   return entry && entry->state == ObjectState::PLASMA_SEALED
              ? ObjectStatus::OBJECT_FOUND
              : ObjectStatus::OBJECT_NOT_FOUND;
@@ -635,26 +586,9 @@ ObjectStatus PlasmaStore::ContainsObject(const ObjectID &object_id) {
 void PlasmaStore::SealObjects(const std::vector<ObjectID> &object_ids) {
   for (size_t i = 0; i < object_ids.size(); ++i) {
     RAY_LOG(DEBUG) << "sealing object " << object_ids[i];
-    auto entry = GetObjectTableEntry(&store_info_, object_ids[i]);
-    RAY_CHECK(entry != nullptr);
-    RAY_CHECK(entry->state == ObjectState::PLASMA_CREATED);
-    // Set the state of object to SEALED.
-    entry->state = ObjectState::PLASMA_SEALED;
-    // Set object construction duration.
-    entry->construct_duration = std::time(nullptr) - entry->create_time;
-
-    num_objects_unsealed_--;
-    num_bytes_unsealed_ -= entry->data_size + entry->metadata_size;
-
-    ray::ObjectInfo info;
-    info.object_id = object_ids[i];
-    info.data_size = entry->data_size;
-    info.metadata_size = entry->metadata_size;
-    info.owner_raylet_id = entry->owner_raylet_id;
-    info.owner_ip_address = entry->owner_ip_address;
-    info.owner_port = entry->owner_port;
-    info.owner_worker_id = entry->owner_worker_id;
-    add_object_callback_(info);
+    auto entry = object_store_.SealObject(object_ids[i]);
+    RAY_CHECK(entry) << object_ids[i] << " doesn't exist or has already been sealed.";
+    add_object_callback_(entry->object_info);
   }
 
   for (size_t i = 0; i < object_ids.size(); ++i) {
@@ -664,7 +598,7 @@ void PlasmaStore::SealObjects(const std::vector<ObjectID> &object_ids) {
 
 int PlasmaStore::AbortObject(const ObjectID &object_id,
                              const std::shared_ptr<Client> &client) {
-  auto entry = GetObjectTableEntry(&store_info_, object_id);
+  auto entry = object_store_.GetObject(object_id);
   RAY_CHECK(entry != nullptr) << "To abort an object it must be in the object table.";
   RAY_CHECK(entry->state != ObjectState::PLASMA_SEALED)
       << "To abort an object it must not have been sealed.";
@@ -682,7 +616,7 @@ int PlasmaStore::AbortObject(const ObjectID &object_id,
 }
 
 PlasmaError PlasmaStore::DeleteObject(ObjectID &object_id) {
-  auto entry = GetObjectTableEntry(&store_info_, object_id);
+  auto entry = object_store_.GetObject(object_id);
   // TODO(rkn): This should probably not fail, but should instead throw an
   // error. Maybe we should also support deleting objects that have been
   // created but not sealed.
@@ -715,7 +649,7 @@ PlasmaError PlasmaStore::DeleteObject(ObjectID &object_id) {
 void PlasmaStore::EvictObjects(const std::vector<ObjectID> &object_ids) {
   for (const auto &object_id : object_ids) {
     RAY_LOG(DEBUG) << "evicting object " << object_id.Hex();
-    auto entry = GetObjectTableEntry(&store_info_, object_id);
+    auto entry = object_store_.GetObject(object_id);
     // TODO(rkn): This should probably not fail, but should instead throw an
     // error. Maybe we should also support deleting objects that have been
     // created but not sealed.
@@ -745,17 +679,17 @@ void PlasmaStore::DisconnectClient(const std::shared_ptr<Client> &client) {
   client->Close();
   RAY_LOG(DEBUG) << "Disconnecting client on fd " << client;
   // Release all the objects that the client was using.
-  std::unordered_map<ObjectID, ObjectTableEntry *> sealed_objects;
+  std::unordered_map<ObjectID, const LocalObject *> sealed_objects;
   for (const auto &object_id : client->object_ids) {
-    auto it = store_info_.objects.find(object_id);
-    if (it == store_info_.objects.end()) {
+    auto entry = object_store_.GetObject(object_id);
+    if (entry == nullptr) {
       continue;
     }
 
-    if (it->second->state == ObjectState::PLASMA_SEALED) {
+    if (entry->state == ObjectState::PLASMA_SEALED) {
       // Add sealed objects to a temporary list of object IDs. Do not perform
       // the remove here, since it potentially modifies the object_ids table.
-      sealed_objects[it->first] = it->second.get();
+      sealed_objects[object_id] = entry;
     } else {
       // Abort unsealed object.
       // Don't call AbortObject() because client->object_ids would be modified.
@@ -958,7 +892,7 @@ bool PlasmaStore::IsObjectSpillable(const ObjectID &object_id) {
   // The lock is acquired when a request is received to the plasma store.
   // recursive mutex is used here to allow
   std::lock_guard<std::recursive_mutex> guard(mutex_);
-  auto entry = GetObjectTableEntry(&store_info_, object_id);
+  auto entry = object_store_.GetObject(object_id);
   return entry->ref_count == 1;
 }
 
@@ -972,81 +906,16 @@ void PlasmaStore::PrintDebugDump() const {
 std::string PlasmaStore::GetDebugDump() const {
   // TODO(swang): We might want to optimize this if it gets called more often.
   std::stringstream buffer;
-
   buffer << "========== Plasma store: =================\n";
-  size_t num_objects_spillable = 0;
-  size_t num_bytes_spillable = 0;
-  size_t num_objects_unsealed = 0;
-  size_t num_bytes_unsealed = 0;
-  size_t num_objects_in_use = 0;
-  size_t num_bytes_in_use = 0;
-  size_t num_objects_evictable = 0;
-  size_t num_bytes_evictable = 0;
-
-  size_t num_objects_created_by_worker = 0;
-  size_t num_bytes_created_by_worker = 0;
-  size_t num_objects_restored = 0;
-  size_t num_bytes_restored = 0;
-  size_t num_objects_received = 0;
-  size_t num_bytes_received = 0;
-  size_t num_objects_errored = 0;
-  size_t num_bytes_errored = 0;
-  for (const auto &obj_entry : store_info_.objects) {
-    const auto &obj = obj_entry.second;
-    if (obj->state == ObjectState::PLASMA_CREATED) {
-      num_objects_unsealed++;
-      num_bytes_unsealed += obj->data_size;
-    } else if (obj->ref_count == 1 && obj->source == fb::ObjectSource::CreatedByWorker) {
-      num_objects_spillable++;
-      num_bytes_spillable += obj->data_size;
-    } else if (obj->ref_count > 0) {
-      num_objects_in_use++;
-      num_bytes_in_use += obj->data_size;
-    } else {
-      num_bytes_evictable++;
-      num_bytes_evictable += obj->data_size;
-    }
-
-    if (obj->source == fb::ObjectSource::CreatedByWorker) {
-      num_objects_created_by_worker++;
-      num_bytes_created_by_worker += obj->data_size;
-    } else if (obj->source == fb::ObjectSource::RestoredFromStorage) {
-      num_objects_restored++;
-      num_bytes_restored += obj->data_size;
-    } else if (obj->source == fb::ObjectSource::ReceivedFromRemoteRaylet) {
-      num_objects_received++;
-      num_bytes_received += obj->data_size;
-    } else if (obj->source == fb::ObjectSource::ErrorStoredByRaylet) {
-      num_objects_errored++;
-      num_bytes_errored += obj->data_size;
-    }
-  }
-
   buffer << "Current usage: " << (allocator_.Allocated() / 1e9) << " / "
          << (allocator_.GetFootprintLimit() / 1e9) << " GB\n";
-  buffer << "- num bytes created total: " << num_bytes_created_total_ << "\n";
+  buffer << "- num bytes created total: " << object_store_.GetNumBytesCreatedTotal()
+         << "\n";
   auto num_pending_requests = create_request_queue_.NumPendingRequests();
   auto num_pending_bytes = create_request_queue_.NumPendingBytes();
   buffer << num_pending_requests << " pending objects of total size "
          << num_pending_bytes / 1024 / 1024 << "MB\n";
-  buffer << "- objects spillable: " << num_objects_spillable << "\n";
-  buffer << "- bytes spillable: " << num_bytes_spillable << "\n";
-  buffer << "- objects unsealed: " << num_objects_unsealed << "\n";
-  buffer << "- bytes unsealed: " << num_bytes_unsealed << "\n";
-  buffer << "- objects in use: " << num_objects_in_use << "\n";
-  buffer << "- bytes in use: " << num_bytes_in_use << "\n";
-  buffer << "- objects evictable: " << num_objects_evictable << "\n";
-  buffer << "- bytes evictable: " << num_bytes_evictable << "\n";
-  buffer << "\n";
-
-  buffer << "- objects created by worker: " << num_objects_created_by_worker << "\n";
-  buffer << "- bytes created by worker: " << num_bytes_created_by_worker << "\n";
-  buffer << "- objects restored: " << num_objects_restored << "\n";
-  buffer << "- bytes restored: " << num_bytes_restored << "\n";
-  buffer << "- objects received: " << num_objects_received << "\n";
-  buffer << "- bytes received: " << num_bytes_received << "\n";
-  buffer << "- objects errored: " << num_objects_errored << "\n";
-  buffer << "- bytes errored: " << num_bytes_errored << "\n";
+  object_store_.GetDebugDump(buffer);
   return buffer.str();
 }
 

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -32,6 +32,7 @@
 #include "ray/object_manager/plasma/connection.h"
 #include "ray/object_manager/plasma/create_request_queue.h"
 #include "ray/object_manager/plasma/eviction_policy.h"
+#include "ray/object_manager/plasma/object_store.h"
 #include "ray/object_manager/plasma/plasma.h"
 #include "ray/object_manager/plasma/plasma_allocator.h"
 #include "ray/object_manager/plasma/protocol.h"
@@ -70,18 +71,7 @@ class PlasmaStore {
   /// Create a new object. The client must do a call to release_object to tell
   /// the store when it is done with the object.
   ///
-  /// \param object_id Object ID of the object to be created.
-  /// \param owner_raylet_id Raylet ID of the object's owner.
-  /// \param owner_ip_address IP address of the object's owner.
-  /// \param owner_port Port of the object's owner.
-  /// \param owner_worker_id Worker ID of the object's owner.
-  /// \param data_size Size in bytes of the object to be created.
-  /// \param metadata_size Size in bytes of the object metadata.
-  /// \param device_num The number of the device where the object is being
-  ///        created.
-  ///        device_num = 0 corresponds to the host,
-  ///        device_num = 1 corresponds to GPU0,
-  ///        device_num = 2 corresponds to GPU1, etc.
+  /// \param object_info Ray object info.
   /// \param client The client that created the object.
   /// \param fallback_allocator Whether to allow falling back to the fs allocator
   /// \param result The object that has been created.
@@ -93,12 +83,10 @@ class PlasmaStore {
   ///  - PlasmaError::OutOfMemory, if the store is out of memory and
   ///    cannot create the object. In this case, the client should not call
   ///    plasma_release.
-  PlasmaError CreateObject(const ObjectID &object_id, const NodeID &owner_raylet_id,
-                           const std::string &owner_ip_address, int owner_port,
-                           const WorkerID &owner_worker_id, int64_t data_size,
-                           int64_t metadata_size, plasma::flatbuf::ObjectSource source,
-                           int device_num, const std::shared_ptr<Client> &client,
-                           bool fallback_allocator, PlasmaObject *result);
+  PlasmaError CreateObject(const ray::ObjectInfo &object_info,
+                           plasma::flatbuf::ObjectSource source,
+                           const std::shared_ptr<Client> &client, bool fallback_allocator,
+                           PlasmaObject *result);
 
   /// Abort a created but unsealed object. If the client is not the
   /// creator, then the abort will fail.
@@ -188,15 +176,17 @@ class PlasmaStore {
   /// Get the available memory for new objects to be created. This includes
   /// memory that is currently being used for created but unsealed objects.
   void GetAvailableMemory(std::function<void(size_t)> callback) const {
-    RAY_CHECK((num_bytes_unsealed_ > 0 && num_objects_unsealed_ > 0) ||
-              (num_bytes_unsealed_ == 0 && num_objects_unsealed_ == 0))
+    RAY_CHECK((object_store_.GetNumBytesUnsealed() > 0 &&
+               object_store_.GetNumObjectsUnsealed() > 0) ||
+              (object_store_.GetNumBytesUnsealed() == 0 &&
+               object_store_.GetNumObjectsUnsealed() == 0))
         << "Tracking for available memory in the plasma store has gone out of sync. "
            "Please file a GitHub issue.";
-    RAY_CHECK(num_bytes_in_use_ >= num_bytes_unsealed_);
+    RAY_CHECK(num_bytes_in_use_ >= object_store_.GetNumBytesUnsealed());
     // We do not count unsealed objects as in use because these may have been
     // created by the object manager.
     int64_t num_bytes_in_use =
-        static_cast<int64_t>(num_bytes_in_use_ - num_bytes_unsealed_);
+        static_cast<int64_t>(num_bytes_in_use_ - object_store_.GetNumBytesUnsealed());
     if (!RayConfig::instance().plasma_unlimited()) {
       RAY_CHECK(allocator_.GetFootprintLimit() >= num_bytes_in_use);
     }
@@ -222,7 +212,7 @@ class PlasmaStore {
   void ReplyToCreateClient(const std::shared_ptr<Client> &client,
                            const ObjectID &object_id, uint64_t req_id);
 
-  void AddToClientObjectIds(const ObjectID &object_id, ObjectTableEntry *entry,
+  void AddToClientObjectIds(const ObjectID &object_id, const LocalObject *entry,
                             const std::shared_ptr<Client> &client);
 
   /// Remove a GetRequest and clean up the relevant data structures.
@@ -239,13 +229,14 @@ class PlasmaStore {
 
   void UpdateObjectGetRequests(const ObjectID &object_id);
 
-  int RemoveFromClientObjectIds(const ObjectID &object_id, ObjectTableEntry *entry,
+  int RemoveFromClientObjectIds(const ObjectID &object_id, const LocalObject *entry,
                                 const std::shared_ptr<Client> &client);
 
   void EraseFromObjectTable(const ObjectID &object_id);
 
-  absl::optional<Allocation> AllocateMemory(size_t size, bool is_create,
-                                            bool fallback_allocator, PlasmaError *error);
+  const LocalObject *CreateObjectInternal(const ray::ObjectInfo &object_info,
+                                          plasma::flatbuf::ObjectSource source,
+                                          bool allow_fallback_allocation);
 
   // Start listening for clients.
   void DoAccept();
@@ -258,11 +249,10 @@ class PlasmaStore {
   boost::asio::basic_socket_acceptor<ray::local_stream_protocol> acceptor_;
   /// The socket to listen on for new clients.
   ray::local_stream_socket socket_;
-
+  /// The allocator that allocates mmaped memory.
   IAllocator &allocator_;
-  /// The plasma store information, including the object tables, that is exposed
-  /// to the eviction policy.
-  PlasmaStoreInfo store_info_;
+  /// The object store stores created objects.
+  ObjectStore object_store_;
   /// The state that is managed by the eviction policy.
   EvictionPolicy eviction_policy_;
   /// A hash table mapping object IDs to a vector of the get requests that are
@@ -324,14 +314,7 @@ class PlasmaStore {
   /// Total number of bytes allocated to objects that are in use by any client.
   /// This includes objects that are being created and objects that a client
   /// called get on.
-  size_t num_bytes_in_use_ = 0;
-
-  /// Total number of bytes allocated to objects that are created but not yet
-  /// sealed.
-  size_t num_bytes_unsealed_ = 0;
-
-  /// Number of objects that are created but not sealed.
-  size_t num_objects_unsealed_ = 0;
+  int64_t num_bytes_in_use_ = 0;
 
   /// Total plasma object bytes that are consumed by core workers.
   int64_t total_consumed_bytes_ = 0;
@@ -339,9 +322,6 @@ class PlasmaStore {
   /// Whether we have dumped debug information on OOM yet. This limits dump
   /// (which can be expensive) to once per OOM event.
   bool dumped_on_oom_ = false;
-
-  /// A running total of the objects that have ever been created on this node.
-  size_t num_bytes_created_total_ = 0;
 };
 
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/test/object_store_test.cc
+++ b/src/ray/object_manager/plasma/test/object_store_test.cc
@@ -1,0 +1,183 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/object_manager/plasma/object_store.h"
+#include <limits>
+#include "absl/random/random.h"
+#include "absl/strings/str_format.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using namespace ray;
+using namespace testing;
+
+namespace plasma {
+namespace {
+template <typename T>
+T Random(T max = std::numeric_limits<T>::max()) {
+  static absl::BitGen bitgen;
+  return absl::Uniform(bitgen, 0, max);
+}
+
+Allocation CreateAllocation(int64_t size) {
+  return Allocation(
+      /* address */ nullptr, size,
+      /* fd */ MEMFD_TYPE(),
+      /* offset */ Random<ptrdiff_t>(),
+      /* device_num */ 0,
+      /* mmap_size */ Random<int64_t>());
+}
+
+const std::string Serialize(const Allocation &allocation) {
+  return absl::StrFormat("%p/%d/%d/%d/%d/%d/%d", allocation.address, allocation.size,
+                         allocation.fd.first, allocation.fd.second, allocation.offset,
+                         allocation.device_num, allocation.mmap_size);
+}
+
+ObjectInfo CreateObjectInfo(ObjectID object_id, int64_t object_size) {
+  ObjectInfo info;
+  info.object_id = object_id;
+  info.data_size = Random<int64_t>(object_size);
+  info.metadata_size = object_size - info.data_size;
+  info.owner_raylet_id = NodeID::FromRandom();
+  info.owner_ip_address = "random_ip";
+  info.owner_port = Random<int>();
+  info.owner_worker_id = WorkerID::FromRandom();
+  return info;
+}
+
+const ObjectID kId1 = ObjectID::FromRandom();
+const ObjectID kId2 = []() {
+  auto id = ObjectID::FromRandom();
+  while (id == kId1) {
+    id = ObjectID::FromRandom();
+  }
+  return id;
+}();
+}  // namespace
+
+class MockAllocator : public IAllocator {
+ public:
+  MOCK_METHOD1(Allocate, absl::optional<Allocation>(size_t bytes));
+  MOCK_METHOD1(FallbackAllocate, absl::optional<Allocation>(size_t bytes));
+  MOCK_METHOD1(Free, void(Allocation));
+  MOCK_CONST_METHOD0(GetFootprintLimit, int64_t());
+  MOCK_CONST_METHOD0(Allocated, int64_t());
+  MOCK_CONST_METHOD0(FallbackAllocated, int64_t());
+};
+
+TEST(ObjectStoreTest, PassThroughTest) {
+  MockAllocator allocator;
+  ObjectStore store(allocator);
+  {
+    auto info = CreateObjectInfo(kId1, 10);
+    auto allocation = CreateAllocation(10);
+    auto alloc_str = Serialize(allocation);
+
+    EXPECT_CALL(allocator, Allocate(10)).Times(1).WillOnce(Invoke([&](size_t bytes) {
+      EXPECT_EQ(bytes, 10);
+      return absl::optional<Allocation>(std::move(allocation));
+    }));
+    auto entry = store.CreateObject(info, {}, /*fallback_allocate*/ false);
+    EXPECT_NE(entry, nullptr);
+    EXPECT_EQ(entry->ref_count, 0);
+    EXPECT_EQ(entry->state, ObjectState::PLASMA_CREATED);
+    EXPECT_EQ(alloc_str, Serialize(entry->allocation));
+    EXPECT_EQ(info, entry->object_info);
+    EXPECT_EQ(store.GetNumBytesCreatedTotal(), 10);
+    EXPECT_EQ(store.GetNumBytesUnsealed(), 10);
+    EXPECT_EQ(store.GetNumObjectsUnsealed(), 1);
+
+    // verify get
+    auto entry1 = store.GetObject(kId1);
+    EXPECT_EQ(entry1, entry);
+
+    // get non exists
+    auto entry2 = store.GetObject(kId2);
+    EXPECT_EQ(entry2, nullptr);
+
+    // seal object
+    auto entry3 = store.SealObject(kId1);
+    EXPECT_EQ(entry3, entry);
+    EXPECT_EQ(entry3->state, ObjectState::PLASMA_SEALED);
+    EXPECT_EQ(store.GetNumBytesCreatedTotal(), 10);
+    EXPECT_EQ(store.GetNumBytesUnsealed(), 0);
+    EXPECT_EQ(store.GetNumObjectsUnsealed(), 0);
+
+    // seal non existing
+    EXPECT_EQ(nullptr, store.SealObject(kId2));
+
+    // delete sealed
+    EXPECT_CALL(allocator, Free(_)).Times(1).WillOnce(Invoke([&](auto &&allocation) {
+      EXPECT_EQ(alloc_str, Serialize(allocation));
+    }));
+
+    EXPECT_TRUE(store.DeleteObject(kId1));
+    EXPECT_EQ(nullptr, store.GetObject(kId1));
+
+    // delete already deleted
+    EXPECT_FALSE(store.DeleteObject(kId1));
+
+    // delete non existing
+    EXPECT_FALSE(store.DeleteObject(kId2));
+  }
+
+  {
+    auto allocation = CreateAllocation(12);
+    auto alloc_str = Serialize(allocation);
+    auto info = CreateObjectInfo(kId2, 12);
+    // allocation failure
+    EXPECT_CALL(allocator, Allocate(12)).Times(1).WillOnce(Invoke([&](size_t bytes) {
+      EXPECT_EQ(bytes, 12);
+      return absl::optional<Allocation>();
+    }));
+
+    EXPECT_EQ(nullptr, store.CreateObject(info, {}, /*fallback_allocate*/ false));
+
+    // fallback allocation successful
+    EXPECT_CALL(allocator, FallbackAllocate(12))
+        .Times(1)
+        .WillOnce(Invoke([&](size_t bytes) {
+          EXPECT_EQ(bytes, 12);
+          return absl::optional<Allocation>(std::move(allocation));
+        }));
+
+    auto entry = store.CreateObject(info, {}, /*fallback_allocate*/ true);
+    EXPECT_NE(entry, nullptr);
+    EXPECT_EQ(entry->ref_count, 0);
+    EXPECT_EQ(entry->state, ObjectState::PLASMA_CREATED);
+    EXPECT_EQ(alloc_str, Serialize(entry->allocation));
+    EXPECT_EQ(info, entry->object_info);
+    EXPECT_EQ(store.GetNumBytesCreatedTotal(), 22);
+    EXPECT_EQ(store.GetNumBytesUnsealed(), 12);
+    EXPECT_EQ(store.GetNumObjectsUnsealed(), 1);
+
+    // delete unsealed
+    EXPECT_CALL(allocator, Free(_)).Times(1).WillOnce(Invoke([&](auto &&allocation) {
+      EXPECT_EQ(alloc_str, Serialize(allocation));
+    }));
+
+    EXPECT_TRUE(store.DeleteObject(kId2));
+
+    EXPECT_EQ(store.GetNumBytesCreatedTotal(), 22);
+    EXPECT_EQ(store.GetNumBytesUnsealed(), 0);
+    EXPECT_EQ(store.GetNumObjectsUnsealed(), 0);
+  }
+}
+}  // namespace plasma
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This the 3nd PR that refactor PlasmaStore for modularization and testability. Previous PR: #17313 Next PR: #17344

In this PR, we 

- create object_store that manages the allocated plasm objects.
- rename ObjectTableEntry to LocalObject
- reuse ObjectInfo in LocalObject.
- added unit tests verify the behavior of ObjectStore.

Test Plan
-[x] existing tests
-[x] added unit tests