### PR TITLE
[Rllib] set self._allow_unknown_config

### DIFF
--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -697,7 +697,7 @@ class Trainer(Trainable):
         # Merge the supplied config with the class default, but store the
         # user-provided one.
         self.raw_user_config = config
-        self.config = self.merge_trainer_configs(self._default_config, config)
+        self.config = self.merge_trainer_configs(self._default_config, config, self._allow_unknown_configs)
 
         # Check and resolve DL framework settings.
         # Enable eager/tracing support.

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -697,7 +697,8 @@ class Trainer(Trainable):
         # Merge the supplied config with the class default, but store the
         # user-provided one.
         self.raw_user_config = config
-        self.config = self.merge_trainer_configs(self._default_config, config, self._allow_unknown_configs)
+        self.config = self.merge_trainer_configs(self._default_config, config,
+                                                 self._allow_unknown_configs)
 
         # Check and resolve DL framework settings.
         # Enable eager/tracing support.


### PR DESCRIPTION
ray version 2.0.0.dev0

Bug fix: self._allow_unknown_configs is not included in call to self.merge_trainer_configs. This ends up calling the cls._allow_unknown_configs in merge_trainer_configs, which returns False even if the object's _allow_uknown_configs is set to True.

The issue occurred while using the [centralized_critic.py](https://github.com/ray-project/ray/blob/master/rllib/examples/centralized_critic.py) example. It's preventing me from passing custom configs to the policy and model. To reproduce, run the example with these changes:
```
CCTrainer = PPOTrainer.with_updates(
    name="CCPPOTrainer",
    default_policy=CCPPOTFPolicy,
    get_policy_class=get_policy_class,
    allow_unknown_configs=True,
)

...

config = {
        "foo": "bar",
        ....
```
Stacktrace:
```
  File "python/ray/_raylet.pyx", line 535, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 485, in ray._raylet.execute_task.function_executor
  File "/home/rohan/miniconda3/envs/mllib/lib/python3.8/site-packages/ray/_private/function_manager.py", line 563, in actor_method_executor
    return method(__ray_actor, *args, **kwargs)
  File "/home/rohan/miniconda3/envs/mllib/lib/python3.8/site-packages/ray/rllib/agents/trainer_template.py", line 136, in __init__
    Trainer.__init__(self, config, env, logger_creator)
  File "/home/rohan/miniconda3/envs/mllib/lib/python3.8/site-packages/ray/rllib/agents/trainer.py", line 591, in __init__
    super().__init__(config, logger_creator)
  File "/home/rohan/miniconda3/envs/mllib/lib/python3.8/site-packages/ray/tune/trainable.py", line 103, in __init__
    self.setup(copy.deepcopy(self.config))
  File "/home/rohan/miniconda3/envs/mllib/lib/python3.8/site-packages/ray/rllib/agents/trainer_template.py", line 146, in setup
    super().setup(config)
  File "/home/rohan/miniconda3/envs/mllib/lib/python3.8/site-packages/ray/rllib/agents/trainer.py", line 699, in setup
    self.config = self.merge_trainer_configs(self._default_config, config)
  File "/home/rohan/miniconda3/envs/mllib/lib/python3.8/site-packages/ray/rllib/agents/trainer.py", line 1345, in merge_trainer_configs
    return deep_update(config1, config2, _allow_unknown_configs,
  File "/home/rohan/miniconda3/envs/mllib/lib/python3.8/site-packages/ray/tune/utils/util.py", line 265, in deep_update
    raise Exception("Unknown config parameter `{}` ".format(k))
```

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
