### PR TITLE
[Autoscaler] Sync Files before Starting Docker

### DIFF
--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -823,8 +823,8 @@ class DockerCommandRunner(CommandRunnerInterface):
         if (not container_running) or requires_re_init:
             if not sync_run_yet:
                 # Do not start the actual image as we need to run file_sync
-                # first to ensure that all folders are created with the 
-                # correct ownership. Docker will create the folders with 
+                # first to ensure that all folders are created with the
+                # correct ownership. Docker will create the folders with
                 # `root` as the owner.
                 return True
             # Get home directory

--- a/python/ray/autoscaler/command_runner.py
+++ b/python/ray/autoscaler/command_runner.py
@@ -85,6 +85,6 @@ class CommandRunnerInterface:
             sync_run_yet (bool): Whether sync has been run yet.
 
         Returns:
-            optional (bool): Whether initialization was run.
+            optional (bool): Whether initialization is necessary.
         """
         pass

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -763,6 +763,10 @@ class AutoscalingTest(unittest.TestCase):
             x for x in commands_with_mount if "docker cp" in x[1]
         ]
         first_mkdir = min(x[0] for x in commands_with_mount if "mkdir" in x[1])
+        docker_run_cmd_indx = [
+            i for i, cmd in enumerate(runner.command_history())
+            if "docker run" in cmd
+        ][0]
         for file_to_check in [
                 "ray_bootstrap_config.yaml", "ray_bootstrap_key.pem"
         ]:
@@ -770,7 +774,12 @@ class AutoscalingTest(unittest.TestCase):
                               if "ray_bootstrap_config.yaml" in x[1])
             first_cp = min(
                 x[0] for x in docker_cp_commands if file_to_check in x[1])
+            # Ensures that `mkdir -p` precedes `docker run` because Docker
+            # will auto-create the folder with wrong permissions.
+            assert first_mkdir < docker_run_cmd_indx
+            # Ensures that the folder is created before running rsync.
             assert first_mkdir < first_rsync
+            # Checks that the file is present before copying into the container
             assert first_rsync < first_cp
 
     def testGetOrCreateHeadNodeFromStoppedRestartOnly(self):
@@ -2247,6 +2256,15 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_has_call("172.0.0.0", "start_ray_worker")
         runner.assert_has_call("172.0.0.0", "docker run")
 
+        docker_run_cmd_indx = [
+            i for i, cmd in enumerate(runner.command_history())
+            if "docker run" in cmd
+        ][0]
+        mkdir_cmd_indx = [
+            i for i, cmd in enumerate(runner.command_history())
+            if "mkdir -p" in cmd
+        ][0]
+        assert mkdir_cmd_indx < docker_run_cmd_indx
         runner.clear_history()
         autoscaler.update()
         runner.assert_not_has_call("172.0.0.0", "setup_cmd")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

### A few pieces of context:
* When a docker container is started with a [mount](https://docs.docker.com/storage/volumes/) where the `host_path` **does not currently exist**, it will be created with `root` ownership.
* When most Linux machines are stopped & started the `/tmp` directory is deleted

### What is the issue:
1. Node Reuse is Enabled
2. A cluster is started (with file mounts), and eventually shutdown.
3. The Ray cluster is restarted and the head node is pulled from the **cache**.
4. `run_init` is executed **before** file mounts are synced
	a.  This causes `/tmp/ray_tmp_mount/`, `/tmp/ray_tmp_mount/<cluster_name>/` and `/tmp/ray_tmp_mount/<cluster_name>/<mount_name_1>` are all created _by docker and with **root** ownership_.
    b. `rsync` happens, and tries to copy files to `/tmp/ray_tmp_mount/<cluster_name>/<mount_name_1>` and fails because `ubuntu` (the default user on the host) cannot edit `root`-owned files.


### The solution:
Flip `4b` and `4a` to ensure that rsync creates the `/tmp/ray_tmp_mount/<cluster_name>/<mount_name_1>` path

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #17228

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
