### PR TITLE
fix single deployment benchmark

### DIFF
--- a/release/serve_tests/workloads/serve_test_cluster_utils.py
+++ b/release/serve_tests/workloads/serve_test_cluster_utils.py
@@ -9,7 +9,7 @@ from ray.serve.config import DeploymentMode
 
 # Cluster setup configs
 NUM_CPU_PER_NODE = 10
-NUM_CONNECTIONS = 100
+NUM_CONNECTIONS = 10
 
 
 def setup_local_single_node_cluster(num_nodes):

--- a/release/serve_tests/workloads/serve_test_utils.py
+++ b/release/serve_tests/workloads/serve_test_utils.py
@@ -200,7 +200,6 @@ def run_one_wrk_trial(trial_length: str,
             "-d",
             trial_length,
             "--latency",
-            "--timeout=5s",
             f"http://{http_host}:{http_port}/{endpoint}",
         ],
         stdout=PIPE,
@@ -272,6 +271,7 @@ def run_wrk_on_all_nodes(trial_length: str,
     """
     all_metrics = defaultdict(list)
     all_wrk_stdout = []
+    all_alive_ray_nodes = [node for node in ray.nodes() if node["Alive"]]
     rst_ray_refs = []
     for node in ray.nodes():
         if node["Alive"]:

--- a/release/serve_tests/workloads/serve_test_utils.py
+++ b/release/serve_tests/workloads/serve_test_utils.py
@@ -271,7 +271,6 @@ def run_wrk_on_all_nodes(trial_length: str,
     """
     all_metrics = defaultdict(list)
     all_wrk_stdout = []
-    all_alive_ray_nodes = [node for node in ray.nodes() if node["Alive"]]
     rst_ray_refs = []
     for node in ray.nodes():
         if node["Alive"]:

--- a/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
@@ -39,7 +39,7 @@ from serve_test_utils import (
 from serve_test_cluster_utils import (
     setup_local_single_node_cluster,
     setup_anyscale_cluster,
-    warm_up_cluster,
+    warm_up_one_cluster,
     NUM_CPU_PER_NODE,
     NUM_CONNECTIONS,
 )
@@ -115,7 +115,7 @@ def main(num_replicas: Optional[int], trial_length: Optional[str],
     deploy_replicas(num_replicas, max_batch_size)
 
     logger.info("Warming up cluster ....\n")
-    warm_up_cluster(10, http_host, http_port)
+    warm_up_one_cluster.remote(10, http_host, http_port, "echo")
 
     logger.info(f"Starting wrk trial on all nodes for {trial_length} ....\n")
     # For detailed discussion, see https://github.com/wg/wrk/issues/205


### PR DESCRIPTION
## Why are these changes needed?

I forgot to update single deployment test after the ray remote function and api change. This is needs to be merged so single deployment benchmark is still running.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
