### PR TITLE
[CLI] Fix `ray submit` when --stop is supplied.

### DIFF
--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -973,8 +973,8 @@ def exec_cluster(config_file: str,
         docker_config=config.get("docker"))
     shutdown_after_run = False
     if cmd and stop:
-        cmd += "; ".join([
-            "ray stop",
+        cmd = "; ".join([
+            cmd, "ray stop",
             "ray teardown ~/ray_bootstrap_config.yaml --yes --workers-only"
         ])
         shutdown_after_run = True

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -166,13 +166,23 @@ def _debug_check_line_by_line(result, expected_lines):
 
 
 @contextmanager
-def _setup_popen_mock(commands_mock):
+def _setup_popen_mock(commands_mock, commands_verifier=None):
+    """
+    Mock subprocess.Popen's behavior and if applicable, intercept the commands
+    received by Popen and check if they are as expected using
+    commands_verifier provided by caller.
+    TODO(xwjiang): Ideally we should write a lexical analyzer that can parse
+    in a more intelligent way.
+    """
     Popen = MockPopen()
     Popen.set_default(behaviour=commands_mock)
 
     with Replacer() as replacer:
         replacer.replace("subprocess.Popen", Popen)
         yield
+
+    if commands_verifier:
+        assert commands_verifier(Popen.all_calls)
 
 
 def _load_output_pattern(name):
@@ -420,7 +430,15 @@ def test_ray_exec(configure_lang, configure_aws, _unlink_test_ssh_key):
         print("This is a test!")
         return PopenBehaviour(stdout=b"This is a test!")
 
-    with _setup_popen_mock(commands_mock):
+    def commands_verifier(calls):
+        for call in calls:
+            if len(call[1]) > 0:
+                for _ in call[1][0]:
+                    if " ray stop; " in _:
+                        return True
+        return False
+
+    with _setup_popen_mock(commands_mock, commands_verifier):
         runner = CliRunner()
         result = runner.invoke(scripts.up, [
             DEFAULT_TEST_CONFIG_PATH, "--no-config-cache", "-y",
@@ -430,7 +448,7 @@ def test_ray_exec(configure_lang, configure_aws, _unlink_test_ssh_key):
 
         result = runner.invoke(scripts.exec, [
             DEFAULT_TEST_CONFIG_PATH, "--no-config-cache",
-            "--log-style=pretty", "\"echo This is a test!\""
+            "--log-style=pretty", "\"echo This is a test!\"", "--stop"
         ])
 
         _check_output_via_pattern("test_ray_exec.txt", result)

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -433,9 +433,8 @@ def test_ray_exec(configure_lang, configure_aws, _unlink_test_ssh_key):
     def commands_verifier(calls):
         for call in calls:
             if len(call[1]) > 0:
-                for _ in call[1][0]:
-                    if " ray stop; " in _:
-                        return True
+                if any(" ray stop; " in token for token in call[1][0]):
+                    return True
         return False
 
     with _setup_popen_mock(commands_mock, commands_verifier):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`ray submit ray/python/ray/autoscaler/aws/example-full.yaml pytorch/transfer_learning_tutorial_ray.py --start --stop` is broken with error msg: `python /home/ray/transfer_learning_tutorial_ray.pyray stop; ray teardown /home/ray/ray_bootstrap_config.yaml --yes --workers-only`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

None
<!-- For example: "Closes #1234" -->

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
