### PR TITLE
[Rllib] Fix multi-GPU discovery for Torch/TF policies

### DIFF
--- a/rllib/policy/tf_policy.py
+++ b/rllib/policy/tf_policy.py
@@ -162,9 +162,9 @@ class TFPolicy(Policy):
         else:
             logger.info("TFPolicy (worker={}) running on {} GPU(s).".format(
                 worker_idx if worker_idx > 0 else "local", num_gpus))
-            gpu_ids = ray.get_gpu_ids()
+            gpu_ids = get_gpu_devices()
             self.devices = [
-                f"/gpu:{i}" for i, _ in enumerate(gpu_ids) if i < num_gpus
+                gpu_id for i, gpu_id in enumerate(gpu_ids) if i < num_gpus
             ]
 
         # Disable env-info placeholder.

--- a/rllib/utils/tf_ops.py
+++ b/rllib/utils/tf_ops.py
@@ -38,7 +38,7 @@ def explained_variance(y, pred):
 
 
 def get_gpu_devices():
-    """Returns a list of GPU device names, e.g. ["/gpu:0", "/gpu:1"].
+    """Returns a list of GPU device names, e.g. ["/device:GPU:0", "/device:GPU:1"].
 
     Supports both tf1.x and tf2.x.
     """
@@ -51,7 +51,7 @@ def get_gpu_devices():
             gpus = tf.config.list_physical_devices("GPU")
         except Exception:
             gpus = tf.config.experimental.list_physical_devices("GPU")
-        return gpus
+        return [x.name for x in gpus]
 
 
 def get_placeholder(*, space=None, value=None, name=None, time_axis=False):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `TorchPolicy` and `TFPolicy` in `rllib` uses `ray.get_gpu_ids()` to discover available GPUs, which cannot find any GPU on my machine:

```console
$ python3 -c 'import ray; print(ray.get_gpu_ids())'
2021-07-28 16:55:06,816 INFO services.py:1245 -- View the Ray dashboard at http://127.0.0.1:8266
[]

$ python3 -c 'import torch; print(torch.cuda.is_available(), torch.cuda.device_count())'
True 10

$ nvidia-smi --list-gpus
GPU 0: NVIDIA GeForce RTX 2080 Ti (UUID: GPU-f9ca790e-683e-3d56-00ba-8f654e977e02)
GPU 1: NVIDIA GeForce RTX 2080 Ti (UUID: GPU-f8e5a624-2c7e-417c-e647-b764d26d4733)
GPU 2: NVIDIA GeForce RTX 2080 Ti (UUID: GPU-6d2a57c9-7783-44bb-9f53-13f36282830a)
GPU 3: NVIDIA GeForce RTX 2080 Ti (UUID: GPU-2428d171-8684-5b64-830c-435cd972ec4a)
GPU 4: NVIDIA GeForce RTX 2080 Ti (UUID: GPU-96de99c9-d68f-84c8-424c-7c75e59cc0a0)
GPU 5: NVIDIA GeForce RTX 2080 Ti (UUID: GPU-18ef14e9-dec6-1d7e-1284-3010c6ce98b1)
GPU 6: NVIDIA GeForce RTX 2080 Ti (UUID: GPU-849d5a8d-610e-eeea-1fd4-81ff44a23794)
GPU 7: NVIDIA GeForce RTX 2080 Ti (UUID: GPU-843ecb19-b449-3be8-f49c-27697124f714)
GPU 8: NVIDIA GeForce RTX 2080 Ti (UUID: GPU-55f97fef-2770-f1da-8757-04b458ab93fe)
GPU 9: NVIDIA GeForce RTX 2080 Ti (UUID: GPU-6ec821a6-121f-02b1-43d1-73e0e24c3229)

$ [[ "${CUDA_VISIBLE_DEVICES-x}" == x ]]; echo $?
0  # CUDA_VISIBLE_DEVICES not set
```

#### My Runtime Environment

- OS version: Ubuntu 20.04 LTS
- Python version: 3.8.10
- ray version: 1.5.0
- NVIDIA driver version: 470.57.02
- CUDA version: 11.1.1

It will get an `IndexError` at `self.devices[0]` when using `TorchPolicy` on GPUs:

https://github.com/ray-project/ray/blob/1f35470560c90de69e7555097a4d2dd85065d6f8/rllib/policy/torch_policy.py#L154-L159

This PR will use the native support from Torch and TF to discover GPU devices, e.g., `torch.cuda.device_count()` instead of `ray.get_gpu_ids()`.

## Related issue number

<!-- For example: "Closes #1234" -->

Maybe introduced by PR #15421 and #17169. They use `ray.get_gpu_ids()` to enumerate GPUs.

Same issue on Windows: https://discuss.ray.io/t/error-with-torch-policy-and-ray-get-gpu-ids-on-windows/2711

Closes #16715 Closes #16848 Closes #17174 Closes #17316 Closes #17397 Closes #17425

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [X] This PR is not tested :(
