### PR TITLE
[tune] re-enable tensorboardx without torch installed

### DIFF
--- a/python/ray/tune/utils/callback.py
+++ b/python/ray/tune/utils/callback.py
@@ -11,15 +11,6 @@ from ray.tune.logger import CSVLoggerCallback, CSVLogger, LoggerCallback, \
     TBXLoggerCallback, TBXLogger
 from ray.tune.syncer import SyncerCallback
 
-try:
-    if "TUNE_TEST_NO_TORCH_IMPORT" in os.environ:
-        _HAS_TORCH = False
-    else:
-        import torch  # noqa: F401
-        _HAS_TORCH = True
-except ImportError:
-    _HAS_TORCH = False
-
 logger = logging.getLogger(__name__)
 
 
@@ -117,9 +108,16 @@ def create_default_callbacks(callbacks: Optional[List[Callback]],
         if not has_json_logger:
             callbacks.append(JsonLoggerCallback())
             last_logger_index = len(callbacks) - 1
-        if not has_tbx_logger and _HAS_TORCH:
-            callbacks.append(TBXLoggerCallback())
-            last_logger_index = len(callbacks) - 1
+        if not has_tbx_logger:
+            try:
+                callbacks.append(TBXLoggerCallback())
+                last_logger_index = len(callbacks) - 1
+            except ImportError:
+                logger.warning(
+                    "The TensorboardX logger cannot be instantiated because "
+                    "either TensorboardX or one of it's dependencies is not "
+                    "installed. Please make sure you have the latest version "
+                    "of TensorboardX installed: `pip install -U tensorboardx`")
 
     # If no SyncerCallback was found, add
     if not has_syncer_callback and os.environ.get(

--- a/rllib/tests/test_dependency_torch.py
+++ b/rllib/tests/test_dependency_torch.py
@@ -6,7 +6,6 @@ import sys
 if __name__ == "__main__":
     # Do not import torch for testing purposes.
     os.environ["RLLIB_TEST_NO_TORCH_IMPORT"] = "1"
-    os.environ["TUNE_TEST_NO_TORCH_IMPORT"] = "1"
 
     from ray.rllib.agents.a3c import A2CTrainer
     assert "torch" not in sys.modules, \
@@ -32,6 +31,5 @@ if __name__ == "__main__":
 
     # Clean up.
     del os.environ["RLLIB_TEST_NO_TORCH_IMPORT"]
-    del os.environ["TUNE_TEST_NO_TORCH_IMPORT"]
 
     print("ok")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

TensorboardX 2.4 removed the hard dependency on torch, so we should be fine to use it again.

This PR also works with Tensorboard 2.3 and will throw a warning if torch is not installed, so remains fully backwards compatible.

cc @tgaddair 

## Related issue number

Related PR #16695
Closes #17366


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
