### PR TITLE
[docs] Link broken in Tune's page (#17394)

### DIFF
--- a/doc/source/tune/index.rst
+++ b/doc/source/tune/index.rst
@@ -17,7 +17,7 @@ Tune is a Python library for experiment execution and hyperparameter tuning at a
 * Choose among state of the art algorithms such as :ref:`Population Based Training (PBT) <tune-scheduler-pbt>`, :ref:`BayesOptSearch <bayesopt>`, :ref:`HyperBand/ASHA <tune-scheduler-hyperband>`.
 * Move your models from training to serving on the same infrastructure with `Ray Serve`_.
 
-.. _`Ray Serve`: serve/index.html
+.. _`Ray Serve`: ../serve/index.html
 
 **Want to get started?** Head over to the :doc:`Key Concepts page </tune/key-concepts>`.
 


### PR DESCRIPTION
## Why are these changes needed?

404 error when I clicked the follow link "Move your models from training to serving on the same infrastructure with Ray Serve".

## Related issue number

#17394 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
