### PR TITLE
[GCP][GPU] Specify GPU name, not the full URL

### DIFF
--- a/python/ray/autoscaler/_private/gcp/node.py
+++ b/python/ray/autoscaler/_private/gcp/node.py
@@ -386,9 +386,21 @@ class GCPCompute(GCPResource):
 
     def _convert_resources_to_urls(
             self, configuration_dict: Dict[str, Any]) -> Dict[str, Any]:
+        """Ensures that resources are in their full URL form.
+
+        GCP expects machineType and accleratorType to be a full URL (e.g.
+        `zones/us-west1/machineTypes/n1-standard-2`) instead of just the
+        type (`n1-standard-2`)
+
+        Args:
+            configuration_dict: Dict of options that will be passed to GCP
+        Returns:
+            Input dictionary, but with possibly expanding `machineType` and
+                `acceleratorType`.
+        """
         configuration_dict = deepcopy(configuration_dict)
         existing_machine_type = configuration_dict["machineType"]
-        if not re.search("zones/*/machineTypes/*", existing_machine_type):
+        if not re.search(".*/machineTypes/.*", existing_machine_type):
             configuration_dict["machineType"] = (
                 "zones/{zone}/machineTypes/{machine_type}"
                 "".format(
@@ -397,8 +409,7 @@ class GCPCompute(GCPResource):
 
         for accelerator in configuration_dict.get("guestAccelerators", []):
             gpu_type = accelerator["acceleratorType"]
-            if not re.search("projects/.*/zones/.*/acceleratorTypes/.*",
-                             gpu_type):
+            if not re.search(".*/acceleratorTypes/.*", gpu_type):
                 accelerator["acceleratorType"] = (
                     "projects/{project}/zones/{zone}/"
                     "acceleratorTypes/{accelerator}".format(

--- a/python/ray/autoscaler/_private/gcp/node.py
+++ b/python/ray/autoscaler/_private/gcp/node.py
@@ -23,7 +23,8 @@ update the ``_generate_node_name`` method and finally update the
 node provider.
 """
 
-from typing import List, Optional, Tuple, Union
+from copy import deepcopy
+from typing import Any, Dict, List, Optional, Tuple, Union
 import logging
 import abc
 import time
@@ -383,24 +384,43 @@ class GCPCompute(GCPResource):
 
         return result
 
+    def _convert_resources_to_urls(
+            self, configuration_dict: Dict[str, Any]) -> Dict[str, Any]:
+        configuration_dict = deepcopy(configuration_dict)
+        existing_machine_type = configuration_dict["machineType"]
+        if not re.search("zones/*/machineTypes/*", existing_machine_type):
+            configuration_dict["machineType"] = (
+                "zones/{zone}/machineTypes/{machine_type}"
+                "".format(
+                    zone=self.availability_zone,
+                    machine_type=configuration_dict["machineType"]))
+
+        for accelerator in configuration_dict.get("guestAccelerators", []):
+            gpu_type = accelerator["acceleratorType"]
+            if not re.search("projects/.*/zones/.*/acceleratorTypes/.*",
+                             gpu_type):
+                accelerator["acceleratorType"] = (
+                    "projects/{project}/zones/{zone}/"
+                    "acceleratorTypes/{accelerator}".format(
+                        project=self.project_id,
+                        zone=self.availability_zone,
+                        accelerator=gpu_type))
+
+        return configuration_dict
+
     def create_instance(self,
                         base_config: dict,
                         labels: dict,
                         wait_for_operation: bool = True) -> Tuple[dict, str]:
 
-        config = base_config.copy()
+        config = self._convert_resources_to_urls(base_config)
         # removing TPU-specific default key set in config.py
         config.pop("networkConfig", None)
         name = _generate_node_name(labels, GCPNodeType.COMPUTE.value)
 
-        machine_type = ("zones/{zone}/machineTypes/{machine_type}"
-                        "".format(
-                            zone=self.availability_zone,
-                            machine_type=base_config["machineType"]))
         labels = dict(config.get("labels", {}), **labels)
 
         config.update({
-            "machineType": machine_type,
             "labels": dict(labels,
                            **{TAG_RAY_CLUSTER_NAME: self.cluster_name}),
             "name": name

--- a/python/ray/autoscaler/gcp/example-gpu-docker.yaml
+++ b/python/ray/autoscaler/gcp/example-gpu-docker.yaml
@@ -71,6 +71,7 @@ available_node_types:
                   diskSizeGb: 50
                   # See https://cloud.google.com/compute/docs/images for more images
                   sourceImage: projects/deeplearning-platform-release/global/images/family/common-cu110
+            # Make sure to set scheduling->onHostMaintenance to TERMINATE when GPUs are present
             guestAccelerators:
               - acceleratorType: nvidia-tesla-k80
                 acceleratorCount: 1
@@ -104,6 +105,7 @@ available_node_types:
                   diskSizeGb: 50
                   # See https://cloud.google.com/compute/docs/images for more images
                   sourceImage: projects/deeplearning-platform-release/global/images/family/common-cu110
+            # Make sure to set scheduling->onHostMaintenance to TERMINATE when GPUs are present
             guestAccelerators:
               - acceleratorType: nvidia-tesla-k80
                 acceleratorCount: 1

--- a/python/ray/autoscaler/gcp/example-gpu-docker.yaml
+++ b/python/ray/autoscaler/gcp/example-gpu-docker.yaml
@@ -72,7 +72,7 @@ available_node_types:
                   # See https://cloud.google.com/compute/docs/images for more images
                   sourceImage: projects/deeplearning-platform-release/global/images/family/common-cu110
             guestAccelerators:
-              - acceleratorType: projects/<project_id>/zones/us-west1-b/acceleratorTypes/nvidia-tesla-k80
+              - acceleratorType: nvidia-tesla-k80
                 acceleratorCount: 1
             metadata:
               items:
@@ -105,7 +105,7 @@ available_node_types:
                   # See https://cloud.google.com/compute/docs/images for more images
                   sourceImage: projects/deeplearning-platform-release/global/images/family/common-cu110
             guestAccelerators:
-              - acceleratorType: projects/<project_id>/zones/us-west1-b/acceleratorTypes/nvidia-tesla-k80
+              - acceleratorType: nvidia-tesla-k80
                 acceleratorCount: 1
             metadata:
               items:

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -245,6 +245,13 @@ py_test(
     deps = ["//:ray_lib"],
 )
 
+py_test(
+    name = "test_gcp_node_provider",
+    size = "small",
+    srcs = SRCS + ["gcp/test_gcp_node_provider.py"],
+    deps = ["//:ray_lib"],
+)
+
 # Note(simon): typing tests are not included in module list
 #    because they requires globs and it might be refactored in the future.
 py_test(

--- a/python/ray/tests/gcp/test_gcp_node_provider.py
+++ b/python/ray/tests/gcp/test_gcp_node_provider.py
@@ -1,0 +1,50 @@
+import pytest
+
+from ray.autoscaler._private.gcp.node import GCPCompute
+
+_PROJECT_NAME = "project-one"
+_AZ = "us-west1-b"
+
+
+@pytest.mark.parametrize(
+    "test_case", [("n1-standard-4", f"zones/{_AZ}/machineTypes/n1-standard-4"),
+                  (f"zones/{_AZ}/machineTypes/n1-standard-4",
+                   f"zones/{_AZ}/machineTypes/n1-standard-4")])
+def test_convert_resources_to_urls_machine(test_case):
+    gcp_compute = GCPCompute(None, _PROJECT_NAME, _AZ, "cluster_name")
+    base_machine, result_machine = test_case
+    modified_config = gcp_compute._convert_resources_to_urls({
+        "machineType": base_machine
+    })
+    assert modified_config["machineType"] == result_machine
+
+
+@pytest.mark.parametrize("test_case", [
+    ("nvidia-tesla-k80",
+     f"projects/{_PROJECT_NAME}/zones/{_AZ}/acceleratorTypes/nvidia-tesla-k80"
+     ),
+    (f"projects/{_PROJECT_NAME}/zones/{_AZ}/acceleratorTypes/nvidia-tesla-k80",
+     f"projects/{_PROJECT_NAME}/zones/{_AZ}/acceleratorTypes/nvidia-tesla-k80"
+     ),
+])
+def test_convert_resources_to_urls_accelerators(test_case):
+    gcp_compute = GCPCompute(None, _PROJECT_NAME, _AZ, "cluster_name")
+    base_accel, result_accel = test_case
+
+    base_config = {
+        "machineType": "n1-standard-4",
+        "guestAccelerators": [{
+            "acceleratorCount": 1,
+            "acceleratorType": base_accel
+        }]
+    }
+    modified_config = gcp_compute._convert_resources_to_urls(base_config)
+
+    assert modified_config["guestAccelerators"][0][
+        "acceleratorType"] == result_accel
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* It is rather annoying to have to manually set: `projects/<project_id>/zones/<zone_id>/acceleratorTypes/<actual_type>` when adding a GPU on GCP.
* This PR makes it possible to just select `actual_type`!
* We currently have similar logic for `machineType` on GCP, so this is just extending that logic to GPUs

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
