### PR TITLE
[doc][sgd] Broken Link in SGD's page. (#17404)

### DIFF
--- a/doc/source/raysgd/raysgd_ptl.rst
+++ b/doc/source/raysgd/raysgd_ptl.rst
@@ -5,7 +5,7 @@ Pytorch Lightning with RaySGD
   :scale: 50 %
 
 
-RaySGD includes an integration with Pytorch Lightning's `LightningModule <https://pytorch-lightning.readthedocs.io/en/latest/lightning_module.html>`_.
+RaySGD includes an integration with Pytorch Lightning's `LightningModule <https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html>`_.
 Easily take your existing ``LightningModule``, and use it with Ray SGD's ``TorchTrainer`` to take advantage of all of Ray SGD's distributed training features with minimal code changes.
 
 .. tip:: This LightningModule integration is currently under active development. If you encounter any bugs, please raise an issue on `Github <https://github.com/ray-project/ray/issues>`_!


### PR DESCRIPTION
## Why are these changes needed?
In the page "https://docs.ray.io/en/master/raysgd/raysgd_ptl.html#pytorch-lightning-with-raysgd".
I faced sorry page when I clicked the follow link "RaySGD includes an integration with Pytorch Lightning’s LightningModule.".

<!-- Please give a short summary of the change and the problem this solves. -->
It should links to "https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html".

## Related issue number

#17404 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :( only document is changed
