### PR TITLE
[nightly test] increase header node memory to 256GB for shuffle 1tb-5000partitions

### DIFF
--- a/release/nightly_tests/nightly_tests.yaml
+++ b/release/nightly_tests/nightly_tests.yaml
@@ -136,7 +136,7 @@
     compute_template: shuffle/shuffle_compute_large_scale.yaml
 
   run:
-    timeout: 3000
+    timeout: 7200
     prepare: python wait_cluster.py 20 900
     script: python shuffle/shuffle_test.py --num-partitions=5000 --partition-size=200e6
 
@@ -147,7 +147,7 @@
     compute_template: shuffle/shuffle_compute_large_scale.yaml
 
   run:
-    timeout: 3000
+    timeout: 7200
     prepare: python wait_cluster.py 20 900
     script: python shuffle/shuffle_test.py --num-partitions=5000 --partition-size=200e6 --no-streaming
 

--- a/release/nightly_tests/shuffle/shuffle_compute_large_scale.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_large_scale.yaml
@@ -9,7 +9,7 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: i3.4xlarge
+    instance_type: i3.8xlarge
     resources: {"object_store_memory": 21474836480}
 
 worker_node_types:


### PR DESCRIPTION
Turns out 25,000,000 objects used up to 120GB memories that leads to OOM. By using ec2 instances with 256GB memories [solves the problem](https://beta.anyscale.com/o/anyscale-internal/projects/prj_SVFGM5yBqK6DHCfLtRMryXHM/sessions/ses_G4MnG6kYNwdjwsfJ3md3y2Ec).

As a separate question, we need to see if 4-5kB metadata per object makes sense, or it's a sign of memory leak.