### PR TITLE
[release tests] limit number of results fetched for alerting

### DIFF
--- a/release/alert.py
+++ b/release/alert.py
@@ -32,6 +32,8 @@ GLOBAL_CONFIG["SLACK_WEBHOOK"] = os.environ.get("SLACK_WEBHOOK", "")
 GLOBAL_CONFIG["SLACK_CHANNEL"] = os.environ.get("SLACK_CHANNEL",
                                                 "#oss-test-cop")
 
+RESULTS_LIMIT = 200
+
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 handler = logging.StreamHandler(stream=sys.stdout)
@@ -69,6 +71,7 @@ def fetch_latest_alerts(rds_data_client):
                last_notification_dt
         FROM   {schema}
         ORDER BY category, test_suite, test_name, last_notification_dt DESC
+        LIMIT {RESULTS_LIMIT}
         """)
 
     result = rds_data_client.execute_statement(
@@ -114,7 +117,8 @@ def fetch_latest_results(rds_data_client,
             },
         ]
 
-    sql += "ORDER BY category, test_suite, test_name, created_on DESC"
+    sql += "ORDER BY category, test_suite, test_name, created_on DESC "
+    sql += f"LIMIT {RESULTS_LIMIT}"
 
     result = rds_data_client.execute_statement(
         database=GLOBAL_CONFIG["RELEASE_AWS_DB_NAME"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Buildkite alerting breaks because the number of returned results is too large:

```
botocore.errorfactory.BadRequestException: An error occurred (BadRequestException) when calling the ExecuteStatement operation: Database returned more than the allowed response size limit
```

Limiting the number of fetched results fixes this.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
