### PR TITLE
[docs] Fix XGBoost-Ray and LightGBM-Ray docs properly

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -19,7 +19,7 @@ import os
 import urllib
 
 sys.path.insert(0, os.path.abspath('.'))
-from custom_directives import CustomGalleryItemDirective
+from custom_directives import CustomGalleryItemDirective, fix_xgb_lgbm_docs
 from datetime import datetime
 
 # These lines added to enable Sphinx to work without installing Ray.
@@ -497,3 +497,5 @@ def setup(app):
     app.add_css_file('css/custom.css')
     # Custom directives
     app.add_directive('customgalleryitem', CustomGalleryItemDirective)
+    # Custom connects
+    app.connect('autodoc-process-docstring', fix_xgb_lgbm_docs)

--- a/doc/source/lightgbm-ray.rst
+++ b/doc/source/lightgbm-ray.rst
@@ -531,8 +531,11 @@ the `examples folder <https://github.com/ray-project/lightgbm_ray/tree/master/ex
 API reference
 -------------
 
-.. .. autoclass:: lightgbm_ray.RayParams
-..     :members:
+.. autoclass:: lightgbm_ray.RayParams
+    :members:
+
+.. note::
+  The ``xgboost_ray.RayDMatrix`` class is shared with :ref:`XGBoost-Ray <xgboost-ray>`.
 
 .. autoclass:: xgboost_ray.RayDMatrix
     :members:

--- a/doc/source/xgboost-ray.rst
+++ b/doc/source/xgboost-ray.rst
@@ -611,14 +611,14 @@ API reference
 scikit-learn API
 ^^^^^^^^^^^^^^^^
 
-.. .. autoclass:: xgboost_ray.RayXGBClassifier
-..     :members:
+.. autoclass:: xgboost_ray.RayXGBClassifier
+    :members:
 
-.. .. autoclass:: xgboost_ray.RayXGBRegressor
-..     :members:
+.. autoclass:: xgboost_ray.RayXGBRegressor
+    :members:
 
-.. .. autoclass:: xgboost_ray.RayXGBRFClassifier
-..     :members:
+.. autoclass:: xgboost_ray.RayXGBRFClassifier
+    :members:
 
-.. .. autoclass:: xgboost_ray.RayXGBRFRegressor
-..     :members:
+.. autoclass:: xgboost_ray.RayXGBRFRegressor
+    :members:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Reenables the API docs for XGBoost-Ray and LightGBM-Ray, using an [autodoc event](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#docstring-preprocessing) to modify the docstrings on the fly, fixing issues that prevented them from being included in the first place. The docs now render correctly.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #17274

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
