### PR TITLE
Add warning if get_gpu_ids() is called on the driver.

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -494,6 +494,11 @@ def get_gpu_ids():
     worker = global_worker
     worker.check_connected()
 
+    if worker.mode != WORKER_MODE:
+        logger.warning(
+            "`ray.get_gpu_ids()` will always return the empty list when "
+            "called from the driver.")
+
     # TODO(ilr) Handle inserting resources in local mode
     all_resource_ids = global_worker.core_worker.resource_ids()
     assigned_ids = set()

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -497,7 +497,8 @@ def get_gpu_ids():
     if worker.mode != WORKER_MODE:
         logger.warning(
             "`ray.get_gpu_ids()` will always return the empty list when "
-            "called from the driver.")
+            "called from the driver. This is because Ray does not manage "
+            "GPU allocations to the driver process.")
 
     # TODO(ilr) Handle inserting resources in local mode
     all_resource_ids = global_worker.core_worker.resource_ids()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Calling get_gpu_ids() on the driver is almost always an error. Print a warning in this case (we should also make sure RLlib isn't triggering this warning etc).