### PR TITLE
hotfix issue where security group is cleared out after the first attempt to launch instances

### DIFF
--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -356,6 +356,7 @@ class AWSNodeProvider(NodeProvider):
         # SubnetIds is not a real config key: we must resolve to a
         # single SubnetId before invoking the AWS API.
         subnet_ids = conf.pop("SubnetIds")
+        security_group_ids = conf.pop("SecurityGroupIds", None)
 
         for attempt in range(1, BOTO_CREATE_MAX_RETRIES + 1):
             try:
@@ -373,7 +374,6 @@ class AWSNodeProvider(NodeProvider):
                     "TagSpecifications": tag_specs
                 })
                 _ = conf.pop("SubnetId", None)
-                security_group_ids = conf.pop("SecurityGroupIds", None)
                 if security_group_ids is not None:
                     conf["NetworkInterfaces"][0]["Groups"] = security_group_ids
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This only hotfixes 1.5.0
In master, most of this code has been altered and a fix is no longer necessary. This PR should NOT be merged.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(

