### PR TITLE
[torch] fix process group timedelta

### DIFF
--- a/python/ray/tune/integration/torch.py
+++ b/python/ray/tune/integration/torch.py
@@ -66,7 +66,7 @@ class _TorchTrainable(DistributedTrainable):
 
     @classmethod
     def default_process_group_parameters(cls) -> Dict:
-        return dict(timeout=timedelta(NCCL_TIMEOUT_S), backend="gloo")
+        return dict(timeout=timedelta(seconds=NCCL_TIMEOUT_S), backend="gloo")
 
     def setup(self, config: Dict):
         self._finished = False
@@ -171,7 +171,7 @@ def DistributedTrainableCreator(func: Callable,
         backend (str): One of "gloo", "nccl".
         timeout_s (float): Seconds before the torch process group
             times out. Useful when machines are unreliable. Defaults
-            to 60 seconds. This value is also reused for triggering
+            to 1800 seconds. This value is also reused for triggering
             placement timeouts if forcing colocation.
 
     Returns:
@@ -206,7 +206,7 @@ def DistributedTrainableCreator(func: Callable,
 
         @classmethod
         def default_process_group_parameters(self) -> Dict:
-            return dict(timeout=timedelta(timeout_s), backend=backend)
+            return dict(timeout=timedelta(seconds=timeout_s), backend=backend)
 
         @classmethod
         def default_resource_request(cls, config: Dict) -> Resources:

--- a/python/ray/util/sgd/v2/backends/torch.py
+++ b/python/ray/util/sgd/v2/backends/torch.py
@@ -85,7 +85,7 @@ def setup_torch_process_group(backend: str,
         init_method=init_method,
         rank=world_rank,
         world_size=world_size,
-        timeout=timedelta(0, timeout_s))
+        timeout=timedelta(seconds=timeout_s))
 
 
 def shutdown_torch():


### PR DESCRIPTION
## Why are these changes needed?

Specify `seconds` for `timedelta` because first argument is `days`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
