### PR TITLE
Validate Redis addresses before making the client

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -415,7 +415,7 @@ def create_redis_client(redis_address, password=None):
             except Exception:
                 create_redis_client.instances.pop(redis_address)
 
-    redis_ip_address, redis_port = redis_address.split(":")
+    _, redis_ip_address, redis_port = validate_redis_address(redis_address)
     # For this command to work, some other client (on the same machine
     # as Redis) must have run "CONFIG SET protected-mode no".
     create_redis_client.instances[redis_address] = redis.StrictRedis(


### PR DESCRIPTION
## Why are these changes needed?
There are various Ray entrypoints that throw cryptic errors when the Redis address is missing the port.

For example, if you run the command line program `ray status --address=localhost`, where `localhost` is missing the port, you will get a stack trace that ends in:
```
  File "/usr/local/lib/python3.8/dist-packages/ray/scripts/scripts.py", line 1488, in status
    redis_client = ray._private.services.create_redis_client(
  File "/usr/local/lib/python3.8/dist-packages/ray/_private/services.py", line 407, in create_redis_client
    redis_ip_address, redis_port = redis_address.split(":")
ValueError: not enough values to unpack (expected 2, got 1)
```

On the other hand, other entrypoints like `ray start` validate the Redis address before using it, which results in a far more user friendly stack trace that ends in:
```
  File "/usr/local/lib/python3.8/dist-packages/ray/scripts/scripts.py", line 665, in start
    redis_address_port) = services.validate_redis_address(address)
  File "/usr/local/lib/python3.8/dist-packages/ray/_private/services.py", line 324, in validate_redis_address
    raise ValueError("Malformed address. Expected '<host>:<port>'.")
ValueError: Malformed address. Expected '<host>:<port>'.
```

My pull request is about making all of the relevant errors look like the second stack trace.

## Related issue number
N/A

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
