### PR TITLE
[ci] run ubsan as part of CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -130,3 +130,22 @@ test:strace --run_under="bash -c 'if command -v strace >/dev/null && strace -qq 
 # [Linux] Uncomment this line (or use --config) to preload libSegFault.so if available, to print a stack trace on aborts and segfault. (Note: This doesn't always work.)
 #test:linux --config=segfault
 test:segfault --run_under="bash -c 'unset GREP_OPTIONS && if ! grep -q -o Microsoft /proc/version 2>/dev/null; then libs=\"$(command -v ldconfig >/dev/null && ldconfig -p | grep -F -o -e \"libSegFault.so\" | uniq | tr \"\\\\n\" :)\" && if [ -n \"${libs%:}\" ]; then export SEGFAULT_SIGNALS=\"abrt segv\" LD_PRELOAD=\"${libs}${LD_PRELOAD-}\"; fi; fi && \"$@\"' -"
+
+# Memory sanitizer
+# CC=clang bazel build --config msan
+build:msan --strip=never
+build:msan --copt -fsanitize=memory
+build:msan --copt -DMEMORY_SANITIZER
+build:msan --copt -g
+build:msan --copt -O3
+build:msan --copt -fno-omit-frame-pointer
+build:msan --linkopt -fsanitize=memory
+
+# Undefined Behavior Sanitizer
+# CC=clang bazel build --config ubsan
+build:ubsan --strip=never
+build:ubsan --copt -fsanitize=undefined
+build:ubsan --copt -fno-sanitize-recover=all
+build:ubsan --copt -g
+build:ubsan --linkopt -fsanitize=undefined
+build:ubsan --linkopt -fno-sanitize-recover=all

--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -80,6 +80,13 @@ steps:
       python/ray/tests/... python/ray/serve/...
     - *epilogue_commands
 
+- label: ":mac: :apple: UBSAN"
+  <<: *common
+  commands:
+    - export RAY_UBSAN_BUILD=1
+    - *prelude_commands
+    - *epilogue_commands
+
     # The follow is running in Travis for now.
     # - bazel test --test_env=CONDA_EXE --test_env=CONDA_PYTHON_EXE --test_env=CONDA_SHLVL --test_env=CONDA_PREFIX --test_env=CONDA_DEFAULT_ENV --test_env=CONDA_PROMPT_MODIFIER --config=ci $(./scripts/bazel_export_options) --test_tag_filters=-kubernetes,-jenkins_only,-medium_size_python_tests_a_to_j,-medium_size_python_tests_k_to_z,-flaky python/ray/tests/...
     # - bazel test --config=ci $(./scripts/bazel_export_options) --test_tag_filters=-kubernetes,-jenkins_only,medium_size_python_tests_k_to_z,-flaky python/ray/tests/...

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -295,7 +295,11 @@ _bazel_build_before_install() {
     target="//:ray_pkg"
   fi
   # NOTE: Do not add build flags here. Use .bazelrc and --config instead.
-  bazel build "${target}"
+  if [ -z "${RAY_UBSAN_BUILD-}" ] || [ "${RAY_UBSAN_BUILD}" -ne "1" ]; then
+    bazel build "${target}"
+  else
+    CC=clang bazel build --config ubsan "${target}"
+  fi
 }
 
 


### PR DESCRIPTION
ubsan checks at [compilation time](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#introduction), thus we just need to compile with ubsan enabled.