### PR TITLE
[nightly-test] fix non_streaming_shuffle_1tb_5000_partitions

### DIFF
--- a/cpp/src/ray/runtime/task/task_executor.cc
+++ b/cpp/src/ray/runtime/task/task_executor.cc
@@ -134,8 +134,10 @@ Status TaskExecutor::ExecuteTask(
     size_t data_size = data->size();
     auto &result_id = return_ids[0];
     auto result_ptr = &(*results)[0];
+    int64_t task_output_inlined_bytes = 0;
     RAY_CHECK_OK(ray::CoreWorkerProcess::GetCoreWorker().AllocateReturnObject(
-        result_id, data_size, nullptr, std::vector<ray::ObjectID>(), result_ptr));
+        result_id, data_size, nullptr, std::vector<ray::ObjectID>(),
+        task_output_inlined_bytes, result_ptr));
 
     auto result = *result_ptr;
     if (result != nullptr) {

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1687,12 +1687,14 @@ cdef class CoreWorker:
             shared_ptr[CBuffer] metadata
             c_vector[CObjectID] contained_id
             c_vector[CObjectID] return_ids_vector
+            int64_t task_output_inlined_bytes
 
         if return_ids.size() == 0:
             return
 
         n_returns = len(outputs)
         returns.resize(n_returns)
+        task_output_inlined_bytes = 0
         for i in range(n_returns):
             return_id, output = return_ids[i], outputs[i]
             context = worker.get_serialization_context()
@@ -1715,7 +1717,7 @@ cdef class CoreWorker:
                 check_status(
                     CCoreWorkerProcess.GetCoreWorker().AllocateReturnObject(
                         return_id, data_size, metadata, contained_id,
-                        &returns[0][i]))
+                        task_output_inlined_bytes, &returns[0][i]))
 
             if returns[0][i].get() != NULL:
                 if returns[0][i].get().HasData():

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -136,6 +136,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
             const size_t &data_size,
             const shared_ptr[CBuffer] &metadata,
             const c_vector[CObjectID] &contained_object_id,
+            int64_t &task_output_inlined_bytes,
             shared_ptr[CRayObject] *return_object)
         CRayStatus SealReturnObject(
             const CObjectID& return_id,

--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -55,6 +55,8 @@ cdef extern from "ray/common/ray_config.h" nogil:
 
         c_bool put_small_object_in_memory_store() const
 
+        int64_t task_output_inlined_bytes_limit() const
+
         uint32_t max_tasks_in_flight_per_worker() const
 
         uint64_t metrics_report_interval_ms() const

--- a/python/ray/tests/test_advanced.py
+++ b/python/ray/tests/test_advanced.py
@@ -567,6 +567,47 @@ def test_future_resolution_skip_plasma(ray_start_cluster):
     assert ray.get(g_ref) == 4
 
 
+def test_task_output_inline_bytes_limit(ray_start_cluster):
+    cluster = ray_start_cluster
+    # Disable worker caching so worker leases are not reused; set object
+    # inlining size threshold and enable storing of small objects in in-memory
+    # object store so the borrowed ref is inlined.
+    # set task_output_inlined_bytes_limit which only allows inline 20 bytes.
+    cluster.add_node(
+        num_cpus=1,
+        resources={"pin_head": 1},
+        _system_config={
+            "worker_lease_timeout_milliseconds": 0,
+            "max_direct_call_object_size": 100 * 1024,
+            "task_output_inlined_bytes_limit": 20,
+            "put_small_object_in_memory_store": True,
+        },
+    )
+    cluster.add_node(num_cpus=1, resources={"pin_worker": 1})
+    ray.init(address=cluster.address)
+
+    @ray.remote(num_returns=5, resources={"pin_head": 1})
+    def f():
+        return list(range(5))
+
+    @ray.remote(resources={"pin_worker": 1})
+    def sum(numbers):
+        result = 0
+        for i, ref in enumerate(numbers):
+            result += ray.get(ref)
+            inlined = ray.worker.global_worker.core_worker.object_exists(
+                ref, memory_store_only=True)
+            if i < 2:
+                assert inlined
+            else:
+                assert not inlined
+        return result
+
+    results = f.remote()
+    g_ref = sum.remote(results)
+    assert ray.get(g_ref) == 10
+
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main(["-v", __file__]))

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -307,6 +307,9 @@ RAY_CONFIG(int64_t, enable_metrics_collection, true)
 /// Whether put small objects in the local memory store.
 RAY_CONFIG(bool, put_small_object_in_memory_store, false)
 
+// Max number bytes of inlined objects in a task execution result.
+RAY_CONFIG(int64_t, task_output_inlined_bytes_limit, 10 * 1024 * 1024)
+
 /// Maximum number of tasks that can be in flight between an owner and a worker for which
 /// the owner has been granted a lease. A value >1 is used when we want to enable
 /// pipelining task submission.

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -847,11 +847,15 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] data_size Size of the return value.
   /// \param[in] metadata Metadata buffer of the return value.
   /// \param[in] contained_object_id ID serialized within each return object.
+  /// \param[in][out] task_output_inlined_bytes Store the total size of all inlined
+  /// objects of a task. It is used to decide if the current object should be inlined. If
+  /// the current object is inlined, the task_output_inlined_bytes will be updated.
   /// \param[out] return_object RayObject containing buffers to write results into.
   /// \return Status.
   Status AllocateReturnObject(const ObjectID &object_id, const size_t &data_size,
                               const std::shared_ptr<Buffer> &metadata,
                               const std::vector<ObjectID> &contained_object_id,
+                              int64_t &task_output_inlined_bytes,
                               std::shared_ptr<RayObject> *return_object);
 
   /// Seal a return object for an executing task. The caller should already have

--- a/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
@@ -154,6 +154,7 @@ JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeInitialize(
         }
         RAY_CHECK_JAVA_EXCEPTION(env);
 
+        int64_t task_output_inlined_bytes = 0;
         // Process return objects.
         if (!return_ids.empty()) {
           std::vector<std::shared_ptr<ray::RayObject>> return_objects;
@@ -172,7 +173,8 @@ JNIEXPORT void JNICALL Java_io_ray_runtime_RayNativeRuntime_nativeInitialize(
             auto result_ptr = &(*results)[0];
 
             RAY_CHECK_OK(ray::CoreWorkerProcess::GetCoreWorker().AllocateReturnObject(
-                result_id, data_size, metadata, contained_object_id, result_ptr));
+                result_id, data_size, metadata, contained_object_id,
+                task_output_inlined_bytes, result_ptr));
 
             // A nullptr is returned if the object already exists.
             auto result = *result_ptr;

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -619,6 +619,7 @@ void CoreWorkerDirectTaskSubmitter::PushNormalTask(
             // need to do anything here.
             return;
           } else if (!status.ok() || !is_actor_creation) {
+            RAY_LOG(DEBUG) << "Task failed with error: " << status;
             // Successful actor creation leases the worker indefinitely from the raylet.
             OnWorkerIdle(addr, scheduling_key,
                          /*error=*/!status.ok(), assigned_resources);


### PR DESCRIPTION
limit the total number of inlined bytes per task execution. in this way we don't overload Grpc and not causing driver to oom.