### PR TITLE
Lower threshold on scalability envelope many tasks

### DIFF
--- a/benchmarks/distributed/test_many_tasks.py
+++ b/benchmarks/distributed/test_many_tasks.py
@@ -35,7 +35,7 @@ def test_max_running_tasks(num_tasks):
     # There are some relevant magic numbers in this check. 10k tasks each
     # require 1/4 cpus. Therefore, ideally 2.5k cpus will be used.
     err_str = f"Only {max_cpus - min_cpus_available}/{max_cpus} cpus used."
-    threshold = num_tasks * cpus_per_task * 0.9
+    threshold = num_tasks * cpus_per_task * 0.75
     assert max_cpus - min_cpus_available > threshold, err_str
 
     for _ in tqdm.trange(num_tasks, desc="Ensuring all tasks have finished"):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#17455 set the threshold higher than it previously was, and this seems to be causing the scalability envelope to fail now. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
