### PR TITLE
[tune] Allow to pass searcher/scheduler string names to `tune.run`

### DIFF
--- a/python/ray/tune/tests/test_api.py
+++ b/python/ray/tune/tests/test_api.py
@@ -23,6 +23,7 @@ from ray.tune.schedulers import (TrialScheduler, FIFOScheduler,
 from ray.tune.stopper import MaximumIterationStopper, TrialPlateauStopper
 from ray.tune.sync_client import CommandBasedClient
 from ray.tune.trial import Trial
+from ray.tune.trial_runner import TrialRunner
 from ray.tune.result import (TIMESTEPS_TOTAL, DONE, HOSTNAME, NODE_IP, PID,
                              EPISODES_TOTAL, TRAINING_ITERATION,
                              TIMESTEPS_THIS_ITER, TIME_THIS_ITER_S,
@@ -1584,6 +1585,60 @@ class ApiTestFast(unittest.TestCase):
         })
         self.assertEqual(trial.status, Trial.TERMINATED)
         self.assertEqual(trial.last_result["mean_accuracy"], float("inf"))
+
+    def testSearcherSchedulerStr(self):
+        def train(config):
+            tune.report(metric=1)
+
+        capture = {}
+
+        class MockTrialRunner(TrialRunner):
+            def __init__(self,
+                         search_alg=None,
+                         scheduler=None,
+                         local_checkpoint_dir=None,
+                         remote_checkpoint_dir=None,
+                         sync_to_cloud=None,
+                         stopper=None,
+                         resume=False,
+                         server_port=None,
+                         fail_fast=False,
+                         checkpoint_period=None,
+                         trial_executor=None,
+                         callbacks=None,
+                         metric=None):
+                # should be converted from strings at this case
+                # and not None
+                capture["search_alg"] = search_alg
+                capture["scheduler"] = scheduler
+                super().__init__(
+                    search_alg=search_alg,
+                    scheduler=scheduler,
+                    local_checkpoint_dir=local_checkpoint_dir,
+                    remote_checkpoint_dir=remote_checkpoint_dir,
+                    sync_to_cloud=sync_to_cloud,
+                    stopper=stopper,
+                    resume=resume,
+                    server_port=server_port,
+                    fail_fast=fail_fast,
+                    checkpoint_period=checkpoint_period,
+                    trial_executor=trial_executor,
+                    callbacks=callbacks,
+                    metric=metric)
+
+        with patch("ray.tune.tune.TrialRunner", MockTrialRunner):
+            tune.run(
+                train,
+                search_alg="random",
+                scheduler="async_hyperband",
+                metric="metric",
+                mode="max",
+                stop={TRAINING_ITERATION: 1})
+
+        self.assertTrue(
+            isinstance(capture["search_alg"], BasicVariantGenerator))
+        self.assertTrue(
+            isinstance(capture["scheduler"], AsyncHyperBandScheduler))
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -75,8 +75,8 @@ def run(
             float, int, Mapping]], PlacementGroupFactory] = None,
         num_samples: int = 1,
         local_dir: Optional[str] = None,
-        search_alg: Optional[Union[Searcher, SearchAlgorithm]] = None,
-        scheduler: Optional[TrialScheduler] = None,
+        search_alg: Optional[Union[Searcher, SearchAlgorithm, str]] = None,
+        scheduler: Optional[Union[TrialScheduler, str]] = None,
         keep_checkpoints_num: Optional[int] = None,
         checkpoint_score_attr: Optional[str] = None,
         checkpoint_freq: int = 0,
@@ -194,9 +194,9 @@ def run(
             samples are generated until a stopping condition is met.
         local_dir (str): Local dir to save training results to.
             Defaults to ``~/ray_results``.
-        search_alg (Searcher|SearchAlgorithm): Search algorithm for
+        search_alg (Searcher|SearchAlgorithm|str): Search algorithm for
             optimization.
-        scheduler (TrialScheduler): Scheduler for executing
+        scheduler (TrialScheduler|str): Scheduler for executing
             the experiment. Choose among FIFO (default), MedianStopping,
             AsyncHyperBand, HyperBand and PopulationBasedTraining. Refer to
             ray.tune.schedulers for more options.
@@ -424,6 +424,16 @@ def run(
 
     if fail_fast and max_failures != 0:
         raise ValueError("max_failures must be 0 if fail_fast=True.")
+
+    if isinstance(search_alg, str):
+        # importing at top level causes a recursive dependency
+        from ray.tune.suggest import create_searcher
+        search_alg = create_searcher(search_alg)
+
+    if isinstance(scheduler, str):
+        # importing at top level causes a recursive dependency
+        from ray.tune.schedulers import create_scheduler
+        scheduler = create_scheduler(scheduler)
 
     if issubclass(type(search_alg), Searcher):
         search_alg = SearchGenerator(search_alg)

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -195,11 +195,12 @@ def run(
         local_dir (str): Local dir to save training results to.
             Defaults to ``~/ray_results``.
         search_alg (Searcher|SearchAlgorithm|str): Search algorithm for
-            optimization.
+            optimization. You can also use the name of the algorithm.
         scheduler (TrialScheduler|str): Scheduler for executing
             the experiment. Choose among FIFO (default), MedianStopping,
             AsyncHyperBand, HyperBand and PopulationBasedTraining. Refer to
-            ray.tune.schedulers for more options.
+            ray.tune.schedulers for more options. You can also use the
+            name of the scheduler.
         keep_checkpoints_num (int): Number of checkpoints to keep. A value of
             `None` keeps all checkpoints. Defaults to `None`. If set, need
             to provide `checkpoint_score_attr`.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We have methods for creating a searcher/scheduler from a string name. This PR allows string names to be passed as the `search_alg`/`scheduler` params to `tune.run`, making use of those methods underneath, simplifying user experience,

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
