### PR TITLE
[Dataset] Fix reading parquet from gcs

### DIFF
--- a/python/ray/experimental/data/datasource/file_based_datasource.py
+++ b/python/ray/experimental/data/datasource/file_based_datasource.py
@@ -158,7 +158,9 @@ def _resolve_paths_and_filesystem(
             filesystems inferred from the provided paths to ensure
             compatibility.
     """
-    from pyarrow.fs import FileType, _resolve_filesystem_and_path
+    from pyarrow.fs import FileSystem, FileType, \
+        PyFileSystem, FSSpecHandler, \
+        _resolve_filesystem_and_path
 
     if isinstance(paths, str):
         paths = [paths]
@@ -168,6 +170,9 @@ def _resolve_paths_and_filesystem(
             "paths must be a path string or a list of path strings.")
     elif len(paths) == 0:
         raise ValueError("Must provide at least one path.")
+
+    if filesystem and not isinstance(filesystem, FileSystem):
+        filesystem = PyFileSystem(FSSpecHandler(filesystem))
 
     resolved_paths = []
     for path in paths:
@@ -179,8 +184,6 @@ def _resolve_paths_and_filesystem(
             path, filesystem)
         if filesystem is None:
             filesystem = resolved_filesystem
-        elif type(resolved_filesystem) != type(filesystem):
-            raise ValueError("All paths must use same filesystem.")
         resolved_path = filesystem.normalize_path(resolved_path)
         resolved_paths.append(resolved_path)
 

--- a/python/ray/experimental/data/datasource/file_based_datasource.py
+++ b/python/ray/experimental/data/datasource/file_based_datasource.py
@@ -43,8 +43,7 @@ class FileBasedDatasource(Datasource[Union[ArrowRow, Any]]):
 
         read_file = self._read_file
 
-        if isinstance(filesystem, pa.fs.S3FileSystem):
-            filesystem = _S3FileSystemWrapper(filesystem)
+        filesystem = _maybe_wrap_fs(filesystem)
 
         def read_files(
                 read_paths: List[str],
@@ -209,6 +208,13 @@ def _unwrap_protocol(path):
     """
     parsed = urlparse(path)
     return parsed.netloc + parsed.path
+
+
+def _maybe_wrap_fs(filesystem: "pyarrow.fs.FileSystem"):
+    import pyarrow as pa
+    if isinstance(filesystem, pa.fs.S3FileSystem):
+        return _S3FileSystemWrapper(filesystem)
+    return filesystem
 
 
 class _S3FileSystemWrapper:

--- a/python/ray/experimental/data/datasource/parquet_datasource.py
+++ b/python/ray/experimental/data/datasource/parquet_datasource.py
@@ -8,7 +8,7 @@ from ray.experimental.data.impl.arrow_block import ArrowRow
 from ray.experimental.data.impl.block_list import BlockMetadata
 from ray.experimental.data.datasource.datasource import Datasource, ReadTask
 from ray.experimental.data.datasource.file_based_datasource import (
-    _resolve_paths_and_filesystem, _maybe_wrap_fs)
+    _resolve_paths_and_filesystem)
 
 logger = logging.getLogger(__name__)
 
@@ -39,8 +39,6 @@ class ParquetDatasource(Datasource[ArrowRow]):
         paths, file_infos, filesystem = _resolve_paths_and_filesystem(
             paths, filesystem)
         file_sizes = [file_info.size for file_info in file_infos]
-
-        filesystem = _maybe_wrap_fs(filesystem)
 
         dataset_kwargs = reader_args.pop("dataset_kwargs", {})
         pq_ds = pq.ParquetDataset(

--- a/python/ray/experimental/data/datasource/parquet_datasource.py
+++ b/python/ray/experimental/data/datasource/parquet_datasource.py
@@ -8,7 +8,7 @@ from ray.experimental.data.impl.arrow_block import ArrowRow
 from ray.experimental.data.impl.block_list import BlockMetadata
 from ray.experimental.data.datasource.datasource import Datasource, ReadTask
 from ray.experimental.data.datasource.file_based_datasource import (
-    _resolve_paths_and_filesystem)
+    _resolve_paths_and_filesystem, _maybe_wrap_fs)
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,6 @@ class ParquetDatasource(Datasource[ArrowRow]):
         """Creates and returns read tasks for a file-based datasource.
         """
         from ray import cloudpickle
-        import pyarrow as pa
         import pyarrow.parquet as pq
         import numpy as np
 
@@ -41,8 +40,7 @@ class ParquetDatasource(Datasource[ArrowRow]):
             paths, filesystem)
         file_sizes = [file_info.size for file_info in file_infos]
 
-        if isinstance(filesystem, pa.fs.S3FileSystem):
-            filesystem = _S3FileSystemWrapper(filesystem)
+        filesystem = _maybe_wrap_fs(filesystem)
 
         dataset_kwargs = reader_args.pop("dataset_kwargs", {})
         pq_ds = pq.ParquetDataset(

--- a/python/ray/experimental/data/datasource/parquet_datasource.py
+++ b/python/ray/experimental/data/datasource/parquet_datasource.py
@@ -33,12 +33,16 @@ class ParquetDatasource(Datasource[ArrowRow]):
         """Creates and returns read tasks for a file-based datasource.
         """
         from ray import cloudpickle
+        import pyarrow as pa
         import pyarrow.parquet as pq
         import numpy as np
 
         paths, file_infos, filesystem = _resolve_paths_and_filesystem(
             paths, filesystem)
         file_sizes = [file_info.size for file_info in file_infos]
+
+        if isinstance(filesystem, pa.fs.S3FileSystem):
+            filesystem = _S3FileSystemWrapper(filesystem)
 
         dataset_kwargs = reader_args.pop("dataset_kwargs", {})
         pq_ds = pq.ParquetDataset(

--- a/python/ray/experimental/data/tests/test_dataset.py
+++ b/python/ray/experimental/data/tests/test_dataset.py
@@ -1,4 +1,3 @@
-import io
 import os
 import random
 import requests
@@ -13,7 +12,6 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 from fsspec.implementations.local import LocalFileSystem
-
 
 import ray
 

--- a/python/ray/experimental/data/tests/test_dataset.py
+++ b/python/ray/experimental/data/tests/test_dataset.py
@@ -431,30 +431,6 @@ def test_fsspec_filesystem(ray_start_regular_shared, tmp_path):
     # Test metadata-only parquet ops.
     assert len(ds._blocks._blocks) == 1
     assert ds.count() == 6
-    assert ds.size_bytes() > 0
-    assert ds.schema() is not None
-    input_files = ds.input_files()
-    assert len(input_files) == 2, input_files
-    assert "test1.parquet" in str(input_files)
-    assert "test2.parquet" in str(input_files)
-    assert str(ds) == \
-        "Dataset(num_blocks=2, num_rows=6, " \
-        "schema={one: int64, two: string})", ds
-    assert repr(ds) == \
-        "Dataset(num_blocks=2, num_rows=6, " \
-        "schema={one: int64, two: string})", ds
-    assert len(ds._blocks._blocks) == 1
-
-    # Forces a data read.
-    values = [[s["one"], s["two"]] for s in ds.take()]
-    assert len(ds._blocks._blocks) == 2
-    assert sorted(values) == [[1, "a"], [2, "b"], [3, "c"], [4, "e"], [5, "f"],
-                              [6, "g"]]
-
-    # Test column selection.
-    ds = ray.experimental.data.read_parquet(str(tmp_path), columns=["one"])
-    values = [s["one"] for s in ds.take()]
-    assert sorted(values) == [1, 2, 3, 4, 5, 6]
 
 
 def test_parquet_read(ray_start_regular_shared, tmp_path):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?


This PR should fix loading files from gcsfs or any other fsspec compatible filesystem.

## Related issue number

Closes #17501
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
