### PR TITLE
[rllib] Ape-X doesn't take the value of `prioritized_replay` into account

### DIFF
--- a/rllib/agents/ddpg/ddpg.py
+++ b/rllib/agents/ddpg/ddpg.py
@@ -193,8 +193,9 @@ def validate_config(config: TrainerConfigDict) -> None:
                              "replay_mode=lockstep.")
     else:
         if config.get("worker_side_prioritization"):
-            raise ValueError("Worker side prioritization is not supported when "
-                             "prioritized_replay=False.")
+            raise ValueError(
+                "Worker side prioritization is not supported when "
+                "prioritized_replay=False.")
 
 
 def get_policy_class(config: TrainerConfigDict) -> Optional[Type[Policy]]:

--- a/rllib/agents/ddpg/ddpg.py
+++ b/rllib/agents/ddpg/ddpg.py
@@ -187,6 +187,15 @@ def validate_config(config: TrainerConfigDict) -> None:
                 "'complete_episodes'. Setting batch_mode=complete_episodes.")
             config["batch_mode"] = "complete_episodes"
 
+    if config.get("prioritized_replay"):
+        if config["multiagent"]["replay_mode"] == "lockstep":
+            raise ValueError("Prioritized replay is not supported when "
+                             "replay_mode=lockstep.")
+    else:
+        if config.get("worker_side_prioritization"):
+            raise ValueError("Worker side prioritization is not supported when "
+                             "prioritized_replay=False.")
+
 
 def get_policy_class(config: TrainerConfigDict) -> Optional[Type[Policy]]:
     """Policy class picker function. Class is chosen based on DL-framework.

--- a/rllib/agents/dqn/apex.py
+++ b/rllib/agents/dqn/apex.py
@@ -162,7 +162,8 @@ def apex_execution_plan(workers: WorkerSet,
     # Update experience priorities post learning.
     def update_prio_and_stats(item: Tuple[ActorHandle, dict, int]) -> None:
         actor, prio_dict, count = item
-        actor.update_priorities.remote(prio_dict)
+        if config.get("prioritized_replay"):
+            actor.update_priorities.remote(prio_dict)
         metrics = _get_shared_metrics()
         # Manually update the steps trained counter since the learner thread
         # is executing outside the pipeline.

--- a/rllib/agents/dqn/dqn.py
+++ b/rllib/agents/dqn/dqn.py
@@ -181,6 +181,10 @@ def validate_config(config: TrainerConfigDict) -> None:
         elif config["replay_sequence_length"] > 1:
             raise ValueError("Prioritized replay is not supported when "
                              "replay_sequence_length > 1.")
+    else:
+        if config.get("worker_side_prioritization"):
+            raise ValueError("Worker side prioritization is not supported when "
+                             "prioritized_replay=False.")
 
     # Multi-agent mode and multi-GPU optimizer.
     if config["multiagent"]["policies"] and not config["simple_optimizer"]:

--- a/rllib/agents/dqn/dqn.py
+++ b/rllib/agents/dqn/dqn.py
@@ -183,8 +183,9 @@ def validate_config(config: TrainerConfigDict) -> None:
                              "replay_sequence_length > 1.")
     else:
         if config.get("worker_side_prioritization"):
-            raise ValueError("Worker side prioritization is not supported when "
-                             "prioritized_replay=False.")
+            raise ValueError(
+                "Worker side prioritization is not supported when "
+                "prioritized_replay=False.")
 
     # Multi-agent mode and multi-GPU optimizer.
     if config["multiagent"]["policies"] and not config["simple_optimizer"]:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
DQN Ape-X and DDPG Ape-X agents do not take the value set by users for the parameter `prioritized_replay`  into account. In addition to the unexpected PER behavior, this prevents these agents from being used with `replay_mode=lockstep`.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #17540 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
