### PR TITLE
Remove many_nodes_smoke_test

### DIFF
--- a/release/.buildkite/build_pipeline.py
+++ b/release/.buildkite/build_pipeline.py
@@ -75,7 +75,6 @@ CORE_NIGHTLY_TESTS = {
         "many_actors_smoke_test",
         "many_tasks_smoke_test",
         "many_pgs_smoke_test",
-        "many_nodes_smoke_test",
     ],
     "~/ray/release/nightly_tests/dataset/dataset_test.yaml": [
         "inference",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

many_nodes and many_tasks share a script, but with different cluster configs/parameters, so we shouldn't try to run this nonexistent smoke test (it's already covered under many_tasks_smoke_test). 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
