### PR TITLE
[nightly-test] deflake autoscaling_shuffle_1tb_1000_partitions

### DIFF
--- a/release/nightly_tests/nightly_tests.yaml
+++ b/release/nightly_tests/nightly_tests.yaml
@@ -104,7 +104,7 @@
     compute_template: shuffle/shuffle_compute_autoscaling.yaml
 
   run:
-    timeout: 3000
+    timeout: 4000
     script: python shuffle/shuffle_test.py --num-partitions=1000 --partition-size=1e9 --no-streaming
 
 # Test multi nodes 1TB streaming shuffle with a large number of partitions.


### PR DESCRIPTION
The latest autoscaling_shuffle_1tb_1000_partitions fails because of  [50 minutes timeout](https://beta.anyscale.com/o/anyscale-internal/projects/prj_2xR6uT6t7jJuu1aCwWMsle/clusters/ses_57wQg9v28dgMpMDf7MZQDzxW?command-history-section=command_history). Increase it to 4000 seconds.
