### PR TITLE
[RLlib] Remove `SampleBatch._get_slice_indices()` deprecated logging spam (moderate).

### DIFF
--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -672,8 +672,8 @@ class SampleBatch(dict):
                 _time_major=self.time_major,
             )
 
+    @Deprecated(error=False)
     def _get_slice_indices(self, slice_size):
-        deprecation_warning("SampleBatch._get_slice_indices", error=False)
         data_slices = []
         data_slices_states = []
         if self.get("seq_lens") is not None and len(self["seq_lens"]) > 0:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fixes "`SampleBatch._get_slice_indices` is deprecated" logging spam.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
