### PR TITLE
[Docker] Add --base-image argument to build-docker.sh

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -19,6 +19,11 @@ case $key in
     GPU="-gpu"
     BASE_IMAGE="nvidia/cuda:11.2.0-cudnn8-devel-ubuntu18.04"
     ;;
+    --base-image)
+    # Override for the base image.
+    shift
+    BASE_IMAGE=$1
+    ;;
     --no-cache-build)
     NO_CACHE="--no-cache"
     ;;
@@ -47,7 +52,7 @@ case $key in
     PYTHON_VERSION=$1
     ;;
     *)
-    echo "Usage: build-docker.sh [ --no-cache-build ] [ --shas-only ] [ --build-development-image ] [ --build-examples ] [ --wheel-to-use ] [ --python-version ]"
+    echo "Usage: build-docker.sh [ --gpu ] [ --base-image ] [ --no-cache-build ] [ --shas-only ] [ --build-development-image ] [ --build-examples ] [ --wheel-to-use ] [ --python-version ]"
     exit 1
 esac
 shift


### PR DESCRIPTION
## Why are these changes needed?

Somebody (e.g. me!) might want to use this script to build against a different base image - e.g. not ubuntu, or more practically, a different CUDA version. An example: `sh build-docker.sh --python-version 3.8.10 --gpu --base-image nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04` for tf 2.3, python 3.8.10.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] I tested the script with this change.
