### PR TITLE
Fixes typo in RolloutWorker.__init__

### DIFF
--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -538,7 +538,7 @@ class RolloutWorker(ParallelIteratorWorker):
                         # Not all Operations support this.
                         torch.use_deterministic_algorithms(True)
                     else:
-                        torch.set_determinstic(True)
+                        torch.set_deterministic(True)
                 # This is only for Convolution no problem.
                 torch.backends.cudnn.deterministic = True
             # Tf2.x.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes the typo in `RolloutWorker.__init__`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #17582

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
