### PR TITLE
[Releaser] Fix bug where iteration time is always logged as 0

### DIFF
--- a/release/long_running_tests/workloads/actor_deaths.py
+++ b/release/long_running_tests/workloads/actor_deaths.py
@@ -111,12 +111,11 @@ while True:
           "  - Total elapsed time: {}.".format(
               iteration, new_time - previous_time, new_time,
               new_time - start_time))
-    previous_time = new_time
-    iteration += 1
-
     update_progress({
         "iteration": iteration,
         "iteration_time": new_time - previous_time,
         "absolute_time": new_time,
         "elapsed_time": new_time - start_time,
     })
+    previous_time = new_time
+    iteration += 1

--- a/release/long_running_tests/workloads/many_actor_tasks.py
+++ b/release/long_running_tests/workloads/many_actor_tasks.py
@@ -76,12 +76,11 @@ while True:
           "  - Total elapsed time: {}.".format(
               iteration, new_time - previous_time, new_time,
               new_time - start_time))
-    previous_time = new_time
-    iteration += 1
-
     update_progress({
         "iteration": iteration,
         "iteration_time": new_time - previous_time,
         "absolute_time": new_time,
         "elapsed_time": new_time - start_time,
     })
+    previous_time = new_time
+    iteration += 1

--- a/release/long_running_tests/workloads/many_drivers.py
+++ b/release/long_running_tests/workloads/many_drivers.py
@@ -108,12 +108,11 @@ while True:
           "  - Total elapsed time: {}.".format(
               iteration, new_time - previous_time, new_time,
               new_time - start_time))
-    previous_time = new_time
-    iteration += 1
-
     update_progress({
         "iteration": iteration,
         "iteration_time": new_time - previous_time,
         "absolute_time": new_time,
         "elapsed_time": new_time - start_time,
     })
+    previous_time = new_time
+    iteration += 1

--- a/release/long_running_tests/workloads/many_tasks.py
+++ b/release/long_running_tests/workloads/many_tasks.py
@@ -72,12 +72,11 @@ while True:
           "  - Total elapsed time: {}.".format(
               iteration, new_time - previous_time, new_time,
               new_time - start_time))
-    previous_time = new_time
-    iteration += 1
-
     update_progress({
         "iteration": iteration,
         "iteration_time": new_time - previous_time,
         "absolute_time": new_time,
         "elapsed_time": new_time - start_time,
     })
+    previous_time = new_time
+    iteration += 1

--- a/release/long_running_tests/workloads/node_failures.py
+++ b/release/long_running_tests/workloads/node_failures.py
@@ -74,12 +74,11 @@ while True:
           "  - Total elapsed time: {}.".format(
               iteration, new_time - previous_time, new_time,
               new_time - start_time))
-    previous_time = new_time
-    iteration += 1
-
     update_progress({
         "iteration": iteration,
         "iteration_time": new_time - previous_time,
         "absolute_time": new_time,
         "elapsed_time": new_time - start_time,
     })
+    previous_time = new_time
+    iteration += 1

--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -134,15 +134,14 @@ class RandomTest:
                   "  - Total elapsed time: {}.".format(
                       iteration, new_time - previous_time, new_time,
                       new_time - start_time))
-            previous_time = new_time
-            iteration += 1
-
             update_progress({
                 "iteration": iteration,
                 "iteration_time": new_time - previous_time,
                 "absolute_time": new_time,
                 "elapsed_time": new_time - start_time,
             })
+            previous_time = new_time
+            iteration += 1
 
 
 random_killer = RandomKiller.remote()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In the release tests, we set `previous_time = new_time` before logging `"iteration_time": new_time - previous_time`, which I think will always make the iteration time zero.  This PR fixes this by moving the line `previous_time = new_time` to after the log.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
