### PR TITLE
Fix mismatched debug log ID formats

### DIFF
--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -384,7 +384,7 @@ class Worker:
 
     def _release_server(self, id: bytes) -> None:
         if self.data_client is not None:
-            logger.debug(f"Releasing {id}")
+            logger.debug(f"Releasing {id.hex()}")
             self.data_client.ReleaseObject(
                 ray_client_pb2.ReleaseRequest(ids=[id]))
 


### PR DESCRIPTION
## Why are these changes needed?

When running ray client w/ debug logs turned on the IDs printed were inconsistently formatted.

e.g.
```
DEBUG:ray.util.client.worker:Retaining a04bf4604d25c606ffffffffffffffffffffffff1000000001000000
DEBUG:ray.util.client.worker:Retaining a04bf4604d25c606ffffffffffffffffffffffff1000000002000000
DEBUG:ray.util.client.worker:Retaining a04bf4604d25c606ffffffffffffffffffffffff1000000003000000
DEBUG:ray.util.client.worker:Releasing b'\xd2\x06R\\\xd7\xf4q\xaf\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x10\x00\x00\x00\x03\x00\x00\x00'
DEBUG:ray.util.client.worker:Releasing b'\xd2\x06R\\\xd7\xf4q\xaf\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x10\x00\x00\x00\x02\x00\x00\x00'
DEBUG:ray.util.client.worker:Releasing b'\xd2\x06R\\\xd7\xf4q\xaf\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x10\x00\x00\x00\x01\x00\x00\x00'
```

This PR standardizes both of them on a hex format.

## Related issue number

n/a

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
