### PR TITLE
[release] increase golden notebook test timeout

### DIFF
--- a/release/golden_notebook_tests/golden_notebook_tests.yaml
+++ b/release/golden_notebook_tests/golden_notebook_tests.yaml
@@ -28,6 +28,6 @@
 
   run:
     use_connect: True
-    timeout: 1800
+    timeout: 2700
     script: python workloads/torch_tune_serve_test.py
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Nightly test is failing because it takes [~30 minutes](https://buildkite.com/ray-project/periodic-ci/builds/687#b624aac3-f36a-4af7-8736-9b072ddd3ca5)) to allocate/start the Anyscale cluster. Currently there is no granular timeout mechanism for the execution of the test itself, so bumping this test timeout up to 45 minutes.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
