### PR TITLE
[ObjectSpill]Remove useless CoreWorker::SpillObjects.

### DIFF
--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -235,7 +235,6 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         CRayStatus SetResource(const c_string &resource_name,
                                const double capacity,
                                const CNodeID &client_Id)
-        CRayStatus SpillObjects(const c_vector[CObjectID] &object_ids)
 
         CJobConfig GetJobConfig()
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1578,63 +1578,6 @@ void CoreWorker::SpillOwnedObject(const ObjectID &object_id,
       });
 }
 
-Status CoreWorker::SpillObjects(const std::vector<ObjectID> &object_ids) {
-  if (object_ids.empty()) {
-    return Status::OK();
-  }
-  auto mutex = std::make_shared<absl::Mutex>();
-  auto num_remaining = std::make_shared<size_t>(object_ids.size());
-  auto ready_promise = std::make_shared<std::promise<void>>(std::promise<void>());
-  Status final_status;
-
-  // TODO(Clark): Add spilled URL and spilled node ID to reference in this callback.
-  auto callback = [mutex, num_remaining, ready_promise]() {
-    absl::MutexLock lock(mutex.get());
-    (*num_remaining)--;
-    if (*num_remaining == 0) {
-      ready_promise->set_value();
-    }
-  };
-
-  for (const auto &object_id : object_ids) {
-    RAY_LOG(DEBUG) << "Requesting spill for object " << object_id;
-    // Acquire a temporary reference to make sure that the object is still in
-    // scope by the time we register the callback to spill the object.
-    // Otherwise, the callback may never get called.
-    AddLocalReference(object_id, "<temporary (get object status)>");
-
-    rpc::Address owner_address;
-    auto has_owner = reference_counter_->GetOwner(object_id, &owner_address);
-    if (!has_owner) {
-      final_status =
-          Status::Invalid("Cannot call spill on objects that have gone out of scope.");
-      callback();
-    } else if (WorkerID::FromBinary(owner_address.worker_id()) !=
-               worker_context_.GetWorkerID()) {
-      final_status = Status::Invalid("Cannot call spill on objects that we do not own.");
-      callback();
-    } else {
-      memory_store_->GetAsync(
-          object_id, [this, object_id, callback](std::shared_ptr<RayObject> obj) {
-            SpillOwnedObject(object_id, obj, callback);
-          });
-    }
-
-    // Remove the temporary reference.
-    RemoveLocalReference(object_id);
-  }
-
-  ready_promise->get_future().wait();
-
-  for (const auto &object_id : object_ids) {
-    // TODO(Clark): Move this to the callback (unless we really wanted to batch it) and
-    // also include the spilled URL, spilled node ID, and updated object size.
-    reference_counter_->HandleObjectSpilled(object_id, "", NodeID::Nil(), -1,
-                                            /*release*/ true);
-  }
-  return final_status;
-}
-
 std::unordered_map<std::string, double> AddPlacementGroupConstraint(
     const std::unordered_map<std::string, double> &resources,
     PlacementGroupID placement_group_id, int64_t bundle_index) {

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -687,14 +687,6 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   Status SetResource(const std::string &resource_name, const double capacity,
                      const NodeID &node_id);
 
-  /// Request an object to be spilled to external storage.
-  /// \param[in] object_ids The objects to be spilled.
-  /// \return Status. Returns Status::Invalid if any of the objects are not
-  /// eligible for spilling (they have gone out of scope or we do not own the
-  /// object). Otherwise, the return status is ok and we will use best effort
-  /// to spill the object.
-  Status SpillObjects(const std::vector<ObjectID> &object_ids);
-
   /// Submit a normal task.
   ///
   /// \param[in] function The remote function to execute.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
The `CoreWorker::SpillObjects` seems redundant, try remove it.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
