### PR TITLE
[Doc] Fold TOC index by default

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -25,7 +25,7 @@ sphinx-gallery
 sphinx-jsonschema
 sphinx-tabs
 sphinx-version-warning
-sphinx-book-theme
+sphinx-book-theme==0.0.42
 sphinxcontrib.yt
 starlette
 tabulate

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -301,6 +301,7 @@ html_theme_options = {
     "use_edit_page_button": True,
     "path_to_docs": "doc/source",
     "home_page_in_toc": True,
+    "show_navbar_depth": 0,
 }
 
 # Add any paths that contain custom themes here, relative to this directory.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently Ray dashboard shows everything in toc on the left, like this
![image](https://user-images.githubusercontent.com/21118851/128412580-4c103f80-4adf-47ac-8a29-859c921e6544.png)

The experience is pretty lousy because it shows all library content. 

To fix it in short term, we can fold it by default so looks this
![image](https://user-images.githubusercontent.com/21118851/128412598-6496e291-a1a9-43ae-87a1-afd5d6cf82a6.png)

And clicking it libraries shows all the context without revealing other libraries
<img width="1399" alt="Screen Shot 2021-08-05 at 12 54 13 PM" src="https://user-images.githubusercontent.com/21118851/128412676-17dd8b58-06d5-48b0-9a0c-b58ca09ddca4.png">

