### PR TITLE
[gcs] Fix actor killing hang due to race condition

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -586,12 +586,10 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
       }
     }
   }
-
   // The actor is already dead, most likely due to process or node failure.
   if (actor->GetState() == rpc::ActorTableData::DEAD) {
     return;
   }
-
   if (actor->GetState() == rpc::ActorTableData::DEPENDENCIES_UNREADY) {
     // The actor creation task still has unresolved dependencies. Remove from the
     // unresolved actors map.

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -564,9 +564,8 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
   const auto actor = std::move(it->second);
 
   registered_actors_.erase(it);
-  RAY_LOG(DEBUG) << "Try to kill actor " << actor->GetActorID()
-                 << ", with status " << actor->GetState()
-                 << ", name " << actor->GetName();
+  RAY_LOG(DEBUG) << "Try to kill actor " << actor->GetActorID() << ", with status "
+                 << actor->GetState() << ", name " << actor->GetName();
   // Clean up the client to the actor's owner, if necessary.
   if (!actor->IsDetached()) {
     RemoveActorFromOwner(actor);
@@ -1112,9 +1111,8 @@ void GcsActorManager::NotifyCoreWorkerToKillActor(const std::shared_ptr<GcsActor
   request.set_force_kill(force_kill);
   request.set_no_restart(no_restart);
   auto actor_client = worker_client_factory_(actor->GetAddress());
-  RAY_LOG(DEBUG) << "Send request to kill actor " << actor->GetActorID()
-                 << " to worker " << actor->GetWorkerID()
-                 << " at node " << actor->GetNodeID();
+  RAY_LOG(DEBUG) << "Send request to kill actor " << actor->GetActorID() << " to worker "
+                 << actor->GetWorkerID() << " at node " << actor->GetNodeID();
   actor_client->KillActor(request, [](auto &status, auto &) {
     RAY_LOG(DEBUG) << "Killing status: " << status.ToString();
   });

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -564,7 +564,9 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
   const auto actor = std::move(it->second);
 
   registered_actors_.erase(it);
-
+  RAY_LOG(DEBUG) << "Try to kill actor " << actor->GetActorID()
+                 << ", with status " << actor->GetState()
+                 << ", name " << actor->GetName();
   // Clean up the client to the actor's owner, if necessary.
   if (!actor->IsDetached()) {
     RemoveActorFromOwner(actor);
@@ -588,6 +590,8 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
   }
   // The actor is already dead, most likely due to process or node failure.
   if (actor->GetState() == rpc::ActorTableData::DEAD) {
+    RAY_LOG(DEBUG) << "Actor " << actor->GetActorID() << "has been dead,"
+                   << "skip sending killing request";
     return;
   }
   if (actor->GetState() == rpc::ActorTableData::DEPENDENCIES_UNREADY) {
@@ -1103,12 +1107,17 @@ void GcsActorManager::RemoveActorFromOwner(const std::shared_ptr<GcsActor> &acto
 
 void GcsActorManager::NotifyCoreWorkerToKillActor(const std::shared_ptr<GcsActor> &actor,
                                                   bool force_kill, bool no_restart) {
-  auto actor_client = worker_client_factory_(actor->GetAddress());
   rpc::KillActorRequest request;
   request.set_intended_actor_id(actor->GetActorID().Binary());
   request.set_force_kill(force_kill);
   request.set_no_restart(no_restart);
-  RAY_UNUSED(actor_client->KillActor(request, nullptr));
+  auto actor_client = worker_client_factory_(actor->GetAddress());
+  RAY_LOG(DEBUG) << "Send request to kill actor " << actor->GetActorID()
+                 << " to worker " << actor->GetWorkerID()
+                 << " at node " << actor->GetNodeID();
+  actor_client->KillActor(request, [](auto &status, auto &) {
+    RAY_LOG(DEBUG) << "Killing status: " << status.ToString();
+  });
 }
 
 void GcsActorManager::KillActor(const ActorID &actor_id, bool force_kill,
@@ -1137,6 +1146,8 @@ void GcsActorManager::KillActor(const ActorID &actor_id, bool force_kill,
     NotifyCoreWorkerToKillActor(actor, force_kill, no_restart);
   } else {
     const auto &task_id = actor->GetCreationTaskSpecification().TaskId();
+    RAY_LOG(DEBUG) << "The actor " << actor->GetActorID()
+                   << " hasn't been created yet, cancel scheduling " << task_id;
     CancelActorInScheduling(actor, task_id);
     ReconstructActor(actor_id, /*need_reschedule=*/true);
   }
@@ -1159,6 +1170,8 @@ void GcsActorManager::AddDestroyedActorToCache(const std::shared_ptr<GcsActor> &
 
 void GcsActorManager::CancelActorInScheduling(const std::shared_ptr<GcsActor> &actor,
                                               const TaskID &task_id) {
+  RAY_LOG(DEBUG) << "Cancel actor in scheduling: actor_id " << actor->GetActorID()
+                 << ", task_id " << task_id;
   const auto &actor_id = actor->GetActorID();
   const auto &node_id = actor->GetNodeID();
   // The actor has not been created yet. It is either being scheduled or is

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -590,7 +590,7 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
   // The actor is already dead, most likely due to process or node failure.
   if (actor->GetState() == rpc::ActorTableData::DEAD) {
     RAY_LOG(DEBUG) << "Actor " << actor->GetActorID() << "has been dead,"
-                   << "skip sending killing request";
+                   << "skip sending killing request.";
     return;
   }
   if (actor->GetState() == rpc::ActorTableData::DEPENDENCIES_UNREADY) {

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
@@ -366,9 +366,7 @@ void GcsActorScheduler::CreateActorOnWorker(std::shared_ptr<GcsActor> actor,
           RAY_LOG(DEBUG) << "Actor " << actor->GetActorID()
                          << " has been removed from creating map. Actor status "
                          << actor->GetState();
-          auto actor_id = status.ok() ?
-                          actor->GetActorID() :
-                          ActorID::Nil();
+          auto actor_id = status.ok() ? actor->GetActorID() : ActorID::Nil();
           KillActorOnWorker(worker->GetAddress(), actor_id);
         }
       });
@@ -376,7 +374,8 @@ void GcsActorScheduler::CreateActorOnWorker(std::shared_ptr<GcsActor> actor,
 
 void GcsActorScheduler::RetryCreatingActorOnWorker(
     std::shared_ptr<GcsActor> actor, std::shared_ptr<GcsLeasedWorker> worker) {
-  RAY_LOG(DEBUG) << "Retry creating actor " << actor->GetActorID() << " on worker " << worker->GetWorkerID();
+  RAY_LOG(DEBUG) << "Retry creating actor " << actor->GetActorID() << " on worker "
+                 << worker->GetWorkerID();
   RAY_UNUSED(execute_after(
       io_context_, [this, actor, worker] { DoRetryCreatingActorOnWorker(actor, worker); },
       RayConfig::instance().gcs_create_actor_retry_interval_ms()));
@@ -404,9 +403,9 @@ std::shared_ptr<WorkerLeaseInterface> GcsActorScheduler::GetOrConnectLeaseClient
   return raylet_client_pool_->GetOrConnectByAddress(raylet_address);
 }
 
-bool GcsActorScheduler::KillActorOnWorker(
-    const rpc::Address& worker_address, ActorID actor_id) {
-  if(worker_address.raylet_id().empty()) {
+bool GcsActorScheduler::KillActorOnWorker(const rpc::Address &worker_address,
+                                          ActorID actor_id) {
+  if (worker_address.raylet_id().empty()) {
     RAY_LOG(DEBUG) << "Invalid worker address, skip the killing of actor " << actor_id;
     return false;
   }

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
@@ -343,6 +343,7 @@ void GcsActorScheduler::CreateActorOnWorker(std::shared_ptr<GcsActor> actor,
         if (iter != node_to_workers_when_creating_.end()) {
           auto worker_iter = iter->second.find(actor->GetWorkerID());
           if (worker_iter != iter->second.end()) {
+            RAY_LOG(DEBUG) << "Worker " << worker_iter->first << " is in creating map. ";
             // The worker is still in the creating map.
             if (status.ok()) {
               // Remove related core worker client.
@@ -361,12 +362,21 @@ void GcsActorScheduler::CreateActorOnWorker(std::shared_ptr<GcsActor> actor,
               RetryCreatingActorOnWorker(actor, worker);
             }
           }
+        } else {
+          RAY_LOG(DEBUG) << "Actor " << actor->GetActorID()
+                         << " has been removed from creating map. Actor status "
+                         << actor->GetState();
+          auto actor_id = status.ok() ?
+                          actor->GetActorID() :
+                          ActorID::Nil();
+          KillActorOnWorker(worker->GetAddress(), actor_id);
         }
       });
 }
 
 void GcsActorScheduler::RetryCreatingActorOnWorker(
     std::shared_ptr<GcsActor> actor, std::shared_ptr<GcsLeasedWorker> worker) {
+  RAY_LOG(DEBUG) << "Retry creating actor " << actor->GetActorID() << " on worker " << worker->GetWorkerID();
   RAY_UNUSED(execute_after(
       io_context_, [this, actor, worker] { DoRetryCreatingActorOnWorker(actor, worker); },
       RayConfig::instance().gcs_create_actor_retry_interval_ms()));
@@ -392,6 +402,26 @@ void GcsActorScheduler::DoRetryCreatingActorOnWorker(
 std::shared_ptr<WorkerLeaseInterface> GcsActorScheduler::GetOrConnectLeaseClient(
     const rpc::Address &raylet_address) {
   return raylet_client_pool_->GetOrConnectByAddress(raylet_address);
+}
+
+bool GcsActorScheduler::KillActorOnWorker(
+    const rpc::Address& worker_address, ActorID actor_id) {
+  if(worker_address.raylet_id().empty()) {
+    RAY_LOG(DEBUG) << "Invalid worker address, skip the killing of actor " << actor_id;
+    return false;
+  }
+
+  auto cli = core_worker_clients_.GetOrConnect(worker_address);
+  rpc::KillActorRequest request;
+  // Set it to be Nil() since it hasn't been setup yet
+  request.set_intended_actor_id(actor_id.Binary());
+  request.set_force_kill(true);
+  request.set_no_restart(true);
+  cli->KillActor(request, [actor_id](auto &status, auto &) {
+    RAY_LOG(DEBUG) << "Killing actor " << actor_id
+                   << " with return status: " << status.ToString();
+  });
+  return true;
 }
 
 std::shared_ptr<rpc::GcsNodeInfo> RayletBasedActorScheduler::SelectNode(
@@ -440,18 +470,6 @@ void RayletBasedActorScheduler::HandleWorkerLeaseReply(
   // gcs_actor_manager will reconstruct it again.
   auto node_id = NodeID::FromBinary(node->node_id());
   auto iter = node_to_actors_when_leasing_.find(node_id);
-  auto kill_worker = [&reply, this]() {
-    auto &worker_address = reply.worker_address();
-    if (!worker_address.raylet_id().empty()) {
-      auto cli = core_worker_clients_.GetOrConnect(worker_address);
-      rpc::KillActorRequest request;
-      // Set it to be Nil() since it hasn't been setup yet
-      request.set_intended_actor_id(ActorID::Nil().Binary());
-      request.set_force_kill(true);
-      request.set_no_restart(true);
-      RAY_UNUSED(cli->KillActor(request, nullptr));
-    }
-  };
   if (iter != node_to_actors_when_leasing_.end()) {
     auto actor_iter = iter->second.find(actor->GetActorID());
     if (actor_iter == iter->second.end()) {
@@ -463,7 +481,10 @@ void RayletBasedActorScheduler::HandleWorkerLeaseReply(
           << " has been already cancelled. The response will be ignored. Job id = "
           << actor->GetActorID().JobId();
       if (actor->GetState() == rpc::ActorTableData::DEAD) {
-        kill_worker();
+        // If the actor has been killed, we need to kill the worker too
+        // otherwise, the worker will be leaked.
+        RAY_LOG(DEBUG) << "Actor " << actor->GetActorID() << " is dead, kill the worker";
+        KillActorOnWorker(reply.worker_address(), ActorID::Nil());
       }
       return;
     }
@@ -493,7 +514,10 @@ void RayletBasedActorScheduler::HandleWorkerLeaseReply(
       RetryLeasingWorkerFromNode(actor, node);
     }
   } else if (actor->GetState() == rpc::ActorTableData::DEAD) {
-    kill_worker();
+    // If the actor has been killed, we need to kill the worker too
+    // otherwise, the worker will be leaked.
+    RAY_LOG(DEBUG) << "Actor " << actor->GetActorID() << " is dead, kill the worker";
+    KillActorOnWorker(reply.worker_address(), ActorID::Nil());
   }
 }
 

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
@@ -343,7 +343,7 @@ void GcsActorScheduler::CreateActorOnWorker(std::shared_ptr<GcsActor> actor,
         if (iter != node_to_workers_when_creating_.end()) {
           auto worker_iter = iter->second.find(actor->GetWorkerID());
           if (worker_iter != iter->second.end()) {
-            RAY_LOG(DEBUG) << "Worker " << worker_iter->first << " is in creating map. ";
+            RAY_LOG(DEBUG) << "Worker " << worker_iter->first << " is in creating map.";
             // The worker is still in the creating map.
             if (status.ok()) {
               // Remove related core worker client.
@@ -412,7 +412,7 @@ bool GcsActorScheduler::KillActorOnWorker(const rpc::Address &worker_address,
 
   auto cli = core_worker_clients_.GetOrConnect(worker_address);
   rpc::KillActorRequest request;
-  // Set it to be Nil() since it hasn't been setup yet
+  // Set it to be Nil() since it hasn't been setup yet.
   request.set_intended_actor_id(actor_id.Binary());
   request.set_force_kill(true);
   request.set_no_restart(true);
@@ -482,7 +482,7 @@ void RayletBasedActorScheduler::HandleWorkerLeaseReply(
       if (actor->GetState() == rpc::ActorTableData::DEAD) {
         // If the actor has been killed, we need to kill the worker too
         // otherwise, the worker will be leaked.
-        RAY_LOG(DEBUG) << "Actor " << actor->GetActorID() << " is dead, kill the worker";
+        RAY_LOG(DEBUG) << "Actor " << actor->GetActorID() << " is dead, kill the worker.";
         KillActorOnWorker(reply.worker_address(), ActorID::Nil());
       }
       return;
@@ -515,7 +515,7 @@ void RayletBasedActorScheduler::HandleWorkerLeaseReply(
   } else if (actor->GetState() == rpc::ActorTableData::DEAD) {
     // If the actor has been killed, we need to kill the worker too
     // otherwise, the worker will be leaked.
-    RAY_LOG(DEBUG) << "Actor " << actor->GetActorID() << " is dead, kill the worker";
+    RAY_LOG(DEBUG) << "Actor " << actor->GetActorID() << " is dead, kill the worker.";
     KillActorOnWorker(reply.worker_address(), ActorID::Nil());
   }
 }

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
@@ -440,6 +440,18 @@ void RayletBasedActorScheduler::HandleWorkerLeaseReply(
   // gcs_actor_manager will reconstruct it again.
   auto node_id = NodeID::FromBinary(node->node_id());
   auto iter = node_to_actors_when_leasing_.find(node_id);
+  auto kill_worker = [&reply, this]() {
+    auto &worker_address = reply.worker_address();
+    if (!worker_address.raylet_id().empty()) {
+      auto cli = core_worker_clients_.GetOrConnect(worker_address);
+      rpc::KillActorRequest request;
+      // Set it to be Nil() since it hasn't been setup yet
+      request.set_intended_actor_id(ActorID::Nil().Binary());
+      request.set_force_kill(true);
+      request.set_no_restart(true);
+      RAY_UNUSED(cli->KillActor(request, nullptr));
+    }
+  };
   if (iter != node_to_actors_when_leasing_.end()) {
     auto actor_iter = iter->second.find(actor->GetActorID());
     if (actor_iter == iter->second.end()) {
@@ -450,6 +462,9 @@ void RayletBasedActorScheduler::HandleWorkerLeaseReply(
           << actor->GetActorID()
           << " has been already cancelled. The response will be ignored. Job id = "
           << actor->GetActorID().JobId();
+      if (actor->GetState() == rpc::ActorTableData::DEAD) {
+        kill_worker();
+      }
       return;
     }
 
@@ -477,6 +492,8 @@ void RayletBasedActorScheduler::HandleWorkerLeaseReply(
     } else {
       RetryLeasingWorkerFromNode(actor, node);
     }
+  } else if (actor->GetState() == rpc::ActorTableData::DEAD) {
+    kill_worker();
   }
 }
 

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
@@ -276,7 +276,7 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
       const rpc::Address &raylet_address);
 
   /// Kill the actor on a node
-  bool KillActorOnWorker(const rpc::Address& worker_address, ActorID actor_id);
+  bool KillActorOnWorker(const rpc::Address &worker_address, ActorID actor_id);
 
  protected:
   /// The io loop that is used to delay execution of tasks (e.g.,

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
@@ -275,6 +275,9 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
   std::shared_ptr<WorkerLeaseInterface> GetOrConnectLeaseClient(
       const rpc::Address &raylet_address);
 
+  /// Kill the actor on a node
+  bool KillActorOnWorker(const rpc::Address& worker_address, ActorID actor_id);
+
  protected:
   /// The io loop that is used to delay execution of tasks (e.g.,
   /// execute_after).


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Creating and killing an actor immediately will have a race condition.

- Lease
- Canceling
- Lease reply
It will leave the worker leak. This PR fixed it.

And there is another race condition:
- Task creating
- Canceling
- Task creating reply received

This will leave the worker leaked too. 

## Related issue number
Closes #17369
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
