### PR TITLE
[Java] fix “argument type mismatch” when an exception occurs in chained tasks

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
@@ -6,6 +6,7 @@ import io.ray.api.id.TaskId;
 import io.ray.api.id.UniqueId;
 import io.ray.runtime.RayRuntimeInternal;
 import io.ray.runtime.exception.RayActorException;
+import io.ray.runtime.exception.RayException;
 import io.ray.runtime.exception.RayIntentionalSystemExitException;
 import io.ray.runtime.exception.RayTaskException;
 import io.ray.runtime.functionmanager.JavaFunctionDescriptor;
@@ -85,6 +86,12 @@ public abstract class TaskExecutor<T extends TaskExecutor.ActorContext> {
     return results;
   }
 
+  private void throwIfDependencyFailed(Object arg) {
+    if (arg instanceof RayException) {
+      throw (RayException) arg;
+    }
+  }
+
   protected List<NativeRayObject> execute(List<String> rayFunctionInfo, List<Object> argsBytes) {
     runtime.setIsContextSet(true);
     TaskType taskType = runtime.getWorkerContext().getCurrentTaskType();
@@ -122,6 +129,10 @@ public abstract class TaskExecutor<T extends TaskExecutor.ActorContext> {
       }
       Object[] args =
           ArgumentsBuilder.unwrap(argsBytes, rayFunction.executable.getParameterTypes());
+      for (Object arg : args) {
+        throwIfDependencyFailed(arg);
+      }
+
       // Execute the task.
       Object result;
       try {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If an argument of a task is a Ray exception, we should fail the task immediately. But currently, Java worker doesn’t check if an argument of a task is a Ray exception. Instead, a “java.lang.IllegalArgumentException: argument type mismatch” exception is thrown. This makes the user experience bad because a user cannot get the root cause of the task failure from the backtrace.

Consider this code:

```java
public class FailureTest
  public static int badFunc() {
    throw new RuntimeException("Oops");
  }

  public static int echo(int obj) {
    return obj;
  }
}

...

ObjectRef<Integer> obj1 = Ray.task(FailureTest::badFunc).remote();
ObjectRef<Integer> obj2 = Ray.task(FailureTest::echo, obj1).remote();
Ray.get(obj2);
```

The `Ray.get(obj2)` throws an exception as below:

```
io.ray.runtime.exception.RayTaskException: (pid=353807, ip=11.159.247.24) Error executing task ee4e90da584ab0ebffffffffffffffffffffffff01000000
        at io.ray.runtime.task.TaskExecutor.execute(TaskExecutor.java:163)
        at io.ray.runtime.RayNativeRuntime.nativeRunTaskExecutor(Native Method)
        at io.ray.runtime.RayNativeRuntime.run(RayNativeRuntime.java:225)
        at io.ray.runtime.runner.worker.DefaultWorker.main(DefaultWorker.java:15)
Caused by: java.lang.IllegalArgumentException: argument type mismatch
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at io.ray.runtime.task.TaskExecutor.execute(TaskExecutor.java:127)
        ... 3 more
```

As you can see, there’s no “Oops” or “badFunc” in the stack trace.

This PR adds the Ray exception check for task arguments before invoking user methods. The behavior is aligned with `raise_if_dependency_failed` in Python. After the fix, the exception is like below:

```
io.ray.runtime.exception.RayTaskException: (pid=379645, ip=11.159.247.24) Error executing task ee4e90da584ab0ebffffffffffffffffffffffff01000000
	at io.ray.runtime.task.TaskExecutor.execute(TaskExecutor.java:174)
	at io.ray.runtime.RayNativeRuntime.nativeRunTaskExecutor(Native Method)
	at io.ray.runtime.RayNativeRuntime.run(RayNativeRuntime.java:225)
	at io.ray.runtime.runner.worker.DefaultWorker.main(DefaultWorker.java:15)
Caused by: io.ray.runtime.exception.RayTaskException: (pid=379645, ip=11.159.247.24) Error executing task 69a6825d641b4613ffffffffffffffffffffffff01000000
	... 4 more
Caused by: java.lang.RuntimeException: Oops
	at io.ray.test.FailureTest.badFunc(FailureTest.java:34)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at io.ray.runtime.task.TaskExecutor.execute(TaskExecutor.java:138)
	... 3 more
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
