### PR TITLE
[Tests] Add runtime envs release test to nightly build script

### DIFF
--- a/release/.buildkite/build_pipeline.py
+++ b/release/.buildkite/build_pipeline.py
@@ -143,6 +143,9 @@ NIGHTLY_TESTS = {
         "single_deployment_1k_noop_replica",
         "multi_deployment_1k_noop_replica",
     ],
+    "~/ray/release/runtime_env_tests/runtime_env_tests.yaml": [
+        "rte_many_tasks_actors",
+    ],
 }
 
 WEEKLY_TESTS = {

--- a/release/e2e.py
+++ b/release/e2e.py
@@ -48,6 +48,7 @@ Each release test requires the following:
    `--smoke-test` argument.
    Usually the command should write its result metrics to a json file.
    The json filename is available in the TEST_OUTPUT_JSON env variable.
+5. Add your test in release/.buildkite/build_pipeline.py.
 
 The script will have access to these environment variables:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Earlier in https://github.com/ray-project/ray/pull/17507 I neglected to add the runtime env release test to the build script, so it wasn't actually being run.  In this PR I add it to the "nightly tests" group, which I think is appropriate because it only takes a few minutes to run.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
