### PR TITLE
[workflow] Test fault tolerance with storage

### DIFF
--- a/python/ray/experimental/workflow/BUILD
+++ b/python/ray/experimental/workflow/BUILD
@@ -35,6 +35,7 @@ py_test_module_list(
       "tests/test_lifetime.py",
       "tests/test_workflow_manager.py",
       "tests/test_virtual_actor.py",
+      "tests/test_storage_failure.py",
   ],
   size = "medium",
   extra_srcs = SRCS,

--- a/python/ray/experimental/workflow/storage/__init__.py
+++ b/python/ray/experimental/workflow/storage/__init__.py
@@ -6,8 +6,6 @@ from ray.experimental.workflow.storage.base import (
 
 logger = logging.getLogger(__name__)
 
-DEBUG_PREFIX = "debug"
-
 
 def create_storage(storage_url: str) -> Storage:
     """A factory function that creates different type of storage according
@@ -44,7 +42,7 @@ def create_storage(storage_url: str) -> Storage:
             raise ValueError(f"Invalid s3 path: {s3_path}")
         params = dict(parse.parse_qsl(parsed_url.query))
         return S3StorageImpl(bucket, s3_path, **params)
-    elif parsed_url.scheme == DEBUG_PREFIX:
+    elif parsed_url.scheme == "debug":
         from ray.experimental.workflow.storage.debug import DebugStorage
         params = dict(parse.parse_qsl(parsed_url.query))
         return DebugStorage(

--- a/python/ray/experimental/workflow/storage/__init__.py
+++ b/python/ray/experimental/workflow/storage/__init__.py
@@ -6,6 +6,8 @@ from ray.experimental.workflow.storage.base import (
 
 logger = logging.getLogger(__name__)
 
+DEBUG_PREFIX = "debug-"
+
 
 def create_storage(storage_url: str) -> Storage:
     """A factory function that creates different type of storage according
@@ -30,12 +32,15 @@ def create_storage(storage_url: str) -> Storage:
         A storage instance.
     """
     parsed_url = parse.urlparse(storage_url)
+    if parsed_url.scheme.startswith(DEBUG_PREFIX):
+        from ray.experimental.workflow.storage.debug import DebugStorage
+        return DebugStorage(create_storage(storage_url[len(DEBUG_PREFIX):]))
     if parsed_url.scheme == "file" or parsed_url.scheme == "":
         from ray.experimental.workflow.storage.filesystem import (
             FilesystemStorageImpl)
         return FilesystemStorageImpl(parsed_url.path)
     elif parsed_url.scheme == "s3":
-        from ray.experimental.workflow.storage.s3 import (S3StorageImpl)
+        from ray.experimental.workflow.storage.s3 import S3StorageImpl
         bucket = parsed_url.netloc
         s3_path = parsed_url.path
         if not s3_path:

--- a/python/ray/experimental/workflow/storage/base.py
+++ b/python/ray/experimental/workflow/storage/base.py
@@ -48,11 +48,11 @@ class Storage(metaclass=abc.ABCMeta):
         """
 
     @abstractmethod
-    async def delete(self, key: str) -> None:
-        """Delete an object.
+    async def delete_prefix(self, key_prefix: str) -> None:
+        """Delete an object with prefix.
 
         Args:
-            key: The key of the object.
+            key_prefix: The prefix to delete.
         """
 
     @abstractmethod

--- a/python/ray/experimental/workflow/storage/debug.py
+++ b/python/ray/experimental/workflow/storage/debug.py
@@ -109,7 +109,7 @@ class DebugStorage(Storage):
         return DEBUG_PREFIX + self._wrapped_storage.storage_url
 
     def __reduce__(self):
-        return DebugStorage, (self._wrapped_storage,)
+        return DebugStorage, (self._wrapped_storage, )
 
     async def replay(self, index: int) -> None:
         """Replay the a record to the storage.

--- a/python/ray/experimental/workflow/storage/filesystem.py
+++ b/python/ray/experimental/workflow/storage/filesystem.py
@@ -160,7 +160,7 @@ class FilesystemStorageImpl(Storage):
 
     @property
     def storage_url(self) -> str:
-        return str(self._workflow_root_dir)
+        return "file://" + str(self._workflow_root_dir.absolute())
 
     def __reduce__(self):
         return FilesystemStorageImpl, (self._workflow_root_dir, )

--- a/python/ray/experimental/workflow/storage/filesystem.py
+++ b/python/ray/experimental/workflow/storage/filesystem.py
@@ -1,6 +1,7 @@
 import contextlib
 import itertools
 import json
+import shutil
 import pathlib
 from typing import Any, List
 import uuid
@@ -148,8 +149,12 @@ class FilesystemStorageImpl(Storage):
             with _open_atomic(pathlib.Path(key), "rb") as f:
                 return ray.cloudpickle.load(f)
 
-    async def delete(self, key: str) -> None:
-        pathlib.Path(key).unlink()
+    async def delete_prefix(self, key_prefix: str) -> None:
+        path = pathlib.Path(key_prefix)
+        if path.is_dir():
+            shutil.rmtree(str(path))
+        else:
+            path.unlink()
 
     async def scan_prefix(self, key_prefix: str) -> List[str]:
         try:

--- a/python/ray/experimental/workflow/storage/s3.py
+++ b/python/ray/experimental/workflow/storage/s3.py
@@ -32,7 +32,11 @@ class S3StorageImpl(Storage):
         self._s3_path.rstrip("/")
         if len(self._s3_path) == 0:
             raise ValueError(f"s3 path {self._s3_path} invalid")
-        self._session = aioboto3.Session()
+        self._session = aioboto3.Session(
+            region_name=region_name,
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token)
         self._region_name = region_name
         self._endpoint_url = endpoint_url
         self._aws_access_key_id = aws_access_key_id
@@ -76,8 +80,10 @@ class S3StorageImpl(Storage):
                 raise
 
     async def delete_prefix(self, key_prefix: str) -> None:
-        async with self._client() as s3:
-            bucket = s3.Bucket(self._bucket)
+        async with self._session.resource(
+                "s3", endpoint_url=self._endpoint_url,
+                config=self._config) as s3:
+            bucket = await s3.Bucket(self._bucket)
             await bucket.objects.filter(Prefix=key_prefix).delete()
 
     async def scan_prefix(self, key_prefix: str) -> List[str]:
@@ -102,13 +108,7 @@ class S3StorageImpl(Storage):
 
     def _client(self):
         return self._session.client(
-            "s3",
-            region_name=self._region_name,
-            endpoint_url=self._endpoint_url,
-            aws_access_key_id=self._aws_access_key_id,
-            aws_secret_access_key=self._aws_secret_access_key,
-            aws_session_token=self._aws_session_token,
-            config=self._config)
+            "s3", endpoint_url=self._endpoint_url, config=self._config)
 
     @property
     def storage_url(self) -> str:

--- a/python/ray/experimental/workflow/storage/s3.py
+++ b/python/ray/experimental/workflow/storage/s3.py
@@ -75,8 +75,10 @@ class S3StorageImpl(Storage):
             else:
                 raise
 
-    async def delete(self, key: str) -> None:
-        raise NotImplementedError
+    async def delete_prefix(self, key_prefix: str) -> None:
+        async with self._client() as s3:
+            bucket = s3.Bucket(self._bucket)
+            await bucket.objects.filter(Prefix=key_prefix).delete()
 
     async def scan_prefix(self, key_prefix: str) -> List[str]:
         keys = []

--- a/python/ray/experimental/workflow/tests/test_storage_failure.py
+++ b/python/ray/experimental/workflow/tests/test_storage_failure.py
@@ -1,13 +1,76 @@
-from typing import Any
-from ray.experimental.workflow.storage.filesystem import FilesystemStorageImpl
+import asyncio
+import os
+from hashlib import sha1
+import random
+
+import pytest
+import ray
+from ray.experimental import workflow
+from ray.experimental.workflow.storage import (get_global_storage,
+                                               set_global_storage)
+from ray.experimental.workflow.storage.debug import DebugStorage
+from ray.experimental.workflow.workflow_storage import STEP_OUTPUTS_METADATA
+from ray.experimental.workflow.workflow_storage import asyncio_run
 
 
-class LoggedFileSystemStorage(FilesystemStorageImpl):
-    def __init__(self, workflow_root_dir: str):
-        super().__init__(workflow_root_dir)
-        self._log_dir = self._workflow_root_dir / "log"
-        if not self._log_dir.exists():
-            self._log_dir.mkdir()
+@workflow.step
+def pass_1(x: str, y: str):
+    return sha1((x + y + "1").encode()).hexdigest()
 
-    async def put(self, key: str, data: Any, is_json: bool = False) -> None:
-        await super().put(key, data, is_json)
+
+@workflow.step
+def pass_2(x: str, y: str):
+    return sha1((x + y + "2").encode()).hexdigest()
+
+
+@workflow.step
+def pass_3(x: str, y: str):
+    return sha1((x + y + "3").encode()).hexdigest()
+
+
+def construct_linear_workflow(input: str, length: int):
+    random.seed(41)
+    x = pass_1.step(input, "0")
+    for i in range(1, length):
+        rnd = random.randint(1, 3)
+        if rnd == 1:
+            x = pass_1.step(x, str(i))
+        elif rnd == 2:
+            x = pass_2.step(x, str(i))
+        else:
+            x = pass_3.step(x, str(i))
+    return x
+
+
+def _alter_storage(new_storage):
+    set_global_storage(new_storage)
+    # alter the storage
+    ray.shutdown()
+    os.system("ray stop --force")
+    workflow.init(new_storage)
+
+
+def _locate_initial_commit(debug_store: DebugStorage) -> int:
+    for i in range(len(debug_store)):
+        log = debug_store.get_log(i)
+        if log["key"].endswith(STEP_OUTPUTS_METADATA):
+            return i
+    return -1
+
+
+@pytest.mark.parametrize(
+    "workflow_start_regular",
+    [{
+        "num_cpus": 4,  # increase CPUs to add pressure
+    }],
+    indirect=True)
+def test_linear_workflow_failure(workflow_start_regular):
+    debug_store = DebugStorage(get_global_storage())
+    _alter_storage(debug_store)
+
+    wf = construct_linear_workflow("start", 20)
+    result = wf.run(workflow_id="linear_workflow")
+
+    index = _locate_initial_commit(debug_store)
+    replays = [debug_store.replay(i) for i in range(index)]
+    asyncio_run(asyncio.gather(*replays))

--- a/python/ray/experimental/workflow/tests/test_storage_failure.py
+++ b/python/ray/experimental/workflow/tests/test_storage_failure.py
@@ -20,12 +20,16 @@ def pass_1(x: str, y: str):
 
 @workflow.step
 def pass_2(x: str, y: str):
-    return sha1((x + y + "2").encode()).hexdigest()
+    if sha1((x + y + "_2").encode()).hexdigest() > x:
+        return sha1((x + y + "2").encode()).hexdigest()
+    return pass_1.step(x, y)
 
 
 @workflow.step
 def pass_3(x: str, y: str):
-    return sha1((x + y + "3").encode()).hexdigest()
+    if sha1((x + y + "_3").encode()).hexdigest() > x:
+        return sha1((x + y + "3").encode()).hexdigest()
+    return pass_2.step(x, y)
 
 
 def construct_linear_workflow(input: str, length: int):

--- a/python/ray/experimental/workflow/tests/test_storage_failure.py
+++ b/python/ray/experimental/workflow/tests/test_storage_failure.py
@@ -3,5 +3,11 @@ from ray.experimental.workflow.storage.filesystem import FilesystemStorageImpl
 
 
 class LoggedFileSystemStorage(FilesystemStorageImpl):
+    def __init__(self, workflow_root_dir: str):
+        super().__init__(workflow_root_dir)
+        self._log_dir = self._workflow_root_dir / "log"
+        if not self._log_dir.exists():
+            self._log_dir.mkdir()
+
     async def put(self, key: str, data: Any, is_json: bool = False) -> None:
         await super().put(key, data, is_json)

--- a/python/ray/experimental/workflow/tests/test_storage_failure.py
+++ b/python/ray/experimental/workflow/tests/test_storage_failure.py
@@ -75,4 +75,4 @@ def test_linear_workflow_failure(workflow_start_regular):
     replays = [debug_store.replay(i) for i in range(index)]
     asyncio_run(asyncio.gather(*replays))
     resumed_result = ray.get(workflow.resume(workflow_id="linear_workflow"))
-    assert resumed_result == resumed_result
+    assert resumed_result == result

--- a/python/ray/experimental/workflow/tests/test_storage_failure.py
+++ b/python/ray/experimental/workflow/tests/test_storage_failure.py
@@ -80,7 +80,7 @@ def test_failure_with_storage(workflow_start_regular):
     debug_store = DebugStorage(get_global_storage())
     _alter_storage(debug_store)
 
-    wf = construct_workflow(5)
+    wf = construct_workflow(length=3)
     result = wf.run(workflow_id="complex_workflow")
     index = _locate_initial_commit(debug_store) + 1
 

--- a/python/ray/experimental/workflow/tests/test_storage_failure.py
+++ b/python/ray/experimental/workflow/tests/test_storage_failure.py
@@ -1,0 +1,7 @@
+from typing import Any
+from ray.experimental.workflow.storage.filesystem import FilesystemStorageImpl
+
+
+class LoggedFileSystemStorage(FilesystemStorageImpl):
+    async def put(self, key: str, data: Any, is_json: bool = False) -> None:
+        await super().put(key, data, is_json)

--- a/python/ray/experimental/workflow/tests/test_storage_failure.py
+++ b/python/ray/experimental/workflow/tests/test_storage_failure.py
@@ -107,3 +107,8 @@ def test_failure_with_storage(workflow_start_regular):
             step_len = max((len(debug_store) - index) // 5, 1)
         for j in range(index, len(debug_store), step_len):
             assert resume(j) == result
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/experimental/workflow/tests/test_storage_failure.py
+++ b/python/ray/experimental/workflow/tests/test_storage_failure.py
@@ -74,3 +74,5 @@ def test_linear_workflow_failure(workflow_start_regular):
     index = _locate_initial_commit(debug_store)
     replays = [debug_store.replay(i) for i in range(index)]
     asyncio_run(asyncio.gather(*replays))
+    resumed_result = ray.get(workflow.resume(workflow_id="linear_workflow"))
+    assert resumed_result == resumed_result


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A thoroughly test to ensure we can resume the workflow correctly when all files after a certain time are lost.

## Related issue number

Closes #17089

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
