### PR TITLE
[Serve] [dashboard]  Change empty serve cluster snapshot from empty list to empty dict

### DIFF
--- a/dashboard/modules/snapshot/snapshot_head.py
+++ b/dashboard/modules/snapshot/snapshot_head.py
@@ -99,7 +99,7 @@ class SnapshotHead(dashboard_utils.DashboardHeadModule):
         # ones have name = SERVE_CONTROLLER_NAME + random letters.
         key = format_key(SERVE_CONTROLLER_NAME, SERVE_SNAPSHOT_KEY)
 
-        return json.loads(_internal_kv_get(key, client) or "[]")
+        return json.loads(_internal_kv_get(key, client) or "{}")
 
     async def get_session_name(self):
         encoded_name = await self._dashboard_head.aioredis_client.get(

--- a/dashboard/modules/snapshot/tests/test_snapshot.py
+++ b/dashboard/modules/snapshot/tests/test_snapshot.py
@@ -58,6 +58,7 @@ ray.get(a.ping.remote())
 
     assert len(data["data"]["snapshot"]["actors"]) == 3
     assert len(data["data"]["snapshot"]["jobs"]) == 4
+    assert len(data["data"]["snapshot"]["deployments"]) == 0
 
     for actor_id, entry in data["data"]["snapshot"]["actors"].items():
         assert entry["jobId"] in data["data"]["snapshot"]["jobs"]

--- a/dashboard/modules/snapshot/tests/test_snapshot.py
+++ b/dashboard/modules/snapshot/tests/test_snapshot.py
@@ -1,8 +1,10 @@
 import os
+import sys
 import json
 import jsonschema
 
 import pprint
+import pytest
 import requests
 
 from ray.test_utils import (
@@ -112,3 +114,7 @@ my_func.deploy()
         assert entry["rayJobId"] is not None
         assert entry["startTime"] == 0
         assert entry["endTime"] == 0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
If Serve hasn't started, the relevant part of the serve cluster snapshot should be an empty dict in order to match with the JSON schema, not an empty list.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
