### PR TITLE
[rllib] Fix classes decorated with @Deprecated to be classes instead of methods

### DIFF
--- a/rllib/utils/annotations.py
+++ b/rllib/utils/annotations.py
@@ -79,6 +79,7 @@ def Deprecated(old=None, *, new=None, help=None, error):
                         error=error,
                     )
                 return obj_init(*args, **kwargs)
+
             obj.__init__ = patched_init
             return obj
 

--- a/rllib/utils/annotations.py
+++ b/rllib/utils/annotations.py
@@ -1,3 +1,5 @@
+import inspect
+
 from ray.util import log_once
 from ray.rllib.utils.deprecation import deprecation_warning
 
@@ -65,6 +67,21 @@ def Deprecated(old=None, *, new=None, help=None, error):
     """
 
     def _inner(obj):
+        if inspect.isclass(obj):
+            obj_init = obj.__init__
+
+            def patched_init(*args, **kwargs):
+                if log_once(old or obj.__name__):
+                    deprecation_warning(
+                        old=old or obj.__name__,
+                        new=new,
+                        help=help,
+                        error=error,
+                    )
+                return obj_init(*args, **kwargs)
+            obj.__init__ = patched_init
+            return obj
+
         def _ctor(*args, **kwargs):
             if log_once(old or obj.__name__):
                 deprecation_warning(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Bug introduced in #17530 caused any class decorated with the `@Deprecated` annotation to become a method instead of a class. This led to some cases where access to class methods or class variables would return an error because methods don't have attributes. For example, `SampleBatchBuilder._next_unroll_id` returns an error at this line: 
https://github.com/ray-project/ray/blob/0858f0e4f211296c27b365bed86f9089878c56b5/rllib/evaluation/sample_batch_builder.py#L65

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
