### PR TITLE
Fix a bug where get_actor crashes gcs if the actor is already killed.

### DIFF
--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1313,6 +1313,12 @@ def test_get_actor_after_killed(shutdown_only):
     ray.kill(actor, no_restart=False)
     assert ray.get(ray.get_actor("namespace/actor_2").ready.remote())
 
+    # TODO(sang): This currently doesn't pass without time.sleep.
+    # ray.kill(actor, no_restart=False)
+    # # Now the actor is killed.
+    # with pytest.raises(ValueError):
+    #     ray.get_actor("namespace/actor_2")
+
 
 if __name__ == "__main__":
     import pytest

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1304,6 +1304,7 @@ def test_get_actor_after_killed(shutdown_only):
 
     actor = A.options(name="namespace/actor", lifetime="detached").remote()
     ray.kill(actor)
+    # This could be flaky due to our caching named actor mechanism.
     with pytest.raises(ValueError):
         ray.get_actor("namespace/actor")
 

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1294,6 +1294,19 @@ def test_actor_namespace_access(ray_start_regular):
         ray.get_actor("actor_name")  # => errors
 
 
+def test_get_actor_after_killed(shutdown_only):
+    ray.init(num_cpus=2)
+
+    @ray.remote
+    class A:
+        pass
+
+    actor = A.options(name="namespace/actor", lifetime="detached").remote()
+    ray.kill(actor)
+    with pytest.raises(ValueError):
+        ray.get_actor("namespace/actor")
+
+
 if __name__ == "__main__":
     import pytest
     # Test suite is timing out. Disable on windows for now.

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1299,12 +1299,19 @@ def test_get_actor_after_killed(shutdown_only):
 
     @ray.remote
     class A:
-        pass
+        def ready(self):
+            return True
 
     actor = A.options(name="namespace/actor", lifetime="detached").remote()
     ray.kill(actor)
     with pytest.raises(ValueError):
         ray.get_actor("namespace/actor")
+
+    actor = A.options(
+        name="namespace/actor_2", lifetime="detached",
+        max_restarts=1).remote()
+    ray.kill(actor, no_restart=False)
+    assert ray.get(ray.get_actor("namespace/actor_2").ready.remote())
 
 
 if __name__ == "__main__":

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2092,7 +2092,7 @@ std::pair<std::shared_ptr<const ActorHandle>, Status> CoreWorker::GetNamedActorH
     stream << "Failed to look up actor with name '" << name << "'. This could "
            << "because 1. You are trying to look up a named actor you "
            << "didn't create. 2. The named actor died. 3. The actor hasn't "
-           << "been created because named actor creation is asynchronous. "
+           << "been created yet because named actor creation is asynchronous. "
            << "4. You did not use a namespace matching the namespace of the "
            << "actor.";
     return std::make_pair(nullptr, Status::NotFound(stream.str()));

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -236,7 +236,7 @@ void GcsActorManager::HandleGetNamedActorInfo(
   ActorID actor_id = GetActorIDByName(name, ray_namespace);
 
   Status status = Status::OK();
-  const auto &iter = registered_actors_.find(actor_id);
+  auto iter = registered_actors_.find(actor_id);
   if (actor_id.IsNil() || iter == registered_actors_.end()) {
     // The named actor was not found or the actor is already removed.
     std::stringstream stream;
@@ -1121,7 +1121,7 @@ void GcsActorManager::KillActor(const ActorID &actor_id, bool force_kill,
                                 bool no_restart) {
   RAY_LOG(DEBUG) << "Killing actor, job id = " << actor_id.JobId()
                  << ", actor id = " << actor_id << ", force_kill = " << force_kill;
-  const auto &it = registered_actors_.find(actor_id);
+  auto it = registered_actors_.find(actor_id);
   if (it == registered_actors_.end()) {
     RAY_LOG(INFO) << "Tried to kill actor that does not exist " << actor_id;
     return;

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -236,15 +236,14 @@ void GcsActorManager::HandleGetNamedActorInfo(
   ActorID actor_id = GetActorIDByName(name, ray_namespace);
 
   Status status = Status::OK();
-  if (actor_id.IsNil()) {
-    // The named actor was not found.
+  const auto &iter = registered_actors_.find(actor_id);
+  if (actor_id.IsNil() || iter == registered_actors_.end()) {
+    // The named actor was not found or the actor is already removed.
     std::stringstream stream;
     stream << "Actor with name '" << name << "' was not found.";
     RAY_LOG(WARNING) << stream.str();
     status = Status::NotFound(stream.str());
   } else {
-    const auto &iter = registered_actors_.find(actor_id);
-    RAY_CHECK(iter != registered_actors_.end());
     reply->mutable_actor_table_data()->CopyFrom(iter->second->GetActorTableData());
     RAY_LOG(DEBUG) << "Finished getting actor info, job id = " << actor_id.JobId()
                    << ", actor id = " << actor_id;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

After the actor is killed, get_actor will crash because of the wrong RAY_CHECK. 

Since ray.kill is synchronous, the current fix won't introduce race conditions. 

## Related issue number

closes https://github.com/ray-project/ray/issues/17629

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
