### PR TITLE
Revert "Added support for the imagePullSecrets in helm chart"

### DIFF
--- a/deploy/charts/ray/templates/operator_cluster_scoped.yaml
+++ b/deploy/charts/ray/templates/operator_cluster_scoped.yaml
@@ -62,8 +62,4 @@ spec:
           limits:
             memory: 2Gi
             cpu: 1
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      {{ toYaml .Values.imagePullSecrets | indent 8 }}
-      {{- end }}
 {{- end }}

--- a/deploy/charts/ray/templates/operator_namespaced.yaml
+++ b/deploy/charts/ray/templates/operator_namespaced.yaml
@@ -63,9 +63,5 @@ spec:
           limits:
             memory: 2Gi
             cpu: 1
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      {{ toYaml .Values.imagePullSecrets | indent 8 }}
-      {{- end }}
 {{- end }}
 

--- a/deploy/charts/ray/templates/raycluster.yaml
+++ b/deploy/charts/ray/templates/raycluster.yaml
@@ -76,10 +76,6 @@ spec:
                 {{- if .GPU }}
                 nvidia.com/gpu: {{ .GPU }}
                 {{- end }}
-          {{- if .Values.imagePullSecrets }}
-          imagePullSecrets:
-          {{ toYaml .Values.imagePullSecrets | indent 8 }}
-          {{- end }}
           {{- if .nodeSelector }}
           nodeSelector:
               {{- toYaml .nodeSelector | nindent 12 }}

--- a/deploy/charts/ray/values.yaml
+++ b/deploy/charts/ray/values.yaml
@@ -1,10 +1,5 @@
 # Default values for Ray.
 
-## Reference to one or more secrets to be used when pulling images
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-imagePullSecrets: []
-# - name: "image-pull-secret"
-
 # RayCluster settings:
 
 # image is Ray image to use for the head and workers of this Ray cluster.


### PR DESCRIPTION
Reverts ray-project/ray#17520

It appears this change was backwards incompatible. Users have reported error
```
Error: template: ray/templates/raycluster.yaml:84:24: executing "ray/templates/raycluster.yaml" at <.Values.imagePullSecrets>: nil pointer evaluating interface {}.imagePullSecrets
```
probably with the previous default Helm chart.
We'll fix and re-revert.