### PR TITLE
[Cluster Launcher] Allow attach/exec on uninitialized head node

### DIFF
--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -907,7 +907,7 @@ def attach_cluster(config_file: str,
         override_cluster_name=override_cluster_name,
         no_config_cache=no_config_cache,
         port_forward=port_forward,
-    )
+        _allow_uninitialize=True)
 
 
 def exec_cluster(config_file: str,
@@ -921,7 +921,8 @@ def exec_cluster(config_file: str,
                  override_cluster_name: Optional[str] = None,
                  no_config_cache: bool = False,
                  port_forward: Optional[Port_forward] = None,
-                 with_output: bool = False) -> str:
+                 with_output: bool = False,
+                 _allow_uninitialized: bool = False) -> str:
     """Runs a command on the specified cluster.
 
     Arguments:
@@ -950,7 +951,11 @@ def exec_cluster(config_file: str,
     config = _bootstrap_config(config, no_config_cache=no_config_cache)
 
     head_node = _get_running_head_node(
-        config, config_file, override_cluster_name, create_if_needed=start)
+        config,
+        config_file,
+        override_cluster_name,
+        create_if_needed=start,
+        _allow_uninitialized=_allow_uninitialized)
 
     provider = _get_node_provider(config["provider"], config["cluster_name"])
     updater = NodeUpdaterThread(
@@ -1187,12 +1192,27 @@ def _get_worker_nodes(config: Dict[str, Any],
     return provider.non_terminated_nodes({TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
 
 
-def _get_running_head_node(config: Dict[str, Any],
-                           printable_config_file: str,
-                           override_cluster_name: Optional[str],
-                           create_if_needed: bool = False,
-                           _provider: Optional[NodeProvider] = None) -> str:
-    """Get a valid, running head node"""
+def _get_running_head_node(
+        config: Dict[str, Any],
+        printable_config_file: str,
+        override_cluster_name: Optional[str],
+        create_if_needed: bool = False,
+        _provider: Optional[NodeProvider] = None,
+        _allow_uninitialized_state: bool = False,
+) -> str:
+    """Get a valid, running head node.
+    Args:
+        config (Dict[str, Any]): Cluster Config dictionary
+        printable_config_file (str): Used for printing formatted CLI commands.
+        override_cluster_name (str): Passed to `get_or_create_head_node` to
+            override the cluster name present in `config`.
+        create_if_needed (bool): Create a head node if one is not present.
+        _provider (NodeProvider): [For testing], a Node Provider to use.
+        _allow_uninitialized_state (bool): Whether to return a head node that
+            is not 'UP TO DATE'. This is used to allow `ray attach` and
+            `ray exec` to debug a cluster in a bad state.
+
+    """
     provider = _provider or _get_node_provider(config["provider"],
                                                config["cluster_name"])
     head_node_tags = {
@@ -1200,11 +1220,13 @@ def _get_running_head_node(config: Dict[str, Any],
     }
     nodes = provider.non_terminated_nodes(head_node_tags)
     head_node = None
+    _backup_head_node = None
     for node in nodes:
         node_state = provider.node_tags(node).get(TAG_RAY_NODE_STATUS)
         if node_state == STATUS_UP_TO_DATE:
             head_node = node
         else:
+            _backup_head_node = head_node
             cli_logger.warning(f"Head node ({node}) is in state {node_state}.")
 
     if head_node is not None:
@@ -1217,12 +1239,24 @@ def _get_running_head_node(config: Dict[str, Any],
             no_restart=False,
             yes=True,
             override_cluster_name=override_cluster_name)
+        # NOTE: `_allow_uninitialized_state` is forced to False if
+        # `create_if_needed` is set to True. This is to ensure that the
+        # commands executed after creation occur on an actually running
+        # cluster.
         return _get_running_head_node(
             config,
             printable_config_file,
             override_cluster_name,
-            create_if_needed=False)
+            create_if_needed=False,
+            _allow_uninitialized_state=False)
     else:
+        if _allow_uninitialized_state and _backup_head_node is not None:
+            cli_logger.warning(
+                f"The head node being returned: {_backup_head_node} is not "
+                "`up-to-date`. If you are not intending to debug a startup "
+                "issue, it is recommended to restart this head node with `ray "
+                f"stop {printable_config_file}`.")
+            return _backup_head_node
         raise RuntimeError("Head node of cluster ({}) not found!".format(
             config["cluster_name"]))
 

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -1257,7 +1257,7 @@ def _get_running_head_node(
                 f"The head node being returned: {_backup_head_node} is not "
                 "`up-to-date`. If you are not debugging a startup issue "
                 "it is recommended to restart this head node with: {}",
-                cf.bold(f"  ray stop  {printable_config_file}"))
+                cf.bold(f"  ray down  {printable_config_file}"))
 
             return _backup_head_node
         raise RuntimeError("Head node of cluster ({}) not found!".format(

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1365,7 +1365,7 @@ def exec(cluster_config_file, cmd, run_env, screen, tmux, stop, start,
         override_cluster_name=cluster_name,
         no_config_cache=no_config_cache,
         port_forward=port_forward,
-        _allow_uninitialized=True)
+        _allow_uninitialized_state=True)
 
 
 @cli.command()

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1364,7 +1364,8 @@ def exec(cluster_config_file, cmd, run_env, screen, tmux, stop, start,
         start=start,
         override_cluster_name=cluster_name,
         no_config_cache=no_config_cache,
-        port_forward=port_forward)
+        port_forward=port_forward,
+        _allow_uninitialized=True)
 
 
 @cli.command()

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -2682,6 +2682,18 @@ MemAvailable:   33000000 kB
             TAG_RAY_NODE_STATUS: "update-failed"
         }, 1)
 
+        # `_allow_uninitialized_state` should return the head node
+        # in the `update-failed` state.
+        allow_failed = commands._get_running_head_node(
+            config,
+            "/fake/path",
+            override_cluster_name=None,
+            create_if_needed=False,
+            _provider=self.provider,
+            _allow_uninitialized_state=True)
+
+        assert allow_failed == 0
+
         # Node 1 is okay.
         self.provider.create_node({}, {
             TAG_RAY_CLUSTER_NAME: "default",
@@ -2697,6 +2709,18 @@ MemAvailable:   33000000 kB
             _provider=self.provider)
 
         assert node == 1
+
+        # `_allow_uninitialized_state` should return the up-to-date head node
+        # if it is present.
+        optionally_failed = commands._get_running_head_node(
+            config,
+            "/fake/path",
+            override_cluster_name=None,
+            create_if_needed=False,
+            _provider=self.provider,
+            _allow_uninitialized_state=True)
+
+        assert optionally_failed == 1
 
     def testNodeTerminatedDuringUpdate(self):
         """


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #17525

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] Manually tested


After a failed `setup_command`:
```
(ray) ubuntu@ip-MY_IP:~/ray$ ray attach myaws.yaml 
Loaded cached provider configuration
If you experience issues with the cloud provider, try re-running the command with --no-config-cache.
Head node (i-xxxx) is in state update-failed.
The head node being returned: i-xxxx is not `up-to-date`. If you are not debugging a startup issueit is recommended to restart this head node with:   ray stop  myaws.yaml
Fetched IP: PUBLIC_IP
(base) ray@ip-PRIVATE_IP:~$ 
```

```
(ray) ubuntu@ip-MY_IP:~/ray$ ray exec  myaws.yaml whoami
Loaded cached provider configuration
If you experience issues with the cloud provider, try re-running the command with --no-config-cache.
Head node (i-xxxx) is in state update-failed.
The head node being returned: i-xxxx is not `up-to-date`. If you are not debugging a startup issue it is recommended to restart this head node with:   ray stop  myaws.yaml
Fetched IP: PUBLIC_IP
Warning: Permanently added 'PUBLIC_IP' (ECDSA) to the list of known hosts.
ray
Shared connection to PUBLIC_IP closed.
```