### PR TITLE
[sgd] Wait for placement_group deletion when shutdown worker_group

### DIFF
--- a/python/ray/util/sgd/tests/test_torch_failure.py
+++ b/python/ray/util/sgd/tests/test_torch_failure.py
@@ -107,6 +107,8 @@ def test_resize(ray_start_2_cpus, use_local):  # noqa: F811
         assert trainer1.worker_group.num_workers == 1
         assert trainer1._num_failures == 1
 
+        ray.util.remove_placement_group(dummy_pg)
+
         def is_placement_group_removed():
             table = ray.util.placement_group_table(dummy_pg)
             if "state" not in table:

--- a/python/ray/util/sgd/tests/test_torch_failure.py
+++ b/python/ray/util/sgd/tests/test_torch_failure.py
@@ -107,7 +107,8 @@ def test_resize(ray_start_2_cpus, use_local):  # noqa: F811
 
         ray.get(dummy_handler.get.remote())
         ray.kill(dummy_handler)
-        time.sleep(1)
+        # make sure RESIZE_COOLDOWN times out
+        time.sleep(10)
         # trigger scale up
         trainer1.train()
         assert trainer1.worker_group.num_workers == 2

--- a/python/ray/util/sgd/torch/worker_group.py
+++ b/python/ray/util/sgd/torch/worker_group.py
@@ -17,7 +17,6 @@ from ray.util.sgd.torch.utils import setup_address
 from ray.util.sgd.utils import check_for_failure
 
 RESIZE_COOLDOWN_S = 10
-SGD_PLACEMENT_GROUP_TIMEOUT_S = 60
 logger = logging.getLogger(__name__)
 
 

--- a/python/ray/util/sgd/torch/worker_group.py
+++ b/python/ray/util/sgd/torch/worker_group.py
@@ -451,7 +451,6 @@ class RemoteWorkerGroup(WorkerGroupInterface):
 
             # Wait the placement_group been deleted
             wait_for_condition(is_placement_group_removed)
-            time.sleep(1)
 
     def reset(self):
         self.shutdown(force=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Wait for placement_group deletion when shutdown worker_group.

https://github.com/ray-project/ray/pull/17401 always failed on `test_torch_failure.py::test_resize`. 

The placement_group will be delete when `_resize_worker_group`. But deletion is asynchronous, `_resize_worker_group` will  get the wrong available_resources and not work as expected.

The `test_torch_failure.py::test_resize` test always failed in docker container, but passed in bare metal.

## Related issue number

https://github.com/ray-project/ray/pull/17401

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
