### PR TITLE
[Datasets] Add support for reading partitioned Parquet datasets.

### DIFF
--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -157,7 +157,8 @@ def _resolve_paths_and_filesystem(
     return resolved_paths, filesystem
 
 
-def _expand_paths(paths, filesystem):
+def _expand_paths(paths: Union[str, List[str]],
+                  filesystem: "pyarrow.fs.FileSystem"):
     """
     Expands all provided paths into concrete file paths by walking directories.
     Also returns a sidecar of file infos.

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -36,8 +36,8 @@ class FileBasedDatasource(Datasource[Union[ArrowRow, Any]]):
         import pyarrow as pa
         import numpy as np
 
-        paths, file_infos, filesystem = _resolve_paths_and_filesystem(
-            paths, filesystem)
+        paths, filesystem = _resolve_paths_and_filesystem(paths, filesystem)
+        paths, file_infos = _expand_paths(paths, filesystem)
         file_sizes = [file_info.size for file_info in file_infos]
 
         read_file = self._read_file
@@ -99,6 +99,96 @@ class FileBasedDatasource(Datasource[Union[ArrowRow, Any]]):
             "Subclasses of FileBasedDatasource must implement _read_files().")
 
 
+# TODO(Clark): Add unit test coverage of _resolve_paths_and_filesystem and
+# _expand_paths.
+
+
+def _resolve_paths_and_filesystem(
+        paths: Union[str, List[str]],
+        filesystem: "pyarrow.fs.FileSystem" = None,
+) -> Tuple[List[str], "pyarrow.fs.FileSystem"]:
+    """
+    Resolves and normalizes all provided paths, infers a filesystem from the
+    paths and ensures that all paths use the same filesystem.
+
+    Args:
+        paths: A single file/directory path or a list of file/directory paths.
+            A list of paths can contain both files and directories.
+        filesystem: The filesystem implementation that should be used for
+            reading these files. If None, a filesystem will be inferred. If not
+            None, the provided filesystem will still be validated against all
+            filesystems inferred from the provided paths to ensure
+            compatibility.
+    """
+    from pyarrow.fs import FileSystem, PyFileSystem, FSSpecHandler, \
+        _resolve_filesystem_and_path
+    import fsspec
+
+    if isinstance(paths, str):
+        paths = [paths]
+    elif (not isinstance(paths, list)
+          or any(not isinstance(p, str) for p in paths)):
+        raise ValueError(
+            "paths must be a path string or a list of path strings.")
+    elif len(paths) == 0:
+        raise ValueError("Must provide at least one path.")
+
+    if filesystem and not isinstance(filesystem, FileSystem):
+        if not isinstance(filesystem, fsspec.spec.AbstractFileSystem):
+            raise TypeError(f"The filesystem passed must either conform to "
+                            f"pyarrow.fs.FileSystem, or "
+                            f"fsspec.spec.AbstractFileSystem. The provided "
+                            f"filesystem was: {filesystem}")
+        filesystem = PyFileSystem(FSSpecHandler(filesystem))
+
+    resolved_paths = []
+    for path in paths:
+        if filesystem is not None:
+            # If we provide a filesystem, _resolve_filesystem_and_path will not
+            # slice off the protocol from the provided URI/path when resolved.
+            path = _unwrap_protocol(path)
+        resolved_filesystem, resolved_path = _resolve_filesystem_and_path(
+            path, filesystem)
+        if filesystem is None:
+            filesystem = resolved_filesystem
+        resolved_path = filesystem.normalize_path(resolved_path)
+        resolved_paths.append(resolved_path)
+
+    return resolved_paths, filesystem
+
+
+def _expand_paths(paths, filesystem):
+    """
+    Expands all provided paths into concrete file paths by walking directories.
+    Also returns a sidecar of file infos.
+
+    This should be used on the output of _resolve_paths_and_filesystem.
+
+    Args:
+        paths: A single file/directory path or a list of file/directory paths.
+            A list of paths can contain both files and directories. These paths
+            should be properly resolved, e.g. the paths returned from
+            _resolve_paths_and_filesystem.
+        filesystem: The filesystem implementation that should be used for
+            reading these files.
+    """
+    from pyarrow.fs import FileType
+    expanded_paths = []
+    file_infos = []
+    for path in paths:
+        file_info = filesystem.get_file_info(path)
+        if file_info.type == FileType.Directory:
+            paths, file_infos_ = _expand_directory(path, filesystem)
+            expanded_paths.extend(paths)
+            file_infos.extend(file_infos_)
+        elif file_info.type == FileType.File:
+            expanded_paths.append(path)
+            file_infos.append(file_info)
+        else:
+            raise FileNotFoundError(path)
+    return expanded_paths, file_infos
+
+
 def _expand_directory(path: str,
                       filesystem: "pyarrow.fs.FileSystem",
                       exclude_prefixes: List[str] = [".", "_"]) -> List[str]:
@@ -133,78 +223,6 @@ def _expand_directory(path: str,
         filtered_paths.append((file_path, file_))
     # We sort the paths to guarantee a stable order.
     return zip(*sorted(filtered_paths, key=lambda x: x[0]))
-
-
-# TODO(Clark): Add unit test coverage of _resolve_paths_and_filesystem.
-
-
-def _resolve_paths_and_filesystem(
-        paths: Union[str, List[str]],
-        filesystem: "pyarrow.fs.FileSystem" = None
-) -> Tuple[List[str], "pyarrow.fs.FileSystem"]:
-    """
-    Resolves and normalizes all provided paths, infers a filesystem from the
-    paths and ensures that all paths use the same filesystem, and expands all
-    directory paths to the underlying file paths.
-
-    Args:
-        paths: A single file/directory path or a list of file/directory paths.
-            A list of paths can contain both files and directories.
-        filesystem: The filesystem implementation that should be used for
-            reading these files. If None, a filesystem will be inferred. If not
-            None, the provided filesystem will still be validated against all
-            filesystems inferred from the provided paths to ensure
-            compatibility.
-    """
-    from pyarrow.fs import FileSystem, FileType, \
-        PyFileSystem, FSSpecHandler, \
-        _resolve_filesystem_and_path
-    import fsspec
-
-    if isinstance(paths, str):
-        paths = [paths]
-    elif (not isinstance(paths, list)
-          or any(not isinstance(p, str) for p in paths)):
-        raise ValueError(
-            "paths must be a path string or a list of path strings.")
-    elif len(paths) == 0:
-        raise ValueError("Must provide at least one path.")
-
-    if filesystem and not isinstance(filesystem, FileSystem):
-        if not isinstance(filesystem, fsspec.spec.AbstractFileSystem):
-            raise TypeError(f"The filesystem passed must either conform to "
-                            f"pyarrow.fs.FileSystem, or "
-                            f"fsspec.spec.AbstractFileSystem. The provided "
-                            f"filesystem was: {filesystem}")
-        filesystem = PyFileSystem(FSSpecHandler(filesystem))
-
-    resolved_paths = []
-    for path in paths:
-        if filesystem is not None:
-            # If we provide a filesystem, _resolve_filesystem_and_path will not
-            # slice off the protocol from the provided URI/path when resolved.
-            path = _unwrap_protocol(path)
-        resolved_filesystem, resolved_path = _resolve_filesystem_and_path(
-            path, filesystem)
-        if filesystem is None:
-            filesystem = resolved_filesystem
-        resolved_path = filesystem.normalize_path(resolved_path)
-        resolved_paths.append(resolved_path)
-
-    expanded_paths = []
-    file_infos = []
-    for path in resolved_paths:
-        file_info = filesystem.get_file_info(path)
-        if file_info.type == FileType.Directory:
-            paths, file_infos_ = _expand_directory(path, filesystem)
-            expanded_paths.extend(paths)
-            file_infos.extend(file_infos_)
-        elif file_info.type == FileType.File:
-            expanded_paths.append(path)
-            file_infos.append(file_info)
-        else:
-            raise FileNotFoundError(path)
-    return expanded_paths, file_infos, filesystem
 
 
 def _unwrap_protocol(path):

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -42,7 +42,9 @@ class ParquetDatasource(Datasource[ArrowRow]):
 
         dataset_kwargs = reader_args.pop("dataset_kwargs", {})
         pq_ds = pq.ParquetDataset(
-            paths, **dataset_kwargs, filesystem=filesystem,
+            paths,
+            **dataset_kwargs,
+            filesystem=filesystem,
             use_legacy_dataset=False)
         if schema is None:
             schema = pq_ds.schema
@@ -66,7 +68,9 @@ class ParquetDatasource(Datasource[ArrowRow]):
             tables = []
             for piece in pieces:
                 table = piece.to_table(
-                    use_threads=use_threads, columns=columns, schema=schema,
+                    use_threads=use_threads,
+                    columns=columns,
+                    schema=schema,
                     **reader_args)
                 part = _get_partition_keys(piece.partition_expression)
                 if part:

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -36,13 +36,16 @@ class ParquetDatasource(Datasource[ArrowRow]):
         import pyarrow.parquet as pq
         import numpy as np
 
-        paths, file_infos, filesystem = _resolve_paths_and_filesystem(
-            paths, filesystem)
-        file_sizes = [file_info.size for file_info in file_infos]
+        paths, filesystem = _resolve_paths_and_filesystem(paths, filesystem)
+        if len(paths) == 1:
+            paths = paths[0]
 
         dataset_kwargs = reader_args.pop("dataset_kwargs", {})
         pq_ds = pq.ParquetDataset(
-            paths, **dataset_kwargs, filesystem=filesystem)
+            paths, **dataset_kwargs, filesystem=filesystem,
+            use_legacy_dataset=False)
+        if schema is None:
+            schema = pq_ds.schema
         pieces = pq_ds.pieces
 
         def read_pieces(serialized_pieces: List[str]):
@@ -56,13 +59,22 @@ class ParquetDatasource(Datasource[ArrowRow]):
             ]
 
             import pyarrow as pa
+            from pyarrow.dataset import _get_partition_keys
+
             logger.debug(f"Reading {len(pieces)} parquet pieces")
             use_threads = reader_args.pop("use_threads", False)
-            tables = [
-                piece.to_table(
-                    use_threads=use_threads, columns=columns, **reader_args)
-                for piece in pieces
-            ]
+            tables = []
+            for piece in pieces:
+                table = piece.to_table(
+                    use_threads=use_threads, columns=columns, schema=schema,
+                    **reader_args)
+                part = _get_partition_keys(piece.partition_expression)
+                if part:
+                    for col, value in part.items():
+                        table = table.set_column(
+                            table.schema.get_field_index(col), col,
+                            pa.array([value] * len(table)))
+                tables.append(table)
             if len(tables) > 1:
                 table = pa.concat_tables(tables)
             else:
@@ -70,21 +82,18 @@ class ParquetDatasource(Datasource[ArrowRow]):
             return table
 
         read_tasks = []
-        for pieces, file_sizes in zip(
-                np.array_split(pieces, parallelism),
-                np.array_split(file_sizes, parallelism)):
-            if len(pieces) == 0:
+        for pieces_ in np.array_split(pieces, parallelism):
+            if len(pieces_) == 0:
                 continue
-            metadata = _get_metadata(pieces, file_sizes, schema)
-            pieces = [cloudpickle.dumps(p) for p in pieces]
+            metadata = _get_metadata(pieces_, schema)
+            pieces_ = [cloudpickle.dumps(p) for p in pieces_]
             read_tasks.append(
-                ReadTask(lambda pieces=pieces: read_pieces(pieces), metadata))
+                ReadTask(lambda pieces=pieces_: read_pieces(pieces), metadata))
 
         return read_tasks
 
 
 def _get_metadata(pieces: List["pyarrow._dataset.ParquetFileFragment"],
-                  file_sizes: List[int],
                   schema: Optional[Union[type, "pyarrow.lib.Schema"]] = None):
     piece_metadata = []
     for p in pieces:
@@ -94,7 +103,7 @@ def _get_metadata(pieces: List["pyarrow._dataset.ParquetFileFragment"],
             break
     input_files = [p.path for p in pieces]
     if len(piece_metadata) == len(pieces):
-        # Piece metadata was available, constructo a normal
+        # Piece metadata was available, construct a normal
         # BlockMetadata.
         block_metadata = BlockMetadata(
             num_rows=sum(m.num_rows for m in piece_metadata),
@@ -102,14 +111,14 @@ def _get_metadata(pieces: List["pyarrow._dataset.ParquetFileFragment"],
                 sum(
                     m.row_group(i).total_byte_size
                     for i in range(m.num_row_groups)) for m in piece_metadata),
-            schema=piece_metadata[0].schema.to_arrow_schema(),
+            schema=schema,
             input_files=input_files)
     else:
         # Piece metadata was not available, construct an empty
         # BlockMetadata.
         block_metadata = BlockMetadata(
             num_rows=None,
-            size_bytes=sum(file_sizes),
+            size_bytes=None,
             schema=schema,
             input_files=input_files)
     return block_metadata

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -489,10 +489,14 @@ def test_parquet_read(ray_start_regular_shared, tmp_path):
 
 def test_parquet_read_partitioned(ray_start_regular_shared, tmp_path):
     df = pd.DataFrame({
-        "one": [1, 1, 1, 3, 3, 3], "two": ["a", "b", "c", "e", "f", "g"]})
+        "one": [1, 1, 1, 3, 3, 3],
+        "two": ["a", "b", "c", "e", "f", "g"]
+    })
     table = pa.Table.from_pandas(df)
     pq.write_to_dataset(
-        table, root_path=str(tmp_path), partition_cols=["one"],
+        table,
+        root_path=str(tmp_path),
+        partition_cols=["one"],
         use_legacy_dataset=False)
     pq_ds = pq.ParquetDataset(str(tmp_path), use_legacy_dataset=False)
     print(pq_ds.read().to_pandas())

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -487,6 +487,47 @@ def test_parquet_read(ray_start_regular_shared, tmp_path):
     assert sorted(values) == [1, 2, 3, 4, 5, 6]
 
 
+def test_parquet_read_partitioned(ray_start_regular_shared, tmp_path):
+    df = pd.DataFrame({
+        "one": [1, 1, 1, 3, 3, 3], "two": ["a", "b", "c", "e", "f", "g"]})
+    table = pa.Table.from_pandas(df)
+    pq.write_to_dataset(
+        table, root_path=str(tmp_path), partition_cols=["one"],
+        use_legacy_dataset=False)
+    pq_ds = pq.ParquetDataset(str(tmp_path), use_legacy_dataset=False)
+    print(pq_ds.read().to_pandas())
+
+    ds = ray.data.read_parquet(str(tmp_path))
+
+    # Test metadata-only parquet ops.
+    assert len(ds._blocks._blocks) == 1
+    assert ds.count() == 6
+    assert ds.size_bytes() > 0
+    assert ds.schema() is not None
+    input_files = ds.input_files()
+    assert len(input_files) == 2, input_files
+    assert str(ds) == \
+        "Dataset(num_blocks=2, num_rows=6, " \
+        "schema={two: string, " \
+        "one: dictionary<values=int32, indices=int32, ordered=0>})", ds
+    assert repr(ds) == \
+        "Dataset(num_blocks=2, num_rows=6, " \
+        "schema={two: string, " \
+        "one: dictionary<values=int32, indices=int32, ordered=0>})", ds
+    assert len(ds._blocks._blocks) == 1
+
+    # Forces a data read.
+    values = [[s["one"], s["two"]] for s in ds.take()]
+    assert len(ds._blocks._blocks) == 2
+    assert sorted(values) == [[1, "a"], [1, "b"], [1, "c"], [3, "e"], [3, "f"],
+                              [3, "g"]]
+
+    # Test column selection.
+    ds = ray.data.read_parquet(str(tmp_path), columns=["one"])
+    values = [s["one"] for s in ds.take()]
+    assert sorted(values) == [1, 1, 1, 3, 3, 3]
+
+
 def test_parquet_write(ray_start_regular_shared, tmp_path):
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
     df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})


### PR DESCRIPTION
This PR adds support for reading partitioned Parquet datasets by making the following changes:

1. Letting `pyarrow.parquet.ParquetDataset` do the filesystem walk, and therefore leveraging its support for path-based partitioning schemes.
2. Always using the dataset-level schema instead of the schema from the first dataset fragment, since the former contains partition column metadata while the latter does not.
3. Forcing the use of the new (V2) `ParquetDataset`, since the legacy dataset doesn't support the new pyarrow filesystems.
4. Manually add the partition columns to the read Parquet fragments.

(4) is done for us in the legacy `ParquetDataset` dataset upon reading the individual fragments/pieces, while the new `ParquetDataset` does not; instead, the new `ParquetDataset` rolls in the partition columns using the compiled partition expression while reading batches from the fragments, at the dataset level, which is an implementation detail within the C++ source and is therefore not accessible to us in Python. We implement our own column injection logic for (4) for now, but we should look at adding back equivalent functionality for reading individual fragments, as exists for the legacy `ParquetDataset`. This might prove untenable since it appears that the fragment APIs are going to be deprecated.

## Related issue number

Closes #17325 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
