### PR TITLE
[client] fix ClientRemoteMethod error message

### DIFF
--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -259,8 +259,9 @@ class ClientRemoteMethod(ClientStub):
         self._method_name = method_name
 
     def __call__(self, *args, **kwargs):
-        raise TypeError(f"Remote method cannot be called directly. "
-                        f"Use {self._name}.remote() instead")
+        raise TypeError("Actor methods cannot be called directly. Instead "
+                        f"of running 'object.{self._method_name}()', try "
+                        f"'object.{self._method_name}.remote()'.")
 
     def remote(self, *args, **kwargs):
         return return_refs(ray.call_remote(self, *args, **kwargs))


### PR DESCRIPTION
Changes the error to match ActorMethod (https://github.com/ray-project/ray/blob/9322f6aab53f4ca5baf5a3573e1ffde12feae519/python/ray/actor.py#L111)

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.

Tested manually.