### PR TITLE
[Fix] Remove binary printing from RAY_CHECK log

### DIFF
--- a/src/ray/common/id.h
+++ b/src/ray/common/id.h
@@ -392,8 +392,7 @@ T BaseID<T>::FromRandom() {
 template <typename T>
 T BaseID<T>::FromBinary(const std::string &binary) {
   RAY_CHECK(binary.size() == T::Size() || binary.size() == 0)
-      << "expected size is " << T::Size() << ", but got data " << binary << " of size "
-      << binary.size();
+      << "expected size is " << T::Size() << ", but got data size is " << binary.size();
   T t;
   std::memcpy(t.MutableData(), binary.data(), binary.size());
   return t;


### PR DESCRIPTION
## Why are these changes needed?
- Avoid messy code in log
![image](https://user-images.githubusercontent.com/26714159/128986152-44f5373a-9123-4cb7-9282-176a795e8dd0.png)
