### PR TITLE
[C++ API][Fix] support ray::Init without RayConfig

### DIFF
--- a/cpp/example/example.cc
+++ b/cpp/example/example.cc
@@ -28,9 +28,8 @@ class Counter {
 RAY_REMOTE(Counter::FactoryCreate, &Counter::Add);
 
 int main(int argc, char **argv) {
-  /// configuration and initialization
-  ray::RayConfig config;
-  ray::Init(config);
+  /// initialization
+  ray::Init();
 
   /// put and get object
   auto object = ray::Put(100);

--- a/cpp/src/ray/api.cc
+++ b/cpp/src/ray/api.cc
@@ -29,7 +29,10 @@ void Init(RayConfig &config, int *argc, char ***argv) {
 
 void Init(RayConfig &config) { Init(config, nullptr, nullptr); }
 
-void Init() { Init(RayConfig(), nullptr, nullptr); }
+void Init() {
+  RayConfig config;
+  Init(config, nullptr, nullptr);
+}
 
 void Shutdown() { ray::internal::AbstractRayRuntime::DoShutdown(); }
 

--- a/cpp/src/ray/api.cc
+++ b/cpp/src/ray/api.cc
@@ -19,19 +19,17 @@
 
 namespace ray {
 
-void Init(ray::RayConfig &config, int *argc, char ***argv) {
+void Init(RayConfig &config, int *argc, char ***argv) {
   ray::internal::ConfigInternal::Instance().Init(config, argc, argv);
-  Init();
-}
-
-void Init(ray::RayConfig &config) { Init(config, nullptr, nullptr); }
-
-void Init() {
   std::call_once(is_inited_, [] {
     auto runtime = ray::internal::AbstractRayRuntime::DoInit();
     ray::internal::RayRuntimeHolder::Instance().Init(runtime);
   });
 }
+
+void Init(RayConfig &config) { Init(config, nullptr, nullptr); }
+
+void Init() { Init(RayConfig(), nullptr, nullptr); }
 
 void Shutdown() { ray::internal::AbstractRayRuntime::DoShutdown(); }
 


### PR DESCRIPTION

## Why are these changes needed?
- A fix while using ` ray::Init` without RayConfig. 
