### PR TITLE
[RayClient] Add the guide for k8s Ingress

### DIFF
--- a/doc/source/cluster/ray-client.rst
+++ b/doc/source/cluster/ray-client.rst
@@ -144,12 +144,12 @@ If you encounter the following error message when connecting to the ``Ray Cluste
 
 If you use ``nginx-ingress-controller``, It may be resolved to add the following Ingress configuration.
 
-..
+
 .. code-block:: yaml
-   #..
+   
    metadata:
      annotations:
         nginx.ingress.kubernetes.io/server-snippet: |
           underscores_in_headers on;
           ignore_invalid_headers on;
-        #..
+   

--- a/doc/source/cluster/ray-client.rst
+++ b/doc/source/cluster/ray-client.rst
@@ -121,3 +121,35 @@ Starting a connection on older Ray versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you encounter ``socket.gaierror: [Errno -2] Name or service not known`` when using ``ray.init("ray://...")`` then you may be on a version of Ray prior to 1.5 that does not support starting client connections through ``ray.init``. If this is the case, see the `1.4.1 docs <https://docs.ray.io/en/releases-1.4.1/cluster/ray-client.html>`_ for Ray client.
+
+Connection through the Ingress
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you encounter the following error message when connecting to the ``Ray Cluster`` through ``Ingress`` then it may be caused the Ingress configuration.
+
+..
+.. code-block:: python
+
+   grpc._channel._MultiThreadedRendezvous: <_MultiThreadedRendezvous of RPC that terminated with:
+       status = StatusCode.INVALID_ARGUMENT
+       details = ""
+       debug_error_string = "{"created":"@1628668820.164591000","description":"Error received from peer ipv4:10.233.120.107:443","file":"src/core/lib/surface/call.cc","file_line":1062,"grpc_message":"","grpc_status":3}"
+   >
+   Got Error from logger channel -- shutting down: <_MultiThreadedRendezvous of RPC that terminated with:
+       status = StatusCode.INVALID_ARGUMENT
+       details = ""
+       debug_error_string = "{"created":"@1628668820.164713000","description":"Error received from peer ipv4:10.233.120.107:443","file":"src/core/lib/surface/call.cc","file_line":1062,"grpc_message":"","grpc_status":3}"
+   >
+
+
+If you use ``nginx-ingress-controller``, It may be resolved to add the following Ingress configuration.
+
+..
+.. code-block:: yaml
+   #..
+   metadata:
+     annotations:
+        nginx.ingress.kubernetes.io/server-snippet: |
+          underscores_in_headers on;
+          ignore_invalid_headers on;
+        #..

--- a/doc/source/cluster/ray-client.rst
+++ b/doc/source/cluster/ray-client.rst
@@ -125,7 +125,7 @@ If you encounter ``socket.gaierror: [Errno -2] Name or service not known`` when 
 Connection through the Ingress
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you encounter the following error message when connecting to the ``Ray Cluster`` through ``Ingress`` then it may be caused the Ingress configuration.
+If you encounter the following error message when connecting to the ``Ray Cluster`` using an ``Ingress``,  it may be caused by the Ingress's configuration.
 
 ..
 .. code-block:: python

--- a/doc/source/cluster/ray-client.rst
+++ b/doc/source/cluster/ray-client.rst
@@ -142,7 +142,7 @@ If you encounter the following error message when connecting to the ``Ray Cluste
    >
 
 
-If you use ``nginx-ingress-controller``, It may be resolved to add the following Ingress configuration.
+If you are using the ``nginx-ingress-controller``, you may be able to resolve the issue by adding the following Ingress configuration.
 
 
 .. code-block:: yaml


### PR DESCRIPTION
- Add the guide how to solve the error when using k8s Ingress.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The lack of guide about Ray Client when using k8s Ingress.

## Related issue number

I asked on Ray discuss page (https://discuss.ray.io/t/doesnt-work-ray-client-on-k8s-with-ingress/3160/4)
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
