### PR TITLE
[Java] Better log message when failed to invoke task.

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
@@ -14,6 +14,7 @@ import io.ray.runtime.functionmanager.RayFunction;
 import io.ray.runtime.generated.Common.TaskType;
 import io.ray.runtime.object.NativeRayObject;
 import io.ray.runtime.object.ObjectSerializer;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -156,7 +157,7 @@ public abstract class TaskExecutor<T extends TaskExecutor.ActorContext> {
               argTypes);
         }
 
-        if (e.getCause() != null) {
+        if (e instanceof InvocationTargetException && e.getCause() != null) {
           throw e.getCause();
         } else {
           throw e;

--- a/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
@@ -14,7 +14,6 @@ import io.ray.runtime.functionmanager.RayFunction;
 import io.ray.runtime.generated.Common.TaskType;
 import io.ray.runtime.object.NativeRayObject;
 import io.ray.runtime.object.ObjectSerializer;
-import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -141,7 +140,7 @@ public abstract class TaskExecutor<T extends TaskExecutor.ActorContext> {
         } else {
           result = rayFunction.getConstructor().newInstance(args);
         }
-      } catch (InvocationTargetException e) {
+      } catch (Exception e) {
         final boolean isIntentionalSystemExit =
             e.getCause() != null && e.getCause() instanceof RayIntentionalSystemExitException;
         if (!isIntentionalSystemExit) {
@@ -150,9 +149,10 @@ public abstract class TaskExecutor<T extends TaskExecutor.ActorContext> {
                   .map(arg -> arg == null ? null : arg.getClass())
                   .collect(Collectors.toList());
           LOGGER.error(
-              "Execute rayFunction {} failed. actor {}, argument types {}",
+              "Execute rayFunction {} failed. actor is {} , task id is {} , argument types are {}",
               rayFunction,
               actor,
+              taskId,
               argTypes);
         }
 

--- a/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
@@ -14,6 +14,7 @@ import io.ray.runtime.functionmanager.RayFunction;
 import io.ray.runtime.generated.Common.TaskType;
 import io.ray.runtime.object.NativeRayObject;
 import io.ray.runtime.object.ObjectSerializer;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -134,10 +135,18 @@ public abstract class TaskExecutor<T extends TaskExecutor.ActorContext> {
 
       // Execute the task.
       Object result;
-      if (!rayFunction.isConstructor()) {
-        result = rayFunction.getMethod().invoke(actor, args);
-      } else {
-        result = rayFunction.getConstructor().newInstance(args);
+      try {
+        if (!rayFunction.isConstructor()) {
+          result = rayFunction.getMethod().invoke(actor, args);
+        } else {
+          result = rayFunction.getConstructor().newInstance(args);
+        }
+      } catch (InvocationTargetException e) {
+        if (e.getCause() != null) {
+          throw e.getCause();
+        } else {
+          throw e;
+        }
       }
 
       // Set result

--- a/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/TaskExecutor.java
@@ -14,7 +14,6 @@ import io.ray.runtime.functionmanager.RayFunction;
 import io.ray.runtime.generated.Common.TaskType;
 import io.ray.runtime.object.NativeRayObject;
 import io.ray.runtime.object.ObjectSerializer;
-import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -128,8 +127,7 @@ public abstract class TaskExecutor<T extends TaskExecutor.ActorContext> {
       if (taskType == TaskType.ACTOR_TASK) {
         actor = actorContext.currentActor;
       }
-      args =
-          ArgumentsBuilder.unwrap(argsBytes, rayFunction.executable.getParameterTypes());
+      args = ArgumentsBuilder.unwrap(argsBytes, rayFunction.executable.getParameterTypes());
       for (Object arg : args) {
         throwIfDependencyFailed(arg);
       }
@@ -159,14 +157,18 @@ public abstract class TaskExecutor<T extends TaskExecutor.ActorContext> {
         throw (RayIntentionalSystemExitException) e;
       }
 
-      final List<Class<?>> argTypes = args == null ? null :
-        Arrays.stream(args)
-          .map(arg -> arg == null ? null : arg.getClass())
-          .collect(Collectors.toList());
+      final List<Class<?>> argTypes =
+          args == null
+              ? null
+              : Arrays.stream(args)
+                  .map(arg -> arg == null ? null : arg.getClass())
+                  .collect(Collectors.toList());
       LOGGER.error(
-        "Failed to execute task {} . rayFunction is {} , argument types are {}",
-        taskId, rayFunction, argTypes, e);
-
+          "Failed to execute task {} . rayFunction is {} , argument types are {}",
+          taskId,
+          rayFunction,
+          argTypes,
+          e);
 
       if (taskType != TaskType.ACTOR_CREATION_TASK) {
         boolean hasReturn = rayFunction != null && rayFunction.hasReturn();

--- a/java/test/src/main/java/io/ray/test/TaskExceptionTest.java
+++ b/java/test/src/main/java/io/ray/test/TaskExceptionTest.java
@@ -2,6 +2,7 @@ package io.ray.test;
 
 import io.ray.api.ActorHandle;
 import io.ray.api.Ray;
+import io.ray.runtime.exception.RayTaskException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -45,5 +46,23 @@ public class TaskExceptionTest extends BaseTest {
     ActorHandle<MyActor> myActor = Ray.actor(MyActor::new).remote();
     Assert.assertEquals("Hi", myActor.task(MyActor::sayHi).remote().get());
     Assert.assertThrows((() -> myActor.task(MyActor::throwUnserializableException).remote().get()));
+  }
+
+  private static String hello() {
+    Ray.task(TaskExceptionTest::throwUnserializableException).remote().get();
+    return "hello";
+  }
+
+  @Test
+  public void testThrowRootExceptionForChainedTasks() {
+    Assert.assertThrows(
+        RayTaskException.class,
+        () -> {
+          try {
+            Ray.task(TaskExceptionTest::hello).remote().get();
+          } catch (Exception e) {
+            throw e.getCause();
+          }
+        });
   }
 }

--- a/java/test/src/main/java/io/ray/test/TaskExceptionTest.java
+++ b/java/test/src/main/java/io/ray/test/TaskExceptionTest.java
@@ -55,14 +55,9 @@ public class TaskExceptionTest extends BaseTest {
 
   @Test
   public void testThrowRootExceptionForChainedTasks() {
-    Assert.assertThrows(
-        RayTaskException.class,
-        () -> {
-          try {
-            Ray.task(TaskExceptionTest::hello).remote().get();
-          } catch (Exception e) {
-            throw e.getCause();
-          }
-        });
+    RayTaskException ex =
+        Assert.expectThrows(
+            RayTaskException.class, () -> Ray.task(TaskExceptionTest::hello).remote().get());
+    Assert.assertTrue(ex.getCause() instanceof RayTaskException);
   }
 }


### PR DESCRIPTION
Catch more broad exceptions when failed to invoke task since `invoke` might throw other exceptions. Better log message will save us away unknown failure reasons.

Close #17704

![image](https://user-images.githubusercontent.com/19473861/128999177-cfb3900d-0008-4f25-9487-ff5d05aa630c.png)
