### PR TITLE
[Core] Add Metric to gRPC Server

### DIFF
--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -122,6 +122,9 @@ void GrpcServer::PollEventsFromCompletionQueue(int index) {
     if (ok) {
       switch (server_call->GetState()) {
       case ServerCallState::PENDING:
+        ray::stats::RequestReceivedCount().Record(
+            1, {{ray::stats::CallNameKey, server_call->GetCallName()},
+                {ray::stats::ThreadIndexKey, std::to_string(index)}});
         // We've received a new incoming request. Now this call object is used to
         // track this request.
         server_call->SetState(ServerCallState::PROCESSING);

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -21,6 +21,7 @@
 #include "ray/common/ray_config.h"
 #include "ray/rpc/grpc_server.h"
 #include "ray/stats/metric.h"
+#include "ray/stats/metric_defs.h"
 #include "ray/util/util.h"
 
 DEFINE_stats(grpc_server_req_latency_ms, "Request latency in grpc server", ("Method"), (),

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -122,7 +122,7 @@ void GrpcServer::PollEventsFromCompletionQueue(int index) {
     if (ok) {
       switch (server_call->GetState()) {
       case ServerCallState::PENDING:
-        ray::stats::RequestReceivedCount().Record(
+        stats::RequestReceivedCount().Record(
             1, {{ray::stats::CallNameKey, server_call->GetCallName()},
                 {ray::stats::ThreadIndexKey, std::to_string(index)}});
         // We've received a new incoming request. Now this call object is used to

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -89,6 +89,8 @@ class ServerCall {
   // Invoked when sending reply fails.
   virtual void OnReplyFailed() = 0;
 
+  virtual const std::string &GetCallName() = 0;
+
   virtual const ServerCallFactory &GetServerCallFactory() = 0;
 
   /// Virtual destruct function to make sure subclass would destruct properly.
@@ -214,6 +216,8 @@ class ServerCallImpl : public ServerCall {
       io_service_.post([callback]() { callback(); }, call_name_ + ".failure_callback");
     }
   }
+
+  const std::string &GetCallName() override { return call_name_; }
 
   const ServerCallFactory &GetServerCallFactory() override { return factory_; }
 

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -167,3 +167,7 @@ static Histogram OutboundHeartbeatSizeKB("outbound_heartbeat_size_kb",
 static Histogram GcsUpdateResourceUsageTime(
     "gcs_update_resource_usage_time", "The average RTT of a UpdateResourceUsage RPC.",
     "ms", {1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000}, {CustomKey});
+
+static Count RequestReceivedCount("ray.gcs_server.request_received_count",
+                                  "Number of request received.", "1",
+                                  {CallNameKey, ThreadIndexKey});

--- a/src/ray/stats/tag_defs.h
+++ b/src/ray/stats/tag_defs.h
@@ -39,3 +39,7 @@ static const TagKeyType DriverPidKey = TagKeyType::Register("DriverPid");
 static const TagKeyType ResourceNameKey = TagKeyType::Register("ResourceName");
 
 static const TagKeyType ActorIdKey = TagKeyType::Register("ActorId");
+
+static const TagKeyType CallNameKey = TagKeyType::Register("CallName");
+
+static const TagKeyType ThreadIndexKey = TagKeyType::Register("ThreadIndex");


### PR DESCRIPTION
## Why are these changes needed?

I add a metric to gRPC server's polling thread.

This is very useful when analyzing GCS's network traffic.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
