### PR TITLE
[Core] Keep Raylet's Historical Debug State Dump

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2000,8 +2000,10 @@ void NodeManager::ProcessSubscribePlasmaReady(
 void NodeManager::DumpDebugState() const {
   std::fstream fs;
   fs.open(initial_config_.session_dir + "/debug_state.txt",
-          std::fstream::out | std::fstream::trunc);
+          std::fstream::out | std::fstream::app);
+  fs << "[" << current_sys_time_formatted() << "]\n";
   fs << DebugString();
+  fs << "\n\n\n";
   fs.close();
 }
 

--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -91,6 +91,14 @@ inline int64_t current_sys_time_us() {
           std::chrono::system_clock::now().time_since_epoch());
   return mu_since_epoch.count();
 }
+	
+inline std::string current_sys_time_formatted() {
+  auto t = std::time(nullptr);
+  auto tm = *std::localtime(&t);
+  std::stringstream ss;
+  ss << std::put_time(&tm, "%d-%m-%Y %H:%M:%S");
+  return ss.str();
+}
 
 /// A helper function to parse command-line arguments in a platform-compatible manner.
 ///

--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <chrono>
+#include <iomanip>
 #include <iterator>
 #include <mutex>
 #include <random>
@@ -91,7 +92,7 @@ inline int64_t current_sys_time_us() {
           std::chrono::system_clock::now().time_since_epoch());
   return mu_since_epoch.count();
 }
-	
+
 inline std::string current_sys_time_formatted() {
   auto t = std::time(nullptr);
   auto tm = *std::localtime(&t);


### PR DESCRIPTION
## Why are these changes needed?

Prior to this PR, `debug_state.txt` only keeps the latest state of raylet.

I changed it from truncating to appending. This will keep the historical state info.

It's very helpful when debugging with a dead raylet.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
