### PR TITLE
[Java] Update rolling logging configuration

### DIFF
--- a/java/test/src/main/java/io/ray/test/RayJavaLoggingTest.java
+++ b/java/test/src/main/java/io/ray/test/RayJavaLoggingTest.java
@@ -33,13 +33,15 @@ public class RayJavaLoggingTest extends BaseTest {
   public void testJavaLoggingRotate() {
     ActorHandle<HeavyLoggingActor> loggingActor =
         Ray.actor(HeavyLoggingActor::new)
-            .setJvmOptions(ImmutableList.of("-Dray.logging.max-file-size=1MB"))
+            .setJvmOptions(
+                ImmutableList.of(
+                    "-Dray.logging.max-file-size=1MB", "-Dray.logging.max-backup-files=3"))
             .remote();
     Assert.assertTrue(loggingActor.task(HeavyLoggingActor::log).remote().get());
     final int pid = loggingActor.task(HeavyLoggingActor::getPid).remote().get();
     final JobId jobId = Ray.getRuntimeContext().getCurrentJobId();
     String currLogDir = "/tmp/ray/session_latest/logs";
-    for (int i = 1; i < 8; ++i) {
+    for (int i = 1; i <= 3; ++i) {
       File rotatedFile =
           new File(String.format("%s/java-worker-%s-%d.%d.log", currLogDir, jobId, pid, i));
       Assert.assertTrue(rotatedFile.exists());


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Allow setting env variables `RAY_ROTATION_MAX_BYTES` and `RAY_ROTATION_BACKUP_COUNT` to overwrite default values in Java logging configuration (like Python and C++ logging).
* Fix a bug that Java logging configuration ignores `ray.logging.max-backup-files`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
