### PR TITLE
[hotfix] pin tensorflow==2.5.1

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -73,7 +73,7 @@ pytest-sugar
 pytest-lazy-fixture
 pytest-timeout
 scikit-learn==0.22.2
-tensorflow
+tensorflow==1.5.1
 testfixtures
 werkzeug
 xlrd

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -73,7 +73,7 @@ pytest-sugar
 pytest-lazy-fixture
 pytest-timeout
 scikit-learn==0.22.2
-tensorflow==1.5.1
+tensorflow==2.5.1
 testfixtures
 werkzeug
 xlrd


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Tune tests in CI are failing with the message ModuleNotFoundError: No module named 'keras.api' , see https://buildkite.com/ray-project/ray-builders-branch/builds/2798#4060abf7-244a-4909-857b-86d158f01ae8/432-980 for example.  It's probably because of the new tensorflow version released today: https://pypi.org/project/tensorflow/#history

This PR pins the tensorflow version in `requirements.txt` to the previous version, 1.5.1.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
