### PR TITLE
[Serve] Remove `serve.start(http_*)` arguments

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -647,8 +647,7 @@ def start(
     if isinstance(http_options, dict):
         http_options = HTTPOptions.parse_obj(http_options)
     if http_options is None:
-        http_options = HTTPOptions(
-            host=http_host, port=http_port, middlewares=http_middlewares)
+        http_options = HTTPOptions()
 
     controller = ServeController.options(
         num_cpus=(1 if dedicated_cpu else 0),

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -566,11 +566,9 @@ class Client:
 @PublicAPI
 def start(
         detached: bool = False,
-        http_host: Optional[str] = DEFAULT_HTTP_HOST,
-        http_port: int = DEFAULT_HTTP_PORT,
-        http_middlewares: List[Any] = [],
         http_options: Optional[Union[dict, HTTPOptions]] = None,
         dedicated_cpu: bool = False,
+        **kwargs,
 ) -> Client:
     """Initialize a serve instance.
 
@@ -586,9 +584,6 @@ def start(
           explicitly stopped with serve.shutdown(). This should *not* be set in
           an anonymous Ray namespace because you will not be able to reconnect
           to the instance after the script exits.
-        http_host (Optional[str]): Deprecated, use http_options instead.
-        http_port (int): Deprecated, use http_options instead.
-        http_middlewares (list): Deprecated, use http_options instead.
         http_options (Optional[Dict, serve.HTTPOptions]): Configuration options
           for HTTP proxy. You can pass in a dictionary or HTTPOptions object
           with fields:
@@ -612,21 +607,12 @@ def start(
         dedicated_cpu (bool): Whether to reserve a CPU core for the internal
           Serve controller actor.  Defaults to False.
     """
-    if ((http_host != DEFAULT_HTTP_HOST) or (http_port != DEFAULT_HTTP_PORT)
-            or (len(http_middlewares) != 0)):
-        if http_options is not None:
+    http_deprecated_args = ["http_host", "http_port", "http_middlewares"]
+    for key in http_deprecated_args:
+        if key in kwargs:
             raise ValueError(
-                "You cannot specify both `http_options` and any of the "
-                "`http_host`, `http_port`, and `http_middlewares` arguments. "
-                "`http_options` is preferred.")
-        else:
-            warn(
-                "`http_host`, `http_port`, `http_middlewares` are deprecated. "
-                "Please use serve.start(http_options={'host': ..., "
-                "'port': ..., middlewares': ...}) instead.",
-                DeprecationWarning,
-            )
-
+                f"{key} is deprecated, please use serve.start(http_options="
+                f'{{"{key}": {kwargs[key]}}}) instead.')
     # Initialize ray if needed.
     ray.worker.global_worker.filter_logs_by_job = False
     if not ray.is_initialized():

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from functools import wraps
 from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple,
                     Type, Union, overload)
-from warnings import warn
 from weakref import WeakValueDictionary
 
 from starlette.requests import Request
@@ -21,8 +20,7 @@ from ray.actor import ActorHandle
 from ray.util.annotations import Deprecated, PublicAPI
 from ray.serve.common import BackendInfo, GoalId
 from ray.serve.config import (BackendConfig, HTTPOptions, ReplicaConfig)
-from ray.serve.constants import (DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT,
-                                 HTTP_PROXY_TIMEOUT, SERVE_CONTROLLER_NAME)
+from ray.serve.constants import (HTTP_PROXY_TIMEOUT, SERVE_CONTROLLER_NAME)
 from ray.serve.controller import ReplicaTag, ServeController
 from ray.serve.exceptions import RayServeException
 from ray.serve.handle import RayServeHandle, RayServeSyncHandle

--- a/python/ray/serve/examples/doc/aiohttp/aiohttp_deploy_serve.py
+++ b/python/ray/serve/examples/doc/aiohttp/aiohttp_deploy_serve.py
@@ -6,7 +6,7 @@ from ray import serve
 ray.init(address="auto")
 
 # Start a detached Ray Serve instance.  It will persist after the script exits.
-serve.start(http_host=None, detached=True)
+serve.start(http_options={"http_host": None}, detached=True)
 
 
 # Set up a deployment with the desired number of replicas. This could also be

--- a/python/ray/serve/examples/doc/fastapi/servehandle_fastapi.py
+++ b/python/ray/serve/examples/doc/fastapi/servehandle_fastapi.py
@@ -23,7 +23,7 @@ class GPT2:
 @app.on_event("startup")  # Code to be run when the server starts.
 async def startup_event():
     ray.init(address="auto")  # Connect to the running Ray cluster.
-    serve.start(http_host=None)  # Start the Ray Serve instance.
+    serve.start(http_options: {"http_host": None})  # Start the Ray Serve instance.
 
     # Deploy our GPT2 Deployment.
     GPT2.deploy()

--- a/python/ray/serve/examples/doc/fastapi/servehandle_fastapi.py
+++ b/python/ray/serve/examples/doc/fastapi/servehandle_fastapi.py
@@ -23,7 +23,8 @@ class GPT2:
 @app.on_event("startup")  # Code to be run when the server starts.
 async def startup_event():
     ray.init(address="auto")  # Connect to the running Ray cluster.
-    serve.start(http_options={"http_host": None})  # Start the Ray Serve instance.
+    serve.start(
+        http_options={"http_host": None})  # Start the Ray Serve instance.
 
     # Deploy our GPT2 Deployment.
     GPT2.deploy()

--- a/python/ray/serve/examples/doc/fastapi/servehandle_fastapi.py
+++ b/python/ray/serve/examples/doc/fastapi/servehandle_fastapi.py
@@ -23,7 +23,7 @@ class GPT2:
 @app.on_event("startup")  # Code to be run when the server starts.
 async def startup_event():
     ray.init(address="auto")  # Connect to the running Ray cluster.
-    serve.start(http_options: {"http_host": None})  # Start the Ray Serve instance.
+    serve.start(http_options={"http_host": None})  # Start the Ray Serve instance.
 
     # Deploy our GPT2 Deployment.
     GPT2.deploy()

--- a/python/ray/serve/examples/doc/tutorial_deploy.py
+++ b/python/ray/serve/examples/doc/tutorial_deploy.py
@@ -69,7 +69,7 @@ ray.init(address="auto")
 # now we initialize /connect to the Ray service
 
 # listen on 0.0.0.0 to make the HTTP server accessible from other machines.
-serve.start(http_host="0.0.0.0")
+serve.start(http_options={"http_host": "0.0.0.0"})
 serve.create_backend("lr:v1", BoostingModel)
 serve.create_endpoint("iris_classifier", backend="lr:v1", route="/regressor")
 # __doc_create_deploy_end__

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -38,7 +38,7 @@ def ray_cluster():
 
 def test_shutdown(ray_shutdown):
     ray.init(num_cpus=16)
-    serve.start(http_port=8003)
+    serve.start(http_options=dict(http_port=8003))
 
     @serve.deployment
     def f():

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -273,9 +273,6 @@ def test_no_http(ray_shutdown):
     # The following should have the same effect.
     options = [
         {
-            "http_host": None
-        },
-        {
             "http_options": {
                 "host": None
             }

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -38,7 +38,7 @@ def ray_cluster():
 
 def test_shutdown(ray_shutdown):
     ray.init(num_cpus=16)
-    serve.start(http_options=dict(http_port=8003))
+    serve.start(http_options=dict(port=8003))
 
     @serve.deployment
     def f():


### PR DESCRIPTION
These arguments have long been deprecated. This PR formally removes them from the API (but leave a friendly error message just in case).