### PR TITLE
[Client] Pass `ray.init()` args to the remote server

### DIFF
--- a/python/ray/_private/ray_client_microbenchmark.py
+++ b/python/ray/_private/ray_client_microbenchmark.py
@@ -78,7 +78,7 @@ def main(results=None):
         "logging_level": logging.WARNING
     }
 
-    def ray_connect_handler(job_config=None):
+    def ray_connect_handler(job_config=None, **ray_init_kwargs):
         from ray._private.client_mode_hook import disable_client_hook
         with disable_client_hook():
             import ray as real_ray

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -1,6 +1,7 @@
 import os
 import sys
 
+import logging
 import pytest
 import redis
 import unittest.mock
@@ -173,11 +174,11 @@ def test_ray_init_invalid_keyword_with_client(shutdown_only):
 
 
 def test_ray_init_valid_keyword_with_client(shutdown_only):
-    with pytest.raises(RuntimeError) as excinfo:
-        # num_cpus is a valid argument for regular ray.init, but not for
-        # init(ray://)
-        ray.init("ray://127.0.0.0", num_cpus=1)
-    assert "num_cpus" in str(excinfo.value)
+    with ray_start_client_server() as given_connection:
+        given_connection.disconnect()
+        # logging_level should be passed to the server
+        with ray.init("ray://localhost:50051", logging_level=logging.INFO):
+            pass
 
 
 def test_env_var_override():

--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Dict, Any
+from typing import List, Tuple, Dict, Any, Optional
 from ray.job_config import JobConfig
 import os
 import sys
@@ -36,7 +36,9 @@ class RayAPIStub:
                 connection_retries: int = 3,
                 namespace: str = None,
                 *,
-                ignore_version: bool = False) -> Dict[str, Any]:
+                ignore_version: bool = False,
+                ray_init_kwargs: Optional[Dict[str, Any]] = None
+                ) -> Dict[str, Any]:
         """Connect the Ray Client to a server.
 
         Args:
@@ -80,7 +82,7 @@ class RayAPIStub:
                 metadata=metadata,
                 connection_retries=connection_retries)
             self.api.worker = self.client_worker
-            self.client_worker._server_init(job_config)
+            self.client_worker._server_init(job_config, ray_init_kwargs)
             conn_info = self.client_worker.connection_info()
             self._check_versions(conn_info, ignore_version)
             self._register_serializers()

--- a/python/ray/util/client/ray_client_helpers.py
+++ b/python/ray/util/client/ray_client_helpers.py
@@ -35,7 +35,7 @@ def ray_start_client_server_pair(metadata=None,
 def ray_start_cluster_client_server_pair(address):
     ray._inside_client_test = True
 
-    def ray_connect_handler(job_config=None):
+    def ray_connect_handler(job_config=None, **ray_init_kwargs):
         real_ray.init(address=address)
 
     server = ray_client_server.serve(

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -392,7 +392,8 @@ def prepare_runtime_init_req(init_request: ray_client_pb2.DataRequest
         job_config = pickle.loads(req.job_config)
     new_job_config = ray_client_server_env_prep(job_config)
     modified_init_req = ray_client_pb2.InitRequest(
-        job_config=pickle.dumps(new_job_config))
+        job_config=pickle.dumps(new_job_config),
+        ray_init_kwargs=init_request.init.ray_init_kwargs)
 
     init_request.init.CopyFrom(modified_init_req)
     return (init_request, new_job_config)

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -588,10 +588,11 @@ def decode_options(
 
 
 def serve(connection_str, ray_connect_handler=None):
-    def default_connect_handler(job_config: JobConfig = None):
+    def default_connect_handler(job_config: JobConfig = None,
+                                **ray_init_kwargs: Dict[str, Any]):
         with disable_client_hook():
             if not ray.is_initialized():
-                return ray.init(job_config=job_config)
+                return ray.init(job_config=job_config, **ray_init_kwargs)
 
     ray_connect_handler = ray_connect_handler or default_connect_handler
     server = grpc.server(
@@ -622,7 +623,7 @@ def init_and_serve(connection_str, *args, **kwargs):
         # Disable client mode inside the worker's environment
         info = ray.init(*args, **kwargs)
 
-    def ray_connect_handler(job_config=None):
+    def ray_connect_handler(job_config=None, **ray_init_kwargs):
         # Ray client will disconnect from ray when
         # num_clients == 0.
         if ray.is_initialized():

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -76,7 +76,14 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
                 current_job_config = worker.core_worker.get_job_config()
             else:
                 extra_kwargs = json.loads(request.ray_init_kwargs or "{}")
-                self.ray_connect_handler(job_config, **extra_kwargs)
+                try:
+                    self.ray_connect_handler(job_config, **extra_kwargs)
+                except Exception as e:
+                    logger.exception("Running Ray Init failed:")
+                    return ray_client_pb2.InitResponse(
+                        ok=False,
+                        msg="Call to `ray.init()` on the server "
+                        f"failed with: {e}")
         if job_config is None:
             return ray_client_pb2.InitResponse(ok=True)
         job_config = job_config.get_proto_job_config()

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -513,11 +513,16 @@ class Worker:
                 f"Init Failure From Server:\n{init_resp.msg}")
         return
 
-    def _server_init(self, job_config: JobConfig):
+    def _server_init(self,
+                     job_config: JobConfig,
+                     ray_init_kwargs: Optional[Dict[str, Any]] = None):
         """Initialize the server"""
+        if ray_init_kwargs is None:
+            ray_init_kwargs = {}
         try:
             if job_config is None:
-                init_req = ray_client_pb2.InitRequest()
+                init_req = ray_client_pb2.InitRequest(
+                    ray_init_kwargs=json.dumps(ray_init_kwargs))
                 self._call_init(init_req)
                 return
 
@@ -528,7 +533,8 @@ class Worker:
                 # Generate the uri for runtime env
                 runtime_env.rewrite_runtime_env_uris(job_config)
                 init_req = ray_client_pb2.InitRequest(
-                    job_config=pickle.dumps(job_config))
+                    job_config=pickle.dumps(job_config),
+                    ray_init_kwargs=json.dumps(ray_init_kwargs))
                 self._call_init(init_req)
                 runtime_env.upload_runtime_env_package_if_needed(job_config)
                 runtime_env.PKG_DIR = old_dir

--- a/python/ray/util/client_connect.py
+++ b/python/ray/util/client_connect.py
@@ -3,17 +3,19 @@ from ray.job_config import JobConfig
 from ray._private.client_mode_hook import _set_client_hook_status
 from ray._private.client_mode_hook import _explicitly_enable_client_mode
 
-from typing import List, Tuple, Dict, Any
+from typing import List, Tuple, Dict, Any, Optional
 
 
-def connect(conn_str: str,
-            secure: bool = False,
-            metadata: List[Tuple[str, str]] = None,
-            connection_retries: int = 3,
-            job_config: JobConfig = None,
-            namespace: str = None,
-            *,
-            ignore_version: bool = False) -> Dict[str, Any]:
+def connect(
+        conn_str: str,
+        secure: bool = False,
+        metadata: List[Tuple[str, str]] = None,
+        connection_retries: int = 3,
+        job_config: JobConfig = None,
+        namespace: str = None,
+        *,
+        ignore_version: bool = False,
+        ray_init_kwargs: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     if ray.is_connected():
         raise RuntimeError("Ray Client is already connected. Maybe you called "
                            'ray.init("ray://<address>") twice by accident?')
@@ -32,7 +34,8 @@ def connect(conn_str: str,
         metadata=metadata,
         connection_retries=connection_retries,
         namespace=namespace,
-        ignore_version=ignore_version)
+        ignore_version=ignore_version,
+        ray_init_kwargs=ray_init_kwargs)
 
 
 def disconnect():

--- a/python/ray/util/horovod/tests/test_horovod.py
+++ b/python/ray/util/horovod/tests/test_horovod.py
@@ -16,17 +16,8 @@ except ImportError:
 @pytest.fixture(params=[False, True])
 def ray_start_4_cpus(request):
     if request.param:
-
-        def ray_connect_handler(job_config=None):
-            # Ray client will disconnect from ray when
-            # num_clients == 0.
-            if ray.is_initialized():
-                return
-            else:
-                return ray.init(job_config=job_config, num_cpus=4)
-
         assert not ray.util.client.ray.is_connected()
-        with ray_start_client_server(ray_connect_handler=ray_connect_handler):
+        with ray_start_client_server(ray_init_kwargs={"num_cpus": 3}):
             assert ray.util.client.ray.is_connected()
             yield
     else:

--- a/rllib/tests/test_ray_client.py
+++ b/rllib/tests/test_ray_client.py
@@ -5,7 +5,6 @@ import unittest
 import pytest
 import ray
 from ray import tune
-from ray.job_config import JobConfig
 from ray.rllib.agents import ppo
 from ray.rllib.examples.env.stateless_cartpole import StatelessCartPole
 from ray.rllib.utils.test_utils import check_learning_achieved
@@ -70,10 +69,8 @@ class TestRayClient(unittest.TestCase):
             check_learning_achieved(results, 150.0)
 
     def test_custom_experiment(self):
-        def ray_connect_handler(job_config: JobConfig = None):
-            ray.init(num_cpus=3)
 
-        with ray_start_client_server(ray_connect_handler=ray_connect_handler):
+        with ray_start_client_server(ray_init_kwargs={"num_cpus": 3}):
             assert ray.util.client.ray.is_connected()
 
             config = ppo.DEFAULT_CONFIG.copy()

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -252,6 +252,7 @@ message KVListResponse {
 message InitRequest {
   // job_config of ray.init
   bytes job_config = 1;
+  string ray_init_kwargs = 2;
 }
 
 message InitResponse {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* This allows fields like `log_to_driver` to be passed from the Ray Client to the Ray Client Server so that when the Ray Client Server connects to the Ray Cluster, these fields are used.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/17697

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
