### PR TITLE
[C++ API]support set resources in RayConfig

### DIFF
--- a/cpp/include/ray/api/ray_config.h
+++ b/cpp/include/ray/api/ray_config.h
@@ -16,6 +16,7 @@
 #include <ray/api/ray_exception.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 #include "boost/optional.hpp"
 
@@ -40,6 +41,17 @@ class RayConfig {
 
   // Prevents external clients without the password from connecting to Redis if provided.
   boost::optional<std::string> redis_password_;
+
+  // Number of CPUs the user wishes to assign to each raylet. By default, this is set
+  // based on virtual cores.
+  int num_cpus = 0;
+
+  // Number of GPUs the user wishes to assign to each raylet. By default, this is set
+  // based on detected GPUs.
+  int num_gpus = 0;
+
+  // A mapping the names of custom resources to the quantities for them available.
+  std::unordered_map<std::string, int> resources;
 };
 
 }  // namespace ray

--- a/cpp/src/ray/config_internal.cc
+++ b/cpp/src/ray/config_internal.cc
@@ -60,6 +60,15 @@ void ConfigInternal::Init(RayConfig &config, int *argc, char ***argv) {
   if (config.redis_password_) {
     redis_password = *config.redis_password_;
   }
+  if (config.num_cpus > 0) {
+    num_cpus = config.num_cpus;
+  }
+  if (config.num_gpus > 0) {
+    num_gpus = config.num_gpus;
+  }
+  if (!config.resources.empty()) {
+    resources = config.resources;
+  }
   if (argc != nullptr && argv != nullptr) {
     // Parse config from command line.
     gflags::ParseCommandLineFlags(argc, argv, true);

--- a/cpp/src/ray/config_internal.h
+++ b/cpp/src/ray/config_internal.h
@@ -53,6 +53,12 @@ class ConfigInternal {
 
   std::string node_ip_address = "";
 
+  int num_cpus = 0;
+
+  int num_gpus = 0;
+
+  std::unordered_map<std::string, int> resources;
+
   static ConfigInternal &Instance() {
     static ConfigInternal config;
     return config;

--- a/cpp/src/ray/test/cluster/cluster_mode_test.cc
+++ b/cpp/src/ray/test/cluster/cluster_mode_test.cc
@@ -28,6 +28,8 @@ DEFINE_int32(redis_port, 6379, "");
 
 TEST(RayClusterModeTest, FullTest) {
   ray::RayConfig config;
+  config.num_cpus = 2;
+  config.resources = {{"resource1", 1}, {"resource2", 2}};
   if (FLAGS_external_cluster) {
     ray::internal::ProcessHelper::GetInstance().StartRayNode(FLAGS_redis_port,
                                                              FLAGS_redis_password);

--- a/cpp/src/ray/util/process_helper.cc
+++ b/cpp/src/ray/util/process_helper.cc
@@ -60,6 +60,20 @@ static std::string GetNodeIpAddress(const std::string &address = "8.8.8.8:53") {
   }
 }
 
+std::string FormatResourcesArg(const std::unordered_map<std::string, int> &resources) {
+  std::ostringstream oss;
+  oss << "{";
+  for (auto iter = resources.begin(); iter != resources.end();) {
+    oss << "\"" << iter->first << "\":" << iter->second;
+    ++iter;
+    if (iter != resources.end()) {
+      oss << ",";
+    }
+  }
+  oss << "}";
+  return oss.str();
+}
+
 void ProcessHelper::StartRayNode(const int redis_port, const std::string redis_password,
                                  const int num_cpus, const int num_gpus,
                                  const std::unordered_map<std::string, int> resources) {
@@ -75,18 +89,8 @@ void ProcessHelper::StartRayNode(const int redis_port, const std::string redis_p
     cmdargs.emplace_back(std::to_string(num_gpus));
   }
   if (!resources.empty()) {
-    std::ostringstream oss;
-    oss << "{";
-    for (auto iter = resources.begin(); iter != resources.end();) {
-      oss << "\"" << iter->first << "\":" << iter->second;
-      ++iter;
-      if (iter != resources.end()) {
-        oss << ",";
-      }
-    }
-    oss << "}";
     cmdargs.emplace_back("--resources");
-    cmdargs.emplace_back(oss.str());
+    cmdargs.emplace_back(FormatResourcesArg(resources));
   }
   RAY_LOG(INFO) << CreateCommandLine(cmdargs);
   RAY_CHECK(!Process::Spawn(cmdargs, true).second);

--- a/cpp/src/ray/util/process_helper.cc
+++ b/cpp/src/ray/util/process_helper.cc
@@ -60,10 +60,34 @@ static std::string GetNodeIpAddress(const std::string &address = "8.8.8.8:53") {
   }
 }
 
-void ProcessHelper::StartRayNode(int redis_port, std::string redis_password) {
+void ProcessHelper::StartRayNode(const int redis_port, const std::string redis_password,
+                                 const int num_cpus, const int num_gpus,
+                                 const std::unordered_map<std::string, int> resources) {
   std::vector<std::string> cmdargs({"ray", "start", "--head", "--port",
                                     std::to_string(redis_port), "--redis-password",
                                     redis_password, "--include-dashboard", "false"});
+  if (num_cpus > 0) {
+    cmdargs.emplace_back("--num-cpus");
+    cmdargs.emplace_back(std::to_string(num_cpus));
+  }
+  if (num_gpus > 0) {
+    cmdargs.emplace_back("--num-gpus");
+    cmdargs.emplace_back(std::to_string(num_gpus));
+  }
+  if (!resources.empty()) {
+    std::ostringstream oss;
+    oss << "{";
+    for (auto iter = resources.begin(); iter != resources.end();) {
+      oss << "\"" << iter->first << "\":" << iter->second;
+      ++iter;
+      if (iter != resources.end()) {
+        oss << ",";
+      }
+    }
+    oss << "}";
+    cmdargs.emplace_back("--resources");
+    cmdargs.emplace_back(oss.str());
+  }
   RAY_LOG(INFO) << CreateCommandLine(cmdargs);
   RAY_CHECK(!Process::Spawn(cmdargs, true).second);
   std::this_thread::sleep_for(std::chrono::seconds(5));
@@ -83,7 +107,9 @@ void ProcessHelper::RayStart(CoreWorkerOptions::TaskExecutionCallback callback) 
   if (ConfigInternal::Instance().worker_type == WorkerType::DRIVER && redis_ip.empty()) {
     redis_ip = "127.0.0.1";
     StartRayNode(ConfigInternal::Instance().redis_port,
-                 ConfigInternal::Instance().redis_password);
+                 ConfigInternal::Instance().redis_password,
+                 ConfigInternal::Instance().num_cpus, ConfigInternal::Instance().num_gpus,
+                 ConfigInternal::Instance().resources);
   }
   if (redis_ip == "127.0.0.1") {
     redis_ip = GetNodeIpAddress();

--- a/cpp/src/ray/util/process_helper.h
+++ b/cpp/src/ray/util/process_helper.h
@@ -27,7 +27,9 @@ class ProcessHelper {
  public:
   void RayStart(CoreWorkerOptions::TaskExecutionCallback callback);
   void RayStop();
-  void StartRayNode(int redis_port, std::string redis_password);
+  void StartRayNode(const int redis_port, const std::string redis_password,
+                    const int num_cpus = 0, const int num_gpus = 0,
+                    const std::unordered_map<std::string, int> resources = {});
   void StopRayNode();
 
   static ProcessHelper &GetInstance() {


### PR DESCRIPTION
## Why are these changes needed?
- support set resources in RayConfig, like:
```
   RayConfig config;
    config.num_cpus = 8;
    config.num_gpus = 4;
    config.resources = {{"Custom", 2}};
    ray::Init(config);
```
