### PR TITLE
Allow requirments.txt for conda and pip combination

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -498,6 +498,8 @@ The ``runtime_env`` is a Python dictionary including one or more of the followin
 
   - Example: ``{"conda": {"dependencies": ["pytorch", “torchvision”, "pip", {"pip": ["pendulum"]}]}}``
 
+  - Example: ``{"conda": {"dependencies": ["pytorch", “torchvision”, "pip", {"pip": ["./requirements.txt"]}]}}``
+
   - Example: ``"./environment.yml"``
 
   - Example: ``"pytorch_p36"``

--- a/python/ray/workers/setup_runtime_env.py
+++ b/python/ray/workers/setup_runtime_env.py
@@ -277,7 +277,7 @@ def requirements_file_to_list(filename: str,
             if skip_ray:
                 return [
                     dependency.strip('\n') for dependency in lines
-                    if 'ray' not in dependency
+                    if "ray" not in dependency
                 ]
             else:
                 return [dependency.strip('\n') for dependency in lines]

--- a/python/ray/workers/setup_runtime_env.py
+++ b/python/ray/workers/setup_runtime_env.py
@@ -257,12 +257,16 @@ def current_ray_pip_specifier() -> Optional[str]:
     else:
         return get_release_wheel_url()
 
-def requirements_file_to_list(filename: str, skip_ray: bool = True) -> List[str]:
-    """Generate a list from a requirements file, this is required to use pip requirements file in conda dependencies.
+
+def requirements_file_to_list(filename: str,
+                              skip_ray: bool = True) -> List[str]:
+    """Generate a list from a requirements file, this is required to use
+            pip requirements file in conda dependencies.
 
     Args:
         filename (str): The requirements file to load
-        skip_ray (bool): If ray has been specified in the requirements file should it be skipped or added
+        skip_ray (bool): If ray has been specified in the requirements
+            file should it be skipped or added
 
     Returns:
         (list): The dependencies in list format
@@ -271,14 +275,18 @@ def requirements_file_to_list(filename: str, skip_ray: bool = True) -> List[str]
         with open(filename) as file:
             lines = file.readlines()
             if skip_ray:
-                return [dependency.strip('\n') for dependency in lines if 'ray' not in dependency]
+                return [
+                    dependency.strip('\n') for dependency in lines
+                    if 'ray' not in dependency
+                ]
             else:
                 return [dependency.strip('\n') for dependency in lines]
-            
+
     except IsADirectoryError:
         return []
     except FileNotFoundError:
         return []
+
 
 def inject_dependencies(
         conda_dict: Dict[Any, Any],
@@ -325,8 +333,9 @@ def inject_dependencies(
                 found_pip_dict = True
                 break
             if isinstance(dep["pip"], str):
-                skip_ray =  "ray[default]" in pip_dependencies
-                dep["pip"] = pip_dependencies + requirements_file_to_list(dep["pip"], skip_ray=skip_ray)
+                skip_ray = "ray[default]" in pip_dependencies
+                dep["pip"] = pip_dependencies + requirements_file_to_list(
+                    dep["pip"], skip_ray=skip_ray)
                 found_pip_dict = True
                 break
     if not found_pip_dict:
@@ -337,5 +346,3 @@ def inject_dependencies(
 
 if __name__ == "__main__":
     setup_worker(sys.argv[1:])
-
-

--- a/python/ray/workers/setup_runtime_env.py
+++ b/python/ray/workers/setup_runtime_env.py
@@ -1,25 +1,26 @@
+import os
+import sys
 import argparse
-import hashlib
 import json
 import logging
-import os
+import yaml
+import hashlib
+import subprocess
 import runpy
 import shutil
-import subprocess
-import sys
-from pathlib import Path
-from typing import Any, Dict, List, Optional
 
-import yaml
 from filelock import FileLock
-from ray._private.conda import (get_conda_activate_commands,
-                                get_or_create_conda_env)
-from ray._private.utils import (get_master_wheel_url, get_release_wheel_url,
-                                get_wheel_filename, try_to_create_directory)
-from ray.workers.pluggable_runtime_env import (RuntimeEnvContext,
-                                               get_hook_logger)
+from typing import Optional, List, Dict, Any
+from pathlib import Path
 
 import ray
+from ray._private.conda import (get_conda_activate_commands,
+                                get_or_create_conda_env)
+from ray._private.utils import try_to_create_directory
+from ray._private.utils import (get_wheel_filename, get_master_wheel_url,
+                                get_release_wheel_url)
+from ray.workers.pluggable_runtime_env import (RuntimeEnvContext,
+                                               get_hook_logger)
 
 logger = logging.getLogger(__name__)
 parser = argparse.ArgumentParser()
@@ -335,3 +336,4 @@ def inject_dependencies(
 
 if __name__ == "__main__":
     setup_worker(sys.argv[1:])
+

--- a/python/ray/workers/setup_runtime_env.py
+++ b/python/ray/workers/setup_runtime_env.py
@@ -325,7 +325,8 @@ def inject_dependencies(
                 found_pip_dict = True
                 break
             if isinstance(dep["pip"], str):
-                dep["pip"] = pip_dependencies + requirements_file_to_list(dep["pip"])
+                skip_ray =  "ray[default]" in pip_dependencies
+                dep["pip"] = pip_dependencies + requirements_file_to_list(dep["pip"], skip_ray=skip_ray)
                 found_pip_dict = True
                 break
     if not found_pip_dict:
@@ -336,4 +337,5 @@ def inject_dependencies(
 
 if __name__ == "__main__":
     setup_worker(sys.argv[1:])
+
 

--- a/python/ray/workers/setup_runtime_env.py
+++ b/python/ray/workers/setup_runtime_env.py
@@ -1,26 +1,25 @@
-import os
-import sys
 import argparse
+import hashlib
 import json
 import logging
-import yaml
-import hashlib
-import subprocess
+import os
 import runpy
 import shutil
-
-from filelock import FileLock
-from typing import Optional, List, Dict, Any
+import subprocess
+import sys
 from pathlib import Path
+from typing import Any, Dict, List, Optional
 
-import ray
+import yaml
+from filelock import FileLock
 from ray._private.conda import (get_conda_activate_commands,
                                 get_or_create_conda_env)
-from ray._private.utils import try_to_create_directory
-from ray._private.utils import (get_wheel_filename, get_master_wheel_url,
-                                get_release_wheel_url)
+from ray._private.utils import (get_master_wheel_url, get_release_wheel_url,
+                                get_wheel_filename, try_to_create_directory)
 from ray.workers.pluggable_runtime_env import (RuntimeEnvContext,
                                                get_hook_logger)
+
+import ray
 
 logger = logging.getLogger(__name__)
 parser = argparse.ArgumentParser()
@@ -276,11 +275,11 @@ def requirements_file_to_list(filename: str,
             lines = file.readlines()
             if skip_ray:
                 return [
-                    dependency.strip('\n') for dependency in lines
+                    dependency.strip("\n") for dependency in lines
                     if "ray" not in dependency
                 ]
             else:
-                return [dependency.strip('\n') for dependency in lines]
+                return [dependency.strip("\n") for dependency in lines]
 
     except IsADirectoryError:
         return []
@@ -346,3 +345,4 @@ def inject_dependencies(
 
 if __name__ == "__main__":
     setup_worker(sys.argv[1:])
+


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->


## Why are these changes needed?

When using pip I would say a pretty common standard is to use a requirements file. In my opinion the expectancy also when using a combination of conda and pip is that pip still allows to use requirment.txt files. However that is not the case. The current implementation overwrites defined requirement file without telling the user. 
@architkulkarni 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
