### PR TITLE
Fix format_batch argument bug in dataset

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -996,17 +996,17 @@ class Dataset(Generic[T]):
             return zip(*iters)
 
         def format_batch(batch: Block, format: str) -> BatchType:
-            if batch_format == "native":
+            if format == "native":
                 return batch
-            elif batch_format == "pandas":
+            elif format == "pandas":
                 batch = BlockAccessor.for_block(batch)
                 return batch.to_pandas()
-            elif batch_format == "pyarrow":
+            elif format == "pyarrow":
                 batch = BlockAccessor.for_block(batch)
                 return batch.to_arrow()
             else:
                 raise ValueError(
-                    f"The given batch format: {batch_format} "
+                    f"The given batch format: {format} "
                     f"is invalid. Supported batch type: {BatchType}")
 
         batcher = Batcher(batch_size=batch_size)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The nested function has a `format` argument while using the `batch_format` from outer scope.

Either change to use `format` or remove `format` argument. I think the first fix might be better.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
