### PR TITLE
Add @architkulkarni to snapshot code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 /src/ray/protobuf/common.proto @wuisawesome @ericl @ameerhajali @robertnishihara @pcmoritz
 /src/ray/protobuf/gcs.proto @wuisawesome @ericl @ameerhajali @robertnishihara @pcmoritz
 /src/ray/protobuf/gcs_service.proto @wuisawesome @ericl @ameerhajali @robertnishihara @pcmoritz
-/dashboard/modules/snapshot @wuisawesome @ijrsvt @joeybai @alanwguo
+/dashboard/modules/snapshot @wuisawesome @ijrsvt @joeybai @alanwguo @architkulkarni
 
 # All C++ code.
 # /src/ray @ray-project/ray-core-cpp


### PR DESCRIPTION
The snapshot API now contains several important Ray Serve fields. Can we add Archit to the code owner. 