### PR TITLE
[core] Drain actor's references before exiting

### DIFF
--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -493,8 +493,8 @@ void ReferenceCounter::DeleteReferenceInternal(ReferenceTable::iterator it,
     }
   }
   if (it->second.borrowers.empty()) {
-    // Check if we are shutting down and deleting this reference is now only
-    // used by the local process.
+    // Check if we are shutting down and if this reference is now only used by
+    // the local process.
     ShutdownIfNeeded();
   }
   if (it->second.ShouldDelete(lineage_pinning_enabled_)) {

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -33,7 +33,7 @@ namespace core {
 
 bool ReferenceCounter::OwnObjectsInBorrowerScope() const {
   absl::MutexLock lock(&mutex_);
-  return OwnObjectsInBorrowerScope();
+  return OwnObjectsInBorrowerScopeInternal();
 }
 
 bool ReferenceCounter::OwnObjectsInBorrowerScopeInternal() const {

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -56,7 +56,6 @@ class CoreWorkerDirectActorTaskSubmitterInterface {
   virtual void DisconnectActor(
       const ActorID &actor_id, int64_t num_restarts, bool dead,
       const std::shared_ptr<rpc::RayException> &creation_task_exception = nullptr) = 0;
-  virtual void KillActor(const ActorID &actor_id, bool force_kill, bool no_restart) = 0;
 
   virtual void CheckTimeoutTasks() = 0;
 
@@ -93,15 +92,6 @@ class CoreWorkerDirectActorTaskSubmitter
   /// \param[in] task The task spec to submit.
   /// \return Status::Invalid if the task is not yet supported.
   Status SubmitTask(TaskSpecification task_spec);
-
-  /// Tell this actor to exit immediately.
-  ///
-  /// \param[in] actor_id The actor_id of the actor to kill.
-  /// \param[in] force_kill Whether to force kill the actor, or let the actor
-  /// try a clean exit.
-  /// \param[in] no_restart If set to true, the killed actor will not be
-  /// restarted anymore.
-  void KillActor(const ActorID &actor_id, bool force_kill, bool no_restart);
 
   /// Create connection to actor and send all pending tasks.
   ///
@@ -221,10 +211,6 @@ class CoreWorkerDirectActorTaskSubmitter
     /// pair key: timestamp in ms when this task should be considered as timeout.
     /// pair value: task specification
     std::deque<std::pair<int64_t, TaskSpecification>> wait_for_death_info_tasks;
-
-    /// A force-kill request that should be sent to the actor once an RPC
-    /// client to the actor is available.
-    absl::optional<rpc::KillActorRequest> pending_force_kill;
   };
 
   /// Push a task to a remote actor via the given client.

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -603,9 +603,10 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
     const auto &worker_id = actor->GetWorkerID();
     auto node_it = created_actors_.find(node_id);
     if (node_it != created_actors_.end() && node_it->second.count(worker_id)) {
-      // The actor has already been created. Destroy the process by force-killing
-      // it.
-      NotifyCoreWorkerToKillActor(actor);
+      // The actor has already been created. Destroy the process by killing
+      // it. We do not force-kill the actor because we want to keep it alive if
+      // it owns ObjectRefs borrowed by other processes.
+      NotifyCoreWorkerToKillActor(actor, /*force_kill=*/false, /*no_restart=*/true);
       RAY_CHECK(node_it->second.erase(actor->GetWorkerID()));
       if (node_it->second.empty()) {
         created_actors_.erase(node_it);

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -403,7 +403,7 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// \param force_kill Whether to force kill an actor by killing the worker.
   /// \param no_restart If set to true, the killed actor will not be restarted anymore.
   void NotifyCoreWorkerToKillActor(const std::shared_ptr<GcsActor> &actor,
-                                   bool force_kill = true, bool no_restart = true);
+                                   bool force_kill, bool no_restart);
 
   /// Add the destroyed actor to the cache. If the cache is full, one actor is randomly
   /// evicted.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When actors go out of scope, they are currently force-killed by the GCS. Unfortunately this means that if they own any objects that are still in scope by another process, the other process will not be able to use their ObjectRef anymore (#17718).

This fixes it by, (a) gentle-killing actors when they go out of scope, and (b) for gentle kills only, actor's owned references are drained before exiting the process.

This also changes the reference draining condition to be weaker than before: previously we wouldn't exit the worker if any object was still owned. This can lead to worker leaks, e.g., an actor will stay alive forever if it calls something like `self.lifetime_ref = ray.put(...)`. Now the worker will only stay alive if there are any objects that are owned *and in reference by a different worker*.

## Related issue number

Closes #17718.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
