### PR TITLE
[Core]  Fix nested ref count bug: add NestedIds to reference_counter once a task returns

### DIFF
--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -834,7 +834,9 @@ void ReferenceCounter::AddNestedObjectIdsInternal(
       for (const auto &inner_id : inner_ids) {
         it->second.contains.insert(inner_id);
         auto inner_it = object_id_refs_.find(inner_id);
-        RAY_CHECK(inner_it != object_id_refs_.end());
+        if (inner_it == object_id_refs_.end()) {
+          inner_it = object_id_refs_.emplace(inner_id, Reference()).first;
+        }
         RAY_LOG(DEBUG) << "Setting inner ID " << inner_id
                        << " contained_in_owned: " << object_id;
         inner_it->second.contained_in_owned.insert(object_id);

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -833,12 +833,13 @@ void ReferenceCounter::AddNestedObjectIdsInternal(
       // until the outer object goes out of scope.
       for (const auto &inner_id : inner_ids) {
         it->second.contains.insert(inner_id);
-        auto inner_it = object_id_refs_.find(inner_id);
-        if (inner_it == object_id_refs_.end()) {
-          inner_it = object_id_refs_.emplace(inner_id, Reference()).first;
-        }
         RAY_LOG(DEBUG) << "Setting inner ID " << inner_id
                        << " contained_in_owned: " << object_id;
+      }
+      // WARNING: Following loop could invalidate `it` iterator on insertion.
+      // That's why we use two loops, and we should avoid using `it` hearafter.
+      for (const auto &inner_id : inner_ids) {
+        auto inner_it = object_id_refs_.emplace(inner_id, Reference()).first;
         inner_it->second.contained_in_owned.insert(object_id);
       }
     }

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -510,9 +510,9 @@ void CoreWorkerDirectTaskReceiver::HandleTask(
             return_object->set_metadata(result->GetMetadata()->Data(),
                                         result->GetMetadata()->Size());
           }
-          for (const auto &nested_id : result->GetNestedIds()) {
-            return_object->add_nested_inlined_ids(nested_id.Binary());
-          }
+        }
+        for (const auto &nested_id : result->GetNestedIds()) {
+          return_object->add_nested_inlined_ids(nested_id.Binary());
         }
       }
       if (task_spec.IsActorCreationTask()) {

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -150,7 +150,8 @@ message RayObject {
   bytes data = 1;
   // Metadata of the object.
   bytes metadata = 2;
-  // ObjectIDs that were nested in data. This is only set for inlined objects.
+  // ObjectIDs that were nested in data. This is set for both inlined
+  // and plasma objects.
   repeated bytes nested_inlined_ids = 3;
 }
 


### PR DESCRIPTION
at high level, our fix composes of follow two steps:

1. when task returns it returns all the nested object refs, currently only inlined nested object refs are returned
2. when the caller received the returned rpc, we update the nest information to reference counter.

Test Plan:
- [x] add integration tests