### PR TITLE
[Metric]Java metric api enhancement

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/metric/Count.java
+++ b/java/runtime/src/main/java/io/ray/runtime/metric/Count.java
@@ -22,6 +22,10 @@ public class Count extends Metric {
     Preconditions.checkState(metricNativePointer != 0, "Count native pointer must not be 0.");
   }
 
+  public Count(String name, String description, Map<String, String> tags) {
+    this(name, description, "", TagKey.tagsFromMap(tags));
+  }
+
   @Override
   public void update(double value) {
     count.add(value);

--- a/java/runtime/src/main/java/io/ray/runtime/metric/Count.java
+++ b/java/runtime/src/main/java/io/ray/runtime/metric/Count.java
@@ -10,6 +10,7 @@ public class Count extends Metric {
 
   private DoubleAdder count;
 
+  @Deprecated
   public Count(String name, String description, String unit, Map<TagKey, String> tags) {
     super(name, tags);
     count = new DoubleAdder();

--- a/java/runtime/src/main/java/io/ray/runtime/metric/Gauge.java
+++ b/java/runtime/src/main/java/io/ray/runtime/metric/Gauge.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 /** Gauge measurement is mapped to gauge object in stats and is recording the last value. */
 public class Gauge extends Metric {
 
+  @Deprecated
   public Gauge(String name, String description, String unit, Map<TagKey, String> tags) {
     super(name, tags);
     metricNativePointer =

--- a/java/runtime/src/main/java/io/ray/runtime/metric/Gauge.java
+++ b/java/runtime/src/main/java/io/ray/runtime/metric/Gauge.java
@@ -18,6 +18,10 @@ public class Gauge extends Metric {
     Preconditions.checkState(metricNativePointer != 0, "Gauge native pointer must not be 0.");
   }
 
+  public Gauge(String name, String description, Map<String, String> tags) {
+    this(name, description, "", TagKey.tagsFromMap(tags));
+  }
+
   public double getValue() {
     return value.doubleValue();
   }

--- a/java/runtime/src/main/java/io/ray/runtime/metric/Histogram.java
+++ b/java/runtime/src/main/java/io/ray/runtime/metric/Histogram.java
@@ -35,6 +35,11 @@ public class Histogram extends Metric {
     histogramWindow = Collections.synchronizedList(new ArrayList<>());
   }
 
+  public Histogram(
+      String name, String description, List<Double> boundaries, Map<String, String> tags) {
+    this(name, description, "", boundaries, TagKey.tagsFromMap(tags));
+  }
+
   private void updateForWindow(double value) {
     if (histogramWindow.size() == HISTOGRAM_WINDOW_SIZE) {
       histogramWindow.remove(0);

--- a/java/runtime/src/main/java/io/ray/runtime/metric/Histogram.java
+++ b/java/runtime/src/main/java/io/ray/runtime/metric/Histogram.java
@@ -17,6 +17,7 @@ public class Histogram extends Metric {
   private List<Double> histogramWindow;
   public static final int HISTOGRAM_WINDOW_SIZE = 100;
 
+  @Deprecated
   public Histogram(
       String name,
       String description,

--- a/java/runtime/src/main/java/io/ray/runtime/metric/Metric.java
+++ b/java/runtime/src/main/java/io/ray/runtime/metric/Metric.java
@@ -3,6 +3,7 @@ package io.ray.runtime.metric;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.AtomicDouble;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -59,14 +60,14 @@ public abstract class Metric {
   protected abstract double getAndReset();
 
   /**
-   * Update gauge value without tags. Update metric info for user.
+   * Update metric value without tags. Update metric info for user.
    *
    * @param value latest value for updating
    */
   public abstract void update(double value);
 
   /**
-   * Update gauge value with dynamic tag values.
+   * Update metric value with dynamic tag values.
    *
    * @param value latest value for updating
    * @param tags tag map
@@ -74,6 +75,30 @@ public abstract class Metric {
   public void update(double value, Map<TagKey, String> tags) {
     update(value);
     this.tags = tags;
+  }
+
+  /**
+   * Update metric value with dynamic tag values in pair string format.
+   *
+   * @param tags tag map
+   * @param value latest value for updating
+   */
+  public void update(Map<String, String> tags, double value) {
+    update(value);
+    this.tags = TagKey.tagsFromMap(tags);
+  }
+
+  /**
+   * Convert tagkey list to map in string format.
+   *
+   * @return tags.
+   */
+  public Map<String, String> getTagMap() {
+    Map<String, String> tagMap = new HashMap<>();
+    for (Map.Entry<TagKey, String> entry : tags.entrySet()) {
+      tagMap.put(entry.getKey().getTagKey(), entry.getValue());
+    }
+    return tagMap;
   }
 
   /** Deallocate object from stats and reset native pointer in null. */

--- a/java/runtime/src/main/java/io/ray/runtime/metric/Sum.java
+++ b/java/runtime/src/main/java/io/ray/runtime/metric/Sum.java
@@ -13,6 +13,7 @@ public class Sum extends Metric {
 
   private DoubleAdder sum;
 
+  @Deprecated
   public Sum(String name, String description, String unit, Map<TagKey, String> tags) {
     super(name, tags);
     metricNativePointer =

--- a/java/runtime/src/main/java/io/ray/runtime/metric/Sum.java
+++ b/java/runtime/src/main/java/io/ray/runtime/metric/Sum.java
@@ -25,6 +25,10 @@ public class Sum extends Metric {
     this.sum = new DoubleAdder();
   }
 
+  public Sum(String name, String description, Map<String, String> tags) {
+    this(name, description, "", TagKey.tagsFromMap(tags));
+  }
+
   @Override
   public void update(double value) {
     sum.add(value);

--- a/java/runtime/src/main/java/io/ray/runtime/metric/TagKey.java
+++ b/java/runtime/src/main/java/io/ray/runtime/metric/TagKey.java
@@ -1,5 +1,7 @@
 package io.ray.runtime.metric;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /** Tagkey is mapping java object to stats tagkey object. */
@@ -14,6 +16,20 @@ public class TagKey {
 
   public String getTagKey() {
     return tagKey;
+  }
+
+  /**
+   * Convert pair of string and string map to tags map that can be recognized in native layer.
+   *
+   * @param tags metrics key value map.
+   * @return
+   */
+  public static Map<TagKey, String> tagsFromMap(Map<String, String> tags) {
+    Map<TagKey, String> tagKeyMap = new HashMap<>();
+    for (Map.Entry<String, String> entry : tags.entrySet()) {
+      tagKeyMap.put(new TagKey(entry.getKey()), entry.getValue());
+    }
+    return tagKeyMap;
   }
 
   @Override

--- a/java/test/src/main/java/io/ray/test/MetricTest.java
+++ b/java/test/src/main/java/io/ray/test/MetricTest.java
@@ -89,6 +89,17 @@ public class MetricTest extends BaseTest {
     gauge.unregister();
   }
 
+  public void testAddGaugeWithTagMap() {
+    Map<String, String> tags = new HashMap<>();
+    tags.put("tag1", "value1");
+
+    Gauge gauge = new Gauge("metric1", "", tags);
+    gauge.update(2);
+    gauge.record();
+    Assert.assertTrue(doubleEqual(gauge.getValue(), 2.0));
+    gauge.unregister();
+  }
+
   public void testAddCount() {
     Map<TagKey, String> tags = new HashMap<>();
     tags.put(new TagKey("tag1"), "value1");


### PR DESCRIPTION
make tagkey transparent for upper level users

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Java users can pass map<string,string> tags for every metrics, so tagkey is transparent to them.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
