### PR TITLE
[rllib] IMPALA sample throughput calculation and full queue slowdown fixes

### DIFF
--- a/rllib/execution/concurrency_ops.py
+++ b/rllib/execution/concurrency_ops.py
@@ -6,12 +6,13 @@ from ray.util.iter_metrics import SharedMetrics
 from ray.rllib.utils.typing import SampleBatchType
 
 
-def Concurrently(ops: List[LocalIterator],
-                 *,
-                 mode: str = "round_robin",
-                 output_indexes: Optional[List[int]] = None,
-                 round_robin_weights: Optional[List[int]] = None
-                 ) -> LocalIterator[SampleBatchType]:
+def Concurrently(
+    ops: List[LocalIterator],
+    *,
+    mode: str = "round_robin",
+    output_indexes: Optional[List[int]] = None,
+    round_robin_weights: Optional[List[int]] = None
+) -> LocalIterator[SampleBatchType]:
     """Operator that runs the given parent iterators concurrently.
 
     Args:
@@ -58,14 +59,13 @@ def Concurrently(ops: List[LocalIterator],
 
         ops = [tag(op, i) for i, op in enumerate(ops)]
 
-    output = ops[0].union(
-        *ops[1:],
-        deterministic=deterministic,
-        round_robin_weights=round_robin_weights)
+    output = ops[0].union(*ops[1:],
+                          deterministic=deterministic,
+                          round_robin_weights=round_robin_weights)
 
     if output_indexes:
-        output = (output.filter(lambda tup: tup[0] in output_indexes)
-                  .for_each(lambda tup: tup[1]))
+        output = (output.filter(lambda tup: tup[0] in output_indexes).for_each(
+            lambda tup: tup[1]))
 
     return output
 
@@ -86,7 +86,6 @@ class Enqueue:
         >>> next(combined_op)
         SampleBatch(...)
     """
-
     def __init__(self, output_queue: queue.Queue):
         if not isinstance(output_queue, queue.Queue):
             raise ValueError("Expected queue.Queue, got {}".format(

--- a/rllib/execution/concurrency_ops.py
+++ b/rllib/execution/concurrency_ops.py
@@ -95,7 +95,7 @@ class Enqueue:
 
     def __call__(self, x: Any) -> Any:
         try:
-            self.queue.put_nowait(x)
+            self.queue.put(x, timeout=0.001)
         except queue.Full:
             return _NextValueNotReady()
         return x
@@ -128,7 +128,7 @@ def Dequeue(input_queue: queue.Queue,
     def base_iterator(timeout=None):
         while check():
             try:
-                item = input_queue.get_nowait()
+                item = input_queue.get(timeout=0.001)
                 yield item
             except queue.Empty:
                 yield _NextValueNotReady()

--- a/rllib/execution/concurrency_ops.py
+++ b/rllib/execution/concurrency_ops.py
@@ -6,13 +6,12 @@ from ray.util.iter_metrics import SharedMetrics
 from ray.rllib.utils.typing import SampleBatchType
 
 
-def Concurrently(
-    ops: List[LocalIterator],
-    *,
-    mode: str = "round_robin",
-    output_indexes: Optional[List[int]] = None,
-    round_robin_weights: Optional[List[int]] = None
-) -> LocalIterator[SampleBatchType]:
+def Concurrently(ops: List[LocalIterator],
+                 *,
+                 mode: str = "round_robin",
+                 output_indexes: Optional[List[int]] = None,
+                 round_robin_weights: Optional[List[int]] = None
+                 ) -> LocalIterator[SampleBatchType]:
     """Operator that runs the given parent iterators concurrently.
 
     Args:
@@ -59,9 +58,10 @@ def Concurrently(
 
         ops = [tag(op, i) for i, op in enumerate(ops)]
 
-    output = ops[0].union(*ops[1:],
-                          deterministic=deterministic,
-                          round_robin_weights=round_robin_weights)
+    output = ops[0].union(
+        *ops[1:],
+        deterministic=deterministic,
+        round_robin_weights=round_robin_weights)
 
     if output_indexes:
         output = (output.filter(lambda tup: tup[0] in output_indexes).for_each(
@@ -86,6 +86,7 @@ class Enqueue:
         >>> next(combined_op)
         SampleBatch(...)
     """
+
     def __init__(self, output_queue: queue.Queue):
         if not isinstance(output_queue, queue.Queue):
             raise ValueError("Expected queue.Queue, got {}".format(

--- a/rllib/execution/learner_thread.py
+++ b/rllib/execution/learner_thread.py
@@ -73,7 +73,6 @@ class LearnerThread(threading.Thread):
             try:
                 batch, _ = self.minibatch_buffer.get()
             except queue.Empty:
-                time.sleep(0.001)
                 return _NextValueNotReady()
 
         with self.grad_timer:

--- a/rllib/execution/learner_thread.py
+++ b/rllib/execution/learner_thread.py
@@ -22,7 +22,6 @@ class LearnerThread(threading.Thread):
     addition, moving heavyweight gradient ops session runs off the main thread
     improves overall throughput.
     """
-
     def __init__(self, local_worker: RolloutWorker, minibatch_buffer_size: int,
                  num_sgd_iter: int, learner_queue_size: int,
                  learner_queue_timeout: int):
@@ -44,12 +43,11 @@ class LearnerThread(threading.Thread):
         self.local_worker = local_worker
         self.inqueue = queue.Queue(maxsize=learner_queue_size)
         self.outqueue = queue.Queue()
-        self.minibatch_buffer = MinibatchBuffer(
-            inqueue=self.inqueue,
-            size=minibatch_buffer_size,
-            timeout=learner_queue_timeout,
-            num_passes=num_sgd_iter,
-            init_num_passes=num_sgd_iter)
+        self.minibatch_buffer = MinibatchBuffer(inqueue=self.inqueue,
+                                                size=minibatch_buffer_size,
+                                                timeout=learner_queue_timeout,
+                                                num_passes=num_sgd_iter,
+                                                init_num_passes=num_sgd_iter)
         self.queue_timer = TimerStat()
         self.grad_timer = TimerStat()
         self.load_timer = TimerStat()
@@ -85,7 +83,6 @@ class LearnerThread(threading.Thread):
 
     def add_learner_metrics(self, result: Dict) -> Dict:
         """Add internal metrics to a trainer result dict."""
-
         def timer_to_ms(timer):
             return round(1000 * timer.mean, 3)
 

--- a/rllib/execution/learner_thread.py
+++ b/rllib/execution/learner_thread.py
@@ -22,6 +22,7 @@ class LearnerThread(threading.Thread):
     addition, moving heavyweight gradient ops session runs off the main thread
     improves overall throughput.
     """
+
     def __init__(self, local_worker: RolloutWorker, minibatch_buffer_size: int,
                  num_sgd_iter: int, learner_queue_size: int,
                  learner_queue_timeout: int):
@@ -43,11 +44,12 @@ class LearnerThread(threading.Thread):
         self.local_worker = local_worker
         self.inqueue = queue.Queue(maxsize=learner_queue_size)
         self.outqueue = queue.Queue()
-        self.minibatch_buffer = MinibatchBuffer(inqueue=self.inqueue,
-                                                size=minibatch_buffer_size,
-                                                timeout=learner_queue_timeout,
-                                                num_passes=num_sgd_iter,
-                                                init_num_passes=num_sgd_iter)
+        self.minibatch_buffer = MinibatchBuffer(
+            inqueue=self.inqueue,
+            size=minibatch_buffer_size,
+            timeout=learner_queue_timeout,
+            num_passes=num_sgd_iter,
+            init_num_passes=num_sgd_iter)
         self.queue_timer = TimerStat()
         self.grad_timer = TimerStat()
         self.load_timer = TimerStat()
@@ -83,6 +85,7 @@ class LearnerThread(threading.Thread):
 
     def add_learner_metrics(self, result: Dict) -> Dict:
         """Add internal metrics to a trainer result dict."""
+
         def timer_to_ms(timer):
             return round(1000 * timer.mean, 3)
 

--- a/rllib/execution/learner_thread.py
+++ b/rllib/execution/learner_thread.py
@@ -1,7 +1,6 @@
 import copy
 from six.moves import queue
 import threading
-import time
 from typing import Dict, Optional
 
 from ray.rllib.evaluation.metrics import get_learner_stats

--- a/rllib/execution/rollout_ops.py
+++ b/rllib/execution/rollout_ops.py
@@ -18,9 +18,7 @@ from ray.rllib.utils.typing import PolicyID, SampleBatchType, ModelGradients
 logger = logging.getLogger(__name__)
 
 
-def ParallelRollouts(workers: WorkerSet,
-                     *,
-                     mode="bulk_sync",
+def ParallelRollouts(workers: WorkerSet, *, mode="bulk_sync",
                      num_async=1) -> LocalIterator[SampleBatch]:
     """Operator to collect experiences in parallel from rollout workers.
 
@@ -154,6 +152,7 @@ class ConcatBatches:
         >>> print(next(rollouts).count)
         10000
     """
+
     def __init__(self, min_batch_size: int, count_steps_by: str = "env_steps"):
         self.min_batch_size = min_batch_size
         self.count_steps_by = count_steps_by
@@ -206,6 +205,7 @@ class SelectExperiences:
         >>> print(next(rollouts).policy_batches.keys())
         {"pol1", "pol2"}
     """
+
     def __init__(self, policy_ids: List[PolicyID]):
         assert isinstance(policy_ids, list), policy_ids
         self.policy_ids = policy_ids
@@ -214,12 +214,11 @@ class SelectExperiences:
         _check_sample_batch_type(samples)
 
         if isinstance(samples, MultiAgentBatch):
-            samples = MultiAgentBatch(
-                {
-                    k: v
-                    for k, v in samples.policy_batches.items()
-                    if k in self.policy_ids
-                }, samples.count)
+            samples = MultiAgentBatch({
+                k: v
+                for k, v in samples.policy_batches.items()
+                if k in self.policy_ids
+            }, samples.count)
 
         return samples
 
@@ -236,6 +235,7 @@ class StandardizeFields:
         >>> print(np.std(next(rollouts)["advantages"]))
         1.0
     """
+
     def __init__(self, fields: List[str]):
         self.fields = fields
 
@@ -244,8 +244,9 @@ class StandardizeFields:
         wrapped = False
 
         if isinstance(samples, SampleBatch):
-            samples = MultiAgentBatch({DEFAULT_POLICY_ID: samples},
-                                      samples.count)
+            samples = MultiAgentBatch({
+                DEFAULT_POLICY_ID: samples
+            }, samples.count)
             wrapped = True
 
         for policy_id in samples.policy_batches:

--- a/rllib/execution/rollout_ops.py
+++ b/rllib/execution/rollout_ops.py
@@ -158,7 +158,7 @@ class ConcatBatches:
         self.count_steps_by = count_steps_by
         self.buffer = []
         self.count = 0
-        self.last_batch_time = None
+        self.last_batch_time = time.perf_counter()
 
     def __call__(self, batch: SampleBatchType) -> List[SampleBatchType]:
         _check_sample_batch_type(batch)
@@ -183,8 +183,7 @@ class ConcatBatches:
 
             perf_counter = time.perf_counter()
             timer = _get_shared_metrics().timers[SAMPLE_TIMER]
-            if self.last_batch_time is not None:
-                timer.push(perf_counter - self.last_batch_time)
+            timer.push(perf_counter - self.last_batch_time)
             timer.push_units_processed(self.count)
 
             self.last_batch_time = perf_counter

--- a/rllib/execution/rollout_ops.py
+++ b/rllib/execution/rollout_ops.py
@@ -182,10 +182,13 @@ class ConcatBatches:
             out = SampleBatch.concat_samples(self.buffer)
 
             perf_counter = time.perf_counter()
+            timer = _get_shared_metrics().timers[SAMPLE_TIMER]
             if self.last_batch_time is not None:
-                timer = _get_shared_metrics().timers[SAMPLE_TIMER]
                 timer.push(perf_counter - self.last_batch_time)
                 timer.push_units_processed(self.count)
+            else:
+                timer.push_units_processed(self.count)
+
             self.last_batch_time = perf_counter
             self.buffer = []
             self.count = 0

--- a/rllib/execution/rollout_ops.py
+++ b/rllib/execution/rollout_ops.py
@@ -185,9 +185,7 @@ class ConcatBatches:
             timer = _get_shared_metrics().timers[SAMPLE_TIMER]
             if self.last_batch_time is not None:
                 timer.push(perf_counter - self.last_batch_time)
-                timer.push_units_processed(self.count)
-            else:
-                timer.push_units_processed(self.count)
+            timer.push_units_processed(self.count)
 
             self.last_batch_time = perf_counter
             self.buffer = []


### PR DESCRIPTION
…availablility of data, calculate the sample time with respect to global time rather than local sample time

## Why are these changes needed?

This is a better fix for the issues around IMPALA causing issues when the sample queues are full up.

The fix is twofold:

1) Originally a thread.sleep was used which stopped python threads busy waiting when queues were full as this causes pytorch's CUDA scheduler to misbehave and switch processing to CPU.
* this worked, but caused issues with tests so was removed #16309
* the new solution should not introduce any more latency that is necessary, as it does not wait if the is capacity in the queues or if there are items to be taken from queues. For threads putting items on queues, if the queue is at capacity, waiting will occur through the queue mutex instead of time.sleep (which is more efficient). The same fix is also applied for threads that are waiting to take items off of queues. This stops the busywaiting/releases the GIL while the threads are in the waiting state.

2) The calculation for sample throughput only calculates the throughput of samples from the point the learner thread has stopped learning, and when a new batch is required. it does not take into account the time taken for a batch to be processed. If there is no waiting time between batches this causes the sample throughput to skyrocket as throughput is calculated using samples/waiting_time. 
* The second fix makes sure that waiting time is calulated including the time taken for samples to be gathered + time taken for batch to be processed. This gives an accurate value for sample throughput in all situations.


## Related issue number

#16162
#16309
#16529

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
