### PR TITLE
[Docker] Exclude `+dbg` builds when finding Wheels

### DIFF
--- a/ci/travis/build-docker-images.py
+++ b/ci/travis/build-docker-images.py
@@ -90,8 +90,12 @@ def _configure_human_version():
 
 def _get_wheel_name(minor_version_number):
     if minor_version_number:
-        matches = glob.glob(f"{_get_root_dir()}/.whl/ray-*{PYTHON_WHL_VERSION}"
-                            f"{minor_version_number}*-manylinux*")
+        matches = [
+            file for file in glob.glob(
+                f"{_get_root_dir()}/.whl/ray-*{PYTHON_WHL_VERSION}"
+                f"{minor_version_number}*-manylinux*")
+            if "+dbg" not in file  # Exclude dbg builds
+        ]
         assert len(matches) == 1, (
             f"Found ({len(matches)}) matches for 'ray-*{PYTHON_WHL_VERSION}"
             f"{minor_version_number}*-manylinux*' instead of 1")

--- a/ci/travis/build-docker-images.py
+++ b/ci/travis/build-docker-images.py
@@ -94,7 +94,7 @@ def _get_wheel_name(minor_version_number):
             file for file in glob.glob(
                 f"{_get_root_dir()}/.whl/ray-*{PYTHON_WHL_VERSION}"
                 f"{minor_version_number}*-manylinux*")
-            if "+dbg" not in file  # Exclude dbg builds
+            if "+" not in file  # Exclude dbg, asan  builds
         ]
         assert len(matches) == 1, (
             f"Found ({len(matches)}) matches for 'ray-*{PYTHON_WHL_VERSION}"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes issue here: 
```
./.whl
--
  | ...
  | ./.whl/ray-2.0.0.dev0+dbg-cp38-cp38-manylinux2014_x86_64.whl
  | ./.whl/ray_cpp-2.0.0.dev0+dbg-cp38-cp38-manylinux2014_x86_64.whl
  | ./.whl/ray-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
  | ./.whl/ray_cpp-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
  | ...
  | Building the following python versions:  {'-py38': '3.8.5'}
  | Building base images:  True
  | Pulling images for caching
  | Cleaned up 0.0MB
  | BUILT:  rayproject/base-deps:nightly-py38-cpu
  | Cleaned up 485.79284286499023MB
  | BUILT:  rayproject/base-deps:nightly-py38-gpu
  | Traceback (most recent call last):
  | File "./ci/travis/build-docker-images.py", line 473, in <module>
  | base_images_built = build_or_pull_base_images(args.base)
  | File "./ci/travis/build-docker-images.py", line 239, in build_or_pull_base_images
  | _build_cpu_gpu_images(image, no_cache=False)
  | File "./ci/travis/build-docker-images.py", line 143, in _build_cpu_gpu_images
  | wheel = _get_wheel_name(build_args["PYTHON_MINOR_VERSION"])
  | File "./ci/travis/build-docker-images.py", line 96, in _get_wheel_name
  | f"Found ({len(matches)}) matches for 'ray-*{PYTHON_WHL_VERSION}"
  | AssertionError: Found (2) matches for 'ray-*cp38*-manylinux*' instead of 1
  | 🚨 Error: The command exited with status 1

```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
