### PR TITLE
[Serve] Add deployment and replica tags to logs

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -398,20 +398,22 @@ class Client:
                                            version, prev_version, route_prefix,
                                            ray.get_runtime_context().job_id))
 
+        tag = f"component=serve deployment={name}"
+
         if updating:
             msg = f"Updating deployment '{name}'"
             if version is not None:
                 msg += f" to version '{version}'"
-            logger.info(f"{msg}.")
+            logger.info(f"{msg}. {tag}")
         else:
             logger.info(f"Deployment '{name}' is already at version "
-                        f"'{version}', not updating.")
+                        f"'{version}', not updating. {tag}")
 
         if _blocking:
             self._wait_for_goal(goal_id)
             logger.info(
                 f"Deployment '{name}{':'+version if version else ''}' is ready"
-                f" at `{url}`.")
+                f" at `{url}`. {tag}")
         else:
             return goal_id
 

--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -91,8 +91,9 @@ class ActorReplicaWrapper:
                     self._placement_group_name)
             except ValueError:
                 logger.debug(
-                    "Creating placement group '{}' for backend '{}'".format(
-                        self._placement_group_name, self._backend_tag))
+                    "Creating placement group '{}' for deployment '{}'".format(
+                        self._placement_group_name, self._backend_tag) +
+                    f" component=serve deployment={self._backend_tag}")
                 self._placement_group = ray.util.placement_group(
                     [self._actor_resources],
                     lifetime="detached" if self._detached else None,
@@ -101,8 +102,10 @@ class ActorReplicaWrapper:
         try:
             self._actor_handle = ray.get_actor(self._actor_name)
         except ValueError:
-            logger.debug("Starting replica '{}' for backend '{}'.".format(
-                self._replica_tag, self._backend_tag))
+            logger.debug("Starting replica '{}' for deployment '{}'.".format(
+                self._replica_tag, self._backend_tag) +
+                         f" component=serve deployment={self._backend_tag} "
+                         f"replica={self._replica_tag}")
             self._actor_handle = backend_info.actor_def.options(
                 name=self._actor_name,
                 lifetime="detached" if self._detached else None,
@@ -363,7 +366,9 @@ class BackendReplica(VersionedReplica):
             # This will be called repeatedly until the replica shuts down.
             logger.debug(
                 f"Replica {self._replica_tag} did not shutdown after "
-                f"{self._graceful_shutdown_timeout_s}s, force-killing.")
+                f"{self._graceful_shutdown_timeout_s}s, force-killing. "
+                f"component=serve deployment={self._backend_tag} "
+                f"replica={self._replica_tag}")
 
             self._actor.force_stop()
         return False
@@ -814,12 +819,15 @@ class BackendState:
                 assert False, "Update must be code version or user config."
 
         if code_version_changes > 0:
-            logger.info(f"Stopping {code_version_changes} replicas of backend "
-                        f"'{backend_tag}' with outdated versions.")
+            logger.info(f"Stopping {code_version_changes} replicas of "
+                        f"deployment '{backend_tag}' with outdated versions. "
+                        f"component=serve deployment={backend_tag}")
 
         if user_config_changes > 0:
-            logger.info(f"Updating {user_config_changes} replicas of backend "
-                        f"'{backend_tag}' with outdated user_configs.")
+            logger.info(f"Updating {user_config_changes} replicas of "
+                        f"deployment '{backend_tag}' with outdated "
+                        f"user_configs. component=serve "
+                        f"deployment={backend_tag}")
 
         return len(replicas_to_update)
 
@@ -869,8 +877,9 @@ class BackendState:
             ])
             to_add = max(delta_replicas - stopping_replicas, 0)
             if to_add > 0:
-                logger.info(f"Adding {to_add} replicas "
-                            f"to backend '{backend_tag}'.")
+                logger.info(f"Adding {to_add} replicas to deployment "
+                            f"'{backend_tag}'. component=serve "
+                            f"deployment={backend_tag}")
             for _ in range(to_add):
                 replica_tag = "{}#{}".format(backend_tag, get_random_letters())
                 self._replicas[backend_tag].add(
@@ -880,8 +889,9 @@ class BackendState:
 
         elif delta_replicas < 0:
             to_remove = -delta_replicas
-            logger.info(f"Removing {to_remove} replicas "
-                        f"from backend '{backend_tag}'.")
+            logger.info(f"Removing {to_remove} replicas from deployment "
+                        f"'{backend_tag}'. component=serve "
+                        f"deployment={backend_tag}")
             replicas_to_stop = self._replicas[backend_tag].pop(
                 states=[
                     ReplicaState.SHOULD_START,
@@ -961,8 +971,10 @@ class BackendState:
                     replicas.add(ReplicaState.RUNNING, replica)
                 else:
                     logger.warning(
-                        f"Replica {replica.replica_tag} of backend "
-                        f"{backend_tag} failed health check, stopping it.")
+                        f"Replica {replica.replica_tag} of deployment "
+                        f"{backend_tag} failed health check, stopping it. "
+                        f"component=serve deployment={backend_tag} "
+                        f"replica={replica.replica_tag}")
                     replica.set_should_stop(0)
                     replicas.add(ReplicaState.SHOULD_STOP, replica)
 
@@ -997,13 +1009,13 @@ class BackendState:
                 required, available = slow_start_replicas[
                     0].resource_requirements()
                 logger.warning(
-                    f"Backend '{backend_tag}' has {len(slow_start_replicas)} "
-                    "replicas that have taken more than "
-                    f"{SLOW_STARTUP_WARNING_S}s to start up. This may be "
-                    "caused by waiting for the cluster to auto-scale or "
-                    "because the constructor is slow. Resources required "
+                    f"Deployment '{backend_tag}' has "
+                    f"{len(slow_start_replicas)} replicas that have taken "
+                    f"more than {SLOW_STARTUP_WARNING_S}s to start up. This "
+                    "may be caused by waiting for the cluster to auto-scale "
+                    "or because the constructor is slow. Resources required "
                     f"for each replica: {required}, resources available: "
-                    f"{available}.")
+                    f"{available}. component=serve deployment={backend_tag}")
 
                 self._prev_startup_warnings[backend_tag] = time.time()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Tags the end of Serve log lines with `component=serve deployment={name} replica={replica_tag}` for easier filtering and ingestion with Loki and grafana.  This format is consistent with the automatic tagging done when a user puts log statements in their Serve deployments.

There are two drawbacks to the approach taken in this PR, open to suggestions for improvement here: 
(1) it makes the user output a bit uglier:
```
In [6]: f.deploy()                                                                                                                                                                                               
2021-08-13 15:06:27,382 INFO api.py:407 -- Updating deployment 'f'. component=serve deployment=f
(pid=84582) 2021-08-13 15:06:27,415     INFO backend_state.py:876 -- Adding 1 replicas to deployment 'f'. component=serve deployment=f
2021-08-13 15:06:27,846 INFO api.py:415 -- Deployment 'f' is ready at `http://127.0.0.1:8000/f`. component=serve deployment=f
```
(2) We are doing this formatting manually because it depends on the context of each message so we can't modify the global Serve logger handler.  (Some messages aren't associated with a replica, for example).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
