### PR TITLE
[Serve] [Doc] Delete docs for removed automatic conda activation feature

### DIFF
--- a/doc/source/serve/core-apis.rst
+++ b/doc/source/serve/core-apis.rst
@@ -254,13 +254,6 @@ Python versions must be the same in both environments.
 
 .. literalinclude:: ../../../python/ray/serve/examples/doc/conda_env.py
 
-.. note::
-  If a conda environment is not specified, your deployment will be started in the
-  same conda environment as the client (the process creating the deployment) by
-  default.  (When using :ref:`ray-client`, your deployment will be started in the
-  conda environment that the Serve controller is running in, which by default is the
-  conda environment the remote Ray cluster was started in.)
-
 The dependencies required in the deployment may be different than
 the dependencies installed in the driver program (the one running Serve API
 calls). In this case, you should use a delayed import within the class to avoid

--- a/doc/source/serve/core-apis.rst
+++ b/doc/source/serve/core-apis.rst
@@ -235,7 +235,7 @@ Dependency Management
 =====================
 
 Ray Serve supports serving deployments with different (possibly conflicting)
-python dependencies.  For example, you can simultaneously serve one deployment
+Python dependencies.  For example, you can simultaneously serve one deployment
 that uses legacy Tensorflow 1 and another that uses Tensorflow 2.
 
 Currently this is supported on Mac OS and Linux using `conda <https://docs.conda.io/en/latest/>`_
@@ -244,7 +244,8 @@ As with all other actor options, pass these in via ``ray_actor_options`` in
 your deployment.
 You must have a conda environment set up for each set of
 dependencies you want to isolate.  If using a multi-node cluster, the
-desired conda environment must be present on all nodes.
+desired conda environment must be present on all nodes. Also, the Python patch version
+(e.g. 3.8.10) must be identical on all nodes (this is a requirement for any Ray cluster).
 See :ref:`runtime-environments` for details.
 
 Here's an example script.  For it to work, first create a conda


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
The "convenience feature" of starting any Serve deployment in the conda environment of the driver script was recently removed in (https://github.com/ray-project/ray/pull/17639).  This PR removes this documentation for this feature.  This PR also adds a note that the Python patch versions must match across all nodes on the cluster.
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
