### PR TITLE
Fix dictionary traversal in AWS "terminate_nodes" method

### DIFF
--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -509,8 +509,7 @@ class AWSNodeProvider(NodeProvider):
         max_terminate_nodes = self.max_terminate_nodes if \
             self.max_terminate_nodes is not None else len(node_ids)
 
-        # for terminate_func, nodes in nodes_to_terminate.items():
-        for nodes, terminate_func in nodes_to_terminate.items():
+        for terminate_func, nodes in nodes_to_terminate.items():
             for start in range(0, len(nodes), max_terminate_nodes):
                 terminate_func(InstanceIds=node_ids[start:start +
                                                     max_terminate_nodes])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#17642 had a typo in a loop that traverses a dictionary.

This line:

https://github.com/ray-project/ray/pull/17642/files/e7a04a63a87d651b168d5cc1322815fad4b9bef4#diff-eeb7bc1d8342583cf12c40536240dbcc67f089466a18a37bd60f187265a2dc94R513

should be

```
for terminate_func, nodes in nodes_to_terminate.items():
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

#17386 and #17642

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
