### PR TITLE
[SGD] v2 Backend specific checkpoint conversion

### DIFF
--- a/python/ray/util/sgd/v2/backends/backend.py
+++ b/python/ray/util/sgd/v2/backends/backend.py
@@ -88,7 +88,7 @@ class BackendExecutor:
                     training_func=train_func,
                     world_rank=world_rank,
                     checkpoint=checkpoint,
-                    process_checkpoint_func=self._backend.convert_checkpoint,
+                    convert_checkpoint_func=self._backend.convert_checkpoint,
                     detailed_autofilled_metrics=use_detailed_autofilled_metrics
                 )
             except ValueError:

--- a/python/ray/util/sgd/v2/session.py
+++ b/python/ray/util/sgd/v2/session.py
@@ -176,12 +176,12 @@ class Session:
         # Update session checkpoint to latest checkpoint.
         self.loaded_checkpoint = kwargs
 
-        # Only store checkpoints on worker with rank 0.
-        if self.world_rank != 0:
+        if self.world_rank == 0:
+            if self.convert_checkpoint_func is not None:
+                kwargs = self.convert_checkpoint_func(kwargs)
+        else:
+            # Only store checkpoints on worker with rank 0.
             kwargs = {}
-
-        if self.convert_checkpoint_func is not None:
-            kwargs = self.convert_checkpoint_func(kwargs)
 
         result = TrainingResult(TrainingResultType.CHECKPOINT, kwargs)
         # Add result to a thread-safe queue.

--- a/python/ray/util/sgd/v2/tests/test_session.py
+++ b/python/ray/util/sgd/v2/tests/test_session.py
@@ -122,6 +122,32 @@ def test_checkpoint():
         save_checkpoint(epoch=2)
 
 
+def test_convert_checkpoint():
+    def train():
+        for i in range(2):
+            save_checkpoint(epoch=i)
+
+    def convert_checkpoint(checkpoint):
+        checkpoint.update({"converted": True})
+        return checkpoint
+
+    def validate_converted():
+        next = session.get_next()
+        assert next is not None
+        assert next.type == TrainingResultType.CHECKPOINT
+        assert next.data["converted"] is True
+
+    init_session(
+        training_func=train,
+        world_rank=0,
+        convert_checkpoint_func=convert_checkpoint)
+    session = get_session()
+    session.start()
+    validate_converted()
+    session.finish()
+    shutdown_session()
+
+
 def test_load_checkpoint_after_save():
     def train():
         for i in range(2):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Adds functionality for backend specific checkpoints converting and unconverting. When checkpoints are collected on the workers, they are first go through the convert function before being sent to the driver. On the driver side, they are unconverted and then stored as checkpoints.

This is useful for Torch where we would run into deserialization errors if we try to checkpoint a GPU model on the driver that only has CPUs. Instead we want to convert the checkpoint to bytes on the worker side, and then convert back to dict on the driver side. 

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
