### PR TITLE
Shutdown clusters on AWS with >1000 nodes

### DIFF
--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -81,6 +81,8 @@ def list_ec2_instances(region: str, aws_credentials: Dict[str, Any] = None
 
 
 class AWSNodeProvider(NodeProvider):
+    max_terminate_nodes = 1000
+
     def __init__(self, provider_config, cluster_name):
         NodeProvider.__init__(self, provider_config, cluster_name)
         self.cache_stopped_nodes = provider_config.get("cache_stopped_nodes",
@@ -459,6 +461,21 @@ class AWSNodeProvider(NodeProvider):
     def terminate_nodes(self, node_ids):
         if not node_ids:
             return
+
+        terminate_instances_func = self.ec2.meta.client.terminate_instances
+        stop_instances_func = self.ec2.meta.client.stop_instances
+
+        # In some cases, this function stops some nodes, but terminates others.
+        # Each of these requires a different EC2 API call. So, we use the
+        # "nodes_to_terminate" dict below to keep track of exactly which API
+        # call will be used to stop/terminate which set of nodes. The key is
+        # the function to use, and the value is the list of nodes to terminate
+        # with that function.
+        nodes_to_terminate = {
+            terminate_instances_func: [],
+            stop_instances_func: []
+        }
+
         if self.cache_stopped_nodes:
             spot_ids = []
             on_demand_ids = []
@@ -478,16 +495,25 @@ class AWSNodeProvider(NodeProvider):
                         "under `provider` in the cluster configuration)"),
                     cli_logger.render_list(on_demand_ids))
 
-                self.ec2.meta.client.stop_instances(InstanceIds=on_demand_ids)
             if spot_ids:
                 cli_logger.print(
                     "Terminating instances {} " +
                     cf.dimmed("(cannot stop spot instances, only terminate)"),
                     cli_logger.render_list(spot_ids))
 
-                self.ec2.meta.client.terminate_instances(InstanceIds=spot_ids)
+            nodes_to_terminate[stop_instances_func] = on_demand_ids
+            nodes_to_terminate[terminate_instances_func] = spot_ids
         else:
-            self.ec2.meta.client.terminate_instances(InstanceIds=node_ids)
+            nodes_to_terminate[terminate_instances_func] = node_ids
+
+        max_terminate_nodes = self.max_terminate_nodes if \
+            self.max_terminate_nodes is not None else len(node_ids)
+
+        # for terminate_func, nodes in nodes_to_terminate.items():
+        for nodes, terminate_func in nodes_to_terminate.items():
+            for start in range(0, len(nodes), max_terminate_nodes):
+                terminate_func(InstanceIds=node_ids[start:start +
+                                                    max_terminate_nodes])
 
     def _get_node(self, node_id):
         """Refresh and get info for this node, updating the cache."""

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -509,11 +509,10 @@ class AWSNodeProvider(NodeProvider):
         max_terminate_nodes = self.max_terminate_nodes if \
             self.max_terminate_nodes is not None else len(node_ids)
 
-        # for terminate_func, nodes in nodes_to_terminate.items():
-        for nodes, terminate_func in nodes_to_terminate.items():
+        for terminate_func, nodes in nodes_to_terminate.items():
             for start in range(0, len(nodes), max_terminate_nodes):
-                terminate_func(InstanceIds=node_ids[start:start +
-                                                    max_terminate_nodes])
+                terminate_func(InstanceIds=nodes[start:start +
+                                                 max_terminate_nodes])
 
     def _get_node(self, node_id):
         """Refresh and get info for this node, updating the cache."""

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -141,6 +141,22 @@ class NodeProvider:
             self.terminate_node(node_id)
         return None
 
+    @property
+    def max_terminate_nodes(self) -> Optional[int]:
+        """The maximum number of nodes which can be terminated in one single
+        API request. By default, this is "None", which means that the node
+        provider's underlying API allows infinite requests to be terminated
+        with one request.
+
+        For example, AWS only allows 1000 nodes to be terminated
+        at once; to terminate more, we must issue multiple separate API
+        requests. If the limit is infinity, then simply set this to None.
+
+        This may be overridden. The value may be useful when overriding the
+        "terminate_nodes" method.
+        """
+        return None
+
     @staticmethod
     def bootstrap_config(cluster_config: Dict[str, Any]) -> Dict[str, Any]:
         """Bootstraps the cluster config by adding env defaults if needed."""

--- a/python/ray/tests/aws/test_autoscaler_aws.py
+++ b/python/ray/tests/aws/test_autoscaler_aws.py
@@ -624,23 +624,33 @@ def test_launch_templates(ec2_client_stub, ec2_client_stub_fail_fast,
     ec2_client_stub_max_retries.assert_no_pending_responses()
 
 
-@pytest.mark.parametrize("num_nodes", [1001, 9999])
+@pytest.mark.parametrize("num_on_demand_nodes", [0, 1001, 9999])
+@pytest.mark.parametrize("num_spot_nodes", [0, 1001, 9999])
 @pytest.mark.parametrize("stop", [True, False])
-@pytest.mark.parametrize("spot", [True, False])
-def test_terminate_nodes(num_nodes, stop, spot):
-    # This test makes sure that we don't try to stop or terminate too many
-    # nodes in a single EC2 request. By default, only 1000 nodes can be
+def test_terminate_nodes(num_on_demand_nodes, num_spot_nodes, stop):
+    # This node makes sure that we stop or terminate all the nodes we're
+    # supposed to stop or terminate when we call "terminate_nodes". This test
+    # alse makes sure that we don't try to stop or terminate too many nodes in
+    # a single EC2 request. By default, only 1000 nodes can be
     # stopped/terminated in one request. To terminate more nodes, we must break
     # them up into multiple smaller requests.
     #
-    # "num_nodes" is the number of nodes to stop or terminate.
+    # "num_on_demand_nodes" is the number of on-demand nodes to stop or
+    #   terminate.
+    # "num_spot_nodes" is the number of on-demand nodes to terminate.
     # "stop" is True if we want to stop nodes, and False to terminate nodes.
     #   Note that spot instances are always terminated, even if "stop" is True.
-    # "spot" is True if we want to terminate/stop spot nodes, and False for on-
-    #   demand nodes.
 
     # Generate a list of unique instance ids to terminate
-    instance_ids = ["i-{:017d}".format(i) for i in range(num_nodes)]
+    on_demand_nodes = {
+        "i-{:017d}".format(i)
+        for i in range(num_on_demand_nodes)
+    }
+    spot_nodes = {
+        "i-{:017d}".format(i + num_on_demand_nodes)
+        for i in range(num_spot_nodes)
+    }
+    node_ids = list(on_demand_nodes.union(spot_nodes))
 
     with patch("ray.autoscaler._private.aws.node_provider.make_ec2_client"):
         provider = AWSNodeProvider(
@@ -654,21 +664,34 @@ def test_terminate_nodes(num_nodes, stop, spot):
     # node is a spot instance or an on-demand instance.
     def mock_get_cached_node(node_id):
         result = Mock()
-        result.spot_instance_request_id = "sir-08b93456" if spot else ""
+        result.spot_instance_request_id = "sir-08b93456" if \
+            node_id in spot_nodes else ""
         return result
 
     provider._get_cached_node = mock_get_cached_node
 
-    provider.terminate_nodes(instance_ids)
+    provider.terminate_nodes(node_ids)
 
-    if spot or not stop:
-        call_args_list = provider.ec2.meta.client.terminate_instances \
-                .call_args_list
+    stop_calls = provider.ec2.meta.client.stop_instances.call_args_list
+    terminate_calls = provider.ec2.meta.client.terminate_instances \
+        .call_args_list
+
+    nodes_to_stop = set()
+    nodes_to_terminate = spot_nodes
+
+    if stop:
+        nodes_to_stop.update(on_demand_nodes)
     else:
-        call_args_list = provider.ec2.meta.client.stop_instances.call_args_list
+        nodes_to_terminate.update(on_demand_nodes)
 
-    for call in call_args_list:
-        assert 0 < len(call[1]["InstanceIds"]) <= provider.max_terminate_nodes
+    for calls, nodes_to_include_in_call in (stop_calls, nodes_to_stop), (
+            terminate_calls, nodes_to_terminate):
+        nodes_included_in_call = set()
+        for call in calls:
+            assert len(call[1]["InstanceIds"]) <= provider.max_terminate_nodes
+            nodes_included_in_call.update(call[1]["InstanceIds"])
+
+        assert nodes_to_include_in_call == nodes_included_in_call
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/aws/test_autoscaler_aws.py
+++ b/python/ray/tests/aws/test_autoscaler_aws.py
@@ -1,10 +1,12 @@
 import copy
 
 import pytest
+from unittest.mock import Mock, patch
 
 from ray.autoscaler._private.aws.config import _get_vpc_id_or_die, \
     bootstrap_aws, log_to_cli, \
     DEFAULT_AMI
+from ray.autoscaler._private.aws.node_provider import AWSNodeProvider
 from ray.autoscaler._private.providers import _get_node_provider
 import ray.tests.aws.utils.stubs as stubs
 import ray.tests.aws.utils.helpers as helpers
@@ -620,6 +622,53 @@ def test_launch_templates(ec2_client_stub, ec2_client_stub_fail_fast,
     ec2_client_stub.assert_no_pending_responses()
     ec2_client_stub_fail_fast.assert_no_pending_responses()
     ec2_client_stub_max_retries.assert_no_pending_responses()
+
+
+@pytest.mark.parametrize("num_nodes", [1001, 9999])
+@pytest.mark.parametrize("stop", [True, False])
+@pytest.mark.parametrize("spot", [True, False])
+def test_terminate_nodes(num_nodes, stop, spot):
+    # This test makes sure that we don't try to stop or terminate too many
+    # nodes in a single EC2 request. By default, only 1000 nodes can be
+    # stopped/terminated in one request. To terminate more nodes, we must break
+    # them up into multiple smaller requests.
+    #
+    # "num_nodes" is the number of nodes to stop or terminate.
+    # "stop" is True if we want to stop nodes, and False to terminate nodes.
+    #   Note that spot instances are always terminated, even if "stop" is True.
+    # "spot" is True if we want to terminate/stop spot nodes, and False for on-
+    #   demand nodes.
+
+    # Generate a list of unique instance ids to terminate
+    instance_ids = ["i-{:017d}".format(i) for i in range(num_nodes)]
+
+    with patch("ray.autoscaler._private.aws.node_provider.make_ec2_client"):
+        provider = AWSNodeProvider(
+            provider_config={
+                "region": "nowhere",
+                "cache_stopped_nodes": stop
+            },
+            cluster_name="default")
+
+    # "_get_cached_node" is used by the AWSNodeProvider to determine whether a
+    # node is a spot instance or an on-demand instance.
+    def mock_get_cached_node(node_id):
+        result = Mock()
+        result.spot_instance_request_id = "sir-08b93456" if spot else ""
+        return result
+
+    provider._get_cached_node = mock_get_cached_node
+
+    provider.terminate_nodes(instance_ids)
+
+    if spot or not stop:
+        call_args_list = provider.ec2.meta.client.terminate_instances \
+                .call_args_list
+    else:
+        call_args_list = provider.ec2.meta.client.stop_instances.call_args_list
+
+    for call in call_args_list:
+        assert 0 < len(call[1]["InstanceIds"]) <= provider.max_terminate_nodes
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray currently fails to shutdown clusters with over 1000 nodes, because the AWS instance termination API only accept a maximum of 1000 instances to terminate in a single request.

To fix this, we loop over all the instances we want to terminate, breaking them into chunks of 1000.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

We previously attempted to implement this in #17642, but that PR was buggy and needed to be reverted. This PR includes a stronger unit test, and fixes typos that were in #17642.

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
The new unit test makes sure that spot and/or on-demand instances are stopped/terminated with the correct EC2 calls, where each EC2 call stops/terminates a maximum of 1000 nodes. The unit test also makes sure that the AWS node provider never attempts to stop a spot instance (because spot instances can only be terminated, not stopped).
   - [ ] Release tests
   - [ ] This PR is not tested :(

I have also tested this PR manually by running `ray down` on clusters with the following configurations (by changing the cluster config yaml):
* 1 on-demand head node, 2 spot worker nodes, `cache_stopped_nodes: True`
* 1 on-demand head node, 2 spot worker nodes, `cache_stopped_nodes: False`
* 1 on-demand head node, 2 on-demand worker nodes, `cache_stopped_nodes: True`
* 1 on-demand head node, 2 on-demand worker nodes, `cache_stopped_nodes: False`
* 1 on-demand head node, 1002 spot worker nodes, `cache_stopped_nodes: True`

**I have not yet tested this PR on a cluster with 1000+ nodes** except for within the new unit test which mocks all EC2 calls. Is there a Ray AWS account that we could test a 1000+ large cluster on?