### PR TITLE
Add an experimental flag to disable CUDA_VISIBLE_DEVICES

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -271,6 +271,9 @@ def set_cuda_visible_devices(gpu_ids):
         gpu_ids (List[str]): List of strings representing GPU IDs.
     """
 
+    if os.environ.get("RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES"):
+        return
+
     global last_set_gpu_ids
     if last_set_gpu_ids == gpu_ids:
         return  # optimization: already set

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -217,6 +217,7 @@ print("local", ray._private.runtime_env.VAR)
 
 
 # https://github.com/ray-project/ray/issues/17842
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows")
 def test_disable_cuda_devices():
     script = """
 import ray

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -216,6 +216,24 @@ print("local", ray._private.runtime_env.VAR)
     assert local_out == "local hello world"
 
 
+# https://github.com/ray-project/ray/issues/17842
+def test_disable_cuda_devices():
+    script = """
+import ray
+ray.init()
+
+@ray.remote
+def check():
+    import os
+    assert "CUDA_VISIBLE_DEVICES" not in os.environ
+
+print("remote", ray.get(check.remote()))
+"""
+
+    run_string_as_driver(script,
+                         {"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1"})
+
+
 def test_put_get(shutdown_only):
     ray.init(num_cpus=0)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

After this change you can set the env var `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1` to disable setting cuda visible devices.

Closes https://github.com/ray-project/ray/issues/17842