### PR TITLE
Add ephemeral-storage: 1Gi requests but no limits. 

### DIFF
--- a/deploy/charts/ray/templates/operator_cluster_scoped.yaml
+++ b/deploy/charts/ray/templates/operator_cluster_scoped.yaml
@@ -59,6 +59,7 @@ spec:
           requests:
             cpu: 1
             memory: 1Gi
+            ephemeral-storage: 1Gi
           limits:
             memory: 2Gi
             cpu: 1

--- a/deploy/charts/ray/templates/operator_namespaced.yaml
+++ b/deploy/charts/ray/templates/operator_namespaced.yaml
@@ -60,8 +60,8 @@ spec:
           requests:
             cpu: 1
             memory: 1Gi
+            ephemeral-storage: 1Gi
           limits:
             memory: 2Gi
             cpu: 1
 {{- end }}
-

--- a/deploy/components/example_cluster.yaml
+++ b/deploy/components/example_cluster.yaml
@@ -73,6 +73,7 @@ spec:
             requests:
               cpu: 1000m
               memory: 512Mi
+              ephemeral-storage: 1Gi
             limits:
               # The maximum memory that this pod is allowed to use. The
               # limit will be detected by ray and split to use 10% for
@@ -118,6 +119,7 @@ spec:
             requests:
               cpu: 1000m
               memory: 512Mi
+              ephemeral-storage: 1Gi
             limits:
               # The maximum memory that this pod is allowed to use. The
               # limit will be detected by ray and split to use 10% for


### PR DESCRIPTION
## Why are these changes needed?

This is useful when scheduling in storage constrained env since ray assumes it has ephemeral storage to use.

## Related issue number

Closes https://github.com/ray-project/ray/issues/13877

## Checks

- [ X ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ X ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ X ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - Deploy on my storage constrained cluster.