### PR TITLE
[Core]Use Separate GCS Client in HeartbeatSender

### DIFF
--- a/src/ray/gcs/gcs_client.h
+++ b/src/ray/gcs/gcs_client.h
@@ -162,6 +162,8 @@ class GcsClient : public std::enable_shared_from_this<GcsClient> {
   /// This function is thread safe.
   InternalKVAccessor &InternalKV() { return *internal_kv_accessor_; }
 
+  const GcsClientOptions &GetOptions() { return options_; }
+
  protected:
   /// Constructor of GcsClient.
   ///

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -26,6 +26,7 @@
 #include "ray/common/common_protocol.h"
 #include "ray/common/constants.h"
 #include "ray/common/status.h"
+#include "ray/gcs/gcs_client/service_based_gcs_client.h"
 #include "ray/gcs/pb_util.h"
 #include "ray/raylet/format/node_manager_generated.h"
 #include "ray/stats/stats.h"
@@ -126,7 +127,7 @@ HeartbeatSender::HeartbeatSender(NodeID self_node_id,
     boost::asio::io_service::work io_service_work_(heartbeat_io_service_);
     heartbeat_io_service_.run();
   }));
-  gcs_client_ = std::make_shared<gcs::ServiceBasedGcsClient>(gcs_client_.GetOptions());
+  gcs_client_ = std::make_shared<gcs::ServiceBasedGcsClient>(gcs_client_->GetOptions());
   gcs_client_->Connect(heartbeat_io_service_);
   heartbeat_runner_.reset(new PeriodicalRunner(heartbeat_io_service_));
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -128,7 +128,7 @@ HeartbeatSender::HeartbeatSender(NodeID self_node_id,
     heartbeat_io_service_.run();
   }));
   gcs_client_ = std::make_shared<gcs::ServiceBasedGcsClient>(gcs_client_->GetOptions());
-  gcs_client_->Connect(heartbeat_io_service_);
+  RAY_CHECK_OK(gcs_client_->Connect(heartbeat_io_service_));
   heartbeat_runner_.reset(new PeriodicalRunner(heartbeat_io_service_));
 
   // Start sending heartbeats to the GCS.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -117,8 +117,8 @@ std::string WorkerOwnerString(std::shared_ptr<WorkerInterface> &worker) {
 }
 
 HeartbeatSender::HeartbeatSender(NodeID self_node_id,
-                                 std::shared_ptr<gcs::GcsClient> gcs_client)
-    : self_node_id_(self_node_id), gcs_client_(gcs_client) {
+                                 const GcsClientOptions &gcs_client_options)
+    : self_node_id_(self_node_id) {
   // Init heartbeat thread and run its io service.
   heartbeat_thread_.reset(new std::thread([this] {
     SetThreadName("heartbeat");
@@ -126,6 +126,8 @@ HeartbeatSender::HeartbeatSender(NodeID self_node_id,
     boost::asio::io_service::work io_service_work_(heartbeat_io_service_);
     heartbeat_io_service_.run();
   }));
+  gcs_client_ = std::make_shared<ServiceBasedGcsClient>(gcs_client_.GetOptions());
+  gcs_clinet_->Connect(heartbeat_io_service_);
   heartbeat_runner_.reset(new PeriodicalRunner(heartbeat_io_service_));
 
   // Start sending heartbeats to the GCS.
@@ -373,7 +375,7 @@ NodeManager::NodeManager(instrumented_io_context &io_service, const NodeID &self
 
 ray::Status NodeManager::RegisterGcs() {
   // Start sending heartbeat here to ensure it happening after raylet being registered.
-  heartbeat_sender_.reset(new HeartbeatSender(self_node_id_, gcs_client_));
+  heartbeat_sender_.reset(new HeartbeatSender(self_node_id_, hearbeat_gcs_client));
   auto on_node_change = [this](const NodeID &node_id, const GcsNodeInfo &data) {
     if (data.state() == GcsNodeInfo::ALIVE) {
       NodeAdded(data);

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -114,7 +114,7 @@ class HeartbeatSender {
   ///
   /// \param self_node_id ID of this node.
   /// \param gcs_client_options options to create a GCS client.
-  HeartbeatSender(NodeID self_node_id, const GcsClientOptions &gcs_client_options);
+  HeartbeatSender(NodeID self_node_id, const gcs::GcsClientOptions &gcs_client_options);
 
   ~HeartbeatSender();
 

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -113,8 +113,8 @@ class HeartbeatSender {
   /// Create a heartbeat sender.
   ///
   /// \param self_node_id ID of this node.
-  /// \param gcs_client GCS client to send heartbeat.
-  HeartbeatSender(NodeID self_node_id, std::shared_ptr<gcs::GcsClient> gcs_client);
+  /// \param gcs_client_options options to create a GCS client.
+  HeartbeatSender(NodeID self_node_id, const GcsClientOptions &gcs_client_options);
 
   ~HeartbeatSender();
 


### PR DESCRIPTION
## Why are these changes needed?

When there is a network error, a ReportHeartbeat call will be replied with an IOError, then this error will be posted to the main IO service to retry.

If the main IO service is busy with some other handlers, this retrying will have a long queueing time. Which will cause this node to be marked as DEAD mistakenly by GCS.

This PR uses a separate GCS client in HearbeatSender so that the main IO service won't affect heartbeat sending.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
