### PR TITLE
[RLlib] Fix update model view requirements from init state for bare-metal policies with custom view-reqs.

### DIFF
--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -936,7 +936,7 @@ class Policy(metaclass=ABCMeta):
             for vr in view_reqs:
                 vr["state_in_{}".format(i)] = ViewRequirement(
                     "state_out_{}".format(i),
-                    shift=-1,
+                    shift=view_reqs['state_in_{}'.format(i)].shift,
                     used_for_compute_actions=True,
                     batch_repeat_value=self.config.get("model", {}).get(
                         "max_seq_len", 1),

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -933,16 +933,18 @@ class Policy(metaclass=ABCMeta):
                     fw.all(state == 0.0) else state
             else:
                 space = state
-            for vr in view_reqs:
-                vr["state_in_{}".format(i)] = ViewRequirement(
-                    "state_out_{}".format(i),
-                    shift=view_reqs['state_in_{}'.format(i)].shift,
-                    used_for_compute_actions=True,
-                    batch_repeat_value=self.config.get("model", {}).get(
-                        "max_seq_len", 1),
-                    space=space)
-                vr["state_out_{}".format(i)] = ViewRequirement(
-                    space=space, used_for_training=True)
+            for vr in view_reqs:            
+                if "state_in_{}".format(i) not in view_reqs:
+                    vr["state_in_{}".format(i)] = ViewRequirement(
+                        "state_out_{}".format(i),
+                        shift=-1,
+                        used_for_compute_actions=True,
+                        batch_repeat_value=self.config.get("model", {}).get(
+                            "max_seq_len", 1),
+                        space=space)
+                if "state_out_{}".format(i) not in view_reqs:
+                    vr["state_out_{}".format(i)] = ViewRequirement(
+                        space=space, used_for_training=True)
 
     @Deprecated(new="save", error=False)
     def export_checkpoint(self, export_dir: str) -> None:

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -933,8 +933,8 @@ class Policy(metaclass=ABCMeta):
                     fw.all(state == 0.0) else state
             else:
                 space = state
-            for vr in view_reqs:            
-                if "state_in_{}".format(i) not in view_reqs:
+            for vr in view_reqs:
+                if "state_in_{}".format(i) not in vr:
                     vr["state_in_{}".format(i)] = ViewRequirement(
                         "state_out_{}".format(i),
                         shift=-1,
@@ -942,7 +942,7 @@ class Policy(metaclass=ABCMeta):
                         batch_repeat_value=self.config.get("model", {}).get(
                             "max_seq_len", 1),
                         space=space)
-                if "state_out_{}".format(i) not in view_reqs:
+                if "state_out_{}".format(i) not in vr:
                     vr["state_out_{}".format(i)] = ViewRequirement(
                         space=space, used_for_training=True)
 

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -934,6 +934,8 @@ class Policy(metaclass=ABCMeta):
             else:
                 space = state
             for vr in view_reqs:
+                # Only override if user has not already provided
+                # custom view-requirements for state_in_n.
                 if "state_in_{}".format(i) not in vr:
                     vr["state_in_{}".format(i)] = ViewRequirement(
                         "state_out_{}".format(i),
@@ -942,6 +944,8 @@ class Policy(metaclass=ABCMeta):
                         batch_repeat_value=self.config.get("model", {}).get(
                             "max_seq_len", 1),
                         space=space)
+                # Only override if user has not already provided
+                # custom view-requirements for state_out_n.
                 if "state_out_{}".format(i) not in vr:
                     vr["state_out_{}".format(i)] = ViewRequirement(
                         space=space, used_for_training=True)


### PR DESCRIPTION
…the 'shift' in view_requirements from a user-defined policy that inherits directly from Policy.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When writing a policy that directly inherits from `Policy` and using the *View Trajectory API* the super class `Policy` calls `_update_view_requirements_from_init_state()` which results in user-defined `view_requirements` for the `state_in_0` column getting overwritten and consequently ignored. 

The fix only sets the view_requirements for the `state` if the user has not given her own. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes [17866](https://github.com/ray-project/ray/issues/17866)
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
