### PR TITLE
[Doc] [runtime env] Add note to install ray[default]

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -432,6 +432,10 @@ Runtime Environments
 
     This API is in beta and may change before becoming stable.
 
+.. note::
+
+    This feature requires the Ray Dashboard to be installed.  You can install it using the command `pip install "ray[default]"`.
+
 On Mac OS and Linux, Ray 1.4+ supports dynamically setting the runtime environment of tasks, actors, and jobs so that they can depend on different Python libraries (e.g., conda environments, pip dependencies) while all running on the same Ray cluster.
 
 The ``runtime_env`` is a (JSON-serializable) dictionary that can be passed as an option to tasks and actors, and can also be passed to ``ray.init()``.

--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -434,7 +434,7 @@ Runtime Environments
 
 .. note::
 
-    This feature requires the Ray Dashboard to be installed.  You can install it using the command `pip install "ray[default]"`.
+    This feature requires a full installation of Ray using `pip install "ray[default]"`.
 
 On Mac OS and Linux, Ray 1.4+ supports dynamically setting the runtime environment of tasks, actors, and jobs so that they can depend on different Python libraries (e.g., conda environments, pip dependencies) while all running on the same Ray cluster.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Runtime environments depends on the dashboard being installed, but this is not documented.  This PR adds this to the documentation.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/17845

To fully close this issue, in a future PR we also need to print a warning to the driver if runtime envs are used but the dashbaord isn't installed.  Currently it just hangs.
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
