### PR TITLE
[WIP] Speed up deserialization of object refs

### DIFF
--- a/python/ray/_private/ray_microbenchmark_helpers.py
+++ b/python/ray/_private/ray_microbenchmark_helpers.py
@@ -15,18 +15,22 @@ def timeit(name, fn, multiplier=1) -> List[Optional[Tuple[str, float, float]]]:
     if filter_pattern not in name:
         return [None]
     # warmup
-    start = time.time()
-    while time.time() - start < 1:
+    start = time.perf_counter()
+    count = 0
+    while time.perf_counter() - start < 1:
         fn()
+        count += 1
     # real run
+    step = count // 10 + 1
     stats = []
     for _ in range(4):
-        start = time.time()
+        start = time.perf_counter()
         count = 0
-        while time.time() - start < 2:
-            fn()
-            count += 1
-        end = time.time()
+        while time.perf_counter() - start < 2:
+            for _ in range(step):
+                fn()
+            count += step
+        end = time.perf_counter()
         stats.append(multiplier * count / (end - start))
 
     mean = np.mean(stats)

--- a/python/ray/_raylet.pxd
+++ b/python/ray/_raylet.pxd
@@ -110,7 +110,7 @@ cdef class CoreWorker:
                             c_bool inline_small_object=*)
     cdef unique_ptr[CAddress] _convert_python_address(self, address=*)
     cpdef add_object_ref_reference(self, ObjectRef object_ref,
-                const c_string &call_site)
+                                   const c_string &call_site)
     cdef deserialize_and_register_object_ref(
                 self, CObjectID object_id,
                 CObjectID outer_object_id,

--- a/python/ray/_raylet.pxd
+++ b/python/ray/_raylet.pxd
@@ -109,6 +109,13 @@ cdef class CoreWorker:
                             owner_address=*,
                             c_bool inline_small_object=*)
     cdef unique_ptr[CAddress] _convert_python_address(self, address=*)
+    cpdef add_object_ref_reference(self, ObjectRef object_ref,
+                const c_string &call_site)
+    cdef deserialize_and_register_object_ref(
+                self, CObjectID object_id,
+                CObjectID outer_object_id,
+                const c_string &serialized_owner_address,
+                const c_string &serialized_object_status)
     cdef store_task_outputs(
             self, worker, outputs, const c_vector[CObjectID] return_ids,
             c_vector[shared_ptr[CRayObject]] *returns)

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -166,6 +166,8 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         pair[c_vector[c_pair[c_string, c_string]], CRayStatus] ListNamedActors(
             c_bool all_namespaces)
         void AddLocalReference(const CObjectID &object_id)
+        void AddLocalReference(const CObjectID &object_id,
+                               const c_string &call_site)
         void RemoveLocalReference(const CObjectID &object_id)
         void PutObjectIntoPlasma(const CRayObject &object,
                                  const CObjectID &object_id)

--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -35,7 +35,7 @@ def _set_future_helper(
 
 cdef class ObjectRef(BaseID):
 
-    def __init__(self, id, c_string call_site = b""):
+    def __init__(self, id, c_string call_site=b""):
         check_id(id)
         self.data = CObjectID.FromBinary(<c_string>id)
         self.in_core_worker = False

--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -35,7 +35,7 @@ def _set_future_helper(
 
 cdef class ObjectRef(BaseID):
 
-    def __init__(self, id):
+    def __init__(self, id, c_string call_site = b""):
         check_id(id)
         self.data = CObjectID.FromBinary(<c_string>id)
         self.in_core_worker = False
@@ -45,7 +45,7 @@ cdef class ObjectRef(BaseID):
         # But there are still some dummy object refs being created outside the
         # context of a core worker.
         if hasattr(worker, "core_worker"):
-            worker.core_worker.add_object_ref_reference(self)
+            worker.core_worker.add_object_ref_reference(self, call_site)
             self.in_core_worker = True
 
     def __dealloc__(self):

--- a/python/ray/ray_perf.py
+++ b/python/ray/ray_perf.py
@@ -69,6 +69,14 @@ def small_value_batch(n):
     return 0
 
 
+@ray.remote
+def create_object_containing_ref():
+    obj_refs = []
+    for _ in range(10000):
+        obj_refs.append(ray.put(1))
+    return obj_refs
+
+
 def check_optimized_build():
     if not ray._raylet.OPTIMIZED:
         msg = ("WARNING: Unoptimized build! "
@@ -139,6 +147,14 @@ def main(results=None):
         ray.get([do_put.remote() for _ in range(10)])
 
     results += timeit("multi client put gigabytes", put_multi, 10 * 8 * 0.1)
+
+    obj_containing_ref = create_object_containing_ref.remote()
+
+    def get_containing_object_ref():
+        ray.get(obj_containing_ref)
+
+    results += timeit("single client get object containing 10k refs",
+                      get_containing_object_ref)
 
     def small_task():
         ray.get(small_value.remote())

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -410,9 +410,17 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
 
   void SetCallerCreationTimestamp();
 
-  /// Increase the reference count for this object ID.
   /// Increase the local reference count for this object ID. Should be called
   /// by the language frontend when a new reference is created.
+  ///
+  /// \param[in] object_id The object ID to increase the reference count for.
+  /// \param[in] call_site The call site from the language frontend, for debugging.
+  void AddLocalReference(const ObjectID &object_id, const std::string &call_site) {
+    reference_counter_->AddLocalReference(object_id, call_site);
+  }
+
+  /// Same as above, except getting the call site from language frontend via
+  /// `CoreWorkerOptions.get_lang_stack`.
   ///
   /// \param[in] object_id The object ID to increase the reference count for.
   void AddLocalReference(const ObjectID &object_id) {
@@ -1084,15 +1092,6 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   ///
   /// Private methods related to task submission.
   ///
-
-  /// Increase the local reference count for this object ID. Should be called
-  /// by the language frontend when a new reference is created.
-  ///
-  /// \param[in] object_id The object ID to increase the reference count for.
-  /// \param[in] call_site The call site from the language frontend.
-  void AddLocalReference(const ObjectID &object_id, std::string call_site) {
-    reference_counter_->AddLocalReference(object_id, call_site);
-  }
 
   /// Stops the children tasks from the given TaskID
   ///


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In #17803 it is reported that calling `ray.get()` on object refs contained within an object can be expectedly slow.

<!-- Please give a short summary of the change and the problem this solves. -->
1. Cache Python call site when creating object refs contained in the same deserializing object. Getting Python call site is the most expensive operation when creating object refs. Also move some deserialization logic into `cython`.

2. Add a microbenchmark for `ray.get()` on objects containing 10k object refs. On `m5.8xlarge`,
    Before: `single client get object containing 10k refs per second 6.68 +- 0.01`
    After: `single client get object containing 10k refs per second 17.52 +- 0.8`

## Related issue number
#17803

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
