### PR TITLE
[RLlib] Config dict should use true instad of True in docs/examples.

### DIFF
--- a/doc/source/rllib-concepts.rst
+++ b/doc/source/rllib-concepts.rst
@@ -423,8 +423,8 @@ Building Policies in TensorFlow Eager
 
 Policies built with ``build_tf_policy`` (most of the reference algorithms are)
 can be run in eager mode by setting
-the ``"framework": "tf2"`` / ``"eager_tracing": True`` config options or
-using ``rllib train '{"framework": "tf2", "eager_tracing": True}'``.
+the ``"framework": "tf2"`` / ``"eager_tracing": true`` config options or
+using ``rllib train '{"framework": "tf2", "eager_tracing": true}'``.
 This will tell RLlib to execute the model forward pass, action distribution,
 loss, and stats functions in eager mode.
 

--- a/doc/source/rllib-training.rst
+++ b/doc/source/rllib-training.rst
@@ -19,7 +19,7 @@ You can train a simple DQN trainer with the following command:
 
 .. code-block:: bash
 
-    rllib train --run DQN --env CartPole-v0  # --config '{"framework": "tf2", "eager_tracing": True}' for eager execution
+    rllib train --run DQN --env CartPole-v0  # --config '{"framework": "tf2", "eager_tracing": true}' for eager execution
 
 By default, the results will be logged to a subdirectory of ``~/ray_results``.
 This subdirectory will contain a file ``params.json`` which contains the
@@ -947,7 +947,7 @@ Eager Mode
 
 Policies built with ``build_tf_policy`` (most of the reference algorithms are)
 can be run in eager mode by setting the
-``"framework": "[tf2|tfe]"`` / ``"eager_tracing": True`` config options or using
+``"framework": "[tf2|tfe]"`` / ``"eager_tracing": true`` config options or using
 ``rllib train --config '{"framework": "tf2"}' [--trace]``.
 This will tell RLlib to execute the model forward pass, action distribution,
 loss, and stats functions in eager mode.

--- a/doc/source/rllib.rst
+++ b/doc/source/rllib.rst
@@ -32,7 +32,7 @@ Then, you can try out training in the following equivalent ways:
 .. code-block:: bash
 
   rllib train --run=PPO --env=CartPole-v0  # -v [-vv] for verbose,
-                                           # --config='{"framework": "tf2", "eager_tracing": True}' for eager,
+                                           # --config='{"framework": "tf2", "eager_tracing": true}' for eager,
                                            # --torch to use PyTorch OR --config='{"framework": "torch"}'
 
 .. code-block:: python


### PR DESCRIPTION
Capital True is not a valid json value, so json.loads() will throw error.

## Why are these changes needed?

Going through RLLib docs, and this is the first command line to try in RLLib's main page.
Fail to run this example is kind of bad first impression.

## Related issue number


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [X] Tried the updated command line, and it runs fine now, under both python 2.7 and 3.9.
