### PR TITLE
[Serve] [Dashboard] Add end times and DELETED state for endpoints

### DIFF
--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -1,12 +1,11 @@
 import math
 import time
 from abc import ABC
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from collections.abc import Iterable
 from enum import Enum
 import os
 from typing import Any, Dict, List, Optional, Tuple
-from typing_extensions import OrderedDict
 
 import ray
 from ray import cloudpickle

--- a/python/ray/serve/common.py
+++ b/python/ray/serve/common.py
@@ -32,7 +32,8 @@ class BackendInfo:
                  start_time_ms: int,
                  actor_def: Optional[ActorClass] = None,
                  version: Optional[str] = None,
-                 deployer_job_id: "Optional[ray._raylet.JobID]" = None):
+                 deployer_job_id: "Optional[ray._raylet.JobID]" = None,
+                 end_time_ms: Optional[int] = None):
         self.backend_config = backend_config
         self.replica_config = replica_config
         # The time when .deploy() was first called for this deployment.
@@ -40,6 +41,8 @@ class BackendInfo:
         self.actor_def = actor_def
         self.version = version
         self.deployer_job_id = deployer_job_id
+        # The time when this deployment was deleted.
+        self.end_time_ms = end_time_ms
 
 
 class TrafficPolicy:

--- a/python/ray/serve/constants.py
+++ b/python/ray/serve/constants.py
@@ -50,3 +50,6 @@ ALL_HTTP_METHODS = [
 ]
 
 SERVE_ROOT_URL_ENV_KEY = "RAY_SERVE_ROOT_URL"
+
+#: Number of historically deleted deployments to store in the checkpoint.
+MAX_NUM_DELETED_DEPLOYMENTS = 1000

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -128,7 +128,8 @@ class ServeController:
     def _put_serve_snapshot(self) -> None:
         val = dict()
         for deployment_name, (backend_info,
-                              route_prefix) in self.list_deployments().items():
+                              route_prefix) in self.list_deployments(
+                                  include_deleted=True).items():
             entry = dict()
             entry["name"] = deployment_name
             entry["namespace"] = ray.get_runtime_context().namespace
@@ -142,28 +143,29 @@ class ServeController:
             # deployments with no HTTP route, update the below line.
             # Or refactor the route_prefix logic in the Deployment class.
             entry["http_route"] = route_prefix or f"/{deployment_name}"
-            entry["status"] = "RUNNING"
             entry["start_time"] = backend_info.start_time_ms
-            entry["end_time"] = 0
-
+            entry["end_time"] = backend_info.end_time_ms or 0
+            entry["status"] = ("DELETED"
+                               if backend_info.end_time_ms else "RUNNING")
             entry["actors"] = dict()
-            replica_state_container = self.backend_state._replicas[
-                deployment_name]
-            running_replicas = replica_state_container.get(
-                [ReplicaState.RUNNING])
-            for replica in running_replicas:
-                try:
-                    actor_handle = replica.actor_handle
-                except ValueError:
-                    # Actor died or hasn't yet been created.
-                    continue
-                actor_id = actor_handle._ray_actor_id.hex()
-                replica_tag = replica.replica_tag
-                replica_version = replica.version.code_version
-                entry["actors"][actor_id] = {
-                    "replica_tag": replica_tag,
-                    "version": replica_version
-                }
+            if entry["status"] == "RUNNING":
+                replica_state_container = self.backend_state._replicas[
+                    deployment_name]
+                running_replicas = replica_state_container.get(
+                    [ReplicaState.RUNNING])
+                for replica in running_replicas:
+                    try:
+                        actor_handle = replica.actor_handle
+                    except ValueError:
+                        # Actor died or hasn't yet been created.
+                        continue
+                    actor_id = actor_handle._ray_actor_id.hex()
+                    replica_tag = replica.replica_tag
+                    replica_version = replica.version.code_version
+                    entry["actors"][actor_id] = {
+                        "replica_tag": replica_tag,
+                        "version": replica_version
+                    }
 
             val[deployment_name] = entry
         self.kv_store.put(SNAPSHOT_KEY, json.dumps(val).encode("utf-8"))
@@ -401,10 +403,24 @@ class ServeController:
 
         return backend_info, route
 
-    def list_deployments(self) -> Dict[str, Tuple[BackendInfo, str]]:
-        """Gets the current information about all active deployments."""
+    def list_deployments(self, include_deleted: Optional[bool] = False
+                         ) -> Dict[str, Tuple[BackendInfo, str]]:
+        """Gets the current information about all deployments.
+
+        Args:
+            include_deleted(bool): Whether to include information about
+                deployments that have been deleted.
+
+        Returns:
+            Dict(deployment_name, (BackendInfo, route))
+
+        Raises:
+            KeyError if the deployment doesn't exist.
+        """
         return {
-            name: (self.backend_state.get_backend(name),
+            name: (self.backend_state.get_backend(
+                name, include_deleted=include_deleted),
                    self.endpoint_state.get_endpoint_route(name))
-            for name in self.backend_state.get_backend_configs()
+            for name in self.backend_state.get_backend_configs(
+                include_deleted=include_deleted)
         }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR stores the history of deleted deployments and their end times in the Serve checkpoint and shows this information in the cluster snapshot.  

Currently the list of deleted deployments can grow without bound, so in a future PR we will need to add some way of limiting the size.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
