### PR TITLE
[hotfix] [runtime env] change MacOS wheel URL from 10_13 to 10_15

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1050,8 +1050,8 @@ def get_wheel_filename(
                                               " '37', or '38'")
 
     os_strings = {
-        "darwin": "macosx_10_13_x86_64"
-        if py_version == "38" else "macosx_10_13_intel",
+        "darwin": "macosx_10_15_x86_64"
+        if py_version == "38" else "macosx_10_15_intel",
         "linux": "manylinux2014_x86_64",
         "win32": "win_amd64"
     }

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -673,7 +673,7 @@ def test_get_wheel_filename():
 
 def test_get_master_wheel_url():
     ray_version = "2.0.0.dev0"
-    test_commit = "ba6cebe30fab6925e5b2d9e859ad064d53015246"
+    test_commit = "58a73821fbfefbf53a19b6c7ffd71e70ccf258c7"
     for sys_platform in ["darwin", "linux", "win32"]:
         for py_version in ["36", "37", "38"]:
             url = get_master_wheel_url(test_commit, sys_platform, ray_version,
@@ -682,11 +682,7 @@ def test_get_master_wheel_url():
 
 
 def test_get_release_wheel_url():
-    test_commits = {
-        "1.4.0rc1": "e7c7f6371a69eb727fa469e4cd6f4fbefd143b4c",
-        "1.3.0": "0b4b444fadcdc23226e11fef066b982175804232",
-        "1.2.0": "1b1a2496ca51b745c07c79fb859946d3350d471b"
-    }
+    test_commits = {"1.6.0": "5052fe67d99f1d4bfc81b2a8694dbf2aa807bbdc"}
     for sys_platform in ["darwin", "linux", "win32"]:
         for py_version in ["36", "37", "38"]:
             for version, commit in test_commits.items():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/pull/16913 updated the URL for the MacOS Ray wheels, which inadvertently broke runtime environments on Mac OS.  This PR updates the corresponding URLs that runtime environments uses to download the appropriate Ray wheel to install in the worker's conda environment. 

A followup PR will add a release test to check these URLs with the current commit on all platforms, in order to prevent future regressions of this type.
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
