### PR TITLE
[Buildkite] Cleanup test wheel environment

### DIFF
--- a/ci/travis/test-wheels.sh
+++ b/ci/travis/test-wheels.sh
@@ -113,6 +113,7 @@ elif [[ "$platform" == "macosx" ]]; then
     PYTHON_WHEEL="$(printf "%s\n" "$ROOT_DIR"/../../.whl/*"$PY_WHEEL_VERSION"* | head -n 1)"
 
     # Install the wheel.
+    "$PIP_CMD" uninstall -y ray
     "$PIP_CMD" install -q "$PYTHON_WHEEL"
 
     # Install the dependencies to run the tests.


### PR DESCRIPTION
The macOS builders are shared and reused across commits.
@clarkzinzow found a bug that the installed version of the wheel
is not the on in PR. This should fix it.

https://buildkite.com/ray-project/ray-builders-pr/builds/11628#be6c5fd6-14a2-449c-8f35-e3382a6ee647

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
