### PR TITLE
[Core] Add support for an app config override to the release test script.

### DIFF
--- a/release/e2e.py
+++ b/release/e2e.py
@@ -98,6 +98,25 @@ The `--no-report` option disables storing the results in the DB and
 artifacts on S3. If you set this option, you do not need access to the
 ray-ossci AWS user.
 
+Using Compilation on Product + App Config Override
+--------------------------------------------------
+For quick iteration when debugging a release test, go/compile-on-product allows
+you to easily modify and recompile Ray, such that the recompilation happens
+within an app build step and can benefit from a warm Bazel cache. See
+go/compile-on-product for more information.
+
+After kicking off the app build, you can give the app config ID to this script
+as an app config override, where the indicated app config will be used instead
+of the app config given in the test config. E.g., running
+
+python e2e.py --no-report --test-config ~/ray/benchmarks/benchmark_tests.yaml --test-name=single_node --app-config-id-override=apt_TBngEXXXrhipMXgexVcrpC9i
+
+would run the single_node benchmark test with the apt_TBngEXXXrhipMXgexVcrpC9i
+app config instead of the app config given in
+~/ray/benchmarks/benchmark_tests.yaml. If the build for the app config is still
+in progress, the script will wait until it completes, same as for a locally
+defined app config.
+
 Running on Head Node vs Running with Anyscale Connect
 -----------------------------------------------------
 By default release tests run their drivers on the head node. Support is being
@@ -1016,6 +1035,7 @@ def run_test_config(
         kick_off_only: bool = False,
         check_progress: bool = False,
         upload_artifacts: bool = True,
+        app_config_id_override: Optional[str] = None,
 ) -> Dict[Any, Any]:
     """
 
@@ -1092,9 +1112,19 @@ def run_test_config(
     # If a test is long running, timeout does not mean it failed
     is_long_running = test_config["run"].get("long_running", False)
 
+    build_id_override = None
     if test_config["run"].get("use_connect"):
         assert not kick_off_only, \
             "Unsupported for running with Anyscale connect."
+        if app_config_id_override is not None:
+            logger.info(
+                "Using connect and an app config override, waiting until "
+                "build finishes so we can fetch the app config in order to "
+                "install its pip packages locally.")
+            build_id_override = wait_for_build_or_raise(
+                sdk, app_config_id_override)
+            response = sdk.get_cluster_environment_build(build_id_override)
+            app_config = response.result.config_json
         install_app_config_packages(app_config)
         install_matching_ray()
 
@@ -1215,7 +1245,9 @@ def run_test_config(
             # First, look for running sessions
             session_id = search_running_session(sdk, project_id, session_name)
             compute_tpl_name = None
+            app_config_id = app_config_id_override
             app_config_name = None
+            build_id = build_id_override
             if not session_id:
                 logger.info("No session found.")
                 # Start session
@@ -1241,9 +1273,22 @@ def run_test_config(
                                 f"{anyscale_compute_tpl_url(compute_tpl_id)}")
 
                     # Find/create app config
-                    app_config_id, app_config_name = create_or_find_app_config(
-                        sdk, project_id, app_config)
-                    build_id = wait_for_build_or_raise(sdk, app_config_id)
+                    if app_config_id is None:
+                        (
+                            app_config_id,
+                            app_config_name,
+                        ) = create_or_find_app_config(sdk, project_id,
+                                                      app_config)
+                    else:
+                        logger.info(
+                            f"Using override app config {app_config_id}")
+                        app_config_name = sdk.get_app_config(
+                            app_config_id).result.name
+                    if build_id is None:
+                        # We might have already retrieved the build ID when
+                        # installing app config packages locally if using
+                        # connect, so only get the build ID if it's not set.
+                        build_id = wait_for_build_or_raise(sdk, app_config_id)
 
                     session_options["compute_template_id"] = compute_tpl_id
                     session_options["build_id"] = build_id
@@ -1640,7 +1685,8 @@ def run_test(test_config_file: str,
              kick_off_only: bool = False,
              check_progress=False,
              report=True,
-             session_name=None):
+             session_name=None,
+             app_config_id_override=None):
     with open(test_config_file, "rt") as f:
         test_configs = yaml.load(f, Loader=yaml.FullLoader)
 
@@ -1687,7 +1733,8 @@ def run_test(test_config_file: str,
         no_terminate=no_terminate,
         kick_off_only=kick_off_only,
         check_progress=check_progress,
-        upload_artifacts=report)
+        upload_artifacts=report,
+        app_config_id_override=app_config_id_override)
 
     status = result.get("status", "invalid")
 
@@ -1777,6 +1824,12 @@ if __name__ == "__main__":
         required=False,
         type=str,
         help="Name of the session to run this test.")
+    parser.add_argument(
+        "--app-config-id-override",
+        required=False,
+        type=str,
+        help=("An app config ID, which will override the test config app "
+              "config."))
     args, _ = parser.parse_known_args()
 
     if not GLOBAL_CONFIG["ANYSCALE_PROJECT"]:
@@ -1813,4 +1866,5 @@ if __name__ == "__main__":
         check_progress=args.check,
         report=not args.no_report,
         session_name=args.session_name,
+        app_config_id_override=args.app_config_id_override,
     )


### PR DESCRIPTION
Adds support for an app config override to the release test script, providing a better integration with go/compile-on-product.

I tested this manually with the example indicated in the e2e.py docstring.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
