### PR TITLE
Do not connect in constructor to avoid potential risk.

### DIFF
--- a/python/ray/includes/gcs_client.pxd
+++ b/python/ray/includes/gcs_client.pxd
@@ -66,7 +66,8 @@ cdef extern from * namespace "_gcs_maker":
           const std::string& ip,
           int port,
           const std::string& password) {
-        std::shared_ptr<RayletGcsClient> raylet_gcs_client = std::make_shared<RayletGcsClient>(
+        std::shared_ptr<RayletGcsClient> raylet_gcs_client =
+          std::make_shared<RayletGcsClient>(
             ray::gcs::GcsClientOptions(ip, port, password));
         raylet_gcs_client->DoConnect();
         return raylet_gcs_client;

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -240,7 +240,8 @@ void GcsActorManager::HandleGetNamedActorInfo(
     rpc::SendReplyCallback send_reply_callback) {
   const std::string &name = request.name();
   const std::string &ray_namespace = request.ray_namespace();
-  RAY_LOG(DEBUG) << "Getting actor info, name = " << name;
+  RAY_LOG(DEBUG) << "Getting actor info, name = " << name << " , namespace = "
+                 << ray_namespace;
 
   // Try to look up the actor ID for the named actor.
   ActorID actor_id = GetActorIDByName(name, ray_namespace);

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -240,8 +240,8 @@ void GcsActorManager::HandleGetNamedActorInfo(
     rpc::SendReplyCallback send_reply_callback) {
   const std::string &name = request.name();
   const std::string &ray_namespace = request.ray_namespace();
-  RAY_LOG(DEBUG) << "Getting actor info, name = " << name << " , namespace = "
-                 << ray_namespace;
+  RAY_LOG(DEBUG) << "Getting actor info, name = " << name
+                 << " , namespace = " << ray_namespace;
 
   // Try to look up the actor ID for the named actor.
   ActorID actor_id = GetActorIDByName(name, ray_namespace);


### PR DESCRIPTION
`ServiceBasedGcsClient::Connect()` does do a heavy work such as resubscribe and others(int Ant, we'll reconnect() and refetch data). Current code is bug free here. https://github.com/ray-project/ray/blob/master/src/ray/gcs/gcs_client/service_based_gcs_client.cc#L35-L116

But it has a potential risk that if users do some async operations in `Connect()` and use a async_callback which received a `shared_from_this`, it'll crash.

For example, if we add such code, it will crash:
```
void ServiceBasedGcsClient::Connect() {
    //// original code.

    //// New code from new developer:
    auto self = shared_from_this();  // This line will crash since it invoked at ctor that means `this` object is not constructed completed.
    redis_client_->async_xxx([self]() {
        use self
    });

}
```

PS: There's another solution: make RayletGcsClient not inherit from `ServiceBasedGcsClient`.