### PR TITLE
[Event] support multi-thread context copy

### DIFF
--- a/src/ray/util/event_test.cc
+++ b/src/ray/util/event_test.cc
@@ -271,9 +271,9 @@ TEST(EVENT_TEST, MULTI_THREAD_CONTEXT_COPY) {
   TestEventReporter::event_list.clear();
 
   std::thread private_thread_2 = std::thread(std::bind([&]() {
-    ray::RayEventContext::Instance().SetCustomField("job_id", "job 1");
     ray::RayEventContext::Instance().SetSourceType(
         rpc::Event_SourceType::Event_SourceType_RAYLET);
+    ray::RayEventContext::Instance().SetCustomField("job_id", "job 1");
     RAY_EVENT(INFO, "label 2") << "send message 2";
   }));
 

--- a/src/ray/util/event_test.cc
+++ b/src/ray/util/event_test.cc
@@ -238,6 +238,55 @@ TEST(EVENT_TEST, LOG_ONE_THREAD) {
   boost::filesystem::remove_all(log_dir.c_str());
 }
 
+TEST(EVENT_TEST, MULTI_THREAD_CONTEXT_COPY) {
+  ray::RayEventContext::Instance().ResetEventContext();
+  TestEventReporter::event_list.clear();
+  ray::EventManager::Instance().ClearReporters();
+  ray::EventManager::Instance().AddReporter(std::make_shared<TestEventReporter>());
+  RAY_EVENT(INFO, "label 0") << "send message 0";
+
+  std::thread private_thread = std::thread(std::bind([&]() {
+    auto custom_fields = std::unordered_map<std::string, std::string>();
+    custom_fields.emplace("node_id", "node 1");
+    custom_fields.emplace("job_id", "job 1");
+    custom_fields.emplace("task_id", "task 1");
+    ray::RayEventContext::Instance().SetEventContext(
+        rpc::Event_SourceType::Event_SourceType_GCS, custom_fields);
+    RAY_EVENT(INFO, "label 2") << "send message 2";
+  }));
+
+  private_thread.join();
+
+  RAY_EVENT(INFO, "label 1") << "send message 1";
+  std::vector<rpc::Event> &result = TestEventReporter::event_list;
+
+  EXPECT_EQ(result.size(), 3);
+  CheckEventDetail(result[0], "", "", "", "COMMON", "INFO", "label 0", "send message 0");
+  CheckEventDetail(result[1], "job 1", "node 1", "task 1", "GCS", "INFO", "label 2",
+                   "send message 2");
+  CheckEventDetail(result[2], "job 1", "node 1", "task 1", "GCS", "INFO", "label 1",
+                   "send message 1");
+
+  ray::RayEventContext::Instance().ResetEventContext();
+  TestEventReporter::event_list.clear();
+
+  std::thread private_thread_2 = std::thread(std::bind([&]() {
+    ray::RayEventContext::Instance().SetCustomField("job_id", "job 1");
+    ray::RayEventContext::Instance().SetSourceType(
+        rpc::Event_SourceType::Event_SourceType_RAYLET);
+    RAY_EVENT(INFO, "label 2") << "send message 2";
+  }));
+
+  private_thread_2.join();
+
+  RAY_EVENT(INFO, "label 3") << "send message 3";
+
+  EXPECT_EQ(result.size(), 2);
+  CheckEventDetail(result[0], "job 1", "", "", "RAYLET", "INFO", "label 2",
+                   "send message 2");
+  CheckEventDetail(result[1], "", "", "", "COMMON", "INFO", "label 3", "send message 3");
+}
+
 TEST(EVENT_TEST, LOG_MULTI_THREAD) {
   std::string log_dir = GenerateLogDir();
 


### PR DESCRIPTION
## Why are these changes needed?
- The event context could be copied automatically in private threads.