### PR TITLE
[easy][test] change the way ray starts in nested_id tests

### DIFF
--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -571,7 +571,9 @@ def test_remove_actor_immediately_after_creation(ray_start_regular):
 
 
 # https://github.com/ray-project/ray/issues/17553
-def test_return_nested_ids(ray_start_regular):
+def test_return_nested_ids(shutdown_only):
+    ray.init()
+
     class Nested:
         def __init__(self, blocks):
             self._blocks = blocks


### PR DESCRIPTION
Interestingly we can't reproduce the nested id bugs with `ray_start_regular` ; i assume this is due to race condition.
By changing how ray is initialized (ray.init vs ray_start_regular fixture) we can reproduce the bug in test, while using ray_start_regular in test succeed without #17802

Test Plan
- [x] verified `pytest ./ray/tests/test_reference_counting.py -k test_return_nested_ids` [fails](https://gist.github.com/scv119/36a5dcbf6dfba2c0decf8034dc4bb5c4) without #17802
- [x] verified `pytest ./ray/tests/test_reference_counting.py -k test_return_nested_ids` [succeeds](https://gist.github.com/scv119/aadcfc1f9338fdd28e2ac2048c82db04) on master