### PR TITLE
[Serve] Mark `serve.start` beta API (instead of stable)

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -575,7 +575,7 @@ class Client:
         return handle
 
 
-@PublicAPI
+@PublicAPI(stability="beta")
 def start(
         detached: bool = False,
         http_options: Optional[Union[dict, HTTPOptions]] = None,


### PR DESCRIPTION
The default for `PublicAPI` is `stability="stable"`. However, serve.start API is still evolving.