### PR TITLE
[Tune] Raise Error when there are insufficient resources.

### DIFF
--- a/doc/source/tune/user-guide.rst
+++ b/doc/source/tune/user-guide.rst
@@ -850,7 +850,7 @@ These are the environment variables Ray Tune currently considers:
 * **TUNE_WARN_THRESHOLD_S**: Threshold for logging if an Tune event loop operation takes too long. Defaults to 0.5 (seconds).
 * **TUNE_WARN_INSUFFICENT_RESOURCE_THRESHOLD_S**: Threshold for throwing a warning if no active trials are in ``RUNNING`` state
   for this amount of seconds. If the Ray Tune job is stuck in this state (most likely due to insufficient resources),
-  the warning message is printed repeatedly every this amount of seconds. Defaults to 1 (seconds).
+  the warning message is printed repeatedly every this amount of seconds. Defaults to 5 (seconds).
 * **TUNE_WARN_INSUFFICENT_RESOURCE_THRESHOLD_S_AUTOSCALER**: Threshold for throwing a warning, when the autoscaler is enabled,
   if no active trials are in ``RUNNING`` state for this amount of seconds.
   If the Ray Tune job is stuck in this state (most likely due to insufficient resources), the warning message is printed

--- a/doc/source/tune/user-guide.rst
+++ b/doc/source/tune/user-guide.rst
@@ -850,7 +850,7 @@ These are the environment variables Ray Tune currently considers:
 * **TUNE_WARN_THRESHOLD_S**: Threshold for logging if an Tune event loop operation takes too long. Defaults to 0.5 (seconds).
 * **TUNE_WARN_INSUFFICENT_RESOURCE_THRESHOLD_S**: Threshold for throwing a warning if no active trials are in ``RUNNING`` state
   for this amount of seconds. If the Ray Tune job is stuck in this state (most likely due to insufficient resources),
-  the warning message is printed repeatedly every this amount of seconds. Defaults to 5 (seconds).
+  the warning message is printed repeatedly every this amount of seconds. Defaults to 10 (seconds).
 * **TUNE_WARN_INSUFFICENT_RESOURCE_THRESHOLD_S_AUTOSCALER**: Threshold for throwing a warning, when the autoscaler is enabled,
   if no active trials are in ``RUNNING`` state for this amount of seconds.
   If the Ray Tune job is stuck in this state (most likely due to insufficient resources), the warning message is printed

--- a/python/ray/tune/tests/test_ray_trial_executor.py
+++ b/python/ray/tune/tests/test_ray_trial_executor.py
@@ -44,13 +44,12 @@ class TrialExecutorInsufficientResourcesTest(unittest.TestCase):
                     "cpu": 5,  # more than what the cluster can offer.
                     "gpu": 3,
                 })
-        msg = (
-            "No trial is running and no new trial has been started within at"
-            " least the last 1.0 seconds. This could be due to the cluster "
-            "not having enough resources available to start the next trial. "
-            "Please stop the tuning job and readjust resources_per_trial "
-            "argument passed into tune.run() and/or start a cluster with more "
-            "resources.")
+        msg = ("You ask for 5 cpu and 3 gpu per trial, "
+               "but the cluster only has 4.0 cpu and 2.0 gpu."
+               "The cluster does not have enough resources available to start "
+               "the next trial. Please stop the tuning job and readjust "
+               "resources_per_trial argument passed into tune.run() "
+               "and/or start a cluster with more resources.")
         assert str(cm._excinfo[1]) == msg
 
 

--- a/python/ray/tune/tests/test_ray_trial_executor.py
+++ b/python/ray/tune/tests/test_ray_trial_executor.py
@@ -45,11 +45,12 @@ class TrialExecutorInsufficientResourcesTest(unittest.TestCase):
                     "gpu": 3,
                 })
         msg = ("You asked for 5.0 cpu and 3.0 gpu per trial, "
-               "but the cluster only has 4.0 cpu and 2.0 gpu."
-               "The cluster does not have enough resources available to start "
-               "the next trial. Please stop the tuning job and adjust "
-               "`resources_per_trial` or `num_workers`(for rllib) "
-               "and/or start a cluster with more resources.")
+               "but the cluster only has 4.0 cpu and 2.0 gpu. "
+               "Stop the tuning job and "
+               "adjust the resources requested per trial "
+               "(possibly via `resources_per_trial` "
+               "or via `num_workers` for rllib) "
+               "and/or add more resources to your Ray runtime.")
         assert str(cm._excinfo[1]) == msg
 
 

--- a/python/ray/tune/tests/test_ray_trial_executor.py
+++ b/python/ray/tune/tests/test_ray_trial_executor.py
@@ -1,13 +1,12 @@
 # coding: utf-8
-from freezegun import freeze_time
-from mock import patch
 import os
+import pytest
 import unittest
 
 import ray
 from ray import tune
 from ray.rllib import _register_all
-from ray.tune import Trainable
+from ray.tune import Trainable, TuneError
 from ray.tune.ray_trial_executor import RayTrialExecutor
 from ray.tune.registry import _global_registry, TRAINABLE_CLASS
 from ray.tune.result import TRAINING_ITERATION
@@ -20,54 +19,39 @@ from ray.tune.utils.placement_groups import PlacementGroupFactory
 
 class TrialExecutorInsufficientResourcesTest(unittest.TestCase):
     def setUp(self):
-        os.environ["TUNE_INSUFFICENT_RESOURCE_WARN_THRESHOLD_S"] = "1"
+        os.environ["TUNE_WARN_INSUFFICENT_RESOURCE_THRESHOLD_S"] = "1"
         self.cluster = Cluster(
             initialize_head=True,
             connect=True,
             head_node_args={
                 "num_cpus": 4,
                 "num_gpus": 2,
-                "_system_config": {
-                    "num_heartbeats_timeout": 10
-                }
             })
 
     def tearDown(self):
         ray.shutdown()
         self.cluster.shutdown()
 
-    @freeze_time("2021-08-03", auto_tick_seconds=15)
-    @patch.object(ray.tune.trial_executor.logger, "warning")
-    def testOutputWarningMessage(self, mocked_warn):
+    # no autoscaler case, resource is not sufficient. Raise error.
+    def testRaiseErrorNoAutoscaler(self):
         def train(config):
             pass
 
-        tune.run(
-            train, resources_per_trial={
-                "cpu": 1,
-                "gpu": 1,
-            })
+        with pytest.raises(TuneError) as cm:
+            tune.run(
+                train,
+                resources_per_trial={
+                    "cpu": 5,  # more than what the cluster can offer.
+                    "gpu": 3,
+                })
         msg = (
             "No trial is running and no new trial has been started within at"
-            " least the last 5.0 seconds. This could be due to the cluster "
+            " least the last 1.0 seconds. This could be due to the cluster "
             "not having enough resources available to start the next trial. "
             "Please stop the tuning job and readjust resources_per_trial "
             "argument passed into tune.run() and/or start a cluster with more "
             "resources.")
-        mocked_warn.assert_called_with(msg)
-
-    @freeze_time("2021-08-03")
-    @patch.object(ray.tune.trial_executor.logger, "warning")
-    def testNotOutputWarningMessage(self, mocked_warn):
-        def train(config):
-            pass
-
-        tune.run(
-            train, resources_per_trial={
-                "cpu": 1,
-                "gpu": 1,
-            })
-        mocked_warn.assert_not_called()
+        assert str(cm._excinfo[1]) == msg
 
 
 class RayTrialExecutorTest(unittest.TestCase):
@@ -475,6 +459,5 @@ class LocalModeExecutorTest(RayTrialExecutorTest):
 
 
 if __name__ == "__main__":
-    import pytest
     import sys
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tune/tests/test_ray_trial_executor.py
+++ b/python/ray/tune/tests/test_ray_trial_executor.py
@@ -49,7 +49,7 @@ class TrialExecutorInsufficientResourcesTest(unittest.TestCase):
             })
         msg = (
             "No trial is running and no new trial has been started within at"
-            " least the last 1.0 seconds. This could be due to the cluster "
+            " least the last 5.0 seconds. This could be due to the cluster "
             "not having enough resources available to start the next trial. "
             "Please stop the tuning job and readjust resources_per_trial "
             "argument passed into tune.run() and/or start a cluster with more "

--- a/python/ray/tune/tests/test_ray_trial_executor.py
+++ b/python/ray/tune/tests/test_ray_trial_executor.py
@@ -44,11 +44,11 @@ class TrialExecutorInsufficientResourcesTest(unittest.TestCase):
                     "cpu": 5,  # more than what the cluster can offer.
                     "gpu": 3,
                 })
-        msg = ("You ask for 5 cpu and 3 gpu per trial, "
+        msg = ("You asked for 5.0 cpu and 3.0 gpu per trial, "
                "but the cluster only has 4.0 cpu and 2.0 gpu."
                "The cluster does not have enough resources available to start "
-               "the next trial. Please stop the tuning job and readjust "
-               "resources_per_trial argument passed into tune.run() "
+               "the next trial. Please stop the tuning job and adjust "
+               "`resources_per_trial` or `num_workers`(for rllib) "
                "and/or start a cluster with more resources.")
         assert str(cm._excinfo[1]) == msg
 

--- a/python/ray/tune/trial_executor.py
+++ b/python/ray/tune/trial_executor.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 # Ideally we want to use @cache; but it's only available for python 3.9.
-# Caching is only helpful for no autoscaler case.
+# Caching is only helpful/correct for no autoscaler case.
 @lru_cache()
 def _get_cluster_resources_no_autoscaler() -> Dict:
     return ray.cluster_resources()
@@ -43,8 +43,10 @@ def _get_insufficient_resources_warning_threshold() -> float:
             os.environ.get(
                 "TUNE_WARN_INSUFFICENT_RESOURCE_THRESHOLD_S_AUTOSCALER", "60"))
     else:
+        # Set the default to 10s so that we don't prematurely determine that
+        # a cluster cannot fulfill the resources requirements.
         return float(
-            os.environ.get("TUNE_WARN_INSUFFICENT_RESOURCE_THRESHOLD_S", "5"))
+            os.environ.get("TUNE_WARN_INSUFFICENT_RESOURCE_THRESHOLD_S", "10"))
 
 
 @lru_cache()
@@ -93,7 +95,7 @@ class TrialExecutor(metaclass=ABCMeta):
         self._trials_to_cache = set()
         # The next two variables are used to keep track of if there is any
         # "progress" made between subsequent calls to `on_no_available_trials`.
-        # TODO(xwjiang): Clean this up once figure out who should have a
+        # TODO(xwjiang): Clean this up once figuring out who should have a
         #  holistic view of trials - runner or executor.
         #  Also iterating over list of trials every time is very inefficient.
         #  Need better visibility APIs into trials.

--- a/python/ray/tune/trial_executor.py
+++ b/python/ray/tune/trial_executor.py
@@ -59,41 +59,35 @@ def _get_insufficient_resources_warning_threshold() -> float:
             os.environ.get("TUNE_WARN_INSUFFICENT_RESOURCE_THRESHOLD_S", "10"))
 
 
+# TODO(xwjiang): Consider having a help page with more detailed instructions.
 @lru_cache()
 def _get_insufficient_resources_warning_msg() -> str:
+    msg = (
+        f"No trial is running and no new trial has been started within"
+        f" at least the last "
+        f"{_get_insufficient_resources_warning_threshold()} seconds. "
+        f"This could be due to the cluster not having enough "
+        f"resources available to start the next trial. "
+        f"Stop the tuning job and adjust the resources requested per trial "
+        f"(possibly via `resources_per_trial` or via `num_workers` for rllib) "
+        f"and/or add more resources to your Ray runtime.")
     if is_ray_cluster():
-        return (
-            f"If autoscaler is still scaling up, ignore this message. No "
-            f"trial is running and no new trial has been started within at "
-            f"least the last {_get_insufficient_resources_warning_threshold()}"
-            f" seconds. "
-            f"This could be due to the cluster not having enough "
-            f"resources available to start the next trial. Please stop the "
-            f"tuning job and adjust `resources_per_trial` or `num_workers`"
-            f"(for rllib) as well as max_workers and worker_nodes "
-            f"InstanceType specified in cluster.yaml.")
+        return "If autoscaler is still scaling up, ignore this message. " + msg
     else:
-        return (f"No trial is running and no new trial has been started within"
-                f" at least the last "
-                f"{_get_insufficient_resources_warning_threshold()} seconds. "
-                f"This could be due to the cluster not having enough "
-                f"resources available to start the next trial. Please stop "
-                f"the tuning job and adjust `resources_per_trial` or "
-                f"`num_workers`(for rllib) and/or start a cluster with more"
-                f" resources.")
+        return msg
 
 
 # A beefed up version when Tune Error is raised.
 def _get_insufficient_resources_error_msg(trial: Trial) -> str:
     trial_cpu_gpu = _get_trial_cpu_and_gpu(trial)
-    return (f"You asked for {trial_cpu_gpu['CPU']} cpu and "
-            f"{trial_cpu_gpu['GPU']} gpu per trial, but the cluster only has "
-            f"{_get_cluster_resources_no_autoscaler().get('CPU', 0)} cpu and "
-            f"{_get_cluster_resources_no_autoscaler().get('GPU', 0)} gpu."
-            f"The cluster does not have enough resources available to "
-            f"start the next trial. Please stop the tuning job and adjust "
-            f"`resources_per_trial` or `num_workers`(for rllib) "
-            f"and/or start a cluster with more resources.")
+    return (
+        f"You asked for {trial_cpu_gpu['CPU']} cpu and "
+        f"{trial_cpu_gpu['GPU']} gpu per trial, but the cluster only has "
+        f"{_get_cluster_resources_no_autoscaler().get('CPU', 0)} cpu and "
+        f"{_get_cluster_resources_no_autoscaler().get('GPU', 0)} gpu. "
+        f"Stop the tuning job and adjust the resources requested per trial "
+        f"(possibly via `resources_per_trial` or via `num_workers` for rllib) "
+        f"and/or add more resources to your Ray runtime.")
 
 
 @DeveloperAPI

--- a/python/ray/tune/trial_executor.py
+++ b/python/ray/tune/trial_executor.py
@@ -285,14 +285,14 @@ class TrialExecutor(metaclass=ABCMeta):
         if len(all_trials) == self._all_trials_size:
             if self._no_running_trials_since == -1:
                 self._no_running_trials_since = time.monotonic()
-            elif time.monotonic(
-            ) - self._no_running_trials_since > _get_insufficient_resources_warning_threshold(  # noqa
-            ):
+            elif (time.monotonic() - self._no_running_trials_since >
+                  _get_insufficient_resources_warning_threshold()):
                 if not is_ray_cluster():  # autoscaler not enabled
                     # If any of the pending trial cannot be fulfilled,
                     # that's a good enough hint of trial resources not enough.
                     for trial in all_trials:
-                        if not _can_fulfill_no_autoscaler(trial):
+                        if (trial.status is Trial.PENDING
+                                and not _can_fulfill_no_autoscaler(trial)):
                             raise TuneError(
                                 _get_insufficient_resources_error_msg(
                                     trial.resources))


### PR DESCRIPTION
When autoscaler is disabled, raise Error when there are insufficient resources.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When autoscaler is disabled, raise Error when there are insufficient resources.
Tested by running on a local cluster on my laptop.

Sample output:
```
Traceback (most recent call last):
  File "single_process_example.py", line 51, in <module>
    main()
  File "single_process_example.py", line 37, in main
    result = tune.run(
  File "/Users/xwjiang/ray/python/ray/tune/tune.py", line 535, in run
    runner.step()
  File "/Users/xwjiang/ray/python/ray/tune/trial_runner.py", line 593, in step
    self._run_and_catch(self.trial_executor.on_no_available_trials)
  File "/Users/xwjiang/ray/python/ray/tune/trial_runner.py", line 373, in _run_and_catch
    func(self.get_trials())
  File "/Users/xwjiang/ray/python/ray/tune/trial_executor.py", line 276, in on_no_available_trials
    self._may_warn_insufficient_resources(trials)
  File "/Users/xwjiang/ray/python/ray/tune/trial_executor.py", line 259, in _may_warn_insufficient_resources
    raise TuneError(_get_warning_msg())
ray.tune.error.TuneError: No trial is running and no new trial has been started within at least the last 5.0 seconds. This could be due to the cluster not having enough resources available to start the next trial. Please stop the tuning job and readjust resources_per_trial argument passed into tune.run() and/or start a cluster with more resources.
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
