### PR TITLE
[release] Add configurable connect autosuspend to e2e.py

### DIFF
--- a/release/e2e.py
+++ b/release/e2e.py
@@ -749,11 +749,12 @@ def wait_for_build_or_raise(sdk: AnyscaleSDK,
 
 def run_job(cluster_name: str, compute_tpl_name: str, cluster_env_name: str,
             job_name: str, min_workers: str, script: str,
-            script_args: List[str],
-            env_vars: Dict[str, str]) -> Tuple[int, str]:
+            script_args: List[str], env_vars: Dict[str, str],
+            autosuspend: int) -> Tuple[int, str]:
     # Start cluster and job
     address = f"anyscale://{cluster_name}?cluster_compute={compute_tpl_name}" \
-              f"&cluster_env={cluster_env_name}&autosuspend=5&&update=True"
+              f"&cluster_env={cluster_env_name}&autosuspend={autosuspend}" \
+               "&&update=True"
     logger.info(f"Starting job {job_name} with Ray address: {address}")
     env = copy.deepcopy(os.environ)
     env.update(GLOBAL_CONFIG)
@@ -1115,6 +1116,7 @@ def run_test_config(
 
     build_id_override = None
     if test_config["run"].get("use_connect"):
+        autosuspend_mins = test_config["run"].get("autosuspend_mins", 5)
         assert not kick_off_only, \
             "Unsupported for running with Anyscale connect."
         if app_config_id_override is not None:
@@ -1128,6 +1130,9 @@ def run_test_config(
             app_config = response.result.config_json
         install_app_config_packages(app_config)
         install_matching_ray()
+    elif "autosuspend_mins" in test_config["run"]:
+        raise ValueError(
+            "'autosuspend_mins' is only supported if 'use_connect' is True.")
 
     # Add information to results dict
     def _update_results(results: Dict):
@@ -1322,7 +1327,8 @@ def run_test_config(
                     min_workers=min_workers,
                     script=test_config["run"]["script"],
                     script_args=script_args,
-                    env_vars=env_vars)
+                    env_vars=env_vars,
+                    autosuspend=autosuspend_mins)
                 _process_finished_client_command(returncode, logs)
                 return
 

--- a/release/golden_notebook_tests/golden_notebook_tests.yaml
+++ b/release/golden_notebook_tests/golden_notebook_tests.yaml
@@ -14,6 +14,7 @@
 
   run:
     use_connect: True
+    autosuspend_mins: 15
     timeout: 1800
     script: python workloads/modin_xgboost_test.py
 
@@ -28,6 +29,7 @@
 
   run:
     use_connect: True
+    autosuspend_mins: 15
     timeout: 2700
     script: python workloads/torch_tune_serve_test.py
 

--- a/release/lightgbm_tests/lightgbm_tests.yaml
+++ b/release/lightgbm_tests/lightgbm_tests.yaml
@@ -5,6 +5,7 @@
 
   run:
     use_connect: True
+    autosuspend_mins: 15
     timeout: 600
     prepare: python wait_cluster.py 4 600
     script: python workloads/train_small.py

--- a/release/xgboost_tests/xgboost_tests.yaml
+++ b/release/xgboost_tests/xgboost_tests.yaml
@@ -5,6 +5,7 @@
 
   run:
     use_connect: True
+    autosuspend_mins: 15
     timeout: 600
     prepare: python wait_cluster.py 4 600
     script: python workloads/train_small.py


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Adds an ability to configure autosuspend minutes for connect tests in order to work around a bug that is currently present in the product.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
