### PR TITLE
[Client] Skip client object ref, actor handle, and actor ref dealloc/del if client package has already been cleaned up

### DIFF
--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -146,6 +146,13 @@ cdef class ClientObjectRef(ObjectRef):
         self.in_core_worker = False
 
     def __dealloc__(self):
+        if client is None or client.ray is None:
+            # Similar issue as mentioned in ObjectRef.__dealloc__ above. The
+            # client package or client.ray object might be set
+            # to None when the script exits. Should be safe to skip
+            # call_release in this case, since the client should have already
+            # disconnected at this point.
+            return
         if client.ray.is_connected() and not self.data.IsNil():
             client.ray.call_release(self.id)
 

--- a/python/ray/includes/unique_ids.pxi
+++ b/python/ray/includes/unique_ids.pxi
@@ -314,6 +314,8 @@ cdef class ClientActorRef(ActorID):
         client.ray.call_retain(id)
 
     def __dealloc__(self):
+        if client is None or client.ray is None:
+            return
         if client.ray.is_connected() and not self.data.IsNil():
             client.ray.call_release(self.id)
 

--- a/python/ray/includes/unique_ids.pxi
+++ b/python/ray/includes/unique_ids.pxi
@@ -315,6 +315,10 @@ cdef class ClientActorRef(ActorID):
 
     def __dealloc__(self):
         if client is None or client.ray is None:
+            # The client package or client.ray object might be set
+            # to None when a script exits. Should be safe to skip
+            # call_release in this case, since the client should have already
+            # disconnected at this point.
             return
         if client.ray.is_connected() and not self.data.IsNil():
             client.ray.call_release(self.id)

--- a/python/ray/includes/unique_ids.pxi
+++ b/python/ray/includes/unique_ids.pxi
@@ -316,7 +316,7 @@ cdef class ClientActorRef(ActorID):
     def __dealloc__(self):
         if client is None or client.ray is None:
             # The client package or client.ray object might be set
-            # to None when a script exits. Should be safe to skip
+            # to None when the script exits. Should be safe to skip
             # call_release in this case, since the client should have already
             # disconnected at this point.
             return

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -612,7 +612,7 @@ def test_client_context_manager(ray_start_regular_shared, connect_to_client):
 object_ref_cleanup_script = """
 import ray
 
-ray.client("localhost:50051").connect()
+ray.init("ray://localhost:50051")
 
 @ray.remote
 def f():

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -608,6 +608,7 @@ def test_client_context_manager(ray_start_regular_shared, connect_to_client):
             assert client_mode_should_convert() is False
             assert ray.util.client.ray.is_connected() is False
 
+
 object_ref_cleanup_script = """
 import ray
 
@@ -619,6 +620,7 @@ def f():
 
 obj_ref = f.remote()
 """
+
 
 def test_object_ref_cleanup():
     # Checks no error output when running the script in

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -618,7 +618,13 @@ ray.client("localhost:50051").connect()
 def f():
     return 42
 
+@ray.remote
+class SomeClass:
+    pass
+
+
 obj_ref = f.remote()
+actor_ref = SomeClass.remote()
 """
 
 

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -217,6 +217,9 @@ class ClientActorHandle(ClientStub):
 
     def __del__(self) -> None:
         if ray is None:
+            # The ray API stub might be set to None when the script exits.
+            # Should be safe to skip call_release in this case, since the
+            # client should have already disconnected at this point.
             return
         if ray.is_connected():
             ray.call_release(self.actor_ref.id)

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -216,6 +216,8 @@ class ClientActorHandle(ClientStub):
                                        is_function_or_method)).keys())
 
     def __del__(self) -> None:
+        if ray is None:
+            return
         if ray.is_connected():
             ray.call_release(self.actor_ref.id)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Check if client package ha been set to None when deallocating client object refs. When `__dealloc__` is called without this check, it errors, leading to `AttributeError` in `ClientObjectRef.__dealloc__`, and sys.excepthook errors when cleaning up ClientRemoteFunc's.

Should fix these confusing messages on script exit:
```
AttributeError: 'NoneType' object has no attribute 'ray'
Exception ignored in: 'ray._raylet.ClientActorRef.__dealloc__'
AttributeError: 'NoneType' object has no attribute 'ray
```

```
Exception ignored in: <function ClientActorHandle.__del__ at 0x7fe48f6c7280>
Traceback (most recent call last):
  File "/Users/cwong/ray38/python/ray/util/client/common.py", line 219, in __del__
AttributeError: 'NoneType' object has no attribute 'is_connected'
```

```
AttributeError: 'NoneType' object has no attribute 'ray'
Exception ignored in: 'ray._raylet.ClientObjectRef.__dealloc__'
```

```
Error in sys.excepthook:

Original exception was:
```

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #17968, Closes #17647
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
