### PR TITLE
[tune] Update trial resources on resume.

### DIFF
--- a/python/ray/tune/tests/test_tune_restore.py
+++ b/python/ray/tune/tests/test_tune_restore.py
@@ -208,7 +208,7 @@ class TuneFailResumeGridTest(unittest.TestCase):
             if not self._checked and iteration >= self._check_after:
                 for trial in trials:
                     if trial.status == Trial.PENDING:
-                        assert trial.resources.cpu == self._expected_new_cpu
+                        assert trial.resources.cpu == self._expected_cpu
                 self._checked = True
 
     def setUp(self):

--- a/python/ray/tune/tests/test_tune_restore.py
+++ b/python/ray/tune/tests/test_tune_restore.py
@@ -205,12 +205,11 @@ class TuneFailResumeGridTest(unittest.TestCase):
             self._check_after = check_after
 
         def on_step_begin(self, iteration: int, trials: List["Trial"], **info):
-            if not self._checked and self._check_after == 0:
+            if not self._checked and iteration >= self._check_after:
                 for trial in trials:
                     if trial.status == Trial.PENDING:
                         assert trial.resources.cpu == self._expected_new_cpu
                 self._checked = True
-                self._check_after -= 1
 
     def setUp(self):
         self.logdir = tempfile.mkdtemp()

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -484,7 +484,10 @@ def run(
         for exp in experiments:
             search_alg.add_configurations([exp])
     else:
-        logger.info("TrialRunner resumed, ignoring new add_experiment.")
+        logger.info("TrialRunner resumed, ignoring new add_experiment but "
+                    "updating trial resources.")
+        if resources_per_trial:
+            runner.update_pending_trial_resources(resources_per_trial)
 
     progress_reporter = progress_reporter or detect_reporter()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Allow users to reconfigure trial resources, when tune job is resumed.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #15570

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
