### PR TITLE
[serve] Remove deprecated routing code (ServeStarletteRouter)

### DIFF
--- a/python/ray/serve/common.py
+++ b/python/ray/serve/common.py
@@ -22,7 +22,6 @@ class EndpointInfo:
     http_methods: List[str]
     python_methods: Optional[List[str]] = field(default_factory=list)
     route: Optional[str] = None
-    legacy: Optional[bool] = True
 
 
 class BackendInfo:

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -20,8 +20,7 @@ from ray.serve.common import (
     TrafficPolicy,
 )
 from ray.serve.config import BackendConfig, HTTPOptions, ReplicaConfig
-from ray.serve.constants import (
-    ALL_HTTP_METHODS, )
+from ray.serve.constants import ALL_HTTP_METHODS
 from ray.serve.endpoint_state import EndpointState
 from ray.serve.http_state import HTTPState
 from ray.serve.storage.kv_store import RayInternalKVStore
@@ -232,8 +231,7 @@ class ServeController:
             endpoint_info = EndpointInfo(
                 ALL_HTTP_METHODS,
                 route=route_prefix,
-                python_methods=python_methods,
-                legacy=False)
+                python_methods=python_methods)
             self.endpoint_state.update_endpoint(name, endpoint_info,
                                                 TrafficPolicy({
                                                     name: 1.0

--- a/python/ray/serve/router.py
+++ b/python/ray/serve/router.py
@@ -30,14 +30,6 @@ class RequestMetadata:
     http_method: str = "GET"
     http_headers: Dict[str, str] = field(default_factory=dict)
 
-    is_shadow_query: bool = False
-
-    # Determines whether or not the backend implementation will be presented
-    # with a ServeRequest object or directly passed args and kwargs. This is
-    # used to maintain backward compatibility and will be removed in the
-    # future.
-    use_serve_request: bool = True
-
     # This flag will be set to true if the input argument is manually pickled
     # and it needs to be deserialized by the backend worker.
     http_arg_is_pickled: bool = False


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

No longer used now that the deprecated APIs have been removed.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
