### PR TITLE
[CI] fix ebs cold start problem

### DIFF
--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -11,6 +11,8 @@ common: &common
     LANG: en_US.UTF-8
 
 prelude_commands: &prelude_commands |-
+  # Warm up ebs to avoid cold start
+  dd if=/dev/sda1 of=/dev/null
   ./ci/travis/upload_build_info.sh
   (which bazel && bazel clean) || true;
   . ./ci/travis/ci.sh init && source ~/.zshrc


### PR DESCRIPTION
we noticed recent mac test failures suffers from degraded disk performances; @rkooo567 suspect this is due to EBS cold start problem. We adopt the suggestion from [stackflow](https://stackoverflow.com/questions/3904678/how-to-warm-up-ec2-ebs-storage) to mitigate this issue.