### PR TITLE
[autoscaler][hotfix] Update node list after terminating unhealthy nodes

### DIFF
--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -397,6 +397,7 @@ class StandardAutoscaler:
         if self.disable_node_updaters:
             # If updaters are unavailable, terminate unhealthy nodes.
             self.terminate_unhealthy_nodes(nodes, now)
+            nodes = self.workers()
         else:
             # Attempt to recover unhealthy nodes
             for node_id in nodes:

--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -719,7 +719,8 @@ class StandardAutoscaler:
                 return True
         return False
 
-    def get_unhealthy_nodes(self, nodes: List[NodeID], now: float) -> List[NodeID]:
+    def get_unhealthy_nodes(self, nodes: List[NodeID],
+                            now: float) -> List[NodeID]:
         """Determine nodes for which we haven't received a heartbeat on time.
         These nodes are subsequently terminated.
 

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -204,7 +204,8 @@ class MockProvider(NodeProvider):
             return self.mock_nodes[node_id].state in ["stopped", "terminated"]
 
     def node_tags(self, node_id):
-        # Don't assume that node providers can retrieve tags from terminated nodes.
+        # Don't assume that node providers can retrieve tags from
+        # terminated nodes.
         if self.is_terminated(node_id):
             raise Exception(f"The node with id {node_id} has been terminated!")
         with self.lock:

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -204,6 +204,9 @@ class MockProvider(NodeProvider):
             return self.mock_nodes[node_id].state in ["stopped", "terminated"]
 
     def node_tags(self, node_id):
+        # Don't assume that node providers can retrieve tags from terminated nodes.
+        if self.is_terminated(node_id):
+            raise Exception(f"The node with id {node_id} has been terminated!")
         with self.lock:
             return self.mock_nodes[node_id].tags
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number


Update the node list `nodes` after terminating unhealthy nodes.
-- not updating the `nodes` after terminating unhealthy nodes can cause autoscaler failure at `self.log_legacy_info_string(nodes)`.

Updated `test_autoscaler.py` to raise an error if trying to read tags from a terminated nodes.

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
