### PR TITLE
[Object Spilling] Unpin before updating URL

### DIFF
--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -124,7 +124,7 @@ ObjectManager::ObjectManager(
   pull_manager_.reset(new PullManager(self_node_id_, object_is_local, send_pull_request,
                                       cancel_pull_request, restore_spilled_object_,
                                       get_time, config.pull_timeout_ms, available_memory,
-                                      pin_object));
+                                      pin_object, get_spilled_object_url));
   // Start object manager rpc server and send & receive request threads
   StartRpcService();
 }

--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -25,7 +25,8 @@ PullManager::PullManager(
     const RestoreSpilledObjectCallback restore_spilled_object,
     const std::function<double()> get_time, int pull_timeout_ms,
     int64_t num_bytes_available,
-    std::function<std::unique_ptr<RayObject>(const ObjectID &)> pin_object)
+    std::function<std::unique_ptr<RayObject>(const ObjectID &)> pin_object,
+    std::function<std::string(const ObjectID &)> get_spilled_object_url)
     : self_node_id_(self_node_id),
       object_is_local_(object_is_local),
       send_pull_request_(send_pull_request),
@@ -35,6 +36,7 @@ PullManager::PullManager(
       pull_timeout_ms_(pull_timeout_ms),
       num_bytes_available_(num_bytes_available),
       pin_object_(pin_object),
+      get_spilled_object_url_(get_spilled_object_url),
       gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {}
 
 uint64_t PullManager::Pull(const std::vector<rpc::ObjectReference> &object_ref_bundle,
@@ -459,9 +461,12 @@ void PullManager::TryToMakeObjectLocal(const ObjectID &object_id) {
   }
 
   // If we can restore directly from this raylet, then try to do so.
+  std::string spilled_url = get_spilled_object_url_(object_id);
   bool can_restore_directly =
-      !request.spilled_url.empty() &&
-      (request.spilled_node_id.IsNil() || request.spilled_node_id == self_node_id_);
+      !spilled_url.empty() ||  // If the object is spilled locally
+      (!request.spilled_url.empty() &&
+       request.spilled_node_id
+           .IsNil());  // Or if the object is spilled on external storages.
   if (can_restore_directly) {
     UpdateRetryTimer(request, object_id);
     restore_spilled_object_(object_id, request.spilled_url,

--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -26,7 +26,7 @@ PullManager::PullManager(
     const std::function<double()> get_time, int pull_timeout_ms,
     int64_t num_bytes_available,
     std::function<std::unique_ptr<RayObject>(const ObjectID &)> pin_object,
-    std::function<std::string(const ObjectID &)> get_spilled_object_url)
+    std::function<std::string(const ObjectID &)> get_locally_spilled_object_url)
     : self_node_id_(self_node_id),
       object_is_local_(object_is_local),
       send_pull_request_(send_pull_request),
@@ -36,7 +36,7 @@ PullManager::PullManager(
       pull_timeout_ms_(pull_timeout_ms),
       num_bytes_available_(num_bytes_available),
       pin_object_(pin_object),
-      get_spilled_object_url_(get_spilled_object_url),
+      get_locally_spilled_object_url_(get_locally_spilled_object_url),
       gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {}
 
 uint64_t PullManager::Pull(const std::vector<rpc::ObjectReference> &object_ref_bundle,
@@ -461,7 +461,7 @@ void PullManager::TryToMakeObjectLocal(const ObjectID &object_id) {
   }
 
   // If we can restore directly from this raylet, then try to do so.
-  std::string spilled_url = get_spilled_object_url_(object_id);
+  std::string spilled_url = get_locally_spilled_object_url_(object_id);
   bool can_restore_directly =
       !spilled_url.empty() ||  // If the object is spilled locally
       (!request.spilled_url.empty() &&

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -66,7 +66,8 @@ class PullManager {
       const RestoreSpilledObjectCallback restore_spilled_object,
       const std::function<double()> get_time, int pull_timeout_ms,
       int64_t num_bytes_available,
-      std::function<std::unique_ptr<RayObject>(const ObjectID &object_id)> pin_object);
+      std::function<std::unique_ptr<RayObject>(const ObjectID &object_id)> pin_object,
+      std::function<std::string(const ObjectID &)> get_spilled_object_url);
 
   /// Add a new pull request for a bundle of objects. The objects in the
   /// request will get pulled once:
@@ -357,6 +358,10 @@ class PullManager {
 
   /// The total size of pinned objects.
   int64_t pinned_objects_size_ = 0;
+
+  // A callback to get the spilled object URL if the object is spilled locally.
+  // It will return an empty string otherwise.
+  std::function<std::string(const ObjectID &)> get_spilled_object_url_;
 
   /// Internally maintained random number generator.
   std::mt19937_64 gen_;

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -67,7 +67,7 @@ class PullManager {
       const std::function<double()> get_time, int pull_timeout_ms,
       int64_t num_bytes_available,
       std::function<std::unique_ptr<RayObject>(const ObjectID &object_id)> pin_object,
-      std::function<std::string(const ObjectID &)> get_spilled_object_url);
+      std::function<std::string(const ObjectID &)> get_locally_spilled_object_url);
 
   /// Add a new pull request for a bundle of objects. The objects in the
   /// request will get pulled once:
@@ -361,7 +361,7 @@ class PullManager {
 
   // A callback to get the spilled object URL if the object is spilled locally.
   // It will return an empty string otherwise.
-  std::function<std::string(const ObjectID &)> get_spilled_object_url_;
+  std::function<std::string(const ObjectID &)> get_locally_spilled_object_url_;
 
   /// Internally maintained random number generator.
   std::mt19937_64 gen_;

--- a/src/ray/object_manager/test/pull_manager_test.cc
+++ b/src/ray/object_manager/test/pull_manager_test.cc
@@ -43,7 +43,8 @@ class PullManagerTestWithCapacity {
               restore_object_callback_ = callback;
             },
             [this]() { return fake_time_; }, 10000, num_available_bytes,
-            [this](const ObjectID &object_id) { return PinReturn(); }) {}
+            [this](const ObjectID &object_id) { return PinReturn(); },
+            [this](const ObjectID &object_id) { return GetSpilledObjectURL(); }) {}
 
   void AssertNoLeaks() {
     ASSERT_TRUE(pull_manager_.get_request_bundles_.empty());
@@ -70,6 +71,8 @@ class PullManagerTestWithCapacity {
     }
   }
 
+  std::string GetSpilledObjectURL(const ObjectID &oid) { return spilled_url_[oid]; }
+
   NodeID self_node_id_;
   bool object_is_local_;
   bool allow_pin_ = false;
@@ -79,6 +82,7 @@ class PullManagerTestWithCapacity {
   double fake_time_;
   PullManager pull_manager_;
   std::unordered_map<ObjectID, int> num_abort_calls_;
+  std::unordered_map<ObjectID, std::string> spilled_url_;
 };
 
 class PullManagerTest : public PullManagerTestWithCapacity,

--- a/src/ray/object_manager/test/pull_manager_test.cc
+++ b/src/ray/object_manager/test/pull_manager_test.cc
@@ -45,7 +45,7 @@ class PullManagerTestWithCapacity {
             [this]() { return fake_time_; }, 10000, num_available_bytes,
             [this](const ObjectID &object_id) { return PinReturn(); },
             [this](const ObjectID &object_id) {
-              return GetSpilledObjectURL(object_id);
+              return GetLocalSpilledObjectURL(object_id);
             }) {}
 
   void AssertNoLeaks() {
@@ -73,7 +73,7 @@ class PullManagerTestWithCapacity {
     }
   }
 
-  std::string GetSpilledObjectURL(const ObjectID &oid) { return spilled_url_[oid]; }
+  std::string GetLocalSpilledObjectURL(const ObjectID &oid) { return spilled_url_[oid]; }
 
   void ObjectSpilled(const ObjectID &oid, std::string url) { spilled_url_[oid] = url; }
 

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -270,7 +270,7 @@ void LocalObjectManager::SpillObjectsInternal(
                 RAY_LOG(ERROR) << "Failed to send object spilling request: "
                                << status.ToString();
               } else {
-                AddSpilledUrls(objects_to_spill, r);
+                OnObjectSpilled(objects_to_spill, r);
               }
               if (callback) {
                 callback(status);
@@ -279,9 +279,8 @@ void LocalObjectManager::SpillObjectsInternal(
       });
 }
 
-void LocalObjectManager::AddSpilledUrls(const std::vector<ObjectID> &object_ids,
-                                        const rpc::SpillObjectsReply &worker_reply) {
-  auto num_remaining = std::make_shared<size_t>(object_ids.size());
+void LocalObjectManager::OnObjectSpilled(const std::vector<ObjectID> &object_ids,
+                                         const rpc::SpillObjectsReply &worker_reply) {
   for (size_t i = 0; i < static_cast<size_t>(worker_reply.spilled_objects_url_size());
        ++i) {
     const ObjectID &object_id = object_ids[i];
@@ -344,7 +343,7 @@ void LocalObjectManager::AddSpilledUrls(const std::vector<ObjectID> &object_ids,
   }
 }
 
-std::string LocalObjectManager::GetSpilledObjectURL(const ObjectID &object_id) {
+std::string LocalObjectManager::GetLocalSpilledObjectURL(const ObjectID &object_id) {
   if (!is_external_storage_type_fs_) {
     // If the external storage is cloud storage like S3, returns the empty string.
     // In that case, the URL is supposed to be obtained by OBOD.

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -261,6 +261,7 @@ void LocalObjectManager::SpillObjectsInternal(
                 auto it = objects_pending_spill_.find(object_id);
                 RAY_CHECK(it != objects_pending_spill_.end());
                 pinned_objects_size_ += it->second.first->GetSize();
+                num_bytes_pending_spill_ -= it->second.first->GetSize();
                 pinned_objects_.emplace(object_id, std::move(it->second));
                 objects_pending_spill_.erase(it);
               }
@@ -268,44 +269,18 @@ void LocalObjectManager::SpillObjectsInternal(
               if (!status.ok()) {
                 RAY_LOG(ERROR) << "Failed to send object spilling request: "
                                << status.ToString();
-                if (callback) {
-                  callback(status);
-                }
               } else {
-                AddSpilledUrls(objects_to_spill, r, callback);
+                AddSpilledUrls(objects_to_spill, r);
+              }
+              if (callback) {
+                callback(status);
               }
             });
       });
 }
 
-void LocalObjectManager::UnpinSpilledObjectCallback(
-    const ObjectID &object_id, const std::string &object_url,
-    std::shared_ptr<size_t> num_remaining,
-    std::function<void(const ray::Status &)> callback, ray::Status status) {
-  if (!status.ok()) {
-    RAY_LOG(DEBUG) << "Failed to send spilled url for object " << object_id
-                   << " to object directory, considering the object to have been freed: "
-                   << status.ToString();
-  } else {
-    RAY_LOG(DEBUG) << "Object " << object_id << " spilled to " << object_url
-                   << " and object directory has been informed";
-  }
-  RAY_LOG(DEBUG) << "Unpinning pending spill object " << object_id;
-  // Unpin the object.
-  auto it = objects_pending_spill_.find(object_id);
-  RAY_CHECK(it != objects_pending_spill_.end());
-  num_bytes_pending_spill_ -= it->second.first->GetSize();
-  objects_pending_spill_.erase(it);
-
-  (*num_remaining)--;
-  if (*num_remaining == 0 && callback) {
-    callback(status);
-  }
-}
-
-void LocalObjectManager::AddSpilledUrls(
-    const std::vector<ObjectID> &object_ids, const rpc::SpillObjectsReply &worker_reply,
-    std::function<void(const ray::Status &)> callback) {
+void LocalObjectManager::AddSpilledUrls(const std::vector<ObjectID> &object_ids,
+                                        const rpc::SpillObjectsReply &worker_reply) {
   auto num_remaining = std::make_shared<size_t>(object_ids.size());
   for (size_t i = 0; i < static_cast<size_t>(worker_reply.spilled_objects_url_size());
        ++i) {
@@ -316,17 +291,6 @@ void LocalObjectManager::AddSpilledUrls(
     // don't need to report where this object is spilled.
     const auto node_id_object_spilled =
         is_external_storage_type_fs_ ? self_node_id_ : NodeID::Nil();
-
-    auto it = objects_pending_spill_.find(object_id);
-    RAY_CHECK(it != objects_pending_spill_.end());
-
-    // There are times that restore request comes before the url is added to the object
-    // directory. By adding the spilled url "before" adding it to the object directory, we
-    // can process the restore request before object directory replies.
-    spilled_objects_url_.emplace(object_id, object_url);
-    auto unpin_callback =
-        std::bind(&LocalObjectManager::UnpinSpilledObjectCallback, this, object_id,
-                  object_url, num_remaining, callback, std::placeholders::_1);
 
     // Update the object_id -> url_ref_count to use it for deletion later.
     // We need to track the references here because a single file can contain
@@ -342,21 +306,40 @@ void LocalObjectManager::AddSpilledUrls(
       url_ref_count_[base_url_it->second] += 1;
     }
 
-    // TODO(Clark): Don't send RPC to owner if we're fulfilling an owner-initiated
-    // spill RPC.
+    // Mark that the object is spilled and unpin the pending requests.
+    spilled_objects_url_.emplace(object_id, object_url);
+    RAY_LOG(DEBUG) << "Unpinning pending spill object " << object_id;
+    auto it = objects_pending_spill_.find(object_id);
+    RAY_CHECK(it != objects_pending_spill_.end());
+    const auto object_size = it->second.first->GetSize();
+    const auto worker_addr = it->second.second;
+    num_bytes_pending_spill_ -= object_size;
+    objects_pending_spill_.erase(it);
+
+    // Asynchronously Update the spilled URL.
     rpc::AddSpilledUrlRequest request;
     request.set_object_id(object_id.Binary());
     request.set_spilled_url(object_url);
     request.set_spilled_node_id(node_id_object_spilled.Binary());
-    request.set_size(it->second.first->GetSize());
+    request.set_size(object_size);
 
-    auto owner_client = owner_client_pool_.GetOrConnect(it->second.second);
+    auto owner_client = owner_client_pool_.GetOrConnect(worker_addr);
     RAY_LOG(DEBUG) << "Sending spilled URL " << object_url << " for object " << object_id
-                   << " to owner " << WorkerID::FromBinary(it->second.second.worker_id());
-    // Send spilled URL, spilled node ID, and object size to owner.
+                   << " to owner " << WorkerID::FromBinary(worker_addr.worker_id());
     owner_client->AddSpilledUrl(
-        request, [unpin_callback](Status status, const rpc::AddSpilledUrlReply &reply) {
-          unpin_callback(status);
+        request,
+        [object_id, object_url](Status status, const rpc::AddSpilledUrlReply &reply) {
+          // TODO(sang): Currently we assume there's no network failure. We should handle
+          // it properly.
+          if (!status.ok()) {
+            RAY_LOG(DEBUG)
+                << "Failed to send spilled url for object " << object_id
+                << " to object directory, considering the object to have been freed: "
+                << status.ToString();
+          } else {
+            RAY_LOG(DEBUG) << "Object " << object_id << " spilled to " << object_url
+                           << " and object directory has been informed";
+          }
         });
   }
 }
@@ -427,7 +410,7 @@ void LocalObjectManager::AsyncRestoreSpilledObject(
 
 void LocalObjectManager::ProcessSpilledObjectsDeleteQueue(uint32_t max_batch_size) {
   std::vector<std::string> object_urls_to_delete;
-
+  RAY_LOG(ERROR) << "Sang " << spilled_object_pending_delete_.size();
   // Process upto batch size of objects to delete.
   while (!spilled_object_pending_delete_.empty() &&
          object_urls_to_delete.size() < max_batch_size) {

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -410,7 +410,6 @@ void LocalObjectManager::AsyncRestoreSpilledObject(
 
 void LocalObjectManager::ProcessSpilledObjectsDeleteQueue(uint32_t max_batch_size) {
   std::vector<std::string> object_urls_to_delete;
-  RAY_LOG(ERROR) << "Sang " << spilled_object_pending_delete_.size();
   // Process upto batch size of objects to delete.
   while (!spilled_object_pending_delete_.empty() &&
          object_urls_to_delete.size() < max_batch_size) {

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -345,6 +345,11 @@ void LocalObjectManager::AddSpilledUrls(const std::vector<ObjectID> &object_ids,
 }
 
 std::string LocalObjectManager::GetSpilledObjectURL(const ObjectID &object_id) {
+  if (!is_external_storage_type_fs_) {
+    // If the external storage is cloud storage like S3, returns the empty string.
+    // In that case, the URL is supposed to be obtained by OBOD.
+    return "";
+  }
   auto entry = spilled_objects_url_.find(object_id);
   if (entry != spilled_objects_url_.end()) {
     return entry->second;

--- a/src/ray/raylet/local_object_manager.h
+++ b/src/ray/raylet/local_object_manager.h
@@ -144,7 +144,7 @@ class LocalObjectManager {
   /// or the empty string otherwise.
   /// If the external storage is cloud, this will always return an empty string.
   /// In that case, the URL is supposed to be obtained by the object directory.
-  std::string GetSpilledObjectURL(const ObjectID &object_id);
+  std::string GetLocalSpilledObjectURL(const ObjectID &object_id);
 
   std::string DebugString() const;
 
@@ -171,9 +171,13 @@ class LocalObjectManager {
   /// Release an object that has been freed by its owner.
   void ReleaseFreedObject(const ObjectID &object_id);
 
-  /// Add objects' spilled URLs to the owner's and its' own object directory.
-  void AddSpilledUrls(const std::vector<ObjectID> &object_ids,
-                      const rpc::SpillObjectsReply &worker_reply);
+  /// Do operations that are needed after spilling objects such as
+  /// 1. Unpin the pending spilling object.
+  /// 2. Update the spilled URL to the owner.
+  /// 3. Update the spilled URL to the local directory if it doesn't
+  ///    use the external storages like S3.
+  void OnObjectSpilled(const std::vector<ObjectID> &object_ids,
+                       const rpc::SpillObjectsReply &worker_reply);
 
   /// Delete spilled objects stored in given urls.
   ///

--- a/src/ray/raylet/local_object_manager.h
+++ b/src/ray/raylet/local_object_manager.h
@@ -168,19 +168,9 @@ class LocalObjectManager {
   /// Release an object that has been freed by its owner.
   void ReleaseFreedObject(const ObjectID &object_id);
 
-  // A callback for unpinning spilled objects. This should be invoked after the object
-  // has been spilled and after the object directory has been sent the spilled URL.
-  void UnpinSpilledObjectCallback(const ObjectID &object_id,
-                                  const std::string &object_url,
-                                  std::shared_ptr<size_t> num_remaining,
-                                  std::function<void(const ray::Status &)> callback,
-                                  ray::Status status);
-
-  /// Add objects' spilled URLs to the global object directory. Call the
-  /// callback once all URLs have been added.
+  /// Add objects' spilled URLs to the owner's and its' own object directory.
   void AddSpilledUrls(const std::vector<ObjectID> &object_ids,
-                      const rpc::SpillObjectsReply &worker_reply,
-                      std::function<void(const ray::Status &)> callback);
+                      const rpc::SpillObjectsReply &worker_reply);
 
   /// Delete spilled objects stored in given urls.
   ///

--- a/src/ray/raylet/local_object_manager.h
+++ b/src/ray/raylet/local_object_manager.h
@@ -140,7 +140,10 @@ class LocalObjectManager {
   /// Record object spilling stats to metrics.
   void RecordObjectSpillingStats() const;
 
-  /// Return the spilled object URL or the empty string.
+  /// Return the spilled object URL if the object is spilled locally,
+  /// or the empty string otherwise.
+  /// If the external storage is cloud, this will always return an empty string.
+  /// In that case, the URL is supposed to be obtained by the object directory.
   std::string GetSpilledObjectURL(const ObjectID &object_id);
 
   std::string DebugString() const;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -210,7 +210,7 @@ NodeManager::NodeManager(instrumented_io_context &io_service, const NodeID &self
           },
           /*get_spilled_object_url=*/
           [this](const ObjectID &object_id) {
-            return GetLocalObjectManager().GetSpilledObjectURL(object_id);
+            return GetLocalObjectManager().GetLocalSpilledObjectURL(object_id);
           },
           /*spill_objects_callback=*/
           [this]() {

--- a/src/ray/raylet/test/local_object_manager_test.cc
+++ b/src/ray/raylet/test/local_object_manager_test.cc
@@ -990,13 +990,13 @@ TEST_F(LocalObjectManagerTest, TestDeleteSpillingObjectsBlocking) {
   // Objects are spilled.
   std::vector<ObjectID> spill_set_1;
   std::vector<ObjectID> spill_set_2;
-  int spill_set_1_size = spilled_urls_size / 2;
-  int spill_set_2_size = spilled_urls_size - spill_set_1_size;
+  size_t spill_set_1_size = spilled_urls_size / 2;
+  size_t spill_set_2_size = spilled_urls_size - spill_set_1_size;
 
-  for (int i = 0; i < spill_set_1_size; i++) {
+  for (size_t i = 0; i < spill_set_1_size; i++) {
     spill_set_1.push_back(object_ids[i]);
   }
-  for (int i = spill_set_1_size; i < spilled_urls_size; i++) {
+  for (size_t i = spill_set_1_size; i < spilled_urls_size; i++) {
     spill_set_2.push_back(object_ids[i]);
   }
   manager.SpillObjects(spill_set_1,

--- a/src/ray/raylet/test/local_object_manager_test.cc
+++ b/src/ray/raylet/test/local_object_manager_test.cc
@@ -407,12 +407,12 @@ TEST_F(LocalObjectManagerTest, TestRestoreSpilledObject) {
 
   std::vector<std::string> urls;
   for (size_t i = 0; i < object_ids.size(); i++) {
-    ASSERT_TRUE(manager.GetSpilledObjectURL(object_ids[i]).empty());
+    ASSERT_TRUE(manager.GetLocalSpilledObjectURL(object_ids[i]).empty());
     urls.push_back(BuildURL("url" + std::to_string(i)));
   }
   ASSERT_TRUE(worker_pool.io_worker_client->ReplySpillObjects(urls));
   for (size_t i = 0; i < object_ids.size(); i++) {
-    ASSERT_FALSE(manager.GetSpilledObjectURL(object_ids[i]).empty());
+    ASSERT_FALSE(manager.GetLocalSpilledObjectURL(object_ids[i]).empty());
   }
   for (size_t i = 0; i < object_ids.size(); i++) {
     ASSERT_TRUE(owner_client->ReplyAddSpilledUrl());
@@ -822,9 +822,9 @@ TEST_F(LocalObjectManagerTest, TestPartialSpillError) {
 
   for (size_t i = 0; i < free_objects_batch_size; i++) {
     if (i < urls.size()) {
-      ASSERT_EQ(urls[i], manager.GetSpilledObjectURL(object_ids[i]));
+      ASSERT_EQ(urls[i], manager.GetLocalSpilledObjectURL(object_ids[i]));
     } else {
-      ASSERT_TRUE(manager.GetSpilledObjectURL(object_ids[i]).empty());
+      ASSERT_TRUE(manager.GetLocalSpilledObjectURL(object_ids[i]).empty());
     }
   }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, we unpin objects "after" the spilled object URL is updated to the owner. This is unnecessary because we don't have any logic that needs to happen after the owner updates the spilled URL to unpin the object (it just GC the objects). 

We also found out that when we check if object is restorable from the local raylet, it checks the OBOD state, which can be stale (and it can be more stale after this PR). We fix it by checking the consistent state from local_object_manager directly that provides the correct information. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
