### PR TITLE
[release] Fix e2e environment variable passing from pipeline

### DIFF
--- a/release/.buildkite/build_pipeline.py
+++ b/release/.buildkite/build_pipeline.py
@@ -360,6 +360,7 @@ def build_pipeline(steps):
     RAY_BRANCH = os.environ.get("RAY_BRANCH", "master")
     RAY_REPO = os.environ.get("RAY_REPO",
                               "https://github.com/ray-project/ray.git")
+    RAY_VERSION = os.environ.get("RAY_VERSION", "")
 
     RAY_TEST_BRANCH = os.environ.get("RAY_TEST_BRANCH", RAY_BRANCH)
     RAY_TEST_REPO = os.environ.get("RAY_TEST_REPO", RAY_REPO)
@@ -372,6 +373,7 @@ def build_pipeline(steps):
         f"Ray repo/branch to test:\n"
         f" RAY_REPO   = {RAY_REPO}\n"
         f" RAY_BRANCH = {RAY_BRANCH}\n\n"
+        f" RAY_VERSION = {RAY_VERSION}\n\n"
         f"Ray repo/branch containing the test configurations and scripts:"
         f" RAY_TEST_REPO   = {RAY_TEST_REPO}\n"
         f" RAY_TEST_BRANCH = {RAY_TEST_BRANCH}\n\n"
@@ -393,8 +395,10 @@ def build_pipeline(steps):
 
             logging.info(f"Adding test: {test_base}/{test_name}")
 
-            cmd = str(f"python release/e2e.py "
-                      f"--ray-branch {RAY_BRANCH} "
+            cmd = str(f"RAY_REPO=\"{RAY_REPO}\" "
+                      f"RAY_BRANCH=\"{RAY_BRANCH}\" "
+                      f"RAY_VERSION=\"{RAY_VERSION}\" "
+                      f"python release/e2e.py "
                       f"--category {RAY_BRANCH} "
                       f"--test-config {test_file} "
                       f"--test-name {test_name}")

--- a/release/e2e.py
+++ b/release/e2e.py
@@ -216,7 +216,7 @@ handler.setFormatter(formatter)
 logger.addHandler(handler)
 
 
-def getenv_default(key: str, default: str = ""):
+def getenv_default(key: str, default: Optional[str] = None):
     """Return environment variable with default value"""
     # If the environment variable is set but "", still return default
     return os.environ.get(key, None) or default

--- a/release/e2e.py
+++ b/release/e2e.py
@@ -215,32 +215,39 @@ formatter = logging.Formatter(fmt="[%(levelname)s %(asctime)s] "
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 
+
+def getenv_default(key: str, default: str = ""):
+    """Return environment variable with default value"""
+    # If the environment variable is set but "", still return default
+    return os.environ.get(key, None) or default
+
+
 GLOBAL_CONFIG = {
-    "ANYSCALE_USER": os.environ.get("ANYSCALE_USER",
+    "ANYSCALE_USER": getenv_default("ANYSCALE_USER",
                                     "release-automation@anyscale.com"),
-    "ANYSCALE_HOST": os.environ.get("ANYSCALE_HOST",
+    "ANYSCALE_HOST": getenv_default("ANYSCALE_HOST",
                                     "https://beta.anyscale.com"),
-    "ANYSCALE_CLI_TOKEN": os.environ.get("ANYSCALE_CLI_TOKEN"),
-    "ANYSCALE_CLOUD_ID": os.environ.get(
+    "ANYSCALE_CLI_TOKEN": getenv_default("ANYSCALE_CLI_TOKEN"),
+    "ANYSCALE_CLOUD_ID": getenv_default(
         "ANYSCALE_CLOUD_ID",
         "cld_4F7k8814aZzGG8TNUGPKnc"),  # cld_4F7k8814aZzGG8TNUGPKnc
-    "ANYSCALE_PROJECT": os.environ.get("ANYSCALE_PROJECT", ""),
-    "RAY_VERSION": os.environ.get("RAY_VERSION", "2.0.0.dev0"),
-    "RAY_REPO": os.environ.get("RAY_REPO",
+    "ANYSCALE_PROJECT": getenv_default("ANYSCALE_PROJECT", ""),
+    "RAY_VERSION": getenv_default("RAY_VERSION", "2.0.0.dev0"),
+    "RAY_REPO": getenv_default("RAY_REPO",
                                "https://github.com/ray-project/ray.git"),
-    "RAY_BRANCH": os.environ.get("RAY_BRANCH", "master"),
-    "RELEASE_AWS_BUCKET": os.environ.get("RELEASE_AWS_BUCKET",
+    "RAY_BRANCH": getenv_default("RAY_BRANCH", "master"),
+    "RELEASE_AWS_BUCKET": getenv_default("RELEASE_AWS_BUCKET",
                                          "ray-release-automation-results"),
-    "RELEASE_AWS_LOCATION": os.environ.get("RELEASE_AWS_LOCATION", "dev"),
-    "RELEASE_AWS_DB_NAME": os.environ.get("RELEASE_AWS_DB_NAME", "ray_ci"),
-    "RELEASE_AWS_DB_TABLE": os.environ.get("RELEASE_AWS_DB_TABLE",
+    "RELEASE_AWS_LOCATION": getenv_default("RELEASE_AWS_LOCATION", "dev"),
+    "RELEASE_AWS_DB_NAME": getenv_default("RELEASE_AWS_DB_NAME", "ray_ci"),
+    "RELEASE_AWS_DB_TABLE": getenv_default("RELEASE_AWS_DB_TABLE",
                                            "release_test_result"),
-    "RELEASE_AWS_DB_SECRET_ARN": os.environ.get(
+    "RELEASE_AWS_DB_SECRET_ARN": getenv_default(
         "RELEASE_AWS_DB_SECRET_ARN",
         "arn:aws:secretsmanager:us-west-2:029272617770:secret:"
         "rds-db-credentials/cluster-7RB7EYTTBK2EUC3MMTONYRBJLE/ray_ci-MQN2hh",
     ),
-    "RELEASE_AWS_DB_RESOURCE_ARN": os.environ.get(
+    "RELEASE_AWS_DB_RESOURCE_ARN": getenv_default(
         "RELEASE_AWS_DB_RESOURCE_ARN",
         "arn:aws:rds:us-west-2:029272617770:cluster:ci-reporting",
     ),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently the ray version/branch are not passed from the buildkite input prompts. This PR fixes this.

Previous automatic builds (cronjobs) were not affected by this bug. 

Test build (canceled after confirmed this fix works: https://buildkite.com/ray-project/periodic-ci/builds/848#_)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
