### PR TITLE
[CI][mac] warm up ebs, second try

### DIFF
--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -12,7 +12,9 @@ common: &common
 
 prelude_commands: &prelude_commands |-
   # Warm up ebs to avoid cold start
-  dd if=/dev/sda1 of=/dev/null
+  # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-initialize.html
+  df
+  dd if=/dev/disk2s5  of=/dev/null
   ./ci/travis/upload_build_info.sh
   (which bazel && bazel clean) || true;
   . ./ci/travis/ci.sh init && source ~/.zshrc


### PR DESCRIPTION
so the previous try failed with this failure:
```
dd: /dev/sda1: No such file or directory
```


ideally we want to warm up ebs whenever we provision a mac.
a less ideal way is to write a file at home folder to indicate that the ebs volume has been warmed up so we don't need to rerun it.