### PR TITLE
[Core] revert: revert Unified worker starter

### DIFF
--- a/cpp/src/ray/config_internal.cc
+++ b/cpp/src/ray/config_internal.cc
@@ -48,6 +48,10 @@ ABSL_FLAG(std::string, ray_logs_dir, "", "Logs dir for workers.");
 
 ABSL_FLAG(std::string, ray_node_ip_address, "", "The ip address for this node.");
 
+/// flag serialized_runtime_env is added in setup_runtime_env.py.
+ABSL_FLAG(std::string, serialized_runtime_env, "{}",
+          "The serialized parsed runtime env dict.");
+
 namespace ray {
 namespace internal {
 

--- a/java/test/src/main/java/io/ray/test/WorkerJvmOptionsTest.java
+++ b/java/test/src/main/java/io/ray/test/WorkerJvmOptionsTest.java
@@ -13,6 +13,10 @@ public class WorkerJvmOptionsTest extends BaseTest {
     String getOptions() {
       return System.getProperty("test.suffix");
     }
+
+    String getEnv(String key) {
+      return System.getProperty(key);
+    }
   }
 
   @Test(groups = {"cluster"})
@@ -25,5 +29,8 @@ public class WorkerJvmOptionsTest extends BaseTest {
             .remote();
     ObjectRef<String> obj = actor.task(Echo::getOptions).remote();
     Assert.assertEquals(obj.get(), "suffix");
+    // Auto injected by setup_runtime_env.py
+    ObjectRef<String> env = actor.task(Echo::getEnv, "serialized-runtime-env").remote();
+    Assert.assertEquals(env.get(), "{}");
   }
 }

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1450,6 +1450,8 @@ def start_raylet(redis_address,
     include_java = has_java_command and ray_java_installed
     if include_java is True:
         java_worker_command = build_java_worker_command(
+            setup_worker_path,
+            worker_setup_hook,
             redis_address,
             plasma_store_name,
             raylet_name,
@@ -1462,8 +1464,9 @@ def start_raylet(redis_address,
 
     if os.path.exists(DEFAULT_WORKER_EXECUTABLE):
         cpp_worker_command = build_cpp_worker_command(
-            "", redis_address, plasma_store_name, raylet_name, redis_password,
-            session_dir, log_dir, node_ip_address)
+            "", setup_worker_path, worker_setup_hook, redis_address,
+            plasma_store_name, raylet_name, redis_password, session_dir,
+            log_dir, node_ip_address)
     else:
         cpp_worker_command = []
 
@@ -1471,11 +1474,14 @@ def start_raylet(redis_address,
     # TODO(architkulkarni): Pipe in setup worker args separately instead of
     # inserting them into start_worker_command and later erasing them if
     # needed.
+    python_executable = sys.executable
     start_worker_command = [
-        sys.executable,
+        python_executable,
         setup_worker_path,
         f"--worker-setup-hook={worker_setup_hook}",
         f"--session-dir={session_dir}",
+        f"--worker-entrypoint={python_executable}",
+        "--worker-language=python",
         worker_path,
         f"--node-ip-address={node_ip_address}",
         "--node-manager-port=RAY_NODE_MANAGER_PORT_PLACEHOLDER",
@@ -1609,6 +1615,8 @@ def get_ray_jars_dir():
 
 
 def build_java_worker_command(
+        setup_worker_path,
+        worker_setup_hook,
         redis_address,
         plasma_store_name,
         raylet_name,
@@ -1650,7 +1658,12 @@ def build_java_worker_command(
     pairs.append(("ray.home", RAY_HOME))
     pairs.append(("ray.logging.dir", os.path.join(session_dir, "logs")))
     pairs.append(("ray.session-dir", session_dir))
-    command = ["java"] + ["-D{}={}".format(*pair) for pair in pairs]
+    command = [sys.executable, setup_worker_path]
+    command += [f"--worker-setup-hook={worker_setup_hook}"]
+    command += [f"--session-dir={session_dir}"]
+    command += ["--worker-entrypoint=java"]
+    command += ["--worker-language=java"]
+    command += ["-D{}={}".format(*pair) for pair in pairs]
 
     # Add ray jars path to java classpath
     ray_jars = os.path.join(get_ray_jars_dir(), "*")
@@ -1662,7 +1675,8 @@ def build_java_worker_command(
     return command
 
 
-def build_cpp_worker_command(cpp_worker_options, redis_address,
+def build_cpp_worker_command(cpp_worker_options, setup_worker_path,
+                             worker_setup_hook, redis_address,
                              plasma_store_name, raylet_name, redis_password,
                              session_dir, log_dir, node_ip_address):
     """This method assembles the command used to start a CPP worker.
@@ -1682,7 +1696,12 @@ def build_cpp_worker_command(cpp_worker_options, redis_address,
     """
 
     command = [
-        DEFAULT_WORKER_EXECUTABLE,
+        sys.executable,
+        setup_worker_path,
+        f"--worker-setup-hook={worker_setup_hook}",
+        f"--session-dir={session_dir}",
+        f"--worker-entrypoint={DEFAULT_WORKER_EXECUTABLE}",
+        "--worker-language=cpp",
         f"--ray_plasma_store_socket_name={plasma_store_name}",
         f"--ray_raylet_socket_name={raylet_name}",
         "--ray_node_manager_port=RAY_NODE_MANAGER_PORT_PLACEHOLDER",
@@ -1932,10 +1951,12 @@ def start_ray_client_server(redis_address,
     conda_shim_flag = (
         "--worker-setup-hook=" + ray_constants.DEFAULT_WORKER_SETUP_HOOK)
 
+    python_executable = sys.executable
     command = [
-        sys.executable,
+        python_executable,
         setup_worker_path,
         conda_shim_flag,  # These two args are to use the shim process.
+        f"--worker-entrypoint={python_executable}",
         "-m",
         "ray.util.client.server",
         "--redis-address=" + str(redis_address),

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1490,13 +1490,9 @@ def start_raylet(redis_address,
     ]
     if redis_password:
         start_worker_command_args += [f"--redis-password={redis_password}"]
-    start_worker_command = _wrap_worker_command(setup_worker_path,
-                                                worker_setup_hook,
-                                                session_dir,
-                                                python_executable,
-                                                "python",
-                                                start_worker_command_args
-                                                )
+    start_worker_command = _wrap_worker_command(
+        setup_worker_path, worker_setup_hook, session_dir, python_executable,
+        "python", start_worker_command_args)
 
     # If the object manager port is None, then use 0 to cause the object
     # manager to choose its own port.
@@ -1603,18 +1599,12 @@ def start_raylet(redis_address,
     return process_info
 
 
-def _wrap_worker_command(setup_worker_path,
-                         worker_setup_hook,
-                         session_dir,
-                         worker_entrypoint,
-                         worker_language,
-                         worker_command
-                         ):
+def _wrap_worker_command(setup_worker_path, worker_setup_hook, session_dir,
+                         worker_entrypoint, worker_language, worker_command):
     if sys.platform == "win32":
         return [worker_entrypoint] + worker_command
     wrapped_worker_command = [
-        sys.executable,
-        setup_worker_path,
+        sys.executable, setup_worker_path,
         f"--worker-setup-hook={worker_setup_hook}",
         f"--session-dir={session_dir}",
         f"--worker-entrypoint={worker_entrypoint}",
@@ -1689,12 +1679,8 @@ def build_java_worker_command(
     command_args += ["RAY_WORKER_DYNAMIC_OPTION_PLACEHOLDER"]
     command_args += ["io.ray.runtime.runner.worker.DefaultWorker"]
 
-    return _wrap_worker_command(setup_worker_path,
-                                worker_setup_hook,
-                                session_dir,
-                                "java",
-                                "java",
-                                command_args)
+    return _wrap_worker_command(setup_worker_path, worker_setup_hook,
+                                session_dir, "java", "java", command_args)
 
 
 def build_cpp_worker_command(cpp_worker_options, setup_worker_path,
@@ -1729,11 +1715,8 @@ def build_cpp_worker_command(cpp_worker_options, setup_worker_path,
         "RAY_WORKER_DYNAMIC_OPTION_PLACEHOLDER",
     ]
 
-    return _wrap_worker_command(setup_worker_path,
-                                worker_setup_hook,
-                                session_dir,
-                                DEFAULT_WORKER_EXECUTABLE,
-                                "cpp",
+    return _wrap_worker_command(setup_worker_path, worker_setup_hook,
+                                session_dir, DEFAULT_WORKER_EXECUTABLE, "cpp",
                                 command_args)
 
 

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1475,13 +1475,7 @@ def start_raylet(redis_address,
     # inserting them into start_worker_command and later erasing them if
     # needed.
     python_executable = sys.executable
-    start_worker_command = [
-        python_executable,
-        setup_worker_path,
-        f"--worker-setup-hook={worker_setup_hook}",
-        f"--session-dir={session_dir}",
-        f"--worker-entrypoint={python_executable}",
-        "--worker-language=python",
+    start_worker_command_args = [
         worker_path,
         f"--node-ip-address={node_ip_address}",
         "--node-manager-port=RAY_NODE_MANAGER_PORT_PLACEHOLDER",
@@ -1495,7 +1489,14 @@ def start_raylet(redis_address,
         "RAY_WORKER_DYNAMIC_OPTION_PLACEHOLDER",
     ]
     if redis_password:
-        start_worker_command += [f"--redis-password={redis_password}"]
+        start_worker_command_args += [f"--redis-password={redis_password}"]
+    start_worker_command = _wrap_worker_command(setup_worker_path,
+                                                worker_setup_hook,
+                                                session_dir,
+                                                python_executable,
+                                                "python",
+                                                start_worker_command_args
+                                                )
 
     # If the object manager port is None, then use 0 to cause the object
     # manager to choose its own port.
@@ -1602,6 +1603,27 @@ def start_raylet(redis_address,
     return process_info
 
 
+def _wrap_worker_command(setup_worker_path,
+                         worker_setup_hook,
+                         session_dir,
+                         worker_entrypoint,
+                         worker_language,
+                         worker_command
+                         ):
+    if sys.platform == "win32":
+        return [worker_entrypoint] + worker_command
+    wrapped_worker_command = [
+        sys.executable,
+        setup_worker_path,
+        f"--worker-setup-hook={worker_setup_hook}",
+        f"--session-dir={session_dir}",
+        f"--worker-entrypoint={worker_entrypoint}",
+        f"--worker-language={worker_language}"
+    ]
+    wrapped_worker_command += worker_command
+    return wrapped_worker_command
+
+
 def get_ray_jars_dir():
     """Return a directory where all ray-related jars and
       their dependencies locate."""
@@ -1658,21 +1680,21 @@ def build_java_worker_command(
     pairs.append(("ray.home", RAY_HOME))
     pairs.append(("ray.logging.dir", os.path.join(session_dir, "logs")))
     pairs.append(("ray.session-dir", session_dir))
-    command = [sys.executable, setup_worker_path]
-    command += [f"--worker-setup-hook={worker_setup_hook}"]
-    command += [f"--session-dir={session_dir}"]
-    command += ["--worker-entrypoint=java"]
-    command += ["--worker-language=java"]
-    command += ["-D{}={}".format(*pair) for pair in pairs]
+    command_args = ["-D{}={}".format(*pair) for pair in pairs]
 
     # Add ray jars path to java classpath
     ray_jars = os.path.join(get_ray_jars_dir(), "*")
-    command += ["-cp", ray_jars]
+    command_args += ["-cp", ray_jars]
 
-    command += ["RAY_WORKER_DYNAMIC_OPTION_PLACEHOLDER"]
-    command += ["io.ray.runtime.runner.worker.DefaultWorker"]
+    command_args += ["RAY_WORKER_DYNAMIC_OPTION_PLACEHOLDER"]
+    command_args += ["io.ray.runtime.runner.worker.DefaultWorker"]
 
-    return command
+    return _wrap_worker_command(setup_worker_path,
+                                worker_setup_hook,
+                                session_dir,
+                                "java",
+                                "java",
+                                command_args)
 
 
 def build_cpp_worker_command(cpp_worker_options, setup_worker_path,
@@ -1695,13 +1717,7 @@ def build_cpp_worker_command(cpp_worker_options, setup_worker_path,
         The command string for starting CPP worker.
     """
 
-    command = [
-        sys.executable,
-        setup_worker_path,
-        f"--worker-setup-hook={worker_setup_hook}",
-        f"--session-dir={session_dir}",
-        f"--worker-entrypoint={DEFAULT_WORKER_EXECUTABLE}",
-        "--worker-language=cpp",
+    command_args = [
         f"--ray_plasma_store_socket_name={plasma_store_name}",
         f"--ray_raylet_socket_name={raylet_name}",
         "--ray_node_manager_port=RAY_NODE_MANAGER_PORT_PLACEHOLDER",
@@ -1713,7 +1729,12 @@ def build_cpp_worker_command(cpp_worker_options, setup_worker_path,
         "RAY_WORKER_DYNAMIC_OPTION_PLACEHOLDER",
     ]
 
-    return command
+    return _wrap_worker_command(setup_worker_path,
+                                worker_setup_hook,
+                                session_dir,
+                                DEFAULT_WORKER_EXECUTABLE,
+                                "cpp",
+                                command_args)
 
 
 def determine_plasma_store_config(object_store_memory,

--- a/python/ray/tests/mock_setup_worker.py
+++ b/python/ray/tests/mock_setup_worker.py
@@ -30,10 +30,22 @@ parser.add_argument(
 parser.add_argument(
     "--session-dir", type=str, help="the directory for the current session")
 
+parser.add_argument(
+    "--worker-entrypoint",
+    type=str,
+    help="the worker entrypoint: python,java etc. ")
+
+parser.add_argument(
+    "--worker-language",
+    type=str,
+    help="the worker entrypoint: python,java,cpp etc.")
+
 args, remaining_args = parser.parse_known_args()
 
 # add worker-shim-pid argument
 remaining_args.append("--worker-shim-pid={}".format(os.getpid()))
+env_vars = {"worker-shim-pid": str(os.getpid())}
+os.environ.update(env_vars)
 py_executable: str = sys.executable
 command_str = " ".join([f"exec {py_executable}"] + remaining_args)
 child_pid = os.fork()

--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -69,7 +69,7 @@ py_test(
 
 py_test(
     name = "test_convergence",
-    size = "medium",
+    size = "large",
     srcs = ["tests/test_convergence.py"],
     deps = [":tune_lib"],
     tags = ["team:ml", "exclusive"],

--- a/python/ray/workers/setup_runtime_env.py
+++ b/python/ray/workers/setup_runtime_env.py
@@ -26,6 +26,16 @@ logger = logging.getLogger(__name__)
 parser = argparse.ArgumentParser()
 
 parser.add_argument(
+    "--worker-entrypoint",
+    type=str,
+    help="the worker entrypoint: python,java etc. ")
+
+parser.add_argument(
+    "--worker-language",
+    type=str,
+    help="the worker entrypoint: python,java,cpp etc.")
+
+parser.add_argument(
     "--serialized-runtime-env",
     type=str,
     help="the serialized parsed runtime env dict")
@@ -139,7 +149,8 @@ def setup_worker(input_args):
     args, remaining_args = parser.parse_known_args(args=input_args)
 
     commands = []
-    py_executable: str = sys.executable
+    worker_executable: str = args.worker_entrypoint
+    worker_language: str = args.worker_language
     runtime_env: dict = json.loads(args.serialized_runtime_env or "{}")
     runtime_env_context: RuntimeEnvContext = None
 
@@ -154,7 +165,7 @@ def setup_worker(input_args):
 
     # activate conda
     if runtime_env_context and runtime_env_context.conda_env_name:
-        py_executable = "python"
+        worker_executable = "python"
         conda_activate_commands = get_conda_activate_commands(
             runtime_env_context.conda_env_name)
         if (conda_activate_commands):
@@ -166,14 +177,29 @@ def setup_worker(input_args):
             "the context %s.", args.serialized_runtime_env,
             args.serialized_runtime_env_context)
 
-    commands += [
-        " ".join(
-            [f"exec {py_executable}"] + remaining_args +
-            # Pass the runtime for working_dir setup.
-            # We can't do it in shim process here because it requires
-            # connection to gcs.
-            ["--serialized-runtime-env", f"'{args.serialized_runtime_env}'"])
-    ]
+    worker_command = [f"exec {worker_executable}"]
+    if worker_language == "java":
+        # Java worker don't parse the command parameters, add option.
+        remaining_args.insert(
+            len(remaining_args) - 1, "-D{}={}".format(
+                "serialized-runtime-env", f"'{args.serialized_runtime_env}'"))
+        worker_command += remaining_args
+    elif worker_language == "cpp":
+        worker_command += remaining_args
+        # cpp worker flags must use underscore
+        worker_command += [
+            "--serialized_runtime_env", f"'{args.serialized_runtime_env}'"
+        ]
+    else:
+        worker_command += remaining_args
+        # Pass the runtime for working_dir setup.
+        # We can't do it in shim process here because it requires
+        # connection to gcs.
+        worker_command += [
+            "--serialized-runtime-env", f"'{args.serialized_runtime_env}'"
+        ]
+
+    commands += [" ".join(worker_command)]
     command_separator = " && "
     command_str = command_separator.join(commands)
 
@@ -181,6 +207,7 @@ def setup_worker(input_args):
     if runtime_env.get("env_vars"):
         env_vars = runtime_env["env_vars"]
         os.environ.update(env_vars)
+
     os.execvp("bash", ["bash", "-c", command_str])
 
 

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -327,15 +327,6 @@ Process WorkerPool::StartWorkerProcess(
       // Allocated_resource_json is only used in "shim process".
       worker_command_args.push_back("--allocated-instances-serialized-json=" +
                                     allocated_instances_serialized_json);
-    } else {
-      // The "shim process" setup worker is not needed, so do not run it.
-      // Check that the arg really is the path to the setup worker before erasing it, to
-      // prevent breaking tests that mock out the worker command args.
-      if (worker_command_args.size() >= 4 &&
-          worker_command_args[1].find(kSetupWorkerFilename) != std::string::npos) {
-        worker_command_args.erase(worker_command_args.begin() + 1,
-                                  worker_command_args.begin() + 4);
-      }
     }
 
     worker_command_args.push_back("--runtime-env-hash=" +


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Use setup_worker.py as an language independent worker initiators, so all worker can use runtime_env in the future.

revert: revert #17401

For now, I disable runtime env on windows in the change.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
