### PR TITLE
[core] fix typo of actor repr

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -955,7 +955,7 @@ class ActorHandle:
     def __repr__(self):
         return ("Actor("
                 f"{self._ray_actor_creation_function_descriptor.class_name}, "
-                f"{self._actor_id.hex()}")
+                f"{self._actor_id.hex()})")
 
     @property
     def _actor_id(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Before this PR:
```
Actor(Actor, e8d028fd1fe740cf1d7bbe3f01000000
```

After this PR
```
Actor(Actor, e8d028fd1fe740cf1d7bbe3f01000000)
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
