### PR TITLE
[Tune] Fix local mode. Add explicit concurrency limiter for local mode.

### DIFF
--- a/python/ray/tune/session.py
+++ b/python/ray/tune/session.py
@@ -49,7 +49,9 @@ def init(reporter, ignore_reinit_error=True):
             "A Tune session already exists in the current process. "
             "If you are using ray.init(local_mode=True), "
             "you must set ray.init(..., num_cpus=1, num_gpus=1) to limit "
-            "available concurrency.")
+            "available concurrency. If you are supplying a wrapped "
+            "Searcher(concurrency, repeating) or customized SearchAlgo. Please"
+            " try limiting the concurrency to 1 there.")
         if ignore_reinit_error:
             logger.warning(reinit_msg)
             return

--- a/python/ray/tune/session.py
+++ b/python/ray/tune/session.py
@@ -50,8 +50,8 @@ def init(reporter, ignore_reinit_error=True):
             "If you are using ray.init(local_mode=True), "
             "you must set ray.init(..., num_cpus=1, num_gpus=1) to limit "
             "available concurrency. If you are supplying a wrapped "
-            "Searcher(concurrency, repeating) or customized SearchAlgo. Please"
-            " try limiting the concurrency to 1 there.")
+            "Searcher(concurrency, repeating) or customized SearchAlgo. "
+            "Please try limiting the concurrency to 1 there.")
         if ignore_reinit_error:
             logger.warning(reinit_msg)
             return

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -22,7 +22,7 @@ from ray.tune.registry import get_trainable_cls
 from ray.tune.stopper import Stopper
 from ray.tune.suggest import BasicVariantGenerator, SearchAlgorithm, \
     SearchGenerator
-from ray.tune.suggest.suggestion import Searcher
+from ray.tune.suggest.suggestion import ConcurrencyLimiter, Searcher
 from ray.tune.suggest.variant_generator import has_unresolved_values
 from ray.tune.syncer import SyncConfig, set_sync_periods, wait_for_sync
 from ray.tune.trainable import Trainable
@@ -434,6 +434,11 @@ def run(
         from ray.tune.suggest import create_searcher
         search_alg = create_searcher(search_alg)
 
+    # if local_mode=True is set during ray.init().
+    is_local_mode = ray.worker._mode() == ray.worker.LOCAL_MODE
+    if search_alg and is_local_mode:
+        search_alg = ConcurrencyLimiter(search_alg, max_concurrent=1)
+
     if isinstance(scheduler, str):
         # importing at top level causes a recursive dependency
         from ray.tune.schedulers import create_scheduler
@@ -443,7 +448,8 @@ def run(
         search_alg = SearchGenerator(search_alg)
 
     if not search_alg:
-        search_alg = BasicVariantGenerator()
+        search_alg = BasicVariantGenerator(
+            max_concurrent=1 if is_local_mode else 0)
 
     if config and not search_alg.set_search_properties(metric, mode, config):
         if has_unresolved_values(config):


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This doesn't fix serialization issue. Local mode(supplied with serializable training
function or not) is broken since the beginning of time.

It was broken because Tune incorrectly relies on PG group to be its concurrency
limiter while PG group is just blindly returning ready().

Tested by:
Applied the patch to an original failing local_mode=True workflow and fixed it.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
