### PR TITLE
[Serve][Hotfix] Skip get_deployment on windows

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -162,6 +162,7 @@ test_python() {
       -python/ray/tests:test_failure
       -python/ray/tests:test_failure_2
       -python/ray/tests:test_gcs_fault_tolerance # flaky
+      -python/ray/serve:test_get_deployment # address violation
       -python/ray/tests:test_global_gc
       -python/ray/tests:test_job
       -python/ray/tests:test_memstat


### PR DESCRIPTION
get_deployment is somehow flaky on windows. It seems to recover but flaky rate has gone up. 
![image](https://user-images.githubusercontent.com/21118851/130543643-6dd3d80a-f1fe-46d9-9a5a-68db165fe239.png)
