### PR TITLE
[Tune] Make single process mode work.

### DIFF
--- a/python/ray/tune/experiment.py
+++ b/python/ray/tune/experiment.py
@@ -127,8 +127,10 @@ class Experiment:
                  checkpoint_score_attr=None,
                  export_formats=None,
                  max_failures=0,
-                 restore=None):
+                 restore=None,
+                 is_single_process=False):
 
+        self._is_single_process = is_single_process
         if loggers is not None:
             # Most users won't run into this as `tune.run()` does not pass
             # the argument anymore. However, we will want to inform users
@@ -153,7 +155,8 @@ class Experiment:
                     "'checkpoint_freq' cannot be used with a "
                     "checkpointable function. You can specify checkpoints "
                     "within your trainable function.")
-        self._run_identifier = Experiment.register_if_needed(run)
+        self._run_identifier = Experiment.register_if_needed(
+            run, is_single_process=self._is_single_process)
         self.name = name or self._run_identifier
 
         # If the name has been set explicitly, we don't want to create
@@ -263,7 +266,7 @@ class Experiment:
         return exp
 
     @classmethod
-    def register_if_needed(cls, run_object):
+    def register_if_needed(cls, run_object, is_single_process=False):
         """Registers Trainable or Function at runtime.
 
         Assumes already registered if run_object is a string.
@@ -299,7 +302,8 @@ class Experiment:
                 logger.warning(
                     "No name detected on trainable. Using {}.".format(name))
             try:
-                register_trainable(name, run_object)
+                register_trainable(
+                    name, run_object, is_single_process=is_single_process)
             except (TypeError, PicklingError) as e:
                 extra_msg = ("Other options: "
                              "\n-Try reproducing the issue by calling "

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -212,6 +212,7 @@ class TrialRunner:
                  metric=None):
         self._search_alg = search_alg or BasicVariantGenerator()
         self._scheduler_alg = scheduler or FIFOScheduler()
+        # TODO(xwjiang): choose different executor based on local_mode.
         self.trial_executor = trial_executor or RayTrialExecutor()
         self._pending_trial_queue_times = {}
 
@@ -557,6 +558,7 @@ class TrialRunner:
                 num_pending_trials += 1
 
         # Update status of staged placement groups
+        # TODO(xwjiang): Figure out what's the implication of this step in single process mode.
         self.trial_executor.stage_and_update_status(self._live_trials)
 
         def _start_trial(trial: Trial) -> bool:

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -290,7 +290,8 @@ def run(
     Raises:
         TuneError: Any trials failed and `raise_on_failed_trial` is True.
     """
-
+    # TODO(xwjiang): Pass in through Tune.run args.
+    is_single_process = bool(os.environ.get("IS_SINGLE_PROCESS", 0))
     if _remote is None:
         _remote = ray.util.client.ray.is_connected()
 
@@ -417,7 +418,8 @@ def run(
                 checkpoint_score_attr=checkpoint_score_attr,
                 export_formats=export_formats,
                 max_failures=max_failures,
-                restore=restore)
+                restore=restore,
+                is_single_process=is_single_process)
     else:
         logger.debug("Ignoring some parameters passed into tune.run.")
 
@@ -443,7 +445,7 @@ def run(
         search_alg = SearchGenerator(search_alg)
 
     if not search_alg:
-        search_alg = BasicVariantGenerator()
+        search_alg = BasicVariantGenerator(max_concurrent=1)
 
     if config and not search_alg.set_search_properties(metric, mode, config):
         if has_unresolved_values(config):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
So that serialization issues can be avoided. This mode is intended for beginner users.
Put up this PR to gather some early feedbacks and then more thoughts would be put into how to structure Tune's code.

Notes for reviewers:
1. single_process_mode != local_mode. In local_mode, we still use GCS store to put and get "remote" functions(which requires serialization), although Ray Tune is only running on single process. single_process_mode doesn't require serialization. Maybe better name can be used here.
2. One goal is to limit code divergence as much as possible. So we still keep the notion of event loop in trial runner. The only difference is every function is pretty much synchronous. Every .remote() call is replaced with a local function call and direct result is obtained instead of obj_ref.
3. There is a notion of local function registry, instead of global one (registry.py). Local function registry doesn't require serialization.
4. I am looking for some good driver code to test different code paths, e.g. different searcher/scheduler so that .save() etc can be exercised. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
