### PR TITLE
[CI] Fix mac test by increasing timeout

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -65,7 +65,6 @@ py_test_module_list(
 py_test_module_list(
   files = [
     "test_memory_scheduling.py",
-    "test_plasma_unlimited.py",
     "test_metrics.py",
     "test_multi_node.py",
     "test_multi_node_2.py",
@@ -160,6 +159,7 @@ py_test_module_list(
     "test_failure_2.py",
     "test_failure_4.py",
     "test_object_spilling.py",
+    "test_plasma_unlimited.py",
   ],
   size = "large",
   extra_srcs = SRCS,

--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -439,9 +439,13 @@ async def test_spill_during_get(object_spilling_config, shutdown_only,
             obj = ray.get(x)
         print(obj.shape)
         del obj
+
+    # In CI, Mac.metal suffers from EBS code start problem. Increase
+    # the timeout to 90.
+    timeout_seconds = 90 if platform.system() == "Darwin" else 30
     duration = datetime.now() - start
     assert duration <= timedelta(
-        seconds=30
+        seconds=timeout_seconds
     ), "Concurrent gets took too long. Maybe IO workers are not started properly."  # noqa: E501
     assert_no_thrashing(address["redis_address"])
 


### PR DESCRIPTION
there are two mac tests affected by ebs cold start. 

- test_spill_during_get takes [50+ seconds to finish.](https://buildkite.com/ray-project/ray-builders-branch/builds/3013#53577f6e-92d6-43c7-9980-fe44cb7e283f/906-2067)
- test_plasma_unlimited takes more than [300 seconds](https://buildkite.com/ray-project/ray-builders-branch/builds/2990#c15b1646-2c42-4f1d-bacd-40bab97d6a76/579-768) (which exceeds limit of medium size tests) to finish.

we fix the issue by increasing the test timeout for both. specifically we 

- increase the timeout to 90 seconds for test_spill_during_get 
- and move test_plasma_unlimited to large size of test.