### PR TITLE
Fix new serve api to retrive endpoints in benchmark

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -3,6 +3,7 @@
 py_library(
     name = "serve_lib",
     srcs = glob(["**/*.py"], exclude=["tests/**/*.py"]),
+    visibility = ["//python/ray/serve:__subpackages__", "//release:__pkg__"],
 )
 
 serve_tests_srcs = glob(["tests/**/*.py"])

--- a/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
@@ -144,7 +144,10 @@ def main(num_replicas: Optional[int], num_deployments: Optional[int],
 
     logger.info("Warming up cluster ....\n")
     rst_ray_refs = []
-    for endpoint in serve.list_endpoints().keys():
+    all_endpoints = list(
+        ray.get(serve_client._controller.get_all_endpoints.remote()).keys())
+
+    for endpoint in all_endpoints:
         rst_ray_refs.append(
             warm_up_one_cluster.options(num_cpus=0.1).remote(
                 10, http_host, http_port, endpoint))
@@ -154,7 +157,6 @@ def main(num_replicas: Optional[int], num_deployments: Optional[int],
     logger.info(f"Starting wrk trial on all nodes for {trial_length} ....\n")
     # For detailed discussion, see https://github.com/wg/wrk/issues/205
     # TODO:(jiaodong) What's the best number to use here ?
-    all_endpoints = list(serve.list_endpoints().keys())
     all_metrics, all_wrk_stdout = run_wrk_on_all_nodes(
         trial_length,
         NUM_CONNECTIONS,

--- a/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
@@ -144,9 +144,7 @@ def main(num_replicas: Optional[int], num_deployments: Optional[int],
 
     logger.info("Warming up cluster ....\n")
     rst_ray_refs = []
-    all_endpoints = list(
-        ray.get(serve_client._controller.get_all_endpoints.remote()).keys())
-
+    all_endpoints = list(serve.list_deployments().keys())
     for endpoint in all_endpoints:
         rst_ray_refs.append(
             warm_up_one_cluster.options(num_cpus=0.1).remote(

--- a/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
@@ -29,8 +29,8 @@ import click
 import math
 import os
 import random
-import ray
 
+import ray
 from ray import serve
 from ray.serve.utils import logger
 from serve_test_utils import (
@@ -48,8 +48,8 @@ from serve_test_cluster_utils import (
 from typing import Optional
 
 # Experiment configs
-DEFAULT_SMOKE_TEST_NUM_REPLICA = 8
-DEFAULT_SMOKE_TEST_NUM_DEPLOYMENTS = 4  # 2 replicas each
+DEFAULT_SMOKE_TEST_NUM_REPLICA = 4
+DEFAULT_SMOKE_TEST_NUM_DEPLOYMENTS = 4  # 1 replicas each
 
 # TODO:(jiaodong) We should investigate and change this back to 1k
 # for now, we won't get valid latency numbers from wrk at 1k replica
@@ -176,3 +176,6 @@ def main(num_replicas: Optional[int], num_deployments: Optional[int],
 
 if __name__ == "__main__":
     main()
+    import pytest
+    import sys
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
@@ -46,7 +46,7 @@ from serve_test_cluster_utils import (
 from typing import Optional
 
 # Experiment configs
-DEFAULT_SMOKE_TEST_NUM_REPLICA = 8
+DEFAULT_SMOKE_TEST_NUM_REPLICA = 4
 DEFAULT_FULL_TEST_NUM_REPLICA = 1000
 
 # Deployment configs
@@ -142,3 +142,6 @@ def main(num_replicas: Optional[int], trial_length: Optional[str],
 
 if __name__ == "__main__":
     main()
+    import pytest
+    import sys
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
@@ -29,6 +29,7 @@ import json
 import math
 import os
 
+import ray
 from ray import serve
 from ray.serve.utils import logger
 from serve_test_utils import (
@@ -120,7 +121,9 @@ def main(num_replicas: Optional[int], trial_length: Optional[str],
     logger.info(f"Starting wrk trial on all nodes for {trial_length} ....\n")
     # For detailed discussion, see https://github.com/wg/wrk/issues/205
     # TODO:(jiaodong) What's the best number to use here ?
-    all_endpoints = list(serve.list_endpoints().keys())
+    all_endpoints = list(
+        ray.get(serve_client._controller.get_all_endpoints.remote()).keys())
+
     all_metrics, all_wrk_stdout = run_wrk_on_all_nodes(
         trial_length,
         NUM_CONNECTIONS,

--- a/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
@@ -29,7 +29,6 @@ import json
 import math
 import os
 
-import ray
 from ray import serve
 from ray.serve.utils import logger
 from serve_test_utils import (
@@ -121,9 +120,7 @@ def main(num_replicas: Optional[int], trial_length: Optional[str],
     logger.info(f"Starting wrk trial on all nodes for {trial_length} ....\n")
     # For detailed discussion, see https://github.com/wg/wrk/issues/205
     # TODO:(jiaodong) What's the best number to use here ?
-    all_endpoints = list(
-        ray.get(serve_client._controller.get_all_endpoints.remote()).keys())
-
+    all_endpoints = list(serve.list_deployments().keys())
     all_metrics, all_wrk_stdout = run_wrk_on_all_nodes(
         trial_length,
         NUM_CONNECTIONS,


### PR DESCRIPTION
## Why are these changes needed?

Current benchmark is broken on master since `list_endpoints` API is gone in serve's init. 

## Test plan

locally execute both single and multi deployment and ensure they pass.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
