### PR TITLE
[CI][Windows] fix windows test failures

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -142,7 +142,6 @@ test_python() {
       -python/ray/serve:test_api # segfault on windows? https://github.com/ray-project/ray/issues/12541
       -python/ray/serve:test_router # timeout
       -python/ray/serve:test_handle # "fatal error" (?) https://github.com/ray-project/ray/pull/13695
-      -python/ray/serve:test_backend_worker # memory error
       -python/ray/serve:test_controller_crashes # timeout
       -python/ray/tests:test_actor_advanced # timeout
       -python/ray/tests:test_actor_failures # flaky


### PR DESCRIPTION
https://github.com/ray-project/ray/runs/3415136989 windows test all passes but still reports failures.
```
Executed 123 out of 123 tests: 123 tests pass.
All tests passed but there were other errors during the build.
```

 Looks it is due to this error: 
```
(20:31:22) DEBUG: bazel/ray_deps_setup.bzl:66:14: No implicit mirrors used because urls were explicitly provided
(20:31:23) ERROR: Skipping 'python/ray/serve:test_backend_worker': no such target '//python/ray/serve:test_backend_worker': target 'test_backend_worker' not declared in package 'python/ray/serve' defined by D:/a/ray/ray/python/ray/serve/BUILD
```

looks `python/ray/serve:test_backend_worker` has been removed in this commit #17989
