### PR TITLE
[Nightly test] Fix a nightly dask on ray test

### DIFF
--- a/release/nightly_tests/dask_on_ray/dask_on_ray_sort.py
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_sort.py
@@ -126,8 +126,8 @@ def trial(client,
         #                      max_branch=float("inf")).compute(
         #                          _ray_enable_progress_bar=True).head(10))
         print(
-            df.set_index("a", shuffle="tasks",
-                         max_branch=float("inf")).compute().head(10))
+            df.set_index("a", shuffle="tasks", max_branch=float("inf")).head(
+                10, npartitions=-1))
 
         trial_end = time.time()
         duration = trial_end - trial_start


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We call .compute which brings 1 TB of data to the driver. This seems to be the root cause of failure now

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
