### PR TITLE
[Core][spilled-object-lost bug] better error message on spilled object lost

### DIFF
--- a/python/ray/external_storage.py
+++ b/python/ray/external_storage.py
@@ -126,7 +126,12 @@ class ExternalStorage(metaclass=abc.ABCMeta):
             address_len = len(owner_address)
             metadata_len = len(metadata)
             if buf is None:
-                raise ValueError(f"object ref {ref.hex()} does not exist.")
+                error = f"object ref {ref.hex()} does not exist."
+                # empty data and 1 byte metadata, this object is
+                # marked as failed.
+                if metadata_len == 1:
+                    error += " This is probably since its owner has failed."
+                raise ValueError(error)
             buf_len = len(buf)
             payload = address_len.to_bytes(8, byteorder="little") + \
                 metadata_len.to_bytes(8, byteorder="little") + \

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -710,7 +710,7 @@ bool PlasmaStore::IsObjectSpillable(const ObjectID &object_id) {
     // Object already evicted or deleted.
     return false;
   }
-  return entry->GetRefCount() == 1;
+  return entry->Sealed() && entry->GetRefCount() == 1;
 }
 
 void PlasmaStore::PrintDebugDump() const {


### PR DESCRIPTION
For #17901 it's evident that the object lost is caused by owner failure:

- the exception throw at [external_storage.py](https://sourcegraph.com/github.com/ray-project/ray/-/blob/python/ray/external_storage.py?L129) indicates the object metadata is not empty but data is null. This could only happen if an object is [MarkObjectsAsFailed](https://sourcegraph.com/github.com/ray-project/ray/-/blob/src/ray/raylet/node_manager.cc?L1703:19), which in turn is caused by owner failure.
- for those cluster this exception happened, actually we found[ logs](https://gist.github.com/scv119/924821568cf3841e05e433038163f6bd#file-gistfile1-txt-L4621) indicating some worker node was marked as dead error message, right before this object spilling error like following
```
Reduce Progress.:   0%|          | 0/1000 [03:52<?, ?it/s][A2021-08-16 05:17:24,945	WARNING worker.py:1215 -- The node with node id: 97c6e7131f6247a550adf6e6c7c4a54fcbe90f7ea14564cedae429eb and ip: 172.31.106.230 has been marked dead because the detector has missed too many heartbeats from it. This can happen when a raylet crashes unexpectedly or has lagging heartbeats.

Map Progress.:  24%|██▍       | 242/1000 [04:00<36:48,  2.91s/it]

Reduce Progress.:   0%|          | 0/1000 [58:47<?, ?it/s][A

Reduce Progress.:   0%|          | 0/1000 [58:56<?, ?it/s][A2021-08-16 06:12:29,396	WARNING worker.py:1215 -- Traceback (most recent call last):
  File "python/ray/_raylet.pyx", line 730, in ray._raylet.spill_objects_handler
  File "python/ray/_raylet.pyx", line 733, in ray._raylet.spill_objects_handler
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/external_storage.py", line 524, in spill_objects
    return _external_storage.spill_objects(object_refs, owner_addresses)
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/external_storage.py", line 280, in spill_objects
    owner_addresses, url)
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/external_storage.py", line 129, in _write_multiple_objects
    raise ValueError(f"object ref {ref.hex()} does not exist.")
ValueError: object ref 3e63a51020b5b425ffffffffffffffffffffffff01000000aa020000 does not exist.
An unexpected internal error occurred while the IO worker was spilling objects: object ref 3e63a51020b5b425ffffffffffffffffffffffff01000000aa020000 does not exist.
2
```

So the error message could be more precise, 
- and we should fix the OBOD thrift overloaded/fault tolerance issue instead.
- or could it be the raylet actually crashed?