### PR TITLE
[RLlib] Fix `final_scale`'s default value to 0.02 (OrnsteinUhlenbeck exploration).

### DIFF
--- a/rllib/agents/ddpg/ddpg.py
+++ b/rllib/agents/ddpg/ddpg.py
@@ -77,7 +77,7 @@ DEFAULT_CONFIG = with_common_config({
         # The initial noise scaling factor.
         "initial_scale": 1.0,
         # The final noise scaling factor.
-        "final_scale": 1.0,
+        "final_scale": 0.02,
         # Timesteps over which to anneal scale (from initial to final values).
         "scale_timesteps": 10000,
     },


### PR DESCRIPTION

Fix `final_scale`'s default value to 0.02 (OrnsteinUhlenbeck exploration).
This parameter had the wrong default value since the introduction of the exploration API in spring 2020.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
