### PR TITLE
[Core][ObjectRef] Change default to not record call stack during ObjectRef creation

### DIFF
--- a/dashboard/memory_utils.py
+++ b/dashboard/memory_utils.py
@@ -432,7 +432,7 @@ entries per group...\n\n\n"
             if size > line_wrap_threshold and line_wrap:
                 call_site_length = 22
                 if len(entry["call_site"]) == 0:
-                    entry["call_site"] = ["?"]
+                    entry["call_site"] = ["disabled"]
                 else:
                     entry["call_site"] = [
                         entry["call_site"][i:i + call_site_length] for i in

--- a/dashboard/memory_utils.py
+++ b/dashboard/memory_utils.py
@@ -394,7 +394,7 @@ def memory_summary(state,
 | {:<4} | {:<14} | {:<10}\n"
 
     if size > line_wrap_threshold and line_wrap:
-        object_ref_string = "{:<12}  {:<5}  {:<6}  {:<22}  {:<6}  {:<18}  \
+        object_ref_string = "{:<15}  {:<5}  {:<6}  {:<22}  {:<6}  {:<18}  \
 {:<56}\n"
 
     mem += f"Grouping by {group_by}...\
@@ -406,12 +406,11 @@ entries per group...\n\n\n"
         # Group summary
         summary = group["summary"]
         ref_size = track_reference_size(group)
-        for key in summary:
-            if key == "total_object_size":
-                summary[key] = str(summary[key] / units[unit]) + f" {unit}"
+        for k, v in summary.items():
+            if k == "total_object_size":
+                summary[k] = str(v / units[unit]) + f" {unit}"
             else:
-                summary[key] = str(
-                    summary[key]) + f", ({ref_size[key] / units[unit]} {unit})"
+                summary[k] = str(v) + f", ({ref_size[k] / units[unit]} {unit})"
         mem += f"--- Summary for {group_by}: {key} ---\n"
         mem += summary_string\
             .format(*summary_labels)
@@ -432,10 +431,13 @@ entries per group...\n\n\n"
             num_lines = 1
             if size > line_wrap_threshold and line_wrap:
                 call_site_length = 22
-                entry["call_site"] = [
-                    entry["call_site"][i:i + call_site_length] for i in range(
-                        0, len(entry["call_site"]), call_site_length)
-                ]
+                if len(entry["call_site"]) == 0:
+                    entry["call_site"] = ["?"]
+                else:
+                    entry["call_site"] = [
+                        entry["call_site"][i:i + call_site_length] for i in
+                        range(0, len(entry["call_site"]), call_site_length)
+                    ]
                 num_lines = len(entry["call_site"])
             else:
                 mem += "\n"
@@ -455,5 +457,8 @@ entries per group...\n\n\n"
                     .format(*row)
             mem += "\n"
             n += 1
-        mem += "\n\n"
+
+    mem += "To record callsite information for each ObjectRef created, set " \
+           "env variable RAY_record_ref_creation_sites=1\n\n"
+
     return mem

--- a/python/ray/_private/ray_microbenchmark_helpers.py
+++ b/python/ray/_private/ray_microbenchmark_helpers.py
@@ -15,18 +15,22 @@ def timeit(name, fn, multiplier=1) -> List[Optional[Tuple[str, float, float]]]:
     if filter_pattern not in name:
         return [None]
     # warmup
-    start = time.time()
-    while time.time() - start < 1:
+    start = time.perf_counter()
+    count = 0
+    while time.perf_counter() - start < 1:
         fn()
+        count += 1
     # real run
+    step = count // 10 + 1
     stats = []
     for _ in range(4):
-        start = time.time()
+        start = time.perf_counter()
         count = 0
-        while time.time() - start < 2:
-            fn()
-            count += 1
-        end = time.time()
+        while time.perf_counter() - start < 2:
+            for _ in range(step):
+                fn()
+            count += step
+        end = time.perf_counter()
         stats.append(multiplier * count / (end - start))
 
     mean = np.mean(stats)

--- a/python/ray/_private/ray_perf.py
+++ b/python/ray/_private/ray_perf.py
@@ -69,6 +69,14 @@ def small_value_batch(n):
     return 0
 
 
+@ray.remote
+def create_object_containing_ref():
+    obj_refs = []
+    for _ in range(10000):
+        obj_refs.append(ray.put(1))
+    return obj_refs
+
+
 def check_optimized_build():
     if not ray._raylet.OPTIMIZED:
         msg = ("WARNING: Unoptimized build! "
@@ -139,6 +147,14 @@ def main(results=None):
         ray.get([do_put.remote() for _ in range(10)])
 
     results += timeit("multi client put gigabytes", put_multi, 10 * 8 * 0.1)
+
+    obj_containing_ref = create_object_containing_ref.remote()
+
+    def get_containing_object_ref():
+        ray.get(obj_containing_ref)
+
+    results += timeit("single client get object containing 10k refs",
+                      get_containing_object_ref)
 
     def small_task():
         ray.get(small_value.remote())

--- a/python/ray/tests/test_memstat.py
+++ b/python/ray/tests/test_memstat.py
@@ -1,4 +1,5 @@
 import numpy as np
+import os
 import time
 
 import pytest
@@ -233,7 +234,11 @@ def test_pinned_object_call_site(ray_start_regular):
 
 
 def test_multi_node_stats(shutdown_only):
-    cluster = Cluster(head_node_args={"_system_config": ray_config})
+    # NOTE(mwtian): using env var only enables the feature on workers, while
+    # using head_node_args={"_system_config": ray_config} only enables the
+    # feature on the driver.
+    os.environ["RAY_record_ref_creation_sites"] = "1"
+    cluster = Cluster()
     for _ in range(2):
         cluster.add_node(num_cpus=1)
 

--- a/python/ray/tests/test_memstat.py
+++ b/python/ray/tests/test_memstat.py
@@ -63,6 +63,10 @@ def count(memory_str, substr):
     return n
 
 
+@pytest.mark.parametrize(
+    "ray_start_regular", [{
+        "_system_config": ray_config
+    }], indirect=True)
 def test_driver_put_ref(ray_start_regular):
     address = ray_start_regular["redis_address"]
     info = memory_summary(address)
@@ -173,6 +177,10 @@ def test_actor_task_refs(ray_start_regular):
     assert num_objects(info) == 0, info
 
 
+@pytest.mark.parametrize(
+    "ray_start_regular", [{
+        "_system_config": ray_config
+    }], indirect=True)
 def test_nested_object_refs(ray_start_regular):
     address = ray_start_regular["redis_address"]
     x_id = ray.put(np.zeros(100000))
@@ -187,6 +195,10 @@ def test_nested_object_refs(ray_start_regular):
     del z_id
 
 
+@pytest.mark.parametrize(
+    "ray_start_regular", [{
+        "_system_config": ray_config
+    }], indirect=True)
 def test_pinned_object_call_site(ray_start_regular):
     address = ray_start_regular["redis_address"]
     # Local ref only.
@@ -221,7 +233,7 @@ def test_pinned_object_call_site(ray_start_regular):
 
 
 def test_multi_node_stats(shutdown_only):
-    cluster = Cluster()
+    cluster = Cluster(head_node_args={"_system_config": ray_config})
     for _ in range(2):
         cluster.add_node(num_cpus=1)
 
@@ -247,6 +259,10 @@ def test_multi_node_stats(shutdown_only):
     assert count(info, PUT_OBJ) == 2, info
 
 
+@pytest.mark.parametrize(
+    "ray_start_regular", [{
+        "_system_config": ray_config
+    }], indirect=True)
 def test_group_by_sort_by(ray_start_regular):
     address = ray_start_regular["redis_address"]
 
@@ -273,6 +289,10 @@ def test_group_by_sort_by(ray_start_regular):
     assert count(info_c, PID) == 1, info_c
 
 
+@pytest.mark.parametrize(
+    "ray_start_regular", [{
+        "_system_config": ray_config
+    }], indirect=True)
 def test_memory_used_output(ray_start_regular):
     address = ray_start_regular["redis_address"]
     import numpy as np

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -61,9 +61,9 @@ RAY_CONFIG(uint64_t, raylet_report_resources_period_milliseconds, 100)
 RAY_CONFIG(uint64_t, num_resource_report_periods_warning, 5)
 
 /// Whether to record the creation sites of object references. This adds more
-/// information to `ray memstat`, but introduces a little extra overhead when
-/// creating object references.
-RAY_CONFIG(bool, record_ref_creation_sites, true)
+/// information to `ray memory`, but introduces a little extra overhead when
+/// creating object references (e.g. 5~10 microsec per call in Python).
+RAY_CONFIG(bool, record_ref_creation_sites, false)
 
 /// Objects that have been unpinned are
 /// added to a local cache. When the cache is flushed, all objects in the cache

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -63,6 +63,7 @@ RAY_CONFIG(uint64_t, num_resource_report_periods_warning, 5)
 /// Whether to record the creation sites of object references. This adds more
 /// information to `ray memory`, but introduces a little extra overhead when
 /// creating object references (e.g. 5~10 microsec per call in Python).
+/// TODO: maybe group this under RAY_DEBUG.
 RAY_CONFIG(bool, record_ref_creation_sites, false)
 
 /// Objects that have been unpinned are


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Recording call stack is 40~50% of CPU overhead for `ObjectRef` creation in Python ([profile](https://gist.github.com/mwtian/c73d7918c4d4a82429ad2c3939a96d27)). I wonder if we should make the feature default to false, and ask user to enable it before running `ray memory`. We can also use sampling or passing call site constants to optimize this. Another more limited change is to cache the call site just for contained object refs (#17882).

On `m5.8xlarge`, before this change:
```
single client get calls per second 35931.41 +- 209.84
single client put calls per second 35649.72 +- 84.53
multi client put calls per second 181739.57 +- 1654.46
single client get calls (Plasma Store) per second 10330.02 +- 211.09
single client put calls (Plasma Store) per second 6384.16 +- 23.45
multi client put calls (Plasma Store) per second 8295.33 +- 88.54
single client put gigabytes per second 20.78 +- 8.12
multi client put gigabytes per second 31.96 +- 3.78
single client get object containing 10k refs per second 6.53 +- 0.01
single client tasks sync per second 2002.61 +- 20.43
single client tasks async per second 14710.71 +- 284.48
multi client tasks async per second 38890.68 +- 500.38
1:1 actor calls sync per second 3297.3 +- 89.64
1:1 actor calls async per second 7181.34 +- 19.17
1:1 actor calls concurrent per second 6352.96 +- 41.57
1:n actor calls async per second 19833.41 +- 71.79
n:n actor calls async per second 46055.91 +- 6647.68
n:n actor calls with arg async per second 7162.26 +- 41.88
1:1 async-actor calls sync per second 2219.81 +- 61.12
1:1 async-actor calls async per second 4645.55 +- 51.89
1:1 async-actor calls with args async per second 3074.96 +- 65.11
1:n async-actor calls async per second 16257.97 +- 88.73
n:n async-actor calls async per second 29373.27 +- 2132.39
```

After this change:
```
single client get calls per second 34963.26 +- 116.83
single client put calls per second 62930.59 +- 451.86
multi client put calls per second 238268.13 +- 2668.02
single client get calls (Plasma Store) per second 11528.71 +- 59.86
single client put calls (Plasma Store) per second 6817.38 +- 151.37
multi client put calls (Plasma Store) per second 8280.51 +- 56.15
single client put gigabytes per second 20.92 +- 6.2
multi client put gigabytes per second 32.56 +- 3.88
single client get object containing 10k refs per second 16.7 +- 0.02
single client tasks sync per second 2052.0 +- 64.46
single client tasks async per second 18896.4 +- 110.65
multi client tasks async per second 38944.39 +- 540.41
1:1 actor calls sync per second 3417.26 +- 31.38
1:1 actor calls async per second 7113.32 +- 94.16
1:1 actor calls concurrent per second 6380.13 +- 64.04
1:n actor calls async per second 20064.44 +- 117.48
n:n actor calls async per second 46639.69 +- 6856.08
n:n actor calls with arg async per second 6974.33 +- 25.07
1:1 async-actor calls sync per second 2283.84 +- 29.82
1:1 async-actor calls async per second 4619.38 +- 107.56
1:1 async-actor calls with args async per second 3100.14 +- 44.4
1:n async-actor calls async per second 17291.48 +- 175.33
n:n async-actor calls async per second 29663.23 +- 1660.87
```

`single client put calls` and `single client get object containing 10k refs` show 80~150% increase in ops/sec.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#17803 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
