### PR TITLE
[serve] Remove unused HTTP method metadata & matching

### DIFF
--- a/python/ray/serve/common.py
+++ b/python/ray/serve/common.py
@@ -17,7 +17,6 @@ Duration = float
 
 @dataclass
 class EndpointInfo:
-    http_methods: List[str]
     python_methods: Optional[List[str]] = field(default_factory=list)
     route: Optional[str] = None
 

--- a/python/ray/serve/constants.py
+++ b/python/ray/serve/constants.py
@@ -38,13 +38,6 @@ DEFAULT_LATENCY_BUCKET_MS = [
 #: Name of backend reconfiguration method implemented by user.
 BACKEND_RECONFIGURE_METHOD = "reconfigure"
 
-#: All defined HTTP methods.
-# https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
-ALL_HTTP_METHODS = [
-    "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE",
-    "PATCH"
-]
-
 SERVE_ROOT_URL_ENV_KEY = "RAY_SERVE_ROOT_URL"
 
 #: Number of historically deleted deployments to store in the checkpoint.

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -19,7 +19,6 @@ from ray.serve.common import (
     ReplicaTag,
 )
 from ray.serve.config import BackendConfig, HTTPOptions, ReplicaConfig
-from ray.serve.constants import ALL_HTTP_METHODS
 from ray.serve.endpoint_state import EndpointState
 from ray.serve.http_state import HTTPState
 from ray.serve.storage.kv_store import RayInternalKVStore
@@ -229,9 +228,7 @@ class ServeController:
             goal_id, updating = self.backend_state.deploy_backend(
                 name, backend_info)
             endpoint_info = EndpointInfo(
-                ALL_HTTP_METHODS,
-                route=route_prefix,
-                python_methods=python_methods)
+                route=route_prefix, python_methods=python_methods)
             self.endpoint_state.update_endpoint(name, endpoint_info)
             return goal_id, updating
 

--- a/python/ray/serve/endpoint_state.py
+++ b/python/ray/serve/endpoint_state.py
@@ -80,7 +80,6 @@ class EndpointState:
         for endpoint, info in self._endpoints.items():
             endpoints[endpoint] = {
                 "route": info.route,
-                "methods": info.http_methods,
                 "python_methods": info.python_methods,
             }
         return endpoints

--- a/python/ray/serve/tests/test_http_prefix_matching.py
+++ b/python/ray/serve/tests/test_http_prefix_matching.py
@@ -14,101 +14,81 @@ def mock_longest_prefix_router() -> LongestPrefixRouter:
 
 def test_no_match(mock_longest_prefix_router):
     router = mock_longest_prefix_router
-    router.update_routes({"endpoint": EndpointInfo({"POST"}, route="/hello")})
-    route, handle = router.match_route("/nonexistent", "POST")
+    router.update_routes({"endpoint": EndpointInfo(route="/hello")})
+    route, handle = router.match_route("/nonexistent")
     assert route is None and handle is None
 
 
 def test_default_route(mock_longest_prefix_router):
     router = mock_longest_prefix_router
-    router.update_routes({"endpoint": EndpointInfo({"POST"})})
+    router.update_routes({"endpoint": EndpointInfo()})
 
-    route, handle = router.match_route("/nonexistent", "POST")
+    route, handle = router.match_route("/nonexistent")
     assert route is None and handle is None
 
-    route, handle = router.match_route("/endpoint", "POST")
+    route, handle = router.match_route("/endpoint")
     assert route == "/endpoint" and handle == "endpoint"
 
 
 def test_trailing_slash(mock_longest_prefix_router):
     router = mock_longest_prefix_router
     router.update_routes({
-        "endpoint": EndpointInfo({"POST"}, route="/test"),
+        "endpoint": EndpointInfo(route="/test"),
     })
 
-    route, handle = router.match_route("/test/", "POST")
+    route, handle = router.match_route("/test/")
     assert route == "/test" and handle == "endpoint"
 
     router.update_routes({
-        "endpoint": EndpointInfo({"POST"}, route="/test/"),
+        "endpoint": EndpointInfo(route="/test/"),
     })
 
-    route, handle = router.match_route("/test", "POST")
+    route, handle = router.match_route("/test")
     assert route is None and handle is None
 
 
 def test_prefix_match(mock_longest_prefix_router):
     router = mock_longest_prefix_router
     router.update_routes({
-        "endpoint1": EndpointInfo({"POST"}, route="/test/test2"),
-        "endpoint2": EndpointInfo({"POST"}, route="/test"),
-        "endpoint3": EndpointInfo({"POST"}, route="/"),
+        "endpoint1": EndpointInfo(route="/test/test2"),
+        "endpoint2": EndpointInfo(route="/test"),
+        "endpoint3": EndpointInfo(route="/"),
     })
 
-    route, handle = router.match_route("/test/test2/subpath", "POST")
+    route, handle = router.match_route("/test/test2/subpath")
     assert route == "/test/test2" and handle == "endpoint1"
-    route, handle = router.match_route("/test/test2/", "POST")
+    route, handle = router.match_route("/test/test2/")
     assert route == "/test/test2" and handle == "endpoint1"
-    route, handle = router.match_route("/test/test2", "POST")
+    route, handle = router.match_route("/test/test2")
     assert route == "/test/test2" and handle == "endpoint1"
 
-    route, handle = router.match_route("/test/subpath", "POST")
+    route, handle = router.match_route("/test/subpath")
     assert route == "/test" and handle == "endpoint2"
-    route, handle = router.match_route("/test/", "POST")
+    route, handle = router.match_route("/test/")
     assert route == "/test" and handle == "endpoint2"
-    route, handle = router.match_route("/test", "POST")
+    route, handle = router.match_route("/test")
     assert route == "/test" and handle == "endpoint2"
 
-    route, handle = router.match_route("/test2", "POST")
+    route, handle = router.match_route("/test2")
     assert route == "/" and handle == "endpoint3"
-    route, handle = router.match_route("/", "POST")
+    route, handle = router.match_route("/")
     assert route == "/" and handle == "endpoint3"
 
 
 def test_update_routes(mock_longest_prefix_router):
     router = mock_longest_prefix_router
-    router.update_routes({"endpoint": EndpointInfo({"POST"})})
+    router.update_routes({"endpoint": EndpointInfo()})
 
-    route, handle = router.match_route("/endpoint", "POST")
+    route, handle = router.match_route("/endpoint")
     assert route == "/endpoint" and handle == "endpoint"
 
-    router.update_routes({"endpoint2": EndpointInfo({"POST"})})
+    router.update_routes({"endpoint2": EndpointInfo()})
 
-    route, handle = router.match_route("/endpoint", "POST")
+    route, handle = router.match_route("/endpoint")
     assert route is None and handle is None
 
-    route, handle = router.match_route("/endpoint2", "POST")
+    route, handle = router.match_route("/endpoint2")
     assert route == "/endpoint2" and handle == "endpoint2"
-
-
-def test_match_method(mock_longest_prefix_router):
-    router = mock_longest_prefix_router
-    router.update_routes({
-        "endpoint": EndpointInfo({"POST", "GET"}, route="/test"),
-        "endpoint2": EndpointInfo({"PATCH"}, route="/")
-    })
-
-    route, handle = router.match_route("/test", "POST")
-    assert route == "/test" and handle == "endpoint"
-
-    route, handle = router.match_route("/test", "GET")
-    assert route == "/test" and handle == "endpoint"
-
-    route, handle = router.match_route("/test", "PATCH")
-    assert route == "/" and handle == "endpoint2"
-
-    route, handle = router.match_route("/test", "OPTIONS")
-    assert route is None and handle is None
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_http_routes.py
+++ b/python/ray/serve/tests/test_http_routes.py
@@ -7,7 +7,6 @@ import requests
 from starlette.responses import RedirectResponse
 
 from ray import serve
-from ray.serve.constants import ALL_HTTP_METHODS
 
 
 def test_path_validation(serve_instance):
@@ -59,16 +58,16 @@ def test_routes_endpoint(serve_instance):
 
     assert len(routes) == 2, routes
     assert "/D1" in routes, routes
-    assert routes["/D1"] == ["D1", ALL_HTTP_METHODS], routes
+    assert routes["/D1"] == "D1", routes
     assert "/hello/world" in routes, routes
-    assert routes["/hello/world"] == ["D2", ALL_HTTP_METHODS], routes
+    assert routes["/hello/world"] == "D2", routes
 
     D1.delete()
 
     routes = requests.get("http://localhost:8000/-/routes").json()
     assert len(routes) == 1, routes
     assert "/hello/world" in routes, routes
-    assert routes["/hello/world"] == ["D2", ALL_HTTP_METHODS], routes
+    assert routes["/hello/world"] == "D2", routes
 
     D2.delete()
     routes = requests.get("http://localhost:8000/-/routes").json()
@@ -86,7 +85,7 @@ def test_routes_endpoint(serve_instance):
     routes = requests.get("http://localhost:8000/-/routes").json()
     assert len(routes) == 1, routes
     assert "/hello" in routes, routes
-    assert routes["/hello"] == ["D3", ALL_HTTP_METHODS], routes
+    assert routes["/hello"] == "D3", routes
 
 
 def test_deployment_options_default_route(serve_instance):
@@ -99,16 +98,16 @@ def test_deployment_options_default_route(serve_instance):
     routes = requests.get("http://localhost:8000/-/routes").json()
     assert len(routes) == 1
     assert "/1" in routes, routes
-    assert routes["/1"] == ["1", ALL_HTTP_METHODS]
+    assert routes["/1"] == "1"
 
     D1.options(name="2").deploy()
 
     routes = requests.get("http://localhost:8000/-/routes").json()
     assert len(routes) == 2
     assert "/1" in routes, routes
-    assert routes["/1"] == ["1", ALL_HTTP_METHODS]
+    assert routes["/1"] == "1"
     assert "/2" in routes, routes
-    assert routes["/2"] == ["2", ALL_HTTP_METHODS]
+    assert routes["/2"] == "2"
 
 
 def test_path_prefixing(serve_instance):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is now deferred to user code (or to FastAPI if using the integration).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
