### PR TITLE
[Datasets] Add pyarrow minimum version check.

### DIFF
--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from ray.data.impl.block_builder import BlockBuilder
 
 from ray.util.annotations import DeveloperAPI
+from ray.data.impl.util import _check_pyarrow_version
 
 T = TypeVar("T")
 
@@ -112,6 +113,7 @@ class BlockAccessor(Generic[T]):
     @staticmethod
     def for_block(block: Block) -> "BlockAccessor[T]":
         """Create a block accessor for the given block."""
+        _check_pyarrow_version()
         import pyarrow
 
         if isinstance(block, pyarrow.Table):

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -9,6 +9,7 @@ from ray.data.block import Block, BlockAccessor, \
     BlockMetadata, T
 from ray.data.impl.arrow_block import ArrowRow
 from ray.util.annotations import PublicAPI
+from ray.data.impl.util import _check_pyarrow_version
 
 WriteResult = Any
 
@@ -161,6 +162,7 @@ class RangeDatasource(Datasource[Union[ArrowRow, int]]):
         while i < n:
             count = min(block_size, n - i)
             if block_format == "arrow":
+                _check_pyarrow_version()
                 import pyarrow
                 schema = pyarrow.Table.from_pydict({"value": [0]}).schema
             elif block_format == "tensor":

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -9,6 +9,7 @@ from ray.data.impl.arrow_block import (ArrowRow, DelegatingArrowBlockBuilder)
 from ray.data.impl.block_list import BlockMetadata
 from ray.data.datasource.datasource import Datasource, ReadTask
 from ray.util.annotations import DeveloperAPI
+from ray.data.impl.util import _check_pyarrow_version
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,7 @@ class FileBasedDatasource(Datasource[Union[ArrowRow, Any]]):
             **reader_args) -> List[ReadTask]:
         """Creates and returns read tasks for a file-based datasource.
         """
+        _check_pyarrow_version()
         import pyarrow as pa
         import numpy as np
 

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -4,11 +4,12 @@ from typing import Optional, List, Union, TYPE_CHECKING
 if TYPE_CHECKING:
     import pyarrow
 
-from ray.data.impl.arrow_block import ArrowRow
-from ray.data.impl.block_list import BlockMetadata
 from ray.data.datasource.datasource import Datasource, ReadTask
 from ray.data.datasource.file_based_datasource import (
     _resolve_paths_and_filesystem)
+from ray.data.impl.arrow_block import ArrowRow
+from ray.data.impl.block_list import BlockMetadata
+from ray.data.impl.util import _check_pyarrow_version
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,7 @@ class ParquetDatasource(Datasource[ArrowRow]):
             **reader_args) -> List[ReadTask]:
         """Creates and returns read tasks for a file-based datasource.
         """
+        _check_pyarrow_version()
         from ray import cloudpickle
         import pyarrow.parquet as pq
         import numpy as np

--- a/python/ray/data/impl/util.py
+++ b/python/ray/data/impl/util.py
@@ -1,0 +1,30 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+MIN_PYARROW_VERSION = (4, 0, 1)
+_VERSION_VALIDATED = False
+
+
+def _check_pyarrow_version():
+    global _VERSION_VALIDATED
+    if not _VERSION_VALIDATED:
+        import pkg_resources
+        try:
+            version_info = pkg_resources.require("pyarrow")
+            version = tuple(int(n) for n in version_info[0].version.split("."))
+            if version < MIN_PYARROW_VERSION:
+                raise ImportError(
+                    "You are using an old, incompatible version of pyarrow, "
+                    "please use version "
+                    f"{'.'.join(str(n) for n in MIN_PYARROW_VERSION)} or "
+                    "higher by e.g. running pip install -U pyarrow")
+        except pkg_resources.DistributionNotFound:
+            logger.warning("You are using the 'pyarrow' module, but "
+                           "the exact version is unknown (possibly carried as "
+                           "an internal component by another module). Please "
+                           "make sure you are using pyarrow >= "
+                           f"{'.'.join(str(n) for n in MIN_PYARROW_VERSION)} "
+                           "to ensure compatibility with Ray Datasets.")
+        else:
+            _VERSION_VALIDATED = True

--- a/python/ray/data/impl/util.py
+++ b/python/ray/data/impl/util.py
@@ -12,13 +12,14 @@ def _check_pyarrow_version():
         import pkg_resources
         try:
             version_info = pkg_resources.require("pyarrow")
-            version = tuple(int(n) for n in version_info[0].version.split("."))
+            version_str = version_info[0].version
+            version = tuple(int(n) for n in version_str.split("."))
             if version < MIN_PYARROW_VERSION:
                 raise ImportError(
-                    "You are using an old, incompatible version of pyarrow, "
-                    "please use version "
-                    f"{'.'.join(str(n) for n in MIN_PYARROW_VERSION)} or "
-                    "higher by e.g. running pip install -U pyarrow")
+                    "Datasets requires pyarrow >= "
+                    f"{'.'.join(str(n) for n in MIN_PYARROW_VERSION)}, "
+                    f"but {version_str} is installed. Upgrade with "
+                    "`pip install -U pyarrow`.")
         except pkg_resources.DistributionNotFound:
             logger.warning("You are using the 'pyarrow' module, but "
                            "the exact version is unknown (possibly carried as "


### PR DESCRIPTION
Adds a lazy pyarrow minimum version check for 4.0.1 or above. The check was added to all of the source paths that I could find, and `BlockAccessor.for_block()` for additional coverage.

## Example error

```python
[3] ds = ray.data.range_arrow(10)
ImportError                               Traceback (most recent call last)
<ipython-input-3-1eb77f3c8059> in <module>
----> 1 ds = ray.data.range_arrow(10)

/mnt/data/workspace/ray2/python/ray/data/read_api.py in range_arrow(n, parallelism)
    100     """
    101     return read_datasource(
--> 102         RangeDatasource(), parallelism=parallelism, n=n, block_format="arrow")
    103
    104

/mnt/data/workspace/ray2/python/ray/data/read_api.py in read_datasource(datasource, parallelism, ray_remote_args, **read_args)
    149     """
    150
--> 151     read_tasks = datasource.prepare_read(parallelism, **read_args)
    152
    153     def remote_read(task: ReadTask) -> Block:

/mnt/data/workspace/ray2/python/ray/data/datasource/datasource.py in prepare_read(self, parallelism, n, block_format, tensor_shape)
    163             count = min(block_size, n - i)
    164             if block_format == "arrow":
--> 165                 _check_pyarrow_version()
    166                 import pyarrow
    167                 schema = pyarrow.Table.from_pydict({"value": [0]}).schema

/mnt/data/workspace/ray2/python/ray/data/impl/util.py in _check_pyarrow_version()
     16             if version < MIN_PYARROW_VERSION:
     17                 raise ImportError(
---> 18                     "You are using an old, incompatible version of Pyarrow, "
     19                     "please use version "
     20                     f"{'.'.join(str(n) for n in MIN_PYARROW_VERSION)} or "

ImportError: You are using an old, incompatible version of pyarrow, please use version 4.0.1 or higher by e.g. running pip install -U pyarrow
```

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #17759 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
