### PR TITLE
[Serve] [doc] Add model URI to deployment example

### DIFF
--- a/doc/source/serve/ml-models.rst
+++ b/doc/source/serve/ml-models.rst
@@ -90,7 +90,8 @@ class will allow you to load a model using its MLflow `Model URI`:
           df = pd.read_csv(csv_text)
           return self.model.predict(df)
 
-  MLflowDeployment.deploy()
+  model_uri = "model:/my_registered_model/Production"
+  MLflowDeployment.deploy(model_uri)
 
 .. tip:: 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
The example was missing an init argument for the model URI.
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
