### PR TITLE
[Datasets] Add pyarrow filesystem test coverage for Parquet reading.

### DIFF
--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -451,15 +451,21 @@ def test_fsspec_filesystem(ray_start_regular_shared, tmp_path):
     assert ds.count() == 6
 
 
-def test_parquet_read(ray_start_regular_shared, tmp_path):
+@pytest.mark.parametrize(
+    "fs,data_path", [(None, lazy_fixture("local_path")),
+                     (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+                     (lazy_fixture("s3_fs"), lazy_fixture("s3_path"))])
+def test_parquet_read(ray_start_regular_shared, fs, data_path):
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
     table = pa.Table.from_pandas(df1)
-    pq.write_table(table, os.path.join(str(tmp_path), "test1.parquet"))
+    path1 = os.path.join(_unwrap_protocol(data_path), "test1.parquet")
+    pq.write_table(table, path1, filesystem=fs)
     df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
     table = pa.Table.from_pandas(df2)
-    pq.write_table(table, os.path.join(str(tmp_path), "test2.parquet"))
+    path2 = os.path.join(_unwrap_protocol(data_path), "test2.parquet")
+    pq.write_table(table, path2, filesystem=fs)
 
-    ds = ray.data.read_parquet(str(tmp_path))
+    ds = ray.data.read_parquet(data_path, filesystem=fs)
 
     # Test metadata-only parquet ops.
     assert len(ds._blocks._blocks) == 1
@@ -485,12 +491,16 @@ def test_parquet_read(ray_start_regular_shared, tmp_path):
                               [6, "g"]]
 
     # Test column selection.
-    ds = ray.data.read_parquet(str(tmp_path), columns=["one"])
+    ds = ray.data.read_parquet(data_path, columns=["one"], filesystem=fs)
     values = [s["one"] for s in ds.take()]
     assert sorted(values) == [1, 2, 3, 4, 5, 6]
 
 
-def test_parquet_read_partitioned(ray_start_regular_shared, tmp_path):
+@pytest.mark.parametrize(
+    "fs,data_path", [(None, lazy_fixture("local_path")),
+                     (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+                     (lazy_fixture("s3_fs"), lazy_fixture("s3_path"))])
+def test_parquet_read_partitioned(ray_start_regular_shared, fs, data_path):
     df = pd.DataFrame({
         "one": [1, 1, 1, 3, 3, 3],
         "two": ["a", "b", "c", "e", "f", "g"]
@@ -498,13 +508,12 @@ def test_parquet_read_partitioned(ray_start_regular_shared, tmp_path):
     table = pa.Table.from_pandas(df)
     pq.write_to_dataset(
         table,
-        root_path=str(tmp_path),
+        root_path=_unwrap_protocol(data_path),
         partition_cols=["one"],
+        filesystem=fs,
         use_legacy_dataset=False)
-    pq_ds = pq.ParquetDataset(str(tmp_path), use_legacy_dataset=False)
-    print(pq_ds.read().to_pandas())
 
-    ds = ray.data.read_parquet(str(tmp_path))
+    ds = ray.data.read_parquet(data_path, filesystem=fs)
 
     # Test metadata-only parquet ops.
     assert len(ds._blocks._blocks) == 1
@@ -530,7 +539,7 @@ def test_parquet_read_partitioned(ray_start_regular_shared, tmp_path):
                               [3, "g"]]
 
     # Test column selection.
-    ds = ray.data.read_parquet(str(tmp_path), columns=["one"])
+    ds = ray.data.read_parquet(data_path, columns=["one"], filesystem=fs)
     values = [s["one"] for s in ds.take()]
     assert sorted(values) == [1, 1, 1, 3, 3, 3]
 


### PR DESCRIPTION
Covers both `test_parquet_read` and `test_parquet_read_partitioned`.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #17725 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
