### PR TITLE
[runtime_env] Better error message for working_dirs that exceed the max size

### DIFF
--- a/python/ray/_private/runtime_env.py
+++ b/python/ray/_private/runtime_env.py
@@ -26,7 +26,8 @@ PKG_DIR = None
 
 logger = logging.getLogger(__name__)
 
-FILE_SIZE_WARNING = 10 * 1024 * 1024  # 10MB
+FILE_SIZE_WARNING = 10 * 1024 * 1024  # 10MiB
+GCS_STORAGE_MAX_SIZE = 512 * 1024 * 1024  # 512MiB
 
 
 class RuntimeEnvDict:
@@ -473,6 +474,12 @@ def fetch_package(pkg_uri: str) -> int:
 
 
 def _store_package_in_gcs(gcs_key: str, data: bytes) -> int:
+    if len(data) > GCS_STORAGE_MAX_SIZE:
+        raise RuntimeError(
+            "working_dir package exceeds the maximum size of 512MiB. You "
+            "can exclude large files using the 'excludes' option to the "
+            "runtime_env.")
+
     _internal_kv_put(gcs_key, data)
     return len(data)
 

--- a/python/ray/_private/runtime_env.py
+++ b/python/ray/_private/runtime_env.py
@@ -474,7 +474,7 @@ def fetch_package(pkg_uri: str) -> int:
 
 
 def _store_package_in_gcs(gcs_key: str, data: bytes) -> int:
-    if len(data) > GCS_STORAGE_MAX_SIZE:
+    if len(data) >= GCS_STORAGE_MAX_SIZE:
         raise RuntimeError(
             "working_dir package exceeds the maximum size of 512MiB. You "
             "can exclude large files using the 'excludes' option to the "

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -897,6 +897,51 @@ def test_no_spurious_worker_startup(ray_start_cluster):
         time.sleep(0.1)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
+def test_large_file_boundary(shutdown_only):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        old_dir = os.getcwd()
+        os.chdir(tmp_dir)
+
+        # Check that packages just under the max size work as expected.
+        size = ray._private.runtime_env.GCS_STORAGE_MAX_SIZE - 1024 * 1024
+        with open("test_file", "wb") as f:
+            f.write(os.urandom(size))
+
+        ray.init(runtime_env={"working_dir": "."})
+
+        @ray.remote
+        class Test:
+            def get_size(self):
+                with open("test_file", "rb") as f:
+                    return len(f.read())
+
+        t = Test.remote()
+        assert ray.get(t.get_size.remote()) == size
+        os.chdir(old_dir)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
+def test_large_file_error(shutdown_only):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        old_dir = os.getcwd()
+        os.chdir(tmp_dir)
+
+        # Write to two separate files, each of which is below the threshold to
+        # make sure the error is for the full package size.
+        size = ray._private.runtime_env.GCS_STORAGE_MAX_SIZE // 2 + 1
+        with open("test_file_1", "wb") as f:
+            f.write(os.urandom(size))
+
+        with open("test_file_2", "wb") as f:
+            f.write(os.urandom(size))
+
+        with pytest.raises(RuntimeError):
+            ray.init(runtime_env={"working_dir": "."})
+
+        os.chdir(old_dir)
+
+
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-sv", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/18091

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
