### PR TITLE
[Datasets] Drop empty tables when reading Parquet pieces.

### DIFF
--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -85,7 +85,7 @@ class ParquetDatasource(Datasource[ArrowRow]):
                 if table.num_rows > 0:
                     tables.append(table)
             if len(tables) > 1:
-                table = pa.concat_tables(tables)
+                table = pa.concat_tables(tables, promote=True)
             elif len(tables) == 1:
                 table = tables[0]
             # If len(tables) == 0, all fragments were empty, and we return the

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -535,6 +535,38 @@ def test_parquet_read_partitioned(ray_start_regular_shared, tmp_path):
     assert sorted(values) == [1, 1, 1, 3, 3, 3]
 
 
+def test_parquet_read_partitioned_with_filter(ray_start_regular_shared,
+                                              tmp_path):
+    df = pd.DataFrame({
+        "one": [1, 1, 1, 3, 3, 3],
+        "two": ["a", "a", "b", "b", "c", "c"]
+    })
+    table = pa.Table.from_pandas(df)
+    pq.write_to_dataset(
+        table,
+        root_path=str(tmp_path),
+        partition_cols=["one"],
+        use_legacy_dataset=False)
+
+    # 2 partitions, 1 empty partition, 1 block/read task
+
+    ds = ray.data.read_parquet(
+        str(tmp_path), parallelism=1, filter=(pa.dataset.field("two") == "a"))
+
+    values = [[s["one"], s["two"]] for s in ds.take()]
+    assert len(ds._blocks._blocks) == 1
+    assert sorted(values) == [[1, "a"], [1, "a"]]
+
+    # 2 partitions, 1 empty partition, 2 block/read tasks, 1 empty block
+
+    ds = ray.data.read_parquet(
+        str(tmp_path), parallelism=2, filter=(pa.dataset.field("two") == "a"))
+
+    values = [[s["one"], s["two"]] for s in ds.take()]
+    assert len(ds._blocks._blocks) == 2
+    assert sorted(values) == [[1, "a"], [1, "a"]]
+
+
 def test_parquet_write(ray_start_regular_shared, tmp_path):
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
     df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})


### PR DESCRIPTION
Drop empty tables when reading Parquet pieces. This ensures proper support for Arrow filter expressions + partitioned datasets, which, before this PR, could result in empty tables that have incompatible schema with non-empty tables.

## Related issue number

Closes #17926 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
