### PR TITLE
[tune] Fix hyperopt points to evaluate for nested lists

### DIFF
--- a/python/ray/tune/suggest/hyperopt.py
+++ b/python/ray/tune/suggest/hyperopt.py
@@ -14,6 +14,7 @@ from ray.tune.sample import Categorical, Domain, Float, Integer, LogUniform, \
 from ray.tune.suggest.suggestion import UNRESOLVED_SEARCH_SPACE, \
     UNDEFINED_METRIC_MODE, UNDEFINED_SEARCH_SPACE
 from ray.tune.suggest.variant_generator import assign_value, parse_spec_vars
+from ray.tune.utils import flatten_dict
 
 try:
     hyperopt_logger = logging.getLogger("hyperopt")
@@ -284,6 +285,10 @@ class HyperOptSearch(Searcher):
 
         # Taken from HyperOpt.base.evaluate
         config = hpo.base.spec_from_misc(new_trial["misc"])
+
+        # We have to flatten nested spaces here so parameter names match
+        config = flatten_dict(config, flatten_list=True)
+
         ctrl = hpo.base.Ctrl(self._hpopt_trials, current_trial=new_trial)
         memo = self.domain.memo_from_config(config)
         hpo.utils.use_obj_for_literal_in_memo(self.domain.expr, ctrl,

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -1475,10 +1475,11 @@ class SearchSpaceTest(unittest.TestCase):
             "nested": [
                 tune.sample.Integer(0, 10),
                 tune.sample.Integer(0, 10),
-            ]
+            ],
+            "nosample": [4, 8]
         }
 
-        points_to_evaluate = [{"nested": [2, 4]}]
+        points_to_evaluate = [{"nested": [2, 4], "nosample": [4, 8]}]
 
         from ray.tune.suggest.hyperopt import HyperOptSearch
         searcher = HyperOptSearch(
@@ -1490,6 +1491,9 @@ class SearchSpaceTest(unittest.TestCase):
 
         self.assertSequenceEqual(config["nested"],
                                  points_to_evaluate[0]["nested"])
+
+        self.assertSequenceEqual(config["nosample"],
+                                 points_to_evaluate[0]["nosample"])
 
     def testPointsToEvaluateNevergrad(self):
         config = {

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -1470,6 +1470,27 @@ class SearchSpaceTest(unittest.TestCase):
         from ray.tune.suggest.hyperopt import HyperOptSearch
         return self._testPointsToEvaluate(HyperOptSearch, config)
 
+    def testPointsToEvaluateHyperOptNested(self):
+        space = {
+            "nested": [
+                tune.sample.Integer(0, 10),
+                tune.sample.Integer(0, 10),
+            ]
+        }
+
+        points_to_evaluate = [{"nested": [2, 4]}]
+
+        from ray.tune.suggest.hyperopt import HyperOptSearch
+        searcher = HyperOptSearch(
+            space=space,
+            metric="_",
+            mode="max",
+            points_to_evaluate=points_to_evaluate)
+        config = searcher.suggest(trial_id="0")
+
+        self.assertSequenceEqual(config["nested"],
+                                 points_to_evaluate[0]["nested"])
+
     def testPointsToEvaluateNevergrad(self):
         config = {
             "metric": tune.sample.Categorical([1, 2, 3, 4]).uniform(),

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -283,19 +283,29 @@ def deep_update(original,
     return original
 
 
-def flatten_dict(dt, delimiter="/", prevent_delimiter=False):
+def flatten_dict(dt: Dict,
+                 delimiter: str = "/",
+                 prevent_delimiter: bool = False,
+                 flatten_list: bool = False):
     """Flatten dict.
 
     Output and input are of the same dict type.
     Input dict remains the same after the operation.
     """
+
+    def _raise_delimiter_exception():
+        raise ValueError(
+            f"Found delimiter `{delimiter}` in key when trying to flatten "
+            f"array. Please avoid using the delimiter in your specification.")
+
     dt = copy.copy(dt)
     if prevent_delimiter and any(delimiter in key for key in dt):
         # Raise if delimiter is any of the keys
-        raise ValueError(
-            "Found delimiter `{}` in key when trying to flatten array."
-            "Please avoid using the delimiter in your specification.")
-    while any(isinstance(v, dict) for v in dt.values()):
+        _raise_delimiter_exception()
+
+    while_check = (dict, list) if flatten_list else dict
+
+    while any(isinstance(v, while_check) for v in dt.values()):
         remove = []
         add = {}
         for key, value in dt.items():
@@ -303,12 +313,19 @@ def flatten_dict(dt, delimiter="/", prevent_delimiter=False):
                 for subkey, v in value.items():
                     if prevent_delimiter and delimiter in subkey:
                         # Raise if delimiter is in any of the subkeys
-                        raise ValueError(
-                            "Found delimiter `{}` in key when trying to "
-                            "flatten array. Please avoid using the delimiter "
-                            "in your specification.")
+                        _raise_delimiter_exception()
+
                     add[delimiter.join([key, str(subkey)])] = v
                 remove.append(key)
+            elif flatten_list and isinstance(value, list):
+                for i, v in enumerate(value):
+                    if prevent_delimiter and delimiter in subkey:
+                        # Raise if delimiter is in any of the subkeys
+                        _raise_delimiter_exception()
+
+                    add[delimiter.join([key, str(i)])] = v
+                remove.append(key)
+
         dt.update(add)
         for k in remove:
             del dt[k]

--- a/rllib/models/tf/fcnet.py
+++ b/rllib/models/tf/fcnet.py
@@ -22,8 +22,8 @@ class FullyConnectedNetwork(TFModelV2):
         super(FullyConnectedNetwork, self).__init__(
             obs_space, action_space, num_outputs, model_config, name)
 
-        hiddens = model_config.get("fcnet_hiddens", []) + \
-            model_config.get("post_fcnet_hiddens", [])
+        hiddens = list(model_config.get("fcnet_hiddens", [])) + \
+            list(model_config.get("post_fcnet_hiddens", []))
         activation = model_config.get("fcnet_activation")
         if not model_config.get("fcnet_hiddens", []):
             activation = model_config.get("post_fcnet_activation")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Internal hyperopt parameter names are flattened for lists (e.g. `nested/0`, `nested/1`). However, when supplying `points_to_evaluate`, we have to flatten those names as well, as they otherwise cannot be mapped to the internal names.

## Related issue number

Closes #14470

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
