### PR TITLE
[CI] Fix clang-format to always compare against master

### DIFF
--- a/ci/travis/check-git-clang-format-output.sh
+++ b/ci/travis/check-git-clang-format-output.sh
@@ -2,9 +2,9 @@
 
 # Compare against the master branch, because most development is done against it.
 base_commit="$(git merge-base HEAD master)"
-if [ "$base_commit" = $(git rev-parse HEAD) ]; then
+if [ "$base_commit" = "$(git rev-parse HEAD)" ]; then
   # Prefix of master branch, so compare against parent commit
-  base_commit=$(git rev-parse HEAD^)
+  base_commit="$(git rev-parse HEAD^)"
   echo "Running clang-format against parent commit $base_commit"
 else
   echo "Running clang-format against parent commit $base_commit from master branch"

--- a/ci/travis/check-git-clang-format-output.sh
+++ b/ci/travis/check-git-clang-format-output.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
 
-if [ -z "${TRAVIS_PULL_REQUEST-}" ] || [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
-  # Not in a pull request, so compare against parent commit
-  base_commit="HEAD^"
-  echo "Running clang-format against parent commit $(git rev-parse "$base_commit")"
+# Compare against the master branch, because most development is done against it.
+base_commit="$(git merge-base HEAD master)"
+if [ "$base_commit" = $(git rev-parse HEAD) ]; then
+  # Prefix of master branch, so compare against parent commit
+  base_commit=$(git rev-parse HEAD^)
+  echo "Running clang-format against parent commit $base_commit"
 else
-  base_commit="$(git merge-base "${TRAVIS_BRANCH}" HEAD)"
-  echo "Running clang-format against branch $base_commit, with hash $(git rev-parse "$base_commit")"
+  echo "Running clang-format against parent commit $base_commit from master branch"
 fi
+
 exclude_regex="(.*thirdparty/|.*redismodule.h|.*.java|.*.jsx?|.*.tsx?)"
-output="$(ci/travis/git-clang-format --binary clang-format --commit "$base_commit" --diff --exclude "$exclude_regex")"
+output="$(ci/travis/git-clang-format --commit "$base_commit" --diff --exclude "$exclude_regex")"
 if [ "$output" = "no modified files to format" ] || [ "$output" = "clang-format did not modify any files" ] ; then
   echo "clang-format passed."
   exit 0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently `git-clang-format` always checks the diff in the last commit only, which may miss changes when there are multiple commits in a PR. Since we almost always develop against the master branch, make `git-clang-format` check against the master branch instead.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
