### PR TITLE
[workflow] Fix nested workflow with catch exception bug

### DIFF
--- a/python/ray/experimental/workflow/examples/comparisons/cadence/trip_booking_workflow.py
+++ b/python/ray/experimental/workflow/examples/comparisons/cadence/trip_booking_workflow.py
@@ -93,5 +93,4 @@ if __name__ == "__main__":
 
     final_result = handle_errors.step(car_req_id, hotel_req_id, flight_req_id,
                                       saga_result)
-    # TODO(ekl) this is failing due to a bug
-    # print(final_result.run())
+    print(final_result.run())

--- a/python/ray/experimental/workflow/step_executor.py
+++ b/python/ray/experimental/workflow/step_executor.py
@@ -260,7 +260,7 @@ def _wrap_run(func: Callable, step_type: StepType, step_id: "StepID",
                 # When it returns a nested workflow, catch_exception
                 # should be passed recursively.
                 assert exception is None
-                result.data.catch_exception = True
+                result.data.catch_exceptions = True
                 persisted_output, volatile_output = result, None
             else:
                 persisted_output, volatile_output = (result, exception), None

--- a/python/ray/experimental/workflow/step_executor.py
+++ b/python/ray/experimental/workflow/step_executor.py
@@ -256,7 +256,14 @@ def _wrap_run(func: Callable, step_type: StepType, step_id: "StepID",
 
     if catch_exceptions:
         if step_type == StepType.FUNCTION:
-            persisted_output, volatile_output = (result, exception), None
+            if isinstance(result, Workflow):
+                # When it returns a nested workflow, catch_exception
+                # should be passed recursively.
+                assert exception is None
+                result.data.catch_exception = True
+                persisted_output, volatile_output = result, None
+            else:
+                persisted_output, volatile_output = (result, exception), None
         elif step_type == StepType.ACTOR_METHOD:
             # virtual actors do not persist exception
             persisted_output, volatile_output = result[0], (result[1],

--- a/python/ray/experimental/workflow/tests/test_basic_workflows.py
+++ b/python/ray/experimental/workflow/tests/test_basic_workflows.py
@@ -275,7 +275,7 @@ def test_nested_catch_exception_2(workflow_start_regular_shared, tmp_path):
         if n == 0:
             raise ValueError()
         else:
-            return f1.step(n-1)
+            return f1.step(n - 1)
 
     ret, err = f1.options(catch_exceptions=True).step(5).run()
     assert ret is None

--- a/python/ray/experimental/workflow/tests/test_basic_workflows.py
+++ b/python/ray/experimental/workflow/tests/test_basic_workflows.py
@@ -257,6 +257,31 @@ def test_step_failure_decorator(workflow_start_regular_shared, tmp_path):
     assert (tmp_path / "test").read_text() == "4"
 
 
+def test_nested_catch_exception(workflow_start_regular_shared, tmp_path):
+    @workflow.step
+    def f2():
+        return 10
+
+    @workflow.step
+    def f1():
+        return f2.step()
+
+    assert (10, None) == f1.options(catch_exceptions=True).step().run()
+
+
+def test_nested_catch_exception_2(workflow_start_regular_shared, tmp_path):
+    @workflow.step
+    def f1(n):
+        if n == 0:
+            raise ValueError()
+        else:
+            return f1.step(n-1)
+
+    ret, err = f1.options(catch_exceptions=True).step(5).run()
+    assert ret is None
+    assert isinstance(err, ValueError)
+
+
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Catch exceptions won't work with nested workflow. This PR fixed this.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #18144 
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
