### PR TITLE
[Datasets] Add from_numpy() and to_numpy() APIs

### DIFF
--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -75,6 +75,9 @@ Datasource Compatibility Matrices
    * - Pandas Dataframe Objects
      - ``ray.data.from_pandas()``
      - ✅
+   * - NumPy ndarray Objects
+     - ``ray.data.from_numpy()``
+     - ✅
    * - Arrow Table Objects
      - ``ray.data.from_arrow()``
      - ✅
@@ -121,6 +124,9 @@ Datasource Compatibility Matrices
      - ✅
    * - Pandas Dataframe Objects
      - ``ds.to_pandas()``
+     - ✅
+   * - NumPy ndarray Objects
+     - ``ds.to_numpy()``
      - ✅
    * - Pandas Dataframe Iterator
      - ``ds.iter_batches(batch_format="pandas")``
@@ -359,6 +365,17 @@ Tensor datasets are also created whenever an array type is returned from a map f
     ds = ds.map_batches(lambda x: np.array(x))
     # -> Dataset(num_blocks=10, num_rows=10,
     #            schema=<Tensor: shape=(None,), dtype=int64>)
+
+Tensor datasets can also be created from NumPy ndarrays that are already stored in the Ray object store:
+
+.. code-block:: python
+
+    import numpy as np
+
+    # Create a Dataset from a list of NumPy ndarray objects.
+    arr1 = np.arange(0, 10)
+    arr2 = np.arange(10, 20)
+    ds = ray.data.from_numpy([ray.put(arr1), ray.put(arr2)])
 
 Limitations: currently tensor-typed values cannot be nested in tabular records (e.g., as in TFRecord / Petastorm format). This is planned for development.
 

--- a/doc/source/data/package-ref.rst
+++ b/doc/source/data/package-ref.rst
@@ -20,6 +20,7 @@ Creating a Dataset
 .. autofunction:: ray.data.from_modin
 .. autofunction:: ray.data.from_mars
 .. autofunction:: ray.data.from_pandas
+.. autofunction:: ray.data.from_numpy
 
 Dataset API
 -----------

--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -1,7 +1,7 @@
 from ray.data.read_api import from_items, range, range_arrow, \
     range_tensor, read_parquet, read_json, read_csv, read_binary_files, \
-    from_dask, from_modin, from_mars, from_pandas, from_arrow, from_spark, \
-    read_datasource, read_numpy, read_text
+    from_dask, from_modin, from_mars, from_pandas, from_numpy, from_arrow, \
+    from_spark, read_datasource, read_numpy, read_text
 from ray.data.datasource import Datasource, ReadTask, WriteTask
 from ray.data.dataset import Dataset
 from ray.data.impl.progress_bar import set_progress_bars
@@ -21,6 +21,7 @@ __all__ = [
     "from_arrow",
     "from_mars",
     "from_modin",
+    "from_numpy",
     "from_pandas",
     "from_spark",
     "range",

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -85,6 +85,10 @@ class BlockAccessor(Generic[T]):
         """Convert this block into a Pandas dataframe."""
         raise NotImplementedError
 
+    def to_numpy(self) -> np.ndarray:
+        """Convert this block into a NumPy ndarray."""
+        raise NotImplementedError
+
     def to_arrow(self) -> Union["pyarrow.Table", "pyarrow.Tensor"]:
         """Convert this block into an Arrow table or tensor."""
         raise NotImplementedError

--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -173,6 +173,9 @@ class ArrowBlockAccessor(BlockAccessor):
     def to_pandas(self) -> "pandas.DataFrame":
         return self._table.to_pandas()
 
+    def to_numpy(self) -> np.ndarray:
+        return np.array(self._table)
+
     def to_arrow(self) -> "pyarrow.Table":
         return self._table
 

--- a/python/ray/data/impl/simple_block.py
+++ b/python/ray/data/impl/simple_block.py
@@ -58,6 +58,9 @@ class SimpleBlockAccessor(BlockAccessor):
         import pandas
         return pandas.DataFrame(self._items)
 
+    def to_numpy(self) -> np.ndarray:
+        return np.array(self._items)
+
     def to_arrow(self) -> "pyarrow.Table":
         import pyarrow
         return pyarrow.Table.from_pandas(self.to_pandas())

--- a/python/ray/data/impl/tensor_block.py
+++ b/python/ray/data/impl/tensor_block.py
@@ -57,6 +57,9 @@ class TensorBlockAccessor(BlockAccessor):
         import pandas
         return pandas.DataFrame(self._tensor)
 
+    def to_numpy(self) -> np.ndarray:
+        return self._tensor
+
     def to_arrow(self) -> "pyarrow.Tensor":
         import pyarrow
         return pyarrow.Tensor.from_numpy(self._tensor)

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -408,8 +408,7 @@ def read_binary_files(
 
 
 @PublicAPI(stability="beta")
-def from_dask(df: "dask.DataFrame", *,
-              parallelism: int = 200) -> Dataset[ArrowRow]:
+def from_dask(df: "dask.DataFrame") -> Dataset[ArrowRow]:
     """Create a dataset from a Dask DataFrame.
 
     Args:
@@ -457,14 +456,11 @@ def from_modin(df: "modin.DataFrame", *,
 
 
 @PublicAPI(stability="beta")
-def from_pandas(dfs: List[ObjectRef["pandas.DataFrame"]],
-                *,
-                parallelism: int = 200) -> Dataset[ArrowRow]:
+def from_pandas(dfs: List[ObjectRef["pandas.DataFrame"]]) -> Dataset[ArrowRow]:
     """Create a dataset from a set of Pandas dataframes.
 
     Args:
         dfs: A list of Ray object references to pandas dataframes.
-        parallelism: The amount of parallelism to use for the dataset.
 
     Returns:
         Dataset holding Arrow records read from the dataframes.
@@ -477,14 +473,11 @@ def from_pandas(dfs: List[ObjectRef["pandas.DataFrame"]],
 
 
 @PublicAPI(stability="beta")
-def from_numpy(ndarrays: List[ObjectRef[np.ndarray]],
-               *,
-               parallelism: int = 200) -> Dataset["np.ndarray"]:
+def from_numpy(ndarrays: List[ObjectRef[np.ndarray]]) -> Dataset[np.ndarray]:
     """Create a dataset from a set of NumPy ndarrays.
 
     Args:
         ndarrays: A list of Ray object references to NumPy ndarrays.
-        parallelism: The amount of parallelism to use for the dataset.
 
     Returns:
         Dataset holding the given ndarrays.
@@ -497,14 +490,11 @@ def from_numpy(ndarrays: List[ObjectRef[np.ndarray]],
 
 
 @PublicAPI(stability="beta")
-def from_arrow(tables: List[ObjectRef["pyarrow.Table"]],
-               *,
-               parallelism: int = 200) -> Dataset[ArrowRow]:
+def from_arrow(tables: List[ObjectRef["pyarrow.Table"]]) -> Dataset[ArrowRow]:
     """Create a dataset from a set of Arrow tables.
 
     Args:
         dfs: A list of Ray object references to Arrow tables.
-        parallelism: The amount of parallelism to use for the dataset.
 
     Returns:
         Dataset holding Arrow records from the tables.

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -398,6 +398,23 @@ def test_to_pandas(ray_start_regular_shared):
     assert df.equals(dfds)
 
 
+def test_to_numpy(ray_start_regular_shared):
+    # Tensor Dataset
+    ds = ray.data.range_tensor(10, parallelism=2)
+    arr = np.concatenate(ray.get(ds.to_numpy()))
+    np.testing.assert_equal(arr, np.expand_dims(np.arange(0, 10), 1))
+
+    # Table Dataset
+    ds = ray.data.range_arrow(10)
+    arr = np.concatenate(ray.get(ds.to_numpy()))
+    np.testing.assert_equal(arr, np.expand_dims(np.arange(0, 10), 1))
+
+    # Simple Dataset
+    ds = ray.data.range(10)
+    arr = np.concatenate(ray.get(ds.to_numpy()))
+    np.testing.assert_equal(arr, np.arange(0, 10))
+
+
 def test_to_arrow(ray_start_regular_shared):
     n = 5
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -370,6 +370,14 @@ def test_from_pandas(ray_start_regular_shared):
     assert values == rows
 
 
+def test_from_numpy(ray_start_regular_shared):
+    arr1 = np.expand_dims(np.arange(0, 4), 1)
+    arr2 = np.expand_dims(np.arange(4, 8), 1)
+    ds = ray.data.from_numpy([ray.put(arr1), ray.put(arr2)])
+    values = np.array(ds.take(8))
+    np.testing.assert_equal(np.concatenate((arr1, arr2)), values)
+
+
 def test_from_arrow(ray_start_regular_shared):
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
     df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})


### PR DESCRIPTION
This PR adds `from_numpy()` and `Dataset.to_numpy()` APIs, providing tensor parity with table APIs.

## Related issue number

Closes #18142

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
