### PR TITLE
[serve] Start RayInternalKVStore in controller namespace

### DIFF
--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -66,8 +66,10 @@ class ServeController:
                        http_config: HTTPOptions,
                        detached: bool = False):
         # Used to read/write checkpoints.
+        controller_namespace = ray.serve.api._get_controller_namespace(
+            detached)
         self.kv_store = RayInternalKVStore(
-            namespace=ray.serve.api._get_controller_namespace(detached))
+            namespace=f"{controller_name}-{controller_namespace}")
 
         # Dictionary of backend_tag -> proxy_name -> most recent queue length.
         self.backend_stats = defaultdict(lambda: defaultdict(dict))

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -66,8 +66,7 @@ class ServeController:
                        http_config: HTTPOptions,
                        detached: bool = False):
         # Used to read/write checkpoints.
-        controller_namespace = ray.serve.api._get_controller_namespace(
-            detached)
+        controller_namespace = ray.get_runtime_context().namespace
         self.kv_store = RayInternalKVStore(
             namespace=f"{controller_name}-{controller_namespace}")
 

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -66,7 +66,8 @@ class ServeController:
                        http_config: HTTPOptions,
                        detached: bool = False):
         # Used to read/write checkpoints.
-        self.kv_store = RayInternalKVStore(namespace=controller_name)
+        self.kv_store = RayInternalKVStore(
+            namespace=ray.serve.api._get_controller_namespace(detached))
 
         # Dictionary of backend_tag -> proxy_name -> most recent queue length.
         self.backend_stats = defaultdict(lambda: defaultdict(dict))

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -8,7 +8,7 @@ import starlette.responses
 
 import ray
 from ray import serve
-from ray._private.test_utils import run_string_as_driver, wait_for_condition
+from ray._private.test_utils import wait_for_condition
 
 
 def test_e2e(serve_instance):
@@ -241,38 +241,6 @@ def test_start_idempotent(serve_instance):
     serve.start(detached=True)
     serve.start()
     assert "start" in serve.list_deployments()
-
-
-def test_checkpoint_isolation_namespace(serve_instance):
-    deployment_ns1 = """
-import ray
-from ray import serve
-
-ray.init(address="{}", namespace="ns1")
-
-serve.start(detached=True)
-
-@serve.deployment
-class A:
-    pass
-
-A.deploy()""".format(ray.worker._global_node._redis_address)
-    run_string_as_driver(deployment_ns1)
-
-    deployment_ns2 = """
-import ray
-from ray import serve
-
-ray.init(address="{}", namespace="ns2")
-
-serve.start(detached=True)
-
-@serve.deployment
-class A:
-    pass
-
-A.deploy()""".format(ray.worker._global_node._redis_address)
-    run_string_as_driver(deployment_ns2)
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -8,7 +8,7 @@ import starlette.responses
 
 import ray
 from ray import serve
-from ray._private.test_utils import wait_for_condition
+from ray._private.test_utils import run_string_as_driver, wait_for_condition
 
 
 def test_e2e(serve_instance):
@@ -241,6 +241,38 @@ def test_start_idempotent(serve_instance):
     serve.start(detached=True)
     serve.start()
     assert "start" in serve.list_deployments()
+
+
+def test_checkpoint_isolation_namespace(serve_instance):
+    deployment_ns1 = """
+import ray
+from ray import serve
+
+ray.init(address="{}", namespace="ns1")
+
+serve.start(detached=True)
+
+@serve.deployment
+class A:
+    pass
+
+A.deploy()""".format(ray.worker._global_node._redis_address)
+    run_string_as_driver(deployment_ns1)
+
+    deployment_ns2 = """
+import ray
+from ray import serve
+
+ray.init(address="{}", namespace="ns2")
+
+serve.start(detached=True)
+
+@serve.deployment
+class A:
+    pass
+
+A.deploy()""".format(ray.worker._global_node._redis_address)
+    run_string_as_driver(deployment_ns2)
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -444,9 +444,9 @@ def test_checkpoint_isolation_namespace(ray_shutdown):
 import ray
 from ray import serve
 
-ray.init(address="{}", namespace="{}")
+ray.init(address="{address}", namespace="{namespace}")
 
-serve.start(detached=True)
+serve.start(detached=True, http_options={{"port": {port}}})
 
 @serve.deployment
 class A:
@@ -454,8 +454,12 @@ class A:
 
 A.deploy()"""
 
-    run_string_as_driver(driver_template.format(address, "test_namespace1"))
-    run_string_as_driver(driver_template.format(address, "test_namespace2"))
+    run_string_as_driver(
+        driver_template.format(
+            address=address, namespace="test_namespace1", port=8000))
+    run_string_as_driver(
+        driver_template.format(
+            address=address, namespace="test_namespace2", port=8001))
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -18,7 +18,7 @@ from ray.serve.exceptions import RayServeException
 from ray.serve.utils import (block_until_http_ready, get_all_node_ids,
                              format_actor_name)
 from ray.serve.config import HTTPOptions
-from ray._private.test_utils import wait_for_condition
+from ray._private.test_utils import run_string_as_driver, wait_for_condition
 from ray._private.services import new_port
 import ray._private.gcs_utils as gcs_utils
 
@@ -433,6 +433,29 @@ def test_serve_controller_namespace(ray_shutdown, namespace: Optional[str],
 
     assert ray.get_actor(
         client._controller_name, namespace=controller_namespace)
+
+
+def test_checkpoint_isolation_namespace(ray_shutdown):
+    info = ray.init(namespace="test_namespace1")
+
+    address = info["redis_address"]
+
+    driver_template = """
+import ray
+from ray import serve
+
+ray.init(address="{}", namespace="{}")
+
+serve.start(detached=True)
+
+@serve.deployment
+class A:
+    pass
+
+A.deploy()"""
+
+    run_string_as_driver(driver_template.format(address, "test_namespace1"))
+    run_string_as_driver(driver_template.format(address, "test_namespace2"))
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -437,6 +437,7 @@ def test_serve_controller_namespace(ray_shutdown, namespace: Optional[str],
 
 
 def test_checkpoint_isolation_namespace():
+    check_call_ray(["stop"])
     check_call_ray(["start", "--head"])
 
     deployment_ns1 = """

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -18,8 +18,7 @@ from ray.serve.exceptions import RayServeException
 from ray.serve.utils import (block_until_http_ready, get_all_node_ids,
                              format_actor_name)
 from ray.serve.config import HTTPOptions
-from ray._private.test_utils import (check_call_ray, run_string_as_driver,
-                                     wait_for_condition)
+from ray._private.test_utils import wait_for_condition
 from ray._private.services import new_port
 import ray._private.gcs_utils as gcs_utils
 
@@ -434,43 +433,6 @@ def test_serve_controller_namespace(ray_shutdown, namespace: Optional[str],
 
     assert ray.get_actor(
         client._controller_name, namespace=controller_namespace)
-
-
-def test_checkpoint_isolation_namespace():
-    check_call_ray(["stop"])
-    check_call_ray(["start", "--head"])
-
-    deployment_ns1 = """
-import ray
-from ray import serve
-
-ray.init(address="auto", namespace="ns1")
-
-serve.start(detached=True)
-
-@serve.deployment
-class A:
-    pass
-
-A.deploy()"""
-    run_string_as_driver(deployment_ns1)
-
-    deployment_ns2 = """
-import ray
-from ray import serve
-
-ray.init(address="auto", namespace="ns2")
-
-serve.start(detached=True)
-
-@serve.deployment
-class A:
-    pass
-
-A.deploy()"""
-    run_string_as_driver(deployment_ns2)
-
-    check_call_ray(["stop"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Previously, Serve instances started in different namespaces were not completely isolated because they shared the checkpoint on the cluster. This is because the checkpoint only included the `controller_name` but not the `controller_namespace`, so it is available to all Serve instances regardless of namespace. This PR passes the current namespace to the `RayInternalKVStore` so the checkpoint name is unique to the current namespace.

## Related issue number

 Closes https://github.com/ray-project/ray/issues/18055

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
