### PR TITLE
[core] Prestart workers up to available CPU limit

### DIFF
--- a/python/ray/tests/test_basic_3.py
+++ b/python/ray/tests/test_basic_3.py
@@ -237,9 +237,7 @@ def test_worker_startup_count(ray_start_cluster):
     cluster.add_node(
         num_cpus=4,
         _system_config={
-            "event_stats_print_interval_ms": 100,
             "debug_dump_period_milliseconds": 100,
-            "event_stats": True
         })
     ray.init(address=cluster.address)
 
@@ -276,6 +274,11 @@ def test_worker_startup_count(ray_start_cluster):
     wait_for_condition(lambda: get_num_workers() == 16)
     time_waited = time.time() - start
     print(f"Waited {time_waited} for debug_state.txt to be updated")
+
+    # Debug.
+    with open(debug_state_path) as f:
+        for line in f.readlines():
+            print(line)
 
     # Check that no more workers started for a while.
     for i in range(100):

--- a/python/ray/tests/test_basic_3.py
+++ b/python/ray/tests/test_basic_3.py
@@ -235,8 +235,7 @@ def test_worker_startup_count(ray_start_cluster):
     cluster = ray_start_cluster
     # Cluster total cpu resources is 4.
     cluster.add_node(
-        num_cpus=4,
-        _system_config={
+        num_cpus=4, _system_config={
             "debug_dump_period_milliseconds": 100,
         })
     ray.init(address=cluster.address)

--- a/python/ray/tests/test_basic_3.py
+++ b/python/ray/tests/test_basic_3.py
@@ -275,14 +275,16 @@ def test_worker_startup_count(ray_start_cluster):
     time_waited = time.time() - start
     print(f"Waited {time_waited} for debug_state.txt to be updated")
 
-    # Debug.
-    with open(debug_state_path) as f:
-        for line in f.readlines():
-            print(line)
-
     # Check that no more workers started for a while.
     for i in range(100):
-        num = get_num_workers()
+        # Sometimes the debug state file can be empty. Retry if needed.
+        for _ in range(3):
+            num = get_num_workers()
+            if num is None:
+                print("Retrying parse debug_state.txt")
+                time.sleep(0.05)
+            else:
+                break
         assert num == 16
         time.sleep(0.1)
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1549,7 +1549,10 @@ void NodeManager::HandleRequestWorkerLease(const rpc::RequestWorkerLeaseRequest 
   task_message.mutable_task_spec()->CopyFrom(request.resource_spec());
   auto backlog_size = -1;
   if (RayConfig::instance().report_worker_backlog()) {
-    backlog_size = request.backlog_size();
+    // We add 1 to the backlog size because we need a worker to fulfill the
+    // current request, as well as workers to serve the requests in the
+    // backlog.
+    backlog_size = request.backlog_size() + 1;
   }
   RayTask task(task_message, backlog_size);
   bool is_actor_creation_task = task.GetTaskSpecification().IsActorCreationTask();

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1569,8 +1569,13 @@ void NodeManager::HandleRequestWorkerLease(const rpc::RequestWorkerLeaseRequest 
 
   if (RayConfig::instance().enable_worker_prestart()) {
     auto task_spec = task.GetTaskSpecification();
+    // We floor the available CPUs to the nearest integer to avoid starting too
+    // many workers when there is less than 1 CPU left. Otherwise, we could end
+    // up repeatedly starting the worker, then killing it because it idles for
+    // too long. The downside is that we will be slower to schedule tasks that
+    // could use a fraction of a CPU.
     int64_t available_cpus =
-        std::ceil(cluster_resource_scheduler_->GetLocalAvailableCpus());
+        static_cast<int64_t>(cluster_resource_scheduler_->GetLocalAvailableCpus());
     worker_pool_.PrestartWorkers(task_spec, request.backlog_size(), available_cpus);
   }
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1569,7 +1569,8 @@ void NodeManager::HandleRequestWorkerLease(const rpc::RequestWorkerLeaseRequest 
 
   if (RayConfig::instance().enable_worker_prestart()) {
     auto task_spec = task.GetTaskSpecification();
-    worker_pool_.PrestartWorkers(task_spec, request.backlog_size());
+    int64_t available_cpus = std::ceil(cluster_resource_scheduler_->GetLocalAvailableCpus());
+    worker_pool_.PrestartWorkers(task_spec, request.backlog_size(), available_cpus);
   }
 
   cluster_task_manager_->QueueAndScheduleTask(task, reply, send_reply_callback);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1569,7 +1569,8 @@ void NodeManager::HandleRequestWorkerLease(const rpc::RequestWorkerLeaseRequest 
 
   if (RayConfig::instance().enable_worker_prestart()) {
     auto task_spec = task.GetTaskSpecification();
-    int64_t available_cpus = std::ceil(cluster_resource_scheduler_->GetLocalAvailableCpus());
+    int64_t available_cpus =
+        std::ceil(cluster_resource_scheduler_->GetLocalAvailableCpus());
     worker_pool_.PrestartWorkers(task_spec, request.backlog_size(), available_cpus);
   }
 

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -1109,6 +1109,13 @@ void ClusterResourceScheduler::FillResourceUsage(rpc::ResourcesData &resources_d
   }
 }
 
+double ClusterResourceScheduler::GetLocalAvailableCpus() const {
+  NodeResources local_resources;
+  RAY_CHECK(GetNodeResources(local_node_id_, &local_resources));
+  auto &capacity = local_resources.predefined_resources[CPU];
+  return capacity.available.Double();
+}
+
 ray::gcs::NodeResourceInfoAccessor::ResourceMap
 ClusterResourceScheduler::GetResourceTotals() const {
   ray::gcs::NodeResourceInfoAccessor::ResourceMap map;

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -414,6 +414,8 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
   void UpdateLastResourceUsage(
       const std::shared_ptr<SchedulingResources> gcs_resources) override;
 
+  double GetLocalAvailableCpus() const override;
+
   /// Serialize task resource instances to json string.
   ///
   /// \param task_allocation Allocated resource instances for a task.

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler_interface.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler_interface.h
@@ -72,6 +72,8 @@ class ClusterResourceSchedulerInterface {
   /// fields used.
   virtual void FillResourceUsage(rpc::ResourcesData &data) = 0;
 
+  virtual double GetLocalAvailableCpus() const = 0;
+
   /// Populate a UpdateResourcesRequest. This is inteneded to update the
   /// resource totals on a node when a custom resource is created or deleted
   /// (e.g. during the placement group lifecycle).

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -1081,9 +1081,7 @@ void WorkerPool::PrestartWorkers(const TaskSpecification &task_spec, int64_t bac
   }
   // Some existing workers may be holding less than 1 CPU each, so we should
   // start as many workers as needed to fill up the remaining CPUs.
-  // We add 1 to the backlog size because we need a worker to fulfill the
-  // current request, as well as workers to serve the requests in the backlog.
-  auto desired_usable_workers = std::min<int64_t>(num_available_cpus, backlog_size + 1);
+  auto desired_usable_workers = std::min<int64_t>(num_available_cpus, backlog_size);
   if (num_usable_workers < desired_usable_workers) {
     // Account for workers that are idle or already starting.
     int64_t num_needed = desired_usable_workers - num_usable_workers;

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -1079,22 +1079,14 @@ void WorkerPool::PrestartWorkers(const TaskSpecification &task_spec, int64_t bac
   for (auto &entry : state.starting_worker_processes) {
     num_usable_workers += entry.second.num_starting_workers;
   }
-  // The number of workers total regardless of suitability for this task.
-  int num_workers_total = 0;
-  for (const auto &worker : GetAllRegisteredWorkers()) {
-    if (!worker->IsDead()) {
-      num_workers_total++;
-    }
-  }
-  // Some workers may be holding less than 1 CPU each, so we should start as
-  // many workers as needed to fill up the remaining CPUs.
-  auto worker_margin =
-      std::max<int64_t>(num_workers_soft_limit_ - num_workers_total, num_available_cpus);
-  auto desired_usable_workers = std::min<int64_t>(worker_margin, backlog_size);
+  // Some existing workers may be holding less than 1 CPU each, so we should
+  // start as many workers as needed to fill up the remaining CPUs.
+  auto desired_usable_workers = std::min<int64_t>(num_available_cpus, backlog_size);
   if (num_usable_workers < desired_usable_workers) {
+    // Account for workers that are idle or already starting.
     int64_t num_needed = desired_usable_workers - num_usable_workers;
     RAY_LOG(DEBUG) << "Prestarting " << num_needed << " workers given task backlog size "
-                   << backlog_size << " and soft limit " << num_workers_soft_limit_;
+                   << backlog_size << " and available CPUs " << num_available_cpus;
     for (int i = 0; i < num_needed; i++) {
       PopWorkerStatus status;
       StartWorkerProcess(task_spec.GetLanguage(), rpc::WorkerType::WORKER,

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -1081,7 +1081,9 @@ void WorkerPool::PrestartWorkers(const TaskSpecification &task_spec, int64_t bac
   }
   // Some existing workers may be holding less than 1 CPU each, so we should
   // start as many workers as needed to fill up the remaining CPUs.
-  auto desired_usable_workers = std::min<int64_t>(num_available_cpus, backlog_size);
+  // We add 1 to the backlog size because we need a worker to fulfill the
+  // current request, as well as workers to serve the requests in the backlog.
+  auto desired_usable_workers = std::min<int64_t>(num_available_cpus, backlog_size + 1);
   if (num_usable_workers < desired_usable_workers) {
     // Account for workers that are idle or already starting.
     int64_t num_needed = desired_usable_workers - num_usable_workers;

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -1063,8 +1063,7 @@ void WorkerPool::PopWorker(const TaskSpecification &task_spec,
   }
 }
 
-void WorkerPool::PrestartWorkers(const TaskSpecification &task_spec,
-                                 int64_t backlog_size,
+void WorkerPool::PrestartWorkers(const TaskSpecification &task_spec, int64_t backlog_size,
                                  int64_t num_available_cpus) {
   // Code path of task that needs a dedicated worker.
   if ((task_spec.IsActorCreationTask() && !task_spec.DynamicWorkerOptions().empty()) ||
@@ -1089,10 +1088,9 @@ void WorkerPool::PrestartWorkers(const TaskSpecification &task_spec,
   }
   // Some workers may be holding less than 1 CPU each, so we should start as
   // many workers as needed to fill up the remaining CPUs.
-  auto worker_margin = std::max<int64_t>(num_workers_soft_limit_ - num_workers_total,
-      num_available_cpus);
-  auto desired_usable_workers =
-      std::min<int64_t>(worker_margin, backlog_size);
+  auto worker_margin =
+      std::max<int64_t>(num_workers_soft_limit_ - num_workers_total, num_available_cpus);
+  auto desired_usable_workers = std::min<int64_t>(worker_margin, backlog_size);
   if (num_usable_workers < desired_usable_workers) {
     int64_t num_needed = desired_usable_workers - num_usable_workers;
     RAY_LOG(DEBUG) << "Prestarting " << num_needed << " workers given task backlog size "

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -323,6 +323,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   ///
   /// \param task_spec The returned worker must be able to execute this task.
   /// \param backlog_size The number of tasks in the client backlog of this shape.
+  /// \param num_available_cpus The number of CPUs that are currently unused.
+  /// We aim to prestart 1 worker per CPU, up to the the backlog size.
   void PrestartWorkers(const TaskSpecification &task_spec, int64_t backlog_size,
                        int64_t num_available_cpus);
 

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -323,7 +323,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   ///
   /// \param task_spec The returned worker must be able to execute this task.
   /// \param backlog_size The number of tasks in the client backlog of this shape.
-  void PrestartWorkers(const TaskSpecification &task_spec, int64_t backlog_size);
+  void PrestartWorkers(const TaskSpecification &task_spec, int64_t backlog_size,
+      int64_t num_available_cpus);
 
   /// Return the current size of the worker pool for the requested language. Counts only
   /// idle workers.

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -324,7 +324,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// \param task_spec The returned worker must be able to execute this task.
   /// \param backlog_size The number of tasks in the client backlog of this shape.
   void PrestartWorkers(const TaskSpecification &task_spec, int64_t backlog_size,
-      int64_t num_available_cpus);
+                       int64_t num_available_cpus);
 
   /// Return the current size of the worker pool for the requested language. Counts only
   /// idle workers.

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -532,19 +532,19 @@ TEST_F(WorkerPoolTest, InitialWorkerProcessCount) {
 TEST_F(WorkerPoolTest, TestPrestartingWorkers) {
   const auto task_spec = ExampleTaskSpec();
   // Prestarts 2 workers.
-  worker_pool_->PrestartWorkers(task_spec, 2);
+  worker_pool_->PrestartWorkers(task_spec, 2, /*num_available_cpus=*/5);
   ASSERT_EQ(worker_pool_->NumWorkersStarting(), 2);
   ASSERT_EQ(worker_pool_->NumWorkerProcessesStarting(), 2);
   // Prestarts 1 more worker.
-  worker_pool_->PrestartWorkers(task_spec, 3);
+  worker_pool_->PrestartWorkers(task_spec, 3, /*num_available_cpus=*/5);
   ASSERT_EQ(worker_pool_->NumWorkersStarting(), 3);
   ASSERT_EQ(worker_pool_->NumWorkerProcessesStarting(), 3);
   // No more needed.
-  worker_pool_->PrestartWorkers(task_spec, 1);
+  worker_pool_->PrestartWorkers(task_spec, 1, /*num_available_cpus=*/5);
   ASSERT_EQ(worker_pool_->NumWorkersStarting(), 3);
   ASSERT_EQ(worker_pool_->NumWorkerProcessesStarting(), 3);
   // Capped by soft limit of 5.
-  worker_pool_->PrestartWorkers(task_spec, 20);
+  worker_pool_->PrestartWorkers(task_spec, 20, /*num_available_cpus=*/5);
   ASSERT_EQ(worker_pool_->NumWorkersStarting(), 5);
   ASSERT_EQ(worker_pool_->NumWorkerProcessesStarting(), 5);
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We prestart workers to improve task scheduling time, but the soft limit is a static limit based on the number of CPUs. This means prestart won't work as expected if some workers are holding less than 1 CPU (such as an actor). This PR allows prestart to start workers up to the number of available CPUs, if this is more than what the soft limit would allow.

## Related issue number

This PR is needed to fix the distributed test_many_tasks.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
