### PR TITLE
[Core] Fix ClientCallManager Memory Leaking

### DIFF
--- a/src/ray/rpc/client_call.h
+++ b/src/ray/rpc/client_call.h
@@ -242,7 +242,7 @@ class ClientCallManager {
 
  private:
   /// This function runs in a background thread. It keeps polling events from the
-  /// `CompletionQueue`, and dispatches the event to the callbacks via the `Cli`entCall`
+  /// `CompletionQueue`, and dispatches the event to the callbacks via the `ClientCall`
   /// objects.
   void PollEventsFromCompletionQueue(int index) {
     SetThreadName("client.poll" + std::to_string(index));


### PR DESCRIPTION
## Why are these changes needed?

There is a memory leaking in ClientCallManager, this PR fixes it.

When gRPC's completion queue is shut down, it won't clear our call tags, we need to clear call tags that are waiting for the server's response.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
