### PR TITLE
[serve] Fix get_handle execution from threads

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -294,14 +294,22 @@ class Client:
         if not missing_ok and endpoint_name not in all_endpoints:
             raise KeyError(f"Endpoint '{endpoint_name}' does not exist.")
 
-        if asyncio.get_event_loop().is_running() and sync:
+        try:
+            asyncio_loop_running = asyncio.get_event_loop().is_running()
+        except RuntimeError as ex:
+            if "There is no current event loop in thread" in str(ex):
+                asyncio_loop_running = False
+            else:
+                raise ex
+
+        if asyncio_loop_running and sync:
             logger.warning(
                 "You are retrieving a sync handle inside an asyncio loop. "
                 "Try getting client.get_handle(.., sync=False) to get better "
                 "performance. Learn more at https://docs.ray.io/en/master/"
                 "serve/http-servehandle.html#sync-and-async-handles")
 
-        if not asyncio.get_event_loop().is_running() and not sync:
+        if not asyncio_loop_running and not sync:
             logger.warning(
                 "You are retrieving an async handle outside an asyncio loop. "
                 "You should make sure client.get_handle is called inside a "

--- a/python/ray/serve/tests/test_handle.py
+++ b/python/ray/serve/tests/test_handle.py
@@ -2,6 +2,7 @@ import pytest
 import requests
 
 import ray
+import concurrent.futures
 from ray import serve
 
 
@@ -41,6 +42,23 @@ def test_sync_handle_serializable(serve_instance):
     handle = f.get_handle(sync=True)
     result_ref = task.remote(handle)
     assert ray.get(result_ref) == "hello"
+
+
+def test_sync_handle_in_thread(serve_instance):
+    @serve.deployment
+    def f():
+        return "hello"
+
+    f.deploy()
+
+    def thread_get_handle(deploy):
+        handle = deploy.get_handle(sync=True)
+        return handle
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        fut = executor.submit(thread_get_handle, f)
+        handle = fut.result()
+        assert ray.get(handle.remote()) == "hello"
 
 
 def test_handle_in_endpoint(serve_instance):


### PR DESCRIPTION
- `asyncio.get_event_loop()` raises RuntimeError
exception if called from other thread than the main
one:
https://github.com/python/cpython/blob/main/Lib/asyncio/events.py#L656

- Gracefully assume that `get_handle()` was called from a context that
doesn't use asyncio in case the exception was raised and
thus `event_loop` isn't running

## Why are these changes needed?

If you need to get ray serve deployment `sync=True` handle from a python thread other than the main one, for example when handling RPC request that is running in a thread managed by `ThreadPoolExecutor`. The current implementation makes it impossible because it raises a `RuntimeError`.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests - serve unit tests are passing under linux / python 3.7
   - [ ] Release tests
   - [ ] This PR is not tested :(
