### PR TITLE
Fix Ray client GOAWAY

### DIFF
--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -504,7 +504,7 @@ class Worker:
         return False
 
     def is_connected(self) -> bool:
-        return self._conn_state == grpc.ChannelConnectivity.READY
+        return self._conn_state in [grpc.ChannelConnectivity.READY, grpc.ChannelConnectivity.IDLE]
 
     def _call_init(self, init_request: ray_client_pb2.InitRequest) -> None:
         init_resp = self.data_client.Init(init_request)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When Ray client is proxied over nginx (e.g. via the Kubernetes nginx ingress) and the configuration reloaded, the proxy sends a GOAWAY to the client, which resets the state of the stream to IDLE. Our code interprets this as a disconnect, but in reality the underlying streams seems to still be functional.

## Related issue number

Fixes a problem with GOAWAYs that was introduced in https://github.com/ray-project/ray/pull/13386/
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
