### PR TITLE
[Nightly test] Support better infra failure detection + stable flag

### DIFF
--- a/release/nightly_tests/nightly_tests.yaml
+++ b/release/nightly_tests/nightly_tests.yaml
@@ -142,6 +142,7 @@
 
 # Stress test for 1TB multi node non-streaming shuffle.
 - name: non_streaming_shuffle_1tb_5000_partitions
+  stable: False
   cluster:
     app_config: shuffle/shuffle_app_config.yaml
     compute_template: shuffle/shuffle_compute_large_scale.yaml


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- Add a stable flag. We'll use it as a way to filter unstable tests from the dashboard. 
- Previously, the prepare command failures (infra failure, e.g., failed to join nodes) were considered as a runtime error. This PR will change that to the infra failure

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
