### PR TITLE
[Dataset] Support dataset from a single dataframe/table.

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -513,30 +513,42 @@ def from_modin(df: "modin.DataFrame") -> Dataset[ArrowRow]:
 
 
 @PublicAPI(stability="beta")
-def from_pandas(dfs: List["pandas.DataFrame"]) -> Dataset[ArrowRow]:
+def from_pandas(
+    dfs: Union["pandas.DataFrame",
+               List["pandas.DataFrame"]]) -> Dataset[ArrowRow]:
     """Create a dataset from a list of Pandas dataframes.
 
     Args:
-        dfs: A list of Pandas dataframes.
+        dfs: A Pandas dataframe or a list of Pandas dataframes.
 
     Returns:
         Dataset holding Arrow records read from the dataframes.
     """
+    import pandas as pd
+
+    if isinstance(dfs, pd.DataFrame):
+        dfs = [dfs]
     return from_pandas_refs([ray.put(df) for df in dfs])
 
 
 @DeveloperAPI
 def from_pandas_refs(
-        dfs: List[ObjectRef["pandas.DataFrame"]]) -> Dataset[ArrowRow]:
+    dfs: Union[ObjectRef["pandas.DataFrame"],
+               List[ObjectRef["pandas.DataFrame"]]]
+) -> Dataset[ArrowRow]:
     """Create a dataset from a list of Ray object references to Pandas
     dataframes.
 
     Args:
-        dfs: A list of Ray object references to pandas dataframes.
+        dfs: A Ray object references to pandas dataframe, or a list of
+             Ray object references to pandas dataframes.
 
     Returns:
         Dataset holding Arrow records read from the dataframes.
     """
+    if isinstance(dfs, ray.ObjectRef):
+        dfs = [dfs]
+
     df_to_block = cached_remote_fn(_df_to_block, num_returns=2)
 
     res = [df_to_block.remote(df) for df in dfs]
@@ -562,31 +574,41 @@ def from_numpy(ndarrays: List[ObjectRef[np.ndarray]]) -> Dataset[ArrowRow]:
 
 @PublicAPI(stability="beta")
 def from_arrow(
-        tables: List[Union["pyarrow.Table", bytes]]) -> Dataset[ArrowRow]:
+    tables: Union["pyarrow.Table", bytes, List[Union["pyarrow.Table", bytes]]]
+) -> Dataset[ArrowRow]:
     """Create a dataset from a list of Arrow tables.
 
     Args:
-        tables: A list of Ray object references to Arrow tables,
+        tables: An Arrow table, or a list of Arrow tables,
                 or its streaming format in bytes.
 
     Returns:
         Dataset holding Arrow records from the tables.
     """
+    import pyarrow as pa
+
+    if isinstance(tables, (pa.Table, bytes)):
+        tables = [tables]
     return from_arrow_refs([ray.put(t) for t in tables])
 
 
 @DeveloperAPI
-def from_arrow_refs(tables: List[ObjectRef[Union["pyarrow.Table", bytes]]]
-                    ) -> Dataset[ArrowRow]:
+def from_arrow_refs(
+    tables: Union[ObjectRef[Union["pyarrow.Table", bytes]],
+                  List[ObjectRef[Union["pyarrow.Table", bytes]]]]
+) -> Dataset[ArrowRow]:
     """Create a dataset from a set of Arrow tables.
 
     Args:
-        tables: A list of Ray object references to Arrow tables,
-                or its streaming format in bytes.
+        tables: A Ray object reference to Arrow table, or list of Ray object
+                references to Arrow tables, or its streaming format in bytes.
 
     Returns:
         Dataset holding Arrow records from the tables.
     """
+    if isinstance(tables, ray.ObjectRef):
+        tables = [tables]
+
     get_metadata = cached_remote_fn(_get_metadata)
     metadata = [get_metadata.remote(t) for t in tables]
     return Dataset(BlockList(tables, ray.get(metadata)))

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -513,9 +513,8 @@ def from_modin(df: "modin.DataFrame") -> Dataset[ArrowRow]:
 
 
 @PublicAPI(stability="beta")
-def from_pandas(
-    dfs: Union["pandas.DataFrame",
-               List["pandas.DataFrame"]]) -> Dataset[ArrowRow]:
+def from_pandas(dfs: Union["pandas.DataFrame", List["pandas.DataFrame"]]
+                ) -> Dataset[ArrowRow]:
     """Create a dataset from a list of Pandas dataframes.
 
     Args:
@@ -532,10 +531,8 @@ def from_pandas(
 
 
 @DeveloperAPI
-def from_pandas_refs(
-    dfs: Union[ObjectRef["pandas.DataFrame"],
-               List[ObjectRef["pandas.DataFrame"]]]
-) -> Dataset[ArrowRow]:
+def from_pandas_refs(dfs: Union[ObjectRef["pandas.DataFrame"], List[ObjectRef[
+        "pandas.DataFrame"]]]) -> Dataset[ArrowRow]:
     """Create a dataset from a list of Ray object references to Pandas
     dataframes.
 
@@ -573,9 +570,8 @@ def from_numpy(ndarrays: List[ObjectRef[np.ndarray]]) -> Dataset[ArrowRow]:
 
 
 @PublicAPI(stability="beta")
-def from_arrow(
-    tables: Union["pyarrow.Table", bytes, List[Union["pyarrow.Table", bytes]]]
-) -> Dataset[ArrowRow]:
+def from_arrow(tables: Union["pyarrow.Table", bytes, List[Union[
+        "pyarrow.Table", bytes]]]) -> Dataset[ArrowRow]:
     """Create a dataset from a list of Arrow tables.
 
     Args:
@@ -594,9 +590,8 @@ def from_arrow(
 
 @DeveloperAPI
 def from_arrow_refs(
-    tables: Union[ObjectRef[Union["pyarrow.Table", bytes]],
-                  List[ObjectRef[Union["pyarrow.Table", bytes]]]]
-) -> Dataset[ArrowRow]:
+        tables: Union[ObjectRef[Union["pyarrow.Table", bytes]], List[ObjectRef[
+            Union["pyarrow.Table", bytes]]]]) -> Dataset[ArrowRow]:
     """Create a dataset from a set of Arrow tables.
 
     Args:

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -933,6 +933,12 @@ def test_from_pandas(ray_start_regular_shared):
     rows = [(r.one, r.two) for _, r in pd.concat([df1, df2]).iterrows()]
     assert values == rows
 
+    # test from single pandas dataframe
+    ds = ray.data.from_pandas(df1)
+    values = [(r["one"], r["two"]) for r in ds.take(3)]
+    rows = [(r.one, r.two) for _, r in df1.iterrows()]
+    assert values == rows
+
 
 def test_from_pandas_refs(ray_start_regular_shared):
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
@@ -940,6 +946,12 @@ def test_from_pandas_refs(ray_start_regular_shared):
     ds = ray.data.from_pandas_refs([ray.put(df1), ray.put(df2)])
     values = [(r["one"], r["two"]) for r in ds.take(6)]
     rows = [(r.one, r.two) for _, r in pd.concat([df1, df2]).iterrows()]
+    assert values == rows
+
+    # test from single pandas dataframe ref
+    ds = ray.data.from_pandas_refs(ray.put(df1))
+    values = [(r["one"], r["two"]) for r in ds.take(3)]
+    rows = [(r.one, r.two) for _, r in df1.iterrows()]
     assert values == rows
 
 
@@ -964,6 +976,12 @@ def test_from_arrow(ray_start_regular_shared):
     rows = [(r.one, r.two) for _, r in pd.concat([df1, df2]).iterrows()]
     assert values == rows
 
+    # test from single pyarrow table
+    ds = ray.data.from_arrow(pa.Table.from_pandas(df1))
+    values = [(r["one"], r["two"]) for r in ds.take(3)]
+    rows = [(r.one, r.two) for _, r in df1.iterrows()]
+    assert values == rows
+
 
 def test_from_arrow_refs(ray_start_regular_shared):
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
@@ -974,6 +992,12 @@ def test_from_arrow_refs(ray_start_regular_shared):
     ])
     values = [(r["one"], r["two"]) for r in ds.take(6)]
     rows = [(r.one, r.two) for _, r in pd.concat([df1, df2]).iterrows()]
+    assert values == rows
+
+    # test from single pyarrow table ref
+    ds = ray.data.from_arrow_refs(ray.put(pa.Table.from_pandas(df1)))
+    values = [(r["one"], r["two"]) for r in ds.take(3)]
+    rows = [(r.one, r.two) for _, r in df1.iterrows()]
     assert values == rows
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add support for creating dataset from a single dataframe and a single table.

It should be reasonable to support such behaviour, and, if users feed into just a single dataframe, the error message is quite hard to understand (as ray is trying to iterate over columns of the dataframe...):

```python
>>> df = pd.DataFrame({"x": [1,2,3]})
>>> ds = ray.data.from_pandas(df)
(pid=42071) df =  x <class 'str'>
---------------------------------------------------------------------------
RayTaskError(TypeError)                   Traceback (most recent call last)
<ipython-input-5-34d40ad42e52> in <module>
----> 1 ds = ray.data.from_pandas(df)

~/ray/python/ray/data/read_api.py in from_pandas(dfs, parallelism)
    474
    475     res = [df_to_block.remote(df) for df in dfs]
--> 476     blocks, metadata = zip(*res)
    477     return Dataset(BlockList(blocks, ray.get(list(metadata))))
    478

~/ray/python/ray/_private/client_mode_hook.py in wrapper(*args, **kwargs)
     80         if client_mode_should_convert():
     81             return getattr(ray, func.__name__)(*args, **kwargs)
---> 82         return func(*args, **kwargs)
     83
     84     return wrapper

~/ray/python/ray/worker.py in get(object_refs, timeout)
   1617                     worker.core_worker.dump_object_store_memory_usage()
   1618                 if isinstance(value, RayTaskError):
-> 1619                     raise value.as_instanceof_cause()
   1620                 else:
   1621                     raise value

RayTaskError(TypeError): ray::_df_to_block() (pid=42071, ip=30.25.96.43)
  File "/Users/linzhu.ht/ray/python/ray/data/read_api.py", line 516, in _df_to_block
    print('df = ', df, type(df))
  File "pyarrow/table.pxi", line 2228, in pyarrow.lib.table
TypeError: Expected pandas DataFrame, python dictionary or list of arrays

In [6]: 2021-08-30 17:56:28,638	ERROR worker.py:79 -- Unhandled error (suppress with RAY_IGNORE_UNHANDLED_ERRORS=1): ray::_df_to_block() (pid=42071, ip=30.25.96.43)
  File "/Users/linzhu.ht/ray/python/ray/data/read_api.py", line 516, in _df_to_block
    print('df = ', df, type(df))
  File "pyarrow/table.pxi", line 2228, in pyarrow.lib.table
TypeError: Expected pandas DataFrame, python dictionary or list of arrays
```

## Related issue number

None.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
