### PR TITLE
[Tune] Respect default_resources during Trial.reset().

### DIFF
--- a/python/ray/tune/tests/test_api.py
+++ b/python/ray/tune/tests/test_api.py
@@ -714,7 +714,7 @@ class TrainableFunctionApiTest(unittest.TestCase):
                 else:
                     return [0, 1, True, {}]
 
-        try:
+        with self.assertRaises(Exception):
             tune.run(
                 "PPO",
                 config={
@@ -722,8 +722,6 @@ class TrainableFunctionApiTest(unittest.TestCase):
                     "framework": "torch"
                 },
                 stop={"training_iteration": 1})
-        except Exception:
-            pass
         trials = tune.run(
             "PPO",
             config={

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -405,6 +405,10 @@ class Trial:
         return bool(self.placement_group_factory)
 
     def reset(self):
+        trainable_cls = self.get_trainable_cls()
+        clear_resources = (trainable_cls and
+                           trainable_cls.default_resource_request(self.config))
+
         return Trial(
             self.trainable_name,
             config=self.config,
@@ -412,8 +416,9 @@ class Trial:
             local_dir=self.local_dir,
             evaluated_params=self.evaluated_params,
             experiment_tag=self.experiment_tag,
-            resources=self.resources,
-            placement_group_factory=self.placement_group_factory,
+            resources=self.resources if not clear_resources else None,
+            placement_group_factory=self.placement_group_factory
+            if not clear_resources else None,
             stopping_criterion=self.stopping_criterion,
             remote_checkpoint_dir=self.remote_checkpoint_dir,
             checkpoint_freq=self.checkpoint_freq,

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -405,9 +405,17 @@ class Trial:
         return bool(self.placement_group_factory)
 
     def reset(self):
+        # If there is `default_resource_request` associated with the trainable,
+        # clear `resources` and `placement_group_factory`.
+        # This is mainly relevant for RLlib tuning jobs, where we save users
+        # of the trouble to specify the resources themselves by having some
+        # default resources for popular RLlib algorithms.
         trainable_cls = self.get_trainable_cls()
         clear_resources = (trainable_cls and
                            trainable_cls.default_resource_request(self.config))
+        resources = self.resources if not clear_resources else None
+        placement_group_factory = (self.placement_group_factory
+                                   if not clear_resources else None)
 
         return Trial(
             self.trainable_name,
@@ -416,9 +424,8 @@ class Trial:
             local_dir=self.local_dir,
             evaluated_params=self.evaluated_params,
             experiment_tag=self.experiment_tag,
-            resources=self.resources if not clear_resources else None,
-            placement_group_factory=self.placement_group_factory
-            if not clear_resources else None,
+            resources=resources,
+            placement_group_factory=placement_group_factory,
             stopping_criterion=self.stopping_criterion,
             remote_checkpoint_dir=self.remote_checkpoint_dir,
             checkpoint_freq=self.checkpoint_freq,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
During trial reset, default_resources take precedence over resources/placement_group_factory. Clear the latter two if default_resources is present.

## Related issue number
Closes #16891
<!-- For example: "Closes #1234" -->

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
