### PR TITLE
[Test] Disable non streaming shuffle 5000 partitions

### DIFF
--- a/release/nightly_tests/nightly_tests.yaml
+++ b/release/nightly_tests/nightly_tests.yaml
@@ -141,16 +141,16 @@
     script: python shuffle/shuffle_test.py --num-partitions=5000 --partition-size=200e6
 
 # Stress test for 1TB multi node non-streaming shuffle.
-- name: non_streaming_shuffle_1tb_5000_partitions
-  stable: False
-  cluster:
-    app_config: shuffle/shuffle_app_config.yaml
-    compute_template: shuffle/shuffle_compute_large_scale.yaml
+# - name: non_streaming_shuffle_1tb_5000_partitions
+#   stable: False
+#   cluster:
+#     app_config: shuffle/shuffle_app_config.yaml
+#     compute_template: shuffle/shuffle_compute_large_scale.yaml
 
-  run:
-    timeout: 7200
-    prepare: python wait_cluster.py 20 900
-    script: python shuffle/shuffle_test.py --num-partitions=5000 --partition-size=200e6 --no-streaming
+#   run:
+#     timeout: 7200
+#     prepare: python wait_cluster.py 20 900
+#     script: python shuffle/shuffle_test.py --num-partitions=5000 --partition-size=200e6 --no-streaming
 
 # Test large scale dask on ray test without spilling.
 - name: dask_on_ray_large_scale_test_no_spilling

--- a/release/nightly_tests/nightly_tests.yaml
+++ b/release/nightly_tests/nightly_tests.yaml
@@ -136,7 +136,7 @@
     compute_template: shuffle/shuffle_compute_large_scale.yaml
 
   run:
-    timeout: 7200
+    timeout: 9000
     prepare: python wait_cluster.py 20 900
     script: python shuffle/shuffle_test.py --num-partitions=5000 --partition-size=200e6
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As discussed, we will disable tests. I will find the best partition size that works without spilling next sprint and add it (maybe around 3000).

This also increases the timeout for regular shuffle, since the performance is not consistent, and it takes a bit more than 2 hours occasionally. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
