### PR TITLE
[Buildkite] Upload jars to os specific dir

### DIFF
--- a/.buildkite/copy_files.py
+++ b/.buildkite/copy_files.py
@@ -76,13 +76,15 @@ def upload_paths(paths, resp, destination):
     branch = os.environ["BUILDKITE_BRANCH"]
     bk_job_id = os.environ["BUILDKITE_JOB_ID"]
 
+    current_os = os.uname().sysname.lower()
+
     for path in paths:
         fn = os.path.split(path)[-1]
         of["key"] = {
             "wheels": f"latest/{fn}",
             "branch_wheels": f"{branch}/{sha}/{fn}",
-            "jars": f"jars/latest/{fn}",
-            "branch_jars": f"jars/{branch}/{sha}/{fn}",
+            "jars": f"jars/latest/{fn}/{current_os}",
+            "branch_jars": f"jars/{branch}/{sha}/{fn}/{current_os}",
             "logs": f"bazel_events/{branch}/{sha}/{bk_job_id}/{fn}"
         }[destination]
         of["file"] = open(path, "rb")


### PR DESCRIPTION
build_jars_multiplatform expect jars to be uploaded to commit/os/...
directory instead of just the commit/ directory.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
