### PR TITLE
[CI][Test] fix off-by-one bug in test_fallback_allocation_failure

### DIFF
--- a/python/ray/tests/test_plasma_unlimited.py
+++ b/python/ray/tests/test_plasma_unlimited.py
@@ -177,7 +177,7 @@ def test_fd_reuse_no_memory_corruption(shutdown_only):
     @ray.remote
     class Actor:
         def produce(self, i):
-            s = int(random.random() * 200)
+            s = random.randrange(1, 200)
             z = np.ones(s * 1024 * 1024)
             z[0] = i
             return z


### PR DESCRIPTION
As title, there is a chance the size of array is 0 and fails with off-by-one error.