### PR TITLE
[Test] Use cheaper instance type for some tests

### DIFF
--- a/release/nightly_tests/shuffle/shuffle_compute_multi.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_multi.yaml
@@ -11,12 +11,12 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: i3.4xlarge
+    instance_type: m5.4xlarge
     resources: {"object_store_memory": 21474836480}
 
 worker_node_types:
     - name: worker_node2
-      instance_type: i3.4xlarge
+      instance_type: m5.4xlarge
       min_workers: 3
       max_workers: 3
       use_spot: false

--- a/release/nightly_tests/shuffle/shuffle_compute_single.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_single.yaml
@@ -11,7 +11,7 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: i3.4xlarge
+    instance_type: m5.4xlarge
     resources: {"object_store_memory": 21474836480}
 
 worker_node_types:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Round 1 only touches instances that have low impact. Since we set object store size, using the same size m5 instances can save 2X. Some other tests that might need more memory is not covered here. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
