### PR TITLE
[nighly-test][test-placement-groups][rfc] call pg.ready() before using it

### DIFF
--- a/release/stress_tests/workloads/test_placement_group.py
+++ b/release/stress_tests/workloads/test_placement_group.py
@@ -104,6 +104,8 @@ def pg_launcher(pre_created_pgs, num_pgs_to_create):
         else:
             pgs_unremoved.append(pg)
 
+    ray.get([pg.ready() for pg in pgs_unremoved])
+
     tasks = []
     max_actor_cnt = 5
     actor_cnt = 0
@@ -124,7 +126,6 @@ def pg_launcher(pre_created_pgs, num_pgs_to_create):
     for pg in pgs_removed:
         remove_placement_group(pg)
 
-    ray.get([pg.ready() for pg in pgs_unremoved])
     ray.get(tasks)
     ray.get([actor.ping.remote() for actor in actors])
     # Since placement groups are scheduled, remove them.

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -742,10 +742,11 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
 }
 
 void CoreWorker::Shutdown() {
-  io_service_.stop();
+  core_worker_server_->Shutdown();
   if (options_.worker_type == WorkerType::WORKER) {
     task_execution_service_.stop();
   }
+  io_service_.stop();
   if (options_.on_worker_shutdown) {
     options_.on_worker_shutdown(GetWorkerID());
   }


### PR DESCRIPTION
Reading the [doc](https://docs.ray.io/en/latest/placement-group.html) it suggests that we should always call pg.ready before using it.

> When using placement groups, users should ensure that their placement groups are ready (by calling ray.get(pg.ready())) and have the proper resources.

In our tests, however we use the pg before it's ready; this aligns which what I observed while debugging: some required pgs resources are not available when calling `ray status`.

**Follow up: should we warn user if a pg is used before ready is called?**

Test plan
-[x] verified release/stress_tests/workloads/test_placement_group.py no longer hangs.