### PR TITLE
[client] Improve Ray Client connection timeout information

### DIFF
--- a/doc/source/cluster/ray-client.rst
+++ b/doc/source/cluster/ray-client.rst
@@ -74,7 +74,7 @@ Step 2: Check ports
 ~~~~~~~~~~~~~~~~~~~
 
 Ensure that the Ray Client port on the head node is reachable from your local machine.
-This means opening that port up (on  `EC2 <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html>`_)
+This means opening that port up by configuring security groups or other access controls (on  `EC2 <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html>`_)
 or proxying from your local machine to the cluster (on `K8s <https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/#forward-a-local-port-to-a-port-on-the-pod>`_).
 
 Step 3: Run Ray code

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -159,8 +159,7 @@ class Worker:
                     "the Ray Client port on the head node is reachable "
                     "from your local machine. See https://docs.ray.io/en"
                     "/latest/cluster/ray-client.html#step-2-check-ports for "
-                    "more information."
-                )
+                    "more information.")
             raise ConnectionError("ray client connection timeout")
 
         # Initialize the streams to finish protocol negotiation.

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -153,6 +153,14 @@ class Worker:
         # it means we've used up our retries and
         # should error back to the user.
         if not service_ready:
+            if log_once("ray_client_security_groups"):
+                warnings.warn(
+                    "Ray Client connection timed out. Ensure that "
+                    "the Ray Client port on the head node is reachable "
+                    "from your local machine. See https://docs.ray.io/en"
+                    "/latest/cluster/ray-client.html#step-2-check-ports for "
+                    "more information."
+                )
             raise ConnectionError("ray client connection timeout")
 
         # Initialize the streams to finish protocol negotiation.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Improves the information user gets when Ray Client times out by including keywords in documentation and printing out an informative warning before the exception is raised.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

https://github.com/ray-project/ray/issues/18226

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
