### PR TITLE
[Core][worker] fix core-worker destruction order

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -372,7 +372,8 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
       num_executed_tasks_(0),
       task_execution_service_work_(task_execution_service_),
       resource_ids_(new ResourceMappingType()),
-      grpc_service_(io_service_, *this) {
+      grpc_service_(io_service_, *this),
+      exiting_(false) {
   RAY_LOG(DEBUG) << "Constructing CoreWorker, worker_id: " << worker_id;
 
   // Initialize task receivers.
@@ -740,11 +741,10 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
 }
 
 void CoreWorker::Shutdown() {
-  core_worker_server_->Shutdown();
+  io_service_.stop();
   if (options_.worker_type == WorkerType::WORKER) {
     task_execution_service_.stop();
   }
-  io_service_.stop();
   if (options_.on_worker_shutdown) {
     options_.on_worker_shutdown(GetWorkerID());
   }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -740,10 +740,11 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
 }
 
 void CoreWorker::Shutdown() {
-  io_service_.stop();
+  core_worker_server_->Shutdown();
   if (options_.worker_type == WorkerType::WORKER) {
     task_execution_service_.stop();
   }
+  io_service_.stop();
   if (options_.on_worker_shutdown) {
     options_.on_worker_shutdown(GetWorkerID());
   }

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1366,6 +1366,9 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// Number of executed tasks.
   std::atomic<int64_t> num_executed_tasks_;
 
+  // Interface that receives tasks from direct actor calls.
+  std::unique_ptr<CoreWorkerDirectTaskReceiver> direct_task_receiver_;
+
   /// Event loop where tasks are processed.
   instrumented_io_context task_execution_service_;
 
@@ -1387,9 +1390,6 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// actor task are ready.
   std::shared_ptr<DependencyWaiterImpl> task_argument_waiter_;
 
-  // Interface that receives tasks from direct actor calls.
-  std::unique_ptr<CoreWorkerDirectTaskReceiver> direct_task_receiver_;
-
   // Queue of tasks to resubmit when the specified time passes.
   std::deque<std::pair<int64_t, TaskSpecification>> to_resubmit_ GUARDED_BY(mutex_);
 
@@ -1409,7 +1409,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
                       ObjectID object_id, void *py_future);
 
   /// Whether we are shutting down and not running further tasks.
-  bool exiting_ = false;
+  std::atomic<bool> exiting_;
 
   int64_t max_direct_call_object_size_;
 


### PR DESCRIPTION
Richard reported a SEGFAULT issue (#18101) while CoreWorker handles the SubmitRequest call.  Reading the crash stack trace it looks like it happens when we calling `send_reply_callback` which calls back to GRPC.
```
(pid=14053, ip=172.31.63.35) *** SIGSEGV received at time=1629779882 on cpu 40 ***
(pid=14053, ip=172.31.63.35) PC: @     0x7f8a60f35d10  (unknown)  ray::core::CoreWorkerDirectTaskReceiver::HandleTask()::{lambda()#1}::operator()()
(pid=14053, ip=172.31.63.35)     @     0x7f8a62b8f980  758251280  (unknown)
(pid=14053, ip=172.31.63.35)     @     0x7f8a60f3648a         80  std::_Function_handler<>::_M_invoke()
(pid=14053, ip=172.31.63.35)     @     0x7f8a60eb7b35        448  ray::core::NormalSchedulingQueue::ScheduleRequests()
(pid=14053, ip=172.31.63.35)     @     0x7f8a612755e6        112  boost::asio::detail::completion_handler<>::do_complete()
(pid=14053, ip=172.31.63.35)     @     0x7f8a61377e58        112  boost::asio::detail::scheduler::do_run_one()
(pid=14053, ip=172.31.63.35)     @     0x7f8a61378a11        160  boost::asio::detail::scheduler::run()
(pid=14053, ip=172.31.63.35)     @     0x7f8a6137a560         64  boost::asio::io_context::run()
(pid=14053, ip=172.31.63.35)     @     0x7f8a60f22405        144  ray::core::CoreWorkerProcess::RunTaskExecutionLoop()
(pid=14053, ip=172.31.63.35)     @     0x7f8a60dad3d7         32  __pyx_pw_3ray_7_raylet_10CoreWorker_9run_task_loop()
(pid=14053, ip=172.31.63.35)     @     0x5576d487ab71  (unknown)  _PyMethodDef_RawFastCallKeywords
(pid=14053, ip=172.31.63.35)     @     0x7f8a60dad3c0  (unknown)  (unknown)
```

After reading the relevant code there is likely hood what happened is:
1. we call `task_execution_service_.stop();` in CoreWorker::Shutdown()
2. the `task_execution_service_.stop()` actually returns immediately, while there is still ` ray::core::NormalSchedulingQueue::ScheduleRequests()` running 
3. we starts CoreWorker's destruction, which first destruct `direct_task_receiver_`, then destructs `task_execution_service_`, and there is a race condition where the the direct_task_receiver_ is destructed beforetask_execution_service_ finishes what's it current executing, which leads to invalidation of this_ pointer.