### PR TITLE
[runtime_env] Remove unused serialized-runtime-env from worker args

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1251,7 +1251,6 @@ def connect(node,
             namespace=None,
             job_config=None,
             runtime_env_hash=0,
-            runtime_env_json="{}",
             worker_shim_pid=0,
             ray_debugger_external=False):
     """Connect this worker to the raylet, to Plasma, and to Redis.

--- a/python/ray/workers/default_worker.py
+++ b/python/ray/workers/default_worker.py
@@ -125,11 +125,6 @@ parser.add_argument(
     default=0,
     help="The PID of the process for setup worker runtime env.")
 parser.add_argument(
-    "--serialized-runtime-env",
-    type=str,
-    default="{}",
-    help="The serialized and validated runtime env json.")
-parser.add_argument(
     "--ray-debugger-external",
     default=False,
     action="store_true",
@@ -195,7 +190,6 @@ if __name__ == "__main__":
         node,
         mode=mode,
         runtime_env_hash=args.runtime_env_hash,
-        runtime_env_json=args.serialized_runtime_env,
         worker_shim_pid=args.worker_shim_pid,
         ray_debugger_external=args.ray_debugger_external)
 

--- a/python/ray/workers/setup_runtime_env.py
+++ b/python/ray/workers/setup_runtime_env.py
@@ -178,15 +178,7 @@ def setup_worker(input_args):
             "the context %s.", args.serialized_runtime_env,
             args.serialized_runtime_env_context)
 
-    commands += [
-        " ".join(
-            [f"exec {py_executable}"] + remaining_args +
-            # Pass the runtime for working_dir setup.
-            # We can't do it in shim process here because it requires
-            # connection to gcs.
-            ["--serialized-runtime-env", f"'{args.serialized_runtime_env}'"])
-    ]
-
+    commands += [" ".join([f"exec {py_executable}"] + remaining_args)]
     command_str = " && ".join(commands)
 
     # update env vars


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
