### PR TITLE
[Datasets] Adds tensor column support (tensors-in-tables) via Pandas/Arrow extension types/arrays.

### DIFF
--- a/doc/source/data/dataset-advanced.rst
+++ b/doc/source/data/dataset-advanced.rst
@@ -1,0 +1,319 @@
+.. _datasets_advanced:
+
+Advanced Datasets Usage
+=======================
+
+Sharding datasets
+-----------------
+
+Datasets can be split up into disjoint sub-datasets. Locality-aware splitting is supported if you pass in a list of actor handles to the ``split()`` function along with the number of desired splits. This is a common pattern useful for loading and splitting data between distributed training actors:
+
+.. code-block:: python
+
+    @ray.remote(num_gpus=1)
+    class Worker:
+        def __init__(self, rank: int):
+            pass
+
+        def train(self, shard: ray.data.Dataset[int]) -> int:
+            for batch in shard.iter_batches(batch_size=256):
+                pass
+            return shard.count()
+
+    workers = [Worker.remote(i) for i in range(16)]
+    # -> [Actor(Worker, ...), Actor(Worker, ...), ...]
+
+    ds = ray.data.range(10000)
+    # -> Dataset(num_blocks=200, num_rows=10000, schema=<class 'int'>)
+
+    shards = ds.split(n=16, locality_hints=workers)
+    # -> [Dataset(num_blocks=13, num_rows=650, schema=<class 'int'>),
+    #     Dataset(num_blocks=13, num_rows=650, schema=<class 'int'>), ...]
+
+    ray.get([w.train.remote(s) for s in shards])
+    # -> [650, 650, ...]
+
+Tensor-typed values
+-------------------
+
+Datasets support tensor-typed values, which are represented in-memory as Arrow tensors (i.e., np.ndarray format). Tensor datasets can be read from and written to ``.npy`` files. Here are some examples:
+
+.. code-block:: python
+
+    # Create a Dataset of tensor-typed values.
+    ds = ray.data.range_tensor(10000, shape=(3, 5))
+    # -> Dataset(num_blocks=200, num_rows=10000,
+    #            schema=<Tensor: shape=(None, 3, 5), dtype=int64>)
+
+    ds.map_batches(lambda t: t + 2).show(2)
+    # -> [[2 2 2 2 2]
+    #     [2 2 2 2 2]
+    #     [2 2 2 2 2]]
+    #    [[3 3 3 3 3]
+    #     [3 3 3 3 3]
+    #     [3 3 3 3 3]]
+
+    # Save to storage.
+    ds.write_numpy("/tmp/tensor_out")
+
+    # Read from storage.
+    ray.data.read_numpy("/tmp/tensor_out")
+    # -> Dataset(num_blocks=200, num_rows=?,
+    #            schema=<Tensor: shape=(None, 3, 5), dtype=int64>)
+
+Tensor datasets are also created whenever an array type is returned from a map function:
+
+.. code-block:: python
+
+    # Create a dataset of Python integers.
+    ds = ray.data.range(10)
+    # -> Dataset(num_blocks=10, num_rows=10, schema=<class 'int'>)
+
+    # It is now converted into a Tensor dataset.
+    ds = ds.map_batches(lambda x: np.array(x))
+    # -> Dataset(num_blocks=10, num_rows=10,
+    #            schema=<Tensor: shape=(None,), dtype=int64>)
+
+Tensor datasets can also be created from NumPy ndarrays that are already stored in the Ray object store:
+
+.. code-block:: python
+
+    import numpy as np
+
+    # Create a Dataset from a list of NumPy ndarray objects.
+    arr1 = np.arange(0, 10)
+    arr2 = np.arange(10, 20)
+    ds = ray.data.from_numpy([ray.put(arr1), ray.put(arr2)])
+
+Tables with tensor columns
+--------------------------
+
+In addition to tensor datasets, Datasets also supports tables with fixed-shape tensor columns, where each element in the column is a tensor (n-dimensional array) with the same shape. As an example, this allows you to use both Pandas and Ray Datasets to read, write, and manipulate a table with a column of e.g. images (2D arrays), with all conversions between Pandas, Arrow, and Parquet, and all application of aggregations/operations to the underlying image ndarrays, being taken care of by Ray Datasets.
+
+With our Pandas extension type, :class:`TensorDtype <ray.data.extensions.tensor_extension.TensorDtype>`, and extension array, :class:`TensorArray <ray.data.extensions.tensor_extension.TensorArray>`, you can do familiar aggregations and arithmetic, comparison, and logical operations on a DataFrame containing a tensor column and the operations will be applied to the underlying tensors as expected. With our Arrow extension type, :class:`ArrowTensorType <ray.data.extensions.tensor_extension.ArrowTensorType>`, and extension array, :class:`ArrowTensorArray <ray.data.extensions.tensor_extension.ArrowTensorArray>`, you'll be able to import that DataFrame into Ray Datasets and read/write the data from/to the Parquet format.
+
+Automatic conversion between the Pandas and Arrow extension types/arrays keeps the details under-the-hood, so you only have to worry about casting the column to a tensor column using our Pandas extension type when first ingesting the table into a ``Dataset``, whether from storage or in-memory. All table operations downstream from that cast should work automatically.
+
+Reading existing serialized tensor columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you already have a Parquet dataset with columns containing serialized tensors, you can have these tensor columns cast to our tensor extension type at read-time by giving a simple schema for the tensor columns. Note that these tensors must have been serialized as their raw NumPy ndarray bytes in C-contiguous order (e.g. serialized via ``arr.tobytes()``).
+
+.. code-block:: python
+
+    import numpy as np
+    import pandas as pd
+    from ray.data.extensions import TensorDtype, TensorArray
+
+    path = "/tmp/some_path"
+
+    # Create a DataFrame with a list of serialized ndarrays as a column.
+    # Note that we do not cast it to a tensor array, so each element in the
+    # column is an opaque blob of bytes.
+    arr = np.arange(24).reshape((3, 2, 2, 2))
+    df = pd.DataFrame({
+        "one": [1, 2, 3],
+        "two": [tensor.tobytes() for tensor in arr]})
+
+    # Write the dataset to Parquet. The tensor column will be written as an
+    # array of opaque byte blobs.
+    ds = ray.data.from_pandas([ray.put(df)])
+    ds.write_parquet(path)
+
+    # Read the Parquet files into a new Dataset, with the serialized tensors
+    # automatically cast to our tensor column extension type.
+    ds = ray.data.read_parquet(
+        path, _tensor_column_schema={"two": (np.int, (2, 2, 2))})
+
+    # Internally, this column is represented with our Arrow tensor extension
+    # type.
+    print(ds.schema())
+    # -> one: int64
+    #    two: extension<arrow.py_extension_type<ArrowTensorType>>
+
+If your serialized tensors don't fit the above constraints (e.g. they're stored in Fortran-contiguous order, or they're pickled), you can manually cast this tensor column to our tensor extension type via a read-time user-defined function. This UDF will be pushed down to Ray Datasets' IO layer and executed on each block in parallel, as it's read from storage.
+
+.. code-block:: python
+
+    import pickle
+
+    # Create a DataFrame with a list of pickled ndarrays as a column.
+    arr = np.arange(24).reshape((3, 2, 2, 2))
+    df = pd.DataFrame({
+        "one": [1, 2, 3],
+        "two": [pickle.dumps(tensor) for tensor in arr]})
+
+    # Write the dataset to Parquet. The tensor column will be written as an
+    # array of opaque byte blobs.
+    ds = ray.data.from_pandas([ray.put(df)])
+    ds.write_parquet(path)
+
+    # Manually deserialize the tensor pickle bytes and cast to our tensor
+    # extension type. For the sake of efficiency, we directly construct a
+    # TensorArray rather than .astype() casting on the mutated column with
+    # TensorDtype.
+    def cast_udf(block: pa.Table) -> pa.Table:
+        block = block.to_pandas()
+        block["two"] = TensorArray([pickle.loads(a) for a in block["two"]])
+        return pa.Table.from_pandas(block)
+
+    # Read the Parquet files into a new Dataset, applying the casting UDF
+    # on-the-fly within the underlying read tasks.
+    ds = ray.data.read_parquet(path, _block_udf=cast_udf)
+
+    # Internally, this column is represented with our Arrow tensor extension
+    # type.
+    print(ds.schema())
+    # -> one: int64
+    #    two: extension<arrow.py_extension_type<ArrowTensorType>>
+
+Please note that the ``_tensor_column_schema`` and ``_block_udf`` parameters are both experimental developer APIs and may break in future versions.
+
+Working with tensor column datasets
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Now that the tensor column is properly typed and in a ``Dataset``, we can perform operations on the dataset as if it was a normal table:
+
+.. code-block:: python
+
+    # Arrow and Pandas is now aware of this tensor column, so we can do the
+    # typical DataFrame operations on this column.
+    ds = ds.map_batches(lambda x: 2 * (x + 1), format="pandas")
+    # -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1123.54it/s]
+    print(ds)
+    # -> Dataset(num_blocks=1, num_rows=3, schema=<class 'int', class ray.data.extensions.tensor_extension.ArrowTensorType>)
+    print([row["two"] for row in ds.take(5)])
+    # -> [2, 4, 6, 8, 10]
+
+Writing and reading tensor columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This dataset can then be written to Parquet files. The tensor column schema will be preserved via the Pandas and Arrow extension types and associated metadata, allowing us to later read the Parquet files into a Dataset without needing to specify a column casting schema. This Pandas --> Arrow --> Parquet --> Arrow --> Pandas conversion support makes working with tensor columns extremely easy when using Ray Datasets to both write and read data.
+
+.. code-block:: python
+
+    # You can write the dataset to Parquet.
+    ds.write_parquet("/some/path")
+    # And you can read it back.
+    read_ds = ray.data.read_parquet("/some/path")
+    print(read_ds.schema())
+    # -> one: int64
+    #    two: extension<arrow.py_extension_type<ArrowTensorType>>
+
+End-to-end workflow with our Pandas extension type
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If working with in-memory Pandas DataFrames that you want to analyze, manipulate, store, and eventually read, the Pandas/Arrow extension types/arrays make it easy to extend this end-to-end workflow to tensor columns.
+
+.. code-block:: python
+
+    # Create a DataFrame with a list of ndarrays as a column.
+    df = pd.DataFrame({
+        "one": [1, 2, 3],
+        "two": list(np.arange(24).reshape((3, 2, 2, 2)))})
+    # Note the opaque np.object dtype for this column.
+    print(df.dtypes)
+    # -> one     int64
+    #    two    object
+    #    dtype: object
+
+    # Cast column to our TensorDtype Pandas extension type.
+    df["two"] = df["two"].astype(TensorDtype())
+
+    # Note that the column dtype is now TensorDtype instead of
+    # np.object.
+    print(df.dtypes)
+    # -> one          int64
+    #    two    TensorDtype
+    #    dtype: object
+
+    # Pandas is now aware of this tensor column, and we can do the
+    # typical DataFrame operations on this column.
+    col = 2 * df["two"]
+    # The ndarrays underlying the tensor column will be manipulated,
+    # but the column itself will continue to be a Pandas type.
+    print(type(col))
+    # -> pandas.core.series.Series
+    print(col)
+    # -> 0   [[[ 2  4]
+    #          [ 6  8]]
+    #         [[10 12]
+    #           [14 16]]]
+    #    1   [[[18 20]
+    #          [22 24]]
+    #         [[26 28]
+    #          [30 32]]]
+    #    2   [[[34 36]
+    #          [38 40]]
+    #         [[42 44]
+    #          [46 48]]]
+    #    Name: two, dtype: TensorDtype
+
+    # Once you do an aggregation on that column that returns a single
+    # row's value, you get back our TensorArrayElement type.
+    tensor = col.mean()
+    print(type(tensor))
+    # -> ray.data.extensions.tensor_extension.TensorArrayElement
+    print(tensor)
+    # -> array([[[18., 20.],
+    #            [22., 24.]],
+    #           [[26., 28.],
+    #            [30., 32.]]])
+
+    # This is a light wrapper around a NumPy ndarray, and can easily
+    # be converted to an ndarray.
+    type(tensor.to_numpy())
+    # -> numpy.ndarray
+
+    # In addition to doing Pandas operations on the tensor column,
+    # you can now put the DataFrame directly into a Dataset.
+    ds = ray.data.from_pandas([ray.put(df)])
+    # Internally, this column is represented with the corresponding
+    # Arrow tensor extension type.
+    print(ds.schema())
+    # -> one: int64
+    #    two: extension<arrow.py_extension_type<ArrowTensorType>>
+
+    # You can write the dataset to Parquet.
+    ds.write_parquet("/some/path")
+    # And you can read it back.
+    read_ds = ray.data.read_parquet("/some/path")
+    print(read_ds.schema())
+    # -> one: int64
+    #    two: extension<arrow.py_extension_type<ArrowTensorType>>
+
+    read_df = ray.get(read_ds.to_pandas())[0]
+    print(read_df.dtypes)
+    # -> one          int64
+    #    two    TensorDtype
+    #    dtype: object
+
+    # The tensor extension type is preserved along the
+    # Pandas --> Arrow --> Parquet --> Arrow --> Pandas
+    # conversion chain.
+    print(read_df.equals(df))
+    # -> True
+
+Limitations
+~~~~~~~~~~~
+
+This feature currently comes with a few known limitations that we are either actively working on addressing or have already implemented workarounds for.
+
+ * All tensors in a tensor column currently must be the same shape. Please let us know if you require heterogeneous tensor shape for your tensor column! Tracking issue is `here <https://github.com/ray-project/ray/issues/18316>`__.
+ * Automatic casting via specifying an override Arrow schema when reading Parquet is blocked by Arrow supporting custom ExtensionType casting kernels. See `issue <https://issues.apache.org/jira/browse/ARROW-5890>`__. An explicit ``_tensor_column_schema`` parameter has been added for :func:`read_parquet() <ray.data.read_api.read_parquet>` as a stopgap solution.
+ * Ingesting tables with tensor columns into pytorch via ``ds.to_torch()`` is blocked by pytorch supporting tensor creation from objects that implement the `__array__` interface. See `issue <https://github.com/pytorch/pytorch/issues/51156>`__. Workarounds are being `investigated <https://github.com/ray-project/ray/issues/18314>`__.
+ * Ingesting tables with tensor columns into TensorFlow via ``ds.to_tf()`` is blocked by a Pandas fix for properly interpreting extension arrays in ``DataFrame.values`` being released. See `PR <https://github.com/pandas-dev/pandas/pull/43160>`__. Workarounds are being `investigated <https://github.com/ray-project/ray/issues/18315>`__.
+
+Custom datasources
+------------------
+
+Datasets can read and write in parallel to `custom datasources <package-ref.html#custom-datasource-api>`__ defined in Python.
+
+.. code-block:: python
+
+    # Read from a custom datasource.
+    ds = ray.data.read_datasource(YourCustomDatasource(), **read_args)
+
+    # Write to a custom datasource.
+    ds.write_datasource(YourCustomDatasource(), **write_args)
+

--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -389,6 +389,7 @@ Automatic conversion between the Pandas and Arrow extension types/arrays keeps t
 If you already have a Parquet dataset with columns containing serialized tensors, you can have these tensor columns cast to our tensor extension type at read-time by giving a simple schema for the tensor columns. Note that these tensors must have been serialized as their raw NumPy ndarray bytes in C-contiguous order (e.g. serialized via ``arr.tobytes()``).
 
 .. code-block:: python
+
     import numpy as np
     import pandas as pd
     from ray.data.extensions import TensorDtype, TensorArray
@@ -422,6 +423,7 @@ If you already have a Parquet dataset with columns containing serialized tensors
 If your serialized tensors don't fit the above constraints (e.g. they're stored in Fortran-contiguous order, or they're pickled), you can manually cast this tensor column to our tensor extension type via a read-time user-defined function. This UDF will be pushed down to Ray Datasets' IO layer and executed on each block in parallel, as it's read from storage.
 
 .. code-block:: python
+
     import pickle
 
     # Create a DataFrame with a list of pickled ndarrays as a column.
@@ -459,6 +461,7 @@ Please note that the ``_tensor_column_schema`` and ``_block_udf`` parameters are
 Now that the tensor column is properly typed and in a ``Dataset``, we can perform operations on the dataset as if it was a normal table:
 
 .. code-block:: python
+
     # Arrow and Pandas is now aware of this tensor column, so we can do the
     # typical DataFrame operations on this column.
     ds = ds.map_batches(lambda x: 2 * (x + 1), format="pandas")
@@ -471,6 +474,7 @@ Now that the tensor column is properly typed and in a ``Dataset``, we can perfor
 This dataset can then be written to Parquet file. The tensor column schema will be preserved via the Pandas and Arrow extension types and associated metadata, allowing us to later read the Parquet files into a Dataset without needing to specify a casting UDF. This Pandas --> Arrow --> Parquet --> Arrow --> Pandas conversion support makes working with tensor columns extremely easy when using Ray Datasets to both write and read data.
 
 .. code-block:: python
+
     # You can write the dataset to Parquet.
     ds.write_parquet("/some/path")
     # And you can read it back.
@@ -572,7 +576,7 @@ If working with in-memory Pandas DataFrames that you want to analyze, manipulate
 
 **Limitations:**
  * All tensors in a tensor column currently must be the same shape. Please let us know if you require heterogeneous tensor shape for your tensor column! Tracking issue is `here <https://github.com/ray-project/ray/issues/18316>`__.
- * Automatic casting via specifying an override Arrow schema when reading Parquet is blocked by Arrow supporting custom ExtensionType casting kernels. See `issue <https://issues.apache.org/jira/browse/ARROW-5890>`__. An explicit ``_tensor_column_schema`` parameter has been added for :function:`read_parquet() <ray.data.read_api.read_parquet>` as a stopgap solution.
+ * Automatic casting via specifying an override Arrow schema when reading Parquet is blocked by Arrow supporting custom ExtensionType casting kernels. See `issue <https://issues.apache.org/jira/browse/ARROW-5890>`__. An explicit ``_tensor_column_schema`` parameter has been added for :func:`read_parquet() <ray.data.read_api.read_parquet>` as a stopgap solution.
  * Ingesting tables with tensor columns into pytorch via ``ds.to_torch()`` is blocked by pytorch supporting tensor creation from objects that implement the `__array__` interface. See `issue <https://github.com/pytorch/pytorch/issues/51156>`__. Workarounds are being `investigated <https://github.com/ray-project/ray/issues/18314>`__.
  * Ingesting tables with tensor columns into TensorFlow via ``ds.to_tf()`` is blocked by a Pandas fix for properly interpreting extension arrays in ``DataFrame.values`` being released. See `PR <https://github.com/pandas-dev/pandas/pull/43160>`__. Workarounds are being `investigated <https://github.com/ray-project/ray/issues/18315>`__.
 

--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -189,7 +189,7 @@ Datasets can be created from files on local disk or remote datasources such as S
     # Read multiple directories.
     ds = ray.data.read_csv(["s3://bucket/path1", "s3://bucket/path2"])
 
-Finally, you can create a Dataset from existing data in the Ray object store or Ray compatible distributed DataFrames:
+Finally, you can create a ``Dataset`` from existing data in the Ray object store or Ray-compatible distributed DataFrames:
 
 .. code-block:: python
 
@@ -218,6 +218,13 @@ Datasets can be written to local or remote storage using ``.write_csv()``, ``.wr
     # Use repartition to control the number of output files:
     ray.data.range(10000).repartition(1).write_csv("/tmp/output2")
     # -> /tmp/output2/data0.csv
+
+You can also convert a ``Dataset`` to Ray-comptabile distributed DataFrames:
+
+.. code-block:: python
+
+    # Convert a Ray Dataset into a Dask-on-Ray DataFrame.
+    dask_df = ds.to_dask()
 
 Transforming Datasets
 ---------------------
@@ -280,7 +287,7 @@ By default, transformations are executed using Ray tasks. For transformations th
     # Save the results.
     ds.repartition(1).write_json("s3://bucket/inference-results")
 
-Exchanging datasets
+Consuming datasets
 -------------------
 
 Datasets can be passed to Ray tasks or actors and read with ``.iter_batches()`` or ``.iter_rows()``. This does not incur a copy, since the blocks of the Dataset are passed by reference as Ray objects:
@@ -298,300 +305,10 @@ Datasets can be passed to Ray tasks or actors and read with ``.iter_batches()`` 
     ray.get(consume.remote(ds))
     # -> 200
 
-Datasets can be split up into disjoint sub-datasets. Locality-aware splitting is supported if you pass in a list of actor handles to the ``split()`` function along with the number of desired splits. This is a common pattern useful for loading and splitting data between distributed training actors:
+Advanced usage
+--------------
 
-.. code-block:: python
-
-    @ray.remote(num_gpus=1)
-    class Worker:
-        def __init__(self, rank: int):
-            pass
-
-        def train(self, shard: ray.data.Dataset[int]) -> int:
-            for batch in shard.iter_batches(batch_size=256):
-                pass
-            return shard.count()
-
-    workers = [Worker.remote(i) for i in range(16)]
-    # -> [Actor(Worker, ...), Actor(Worker, ...), ...]
-
-    ds = ray.data.range(10000)
-    # -> Dataset(num_blocks=200, num_rows=10000, schema=<class 'int'>)
-
-    shards = ds.split(n=16, locality_hints=workers)
-    # -> [Dataset(num_blocks=13, num_rows=650, schema=<class 'int'>),
-    #     Dataset(num_blocks=13, num_rows=650, schema=<class 'int'>), ...]
-
-    ray.get([w.train.remote(s) for s in shards])
-    # -> [650, 650, ...]
-
-Tensor-typed values
--------------------
-
-Datasets support tensor-typed values, which are represented in-memory as Arrow tensors (i.e., np.ndarray format). Tensor datasets can be read from and written to ``.npy`` files. Here are some examples:
-
-.. code-block:: python
-
-    # Create a Dataset of tensor-typed values.
-    ds = ray.data.range_tensor(10000, shape=(3, 5))
-    # -> Dataset(num_blocks=200, num_rows=10000,
-    #            schema=<Tensor: shape=(None, 3, 5), dtype=int64>)
-
-    ds.map_batches(lambda t: t + 2).show(2)
-    # -> [[2 2 2 2 2]
-    #     [2 2 2 2 2]
-    #     [2 2 2 2 2]]
-    #    [[3 3 3 3 3]
-    #     [3 3 3 3 3]
-    #     [3 3 3 3 3]]
-
-    # Save to storage.
-    ds.write_numpy("/tmp/tensor_out")
-
-    # Read from storage.
-    ray.data.read_numpy("/tmp/tensor_out")
-    # -> Dataset(num_blocks=200, num_rows=?,
-    #            schema=<Tensor: shape=(None, 3, 5), dtype=int64>)
-
-Tensor datasets are also created whenever an array type is returned from a map function:
-
-.. code-block:: python
-
-    # Create a dataset of Python integers.
-    ds = ray.data.range(10)
-    # -> Dataset(num_blocks=10, num_rows=10, schema=<class 'int'>)
-
-    # It is now converted into a Tensor dataset.
-    ds = ds.map_batches(lambda x: np.array(x))
-    # -> Dataset(num_blocks=10, num_rows=10,
-    #            schema=<Tensor: shape=(None,), dtype=int64>)
-
-Tensor datasets can also be created from NumPy ndarrays that are already stored in the Ray object store:
-
-.. code-block:: python
-
-    import numpy as np
-
-    # Create a Dataset from a list of NumPy ndarray objects.
-    arr1 = np.arange(0, 10)
-    arr2 = np.arange(10, 20)
-    ds = ray.data.from_numpy([ray.put(arr1), ray.put(arr2)])
-
-Tables with tensor columns
---------------------------
-
-In addition to tensor datasets, Datasets also supports tables with fixed-shape tensor columns, where each element in the column is a tensor (n-dimensional array) with the same shape. As an example, this allows you to use both Pandas and Ray Datasets to read, write, and manipulate a table with a column of e.g. images (2D arrays), with all conversions between Pandas, Arrow, and Parquet, and all application of aggregations/operations to the underlying image ndarrays, being taken care of by Ray Datasets.
-
-With our Pandas extension type, :class:`TensorDtype <ray.data.extensions.tensor_extension.TensorDtype>`, and extension array, :class:`TensorArray <ray.data.extensions.tensor_extension.TensorArray>`, you can do familiar aggregations and arithmetic, comparison, and logical operations on a DataFrame containing a tensor column and the operations will be applied to the underlying tensors as expected. With our Arrow extension type, :class:`ArrowTensorType <ray.data.extensions.tensor_extension.ArrowTensorType>`, and extension array, :class:`ArrowTensorArray <ray.data.extensions.tensor_extension.ArrowTensorArray>`, you'll be able to import that DataFrame into Ray Datasets and read/write the data from/to the Parquet format.
-
-Automatic conversion between the Pandas and Arrow extension types/arrays keeps the details under-the-hood, so you only have to worry about casting the column to a tensor column using our Pandas extension type when first ingesting the table into a ``Dataset``, whether from storage or in-memory. All table operations downstream from that cast should work automatically.
-
-If you already have a Parquet dataset with columns containing serialized tensors, you can have these tensor columns cast to our tensor extension type at read-time by giving a simple schema for the tensor columns. Note that these tensors must have been serialized as their raw NumPy ndarray bytes in C-contiguous order (e.g. serialized via ``arr.tobytes()``).
-
-.. code-block:: python
-
-    import numpy as np
-    import pandas as pd
-    from ray.data.extensions import TensorDtype, TensorArray
-
-    path = "/tmp/some_path"
-
-    # Create a DataFrame with a list of serialized ndarrays as a column.
-    # Note that we do not cast it to a tensor array, so each element in the
-    # column is an opaque blob of bytes.
-    arr = np.arange(24).reshape((3, 2, 2, 2))
-    df = pd.DataFrame({
-        "one": [1, 2, 3],
-        "two": [tensor.tobytes() for tensor in arr]})
-
-    # Write the dataset to Parquet. The tensor column will be written as an
-    # array of opaque byte blobs.
-    ds = ray.data.from_pandas([ray.put(df)])
-    ds.write_parquet(path)
-
-    # Read the Parquet files into a new Dataset, with the serialized tensors
-    # automatically cast to our tensor column extension type.
-    ds = ray.data.read_parquet(
-        path, _tensor_column_schema={"two": (np.int, (2, 2, 2))})
-
-    # Internally, this column is represented with our Arrow tensor extension
-    # type.
-    print(ds.schema())
-    # -> one: int64
-    #    two: extension<arrow.py_extension_type<ArrowTensorType>>
-
-If your serialized tensors don't fit the above constraints (e.g. they're stored in Fortran-contiguous order, or they're pickled), you can manually cast this tensor column to our tensor extension type via a read-time user-defined function. This UDF will be pushed down to Ray Datasets' IO layer and executed on each block in parallel, as it's read from storage.
-
-.. code-block:: python
-
-    import pickle
-
-    # Create a DataFrame with a list of pickled ndarrays as a column.
-    arr = np.arange(24).reshape((3, 2, 2, 2))
-    df = pd.DataFrame({
-        "one": [1, 2, 3],
-        "two": [pickle.dumps(tensor) for tensor in arr]})
-
-    # Write the dataset to Parquet. The tensor column will be written as an
-    # array of opaque byte blobs.
-    ds = ray.data.from_pandas([ray.put(df)])
-    ds.write_parquet(path)
-
-    # Manually deserialize the tensor pickle bytes and cast to our tensor
-    # extension type. For the sake of efficiency, we directly construct a
-    # TensorArray rather than .astype() casting on the mutated column with
-    # TensorDtype.
-    def cast_udf(block: pa.Table) -> pa.Table:
-        block = block.to_pandas()
-        block["two"] = TensorArray([pickle.loads(a) for a in block["two"]])
-        return pa.Table.from_pandas(block)
-
-    # Read the Parquet files into a new Dataset, applying the casting UDF
-    # on-the-fly within the underlying read tasks.
-    ds = ray.data.read_parquet(path, _block_udf=cast_udf)
-
-    # Internally, this column is represented with our Arrow tensor extension
-    # type.
-    print(ds.schema())
-    # -> one: int64
-    #    two: extension<arrow.py_extension_type<ArrowTensorType>>
-
-Please note that the ``_tensor_column_schema`` and ``_block_udf`` parameters are both experimental developer APIs and may break in future versions.
-
-Now that the tensor column is properly typed and in a ``Dataset``, we can perform operations on the dataset as if it was a normal table:
-
-.. code-block:: python
-
-    # Arrow and Pandas is now aware of this tensor column, so we can do the
-    # typical DataFrame operations on this column.
-    ds = ds.map_batches(lambda x: 2 * (x + 1), format="pandas")
-    # -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1123.54it/s]
-    print(ds)
-    # -> Dataset(num_blocks=1, num_rows=3, schema=<class 'int', class ray.data.extensions.tensor_extension.ArrowTensorType>)
-    print([row["two"] for row in ds.take(5)])
-    # -> [2, 4, 6, 8, 10]
-
-This dataset can then be written to Parquet file. The tensor column schema will be preserved via the Pandas and Arrow extension types and associated metadata, allowing us to later read the Parquet files into a Dataset without needing to specify a casting UDF. This Pandas --> Arrow --> Parquet --> Arrow --> Pandas conversion support makes working with tensor columns extremely easy when using Ray Datasets to both write and read data.
-
-.. code-block:: python
-
-    # You can write the dataset to Parquet.
-    ds.write_parquet("/some/path")
-    # And you can read it back.
-    read_ds = ray.data.read_parquet("/some/path")
-    print(read_ds.schema())
-    # -> one: int64
-    #    two: extension<arrow.py_extension_type<ArrowTensorType>>
-
-If working with in-memory Pandas DataFrames that you want to analyze, manipulate, store, and eventually read, the Pandas/Arrow extension types/arrays make it easy to extend this end-to-end workflow to tensor columns.
-
-.. code-block:: python
-
-    # Create a DataFrame with a list of ndarrays as a column.
-    df = pd.DataFrame({
-        "one": [1, 2, 3],
-        "two": list(np.arange(24).reshape((3, 2, 2, 2)))})
-    # Note the opaque np.object dtype for this column.
-    print(df.dtypes)
-    # -> one     int64
-    #    two    object
-    #    dtype: object
-
-    # Cast column to our TensorDtype Pandas extension type.
-    df["two"] = df["two"].astype(TensorDtype())
-
-    # Note that the column dtype is now TensorDtype instead of
-    # np.object.
-    print(df.dtypes)
-    # -> one          int64
-    #    two    TensorDtype
-    #    dtype: object
-
-    # Pandas is now aware of this tensor column, and we can do the
-    # typical DataFrame operations on this column.
-    col = 2 * df["two"]
-    # The ndarrays underlying the tensor column will be manipulated,
-    # but the column itself will continue to be a Pandas type.
-    print(type(col))
-    # -> pandas.core.series.Series
-    print(col)
-    # -> 0   [[[ 2  4]
-    #          [ 6  8]]
-    #         [[10 12]
-    #           [14 16]]]
-    #    1   [[[18 20]
-    #          [22 24]]
-    #         [[26 28]
-    #          [30 32]]]
-    #    2   [[[34 36]
-    #          [38 40]]
-    #         [[42 44]
-    #          [46 48]]]
-    #    Name: two, dtype: TensorDtype
-
-    # Once you do an aggregation on that column that returns a single
-    # row's value, you get back our TensorArrayElement type.
-    tensor = col.mean()
-    print(type(tensor))
-    # -> ray.data.extensions.tensor_extension.TensorArrayElement
-    print(tensor)
-    # -> array([[[18., 20.],
-    #            [22., 24.]],
-    #           [[26., 28.],
-    #            [30., 32.]]])
-
-    # This is a light wrapper around a NumPy ndarray, and can easily
-    # be converted to an ndarray.
-    type(tensor.to_numpy())
-    # -> numpy.ndarray
-
-    # In addition to doing Pandas operations on the tensor column,
-    # you can now put the DataFrame directly into a Dataset.
-    ds = ray.data.from_pandas([ray.put(df)])
-    # Internally, this column is represented with the corresponding
-    # Arrow tensor extension type.
-    print(ds.schema())
-    # -> one: int64
-    #    two: extension<arrow.py_extension_type<ArrowTensorType>>
-
-    # You can write the dataset to Parquet.
-    ds.write_parquet("/some/path")
-    # And you can read it back.
-    read_ds = ray.data.read_parquet("/some/path")
-    print(read_ds.schema())
-    # -> one: int64
-    #    two: extension<arrow.py_extension_type<ArrowTensorType>>
-
-    read_df = ray.get(read_ds.to_pandas())[0]
-    print(read_df.dtypes)
-    # -> one          int64
-    #    two    TensorDtype
-    #    dtype: object
-
-    # The tensor extension type is preserved along the
-    # Pandas --> Arrow --> Parquet --> Arrow --> Pandas
-    # conversion chain.
-    print(read_df.equals(df))
-    # -> True
-
-**Limitations:**
- * All tensors in a tensor column currently must be the same shape. Please let us know if you require heterogeneous tensor shape for your tensor column! Tracking issue is `here <https://github.com/ray-project/ray/issues/18316>`__.
- * Automatic casting via specifying an override Arrow schema when reading Parquet is blocked by Arrow supporting custom ExtensionType casting kernels. See `issue <https://issues.apache.org/jira/browse/ARROW-5890>`__. An explicit ``_tensor_column_schema`` parameter has been added for :func:`read_parquet() <ray.data.read_api.read_parquet>` as a stopgap solution.
- * Ingesting tables with tensor columns into pytorch via ``ds.to_torch()`` is blocked by pytorch supporting tensor creation from objects that implement the `__array__` interface. See `issue <https://github.com/pytorch/pytorch/issues/51156>`__. Workarounds are being `investigated <https://github.com/ray-project/ray/issues/18314>`__.
- * Ingesting tables with tensor columns into TensorFlow via ``ds.to_tf()`` is blocked by a Pandas fix for properly interpreting extension arrays in ``DataFrame.values`` being released. See `PR <https://github.com/pandas-dev/pandas/pull/43160>`__. Workarounds are being `investigated <https://github.com/ray-project/ray/issues/18315>`__.
-
-Custom datasources
-------------------
-
-Datasets can read and write in parallel to `custom datasources <package-ref.html#custom-datasource-api>`__ defined in Python.
-
-.. code-block:: python
-
-    # Read from a custom datasource.
-    ds = ray.data.read_datasource(YourCustomDatasource(), **read_args)
-
-    # Write to a custom datasource.
-    ds.write_datasource(YourCustomDatasource(), **write_args)
+See the `advanced usage page </data/dataset-advanced>` for docs on dataset sharding, tensor datasets, using tensor columns in your tables, and implementing your own custom datasource.
 
 Contributing
 ------------

--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -420,7 +420,7 @@ If you already have Parquet files with tensor columns containing serialized tens
 
     # Read the Parquet files into a new Dataset, applying the casting UDF
     # on-the-fly within the underlying read tasks.
-    ds = ray.data.read_parquet(path, block_udf=cast_udf)
+    ds = ray.data.read_parquet(path, _block_udf=cast_udf)
 
     # Internally, this column is represented with our Arrow tensor extension
     # type.
@@ -428,7 +428,7 @@ If you already have Parquet files with tensor columns containing serialized tens
     # -> one: int64
     #    two: extension<arrow.py_extension_type<ArrowTensorType>>
 
-Please note that the ``block_udf=`` parameter is an experimental developer API and may break in future versions. We're currently exploring ways to do this cast automatically and with minimal user input; see the "Limitations" section below.
+Please note that the ``_block_udf=`` parameter is an experimental developer API and may break in future versions. We're currently exploring ways to do this cast automatically and with minimal user input; see the "Limitations" section below.
 
 Now that the tensor column is properly typed and in a ``Dataset``, we can perform operations on the dataset as if it was a normal table:
 

--- a/doc/source/data/package-ref.rst
+++ b/doc/source/data/package-ref.rst
@@ -34,6 +34,21 @@ DatasetPipeline API
 .. autoclass:: ray.data.dataset_pipeline.DatasetPipeline
     :members:
 
+Tensor Column Extension API
+---------------------
+
+.. autoclass:: ray.data.extensions.tensor_extension.TensorDtype
+    :members:
+
+.. autoclass:: ray.data.extensions.tensor_extension.TensorArray
+    :members:
+
+.. autoclass:: ray.data.extensions.tensor_extension.ArrowTensorType
+    :members:
+
+.. autoclass:: ray.data.extensions.tensor_extension.ArrowTensorArray
+    :members:
+
 Custom Datasource API
 ---------------------
 

--- a/doc/source/data/package-ref.rst
+++ b/doc/source/data/package-ref.rst
@@ -35,7 +35,7 @@ DatasetPipeline API
     :members:
 
 Tensor Column Extension API
----------------------
+---------------------------
 
 .. autoclass:: ray.data.extensions.tensor_extension.TensorDtype
     :members:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -277,6 +277,7 @@ Papers
    :caption: Ray Data
 
    data/dataset.rst
+   data/dataset-advanced.rst
    data/dataset-pipeline.rst
    data/package-ref.rst
    data/dask-on-ray.rst

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -277,7 +277,7 @@ Papers
    :caption: Ray Data
 
    data/dataset.rst
-   data/dataset-advanced.rst
+   data/dataset-tensor-support.rst
    data/dataset-pipeline.rst
    data/package-ref.rst
    data/dask-on-ray.rst

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1183,6 +1183,8 @@ class Dataset(Generic[T]):
                 target_col = batch.pop(label_column)
                 if feature_columns:
                     batch = batch[feature_columns]
+                # TODO(Clark): Support batches containining our extension array
+                # TensorArray.
                 yield batch.values, target_col.values
 
         return tf.data.Dataset.from_generator(

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1183,7 +1183,7 @@ class Dataset(Generic[T]):
                 target_col = batch.pop(label_column)
                 if feature_columns:
                     batch = batch[feature_columns]
-                # TODO(Clark): Support batches containining our extension array
+                # TODO(Clark): Support batches containing our extension array
                 # TensorArray.
                 yield batch.values, target_col.values
 

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -36,7 +36,7 @@ class FileBasedDatasource(Datasource[Union[ArrowRow, Any]]):
             paths: Union[str, List[str]],
             filesystem: Optional["pyarrow.fs.FileSystem"] = None,
             schema: Optional[Union[type, "pyarrow.lib.Schema"]] = None,
-            block_udf: Optional[Callable[[Block], Block]] = None,
+            _block_udf: Optional[Callable[[Block], Block]] = None,
             **reader_args) -> List[ReadTask]:
         """Creates and returns read tasks for a file-based datasource.
         """
@@ -68,8 +68,8 @@ class FileBasedDatasource(Datasource[Union[ArrowRow, Any]]):
                     else:
                         builder.add(data)
             block = builder.build()
-            if block_udf is not None:
-                block = block_udf(block)
+            if _block_udf is not None:
+                block = _block_udf(block)
             return block
 
         read_tasks = []
@@ -115,7 +115,7 @@ class FileBasedDatasource(Datasource[Union[ArrowRow, Any]]):
                  path: str,
                  dataset_uuid: str,
                  filesystem: Optional["pyarrow.fs.FileSystem"] = None,
-                 block_udf: Optional[Callable[[Block], Block]] = None,
+                 _block_udf: Optional[Callable[[Block], Block]] = None,
                  **write_args) -> List[ObjectRef[WriteResult]]:
         """Creates and returns write tasks for a file-based datasource."""
         path, filesystem = _resolve_paths_and_filesystem(path, filesystem)
@@ -129,8 +129,8 @@ class FileBasedDatasource(Datasource[Union[ArrowRow, Any]]):
             fs = filesystem
             if isinstance(fs, _S3FileSystemWrapper):
                 fs = fs.unwrap()
-            if block_udf is not None:
-                block = block_udf(block)
+            if _block_udf is not None:
+                block = _block_udf(block)
             with fs.open_output_stream(write_path) as f:
                 _write_block_to_file(f, BlockAccessor.for_block(block))
 

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -1,10 +1,10 @@
 import logging
-from typing import Optional, List, Union, TYPE_CHECKING
+from typing import Callable, Optional, List, Union, TYPE_CHECKING
 
 if TYPE_CHECKING:
     import pyarrow
 
-from ray.data.block import BlockAccessor
+from ray.data.block import Block, BlockAccessor
 from ray.data.datasource.datasource import ReadTask
 from ray.data.datasource.file_based_datasource import (
     FileBasedDatasource, _resolve_paths_and_filesystem)
@@ -30,6 +30,7 @@ class ParquetDatasource(FileBasedDatasource):
             filesystem: Optional["pyarrow.fs.FileSystem"] = None,
             columns: Optional[List[str]] = None,
             schema: Optional[Union[type, "pyarrow.lib.Schema"]] = None,
+            block_udf: Optional[Callable[[Block], Block]] = None,
             **reader_args) -> List[ReadTask]:
         """Creates and returns read tasks for a Parquet file-based datasource.
         """
@@ -58,7 +59,6 @@ class ParquetDatasource(FileBasedDatasource):
         if columns:
             schema = pa.schema([schema.field(column) for column in columns],
                                schema.metadata)
-        pieces = pq_ds.pieces
 
         def read_pieces(serialized_pieces: List[str]):
             # Implicitly trigger S3 subsystem initialization by importing
@@ -97,18 +97,35 @@ class ParquetDatasource(FileBasedDatasource):
                 table = pa.concat_tables(tables, promote=True)
             elif len(tables) == 1:
                 table = tables[0]
+            if block_udf is not None:
+                table = block_udf(table)
             # If len(tables) == 0, all fragments were empty, and we return the
             # empty table from the last fragment.
             return table
 
+        if block_udf is not None:
+            # Try to infer dataset schema by passing dummy table through UDF.
+            dummy_table = schema.empty_table()
+            try:
+                inferred_schema = block_udf(dummy_table).schema
+                inferred_schema = inferred_schema.with_metadata(
+                    schema.metadata)
+            except Exception as e:
+                logger.info(
+                    "Failed to infer schema of dataset by passing dummy table "
+                    f"through UDF: {e}")
+                inferred_schema = schema
+        else:
+            inferred_schema = schema
         read_tasks = []
-        for pieces_ in np.array_split(pieces, parallelism):
-            if len(pieces_) == 0:
+        for pieces in np.array_split(pq_ds.pieces, parallelism):
+            if len(pieces) == 0:
                 continue
-            metadata = _get_metadata(pieces_, schema)
-            pieces_ = [cloudpickle.dumps(p) for p in pieces_]
+            metadata = _get_metadata(pieces, inferred_schema)
+            pieces = [cloudpickle.dumps(p) for p in pieces]
             read_tasks.append(
-                ReadTask(lambda pieces=pieces_: read_pieces(pieces), metadata))
+                ReadTask(
+                    lambda pieces_=pieces: read_pieces(pieces_), metadata))
 
         return read_tasks
 

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -110,10 +110,11 @@ class ParquetDatasource(FileBasedDatasource):
                 inferred_schema = _block_udf(dummy_table).schema
                 inferred_schema = inferred_schema.with_metadata(
                     schema.metadata)
-            except Exception as e:
+            except Exception:
                 logger.info(
                     "Failed to infer schema of dataset by passing dummy table "
-                    f"through UDF: {e}")
+                    "through UDF due to the following exception:",
+                    exc_info=True)
                 inferred_schema = schema
         else:
             inferred_schema = schema

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -30,7 +30,7 @@ class ParquetDatasource(FileBasedDatasource):
             filesystem: Optional["pyarrow.fs.FileSystem"] = None,
             columns: Optional[List[str]] = None,
             schema: Optional[Union[type, "pyarrow.lib.Schema"]] = None,
-            block_udf: Optional[Callable[[Block], Block]] = None,
+            _block_udf: Optional[Callable[[Block], Block]] = None,
             **reader_args) -> List[ReadTask]:
         """Creates and returns read tasks for a Parquet file-based datasource.
         """
@@ -97,17 +97,17 @@ class ParquetDatasource(FileBasedDatasource):
                 table = pa.concat_tables(tables, promote=True)
             elif len(tables) == 1:
                 table = tables[0]
-            if block_udf is not None:
-                table = block_udf(table)
+            if _block_udf is not None:
+                table = _block_udf(table)
             # If len(tables) == 0, all fragments were empty, and we return the
             # empty table from the last fragment.
             return table
 
-        if block_udf is not None:
+        if _block_udf is not None:
             # Try to infer dataset schema by passing dummy table through UDF.
             dummy_table = schema.empty_table()
             try:
-                inferred_schema = block_udf(dummy_table).schema
+                inferred_schema = _block_udf(dummy_table).schema
                 inferred_schema = inferred_schema.with_metadata(
                     schema.metadata)
             except Exception as e:

--- a/python/ray/data/extensions/__init__.py
+++ b/python/ray/data/extensions/__init__.py
@@ -1,0 +1,10 @@
+from ray.data.extensions.tensor_extension import (
+    TensorDtype, TensorArray, ArrowTensorType, ArrowTensorArray)
+
+__all__ = [
+    # Tensor array extension.
+    "TensorDtype",
+    "TensorArray",
+    "ArrowTensorType",
+    "ArrowTensorArray",
+]

--- a/python/ray/data/extensions/tensor_extension.py
+++ b/python/ray/data/extensions/tensor_extension.py
@@ -119,7 +119,7 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
                [[26., 28.],
                 [30., 32.]]])
         >>> # This is a light wrapper around a NumPy ndarray, and can easily
-        >>> # be converted to a NumPy ndarray.
+        >>> # be converted to an ndarray.
         >>> type(tensor.to_numpy())
         numpy.ndarray
 
@@ -401,7 +401,7 @@ class TensorArray(pd.api.extensions.ExtensionArray, TensorOpsMixin):
                [[26., 28.],
                 [30., 32.]]])
         >>> # This is a light wrapper around a NumPy ndarray, and can easily
-        >>> # be converted to a NumPy ndarray.
+        >>> # be converted to an ndarray.
         >>> type(tensor.to_numpy())
         numpy.ndarray
 
@@ -1103,6 +1103,7 @@ TensorArray._add_logical_ops()
 # -----------------------------------------------------------------------------
 
 
+@PublicAPI(stability="beta")
 class ArrowTensorType(pa.PyExtensionType):
     """
     Arrow ExtensionType for an array of fixed-shaped, homogeneous-typed
@@ -1155,6 +1156,7 @@ class ArrowTensorType(pa.PyExtensionType):
         return ArrowTensorArray
 
 
+@PublicAPI(stability="beta")
 class ArrowTensorArray(pa.ExtensionArray):
     """
     An array of fixed-shape, homogeneous-typed tensors.

--- a/python/ray/data/extensions/tensor_extension.py
+++ b/python/ray/data/extensions/tensor_extension.py
@@ -1,0 +1,1289 @@
+# Adapted from
+# https://github.com/CODAIT/text-extensions-for-pandas/blob/dc03278689fe1c5f131573658ae19815ba25f33e/text_extensions_for_pandas/array/tensor.py
+# and
+# https://github.com/CODAIT/text-extensions-for-pandas/blob/dc03278689fe1c5f131573658ae19815ba25f33e/text_extensions_for_pandas/array/arrow_conversion.py
+
+#
+#  Copyright (c) 2020 IBM Corp.
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Modifications:
+# - Added ArrowTensorType.to_pandas_type()
+# - Added ArrowTensorArray.__getitem__()
+# - Added ArrowTensorArray.__iter__()
+# - Added support for column casts to extension types.
+# - Fleshed out docstrings and examples.
+# - Fixed TensorArray.isna() so it returns an appropriate ExtensionArray.
+# - Added different (more vectorized) TensorArray.take() operation.
+# - Added support for more reducers (agg funcs) to TensorArray.
+# - Added support for logical operators to TensorArray(Element).
+# - Miscellaneous small bug fixes and optimizations.
+
+from collections import Iterable
+import numbers
+from typing import Sequence, Any, Union, Tuple, Optional, Callable
+
+import numpy as np
+import pandas as pd
+from pandas._typing import Dtype
+from pandas.compat import set_function_name
+from pandas.core.dtypes.generic import ABCDataFrame, ABCSeries
+try:
+    from pandas.core.dtypes.generic import ABCIndex
+except ImportError:
+    # ABCIndexClass changed to ABCIndex in Pandas 1.3
+    from pandas.core.dtypes.generic import ABCIndexClass as ABCIndex
+from pandas.core.indexers import check_array_indexer, validate_indices
+import pyarrow as pa
+
+from ray.util.annotations import PublicAPI
+
+# -----------------------------------------------------------------------------
+#                       Pandas extension type and array
+# -----------------------------------------------------------------------------
+
+
+@PublicAPI(stability="beta")
+@pd.api.extensions.register_extension_dtype
+class TensorDtype(pd.api.extensions.ExtensionDtype):
+    """
+    Pandas extension type for a column of fixed-shape, homogeneous-typed
+    tensors.
+
+    See:
+    https://github.com/pandas-dev/pandas/blob/master/pandas/core/dtypes/base.py
+    for up-to-date interface documentation and the subclassing contract. The
+    docstrings of the below properties and methods were copied from the base
+    ExtensionDtype.
+
+    Examples:
+        >>> # Create a DataFrame with a list of ndarrays as a column.
+        >>> df = pd.DataFrame({
+                "one": [1, 2, 3],
+                "two": list(np.arange(24).reshape((3, 2, 2, 2)))})
+        >>> # Note the opaque np.object dtype for this column.
+        >>> df.dtypes
+        one     int64
+        two    object
+        dtype: object
+
+        >>> # Cast column to our TensorDtype extension type.
+        >>> df["two"] = df["two"].astype(TensorDtype())
+
+        >>> # Note that the column dtype is now TensorDtype instead of
+        >>> # np.object.
+        >>> df.dtypes
+        one          int64
+        two    TensorDtype
+        dtype: object
+
+        >>> # Pandas is now aware of this tensor column, and we can do the
+        >>> # typical DataFrame operations on this column.
+        >>> col = 2 * (df["two"] + 10)
+        >>> # The ndarrays underlying the tensor column will be manipulated,
+        >>> # but the column itself will continue to be a Pandas type.
+        >>> type(col)
+        pandas.core.series.Series
+        >>> col
+        0   [[[ 2  4]
+              [ 6  8]]
+             [[10 12]
+               [14 16]]]
+        1   [[[18 20]
+              [22 24]]
+             [[26 28]
+              [30 32]]]
+        2   [[[34 36]
+              [38 40]]
+             [[42 44]
+              [46 48]]]
+        Name: two, dtype: TensorDtype
+        >>> # Once you do an aggregation on that column that returns a single
+        >>> # row's value, you get back our TensorArrayElement type.
+        >>> tensor = col.mean()
+        >>> type(tensor)
+        ray.data.extensions.tensor_extension.TensorArrayElement
+        >>> tensor
+        array([[[18., 20.],
+                [22., 24.]],
+               [[26., 28.],
+                [30., 32.]]])
+        >>> # This is a light wrapper around a NumPy ndarray, and can easily
+        >>> # be converted to a NumPy ndarray.
+        >>> type(tensor.to_numpy())
+        numpy.ndarray
+
+        >>> # In addition to doing Pandas operations on the tensor column,
+        >>> # you can now put the DataFrame into a Dataset.
+        >>> ds = ray.data.from_pandas([ray.put(df)])
+        >>> # Internally, this column is represented the corresponding
+        >>> # Arrow tensor extension type.
+        >>> ds.schema()
+        one: int64
+        two: extension<arrow.py_extension_type<ArrowTensorType>>
+
+        >>> # You can write the dataset to Parquet.
+        >>> ds.write_parquet("/some/path")
+        >>> # And you can read it back.
+        >>> read_ds = ray.data.read_parquet("/some/path")
+        >>> read_ds.schema()
+        one: int64
+        two: extension<arrow.py_extension_type<ArrowTensorType>>
+
+        >>> read_df = ray.get(read_ds.to_pandas())[0]
+        >>> read_df.dtypes
+        one          int64
+        two    TensorDtype
+        dtype: object
+        >>> # The tensor extension type is preserved along the
+        >>> # Pandas --> Arrow --> Parquet --> Arrow --> Pandas
+        >>> # conversion chain.
+        >>> read_df.equals(df)
+        True
+    """
+    # NOTE(Clark): This is apparently required to prevent integer indexing
+    # errors, but is an undocumented ExtensionDtype attribute. See issue:
+    # https://github.com/CODAIT/text-extensions-for-pandas/issues/166
+    base = None
+
+    @property
+    def type(self):
+        """
+        The scalar type for the array, e.g. ``int``
+        It's expected ``ExtensionArray[item]`` returns an instance
+        of ``ExtensionDtype.type`` for scalar ``item``, assuming
+        that value is valid (not NA). NA values do not need to be
+        instances of `type`.
+        """
+        return TensorArrayElement
+
+    @property
+    def name(self) -> str:
+        """
+        A string identifying the data type.
+        Will be used for display in, e.g. ``Series.dtype``
+        """
+        return "TensorDtype"
+
+    @classmethod
+    def construct_from_string(cls, string: str):
+        """
+        Construct this type from a string.
+
+        This is useful mainly for data types that accept parameters.
+        For example, a period dtype accepts a frequency parameter that
+        can be set as ``period[H]`` (where H means hourly frequency).
+
+        By default, in the abstract class, just the name of the type is
+        expected. But subclasses can overwrite this method to accept
+        parameters.
+
+        Parameters
+        ----------
+        string : str
+            The name of the type, for example ``category``.
+
+        Returns
+        -------
+        ExtensionDtype
+            Instance of the dtype.
+
+        Raises
+        ------
+        TypeError
+            If a class cannot be constructed from this 'string'.
+
+        Examples
+        --------
+        For extension dtypes with arguments the following may be an
+        adequate implementation.
+
+        >>> @classmethod
+        ... def construct_from_string(cls, string):
+        ...     pattern = re.compile(r"^my_type\[(?P<arg_name>.+)\]$")
+        ...     match = pattern.match(string)
+        ...     if match:
+        ...         return cls(**match.groupdict())
+        ...     else:
+        ...         raise TypeError(
+        ...             f"Cannot construct a '{cls.__name__}' from '{string}'"
+        ...         )
+        """
+        if not isinstance(string, str):
+            raise TypeError(
+                f"'construct_from_string' expects a string, got {type(string)}"
+            )
+        # Upstream code uses exceptions as part of its normal control flow and
+        # will pass this method bogus class names.
+        if string == cls.__name__:
+            return cls()
+        else:
+            raise TypeError(
+                f"Cannot construct a '{cls.__name__}' from '{string}'")
+
+    @classmethod
+    def construct_array_type(cls):
+        """
+        Return the array type associated with this dtype.
+
+        Returns
+        -------
+        type
+        """
+        return TensorArray
+
+    def __from_arrow__(self, array: Union[pa.Array, pa.ChunkedArray]):
+        """
+        Convert a pyarrow (chunked) array to a TensorArray.
+
+        This and TensorArray.__arrow_array__ make up the
+        Pandas extension type + array <--> Arrow extension type + array
+        interoperability protocol. See
+        https://pandas.pydata.org/pandas-docs/stable/development/extending.html#compatibility-with-apache-arrow
+        for more information.
+        """
+        if isinstance(array, pa.ChunkedArray):
+            if array.num_chunks > 1:
+                # TODO(Clark): Remove concat and construct from list with
+                # shape.
+                values = np.concatenate(
+                    [chunk.to_numpy() for chunk in array.iterchunks()])
+            else:
+                values = array.chunk(0).to_numpy()
+        else:
+            values = array.to_numpy()
+
+        return TensorArray(values)
+
+
+class TensorOpsMixin(pd.api.extensions.ExtensionScalarOpsMixin):
+    """
+    Mixin for TensorArray operator support, applying operations on the
+    underlying ndarrays.
+    """
+
+    @classmethod
+    def _create_method(cls, op, coerce_to_dtype=True, result_dtype=None):
+        """
+        Add support for binary operators by unwrapping, applying, and
+        rewrapping.
+        """
+
+        # NOTE(Clark): This overrides, but coerce_to_dtype, result_dtype might
+        # not be needed
+
+        def _binop(self, other):
+            lvalues = self._tensor
+
+            if isinstance(other, (ABCDataFrame, ABCSeries, ABCIndex)):
+                # Rely on Pandas to unbox and dispatch to us.
+                return NotImplemented
+
+            # divmod returns a tuple
+            if op_name in ["__divmod__", "__rdivmod__"]:
+                # TODO(Clark): Add support for divmod and rdivmod.
+                # div, mod = result
+                raise NotImplementedError
+
+            if isinstance(other, (TensorArray, TensorArrayElement)):
+                rvalues = other._tensor
+            else:
+                rvalues = other
+
+            result = op(lvalues, rvalues)
+
+            # Force a TensorArray if rvalue is not a scalar.
+            if (isinstance(self, TensorArrayElement)
+                    and (not isinstance(other, TensorArrayElement)
+                         or not np.isscalar(other))):
+                result_wrapped = TensorArray(result)
+            else:
+                result_wrapped = cls(result)
+
+            return result_wrapped
+
+        op_name = f"__{op.__name__}__"
+        return set_function_name(_binop, op_name, cls)
+
+    @classmethod
+    def _create_logical_method(cls, op):
+        return cls._create_method(op)
+
+
+class TensorArrayElement(TensorOpsMixin):
+    """
+    Single element of a TensorArray, wrapping an underlying ndarray.
+    """
+
+    def __init__(self, values: np.ndarray):
+        """
+        Construct a TensorArrayElement from a NumPy ndarray.
+
+        Args:
+            values: ndarray that underlies this TensorArray element.
+        """
+        self._tensor = values
+
+    def __repr__(self):
+        return self._tensor.__repr__()
+
+    def __str__(self):
+        return self._tensor.__str__()
+
+    def to_numpy(self):
+        """
+        Return the values of this element as a NumPy ndarray.
+        """
+        return np.asarray(self._tensor)
+
+    def __array__(self):
+        return np.asarray(self._tensor)
+
+
+@PublicAPI(stability="beta")
+class TensorArray(pd.api.extensions.ExtensionArray, TensorOpsMixin):
+    """
+    Pandas `ExtensionArray` representing a tensor column, i.e. a column
+    consisting of ndarrays as elements. All tensors in a column must have the
+    same shape.
+
+    Examples:
+        >>> # Create a DataFrame with a list of ndarrays as a column.
+        >>> df = pd.DataFrame({
+                "one": [1, 2, 3],
+                "two": TensorArray(np.arange(24).reshape((3, 2, 2, 2)))})
+
+        >>> # Note that the column dtype is TensorDtype.
+        >>> df.dtypes
+        one          int64
+        two    TensorDtype
+        dtype: object
+
+        >>> # Pandas is aware of this tensor column, and we can do the
+        >>> # typical DataFrame operations on this column.
+        >>> col = 2 * (df["two"] + 10)
+        >>> # The ndarrays underlying the tensor column will be manipulated,
+        >>> # but the column itself will continue to be a Pandas type.
+        >>> type(col)
+        pandas.core.series.Series
+        >>> col
+        0   [[[ 2  4]
+              [ 6  8]]
+             [[10 12]
+               [14 16]]]
+        1   [[[18 20]
+              [22 24]]
+             [[26 28]
+              [30 32]]]
+        2   [[[34 36]
+              [38 40]]
+             [[42 44]
+              [46 48]]]
+        Name: two, dtype: TensorDtype
+        >>> # Once you do an aggregation on that column that returns a single
+        >>> # row's value, you get back our TensorArrayElement type.
+        >>> tensor = col.mean()
+        >>> type(tensor)
+        ray.data.extensions.tensor_extension.TensorArrayElement
+        >>> tensor
+        array([[[18., 20.],
+                [22., 24.]],
+               [[26., 28.],
+                [30., 32.]]])
+        >>> # This is a light wrapper around a NumPy ndarray, and can easily
+        >>> # be converted to a NumPy ndarray.
+        >>> type(tensor.to_numpy())
+        numpy.ndarray
+
+        >>> # In addition to doing Pandas operations on the tensor column,
+        >>> # you can now put the DataFrame into a Dataset.
+        >>> ds = ray.data.from_pandas([ray.put(df)])
+        >>> # Internally, this column is represented the corresponding
+        >>> # Arrow tensor extension type.
+        >>> ds.schema()
+        one: int64
+        two: extension<arrow.py_extension_type<ArrowTensorType>>
+
+        >>> # You can write the dataset to Parquet.
+        >>> ds.write_parquet("/some/path")
+        >>> # And you can read it back.
+        >>> read_ds = ray.data.read_parquet("/some/path")
+        >>> read_ds.schema()
+        one: int64
+        two: extension<arrow.py_extension_type<ArrowTensorType>>
+
+        >>> read_df = ray.get(read_ds.to_pandas())[0]
+        >>> read_df.dtypes
+        one          int64
+        two    TensorDtype
+        dtype: object
+        >>> # The tensor extension type is preserved along the
+        >>> # Pandas --> Arrow --> Parquet --> Arrow --> Pandas
+        >>> # conversion chain.
+        >>> read_df.equals(df)
+        True
+    """
+    SUPPORTED_REDUCERS = {
+        "sum": np.sum,
+        "all": np.all,
+        "any": np.any,
+        "min": np.min,
+        "max": np.max,
+        "mean": np.mean,
+        "median": np.median,
+        "prod": np.prod,
+        "std": np.std,
+        "var": np.var,
+    }
+
+    # See https://github.com/pandas-dev/pandas/blob/master/pandas/core/arrays/base.py  # noqa
+    # for interface documentation and the subclassing contract.
+    def __init__(self, values: Union[np.ndarray, ABCSeries, Sequence[Union[
+            np.ndarray, TensorArrayElement]], TensorArrayElement, Any]):
+        """
+        Args:
+            values: A NumPy ndarray or sequence of NumPy ndarrays of equal
+                shape.
+        """
+        if isinstance(values, ABCSeries):
+            # Convert series to ndarray and passthrough to ndarray handling
+            # logic.
+            values = values.to_numpy()
+
+        if isinstance(values, np.ndarray):
+            if (values.dtype.type is np.object_ and len(values) > 0
+                    and isinstance(values[0],
+                                   (np.ndarray, TensorArrayElement))):
+                # Convert ndarrays of ndarrays/TensorArrayElements
+                # with an opaque object type to a properly typed ndarray of
+                # ndarrays.
+                self._tensor = np.array([np.asarray(v) for v in values])
+            else:
+                self._tensor = values
+        elif isinstance(values, Sequence):
+            if len(values) == 0:
+                self._tensor = np.array([])
+            else:
+                self._tensor = np.stack(
+                    [np.asarray(v) for v in values], axis=0)
+        elif isinstance(values, TensorArrayElement):
+            self._tensor = np.array([np.asarray(values)])
+        elif np.isscalar(values):
+            # `values` is a single element:
+            self._tensor = np.array([values])
+        elif isinstance(values, TensorArray):
+            raise TypeError(
+                "Use the copy() method to create a copy of a TensorArray")
+        else:
+            raise TypeError(
+                "Expected a numpy.ndarray or sequence of numpy.ndarray, "
+                f"but received {values} "
+                f"of type '{type(values)}' instead.")
+
+    @classmethod
+    def _from_sequence(cls,
+                       scalars,
+                       *,
+                       dtype: Optional[Dtype] = None,
+                       copy: bool = False):
+        """
+        Construct a new ExtensionArray from a sequence of scalars.
+
+        Parameters
+        ----------
+        scalars : Sequence
+            Each element will be an instance of the scalar type for this
+            array, ``cls.dtype.type`` or be converted into this type in this
+            method.
+        dtype : dtype, optional
+            Construct for this particular dtype. This should be a Dtype
+            compatible with the ExtensionArray.
+        copy : bool, default False
+            If True, copy the underlying data.
+
+        Returns
+        -------
+        ExtensionArray
+        """
+        if copy and isinstance(scalars, np.ndarray):
+            scalars = scalars.copy()
+        elif isinstance(scalars, TensorArray):
+            scalars = scalars._tensor.copy() if copy else scalars._tensor
+        return TensorArray(scalars)
+
+    @classmethod
+    def _from_factorized(cls, values: np.ndarray,
+                         original: pd.api.extensions.ExtensionArray):
+        """
+        Reconstruct an ExtensionArray after factorization.
+
+        Parameters
+        ----------
+        values : ndarray
+            An integer ndarray with the factorized values.
+        original : ExtensionArray
+            The original ExtensionArray that factorize was called on.
+
+        See Also
+        --------
+        factorize : Top-level factorize method that dispatches here.
+        ExtensionArray.factorize : Encode the extension array as an enumerated
+            type.
+        """
+        raise NotImplementedError
+
+    def __getitem__(self, item: Union[int, slice, np.ndarray]
+                    ) -> Union["TensorArray", "TensorArrayElement"]:
+        """
+        Select a subset of self.
+
+        Parameters
+        ----------
+        item : int, slice, or ndarray
+            * int: The position in 'self' to get.
+            * slice: A slice object, where 'start', 'stop', and 'step' are
+              integers or None
+            * ndarray: A 1-d boolean NumPy ndarray the same length as 'self'
+
+        Returns
+        -------
+        item : scalar or ExtensionArray
+
+        Notes
+        -----
+        For scalar ``item``, return a scalar value suitable for the array's
+        type. This should be an instance of ``self.dtype.type``.
+        For slice ``key``, return an instance of ``ExtensionArray``, even
+        if the slice is length 0 or 1.
+        For a boolean mask, return an instance of ``ExtensionArray``, filtered
+        to the values where ``item`` is True.
+        """
+        # Return scalar if single value is selected, a TensorArrayElement for
+        # single array element, or TensorArray for slice.
+        if isinstance(item, int):
+            value = self._tensor[item]
+            if np.isscalar(value):
+                return value
+            else:
+                return TensorArrayElement(value)
+        else:
+            # BEGIN workaround for Pandas issue #42430
+            if (isinstance(item, tuple) and len(item) > 1
+                    and item[0] == Ellipsis):
+                if len(item) > 2:
+                    # Hopefully this case is not possible, but can't be sure
+                    raise ValueError("Workaround Pandas issue #42430 not "
+                                     "implemented for tuple length > 2")
+                item = item[1]
+            # END workaround for issue #42430
+            if isinstance(item, TensorArray):
+                item = np.asarray(item)
+            item = check_array_indexer(self, item)
+            return TensorArray(self._tensor[item])
+
+    def __len__(self) -> int:
+        """
+        Length of this array.
+
+        Returns
+        -------
+        length : int
+        """
+        return len(self._tensor)
+
+    @property
+    def dtype(self) -> pd.api.extensions.ExtensionDtype:
+        """
+        An instance of 'ExtensionDtype'.
+        """
+        return TensorDtype()
+
+    @property
+    def nbytes(self) -> int:
+        """
+        The number of bytes needed to store this object in memory.
+        """
+        return self._tensor.nbytes
+
+    def isna(self) -> "TensorArray":
+        """
+        A 1-D array indicating if each value is missing.
+
+        Returns
+        -------
+        na_values : Union[np.ndarray, ExtensionArray]
+            In most cases, this should return a NumPy ndarray. For
+            exceptional cases like ``SparseArray``, where returning
+            an ndarray would be expensive, an ExtensionArray may be
+            returned.
+
+        Notes
+        -----
+        If returning an ExtensionArray, then
+
+        * ``na_values._is_boolean`` should be True
+        * `na_values` should implement :func:`ExtensionArray._reduce`
+        * ``na_values.any`` and ``na_values.all`` should be implemented
+        """
+        if self._tensor.dtype.type is np.object_:
+            # Avoid comparing with __eq__ because the elements of the tensor
+            # may do something funny with that operation.
+            result_list = [self._tensor[i] is None for i in range(len(self))]
+            result = np.broadcast_to(
+                np.array(result_list, dtype=np.bool), self.numpy_shape)
+        elif self._tensor.dtype.type is np.str_:
+            result = self._tensor == ""
+        else:
+            result = np.isnan(self._tensor)
+        return TensorArray(result)
+
+    def take(self,
+             indices: Sequence[int],
+             allow_fill: bool = False,
+             fill_value: Any = None) -> "TensorArray":
+        """
+        Take elements from an array.
+
+        Parameters
+        ----------
+        indices : sequence of int
+            Indices to be taken.
+        allow_fill : bool, default False
+            How to handle negative values in `indices`.
+
+            * False: negative values in `indices` indicate positional indices
+              from the right (the default). This is similar to
+              :func:`numpy.take`.
+
+            * True: negative values in `indices` indicate
+              missing values. These values are set to `fill_value`. Any other
+              other negative values raise a ``ValueError``.
+
+        fill_value : any, optional
+            Fill value to use for NA-indices when `allow_fill` is True.
+            This may be ``None``, in which case the default NA value for
+            the type, ``self.dtype.na_value``, is used.
+
+            For many ExtensionArrays, there will be two representations of
+            `fill_value`: a user-facing "boxed" scalar, and a low-level
+            physical NA value. `fill_value` should be the user-facing version,
+            and the implementation should handle translating that to the
+            physical version for processing the take if necessary.
+
+        Returns
+        -------
+        ExtensionArray
+
+        Raises
+        ------
+        IndexError
+            When the indices are out of bounds for the array.
+        ValueError
+            When `indices` contains negative values other than ``-1``
+            and `allow_fill` is True.
+
+        See Also
+        --------
+        numpy.take : Take elements from an array along an axis.
+        api.extensions.take : Take elements from an array.
+
+        Notes
+        -----
+        ExtensionArray.take is called by ``Series.__getitem__``, ``.loc``,
+        ``iloc``, when `indices` is a sequence of values. Additionally,
+        it's called by :meth:`Series.reindex`, or any other method
+        that causes realignment, with a `fill_value`.
+
+        Examples
+        --------
+        Here's an example implementation, which relies on casting the
+        extension array to object dtype. This uses the helper method
+        :func:`pandas.api.extensions.take`.
+
+        .. code-block:: python
+
+           def take(self, indices, allow_fill=False, fill_value=None):
+               from pandas.core.algorithms import take
+
+               # If the ExtensionArray is backed by an ndarray, then
+               # just pass that here instead of coercing to object.
+               data = self.astype(object)
+
+               if allow_fill and fill_value is None:
+                   fill_value = self.dtype.na_value
+
+               # fill value should always be translated from the scalar
+               # type for the array, to the physical storage type for
+               # the data, before passing to take.
+
+               result = take(data, indices, fill_value=fill_value,
+                             allow_fill=allow_fill)
+               return self._from_sequence(result, dtype=self.dtype)
+        """
+        if allow_fill:
+            # With allow_fill being True, negative values in `indices` indicate
+            # missing values and should be set to `fill_value`.
+            indices = np.asarray(indices, dtype=np.intp)
+            validate_indices(indices, len(self._tensor))
+
+            # Check if there are missing indices to fill, otherwise we can
+            # delegate to NumPy ndarray .take().
+            has_missing = np.any(indices < 0)
+            if has_missing:
+                if fill_value is None:
+                    fill_value = np.nan
+
+                # Create an array populated with fill value.
+                values = np.full((len(indices), ) + self._tensor.shape[1:],
+                                 fill_value)
+
+                # Put tensors at the given positive indices into array.
+                is_nonneg = indices >= 0
+                np.put(values,
+                       np.where(is_nonneg)[0],
+                       self._tensor[indices[is_nonneg]])
+
+                return TensorArray(values)
+
+        # Delegate take to NumPy array.
+        values = self._tensor.take(indices, axis=0)
+
+        return TensorArray(values)
+
+    def copy(self) -> "TensorArray":
+        """
+        Return a copy of the array.
+
+        Returns
+        -------
+        ExtensionArray
+        """
+        # TODO(Clark): Copy cached properties.
+        return TensorArray(self._tensor.copy())
+
+    @classmethod
+    def _concat_same_type(cls,
+                          to_concat: Sequence["TensorArray"]) -> "TensorArray":
+        """
+        Concatenate multiple array of this dtype.
+
+        Parameters
+        ----------
+        to_concat : sequence of this type
+
+        Returns
+        -------
+        ExtensionArray
+        """
+        return TensorArray(np.concatenate([a._tensor for a in to_concat]))
+
+    def __setitem__(self, key: Union[int, np.ndarray], value: Any) -> None:
+        """
+        Set one or more values inplace.
+
+        This method is not required to satisfy the pandas extension array
+        interface.
+
+        Parameters
+        ----------
+        key : int, ndarray, or slice
+            When called from, e.g. ``Series.__setitem__``, ``key`` will be
+            one of
+
+            * scalar int
+            * ndarray of integers.
+            * boolean ndarray
+            * slice object
+
+        value : ExtensionDtype.type, Sequence[ExtensionDtype.type], or object
+            value or values to be set of ``key``.
+
+        Returns
+        -------
+        None
+        """
+        key = check_array_indexer(self, key)
+        if isinstance(value, TensorArrayElement) or np.isscalar(value):
+            value = np.asarray(value)
+        if isinstance(value, list):
+            value = [
+                np.asarray(v) if isinstance(v, TensorArrayElement) else v
+                for v in value
+            ]
+        if (isinstance(value, ABCSeries)
+                and isinstance(value.dtype, TensorDtype)):
+            value = value.values
+        if value is None or isinstance(value, Sequence) and len(value) == 0:
+            self._tensor[key] = np.full_like(self._tensor[key], np.nan)
+        elif isinstance(key, (int, slice, np.ndarray)):
+            self._tensor[key] = value
+        else:
+            raise NotImplementedError(
+                f"__setitem__ with key type '{type(key)}' not implemented")
+
+    def __contains__(self, item) -> bool:
+        """
+        Return for `item in self`.
+        """
+        if isinstance(item, TensorArrayElement):
+            np_item = np.asarray(item)
+            if np_item.size == 1 and np.isnan(np_item).all():
+                return self.isna().any()
+        return super().__contains__(item)
+
+    def __repr__(self):
+        return self._tensor.__repr__()
+
+    def __str__(self):
+        return self._tensor.__str__()
+
+    def _values_for_factorize(self) -> Tuple[np.ndarray, Any]:
+        # TODO(Clark): return self._tensor, np.nan
+        raise NotImplementedError
+
+    def _reduce(self, name: str, skipna: bool = True, **kwargs):
+        """
+        Return a scalar result of performing the reduction operation.
+
+        Parameters
+        ----------
+        name : str
+            Name of the function, supported values are:
+            { any, all, min, max, sum, mean, median, prod,
+            std, var, sem, kurt, skew }.
+        skipna : bool, default True
+            If True, skip NaN values.
+        **kwargs
+            Additional keyword arguments passed to the reduction function.
+            Currently, `ddof` is the only supported kwarg.
+
+        Returns
+        -------
+        scalar
+
+        Raises
+        ------
+        TypeError : subclass does not define reductions
+        """
+        supported_kwargs = ["ddof"]
+        reducer_kwargs = {}
+        for kw in supported_kwargs:
+            try:
+                reducer_kwargs[kw] = kwargs[kw]
+            except KeyError:
+                pass
+        try:
+            return TensorArrayElement(self.SUPPORTED_REDUCERS[name](
+                self._tensor, axis=0, **reducer_kwargs))
+        except KeyError:
+            raise NotImplementedError(
+                f"'{name}' aggregate not implemented.") from None
+
+    def __array__(self, dtype: np.dtype = None):
+        return np.asarray(self._tensor, dtype=dtype)
+
+    def __array_ufunc__(self, ufunc: Callable, method: str, *inputs, **kwargs):
+        """
+        Supports NumPy ufuncs without requiring sloppy coercion to an
+        ndarray.
+        """
+        out = kwargs.get("out", ())
+        for x in inputs + out:
+            if not isinstance(x, (TensorArray, np.ndarray, numbers.Number)):
+                return NotImplemented
+
+        # Defer to the implementation of the ufunc on unwrapped values.
+        inputs = tuple(
+            x._tensor if isinstance(x, TensorArray) else x for x in inputs)
+        if out:
+            kwargs["out"] = tuple(
+                x._tensor if isinstance(x, TensorArray) else x for x in out)
+        result = getattr(ufunc, method)(*inputs, **kwargs)
+
+        if type(result) is tuple:
+            # Multiple return values.
+            return tuple(type(self)(x) for x in result)
+        elif method == "at":
+            # No return value.
+            return None
+        else:
+            # One return value.
+            return type(self)(result)
+
+    def to_numpy(self,
+                 dtype: np.dtype = None,
+                 copy: bool = False,
+                 na_value: Any = pd.api.extensions.no_default):
+        """
+        Convert to a NumPy ndarray.
+
+        .. versionadded:: 1.0.0
+
+        This is similar to :meth:`numpy.asarray`, but may provide additional
+        control over how the conversion is done.
+
+        Parameters
+        ----------
+        dtype : str or numpy.dtype, optional
+            The dtype to pass to :meth:`numpy.asarray`.
+        copy : bool, default False
+            Whether to ensure that the returned value is a not a view on
+            another array. Note that ``copy=False`` does not *ensure* that
+            ``to_numpy()`` is no-copy. Rather, ``copy=True`` ensure that
+            a copy is made, even if not strictly necessary.
+        na_value : Any, optional
+            The value to use for missing values. The default value depends
+            on `dtype` and the type of the array.
+
+        Returns
+        -------
+        numpy.ndarray
+        """
+        if dtype is not None:
+            dtype = pd.api.types.pandas_dtype(dtype)
+            if copy:
+                values = np.array(self._tensor, dtype=dtype, copy=True)
+            else:
+                values = self._tensor.astype(dtype)
+        elif copy:
+            values = self._tensor.copy()
+        else:
+            values = self._tensor
+        return values
+
+    @property
+    def numpy_dtype(self):
+        """
+        Get the dtype of the tensor.
+        :return: The numpy dtype of the backing ndarray
+        """
+        return self._tensor.dtype
+
+    @property
+    def numpy_ndim(self):
+        """
+        Get the number of tensor dimensions.
+        :return: integer for the number of dimensions
+        """
+        return self._tensor.ndim
+
+    @property
+    def numpy_shape(self):
+        """
+        Get the shape of the tensor.
+        :return: A tuple of integers for the numpy shape of the backing ndarray
+        """
+        return self._tensor.shape
+
+    @property
+    def _is_boolean(self):
+        """
+        Whether this extension array should be considered boolean.
+
+        By default, ExtensionArrays are assumed to be non-numeric.
+        Setting this to True will affect the behavior of several places,
+        e.g.
+
+        * is_bool
+        * boolean indexing
+
+        Returns
+        -------
+        bool
+        """
+        # This is needed to support returning a TensorArray from .isnan().
+        # TODO(Clark): Propagate tensor dtype to extension TensorDtype and
+        # move this property there.
+        return np.issubdtype(self._tensor.dtype, np.bool)
+
+    def astype(self, dtype, copy=True):
+        """
+        Cast to a NumPy array with 'dtype'.
+
+        Parameters
+        ----------
+        dtype : str or dtype
+            Typecode or data-type to which the array is cast.
+        copy : bool, default True
+            Whether to copy the data, even if not necessary. If False,
+            a copy is made only if the old dtype does not match the
+            new dtype.
+
+        Returns
+        -------
+        array : ndarray
+            NumPy ndarray with 'dtype' for its dtype.
+        """
+        dtype = pd.api.types.pandas_dtype(dtype)
+
+        if isinstance(dtype, TensorDtype):
+            values = TensorArray(self._tensor.copy()) if copy else self
+        elif not (pd.api.types.is_object_dtype(dtype)
+                  and pd.api.types.is_string_dtype(dtype)):
+            values = np.array([str(t) for t in self._tensor])
+            if isinstance(dtype, pd.StringDtype):
+                return dtype.construct_array_type()._from_sequence(
+                    values, copy=False)
+            else:
+                return values
+        elif pd.api.types.is_object_dtype(dtype):
+            # Interpret astype(object) as "cast to an array of numpy arrays"
+            values = np.empty(len(self), dtype=object)
+            for i in range(len(self)):
+                values[i] = self._tensor[i]
+        else:
+            values = self._tensor.astype(dtype, copy=copy)
+        return values
+
+    def any(self, axis=None, out=None, keepdims=False):
+        """
+        Test whether any array element along a given axis evaluates to True.
+
+        See numpy.any() documentation for more information
+        https://numpy.org/doc/stable/reference/generated/numpy.any.html#numpy.any
+
+        :param axis: Axis or axes along which a logical OR reduction is
+            performed.
+        :param out: Alternate output array in which to place the result.
+        :param keepdims: If this is set to True, the axes which are reduced are
+            left in the result as dimensions with size one.
+        :return: single boolean unless axis is not None else TensorArray
+        """
+        result = self._tensor.any(axis=axis, out=out, keepdims=keepdims)
+        return result if axis is None else TensorArray(result)
+
+    def all(self, axis=None, out=None, keepdims=False):
+        """
+        Test whether all array elements along a given axis evaluate to True.
+
+        :param axis: Axis or axes along which a logical AND reduction is
+            performed.
+        :param out: Alternate output array in which to place the result.
+        :param keepdims: If this is set to True, the axes which are reduced are
+            left in the result as dimensions with size one.
+        :return: single boolean unless axis is not None else TensorArray
+        """
+        result = self._tensor.all(axis=axis, out=out, keepdims=keepdims)
+        return result if axis is None else TensorArray(result)
+
+    def __arrow_array__(self, type=None):
+        """
+        Convert this TensorArray to an ArrowTensorArray extension array.
+
+        This and TensorDtype.__from_arrow__ make up the
+        Pandas extension type + array <--> Arrow extension type + array
+        interoperability protocol. See
+        https://pandas.pydata.org/pandas-docs/stable/development/extending.html#compatibility-with-apache-arrow
+        for more information.
+        """
+        return ArrowTensorArray.from_numpy(self._tensor)
+
+
+# Add operators from the mixin to the TensorArrayElement and TensorArray
+# classes.
+TensorArrayElement._add_arithmetic_ops()
+TensorArrayElement._add_comparison_ops()
+TensorArrayElement._add_logical_ops()
+TensorArray._add_arithmetic_ops()
+TensorArray._add_comparison_ops()
+TensorArray._add_logical_ops()
+
+# -----------------------------------------------------------------------------
+#                       Arrow extension type and array
+# -----------------------------------------------------------------------------
+
+
+class ArrowTensorType(pa.PyExtensionType):
+    """
+    Arrow ExtensionType for an array of fixed-shaped, homogeneous-typed
+    tensors.
+
+    This is the Arrow side of TensorDtype.
+
+    See Arrow extension type docs:
+    https://arrow.apache.org/docs/python/extending_types.html#defining-extension-types-user-defined-types
+    """
+
+    def __init__(self, shape: Tuple[int, ...], dtype: pa.DataType):
+        """
+        Construct the Arrow extension type for array of fixed-shaped tensors.
+
+        Args:
+            shape: Shape of contained tensors.
+            dtype: pyarrow dtype of tensor elements.
+        """
+        self._shape = shape
+        super().__init__(pa.list_(dtype))
+
+    @property
+    def shape(self):
+        """
+        Shape of contained tensors.
+        """
+        return self._shape
+
+    def to_pandas_dtype(self):
+        """
+        Convert Arrow extension type to corresponding Pandas dtype.
+
+        Returns:
+            An instance of pd.api.extensions.ExtensionDtype.
+        """
+        return TensorDtype()
+
+    def __reduce__(self):
+        return ArrowTensorType, (self._shape, self.storage_type.value_type)
+
+    def __arrow_ext_class__(self):
+        """
+        ExtensionArray subclass with custom logic for this array of tensors
+        type.
+
+        Returns:
+            A subclass of pd.api.extensions.ExtensionArray.
+        """
+        return ArrowTensorArray
+
+
+class ArrowTensorArray(pa.ExtensionArray):
+    """
+    An array of fixed-shape, homogeneous-typed tensors.
+
+    This is the Arrow side of TensorArray.
+
+    See Arrow docs for customizing extension arrays:
+    https://arrow.apache.org/docs/python/extending_types.html#custom-extension-array-class
+    """
+    OFFSET_DTYPE = np.int32
+
+    def __getitem__(self, key):
+        # This __getitem__ hook allows us to support proper
+        # indexing when accessing a single tensor (a "scalar" item of the
+        # array). Without this hook for integer keys, the indexing will fail on
+        # all currently released pyarrow versions due to a lack of proper
+        # ExtensionScalar support. Support was added in
+        # https://github.com/apache/arrow/pull/10904, but hasn't been released
+        # at the time of this comment, and even with this support, the returned
+        # ndarray is a flat representation of the n-dimensional tensor.
+
+        # NOTE(Clark): We'd like to override the pa.Array.getitem() helper
+        # instead, which would obviate the need for overriding __iter__()
+        # below, but unfortunately overriding Cython cdef methods with normal
+        # Python methods isn't allowed.
+        if isinstance(key, slice):
+            return super().__getitem__(key)
+        return self._to_numpy(key)
+
+    def __iter__(self):
+        # Override pa.Array.__iter__() in order to return an iterator of
+        # properly shaped tensors instead of an iterator of flattened tensors.
+        # See comment in above __getitem__ method.
+        for i in range(len(self)):
+            # Use overridden __getitem__ method.
+            yield self.__getitem__(i)
+
+    @classmethod
+    def from_numpy(cls, arr):
+        """
+        Convert an ndarray or an iterable of fixed-shape ndarrays to an array
+        of fixed-shape, homogeneous-typed tensors.
+
+        Args:
+            arr: An ndarray or an iterable of fixed-shape ndarrays.
+
+        Returns:
+            An ArrowTensorArray containing len(arr) tensors of fixed shape.
+        """
+        if isinstance(arr, (list, tuple)):
+            if np.isscalar(arr[0]):
+                return pa.array(arr)
+            elif isinstance(arr[0], np.ndarray):
+                # Stack ndarrays and pass through to ndarray handling logic
+                # below.
+                arr = np.stack(arr, axis=0)
+        if isinstance(arr, np.ndarray):
+            if not arr.flags.c_contiguous:
+                # We only natively support C-contiguous ndarrays.
+                arr = np.ascontiguousarray(arr)
+            pa_dtype = pa.from_numpy_dtype(arr.dtype)
+            outer_len = arr.shape[0]
+            element_shape = arr.shape[1:]
+            total_num_items = arr.size
+            num_items_per_element = (np.prod(element_shape)
+                                     if element_shape else 1)
+
+            # Data buffer.
+            data_buffer = pa.py_buffer(arr)
+            data_array = pa.Array.from_buffers(pa_dtype, total_num_items,
+                                               [None, data_buffer])
+
+            # Offset buffer.
+            offset_buffer = pa.py_buffer(
+                cls.OFFSET_DTYPE(
+                    [i * num_items_per_element for i in range(outer_len + 1)]))
+
+            storage = pa.Array.from_buffers(
+                pa.list_(pa_dtype),
+                outer_len, [None, offset_buffer],
+                children=[data_array])
+            type_ = ArrowTensorType(element_shape, pa_dtype)
+            return pa.ExtensionArray.from_storage(type_, storage)
+        elif isinstance(arr, Iterable):
+            return cls.from_numpy(list(arr))
+        else:
+            raise ValueError("Must give ndarray or iterable of ndarrays.")
+
+    def _to_numpy(self, index: Optional[int] = None):
+        """
+        Helper for getting either an element of the array of tensors as an
+        ndarray, or the entire array of tensors as a single ndarray.
+
+        Args:
+            index: The index of the tensor element that we wish to return as
+                an ndarray. If not given, the entire array of tensors is
+                returned as an ndarray.
+
+        Returns:
+            The corresponding tensor element as an ndarray if an index was
+            given, or the entire array of tensors as an ndarray otherwise.
+        """
+        # Buffers schema:
+        # [None, offset_buffer, None, data_buffer]
+        buffers = self.buffers()
+        data_buffer = buffers[3]
+        storage_list_type = self.storage.type
+        ext_dtype = storage_list_type.value_type.to_pandas_dtype()
+        if index is not None:
+            # Getting a single tensor element of the array.
+            offset_buffer = buffers[1]
+            offset_array = np.ndarray(
+                (len(self), ), buffer=offset_buffer, dtype=self.OFFSET_DTYPE)
+            offset = (offset_array[index] +
+                      self.offset) * storage_list_type.value_type.bit_width
+            shape = self.type.shape
+        else:
+            # Getting the entire array of tensors.
+            offset = 0
+            shape = (len(self), ) + self.type.shape
+        # TODO(Clark): Support strides?
+        return np.ndarray(
+            shape, dtype=ext_dtype, buffer=data_buffer, offset=offset)
+
+    def to_numpy(self):
+        """
+        Convert the entire array of tensors into a single ndarray.
+
+        Returns:
+            A single ndarray representing the entire array of tensors.
+        """
+        return self._to_numpy()

--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -45,14 +45,14 @@ class ArrowRow:
         col = self._row[key]
         if len(col) == 0:
             return None
-        else:
-            item = col[0]
-            if isinstance(item, np.ndarray):
-                # Tensor columns have ndarrays as row values.
-                return item
-            else:
-                # Assuming that this is a pyarrow.Scalar value.
-                return item.as_py()
+        item = col[0]
+        try:
+            # Try to interpret this as a pyarrow.Scalar value.
+            return item.as_py()
+        except AttributeError:
+            # Assume that this row is an element of an extension array, and
+            # that it is bypassing pyarrow's scalar model.
+            return item
 
     def __eq__(self, other: Any) -> bool:
         return self.as_pydict() == other

--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -42,7 +42,16 @@ class ArrowRow:
         return self.as_pydict().items()
 
     def __getitem__(self, key: str) -> Any:
-        return self._row[key][0].as_py()
+        col = self._row[key]
+        if len(col) == 0:
+            return None
+        else:
+            item = col[0]
+            if isinstance(item, np.ndarray):
+                return item
+            else:
+                # Assuming that this is a pyarrow.Scalar value.
+                return item.as_py()
 
     def __eq__(self, other: Any) -> bool:
         return self.as_pydict() == other

--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -48,6 +48,7 @@ class ArrowRow:
         else:
             item = col[0]
             if isinstance(item, np.ndarray):
+                # Tensor columns have ndarrays as row values.
                 return item
             else:
                 # Assuming that this is a pyarrow.Scalar value.

--- a/python/ray/data/impl/util.py
+++ b/python/ray/data/impl/util.py
@@ -13,7 +13,8 @@ def _check_pyarrow_version():
         try:
             version_info = pkg_resources.require("pyarrow")
             version_str = version_info[0].version
-            version = tuple(int(n) for n in version_str.split("."))
+            version = tuple(
+                int(n) for n in version_str.split(".") if "dev" not in n)
             if version < MIN_PYARROW_VERSION:
                 raise ImportError(
                     "Datasets requires pyarrow >= "

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -189,6 +189,8 @@ def read_parquet(paths: Union[str, List[str]],
                  columns: Optional[List[str]] = None,
                  parallelism: int = 200,
                  ray_remote_args: Dict[str, Any] = None,
+                 _tensor_column_schema: Optional[Dict[str, Tuple[
+                     np.dtype, Tuple[int, ...]]]] = None,
                  **arrow_parquet_args) -> Dataset[ArrowRow]:
     """Create an Arrow dataset from parquet files.
 
@@ -205,11 +207,43 @@ def read_parquet(paths: Union[str, List[str]],
         columns: A list of column names to read.
         parallelism: The amount of parallelism to use for the dataset.
         ray_remote_args: kwargs passed to ray.remote in the read tasks.
+        _tensor_column_schema: A dict of column name --> tensor dtype and shape
+            mappings for converting a Parquet column containing serialized
+            tensors (ndarrays) as their elements to our tensor column extension
+            type. This assumes that the tensors were serialized in the raw
+            NumPy array format in C-contiguous order (e.g. via
+            `arr.tobytes()`).
         arrow_parquet_args: Other parquet read options to pass to pyarrow.
 
     Returns:
         Dataset holding Arrow records read from the specified paths.
     """
+    if _tensor_column_schema is not None:
+        existing_block_udf = arrow_parquet_args.pop("_block_udf", None)
+
+        def _block_udf(block: "pyarrow.Table") -> "pyarrow.Table":
+            from ray.data.extensions import ArrowTensorArray
+
+            for tensor_col_name, (dtype,
+                                  shape) in _tensor_column_schema.items():
+                # NOTE(Clark): We use NumPy to consolidate these potentially
+                # non-contiguous buffers, and to do buffer bookkeeping in
+                # general.
+                np_col = np.array([
+                    np.ndarray(shape, buffer=buf.as_buffer(), dtype=dtype)
+                    for buf in block.column(tensor_col_name)
+                ])
+
+                block = block.set_column(
+                    block._ensure_integer_index(tensor_col_name),
+                    tensor_col_name, ArrowTensorArray.from_numpy(np_col))
+            if existing_block_udf is not None:
+                # Apply UDF after casting the tensor columns.
+                block = existing_block_udf(block)
+            return block
+
+        arrow_parquet_args["_block_udf"] = _block_udf
+
     return read_datasource(
         ParquetDatasource(),
         parallelism=parallelism,

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -239,6 +239,34 @@ def test_tensor_array_reductions(ray_start_regular_shared):
                                 reducer(arr, axis=0, **np_kwargs))
 
 
+def test_arrow_tensor_array_getitem(ray_start_regular_shared):
+    outer_dim = 3
+    inner_shape = (2, 2, 2)
+    shape = (outer_dim, ) + inner_shape
+    num_items = np.prod(np.array(shape))
+    arr = np.arange(num_items).reshape(shape)
+
+    t_arr = ArrowTensorArray.from_numpy(arr)
+
+    for idx in range(outer_dim):
+        np.testing.assert_array_equal(t_arr[idx], arr[idx])
+
+    # Test __iter__.
+    for t_subarr, subarr in zip(t_arr, arr):
+        np.testing.assert_array_equal(t_subarr, subarr)
+
+    # Test to_pylist.
+    np.testing.assert_array_equal(t_arr.to_pylist(), list(arr))
+
+    # Test slicing and indexing.
+    t_arr2 = t_arr[1:]
+
+    np.testing.assert_array_equal(t_arr2.to_numpy(), arr[1:])
+
+    for idx in range(1, outer_dim):
+        np.testing.assert_array_equal(t_arr2[idx - 1], arr[idx])
+
+
 def test_tensors_in_tables_from_pandas(ray_start_regular_shared):
     outer_dim = 3
     inner_shape = (2, 2, 2)


### PR DESCRIPTION
Adds support for fixed-shape, homogeneous-typed tensor columns (tensors-in-tables) by adding Pandas and pyarrow extension types and arrays. See [Arrow](https://arrow.apache.org/docs/python/extending_types.html#extending-pyarrow) and [Pandas](https://pandas.pydata.org/pandas-docs/stable/development/extending.html#extension-types) docs for details on the protocol, and see this [file](python/ray/data/extensions/tensor_extension.py) for the majority of this change.

## Features:

- [x] Represent a static Pandas DataFrame containing a tensor column.
- [x] Arithmetic, comparison, and logical operations on a DataFrame containing a tensor column.
- [x] Aggregations on a DataFrame containing a tensor column.
- [x] Cast opaque list of ndarray column to tensor column via `col.astype(TensorDtype())` cast.
- [x] Datasets + Pandas transparent roundtrip (Pandas --> Datasets/Arrow --> Pandas).
- [x] Parquet + Datasets + Pandas transparent roundtrip (Pandas --> Datasets/Arrow --> Parquet --> Datasets/Arrow --> Parquet).
- [x] Read Parquet containing tensor column using user-supplied override schema.
- [x] Read Parquet containing bytes tensor column using user-supplied manual Pandas deserialization mapper.
- [x] Read Parquet containing pickled bytes tensor column using user-supplied manual Arrow deserialization mapper.
- [x] Read Parquet containing bytes tensor column using user-supplied override schema: **blocked by Arrow supporting registering custom `ExtensionType` casting kernels. See [upstream issue](https://issues.apache.org/jira/browse/ARROW-5890) and our [tracking issue](https://github.com/ray-project/ray/issues/18313); the latter contains possible workarounds.**
- [ ] Distributed Torch data loading on tensor column datasets: **blocked by pytorch supporting tensor creation from objects that implement the __array__ interface. See [upstream issue](https://github.com/pytorch/pytorch/issues/51156) and our [tracking issue](https://github.com/ray-project/ray/issues/18314); the latter contains possible workarounds.**
- [ ] Distributed TensorFlow data loading on tensor column datasets: **blocked by Pandas `DataFrame.values` for extension arrays fix being released. See [upstream PR](https://github.com/pandas-dev/pandas/pull/43160) and our [tracking issue](https://github.com/ray-project/ray/issues/18315); the latter contains possible workarounds.**

All of the above features (including unfinished features) are covered by tests.

## TODOs

- [x] Add high-level docs (landing page section, examples, etc.) for the features.
- [x] (Optional) Add stopgap helper for converting/casting bytes tensor columns without needing to map over the dataset (i.e. do the conversion/cast within the read tasks); this would be removed once [support for custom `ExtensionType` casting kernels](https://issues.apache.org/jira/browse/ARROW-5890) is added. If we piggy-backed off of the schema override argument for Parquet by checking if any of the given fields are extension types, changing the field type to be opaque bytes, and doing the cast manually on read, we could keep from introducing a conversion API that will be eventually deprecated; however, we wouldn't be able to support more than one serialization scheme (e.g. raw NumPy bytes vs pickle bytes) without exposing a new argument. We might end up needing the latter anyways even with a custom casting kernel for our extension type, since we'd still need to known the serialization scheme in order to properly deserialize the bytes.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #17457, closes #18313

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
