### PR TITLE
[Core][plasma] fix the data race issue

### DIFF
--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -453,6 +453,7 @@ void PlasmaStore::DoAccept() {
 }
 
 void PlasmaStore::ProcessCreateRequests() {
+  std::lock_guard<std::recursive_mutex> guard(mutex_);
   // Only try to process requests if the timer is not set. If the timer is set,
   // that means that the first request is currently not serviceable because
   // there is not enough memory. In that case, we should wait for the timer to

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -24,6 +24,8 @@
 #include <unordered_set>
 #include <vector>
 
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
 #include "ray/common/asio/instrumented_io_context.h"
 #include "ray/common/ray_config.h"
 #include "ray/common/status.h"
@@ -68,102 +70,22 @@ class PlasmaStore {
   /// Stop this store.
   void Stop();
 
-  /// Create a new object. The client must do a call to release_object to tell
-  /// the store when it is done with the object.
-  ///
-  /// \param object_info Ray object info.
-  /// \param client The client that created the object.
-  /// \param fallback_allocator Whether to allow falling back to the fs allocator
-  /// \param result The object that has been created.
-  /// \return One of the following error codes:
-  ///  - PlasmaError::OK, if the object was created successfully.
-  ///  - PlasmaError::ObjectExists, if an object with this ID is already
-  ///    present in the store. In this case, the client should not call
-  ///    plasma_release.
-  ///  - PlasmaError::OutOfMemory, if the store is out of memory and
-  ///    cannot create the object. In this case, the client should not call
-  ///    plasma_release.
-  PlasmaError CreateObject(const ray::ObjectInfo &object_info,
-                           plasma::flatbuf::ObjectSource source,
-                           const std::shared_ptr<Client> &client, bool fallback_allocator,
-                           PlasmaObject *result);
-
-  /// Abort a created but unsealed object. If the client is not the
-  /// creator, then the abort will fail.
-  ///
-  /// \param object_id Object ID of the object to be aborted.
-  /// \param client The client who created the object. If this does not
-  ///   match the creator of the object, then the abort will fail.
-  /// \return 1 if the abort succeeds, else 0.
-  int AbortObject(const ObjectID &object_id, const std::shared_ptr<Client> &client);
-
-  /// Delete a specific object by object_id that have been created in the hash table.
-  ///
-  /// \param object_id Object ID of the object to be deleted.
-  /// \return One of the following error codes:
-  ///  - PlasmaError::OK, if the object was delete successfully.
-  ///  - PlasmaError::ObjectNonexistent, if ths object isn't existed.
-  ///  - PlasmaError::ObjectInUse, if the object is in use.
-  PlasmaError DeleteObject(ObjectID &object_id);
-
-  /// Process a get request from a client. This method assumes that we will
-  /// eventually have these objects sealed. If one of the objects has not yet
-  /// been sealed, the client that requested the object will be notified when it
-  /// is sealed.
-  ///
-  /// For each object, the client must do a call to release_object to tell the
-  /// store when it is done with the object.
-  ///
-  /// \param client The client making this request.
-  /// \param object_ids Object IDs of the objects to be gotten.
-  /// \param timeout_ms The timeout for the get request in milliseconds.
-  void ProcessGetRequest(const std::shared_ptr<Client> &client,
-                         const std::vector<ObjectID> &object_ids, int64_t timeout_ms,
-                         bool is_from_worker);
-
-  /// Seal a vector of objects. The objects are now immutable and can be accessed with
-  /// get.
-  ///
-  /// \param object_ids The vector of Object IDs of the objects to be sealed.
-  void SealObjects(const std::vector<ObjectID> &object_ids);
-
-  /// Record the fact that a particular client is no longer using an object.
-  ///
-  /// \param object_id The object ID of the object that is being released.
-  /// \param client The client making this request.
-  void ReleaseObject(const ObjectID &object_id, const std::shared_ptr<Client> &client);
-
-  /// Connect a new client to the PlasmaStore.
-  ///
-  /// \param error The error code from the acceptor.
-  void ConnectClient(const boost::system::error_code &error);
-
-  /// Disconnect a client from the PlasmaStore.
-  ///
-  /// \param client The client that is disconnected.
-  void DisconnectClient(const std::shared_ptr<Client> &client);
-
-  Status ProcessMessage(const std::shared_ptr<Client> &client,
-                        plasma::flatbuf::MessageType type,
-                        const std::vector<uint8_t> &message);
-
   /// Return true if the given object id has only one reference.
   /// Only one reference means there's only a raylet that pins the object
   /// so it is safe to spill the object.
   /// NOTE: Avoid using this method outside object spilling context (e.g., unless you
   /// absolutely know what's going on). This method won't work correctly if it is used
   /// before the object is pinned by raylet for the first time.
-  bool IsObjectSpillable(const ObjectID &object_id);
+  bool IsObjectSpillable(const ObjectID &object_id) LOCKS_EXCLUDED(mutex_);
 
   /// Return the plasma object bytes that are consumed by core workers.
   int64_t GetConsumedBytes();
 
-  /// Process queued requests to create an object.
-  void ProcessCreateRequests();
-
   /// Get the available memory for new objects to be created. This includes
   /// memory that is currently being used for created but unsealed objects.
-  void GetAvailableMemory(std::function<void(size_t)> callback) const {
+  void GetAvailableMemory(std::function<void(size_t)> callback) const
+      LOCKS_EXCLUDED(mutex_) {
+    absl::MutexLock lock(&mutex_);
     RAY_CHECK((object_lifecycle_mgr_.GetNumBytesUnsealed() > 0 &&
                object_lifecycle_mgr_.GetNumObjectsUnsealed() > 0) ||
               (object_lifecycle_mgr_.GetNumBytesUnsealed() == 0 &&
@@ -183,31 +105,123 @@ class PlasmaStore {
     callback(available);
   }
 
-  void PrintDebugDump() const;
-
-  // NOTE(swang): This will iterate through all objects in the
-  // object store, so it should be called sparingly.
-  std::string GetDebugDump() const;
-
  private:
+  /// Create a new object. The client must do a call to release_object to tell
+  /// the store when it is done with the object.
+  ///
+  /// \param object_info Ray object info.
+  /// \param client The client that created the object.
+  /// \param fallback_allocator Whether to allow falling back to the fs allocator
+  /// \param result The object that has been created.
+  /// \return One of the following error codes:
+  ///  - PlasmaError::OK, if the object was created successfully.
+  ///  - PlasmaError::ObjectExists, if an object with this ID is already
+  ///    present in the store. In this case, the client should not call
+  ///    plasma_release.
+  ///  - PlasmaError::OutOfMemory, if the store is out of memory and
+  ///    cannot create the object. In this case, the client should not call
+  ///    plasma_release.
+  PlasmaError CreateObject(const ray::ObjectInfo &object_info,
+                           plasma::flatbuf::ObjectSource source,
+                           const std::shared_ptr<Client> &client, bool fallback_allocator,
+                           PlasmaObject *result) EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+
+  /// Abort a created but unsealed object. If the client is not the
+  /// creator, then the abort will fail.
+  ///
+  /// \param object_id Object ID of the object to be aborted.
+  /// \param client The client who created the object. If this does not
+  ///   match the creator of the object, then the abort will fail.
+  /// \return 1 if the abort succeeds, else 0.
+  int AbortObject(const ObjectID &object_id, const std::shared_ptr<Client> &client)
+      EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+
+  /// Delete a specific object by object_id that have been created in the hash table.
+  ///
+  /// \param object_id Object ID of the object to be deleted.
+  /// \return One of the following error codes:
+  ///  - PlasmaError::OK, if the object was delete successfully.
+  ///  - PlasmaError::ObjectNonexistent, if ths object isn't existed.
+  ///  - PlasmaError::ObjectInUse, if the object is in use.
+  PlasmaError DeleteObject(ObjectID &object_id) EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+
+  /// Process a get request from a client. This method assumes that we will
+  /// eventually have these objects sealed. If one of the objects has not yet
+  /// been sealed, the client that requested the object will be notified when it
+  /// is sealed.
+  ///
+  /// For each object, the client must do a call to release_object to tell the
+  /// store when it is done with the object.
+  ///
+  /// \param client The client making this request.
+  /// \param object_ids Object IDs of the objects to be gotten.
+  /// \param timeout_ms The timeout for the get request in milliseconds.
+  void ProcessGetRequest(const std::shared_ptr<Client> &client,
+                         const std::vector<ObjectID> &object_ids, int64_t timeout_ms,
+                         bool is_from_worker) EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+
+  /// Process queued requests to create an object.
+  void ProcessCreateRequests() EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+
+  /// Seal a vector of objects. The objects are now immutable and can be accessed with
+  /// get.
+  ///
+  /// \param object_ids The vector of Object IDs of the objects to be sealed.
+  void SealObjects(const std::vector<ObjectID> &object_ids)
+      EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+
+  /// Record the fact that a particular client is no longer using an object.
+  ///
+  /// \param object_id The object ID of the object that is being released.
+  /// \param client The client making this request.
+  void ReleaseObject(const ObjectID &object_id, const std::shared_ptr<Client> &client)
+      EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+
+  /// Connect a new client to the PlasmaStore.
+  ///
+  /// \param error The error code from the acceptor.
+  void ConnectClient(const boost::system::error_code &error)
+      EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+
+  /// Disconnect a client from the PlasmaStore.
+  ///
+  /// \param client The client that is disconnected.
+  void DisconnectClient(const std::shared_ptr<Client> &client)
+      EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+
+  Status ProcessMessage(const std::shared_ptr<Client> &client,
+                        plasma::flatbuf::MessageType type,
+                        const std::vector<uint8_t> &message) LOCKS_EXCLUDED(mutex_);
+
   PlasmaError HandleCreateObjectRequest(const std::shared_ptr<Client> &client,
                                         const std::vector<uint8_t> &message,
                                         bool fallback_allocator, PlasmaObject *object,
-                                        bool *spilling_required);
+                                        bool *spilling_required)
+      EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   void ReplyToCreateClient(const std::shared_ptr<Client> &client,
-                           const ObjectID &object_id, uint64_t req_id);
+                           const ObjectID &object_id, uint64_t req_id)
+      EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   void AddToClientObjectIds(const ObjectID &object_id,
-                            const std::shared_ptr<ClientInterface> &client);
+                            const std::shared_ptr<ClientInterface> &client)
+      EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   void ReturnFromGet(const std::shared_ptr<GetRequest> &get_request);
 
   int RemoveFromClientObjectIds(const ObjectID &object_id,
-                                const std::shared_ptr<Client> &client);
+                                const std::shared_ptr<Client> &client)
+      EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   // Start listening for clients.
   void DoAccept();
+
+  void PrintDebugDump() const LOCKS_EXCLUDED(mutex_);
+
+  std::string GetDebugDump() const EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+
+ private:
+  friend class GetRequestQueue;
 
   // A reference to the asio io context.
   instrumented_io_context &io_context_;
@@ -217,10 +231,17 @@ class PlasmaStore {
   boost::asio::basic_socket_acceptor<ray::local_stream_protocol> acceptor_;
   /// The socket to listen on for new clients.
   ray::local_stream_socket socket_;
-  /// The allocator that allocates mmaped memory.
-  IAllocator &allocator_;
 
-  std::unordered_set<ObjectID> deletion_cache_;
+  /// This mutex is used in order to make plasma store threas-safe with raylet.
+  /// Raylet's local_object_manager needs to ping access plasma store's method in order to
+  /// figure out the correct view of the object store. recursive_mutex is used to avoid
+  /// deadlock while we keep the simplest possible change. NOTE(sang): Avoid adding more
+  /// interface that node manager or object manager can access the plasma store with this
+  /// mutex if it is not absolutely necessary.
+  mutable absl::Mutex mutex_;
+
+  /// The allocator that allocates mmaped memory.
+  IAllocator &allocator_ GUARDED_BY(mutex_);
 
   /// A callback to asynchronously notify that an object is sealed.
   /// NOTE: This function should guarantee the thread-safety because the callback is
@@ -232,7 +253,7 @@ class PlasmaStore {
   /// shared with the main raylet thread.
   const ray::DeleteObjectCallback delete_object_callback_;
 
-  ObjectLifecycleManager object_lifecycle_mgr_;
+  ObjectLifecycleManager object_lifecycle_mgr_ GUARDED_BY(mutex_);
 
   /// The amount of time to wait before retrying a creation request after an
   /// OOM error.
@@ -244,30 +265,22 @@ class PlasmaStore {
   /// A timer that is set when the first request in the queue is not
   /// serviceable because there is not enough memory. The request will be
   /// retried when this timer expires.
-  std::shared_ptr<boost::asio::deadline_timer> create_timer_;
+  std::shared_ptr<boost::asio::deadline_timer> create_timer_ GUARDED_BY(mutex_);
 
   /// Timer for printing debug information.
-  mutable std::shared_ptr<boost::asio::deadline_timer> stats_timer_;
+  mutable std::shared_ptr<boost::asio::deadline_timer> stats_timer_ GUARDED_BY(mutex_);
 
   /// Queue of object creation requests.
-  CreateRequestQueue create_request_queue_;
-
-  /// This mutex is used in order to make plasma store threas-safe with raylet.
-  /// Raylet's local_object_manager needs to ping access plasma store's method in order to
-  /// figure out the correct view of the object store. recursive_mutex is used to avoid
-  /// deadlock while we keep the simplest possible change. NOTE(sang): Avoid adding more
-  /// interface that node manager or object manager can access the plasma store with this
-  /// mutex if it is not absolutely necessary.
-  std::recursive_mutex mutex_;
+  CreateRequestQueue create_request_queue_ GUARDED_BY(mutex_);
 
   /// Total plasma object bytes that are consumed by core workers.
-  int64_t total_consumed_bytes_ = 0;
+  std::atomic<int64_t> total_consumed_bytes_;
 
   /// Whether we have dumped debug information on OOM yet. This limits dump
   /// (which can be expensive) to once per OOM event.
-  bool dumped_on_oom_ = false;
+  bool dumped_on_oom_ GUARDED_BY(mutex_) = false;
 
-  GetRequestQueue get_request_queue_;
+  GetRequestQueue get_request_queue_ GUARDED_BY(mutex_);
 };
 
 }  // namespace plasma


### PR DESCRIPTION
TL;DR: ProcessCreateRequests will be [scheduled asynchronously](https://github.com/ray-project/ray/pull/18312/files#diff-5698038aacf457a9c1e23a09a422a1fdc8dec111fd59929de955feffc150b075R678) when the initial call failed. Unfortunately this is not protected by the lock and could cause data race. 

More details:

-  IsObjectSpillable is called by a different thread from LocalObjectManager and protected by a PlasmaStore.cc mutex;
- ProcessCreateRequests is called by PlasmaStore.cc HandleRequest in PlasmaStore’s own thread. The HandleRequest grab the PlasmaStore.cc mutex before calling ProcessCreateRequests, which is thread safe;
- However, ProcessCreateRequests also schedule an asynchronous ProcessCreateRequests onto the PlasmaStore’s asio thread with a timer, which doesn’t grab the PlasmaStore.cc mutex

This issue is revealed by this crash, where `plasma::PlasmaStore::IsObjectSpillable()` is called from a different thread.
```
Reduce Progress.:   0%|          | 0/5000 [23:53<?, ?it/s](raylet) *** SIGSEGV received at time=1630457392 on cpu 10 ***
(raylet) PC: @     0x5629c576222a  (unknown)  plasma::ObjectStore::GetObject()
(raylet)     @     0x7f783cf9d3c0  1481612800  (unknown)
(raylet)     @     0x5629c575603f         48  plasma::PlasmaStore::IsObjectSpillable()
(raylet)     @     0x5629c56f393c        240  ray::raylet::LocalObjectManager::SpillObjectsOfSize()
(raylet)     @     0x5629c56f3daf         64  ray::raylet::LocalObjectManager::SpillObjectUptoMaxThroughput()
(raylet)     @     0x5629c586f946        112  boost::asio::detail::completion_handler<>::do_complete()
(raylet)     @     0x5629c5d0d348        112  boost::asio::detail::scheduler::do_run_one()
(raylet)     @     0x5629c5d0e721        160  boost::asio::detail::scheduler::run()
(raylet)     @     0x5629c5d106b0         64  boost::asio::io_context::run()
(raylet)     @     0x5629c55d35d9       1456  main
(raylet)     @     0x7f783ca670b3  (unknown)  __libc_start_main
```
https://beta.anyscale.com/o/anyscale-internal/projects/prj_2xR6uT6t7jJuu1aCwWMsle/clu[…]wRSu9Wep769HhJPTSWgL?command-history-section=command_history

we also switch to use absl::mutex with annotations