### PR TITLE
[sgd] add support for additional resources per worker

### DIFF
--- a/python/ray/util/sgd/v2/backends/backend.py
+++ b/python/ray/util/sgd/v2/backends/backend.py
@@ -235,8 +235,7 @@ class BackendExecutor:
             num_cpus_per_worker: float = 1,
             num_gpus_per_worker: float = 0,
             additional_resources_per_worker: Optional[Dict[str, float]] = None,
-            max_retries: int = 3
-    ):
+            max_retries: int = 3):
         self._backend_config = backend_config
         self._backend = self._backend_config.backend_cls()
         self._num_workers = num_workers
@@ -260,10 +259,9 @@ class BackendExecutor:
 
     def start(self, initialization_hook: Optional[Callable[[], None]] = None):
         """Starts the worker group."""
-        self.worker_group = WorkerGroup(self._num_workers,
-                                        self._num_cpus_per_worker,
-                                        self._num_gpus_per_worker,
-                                        self._additional_resources_per_worker)
+        self.worker_group = WorkerGroup(
+            self._num_workers, self._num_cpus_per_worker,
+            self._num_gpus_per_worker, self._additional_resources_per_worker)
         try:
             if initialization_hook:
                 self._initialization_hook = initialization_hook

--- a/python/ray/util/sgd/v2/trainer.py
+++ b/python/ray/util/sgd/v2/trainer.py
@@ -70,8 +70,8 @@ class Trainer:
             argument.
         resources_per_worker (Optional[Dict]): If specified, the resources
             defined in this Dict will be reserved for each worker. The
-            ``CPU`` and ``GPU`` keys can be defined to override the number of
-            CPU/GPUs used by each worker.
+            ``CPU`` and ``GPU`` keys (case-sensitive) can be defined to
+            override the number of CPU/GPUs used by each worker.
         logdir (Optional[str]): Path to the file directory where logs
             should be persisted. If this is not specified, one will be
             generated.
@@ -107,7 +107,6 @@ class Trainer:
 
         if resources_per_worker:
             # Override CPU and GPU resources and remove from dict.
-            # TODO: case-sensitive? Ray uses capital, RayTune uses lower
             num_cpus = resources_per_worker.pop("CPU", num_cpus)
             num_gpus = resources_per_worker.pop("GPU", num_gpus)
             if not use_gpu and num_gpus > 0:

--- a/python/ray/util/sgd/v2/trainer.py
+++ b/python/ray/util/sgd/v2/trainer.py
@@ -49,11 +49,17 @@ class Trainer:
             a subclass of ``BackendConfig`` can be passed in.
             Supported ``str`` values: {"torch"}.
         num_workers (int): The number of workers (Ray actors) to launch.
-            Defaults to 1. Each worker will reserve 1 CPU by default.
+            Defaults to 1. Each worker will reserve 1 CPU by default. The
+            number of CPUs reserved by each worker can be overridden with the
+            ``resources_per_worker`` argument.
         use_gpu (bool): If True, training will be done on GPUs (1 per
-            worker). Defaults to False.
+            worker). Defaults to False. The number of GPUs reserved by each
+            worker can be overridden with the ``resources_per_worker``
+            argument.
         resources_per_worker (Optional[Dict]): If specified, the resources
-            defined in this Dict will be reserved for each worker.
+            defined in this Dict will be reserved for each worker. The
+            ``CPU`` and ``GPU`` keys can be defined to override the number of
+            CPU/GPUs used by each worker.
         logdir (Optional[str]): Path to the file directory where logs
             should be persisted. If this is not specified, one will be
             generated.
@@ -74,12 +80,29 @@ class Trainer:
         # Setup executor.
         backend_config = self._get_backend_config(backend)
 
-        if resources_per_worker:
-            raise NotImplementedError("`resources_per_worker` argument is not "
-                                      "supported yet.")
+        num_cpus = 1
+        num_gpus = int(use_gpu)
 
-        self._executor = BackendExecutor(backend_config, num_workers, 1,
-                                         int(use_gpu), logdir)
+        if resources_per_worker:
+            # Override CPU and GPU resources and remove from dict.
+            # TODO: case-sensitive? Ray uses capital, RayTune uses lower
+            num_cpus = resources_per_worker.pop("CPU", num_cpus)
+            num_gpus = resources_per_worker.pop("GPU", num_gpus)
+            if not use_gpu and num_gpus > 0:
+                raise ValueError(
+                    "`use_gpu` is False but `GPU` was found in "
+                    "`resources_per_worker`. Either set `use_gpu` to True or "
+                    "remove `GPU` from `resources_per_worker.")
+            if use_gpu and num_gpus == 0:
+                raise ValueError(
+                    "`use_gpu` is True but `GPU` is set to 0 in "
+                    "`resources_per_worker`. Either set `use_gpu` to False or "
+                    "request a positive number of `GPU` in "
+                    "`resources_per_worker.")
+
+        self._executor = BackendExecutor(backend_config, num_workers, num_cpus,
+                                         num_gpus, resources_per_worker,
+                                         logdir)
 
     def _get_backend_config(
             self, backend: Union[str, BackendConfig]) -> BackendConfig:

--- a/python/ray/util/sgd/v2/worker_group.py
+++ b/python/ray/util/sgd/v2/worker_group.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, List, TypeVar
+from typing import Callable, List, TypeVar, Optional, Dict
 
 import ray
 from ray.types import ObjectRef
@@ -39,6 +39,11 @@ class WorkerGroup:
             worker. Fractional values are allowed. Defaults to 1.
         num_gpus_per_worker (float): The number of GPUs to reserve for each
             worker. Fractional values are allowed. Defaults to 0.
+        additional_resources_per_worker (Optional[Dict[str, float]]):
+            Dictionary specifying the extra resources that will be
+            requested for each worker in addition to ``num_cpus_per_worker``
+            and ``num_gpus_per_worker``.
+
 
     Example:
 
@@ -53,7 +58,9 @@ class WorkerGroup:
     def __init__(self,
                  num_workers: int = 1,
                  num_cpus_per_worker: float = 1,
-                 num_gpus_per_worker: float = 0):
+                 num_gpus_per_worker: float = 0,
+                 additional_resources_per_worker: Optional[Dict[
+                     str, float]] = None):
 
         if num_workers <= 0:
             raise ValueError("The provided `num_workers` must be greater "
@@ -68,6 +75,7 @@ class WorkerGroup:
         self.num_workers = num_workers
         self.num_cpus_per_worker = num_cpus_per_worker
         self.num_gpus_per_worker = num_gpus_per_worker
+        self.additional_resources_per_worker = additional_resources_per_worker
         self.workers = []
         self.start()
 
@@ -77,9 +85,13 @@ class WorkerGroup:
             raise RuntimeError("The workers have already been started. "
                                "Please call `shutdown` first if you want to "
                                "restart them.")
+
+        # TODO validate resources
+
         remote_cls = ray.remote(
             num_cpus=self.num_cpus_per_worker,
-            num_gpus=self.num_gpus_per_worker)(BaseWorker)
+            num_gpus=self.num_gpus_per_worker,
+            resources=self.additional_resources_per_worker)(BaseWorker)
         logger.debug(f"Starting {self.num_workers} workers.")
         self.workers = [remote_cls.remote() for _ in range(self.num_workers)]
         logger.debug(f"{len(self.workers)} workers have successfully started.")

--- a/python/ray/util/sgd/v2/worker_group.py
+++ b/python/ray/util/sgd/v2/worker_group.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, List, TypeVar
+from typing import Callable, List, TypeVar, Optional, Dict
 
 import ray
 from ray.types import ObjectRef
@@ -39,6 +39,11 @@ class WorkerGroup:
             worker. Fractional values are allowed. Defaults to 1.
         num_gpus_per_worker (float): The number of GPUs to reserve for each
             worker. Fractional values are allowed. Defaults to 0.
+        additional_resources_per_worker (Optional[Dict[str, float]]):
+            Dictionary specifying the extra resources that will be
+            requested for each worker in addition to ``num_cpus_per_worker``
+            and ``num_gpus_per_worker``.
+
 
     Example:
 
@@ -53,7 +58,9 @@ class WorkerGroup:
     def __init__(self,
                  num_workers: int = 1,
                  num_cpus_per_worker: float = 1,
-                 num_gpus_per_worker: float = 0):
+                 num_gpus_per_worker: float = 0,
+                 additional_resources_per_worker: Optional[Dict[
+                     str, float]] = None):
 
         if num_workers <= 0:
             raise ValueError("The provided `num_workers` must be greater "
@@ -68,6 +75,7 @@ class WorkerGroup:
         self.num_workers = num_workers
         self.num_cpus_per_worker = num_cpus_per_worker
         self.num_gpus_per_worker = num_gpus_per_worker
+        self.additional_resources_per_worker = additional_resources_per_worker
         self.workers = []
         self.start()
 
@@ -77,9 +85,14 @@ class WorkerGroup:
             raise RuntimeError("The workers have already been started. "
                                "Please call `shutdown` first if you want to "
                                "restart them.")
+
+        # TODO(matt): Validate resources. Fast-fail if it is impossible to
+        #  handle the request, rather than hang indefinitely.
+
         remote_cls = ray.remote(
             num_cpus=self.num_cpus_per_worker,
-            num_gpus=self.num_gpus_per_worker)(BaseWorker)
+            num_gpus=self.num_gpus_per_worker,
+            resources=self.additional_resources_per_worker)(BaseWorker)
         logger.debug(f"Starting {self.num_workers} workers.")
         self.workers = [remote_cls.remote() for _ in range(self.num_workers)]
         logger.debug(f"{len(self.workers)} workers have successfully started.")


### PR DESCRIPTION
Extend the `Trainer` constructor to support `resources_per_worker` argument.

## Why are these changes needed?

This allows the user to input resource requests for custom resources.

This also allows the user to **override** the number of CPUs and GPUs that each worker will reserve by specifying entries for `"CPU"` or `"GPU"` (case-sensitive).  The number of resources can be fractional (between 0 and 1) or multiple (integers greater than 1).

**GPU Validation:** 
Special validation is done to ensure that any requested `"GPU"` values is consistent with the `use_gpu` argument.
1. By default (if `"GPU"` is not a key in `resources_per_worker`), 1 GPU will be requested if `use_gpu` is `True` and 0 if `False`.
1. If `use_gpu` is `True` and `"GPU"` is present in `resources_per_worker`, its value must be greater than 0.
2. If `use_gpu` is `False` and `"GPU"` is present in `resources_per_worker`, its value must be exactly 0. Note that this is equivalent to the default behavior.

## Implementation

1. `Trainer` handles separating CPU and GPU requests from additional (custom) resource requests, and performs GPU request validation.
2. `BackendExecutor` is a simple passthrough from `Trainer` to `WorkerGroup`.
3. Currently `WorkerGroup` does a simple passthrough of the resources to `ray.remote`. Validation should be added here to ensure that the requested resources can be fulfilled, and raise an error if it cannot. 

### Resource Fulfillment Validation
The current implementation solves for the happy path in which the aggregate amount of resources requested across all the workers can be successfully fulfilled. When the resource request cannot be fulfilled, the user script will hang indefinitely as it waits for resources that may never be available.

In an ideal world, the `WorkerGroup` should detect when the resource request cannot be fulfilled, and raise an error. A simple (incomplete) solution would be to compare the number of resources requested with `ray.available_resources()`. For a more robust solution the following must be taken into consideration:

1. If Autoscaling is enabled, the amount of available resources may change to support the request.
2. If there are multiple processes in the same Ray cluster, they may contend for available resources.
3. When placement group support is added, resources will be requested earlier when the placement group is created, rather than when the workers are created.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
