### PR TITLE
[CI] use clang for C++ tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -94,6 +94,9 @@ build:asan --copt -fno-omit-frame-pointer
 build:asan --linkopt -fsanitize=address
 test:asan --jobs=1
 test:asan --test_env=ASAN_OPTIONS="detect_leaks=0"
+# https://github.com/google/sanitizers/issues/1017
+build:asan-clang --copt -mllvm
+build:asan-clang --copt -asan-use-private-alias=1
 
 build:asan-build --strip=never
 build:asan-build -c dbg

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -32,8 +32,11 @@ RUN apt-get install -y -qq \
     sudo unzip unrar apt-utils dialog tzdata wget rsync \
     language-pack-en tmux cmake gdb vim htop \
     libgtk2.0-dev zlib1g-dev libgl1-mesa-dev maven \
-    openjdk-8-jre openjdk-8-jdk clang-format-7
+    openjdk-8-jre openjdk-8-jdk clang-format-7 \
+    clang-12
 RUN ln -s /usr/bin/clang-format-7 /usr/bin/clang-format
+RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 100
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 100
 RUN curl -o- https://get.docker.com | sh
 
 # System conf for tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -135,7 +135,7 @@
 - label: ":cpp: Tests"
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
-    - bazel test --config=ci $(./scripts/bazel_export_options)
+    - CC=clang bazel test --config=ci $(./scripts/bazel_export_options)
       --build_tests_only
       --test_tag_filters=-flaky
       -- //:all -rllib/... -core_worker_test
@@ -143,9 +143,8 @@
 - label: ":cpp: Tests (ASAN)"
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
-    - bazel test --config=ci --config=asan $(./scripts/bazel_export_options)
+    - CC=clang bazel test --config=ci --config=asan --config=asan-clang $(./scripts/bazel_export_options)
       --build_tests_only
-      --config=asan-buildkite
       --jobs=2
       --test_tag_filters=-flaky
       -- //:all -//:core_worker_test
@@ -162,7 +161,7 @@
 - label: ":cpp: Tests (TSAN)"
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
-    - bazel test --config=ci --config=tsan $(./scripts/bazel_export_options)
+    - CC=clang bazel test --config=ci --config=tsan $(./scripts/bazel_export_options)
       --build_tests_only
       --jobs=2
       --test_tag_filters=-flaky

--- a/src/ray/object_manager/plasma/test/stats_collector_test.cc
+++ b/src/ray/object_manager/plasma/test/stats_collector_test.cc
@@ -159,6 +159,7 @@ struct ObjectStatsCollectorTest : public Test {
     ray::ObjectInfo info;
     info.object_id = id;
     info.data_size = data_size;
+    info.metadata_size = 0;
     return info;
   }
 


### PR DESCRIPTION
Introducing clang-12 into our CI pipeline to run C++ tests.