### PR TITLE
[Docker] Apply NO_CACHE for development image

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -80,10 +80,10 @@ if [ $BUILD_DEV ]; then
     git rev-parse HEAD > ./docker/development/git-rev
     git archive -o ./docker/development/ray.tar "$(git rev-parse HEAD)"
     if [ $OUTPUT_SHA ]; then
-        IMAGE_SHA=$(docker build --no-cache -q -t rayproject/development docker/development)
+        IMAGE_SHA=$(docker build $NO_CACHE -q -t rayproject/development docker/development)
         echo "rayproject/development:latest SHA:$IMAGE_SHA"
     else
-        docker build --no-cache -t rayproject/development docker/development
+        docker build $NO_CACHE -t rayproject/development docker/development
     fi
     rm ./docker/development/ray.tar ./docker/development/git-rev
 fi


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
development image build commands always use `--no-cache` and it should be changed to use `$NO_CACHE`

development usage
https://github.com/ray-project/ray/blob/7916500c43de46721c51e6b95fb51cfa2c6078ba/build-docker.sh#L78-L81

scripts's global argument
https://github.com/ray-project/ray/blob/7916500c43de46721c51e6b95fb51cfa2c6078ba/build-docker.sh#L22-L23

## Related issue number
Close https://github.com/ray-project/ray/issues/18363

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

I doubt there's unit test and release test for this scripts? I manually run the scripts and verified `--no-cache` arg is part of build command when we run `./build-docker.sh --no-cache-build`

```
+ docker build --no-cache --build-arg GPU= --build-arg BASE_IMAGE=ubuntu:focal --build-arg WHEEL_PATH=ray-2.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl --build-arg PYTHON_VERSION=3.7.7 -t rayproject/ray-deps:nightly docker/ray-deps
```

If I remove `--no-cache-build`, `--no-cache` is removed from docker build args which meet expectation