### PR TITLE
[RLlib] Fix crash when using StochasticSampling exploration (most PG-style algos) w/ tf and numpy > 1.19.5

### DIFF
--- a/release/rllib_tests/app_config.yaml
+++ b/release/rllib_tests/app_config.yaml
@@ -8,7 +8,4 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y numpy ray || true
-  - sudo rm -rf /home/ray/anaconda3/lib/python3.7/site-packages/numpy
-  - pip3 install numpy==1.19.5 || true
   - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}

--- a/rllib/examples/nested_action_spaces.py
+++ b/rllib/examples/nested_action_spaces.py
@@ -27,6 +27,10 @@ parser.add_argument(
     help="Whether this script should be run as a test: --stop-reward must "
     "be achieved within --stop-timesteps AND --stop-iters.")
 parser.add_argument(
+    "--local-mode",
+    action="store_true",
+    help="Init Ray in local mode for easier debugging.")
+parser.add_argument(
     "--stop-iters",
     type=int,
     default=100,
@@ -44,7 +48,7 @@ parser.add_argument(
 
 if __name__ == "__main__":
     args = parser.parse_args()
-    ray.init(num_cpus=args.num_cpus or None)
+    ray.init(num_cpus=args.num_cpus or None, local_mode=args.local_mode)
     register_env("NestedSpaceRepeatAfterMeEnv",
                  lambda c: NestedSpaceRepeatAfterMeEnv(c))
 

--- a/rllib/utils/exploration/gaussian_noise.py
+++ b/rllib/utils/exploration/gaussian_noise.py
@@ -133,9 +133,6 @@ class GaussianNoise(Exploration):
             false_fn=lambda: deterministic_actions)
         # Logp=always zero.
         logp = zero_logps_from_actions(deterministic_actions)
-        #logp = tf.zeros_like(deterministic_actions, dtype=tf.float32)
-        #if len(deterministic_actions.shape) > 1:
-        #    logp = logp[:, 0]
 
         # Increment `last_timestep` by 1 (or set to `timestep`).
         if self.framework in ["tf2", "tfe"]:

--- a/rllib/utils/exploration/gaussian_noise.py
+++ b/rllib/utils/exploration/gaussian_noise.py
@@ -131,7 +131,9 @@ class GaussianNoise(Exploration):
             true_fn=lambda: stochastic_actions,
             false_fn=lambda: deterministic_actions)
         # Logp=always zero.
-        logp = tf.zeros_like(deterministic_actions, dtype=tf.float32)[:, 0]
+        logp = tf.zeros_like(deterministic_actions, dtype=tf.float32)
+        if len(deterministic_actions.shape) > 1:
+            logp = logp[:, 0]
 
         # Increment `last_timestep` by 1 (or set to `timestep`).
         if self.framework in ["tf2", "tfe"]:

--- a/rllib/utils/exploration/gaussian_noise.py
+++ b/rllib/utils/exploration/gaussian_noise.py
@@ -12,6 +12,7 @@ from ray.rllib.utils.framework import try_import_tf, try_import_torch, \
 from ray.rllib.utils.numpy import convert_to_numpy
 from ray.rllib.utils.schedules import Schedule
 from ray.rllib.utils.schedules.piecewise_schedule import PiecewiseSchedule
+from ray.rllib.utils.tf_ops import zero_logps_from_actions
 
 tf1, tf, tfv = try_import_tf()
 torch, _ = try_import_torch()
@@ -131,9 +132,10 @@ class GaussianNoise(Exploration):
             true_fn=lambda: stochastic_actions,
             false_fn=lambda: deterministic_actions)
         # Logp=always zero.
-        logp = tf.zeros_like(deterministic_actions, dtype=tf.float32)
-        if len(deterministic_actions.shape) > 1:
-            logp = logp[:, 0]
+        logp = zero_logps_from_actions(deterministic_actions)
+        #logp = tf.zeros_like(deterministic_actions, dtype=tf.float32)
+        #if len(deterministic_actions.shape) > 1:
+        #    logp = logp[:, 0]
 
         # Increment `last_timestep` by 1 (or set to `timestep`).
         if self.framework in ["tf2", "tfe"]:

--- a/rllib/utils/exploration/ornstein_uhlenbeck_noise.py
+++ b/rllib/utils/exploration/ornstein_uhlenbeck_noise.py
@@ -136,9 +136,6 @@ class OrnsteinUhlenbeckNoise(GaussianNoise):
             false_fn=lambda: deterministic_actions)
         # Logp=always zero.
         logp = zero_logps_from_actions(deterministic_actions)
-        #tf.zeros_like(deterministic_actions, dtype=tf.float32)
-        #if len(deterministic_actions.shape) > 1:
-        #    logp = logp[:, 0]
 
         # Increment `last_timestep` by 1 (or set to `timestep`).
         if self.framework in ["tf2", "tfe"]:

--- a/rllib/utils/exploration/ornstein_uhlenbeck_noise.py
+++ b/rllib/utils/exploration/ornstein_uhlenbeck_noise.py
@@ -134,7 +134,9 @@ class OrnsteinUhlenbeckNoise(GaussianNoise):
             true_fn=lambda: exploration_actions,
             false_fn=lambda: deterministic_actions)
         # Logp=always zero.
-        logp = tf.zeros_like(deterministic_actions, dtype=tf.float32)[:, 0]
+        logp = tf.zeros_like(deterministic_actions, dtype=tf.float32)
+        if len(deterministic_actions.shape) > 1:
+            logp = logp[:, 0]
 
         # Increment `last_timestep` by 1 (or set to `timestep`).
         if self.framework in ["tf2", "tfe"]:

--- a/rllib/utils/exploration/ornstein_uhlenbeck_noise.py
+++ b/rllib/utils/exploration/ornstein_uhlenbeck_noise.py
@@ -8,6 +8,7 @@ from ray.rllib.utils.framework import try_import_tf, try_import_torch, \
     get_variable, TensorType
 from ray.rllib.utils.numpy import convert_to_numpy
 from ray.rllib.utils.schedules import Schedule
+from ray.rllib.utils.tf_ops import zero_logps_from_actions
 
 tf1, tf, tfv = try_import_tf()
 torch, _ = try_import_torch()
@@ -134,9 +135,10 @@ class OrnsteinUhlenbeckNoise(GaussianNoise):
             true_fn=lambda: exploration_actions,
             false_fn=lambda: deterministic_actions)
         # Logp=always zero.
-        logp = tf.zeros_like(deterministic_actions, dtype=tf.float32)
-        if len(deterministic_actions.shape) > 1:
-            logp = logp[:, 0]
+        logp = zero_logps_from_actions(deterministic_actions)
+        #tf.zeros_like(deterministic_actions, dtype=tf.float32)
+        #if len(deterministic_actions.shape) > 1:
+        #    logp = logp[:, 0]
 
         # Increment `last_timestep` by 1 (or set to `timestep`).
         if self.framework in ["tf2", "tfe"]:

--- a/rllib/utils/exploration/random.py
+++ b/rllib/utils/exploration/random.py
@@ -73,6 +73,10 @@ class Random(Exploration):
             # Function to produce random samples from primitive space
             # components: (Multi)Discrete or Box.
             def random_component(component):
+                # Have at least an additional shape of (1,), even if the
+                # component is Box(-1.0, 1.0, shape=()).
+                shape = component.shape or (1, )
+
                 if isinstance(component, Discrete):
                     return tf.random.uniform(
                         shape=(batch_size, ) + component.shape,
@@ -92,19 +96,19 @@ class Random(Exploration):
                             component.bounded_below.all():
                         if component.dtype.name.startswith("int"):
                             return tf.random.uniform(
-                                shape=(batch_size, ) + component.shape,
+                                shape=(batch_size, ) + shape,
                                 minval=component.low.flat[0],
                                 maxval=component.high.flat[0],
                                 dtype=component.dtype)
                         else:
                             return tf.random.uniform(
-                                shape=(batch_size, ) + component.shape,
+                                shape=(batch_size, ) + shape,
                                 minval=component.low,
                                 maxval=component.high,
                                 dtype=component.dtype)
                     else:
                         return tf.random.normal(
-                            shape=(batch_size, ) + component.shape,
+                            shape=(batch_size, ) + shape,
                             dtype=component.dtype)
                 else:
                     assert isinstance(component, Simplex), \
@@ -112,7 +116,7 @@ class Random(Exploration):
                         "sampling!".format(component)
                     return tf.nn.softmax(
                         tf.random.uniform(
-                            shape=(batch_size, ) + component.shape,
+                            shape=(batch_size, ) + shape,
                             minval=0.0,
                             maxval=1.0,
                             dtype=component.dtype))

--- a/rllib/utils/exploration/random.py
+++ b/rllib/utils/exploration/random.py
@@ -12,6 +12,7 @@ from ray.rllib.utils.framework import try_import_tf, try_import_torch, \
     TensorType
 from ray.rllib.utils.spaces.simplex import Simplex
 from ray.rllib.utils.spaces.space_utils import get_base_struct_from_space
+from ray.rllib.utils.tf_ops import zero_logps_from_actions
 
 tf1, tf, tfv = try_import_tf()
 torch, _ = try_import_torch()
@@ -129,8 +130,9 @@ class Random(Exploration):
             true_fn=true_fn,
             false_fn=false_fn)
 
-        # TODO(sven): Move into (deterministic_)sample(logp=True|False)
-        logp = tf.zeros_like(tree.flatten(action)[0], dtype=tf.float32)[:1]
+        ## TODO(sven): Move into (deterministic_)sample(logp=True|False)
+        logp = zero_logps_from_actions(action)
+        #tf.zeros_like(tree.flatten(action)[0], dtype=tf.float32)[:1]
         return action, logp
 
     def get_torch_exploration_action(self, action_dist: ActionDistribution,

--- a/rllib/utils/exploration/random.py
+++ b/rllib/utils/exploration/random.py
@@ -130,9 +130,7 @@ class Random(Exploration):
             true_fn=true_fn,
             false_fn=false_fn)
 
-        ## TODO(sven): Move into (deterministic_)sample(logp=True|False)
         logp = zero_logps_from_actions(action)
-        #tf.zeros_like(tree.flatten(action)[0], dtype=tf.float32)[:1]
         return action, logp
 
     def get_torch_exploration_action(self, action_dist: ActionDistribution,

--- a/rllib/utils/exploration/stochastic_sampling.py
+++ b/rllib/utils/exploration/stochastic_sampling.py
@@ -91,7 +91,7 @@ class StochasticSampling(Exploration):
 
         def logp_false_fn():
             logp_ = tf.zeros_like(deterministic_actions, dtype=tf.float32)
-            if list(tf.shape(deterministic_actions)) > 1:
+            if len(deterministic_actions.shape) > 1:
                 logp_ = logp_[:, 0]
             return logp_
 

--- a/rllib/utils/exploration/stochastic_sampling.py
+++ b/rllib/utils/exploration/stochastic_sampling.py
@@ -1,6 +1,5 @@
 import gym
 import numpy as np
-import tree  # pip install dm_tree
 from typing import Union
 
 from ray.rllib.models.action_dist import ActionDistribution

--- a/rllib/utils/exploration/stochastic_sampling.py
+++ b/rllib/utils/exploration/stochastic_sampling.py
@@ -91,8 +91,7 @@ class StochasticSampling(Exploration):
             false_fn=lambda: deterministic_actions)
 
         def logp_false_fn():
-            batch_size = tf.shape(tree.flatten(action)[0])[0]
-            return tf.zeros(shape=(batch_size, ), dtype=tf.float32)
+            return tf.zeros_like(deterministic_actions, dtype=tf.float32)[:, 0]
 
         logp = tf.cond(
             tf.math.logical_and(

--- a/rllib/utils/exploration/stochastic_sampling.py
+++ b/rllib/utils/exploration/stochastic_sampling.py
@@ -90,7 +90,10 @@ class StochasticSampling(Exploration):
             false_fn=lambda: deterministic_actions)
 
         def logp_false_fn():
-            return tf.zeros_like(deterministic_actions, dtype=tf.float32)[:, 0]
+            logp_ = tf.zeros_like(deterministic_actions, dtype=tf.float32)
+            if list(tf.shape(deterministic_actions)) > 1:
+                logp_ = logp_[:, 0]
+            return logp_
 
         logp = tf.cond(
             tf.math.logical_and(

--- a/rllib/utils/exploration/stochastic_sampling.py
+++ b/rllib/utils/exploration/stochastic_sampling.py
@@ -95,8 +95,8 @@ class StochasticSampling(Exploration):
             tf.math.logical_and(
                 explore, tf.convert_to_tensor(ts >= self.random_timesteps)),
             true_fn=lambda: action_dist.sampled_action_logp(),
-            false_fn=functools.partial(
-                zero_logps_from_actions, deterministic_actions))
+            false_fn=functools.partial(zero_logps_from_actions,
+                                       deterministic_actions))
 
         # Increment `last_timestep` by 1 (or set to `timestep`).
         if self.framework in ["tf2", "tfe"]:

--- a/rllib/utils/tf_ops.py
+++ b/rllib/utils/tf_ops.py
@@ -125,7 +125,8 @@ def zero_logps_from_actions(actions: TensorStructType) -> TensorType:
     """
     # Need to flatten `actions` in case we have a complex action space.
     # Take the 0th component to extract the batch dim.
-    logp_ = tf.zeros_like(tree.flatten(actions)[0], dtype=tf.float32)
+    action_component = tree.flatten(actions)[0]
+    logp_ = tf.zeros_like(action_component, dtype=tf.float32)
     # Logp's should be single values (but with the same batch dim as
     # `deterministic_actions` or `stochastic_actions`). In case
     # actions are just [B], zeros_like works just fine here, but if

--- a/rllib/utils/tf_ops.py
+++ b/rllib/utils/tf_ops.py
@@ -4,6 +4,7 @@ import numpy as np
 import tree  # pip install dm_tree
 
 from ray.rllib.utils.framework import try_import_tf
+from ray.rllib.utils.typing import TensorStructType, TensorType
 
 tf1, tf, tfv = try_import_tf()
 
@@ -108,6 +109,30 @@ def huber_loss(x, delta=1.0):
     return tf.where(
         tf.abs(x) < delta,
         tf.math.square(x) * 0.5, delta * (tf.abs(x) - 0.5 * delta))
+
+
+def zero_logps_from_actions(actions: TensorStructType) -> TensorType:
+    """Helper function useful for returning dummy logp's (0) for some actions.
+
+    Args:
+        actions (TensorStructType): The input actions. This can be any struct
+            of complex action components or a simple tensor of different
+            dimensions, e.g. [B], [B, 2], or {"a": [B, 4, 5], "b": [B]}.
+
+    Returns:
+        TensorType: A 1D tensor of 0.0 (dummy logp's) matching the batch
+            dim of `actions` (shape=[B]).
+    """
+    # Need to flatten `actions` in case we have a complex action space.
+    # Take the 0th component to extract the batch dim.
+    logp_ = tf.zeros_like(tree.flatten(actions[0]), dtype=tf.float32)
+    # Logp's should be single values (but with the same batch dim as
+    # `deterministic_actions` or `stochastic_actions`). In case
+    # actions are just [B], zeros_like works just fine here, but if
+    # actions are [B, ...], we have to reduce logp back to just [B].
+    if len(actions.shape) > 1:
+        logp_ = logp_[:, 0]
+    return logp_
 
 
 def one_hot(x, space):

--- a/rllib/utils/tf_ops.py
+++ b/rllib/utils/tf_ops.py
@@ -130,7 +130,7 @@ def zero_logps_from_actions(actions: TensorStructType) -> TensorType:
     # `deterministic_actions` or `stochastic_actions`). In case
     # actions are just [B], zeros_like works just fine here, but if
     # actions are [B, ...], we have to reduce logp back to just [B].
-    if len(actions.shape) > 1:
+    if len(logp_.shape) > 1:
         logp_ = logp_[:, 0]
     return logp_
 

--- a/rllib/utils/tf_ops.py
+++ b/rllib/utils/tf_ops.py
@@ -125,7 +125,7 @@ def zero_logps_from_actions(actions: TensorStructType) -> TensorType:
     """
     # Need to flatten `actions` in case we have a complex action space.
     # Take the 0th component to extract the batch dim.
-    logp_ = tf.zeros_like(tree.flatten(actions[0]), dtype=tf.float32)
+    logp_ = tf.zeros_like(tree.flatten(actions)[0], dtype=tf.float32)
     # Logp's should be single values (but with the same batch dim as
     # `deterministic_actions` or `stochastic_actions`). In case
     # actions are just [B], zeros_like works just fine here, but if


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix crash when using StochasticSampling exploration (most PG-style algos) w/ tf and numpy > 1.19.5.

A strange error message is thrown by tf, when using numpy versions larger than 1.19.5 and the StochasticSampling exploration module (most PG-style algos use this component).

To reproduce:

```
pip install -U numpy
rllib train -f rllib/tuned_examples/sac/pendulum-sac.yaml
```

The error thrown is:
```
pid=5579) 2021-09-05 05:25:57,503      ERROR worker.py:409 -- Exception raised in creation task: The actor died because of an error raised in its creation task, ray::SAC.__init__() (pid=5579, ip=172.31.53.94)
(pid=5579)   File "python/ray/_raylet.pyx", line 501, in ray._raylet.execute_task
(pid=5579)   File "python/ray/_raylet.pyx", line 451, in ray._raylet.execute_task.function_executor
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/function_manager.py", line 563, in actor_method_executor
(pid=5579)     return method(__ray_actor, *args, **kwargs)
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/rllib/agents/trainer_template.py", line 123, in __init__
(pid=5579)     Trainer.__init__(self, config, env, logger_creator)
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/rllib/agents/trainer.py", line 548, in __init__
(pid=5579)     super().__init__(config, logger_creator)
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/tune/trainable.py", line 100, in __init__
(pid=5579)     self.setup(copy.deepcopy(self.config))
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/rllib/agents/trainer.py", line 709, in setup
(pid=5579)     self._init(self.config, self.env_creator)
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/rllib/agents/trainer_template.py", line 150, in _init
(pid=5579)     self.workers = self._make_workers(
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/rllib/agents/trainer.py", line 791, in _make_workers
(pid=5579)     return WorkerSet(
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/rllib/evaluation/worker_set.py", line 92, in __init__
(pid=5579)     self._local_worker = self._make_worker(
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/rllib/evaluation/worker_set.py", line 367, in _make_worker
(pid=5579)     worker = cls(
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/rllib/evaluation/rollout_worker.py", line 534, in __init__
(pid=5579)     self._build_policy_map(policy_dict, policy_config)
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/rllib/evaluation/rollout_worker.py", line 1193, in _build_policy_map
(pid=5579)     policy_map[name] = cls(obs_space, act_space, merged_conf)
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/rllib/policy/tf_policy_template.py", line 237, in __init__
(pid=5579)     DynamicTFPolicy.__init__(
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/rllib/policy/dynamic_tf_policy.py", line 309, in __init__
(pid=5579)     self.exploration.get_exploration_action(
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/rllib/utils/exploration/stochastic_sampling.py", line 72, in get_exploration_action
(pid=5579)     return self._get_tf_exploration_action_op(action_distribution,
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/rllib/utils/exploration/stochastic_sampling.py", line 78, in _get_tf_exploration_action_op
(pid=5579)     stochastic_actions = tf.cond(
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/tensorflow/python/util/dispatch.py", line 206, in wrapper
(pid=5579)     return target(*args, **kwargs)
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/tensorflow/python/ops/control_flow_ops.py", line 1438, in cond_for_tf_v2
(pid=5579)     return cond(pred, true_fn=true_fn, false_fn=false_fn, strict=True, name=name)
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/tensorflow/python/util/dispatch.py", line 206, in wrapper
(pid=5579)     return target(*args, **kwargs)
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/tensorflow/python/util/deprecation.py", line 535, in new_func
(pid=5579)     return func(*args, **kwargs)
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/tensorflow/python/ops/control_flow_ops.py", line 1272, in cond
(pid=5579)     orig_res_t, res_t = context_t.BuildCondBranch(true_fn)
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/tensorflow/python/ops/control_flow_ops.py", line 1072, in BuildCondBranch
(pid=5579)     original_result = fn()
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/rllib/utils/exploration/stochastic_sampling.py", line 81, in <lambda>
(pid=5579)     self.random_exploration.get_tf_exploration_action_op(
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/rllib/utils/exploration/random.py", line 134, in get_tf_exploration_action_op
(pid=5579)     logp = tf.zeros(shape=(batch_size, ), dtype=tf.float32)
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/tensorflow/python/util/dispatch.py", line 206, in wrapper
(pid=5579)     return target(*args, **kwargs)
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/tensorflow/python/ops/array_ops.py", line 2911, in wrapped
(pid=5579)     tensor = fun(*args, **kwargs)
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/tensorflow/python/ops/array_ops.py", line 2960, in zeros
(pid=5579)     output = _constant_if_small(zero, shape, dtype, name)
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/tensorflow/python/ops/array_ops.py", line 2896, in _constant_if_small
(pid=5579)     if np.prod(shape) < 1000:
(pid=5579)   File "<__array_function__ internals>", line 5, in prod
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/numpy/core/fromnumeric.py", line 3051, in prod
(pid=5579)     return _wrapreduction(a, np.multiply, 'prod', axis, dtype, out,
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/numpy/core/fromnumeric.py", line 86, in _wrapreduction
(pid=5579)     return ufunc.reduce(obj, axis, dtype, out, **passkwargs)
(pid=5579)   File "/home/ray/anaconda3/lib/python3.8/site-packages/tensorflow/python/framework/ops.py", line 867, in __array__
(pid=5579)     raise NotImplementedError(
(pid=5579) NotImplementedError: Cannot convert a symbolic Tensor (default_policy/cond/strided_slice:0) to a numpy array. This error may indicate that you're trying to pass a Tensor to a NumPy call, which is not supported
```


<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
