### PR TITLE
[RLlib] No Preprocessors; preparatory PR #1

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2245,9 +2245,9 @@ py_test(
     name = "examples/custom_observation_filters",
     main = "examples/custom_observation_filters.py",
     tags = ["team:ml", "examples", "examples_C"],
-    size = "small",
+    size = "medium",
     srcs = ["examples/custom_observation_filters.py"],
-    args = ["--stop-iters=2"]
+    args = ["--stop-iters=3"]
 )
 
 py_test(

--- a/rllib/agents/dqn/dqn_tf_policy.py
+++ b/rllib/agents/dqn/dqn_tf_policy.py
@@ -416,6 +416,8 @@ def postprocess_nstep_and_prio(policy: Policy,
                       batch[SampleBatch.REWARDS], batch[SampleBatch.NEXT_OBS],
                       batch[SampleBatch.DONES])
 
+    # Create dummy prio-weights (1.0) in case we don't have any in
+    # the batch.
     if PRIO_WEIGHTS not in batch:
         batch[PRIO_WEIGHTS] = np.ones_like(batch[SampleBatch.REWARDS])
 

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -188,15 +188,17 @@ COMMON_CONFIG: TrainerConfigDict = {
     # Tuple[value1, value2]: Clip at value1 and value2.
     "clip_rewards": None,
     # If True, RLlib will learn entirely inside a normalized action space
-    # (0.0 centered with small stddev; only affecting Box components) and
-    # only unsquash actions (and clip just in case) to the bounds of
-    # env's action space before sending actions back to the env.
+    # (0.0 centered with small stddev; only affecting Box components).
+    # We will unsquash actions (and clip, just in case) to the bounds of
+    # the env's action space before sending actions back to the env.
     "normalize_actions": True,
     # If True, RLlib will clip actions according to the env's bounds
     # before sending them back to the env.
     # TODO: (sven) This option should be obsoleted and always be False.
     "clip_actions": False,
     # Whether to use "rllib" or "deepmind" preprocessors by default
+    # Set to None for using no preprocessor. In this case, the model will have
+    # to handle possibly complex observations from the environment.
     "preprocessor_pref": "deepmind",
 
     # === Debug Settings ===
@@ -1003,7 +1005,7 @@ class Trainer(Trainable):
 
         # Check the preprocessor and preprocess, if necessary.
         pp = local_worker.preprocessors[policy_id]
-        if type(pp).__name__ != "NoPreprocessor":
+        if pp and type(pp).__name__ != "NoPreprocessor":
             observation = pp.transform(observation)
         filtered_observation = local_worker.filters[policy_id](
             observation, update=False)
@@ -1467,6 +1469,12 @@ class Trainer(Trainable):
                     config["input_evaluation"]))
 
         # Check model config.
+        # If no preprocessing, propagate into model's config as well
+        # (so model will know, whether inputs are preprocessed or not).
+        if config["preprocessor_pref"] is None:
+            model_config["_no_preprocessor"] = True
+
+        # Prev_a/r settings.
         prev_a_r = model_config.get("lstm_use_prev_action_reward",
                                     DEPRECATED_VALUE)
         if prev_a_r != DEPRECATED_VALUE:

--- a/rllib/env/multi_agent_env.py
+++ b/rllib/env/multi_agent_env.py
@@ -142,7 +142,7 @@ def make_multi_agent(env_name_or_creator):
     Returns:
         Type[MultiAgentEnv]: New MultiAgentEnv class to be used as env.
             The constructor takes a config dict with `num_agents` key
-            (default=1). The reset of the config dict will be passed on to the
+            (default=1). The rest of the config dict will be passed on to the
             underlying single-agent env's constructor.
 
     Examples:

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -18,7 +18,7 @@ from ray.rllib.env.wrappers.atari_wrappers import wrap_deepmind, is_atari
 from ray.rllib.evaluation.sampler import AsyncSampler, SyncSampler
 from ray.rllib.evaluation.rollout_metrics import RolloutMetrics
 from ray.rllib.models import ModelCatalog
-from ray.rllib.models.preprocessors import Preprocessor
+from ray.rllib.models.preprocessors import NoPreprocessor, Preprocessor
 from ray.rllib.offline import NoopOutput, IOContext, OutputWriter, InputReader
 from ray.rllib.offline.off_policy_estimator import OffPolicyEstimator, \
     OffPolicyEstimate
@@ -1363,7 +1363,13 @@ class RolloutWorker(ParallelIteratorWorker):
                 if preprocessor is not None:
                     obs_space = preprocessor.observation_space
             else:
-                self.preprocessors[name] = None
+                self.preprocessors[name] = NoPreprocessor(obs_space)
+
+            if isinstance(obs_space, (gym.spaces.Dict, gym.spaces.Tuple)):
+                raise ValueError(
+                    "Found raw Tuple|Dict space as input to policy. "
+                    "Please preprocess these observations with a "
+                    "Tuple|DictFlatteningPreprocessor.")
 
             self.policy_map.create_policy(name, orig_cls, obs_space, act_space,
                                           conf, merged_conf)

--- a/rllib/examples/custom_observation_filters.py
+++ b/rllib/examples/custom_observation_filters.py
@@ -137,9 +137,6 @@ if __name__ == "__main__":
     }
 
     results = tune.run(
-        "PG",
-        args.run,
-        config=config,
-        stop={"training_iteration": args.stop_iters})
+        args.run, config=config, stop={"training_iteration": args.stop_iters})
 
     ray.shutdown()

--- a/rllib/models/modelv2.py
+++ b/rllib/models/modelv2.py
@@ -216,18 +216,32 @@ class ModelV2:
             input_dict["is_training"] = input_dict.is_training
         else:
             restored = input_dict.copy()
-        restored["obs"] = restore_original_dimensions(
-            input_dict["obs"], self.obs_space, self.framework)
-        try:
-            if len(input_dict["obs"].shape) > 2:
-                restored["obs_flat"] = flatten(input_dict["obs"],
-                                               self.framework)
-            else:
-                restored["obs_flat"] = input_dict["obs"]
-        except AttributeError:
+
+        # No Preprocessor used: `config.preprocessor_pref`=None.
+        # TODO: This is unnecessary for when no preprocessor is used.
+        #  Obs are not flat then anymore. However, we'll keep this
+        #  here for backward-compatibility until Preprocessors have
+        #  been fully deprecated.
+        if self.model_config.get("_no_preprocessing"):
             restored["obs_flat"] = input_dict["obs"]
+        # Input to this Model went through a Preprocessor.
+        # Generate extra keys: "obs_flat" (vs "obs", which will hold the
+        # original obs).
+        else:
+            restored["obs"] = restore_original_dimensions(
+                input_dict["obs"], self.obs_space, self.framework)
+            try:
+                if len(input_dict["obs"].shape) > 2:
+                    restored["obs_flat"] = flatten(input_dict["obs"],
+                                                   self.framework)
+                else:
+                    restored["obs_flat"] = input_dict["obs"]
+            except AttributeError:
+                restored["obs_flat"] = input_dict["obs"]
+
         with self.context():
             res = self.forward(restored, state or [], seq_lens)
+
         if ((not isinstance(res, list) and not isinstance(res, tuple))
                 or len(res) != 2):
             raise ValueError(

--- a/rllib/models/preprocessors.py
+++ b/rllib/models/preprocessors.py
@@ -213,9 +213,14 @@ class TupleFlatteningPreprocessor(Preprocessor):
         for i in range(len(self._obs_space.spaces)):
             space = self._obs_space.spaces[i]
             logger.debug("Creating sub-preprocessor for {}".format(space))
-            preprocessor = get_preprocessor(space)(space, self._options)
+            preprocessor_class = get_preprocessor(space)
+            if preprocessor_class is not None:
+                preprocessor = preprocessor_class(space, self._options)
+                size += preprocessor.size
+            else:
+                preprocessor = None
+                size += int(np.product(space.shape))
             self.preprocessors.append(preprocessor)
-            size += preprocessor.size
         return (size, )
 
     @override(Preprocessor)
@@ -247,9 +252,14 @@ class DictFlatteningPreprocessor(Preprocessor):
         self.preprocessors = []
         for space in self._obs_space.spaces.values():
             logger.debug("Creating sub-preprocessor for {}".format(space))
-            preprocessor = get_preprocessor(space)(space, self._options)
+            preprocessor_class = get_preprocessor(space)
+            if preprocessor_class is not None:
+                preprocessor = preprocessor_class(space, self._options)
+                size += preprocessor.size
+            else:
+                preprocessor = None
+                size += int(np.product(space.shape))
             self.preprocessors.append(preprocessor)
-            size += preprocessor.size
         return (size, )
 
     @override(Preprocessor)

--- a/rllib/models/tf/complex_input_net.py
+++ b/rllib/models/tf/complex_input_net.py
@@ -1,5 +1,6 @@
-from gym.spaces import Box, Discrete, Tuple
+from gym.spaces import Box, Dict, Discrete, MultiDiscrete, Tuple
 import numpy as np
+import tree  # pip install dm_tree
 
 from ray.rllib.models.catalog import ModelCatalog
 from ray.rllib.models.modelv2 import ModelV2, restore_original_dimensions
@@ -9,6 +10,7 @@ from ray.rllib.models.utils import get_filter_config
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.framework import try_import_tf
+from ray.rllib.utils.spaces.space_utils import flatten_space
 from ray.rllib.utils.tf_ops import one_hot
 
 tf1, tf, tfv = try_import_tf()
@@ -31,21 +33,22 @@ class ComplexInputNetwork(TFModelV2):
 
     def __init__(self, obs_space, action_space, num_outputs, model_config,
                  name):
-        # TODO: (sven) Support Dicts as well.
         self.original_space = obs_space.original_space if \
             hasattr(obs_space, "original_space") else obs_space
-        assert isinstance(self.original_space, (Tuple)), \
-            "`obs_space.original_space` must be Tuple!"
+        assert isinstance(self.original_space, (Dict, Tuple)), \
+            "`obs_space.original_space` must be [Dict|Tuple]!"
 
         super().__init__(self.original_space, action_space, num_outputs,
                          model_config, name)
+
+        self.flattened_input_space = flatten_space(self.original_space)
 
         # Build the CNN(s) given obs_space's image components.
         self.cnns = {}
         self.one_hot = {}
         self.flatten = {}
         concat_size = 0
-        for i, component in enumerate(self.original_space):
+        for i, component in enumerate(self.flattened_input_space):
             # Image space.
             if len(component.shape) == 3:
                 config = {
@@ -64,11 +67,13 @@ class ComplexInputNetwork(TFModelV2):
                     name="cnn_{}".format(i))
                 concat_size += cnn.num_outputs
                 self.cnns[i] = cnn
-            # Discrete inputs -> One-hot encode.
+            # Discrete|MultiDiscrete inputs -> One-hot encode.
             elif isinstance(component, Discrete):
                 self.one_hot[i] = True
                 concat_size += component.n
-            # TODO: (sven) Multidiscrete (see e.g. our auto-LSTM wrappers).
+            elif isinstance(component, MultiDiscrete):
+                self.one_hot[i] = True
+                concat_size += sum(component.nvec)
             # Everything else (1D Box).
             else:
                 self.flatten[i] = int(np.product(component.shape))
@@ -123,18 +128,22 @@ class ComplexInputNetwork(TFModelV2):
                                                    self.obs_space, "tf")
         # Push image observations through our CNNs.
         outs = []
-        for i, component in enumerate(orig_obs):
+        for i, component in enumerate(tree.flatten(orig_obs)):
             if i in self.cnns:
                 cnn_out, _ = self.cnns[i]({SampleBatch.OBS: component})
                 outs.append(cnn_out)
             elif i in self.one_hot:
                 if component.dtype in [tf.int32, tf.int64, tf.uint8]:
                     outs.append(
-                        one_hot(component, self.original_space.spaces[i]))
+                        one_hot(component, self.flattened_input_space[i]))
                 else:
                     outs.append(component)
             else:
-                outs.append(tf.reshape(component, [-1, self.flatten[i]]))
+                outs.append(
+                    tf.cast(
+                        tf.reshape(component, [-1, self.flatten[i]]),
+                        dtype=tf.float32,
+                    ))
         # Concat all outputs and the non-image inputs.
         out = tf.concat(outs, axis=1)
         # Push through (optional) FC-stack (this may be an empty stack).

--- a/rllib/models/torch/complex_input_net.py
+++ b/rllib/models/torch/complex_input_net.py
@@ -1,16 +1,19 @@
-from gym.spaces import Box, Discrete, Tuple
+from gym.spaces import Box, Dict, Discrete, MultiDiscrete, Tuple
 import numpy as np
+import tree  # pip install dm_tree
 
 # TODO (sven): add IMPALA-style option.
 # from ray.rllib.examples.models.impala_vision_nets import TorchImpalaVisionNet
 from ray.rllib.models.torch.misc import normc_initializer as \
     torch_normc_initializer, SlimFC
 from ray.rllib.models.catalog import ModelCatalog
-from ray.rllib.models.modelv2 import ModelV2
+from ray.rllib.models.modelv2 import ModelV2, restore_original_dimensions
 from ray.rllib.models.torch.torch_modelv2 import TorchModelV2
 from ray.rllib.models.utils import get_filter_config
+from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.framework import try_import_torch
+from ray.rllib.utils.spaces.space_utils import flatten_space
 from ray.rllib.utils.torch_ops import one_hot
 
 torch, nn = try_import_torch()
@@ -32,15 +35,16 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
 
     def __init__(self, obs_space, action_space, num_outputs, model_config,
                  name):
-        # TODO: (sven) Support Dicts as well.
         self.original_space = obs_space.original_space if \
             hasattr(obs_space, "original_space") else obs_space
-        assert isinstance(self.original_space, (Tuple)), \
-            "`obs_space.original_space` must be Tuple!"
+        assert isinstance(self.original_space, (Dict, Tuple)), \
+            "`obs_space.original_space` must be [Dict|Tuple]!"
 
         nn.Module.__init__(self)
         TorchModelV2.__init__(self, self.original_space, action_space,
                               num_outputs, model_config, name)
+
+        self.flattened_input_space = flatten_space(self.original_space)
 
         # Atari type CNNs or IMPALA type CNNs (with residual layers)?
         # self.cnn_type = self.model_config["custom_model_config"].get(
@@ -51,7 +55,7 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
         self.one_hot = {}
         self.flatten = {}
         concat_size = 0
-        for i, component in enumerate(self.original_space):
+        for i, component in enumerate(self.flattened_input_space):
             # Image space.
             if len(component.shape) == 3:
                 config = {
@@ -81,11 +85,13 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
                 concat_size += cnn.num_outputs
                 self.cnns[i] = cnn
                 self.add_module("cnn_{}".format(i), cnn)
-            # Discrete inputs -> One-hot encode.
+            # Discrete|MultiDiscrete inputs -> One-hot encode.
             elif isinstance(component, Discrete):
                 self.one_hot[i] = True
                 concat_size += component.n
-            # TODO: (sven) Multidiscrete (see e.g. our auto-LSTM wrappers).
+            elif isinstance(component, MultiDiscrete):
+                self.one_hot[i] = True
+                concat_size += sum(component.nvec)
             # Everything else (1D Box).
             else:
                 self.flatten[i] = int(np.product(component.shape))
@@ -131,16 +137,21 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
 
     @override(ModelV2)
     def forward(self, input_dict, state, seq_lens):
+        if SampleBatch.OBS in input_dict and "obs_flat" in input_dict:
+            orig_obs = input_dict[SampleBatch.OBS]
+        else:
+            orig_obs = restore_original_dimensions(input_dict[SampleBatch.OBS],
+                                                   self.obs_space, "tf")
         # Push image observations through our CNNs.
         outs = []
-        for i, component in enumerate(input_dict["obs"]):
+        for i, component in enumerate(tree.flatten(orig_obs)):
             if i in self.cnns:
-                cnn_out, _ = self.cnns[i]({"obs": component})
+                cnn_out, _ = self.cnns[i]({SampleBatch.OBS: component})
                 outs.append(cnn_out)
             elif i in self.one_hot:
                 if component.dtype in [torch.int32, torch.int64, torch.uint8]:
                     outs.append(
-                        one_hot(component, self.original_space.spaces[i]))
+                        one_hot(component, self.flattened_input_space[i]))
                 else:
                     outs.append(component)
             else:
@@ -148,7 +159,7 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
         # Concat all outputs and the non-image inputs.
         out = torch.cat(outs, dim=1)
         # Push through (optional) FC-stack (this may be an empty stack).
-        out, _ = self.post_fc_stack({"obs": out}, [], None)
+        out, _ = self.post_fc_stack({SampleBatch.OBS: out}, [], None)
 
         # No logits/value branches.
         if self.logits_layer is None:

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -14,7 +14,8 @@ from ray.rllib.utils.exploration.exploration import Exploration
 from ray.rllib.utils.framework import try_import_tf, try_import_torch
 from ray.rllib.utils.from_config import from_config
 from ray.rllib.utils.spaces.space_utils import clip_action, \
-    get_base_struct_from_space, unbatch, unsquash_action
+    get_base_struct_from_space, get_dummy_batch_for_space, unbatch, \
+    unsquash_action
 from ray.rllib.utils.typing import AgentID, ModelGradients, ModelWeights, \
     TensorType, TrainerConfigDict, Tuple, Union
 
@@ -291,7 +292,7 @@ class Policy(metaclass=ABCMeta):
     @DeveloperAPI
     def compute_actions_from_input_dict(
             self,
-            input_dict: Dict[str, TensorType],
+            input_dict: SampleBatch,
             explore: bool = None,
             timestep: Optional[int] = None,
             episodes: Optional[List["MultiAgentEpisode"]] = None,
@@ -303,10 +304,10 @@ class Policy(metaclass=ABCMeta):
         to construct the input_dict for the Model.
 
         Args:
-            input_dict (Dict[str, TensorType]): An input dict mapping str
-                keys to Tensors. `input_dict` already abides to the Policy's
-                as well as the Model's view requirements and can be passed
-                to the Model as-is.
+            input_dict (SampleBatch): A SampleBatch containing the Tensors
+                to compute actions. `input_dict` already abides to the
+                Policy's as well as the Model's view requirements and can
+                thus be passed to the Model as-is.
             explore (bool): Whether to pick an exploitation or exploration
                 action (default: None -> use self.config["explore"]).
             timestep (Optional[int]): The current (sampling) time step.
@@ -850,7 +851,9 @@ class Policy(metaclass=ABCMeta):
         """
         ret = {}
         for view_col, view_req in self.view_requirements.items():
-            if isinstance(view_req.space, (gym.spaces.Dict, gym.spaces.Tuple)):
+            if self.config["preprocessor_pref"] is not None and \
+                    isinstance(view_req.space,
+                               (gym.spaces.Dict, gym.spaces.Tuple)):
                 _, shape = ModelCatalog.get_action_shape(
                     view_req.space, framework=self.config["framework"])
                 ret[view_col] = \
@@ -858,23 +861,23 @@ class Policy(metaclass=ABCMeta):
             else:
                 # Range of indices on time-axis, e.g. "-50:-1".
                 if view_req.shift_from is not None:
-                    ret[view_col] = np.zeros_like([[
-                        view_req.space.sample()
-                        for _ in range(view_req.shift_to -
-                                       view_req.shift_from + 1)
-                    ] for _ in range(batch_size)])
-                # Set of (probably non-consecutive) indices.
+                    ret[view_col] = get_dummy_batch_for_space(
+                        view_req.space,
+                        batch_size=batch_size,
+                        time_size=view_req.shift_to - view_req.shift_from + 1)
+                # Sequence of (probably non-consecutive) indices.
                 elif isinstance(view_req.shift, (list, tuple)):
-                    ret[view_col] = np.zeros_like([[
-                        view_req.space.sample()
-                        for t in range(len(view_req.shift))
-                    ] for _ in range(batch_size)])
+                    ret[view_col] = get_dummy_batch_for_space(
+                        view_req.space,
+                        batch_size=batch_size,
+                        time_size=len(view_req.shift))
                 # Single shift int value.
                 else:
                     if isinstance(view_req.space, gym.spaces.Space):
-                        ret[view_col] = np.zeros_like([
-                            view_req.space.sample() for _ in range(batch_size)
-                        ])
+                        ret[view_col] = get_dummy_batch_for_space(
+                            view_req.space,
+                            batch_size=batch_size,
+                            fill_value=0.0)
                     else:
                         ret[view_col] = [
                             view_req.space for _ in range(batch_size)

--- a/rllib/utils/spaces/space_utils.py
+++ b/rllib/utils/spaces/space_utils.py
@@ -2,7 +2,7 @@ import gym
 from gym.spaces import Tuple, Dict
 import numpy as np
 import tree  # pip install dm_tree
-from typing import List
+from typing import List, Optional, Union
 
 
 def flatten_space(space: gym.Space) -> List[gym.Space]:
@@ -63,6 +63,76 @@ def get_base_struct_from_space(space):
             return space_
 
     return _helper_struct(space)
+
+
+def get_dummy_batch_for_space(
+        space: gym.Space,
+        batch_size: int = 32,
+        fill_value: Union[float, int, str] = 0.0,
+        time_size: Optional[int] = None,
+        time_major: bool = False,
+) -> np.ndarray:
+    """Returns batched dummy data (using `batch_size`) for the given `space`.
+
+    Note: The returned batch will not pass a `space.contains(batch)` test
+    as an additional batch dimension has to be added as dim=0.
+
+    Args:
+        space (gym.Space): The space to get a dummy batch for.
+        batch_size(int): The required batch size (B). Note that this can also
+            be 0 (only if `time_size` is None!), which will result in a
+            non-batched sample for the given space (no batch dim).
+        fill_value (Union[float, int, str]): The value to fill the batch with
+            or "random" for random values.
+        time_size (Optional[int]): If not None, add an optional time axis
+            of `time_size` size to the returned batch.
+        time_major (bool): If True AND `time_size` is not None, return batch
+            as shape [T x B x ...], otherwise as [B x T x ...]. If `time_size`
+            if None, ignore this setting and return [B x ...].
+
+    Returns:
+        The dummy batch of size `bqtch_size` matching the given space.
+    """
+    # Complex spaces. Perform recursive calls of this function.
+    if isinstance(space, (gym.spaces.Dict, gym.spaces.Tuple)):
+        return tree.map_structure(
+            lambda s: get_dummy_batch_for_space(s, batch_size, fill_value),
+            get_base_struct_from_space(space),
+        )
+    # Primivite spaces: Box, Discrete, MultiDiscrete.
+    # Random values: Use gym's sample() method.
+    elif fill_value == "random":
+        if time_size is not None:
+            assert batch_size > 0 and time_size > 0
+            if time_major:
+                return np.array(
+                    [[space.sample() for _ in range(batch_size)]
+                     for t in range(time_size)],
+                    dtype=space.dtype)
+            else:
+                return np.array(
+                    [[space.sample() for t in range(time_size)]
+                     for _ in range(batch_size)],
+                    dtype=space.dtype)
+        else:
+            return np.array(
+                [space.sample() for _ in range(batch_size)]
+                if batch_size > 0 else space.sample(),
+                dtype=space.dtype)
+    # Fill value given: Use np.full.
+    else:
+        if time_size is not None:
+            assert batch_size > 0 and time_size > 0
+            if time_major:
+                shape = [time_size, batch_size]
+            else:
+                shape = [batch_size, time_size]
+        else:
+            shape = [batch_size] if batch_size > 0 else []
+        return np.full(
+            shape + list(space.shape),
+            fill_value=fill_value,
+            dtype=space.dtype)
 
 
 def flatten_to_single_ndarray(input_):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

This PR was motivated in preparation for soon allowing individual observation components to be addressed by the trajectory view API, for example to enable frame-stacking for individual observation components within a complex observation space (Tuple|Dict). Also, soon soft-deprecating RLlib's Preprocessor API should increase transparency for the users and allow batched, model-based preprocessing of observations. Observations will arrive in the model exactly as they are returned by the env.

This PR is a preparatory PR that lays some groundwork in order to fully support this feature (in 1 follow up PR).

- New config setting for preprocessor_pref: None; Set to None for disabling Preprocessors altogether (not even use NoPreprocessor class anymore).
- ComplexInputModel (which already exists and handles complex, unflattened inputs) was enhanced to support Dict inputs as well (so far, only Tuple inputs).
- Some docs strings and comments added.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
