### PR TITLE
[RLlib] Add support for evaluation_num_episodes=auto (run eval for as long as the parallel train step takes).

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2527,12 +2527,12 @@ py_test(
 )
 
 py_test(
-    name = "examples/parallel_evaluation_and_training_tf",
+    name = "examples/parallel_evaluation_and_training_13_episodes_tf",
     main = "examples/parallel_evaluation_and_training.py",
     tags = ["team:ml", "examples", "examples_P"],
     size = "medium",
     srcs = ["examples/parallel_evaluation_and_training.py"],
-    args = ["--as-test", "--stop-reward=50.0", "--num-cpus=6"]
+    args = ["--as-test", "--stop-reward=50.0", "--num-cpus=6", "--evaluation-num-episodes=13"]
 )
 
 py_test(
@@ -2545,21 +2545,21 @@ py_test(
 )
 
 py_test(
-    name = "examples/parallel_evaluation_and_training_tf2",
+    name = "examples/parallel_evaluation_and_training_11_episodes_tf2",
     main = "examples/parallel_evaluation_and_training.py",
     tags = ["team:ml", "examples", "examples_P"],
     size = "medium",
     srcs = ["examples/parallel_evaluation_and_training.py"],
-    args = ["--as-test", "--framework=tf2", "--stop-reward=30.0", "--num-cpus=6"]
+    args = ["--as-test", "--framework=tf2", "--stop-reward=30.0", "--num-cpus=6", "--evaluation-num-episodes=11"]
 )
 
 py_test(
-    name = "examples/parallel_evaluation_and_training_torch",
+    name = "examples/parallel_evaluation_and_training_14_episodes_torch",
     main = "examples/parallel_evaluation_and_training.py",
     tags = ["team:ml", "examples", "examples_P"],
     size = "medium",
     srcs = ["examples/parallel_evaluation_and_training.py"],
-    args = ["--as-test", "--framework=torch", "--stop-reward=30.0", "--num-cpus=6"]
+    args = ["--as-test", "--framework=torch", "--stop-reward=30.0", "--num-cpus=6", "--evaluation-num-episodes=14"]
 )
 
 py_test(

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2508,12 +2508,30 @@ py_test(
 )
 
 py_test(
+    name = "examples/parallel_evaluation_and_training_auto_num_episodes_tf",
+    main = "examples/parallel_evaluation_and_training.py",
+    tags = ["team:ml", "examples", "examples_P"],
+    size = "medium",
+    srcs = ["examples/parallel_evaluation_and_training.py"],
+    args = ["--as-test", "--stop-reward=50.0", "--num-cpus=6", "--evaluation-num-episodes=auto"]
+)
+
+py_test(
     name = "examples/parallel_evaluation_and_training_tf2",
     main = "examples/parallel_evaluation_and_training.py",
     tags = ["team:ml", "examples", "examples_P"],
     size = "medium",
     srcs = ["examples/parallel_evaluation_and_training.py"],
     args = ["--as-test", "--framework=tf2", "--stop-reward=30.0", "--num-cpus=6"]
+)
+
+py_test(
+    name = "examples/parallel_evaluation_and_training_torch",
+    main = "examples/parallel_evaluation_and_training.py",
+    tags = ["team:ml", "examples", "examples_P"],
+    size = "medium",
+    srcs = ["examples/parallel_evaluation_and_training.py"],
+    args = ["--as-test", "--framework=torch", "--stop-reward=30.0", "--num-cpus=6"]
 )
 
 py_test(

--- a/rllib/agents/cql/tests/test_cql.py
+++ b/rllib/agents/cql/tests/test_cql.py
@@ -60,7 +60,7 @@ class TestCQL(unittest.TestCase):
         config["evaluation_interval"] = 2
         config["evaluation_num_episodes"] = 10
         config["evaluation_config"]["input"] = "sampler"
-        config["evaluation_parallel_to_training"] = True
+        config["evaluation_parallel_to_training"] = False
         config["evaluation_num_workers"] = 2
 
         num_iterations = 4

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -1555,15 +1555,16 @@ class Trainer(Trainable):
 
         # If `evaluation_num_episodes=auto`, error if
         # `evaluation_parallel_to_training=False`.
-        if config["evaluation_num_episodes"] == "auto" and \
-                not config["evaluation_parallel_to_training"]:
-            raise ValueError(
-                "`evaluation_num_episodes=auto` not supported for "
-                "`evaluation_parallel_to_training=False`!")
+        if config["evaluation_num_episodes"] == "auto":
+            if not config["evaluation_parallel_to_training"]:
+                raise ValueError(
+                    "`evaluation_num_episodes=auto` not supported for "
+                    "`evaluation_parallel_to_training=False`!")
+        # Make sure, it's an int otherwise.
         elif not isinstance(config["evaluation_num_episodes"], int):
             raise ValueError(
-                "`evaluation_num_episodes` "
-                f"({config['evaluation_num_episodes']}) must be an int!")
+                "`evaluation_num_episodes` ({}) must be an int and "
+                ">0!".format(config["evaluation_num_episodes"]))
 
     def _try_recover(self):
         """Try to identify and remove any unhealthy workers.

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -252,8 +252,13 @@ COMMON_CONFIG: TrainerConfigDict = {
     # Note that evaluation is currently not parallelized, and that for Ape-X
     # metrics are already only reported for the lowest epsilon workers.
     "evaluation_interval": None,
-    # Number of episodes to run per evaluation period. If using multiple
-    # evaluation workers, we will run at least this many episodes total.
+    # Number of episodes to run in total per evaluation period.
+    # If using multiple evaluation workers (evaluation_num_workers > 1),
+    # episodes will be split amongst these.
+    # If "auto":
+    # - evaluation_parallel_to_training=True: Will run as many episodes as the
+    #   training step takes.
+    # - evaluation_parallel_to_training=False: Error.
     "evaluation_num_episodes": 10,
     # Whether to run evaluation in parallel to a Trainer.train() call
     # using threading. Default=False.
@@ -841,11 +846,19 @@ class Trainer(Trainable):
         return self.evaluate()
 
     @PublicAPI
-    def evaluate(self) -> dict:
+    def evaluate(self, done_function: Optional[Callable[[int], bool]] = None
+                 ) -> dict:
         """Evaluates current policy under `evaluation_config` settings.
 
         Note that this default implementation does not do anything beyond
         merging evaluation_config with the normal trainer config.
+
+        Args:
+            done_function (Optional[Callable[[int], bool]]): An optional
+                callable taking the already run episodes as only arg. It's
+                used to find out whether evaluation should continue. Useful
+                for evaluation parallel to training and
+                evaluation_num_episodes=auto.
         """
         # In case we are evaluating (in a thread) parallel to training,
         # we may have to re-enable eager mode here (gets disabled in the
@@ -871,15 +884,23 @@ class Trainer(Trainable):
                 raise ValueError("Custom eval function must return "
                                  "dict of metrics, got {}.".format(metrics))
         else:
-            logger.info("Evaluating current policy for {} episodes.".format(
-                self.config["evaluation_num_episodes"]))
+            # How many episodes do we need to run?
+            # In "auto" mode (only for parallel eval + training): Run one
+            # episode per eval worker.
+            num_episodes = self.config["evaluation_num_episodes"] if \
+                self.config["evaluation_num_episodes"] != "auto" else \
+                (self.config["evaluation_num_workers"] or 1)
+
+            logger.info(
+                f"Evaluating current policy for {num_episodes} episodes.")
+
             metrics = None
             # No evaluation worker set ->
             # Do evaluation using the local worker. Expect error due to the
             # local worker not having an env.
             if self.evaluation_workers is None:
                 try:
-                    for _ in range(self.config["evaluation_num_episodes"]):
+                    for _ in range(num_episodes):
                         self.workers.local_worker().sample()
                     metrics = collect_metrics(self.workers.local_worker())
                 except ValueError as e:
@@ -899,16 +920,17 @@ class Trainer(Trainable):
 
             # Evaluation worker set only has local worker.
             elif self.config["evaluation_num_workers"] == 0:
-                for _ in range(self.config["evaluation_num_episodes"]):
+                for _ in range(num_episodes):
                     self.evaluation_workers.local_worker().sample()
+
             # Evaluation worker set has n remote workers.
             else:
-                # How many episodes do we need to run?
-                num_episodes = self.config["evaluation_num_episodes"]
-                # How many have we run (across all evaluation workers)?
+                # How many episodes have we run (across all eval workers)?
                 num_episodes_done = 0
                 round_ = 0
-                while num_episodes_done < num_episodes:
+                while num_episodes_done < num_episodes or (
+                        done_function is not None
+                        and not done_function(num_episodes_done)):
                     round_ += 1
                     episodes_left_to_do = num_episodes - num_episodes_done
                     batches = ray.get([
@@ -1501,8 +1523,9 @@ class Trainer(Trainable):
                 "`count_steps_by` must be one of [env_steps|agent_steps]! "
                 "Got {}".format(config["multiagent"]["count_steps_by"]))
 
-        # If evaluation_num_workers > 0, warn if evaluation_interval is None
-        # (also set it to 1).
+        # Evaluation settings.
+        # If `evaluation_num_workers` > 0, warn if `evaluation_interval` is
+        # None (also set `evaluation_interval` to 1).
         if config["evaluation_num_workers"] > 0 and \
                 not config["evaluation_interval"]:
             logger.warning(
@@ -1511,6 +1534,10 @@ class Trainer(Trainable):
                 "If this is too frequent, set `evaluation_interval` to some "
                 "larger value.".format(config["evaluation_num_workers"]))
             config["evaluation_interval"] = 1
+        # If `evaluation_num_workers=0` and
+        # `evaluation_parallel_to_training=True`, warn that you need
+        # at least one remote eval worker for parallel training and
+        # evaluation, and set `evaluation_parallel_to_training` to False.
         elif config["evaluation_num_workers"] == 0 and \
                 config.get("evaluation_parallel_to_training", False):
             logger.warning(
@@ -1518,6 +1545,14 @@ class Trainer(Trainable):
                 "`evaluation_num_workers` > 0! Setting "
                 "`evaluation_parallel_to_training` to False.")
             config["evaluation_parallel_to_training"] = False
+
+        # If `evaluation_num_episodes=auto`, error if
+        # `evaluation_parallel_to_training=False`.
+        if config["evaluation_num_episodes"] == "auto" and \
+                not config["evaluation_parallel_to_training"]:
+            raise ValueError(
+                "`evaluation_num_episodes=auto` not supported for "
+                "`evaluation_parallel_to_training=False`!")
 
     def _try_recover(self):
         """Try to identify and remove any unhealthy workers.

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -1560,6 +1560,10 @@ class Trainer(Trainable):
             raise ValueError(
                 "`evaluation_num_episodes=auto` not supported for "
                 "`evaluation_parallel_to_training=False`!")
+        elif not isinstance(config["evaluation_num_episodes"], int):
+            raise ValueError(
+                "`evaluation_num_episodes` "
+                f"({config['evaluation_num_episodes']}) must be an int!")
 
     def _try_recover(self):
         """Try to identify and remove any unhealthy workers.

--- a/rllib/agents/trainer_template.py
+++ b/rllib/agents/trainer_template.py
@@ -221,12 +221,16 @@ def build_trainer(
 
                             # Run at least one `evaluate()` (num_episodes_done
                             # must be > 0), even if the training is very fast.
-                            def stop_eval(num_episodes_done):
-                                return (num_episodes_done > 0
-                                        and train_future.done())
+                            def episodes_left_fn(num_episodes_done):
+                                if num_episodes_done > 0 and \
+                                        train_future.done():
+                                    return 0
+                                else:
+                                    return self.config[
+                                        "evaluation_num_workers"]
 
                             evaluation_metrics = self.evaluate(
-                                done_function=stop_eval)
+                                episodes_left_fn=episodes_left_fn)
                         else:
                             evaluation_metrics = self.evaluate()
                         # Collect the training results from the future.

--- a/rllib/agents/trainer_template.py
+++ b/rllib/agents/trainer_template.py
@@ -203,28 +203,42 @@ def build_trainer(
 
             # No evaluation necessary, just run the next training iteration.
             if not evaluate_this_iter:
-                res = next(self.train_exec_impl)
+                step_results = next(self.train_exec_impl)
             # We have to evaluate in this training iteration.
             else:
                 # No parallelism.
                 if not self.config["evaluation_parallel_to_training"]:
-                    res = next(self.train_exec_impl)
+                    step_results = next(self.train_exec_impl)
 
                 # Kick off evaluation-loop (and parallel train() call,
                 # if requested).
                 # Parallel eval + training.
                 if self.config["evaluation_parallel_to_training"]:
                     with concurrent.futures.ThreadPoolExecutor() as executor:
-                        eval_future = executor.submit(self.evaluate)
-                        res = next(self.train_exec_impl)
-                        evaluation_metrics = eval_future.result()
+                        train_future = executor.submit(
+                            lambda: next(self.train_exec_impl))
+                        if self.config["evaluation_num_episodes"] == "auto":
+
+                            # Run at least one `evaluate()` (num_episodes_done
+                            # must be > 0), even if the training is very fast.
+                            def stop_eval(num_episodes_done):
+                                return (num_episodes_done > 0
+                                        and train_future.done())
+
+                            evaluation_metrics = self.evaluate(
+                                done_function=stop_eval)
+                        else:
+                            evaluation_metrics = self.evaluate()
+                        # Collect the training results from the future.
+                        step_results = train_future.result()
                 # Sequential: train (already done above), then eval.
                 else:
                     evaluation_metrics = self.evaluate()
 
+                # Add evaluation results to train results.
                 assert isinstance(evaluation_metrics, dict), \
                     "Trainer.evaluate() needs to return a dict."
-                res.update(evaluation_metrics)
+                step_results.update(evaluation_metrics)
 
             # Check `env_task_fn` for possible update of the env's task.
             if self.config["env_task_fn"] is not None:
@@ -234,7 +248,7 @@ def build_trainer(
                         "[train_results, env, env_ctx] as args!")
 
                 def fn(env, env_context, task_fn):
-                    new_task = task_fn(res, env, env_context)
+                    new_task = task_fn(step_results, env, env_context)
                     cur_task = env.get_task()
                     if cur_task != new_task:
                         env.set_task(new_task)
@@ -242,7 +256,7 @@ def build_trainer(
                 fn = partial(fn, task_fn=self.config["env_task_fn"])
                 self.workers.foreach_env_with_context(fn)
 
-            return res
+            return step_results
 
         @staticmethod
         @override(Trainer)

--- a/rllib/examples/parallel_evaluation_and_training.py
+++ b/rllib/examples/parallel_evaluation_and_training.py
@@ -8,7 +8,7 @@ parser = argparse.ArgumentParser()
 
 parser.add_argument(
     "--evaluation-num-episodes",
-    type=lambda v: str(v) if isinstance(v, str) else int(v),
+    type=lambda v: v if v == "auto" else int(v),
     default=13,
     help="Number of evaluation episodes to run each iteration. "
     "If 'auto', will run as many as possible during train pass.")

--- a/rllib/examples/parallel_evaluation_and_training.py
+++ b/rllib/examples/parallel_evaluation_and_training.py
@@ -5,6 +5,14 @@ from ray.rllib.agents.callbacks import DefaultCallbacks
 from ray.rllib.utils.test_utils import check_learning_achieved
 
 parser = argparse.ArgumentParser()
+
+parser.add_argument(
+    "--evaluation-num-episodes",
+    type=lambda v: str(v) if isinstance(v, str) else int(v),
+    default=13,
+    help="Number of evaluation episodes to run each iteration. "
+    "If 'auto', will run as many as possible during train pass.")
+
 parser.add_argument(
     "--run",
     type=str,
@@ -36,6 +44,10 @@ parser.add_argument(
     type=float,
     default=100.0,
     help="Reward at which we stop training.")
+parser.add_argument(
+    "--local-mode",
+    action="store_true",
+    help="Init Ray in local mode for easier debugging.")
 
 
 class AssertNumEvalEpisodesCallback(DefaultCallbacks):
@@ -45,13 +57,19 @@ class AssertNumEvalEpisodesCallback(DefaultCallbacks):
         # `evaluation_num_workers` or `evaluation_parallel_to_training`).
         if "evaluation" in result:
             hist_stats = result["evaluation"]["hist_stats"]
+            num_episodes_done = len(hist_stats["episode_lengths"])
             # Compare number of entries in episode_lengths (this is the
             # number of episodes actually run) with desired number of
             # episodes from the config.
-            assert len(hist_stats["episode_lengths"]) == \
-                trainer.config["evaluation_num_episodes"]
-            print("Number of evaluation episodes is exactly "
-                  f"{trainer.config['evaluation_num_episodes']} (ok)!")
+            if isinstance(trainer.config["evaluation_num_episodes"], int):
+                assert num_episodes_done == \
+                    trainer.config["evaluation_num_episodes"]
+            else:
+                assert trainer.config["evaluation_num_episodes"] == "auto"
+                assert num_episodes_done >= \
+                       trainer.config["evaluation_num_workers"]
+            print("Number of run evaluation episodes: "
+                  f"{num_episodes_done} (ok)!")
 
 
 if __name__ == "__main__":
@@ -60,7 +78,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    ray.init(num_cpus=args.num_cpus or None)
+    ray.init(num_cpus=args.num_cpus or None, local_mode=args.local_mode)
 
     config = {
         "env": "CartPole-v0",
@@ -79,10 +97,13 @@ if __name__ == "__main__":
         # Evaluate every other training iteration (together
         # with every other call to Trainer.train()).
         "evaluation_interval": 2,
-        # Run for 50 episodes (25 per eval worker and per
-        # evaluation round). The longer it takes to evaluate, the more
+        "train_batch_size": 16000,
+        # Run for n episodes (properly distribute load amongst all eval
+        # workers). The longer it takes to evaluate, the more
         # sense it makes to use `evaluation_parallel_to_training=True`.
-        "evaluation_num_episodes": 13,
+        # Use "auto" to run evaluation for roughly as long as the training
+        # step takes.
+        "evaluation_num_episodes": args.evaluation_num_episodes,
         # Switch on evaluation in parallel with training.
         "evaluation_parallel_to_training": True,
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Add support for `evaluation_num_episodes=auto`:
- If evaluation_num_episodes=auto
-- If evaluation_parallel_to_training=True, run as many evaluation episodes as the training step takes.
-- If evaluation_parallel_to_training=False, raise an error.
- Added a new test for the existing example script (parallel_evaluation_and_training.py) to BUILD.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
