### PR TITLE
[Core] Make It Easier to Grep Debug State Dump

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -477,8 +477,11 @@ ray::Status NodeManager::RegisterGcs() {
   if (event_stats_print_interval_ms != -1 && RayConfig::instance().event_stats()) {
     periodical_runner_.RunFnPeriodically(
         [this] {
-          RAY_LOG(INFO) << "Event stats:\n\n" << io_service_.StatsString() << "\n\n";
-          RAY_LOG(INFO) << DebugString() << "\n\n";
+          std::stringstream debug_msg;
+          debug_msg << "Event stats:\n\n"
+                    << io_service_.StatsString() << "\n\n"
+                    << DebugString() << "\n\n";
+          RAY_LOG(INFO) << AppendToEachLine(debug_msg.str(), "[state-dump] ");
         },
         event_stats_print_interval_ms,
         "NodeManager.deadline_timer.print_event_loop_stats");

--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -65,7 +65,8 @@ inline std::string StringToHex(const std::string &str) {
 }
 
 // Append append_str to the begining of each line of str.
-inline std::string AppendToEachLine(const std::string str, const std::string append_str) {
+inline std::string AppendToEachLine(const std::string &str,
+                                    const std::string &append_str) {
   std::stringstream ss;
   ss << append_str;
   for (char c : str) {

--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -64,6 +64,19 @@ inline std::string StringToHex(const std::string &str) {
   return result;
 }
 
+// Append append_str to the begining of each line of str.
+inline std::string AppendToEachLine(const std::string str, const std::string append_str) {
+  std::stringstream ss;
+  ss << append_str;
+  for (char c : str) {
+    ss << c;
+    if (c == '\n') {
+      ss << append_str;
+    }
+  }
+  return ss.str();
+}
+
 /// Return the number of milliseconds since the steady clock epoch. NOTE: The
 /// returned timestamp may be used for accurately measuring intervals but has
 /// no relation to wall clock time. It must not be used for synchronization


### PR DESCRIPTION
## Why are these changes needed?

Sometimes I need to dump debug states frequently in order to trace stack states.

But when I set `event_stats_print_interval_ms` to, for example, 1s. The raylet.out file will be filled with state dump. Which makes it hard to read normal logs.

In this PR I add a keyword `[state-dump]` to each line of the state dump, so that I can easily `grep` or `grep -v` them from the log file.

the log looks like this:
```
[2021-09-06 20:40:39,709 I 314260 314260] node_manager.cc:484: [state-dump] Event stats:
[state-dump]
[state-dump]
[state-dump] Global stats: 20 total (8 active)
[state-dump] Queueing time: mean = 5.225 ms, max = 83.099 ms, min = 2.225 us, total = 104.498 ms
[state-dump] Execution time:  mean = 5.470 ms, total = 109.394 ms
[state-dump] Handler stats:
[state-dump]    UNKNOWN - 10 total (1 active, 1 running), CPU time: mean = 798.850 us, total = 7.988 ms
[state-dump]    NodeManager.deadline_timer.debug_state_dump - 1 total (1 active), CPU time: mean = 0.000 s, total = 0.000 s
[state-dump]    NodeResourceInfoGcsService.grpc_client.UpdateResources - 1 total (1 active), CPU time: mean = 0.000 s, total = 0.000 s
[state-dump]    RayletWorkerPool.deadline_timer.kill_idle_workers - 1 total (1 active), CPU time: mean = 0.000 s, total = 0.000 s
[state-dump]    NodeManager.deadline_timer.flush_free_objects - 1 total (1 active), CPU time: mean = 0.000 s, total = 0.000 s
[state-dump]    NodeInfoGcsService.grpc_client.GetInternalConfig - 1 total (0 active), CPU time: mean = 98.167 ms, total = 98.167 ms
[state-dump]    NodeManagerService.grpc_server.RequestResourceReport - 1 total (0 active), CPU time: mean = 757.261 us, total = 757.261 us
[state-dump]    NodeInfoGcsService.grpc_client.RegisterNode - 1 total (0 active), CPU time: mean = 2.482 ms, total = 2.482 ms
[state-dump]    HeartbeatInfoGcsService.grpc_client.ReportHeartbeat - 1 total (1 active), CPU time: mean = 0.000 s, total = 0.000 s
[state-dump]    NodeManager.deadline_timer.record_metrics - 1 total (1 active), CPU time: mean = 0.000 s, total = 0.000 s
[state-dump]    GcsClient.deadline_timer.check_gcs_service_address - 1 total (1 active), CPU time: mean = 0.000 s, total = 0.000 s
[state-dump]
[state-dump] NodeManager:
[state-dump] InitialConfigResources: {node:11.124.129.159: 1.000000}, {CPU: 8.000000}, {memory: 16.672547 GiB}, {object_store_memory: 8.336274 GiB}
```
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
