### PR TITLE
[Datasets] Add test coverage for writing to fsspec filesystems.

### DIFF
--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -486,10 +486,10 @@ def test_fsspec_filesystem(ray_start_regular_shared, tmp_path):
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
     table = pa.Table.from_pandas(df1)
     path1 = os.path.join(str(tmp_path), "test1.parquet")
-    path2 = os.path.join(str(tmp_path), "test2.parquet")
     pq.write_table(table, path1)
     df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
     table = pa.Table.from_pandas(df2)
+    path2 = os.path.join(str(tmp_path), "test2.parquet")
     pq.write_table(table, path2)
 
     fs = LocalFileSystem()
@@ -499,6 +499,18 @@ def test_fsspec_filesystem(ray_start_regular_shared, tmp_path):
     # Test metadata-only parquet ops.
     assert len(ds._blocks._blocks) == 1
     assert ds.count() == 6
+
+    out_path = os.path.join(tmp_path, "out")
+    os.mkdir(out_path)
+
+    ds._set_uuid("data")
+    ds.write_parquet(out_path)
+
+    ds_df1 = pd.read_parquet(os.path.join(out_path, "data_000000.parquet"))
+    ds_df2 = pd.read_parquet(os.path.join(out_path, "data_000001.parquet"))
+    ds_df = pd.concat([ds_df1, ds_df2])
+    df = pd.concat([df1, df2])
+    assert ds_df.equals(df)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Support for writing to fsspec filesystems was added in [this PR](https://github.com/ray-project/ray/pull/18135), which ported the write side of the Datasets IO layer to our datasource abstraction. However, we never added test coverage for the write side, so this PR adds that test coverage.

## Related issue number

Closes #18393 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
