### PR TITLE
[Core][Plasma][GetRequestQueue] don't remove request twice

### DIFF
--- a/src/ray/object_manager/plasma/get_request_queue.cc
+++ b/src/ray/object_manager/plasma/get_request_queue.cc
@@ -115,6 +115,13 @@ void GetRequestQueue::RemoveGetRequestsForClient(
 }
 
 void GetRequestQueue::RemoveGetRequest(const std::shared_ptr<GetRequest> &get_request) {
+  // If the get request is already removed, do no-op. This can happen because the boost
+  // timer is not atomic. See https://github.com/ray-project/ray/pull/15071 and
+  // https://github.com/ray-project/ray/issues/18400
+  if (get_request->IsRemoved()) {
+    return;
+  }
+
   // Remove the get request from each of the relevant object_get_requests hash
   // tables if it is present there. It should only be present there if the get
   // request timed out or if it was issued by a client that has disconnected.


### PR DESCRIPTION
We noticed two consecutive crashes [[1](https://beta.anyscale.com/o/anyscale-internal/projects/prj_2xR6uT6t7jJuu1aCwWMsle/clusters/ses_rdNbcqF24WsBPzakWkg1hgf6?command-history-section=command_history)][[2](https://beta.anyscale.com/o/anyscale-internal/projects/prj_2xR6uT6t7jJuu1aCwWMsle/clusters/ses_ScwBzMDhr1zn4bCCafPwC4JL?command-history-section=command_history)] with following stacktrace. After a brief investigation it looks to do with the race condition in boost::steady_timer.cancel. 

This bug is similar to https://github.com/ray-project/ray/pull/15071/files where the steady_timer is canceled, but the callback is still being called.

Our fix is simple, we make sure the `RemoveGetRequest` is only called once.

```
Reduce Progress.:  82%|████████▏ | 4122/5000 [1:16:04<06:11,  2.37it/s][A[2m[33m(raylet, ip=172.31.67.29)[0m [2021-09-06 06:46:52,138 C 96 113] get_request_queue.cc:41:  Check failed: !is_removed_ 
[2m[33m(raylet, ip=172.31.67.29)[0m *** StackTrace Information ***
[2m[33m(raylet, ip=172.31.67.29)[0m     ray::SpdLogMessage::Flush()
[2m[33m(raylet, ip=172.31.67.29)[0m     ray::RayLog::~RayLog()
[2m[33m(raylet, ip=172.31.67.29)[0m     plasma::GetRequest::CancelTimer()
[2m[33m(raylet, ip=172.31.67.29)[0m     plasma::GetRequestQueue::RemoveGetRequest()
[2m[33m(raylet, ip=172.31.67.29)[0m     boost::asio::detail::executor_function<>::do_complete()
[2m[33m(raylet, ip=172.31.67.29)[0m     boost::asio::io_context::executor_type::dispatch<>()
[2m[33m(raylet, ip=172.31.67.29)[0m     boost::asio::detail::wait_handler<>::do_complete()
[2m[33m(raylet, ip=172.31.67.29)[0m     boost::asio::detail::scheduler::do_run_one()
[2m[33m(raylet, ip=172.31.67.29)[0m     boost::asio::detail::scheduler::run()
[2m[33m(raylet, ip=172.31.67.29)[0m     boost::asio::io_context::run()
[2m[33m(raylet, ip=172.31.67.29)[0m     plasma::PlasmaStoreRunner::Start()
[2m[33m(raylet, ip=172.31.67.29)[0m     std::thread::_State_impl<>::_M_run()
[2m[33m(raylet, ip=172.31.67.29)[0m     execute_native_thread_routine
[2m[33m(raylet, ip=172.31.67.29)[0m 


Reduce Progress.:  83%|████████▎ | 4128/5000 [1:16:06<05:26,  2.67it/s][A[2m[36m(pid=194, ip=172.31.80.58)[0m 2021-09-06 06:46:52,458	WARNING worker.py:1619 -- Local object store memory usage:
```