### PR TITLE
[runtime_env] Don't modify passed runtime_env dictionary when validating

### DIFF
--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -64,7 +64,7 @@ class RuntimeEnvDict:
                 {"OMP_NUM_THREADS": "32", "TF_WARNINGS": "none"}
     """
 
-    def __init__(self, runtime_env_json: dict):
+    def __init__(self, runtime_env_json: dict, working_dir: Optional[str] = None):
         # Simple dictionary with all options validated. This will always
         # contain all supported keys; values will be set to None if
         # unspecified. However, if all values are None this is set to {}.
@@ -78,7 +78,7 @@ class RuntimeEnvDict:
             working_dir = Path(self._dict["working_dir"]).absolute()
         else:
             self._dict["working_dir"] = None
-            working_dir = None
+            working_dir = Path(working_dir).absolute() if working_dir else None
 
         self._dict["conda"] = None
         if "conda" in runtime_env_json:
@@ -213,13 +213,12 @@ def override_task_or_actor_runtime_env(
                 "Overriding working_dir for actors is not supported. "
                 "Please use ray.init(runtime_env={'working_dir': ...}) "
                 "to configure per-job environment instead.")
-        # NOTE(edoakes): this is sort of hacky, but we manually add the right
+        # NOTE(edoakes): this is sort of hacky, but we pass in the parent
         # working_dir here so the relative path to a requirements.txt file
         # works. The right solution would be to merge the runtime_env with the
         # parent runtime env before validation.
-        if parent_runtime_env.get("working_dir"):
-            runtime_env["working_dir"] = parent_runtime_env["working_dir"]
-        runtime_env_dict = RuntimeEnvDict(runtime_env).get_parsed_dict()
+        runtime_env_dict = RuntimeEnvDict(
+                runtime_env, working_dir=parent_runtime_env.get("working_dir")).get_parsed_dict()
     else:
         runtime_env_dict = {}
 

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -64,7 +64,9 @@ class RuntimeEnvDict:
                 {"OMP_NUM_THREADS": "32", "TF_WARNINGS": "none"}
     """
 
-    def __init__(self, runtime_env_json: dict, working_dir: Optional[str] = None):
+    def __init__(self,
+                 runtime_env_json: dict,
+                 working_dir: Optional[str] = None):
         # Simple dictionary with all options validated. This will always
         # contain all supported keys; values will be set to None if
         # unspecified. However, if all values are None this is set to {}.
@@ -218,7 +220,8 @@ def override_task_or_actor_runtime_env(
         # works. The right solution would be to merge the runtime_env with the
         # parent runtime env before validation.
         runtime_env_dict = RuntimeEnvDict(
-                runtime_env, working_dir=parent_runtime_env.get("working_dir")).get_parsed_dict()
+            runtime_env, working_dir=parent_runtime_env.get(
+                "working_dir")).get_parsed_dict()
     else:
         runtime_env_dict = {}
 

--- a/python/ray/serve/tests/test_runtime_env.py
+++ b/python/ray/serve/tests/test_runtime_env.py
@@ -106,6 +106,9 @@ class Test:
 Test.deploy()
 handle = Test.get_handle()
 assert ray.get(handle.remote()) == "world"
+
+Test.options(num_replicas=2).deploy()
+assert ray.get(handle.remote()) == "world"
 """.format(
         use_ray_client=use_ray_client, client_addr=ray_start)
 

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -13,7 +13,7 @@ import ray.experimental.internal_kv as kv
 from ray._private.test_utils import (
     run_string_as_driver, run_string_as_driver_nonblocking, wait_for_condition)
 from ray._private.runtime_env import working_dir as working_dir_pkg
-from ray._private.runtime_env.validation import override_task_or_actor_runtime_env
+from ray._private.runtime_env.validation import override_task_or_actor_runtime_env  # noqa: E501
 from ray._private.utils import (get_wheel_filename, get_master_wheel_url,
                                 get_release_wheel_url)
 
@@ -931,6 +931,7 @@ def test_large_file_error(shutdown_only):
 
         os.chdir(old_dir)
 
+
 class TestOverrideTaskOrActorRuntimeEnv:
     def test_working_dir_in_child_invalid(self):
         child_env = {"working_dir": "some_dir"}
@@ -954,7 +955,7 @@ class TestOverrideTaskOrActorRuntimeEnv:
         parent_env = {"working_dir": "other_dir", "uris": ["a", "b"]}
         result_env = override_task_or_actor_runtime_env(child_env, parent_env)
         assert result_env["uris"] == ["c", "d"]
-        assert result_env.get("working_dir") == None
+        assert result_env.get("working_dir") is None
 
         # The dicts passed in should not be mutated.
         assert child_env == {"uris": ["c", "d"]}

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -13,6 +13,7 @@ import ray.experimental.internal_kv as kv
 from ray._private.test_utils import (
     run_string_as_driver, run_string_as_driver_nonblocking, wait_for_condition)
 from ray._private.runtime_env import working_dir as working_dir_pkg
+from ray._private.runtime_env.validation import override_task_or_actor_runtime_env
 from ray._private.utils import (get_wheel_filename, get_master_wheel_url,
                                 get_release_wheel_url)
 
@@ -929,6 +930,45 @@ def test_large_file_error(shutdown_only):
             ray.init(runtime_env={"working_dir": "."})
 
         os.chdir(old_dir)
+
+class TestOverrideTaskOrActorRuntimeEnv:
+    def test_working_dir_in_child_invalid(self):
+        child_env = {"working_dir": "some_dir"}
+        parent_env = {"working_dir": "other_dir", "uris": ["a", "b"]}
+
+        with pytest.raises(NotImplementedError):
+            override_task_or_actor_runtime_env(child_env, parent_env)
+
+    def test_uri_inherit(self):
+        child_env = {}
+        parent_env = {"working_dir": "other_dir", "uris": ["a", "b"]}
+        result_env = override_task_or_actor_runtime_env(child_env, parent_env)
+        assert result_env == {"uris": ["a", "b"]}
+
+        # The dicts passed in should not be mutated.
+        assert child_env == {}
+        assert parent_env == {"working_dir": "other_dir", "uris": ["a", "b"]}
+
+    def test_uri_override(self):
+        child_env = {"uris": ["c", "d"]}
+        parent_env = {"working_dir": "other_dir", "uris": ["a", "b"]}
+        result_env = override_task_or_actor_runtime_env(child_env, parent_env)
+        assert result_env["uris"] == ["c", "d"]
+        assert result_env.get("working_dir") == None
+
+        # The dicts passed in should not be mutated.
+        assert child_env == {"uris": ["c", "d"]}
+        assert parent_env == {"working_dir": "other_dir", "uris": ["a", "b"]}
+
+    def test_no_mutate(self):
+        child_env = {}
+        parent_env = {"working_dir": "other_dir", "uris": ["a", "b"]}
+        result_env = override_task_or_actor_runtime_env(child_env, parent_env)
+        assert result_env == {"uris": ["a", "b"]}
+
+        # The dictis passed in should not be mutated.
+        assert child_env == {}
+        assert parent_env == {"working_dir": "other_dir", "uris": ["a", "b"]}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We were modifying the passed in dictionary in-place in order to handle an edge case of `working_dir`. This was causing failures in Serve as the passed dictionary was stored and used for more deployments in the future.

This modifies the logic to not modify the dictionary and instead pass along the parent's working dir as a separate parameter.

## Related issue number

Closes https://github.com/ray-project/ray/issues/18403

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
