### PR TITLE
[Placement group] Placement group scheduling hangs due to creation/removal race condition

### DIFF
--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -1856,32 +1856,77 @@ def test_placement_group_gpu_unique_assigned(ray_start_cluster,
     assert len(gpu_ids_res) == 4
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_placement_group_remove_stress(ray_start_cluster, connect_to_client):
+@pytest.mark.parametrize('execution_number', range(3))
+def test_placement_group_remove_stress(ray_start_cluster, execution_number):
+    # This test checks the race condition between remove / creation.
+    # This test shouldn't be flaky. If it fails on the last ray.get
+    # that highly likely indicates a real bug.
+    # It also runs 3 times to make sure the test consistently passes.
     cluster = ray_start_cluster
-    # 3 nodes.
-    num_gpus = 3000
-    num_gpus_per_node = num_gpus // 3
-    cluster.add_node(num_gpus=num_gpus_per_node)
-    cluster.add_node(num_gpus=num_gpus_per_node)
-    cluster.add_node(num_gpus=num_gpus_per_node)
+    resource_quantity = 999
+    num_nodes = 5
+    custom_resources = {"pg_custom": resource_quantity}
+    # Create pg that uses 1 resource of cpu & custom resource.
+    num_pg = resource_quantity
+
+    # TODO(sang): Cluster setup. Remove when running in real clusters.
+    nodes = []
+    for _ in range(num_nodes):
+        nodes.append(
+            cluster.add_node(
+                num_cpus=3, num_gpus=resource_quantity,
+                resources=custom_resources))
+    cluster.wait_for_nodes()
+
     ray.init(address=cluster.address)
+    while not ray.is_initialized():
+        time.sleep(0.1)
+    bundles = [{"GPU": 1, "pg_custom": 1}] * num_nodes
 
-    @ray.remote(num_gpus=1, num_cpus=0)
-    def f():
-        pass
+    @ray.remote(num_cpus=0, num_gpus=1, max_calls=0)
+    def mock_task():
+        time.sleep(0.1)
+        return True
 
-    with connect_to_client_or_not(connect_to_client):
-        pgs = [ray.util.placement_group([{"GPU": 1}, {"GPU": 1}, {"GPU": 1}], strategy="STRICT_SPREAD") for _ in range(num_gpus_per_node)]
+    @ray.remote(num_cpus=0)
+    def pg_launcher(num_pgs_to_create):
+        print("Creating pgs")
+        pgs = []
+        for i in range(num_pgs_to_create):
+            pgs.append(placement_group(bundles, strategy="STRICT_SPREAD"))
+
         pgs_removed = []
         pgs_unremoved = []
+        # Randomly choose placement groups to remove.
+        print("removing pgs")
         for pg in pgs:
             if random() < .5:
                 pgs_removed.append(pg)
-                remove_placement_group(pg)
             else:
                 pgs_unremoved.append(pg)
-        ray.get([pg.ready() for pg in pgs_unremoved], timeout=60)
+
+        tasks = []
+        # Randomly schedule tasks or actors on placement groups that
+        # are not removed.
+        for pg in pgs_unremoved:
+            tasks.append(
+                mock_task.options(
+                    placement_group=pg).remote())
+        # Remove the rest of placement groups.
+        for pg in pgs_removed:
+            remove_placement_group(pg)
+        ray.get(tasks)
+        # Since placement groups are scheduled, remove them.
+        for pg in pgs_unremoved:
+            remove_placement_group(pg)
+
+
+    num_pgs_to_create = num_pg
+    pg_launchers = []
+    for _ in range(3):
+        pg_launchers.append(pg_launcher.remote(num_pg // 3))
+
+    ray.get(pg_launchers, timeout=120)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -1885,6 +1885,8 @@ def test_placement_group_remove_stress(ray_start_cluster, execution_number):
     # This test shouldn't be flaky. If it fails on the last ray.get
     # that highly likely indicates a real bug.
     # It also runs 3 times to make sure the test consistently passes.
+    # When 999 resource quantity is used, it fails about every other time
+    # when the test was written.
     cluster = ray_start_cluster
     resource_quantity = 999
     num_nodes = 5

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -1856,7 +1856,7 @@ def test_placement_group_gpu_unique_assigned(ray_start_cluster,
     assert len(gpu_ids_res) == 4
 
 
-@pytest.mark.parametrize('execution_number', range(3))
+@pytest.mark.parametrize("execution_number", range(3))
 def test_placement_group_remove_stress(ray_start_cluster, execution_number):
     # This test checks the race condition between remove / creation.
     # This test shouldn't be flaky. If it fails on the last ray.get
@@ -1874,7 +1874,8 @@ def test_placement_group_remove_stress(ray_start_cluster, execution_number):
     for _ in range(num_nodes):
         nodes.append(
             cluster.add_node(
-                num_cpus=3, num_gpus=resource_quantity,
+                num_cpus=3,
+                num_gpus=resource_quantity,
                 resources=custom_resources))
     cluster.wait_for_nodes()
 
@@ -1909,9 +1910,7 @@ def test_placement_group_remove_stress(ray_start_cluster, execution_number):
         # Randomly schedule tasks or actors on placement groups that
         # are not removed.
         for pg in pgs_unremoved:
-            tasks.append(
-                mock_task.options(
-                    placement_group=pg).remote())
+            tasks.append(mock_task.options(placement_group=pg).remote())
         # Remove the rest of placement groups.
         for pg in pgs_removed:
             remove_placement_group(pg)
@@ -1920,8 +1919,6 @@ def test_placement_group_remove_stress(ray_start_cluster, execution_number):
         for pg in pgs_unremoved:
             remove_placement_group(pg)
 
-
-    num_pgs_to_create = num_pg
     pg_launchers = []
     for _ in range(3):
         pg_launchers.append(pg_launcher.remote(num_pg // 3))

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -71,8 +71,7 @@ class PlacementGroup:
             f"{len(self.bundle_cache)}")
 
         return bundle_reservation_check.options(
-            placement_group=self,
-            resources={
+            placement_group=self, resources={
                 "bundle": 0.001
             }).remote(self)
 

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -72,7 +72,6 @@ class PlacementGroup:
 
         return bundle_reservation_check.options(
             placement_group=self,
-            placement_group_bundle_index=0,
             resources={
                 "bundle": 0.001
             }).remote(self)

--- a/release/stress_tests/workloads/test_placement_group.py
+++ b/release/stress_tests/workloads/test_placement_group.py
@@ -15,7 +15,7 @@ from ray.util.placement_group import (placement_group, remove_placement_group)
 
 # TODO(sang): Increase the number in the actual stress test.
 # This number should be divisible by 3.
-resource_quantity = 999
+resource_quantity = 666
 num_nodes = 5
 custom_resources = {"pg_custom": resource_quantity}
 # Create pg that uses 1 resource of cpu & custom resource.
@@ -113,12 +113,12 @@ def pg_launcher(pre_created_pgs, num_pgs_to_create):
     for pg in pgs_unremoved:
         # TODO(sang): Comment in this line causes GCS actor management
         # failure. We need to fix it.
-        # if random() < .5:
-        tasks.append(mock_task.options(placement_group=pg).remote())
-        # else:
-        #     if actor_cnt < max_actor_cnt:
-        #         actors.append(MockActor.options(placement_group=pg).remote())
-        #         actor_cnt += 1
+        if random() < .5:
+            tasks.append(mock_task.options(placement_group=pg).remote())
+        else:
+            if actor_cnt < max_actor_cnt:
+                actors.append(MockActor.options(placement_group=pg).remote())
+                actor_cnt += 1
 
     # Remove the rest of placement groups.
     for pg in pgs_removed:

--- a/release/stress_tests/workloads/test_placement_group.py
+++ b/release/stress_tests/workloads/test_placement_group.py
@@ -60,8 +60,9 @@ for _ in range(repeat):
         total_removing_time += (end - start)
 
 # Validate the correctness.
-assert ray.cluster_resources()["GPU"] == num_nodes * resource_quantity
-assert ray.cluster_resources()["pg_custom"] == num_nodes * resource_quantity
+time.sleep(30)
+assert ray.available_resources()["GPU"] == num_nodes * resource_quantity
+assert ray.available_resources()["pg_custom"] == num_nodes * resource_quantity
 
 
 # Scenario 2:
@@ -144,8 +145,9 @@ for i in range(3):
         pg_launcher.remote(pre_created_pgs, num_pgs_to_create // 3))
 
 ray.get(pg_launchers)
-assert ray.cluster_resources()["GPU"] == num_nodes * resource_quantity
-assert ray.cluster_resources()["pg_custom"] == num_nodes * resource_quantity
+time.sleep(30)
+assert ray.available_resources()["GPU"] == num_nodes * resource_quantity
+assert ray.available_resources()["pg_custom"] == num_nodes * resource_quantity
 ray.shutdown()
 print("Avg placement group creating time: "
       f"{total_creating_time / total_trial * 1000} ms")

--- a/release/stress_tests/workloads/test_placement_group.py
+++ b/release/stress_tests/workloads/test_placement_group.py
@@ -15,7 +15,7 @@ from ray.util.placement_group import (placement_group, remove_placement_group)
 
 # TODO(sang): Increase the number in the actual stress test.
 # This number should be divisible by 3.
-resource_quantity = 666
+resource_quantity = 999
 num_nodes = 5
 custom_resources = {"pg_custom": resource_quantity}
 # Create pg that uses 1 resource of cpu & custom resource.
@@ -113,12 +113,12 @@ def pg_launcher(pre_created_pgs, num_pgs_to_create):
     for pg in pgs_unremoved:
         # TODO(sang): Comment in this line causes GCS actor management
         # failure. We need to fix it.
-        if random() < .5:
-            tasks.append(mock_task.options(placement_group=pg).remote())
-        else:
-            if actor_cnt < max_actor_cnt:
-                actors.append(MockActor.options(placement_group=pg).remote())
-                actor_cnt += 1
+        # if random() < .5:
+        tasks.append(mock_task.options(placement_group=pg).remote())
+        # else:
+        #     if actor_cnt < max_actor_cnt:
+        #         actors.append(MockActor.options(placement_group=pg).remote())
+        #         actor_cnt += 1
 
     # Remove the rest of placement groups.
     for pg in pgs_removed:

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -287,7 +287,7 @@ void GcsPlacementGroupManager::SchedulePendingPlacementGroups() {
   }
 
   bool is_new_placement_group_scheduled = false;
-  while (!pending_placement_groups_.empty() || !is_new_placement_group_scheduled) {
+  while (!pending_placement_groups_.empty() && !is_new_placement_group_scheduled) {
     const auto placement_group = pending_placement_groups_.front();
     pending_placement_groups_.pop_front();
     const auto &placement_group_id = placement_group->GetPlacementGroupID();

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -281,7 +281,8 @@ void GcsPlacementGroupManager::SchedulePendingPlacementGroups() {
   }
 
   if (IsSchedulingInProgress()) {
-    RAY_LOG(DEBUG) << "Placement group scheduling is still in progress. New placement groups will be scheduled after the current scheduling is done.";
+    RAY_LOG(DEBUG) << "Placement group scheduling is still in progress. New placement "
+                      "groups will be scheduled after the current scheduling is done.";
     return;
   }
 
@@ -302,7 +303,8 @@ void GcsPlacementGroupManager::SchedulePendingPlacementGroups() {
           });
       break;
     }
-    // If the placement group is not registered == removed, keep checking the next pending groups.
+    // If the placement group is not registered == removed, keep checking the next pending
+    // groups.
   }
 }
 

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -285,25 +285,7 @@ void GcsPlacementGroupManager::SchedulePendingPlacementGroups() {
     return;
   }
 
-  // while (!pending_placement_groups_.empty()) {
-  //   const auto placement_group = pending_placement_groups_.front();
-  //   pending_placement_groups_.pop_front();
-  //   const auto &placement_group_id = placement_group->GetPlacementGroupID();
-  //   // Do not reschedule if the placement group has removed already.
-  //   if (registered_placement_groups_.contains(placement_group_id)) {
-  //     MarkSchedulingStarted(placement_group_id);
-  //     gcs_placement_group_scheduler_->ScheduleUnplacedBundles(
-  //         placement_group,
-  //         [this](std::shared_ptr<GcsPlacementGroup> placement_group) {
-  //           OnPlacementGroupCreationFailed(std::move(placement_group));
-  //         },
-  //         [this](std::shared_ptr<GcsPlacementGroup> placement_group) {
-  //           OnPlacementGroupCreationSuccess(std::move(placement_group));
-  //         });
-  //     break;
-  //   }
-  //   // If the placement group is not registered == removed, keep checking the next pending groups.
-  // }
+  while (!pending_placement_groups_.empty()) {
     const auto placement_group = pending_placement_groups_.front();
     pending_placement_groups_.pop_front();
     const auto &placement_group_id = placement_group->GetPlacementGroupID();
@@ -318,7 +300,10 @@ void GcsPlacementGroupManager::SchedulePendingPlacementGroups() {
           [this](std::shared_ptr<GcsPlacementGroup> placement_group) {
             OnPlacementGroupCreationSuccess(std::move(placement_group));
           });
+      break;
     }
+    // If the placement group is not registered == removed, keep checking the next pending groups.
+  }
 }
 
 void GcsPlacementGroupManager::HandleCreatePlacementGroup(

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #pragma once
+#include <gtest/gtest_prod.h>
 #include <utility>
 
 #include "absl/container/flat_hash_map.h"
@@ -269,6 +270,8 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoHandler {
   std::string DebugString() const;
 
  private:
+  friend class GcsPlacementGroupManagerTest;
+
   /// Try to create placement group after a short time.
   void RetryCreatingPlacementGroup();
 

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #pragma once
-#include <gtest/gtest_prod.h>
 #include <utility>
 
 #include "absl/container/flat_hash_map.h"
@@ -270,8 +269,6 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoHandler {
   std::string DebugString() const;
 
  private:
-  friend class GcsPlacementGroupManagerTest;
-
   /// Try to create placement group after a short time.
   void RetryCreatingPlacementGroup();
 

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "ray/gcs/gcs_server/gcs_placement_group_manager.h"
+
 #include <memory>
 
 #include "gtest/gtest.h"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Note that there was other issue; https://github.com/ray-project/ray/issues/18409 With this PR, it will highly likely resolve the current existing placement group hanging issue in the nightly test thought https://github.com/ray-project/ray/issues/18080. 

This fixes the pg creation / removal race condition. Currently, if the placement group is removed, they are added back to the pending queue, and `SchedulePendingPlacementGroups` function handles them properly. The problem is that in some subtle cases, `SchedulePendingPlacementGroups` stops scheduling "next" placement groups after removing the "removed placement groups" from the queue. As a result, the additional pending placement groups are not scheduled until `SchedulePendingPlacementGroups` is called again (which happens when new pgs are created or existing pg schedulings are failed).

I spent some hours trying to write a cpp unit test, but it wasn't easy without some refactoring. I eventually added the stress test to our CI (which could pretty consistently reproduce the issue)

Here's a detailed scenario about the race condition. 

- 2 pgs are created [1: SCHEDULING, 2: PENDING]
- the first pg is removed and failed to be scheduled [2: PENDING, 1: REMOVED]
- The second pg is scheduling [2: SCHEDULING, 1: REMOVED]
- The third pg is scheduled [2: SCHEDULING, 1: REMOVED, 3: PENDING]
- The second pg is created, and `SchedulePendingPlacementGroups` schedules the next entry; [1: REMOVED, 3: PENDING] -> [3: PENDING]
- After this, `SchedulePendingPlacementGroups` is returned and not called anymore, which will stop scheduling 3. 

NOTE: 
As a safe check, it is probably possible to always try scheduling placement groups (like we are doing for object pulling). I am open to this approach as well. There's no other known race condition other than this now. 

## Related issue number

https://github.com/ray-project/ray/issues/18080

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
