### PR TITLE
[client] pass _credentials down from init

### DIFF
--- a/python/ray/client_builder.py
+++ b/python/ray/client_builder.py
@@ -87,6 +87,7 @@ class ClientBuilder:
         # Whether to allow connections to multiple clusters"
         # " (allow_multiple=True).
         self._allow_multiple_connections = False
+        self._credentials = None
 
     def env(self, env: Dict[str, Any]) -> "ClientBuilder":
         """
@@ -137,6 +138,7 @@ class ClientBuilder:
         client_info_dict = ray.util.client_connect.connect(
             self.address,
             job_config=self._job_config,
+            _credentials=self._credentials,
             ray_init_kwargs=self._remote_init_kwargs)
         dashboard_url = ray.get(
             ray.remote(ray.worker.get_dashboard_url).remote())
@@ -181,6 +183,10 @@ class ClientBuilder:
         if kwargs.get("allow_multiple") is True:
             self._allow_multiple_connections = True
             del kwargs["allow_multiple"]
+
+        if "_credentials" in kwargs.keys():
+            self._credentials = kwargs["_credentials"]
+            del kwargs["_credentials"]
 
         if kwargs:
             expected_sig = inspect.signature(ray_driver_init)

--- a/python/ray/util/client_connect.py
+++ b/python/ray/util/client_connect.py
@@ -5,6 +5,8 @@ from ray._private.client_mode_hook import _explicitly_enable_client_mode
 
 from typing import List, Tuple, Dict, Any, Optional
 
+import grpc
+
 
 def connect(
         conn_str: str,
@@ -15,6 +17,7 @@ def connect(
         namespace: str = None,
         *,
         ignore_version: bool = False,
+        _credentials: Optional[grpc.ChannelCredentials] = None,
         ray_init_kwargs: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     if ray.is_connected():
         raise RuntimeError("Ray Client is already connected. Maybe you called "
@@ -35,6 +38,7 @@ def connect(
         connection_retries=connection_retries,
         namespace=namespace,
         ignore_version=ignore_version,
+        _credentials=_credentials,
         ray_init_kwargs=ray_init_kwargs)
     return conn
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Follow up to expose `_credentials` in `ray.init`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   
Make it possible to do specify credentials in ray.init.
This is a followup to #18365