### PR TITLE
[RLlib] Deepcopy env_ctx for vectorized sub-envs AND add eval-worker-option to `Trainer.add_policy()`

### DIFF
--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -1272,6 +1272,7 @@ class Trainer(Trainable):
             *,
             policy_mapping_fn: Optional[Callable[[AgentID], PolicyID]] = None,
             policies_to_train: Optional[List[PolicyID]] = None,
+            evaluation_workers: bool = True,
     ) -> None:
         """Removes a new policy from this Trainer.
 
@@ -1286,6 +1287,8 @@ class Trainer(Trainable):
                 policy IDs to be trained. If None, will keep the existing list
                 in place. Policies, whose IDs are not in the list will not be
                 updated.
+            evaluation_workers (bool): Whether to also remove the policy from
+                the evaluation WorkerSet.
         """
 
         def fn(worker):
@@ -1296,7 +1299,7 @@ class Trainer(Trainable):
             )
 
         self.workers.foreach_worker(fn)
-        if self.evaluation_workers is not None:
+        if evaluation_workers and self.evaluation_workers is not None:
             self.evaluation_workers.foreach_worker(fn)
 
     @DeveloperAPI

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -1213,6 +1213,7 @@ class Trainer(Trainable):
             policy_mapping_fn: Optional[Callable[[AgentID, EpisodeID],
                                                  PolicyID]] = None,
             policies_to_train: Optional[List[PolicyID]] = None,
+            evaluation_workers: bool = True,
     ) -> Policy:
         """Adds a new policy to this Trainer.
 
@@ -1235,6 +1236,8 @@ class Trainer(Trainable):
                 policy IDs to be trained. If None, will keep the existing list
                 in place. Policies, whose IDs are not in the list will not be
                 updated.
+            evaluation_workers (bool): Whether to add the new policy also
+                to the evaluation WorkerSet.
 
         Returns:
             Policy: The newly added policy (the copy that got added to the
@@ -1256,7 +1259,7 @@ class Trainer(Trainable):
 
         # Run foreach_worker fn on all workers (incl. evaluation workers).
         self.workers.foreach_worker(fn)
-        if self.evaluation_workers is not None:
+        if evaluation_workers and self.evaluation_workers is not None:
             self.evaluation_workers.foreach_worker(fn)
 
         # Return newly added policy (from the local rollout worker).
@@ -1718,7 +1721,7 @@ class Trainer(Trainable):
                     name,
                     lambda cfg: ray.remote(num_cpus=0)(env_object).remote(cfg))
             else:
-                register_env(name, lambda config: env_object(config))
+                register_env(name, lambda cfg: env_object(cfg))
             return name
         elif env_object is None:
             return None

--- a/rllib/env/env_context.py
+++ b/rllib/env/env_context.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Optional
 
 from ray.rllib.utils.annotations import PublicAPI
@@ -42,7 +43,7 @@ class EnvContext(dict):
                             remote: bool = None,
                             num_workers: Optional[int] = None) -> "EnvContext":
         return EnvContext(
-            env_config if env_config is not None else self,
+            copy.deepcopy(env_config) if env_config is not None else self,
             worker_index if worker_index is not None else self.worker_index,
             vector_index if vector_index is not None else self.vector_index,
             remote if remote is not None else self.remote,

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -1,3 +1,4 @@
+import copy
 import gym
 import logging
 import platform
@@ -390,7 +391,11 @@ class RolloutWorker(ParallelIteratorWorker):
             enable_periodic_logging()
 
         env_context = EnvContext(
-            env_config or {}, worker_index, num_workers=num_workers)
+            env_config or {},
+            worker_index=worker_index,
+            vector_index=0,
+            num_workers=num_workers,
+        )
         self.env_context = env_context
         self.policy_config: TrainerConfigDict = policy_config
         if callbacks:
@@ -442,7 +447,7 @@ class RolloutWorker(ParallelIteratorWorker):
         if not (worker_index == 0 and num_workers > 0
                 and not policy_config.get("create_env_on_driver")):
             # Run the `env_creator` function passing the EnvContext.
-            self.env = env_creator(env_context)
+            self.env = env_creator(copy.deepcopy(self.env_context))
 
         if self.env is not None:
             # Validate environment (general validation function).

--- a/rllib/examples/self_play_with_open_spiel.py
+++ b/rllib/examples/self_play_with_open_spiel.py
@@ -32,7 +32,7 @@ from ray.rllib.agents.ppo import PPOTrainer
 from ray.rllib.examples.policy.random_policy import RandomPolicy
 from ray.rllib.env.wrappers.open_spiel import OpenSpielEnv
 from ray.rllib.policy.policy import PolicySpec
-from ray.tune import register_env
+from ray.tune import CLIReporter, register_env
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -61,7 +61,7 @@ parser.add_argument(
 parser.add_argument(
     "--stop-timesteps",
     type=int,
-    default=1000000,
+    default=10000000,
     help="Number of timesteps to train.")
 parser.add_argument(
     "--win-rate-threshold",
@@ -121,6 +121,7 @@ class SelfPlayCallback(DefaultCallbacks):
             if r_main > r_opponent:
                 won += 1
         win_rate = won / len(main_rew)
+        result["win_rate"] = win_rate
         print(f"Iter={trainer.iteration} win-rate={win_rate} -> ", end="")
         # If win rate is good -> Snapshot current policy and play against
         # it next, keeping the snapshot fixed and only improving the "main"
@@ -157,6 +158,9 @@ class SelfPlayCallback(DefaultCallbacks):
             trainer.workers.sync_weights()
         else:
             print("not good enough; will keep learning ...")
+
+        # +2 = main + random
+        result["league_size"] = self.current_opponent + 2
 
 
 if __name__ == "__main__":
@@ -218,7 +222,20 @@ if __name__ == "__main__":
             stop=stop,
             checkpoint_at_end=True,
             checkpoint_freq=10,
-            verbose=1)
+            verbose=2,
+            progress_reporter=CLIReporter(
+                metric_columns={
+                    "training_iteration": "iter",
+                    "time_total_s": "time_total_s",
+                    "timesteps_total": "ts",
+                    "episodes_this_iter": "train_episodes",
+                    "policy_reward_mean/main": "reward",
+                    "win_rate": "win_rate",
+                    "league_size": "league_size",
+                },
+                sort_by_metric=True,
+            ),
+        )
 
     # Restore trained trainer (set to non-explore behavior) and play against
     # human on command line.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Deepcopy env_ctx for vectorized sub-envs AND add eval-worker-option to `Trainer.add_policy()`.
This PR:
- Fixes an issue where the first sub-env in a vectorized one alters the given config dict. E.g. in its c'tor, it pops out a key from the dict, then the next sub-envs in the vectorized env don't see this key anymore.
- Adds the `evaluation_workers=True` arg to `Trainer.add_policy()` and `Trainer.remove_policy()`, to be able to control, whether a policy should also be added to/removed from the evaluation WorkerSet (defaults: False).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
