### PR TITLE
[Datasets] Create directory on write if it doesn't exist.

### DIFF
--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -115,6 +115,7 @@ class FileBasedDatasource(Datasource[Union[ArrowRow, Any]]):
         """Creates and returns write tasks for a file-based datasource."""
         path, filesystem = _resolve_paths_and_filesystem(path, filesystem)
         path = path[0]
+        filesystem.create_dir(path, recursive=True)
         filesystem = _wrap_s3_serialization_workaround(filesystem)
 
         _write_block_to_file = self._write_block


### PR DESCRIPTION
Create a directory at the provided write path if the directory doesn't already exist.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #17616 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
