### PR TITLE
Never close trial_syncer because it is cached and reused.

### DIFF
--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -450,7 +450,6 @@ class SyncerCallback(Callback):
             trainable_ip = ray.get(trial.runner.get_current_ip.remote())
         trial_syncer.set_worker_ip(trainable_ip)
         trial_syncer.sync_down_if_needed()
-        trial_syncer.close()
 
     def on_checkpoint(self, iteration: int, trials: List["Trial"],
                       trial: "Trial", checkpoint: Checkpoint, **info):


### PR DESCRIPTION
## Why are these changes needed?

Closing `trial_syncer` causes all subsequent syncs from the same node to fail because `trial_syncer` is cached and reused.

Never closing `trial_syncer` fixes the errors.

## Related issue number

Fixes #17506 
@richardliaw 

## Checks

Verified by running distributed tuning in Google Compute Engine. Without the fix distributed tuning fails.

None of ray unittest can run on my workstation.

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
