### PR TITLE
[Datasets] URL-encode paths if they are URLs.

### DIFF
--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -317,7 +317,7 @@ def _expand_directory(path: str,
 
 
 def _is_url(path) -> bool:
-    return isinstance(path, str) and "://" in path
+    return urlparse(path).scheme != ""
 
 
 def _encode_url(path):

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -222,6 +222,9 @@ def _resolve_paths_and_filesystem(
         resolved_path = filesystem.normalize_path(resolved_path)
         if is_url:
             # URL-encode the path if it's a URL.
+            # We need to URL-encode paths since pyarrow filesystems appear to
+            # not do any URL-encoding themselves. See
+            # https://github.com/ray-project/ray/issues/18414
             resolved_path = _encode_url(resolved_path)
         resolved_paths.append(resolved_path)
 

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -21,6 +21,8 @@ logger = logging.getLogger(__name__)
 _PYARROW_FSES_NEEDING_URL_ENCODING = None
 
 
+# We delay creation of the set of pyarrow fses that need URL encoding in order
+# to delay the pyarrow import until we're sure that the user needs pyarrow.
 def _get_pyarrow_fses_needing_url_encoding():
     import pyarrow as pa
 

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -17,7 +17,6 @@ from ray.data.impl.remote_fn import cached_remote_fn
 
 logger = logging.getLogger(__name__)
 
-
 _PYARROW_FSES_NEEDING_URL_ENCODING = None
 
 
@@ -29,8 +28,7 @@ def _get_pyarrow_fses_needing_url_encoding():
     global _PYARROW_FSES_NEEDING_URL_ENCODING
 
     if _PYARROW_FSES_NEEDING_URL_ENCODING is None:
-        _PYARROW_FSES_NEEDING_URL_ENCODING = (
-            pa.fs.S3FileSystem,)
+        _PYARROW_FSES_NEEDING_URL_ENCODING = (pa.fs.S3FileSystem, )
 
     return _PYARROW_FSES_NEEDING_URL_ENCODING
 
@@ -237,8 +235,8 @@ def _resolve_paths_and_filesystem(
         if filesystem is None:
             filesystem = resolved_filesystem
         resolved_path = filesystem.normalize_path(resolved_path)
-        if is_url and isinstance(
-                filesystem, _get_pyarrow_fses_needing_url_encoding()):
+        if is_url and isinstance(filesystem,
+                                 _get_pyarrow_fses_needing_url_encoding()):
             # URL-encode the path if it's a URL.
             # We need to URL-encode paths since pyarrow filesystems appear to
             # not do any URL-encoding themselves. See

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -111,7 +111,7 @@ class ParquetDatasource(FileBasedDatasource):
                 inferred_schema = inferred_schema.with_metadata(
                     schema.metadata)
             except Exception:
-                logger.info(
+                logger.debug(
                     "Failed to infer schema of dataset by passing dummy table "
                     "through UDF due to the following exception:",
                     exc_info=True)

--- a/python/ray/data/tests/mock_server.py
+++ b/python/ray/data/tests/mock_server.py
@@ -58,7 +58,13 @@ def stop_process(process):
         raise RuntimeError(msg)
 
 
-@pytest.fixture(scope="session")
+# TODO(Clark): We should be able to use "session" scope here, but we've found
+# that the s3_fs fixture ends up hanging with S3 ops timing out (or the server
+# being unreachable). This appears to only be an issue when using the tmp_dir
+# fixture as the S3 dir path. We should fix this since "session" scope should
+# reduce a lot of the per-test overhead (2x faster execution for IO methods in
+# test_dataset.py).
+@pytest.fixture(scope="function")
 def s3_server():
     host = "localhost"
     port = 5002

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1072,7 +1072,7 @@ def test_parquet_read_with_udf(ray_start_regular_shared, tmp_path):
     pq.write_to_dataset(
         table,
         root_path=str(tmp_path),
-        partition_cols=["one"],
+        partition_cols=["two"],
         use_legacy_dataset=False)
 
     def _block_udf(block: pa.Table):
@@ -2053,6 +2053,11 @@ def test_json_roundtrip(ray_start_regular_shared, fs, data_path):
     # Test metadata ops.
     for block, meta in zip(ds2._blocks, ds2._blocks.get_metadata()):
         BlockAccessor.for_block(ray.get(block)).size_bytes() == meta.size_bytes
+
+    if fs is None:
+        os.remove(file_path)
+    else:
+        fs.delete_file(_unwrap_protocol(file_path))
 
     # Two blocks.
     df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -20,8 +20,9 @@ from ray.tests.conftest import *  # noqa
 from ray.data.datasource import DummyOutputDatasource
 from ray.data.datasource.csv_datasource import CSVDatasource
 from ray.data.block import BlockAccessor
-from ray.data.datasource.file_based_datasource import (_unwrap_protocol,
-                                                       _is_url, _encode_url)
+from ray.data.datasource.file_based_datasource import (
+    _unwrap_protocol, _is_url, _encode_url,
+    _get_pyarrow_fses_needing_url_encoding)
 from ray.data.extensions.tensor_extension import (
     TensorArray, TensorDtype, ArrowTensorType, ArrowTensorArray)
 import ray.data.tests.util as util
@@ -939,7 +940,8 @@ def test_fsspec_filesystem(ray_start_regular_shared, tmp_path):
 def test_parquet_read(ray_start_regular_shared, fs, data_path):
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
     table = pa.Table.from_pandas(df1)
-    if _is_url(data_path):
+    if _is_url(data_path) and isinstance(
+            fs, _get_pyarrow_fses_needing_url_encoding()):
         setup_data_path = _encode_url(_unwrap_protocol(data_path))
     else:
         setup_data_path = _unwrap_protocol(data_path)


### PR DESCRIPTION
URL-encode paths if they are URLs, so pyarrow will properly interpret e.g. spaces in S3 paths.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #18414 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
