### PR TITLE
Implements equality operator for Repeated Space

### DIFF
--- a/rllib/tests/test_nested_observation_spaces.py
+++ b/rllib/tests/test_nested_observation_spaces.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from gym import spaces
 from gym.envs.registration import EnvSpec
 import gym
@@ -572,7 +573,7 @@ class NestedSpacesTest(unittest.TestCase):
             # the ray-kv indices before training.
             self.assertEqual(
                 to_list(seen[:][-1]), to_list(REPEATED_SAMPLES[i]))
-    
+
     def test_repeated_space_eq(self):
         # exact same should pass
         space1 = Repeated(DICT_SPACE, max_len=3)

--- a/rllib/tests/test_nested_observation_spaces.py
+++ b/rllib/tests/test_nested_observation_spaces.py
@@ -585,7 +585,7 @@ class NestedSpacesTest(unittest.TestCase):
         dict_space2 = deepcopy(DICT_SPACE)
         dict_space2.spaces["sensors"].spaces["position"] = spaces.Box(
             low=-100, high=100, shape=(4, ))
-        space2 = Repeated(DICT_SPACE, max_len=3)
+        space2 = Repeated(dict_space2, max_len=3)
         assert space1 != space2
 
 

--- a/rllib/tests/test_nested_observation_spaces.py
+++ b/rllib/tests/test_nested_observation_spaces.py
@@ -572,6 +572,21 @@ class NestedSpacesTest(unittest.TestCase):
             # the ray-kv indices before training.
             self.assertEqual(
                 to_list(seen[:][-1]), to_list(REPEATED_SAMPLES[i]))
+    
+    def test_repeated_space_eq(self):
+        # exact same should pass
+        space1 = Repeated(DICT_SPACE, max_len=3)
+        space2 = Repeated(DICT_SPACE, max_len=3)
+        assert space1 == space2
+        # change max_length to fail
+        space2 = Repeated(DICT_SPACE, max_len=5)
+        assert space1 != space2
+        # change something in the child space to fail
+        dict_space2 = deepcopy(DICT_SPACE)
+        dict_space2.spaces["sensors"].spaces["position"] = spaces.Box(
+            low=-100, high=100, shape=(4, ))
+        space2 = Repeated(DICT_SPACE, max_len=3)
+        assert space1 != space2
 
 
 if __name__ == "__main__":

--- a/rllib/utils/spaces/repeated.py
+++ b/rllib/utils/spaces/repeated.py
@@ -14,7 +14,6 @@ class Repeated(gym.Space):
     See also: documentation for rllib.models.RepeatedValues, which shows how
         the lists are represented as batched input for ModelV2 classes.
     """
-
     def __init__(self, child_space: gym.Space, max_len: int):
         super().__init__()
         self.child_space = child_space
@@ -33,4 +32,4 @@ class Repeated(gym.Space):
     def __eq__(self, other):
         return (isinstance(other, Repeated)
                 and self.child_space == other.child_space
-                and self.max_len == other.max_len) 
+                and self.max_len == other.max_len)

--- a/rllib/utils/spaces/repeated.py
+++ b/rllib/utils/spaces/repeated.py
@@ -33,4 +33,4 @@ class Repeated(gym.Space):
     def __eq__(self, other):
         return (isinstance(other, Repeated)
                 and self.child_space == other.child_space
-                and self.max_len == other.max_len)
+                and self.max_len == other.max_len) 

--- a/rllib/utils/spaces/repeated.py
+++ b/rllib/utils/spaces/repeated.py
@@ -29,3 +29,8 @@ class Repeated(gym.Space):
     def contains(self, x):
         return (isinstance(x, list) and len(x) <= self.max_len
                 and all(self.child_space.contains(c) for c in x))
+    
+    def __eq__(self, other):
+        return (isinstance(other, Repeated)
+                and self.child_space == other.child_space
+                and self.max_len == other.max_len)

--- a/rllib/utils/spaces/repeated.py
+++ b/rllib/utils/spaces/repeated.py
@@ -29,7 +29,7 @@ class Repeated(gym.Space):
     def contains(self, x):
         return (isinstance(x, list) and len(x) <= self.max_len
                 and all(self.child_space.contains(c) for c in x))
-    
+
     def __eq__(self, other):
         return (isinstance(other, Repeated)
                 and self.child_space == other.child_space


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The equality operator is not implemented for the Repeated Space, which means downstream code depending on spaces
implementing the operator will not work

the ci linting completely relinted the unit test file, the only new additions is the new test at the bottom

## Checks

- [X ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ NA ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
  I ran the unit test I wrote and verified it was correct
