### PR TITLE
[Tune] Subsequent calls to SyncClient after close is ignored.

### DIFF
--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -36,6 +36,9 @@ CLOUD_SYNC_PERIOD = 300
 NODE_SYNC_PERIOD = 300
 
 _log_sync_warned = False
+# TODO(xwjiang): Currently there is no GC mechanism for _syncers.
+# One syncer per trial means a lot of syncers.
+# Could be a problem when trial number is big.
 _syncers = {}
 
 
@@ -209,6 +212,8 @@ class Syncer:
         self.sync_client.reset()
 
     def close(self):
+        # Force one last sync before closing out.
+        self.sync_down()
         self.sync_client.close()
 
     @property


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Note to reviewer: Please see specific questions in code comment.

Subsequent calls to SyncClient after close is ignored.
Updated the implementation of CommandBasedClient and the public facing API contract of SyncClient.

I also tested the file descriptor behavior with popen to see if I immediately close the file descriptor in parent process, does that cause any issue with the still going-on child process. It seems fine. Furthermore, Matt linked me [this](https://stackoverflow.com/questions/37713514/whats-going-on-with-closed-file-descriptors) - fd is actually copied into child process. 
I also sanity checked that after child process is done, its file descriptor is also released. Used command: `lsof -p {pid}`

## Related issue number

<!-- For example: "Closes #1234" -->
#17506

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
