### PR TITLE
[Ray Client] [runtime env] Print error logs in driver upon connection failure

### DIFF
--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -227,10 +227,10 @@ def test_runtime_install_error_message(call_ray_start):
     """
     with pytest.raises(ConnectionAbortedError) as excinfo:
         ray.client("localhost:25031").env({
-            "pip": ["anyscale-this-doesnt-exist"]
+            "pip": ["ray-this-doesnt-exist"]
         }).connect()
     assert (
-        "No matching distribution found for anyscale-this-doesnt-exist" in str(
+        "No matching distribution found for ray-this-doesnt-exist" in str(
             excinfo.value))
 
     ray.util.disconnect()

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -211,6 +211,31 @@ def test_startup_error_yields_clean_result(shutdown_only):
     server.stop(0)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="PSUtil does not work the same on windows.")
+@pytest.mark.parametrize(
+    "call_ray_start", [
+        "ray start --head --ray-client-server-port 25031 "
+        "--port 0 --redis-password=password"
+    ],
+    indirect=True)
+def test_runtime_install_error_message(call_ray_start):
+    """
+    Check that an error while preparing the runtime environment for the client
+    server yields an actionable, clear error on the *client side*.
+    """
+    with pytest.raises(ConnectionAbortedError) as excinfo:
+        ray.client("localhost:25031").env({
+            "pip": ["anyscale-this-doesnt-exist"]
+        }).connect()
+    assert (
+        "No matching distribution found for anyscale-this-doesnt-exist" in str(
+            excinfo.value))
+
+    ray.util.disconnect()
+
+
 def test_prepare_runtime_init_req_fails():
     """
     Check that a connection that is initiated with a non-Init request

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -229,9 +229,8 @@ def test_runtime_install_error_message(call_ray_start):
         ray.client("localhost:25031").env({
             "pip": ["ray-this-doesnt-exist"]
         }).connect()
-    assert (
-        "No matching distribution found for ray-this-doesnt-exist" in str(
-            excinfo.value))
+    assert ("No matching distribution found for ray-this-doesnt-exist" in str(
+        excinfo.value))
 
     ray.util.disconnect()
 

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -544,13 +544,21 @@ class DataServicerProxy(ray_client_pb2_grpc.RayletDataStreamerServicer):
                     logger.error(
                         f"Server startup failed for client: {client_id}, "
                         f"using JobConfig: {job_config}!")
+                    # TODO(architkulkarni): Once the client server runtime env
+                    # setup is moved into the runtime env agent, revisit this
+                    # and double check where the error logs end up being saved.
+                    try:
+                        with open("/tmp/ray/session_latest/logs/"
+                                  f"ray_client_server_{server.port}.err") as f:
+                            runtime_env_error_str = f.read()
+                    except FileNotFoundError:
+                        runtime_env_error_str = "(File not found)"
                     raise RuntimeError(
                         "Starting Ray client server failed. This is most "
                         "likely because the runtime_env failed to be "
-                        f"installed. See ray_client_server_{server.port}.err "
-                        "on the head node of the cluster for the relevant "
-                        "logs.  By default these are located at "
-                        "/tmp/ray/session_latest/logs.")
+                        f"installed. Printing the contents of "
+                        f"ray_client_server_{server.port}.err below: \n"
+                        f"{runtime_env_error_str}")
                 channel = self.proxy_manager.get_channel(client_id)
                 if channel is None:
                     logger.error(f"Channel not found for {client_id}")

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -547,14 +547,20 @@ class DataServicerProxy(ray_client_pb2_grpc.RayletDataStreamerServicer):
                     raise RuntimeError(
                         "Starting Ray client server failed. This is most "
                         "likely because the runtime_env failed to be "
-                        "installed. See ray_client_server_[port].err on the "
-                        "head node of the cluster for the relevant logs.")
+                        f"installed. See ray_client_server_{server.port}.err "
+                        "on the head node of the cluster for the relevant "
+                        "logs.  By default these are located at "
+                        "/tmp/ray/session_latest/logs.")
                 channel = self.proxy_manager.get_channel(client_id)
                 if channel is None:
                     logger.error(f"Channel not found for {client_id}")
                     raise RuntimeError(
                         "Proxy failed to Connect to backend! Check "
-                        "`ray_client_server.err` on the cluster.")
+                        "`ray_client_server.err` and "
+                        f"`ray_client_server_{server.port}.err` on the head "
+                        "node of the cluster for the relevant logs. "
+                        "By default these are located at "
+                        "/tmp/ray/session_latest/logs.")
                 stub = ray_client_pb2_grpc.RayletDataStreamerStub(channel)
             except Exception:
                 init_resp = ray_client_pb2.DataResponse(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Previously, when the runtime env failed to install (for example, due to a typo in a specified pip package name), an error message would be printed on the driver directing the user to check `ray_client_server_<port>.err` on the head node.  However, the proxier returning this error lies on the head node itself, so we can easily read this file and include its contents in the error message. The error message then gets printed on the driver.

This way, the user can see the error message in their terminal without having to ssh into the cluster, which will increase their iteration speed.

Sample traceback:
```
ConnectionAbortedError: Initialization failure from server:
Traceback (most recent call last):
  File "/Users/archit/ray/python/ray/util/client/server/proxier.py", line 557, in Datapath
    "Starting Ray client server failed. This is most "
RuntimeError: Starting Ray client server failed. This is most likely because the runtime_env failed to be installed. Printing the contents of ray_client_server_23000.err below: 
Current Ray version could not be detected, most likely because you have manually built Ray from source.  To use runtime_env in this case, set the environment variable RAY_RUNTIME_ENV_LOCAL_DEV_MODE=1.


Pip subprocess error:
ERROR: Could not find a version that satisfies the requirement this-doesnt-exist-2 (from versions: none)
ERROR: No matching distribution found for this-doesnt-exist-2


CondaEnvException: Pip failed

Traceback (most recent call last):
  File "/Users/archit/ray/python/ray/workers/setup_worker.py", line 123, in <module>
    setup(remaining_args)
  File "/Users/archit/ray/python/ray/workers/setup_runtime_env.py", line 46, in setup_worker
    setup_conda_or_pip(runtime_env, runtime_env_context, logger=logger)
  File "/Users/archit/ray/python/ray/_private/runtime_env/conda.py", line 110, in setup_conda_or_pip
    conda_yaml_path, conda_dir, logger=logger)
  File "/Users/archit/ray/python/ray/_private/runtime_env/conda_utils.py", line 110, in get_or_create_conda_env
    stream_output=True)
  File "/Users/archit/ray/python/ray/_private/runtime_env/conda_utils.py", line 154, in exec_cmd
    raise ShellCommandException("Non-zero exitcode: %s" % (exit_code))
ray._private.runtime_env.conda_utils.ShellCommandException: Non-zero exitcode: 1

```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #18177 
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
