### PR TITLE
[Serve] Allow method redefinition for FastAPI

### DIFF
--- a/python/ray/serve/http_util.py
+++ b/python/ray/serve/http_util.py
@@ -165,13 +165,15 @@ def make_fastapi_class_based_view(fastapi_app, cls: Type) -> None:
         return serve.get_replica_context().servable_object
 
     # Find all the class method routes
-    member_methods = {
-        func
-        for _, func in inspect.getmembers(cls, inspect.isfunction)
-    }
     class_method_routes = [
-        route for route in fastapi_app.routes
-        if isinstance(route, APIRoute) and route.endpoint in member_methods
+        route for route in fastapi_app.routes if
+        # User defined routes must all be APIRoute.
+        isinstance(route, APIRoute)
+        # We want to find the route that's bound to the `cls`.
+        # NOTE(simon): we can't use `route.endpoint in inspect.getmembers(cls)`
+        # because the FastAPI supports different routes for the methods with
+        # same name. See #17559.
+        and (cls.__qualname__ in route.endpoint.__qualname__)
     ]
 
     # Modify these routes and mount it to a new APIRouter.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Note that we allowed redefined methods because FastAPI actually supports it
```python
from fastapi import FastAPI
app = FastAPI()

@app.get("/")
async def root():
    return {"message": "Hello World Get"}

@app.post("/")
async def root():
    return {"message": "Hello World Post"}

# Both works!
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #17559
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
