### PR TITLE
[workflow] Define default `__getstate__` and `__setstate__`

### DIFF
--- a/python/ray/experimental/workflow/tests/test_virtual_actor.py
+++ b/python/ray/experimental/workflow/tests/test_virtual_actor.py
@@ -259,6 +259,7 @@ def test_default_getset(workflow_start_regular):
     a1.set.run(10)
 
     with pytest.raises(ValueError):
+
         @workflow.virtual_actor
         class ActorWithSetStateOnly:
             def __init__(self):
@@ -271,6 +272,7 @@ def test_default_getset(workflow_start_regular):
                 self.x = x
 
     with pytest.raises(ValueError):
+
         @workflow.virtual_actor
         class ActorWithGetStateOnly:
             def __init__(self):
@@ -290,11 +292,13 @@ def test_default_getset(workflow_start_regular):
 
         def set(self, x):
             self.x = x
+
     # TODO (yic) We need better error message here
     # https://github.com/ray-project/ray/issues/18147
     with pytest.raises(ray.exceptions.RaySystemError):
         a2 = ActorHavingComplicatedStructure.get_or_create("a2")
         a2.set.run(10)
+
 
 if __name__ == "__main__":
     import sys

--- a/python/ray/experimental/workflow/virtual_actor_class.py
+++ b/python/ray/experimental/workflow/virtual_actor_class.py
@@ -129,6 +129,7 @@ class ActorMethod(ActorMethodBase):
     def __setstate__(self, state):
         self.__init__(state["actor"], state["method_name"])
 
+
 def __getstate(instance):
     if hasattr(instance, "__getstate__"):
         state = instance.__getstate__()
@@ -141,11 +142,13 @@ def __getstate(instance):
                              "and `__setstate__` explicitly.") from e
     return state
 
+
 def __setstate(instance, v):
     if hasattr(instance, "__setstate__"):
         return instance.__setstate__(v)
     else:
         instance.__dict__ = json.loads(v)
+
 
 class VirtualActorMetadata:
     """Recording the metadata of a virtual actor class, including

--- a/python/ray/experimental/workflow/virtual_actor_class.py
+++ b/python/ray/experimental/workflow/virtual_actor_class.py
@@ -137,9 +137,10 @@ def __getstate(instance):
         try:
             state = json.dumps(instance.__dict__)
         except TypeError as e:
-            raise ValueError("The virtual actor contains field that can't be "
+            raise ValueError("The virtual actor contains fields that can't be "
                              "converted to JSON. Please define `__getstate__` "
-                             "and `__setstate__` explicitly.") from e
+                             "and `__setstate__` explicitly:"
+                             f" {instance.__dict__}") from e
     return state
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Use `__dict__` as default getstate and setstate. Validation is added to make sure `__dict__` is able to be converted to JSON.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #18426 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
