### PR TITLE
[Java] fix WaitPlacementGroupReady API

### DIFF
--- a/java/api/src/main/java/io/ray/api/runtime/RayRuntime.java
+++ b/java/api/src/main/java/io/ray/api/runtime/RayRuntime.java
@@ -250,10 +250,10 @@ public interface RayRuntime {
    * Wait for the placement group to be ready within the specified time.
    *
    * @param id Id of placement group.
-   * @param timeoutMs Timeout in milliseconds.
+   * @param timeoutSeconds Timeout in seconds.
    * @return True if the placement group is created. False otherwise.
    */
-  boolean waitPlacementGroupReady(PlacementGroupId id, int timeoutMs);
+  boolean waitPlacementGroupReady(PlacementGroupId id, int timeoutSeconds);
 
   /** Create concurrency group instance at runtime. */
   ConcurrencyGroup createConcurrencyGroup(String name, int maxConcurrency, List<RayFunc> funcs);

--- a/java/runtime/src/main/java/io/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/io/ray/runtime/AbstractRayRuntime.java
@@ -221,8 +221,8 @@ public abstract class AbstractRayRuntime implements RayRuntimeInternal {
   }
 
   @Override
-  public boolean waitPlacementGroupReady(PlacementGroupId id, int timeoutMs) {
-    return taskSubmitter.waitPlacementGroupReady(id, timeoutMs);
+  public boolean waitPlacementGroupReady(PlacementGroupId id, int timeoutSeconds) {
+    return taskSubmitter.waitPlacementGroupReady(id, timeoutSeconds);
   }
 
   @SuppressWarnings("unchecked")

--- a/java/runtime/src/main/java/io/ray/runtime/task/LocalModeTaskSubmitter.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/LocalModeTaskSubmitter.java
@@ -372,7 +372,7 @@ public class LocalModeTaskSubmitter implements TaskSubmitter {
   }
 
   @Override
-  public boolean waitPlacementGroupReady(PlacementGroupId id, int timeoutMs) {
+  public boolean waitPlacementGroupReady(PlacementGroupId id, int timeoutSeconds) {
     return true;
   }
 

--- a/java/runtime/src/main/java/io/ray/runtime/task/NativeTaskSubmitter.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/NativeTaskSubmitter.java
@@ -115,8 +115,8 @@ public class NativeTaskSubmitter implements TaskSubmitter {
   }
 
   @Override
-  public boolean waitPlacementGroupReady(PlacementGroupId id, int timeoutMs) {
-    return nativeWaitPlacementGroupReady(id.getBytes(), timeoutMs);
+  public boolean waitPlacementGroupReady(PlacementGroupId id, int timeoutSeconds) {
+    return nativeWaitPlacementGroupReady(id.getBytes(), timeoutSeconds);
   }
 
   private static native List<byte[]> nativeSubmitTask(
@@ -146,5 +146,5 @@ public class NativeTaskSubmitter implements TaskSubmitter {
   private static native void nativeRemovePlacementGroup(byte[] placementGroupId);
 
   private static native boolean nativeWaitPlacementGroupReady(
-      byte[] placementGroupId, int timeoutMs);
+      byte[] placementGroupId, int timeoutSeconds);
 }

--- a/java/runtime/src/main/java/io/ray/runtime/task/TaskSubmitter.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/TaskSubmitter.java
@@ -78,10 +78,10 @@ public interface TaskSubmitter {
    * Wait for the placement group to be ready within the specified time.
    *
    * @param id Id of placement group.
-   * @param timeoutMs Timeout in milliseconds.
+   * @param timeoutSeconds Timeout in seconds.
    * @return True if the placement group is created. False otherwise.
    */
-  boolean waitPlacementGroupReady(PlacementGroupId id, int timeoutMs);
+  boolean waitPlacementGroupReady(PlacementGroupId id, int timeoutSeconds);
 
   BaseActorHandle getActor(ActorId actorId);
 }

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -120,7 +120,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         CRayStatus RemovePlacementGroup(
             const CPlacementGroupID &placement_group_id)
         CRayStatus WaitPlacementGroupReady(
-            const CPlacementGroupID &placement_group_id, int timeout_ms)
+            const CPlacementGroupID &placement_group_id, int timeout_seconds)
         c_vector[CObjectReference] SubmitActorTask(
             const CActorID &actor_id, const CRayFunction &function,
             const c_vector[unique_ptr[CTaskArg]] &args,


### PR DESCRIPTION
## Why are these changes needed?
- A little fix: rename  `timeoutMs` to `timeoutSeconds`
