### PR TITLE
[SGD] Fix shutdown hang on macOS Python 3.7

### DIFF
--- a/python/ray/util/sgd/torch/torch_runner.py
+++ b/python/ray/util/sgd/torch/torch_runner.py
@@ -263,7 +263,6 @@ class TorchRunner:
         """Attempts to shut down the worker."""
         del self.train_iterator
         del self.val_iterator
-        del self.training_operator
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Trainer shutdown hangs on Python 3.7 Mac OS, but not in 3.8 (https://github.com/ray-project/ray/issues/18443).

It was hanging on the following line: `del self.training_operator`. Confirmed that removing this line causes shutdown to run successfully on Python 3.7 on macOS.

This line doesn't seem necessary to begin with since we are terminating the actor processes anyways.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
