### PR TITLE
Revert "[cpp] Upgrade cpp from 14 -> 17 (#18455)"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,10 +7,10 @@ build --enable_platform_specific_config
 build --action_env=PATH
 # For --compilation_mode=dbg, consider enabling checks in the standard library as well (below).
 build --compilation_mode=opt
-build:linux --cxxopt="-std=c++17"
-build:macos --cxxopt="-std=c++17"
-build:clang-cl --cxxopt="-std=c++17"
-build:msvc --cxxopt="/std:c++17"
+build:linux --cxxopt="-std=c++14"
+build:macos --cxxopt="-std=c++14"
+build:clang-cl --cxxopt="-std=c++14"
+build:msvc --cxxopt="/std:c++14"
 # This workaround is needed to prevent Bazel from compiling the same file twice (once PIC and once not).
 build:linux --force_pic
 build:macos --force_pic


### PR DESCRIPTION
This reverts commit ccc16a46bbc81ba22f6c3d6ae2e791c4567a4965.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It looks like this causes my local build to fail with this error message.

```cpp
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/memory:4325:5: error: static_assert failed due to requirement 'is_constructible<grpc_core::XdsApi::LdsUpdate::FilterChainData>::value' "Can't construct object in make_shared"
    static_assert( is_constructible<_Tp, _Args...>::value, "Can't construct object in make_shared" );
    ^              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/memory:4710:29: note: in instantiation of function template specialization 'std::__1::shared_ptr<grpc_core::XdsApi::LdsUpdate::FilterChainData>::make_shared<>' requested here
    return shared_ptr<_Tp>::make_shared(_VSTD::forward<_Args>(__args)...);
                            ^
external/com_github_grpc_grpc/src/core/ext/xds/xds_api.cc:2214:12: note: in instantiation of function template specialization 'std::__1::make_shared<grpc_core::XdsApi::LdsUpdate::FilterChainData>' requested here
      std::make_shared<XdsApi::LdsUpdate::FilterChainData>();
```

There's probably some mismatches with grpc core. I am not sure what the root cause is. @iycheng can you verify if this works on your local Mac? 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
