### PR TITLE
[release] increase torch_tune_serve timeout to 20 min

### DIFF
--- a/release/golden_notebook_tests/golden_notebook_tests.yaml
+++ b/release/golden_notebook_tests/golden_notebook_tests.yaml
@@ -32,6 +32,6 @@
   run:
     use_connect: True
     autosuspend_mins: 10
-    timeout: 600
+    timeout: 1200
     script: python workloads/torch_tune_serve_test.py
 


### PR DESCRIPTION


## Why are these changes needed?

Timeout was decreased from 45 minutes to 10 minutes in https://github.com/ray-project/ray/pull/17873. Due to fluctuations in cluster startup time (taking ~10 minutes) this job will time out.

As a short term fix, this PR bumps this timeout up to 20 minutes.

In the long term, we will look into changing these Anyscale Connect tests into 2 parts:
1. Cluster startup
2. Job execution

The timeout currently applies to steps 1 and 2 together, but logically we want it to apply only to step 2.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
