### PR TITLE
[Streaming]Remove custom resource from streaming

### DIFF
--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -294,6 +294,8 @@ java_binary(
         "//java:io_ray_ray_api",
         "//java:io_ray_ray_runtime",
         "//java:io_ray_ray_serve",
+        "//streaming/java:io_ray_ray_streaming-api",
+        "//streaming/java:io_ray_ray_streaming-runtime",
     ],
 )
 
@@ -302,6 +304,7 @@ genrule(
     srcs = [
         "//java:ray_dist_deploy.jar",
         "//java:gen_maven_deps",
+        "//streaming/java:gen_maven_deps",
     ],
     outs = ["ray_java_pkg.out"],
     cmd = """

--- a/java/build-jar-multiplatform.sh
+++ b/java/build-jar-multiplatform.sh
@@ -7,8 +7,9 @@ set -e
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)"
 WORKSPACE_DIR="${ROOT_DIR}/.."
-JAVA_DIRS_PATH=('java')
+JAVA_DIRS_PATH=('java' 'streaming/java')
 RAY_JAVA_MODULES=('api' 'runtime')
+RAY_STREAMING_JAVA_MODULES=('streaming-api' 'streaming-runtime' 'streaming-state')
 JAR_BASE_DIR="$WORKSPACE_DIR"/.jar
 mkdir -p "$JAR_BASE_DIR"
 cd "$WORKSPACE_DIR/java"
@@ -46,8 +47,9 @@ build_jars() {
     echo "Finished building jars for $p"
   done
   copy_jars "$JAR_DIR"
-  # ray runtime jar in a dir specifed by maven-jar-plugin
+  # ray runtime jar and streaming runtime jar are in a dir specifed by maven-jar-plugin
   cp -f "$WORKSPACE_DIR"/build/java/ray*.jar "$JAR_DIR"
+  cp -f "$WORKSPACE_DIR"/streaming/build/java/streaming*.jar "$JAR_DIR"
   echo "Finished building jar for $platform"
 }
 
@@ -57,8 +59,12 @@ copy_jars() {
   for module in "${RAY_JAVA_MODULES[@]}"; do
     cp -f "$WORKSPACE_DIR"/java/"$module"/target/*jar "$JAR_DIR"
   done
-  # ray runtime jar and are in a dir specifed by maven-jar-plugin
+  for module in "${RAY_STREAMING_JAVA_MODULES[@]}"; do
+    cp -f "$WORKSPACE_DIR"/streaming/java/"$module"/target/*jar "$JAR_DIR"
+  done
+  # ray runtime jar and streaming runtime jar are in a dir specifed by maven-jar-plugin
   cp -f "$WORKSPACE_DIR"/build/java/ray*.jar "$JAR_DIR"
+  cp -f "$WORKSPACE_DIR"/streaming/build/java/streaming*.jar "$JAR_DIR"
 }
 
 # This function assuem all dependencies are installed already.
@@ -79,7 +85,7 @@ build_jars_multiplatform() {
       return
     fi
   fi
-  if download_jars "ray-runtime-$version.jar"; then
+  if download_jars "ray-runtime-$version.jar" "streaming-runtime-$version.jar"; then
     prepare_native
     build_jars multiplatform false
   else
@@ -131,6 +137,11 @@ prepare_native() {
     mkdir -p "$native_dir"
     rm -rf "$native_dir"
     mv "native/$os" "$native_dir"
+    jar xf "streaming-runtime-$version.jar" "native/$os"
+    local native_dir="$WORKSPACE_DIR/streaming/java/streaming-runtime/native_dependencies/native/$os"
+    mkdir -p "$native_dir"
+    rm -rf "$native_dir"
+    mv "native/$os" "$native_dir"
   done
 }
 
@@ -140,6 +151,7 @@ native_files_exist() {
   for os in 'darwin' 'linux'; do
     native_dirs=()
     native_dirs+=("$WORKSPACE_DIR/java/runtime/native_dependencies/native/$os")
+    native_dirs+=("$WORKSPACE_DIR/streaming/java/streaming-runtime/native_dependencies/native/$os")
     for native_dir in "${native_dirs[@]}"; do
       if [ ! -d "$native_dir" ]; then
         echo "$native_dir doesn't exist"
@@ -166,6 +178,10 @@ deploy_jars() {
     (
       cd "$WORKSPACE_DIR/java"
       mvn -T16 install deploy -Dmaven.test.skip=true -Dcheckstyle.skip -Prelease -Dgpg.skip="${GPG_SKIP:-true}"
+    )
+    (
+      cd "$WORKSPACE_DIR/streaming/java"
+      mvn -T16 deploy -Dmaven.test.skip=true -Dcheckstyle.skip -Prelease -Dgpg.skip="${GPG_SKIP:-true}"
     )
     echo "Finished deploying jars"
   else

--- a/src/ray/ray_exported_symbols.lds
+++ b/src/ray/ray_exported_symbols.lds
@@ -26,7 +26,10 @@
 *ray*metrics*
 *opencensus*
 *ray*stats*
+*ray*rpc*
+*ray*gcs*
 *ray*CoreWorker*
+*ray*PeriodicalRunner*;
 *PyInit*
 *init_raylet*
 *Java*
@@ -34,3 +37,5 @@
 *ray*streaming*
 *aligned_free*
 *aligned_malloc*
+*absl*
+*grpc*

--- a/src/ray/ray_version_script.lds
+++ b/src/ray/ray_version_script.lds
@@ -27,8 +27,11 @@ VERSION_1.0 {
         # Others
         *ray*metrics*;
         *opencensus*;
+        *ray*rpc*;
+        *ray*gcs*;
         *ray*stats*;
         *ray*CoreWorker*;
+        *ray*PeriodicalRunner*;
         *PyInit*;
         *init_raylet*;
         *Java*;
@@ -36,5 +39,7 @@ VERSION_1.0 {
         *ray*streaming*;
         *aligned_free*;
         *aligned_malloc*;
+        *absl*;
+        *grpc*;
     local: *;
 };

--- a/streaming/java/streaming-runtime/src/main/java/io/ray/streaming/runtime/core/resource/Container.java
+++ b/streaming/java/streaming-runtime/src/main/java/io/ray/streaming/runtime/core/resource/Container.java
@@ -117,8 +117,6 @@ public class Container implements Serializable {
 
     executionVertexIds.add(vertex.getExecutionVertexId());
     vertex.setContainerIfNotExist(this.getId());
-    // Binding dynamic resource
-    vertex.getResource().put(getName(), 1.0);
     decreaseResource(vertex.getResource());
   }
 

--- a/streaming/java/streaming-runtime/src/main/java/io/ray/streaming/runtime/master/resourcemanager/ResourceManagerImpl.java
+++ b/streaming/java/streaming-runtime/src/main/java/io/ray/streaming/runtime/master/resourcemanager/ResourceManagerImpl.java
@@ -145,11 +145,6 @@ public class ResourceManagerImpl implements ResourceManager {
     // failover case: container has already allocated actors
     double availableCapacity = actorNumPerContainer - container.getAllocatedActorNum();
 
-    // Create ray resource.
-    Ray.setResource(container.getNodeId(), container.getName(), availableCapacity);
-    // Mark container is already registered.
-    Ray.setResource(container.getNodeId(), CONTAINER_ENGAGED_KEY, 1);
-
     // update container's available dynamic resources
     container.getAvailableResources().put(container.getName(), availableCapacity);
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Once run streaming python test, the following exception stack might note streaming java has not built yet.

```
ray.exceptions.CrossLanguageError: An exception raised from JAVA:
io.ray.runtime.exception.RayActorException: (pid=58331, ip=11.124.176.62) The actor died because of it's creation task failed
        at io.ray.runtime.task.TaskExecutor.execute(TaskExecutor.java:216)
        at io.ray.runtime.RayNativeRuntime.nativeRunTaskExecutor(Native Method)
        at io.ray.runtime.RayNativeRuntime.run(RayNativeRuntime.java:225)
        at io.ray.runtime.runner.worker.DefaultWorker.main(DefaultWorker.java:15)
Caused by: java.lang.RuntimeException: Failed to load functions from class io.ray.streaming.runtime.python.PythonGateway
        at io.ray.runtime.functionmanager.FunctionManager$JobFunctionTable.loadFunctionsForClass(FunctionManager.java:240)
        at io.ray.runtime.functionmanager.FunctionManager$JobFunctionTable.getFunction(FunctionManager.java:173)
        at io.ray.runtime.functionmanager.FunctionManager.getFunction(FunctionManager.java:108)
        at io.ray.runtime.task.TaskExecutor.getRayFunction(TaskExecutor.java:69)
        at io.ray.runtime.task.TaskExecutor.execute(TaskExecutor.java:121)
        ... 3 more
Caused by: java.lang.ClassNotFoundException: io.ray.streaming.runtime.python.PythonGateway
        at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
        at java.lang.Class.forName0(Native Method)
        at java.lang.Class.forName(Class.java:348)
        at io.ray.runtime.functionmanager.FunctionManager$JobFunctionTable.loadFunctionsForClass(FunctionManager.java:199)
        ... 7 more

```

Streaming jar is not packed in ray-dist, so users can not run streaming app.
## Related issue number
https://github.com/ray-project/ray/issues/18488
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
