### PR TITLE
[Core] Fix Flaky Test: test_gcs_fault_tolerance.py

### DIFF
--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -24,7 +24,7 @@ def increase(x):
 @pytest.mark.parametrize(
     "ray_start_regular", [
         generate_system_config_map(
-            num_heartbeats_timeout=2, ping_gcs_rpc_server_max_retries=60)
+            num_heartbeats_timeout=20, ping_gcs_rpc_server_max_retries=60)
     ],
     indirect=True)
 def test_gcs_server_restart(ray_start_regular):


### PR DESCRIPTION
## Why are these changes needed?

Fixes a flaky test: `test_gcs_fault_tolerance.py`

This test sometimes failed because the raylet crashed due to heartbeat timeout. This PR fixes it by increasing the timeout.

```
[2021-09-10 21:53:04,897 C 12338 12338] node_manager.cc:789:  Check failed: node_id != self_node_id_ Exiting because this node manager has mistakenly been marked dead by the monitor: GCS didn't receive heartbeats within timeout 2000 ms. This is likely since the machine or raylet became overloaded.
*** StackTrace Information ***
    ray::GetCallTrace()
    ray::SpdLogMessage::Flush()
    ray::RayLog::~RayLog()
    ray::raylet::NodeManager::NodeRemoved()
    std::_Function_handler<>::_M_invoke()
    ray::gcs::ServiceBasedNodeInfoAccessor::HandleNotification()
    std::_Function_handler<>::_M_invoke()
    ray::gcs::GcsPubSub::ExecuteCommandIfPossible()::{lambda()#1}::operator()()
    std::_Function_handler<>::_M_invoke()
    std::_Function_handler<>::_M_invoke()
    boost::asio::detail::completion_handler<>::do_complete()
    boost::asio::detail::scheduler::do_run_one()
    boost::asio::detail::scheduler::run()
    boost::asio::io_context::run()
    main
    __libc_start_main
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
