### PR TITLE
[Core] Add gRPC Server Backpressure Tests

### DIFF
--- a/src/ray/protobuf/test_service.proto
+++ b/src/ray/protobuf/test_service.proto
@@ -17,11 +17,11 @@ syntax = "proto3";
 package ray.rpc;
 
 // Serivce that is only used to test GrpcServer
-message SleepRequest {
-  int64 sleep_time_ms = 1;
+message PingRequest {
 }
-message SleepReply {
+message PingReply {
+  bool no_reply = 1;
 }
 service TestService {
-  rpc Sleep(SleepRequest) returns (SleepReply);
+  rpc Ping(PingRequest) returns (PingReply);
 }

--- a/src/ray/protobuf/test_service.proto
+++ b/src/ray/protobuf/test_service.proto
@@ -18,9 +18,9 @@ package ray.rpc;
 
 // Serivce that is only used to test GrpcServer
 message PingRequest {
+  bool no_reply = 1;
 }
 message PingReply {
-  bool no_reply = 1;
 }
 service TestService {
   rpc Ping(PingRequest) returns (PingReply);

--- a/src/ray/rpc/test/grpc_server_client_test.cc
+++ b/src/ray/rpc/test/grpc_server_client_test.cc
@@ -22,15 +22,14 @@ namespace ray {
 namespace rpc {
 class TestServiceHandler {
  public:
-  void HandleSleep(const SleepRequest &request, SleepReply *reply,
-                   SendReplyCallback send_reply_callback) {
-    RAY_LOG(INFO) << "Got sleep request, time=" << request.sleep_time_ms() << "ms";
+  void HandlePing(const PingRequest &request, PingReply *reply,
+                  SendReplyCallback send_reply_callback) {
+    RAY_LOG(INFO) << "Got ping request, no_reply=" << request.no_reply();
     while (frozen) {
       RAY_LOG(INFO) << "Server is frozen...";
       std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     }
     RAY_LOG(INFO) << "Handling and replying request.";
-    std::this_thread::sleep_for(std::chrono::milliseconds(request.sleep_time_ms()));
     send_reply_callback(ray::Status::OK(),
                         /*reply_success=*/[]() { RAY_LOG(INFO) << "Reply success."; },
                         /*reply_failure=*/
@@ -59,7 +58,7 @@ class TestGrpcService : public GrpcService {
   void InitServerCallFactories(
       const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
       std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories) override {
-    RPC_SERVICE_HANDLER(TestService, Sleep, /*max_active_rpcs=*/1);
+    RPC_SERVICE_HANDLER(TestService, Ping, /*max_active_rpcs=*/1);
   }
 
  private:
@@ -116,7 +115,7 @@ class TestGrpcServerClientFixture : public ::testing::Test {
   }
 
  protected:
-  VOID_RPC_CLIENT_METHOD(TestService, Sleep, grpc_client_, )
+  VOID_RPC_CLIENT_METHOD(TestService, Ping, grpc_client_, )
   // Server
   TestServiceHandler test_service_handler_;
   instrumented_io_context handler_io_service_;
@@ -134,10 +133,9 @@ class TestGrpcServerClientFixture : public ::testing::Test {
 
 TEST_F(TestGrpcServerClientFixture, TestBasic) {
   // Send request
-  SleepRequest request;
-  request.set_sleep_time_ms(1);
+  PingRequest request;
   std::atomic<bool> done(false);
-  Sleep(request, [&done](const Status &status, const SleepReply &reply) {
+  Ping(request, [&done](const Status &status, const PingReply &reply) {
     RAY_LOG(INFO) << "replied, status=" << status;
     done = true;
   });
@@ -145,6 +143,24 @@ TEST_F(TestGrpcServerClientFixture, TestBasic) {
     RAY_LOG(INFO) << "waiting";
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   }
+}
+
+TEST_F(TestGrpcServerClientFixture, TestBackpressure) {
+  // Freeze server
+  test_service_handler_.frozen = true;
+  // Send a request which won't be replied to.
+  PingRequest request;
+  request.set_no_reply(true);
+  Ping(request, [](const Status &status, const PingReply &reply) {
+    FAIL() << "Should have no response.";
+  });
+  // Send a normal request, this request will be blocked by backpressure since
+  // max_active_rpcs is 1.
+  request.set_no_reply(false);
+  Ping(request, [](const Status &status, const PingReply &reply) {
+    FAIL() << "Should have no response.";
+  });
+  std::this_thread::sleep_for(std::chrono::milliseconds(5000));
 }
 
 TEST_F(TestGrpcServerClientFixture, TestClientCallManagerTimeout) {
@@ -158,10 +174,9 @@ TEST_F(TestGrpcServerClientFixture, TestClientCallManagerTimeout) {
   // Freeze server first, it won't reply any request.
   test_service_handler_.frozen = true;
   // Send request.
-  SleepRequest request;
-  request.set_sleep_time_ms(1);
+  PingRequest request;
   std::atomic<bool> call_timed_out(false);
-  Sleep(request, [&call_timed_out](const Status &status, const SleepReply &reply) {
+  Ping(request, [&call_timed_out](const Status &status, const PingReply &reply) {
     RAY_LOG(INFO) << "Replied, status=" << status;
     ASSERT_TRUE(status.IsIOError());
     call_timed_out = true;
@@ -191,10 +206,9 @@ TEST_F(TestGrpcServerClientFixture, TestClientDiedBeforeReply) {
   // Freeze server first, it won't reply any request.
   test_service_handler_.frozen = true;
   // Send request.
-  SleepRequest request;
-  request.set_sleep_time_ms(1);
+  PingRequest request;
   std::atomic<bool> call_timed_out(false);
-  Sleep(request, [&call_timed_out](const Status &status, const SleepReply &reply) {
+  Ping(request, [&call_timed_out](const Status &status, const PingReply &reply) {
     RAY_LOG(INFO) << "Replied, status=" << status;
     ASSERT_TRUE(status.IsIOError());
     call_timed_out = true;
@@ -220,7 +234,7 @@ TEST_F(TestGrpcServerClientFixture, TestClientDiedBeforeReply) {
   // Send again, this request should be replied. If any leaking happened, this call won't
   // be replied to since the max_active_rpcs is 1.
   std::atomic<bool> done(false);
-  Sleep(request, [&done](const Status &status, const SleepReply &reply) {
+  Ping(request, [&done](const Status &status, const PingReply &reply) {
     RAY_LOG(INFO) << "replied, status=" << status;
     done = true;
   });

--- a/src/ray/rpc/test/grpc_server_client_test.cc
+++ b/src/ray/rpc/test/grpc_server_client_test.cc
@@ -165,7 +165,7 @@ TEST_F(TestGrpcServerClientFixture, TestBackpressure) {
     FAIL() << "Should have no response.";
   });
   while (test_service_handler_.request_count <= 0) {
-    RAY_LOG(INFO) << "Waiting for reqeust to arrive";
+    RAY_LOG(INFO) << "Waiting for request to arrive";
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   }
   // Send a normal request, this request will be blocked by backpressure since


### PR DESCRIPTION
## Why are these changes needed?

In https://github.com/ray-project/ray/pull/17863#discussion_r701638470 we mentioned that we should add a test for backpressure. This PR adds one.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
