### PR TITLE
Revert "[serve] Fix get_handle execution from threads (#18198)"

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -293,22 +293,14 @@ class Client:
         if not missing_ok and endpoint_name not in all_endpoints:
             raise KeyError(f"Endpoint '{endpoint_name}' does not exist.")
 
-        try:
-            asyncio_loop_running = asyncio.get_event_loop().is_running()
-        except RuntimeError as ex:
-            if "There is no current event loop in thread" in str(ex):
-                asyncio_loop_running = False
-            else:
-                raise ex
-
-        if asyncio_loop_running and sync:
+        if asyncio.get_event_loop().is_running() and sync:
             logger.warning(
                 "You are retrieving a sync handle inside an asyncio loop. "
                 "Try getting client.get_handle(.., sync=False) to get better "
                 "performance. Learn more at https://docs.ray.io/en/master/"
                 "serve/http-servehandle.html#sync-and-async-handles")
 
-        if not asyncio_loop_running and not sync:
+        if not asyncio.get_event_loop().is_running() and not sync:
             logger.warning(
                 "You are retrieving an async handle outside an asyncio loop. "
                 "You should make sure client.get_handle is called inside a "

--- a/python/ray/serve/tests/test_handle.py
+++ b/python/ray/serve/tests/test_handle.py
@@ -2,7 +2,6 @@ import pytest
 import requests
 
 import ray
-import concurrent.futures
 from ray import serve
 
 
@@ -42,23 +41,6 @@ def test_sync_handle_serializable(serve_instance):
     handle = f.get_handle(sync=True)
     result_ref = task.remote(handle)
     assert ray.get(result_ref) == "hello"
-
-
-def test_sync_handle_in_thread(serve_instance):
-    @serve.deployment
-    def f():
-        return "hello"
-
-    f.deploy()
-
-    def thread_get_handle(deploy):
-        handle = deploy.get_handle(sync=True)
-        return handle
-
-    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-        fut = executor.submit(thread_get_handle, f)
-        handle = fut.result()
-        assert ray.get(handle.remote()) == "hello"
 
 
 def test_handle_in_endpoint(serve_instance):


### PR DESCRIPTION
This reverts commit 1a72c4900941501dcfc42825f9df790de9f4f03b.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
