### PR TITLE
[workflow] Support name to be passed via decorator

### DIFF
--- a/python/ray/experimental/workflow/api.py
+++ b/python/ray/experimental/workflow/api.py
@@ -94,6 +94,9 @@ def step(*args, **kwargs):
     catch_exceptions = kwargs.pop("catch_exceptions", None)
     if catch_exceptions is not None:
         step_options["catch_exceptions"] = catch_exceptions
+    name = kwargs.pop("name", None)
+    if name is not None:
+        step_options["name"] = name
     if len(kwargs) != 0:
         step_options["ray_options"] = kwargs
     return make_step_decorator(step_options)

--- a/python/ray/experimental/workflow/tests/test_basic_workflows_2.py
+++ b/python/ray/experimental/workflow/tests/test_basic_workflows_2.py
@@ -217,12 +217,12 @@ def test_get_named_step_default(workflow_start_regular, tmp_path):
 
 
 def test_get_named_step_duplicate(workflow_start_regular):
-    @workflow.step
+    @workflow.step(name="f")
     def f(n, dep):
         return n
 
-    inner = f.options(name="f").step(10, None)
-    outer = f.options(name="f").step(20, inner)
+    inner = f.step(10, None)
+    outer = f.step(20, inner)
     assert 20 == outer.run("duplicate")
     # The outer will be checkpointed first. So there is no suffix for the name
     assert ray.get(workflow.get_output("duplicate", name="f")) == 20


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Support this:
```
@workflow.step(name="ABC")
def step(): ...
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
