### PR TITLE
Fix async actor worker process leak after calling ray.actor.exit_actor()

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1839,7 +1839,8 @@ cdef class CoreWorker:
 
     def destroy_event_loop_if_exists(self):
         if self.async_event_loop is not None:
-            self.async_event_loop.stop()
+            self.async_event_loop.call_soon_threadsafe(
+                self.async_event_loop.stop)
         if self.async_thread is not None:
             self.async_thread.join()
 

--- a/python/ray/tests/test_asyncio.py
+++ b/python/ray/tests/test_asyncio.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import asyncio
+import os
 import sys
 import threading
 import time
@@ -7,8 +8,9 @@ import time
 import pytest
 
 import ray
-from ray._private.test_utils import (
-    SignalActor, kill_actor_and_wait_for_failure, wait_for_condition)
+from ray._private.test_utils import (SignalActor,
+                                     kill_actor_and_wait_for_failure,
+                                     wait_for_condition, wait_for_pid_to_exit)
 
 
 def test_asyncio_actor(ray_start_regular_shared):
@@ -240,6 +242,22 @@ async def test_asyncio_exit_actor(ray_start_regular_shared):
         wait_for_condition(cond)
 
     ray.get(check_actor_gone_now.remote())
+
+
+def test_asyncio_exit_actor_no_process_leak(ray_start_regular_shared):
+    @ray.remote
+    class Actor:
+        def getpid(self):
+            return os.getpid()
+
+        async def exit(self):
+            ray.actor.exit_actor()
+
+    a = Actor.remote()
+    pid = ray.get(a.getpid.remote())
+    with pytest.raises(ray.exceptions.RayActorError):
+        ray.get(a.exit.remote())
+    wait_for_pid_to_exit(pid)
 
 
 def test_async_callback(ray_start_regular_shared):

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -550,10 +550,10 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] contained_object_ids The IDs serialized in this object.
   /// \param[out] object_id Object ID generated for the put.
   /// \param[out] data Buffer for the user to write the object into.
-  /// \param[in] object create by worker or not.
+  /// \param[in] created_by_worker create by worker or not.
   /// \param[in] owner_address The address of object's owner. If not provided,
   /// defaults to this worker.
-  /// \param[in] inline_small_object wether to inline create this object if it's
+  /// \param[in] inline_small_object Whether to inline create this object if it's
   /// small.
   /// \return Status.
   Status CreateOwned(const std::shared_ptr<Buffer> &metadata, const size_t data_size,

--- a/src/ray/core_worker/fiber.h
+++ b/src/ray/core_worker/fiber.h
@@ -130,7 +130,7 @@ class FiberState {
 
  private:
   /// The fiber channel used to send task between the submitter thread
-  /// (main direct_actor_trasnport thread) and the fiber_worker_thread_ (defined below)
+  /// (main direct_actor_trasnport thread) and the fiber_runner_thread_ (defined below)
   FiberChannel channel_;
   /// The fiber semaphore used to limit the number of concurrent fibers
   /// running at once.

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -53,7 +53,6 @@ using flatbuf::PlasmaError;
 
 class PlasmaStore {
  public:
-  // TODO: PascalCase PlasmaStore methods.
   PlasmaStore(instrumented_io_context &main_service, IAllocator &allocator,
               const std::string &socket_name, uint32_t delay_on_oom_ms,
               float object_spilling_threshold,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When we call ray.actor.exit_actor() to terminate an async actor worker process, the process is actually not killed. The reason is that the stop() method of asyncio event loop has to be called inside the event loop to actually stop it but we are calling it in a different thread. Reference: https://try2explore.com/questions/11439804. As a result, the process is stuck in self.async_thread.join() and is not able to exit.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #16802
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
