### PR TITLE
[deflaky] Fix workflow storage test

### DIFF
--- a/python/ray/experimental/workflow/storage/debug.py
+++ b/python/ray/experimental/workflow/storage/debug.py
@@ -78,6 +78,7 @@ class DebugStorage(Storage):
     """A storage for debugging purpose."""
 
     def __init__(self, wrapped_storage: "Storage", path: str):
+        self._log_on = True
         self._path = path
         self._wrapped_storage = wrapped_storage
         log_path = pathlib.Path(path)
@@ -95,11 +96,13 @@ class DebugStorage(Storage):
         return await self._wrapped_storage.get(key, is_json)
 
     async def put(self, key: str, data: Any, is_json: bool = False) -> None:
-        await self._logged_storage.put(key, data, is_json)
+        if self._log_on:
+            await self._logged_storage.put(key, data, is_json)
         await self._wrapped_storage.put(key, data, is_json)
 
     async def delete_prefix(self, prefix: str) -> None:
-        await self._logged_storage.delete_prefix(prefix)
+        if self._log_on:
+            await self._logged_storage.delete_prefix(prefix)
         await self._wrapped_storage.delete_prefix(prefix)
 
     async def scan_prefix(self, key_prefix: str) -> List[str]:
@@ -147,6 +150,12 @@ class DebugStorage(Storage):
 
     def get_value(self, index: int, is_json: bool) -> Any:
         return self._logged_storage.get_value(index, is_json)
+
+    def log_off(self):
+        self._log_on = False
+
+    def log_on(self):
+        self._log_on = True
 
     def __len__(self):
         return len(self._logged_storage)

--- a/python/ray/experimental/workflow/tests/test_storage_failure.py
+++ b/python/ray/experimental/workflow/tests/test_storage_failure.py
@@ -76,7 +76,6 @@ def _locate_initial_commit(debug_store: DebugStorage) -> int:
         "num_cpus": 4,  # increase CPUs to add pressure
     }],
     indirect=True)
-@pytest.mark.repeat(100)
 def test_failure_with_storage(workflow_start_regular):
     with tempfile.TemporaryDirectory() as temp_dir:
         debug_store = DebugStorage(get_global_storage(), temp_dir)

--- a/python/ray/experimental/workflow/tests/test_storage_failure.py
+++ b/python/ray/experimental/workflow/tests/test_storage_failure.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 from hashlib import sha1
 import tempfile
@@ -87,13 +86,16 @@ def test_failure_with_storage(workflow_start_regular):
         result = wf.run(workflow_id="complex_workflow")
         index = _locate_initial_commit(debug_store) + 1
         debug_store.log_off()
+
         def resume(num_records_replayed):
             key = debug_store.wrapped_storage.make_key("complex_workflow")
             asyncio_run(debug_store.wrapped_storage.delete_prefix(key))
+
             async def replay():
                 # We need to replay one by one to avoid conflict
                 for i in range(num_records_replayed):
                     await debug_store.replay(i)
+
             asyncio_run(replay())
             return ray.get(workflow.resume(workflow_id="complex_workflow"))
 
@@ -107,7 +109,6 @@ def test_failure_with_storage(workflow_start_regular):
             step_len = 1
         else:
             step_len = max((len(debug_store) - index) // 5, 1)
-
 
         for j in range(index, len(debug_store), step_len):
             assert resume(j) == result


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Concurrent replay will lead to conflict. This PR fixed it.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
