### PR TITLE
[Client] fix propagating errors to async calls during disconnect, and other cleanup

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -220,7 +220,7 @@
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
     - bazel test --config=ci $(./scripts/bazel_export_options)
-      --test_tag_filters=-kubernetes,-jenkins_only,-medium_size_python_tests_a_to_j,-medium_size_python_tests_k_to_z,-flaky,-post_wheel_build,-worker-container
+      --test_tag_filters=-kubernetes,-jenkins_only,-medium_size_python_tests_a_to_j,-medium_size_python_tests_k_to_z,-client_tests,-flaky,-post_wheel_build,-worker-container
       --test_env=CONDA_EXE
       --test_env=CONDA_PYTHON_EXE
       --test_env=CONDA_SHLVL

--- a/python/ray/_private/client_mode_hook.py
+++ b/python/ray/_private/client_mode_hook.py
@@ -151,7 +151,7 @@ def client_mode_convert_actor(actor_cls, in_args, in_kwargs, **kwargs):
     The common case for this decorator is for instantiating an ActorClass
     transparently as a ClientActorClass. This happens in circumstances where
     the ActorClass is declared early, in a library and only then is Ray used in
-    client mode -- nescessitating a conversion.
+    client mode -- necessitating a conversion.
     """
     from ray.util.client import ray
 

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -602,7 +602,8 @@ def get_shared_memory_bytes():
     return shm_avail
 
 
-def check_oversized_function(pickled: bytes, name: str, obj_type: str, worker):
+def check_oversized_function(pickled: bytes, name: str, obj_type: str,
+                             worker: "ray.Worker") -> None:
     """Send a warning message if the pickled function is too large.
 
     Args:

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -602,7 +602,7 @@ def get_shared_memory_bytes():
     return shm_avail
 
 
-def check_oversized_function(pickled, name, obj_type, worker):
+def check_oversized_function(pickled: bytes, name: str, obj_type: str, worker):
     """Send a warning message if the pickled function is too large.
 
     Args:
@@ -610,7 +610,8 @@ def check_oversized_function(pickled, name, obj_type, worker):
         name: name of the pickled object.
         obj_type: type of the pickled object, can be 'function',
             'remote function', or 'actor'.
-        worker: the worker used to send warning message.
+        worker: the worker used to send warning message. message will be logged
+            locally if None.
     """
     length = len(pickled)
     if length <= ray_constants.FUNCTION_SIZE_WARN_THRESHOLD:
@@ -622,11 +623,12 @@ def check_oversized_function(pickled, name, obj_type, worker):
             "array or other object in scope. Tip: use ray.put() to put large "
             "objects in the Ray object store.").format(obj_type, name,
                                                        length // (1024 * 1024))
-        push_error_to_driver(
-            worker,
-            ray_constants.PICKLING_LARGE_OBJECT_PUSH_ERROR,
-            "Warning: " + warning_message,
-            job_id=worker.current_job_id)
+        if worker:
+            push_error_to_driver(
+                worker,
+                ray_constants.PICKLING_LARGE_OBJECT_PUSH_ERROR,
+                "Warning: " + warning_message,
+                job_id=worker.current_job_id)
     else:
         error = (
             "The {} {} is too large ({} MiB > FUNCTION_SIZE_ERROR_THRESHOLD={}"

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -353,13 +353,13 @@ def test_keyword_args(ray_start_regular_shared):
 
     # Make sure we get an exception if the constructor is called
     # incorrectly.
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         actor = Actor.remote()
 
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         actor = Actor.remote(0, 1, 2, arg3=3)
 
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         actor = Actor.remote(0, arg0=1)
 
     # Make sure we get an exception if the method is called incorrectly.

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -554,20 +554,20 @@ def test_keyword_args(ray_start_shared_local_modes):
         return
 
     # Make sure we get an exception if too many arguments are passed in.
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         f1.remote(3)
 
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         f1.remote(x=3)
 
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         f2.remote(0, w=0)
 
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         f2.remote(3, x=3)
 
     # Make sure we get an exception if too many arguments are passed in.
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         f2.remote(1, 2, 3, 4)
 
     @ray.remote
@@ -652,10 +652,11 @@ def test_oversized_function(ray_start_shared_local_modes):
     def f():
         return len(bar)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+            ValueError, match="The remote function .*f is too large"):
         f.remote()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="The actor Actor is too large"):
         Actor.remote()
 
 

--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -60,9 +60,9 @@ def test_variable_number_of_args(shutdown_only):
     assert ray.get(f1.remote()) == ()
     assert ray.get(f1.remote(1)) == (1, )
     assert ray.get(f1.remote(1, 2, 3)) == (1, 2, 3)
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         f2.remote()
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         f2.remote(1)
     assert ray.get(f2.remote(1, 2)) == (1, 2, ())
     assert ray.get(f2.remote(1, 2, 3)) == (1, 2, (3, ))

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -215,15 +215,6 @@ class ClientActorHandle(ClientStub):
                     inspect.getmembers(actor_class.actor_cls,
                                        is_function_or_method)).keys())
 
-    def __del__(self) -> None:
-        if ray is None:
-            # The ray API stub might be set to None when the script exits.
-            # Should be safe to skip call_release in this case, since the
-            # client should have already disconnected at this point.
-            return
-        if ray.is_connected():
-            ray.call_release(self.actor_ref.id)
-
     def __dir__(self) -> List[str]:
         if self._dir is not None:
             return self._dir

--- a/python/ray/util/client/server/dataservicer.py
+++ b/python/ray/util/client/server/dataservicer.py
@@ -49,8 +49,8 @@ class DataServicer(ray_client_pb2_grpc.RayletDataStreamerServicer):
 
     def Datapath(self, request_iterator, context):
         metadata = {k: v for k, v in context.invocation_metadata()}
-        client_id = metadata.get("client_id") or ""
-        if client_id == "":
+        client_id = metadata.get("client_id")
+        if client_id is None:
             logger.error("Client connecting with no client_id")
             return
         logger.debug(f"New data connection from client {client_id}: ")
@@ -134,32 +134,6 @@ class DataServicer(ray_client_pb2_grpc.RayletDataStreamerServicer):
                             req.list_named_actors)
                         resp = ray_client_pb2.DataResponse(
                             list_named_actors=response)
-                elif req_type == "cluster_info":
-                    with self.clients_lock:
-                        response = self.basic_service.ClusterInfo(
-                            req.cluster_info)
-                        resp = ray_client_pb2.DataResponse(
-                            cluster_info=response)
-                elif req_type == "kv_get":
-                    with self.clients_lock:
-                        response = self.basic_service.KVGet(req.kv_get)
-                        resp = ray_client_pb2.DataResponse(kv_get=response)
-                elif req_type == "kv_exists":
-                    with self.clients_lock:
-                        response = self.basic_service.KVExists(req.kv_exists)
-                        resp = ray_client_pb2.DataResponse(kv_exists=response)
-                elif req_type == "kv_put":
-                    with self.clients_lock:
-                        response = self.basic_service.KVPut(req.kv_put)
-                        resp = ray_client_pb2.DataResponse(kv_put=response)
-                elif req_type == "kv_del":
-                    with self.clients_lock:
-                        response = self.basic_service.KVDel(req.kv_del)
-                        resp = ray_client_pb2.DataResponse(kv_del=response)
-                elif req_type == "kv_list":
-                    with self.clients_lock:
-                        response = self.basic_service.KVList(req.kv_list)
-                        resp = ray_client_pb2.DataResponse(kv_list=response)
                 else:
                     raise Exception(f"Unreachable code: Request type "
                                     f"{req_type} not handled in Datapath")

--- a/python/ray/util/client/server/dataservicer.py
+++ b/python/ray/util/client/server/dataservicer.py
@@ -115,21 +115,6 @@ class DataServicer(ray_client_pb2_grpc.RayletDataStreamerServicer):
                             req.prep_runtime_env)
                         resp = ray_client_pb2.DataResponse(
                             prep_runtime_env=resp_prep)
-                elif req_type == "task":
-                    with self.clients_lock:
-                        resp_ticket = self.basic_service.Schedule(req.task)
-                        resp = ray_client_pb2.DataResponse(
-                            task_ticket=resp_ticket)
-                elif req_type == "terminate":
-                    with self.clients_lock:
-                        response = self.basic_service.Terminate(req.terminate)
-                        resp = ray_client_pb2.DataResponse(terminate=response)
-                elif req_type == "list_named_actors":
-                    with self.clients_lock:
-                        response = self.basic_service.ListNamedActors(
-                            req.list_named_actors)
-                        resp = ray_client_pb2.DataResponse(
-                            list_named_actors=response)
                 else:
                     raise Exception(f"Unreachable code: Request type "
                                     f"{req_type} not handled in Datapath")

--- a/python/ray/util/client/server/dataservicer.py
+++ b/python/ray/util/client/server/dataservicer.py
@@ -95,10 +95,6 @@ class DataServicer(ray_client_pb2_grpc.RayletDataStreamerServicer):
                         get_resp = self.basic_service._get_object(
                             req.get, client_id)
                     resp = ray_client_pb2.DataResponse(get=get_resp)
-                elif req_type == "wait":
-                    with self.clients_lock:
-                        wait_resp = self.basic_service.WaitObject(req.wait)
-                        resp = ray_client_pb2.DataResponse(wait=wait_resp)
                 elif req_type == "put":
                     put_resp = self.basic_service._put_object(
                         req.put, client_id)

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -306,6 +306,9 @@ class ProxyManager():
             with self.server_lock:
                 for client_id, specific_server in list(self.servers.items()):
                     if specific_server.poll() is not None:
+                        logger.info(
+                            f"Specific server {client_id} is no longer running"
+                            f", freeing its port {specific_server.port}")
                         del self.servers[client_id]
                         # Port is available to use again.
                         self._free_ports.append(specific_server.port)

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -95,7 +95,7 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
         # If the server has been initialized, we need to compare whether the
         # runtime env is compatible.
         if current_job_config and \
-           set(job_config.runtime_env.uris) != set(
+                set(job_config.runtime_env.uris) != set(
                 current_job_config.runtime_env.uris) and \
                 len(job_config.runtime_env.uris) > 0:
             return ray_client_pb2.InitResponse(
@@ -256,7 +256,7 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
         if req.WhichOneof("terminate_type") == "task_object":
             try:
                 object_ref = \
-                        self.object_refs[req.client_id][req.task_object.id]
+                    self.object_refs[req.client_id][req.task_object.id]
                 with disable_client_hook():
                     ray.cancel(
                         object_ref,
@@ -294,7 +294,12 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
             if ref:
                 refs.append(ref)
             else:
-                return ray_client_pb2.GetResponse(valid=False)
+                return ray_client_pb2.GetResponse(
+                    valid=False,
+                    error=cloudpickle.dumps(
+                        ValueError(
+                            f"ClientObjectRef with id {rid} not found for "
+                            f"client {client_id}")))
         try:
             logger.debug("async get: %s" % refs)
             with disable_client_hook():
@@ -307,12 +312,11 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
                         serialized = dumps_from_server(result, client_id, self)
                         get_resp = ray_client_pb2.GetResponse(
                             valid=True, data=serialized)
-                    except Exception as e:
+                    except Exception as exc:
                         get_resp = ray_client_pb2.GetResponse(
-                            valid=False, error=cloudpickle.dumps(e))
+                            valid=False, error=cloudpickle.dumps(exc))
                     resp = ray_client_pb2.DataResponse(
                         get=get_resp, req_id=req_id)
-                    resp.req_id = req_id
                     result_queue.put(resp)
 
                 for ref in refs:
@@ -323,20 +327,30 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
             return ray_client_pb2.GetResponse(
                 valid=False, error=cloudpickle.dumps(e))
 
-    def GetObject(self, request: ray_client_pb2.GetRequest, context=None):
-        return self._get_object(request, "", context)
+    def GetObject(self, request: ray_client_pb2.GetRequest, context):
+        metadata = {k: v for k, v in context.invocation_metadata()}
+        client_id = metadata.get("client_id") or ""
+        if client_id == "":
+            return ray_client_pb2.GetResponse(
+                valid=False,
+                error=cloudpickle.dumps(
+                    ValueError(
+                        "client_id is not specified in request metadata")))
+        return self._get_object(request, client_id)
 
-    def _get_object(self,
-                    request: ray_client_pb2.GetRequest,
-                    client_id: str,
-                    context=None):
+    def _get_object(self, request: ray_client_pb2.GetRequest, client_id: str):
         objectrefs = []
         for rid in request.ids:
             ref = self.object_refs[client_id].get(rid, None)
             if ref:
                 objectrefs.append(ref)
             else:
-                return ray_client_pb2.GetResponse(valid=False)
+                return ray_client_pb2.GetResponse(
+                    valid=False,
+                    error=cloudpickle.dumps(
+                        ValueError(
+                            f"ClientObjectRef {rid} is not found for client "
+                            f"{client_id}")))
         try:
             logger.debug("get: %s" % objectrefs)
             with disable_client_hook():
@@ -344,8 +358,8 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
         except Exception as e:
             return ray_client_pb2.GetResponse(
                 valid=False, error=cloudpickle.dumps(e))
-        items_ser = dumps_from_server(items, client_id, self)
-        return ray_client_pb2.GetResponse(valid=True, data=items_ser)
+        serialized = dumps_from_server(items, client_id, self)
+        return ray_client_pb2.GetResponse(valid=True, data=serialized)
 
     def PutObject(self, request: ray_client_pb2.PutRequest,
                   context=None) -> ray_client_pb2.PutResponse:
@@ -383,12 +397,12 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
 
     def WaitObject(self, request, context=None) -> ray_client_pb2.WaitResponse:
         object_refs = []
-        for id in request.object_ids:
-            if id not in self.object_refs[request.client_id]:
+        for rid in request.object_ids:
+            if rid not in self.object_refs[request.client_id]:
                 raise Exception(
                     "Asking for a ref not associated with this client: %s" %
-                    str(id))
-            object_refs.append(self.object_refs[request.client_id][id])
+                    str(rid))
+            object_refs.append(self.object_refs[request.client_id][rid])
         num_returns = request.num_returns
         timeout = request.timeout
         try:
@@ -416,7 +430,8 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
             ready_object_ids=ready_object_ids,
             remaining_object_ids=remaining_object_ids)
 
-    def Schedule(self, task, context=None) -> ray_client_pb2.ClientTaskTicket:
+    def Schedule(self, task: ray_client_pb2.ClientTask,
+                 context=None) -> ray_client_pb2.ClientTaskTicket:
         logger.debug(
             "schedule: %s %s" % (task.name,
                                  ray_client_pb2.ClientTask.RemoteExecType.Name(

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -327,8 +327,8 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
 
     def GetObject(self, request: ray_client_pb2.GetRequest, context):
         metadata = {k: v for k, v in context.invocation_metadata()}
-        client_id = metadata.get("client_id") or ""
-        if client_id == "":
+        client_id = metadata.get("client_id")
+        if client_id is None:
             return ray_client_pb2.GetResponse(
                 valid=False,
                 error=cloudpickle.dumps(
@@ -611,7 +611,9 @@ def serve(connection_str, ray_connect_handler=None):
 
     ray_connect_handler = ray_connect_handler or default_connect_handler
     server = grpc.server(
-        futures.ThreadPoolExecutor(max_workers=CLIENT_SERVER_MAX_THREADS),
+        futures.ThreadPoolExecutor(
+            max_workers=CLIENT_SERVER_MAX_THREADS,
+            thread_name_prefix="ray_client_server"),
         options=GRPC_OPTIONS)
     task_servicer = RayletServicer(ray_connect_handler)
     data_servicer = DataServicer(task_servicer)

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -350,9 +350,6 @@ message DataRequest {
     ConnectionInfoRequest connection_info = 5;
     InitRequest init = 6;
     PrepRuntimeEnvRequest prep_runtime_env = 7;
-    ClientTask task = 8;
-    ClientListNamedActorsRequest list_named_actors = 9;
-    TerminateRequest terminate = 10;
   }
 }
 
@@ -366,9 +363,6 @@ message DataResponse {
     ConnectionInfoResponse connection_info = 5;
     InitResponse init = 6;
     PrepRuntimeEnvResponse prep_runtime_env = 7;
-    ClientTaskTicket task_ticket = 8;
-    ClientListNamedActorsResponse list_named_actors = 9;
-    TerminateResponse terminate = 10;
   }
 }
 

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -346,10 +346,20 @@ message DataRequest {
   oneof type {
     GetRequest get = 2;
     PutRequest put = 3;
+    WaitRequest wait = 9;
     ReleaseRequest release = 4;
     ConnectionInfoRequest connection_info = 5;
     InitRequest init = 6;
     PrepRuntimeEnvRequest prep_runtime_env = 7;
+    ClientTask task = 8;
+    TerminateRequest terminate = 10;
+    ClusterInfoRequest cluster_info = 11;
+    ClientListNamedActorsRequest list_named_actors = 12;
+    KVGetRequest kv_get = 13;
+    KVPutRequest kv_put = 14;
+    KVDelRequest kv_del = 15;
+    KVListRequest kv_list = 16;
+    KVExistsRequest kv_exists = 17;
   }
 }
 
@@ -359,10 +369,20 @@ message DataResponse {
   oneof type {
     GetResponse get = 2;
     PutResponse put = 3;
+    WaitResponse wait = 9;
     ReleaseResponse release = 4;
     ConnectionInfoResponse connection_info = 5;
     InitResponse init = 6;
     PrepRuntimeEnvResponse prep_runtime_env = 7;
+    ClientTaskTicket task_ticket = 8;
+    TerminateResponse terminate = 10;
+    ClusterInfoResponse cluster_info = 11;
+    ClientListNamedActorsResponse list_named_actors = 12;
+    KVGetResponse kv_get = 13;
+    KVPutResponse kv_put = 14;
+    KVDelResponse kv_del = 15;
+    KVListResponse kv_list = 16;
+    KVExistsResponse kv_exists = 17;
   }
 }
 

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -346,20 +346,13 @@ message DataRequest {
   oneof type {
     GetRequest get = 2;
     PutRequest put = 3;
-    WaitRequest wait = 9;
     ReleaseRequest release = 4;
     ConnectionInfoRequest connection_info = 5;
     InitRequest init = 6;
     PrepRuntimeEnvRequest prep_runtime_env = 7;
     ClientTask task = 8;
+    ClientListNamedActorsRequest list_named_actors = 9;
     TerminateRequest terminate = 10;
-    ClusterInfoRequest cluster_info = 11;
-    ClientListNamedActorsRequest list_named_actors = 12;
-    KVGetRequest kv_get = 13;
-    KVPutRequest kv_put = 14;
-    KVDelRequest kv_del = 15;
-    KVListRequest kv_list = 16;
-    KVExistsRequest kv_exists = 17;
   }
 }
 
@@ -369,20 +362,13 @@ message DataResponse {
   oneof type {
     GetResponse get = 2;
     PutResponse put = 3;
-    WaitResponse wait = 9;
     ReleaseResponse release = 4;
     ConnectionInfoResponse connection_info = 5;
     InitResponse init = 6;
     PrepRuntimeEnvResponse prep_runtime_env = 7;
     ClientTaskTicket task_ticket = 8;
+    ClientListNamedActorsResponse list_named_actors = 9;
     TerminateResponse terminate = 10;
-    ClusterInfoResponse cluster_info = 11;
-    ClientListNamedActorsResponse list_named_actors = 12;
-    KVGetResponse kv_get = 13;
-    KVPutResponse kv_put = 14;
-    KVDelResponse kv_del = 15;
-    KVListResponse kv_list = 16;
-    KVExistsResponse kv_exists = 17;
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This is part of the bigger change from #18298, separated out for easier reviewing.

<!-- Please give a short summary of the change and the problem this solves. -->
Changes are mainly bug fixes and cleanups:
- Avoid running client tests without client mode in CI.
- Allow `check_oversized_function()` to be called from client.
- Tighten the expectation for some tests.
- Delete unnecessary logic in `ClientActorHandle.__del__()`, because releasing the ID is and should be managed by the underlying `ClientActorRef`.
- Improve locking in `dataclient.py`.
- Fix propagating errors to async calls during disconnect.
- Use a common function for shutdown.
- Fix `GetObject()` handler to retrieve `client_id`.
- Implement handling of remaining request types in streaming RPC.
- Ensure async `Get` requests contain only 1 Object ID.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
