### PR TITLE
[tests] Increase golden notebook test timeout to 20 mins

### DIFF
--- a/python/ray/tune/examples/optuna_define_by_run_example.py
+++ b/python/ray/tune/examples/optuna_define_by_run_example.py
@@ -37,8 +37,8 @@ def define_by_run_func(trial) -> Optional[Dict[str, Any]]:
     """Define-by-run function to create the search space.
 
     Ensure no actual computation takes place here. That should go into
-    the trainable passed to ``tune.run`` (in tis example, that's
-    ``easy_objective``.
+    the trainable passed to ``tune.run`` (in this example, that's
+    ``easy_objective``).
 
     For more information, see https://optuna.readthedocs.io/en/stable\
 /tutorial/10_key_features/002_configurations.html

--- a/release/golden_notebook_tests/golden_notebook_tests.yaml
+++ b/release/golden_notebook_tests/golden_notebook_tests.yaml
@@ -6,7 +6,7 @@
   run:
     use_connect: True
     autosuspend_mins: 10
-    timeout: 600
+    timeout: 1200
     script: python workloads/dask_xgboost_test.py
 
 - name: modin_xgboost_test
@@ -17,7 +17,7 @@
   run:
     use_connect: True
     autosuspend_mins: 10
-    timeout: 600
+    timeout: 1200
     script: python workloads/modin_xgboost_test.py
 
 - name: torch_tune_serve_test


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Increases timeout for golden notebook test to compensate for cluster startup slowness.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

https://github.com/ray-project/ray/issues/18553

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
