### PR TITLE
Minor change to switch result checking order so there is no artificial delay.

### DIFF
--- a/release/e2e.py
+++ b/release/e2e.py
@@ -851,6 +851,11 @@ def create_and_wait_for_session(
     start_wait = time.time()
     next_report = start_wait + REPORT_S
     while not completed:
+        session_operation_response = sdk.get_session_operation(
+            sop_id, _request_timeout=30)
+        session_operation = session_operation_response.result
+        completed = session_operation.completed
+
         _check_stop(stop_event, "session")
         now = time.time()
         if now > next_report:
@@ -858,10 +863,6 @@ def create_and_wait_for_session(
                         f"({int(now - start_wait)} seconds) ...")
             next_report = next_report + REPORT_S
 
-        session_operation_response = sdk.get_session_operation(
-            sop_id, _request_timeout=30)
-        session_operation = session_operation_response.result
-        completed = session_operation.completed
         time.sleep(1)
 
     return session_id
@@ -898,6 +899,9 @@ def wait_for_session_command_to_complete(create_session_command_result,
     start_wait = time.time()
     next_report = start_wait + REPORT_S
     while not completed:
+        result = sdk.get_session_command(session_command_id=scd_id)
+        completed = result.result.finished_at
+
         if state_str == "CMD_RUN":
             _check_stop(stop_event, "command")
         elif state_str == "CMD_PREPARE":
@@ -909,8 +913,6 @@ def wait_for_session_command_to_complete(create_session_command_result,
                         f"({int(now - start_wait)} seconds) ...")
             next_report = next_report + REPORT_S
 
-        result = sdk.get_session_command(session_command_id=scd_id)
-        completed = result.result.finished_at
         time.sleep(1)
 
     status_code = result.result.status_code

--- a/release/e2e.py
+++ b/release/e2e.py
@@ -851,6 +851,9 @@ def create_and_wait_for_session(
     start_wait = time.time()
     next_report = start_wait + REPORT_S
     while not completed:
+        # Sleep 1 sec before next check.
+        time.sleep(1)
+
         session_operation_response = sdk.get_session_operation(
             sop_id, _request_timeout=30)
         session_operation = session_operation_response.result
@@ -862,8 +865,6 @@ def create_and_wait_for_session(
             logger.info(f"... still waiting for session {session_name} "
                         f"({int(now - start_wait)} seconds) ...")
             next_report = next_report + REPORT_S
-
-        time.sleep(1)
 
     return session_id
 
@@ -899,6 +900,9 @@ def wait_for_session_command_to_complete(create_session_command_result,
     start_wait = time.time()
     next_report = start_wait + REPORT_S
     while not completed:
+        # Sleep 1 sec before next check.
+        time.sleep(1)
+
         result = sdk.get_session_command(session_command_id=scd_id)
         completed = result.result.finished_at
 
@@ -912,8 +916,6 @@ def wait_for_session_command_to_complete(create_session_command_result,
             logger.info(f"... still waiting for command to finish "
                         f"({int(now - start_wait)} seconds) ...")
             next_report = next_report + REPORT_S
-
-        time.sleep(1)
 
     status_code = result.result.status_code
     runtime = time.time() - start_wait


### PR DESCRIPTION
## Why are these changes needed?

I noticed this minor issue while debug our regression test.
Existing logic has a 1 sec delay between result fetching and actual result checking, which seems unnecessary.
This PR simply moves some statements around to avoid sleeping in between blocks. Shouldn't have any functionality changes.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
