### PR TITLE
Revert "[runtime_env] Don't modify passed runtime_env dictionary when validating"

### DIFF
--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -64,9 +64,7 @@ class RuntimeEnvDict:
                 {"OMP_NUM_THREADS": "32", "TF_WARNINGS": "none"}
     """
 
-    def __init__(self,
-                 runtime_env_json: dict,
-                 working_dir: Optional[str] = None):
+    def __init__(self, runtime_env_json: dict):
         # Simple dictionary with all options validated. This will always
         # contain all supported keys; values will be set to None if
         # unspecified. However, if all values are None this is set to {}.
@@ -80,7 +78,7 @@ class RuntimeEnvDict:
             working_dir = Path(self._dict["working_dir"]).absolute()
         else:
             self._dict["working_dir"] = None
-            working_dir = Path(working_dir).absolute() if working_dir else None
+            working_dir = None
 
         self._dict["conda"] = None
         if "conda" in runtime_env_json:
@@ -215,13 +213,13 @@ def override_task_or_actor_runtime_env(
                 "Overriding working_dir for actors is not supported. "
                 "Please use ray.init(runtime_env={'working_dir': ...}) "
                 "to configure per-job environment instead.")
-        # NOTE(edoakes): this is sort of hacky, but we pass in the parent
+        # NOTE(edoakes): this is sort of hacky, but we manually add the right
         # working_dir here so the relative path to a requirements.txt file
         # works. The right solution would be to merge the runtime_env with the
         # parent runtime env before validation.
-        runtime_env_dict = RuntimeEnvDict(
-            runtime_env, working_dir=parent_runtime_env.get(
-                "working_dir")).get_parsed_dict()
+        if parent_runtime_env.get("working_dir"):
+            runtime_env["working_dir"] = parent_runtime_env["working_dir"]
+        runtime_env_dict = RuntimeEnvDict(runtime_env).get_parsed_dict()
     else:
         runtime_env_dict = {}
 

--- a/python/ray/serve/tests/test_runtime_env.py
+++ b/python/ray/serve/tests/test_runtime_env.py
@@ -106,9 +106,6 @@ class Test:
 Test.deploy()
 handle = Test.get_handle()
 assert ray.get(handle.remote()) == "world"
-
-Test.options(num_replicas=2).deploy()
-assert ray.get(handle.remote()) == "world"
 """.format(
         use_ray_client=use_ray_client, client_addr=ray_start)
 

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -13,7 +13,6 @@ import ray.experimental.internal_kv as kv
 from ray._private.test_utils import (
     run_string_as_driver, run_string_as_driver_nonblocking, wait_for_condition)
 from ray._private.runtime_env import working_dir as working_dir_pkg
-from ray._private.runtime_env.validation import override_task_or_actor_runtime_env  # noqa: E501
 from ray._private.utils import (get_wheel_filename, get_master_wheel_url,
                                 get_release_wheel_url)
 
@@ -942,46 +941,6 @@ def test_large_file_error(shutdown_only):
             ray.init(runtime_env={"working_dir": "."})
 
         os.chdir(old_dir)
-
-
-class TestOverrideTaskOrActorRuntimeEnv:
-    def test_working_dir_in_child_invalid(self):
-        child_env = {"working_dir": "some_dir"}
-        parent_env = {"working_dir": "other_dir", "uris": ["a", "b"]}
-
-        with pytest.raises(NotImplementedError):
-            override_task_or_actor_runtime_env(child_env, parent_env)
-
-    def test_uri_inherit(self):
-        child_env = {}
-        parent_env = {"working_dir": "other_dir", "uris": ["a", "b"]}
-        result_env = override_task_or_actor_runtime_env(child_env, parent_env)
-        assert result_env == {"uris": ["a", "b"]}
-
-        # The dicts passed in should not be mutated.
-        assert child_env == {}
-        assert parent_env == {"working_dir": "other_dir", "uris": ["a", "b"]}
-
-    def test_uri_override(self):
-        child_env = {"uris": ["c", "d"]}
-        parent_env = {"working_dir": "other_dir", "uris": ["a", "b"]}
-        result_env = override_task_or_actor_runtime_env(child_env, parent_env)
-        assert result_env["uris"] == ["c", "d"]
-        assert result_env.get("working_dir") is None
-
-        # The dicts passed in should not be mutated.
-        assert child_env == {"uris": ["c", "d"]}
-        assert parent_env == {"working_dir": "other_dir", "uris": ["a", "b"]}
-
-    def test_no_mutate(self):
-        child_env = {}
-        parent_env = {"working_dir": "other_dir", "uris": ["a", "b"]}
-        result_env = override_task_or_actor_runtime_env(child_env, parent_env)
-        assert result_env == {"uris": ["a", "b"]}
-
-        # The dictis passed in should not be mutated.
-        assert child_env == {}
-        assert parent_env == {"working_dir": "other_dir", "uris": ["a", "b"]}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reverts ray-project/ray#18404

May be causing flakiness of `test_runtime_env::test_working_dir_basic` on MacOS and Linux, as this PR touches `working_dir` and the timing roughly lines up: 
<img width="527" alt="Screen Shot 2021-09-13 at 8 56 50 AM" src="https://user-images.githubusercontent.com/5459654/133121091-d66cd043-28ef-4e6f-aecd-deaa245e08e5.png">
