### PR TITLE
[ci] Do not use anyscale connect for xgboost_tests/train_small

### DIFF
--- a/release/xgboost_tests/xgboost_tests.yaml
+++ b/release/xgboost_tests/xgboost_tests.yaml
@@ -4,8 +4,8 @@
     compute_template: tpl_cpu_small.yaml
 
   run:
-    use_connect: True
-    autosuspend_mins: 10
+    # use_connect: True
+    # autosuspend_mins: 10
     timeout: 600
     prepare: python wait_cluster.py 4 600
     script: python workloads/train_small.py


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Before we adjust the e2e release test workflow to start clusters before using anyscale connect, let's disable anyscale connect for this test for now.

cc @mwtian 

Pass: https://buildkite.com/ray-project/periodic-ci/builds/974#_

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
