### PR TITLE
Added documentation around depdendency variants for Ray installation via pip

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -109,7 +109,7 @@ These variants can be installed with:
 
 Availiable variant strings include:
 
-* ``default``: same as ``pip install ray``, includes things like :ref:`Ray dashboard <ray-dashboard>` and cluster launcher
+* ``default``: includes things like :ref:`Ray dashboard <ray-dashboard>` and cluster launcher
 * ``serve``: includes dependencies for :ref:`Ray Serve <rayserve>`
 * ``tune``: includes dependencies for :ref:`Ray Tune <tune-60-seconds>`
 * ``rllib``: includes dependencies for :ref:`RLlib <rllib-index>`

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -112,6 +112,7 @@ Availiable variant strings include:
 * ``default``: same as ``pip install ray``, includes things like :ref:`Ray dashboard <ray-dashboard>` and cluster launcher
 * ``serve``: includes dependencies for :ref:`Ray Serve <rayserve>`
 * ``tune``: includes dependencies for :ref:`Ray Tune <tune-60-seconds>`
+* ``rllib``: includes dependencies for :ref:`RLlib <rllib-index>`
 * ``k8s``:  includes dependencies for running :ref:`Ray on Kubernetes <ray-k8s-deploy>` (k8s)
 * ``observability``: includes dependencies for monitoring with Grafana
 * ``all``: includes all dependencies, safest but heaviest option

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -109,16 +109,16 @@ These variants can be installed with:
 
 Availiable variant strings include:
 
-* ``default``: same as ``pip install ray``, includes standard Ray deps, but not things like :ref:`Ray dashboard <ray-dashboard>`, :ref:`Ray Serve <rayserve>`, etc 
+* ``default``: same as ``pip install ray``, includes things like :ref:`Ray dashboard <ray-dashboard>` and cluster launcher
 * ``serve``: includes dependencies for :ref:`Ray Serve <rayserve>`
 * ``tune``: includes dependencies for :ref:`Ray Tune <tune-60-seconds>`
 * ``k8s``:  includes dependencies for running :ref:`Ray on Kubernetes <ray-k8s-deploy>` (k8s)
 * ``observability``: includes dependencies for monitoring with Grafana
 * ``all``: includes all dependencies, safest but heaviest option
 
-We recommend installing with ``pip install ray`` (same as ``pip install ray[default]``), but checking for warnings or ``ImportError`` that may arise and installing variants as needed. This will keep your depdencies as lightweight as possible.
-
 If you want to see the exact packages or understand more deeply how these variants affect the installation process, `here's the code <https://github.com/ray-project/ray/blob/03a2c69a8a977f912694960a40e490a304c9cd62/python/setup.py#L178-L217>`__ (may need to change commit hash in URL to "master" to see latest version).
+
+We recommend installing with ``pip install ray``, but checking for warnings or ``ImportError`` that may arise and installing variants as needed. This will keep your depdencies as lightweight as possible.
 
 Install Ray Java with Maven
 ---------------------------

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -97,6 +97,29 @@ Here's a summary of the variations:
 
 .. _ray-install-java:
 
+Installing a specific dependency variant
+----------------------------------------
+To get finer grained control over the size of your dependencies for your Ray application, Ray provides a few optional dependency installation specifications. 
+
+These variants can be installed with:
+
+.. code-block:: bash
+
+    pip install ray[variant_string_goes_here]
+
+Availiable variant strings include:
+
+* ``default``: same as ``pip install ray``, includes standard Ray deps, but not things like :ref:`Ray dashboard <ray-dashboard>`, :ref:`Ray Serve <rayserve>`, etc 
+* ``serve``: includes dependencies for :ref:`Ray Serve <rayserve>`
+* ``tune``: includes dependencies for :ref:`Ray Tune <tune-60-seconds>`
+* ``k8s``:  includes dependencies for running :ref:`Ray on Kubernetes <ray-k8s-deploy>` (k8s)
+* ``observability``: includes dependencies for monitoring with Grafana
+* ``all``: includes all dependencies, safest but heaviest option
+
+We recommend installing with ``pip install ray`` (same as ``pip install ray[default]``), but checking for warnings or ``ImportError`` that may arise and installing variants as needed. This will keep your depdencies as lightweight as possible.
+
+If you want to see the exact packages or understand more deeply how these variants affect the installation process, `here's the code <https://github.com/ray-project/ray/blob/03a2c69a8a977f912694960a40e490a304c9cd62/python/setup.py#L178-L217>`__ (may need to change commit hash in URL to "master" to see latest version).
+
 Install Ray Java with Maven
 ---------------------------
 Before installing Ray Java with Maven, you should install Ray Python with `pip install -U ray` . Note that the versions of Ray Java and Ray Python must match.

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -107,7 +107,7 @@ These variants can be installed with:
 
     pip install ray[variant_string_goes_here]
 
-Availiable variant strings include:
+Available variant strings include:
 
 * ``default``: includes things like :ref:`Ray dashboard <ray-dashboard>` and cluster launcher
 * ``serve``: includes dependencies for :ref:`Ray Serve <rayserve>`


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Better document package variant strings for pip installation (ie `pip install ray[serve]`).

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(

Was unable to run test suite given code in the Testing section of docs!