### PR TITLE
[core] Fix race condition in distributed ref counting

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2206,19 +2206,15 @@ Status CoreWorker::ExecuteTask(const TaskSpecification &task_spec,
       task_spec.GetDebuggerBreakpoint(), return_objects, creation_task_exception_pb_bytes,
       is_application_level_error);
 
-  // Get the reference counts for any IDs that we borrowed during this task and
-  // return them to the caller. This will notify the caller of any IDs that we
-  // (or a nested task) are still borrowing. It will also notify the caller of
-  // any new IDs that were contained in a borrowed ID that we (or a nested
-  // task) are now borrowing.
-  if (!borrowed_ids.empty()) {
-    reference_counter_->GetAndClearLocalBorrowers(borrowed_ids, borrowed_refs);
-  }
-  // Unpin the borrowed IDs.
+  // Get the reference counts for any IDs that we borrowed during this task,
+  // remove the local reference for these IDs, and return the ref count info to
+  // the caller. This will notify the caller of any IDs that we (or a nested
+  // task) are still borrowing. It will also notify the caller of any new IDs
+  // that were contained in a borrowed ID that we (or a nested task) are now
+  // borrowing.
   std::vector<ObjectID> deleted;
-  for (const auto &borrowed_id : borrowed_ids) {
-    RAY_LOG(DEBUG) << "Decrementing ref for borrowed ID " << borrowed_id;
-    reference_counter_->RemoveLocalReference(borrowed_id, &deleted);
+  if (!borrowed_ids.empty()) {
+    reference_counter_->PopAndClearLocalBorrowers(borrowed_ids, borrowed_refs, &deleted);
   }
   memory_store_->Delete(deleted);
 

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -120,6 +120,10 @@ bool ReferenceCounter::AddBorrowedObjectInternal(const ObjectID &object_id,
       outer_it->second.contains.insert(object_id);
     }
   }
+
+  if (it->second.RefCount() == 0) {
+    DeleteReferenceInternal(it, nullptr);
+  }
   return true;
 }
 
@@ -620,9 +624,9 @@ ReferenceCounter::GetAllReferenceCounts() const {
   return all_ref_counts;
 }
 
-void ReferenceCounter::GetAndClearLocalBorrowers(
+void ReferenceCounter::PopAndClearLocalBorrowers(
     const std::vector<ObjectID> &borrowed_ids,
-    ReferenceCounter::ReferenceTableProto *proto) {
+    ReferenceCounter::ReferenceTableProto *proto, std::vector<ObjectID> *deleted) {
   absl::MutexLock lock(&mutex_);
   ReferenceTable borrowed_refs;
   for (const auto &borrowed_id : borrowed_ids) {
@@ -638,6 +642,28 @@ void ReferenceCounter::GetAndClearLocalBorrowers(
     }
   }
   ReferenceTableToProto(borrowed_refs, proto);
+
+  for (const auto &borrowed_id : borrowed_ids) {
+    RAY_LOG(DEBUG) << "Remove local reference to borrowed object " << borrowed_id;
+    auto it = object_id_refs_.find(borrowed_id);
+    if (it == object_id_refs_.end()) {
+      RAY_LOG(WARNING) << "Tried to decrease ref count for nonexistent object ID: "
+                       << borrowed_id;
+      continue;
+    }
+    if (it->second.local_ref_count == 0) {
+      RAY_LOG(WARNING)
+          << "Tried to decrease ref count for object ID that has count 0 " << borrowed_id
+          << ". This should only happen if ray.internal.free was called earlier.";
+      continue;
+    }
+
+    it->second.local_ref_count--;
+    PRINT_REF_COUNT(it);
+    if (it->second.RefCount() == 0) {
+      DeleteReferenceInternal(it, deleted);
+    }
+  }
 }
 
 bool ReferenceCounter::GetAndClearLocalBorrowersInternal(const ObjectID &object_id,

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -297,10 +297,9 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// IDs that were passed by reference in the task spec or that were
   /// serialized in inlined arguments.
   ///
-  /// NOTE(swang): These arguments should be pinned with an artificial local
-  /// reference during task execution, and this method unpins this reference so
-  /// that the reference deletion is atomic with removing the borrow
-  /// information.
+  /// NOTE(swang): Task arguments should be pinned with a fake local reference
+  /// during task execution. This method removes the fake references so that
+  /// the reference deletion is atomic with removing the ref count information.
   ///
   /// See GetAndClearLocalBorrowersInternal for the spec of the returned table
   /// and how this mutates the local reference count.

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -297,6 +297,11 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// IDs that were passed by reference in the task spec or that were
   /// serialized in inlined arguments.
   ///
+  /// NOTE(swang): These arguments should be pinned with an artificial local
+  /// reference during task execution, and this method unpins this reference so
+  /// that the reference deletion is atomic with removing the borrow
+  /// information.
+  ///
   /// See GetAndClearLocalBorrowersInternal for the spec of the returned table
   /// and how this mutates the local reference count.
   ///
@@ -307,8 +312,9 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// arguments.
   /// \param[out] proto The protobuf table to populate with the borrowed
   /// references.
-  void GetAndClearLocalBorrowers(const std::vector<ObjectID> &borrowed_ids,
-                                 ReferenceTableProto *proto) LOCKS_EXCLUDED(mutex_);
+  void PopAndClearLocalBorrowers(const std::vector<ObjectID> &borrowed_ids,
+                                 ReferenceTableProto *proto,
+                                 std::vector<ObjectID> *deleted) LOCKS_EXCLUDED(mutex_);
 
   /// Mark that this ObjectID contains another ObjectID(s). This should be
   /// called in two cases:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This fixes an edge case that was missed in #17834. There is an assertion check to make sure that when we delete an ObjectRef from the ref counting table, we also include information about any nested refs. However, previously we did not delete the ObjectRef atomically with its nested ref information, so the following could happen if an ObjectRef was deleted concurrently with its GetObjectStatusReply:

Object A contains ObjectRef B.
1. Task receives ObjectRef A, starts async future resolution by calling GetObjectStatus.
2. Task finishes part 1, removes A's nested ref information from the ref count table.
3. Receive GetObjectStatus reply for A; this adds a new ref count entry B which is contained in A.
4. Task finishes part 2, removes A's ref and deletes it from the table. Here we get an assertion check failure because A contains info about B that should have been removed in step 2.

This PR fixes it by making steps 2 and 4 atomic, so that they can't race with step 3.

## Related issue number

Closes #18557.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
