### PR TITLE
[Test] Mark app config failure as a infra failure

### DIFF
--- a/release/long_running_tests/app_config.yaml
+++ b/release/long_running_tests/app_config.yaml
@@ -13,6 +13,7 @@ post_build_cmds:
   - pip uninstall -y numpy ray || true
   - sudo rm -rf /home/ray/anaconda3/lib/python3.7/site-packages/numpy
   - pip3 install numpy || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 install -U https://s3-us-west-2.amazonaws.com/ray-wheels/test_wheels/fix-many-ppo-pg-bug/6540069bb6564d85b78078775c660419d75beb8f/ray-2.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
+  # - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install -U ray[all] gym[atari]
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/long_running_tests/app_config.yaml
+++ b/release/long_running_tests/app_config.yaml
@@ -13,7 +13,6 @@ post_build_cmds:
   - pip uninstall -y numpy ray || true
   - sudo rm -rf /home/ray/anaconda3/lib/python3.7/site-packages/numpy
   - pip3 install numpy || true
-  - pip3 install -U https://s3-us-west-2.amazonaws.com/ray-wheels/test_wheels/fix-many-ppo-pg-bug/6540069bb6564d85b78078775c660419d75beb8f/ray-2.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
-  # - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install -U ray[all] gym[atari]
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, app config failure is considered as a runtime error, which is not good. Mark it as a infra failure

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
