### PR TITLE
prioritize non-gpu nodes when scheduling CPU-only requests

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -471,3 +471,6 @@ RAY_CONFIG(bool, event_log_reporter_enabled, false)
 
 /// Event severity threshold value
 RAY_CONFIG(std::string, event_level, "warning")
+
+/// Whether to avoid scheduling cpu requests on gpu nodes
+RAY_CONFIG(bool, avoid_scheduling_cpu_requests_on_gpu_nodes, false)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -473,4 +473,4 @@ RAY_CONFIG(bool, event_log_reporter_enabled, false)
 RAY_CONFIG(std::string, event_level, "warning")
 
 /// Whether to avoid scheduling cpu requests on gpu nodes
-RAY_CONFIG(bool, avoid_scheduling_cpu_requests_on_gpu_nodes, false)
+RAY_CONFIG(bool, scheduler_avoid_gpu_nodes, false)

--- a/src/ray/raylet/scheduling/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/scheduling_policy.cc
@@ -14,29 +14,69 @@
 
 #include "ray/raylet/scheduling/scheduling_policy.h"
 
+#include <functional>
+
 namespace ray {
 
 namespace raylet_scheduling_policy {
+namespace {
+bool IsCPUOnlyRequest(const ResourceRequest &resource_request) {
+  if (resource_request.predefined_resources.size() <= GPU) {
+    return true;
+  }
+  return resource_request.predefined_resources[GPU] == 0;
+}
+bool DoesNodeHaveGPUs(const NodeResources &resources) {
+  if (resources.predefined_resources.size() <= GPU) {
+    return false;
+  }
+  return resources.predefined_resources[GPU].total > 0;
+}
+}  // namespace
 
-int64_t HybridPolicy(const ResourceRequest &resource_request, const int64_t local_node_id,
-                     const absl::flat_hash_map<int64_t, Node> &nodes,
-                     float spread_threshold, bool force_spillback,
-                     bool require_available) {
+int64_t HybridPolicyWithFilter(const ResourceRequest &resource_request,
+                               const int64_t local_node_id,
+                               const absl::flat_hash_map<int64_t, Node> &nodes,
+                               float spread_threshold, bool force_spillback,
+                               bool require_available, NodeFilter node_filter) {
   // Step 1: Generate the traversal order. We guarantee that the first node is local, to
   // encourage local scheduling. The rest of the traversal order should be globally
   // consistent, to encourage using "warm" workers.
   std::vector<int64_t> round;
-  {
-    // Make sure the local node is at the front of the list so that 1. It's first in
-    // traversal order. 2. It's easy to avoid sorting it.
-    round.push_back(local_node_id);
-    for (const auto &pair : nodes) {
-      if (pair.first != local_node_id) {
-        round.push_back(pair.first);
-      }
+  round.reserve(nodes.size());
+  const auto local_it = nodes.find(local_node_id);
+  RAY_CHECK(local_it != nodes.end());
+
+  auto predicate = [node_filter](const auto &node) {
+    if (node_filter == NodeFilter::kAny) {
+      return true;
     }
-    std::sort(round.begin() + 1, round.end());
+    const bool has_gpu = DoesNodeHaveGPUs(node);
+    if (node_filter == NodeFilter::kGPU) {
+      return has_gpu;
+    }
+    RAY_CHECK(node_filter == NodeFilter::kCPUOnly);
+    return !has_gpu;
+  };
+
+  const auto &local_node = local_it->second.GetLocalView();
+  // If we should include local node at all, make sure it is at the front of the list
+  // so that
+  // 1. It's first in traversal order.
+  // 2. It's easy to avoid sorting it.
+  if (predicate(local_node) && !force_spillback) {
+    round.push_back(local_node_id);
   }
+
+  const auto start_index = round.size();
+  for (const auto &pair : nodes) {
+    if (pair.first != local_node_id && predicate(pair.second.GetLocalView())) {
+      round.push_back(pair.first);
+    }
+  }
+  // Sort all the nodes, making sure that if we added the local node in front, it stays in
+  // place.
+  std::sort(round.begin() + start_index, round.end());
 
   int64_t best_node_id = -1;
   float best_utilization_score = INFINITY;
@@ -44,11 +84,6 @@ int64_t HybridPolicy(const ResourceRequest &resource_request, const int64_t loca
 
   // Step 2: Perform the round robin.
   auto round_it = round.begin();
-  if (force_spillback) {
-    // The first node will always be the local node. If we want to spillback, we can just
-    // never consider scheduling locally.
-    round_it++;
-  }
   for (; round_it != round.end(); round_it++) {
     const auto &node_id = *round_it;
     const auto &it = nodes.find(node_id);
@@ -103,6 +138,27 @@ int64_t HybridPolicy(const ResourceRequest &resource_request, const int64_t loca
   return best_node_id;
 }
 
-}  // namespace raylet_scheduling_policy
+int64_t HybridPolicy(const ResourceRequest &resource_request, const int64_t local_node_id,
+                     const absl::flat_hash_map<int64_t, Node> &nodes,
+                     float spread_threshold, bool force_spillback, bool require_available,
+                     bool avoid_scheduling_cpu_requests_on_gpu_nodes) {
+  if (!avoid_scheduling_cpu_requests_on_gpu_nodes ||
+      !IsCPUOnlyRequest(resource_request)) {
+    return HybridPolicyWithFilter(resource_request, local_node_id, nodes,
+                                  spread_threshold, force_spillback, require_available);
+  }
 
+  // Try schedule on CPU-only nodes.
+  const auto node_id =
+      HybridPolicyWithFilter(resource_request, local_node_id, nodes, spread_threshold,
+                             force_spillback, require_available, NodeFilter::kCPUOnly);
+  if (node_id != -1) {
+    return node_id;
+  }
+  // Could not schedule on CPU-only nodes, schedule on GPU nodes as a last resort.
+  return HybridPolicyWithFilter(resource_request, local_node_id, nodes, spread_threshold,
+                                force_spillback, require_available, NodeFilter::kGPU);
+}
+
+}  // namespace raylet_scheduling_policy
 }  // namespace ray

--- a/src/ray/raylet/scheduling/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/scheduling_policy.cc
@@ -20,7 +20,7 @@ namespace ray {
 
 namespace raylet_scheduling_policy {
 namespace {
-bool IsCPUOnlyRequest(const ResourceRequest &resource_request) {
+bool IsGPURequest(const ResourceRequest &resource_request) {
   if (resource_request.predefined_resources.size() <= GPU) {
     return true;
   }
@@ -141,9 +141,8 @@ int64_t HybridPolicyWithFilter(const ResourceRequest &resource_request,
 int64_t HybridPolicy(const ResourceRequest &resource_request, const int64_t local_node_id,
                      const absl::flat_hash_map<int64_t, Node> &nodes,
                      float spread_threshold, bool force_spillback, bool require_available,
-                     bool avoid_scheduling_cpu_requests_on_gpu_nodes) {
-  if (!avoid_scheduling_cpu_requests_on_gpu_nodes ||
-      !IsCPUOnlyRequest(resource_request)) {
+                     bool scheduler_avoid_gpu_nodes) {
+  if (!scheduler_avoid_gpu_nodes || !IsGPURequest(resource_request)) {
     return HybridPolicyWithFilter(resource_request, local_node_id, nodes,
                                   spread_threshold, force_spillback, require_available);
   }

--- a/src/ray/raylet/scheduling/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/scheduling_policy.cc
@@ -20,12 +20,14 @@ namespace ray {
 
 namespace raylet_scheduling_policy {
 namespace {
+
 bool IsGPURequest(const ResourceRequest &resource_request) {
   if (resource_request.predefined_resources.size() <= GPU) {
-    return true;
+    return false;
   }
-  return resource_request.predefined_resources[GPU] == 0;
+  return resource_request.predefined_resources[GPU] > 0;
 }
+
 bool DoesNodeHaveGPUs(const NodeResources &resources) {
   if (resources.predefined_resources.size() <= GPU) {
     return false;
@@ -142,7 +144,7 @@ int64_t HybridPolicy(const ResourceRequest &resource_request, const int64_t loca
                      const absl::flat_hash_map<int64_t, Node> &nodes,
                      float spread_threshold, bool force_spillback, bool require_available,
                      bool scheduler_avoid_gpu_nodes) {
-  if (!scheduler_avoid_gpu_nodes || !IsGPURequest(resource_request)) {
+  if (!scheduler_avoid_gpu_nodes || IsGPURequest(resource_request)) {
     return HybridPolicyWithFilter(resource_request, local_node_id, nodes,
                                   spread_threshold, force_spillback, require_available);
   }

--- a/src/ray/raylet/scheduling/scheduling_policy.h
+++ b/src/ray/raylet/scheduling/scheduling_policy.h
@@ -14,6 +14,7 @@
 
 #include <vector>
 
+#include "ray/common/ray_config.h"
 #include "ray/raylet/scheduling/cluster_resource_data.h"
 
 namespace ray {
@@ -49,12 +50,39 @@ namespace raylet_scheduling_policy {
 /// \param nodes: The summary view of all the nodes that can be scheduled on.
 /// \param spread_threshold: Below this threshold, critical resource utilization will be
 /// truncated to 0.
+/// \param avoid_scheduling_cpu_requests_on_gpu_nodes: if set, we would try scheduling
+/// CPU-only requests on CPU-only nodes, and will fallback to scheduling on GPU nodes if
+/// needed.
 ///
-/// \return -1 if the task is infeasible, otherwise the node id (key in `nodes`) to
+/// \return -1 if the task is unfeasible, otherwise the node id (key in `nodes`) to
 /// schedule on.
-int64_t HybridPolicy(const ResourceRequest &resource_request, const int64_t local_node_id,
-                     const absl::flat_hash_map<int64_t, Node> &nodes,
-                     float spread_threshold, bool force_spillback,
-                     bool require_available);
+int64_t HybridPolicy(
+    const ResourceRequest &resource_request, const int64_t local_node_id,
+    const absl::flat_hash_map<int64_t, Node> &nodes, float spread_threshold,
+    bool force_spillback, bool require_available,
+    bool avoid_scheduling_cpu_requests_on_gpu_nodes =
+        RayConfig::instance().avoid_scheduling_cpu_requests_on_gpu_nodes());
+
+//
+enum class NodeFilter { kAny, kGPU, kCPUOnly };
+
+/// \param resource_request: The resource request we're attempting to schedule.
+/// \param local_node_id: The id of the local node, which is needed for traversal order.
+/// \param nodes: The summary view of all the nodes that can be scheduled on.
+/// \param spread_threshold: Below this threshold, critical resource utilization will be
+/// truncated to 0.
+/// \param node_filter: defines the subset of nodes were are allowed to schedule on.
+/// can be one of kAny (can schedule on all nodes), kGPU (can only schedule on kGPU
+/// nodes), kCPUOnly (can only schedule on non-GPU nodes.
+///
+/// \return -1 if the task is unfeasible, otherwise the node id (key in `nodes`) to
+/// schedule on.
+int64_t HybridPolicyWithFilter(const ResourceRequest &resource_request,
+                               const int64_t local_node_id,
+                               const absl::flat_hash_map<int64_t, Node> &nodes,
+                               float spread_threshold, bool force_spillback,
+                               bool require_available,
+                               NodeFilter node_filter = NodeFilter::kAny);
+
 }  // namespace raylet_scheduling_policy
 }  // namespace ray

--- a/src/ray/raylet/scheduling/scheduling_policy.h
+++ b/src/ray/raylet/scheduling/scheduling_policy.h
@@ -50,7 +50,7 @@ namespace raylet_scheduling_policy {
 /// \param nodes: The summary view of all the nodes that can be scheduled on.
 /// \param spread_threshold: Below this threshold, critical resource utilization will be
 /// truncated to 0.
-/// \param avoid_scheduling_cpu_requests_on_gpu_nodes: if set, we would try scheduling
+/// \param scheduler_avoid_gpu_nodes: if set, we would try scheduling
 /// CPU-only requests on CPU-only nodes, and will fallback to scheduling on GPU nodes if
 /// needed.
 ///
@@ -60,8 +60,7 @@ int64_t HybridPolicy(
     const ResourceRequest &resource_request, const int64_t local_node_id,
     const absl::flat_hash_map<int64_t, Node> &nodes, float spread_threshold,
     bool force_spillback, bool require_available,
-    bool avoid_scheduling_cpu_requests_on_gpu_nodes =
-        RayConfig::instance().avoid_scheduling_cpu_requests_on_gpu_nodes());
+    bool scheduler_avoid_gpu_nodes = RayConfig::instance().scheduler_avoid_gpu_nodes());
 
 //
 enum class NodeFilter { kAny, kGPU, kCPUOnly };


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
18579

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(


When scheduling CPU-only tasks/actors, prefer to use non-gpu nodes.
This PR introduces a feature flag "avoid_scheduling_cpu_requests_on_gpu_nodes" (false by default).
When `scheduler_avoid_gpu_nodes` is enabled, HybridPolicy would schedule CPU-only requests on CPU-only node first, only using GPU nodes if there is no other way to satisfy the request.

