### PR TITLE
[autoscaler] AWS Autoscaler CloudWatch Integration

### DIFF
--- a/python/ray/autoscaler/_private/aws/cloudwatch/cloudwatch_helper.py
+++ b/python/ray/autoscaler/_private/aws/cloudwatch/cloudwatch_helper.py
@@ -1,0 +1,644 @@
+import botocore
+import copy
+import json
+import os
+import logging
+import time
+import hashlib
+from typing import Any, Dict, List, Union, Tuple
+from ray.autoscaler._private.aws.utils import client_cache, resource_cache
+from ray.autoscaler.tags import TAG_RAY_CLUSTER_NAME, \
+    NODE_KIND_HEAD, TAG_RAY_NODE_KIND
+
+logger = logging.getLogger(__name__)
+
+RAY = "ray-autoscaler"
+CLOUDWATCH_RAY_INSTANCE_PROFILE = RAY + "-cloudwatch-v1"
+CLOUDWATCH_RAY_IAM_ROLE = RAY + "-cloudwatch-v1"
+CLOUDWATCH_AGENT_INSTALLED_AMI_TAG = "T6Iq2faj"
+CLOUDWATCH_AGENT_INSTALLED_TAG = "cloudwatch-agent-installed"
+CLOUDWATCH_CONFIG_HASH_TAG_BASE = "cloudwatch-config-hash"
+
+
+class CloudwatchHelper:
+    def __init__(self, provider_config: Dict[str, Any], node_ids: List[str],
+                 cluster_name: str) -> None:
+        # dedupe and sort node IDs to support deterministic unit test stubs
+        self.node_ids = sorted(set(node_ids))
+        self.cluster_name = cluster_name
+        self.provider_config = provider_config
+        region = provider_config["region"]
+        self.ec2_resource = resource_cache("ec2", region)
+        self.ec2_client = self.ec2_resource.meta.client
+        self.ssm_client = client_cache("ssm", region)
+        cloudwatch_resource = resource_cache("cloudwatch", region)
+        self.cloudwatch_client = cloudwatch_resource.meta.client
+
+    def update_from_config(self, is_head_node: bool) -> None:
+        """Discovers and applies CloudWatch config updates as required.
+
+        Args:
+            is_head_node: whether this node is the head node.
+        """
+        if CloudwatchHelper.cloudwatch_config_exists(self.provider_config,
+                                                     "config"):
+            self._update_cloudwatch_agent_config(is_head_node)
+
+    def _ec2_health_check_waiter(self, node_ids: List[str]) -> None:
+        # wait for all EC2 instance checks to complete
+        try:
+            logger.info(
+                "Waiting for EC2 instance health checks to complete before "
+                "configuring Unified Cloudwatch Agent. This may take a few "
+                "minutes...")
+            waiter = self.ec2_client.get_waiter("instance_status_ok")
+            waiter.wait(InstanceIds=node_ids)
+        except botocore.exceptions.WaiterError as e:
+            logger.error(
+                "Failed while waiting for EC2 instance checks to complete: {}".
+                format(e.message))
+            raise e
+
+    def _update_cloudwatch_agent_config(self, is_head_node: bool) -> None:
+        """ check whether update operations are needed.
+        """
+        cwa_installed = self._setup_cwa()
+        param_name = self._get_ssm_param_name()
+        if cwa_installed:
+            if is_head_node:
+                cw_config_ssm = self._set_cloudwatch_ssm_config_param(
+                    param_name)
+                cur_cw_config_hash = self._sha1_hash_file()
+                ssm_cw_config_hash = self._sha1_hash_json(cw_config_ssm)
+                # check if user updated Unified Cloudwatch Agent config file.
+                # if so, perform corresponding actions.
+                if cur_cw_config_hash != ssm_cw_config_hash:
+                    logger.info(
+                        "Unified Cloudwatch Agent config file has changed.")
+                    self._upload_config_to_ssm_and_set_hash_tag()
+                    self._restart_cloudwatch_agent()
+            else:
+                head_node_hash = self._get_head_node_config_hash()
+                cur_node_hash = self._get_cur_node_config_hash()
+                if head_node_hash != cur_node_hash:
+                    logger.info(
+                        "Unified Cloudwatch Agent config file has changed.")
+                    self._restart_cloudwatch_agent()
+                    self._update_cloudwatch_hash_tag_value(
+                        self.node_ids, head_node_hash)
+
+    def _send_command_to_nodes(self, document_name: str, parameters: List[str],
+                               node_ids: List[str]) -> Dict[str, Any]:
+        """ send SSM command to the given nodes """
+        logger.debug("Sending SSM command to {} node(s). Document name: {}. "
+                     "Parameters: {}.".format(
+                         len(node_ids), document_name, parameters))
+        response = self.ssm_client.send_command(
+            InstanceIds=node_ids,
+            DocumentName=document_name,
+            Parameters=parameters,
+            MaxConcurrency=str(min(len(node_ids), 100)),
+            MaxErrors="0")
+        return response
+
+    def _ssm_command_waiter(self,
+                            document_name: str,
+                            parameters: List[str],
+                            node_ids: List[str],
+                            retry_failed: bool = True) -> bool:
+        """ wait for SSM command to complete on all cluster nodes """
+
+        # This waiter differs from the built-in SSM.Waiter by
+        # optimistically waiting for the command invocation to
+        # exist instead of failing immediately, and by resubmitting
+        # any failed command until all retry attempts are exhausted
+        # by default.
+        response = self._send_command_to_nodes(document_name, parameters,
+                                               node_ids)
+        command_id = response["Command"]["CommandId"]
+
+        cloudwatch_config = self.provider_config["cloudwatch"]
+        agent_retryer_config = cloudwatch_config \
+            .get("agent", {}) \
+            .get("retryer", {})
+        max_attempts = agent_retryer_config.get("max_attempts", 120)
+        delay_seconds = agent_retryer_config.get("delay_seconds", 30)
+        num_attempts = 0
+        cmd_invocation_res = {}
+        for node_id in node_ids:
+            while True:
+                num_attempts += 1
+                logger.debug("Listing SSM command ID {} invocations on node {}"
+                             .format(command_id, node_id))
+                response = self.ssm_client.list_command_invocations(
+                    CommandId=command_id,
+                    InstanceId=node_id,
+                )
+                cmd_invocations = response["CommandInvocations"]
+                if not cmd_invocations:
+                    logger.debug(
+                        "SSM Command ID {} invocation does not exist. If "
+                        "the command was just started, it may take a "
+                        "few seconds to register.".format(command_id))
+                else:
+                    if len(cmd_invocations) > 1:
+                        logger.warning(
+                            "Expected to find 1 SSM command invocation with "
+                            "ID {} on node {} but found {}: {}".format(
+                                command_id,
+                                node_id,
+                                len(cmd_invocations),
+                                cmd_invocations,
+                            ))
+                    cmd_invocation = cmd_invocations[0]
+                    if cmd_invocation["Status"] == "Success":
+                        logger.debug(
+                            "SSM Command ID {} completed successfully."
+                            .format(command_id))
+                        cmd_invocation_res[node_id] = True
+                        break
+                    if num_attempts >= max_attempts:
+                        logger.error(
+                            "Max attempts for command {} exceeded on node {}"
+                            .format(command_id, node_id))
+                        raise botocore.exceptions.WaiterError(
+                            name="ssm_waiter",
+                            reason="Max attempts exceeded",
+                            last_response=cmd_invocation,
+                        )
+                    if cmd_invocation["Status"] == "Failed":
+                        logger.debug(f"SSM Command ID {command_id} failed.")
+                        if retry_failed:
+                            logger.debug(
+                                f"Retrying in {delay_seconds} seconds.")
+                            response = self._send_command_to_nodes(
+                                document_name, parameters, [node_id])
+                            command_id = response["Command"]["CommandId"]
+                            logger.debug("Sent SSM command ID {} to node {}"
+                                         .format(command_id, node_id))
+                        else:
+                            logger.debug(
+                                f"Ignoring Command ID {command_id} failure.")
+                            cmd_invocation_res[node_id] = False
+                            break
+
+                time.sleep(delay_seconds)
+        return cmd_invocation_res
+
+    def _replace_config_variables(self, string: str, node_id: str,
+                                  cluster_name: str, region: str) -> str:
+        """
+        replace known config variable occurrences in the input string
+        does not replace variables with undefined or empty strings
+        """
+
+        if node_id:
+            string = string.replace("{instance_id}", node_id)
+        if cluster_name:
+            string = string.replace("{cluster_name}", cluster_name)
+        if region:
+            string = string.replace("{region}", region)
+        return string
+
+    def _replace_all_config_variables(
+            self, collection: Union[dict, list], node_id: str,
+            cluster_name: str, region: str) -> Tuple[(Union[dict, list], int)]:
+        """
+        Replace known config variable occurrences in the input collection.
+
+        The input collection must be either a dict or list.
+        Returns a tuple consisting of the output collection and the number of
+        modified strings in the collection (which is not necessarily equal to
+        the number of variables replaced).
+        """
+        modified_value_count = 0
+        for key in collection:
+            if type(collection) is dict:
+                value = collection.get(key)
+                index_key = key
+            elif type(collection) is list:
+                value = key
+                index_key = collection.index(key)
+            if type(value) is str:
+                collection[index_key] = self._replace_config_variables(
+                    value, node_id, cluster_name, region)
+                modified_value_count += (collection[index_key] != value)
+            elif type(value) is dict or type(value) is list:
+                collection[index_key], modified_count = self. \
+                    _replace_all_config_variables(
+                    value, node_id, cluster_name, region)
+                modified_value_count += modified_count
+        return collection, modified_value_count
+
+    def _load_config_file(self) -> Dict[str, Any]:
+        """load JSON config file"""
+        cloudwatch_config = self.provider_config["cloudwatch"]
+        json_config_file_section = cloudwatch_config.get("agent", {})
+        json_config_file_path = json_config_file_section.get("config", {})
+        json_config_path = os.path.abspath(json_config_file_path)
+        with open(json_config_path) as f:
+            data = json.load(f)
+        return data
+
+    def _set_cloudwatch_ssm_config_param(self, parameter_name: str) -> str:
+        """
+        get cloudwatch config for the given param and config type from SSM
+        if it exists, returns empty str if not.
+        """
+        try:
+            parameter_value = self._get_ssm_param(parameter_name)
+        except botocore.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] == "ParameterNotFound":
+                logger.info(
+                    "Unified Cloudwatch Agent config file is not found "
+                    "at SSM parameter store. "
+                    "Checking for Unified Cloudwatch Agent installation")
+                return self._get_default_empty_config_file_hash()
+            else:
+                logger.info(
+                    "Failed to fetch Unified Cloudwatch Agent config from SSM "
+                    "parameter store.")
+                logger.error(e)
+                raise e
+        return parameter_value
+
+    def _get_default_empty_config_file_hash(self):
+        default_cwa_config = "{}"
+        parameter_value = self._sha1_hash_json(default_cwa_config)
+        return parameter_value
+
+    def _get_ssm_param(self, parameter_name: str) -> str:
+        """
+        get the SSM parameter value associated with the given parameter name
+        """
+        response = self.ssm_client.get_parameter(Name=parameter_name)
+        logger.info(
+            "Successfully fetch ssm parameter: {}".format(parameter_name))
+        res = response.get("Parameter", {})
+        cwa_parameter = res.get("Value", {})
+        return cwa_parameter
+
+    def _sha1_hash_json(self, value: str) -> str:
+        """calculate the json string sha1 hash"""
+        hash = hashlib.new("sha1")
+        binary_value = value.encode("ascii")
+        hash.update(binary_value)
+        sha1_res = hash.hexdigest()
+        return sha1_res
+
+    def _sha1_hash_file(self) -> str:
+        """calculate the config file sha1 hash"""
+        config = self._replace_cwa_config_variables()
+        value = json.dumps(config)
+        sha1_res = self._sha1_hash_json(value)
+        return sha1_res
+
+    def _upload_config_to_ssm_and_set_hash_tag(self):
+        """This function should only be called by head node"""
+        data = self._replace_cwa_config_variables()
+        sha1_hash_value = self._sha1_hash_file()
+        self._upload_config_to_ssm(data)
+        self._update_cloudwatch_hash_tag_value(self.node_ids, sha1_hash_value)
+
+    def _add_cwa_installed_tag(self, node_ids: List[str]) -> None:
+        self.ec2_client.create_tags(
+            Resources=node_ids,
+            Tags=[{
+                "Key": CLOUDWATCH_AGENT_INSTALLED_TAG,
+                "Value": "True"
+            }])
+        logger.info("Successfully add Unified Cloudwatch Agent installed "
+                    "tag on {}".format(node_ids))
+
+    def _update_cloudwatch_hash_tag_value(self, node_ids: List[str],
+                                          sha1_hash_value: str):
+        hash_key_value = "-".join([CLOUDWATCH_CONFIG_HASH_TAG_BASE, "agent"])
+        self.ec2_client.create_tags(
+            Resources=node_ids,
+            Tags=[{
+                "Key": hash_key_value,
+                "Value": sha1_hash_value
+            }])
+        logger.info(
+            "Successfully update Unified Cloudwatch Agent hash tag on {}".
+            format(node_ids))
+
+    def _get_ssm_param_name(self) -> str:
+        """return the parameter name for cloudwatch configs"""
+        ssm_config_param_name = \
+            "AmazonCloudWatch-" + "ray_{}_config_{}". \
+            format("agent", self.cluster_name)
+        return ssm_config_param_name
+
+    def _put_ssm_param(self, parameter: Dict[str, Any],
+                       parameter_name: str) -> None:
+        """upload cloudwatch config to the SSM parameter store"""
+        self.ssm_client.put_parameter(
+            Name=parameter_name,
+            Type="String",
+            Value=json.dumps(parameter),
+            Overwrite=True,
+            Tier="Intelligent-Tiering",
+        )
+
+    def _upload_config_to_ssm(self, param: Dict[str, Any]):
+        param_name = self._get_ssm_param_name()
+        self._put_ssm_param(param, param_name)
+
+    def _replace_cwa_config_variables(self) -> Dict[str, Any]:
+        """
+        replace known variable occurrences in
+        Unified Cloudwatch Agent config file
+        """
+        cwa_config = self._load_config_file()
+        self._replace_all_config_variables(
+            cwa_config,
+            self.node_ids[0],
+            self.cluster_name,
+            self.provider_config["region"],
+        )
+        return cwa_config
+
+    def _restart_cloudwatch_agent(self) -> None:
+        """restart Unified Cloudwatch Agent"""
+        cwa_param_name = self._get_ssm_param_name()
+        logger.info(
+            "Restarting Unified Cloudwatch Agent package on {} node(s)."
+            .format(len(self.node_ids)))
+        self._stop_cloudwatch_agent()
+        self._start_cloudwatch_agent(cwa_param_name)
+
+    def _stop_cloudwatch_agent(self) -> None:
+        """stop Unified Cloudwatch Agent"""
+        logger.info("Stopping Unified Cloudwatch Agent package on {} node(s)."
+                    .format(len(self.node_ids)))
+        parameters_stop_cwa = {
+            "action": ["stop"],
+            "mode": ["ec2"],
+        }
+        # don't retry failed stop commands
+        # (there's not always an agent to stop)
+        self._ssm_command_waiter(
+            "AmazonCloudWatch-ManageAgent",
+            parameters_stop_cwa,
+            self.node_ids,
+            False,
+        )
+        logger.info("Unified Cloudwatch Agent stopped on {} node(s).".format(
+            len(self.node_ids)))
+
+    def _start_cloudwatch_agent(self, cwa_param_name: str) -> None:
+        """start Unified Cloudwatch Agent"""
+        logger.info("Starting Unified Cloudwatch Agent package on {} node(s)."
+                    .format(len(self.node_ids)))
+        parameters_start_cwa = {
+            "action": ["configure"],
+            "mode": ["ec2"],
+            "optionalConfigurationSource": ["ssm"],
+            "optionalConfigurationLocation": [cwa_param_name],
+            "optionalRestart": ["yes"],
+        }
+        self._ssm_command_waiter("AmazonCloudWatch-ManageAgent",
+                                 parameters_start_cwa, self.node_ids)
+        logger.info(
+            "Unified Cloudwatch Agent started successfully on {} node(s)."
+            .format(len(self.node_ids)))
+
+    def _setup_cwa(self) -> bool:
+        cwa_installed = self._check_cwa_installed_ec2_tag()
+        if cwa_installed == "False":
+            res_cwa_installed = self._ensure_cwa_installed_ssm(self.node_ids)
+            return res_cwa_installed
+        else:
+            return True
+
+    def _get_head_node_config_hash(self) -> str:
+        hash_key_value = "-".join([CLOUDWATCH_CONFIG_HASH_TAG_BASE, "agent"])
+        filters = copy.deepcopy(
+            self._get_current_cluster_session_nodes(self.cluster_name))
+        filters.append({
+            "Name": "tag:{}".format(TAG_RAY_NODE_KIND),
+            "Values": [NODE_KIND_HEAD],
+        })
+        try:
+            instance = list(
+                self.ec2_resource.instances.filter(Filters=filters))
+            assert len(instance) == 1, "More than 1 head node found!"
+            for tag in instance[0].tags:
+                if tag["Key"] == hash_key_value:
+                    return tag["Value"]
+        except botocore.exceptions.ClientError as e:
+            logger.warning(
+                "{} Error caught when getting value of {} tag on head node".
+                format(e.response["Error"], hash_key_value))
+
+    def _get_cur_node_config_hash(self) -> str:
+        hash_key_value = "-".join([CLOUDWATCH_CONFIG_HASH_TAG_BASE, "agent"])
+        try:
+            response = self.ec2_client.describe_instances(
+                InstanceIds=self.node_ids)
+            reservations = response["Reservations"]
+            message = "More than 1 response received from " \
+                      "describing current node"
+            assert len(reservations) == 1, message
+            instances = reservations[0]["Instances"]
+            assert len(reservations) == 1, message
+            tags = instances[0]["Tags"]
+            hash_value = self._get_default_empty_config_file_hash()
+            for tag in tags:
+                if tag["Key"] == hash_key_value:
+                    logger.info("Successfully get Unified Cloudwatch Agent "
+                                "hash tag value from node {}".format(
+                                    self.node_ids))
+                    hash_value = tag["Value"]
+            return hash_value
+        except botocore.exceptions.ClientError as e:
+            logger.warning(
+                "{} Error caught when getting hash tag {} tag".format(
+                    e.response["Error"], hash_key_value))
+
+    def _ensure_cwa_installed_ssm(self, node_ids: List[str]) -> bool:
+        """
+        Check if Unified Cloudwatch Agent is installed via ssm run command.
+
+        If not, notify user to use an AMI with
+        the Unified CloudWatch Agent installed.
+        """
+        logger.info("Checking Unified Cloudwatch Agent "
+                    "status on {} nodes".format(len(node_ids)))
+        parameters_status_cwa = {
+            "action": ["status"],
+            "mode": ["ec2"],
+        }
+        self._ec2_health_check_waiter(node_ids)
+        cmd_invocation_res = self._ssm_command_waiter(
+            "AmazonCloudWatch-ManageAgent", parameters_status_cwa, node_ids,
+            False)
+        uninstalled_nodes = []
+        installed_nodes = []
+        for node_id, res in cmd_invocation_res.items():
+            if not res:
+                uninstalled_nodes.append(node_id)
+            else:
+                installed_nodes.append(node_id)
+        if len(uninstalled_nodes) > 0:
+            logger.warning(
+                "Unified CloudWatch Agent not installed on {}. "
+                "Ray logs, metrics not picked up. "
+                "Please use an AMI with Unified CloudWatch Agent installed."
+                .format(uninstalled_nodes))
+            return False
+        else:
+            return True
+
+    def _get_current_cluster_session_nodes(self,
+                                           cluster_name: str) -> List[dict]:
+        filters = [{
+            "Name": "instance-state-name",
+            "Values": ["pending", "running"],
+        }, {
+            "Name": "tag:{}".format(TAG_RAY_CLUSTER_NAME),
+            "Values": [cluster_name],
+        }]
+        return filters
+
+    def _check_cwa_installed_ec2_tag(self) -> List[str]:
+        """
+        Check if Unified Cloudwatch Agent is installed.
+        """
+        try:
+            response = self.ec2_client.describe_instances(
+                InstanceIds=self.node_ids)
+            reservations = response["Reservations"]
+            message = "More than 1 response received from " \
+                      "describing current node"
+            assert len(reservations) == 1, message
+            instances = reservations[0]["Instances"]
+            assert len(instances) == 1, message
+            tags = instances[0]["Tags"]
+            cwa_installed = str(False)
+            for tag in tags:
+                if tag["Key"] == CLOUDWATCH_AGENT_INSTALLED_TAG:
+                    logger.info("Unified Cloudwatch Agent is installed on "
+                                "node {}".format(self.node_ids))
+                    cwa_installed = tag["Value"]
+            return cwa_installed
+        except botocore.exceptions.ClientError as e:
+            logger.warning(
+                "{} Error caught when getting Unified Cloudwatch Agent status "
+                "based on {} tag".format(e.response["Error"],
+                                         CLOUDWATCH_AGENT_INSTALLED_TAG))
+
+    @staticmethod
+    def resolve_instance_profile_name(
+            config: Dict[str, Any], default_instance_profile_name: str) -> str:
+        """Get default cloudwatch instance profile name.
+
+        Args:
+            config: provider section of cluster config file.
+            default_instance_profile_name: default ray instance profile name.
+
+        Returns:
+            default cloudwatch instance profile name if cloudwatch config file
+                exists.
+            default ray instance profile name if cloudwatch config file
+                doesn't exist.
+        """
+        cwa_cfg_exists = CloudwatchHelper.cloudwatch_config_exists(
+            config, "config")
+        return CLOUDWATCH_RAY_INSTANCE_PROFILE if cwa_cfg_exists \
+            else default_instance_profile_name
+
+    @staticmethod
+    def resolve_iam_role_name(config: Dict[str, Any],
+                              default_iam_role_name: str) -> str:
+        """Get default cloudwatch iam role name.
+
+        Args:
+            config: provider section of cluster config file.
+            default_iam_role_name: default ray iam role name.
+
+        Returns:
+            default cloudwatch iam role name if cloudwatch config file exists.
+            default ray iam role name if cloudwatch config file doesn't exist.
+        """
+        cwa_cfg_exists = CloudwatchHelper.cloudwatch_config_exists(
+            config, "config")
+        return CLOUDWATCH_RAY_IAM_ROLE if cwa_cfg_exists \
+            else default_iam_role_name
+
+    @staticmethod
+    def resolve_policy_arns(config: Dict[str, Any], iam: Any,
+                            default_policy_arns: List[str]) -> List[str]:
+        """Attach necessary AWS policies for CloudWatch related operations.
+
+        Args:
+            config: provider section of cluster config file.
+            iam: AWS iam resource.
+            default_policy_arns: List of default ray AWS policies.
+
+        Returns:
+            list of policy arns including additional policies for CloudWatch
+                related operations if cloudwatch agent config is specifed in
+                cluster config file.
+        """
+        cwa_cfg_exists = CloudwatchHelper.cloudwatch_config_exists(
+            config, "config")
+        if cwa_cfg_exists:
+            cloudwatch_managed_policy = {
+                "Version": "2012-10-17",
+                "Statement": [{
+                    "Effect": "Allow",
+                    "Action": [
+                        "ssm:SendCommand", "ssm:ListCommandInvocations",
+                        "iam:PassRole"
+                    ],
+                    "Resource": "*"
+                }]
+            }
+            iam_client = iam.meta.client
+            iam_client.create_policy(
+                PolicyName="CloudwatchManagedPolicies",
+                PolicyDocument=json.dumps(cloudwatch_managed_policy))
+            sts_client = client_cache("sts", config["region"])
+            account_id = sts_client.get_caller_identity().get("Account")
+            managed_policy_arn = \
+                "arn:aws:iam::{}:policy/CloudwatchManagedPolicies".\
+                format(account_id)
+            policy_waiter = iam_client.get_waiter("policy_exists")
+            policy_waiter.wait(
+                PolicyArn=managed_policy_arn,
+                WaiterConfig={
+                    "Delay": 2,
+                    "MaxAttempts": 200
+                })
+            new_policy_arns = copy.copy(default_policy_arns)
+            new_policy_arns.extend([
+                "arn:aws:iam::aws:policy/CloudWatchAgentAdminPolicy",
+                "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+                managed_policy_arn
+            ])
+            return new_policy_arns
+        else:
+            return default_policy_arns
+
+    @staticmethod
+    def cloudwatch_config_exists(config: Dict[str, Any],
+                                 config_key_name: str) -> bool:
+        """Check if CloudWatch configuration was specified by the user
+        in their cluster config file.
+
+        Specifically, this function checks if a CloudWatch config file is
+        specified by the user in their cluster config file.
+
+        Args:
+            config: provider section of cluster config file.
+            config_key_name: config file name.
+
+        Returns:
+            True if config file is specified by user.
+            False if config file is not specified.
+        """
+        cfg = config.get("cloudwatch", {}).get("agent",
+                                               {}).get(config_key_name)
+        return bool(cfg)

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -20,6 +20,10 @@ from ray.autoscaler._private.aws.utils import boto_exception_handler, \
 from ray.autoscaler._private.cli_logger import cli_logger, cf
 import ray.ray_constants as ray_constants
 
+from ray.autoscaler._private.aws.cloudwatch.cloudwatch_helper import \
+    CloudwatchHelper, CLOUDWATCH_AGENT_INSTALLED_AMI_TAG,\
+    CLOUDWATCH_AGENT_INSTALLED_TAG
+
 logger = logging.getLogger(__name__)
 
 TAG_BATCH_DELAY = 1
@@ -356,6 +360,14 @@ class AWSNodeProvider(NodeProvider):
                 "Key": k,
                 "Value": v,
             })
+        if CloudwatchHelper.cloudwatch_config_exists(self.provider_config,
+                                                     "config"):
+            cwa_installed = self._check_ami_cwa_installation(node_config)
+            if cwa_installed:
+                tag_pairs.extend([{
+                    "Key": CLOUDWATCH_AGENT_INSTALLED_TAG,
+                    "Value": "True",
+                }])
         tag_specs = [{
             "ResourceType": "instance",
             "Tags": tag_pairs,
@@ -430,9 +442,11 @@ class AWSNodeProvider(NodeProvider):
                     cli_logger.warning(
                         "create_instances: Attempt failed with {}, retrying.",
                         exc)
+
                 # Launch failure may be due to instance type availability in
                 # the given AZ
                 subnet_idx += 1
+
         return created_nodes_dict
 
     def terminate_node(self, node_id):
@@ -460,6 +474,20 @@ class AWSNodeProvider(NodeProvider):
         # If this leak becomes bad, we can garbage collect the tag cache when
         # the node cache is updated.
         pass
+
+    def _check_ami_cwa_installation(self, config):
+        response = self.ec2.meta.client.describe_images(
+            ImageIds=[config["ImageId"]])
+        cwa_installed = False
+        images = response.get("Images")
+        if images:
+            assert len(images) == 1, \
+                f"Expected to find only 1 AMI with the given ID, " \
+                f"but found {len(images)}."
+            image_name = images[0].get("Name", "")
+            if CLOUDWATCH_AGENT_INSTALLED_AMI_TAG in image_name:
+                cwa_installed = True
+        return cwa_installed
 
     def terminate_nodes(self, node_ids):
         if not node_ids:

--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -303,6 +303,13 @@ class NodeUpdater:
         node_tags = self.provider.node_tags(self.node_id)
         logger.debug("Node tags: {}".format(str(node_tags)))
 
+        if self.provider_type == "aws" and self.provider.provider_config:
+            from ray.autoscaler._private.aws.cloudwatch.cloudwatch_helper \
+                import CloudwatchHelper
+            CloudwatchHelper(self.provider.provider_config,
+                             [self.node_id], self.provider.cluster_name). \
+                update_from_config(self.is_head_node)
+
         if node_tags.get(TAG_RAY_RUNTIME_CONFIG) == self.runtime_hash:
             # When resuming from a stopped instance the runtime_hash may be the
             # same, but the container will not be started.

--- a/python/ray/autoscaler/aws/cloudwatch/example-cloudwatch-agent-config.json
+++ b/python/ray/autoscaler/aws/cloudwatch/example-cloudwatch-agent-config.json
@@ -1,0 +1,175 @@
+{
+   "agent":{
+      "metrics_collection_interval":60,
+      "run_as_user":"root"
+   },
+   "csm":{
+      "memory_limit_in_mb":20,
+      "port":31000
+   },
+   "logs":{
+      "metrics_collected": {
+        "prometheus": {
+          "log_group_name": "{cluster_name}-ray-prometheus",
+          "prometheus_config_path": "/opt/aws/amazon-cloudwatch-agent/etc/prometheus.yml",
+          "emf_processor": {
+            "metric_declaration_dedup": true,
+            "metric_namespace": "{cluster_name}-ray-prometheus",
+            "metric_unit":{
+              "python_gc_collections_total": "Count",
+              "python_gc_objects": "Count",
+              "python_gc_objects_uncollectable_total": "Count",
+              "python_gc_objects_collected_total": "Count",
+              "ray_cluster_active_nodes": "Count",
+              "ray_cluster_pending_nodes": "Count",
+              "ray_node_cpu_count": "Count",
+              "ray_node_cpu_utilization": "Percent",
+              "ray_node_disk_free": "Bytes",
+              "ray_node_disk_usage": "Bytes",
+              "ray_node_disk_utilization_percentage": "Percent",
+              "ray_node_mem_available": "Bytes",
+              "ray_node_mem_total": "Bytes",
+              "ray_node_mem_used": "Bytes",
+              "ray_node_network_receive_speed": "Bytes",
+              "ray_node_network_received": "Bytes",
+              "ray_node_network_send_speed": "Bytes",
+              "ray_node_network_sent": "Bytes",
+              "ray_avg_num_executed_tasks": "Count",
+              "ray_avg_num_scheduled_tasks": "Count",
+              "ray_avg_num_spilled_back_tasks": "Count",
+              "ray_object_manager_num_pull_requests": "Count",
+              "ray_object_store_available_memory": "Bytes",
+              "ray_object_store_used_memory": "Bytes",
+              "ray_object_store_fallback_memory":"Bytes",
+              "ray_object_store_num_local_objects": "Count",
+              "ray_object_directory_subscriptions": "Count",
+              "ray_object_directory_added_locations": "Count",
+              "ray_object_directory_removed_locations": "Count",
+              "ray_object_directory_lookups": "Count",
+              "ray_object_directory_updates": "Count",
+              "ray_pending_actors": "Count",
+              "ray_pending_placement_groups": "Count",
+              "ray_raylet_cpu": "Count",
+              "ray_raylet_mem": "Bytes",
+              "ray_internal_num_spilled_tasks": "Count",
+              "ray_internal_num_infeasible_tasks": "Count",
+              "ray_internal_num_processes_started": "Count",
+              "ray_internal_num_received_tasks": "Count",
+              "ray_internal_num_dispatched_tasks": "Count",
+              "process_max_fds": "Count",
+              "process_open_fds": "Count",
+              "process_resident_memory_bytes": "Bytes",
+              "process_virtual_memory_bytes": "Bytes",
+              "process_start_time_seconds": "Seconds",
+              "process_cpu_seconds_total": "Seconds",
+              "autoscaler_config_validation_exceptions": "Count",
+              "autoscaler_node_launch_exceptions": "Count",
+              "autoscaler_pending_nodes": "Count",
+              "autoscaler_reset_exceptions": "Count",
+              "autoscaler_running_workers": "Count",
+              "autoscaler_started_nodes": "Count",
+              "autoscaler_stopped_nodes": "Count",
+              "autoscaler_update_loop_exceptions": "Count",
+              "autoscaler_worker_create_node_time": "Seconds",
+              "autoscaler_worker_update_time": "Seconds",
+              "autoscaler_updating_nodes": "Count",
+              "autoscaler_successful_updates": "Count",
+              "autoscaler_failed_updates": "Count",
+              "autoscaler_failed_create_nodes": "Count",
+              "autoscaler_recovering_nodes": "Count",
+              "autoscaler_successful_recoveries": "Count",
+              "autoscaler_failed_recoveries": "Count"
+            },
+            "metric_declaration": [
+              {
+                "source_labels": [
+                  "job"
+                ],
+                "label_matcher": "ray",
+                "dimensions": [
+                  [
+                    "instance"
+                  ]
+                ],
+                "metric_selectors": [
+                  ""
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "logs_collected":{
+         "files":{
+            "collect_list":[
+               {
+                  "file_path":"/tmp/ray/session_*/logs/**.out",
+                  "log_group_name":"{cluster_name}-ray_logs_out",
+                  "log_stream_name":"{instance_id}"
+               },
+               {
+                  "file_path":"/tmp/ray/session_*/logs/**.err",
+                  "log_group_name":"{cluster_name}-ray_logs_err",
+                  "log_stream_name":"{instance_id}"
+               }
+            ]
+         }
+      }
+   },
+   "metrics":{
+      "append_dimensions":{
+         "AutoScalingGroupName":"${aws:AutoScalingGroupName}",
+         "InstanceId":"${aws:InstanceId}"
+      },
+      "metrics_collected":{
+         "collectd":{
+            "metrics_aggregation_interval":60
+         },
+         "cpu":{
+            "measurement":[
+               "usage_active",
+               "usage_system",
+               "usage_user",
+               "usage_idle",
+               "time_active",
+               "time_system",
+               "time_user",
+               "time_idle"
+            ]
+         },
+         "processes":{
+            "measurement":[
+               "processes_running",
+               "processes_sleeping",
+               "processes_zombies",
+               "processes_dead",
+               "processes_total"
+            ],
+            "metrics_collection_interval":60,
+            "resources":[
+               "*"
+            ]
+         },
+         "disk":{
+            "measurement":[
+               "disk_used_percent"
+            ],
+            "metrics_collection_interval":60,
+            "resources":[
+               "*"
+            ]
+         },
+         "mem":{
+            "measurement":[
+               "mem_used_percent"
+            ],
+            "metrics_collection_interval":60
+         },
+         "statsd":{
+            "metrics_aggregation_interval":60,
+            "metrics_collection_interval":10,
+            "service_address":":8125"
+         }
+      }
+   }
+}

--- a/python/ray/autoscaler/aws/cloudwatch/prometheus.yml
+++ b/python/ray/autoscaler/aws/cloudwatch/prometheus.yml
@@ -1,0 +1,15 @@
+# Prometheus config file
+
+# my global config
+global:
+  scrape_interval:     10s
+  evaluation_interval: 10s
+  scrape_timeout: 10s
+
+# use ray file-based service discovery file as scrape target.
+scrape_configs:
+- job_name: 'ray'
+  file_sd_configs:
+  - files:
+    - '/tmp/ray/prom_metrics_service_discovery.json'
+    refresh_interval: 1m

--- a/python/ray/autoscaler/aws/cloudwatch/ray_prometheus_waiter.sh
+++ b/python/ray/autoscaler/aws/cloudwatch/ray_prometheus_waiter.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+MAX_ATTEMPTS=120
+DELAY_SECONDS=10
+RAY_PROM_METRICS_FILE_PATH="/tmp/ray/prom_metrics_service_discovery.json"
+CLUSTER_NAME=$1
+while [ $MAX_ATTEMPTS -gt 0 ]; do
+  if [ -f $RAY_PROM_METRICS_FILE_PATH ]; then
+    echo "Ray Prometheus metrics service discovery file found at: $RAY_PROM_METRICS_FILE_PATH."
+    echo "Restarting cloudwatch agent.This may take a few minutes..."
+    sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a stop
+    echo "Cloudwatch agent stopped, starting cloudwatch agent..."
+    sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c "ssm:AmazonCloudWatch-ray_agent_config_$CLUSTER_NAME"
+    echo "Cloudwatch agent successfully restarted!"
+    exit 0
+  else
+    echo "Ray Prometheus metrics service discovery file not found at: $RAY_PROM_METRICS_FILE_PATH. Will check again in $DELAY_SECONDS seconds..."
+    sleep $DELAY_SECONDS
+    MAX_ATTEMPTS=$((MAX_ATTEMPTS-1))
+  fi
+done
+echo "Ray Prometheus metrics service discovery file not found at: $RAY_PROM_METRICS_FILE_PATH. Ray system metrics will not be available in CloudWatch."
+exit 1

--- a/python/ray/autoscaler/aws/example-cloudwatch.yaml
+++ b/python/ray/autoscaler/aws/example-cloudwatch.yaml
@@ -1,0 +1,88 @@
+# An unique identifier for the head node and workers of this cluster.
+cluster_name: cloudwatch
+
+# The maximum number of workers nodes to launch in addition to the head node.
+max_workers: 2
+
+# Cloud-provider specific configuration.
+provider:
+    type: aws
+    region: us-west-2
+    availability_zone: us-west-2a
+    # Start by defining a `cloudwatch` section to enable CloudWatch integration with your Ray cluster.
+    cloudwatch:
+        # We depend on AWS Systems Manager (SSM) to deploy CloudWatch configuration updates to your cluster,
+        # with relevant configuration created or updated in the SSM Parameter Store during `ray up`.
+
+        # The `AmazonCloudWatch-ray_agent_config_{cluster_name}` SSM Parameter Store Config Key is used to
+        # store a remote cache of the last Unified CloudWatch Agent config applied.
+
+        # Every time you run `ray up` to update your cluster, we compare your local CloudWatch config file contents
+        # to the SSM Parameter Store's contents for that config and, if they differ, then the associated CloudWatch
+        # config will be applied and uploaded to the SSM Parameter Store.
+        # For CloudWatch Unified Agent config files, we will also replace references to
+        # `{instance_id}` with your head node's EC2 instance ID, `{region}` with your cluster's region name, and `{cluster_name}` with your cluster name.
+        agent:
+            # The Unified CloudWatch Agent is configured via the config file described
+            # at https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html.
+            # We've configured our `example-cloudwatch-agent-config.json` file to ship the following log files to CloudWatch:
+            # 1. `/tmp/ray/session_*/logs/**.out` are shipped to the `{cluster_name}-ray_logs_out` CloudWatch Log Group.
+            # 2. `/tmp/ray/session_*/logs/**.err` are shipped to the `{cluster_name}-ray_logs_err` CloudWatch Log Group.
+            # If enabled, Prometheus metrics can be found in the CloudWatch > Metrics > `{cluster-name}-ray-prometheus` namespace.
+            # CloudWatch Log Stream names will be the same as your cluster head node's EC2 instance ID.
+            # See https://docs.ray.io/en/master/ray-logging.html for ray logging system details.
+
+            # Path to Unified CloudWatch Agent config file
+            config: "cloudwatch/example-cloudwatch-agent-config.json"
+            retryer:
+                # Max allowed Unified CloudWatch Agent SSM config update attempts on any host.
+                max_attempts: 120
+                # Seconds to wait between each Unified CloudWatch Agent SSM config update attempt.
+                delay_seconds: 30
+
+# How Ray will authenticate with newly launched nodes.
+auth:
+    ssh_user: ubuntu
+
+available_node_types:
+  ray.head.default:
+      node_config:
+        InstanceType: c5a.large
+        # Disclaimer: CloudWatch integration with Ray requires an AMI (or Docker image) with the Unified CloudWatch Agent pre-installed.
+        # The AMI below is provided by the Amazon Ray Team, is based on version 48 of the Ubuntu 18.04 AWS Deep Learning AMI,
+        # and ships with Unified CloudWatch Agent v1.247348.0b251302.
+        # Please direct any questions, comments, or issues to the Amazon Ray Team at https://github.com/amzn/amazon-ray/issues/new/choose.
+        # Up-to-date versions of this AMI and AMIs for other regions can be found at https://github.com/amzn/amazon-ray.
+        ImageId: ami-0d88d9cbe28fac870
+      resources: {}
+  ray.worker.default:
+      node_config:
+        InstanceType: c5a.large
+        ImageId: ami-0d88d9cbe28fac870
+        # Note: IamInstanceProfile is needed to grant worker nodes required permission to make boto3 call for Cloudwatch setup.
+        # Default IamInstanceProfile is `arn:aws:iam::{your_aws_account_number}:instance-profile/ray-autoscaler-cloudwatch-v1`.
+        IamInstanceProfile:
+          Name: ray-autoscaler-cloudwatch-v1
+      resources: {}
+      min_workers: 0
+      max_workers: 2
+head_node_type: ray.head.default
+
+# If you want to export Ray's Prometheus system metrics to CloudWatch, you should first ensure that your cluster has the
+# Unified CloudWatch Agent and Ray Dashboard installed, then uncomment the `head_setup_commands` section below.
+# Note that this relies on CloudWatch's Embedded Metric Format (EMF), and will thus incur CloudWatch log and metric costs in
+# accordance with https://aws.amazon.com/cloudwatch/pricing/. Also note that we use the following files to enable this feature:
+# 1. prometheus.yml: The configuration file that tells Prometheus which metrics to scrape. In this case, we've configured
+# it to scrape all available Ray system metrics. For more information, see:
+# https://prometheus.io/docs/prometheus/latest/configuration/configuration/.
+# 2. ray_prometheus_waiter.sh: A bash script that waits for the Ray Prometheus service discovery file to appear at
+# `/tmp/ray/prom_metrics_service_discovery.json`, then restarts the CloudWatch Agent to start capturing all scraped
+# Prometheus metrics.
+# See https://docs.ray.io/en/latest/ray-metrics.html for more details about exporting Ray Prometheus metrics.
+#head_setup_commands:
+#  # Make `ray_prometheus_waiter.sh` executable.
+#  - RAY_INSTALL_DIR=`pip show ray | grep -Po "(?<=Location:).*"` && sudo chmod +x $RAY_INSTALL_DIR/ray/autoscaler/aws/cloudwatch/ray_prometheus_waiter.sh
+#  # Copy `prometheus.yml` to Unified CloudWatch Agent folder
+#  - RAY_INSTALL_DIR=`pip show ray | grep -Po "(?<=Location:).*"` && sudo cp -f $RAY_INSTALL_DIR/ray/autoscaler/aws/cloudwatch/prometheus.yml /opt/aws/amazon-cloudwatch-agent/etc
+#  # First get current cluster name, then let the Unified CloudWatch Agent restart and use `AmazonCloudWatch-ray_agent_config_{cluster_name}` parameter at SSM Parameter Store.
+#  - nohup sudo sh -c "`pip show ray | grep -Po "(?<=Location:).*"`/ray/autoscaler/aws/cloudwatch/ray_prometheus_waiter.sh `cat ~/ray_bootstrap_config.yaml | jq '.cluster_name'` >> '/opt/aws/amazon-cloudwatch-agent/logs/ray_prometheus_waiter.out' 2>> '/opt/aws/amazon-cloudwatch-agent/logs/ray_prometheus_waiter.err'" &

--- a/python/ray/autoscaler/ray-schema.json
+++ b/python/ray/autoscaler/ray-schema.json
@@ -180,6 +180,28 @@
                             "description": "Oauth token or JSON string constituting service account credentials"
                         }
                     }
+                },
+                "cloudwatch": {
+                    "agent": {
+                        "CLOUDWATCH_AGENT_INSTALLED_AMI_TAG": {
+                            "type": ["string"],
+                            "description": "Tag to be added to cloudwatch agent pre-installed AMI name."
+                        },
+                        "config": {
+                            "type": ["string", "null"],
+                            "description": "Path to Unified CloudWatch Agent config file. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html for additional details."
+                        },
+                        "retryer": {
+                            "max_attempts": {
+                                "type": ["integer", "null"],
+                                "description": "Max allowed Unified CloudWatch Agent installation attempts on any host."
+                            },
+                            "delay_seconds": {
+                                "type": ["integer", "null"],
+                                "description": "Seconds to wait between each Unified CloudWatch Agent installation attempt."
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/python/setup.py
+++ b/python/setup.py
@@ -167,6 +167,8 @@ ray_files.append("ray/nightly-wheels.yaml")
 # Autoscaler files.
 ray_files += [
     "ray/autoscaler/aws/defaults.yaml",
+    "ray/autoscaler/aws/cloudwatch/prometheus.yml",
+    "ray/autoscaler/aws/cloudwatch/ray_prometheus_waiter.sh",
     "ray/autoscaler/azure/defaults.yaml",
     "ray/autoscaler/_private/_azure/azure-vm-template.json",
     "ray/autoscaler/_private/_azure/azure-config-template.json",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

These changes add a set of improvements to enable automatic creation and update of CloudWatch logs, metrics, and dashboards when provisioning AWS Autoscaling clusters. Successful implementation of these improvements will allow AWS Autoscaler users to:

1. Write, monitor, and query their cluster's CloudWatch log streams.
2. Push CloudWatch metrics collected by on-cluster CloudWatch agents to the AWS CloudWatch console automatically.
3. Configure CloudWatch metric and composite alarms for their clusters.
4. Get rapid insights into their cluster state via CloudWatch dashboards.
5. Collect and publish Ray system-level Prometheus metrics to CloudWatch console automatically.
6. Allow users to update their CloudWatch agent, dashboard, alarm JSON configuration files during Ray up execution time.

Notes: 

1. We will follow up with all unit tests on CloudWatch integration after the initial review.
2. We will follow up with documentation on CloudWatch integration after the initial review.

Best Practices (these should probably be included in Ray docs in a subsequent update):
Since CloudWatch Unified Agent install can take 15-60 minutes on a newly launched Ubuntu deep-learning AMI, we recommend launching a single head node with CloudWatch Agent installed, create an AMI from that instance, and then launch a new Ray cluster from that AMI.
When creating an AMI with CloudWatch Unified Agent install, Add "T6Iq2faj" tag to your customized AMI name with CloudWatch Unified Agent installed. This tag serve as unique identifier of whether CloudWatch Unified Agent is installed on an AMI.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #https://github.com/ray-project/ray/pull/9644 #8967 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
