### PR TITLE
Do not run RLlib learning and stress tests as smoke tests.

### DIFF
--- a/release/.buildkite/build_pipeline.py
+++ b/release/.buildkite/build_pipeline.py
@@ -139,8 +139,8 @@ NIGHTLY_TESTS = {
         "distributed_api_test",
     ],
     "~/ray/release/rllib_tests/rllib_tests.yaml": [
-        SmokeTest("learning_tests"),
-        SmokeTest("stress_tests"),
+        "learning_tests",
+        "stress_tests",
         "multi_gpu_learning_tests",
         "multi_gpu_with_lstm_learning_tests",
         "multi_gpu_with_attention_learning_tests",

--- a/release/rllib_tests/learning_tests/hard_learning_tests.yaml
+++ b/release/rllib_tests/learning_tests/hard_learning_tests.yaml
@@ -416,42 +416,45 @@ ppo-breakoutnoframeskip-v4:
             vf_share_layers: true
         num_gpus: 1
 
+# tensorflow-probability does not work with tf 2.4.3.
+# TODO(jungong) : un-comment after regression docker image is upgraded
+# to use tf 2.5.0.
 # Expect roughly 1000 reward after 1h on 1GPU
-sac-halfcheetahbulletenv-v0:
-    env: HalfCheetahBulletEnv-v0
-    run: SAC
-    # Minimum reward and total ts (in given time_total_s) to pass this test.
-    pass_criteria:
-        episode_reward_mean: 600.0
-        timesteps_total: 100000
-    stop:
-        time_total_s: 7200
-    config:
-        horizon: 1000
-        soft_horizon: false
-        Q_model:
-            fcnet_activation: relu
-            fcnet_hiddens: [256, 256]
-        policy_model:
-            fcnet_activation: relu
-            fcnet_hiddens: [256, 256]
-        tau: 0.005
-        target_entropy: auto
-        no_done_at_end: false
-        n_step: 3
-        rollout_fragment_length: 1
-        prioritized_replay: true
-        train_batch_size: 256
-        target_network_update_freq: 1
-        timesteps_per_iteration: 1000
-        learning_starts: 10000
-        optimization:
-            actor_learning_rate: 0.0003
-            critic_learning_rate: 0.0003
-            entropy_learning_rate: 0.0003
-        num_workers: 0
-        num_gpus: 1
-        metrics_smoothing_episodes: 5
+#sac-halfcheetahbulletenv-v0:
+#    env: HalfCheetahBulletEnv-v0
+#    run: SAC
+#    # Minimum reward and total ts (in given time_total_s) to pass this test.
+#    pass_criteria:
+#        episode_reward_mean: 600.0
+#        timesteps_total: 100000
+#    stop:
+#        time_total_s: 7200
+#    config:
+#        horizon: 1000
+#        soft_horizon: false
+#        Q_model:
+#            fcnet_activation: relu
+#            fcnet_hiddens: [256, 256]
+#        policy_model:
+#            fcnet_activation: relu
+#            fcnet_hiddens: [256, 256]
+#        tau: 0.005
+#        target_entropy: auto
+#        no_done_at_end: false
+#        n_step: 3
+#        rollout_fragment_length: 1
+#        prioritized_replay: true
+#        train_batch_size: 256
+#        target_network_update_freq: 1
+#        timesteps_per_iteration: 1000
+#        learning_starts: 10000
+#        optimization:
+#            actor_learning_rate: 0.0003
+#            critic_learning_rate: 0.0003
+#            entropy_learning_rate: 0.0003
+#        num_workers: 0
+#        num_gpus: 1
+#        metrics_smoothing_episodes: 5
 
 td3-halfcheetahbulletenv-v0:
     env: HalfCheetahBulletEnv-v0


### PR DESCRIPTION
## Why are these changes needed?

Looking at learning_tests, I noticed that these are currently being run as smoke tests.
These learning tests typically need more than an hour of time to finish/pass the critieria.
So all of them basically timeout right now.
I think they should not be run as smoke-test?

Also comment out a learning test that still errors out right now, due to incompatible tensorflow-probability version.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
