### PR TITLE
[ci] Fix HEBO breaking Tune tests

### DIFF
--- a/python/requirements/tune/requirements_tune.txt
+++ b/python/requirements/tune/requirements_tune.txt
@@ -14,7 +14,7 @@ gym[atari]==0.18.3
 h5py==3.1.0; python_version < '3.7'
 h5py==3.3.0; python_version >= '3.7'
 hpbandster==0.7.4
-pymoo==0.4.2.2  # this is a HEBO dependency, remove after https://github.com/huawei-noah/noah-research/issues/41 is fixed
+pymoo<0.5.0  # this is a HEBO dependency, remove after https://github.com/huawei-noah/noah-research/issues/41 is fixed
 HEBO==0.1.0
 hyperopt==0.2.5
 jupyter==1.0.0

--- a/python/requirements/tune/requirements_tune.txt
+++ b/python/requirements/tune/requirements_tune.txt
@@ -14,6 +14,7 @@ gym[atari]==0.18.3
 h5py==3.1.0; python_version < '3.7'
 h5py==3.3.0; python_version >= '3.7'
 hpbandster==0.7.4
+pymoo==0.4.2.2  # this is a HEBO dependency, remove after https://github.com/huawei-noah/noah-research/issues/41 is fixed
 HEBO==0.1.0
 hyperopt==0.2.5
 jupyter==1.0.0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

With the newest release of pymoo, a HEBO dependency, HEBO fails to import. This is a temporary fix to make CI pass until https://github.com/huawei-noah/noah-research/issues/41 is closed.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
