### PR TITLE
Hash file modification time and size instead of contents.

### DIFF
--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import threading
+import struct
 from typing import Any, Dict, Optional, Tuple, List, Union
 
 import ray
@@ -338,9 +339,9 @@ def hash_runtime_conf(file_mounts,
 
     def add_content_hashes(path, allow_non_existing_paths: bool = False):
         def add_hash_of_file(fpath):
-            with open(fpath, "rb") as f:
-                for chunk in iter(lambda: f.read(2**20), b""):
-                    contents_hasher.update(chunk)
+            si = os.stat(fpath)
+            content_id = struct.pack("<dq", si.st_mtime, si.st_size)
+            contents_hasher.update(content_id)
 
         path = os.path.expanduser(path)
         if allow_non_existing_paths and not os.path.exists(path):


### PR DESCRIPTION
## Why are these changes needed?

Hash file modification time and size instead of entire file contents for the purpose of identifying changes in `file_mounts` and `cluster_synced_files` directories in the cluster config.

With this change it takes a second or two to hash 70k files 13GB, instead of 15+ minutes.

## Related issue number

Fixes #18618
@richardliaw 

## Checks
The change is tested by running `ray up` in a gcp instance with "balanced persisten storage" disk. 

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
