### PR TITLE
[Datasets] Properly support fs inference on path with space.

### DIFF
--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from typing import Callable, Optional, List, Tuple, Union, Any, TYPE_CHECKING
-from urllib.parse import urlparse
+import urllib.parse
 
 if TYPE_CHECKING:
     import pyarrow
@@ -303,26 +303,22 @@ def _expand_directory(path: str,
 
 
 def _is_url(path) -> bool:
-    return urlparse(path).scheme != ""
+    return urllib.parse.urlparse(path).scheme != ""
 
 
 def _encode_url(path):
-    from urllib.parse import quote
-
-    return quote(path, safe="/:")
+    return urllib.parse.quote(path, safe="/:")
 
 
 def _decode_url(path):
-    from urllib.parse import unquote
-
-    return unquote(path)
+    return urllib.parse.unquote(path)
 
 
 def _unwrap_protocol(path):
     """
     Slice off any protocol prefixes on path.
     """
-    parsed = urlparse(path)
+    parsed = urllib.parse.urlparse(path)
     return parsed.netloc + parsed.path
 
 


### PR DESCRIPTION
It appears that all other `FileSystem` APIs expect non-URL-encoded paths, so we limit the scope of the encoding to just filesystem inference.

Also tested manually that the use case given in #18414 works.

## Related issue number

Closes #18414 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
