### PR TITLE
[GCP] Add `conda` to the path when possible.

### DIFF
--- a/python/ray/autoscaler/gcp/defaults.yaml
+++ b/python/ray/autoscaler/gcp/defaults.yaml
@@ -136,6 +136,9 @@ setup_commands:
     # below with a git checkout <your_sha> (and possibly a recompile).
     # - echo 'export PATH="$HOME/anaconda3/envs/tensorflow_p36/bin:$PATH"' >> ~/.bashrc
     # Install ray if not present
+    - >-
+        (stat /opt/conda/bin/ &> /dev/null &&
+        echo 'export PATH="/opt/conda/bin:$PATH"' >> ~/.bashrc) || true
     - which ray || pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* When not in Docker, conda is sometimes not properly configured.
* This is similar to what we do on AWS https://github.com/ray-project/ray/blob/8a72824c63dbae9d8d189ce9c553c2e8c4299494/python/ray/autoscaler/aws/defaults.yaml#L126
* The main problem with using the non-conda version of Python is that 1) future interactions with the cluster **will use the conda version** and 2) the system version may still be **Python 2.7**.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/16539

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
