### PR TITLE
Add Codeowners for Java API.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,12 @@
 #!/python/ray/rllib/ @ray-project/ray-core-python
 
 # Java worker.
-#/java/ @ray-project/ray-core-java
+/java/pom.xml @jovany-wang @kfstorm @raulchen
+/java/pom_template.xml @jovany-wang @kfstorm @raulchen
+/java/*/pom.xml @jovany-wang @kfstorm @raulchen
+/java/*/pom_template.xml @jovany-wang @kfstorm @raulchen
+/java/api/ @jovany-wang @kfstorm @raulchen
+
 
 # Ray Client
 /src/ray/protobuf/ray_client.proto @ijrsvt @ameerhajali @ckw017 @mwtian


### PR DESCRIPTION
The Java API change PR should be approved by Java team to confirm there's no breaking for user usages.

https://github.com/ray-project/ray/issues/18488