### PR TITLE
Publish actor state PENDING_CREATION for dashboard showing.

### DIFF
--- a/dashboard/modules/actor/tests/test_actor.py
+++ b/dashboard/modules/actor/tests/test_actor.py
@@ -240,7 +240,6 @@ def test_actor_pubsub(disable_aiohttp_cache, ray_start_with_dashboard):
 
     msgs = []
     handle_pub_messages(p, msgs, timeout, 2)
-    print(msgs)
     # Assert we received published actor messages with state
     # DEPENDENCIES_UNREADY and PENDING_CREATION.
     assert len(msgs) == 2
@@ -267,7 +266,6 @@ def test_actor_pubsub(disable_aiohttp_cache, ray_start_with_dashboard):
         actor_data_dict = actor_table_data_to_dict(msg)
         # DEPENDENCIES_UNREADY is 0, PENDING_CREATION is 1, which would not be
         # keeped in dict. We need check its original value.
-
         if msg.state == 0 or msg.state == 1:
             assert len(actor_data_dict) > 5
             for k in non_state_keys:

--- a/dashboard/modules/actor/tests/test_actor.py
+++ b/dashboard/modules/actor/tests/test_actor.py
@@ -264,7 +264,7 @@ def test_actor_pubsub(disable_aiohttp_cache, ray_start_with_dashboard):
 
     for msg in msgs:
         actor_data_dict = actor_table_data_to_dict(msg)
-        # DEPENDENCIES_UNREADY is 0, which would not be keeped in dict. We
+        # DEPENDENCIES_UNREADY is 0, which would not be kept in dict. We
         # need check its original value.
         if msg.state == 0:
             assert len(actor_data_dict) > 5

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -476,6 +476,10 @@ Status GcsActorManager::CreateActor(const ray::rpc::CreateActorRequest &request,
   auto actor =
       std::make_shared<GcsActor>(request.task_spec(), get_ray_namespace_(job_id));
   actor->GetMutableActorTableData()->set_state(rpc::ActorTableData::PENDING_CREATION);
+  const auto &actor_table_data = actor->GetActorTableData();
+  // Pub this state for dashboard showing.
+  RAY_CHECK_OK(gcs_pub_sub_->Publish(ACTOR_CHANNEL, actor_id.Hex(),
+                                     actor_table_data.SerializeAsString(), nullptr));
   RemoveUnresolvedActor(actor);
 
   // Update the registered actor as its creation task specification may have changed due


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR aims to address the issue that dashboard cannot show the state correctly for an actor.
We didn't publish the PENDING_CREATION state before, so that it always be labeled as DEPENDENCIES_UNREADY which is too confusing to user end.

After this PR, the state PENDING_CREATION will be showed as what it actually is.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
