### PR TITLE
Extend --smoke-test deadlines for learning and stress regression tests.

### DIFF
--- a/release/rllib_tests/rllib_tests.yaml
+++ b/release/rllib_tests/rllib_tests.yaml
@@ -5,12 +5,12 @@
     compute_template: 8gpus_64cpus.yaml
 
   run:
-    timeout: 14400
+    timeout: 21600
     script: python learning_tests/run.py
 
   smoke_test:
       run:
-        timeout: 900
+        timeout: 7200
       cluster:
         compute_template: 4gpus_64cpus.yaml
 
@@ -69,4 +69,4 @@
 
   smoke_test:
       run:
-        timeout: 900
+        timeout: 1800


### PR DESCRIPTION
## Why are these changes needed?

As discussed offline, I think this is necessary before our learning and stress tests can pass.
These deadlines are only used by e2e.py as the overall test suite deadline.

Timeouts for individual learning tasks are currently hardcoded in run_learning_tests_from_yaml to be 4mins.
https://github.com/ray-project/ray/blame/master/rllib/utils/test_utils.py#L423

It's quite impossible for e2e.py to finish running all the individual learning tasks defined in learing_tests in 15mins if each task takes 4 mins.
So just to be safe, I am bumping the deadlines to 2hrs for now.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
