### PR TITLE
change headnode type for serve benchmark

### DIFF
--- a/release/serve_tests/compute_tpl_single_node.yaml
+++ b/release/serve_tests/compute_tpl_single_node.yaml
@@ -5,13 +5,13 @@ max_workers: 0
 
 head_node_type:
     name: head_node
-    # 8 cpus, x86, 32G mem, 10Gb NIC, $0.384/hr on demand
-    instance_type: m5.2xlarge
+    # 16 cpus, x86, 64G mem, 10Gb NIC, $0.484/hr on demand
+    instance_type: m5.4xlarge
 
 worker_node_types:
     - name: worker_node
-      # 8 cpus, x86, 32G mem, 10Gb NIC, $0.384/hr on demand
-      instance_type: m5.2xlarge
+      # 16 cpus, x86, 64G mem, 10Gb NIC, $0.484/hr on demand
+      instance_type: m5.4xlarge
       min_workers: 0
       # 1k max replicas
       max_workers: 0


### PR DESCRIPTION
Current node type has 8 CPUs but we also need 8 replicas in micro benchmark, not enough for head node since it controller + HttpProxy also requires some CPU resource 

Closes #18648

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
