### PR TITLE
[Datasets] Shuffled data loading support

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -349,13 +349,18 @@ class Dataset(Generic[T]):
         Returns:
             The shuffled dataset.
         """
-
+        num_blocks = self.num_blocks()
         new_blocks = simple_shuffle(
-            self._blocks,
-            num_blocks or self.num_blocks(),
+            self.move_blocks(),
+            num_blocks or num_blocks,
             random_shuffle=True,
             random_seed=seed)
         return Dataset(new_blocks)
+
+    def move_blocks(self):
+        blocks = self._blocks
+        self._blocks = None
+        return blocks
 
     def split(self,
               n: int,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -327,7 +327,7 @@ class Dataset(Generic[T]):
                        *,
                        seed: Optional[int] = None,
                        num_blocks: Optional[int] = None,
-                       move: Optional[bool] = False) -> "Dataset[T]":
+                       _move: Optional[bool] = False) -> "Dataset[T]":
         """Randomly shuffle the elements of this dataset.
 
         This is a blocking operation similar to repartition().
@@ -346,10 +346,6 @@ class Dataset(Generic[T]):
                 based on system randomness.
             num_blocks: The number of output blocks after the shuffle, or None
                 to retain the number of blocks.
-            move: Whether the blocks for the source dataset should be moved
-                into the new, shuffled dataset, which should reduce memory
-                utilization during shuffle. This will make the source dataset
-                unusable.
 
         Returns:
             The shuffled dataset.
@@ -357,7 +353,7 @@ class Dataset(Generic[T]):
         if num_blocks is None:
             num_blocks = self.num_blocks()
         new_blocks = simple_shuffle(
-            self._move_blocks() if move else self._blocks,
+            self._move_blocks() if _move else self._blocks,
             num_blocks,
             random_shuffle=True,
             random_seed=seed)

--- a/python/ray/data/impl/block_list.py
+++ b/python/ray/data/impl/block_list.py
@@ -20,7 +20,20 @@ class BlockList(Iterable[ObjectRef[Block]]):
     def get_metadata(self) -> List[BlockMetadata]:
         return self._metadata.copy()
 
+    def copy(self) -> "BlockList":
+        return BlockList(self._blocks, self._metadata)
+
+    def clear(self):
+        self._blocks = None
+
+    def _check_if_cleared(self):
+        if self._blocks is None:
+            raise ValueError(
+                "This Dataset's blocks have been moved, which means that you "
+                "can no longer use this Dataset.")
+
     def split(self, split_size: int) -> List["BlockList"]:
+        self._check_if_cleared()
         num_splits = math.ceil(len(self._blocks) / split_size)
         blocks = np.array_split(self._blocks, num_splits)
         meta = np.array_split(self._metadata, num_splits)
@@ -30,7 +43,9 @@ class BlockList(Iterable[ObjectRef[Block]]):
         return output
 
     def __len__(self):
+        self._check_if_cleared()
         return len(self._blocks)
 
     def __iter__(self):
+        self._check_if_cleared()
         return iter(self._blocks)

--- a/python/ray/data/impl/shuffle.py
+++ b/python/ray/data/impl/shuffle.py
@@ -30,6 +30,7 @@ def simple_shuffle(input_blocks: BlockList[T],
         shuffle_map.remote(block, i, output_num_blocks, random_shuffle,
                            random_seed) for i, block in enumerate(input_blocks)
     ]
+    del input_blocks
     if output_num_blocks == 1:
         # Handle the num_returns=1 edge case which doesn't return a list.
         shuffle_map_out = [[x] for x in shuffle_map_out]
@@ -48,6 +49,7 @@ def simple_shuffle(input_blocks: BlockList[T],
             *[shuffle_map_out[i][j] for i in range(input_num_blocks)])
         for j in range(output_num_blocks)
     ]
+    del shuffle_map_out
     new_blocks, new_metadata = zip(*shuffle_reduce_out)
     reduce_bar.block_until_complete(list(new_blocks))
     new_metadata = ray.get(list(new_metadata))

--- a/python/ray/data/impl/shuffle.py
+++ b/python/ray/data/impl/shuffle.py
@@ -1,6 +1,7 @@
 import itertools
 import math
-from typing import TypeVar, List, Optional, Dict, Any, Iterable
+import os
+from typing import TypeVar, List, Optional, Dict, Any
 
 import numpy as np
 
@@ -20,34 +21,46 @@ def simple_shuffle(
         *,
         random_shuffle: bool = False,
         random_seed: Optional[int] = None,
-        map_ray_remote_args: Dict[str, Any] = None,
-        reduce_ray_remote_args: Dict[str, Any] = None,
-        _round_robin_resource_provider: Iterable[Dict[str, float]] = None
+        map_ray_remote_args: Optional[Dict[str, Any]] = None,
+        reduce_ray_remote_args: Optional[Dict[str, Any]] = None
 ) -> BlockList[T]:
-    if _round_robin_resource_provider is None:
+    # Check for spread resource labels in environment variable, and use
+    # the given labels for round-robin resource-based scheduling.
+    shuffle_spread_custom_resource_labels = os.getenv(
+        "RAY_DATASETS_SHUFFLE_SPREAD_CUSTOM_RESOURCE_LABELS", None)
+    if shuffle_spread_custom_resource_labels is not None:
+        shuffle_spread_custom_resource_labels = (
+            shuffle_spread_custom_resource_labels.split(","))
+        round_robin_resource_provider = itertools.cycle(
+            map(lambda resource: {resource: 0.001},
+                shuffle_spread_custom_resource_labels))
+    else:
         # If no round-robin resource provider given, yield an empty
         # dictionary.
-        _round_robin_resource_provider = itertools.repeat({})
+        round_robin_resource_provider = itertools.repeat({})
     # Create separate resource iterators for the map and reduce stages.
     map_resource_iter, reduce_resource_iter = itertools.tee(
-        _round_robin_resource_provider, 2)
+        round_robin_resource_provider, 2)
     if map_ray_remote_args is None:
         map_ray_remote_args = {}
     if reduce_ray_remote_args is None:
         reduce_ray_remote_args = {}
     input_num_blocks = len(input_blocks)
 
-    shuffle_map = cached_remote_fn(_shuffle_map, num_returns=output_num_blocks)
-    shuffle_reduce = cached_remote_fn(_shuffle_reduce, num_returns=2)
+    shuffle_map = cached_remote_fn(_shuffle_map)
+    shuffle_reduce = cached_remote_fn(_shuffle_reduce)
 
     map_bar = ProgressBar("Shuffle Map", position=0, total=input_num_blocks)
 
     shuffle_map_out = [
         shuffle_map.options(
-            **map_ray_remote_args, resources=next(map_resource_iter)).remote(
+            **map_ray_remote_args, num_returns=output_num_blocks,
+            resources=next(map_resource_iter)).remote(
                 block, i, output_num_blocks, random_shuffle, random_seed)
         for i, block in enumerate(input_blocks)
     ]
+    # Eagerly delete the input block references in order to eagerly release
+    # the blocks' memory.
     del input_blocks
     if output_num_blocks == 1:
         # Handle the num_returns=1 edge case which doesn't return a list.
@@ -65,10 +78,13 @@ def simple_shuffle(
     shuffle_reduce_out = [
         shuffle_reduce.options(
             **reduce_ray_remote_args,
+            num_returns=2,
             resources=next(reduce_resource_iter)).remote(
                 *[shuffle_map_out[i][j] for i in range(input_num_blocks)])
         for j in range(output_num_blocks)
     ]
+    # Eagerly delete the map block references in order to eagerly release
+    # the blocks' memory.
     del shuffle_map_out
     new_blocks, new_metadata = zip(*shuffle_reduce_out)
     reduce_bar.block_until_complete(list(new_blocks))

--- a/python/ray/data/impl/shuffle.py
+++ b/python/ray/data/impl/shuffle.py
@@ -15,15 +15,14 @@ from ray.data.impl.remote_fn import cached_remote_fn
 T = TypeVar("T")
 
 
-def simple_shuffle(
-        input_blocks: BlockList[T],
-        output_num_blocks: int,
-        *,
-        random_shuffle: bool = False,
-        random_seed: Optional[int] = None,
-        map_ray_remote_args: Optional[Dict[str, Any]] = None,
-        reduce_ray_remote_args: Optional[Dict[str, Any]] = None
-) -> BlockList[T]:
+def simple_shuffle(input_blocks: BlockList[T],
+                   output_num_blocks: int,
+                   *,
+                   random_shuffle: bool = False,
+                   random_seed: Optional[int] = None,
+                   map_ray_remote_args: Optional[Dict[str, Any]] = None,
+                   reduce_ray_remote_args: Optional[Dict[str, Any]] = None
+                   ) -> BlockList[T]:
     # Check for spread resource labels in environment variable, and use
     # the given labels for round-robin resource-based scheduling.
     shuffle_spread_custom_resource_labels = os.getenv(
@@ -54,7 +53,8 @@ def simple_shuffle(
 
     shuffle_map_out = [
         shuffle_map.options(
-            **map_ray_remote_args, num_returns=output_num_blocks,
+            **map_ray_remote_args,
+            num_returns=output_num_blocks,
             resources=next(map_resource_iter)).remote(
                 block, i, output_num_blocks, random_shuffle, random_seed)
         for i, block in enumerate(input_blocks)

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -36,6 +36,21 @@ def maybe_pipeline(ds, enabled):
         return ds
 
 
+@pytest.fixture
+def enable_shuffle_spread():
+    os.environ[
+        "RAY_DATASETS_SHUFFLE_SPREAD_CUSTOM_RESOURCE_LABELS"] = "bar,baz"
+    yield
+    del os.environ["RAY_DATASETS_SHUFFLE_SPREAD_CUSTOM_RESOURCE_LABELS"]
+
+
+@pytest.fixture
+def enable_read_spread():
+    os.environ["RAY_DATASETS_READ_SPREAD_CUSTOM_RESOURCE_LABELS"] = "bar,baz"
+    yield
+    del os.environ["RAY_DATASETS_READ_SPREAD_CUSTOM_RESOURCE_LABELS"]
+
+
 @pytest.mark.parametrize("pipelined", [False, True])
 def test_basic_actors(shutdown_only, pipelined):
     ray.init(num_cpus=2)
@@ -2392,9 +2407,11 @@ def test_random_shuffle(shutdown_only, pipelined):
     assert r1 != r2, (r1, r2)
 
 
-def test_random_shuffle_spread(ray_start_cluster):
+def test_random_shuffle_spread(ray_start_cluster, enable_shuffle_spread):
     cluster = ray_start_cluster
-    cluster.add_node(resources={"foo": 100})
+    cluster.add_node(
+        resources={"foo": 100},
+        _system_config={"max_direct_call_object_size": 0})
     cluster.add_node(resources={"bar": 100})
     cluster.add_node(resources={"baz": 100})
 
@@ -2407,10 +2424,7 @@ def test_random_shuffle_spread(ray_start_cluster):
     bar_node_id = ray.get(get_node_id.options(resources={"bar": 1}).remote())
     baz_node_id = ray.get(get_node_id.options(resources={"baz": 1}).remote())
 
-    os.environ[
-        "RAY_DATASETS_SHUFFLE_SPREAD_CUSTOM_RESOURCE_LABELS"] = "bar,baz"
-
-    ds = ray.data.range_arrow(1000000, parallelism=2).random_shuffle()
+    ds = ray.data.range(100, parallelism=2).random_shuffle()
     blocks = ds.get_blocks()
     ray.wait(blocks, num_returns=len(blocks), fetch_local=False)
     location_data = ray.experimental.get_object_locations(blocks)
@@ -2420,9 +2434,11 @@ def test_random_shuffle_spread(ray_start_cluster):
     assert set(locations) == {bar_node_id, baz_node_id}
 
 
-def test_parquet_read_spread(ray_start_cluster, tmp_path):
+def test_parquet_read_spread(ray_start_cluster, tmp_path, enable_read_spread):
     cluster = ray_start_cluster
-    cluster.add_node(resources={"foo": 100})
+    cluster.add_node(
+        resources={"foo": 100},
+        _system_config={"max_direct_call_object_size": 0})
     cluster.add_node(resources={"bar": 100})
     cluster.add_node(resources={"baz": 100})
 
@@ -2436,20 +2452,15 @@ def test_parquet_read_spread(ray_start_cluster, tmp_path):
     baz_node_id = ray.get(get_node_id.options(resources={"baz": 1}).remote())
 
     data_path = str(tmp_path)
-    df1 = pd.DataFrame({
-        "one": list(range(100000)),
-        "two": list(range(100000, 200000))
-    })
+    df1 = pd.DataFrame({"one": list(range(100)), "two": list(range(100, 200))})
     path1 = os.path.join(data_path, "test1.parquet")
     df1.to_parquet(path1)
     df2 = pd.DataFrame({
-        "one": list(range(300000, 400000)),
-        "two": list(range(400000, 500000))
+        "one": list(range(300, 400)),
+        "two": list(range(400, 500))
     })
     path2 = os.path.join(data_path, "test2.parquet")
     df2.to_parquet(path2)
-
-    os.environ["RAY_DATASETS_READ_SPREAD_CUSTOM_RESOURCE_LABELS"] = "bar,baz"
 
     ds = ray.data.read_parquet(data_path)
 
@@ -2466,7 +2477,7 @@ def test_parquet_read_spread(ray_start_cluster, tmp_path):
 
 
 @pytest.mark.parametrize("num_items,parallelism", [(100, 1), (1000, 4)])
-def test_sort_arrow(ray_start_regular_shared, num_items, parallelism):
+def test_sort_arrow(ray_start_regular, num_items, parallelism):
     a = list(reversed(range(num_items)))
     b = [f"{x:03}" for x in range(num_items)]
     shard = int(np.ceil(num_items / parallelism))
@@ -2494,7 +2505,7 @@ def test_sort_arrow(ray_start_regular_shared, num_items, parallelism):
         ds.sort(key=[("b", "descending")]), zip(reversed(a), reversed(b)))
 
 
-def test_dataset_retry_exceptions(ray_start_regular_shared, local_path):
+def test_dataset_retry_exceptions(ray_start_regular, local_path):
     @ray.remote
     class Counter:
         def __init__(self):

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -2376,7 +2376,7 @@ def test_random_shuffle(shutdown_only, pipelined):
 
     # Test move.
     ds = range(100, parallelism=2)
-    r1 = ds.random_shuffle(move=True).take(999)
+    r1 = ds.random_shuffle(_move=True).take(999)
     if pipelined:
         # Reusing source pipeline works fine when moving blocks, since the
         # move happens after the pipeline creation so reusing the source
@@ -2388,7 +2388,7 @@ def test_random_shuffle(shutdown_only, pipelined):
         # Source dataset should be unusable if not pipelining.
         with pytest.raises(ValueError):
             ds = ds.map(lambda x: x).take(999)
-    r2 = range(100).random_shuffle(move=True).take(999)
+    r2 = range(100).random_shuffle(_move=True).take(999)
     assert r1 != r2, (r1, r2)
 
 


### PR DESCRIPTION
A few hotfixes for shuffled data loading support.

1. Move the block refs when shuffling and delete intermediate block refs in order to reduce the number of dataset copies during shuffling.
2. Pass remote args during reads as submission-time task options, allowing for more options (e.g. placement groups).
3. Add round-robin resource-based load balancing (private, undocumented) option to reading and shuffling via a few environment variables.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
