### PR TITLE
Remove redis part in internal kv

### DIFF
--- a/python/ray/experimental/internal_kv.py
+++ b/python/ray/experimental/internal_kv.py
@@ -5,7 +5,6 @@ from typing import List, Union
 
 from ray._private.client_mode_hook import client_mode_hook
 
-redis = os.environ.get("RAY_KV_USE_GCS", "0") == "0"
 _initialized = False
 
 
@@ -13,23 +12,19 @@ def _initialize_internal_kv(gcs_client: "ray._raylet.GcsClient" = None):
     """Initialize the internal KV for use in other function calls.
 
     We try to use a GCS client, either passed in here or from the Ray worker
-    global scope. If that is not possible or it's feature-flagged off with the
-    RAY_KV_USE_GCS env variable, we fall back to using the Ray worker redis
-    client directly.
+    global scope.
     """
     global global_gcs_client, _initialized
 
     if not _initialized:
         if gcs_client is not None:
             global_gcs_client = gcs_client
-        elif redis:
-            global_gcs_client = None
         else:
             try:
                 ray.worker.global_worker.gcs_client.kv_exists("dummy")
                 global_gcs_client = ray.worker.global_worker.gcs_client
             except grpc.RpcError:
-                global_gcs_client = None
+                raise OSError("Could not connect to gcs, retry later.")
 
     _initialized = True
     return global_gcs_client
@@ -39,11 +34,7 @@ def _initialize_internal_kv(gcs_client: "ray._raylet.GcsClient" = None):
 def _internal_kv_initialized():
     gcs_client = _initialize_internal_kv()
 
-    worker = ray.worker.global_worker
-    if gcs_client is not None:
-        return True
-    else:
-        return hasattr(worker, "mode") and worker.mode is not None
+    return gcs_client is not None
 
 
 @client_mode_hook
@@ -51,20 +42,14 @@ def _internal_kv_get(key: Union[str, bytes]) -> bytes:
     """Fetch the value of a binary key."""
     gcs_client = _initialize_internal_kv()
 
-    if gcs_client is not None:
-        return gcs_client.kv_get(key)
-    else:
-        return ray.worker.global_worker.redis_client.hget(key, "value")
+    return gcs_client.kv_get(key)
 
 
 @client_mode_hook
 def _internal_kv_exists(key: Union[str, bytes]) -> bool:
     """Check key exists or not."""
     gcs_client = _initialize_internal_kv()
-    if gcs_client is not None:
-        return gcs_client.kv_exists(key)
-    else:
-        return ray.worker.global_worker.redis_client.hexists(key, "value")
+    return gcs_client.kv_exists(key)
 
 
 @client_mode_hook
@@ -79,25 +64,13 @@ def _internal_kv_put(key: Union[str, bytes],
         already_exists (bool): whether the value already exists.
     """
     gcs_client = _initialize_internal_kv()
-    if gcs_client is not None:
-        return not gcs_client.kv_put(key, value, overwrite)
-    else:
-        if overwrite:
-            updated = ray.worker.global_worker.redis_client.hset(
-                key, "value", value)
-        else:
-            updated = ray.worker.global_worker.redis_client.hsetnx(
-                key, "value", value)
-        return updated == 0  # already exists
+    return not gcs_client.kv_put(key, value, overwrite)
 
 
 @client_mode_hook
 def _internal_kv_del(key: Union[str, bytes]):
     gcs_client = _initialize_internal_kv()
-    if gcs_client is not None:
-        return gcs_client.kv_del(key)
-    else:
-        return ray.worker.global_worker.redis_client.delete(key)
+    return gcs_client.kv_del(key)
 
 
 @client_mode_hook
@@ -105,11 +78,4 @@ def _internal_kv_list(prefix: Union[str, bytes]) -> List[bytes]:
     """List all keys in the internal KV store that start with the prefix.
     """
     gcs_client = _initialize_internal_kv()
-    if gcs_client is not None:
-        return gcs_client.kv_keys(prefix)
-    else:
-        if isinstance(prefix, bytes):
-            pattern = prefix + b"*"
-        else:
-            pattern = prefix + "*"
-        return ray.worker.global_worker.redis_client.keys(pattern=pattern)
+    return gcs_client.kv_keys(prefix)

--- a/python/ray/experimental/internal_kv.py
+++ b/python/ray/experimental/internal_kv.py
@@ -1,6 +1,5 @@
 import ray
 import grpc
-import os
 from typing import List, Union
 
 from ray._private.client_mode_hook import client_mode_hook


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The gcs client implementation of internal kv has been merged and enabled for six months and it shows stable and ok.
I'd like to remove the old implementation with redis, as part of removing redis dependency in Python codes.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
