### PR TITLE
[CI] Remove config that disables Bazel test result cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -129,13 +129,13 @@ build:ci-github --experimental_repository_cache_hardlinks # GitHub Actions has l
 build:ci-github --disk_cache=~/ray-bazel-cache
 build:ci-github --remote_cache="https://storage.googleapis.com/ray-bazel-cache"
 test:ci --flaky_test_attempts=3
-test:ci --spawn_strategy=local
+test:ci --genrule_strategy=local
 test:ci --test_output=errors
 test:ci --test_verbose_timeout_warnings
 test:ci-debug -c dbg
 test:ci-debug --copt="-g"
 test:ci-debug --flaky_test_attempts=3
-test:ci-debug --spawn_strategy=local
+test:ci-debug --genrule_strategy=local
 test:ci-debug --test_output=errors
 test:ci-debug --test_verbose_timeout_warnings
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -129,14 +129,12 @@ build:ci-github --experimental_repository_cache_hardlinks # GitHub Actions has l
 build:ci-github --disk_cache=~/ray-bazel-cache
 build:ci-github --remote_cache="https://storage.googleapis.com/ray-bazel-cache"
 test:ci --flaky_test_attempts=3
-test:ci --nocache_test_results
 test:ci --spawn_strategy=local
 test:ci --test_output=errors
 test:ci --test_verbose_timeout_warnings
 test:ci-debug -c dbg
 test:ci-debug --copt="-g"
 test:ci-debug --flaky_test_attempts=3
-test:ci-debug --nocache_test_results
 test:ci-debug --spawn_strategy=local
 test:ci-debug --test_output=errors
 test:ci-debug --test_verbose_timeout_warnings

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -48,7 +48,7 @@ RUN echo "ulimit -c 0" >> /root/.bashrc
 
 # Setup Bazel caches
 RUN (echo "build --remote_cache=${REMOTE_CACHE_URL}" >> /root/.bazelrc); \
-    (if [ "${BUILDKITE_PULL_REQUEST}" != "false" ]; then (echo "build --remote_upload_local_results=false" >> /root/.bazelrc); fi); \
+    (if [ "${BUILDKITE_BRANCH}" != "master" ]; then (echo "test --nocache_test_results" >> /root/.bazelrc); fi); \
     cat /root/.bazelrc
 
 RUN mkdir /ray

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -48,7 +48,10 @@ RUN echo "ulimit -c 0" >> /root/.bashrc
 
 # Setup Bazel caches
 RUN (echo "build --remote_cache=${REMOTE_CACHE_URL}" >> /root/.bazelrc); \
-    (if [ "${BUILDKITE_BRANCH}" != "master" ]; then (echo "test --nocache_test_results" >> /root/.bazelrc); fi); \
+    # Prevent uploading binary asserts to the cache.
+    (if [ "${BUILDKITE_PULL_REQUEST}" != "false" ]; then (echo "build --remote_upload_local_results=false" >> /root/.bazelrc); fi); \
+    # Not use cached test results to ensure post-merge CI can discover flakiness.
+    (if [ "${BUILDKITE_BRANCH}" == "master" ]; then (echo "test --nocache_test_results" >> /root/.bazelrc); fi); \
     cat /root/.bazelrc
 
 RUN mkdir /ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
I believe there is no reason to disable Bazel test result cache. Removing these configs do not enable Bazel test result caching in CI yet, likely because of different environments in each CI run. But I think it is still useful to remove them first.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
