### PR TITLE
[tune] Cache unstaged placement groups for potential re-use

### DIFF
--- a/python/ray/tune/tests/test_trial_runner_pg.py
+++ b/python/ray/tune/tests/test_trial_runner_pg.py
@@ -80,6 +80,8 @@ class TrialRunnerPlacementGroupTest(unittest.TestCase):
 
         head_bundle = {"CPU": 4, "GPU": 0, "custom": 0}
         child_bundle = {"custom": 1}
+        # Manually calculated number of parallel trials
+        max_num_parallel = 2
 
         placement_group_factory = PlacementGroupFactory(
             [head_bundle, child_bundle, child_bundle])
@@ -118,14 +120,25 @@ class TrialRunnerPlacementGroupTest(unittest.TestCase):
                     scheduled,
                     min(scheduled, len(trials)),
                     msg=f"Num trials iter {iteration}")
+
+                # The following two tests were relaxed for reuse_actors=True
+                # so that up to `max_num_parallel` more placement groups can
+                # exist than we would expect. This is because caching
+                # relies on reconciliation for cleanup to avoid overscheduling
+                # of new placement groups.
+                num_parallel_reuse = int(reuse_actors) * max_num_parallel
+
                 # The number of PGs should decrease when trials finish
-                this.assertEqual(
-                    max(scheduled, len(trials)) - num_finished,
+                this.assertGreaterEqual(
+                    max(scheduled, len(trials)) - num_finished +
+                    num_parallel_reuse,
                     total_num_tracked,
                     msg=f"Num tracked iter {iteration}")
+
                 # The number of actual placement groups should match this
-                this.assertEqual(
-                    max(scheduled, len(trials)) - num_finished,
+                this.assertGreaterEqual(
+                    max(scheduled, len(trials)) - num_finished +
+                    num_parallel_reuse,
                     num_non_removed_pgs - num_removal_scheduled_pgs,
                     msg=f"Num actual iter {iteration}")
 

--- a/python/ray/tune/utils/placement_groups.py
+++ b/python/ray/tune/utils/placement_groups.py
@@ -240,7 +240,8 @@ class PlacementGroupManager:
         # Ray futures to check if a placement group is ready
         self._staging_futures: Dict[ObjectRef, Tuple[PlacementGroupFactory,
                                                      PlacementGroup]] = {}
-        # Set of unstaged PGs (cleaned after full PG removal)
+
+        # Cache of unstaged PGs (cleaned after full PG removal)
         self._unstaged_pg_pgf: Dict[PlacementGroup, PlacementGroupFactory] = {}
         self._unstaged_pgf_pg: Dict[PlacementGroupFactory, Set[
             PlacementGroup]] = defaultdict(set)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The changes in #18650 come with some problems, notably when we only allow 1 pending placement group, as cleanup is usually delayed by 2 seconds (per default).

Instead, we should just cache unstaged placement groups and re-use them if their placement group factory gets requested before they've been completely removed.



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
