### PR TITLE
[tune] Add TrialMeanStopper

### DIFF
--- a/doc/source/tune/api_docs/stoppers.rst
+++ b/doc/source/tune/api_docs/stoppers.rst
@@ -44,3 +44,9 @@ TimeoutStopper (tune.stopper.TimeoutStopper)
 --------------------------------------------
 
 .. autoclass:: ray.tune.stopper.TimeoutStopper
+
+
+TrialMeanStopper (tune.stopper.TrialMeanStopper)
+--------------------------------------------
+
+.. autoclass:: ray.tune.stopper.TrialMeanStopper

--- a/python/ray/tune/stopper.py
+++ b/python/ray/tune/stopper.py
@@ -414,7 +414,8 @@ class TrialMeanStopper(Stopper):
         #  Get Metric from legacy metrics, or from custom ones.
         if self._metric in result:
             self._trial_results[trial_id].append(result.get(self._metric))
-        elif "custom_metrics" in result and self._metric in result["custom_metrics"]:
+        elif "custom_metrics" in result and self._metric in result[
+                "custom_metrics"]:
             self._trial_results[trial_id].append(result["custom_metrics"].get(
                 self._metric))
         else:
@@ -424,7 +425,8 @@ class TrialMeanStopper(Stopper):
         # Get Time metric from legacy metrics, or from custom ones.
         if self._time_metric in result:
             current_time = result.get(self._time_metric)
-        elif "custom_metrics" in result and self._time_metric in result["custom_metrics"]:
+        elif "custom_metrics" in result and self._time_metric in result[
+                "custom_metrics"]:
             current_time = result["custom_metrics"].get(self._time_metric)
         else:
             raise ValueError(

--- a/python/ray/tune/stopper.py
+++ b/python/ray/tune/stopper.py
@@ -414,7 +414,7 @@ class TrialMeanStopper(Stopper):
         #  Get Metric from legacy metrics, or from custom ones.
         if self._metric in result:
             self._trial_results[trial_id].append(result.get(self._metric))
-        elif self._metric in result["custom_metrics"]:
+        elif "custom_metrics" in result and self._metric in result["custom_metrics"]:
             self._trial_results[trial_id].append(result["custom_metrics"].get(
                 self._metric))
         else:
@@ -424,7 +424,7 @@ class TrialMeanStopper(Stopper):
         # Get Time metric from legacy metrics, or from custom ones.
         if self._time_metric in result:
             current_time = result.get(self._time_metric)
-        elif self._time_metric in result["custom_metrics"]:
+        elif "custom_metrics" in result and self._time_metric in result["custom_metrics"]:
             current_time = result["custom_metrics"].get(self._time_metric)
         else:
             raise ValueError(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This stopper allows to stop a trial based on the running mean of a specific metric.
(similar to : https://keras.io/api/callbacks/early_stopping/).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
