### PR TITLE
[CI][nightly test] Fix infra error

### DIFF
--- a/benchmarks/distributed/config.yaml
+++ b/benchmarks/distributed/config.yaml
@@ -7,7 +7,8 @@ upscaling_speed: 9999999
 provider:
     type: aws
     region: us-west-2
-    availability_zone: us-west-2a, us-west-2b, us-west-2c, us-west-2d
+    # r5dn.16xlarge is not supported in us-west-2d
+    availability_zone: us-west-2a, us-west-2b, us-west-2c
 
 auth:
     ssh_user: ubuntu

--- a/benchmarks/distributed_smoke_test.yaml
+++ b/benchmarks/distributed_smoke_test.yaml
@@ -1,5 +1,5 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west-2b
+region: us-west-2
 
 max_workers: 999
 

--- a/benchmarks/distributed_smoke_test.yaml
+++ b/benchmarks/distributed_smoke_test.yaml
@@ -1,5 +1,5 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west-2
+region: us-west-2b
 
 max_workers: 999
 


### PR DESCRIPTION
we have few infra failures (https://beta.anyscale.com/o/anyscale-internal/projects/prj_2xR6uT6t7jJuu1aCwWMsle/clusters/ses_pPGPzPaxUSLR3du5fmuBXpkn,   https://beta.anyscale.com/o/anyscale-internal/projects/prj_2xR6uT6t7jJuu1aCwWMsle/clusters/ses_NZJRifHzB61Xt1Ydty2tKwQA, https://beta.anyscale.com/o/anyscale-internal/projects/prj_2xR6uT6t7jJuu1aCwWMsle/clusters/ses_6eH4GjWt6ANgFXKZU5bAMPjn
) 
suggests r5dn.16xlarge  is not supported in Availability Zone us-west-2d. 
we explicitly choose us-west-2a, us-west-2b, us-west-2c instead.