### PR TITLE
[core] avoid scheduling on gpu nodes by default

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -473,4 +473,4 @@ RAY_CONFIG(bool, event_log_reporter_enabled, false)
 RAY_CONFIG(std::string, event_level, "warning")
 
 /// Whether to avoid scheduling cpu requests on gpu nodes
-RAY_CONFIG(bool, scheduler_avoid_gpu_nodes, false)
+RAY_CONFIG(bool, scheduler_avoid_gpu_nodes, true)

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -102,10 +102,10 @@ class MockWorkerPool : public WorkerPoolInterface {
 };
 
 std::shared_ptr<ClusterResourceScheduler> CreateSingleNodeScheduler(
-    const std::string &id) {
+    const std::string &id, double num_gpus = 0.0) {
   std::unordered_map<std::string, double> local_node_resources;
   local_node_resources[ray::kCPU_ResourceLabel] = 8;
-  local_node_resources[ray::kGPU_ResourceLabel] = 4;
+  local_node_resources[ray::kGPU_ResourceLabel] = num_gpus;
   local_node_resources[ray::kMemory_ResourceLabel] = 128;
 
   auto scheduler = std::make_shared<ClusterResourceScheduler>(
@@ -177,9 +177,9 @@ class MockTaskDependencyManager : public TaskDependencyManagerInterface {
 
 class ClusterTaskManagerTest : public ::testing::Test {
  public:
-  ClusterTaskManagerTest()
+  ClusterTaskManagerTest(double num_gpus_at_head = 0.0)
       : id_(NodeID::FromRandom()),
-        scheduler_(CreateSingleNodeScheduler(id_.Binary())),
+        scheduler_(CreateSingleNodeScheduler(id_.Binary(), num_gpus_at_head)),
         is_owner_alive_(true),
         node_info_calls_(0),
         announce_infeasible_task_calls_(0),
@@ -282,6 +282,12 @@ class ClusterTaskManagerTest : public ::testing::Test {
 
   MockTaskDependencyManager dependency_manager_;
   ClusterTaskManager task_manager_;
+};
+
+// Same as ClusterTaskManagerTest, but the head node starts with 4.0 num gpus.
+class ClusterTaskManagerTestWithGPUsAtHead : public ClusterTaskManagerTest {
+ public:
+  ClusterTaskManagerTestWithGPUsAtHead() : ClusterTaskManagerTest(4.0) {}
 };
 
 TEST_F(ClusterTaskManagerTest, BasicTest) {
@@ -1196,7 +1202,7 @@ TEST_F(ClusterTaskManagerTest, FeasibleToNonFeasible) {
             task1.GetTaskSpecification().TaskId());
 }
 
-TEST_F(ClusterTaskManagerTest, RleaseAndReturnWorkerCpuResources) {
+TEST_F(ClusterTaskManagerTestWithGPUsAtHead, RleaseAndReturnWorkerCpuResources) {
   const NodeResources &node_resources = scheduler_->GetLocalNodeResources();
   ASSERT_EQ(node_resources.predefined_resources[PredefinedResources::CPU].available, 8);
   ASSERT_EQ(node_resources.predefined_resources[PredefinedResources::GPU].available, 4);

--- a/src/ray/raylet/scheduling/scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/scheduling_policy_test.cc
@@ -270,6 +270,13 @@ TEST_F(SchedulingPolicyTest, AvoidSchedulingCPURequestsOnGPUNodes) {
     ASSERT_EQ(to_schedule, local_node);
   }
   {
+    // A CPU request can be be scheduled on a CPU node.
+    const ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}}, false);
+    const int to_schedule = raylet_scheduling_policy::HybridPolicy(
+        req, local_node, nodes, 0.51, false, true, true);
+    ASSERT_EQ(to_schedule, remote_node);
+  }
+  {
     // A mixed CPU/GPU request should be scheduled on a GPU node.
     const ResourceRequest req =
         ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}}, false);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
