### PR TITLE
[Core][GlobalStateAccessor] fix GlobalStateAccessor's thread-safety

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -167,7 +167,7 @@
       --test_tag_filters=-flaky
       -- //:all -//:core_worker_test -//:event_test -//:gcs_actor_manager_test
       -//:gcs_placement_group_manager_test -//:gcs_placement_group_scheduler_test
-      -//:gcs_server_rpc_test -//:gcs_server_test -//:global_state_accessor_test
+      -//:gcs_server_rpc_test -//:gcs_server_test
       -//:metric_exporter_client_test -//:stats_test -//:worker_pool_test
 
 - label: ":serverless: Dashboard + Serve Tests"

--- a/src/ray/common/asio/instrumented_io_context.cc
+++ b/src/ray/common/asio/instrumented_io_context.cc
@@ -115,13 +115,14 @@ void instrumented_io_context::dispatch(std::function<void()> handler,
 std::shared_ptr<StatsHandle> instrumented_io_context::RecordStart(
     const std::string &name, int64_t expected_queueing_delay_ns) {
   auto stats = GetOrCreate(name);
+  int64_t curr_count = 0;
   {
     absl::MutexLock lock(&(stats->mutex));
     stats->stats.cum_count++;
-    stats->stats.curr_count++;
+    curr_count = ++stats->stats.curr_count;
   }
-  STATS_operation_count.Record(stats->stats.curr_count, name);
-  STATS_operation_active_count.Record(stats->stats.curr_count, name);
+  STATS_operation_count.Record(curr_count, name);
+  STATS_operation_active_count.Record(curr_count, name);
   return std::make_shared<StatsHandle>(
       name, absl::GetCurrentTimeNanos() + expected_queueing_delay_ns, stats,
       global_stats_);

--- a/src/ray/common/asio/instrumented_io_context.h
+++ b/src/ray/common/asio/instrumented_io_context.h
@@ -70,7 +70,7 @@ struct StatsHandle {
   int64_t start_time;
   std::shared_ptr<GuardedHandlerStats> handler_stats;
   std::shared_ptr<GuardedGlobalStats> global_stats;
-  bool execution_recorded = false;
+  std::atomic<bool> execution_recorded;
 
   StatsHandle(std::string handler_name_, int64_t start_time_,
               std::shared_ptr<GuardedHandlerStats> handler_stats_,
@@ -78,7 +78,8 @@ struct StatsHandle {
       : handler_name(std::move(handler_name_)),
         start_time(start_time_),
         handler_stats(std::move(handler_stats_)),
-        global_stats(std::move(global_stats_)) {}
+        global_stats(std::move(global_stats_)),
+        execution_recorded(false) {}
 
   void ZeroAccumulatedQueuingDelay() { start_time = absl::GetCurrentTimeNanos(); }
 

--- a/src/ray/common/asio/periodical_runner.cc
+++ b/src/ray/common/asio/periodical_runner.cc
@@ -20,9 +20,10 @@
 namespace ray {
 
 PeriodicalRunner::PeriodicalRunner(instrumented_io_context &io_service)
-    : io_service_(io_service) {}
+    : io_service_(io_service), mutex_() {}
 
 PeriodicalRunner::~PeriodicalRunner() {
+  absl::MutexLock lock(&mutex_);
   for (const auto &timer : timers_) {
     timer->cancel();
   }
@@ -33,7 +34,10 @@ void PeriodicalRunner::RunFnPeriodically(std::function<void()> fn, uint64_t peri
                                          const std::string name) {
   if (period_ms > 0) {
     auto timer = std::make_shared<boost::asio::deadline_timer>(io_service_);
-    timers_.push_back(timer);
+    {
+      absl::MutexLock lock(&mutex_);
+      timers_.push_back(timer);
+    }
     io_service_.post(
         [this, fn = std::move(fn), period_ms, name, timer = std::move(timer)]() {
           if (RayConfig::instance().event_stats()) {
@@ -50,6 +54,7 @@ void PeriodicalRunner::DoRunFnPeriodically(const std::function<void()> &fn,
                                            boost::posix_time::milliseconds period,
                                            boost::asio::deadline_timer &timer) {
   fn();
+  absl::MutexLock lock(&mutex_);
   timer.expires_from_now(period);
   timer.async_wait(
       [this, fn = std::move(fn), period, &timer](const boost::system::error_code &error) {
@@ -68,6 +73,7 @@ void PeriodicalRunner::DoRunFnPeriodicallyInstrumented(
     const std::function<void()> &fn, boost::posix_time::milliseconds period,
     boost::asio::deadline_timer &timer, const std::string name) {
   fn();
+  absl::MutexLock lock(&mutex_);
   timer.expires_from_now(period);
   // NOTE: We add the timer period to the enqueue time in order only measure the time in
   // which the handler was elgible to execute on the event loop but was queued by the

--- a/src/ray/gcs/gcs_client/global_state_accessor.h
+++ b/src/ray/gcs/gcs_client/global_state_accessor.h
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
+
 #include "ray/common/asio/instrumented_io_context.h"
 #include "ray/gcs/gcs_client/service_based_gcs_client.h"
 #include "ray/rpc/server_call.h"
@@ -34,46 +37,46 @@ class GlobalStateAccessor {
   explicit GlobalStateAccessor(const std::string &redis_address,
                                const std::string &redis_password);
 
-  ~GlobalStateAccessor();
+  ~GlobalStateAccessor() LOCKS_EXCLUDED(mutex_);
 
   /// Connect gcs server.
   ///
   /// \return Whether the connection is successful.
-  bool Connect();
+  bool Connect() LOCKS_EXCLUDED(mutex_);
 
   /// Disconnect from gcs server.
-  void Disconnect();
+  void Disconnect() LOCKS_EXCLUDED(mutex_);
 
   /// Get information of all jobs from GCS Service.
   ///
   /// \return All job info. To support multi-language, we serialize each JobTableData and
   /// return the serialized string. Where used, it needs to be deserialized with
   /// protobuf function.
-  std::vector<std::string> GetAllJobInfo();
+  std::vector<std::string> GetAllJobInfo() LOCKS_EXCLUDED(mutex_);
 
   /// Get next job id from GCS Service.
   ///
   /// \return Next job id.
-  JobID GetNextJobID();
+  JobID GetNextJobID() LOCKS_EXCLUDED(mutex_);
 
   /// Get all node information from GCS.
   ///
   /// \return A list of `GcsNodeInfo` objects serialized in protobuf format.
-  std::vector<std::string> GetAllNodeInfo();
+  std::vector<std::string> GetAllNodeInfo() LOCKS_EXCLUDED(mutex_);
 
   /// Get information of all profiles from GCS Service.
   ///
   /// \return All profile info. To support multi-language, we serialized each
   /// ProfileTableData and returned the serialized string. Where used, it needs to be
   /// deserialized with protobuf function.
-  std::vector<std::string> GetAllProfileInfo();
+  std::vector<std::string> GetAllProfileInfo() LOCKS_EXCLUDED(mutex_);
 
   /// Get information of all objects from GCS Service.
   ///
   /// \return All object info. To support multi-language, we serialize each
   /// ObjectTableData and return the serialized string. Where used, it needs to be
   /// deserialized with protobuf function.
-  std::vector<std::string> GetAllObjectInfo();
+  std::vector<std::string> GetAllObjectInfo() LOCKS_EXCLUDED(mutex_);
 
   /// Get information of an object from GCS Service.
   ///
@@ -81,7 +84,8 @@ class GlobalStateAccessor {
   /// \return Object info. To support multi-language, we serialize each ObjectTableData
   /// and return the serialized string. Where used, it needs to be deserialized with
   /// protobuf function.
-  std::unique_ptr<std::string> GetObjectInfo(const ObjectID &object_id);
+  std::unique_ptr<std::string> GetObjectInfo(const ObjectID &object_id)
+      LOCKS_EXCLUDED(mutex_);
 
   /// Get information of a node resource from GCS Service.
   ///
@@ -89,14 +93,14 @@ class GlobalStateAccessor {
   /// \return node resource map info. To support multi-language, we serialize each
   /// ResourceTableData and return the serialized string. Where used, it needs to be
   /// deserialized with protobuf function.
-  std::string GetNodeResourceInfo(const NodeID &node_id);
+  std::string GetNodeResourceInfo(const NodeID &node_id) LOCKS_EXCLUDED(mutex_);
 
   /// Get available resources of all nodes.
   ///
   /// \return available resources of all nodes. To support multi-language, we serialize
   /// each AvailableResources and return the serialized string. Where used, it needs to be
   /// deserialized with protobuf function.
-  std::vector<std::string> GetAllAvailableResources();
+  std::vector<std::string> GetAllAvailableResources() LOCKS_EXCLUDED(mutex_);
 
   /// Get newest resource usage of all nodes from GCS Service. Only used when light
   /// rerouce usage report enabled.
@@ -104,14 +108,14 @@ class GlobalStateAccessor {
   /// \return resource usage info. To support multi-language, we serialize each
   /// data and return the serialized string. Where used, it needs to be
   /// deserialized with protobuf function.
-  std::unique_ptr<std::string> GetAllResourceUsage();
+  std::unique_ptr<std::string> GetAllResourceUsage() LOCKS_EXCLUDED(mutex_);
 
   /// Get information of all actors from GCS Service.
   ///
   /// \return All actor info. To support multi-language, we serialize each ActorTableData
   /// and return the serialized string. Where used, it needs to be deserialized with
   /// protobuf function.
-  std::vector<std::string> GetAllActorInfo();
+  std::vector<std::string> GetAllActorInfo() LOCKS_EXCLUDED(mutex_);
 
   /// Get information of an actor from GCS Service.
   ///
@@ -119,7 +123,8 @@ class GlobalStateAccessor {
   /// \return Actor info. To support multi-language, we serialize each ActorTableData and
   /// return the serialized string. Where used, it needs to be deserialized with
   /// protobuf function.
-  std::unique_ptr<std::string> GetActorInfo(const ActorID &actor_id);
+  std::unique_ptr<std::string> GetActorInfo(const ActorID &actor_id)
+      LOCKS_EXCLUDED(mutex_);
 
   /// Get information of a worker from GCS Service.
   ///
@@ -127,28 +132,29 @@ class GlobalStateAccessor {
   /// \return Worker info. To support multi-language, we serialize each WorkerTableData
   /// and return the serialized string. Where used, it needs to be deserialized with
   /// protobuf function.
-  std::unique_ptr<std::string> GetWorkerInfo(const WorkerID &worker_id);
+  std::unique_ptr<std::string> GetWorkerInfo(const WorkerID &worker_id)
+      LOCKS_EXCLUDED(mutex_);
 
   /// Get information of all workers from GCS Service.
   ///
   /// \return All worker info. To support multi-language, we serialize each
   /// WorkerTableData and return the serialized string. Where used, it needs to be
   /// deserialized with protobuf function.
-  std::vector<std::string> GetAllWorkerInfo();
+  std::vector<std::string> GetAllWorkerInfo() LOCKS_EXCLUDED(mutex_);
 
   /// Add information of a worker to GCS Service.
   ///
   /// \param serialized_string The serialized data of worker to be added in the GCS
   /// Service, use string is convenient for python to use.
   /// \return Is operation success.
-  bool AddWorkerInfo(const std::string &serialized_string);
+  bool AddWorkerInfo(const std::string &serialized_string) LOCKS_EXCLUDED(mutex_);
 
   /// Get information of all placement group from GCS Service.
   ///
   /// \return All placement group info. To support multi-language, we serialize each
   /// PlacementGroupTableData and return the serialized string. Where used, it needs to be
   /// deserialized with protobuf function.
-  std::vector<std::string> GetAllPlacementGroupInfo();
+  std::vector<std::string> GetAllPlacementGroupInfo() LOCKS_EXCLUDED(mutex_);
 
   /// Get information of a placement group from GCS Service by ID.
   ///
@@ -157,7 +163,7 @@ class GlobalStateAccessor {
   /// PlacementGroupTableData and return the serialized string. Where used, it needs to be
   /// deserialized with protobuf function.
   std::unique_ptr<std::string> GetPlacementGroupInfo(
-      const PlacementGroupID &placement_group_id);
+      const PlacementGroupID &placement_group_id) LOCKS_EXCLUDED(mutex_);
 
   /// Get information of a placement group from GCS Service by name.
   ///
@@ -167,18 +173,20 @@ class GlobalStateAccessor {
   /// PlacementGroupTableData and return the serialized string. Where used, it needs to be
   /// deserialized with protobuf function.
   std::unique_ptr<std::string> GetPlacementGroupByName(
-      const std::string &placement_group_name, const std::string &ray_namespace);
+      const std::string &placement_group_name, const std::string &ray_namespace)
+      LOCKS_EXCLUDED(mutex_);
 
   /// Get value of the key from GCS Service.
   ///
   /// \param key key to get.
   /// \return Value of the key.
-  std::unique_ptr<std::string> GetInternalKV(const std::string &key);
+  std::unique_ptr<std::string> GetInternalKV(const std::string &key)
+      LOCKS_EXCLUDED(mutex_);
 
   /// Get the serialized system config from GCS.
   ///
   /// \return The serialized system config.
-  std::string GetSystemConfig();
+  std::string GetSystemConfig() LOCKS_EXCLUDED(mutex_);
 
   /// Get the node to connect for a Ray driver.
   ///
@@ -187,7 +195,8 @@ class GlobalStateAccessor {
   /// multi-language, we serialize each GcsNodeInfo and return the serialized string.
   /// Where used, it needs to be deserialized with protobuf function.
   ray::Status GetNodeToConnectForDriver(const std::string &node_ip_address,
-                                        std::string *node_to_connect);
+                                        std::string *node_to_connect)
+      LOCKS_EXCLUDED(mutex_);
 
  private:
   /// MultiItem transformation helper in template style.
@@ -234,10 +243,12 @@ class GlobalStateAccessor {
   std::string redis_address_;
   std::string redis_ip_address_;
 
-  /// Whether this client is connected to gcs server.
-  bool is_connected_{false};
+  // protects is_connected_ and gcs_client_
+  mutable absl::Mutex mutex_;
 
-  std::unique_ptr<ServiceBasedGcsClient> gcs_client_;
+  /// Whether this client is connected to gcs server.
+  bool is_connected_ GUARDED_BY(mutex_) = false;
+  std::unique_ptr<ServiceBasedGcsClient> gcs_client_ GUARDED_BY(mutex_);
 
   std::unique_ptr<std::thread> thread_io_service_;
   std::unique_ptr<instrumented_io_context> io_service_;

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -40,7 +40,9 @@ GcsServer::GcsServer(const ray::gcs::GcsServerConfig &config,
       client_call_manager_(main_service),
       raylet_client_pool_(
           std::make_shared<rpc::NodeManagerClientPool>(client_call_manager_)),
-      pubsub_periodical_runner_(main_service_) {}
+      pubsub_periodical_runner_(main_service_),
+      is_started_(false),
+      is_stopped_(false) {}
 
 GcsServer::~GcsServer() { Stop(); }
 

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -224,8 +224,8 @@ class GcsServer {
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
   std::unique_ptr<ray::RuntimeEnvManager> runtime_env_manager_;
   /// Gcs service state flag, which is used for ut.
-  bool is_started_ = false;
-  bool is_stopped_ = false;
+  std::atomic<bool> is_started_;
+  std::atomic<bool> is_stopped_;
 };
 
 }  // namespace gcs


### PR DESCRIPTION
GlobalStateAccessor is not thread safe. Specifically the Connect() could be called from one thread while the Getters are called by other threads. This is the root cause of #18680 

This PR we ensure GlobalStateAccessor is thread safe by absl::mutex.

Test Plan
- [x] enable TSAN test for global_state_accessor_test