### PR TITLE
Actor repr for log prefix should be computed after init, not before

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -453,7 +453,7 @@ cdef execute_task(
         actor = actor_class.__new__(actor_class)
         worker.actors[actor_id] = actor
         if (<int>task_type == <int>TASK_TYPE_ACTOR_CREATION_TASK):
-            # Record the actor class via :actor_name: magic token in the log file.
+            # Record the actor class via :actor_name: magic token in the log.
             # (Phase 1): this covers code run before __init__ finishes.
             print("{}{}".format(
                 ray_constants.LOG_PREFIX_ACTOR_NAME, actor_class.__name__))
@@ -596,10 +596,11 @@ cdef execute_task(
                 if c_return_ids.size() == 1:
                     outputs = (outputs,)
             if (<int>task_type == <int>TASK_TYPE_ACTOR_CREATION_TASK):
-                # Record the actor repr via :actor_name: magic token in the log file.
+                # Record actor repr via :actor_name: magic token in the log.
                 # (Phase 2): this covers code run after __init__ finishes.
                 if (hasattr(actor_class, "__ray_actor_class__") and
-                        "__repr__" in actor_class.__ray_actor_class__.__dict__):
+                        "__repr__" in
+                        actor_class.__ray_actor_class__.__dict__):
                     print("{}{}".format(
                         ray_constants.LOG_PREFIX_ACTOR_NAME, repr(actor)))
             # Check for a cancellation that was called when the function

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -452,13 +452,9 @@ cdef execute_task(
         actor_id = core_worker.get_actor_id()
         actor = actor_class.__new__(actor_class)
         worker.actors[actor_id] = actor
-        # Record the actor name via :actor_name: magic token in the log file.
-        # This is used for the prefix in driver logs `(actor_repr pid=123)...`
-        if (hasattr(actor_class, "__ray_actor_class__") and
-                "__repr__" in actor_class.__ray_actor_class__.__dict__):
-            print("{}{}".format(
-                ray_constants.LOG_PREFIX_ACTOR_NAME, repr(actor)))
-        else:
+        if (<int>task_type == <int>TASK_TYPE_ACTOR_CREATION_TASK):
+            # Record the actor class via :actor_name: magic token in the log file.
+            # (Phase 1): this covers code run before __init__ finishes.
             print("{}{}".format(
                 ray_constants.LOG_PREFIX_ACTOR_NAME, actor_class.__name__))
 
@@ -599,6 +595,13 @@ cdef execute_task(
                     raise e
                 if c_return_ids.size() == 1:
                     outputs = (outputs,)
+            if (<int>task_type == <int>TASK_TYPE_ACTOR_CREATION_TASK):
+                # Record the actor repr via :actor_name: magic token in the log file.
+                # (Phase 2): this covers code run after __init__ finishes.
+                if (hasattr(actor_class, "__ray_actor_class__") and
+                        "__repr__" in actor_class.__ray_actor_class__.__dict__):
+                    print("{}{}".format(
+                        ray_constants.LOG_PREFIX_ACTOR_NAME, repr(actor)))
             # Check for a cancellation that was called when the function
             # was exiting and was raised after the except block.
             if not check_signals().ok():

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -459,7 +459,7 @@ cdef execute_task(
             # We need to handle this separately because `__repr__` may not be
             # runnable until after `__init__` (e.g., if it accesses fields
             # defined in the constructor).
-            print("{}{}.__init__".format(
+            print("{}{}".format(
                 ray_constants.LOG_PREFIX_ACTOR_NAME, actor_class.__name__))
 
     execution_info = execution_infos.get(function_descriptor)

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -161,8 +161,8 @@ ray.get(b.f.remote())
     assert "hi" in out_str, out_str
     assert "(Actor1 pid=" in out_str, out_str
     assert "bye" in out_str, out_str
-    assert re.search("Actor2.__init__ pid=.*init", out_str), out_str
-    assert not re.search("ActorX.*init", out_str), out_str
+    assert re.search("Actor2 pid=.*init", out_str), out_str
+    assert not re.search("ActorX pid=.*init", out_str), out_str
     assert re.search("ActorX pid=.*bye", out_str), out_str
     assert not re.search("Actor2 pid=.*bye", out_str), out_str
 

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -161,8 +161,8 @@ ray.get(b.f.remote())
     assert "hi" in out_str, out_str
     assert "(Actor1 pid=" in out_str, out_str
     assert "bye" in out_str, out_str
-    assert re.search("Actor2 pid=.*init", out_str), out_str
-    assert not re.search("ActorX pid=.*init", out_str), out_str
+    assert re.search("Actor2.__init__ pid=.*init", out_str), out_str
+    assert not re.search("ActorX.*init", out_str), out_str
     assert re.search("ActorX pid=.*bye", out_str), out_str
     assert not re.search("Actor2 pid=.*bye", out_str), out_str
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Closes https://github.com/ray-project/ray/issues/18748