### PR TITLE
[Core] fix another thread safety issue in instrumented_io_context

### DIFF
--- a/src/ray/common/asio/instrumented_io_context.cc
+++ b/src/ray/common/asio/instrumented_io_context.cc
@@ -176,6 +176,7 @@ void instrumented_io_context::RecordExecution(const std::function<void()> &fn,
 std::shared_ptr<GuardedHandlerStats> instrumented_io_context::GetOrCreate(
     const std::string &name) {
   // Get this handler's stats.
+  std::shared_ptr<GuardedHandlerStats> result;
   mutex_.ReaderLock();
   auto it = post_handler_stats_.find(name);
   if (it == post_handler_stats_.end()) {
@@ -195,10 +196,12 @@ std::shared_ptr<GuardedHandlerStats> instrumented_io_context::GetOrCreate(
       // the table.
       RAY_CHECK(it != post_handler_stats_.end());
     }
+    result = it->second;
   } else {
+    result = it->second;
     mutex_.ReaderUnlock();
   }
-  return it->second;
+  return result;
 }
 
 GlobalStats instrumented_io_context::get_global_stats() const {


### PR DESCRIPTION
global_state_accessor_test TSAN test is still [failing](https://buildkite.com/ray-project/ray-builders-branch/builds/3560#e30b37c3-fefc-4590-94bf-949dd8c68549/6-68). This is because our access to `post_handler_stats_`'s iterator is not protected by mutex and subject to thread safety issues. 
In this PR we ensure it's protected by mutex.
- [ ] wait for CI TSAN test pass.
