### PR TITLE
[dataset] enable shuffle custom resource label for dataset pipeline

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -72,6 +72,7 @@ class Dataset(Generic[T]):
         """
         self._blocks: BlockList[T] = blocks
         self._uuid = uuid4().hex
+        self._shuffle_spread_custom_resource_labels: Optional[List[str]] = None
         assert isinstance(self._blocks, BlockList), self._blocks
 
     def map(self,
@@ -356,13 +357,20 @@ class Dataset(Generic[T]):
             self._move_blocks() if _move else self._blocks,
             num_blocks,
             random_shuffle=True,
-            random_seed=seed)
+            random_seed=seed,
+            _shuffle_spread_custom_resource_labels=self.
+            _shuffle_spread_custom_resource_labels)
         return Dataset(new_blocks)
 
     def _move_blocks(self):
         blocks = self._blocks.copy()
         self._blocks.clear()
         return blocks
+
+    def _set_shuffle_spread_custom_resource_labels(
+            self, labels: List[str]) -> "Dataset[T]":
+        self._shuffle_spread_custom_resource_labels = labels
+        return self
 
     def split(self,
               n: int,

--- a/python/ray/data/impl/shuffle.py
+++ b/python/ray/data/impl/shuffle.py
@@ -1,6 +1,5 @@
 import itertools
 import math
-import os
 from typing import TypeVar, List, Optional, Dict, Any
 
 import numpy as np
@@ -15,24 +14,22 @@ from ray.data.impl.remote_fn import cached_remote_fn
 T = TypeVar("T")
 
 
-def simple_shuffle(input_blocks: BlockList[T],
-                   output_num_blocks: int,
-                   *,
-                   random_shuffle: bool = False,
-                   random_seed: Optional[int] = None,
-                   map_ray_remote_args: Optional[Dict[str, Any]] = None,
-                   reduce_ray_remote_args: Optional[Dict[str, Any]] = None
-                   ) -> BlockList[T]:
-    # Check for spread resource labels in environment variable, and use
-    # the given labels for round-robin resource-based scheduling.
-    shuffle_spread_custom_resource_labels = os.getenv(
-        "RAY_DATASETS_SHUFFLE_SPREAD_CUSTOM_RESOURCE_LABELS", None)
-    if shuffle_spread_custom_resource_labels is not None:
-        shuffle_spread_custom_resource_labels = (
-            shuffle_spread_custom_resource_labels.split(","))
+def simple_shuffle(
+        input_blocks: BlockList[T],
+        output_num_blocks: int,
+        *,
+        random_shuffle: bool = False,
+        random_seed: Optional[int] = None,
+        map_ray_remote_args: Optional[Dict[str, Any]] = None,
+        reduce_ray_remote_args: Optional[Dict[str, Any]] = None,
+        _shuffle_spread_custom_resource_labels: Optional[List[str]] = None
+) -> BlockList[T]:
+    # use shuffle_spread_custom_resource_labels
+    # for round-robin resource-based scheduling.
+    if _shuffle_spread_custom_resource_labels is not None:
         round_robin_resource_provider = itertools.cycle(
             map(lambda resource: {resource: 0.001},
-                shuffle_spread_custom_resource_labels))
+                _shuffle_spread_custom_resource_labels))
     else:
         # If no round-robin resource provider given, yield an empty
         # dictionary.

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -204,7 +204,11 @@ def read_datasource(datasource: Datasource[T],
                 input_files=metadata[0].input_files,
             ))
 
-    return Dataset(block_list)
+    ds = Dataset(block_list)
+    if read_spread_custom_resource_labels:
+        ds._set_shuffle_spread_custom_resource_labels(
+            read_spread_custom_resource_labels)
+    return ds
 
 
 @PublicAPI(stability="beta")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://github.com/ray-project/ray/pull/18678 doesn't work with dataset_pipeline. I realized this is because the environment variable is not propagated to worker/remote node, and usually we only set environment variable at driver.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
