### PR TITLE
[tune] Depreciate `max_concurrent` in `TuneBOHB`

### DIFF
--- a/python/ray/tune/suggest/bohb.py
+++ b/python/ray/tune/suggest/bohb.py
@@ -48,7 +48,7 @@ class TuneBOHB(Searcher):
             Parameters will be sampled from this space which will be used
             to run trials.
         bohb_config (dict): configuration for HpBandSter BOHB algorithm
-        max_concurrent (int): Depreciated. Use
+        max_concurrent (int): Deprecated. Use
             ``tune.suggest.ConcurrencyLimiter()``.
         metric (str): The training result objective value attribute. If None
             but a mode was passed, the anonymous metric `_metric` will be used

--- a/python/ray/tune/suggest/bohb.py
+++ b/python/ray/tune/suggest/bohb.py
@@ -113,7 +113,7 @@ class TuneBOHB(Searcher):
                  space: Optional[Union[
                      Dict, "ConfigSpace.ConfigurationSpace"]] = None,
                  bohb_config: Optional[Dict] = None,
-                 max_concurrent: int = 10,
+                 max_concurrent: Optional[int] = None,
                  metric: Optional[str] = None,
                  mode: Optional[str] = None,
                  points_to_evaluate: Optional[List[Dict]] = None,

--- a/python/ray/tune/suggest/bohb.py
+++ b/python/ray/tune/suggest/bohb.py
@@ -48,8 +48,8 @@ class TuneBOHB(Searcher):
             Parameters will be sampled from this space which will be used
             to run trials.
         bohb_config (dict): configuration for HpBandSter BOHB algorithm
-        max_concurrent (int): Number of maximum concurrent trials. Defaults
-            to 10.
+        max_concurrent (int): Depreciated. Use
+            ``tune.suggest.ConcurrencyLimiter()``.
         metric (str): The training result objective value attribute. If None
             but a mode was passed, the anonymous metric `_metric` will be used
             per default.
@@ -74,7 +74,7 @@ class TuneBOHB(Searcher):
             "activation": tune.choice(["relu", "tanh"])
         }
 
-        algo = TuneBOHB(max_concurrent=4, metric="mean_loss", mode="min")
+        algo = TuneBOHB(metric="mean_loss", mode="min")
         bohb = HyperBandForBOHB(
             time_attr="training_iteration",
             metric="mean_loss",
@@ -99,7 +99,7 @@ class TuneBOHB(Searcher):
                 name="activation", choices=["relu", "tanh"]))
 
         algo = TuneBOHB(
-            config_space, max_concurrent=4, metric="mean_loss", mode="min")
+            config_space, metric="mean_loss", mode="min")
         bohb = HyperBandForBOHB(
             time_attr="training_iteration",
             metric="mean_loss",
@@ -144,7 +144,8 @@ class TuneBOHB(Searcher):
 
         self._points_to_evaluate = points_to_evaluate
 
-        super(TuneBOHB, self).__init__(metric=self._metric, mode=mode)
+        super(TuneBOHB, self).__init__(
+            metric=self._metric, mode=mode, max_concurrent=max_concurrent)
 
         if self._space:
             self._setup_bohb()
@@ -195,16 +196,14 @@ class TuneBOHB(Searcher):
                     metric=self._metric,
                     mode=self._mode))
 
-        if len(self.running) < self._max_concurrent:
-            if self._points_to_evaluate:
-                config = self._points_to_evaluate.pop(0)
-            else:
-                # This parameter is not used in hpbandster implementation.
-                config, info = self.bohber.get_config(None)
-            self.trial_to_params[trial_id] = copy.deepcopy(config)
-            self.running.add(trial_id)
-            return unflatten_list_dict(config)
-        return None
+        if self._points_to_evaluate:
+            config = self._points_to_evaluate.pop(0)
+        else:
+            # This parameter is not used in hpbandster implementation.
+            config, _ = self.bohber.get_config(None)
+        self.trial_to_params[trial_id] = copy.deepcopy(config)
+        self.running.add(trial_id)
+        return unflatten_list_dict(config)
 
     def on_trial_result(self, trial_id: str, result: Dict):
         if trial_id not in self.paused:

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -570,8 +570,7 @@ class SearchSpaceTest(unittest.TestCase):
         for k in ignore:
             config.pop(k)
 
-        searcher = TuneBOHB(
-            space=config, metric="a", mode="max", max_concurrent=1000)
+        searcher = TuneBOHB(space=config, metric="a", mode="max")
 
         def config_generator():
             for i in range(1000):

--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -22,6 +22,7 @@ from ray.tune.schedulers import (FIFOScheduler, HyperBandScheduler,
 
 from ray.tune.schedulers.pbt import explore, PopulationBasedTrainingReplay
 from ray.tune.suggest._mock import _MockSearcher
+from ray.tune.suggest.suggestion import ConcurrencyLimiter
 from ray.tune.trial import Trial, Checkpoint
 from ray.tune.trial_executor import TrialExecutor
 from ray.tune.resources import Resources
@@ -816,7 +817,7 @@ class BOHBSuite(unittest.TestCase):
         config = {"test_variable": tune.uniform(0, 20)}
         sched = HyperBandForBOHB(
             max_t=10, reduction_factor=3, stop_last_trials=False)
-        alg = TuneBOHB(max_concurrent=4)
+        alg = ConcurrencyLimiter(TuneBOHB(), 4)
         analysis = tune.run(
             train,
             scheduler=sched,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Depreciates the `max_concurrent` argument in `TuneBOHB` searcher.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
