### PR TITLE
[Datasets] Add spread resource prefix for manual round-robin resource-based task load balancing.

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -323,11 +323,13 @@ class Dataset(Generic[T]):
         new_blocks = simple_shuffle(self._blocks, num_blocks)
         return Dataset(new_blocks)
 
-    def random_shuffle(self,
-                       *,
-                       seed: Optional[int] = None,
-                       num_blocks: Optional[int] = None,
-                       _move: Optional[bool] = False) -> "Dataset[T]":
+    def random_shuffle(
+            self,
+            *,
+            seed: Optional[int] = None,
+            num_blocks: Optional[int] = None,
+            _move: Optional[bool] = False,
+            _spread_resource_prefix: Optional[str] = None) -> "Dataset[T]":
         """Randomly shuffle the elements of this dataset.
 
         This is a blocking operation similar to repartition().
@@ -356,7 +358,8 @@ class Dataset(Generic[T]):
             self._move_blocks() if _move else self._blocks,
             num_blocks,
             random_shuffle=True,
-            random_seed=seed)
+            random_seed=seed,
+            _spread_resource_prefix=_spread_resource_prefix)
         return Dataset(new_blocks)
 
     def _move_blocks(self):

--- a/python/ray/data/impl/util.py
+++ b/python/ray/data/impl/util.py
@@ -1,4 +1,9 @@
+import itertools
 import logging
+from typing import List, Dict, Any
+
+from ray.remote_function import DEFAULT_REMOTE_FUNCTION_CPUS
+import ray.ray_constants as ray_constants
 
 logger = logging.getLogger(__name__)
 
@@ -30,3 +35,60 @@ def _check_pyarrow_version():
                            "to ensure compatibility with Ray Datasets.")
         else:
             _VERSION_VALIDATED = True
+
+
+def _get_spread_resources_iter(nodes: List[Dict[str, Any]],
+                               spread_resource_prefix: str,
+                               ray_remote_args: Dict[str, Any]):
+    """Returns a round-robin iterator over resources that match the given
+    prefix and that coexist on nodes with the resource requests given in the
+    provided remote args (along with the task resource request defaults).
+    """
+    # Extract the resource labels from the remote args.
+    resource_request_labels = _get_resource_request_labels(ray_remote_args)
+    # Filter on the prefix and the requested resources.
+    spread_resource_labels = _filtered_resources(
+        nodes,
+        include_prefix=spread_resource_prefix,
+        include_colocated_with=resource_request_labels)
+    # Return a round-robin resource iterator over the spread labels.
+    return itertools.cycle([{
+        label: 0.001
+    } for label in spread_resource_labels])
+
+
+def _get_resource_request_labels(ray_remote_args: Dict[str, Any]):
+    """Extracts the resource labels from the given remote args, filling in
+    task resource request defaults.
+    """
+    resource_request_labels = set(ray_remote_args.get("resources", {}).keys())
+    if DEFAULT_REMOTE_FUNCTION_CPUS > 0:
+        resource_request_labels.add("CPU")
+    if "num_gpus" in ray_remote_args:
+        resource_request_labels.add("GPU")
+    try:
+        accelerator_type = ray_remote_args["accelerator_type"]
+    except KeyError:
+        pass
+    else:
+        resource_request_labels.add(
+            f"{ray_constants.RESOURCE_CONSTRAINT_PREFIX}"
+            f"{accelerator_type}")
+    return resource_request_labels
+
+
+def _filtered_resources(nodes: List[Dict[str, Any]], include_prefix: str,
+                        include_colocated_with: List[str]):
+    """Filters cluster resource labels based on the given prefix and the
+    given resource colocation constraints.
+
+    Returns a list of unique, sorted resource labels.
+    """
+    resources = [
+        resource for node in nodes
+        if set(include_colocated_with) <= set(node["Resources"].keys())
+        for resource in node["Resources"].keys()
+        if resource.startswith(include_prefix)
+    ]
+    # Ensure stable ordering of unique resources.
+    return sorted(set(resources))

--- a/python/ray/data/impl/util.py
+++ b/python/ray/data/impl/util.py
@@ -51,6 +51,12 @@ def _get_spread_resources_iter(nodes: List[Dict[str, Any]],
         nodes,
         include_prefix=spread_resource_prefix,
         include_colocated_with=resource_request_labels)
+    if not spread_resource_labels:
+        # No spreadable resource labels available, raise an error.
+        raise ValueError(
+            "No resources both match the provided prefix "
+            f"{spread_resource_prefix} and are colocated with resources "
+            f"{resource_request_labels}.")
     # Return a round-robin resource iterator over the spread labels.
     return itertools.cycle([{
         label: 0.001

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1,6 +1,5 @@
 import itertools
 import logging
-import os
 from typing import List, Any, Dict, Union, Optional, Tuple, Callable, \
     TypeVar, TYPE_CHECKING
 
@@ -26,6 +25,7 @@ from ray.data.impl.arrow_block import ArrowRow, \
 from ray.data.impl.block_list import BlockList
 from ray.data.impl.lazy_block_list import LazyBlockList
 from ray.data.impl.remote_fn import cached_remote_fn
+from ray.data.impl.util import _get_spread_resources_iter
 
 T = TypeVar("T")
 
@@ -137,6 +137,7 @@ def read_datasource(datasource: Datasource[T],
                     *,
                     parallelism: int = 200,
                     ray_remote_args: Dict[str, Any] = None,
+                    _spread_resource_prefix: Optional[str] = None,
                     **read_args) -> Dataset[T]:
     """Read a dataset from a custom data source.
 
@@ -165,18 +166,15 @@ def read_datasource(datasource: Datasource[T],
         ray_remote_args["num_cpus"] = 0.5
     remote_read = cached_remote_fn(remote_read)
 
-    read_spread_custom_resource_labels = os.getenv(
-        "RAY_DATASETS_READ_SPREAD_CUSTOM_RESOURCE_LABELS", None)
-    if read_spread_custom_resource_labels is not None:
-        read_spread_custom_resource_labels = (
-            read_spread_custom_resource_labels.split(","))
-        round_robin_resource_provider = itertools.cycle(
-            map(lambda resource: {resource: 0.001},
-                read_spread_custom_resource_labels))
+    if _spread_resource_prefix is not None:
+        # Use given spread resource prefix for round-robin resource-based
+        # scheduling.
+        nodes = ray.nodes()
+        resource_iter = _get_spread_resources_iter(
+            nodes, _spread_resource_prefix, ray_remote_args)
     else:
-        round_robin_resource_provider = itertools.repeat({})
-
-    resource_iter = iter(round_robin_resource_provider)
+        # If no spread resource prefix given, yield an empty dictionary.
+        resource_iter = itertools.repeat({})
 
     calls: List[Callable[[], ObjectRef[Block]]] = []
     metadata: List[BlockMetadata] = []


### PR DESCRIPTION
Adds a private spread resource prefix API for manual round-robin resource-based task load balancing, used for read and shuffle stages. Nodes (and therefore resources that match the spread prefix) that don't satisfy the task's resource requests are automatically filtered out, so a secondary custom resource or setting `num_cpus=0` on nodes can both be used to prevent these tasks from matching some subset of nodes (e.g. isolating a set of GPU workers from CPU workers).

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
