### PR TITLE
[Repo Config] Allow blank issues.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Ask a question or get support
     url: https://discuss.ray.io/


### PR DESCRIPTION
The issue templates don't match the OSS teams' current issue schemas, and is a lot of overhead for quick issues. We should still allow for a blank issue escape hatch.