### PR TITLE
[CI] Disable failing mac spilling tests

### DIFF
--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -387,7 +387,7 @@ def test_spill_stats(object_spilling_config, shutdown_only):
 
 
 @pytest.mark.skipif(
-    platform.system() == "Windows", reason="Failing on Windows.")
+    platform.system() != "Linux", reason="Failing on Windows/macOS.")
 @pytest.mark.asyncio
 @pytest.mark.parametrize("is_async", [False, True])
 async def test_spill_during_get(object_spilling_config, shutdown_only,
@@ -440,9 +440,7 @@ async def test_spill_during_get(object_spilling_config, shutdown_only,
         print(obj.shape)
         del obj
 
-    # In CI, Mac.metal suffers from EBS code start problem. Increase
-    # the timeout to 90.
-    timeout_seconds = 90 if platform.system() == "Darwin" else 30
+    timeout_seconds = 30
     duration = datetime.now() - start
     assert duration <= timedelta(
         seconds=timeout_seconds

--- a/python/ray/tests/test_object_spilling_3.py
+++ b/python/ray/tests/test_object_spilling_3.py
@@ -112,19 +112,19 @@ def _test_object_spilling_threshold(thres, num_objects, num_objects_spilled):
 
 
 @pytest.mark.skipif(
-    platform.system() == "Windows", reason="Failing on Windows.")
+    platform.system() != "Linux", reason="Failing on Windows/macOS.")
 def test_object_spilling_threshold_default():
     _test_object_spilling_threshold(None, 10, 5)
 
 
 @pytest.mark.skipif(
-    platform.system() == "Windows", reason="Failing on Windows.")
+    platform.system() != "Linux", reason="Failing on Windows/macOS.")
 def test_object_spilling_threshold_1_0():
     _test_object_spilling_threshold(1.0, 10, 0)
 
 
 @pytest.mark.skipif(
-    platform.system() == "Windows", reason="Failing on Windows.")
+    platform.system() != "Linux", reason="Failing on Windows/macOS.")
 def test_object_spilling_threshold_0_1():
     _test_object_spilling_threshold(0.1, 10, 5)
 


### PR DESCRIPTION
As we discussed, we disable those time consuming spilling test on Mac as they subject to ebs cold start problems.