### PR TITLE
Enable gcs internal kv by default

### DIFF
--- a/python/ray/experimental/internal_kv.py
+++ b/python/ray/experimental/internal_kv.py
@@ -5,7 +5,7 @@ from typing import List, Union
 
 from ray._private.client_mode_hook import client_mode_hook
 
-redis = os.environ.get("RAY_KV_USE_GCS", "0") == "0"
+redis = os.environ.get("RAY_KV_USE_GCS", "1") == "0"
 _initialized = False
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The gcs based internal kv has been merged by not enabled by default. We can turn on that switch to see if it's stable and remove the redis part if ok.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
