### PR TITLE
[Dashboard] Keep Job timestamp as millisecond

### DIFF
--- a/dashboard/client/src/pages/job/index.tsx
+++ b/dashboard/client/src/pages/job/index.tsx
@@ -110,9 +110,7 @@ const JobList = () => {
                         {isDead ? "true" : "false"}
                       </TableCell>
                       <TableCell align="center">
-                        {dayjs(Math.floor(timestamp)).format(
-                          "YYYY/MM/DD HH:mm:ss",
-                        )}
+                        {dayjs(Number(timestamp)).format("YYYY/MM/DD HH:mm:ss")}
                       </TableCell>
                     </TableRow>
                   ),

--- a/dashboard/client/src/pages/job/index.tsx
+++ b/dashboard/client/src/pages/job/index.tsx
@@ -110,7 +110,9 @@ const JobList = () => {
                         {isDead ? "true" : "false"}
                       </TableCell>
                       <TableCell align="center">
-                        {dayjs(Math.floor(timestamp)).format("YYYY/MM/DD HH:mm:ss")}
+                        {dayjs(Math.floor(timestamp)).format(
+                          "YYYY/MM/DD HH:mm:ss",
+                        )}
                       </TableCell>
                     </TableRow>
                   ),

--- a/dashboard/client/src/pages/job/index.tsx
+++ b/dashboard/client/src/pages/job/index.tsx
@@ -110,7 +110,7 @@ const JobList = () => {
                         {isDead ? "true" : "false"}
                       </TableCell>
                       <TableCell align="center">
-                        {dayjs(timestamp * 1000).format("YYYY/MM/DD HH:mm:ss")}
+                        {dayjs(Math.floor(timestamp)).format("YYYY/MM/DD HH:mm:ss")}
                       </TableCell>
                     </TableRow>
                   ),


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The `Timestamp` column in Job list view is miscalculated.

Current the `timestamp` is already millisecond based, so no need to * 1000,
but should convert to integer value for `dayjs` in the dashboard UI.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
