### PR TITLE
[WIP] Inheritance-based FastAPI wrapper

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -568,7 +568,7 @@ def ingress(app: Union["FastAPI", "APIRouter", Callable]):
         frozen_app = cloudpickle.loads(cloudpickle.dumps(app))
 
         class ASGIAppWrapper(cls):
-            async def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
 
                 self._serve_app = frozen_app
@@ -579,6 +579,9 @@ def ingress(app: Union["FastAPI", "APIRouter", Callable]):
                     Config(self._serve_app, lifespan="on"))
                 # Replace uvicorn logger with our own.
                 self._serve_asgi_lifespan.logger = logger
+
+            async def _async_setup(self):
+            """Runs FastAPI startup hooks, will be run at replica startup."""
                 # LifespanOn's logger logs in INFO level thus becomes spammy
                 # Within this block we temporarily uplevel for cleaner logging
                 with LoggingContext(

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -581,8 +581,7 @@ def ingress(app: Union["FastAPI", "APIRouter", Callable]):
                 self._serve_asgi_lifespan.logger = logger
 
             async def _async_setup(self):
-            """Runs FastAPI startup hooks, will be run at replica startup."""
-
+                """Runs FastAPI startup hooks, will be run at startup."""
                 # LifespanOn's logger logs in INFO level thus becomes spammy
                 # Within this block we temporarily uplevel for cleaner logging
                 with LoggingContext(

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -582,6 +582,7 @@ def ingress(app: Union["FastAPI", "APIRouter", Callable]):
 
             async def _async_setup(self):
             """Runs FastAPI startup hooks, will be run at replica startup."""
+
                 # LifespanOn's logger logs in INFO level thus becomes spammy
                 # Within this block we temporarily uplevel for cleaner logging
                 with LoggingContext(

--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -71,8 +71,9 @@ def create_backend_replica(name: str, serialized_backend_def: bytes):
             else:
                 # This allows backends to define an async __init__ method
                 # (required for FastAPI backend definition).
-                _callable = backend.__new__(backend)
-                await sync_to_async(_callable.__init__)(*init_args)
+                _callable = backend(*init_args)
+                if hasattr(_callable, "_async_setup"):
+                    await _callable._async_setup()
             # Setting the context again to update the servable_object.
             ray.serve.api._set_internal_replica_context(
                 backend_tag,

--- a/python/ray/serve/fastapi.py
+++ b/python/ray/serve/fastapi.py
@@ -3,7 +3,7 @@ import inspect
 from functools import wraps
 from typing import Any, Callable, Dict, Tuple
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from starlette.requests import Request
 from uvicorn.config import Config
 from uvicorn.lifespan.on import LifespanOn
@@ -50,7 +50,7 @@ class FastAPIWrapper:
 
         # LifespanOn's logger logs in INFO level thus becomes spammy
         # Within this block we temporarily uplevel for cleaner logging
-        # XXX: fix this, no await?
+        # XXX: fix this, no await in __init__
         # with LoggingContext(
                 # self._serve_asgi_lifespan.logger,
                 # level=logging.WARNING):
@@ -70,7 +70,8 @@ class FastAPIWrapper:
                 "their first argument.")
 
         old_self_parameter = old_parameters[0]
-        new_self_parameter = old_self_parameter.replace(default=self)
+        # XXX: why do we need Depends? Just passing self gives recursion depth exceeded.
+        new_self_parameter = old_self_parameter.replace(default=Depends(lambda: self))
         new_parameters = [new_self_parameter] + [
             # Make the rest of the parameters keyword only because
             # the first argument is no longer positional.

--- a/python/ray/serve/fastapi.py
+++ b/python/ray/serve/fastapi.py
@@ -45,16 +45,18 @@ class FastAPIWrapper:
         # startup and shutdown event.
         self._serve_asgi_lifespan = LifespanOn(
             Config(self._app, lifespan="on"))
+
         # Replace uvicorn logger with our own.
         self._serve_asgi_lifespan.logger = logger
 
+    async def _async_setup(self):
+        """Runs FastAPI startup hooks, will be run at replica startup."""
         # LifespanOn's logger logs in INFO level thus becomes spammy
         # Within this block we temporarily uplevel for cleaner logging
-        # XXX: fix this, no await in __init__
-        # with LoggingContext(
-                # self._serve_asgi_lifespan.logger,
-                # level=logging.WARNING):
-            # await self._serve_asgi_lifespan.startup()
+        with LoggingContext(
+                self._serve_asgi_lifespan.logger,
+                level=logging.WARNING):
+            await self._serve_asgi_lifespan.startup()
 
     def _add_method_route_to_app(self, method: Callable):
         # This block just adds a default values to the self parameters so that

--- a/python/ray/serve/fastapi.py
+++ b/python/ray/serve/fastapi.py
@@ -1,0 +1,140 @@
+from dataclasses import dataclass
+import inspect
+from functools import wraps
+from typing import Any, Callable, Dict, Tuple
+
+from fastapi import FastAPI
+from starlette.requests import Request
+from uvicorn.config import Config
+from uvicorn.lifespan.on import LifespanOn
+
+from ray.serve.exceptions import RayServeException
+from ray.serve.http_util import ASGIHTTPSender
+from ray.serve.utils import logger, LoggingContext
+
+FASTAPI_METHODS = ["GET", "PUT", "POST", "DELETE", "OPTIONS", "HEAD", "PATCH", "TRACE"]
+ROUTE_METADATA_ATTR = "__ray_serve_fastapi_route_metadata"
+
+GENERATED_METHOD_DOCSTRING = """
+Adds a {method_upper} route to the wrapped FastAPI app.
+
+This supports the same arguments as the `@app.{method_lower}` decorator of a
+regular FastAPI app (`fastapi.FastAPI`).
+
+This can only be used on a class that also inherits from {wrapper_class_name}
+The route will be added to the app when the {wrapper_class_name} constructor
+is called using `super().__init__(app)`.
+"""
+
+class FastAPIRouteMetadata:
+    def __init__(self, method: str, path: str, func: Callable, kwargs: Dict[Any, Any]):
+        self._path = path
+        self._func = func
+        self._kwargs = kwargs
+        self._kwargs["methods"] = [method]
+
+    def add_to_fastapi_app(self, app: FastAPI):
+        app.add_api_route(self._path, self._func, **self._kwargs)
+
+class FastAPIWrapper:
+    def __init__(self, app: FastAPI):
+        self._app = app
+        self._add_method_routes_to_app()
+
+        # Use uvicorn's lifespan handling code to properly deal with
+        # startup and shutdown event.
+        self._serve_asgi_lifespan = LifespanOn(
+            Config(self._app, lifespan="on"))
+        # Replace uvicorn logger with our own.
+        self._serve_asgi_lifespan.logger = logger
+
+        # LifespanOn's logger logs in INFO level thus becomes spammy
+        # Within this block we temporarily uplevel for cleaner logging
+        # XXX: fix this, no await?
+        # with LoggingContext(
+                # self._serve_asgi_lifespan.logger,
+                # level=logging.WARNING):
+            # await self._serve_asgi_lifespan.startup()
+
+    def _add_method_route_to_app(self, method: Callable):
+        # This block just adds a default values to the self parameters so that
+        # FastAPI knows to inject the object when calling the route.
+        # Before: def method(self, i): ...
+        # After: def method(self=self, *, i):...
+        old_signature = inspect.signature(method)
+        old_parameters = list(old_signature.parameters.values())
+        if len(old_parameters) == 0:
+            # TODO(simon): make it more flexible to support no arguments.
+            raise RayServeException(
+                "Methods in FastAPI class-based view must have ``self`` as "
+                "their first argument.")
+
+        old_self_parameter = old_parameters[0]
+        new_self_parameter = old_self_parameter.replace(default=self)
+        new_parameters = [new_self_parameter] + [
+            # Make the rest of the parameters keyword only because
+            # the first argument is no longer positional.
+            parameter.replace(kind=inspect.Parameter.KEYWORD_ONLY)
+            for parameter in old_parameters[1:]
+        ]
+        new_signature = old_signature.replace(parameters=new_parameters)
+        setattr(method, "__signature__", new_signature)
+
+        route_metadata: FastAPIRouteMetadata = getattr(method, ROUTE_METADATA_ATTR)
+        route_metadata.add_to_fastapi_app(self._app)
+
+    def _add_method_routes_to_app(self):
+        assert isinstance(self._app, FastAPI)
+
+        for attribute_name in dir(self.__class__):
+            attribute = getattr(self.__class__, attribute_name)
+            if hasattr(attribute, ROUTE_METADATA_ATTR):
+                self._add_method_route_to_app(attribute)
+
+    @classmethod
+    def _add_method_decorator(cls, method: str):
+        def method_decorator(cls, path: str, **kwargs):
+            if callable(path):
+                method_str = f"{cls.__name__}.{method.lower()}"
+                raise ValueError(f"{method_str} does not support being called "
+                                 "with no arguments. You must at least "
+                                 "provide a route, e.g., "
+                                 f"@{method_str}(\"/\").")
+            elif not isinstance(path, str):
+                raise TypeError("Path argument must be a string.")
+
+            def inner_decorator(func: Callable):
+                print(f"ADDING ATTR TO {func}")
+                setattr(func, ROUTE_METADATA_ATTR, FastAPIRouteMetadata(method, path, func, kwargs))
+                return func
+
+            return inner_decorator
+
+        method_decorator.__name__ = method.lower()
+        method_decorator.__doc__ = GENERATED_METHOD_DOCSTRING.format(
+                method_upper = method,
+                method_lower = method.lower(),
+                wrapper_class_name = cls.__name__)
+        setattr(cls, method.lower(), classmethod(method_decorator))
+
+    async def __call__(self, request: Request):
+        sender = ASGIHTTPSender()
+        await self._app(
+            request.scope,
+            request._receive,
+            sender,
+        )
+        return sender.build_starlette_response()
+
+    def __del__(self):
+        # LifespanOn's logger logs in INFO level thus becomes spammy
+        # Within this block we temporarily uplevel for cleaner logging
+        return
+        with LoggingContext(
+                self._serve_asgi_lifespan.logger,
+                level=logging.WARNING):
+            asyncio.get_event_loop().run_until_complete(
+                self._serve_asgi_lifespan.shutdown())
+
+for method in FASTAPI_METHODS:
+    FastAPIWrapper._add_method_decorator(method)

--- a/python/ray/serve/http/__init__.py
+++ b/python/ray/serve/http/__init__.py
@@ -1,0 +1,4 @@
+from ray.serve.http.asgi import ASGIWrapper
+from ray.serve.http.fastapi import FastAPIWrapper
+
+__all__ = ["ASGIWrapper", "FastAPIWrapper"]

--- a/python/ray/serve/http/asgi.py
+++ b/python/ray/serve/http/asgi.py
@@ -7,6 +7,7 @@ from uvicorn.lifespan.on import LifespanOn
 from ray.serve.http_util import ASGIHTTPSender
 from ray.serve.utils import logger, LoggingContext
 
+
 class ASGIWrapper:
     def __init__(self, app: Callable):
         self._app = app
@@ -24,8 +25,7 @@ class ASGIWrapper:
         # LifespanOn's logger logs in INFO level thus becomes spammy
         # Within this block we temporarily uplevel for cleaner logging
         with LoggingContext(
-                self._serve_asgi_lifespan.logger,
-                level=logging.WARNING):
+                self._serve_asgi_lifespan.logger, level=logging.WARNING):
             await self._serve_asgi_lifespan.startup()
 
     async def __call__(self, request: Request):
@@ -41,7 +41,6 @@ class ASGIWrapper:
         # LifespanOn's logger logs in INFO level thus becomes spammy
         # Within this block we temporarily uplevel for cleaner logging
         with LoggingContext(
-                self._serve_asgi_lifespan.logger,
-                level=logging.WARNING):
+                self._serve_asgi_lifespan.logger, level=logging.WARNING):
             asyncio.get_event_loop().run_until_complete(
                 self._serve_asgi_lifespan.shutdown())

--- a/python/ray/serve/http/asgi.py
+++ b/python/ray/serve/http/asgi.py
@@ -1,3 +1,5 @@
+import asyncio
+import logging
 from typing import Callable
 
 from starlette.requests import Request

--- a/python/ray/serve/http/asgi.py
+++ b/python/ray/serve/http/asgi.py
@@ -1,0 +1,47 @@
+from typing import Callable
+
+from starlette.requests import Request
+from uvicorn.config import Config
+from uvicorn.lifespan.on import LifespanOn
+
+from ray.serve.http_util import ASGIHTTPSender
+from ray.serve.utils import logger, LoggingContext
+
+class ASGIWrapper:
+    def __init__(self, app: Callable):
+        self._app = app
+
+        # Use uvicorn's lifespan handling code to properly deal with
+        # startup and shutdown event.
+        self._serve_asgi_lifespan = LifespanOn(
+            Config(self._app, lifespan="on"))
+
+        # Replace uvicorn logger with our own.
+        self._serve_asgi_lifespan.logger = logger
+
+    async def _async_setup(self):
+        """Runs FastAPI startup hooks, will be run at replica startup."""
+        # LifespanOn's logger logs in INFO level thus becomes spammy
+        # Within this block we temporarily uplevel for cleaner logging
+        with LoggingContext(
+                self._serve_asgi_lifespan.logger,
+                level=logging.WARNING):
+            await self._serve_asgi_lifespan.startup()
+
+    async def __call__(self, request: Request):
+        sender = ASGIHTTPSender()
+        await self._app(
+            request.scope,
+            request._receive,
+            sender,
+        )
+        return sender.build_starlette_response()
+
+    def __del__(self):
+        # LifespanOn's logger logs in INFO level thus becomes spammy
+        # Within this block we temporarily uplevel for cleaner logging
+        with LoggingContext(
+                self._serve_asgi_lifespan.logger,
+                level=logging.WARNING):
+            asyncio.get_event_loop().run_until_complete(
+                self._serve_asgi_lifespan.shutdown())

--- a/python/ray/serve/http/fastapi.py
+++ b/python/ray/serve/http/fastapi.py
@@ -1,7 +1,5 @@
-from dataclasses import dataclass
 import inspect
-from functools import wraps
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Dict
 
 from fastapi import Depends, FastAPI
 
@@ -56,7 +54,8 @@ class FastAPIWrapper(ASGIWrapper):
                 "their first argument.")
 
         old_self_parameter = old_parameters[0]
-        # XXX: why do we need Depends? Just passing self gives recursion depth exceeded.
+        # XXX: why do we need Depends?
+        # Just passing self gives recursion depth exceeded.
         new_self_parameter = old_self_parameter.replace(
             default=Depends(lambda: self))
         new_parameters = [new_self_parameter] + [

--- a/python/ray/serve/tests/fault_tolerance_tests/test_controller_recovery.py
+++ b/python/ray/serve/tests/fault_tolerance_tests/test_controller_recovery.py
@@ -23,9 +23,6 @@ def test_recover_start_from_replica_actor_names(serve_instance):
     @serve.deployment(
         name="recover_start_from_replica_actor_names", num_replicas=2)
     class TransientConstructorFailureDeployment:
-        def __init__(self):
-            return True
-
         def __call__(self, *args):
             return "hii"
 

--- a/python/ray/serve/tests/test_constructor_failure.py
+++ b/python/ray/serve/tests/test_constructor_failure.py
@@ -70,8 +70,6 @@ def test_deploy_with_partial_constructor_failure(serve_instance):
                         if content == serve.get_replica_context().replica_tag:
                             raise RuntimeError(
                                 "Consistently throwing on same replica.")
-                        else:
-                            return True
 
             async def serve(self, request):
                 return "hi"
@@ -95,9 +93,7 @@ def test_deploy_with_transient_constructor_failure(serve_instance):
         @serve.deployment(num_replicas=2)
         class TransientConstructorFailureDeployment:
             def __init__(self):
-                if os.path.exists(file_path):
-                    return True
-                else:
+                if not os.path.exists(file_path):
                     with open(file_path, "w") as f:
                         f.write("ONE")
                     raise RuntimeError("Intentionally throw on first try.")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Example:
```python
from fastapi import FastAPI

import ray
from ray import serve
from ray.serve.http import FastAPIWrapper

serve.start()

@serve.deployment
class Test(FastAPIWrapper):
    def __init__(self):
        self.msg = "hello world"

        app = FastAPI()

        @app.get("/regular_route")
        def f():
            return "hi"

        super().__init__(app)

    @FastAPIWrapper.get("/hi1")
    def method1(self):
        return self.msg

    @FastAPIWrapper.post("/hi2")
    def method2(self, inp: int):
        return "hi2"

Test.deploy()
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
