### PR TITLE
[Serve] Exit run_forever when actor shutdown

### DIFF
--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -90,7 +90,7 @@ def create_backend_replica(name: str, serialized_backend_def: bytes):
                                            backend_config.user_config, version,
                                            is_function, controller_handle)
 
-            # asyncio.Event to be used to signal replica enterred shutdown phase.
+            # asyncio.Event used to signal that the replica is shutting down.
             self.shutdown_event = asyncio.Event()
 
         @ray.method(num_returns=2)

--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -90,6 +90,9 @@ def create_backend_replica(name: str, serialized_backend_def: bytes):
                                            backend_config.user_config, version,
                                            is_function, controller_handle)
 
+            # asyncio.Event to be used to signal replica enterred shutdown phase.
+            self.shutdown_event = asyncio.Event()
+
         @ray.method(num_returns=2)
         async def handle_request(
                 self,
@@ -112,11 +115,11 @@ def create_backend_replica(name: str, serialized_backend_def: bytes):
             return self.backend.version
 
         async def prepare_for_shutdown(self):
+            self.shutdown_event.set()
             return await self.backend.prepare_for_shutdown()
 
         async def run_forever(self):
-            while True:
-                await asyncio.sleep(10000)
+            await self.shutdown_event.wait()
 
     RayServeWrappedReplica.__name__ = name
     return RayServeWrappedReplica


### PR DESCRIPTION
When actor shutdown, the task run_forever will be marked as failed.
Leading to error message like
```
(pid=72051) [2021-09-22 11:52:46,978 E 72051 3965153]
task_manager.cc:375: Task failed: IOError: 14: Socket closed:
Type=ACTOR_TASK, Language=PYTHON, Resources: {},
function_descriptor={type=PythonFunctionDescriptor,
module_name=ray.serve.backend_worker,
class_name=create_backend_replica.<locals>.RayServeWrappedReplica,
function_name=run_forever, function_hash=},
task_id=e7c9251228ae8220f130475afab0342eea6224ed01000000,
task_name=RayServeWrappedReplica.run_forever(), job_id=01000000,
num_args=0, num_returns=2,
actor_task_spec={actor_id=f130475afab0342eea6224ed01000000,
actor_caller_id=ffffffffffffffff6d78b6de6e960cea3733648001000000,
actor_counter=1
```

We can exit the run_forever function, which is only used in
backend_state to monitor the health. When prepare_for_shutdown is
called, the actor should already enter `STOPPING` state and
`health_check_ref` is ignored.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #18817
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
