### PR TITLE
Revert "Upgrade default bazel installation to ver 4.2.1 (#18714)"

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -23,7 +23,7 @@ import urllib.request
 logger = logging.getLogger(__name__)
 
 SUPPORTED_PYTHONS = [(3, 6), (3, 7), (3, 8), (3, 9)]
-SUPPORTED_BAZEL = (4, 2, 1)
+SUPPORTED_BAZEL = (3, 4, 1)
 
 ROOT_DIR = os.path.dirname(__file__)
 BUILD_JAVA = os.getenv("RAY_INSTALL_JAVA") == "1"


### PR DESCRIPTION
Window build seems to have issue.

This reverts commit eb3620898c247ce390182b23d0f24045d73cfdbc.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
