### PR TITLE
[Build] include minimal debug info in C++ build; upgrade clang-format to 12

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,9 @@ build --enable_platform_specific_config
 build --action_env=PATH
 # For --compilation_mode=dbg, consider enabling checks in the standard library as well (below).
 build --compilation_mode=opt
+# Generate minimal debug symbols on Linux and MacOS
+build:linux --copt="-g1"
+build:macos --copt="-g1"
 # Using C++ 17 on all platforms.
 build:linux --cxxopt="-std=c++17"
 build:macos --cxxopt="-std=c++17"

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get install -y -qq \
     libgtk2.0-dev zlib1g-dev libgl1-mesa-dev maven \
     openjdk-8-jre openjdk-8-jdk clang-format-12 jq \
     clang-tidy-12 clang-12
-RUN ln -s /usr/bin/clang-format-7 /usr/bin/clang-format && \
+RUN ln -s /usr/bin/clang-format-12 /usr/bin/clang-format && \
     ln -s /usr/bin/clang-tidy-12 /usr/bin/clang-tidy && \
     ln -s /usr/bin/clang-12 /usr/bin/clang
 

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get install -y -qq \
     sudo unzip unrar apt-utils dialog tzdata wget rsync \
     language-pack-en tmux cmake gdb vim htop \
     libgtk2.0-dev zlib1g-dev libgl1-mesa-dev maven \
-    openjdk-8-jre openjdk-8-jdk clang-format-7 jq \
+    openjdk-8-jre openjdk-8-jdk clang-format-12 jq \
     clang-tidy-12 clang-12
 RUN ln -s /usr/bin/clang-format-7 /usr/bin/clang-format && \
     ln -s /usr/bin/clang-tidy-12 /usr/bin/clang-tidy && \

--- a/.buildkite/Dockerfile.gpu
+++ b/.buildkite/Dockerfile.gpu
@@ -28,14 +28,15 @@ ENV DOCKER_CERT_PATH=/certs/client
 ENV TRAVIS_COMMIT=${BUILDKITE_COMMIT}
 ENV BUILDKITE_BAZEL_CACHE_URL=${REMOTE_CACHE_URL}
 
-RUN apt-get update -qq
+RUN apt-get update -qq && apt-get upgrade -qq
 RUN apt-get install -y -qq \
     curl git build-essential \
     sudo unzip unrar apt-utils dialog tzdata wget rsync \
     language-pack-en tmux cmake gdb vim htop \
     libgtk2.0-dev zlib1g-dev libgl1-mesa-dev maven \
-    openjdk-8-jre openjdk-8-jdk clang-format-7
-RUN ln -s /usr/bin/clang-format-7 /usr/bin/clang-format
+    openjdk-8-jre openjdk-8-jdk gcc-8 g++-8
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 --slave /usr/bin/g++ g++ /usr/bin/g++-8 \
+    --slave /usr/bin/gcov gcov /usr/bin/gcov-8
 RUN curl -o- https://get.docker.com | sh
 
 # System conf for tests

--- a/.buildkite/Dockerfile.gpu
+++ b/.buildkite/Dockerfile.gpu
@@ -34,9 +34,7 @@ RUN apt-get install -y -qq \
     sudo unzip unrar apt-utils dialog tzdata wget rsync \
     language-pack-en tmux cmake gdb vim htop \
     libgtk2.0-dev zlib1g-dev libgl1-mesa-dev maven \
-    openjdk-8-jre openjdk-8-jdk gcc-8 g++-8
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 --slave /usr/bin/g++ g++ /usr/bin/g++-8 \
-    --slave /usr/bin/gcov gcov /usr/bin/gcov-8
+    openjdk-8-jre openjdk-8-jdk
 RUN curl -o- https://get.docker.com | sh
 
 # System conf for tests

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -390,7 +390,7 @@ lint_readme() {
 }
 
 lint_scripts() {
-  FORMAT_SH_PRINT_DIFF=1 "${ROOT_DIR}"/format.sh --all
+  FORMAT_SH_PRINT_DIFF=1 "${ROOT_DIR}"/format.sh --all-scripts
 }
 
 lint_bazel() {

--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -65,7 +65,7 @@ tool_version_check "mypy" "$MYPY_VERSION" "$MYPY_VERSION_REQUIRED"
 
 if which clang-format >/dev/null; then
   CLANG_FORMAT_VERSION=$(clang-format --version | awk '{print $3}')
-  tool_version_check "clang-format" "$CLANG_FORMAT_VERSION" "7.0.0"
+  tool_version_check "clang-format" "$CLANG_FORMAT_VERSION" "12.0.0"
 else
     echo "WARNING: clang-format is not installed!"
 fi

--- a/doc/source/getting-involved.rst
+++ b/doc/source/getting-involved.rst
@@ -151,9 +151,7 @@ We also have tests for code formatting and linting that need to pass before merg
 
   pip install -r python/requirements_linters.txt
 
-* If developing for C++, you will need `clang-format <https://www.kernel.org/doc/html/latest/process/clang-format.html>`_ version ``7.0.0`` (download this version of Clang from `here <http://releases.llvm.org/download.html>`_)
-
-.. note:: On MacOS X, don't use HomeBrew to install ``clang-format``, as the only version available is too new.
+* If developing for C++, you will need `clang-format <https://www.kernel.org/doc/html/latest/process/clang-format.html>`_ version ``12`` (download this version of Clang from `here <http://releases.llvm.org/download.html>`_)
 
 You can run the following locally:
 
@@ -185,7 +183,7 @@ In addition, there are other formatting and semantic checkers for components lik
 
     ./ci/travis/bazel-format.sh
 
-* clang-tidy for C++ anti-patterns, requires ``clang`` and ``clang-tidy`` version 12 to be installed:
+* clang-tidy for C++ lint, requires ``clang`` and ``clang-tidy`` version 12 to be installed:
 
 .. code-block:: shell
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Including debug info can improve debugging experience.

Also upgrade clang-format to 12.0.0. Disable running clang-format on all files, but leave clang-format running on diff.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
