### PR TITLE
[runtime env] [Serve] Fix error when uris field is None

### DIFF
--- a/dashboard/modules/runtime_env/runtime_env_agent.py
+++ b/dashboard/modules/runtime_env/runtime_env_agent.py
@@ -94,7 +94,7 @@ class RuntimeEnvAgent(dashboard_utils.DashboardAgentModule,
 
                 # Add the mapping of URIs -> the serialized environment to be
                 # used for cache invalidation.
-                for uri in runtime_env.get("uris", []):
+                for uri in runtime_env.get("uris") or []:
                     self._working_dir_uri_to_envs[uri].add(
                         serialized_runtime_env)
 

--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -226,7 +226,7 @@ py_test(
     name = "test_runtime_env",
     size = "medium",
     srcs = serve_tests_srcs,
-    tags = ["exclusive", "team:serve"],
+    tags = ["exclusive", "post_wheel_build", "team:serve"],
     deps = [":serve_lib"],
 )
 

--- a/python/ray/serve/tests/test_runtime_env.py
+++ b/python/ray/serve/tests/test_runtime_env.py
@@ -299,6 +299,8 @@ Test.delete()
 
 @pytest.mark.parametrize("use_ray_client", [False, True])
 @pytest.mark.skipif(
+    sys.platform == "win32", reason="Runtime env unsupported on Windows")
+@pytest.mark.skipif(
     os.environ.get("CI") and sys.platform != "linux",
     reason="Post-wheel-build test is only run on linux CI machines.")
 def test_pip_no_working_dir(ray_start, use_ray_client):

--- a/python/ray/serve/tests/test_runtime_env.py
+++ b/python/ray/serve/tests/test_runtime_env.py
@@ -12,6 +12,11 @@ from ray._private.test_utils import run_string_as_driver
 MIN_DYNAMIC_PORT = 49152
 MAX_DYNAMIC_PORT = 65535
 
+if not os.environ.get("CI"):
+    # This flag turns on the local development that links against current Ray
+    # packages and falls back all the dependencies to the current Python site.
+    os.environ["RAY_RUNTIME_ENV_LOCAL_DEV_MODE"] = "1"
+
 
 @pytest.fixture
 def ray_start(scope="module"):
@@ -290,6 +295,44 @@ Test.delete()
         use_ray_client=use_ray_client, client_addr=ray_start)
 
     run_string_as_driver(driver2)
+
+
+@pytest.mark.parametrize("use_ray_client", [False, True])
+@pytest.mark.skipif(
+    os.environ.get("CI") and sys.platform != "linux",
+    reason="Post-wheel-build test is only run on linux CI machines.")
+def test_pip_no_working_dir(ray_start, use_ray_client):
+
+    driver = """
+import ray
+from ray import serve
+import requests
+
+if {use_ray_client}:
+    ray.util.connect("{client_addr}")
+else:
+    ray.init(address="auto")
+
+serve.start()
+
+
+@serve.deployment
+def requests_version(request):
+    return requests.__version__
+
+
+requests_version.options(
+    ray_actor_options={{
+        "runtime_env": {{
+            "pip": ["ray[serve]", "requests==2.25.1"]
+        }}
+    }}).deploy()
+
+assert requests.get("http://127.0.0.1:8000/requests_version").text == "2.25.1"
+""".format(
+        use_ray_client=use_ray_client, client_addr=ray_start)
+
+    run_string_as_driver(driver)
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_runtime_env.py
+++ b/python/ray/serve/tests/test_runtime_env.py
@@ -13,8 +13,8 @@ MIN_DYNAMIC_PORT = 49152
 MAX_DYNAMIC_PORT = 65535
 
 if not os.environ.get("CI"):
-    # This flag turns on the local development that links against current Ray
-    # packages and falls back all the dependencies to the current Python site.
+    # This flag allows for local testing of runtime env conda/pip functionality
+    # without needing a built Ray wheel.  It links to the current Python site.
     os.environ["RAY_RUNTIME_ENV_LOCAL_DEV_MODE"] = "1"
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When Ray Serve starts a deployment, it overwrites the uris field with the uris from the JobConfig.  However, if there are no uris, it sets `runtime_env[uris]` to `None`, which causes an error later on when we try to iterate through `runtime_env[uris]`.  This PR handles the `None` case and adds a test.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #18865 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
