### PR TITLE
[ci/release] Start cluster before connecting via anyscale connect

### DIFF
--- a/release/xgboost_tests/xgboost_tests.yaml
+++ b/release/xgboost_tests/xgboost_tests.yaml
@@ -4,8 +4,8 @@
     compute_template: tpl_cpu_small.yaml
 
   run:
-    # use_connect: True
-    # autosuspend_mins: 10
+    use_connect: True
+    autosuspend_mins: 10
     timeout: 600
     prepare: python wait_cluster.py 4 600
     script: python workloads/train_small.py


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We currently can't sensibly enforce timeouts in anyscale connect release tests as the test runtime includes cluster startup time. This change will start the cluster and run the preparation commands before kicking off the anyscale connect release test, making it easier to distinguish between actual test run time and general setup time.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #18593

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
