### PR TITLE
[ci/release] Fix long running serve test result fetching

### DIFF
--- a/release/long_running_tests/workloads/serve.py
+++ b/release/long_running_tests/workloads/serve.py
@@ -38,9 +38,8 @@ def update_progress(result):
     result["last_update"] = time.time()
     test_output_json = os.environ.get("TEST_OUTPUT_JSON",
                                       "/tmp/release_test_output.json")
-    with open(test_output_json, "at") as f:
+    with open(test_output_json, "wt") as f:
         json.dump(result, f)
-        f.write("\n")
 
 
 cluster = Cluster()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A bug was introduced in https://github.com/ray-project/ray/pull/16631, appending to the results json instead of overwriting it, leading to an error when parsing the results in postprocessing.

cc @jiaodong @jjyao 

## Related issue number

Closes #18841

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
