### PR TITLE
Revert "Revert "[Build] include minimal debug info in C++ build; upgrade clang-format to 12""

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,9 @@ build --enable_platform_specific_config
 build --action_env=PATH
 # For --compilation_mode=dbg, consider enabling checks in the standard library as well (below).
 build --compilation_mode=opt
+# Generate minimal debug symbols on Linux and MacOS
+build:linux --copt="-g1"
+build:macos --copt="-g1"
 # Using C++ 17 on all platforms.
 build:linux --cxxopt="-std=c++17"
 build:macos --cxxopt="-std=c++17"

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -32,9 +32,9 @@ RUN apt-get install -y -qq \
     sudo unzip unrar apt-utils dialog tzdata wget rsync \
     language-pack-en tmux cmake gdb vim htop \
     libgtk2.0-dev zlib1g-dev libgl1-mesa-dev maven \
-    openjdk-8-jre openjdk-8-jdk clang-format-7 jq \
+    openjdk-8-jre openjdk-8-jdk clang-format-12 jq \
     clang-tidy-12 clang-12
-RUN ln -s /usr/bin/clang-format-7 /usr/bin/clang-format && \
+RUN ln -s /usr/bin/clang-format-12 /usr/bin/clang-format && \
     ln -s /usr/bin/clang-tidy-12 /usr/bin/clang-tidy && \
     ln -s /usr/bin/clang-12 /usr/bin/clang
 

--- a/.buildkite/Dockerfile.gpu
+++ b/.buildkite/Dockerfile.gpu
@@ -28,14 +28,13 @@ ENV DOCKER_CERT_PATH=/certs/client
 ENV TRAVIS_COMMIT=${BUILDKITE_COMMIT}
 ENV BUILDKITE_BAZEL_CACHE_URL=${REMOTE_CACHE_URL}
 
-RUN apt-get update -qq
+RUN apt-get update -qq && apt-get upgrade -qq
 RUN apt-get install -y -qq \
     curl git build-essential \
     sudo unzip unrar apt-utils dialog tzdata wget rsync \
     language-pack-en tmux cmake gdb vim htop \
     libgtk2.0-dev zlib1g-dev libgl1-mesa-dev maven \
-    openjdk-8-jre openjdk-8-jdk clang-format-7
-RUN ln -s /usr/bin/clang-format-7 /usr/bin/clang-format
+    openjdk-8-jre openjdk-8-jdk
 RUN curl -o- https://get.docker.com | sh
 
 # System conf for tests

--- a/.buildkite/Dockerfile.gpu
+++ b/.buildkite/Dockerfile.gpu
@@ -34,7 +34,9 @@ RUN apt-get install -y -qq \
     sudo unzip unrar apt-utils dialog tzdata wget rsync \
     language-pack-en tmux cmake gdb vim htop \
     libgtk2.0-dev zlib1g-dev libgl1-mesa-dev maven \
-    openjdk-8-jre openjdk-8-jdk
+    openjdk-8-jre openjdk-8-jdk gcc-8 g++-8
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 --slave /usr/bin/g++ g++ /usr/bin/g++-8 \
+    --slave /usr/bin/gcov gcov /usr/bin/gcov-8
 RUN curl -o- https://get.docker.com | sh
 
 # System conf for tests

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -392,7 +392,7 @@ lint_readme() {
 }
 
 lint_scripts() {
-  FORMAT_SH_PRINT_DIFF=1 "${ROOT_DIR}"/format.sh --all
+  FORMAT_SH_PRINT_DIFF=1 "${ROOT_DIR}"/format.sh --all-scripts
 }
 
 lint_bazel() {

--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -65,7 +65,7 @@ tool_version_check "mypy" "$MYPY_VERSION" "$MYPY_VERSION_REQUIRED"
 
 if which clang-format >/dev/null; then
   CLANG_FORMAT_VERSION=$(clang-format --version | awk '{print $3}')
-  tool_version_check "clang-format" "$CLANG_FORMAT_VERSION" "7.0.0"
+  tool_version_check "clang-format" "$CLANG_FORMAT_VERSION" "12.0.0"
 else
     echo "WARNING: clang-format is not installed!"
 fi
@@ -204,9 +204,7 @@ format_files() {
     fi
 }
 
-# Format all files, and print the diff to stdout for travis.
-# Mypy is run only on files specified in the array MYPY_FILES.
-format_all() {
+format_all_scripts() {
     command -v flake8 &> /dev/null;
     HAS_FLAKE8=$?
 
@@ -224,16 +222,6 @@ format_all() {
         flake8 --config=.flake8 "$FLAKE8_PYX_IGNORES"
     fi
 
-    echo "$(date)" "clang-format...."
-    if command -v clang-format >/dev/null; then
-      git ls-files -- '*.cc' '*.h' '*.proto' "${GIT_LS_EXCLUDES[@]}" | xargs -P 5 clang-format -i
-    fi
-
-    echo "$(date)" "format java...."
-    if command -v java >/dev/null & [ -f "$GOOGLE_JAVA_FORMAT_JAR" ]; then
-      git ls-files -- '*.java' "${GIT_LS_EXCLUDES[@]}" | sed -E "\:$JAVA_EXCLUDES_REGEX:d" | xargs -P 5 java -jar "$GOOGLE_JAVA_FORMAT_JAR" -i
-    fi
-
     if command -v shellcheck >/dev/null; then
       local shell_files non_shell_files
       non_shell_files=($(git ls-files -- ':(exclude)*.sh'))
@@ -246,6 +234,23 @@ format_all() {
         shellcheck_scripts "${shell_files[@]}"
       fi
     fi
+}
+
+# Format all files, and print the diff to stdout for travis.
+# Mypy is run only on files specified in the array MYPY_FILES.
+format_all() {
+    format_all_scripts "${@}"
+
+    echo "$(date)" "clang-format...."
+    if command -v clang-format >/dev/null; then
+      git ls-files -- '*.cc' '*.h' '*.proto' "${GIT_LS_EXCLUDES[@]}" | xargs -P 5 clang-format -i
+    fi
+
+    echo "$(date)" "format java...."
+    if command -v java >/dev/null & [ -f "$GOOGLE_JAVA_FORMAT_JAR" ]; then
+      git ls-files -- '*.java' "${GIT_LS_EXCLUDES[@]}" | sed -E "\:$JAVA_EXCLUDES_REGEX:d" | xargs -P 5 java -jar "$GOOGLE_JAVA_FORMAT_JAR" -i
+    fi
+
     echo "$(date)" "done!"
 }
 
@@ -307,8 +312,12 @@ format_changed() {
 # arg to use this option.
 if [ "${1-}" == '--files' ]; then
     format_files "${@:2}"
-    # If `--all` is passed, then any further arguments are ignored and the
-    # entire python directory is formatted.
+# If `--all` or `--scripts` are passed, then any further arguments are ignored.
+# Format the entire python directory and other scripts.
+elif [ "${1-}" == '--all-scripts' ]; then
+    format_all_scripts "${@}"
+    if [ -n "${FORMAT_SH_PRINT_DIFF-}" ]; then git --no-pager diff; fi
+# Format the all Python, C++, Java and other script files.
 elif [ "${1-}" == '--all' ]; then
     format_all "${@}"
     if [ -n "${FORMAT_SH_PRINT_DIFF-}" ]; then git --no-pager diff; fi

--- a/doc/source/getting-involved.rst
+++ b/doc/source/getting-involved.rst
@@ -151,9 +151,7 @@ We also have tests for code formatting and linting that need to pass before merg
 
   pip install -r python/requirements_linters.txt
 
-* If developing for C++, you will need `clang-format <https://www.kernel.org/doc/html/latest/process/clang-format.html>`_ version ``7.0.0`` (download this version of Clang from `here <http://releases.llvm.org/download.html>`_)
-
-.. note:: On MacOS X, don't use HomeBrew to install ``clang-format``, as the only version available is too new.
+* If developing for C++, you will need `clang-format <https://www.kernel.org/doc/html/latest/process/clang-format.html>`_ version ``12`` (download this version of Clang from `here <http://releases.llvm.org/download.html>`_)
 
 You can run the following locally:
 
@@ -185,7 +183,7 @@ In addition, there are other formatting and semantic checkers for components lik
 
     ./ci/travis/bazel-format.sh
 
-* clang-tidy for C++ anti-patterns, requires ``clang`` and ``clang-tidy`` version 12 to be installed:
+* clang-tidy for C++ lint, requires ``clang`` and ``clang-tidy`` version 12 to be installed:
 
 .. code-block:: shell
 


### PR DESCRIPTION
Reverts ray-project/ray#18886
Upgrade from GCC7 to GCC 8 for compiling in `setting-up-gpu-bootstrap-env-docker`.
Currently CI uses GCC 9 in `setting-up-bootstrap-env-docker`.  Building wheels also work with the existing compilers.