### PR TITLE
Disable test_reference_counting on Windows build

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -180,6 +180,7 @@ test_python() {
       -python/ray/tests:test_placement_group_mini_integration
       -python/ray/tests:test_ray_init  # test_redis_port() seems to fail here, but pass in isolation
       -python/ray/tests:test_resource_demand_scheduler
+      -python/ray/tests:test_reference_counting  # too flaky 9/25/21
       -python/ray/tests:test_runtime_env_env_vars # runtime_env not supported on Windows
       -python/ray/tests:test_runtime_env_complicated # conda install slow leading to timeout
       -python/ray/tests:test_stress  # timeout


### PR DESCRIPTION
(this test is too flaky)