### PR TITLE
[Core] fix worker shutdown using os._exit and never destruct core_worker

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -14,6 +14,8 @@
 
 #include "ray/core_worker/core_worker.h"
 
+#include <cstdlib>
+
 #include "boost/fiber/all.hpp"
 #include "ray/common/bundle_spec.h"
 #include "ray/common/ray_config.h"
@@ -106,8 +108,6 @@ void CoreWorkerProcess::Shutdown() {
   RAY_CHECK(core_worker_process->global_worker_);
   core_worker_process->global_worker_->Disconnect();
   core_worker_process->global_worker_->Shutdown();
-  core_worker_process->RemoveWorker(core_worker_process->global_worker_);
-  core_worker_process.reset();
 }
 
 bool CoreWorkerProcess::IsInitialized() { return core_worker_process != nullptr; }


### PR DESCRIPTION
We encountered issues during worker shutdown. more specifically, it's really hard to destruct core_worker properly without hitting weird grpc issues. this PR works around issue by

- never destruct core_worker
- call os._exit instead of sys.exit which doesn't preform clean up.


