### PR TITLE
[client] update documentation with AWS security_group

### DIFF
--- a/doc/source/cluster/config.rst
+++ b/doc/source/cluster/config.rst
@@ -109,6 +109,8 @@ Provider
             :ref:`region <cluster-configuration-region>`: str
             :ref:`availability_zone <cluster-configuration-availability-zone>`: str
             :ref:`cache_stopped_nodes <cluster-configuration-cache-stopped-nodes>`: bool
+            :ref:`security_group <cluster-configuration-security-group>`:
+                :ref:`Security Group <cluster-configuration-security-group-type>`
 
     .. group-tab:: Azure
 
@@ -129,6 +131,20 @@ Provider
             :ref:`availability_zone <cluster-configuration-availability-zone>`: str
             :ref:`project_id <cluster-configuration-project-id>`: str
             :ref:`cache_stopped_nodes <cluster-configuration-cache-stopped-nodes>`: bool
+
+.. _cluster-configuration-security-group-type:
+
+Security Group
+~~~~~~~~~~~~~~
+
+.. tabs::
+    .. group-tab:: AWS
+
+        .. parsed-literal::
+
+            :ref:`GroupName <cluster-configuration-group-name>`: str
+            :ref:`IpPermissions <cluster-configuration-ip-permissions>`:
+                - `IpPermission <https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html>`_
 
 .. _cluster-configuration-node-types-type:
 
@@ -922,6 +938,52 @@ If enabled, nodes will be *stopped* when the cluster scales down. If disabled, n
 * **Importance:** Low
 * **Type:** Boolean
 * **Default:** ``True``
+
+.. _cluster-configuration-security-group:
+
+``provider.security_group``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+    .. group-tab:: AWS
+
+        A security group that can be used to specify custom inbound rules.
+
+        * **Required:** No
+        * **Importance:** Medium
+        * **Type:** :ref:`Security Group <cluster-configuration-security-group-type>`
+
+    .. group-tab:: Azure
+
+        Not available.
+
+    .. group-tab:: GCP
+
+        Not available.
+
+
+.. _cluster-configuration-group-name:
+
+``security_group.GroupName``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The name of the security group. This name must be unique within the VPC.
+
+* **Required:** No
+* **Importance:** Low
+* **Type:** String
+* **Default:** ``"ray-autoscaler-{cluster-name}"``
+
+.. _cluster-configuration-ip-permissions:
+
+``security_group.IpPermissions``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The inbound rules associated with the security group.
+
+* **Required:** No
+* **Importance:** Medium
+* **Type:** `IpPermission <https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html>`_
 
 .. _cluster-configuration-node-config:
 

--- a/doc/source/cluster/ray-client.rst
+++ b/doc/source/cluster/ray-client.rst
@@ -125,7 +125,7 @@ Now, connect to the Ray Cluster with the following and then use Ray like you nor
 
    #....
 
-Alternative Approach: Port Forwarding
+Alternative Approach: SSH Port Forwarding
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As an alternative to configuring inbound traffic rules, you can also set up

--- a/doc/source/cluster/ray-client.rst
+++ b/doc/source/cluster/ray-client.rst
@@ -126,7 +126,7 @@ Now, connect to the Ray Cluster with the following and then use Ray like you nor
    #....
 
 Alternative Approach: SSH Port Forwarding
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As an alternative to configuring inbound traffic rules, you can also set up
 Ray Client via port forwarding. While this approach does require an open SSH


### PR DESCRIPTION
Update Ray Client docs so that it is easier to follow step-by-step how to enable cluster access.

## Why are these changes needed?

The existing Ray Client documentation points to EC2 documentation for enabling inbound access by configuring inbound access rules via security group through the EC2 console. While this does work, for development purposes I found the following two approaches to be easier to follow:
1. Defining Security Group in `cluster.yaml`.
2. SSH Port Forwarding.

## Changelist

1. Add an example to Ray Client doc for configuring `provider.security_group` in `cluster.yaml`  to enable access.
2. Add an `Alternative Approach: Port Forwarding` section.
3. Update cluster config docs to include `provider.security_group` which was previously undocumented.
4. Fix broken Ray Cluster Launcher links.
## Related issue number

<!-- For example: "Closes #1234" -->
n/a

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
