### PR TITLE
Add optional columns to the dataset to be merged

### DIFF
--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -109,7 +109,7 @@ class BlockAccessor(Generic[T]):
             schema=self.schema(),
             input_files=input_files)
 
-    def zip(self, other: "Block[T]") -> "Block[T]":
+    def zip(self, other: "Block[T]", column_names: Optional[List[str]] = None) -> "Block[T]":
         """Zip this block with another block of the same type and size."""
         raise NotImplementedError
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -655,7 +655,7 @@ class Dataset(Generic[T]):
         """
         return Dataset(sort_impl(self._blocks, key, descending))
 
-    def zip(self, other: "Dataset[U]") -> "Dataset[(T, U)]":
+    def zip(self, other: "Dataset[U]", column_names: Optional[List[str]] = None) -> "Dataset[(T, U)]":
         """Zip this dataset with the elements of another.
 
         The datasets must have identical num rows, block types, and block sizes

--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -200,7 +200,7 @@ class ArrowBlockAccessor(BlockAccessor):
     def size_bytes(self) -> int:
         return self._table.nbytes
 
-    def zip(self, other: "Block[T]") -> "Block[T]":
+    def zip(self, other: "Block[T]", column_names: Optional[List[str]] = None) -> "Block[T]":
         acc = BlockAccessor.for_block(other)
         if not isinstance(acc, ArrowBlockAccessor):
             raise ValueError("Cannot zip {} with block of type {}".format(
@@ -211,7 +211,10 @@ class ArrowBlockAccessor(BlockAccessor):
                     self.num_rows(), acc.num_rows()))
         r = self.to_arrow()
         s = acc.to_arrow()
-        for col_name in s.column_names:
+        for col_name in column_names:
+            if col_name not in s.column_names:
+                raise ValueError("{} must be in the {}.column_names".format(col_name, other))
+        for col_name in column_names:
             col = s.column(col_name)
             # Ensure the column names are unique after zip.
             if col_name in r.column_names:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We want the column of the dataset to be merged to be optional, or can we realize that the columns of the two datasets to be merged are both optional, use the function “merge”。
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
