### PR TITLE
[tune] fix `tune list-trials` metric

### DIFF
--- a/python/ray/tune/commands.py
+++ b/python/ray/tune/commands.py
@@ -116,10 +116,9 @@ def list_trials(experiment_path,
     _check_tabulate()
 
     try:
-        checkpoints_df = Analysis(experiment_path).dataframe(
-            metric="episode_reward_mean", mode="max")
-    except TuneError:
-        raise click.ClickException("No trial data found!")
+        checkpoints_df = Analysis(experiment_path).dataframe()  # last result
+    except TuneError as e:
+        raise click.ClickException("No trial data found!") from e
 
     def key_filter(k):
         return k in DEFAULT_CLI_KEYS or k.startswith(CONFIG_PREFIX)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fetching result dataframes using metric and mode gives unexpected results and only works with rllib trainables.

Instead we should present the last observed results and not require any particular metric.

## Related issue number

Follow-up to #18850
Closes #18740

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
