### PR TITLE
[docs] Don't recommend SignalActor from test_utils

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -42,17 +42,23 @@ This often occurs for data loading and preprocessing.
     # hi there!
     # hi there!
 
-Multi-node synchronization using ``SignalActor``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Multi-node synchronization using an Actor
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When you have multiple tasks that need to wait on some condition, you can use a ``SignalActor`` to coordinate.
+When you have multiple tasks that need to wait on some condition or otherwise
+need to synchronize across tasks & actors on a cluster, you can use a central
+actor to coordinate among them. Below is an example of using a ``SignalActor``
+that wraps an ``asyncio.Event`` for basic synchronization.
 
 .. code-block:: python
 
-    # Also available via `from ray._private.test_utils import SignalActor`
-    import ray
     import asyncio
 
+    import ray
+
+    ray.init()
+
+    # We set num_cpus to zero because this actor will mostly just block on I/O.
     @ray.remote(num_cpus=0)
     class SignalActor:
         def __init__(self):
@@ -73,7 +79,6 @@ When you have multiple tasks that need to wait on some condition, you can use a 
 
         print("go!")
 
-    ray.init()
     signal = SignalActor.remote()
     tasks = [wait_and_go.remote(signal) for _ in range(4)]
     print("ready...")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We shouldn't have users depending on private APIs. SignalActor is simple enough to have people replicate with their own utilities.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
