### PR TITLE
Remove ray_trace_ctx from kwargs if tracing disabled

### DIFF
--- a/python/ray/util/tracing/tracing_helper.py
+++ b/python/ray/util/tracing/tracing_helper.py
@@ -366,7 +366,8 @@ def _tracing_actor_creation(method):
         # If tracing feature flag is not on, perform a no-op
         if not is_tracing_enabled():
             if not self.__ray_metadata__.is_cross_language:
-                kwargs["_ray_trace_ctx"] = None
+                # Remove _ray_trace_ctx from kwargs if tracing disabled
+                kwargs.pop("_ray_trace_ctx", None)
             return method(self, args, kwargs, *_args, **_kwargs)
 
         class_name = self.__ray_metadata__.class_name


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Looks like there's currently an issue with how client serializes modified signatures that leads to `TypeError: got an unexpected keyword argument '_ray_trace_ctx'`. This will remove _ray_trace_ctx kwarg when tracing is disabled instead of setting the it to None (should be the same behavior w/o client, since the default value is already None).

Manually tested, appears to fix the horovod issue seen by uber/ludwig

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
