### PR TITLE
[SGD] add SGDv2 survey link to docs

### DIFF
--- a/doc/source/raysgd/raysgd_pytorch.rst
+++ b/doc/source/raysgd/raysgd_pytorch.rst
@@ -9,7 +9,7 @@ The RaySGD ``TorchTrainer`` simplifies distributed model training for PyTorch.
 .. image:: raysgd-actors.svg
     :align: center
 
-.. tip:: Get in touch with us if you're using or considering using `RaySGD <https://forms.gle/26EMwdahdgm7Lscy9>`_!
+.. tip:: Get in touch with us if you're using or considering using `RaySGD <https://forms.gle/PXFcJmHwszCwQhqX7>`_!
 
 The ``TorchTrainer`` is a wrapper around ``torch.distributed.launch`` with a Python API to easily incorporate distributed training into a larger Python application, as opposed to needing to wrap your training code in bash scripts.
 

--- a/doc/source/raysgd/raysgd_tensorflow.rst
+++ b/doc/source/raysgd/raysgd_tensorflow.rst
@@ -8,7 +8,7 @@ Under the hood, ``TFTrainer`` will create *replicas* of your model (controlled b
 .. image:: raysgd-actors.svg
     :align: center
 
-.. tip:: We need your feedback! RaySGD is currently early in its development, and we're hoping to get feedback from people using or considering it. We'd love `to get in touch <https://forms.gle/26EMwdahdgm7Lscy9>`_!
+.. tip:: Get in touch with us if you're using or considering using `RaySGD <https://forms.gle/PXFcJmHwszCwQhqX7>`_!
 
 ----------
 

--- a/doc/source/raysgd/v2/raysgd.rst
+++ b/doc/source/raysgd/v2/raysgd.rst
@@ -5,6 +5,8 @@ RaySGD: Deep Learning on Ray
 
 .. _`issue on GitHub`: https://github.com/ray-project/ray/issues
 
+.. tip:: Get in touch with us if you're using or considering using `RaySGD <https://forms.gle/PXFcJmHwszCwQhqX7>`_!
+
 RaySGD is a lightweight library for distributed deep learning, allowing you
 to scale up and speed up training for your deep learning models.
 
@@ -20,8 +22,6 @@ The main features are:
   future Ray releases. If you encounter any bugs, please file an
   `issue on GitHub`_.
   If you are looking for the previous API documentation, see :ref:`sgd-index`.
-
-.. tip:: Get in touch with us if you're using or considering using `RaySGD <https://forms.gle/PXFcJmHwszCwQhqX7>`_!
 
 Intro to RaySGD
 ---------------

--- a/doc/source/raysgd/v2/raysgd.rst
+++ b/doc/source/raysgd/v2/raysgd.rst
@@ -21,6 +21,7 @@ The main features are:
   `issue on GitHub`_.
   If you are looking for the previous API documentation, see :ref:`sgd-index`.
 
+.. tip:: Get in touch with us if you're using or considering using `RaySGD <https://forms.gle/PXFcJmHwszCwQhqX7>`_!
 
 Intro to RaySGD
 ---------------

--- a/doc/source/raysgd/v2/user_guide.rst
+++ b/doc/source/raysgd/v2/user_guide.rst
@@ -12,6 +12,9 @@ In this guide, we cover examples for the following use cases:
 * How do I use RaySGD to :ref:`train with a large dataset <sgd-datasets>`?
 * How do I :ref:`tune <sgd-tune>` my RaySGD model?
 
+
+.. tip:: Get in touch with us if you're using or considering using `RaySGD <https://forms.gle/PXFcJmHwszCwQhqX7>`_!
+
 .. _sgd-backends:
 
 Backends

--- a/doc/source/raysgd/v2/user_guide.rst
+++ b/doc/source/raysgd/v2/user_guide.rst
@@ -3,6 +3,8 @@
 RaySGD User Guide
 =================
 
+.. tip:: Get in touch with us if you're using or considering using `RaySGD <https://forms.gle/PXFcJmHwszCwQhqX7>`_!
+
 In this guide, we cover examples for the following use cases:
 
 * How do I :ref:`port my code <sgd-porting-code>` to using RaySGD?
@@ -11,9 +13,6 @@ In this guide, we cover examples for the following use cases:
   (:ref:`fault tolerance <sgd-fault-tolerance>`)?
 * How do I use RaySGD to :ref:`train with a large dataset <sgd-datasets>`?
 * How do I :ref:`tune <sgd-tune>` my RaySGD model?
-
-
-.. tip:: Get in touch with us if you're using or considering using `RaySGD <https://forms.gle/PXFcJmHwszCwQhqX7>`_!
 
 .. _sgd-backends:
 


### PR DESCRIPTION
Add link to [Getting in touch - Ray SGDv2](https://forms.gle/PXFcJmHwszCwQhqX7) survey to all SGD docs (both v1 and v2).

## Why are these changes needed?
SGD v2 Alpha release will come out with Ray 1.7.0. Adding this survey to collect early user feedback as we work on Beta implementation.

Updating SGD v1 survey links to point to this survey as we will be deprecating v1 and should unify feedback for v2.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
