### PR TITLE
[RLlib] Allow n-step > 1 and prio. replay for R2D2 and RNNSAC.

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -876,24 +876,12 @@ py_test(
     srcs = ["agents/ddpg/tests/test_ddpg.py"]
 )
 
-# DQNTrainer/SimpleQTrainer
+# DQNTrainer
 py_test(
     name = "test_dqn",
     tags = ["team:ml", "trainers_dir"],
     size = "large",
     srcs = ["agents/dqn/tests/test_dqn.py"]
-)
-py_test(
-    name = "test_r2d2",
-    tags = ["team:ml", "trainers_dir"],
-    size = "large",
-    srcs = ["agents/dqn/tests/test_r2d2.py"]
-)
-py_test(
-    name = "test_simple_q",
-    tags = ["team:ml", "trainers_dir"],
-    size = "medium",
-    srcs = ["agents/dqn/tests/test_simple_q.py"]
 )
 
 # Dreamer
@@ -1002,6 +990,14 @@ py_test(
     srcs = ["agents/qmix/tests/test_qmix.py"]
 )
 
+# R2D2Trainer
+py_test(
+    name = "test_r2d2",
+    tags = ["team:ml", "trainers_dir"],
+    size = "large",
+    srcs = ["agents/dqn/tests/test_r2d2.py"]
+)
+
 # RNNSACTrainer
 py_test(
     name = "test_rnnsac",
@@ -1016,6 +1012,14 @@ py_test(
     tags = ["team:ml", "trainers_dir"],
     size = "large",
     srcs = ["agents/sac/tests/test_sac.py"]
+)
+
+# SimpleQTrainer
+py_test(
+    name = "test_simple_q",
+    tags = ["team:ml", "trainers_dir"],
+    size = "medium",
+    srcs = ["agents/dqn/tests/test_simple_q.py"]
 )
 
 # TD3Trainer

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1002,6 +1002,14 @@ py_test(
     srcs = ["agents/qmix/tests/test_qmix.py"]
 )
 
+# RNNSACTrainer
+py_test(
+    name = "test_rnnsac",
+    tags = ["team:ml", "trainers_dir"],
+    size = "medium",
+    srcs = ["agents/sac/tests/test_rnnsac.py"]
+)
+
 # SACTrainer
 py_test(
     name = "test_sac",

--- a/rllib/agents/dqn/r2d2.py
+++ b/rllib/agents/dqn/r2d2.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_CONFIG = dqn.DQNTrainer.merge_trainer_configs(
     dqn.DEFAULT_CONFIG,  # See keys in impala.py, which are also supported.
     {
-        # Learning rate for adam optimizer
+        # Learning rate for adam optimizer.
         "lr": 1e-4,
         # Discount factor.
         "gamma": 0.997,
@@ -40,8 +40,6 @@ DEFAULT_CONFIG = dqn.DQNTrainer.merge_trainer_configs(
         "num_workers": 2,
         # Batch mode must be complete_episodes.
         "batch_mode": "complete_episodes",
-        # R2D2 does not suport n-step > 1 yet!
-        "n_step": 1,
 
         # If True, assume a zero-initialized state input (no matter where in
         # the episode the sequence is located).
@@ -70,9 +68,6 @@ DEFAULT_CONFIG = dqn.DQNTrainer.merge_trainer_configs(
         # === Hyperparameters from the paper [1] ===
         # Size of the replay buffer (in sequences, not timesteps).
         "buffer_size": 100000,
-        # If True prioritized replay buffer will be used.
-        # Note: Not supported yet by R2D2!
-        "prioritized_replay": False,
         # Set automatically: The number of contiguous environment steps to
         # replay at once. Will be calculated via
         # model->max_seq_len + burn_in.
@@ -91,7 +86,8 @@ DEFAULT_CONFIG = dqn.DQNTrainer.merge_trainer_configs(
 def validate_config(config: TrainerConfigDict) -> None:
     """Checks and updates the config based on settings.
 
-    Rewrites rollout_fragment_length to take into account n_step truncation.
+    Rewrites rollout_fragment_length to take into account burn-in and
+    max_seq_len truncation.
     """
     if config["replay_sequence_length"] != -1:
         raise ValueError(
@@ -107,9 +103,6 @@ def validate_config(config: TrainerConfigDict) -> None:
 
     if config.get("batch_mode") != "complete_episodes":
         raise ValueError("`batch_mode` must be 'complete_episodes'!")
-
-    if config["n_step"] > 1:
-        raise ValueError("`n_step` > 1 not yet supported by R2D2!")
 
 
 def calculate_rr_weights(config: TrainerConfigDict) -> List[float]:

--- a/rllib/agents/dqn/r2d2.py
+++ b/rllib/agents/dqn/r2d2.py
@@ -98,9 +98,6 @@ def validate_config(config: TrainerConfigDict) -> None:
     config["replay_sequence_length"] = \
         config["burn_in"] + config["model"]["max_seq_len"]
 
-    if config.get("prioritized_replay"):
-        raise ValueError("Prioritized replay is not supported for R2D2 yet!")
-
     if config.get("batch_mode") != "complete_episodes":
         raise ValueError("`batch_mode` must be 'complete_episodes'!")
 

--- a/rllib/agents/dqn/r2d2_torch_policy.py
+++ b/rllib/agents/dqn/r2d2_torch_policy.py
@@ -171,7 +171,7 @@ def r2d2_loss(policy: Policy, model, _,
         td_error = td_error * seq_mask
         weights = weights.reshape([B, T])[:, :-1]
         policy._total_loss = reduce_mean_valid(weights * huber_loss(td_error))
-        policy._td_error = td_error.reshape([-1])
+        policy._td_error = torch.mean(td_error, dim=-1)
         policy._loss_stats = {
             "mean_q": reduce_mean_valid(q_selected),
             "min_q": torch.min(q_selected),

--- a/rllib/agents/sac/rnnsac.py
+++ b/rllib/agents/sac/rnnsac.py
@@ -11,10 +11,6 @@ DEFAULT_CONFIG = SACTrainer.merge_trainer_configs(
     {
         # Batch mode (see common config)
         "batch_mode": "complete_episodes",
-        # If True prioritized replay buffer will be used.
-        "prioritized_replay": False,
-        # RNNSAC does not suport n-step > 1 yet!
-        "n_step": 1,
         # If True, assume a zero-initialized state input (no matter where in
         # the episode the sequence is located).
         # If False, store the initial states along with each SampleBatch, use
@@ -49,9 +45,6 @@ def validate_config(config: TrainerConfigDict) -> None:
     # Set the replay sequence length to the max_seq_len of the model.
     config["replay_sequence_length"] = \
         config["burn_in"] + config["model"]["max_seq_len"]
-
-    if config["n_step"] > 1:
-        raise ValueError("`n_step` > 1 not yet supported by RNNSAC!")
 
 
 def get_policy_class(config: TrainerConfigDict) -> Optional[Type[Policy]]:

--- a/rllib/agents/sac/tests/test_rnnsac.py
+++ b/rllib/agents/sac/tests/test_rnnsac.py
@@ -1,0 +1,73 @@
+import unittest
+
+import ray
+import ray.rllib.agents.sac as sac
+from ray.rllib.utils.framework import try_import_tf, try_import_torch
+from ray.rllib.utils.test_utils import check_compute_single_action, \
+    framework_iterator
+
+tf1, tf, tfv = try_import_tf()
+torch, nn = try_import_torch()
+
+
+class TestRNNSAC(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        ray.init()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        ray.shutdown()
+
+    def test_rnnsac_compilation(self):
+        """Test whether a R2D2Trainer can be built on all frameworks."""
+        config = sac.RNNSAC_DEFAULT_CONFIG.copy()
+        config["num_workers"] = 0  # Run locally.
+
+        # Wrap with an LSTM and use a very simple base-model.
+        config["model"] = {
+            "max_seq_len": 20,
+        }
+        config["policy_model"] = {
+            "use_lstm": True,
+            "lstm_cell_size": 64,
+            "fcnet_hiddens": [10],
+            "lstm_use_prev_action": True,
+            "lstm_use_prev_reward": True,
+        }
+        config["Q_model"] = {
+            "use_lstm": True,
+            "lstm_cell_size": 64,
+            "fcnet_hiddens": [10],
+            "lstm_use_prev_action": True,
+            "lstm_use_prev_reward": True,
+        }
+
+        # Test with PR activated.
+        config["prioritized_replay"] = True
+
+        config["burn_in"] = 20
+        config["zero_init_states"] = True
+
+        config["lr"] = 5e-4
+
+        num_iterations = 1
+
+        # Test building an RNNSAC agent in all frameworks.
+        for _ in framework_iterator(config, frameworks="torch"):
+            trainer = sac.RNNSACTrainer(config=config, env="CartPole-v0")
+            for i in range(num_iterations):
+                results = trainer.train()
+                print(results)
+
+            check_compute_single_action(
+                trainer,
+                include_state=True,
+                include_prev_action_reward=True,
+            )
+
+
+if __name__ == "__main__":
+    import pytest
+    import sys
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Allow n-step > 1 and prio. replay for R2D2 and RNNSAC.

This PR removes the restrictions on n-step > 1 or prioritized_replay=True for the two algos: R2D2 and RNNSAC. Both already handle these setups well.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
