### PR TITLE
Revert "Revert "[Serve] [doc] Improve runtime env doc""

### DIFF
--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -64,7 +64,7 @@ steps:
   commands:
     - *prelude_commands
     - TORCH_VERSION=1.6 ./ci/travis/install-dependencies.sh
-    - bazel test --config=ci --test_env=CI $(./scripts/bazel_export_options) --build_tests_only --test_tag_filters=-flaky,-flaky-mac --
+    - bazel test --config=ci --test_env=CI $(./scripts/bazel_export_options) --build_tests_only --test_tag_filters=-flaky,-flaky-mac,-post_wheel_build --
       //:all python/ray/serve/... python/ray/dashboard/... -rllib/... -core_worker_test
     - *epilogue_commands
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -182,7 +182,9 @@
     - TORCH_VERSION=1.6 ./ci/travis/install-dependencies.sh
     - ./dashboard/tests/run_ui_tests.sh
     - bazel test --config=ci $(./scripts/bazel_export_options) python/ray/dashboard/...
-    - bazel test --config=ci $(./scripts/bazel_export_options) python/ray/serve/...
+    - bazel test --config=ci $(./scripts/bazel_export_options)
+      --test_tag_filters=-post_wheel_build
+      python/ray/serve/...
 
 - label: ":python: Minimal install"
   conditions: ["RAY_CI_PYTHON_AFFECTED"]

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -139,6 +139,7 @@ test_python() {
     args+=(
       python/ray/serve/...
       python/ray/tests/...
+      -python/ray/serve:conda_env # runtime_env unsupported on Windows
       -python/ray/serve:test_api # segfault on windows? https://github.com/ray-project/ray/issues/12541
       -python/ray/serve:test_router # timeout
       -python/ray/serve:test_handle # "fatal error" (?) https://github.com/ray-project/ray/pull/13695

--- a/doc/source/serve/core-apis.rst
+++ b/doc/source/serve/core-apis.rst
@@ -238,27 +238,31 @@ Ray Serve supports serving deployments with different (possibly conflicting)
 Python dependencies.  For example, you can simultaneously serve one deployment
 that uses legacy Tensorflow 1 and another that uses Tensorflow 2.
 
-Currently this is supported on Mac OS and Linux using `conda <https://docs.conda.io/en/latest/>`_
-via Ray's built-in ``runtime_env`` option for actors.
-As with all other actor options, pass these in via ``ray_actor_options`` in
-your deployment.
-You must have a conda environment set up for each set of
-dependencies you want to isolate.  If using a multi-node cluster, the
-desired conda environment must be present on all nodes. Also, the Python patch version
-(e.g. 3.8.10) must be identical on all nodes (this is a requirement for any Ray cluster).
-See :ref:`runtime-environments` for details.
+This is supported on Mac OS and Linux using Ray's :ref:`runtime-environments` feature.
+As with all other Ray actor options, pass the runtime environment in via ``ray_actor_options`` in
+your deployment.  Be sure to first run ``pip install "ray[default]"`` to ensure the
+Runtime Environments feature is installed.
 
-Here's an example script.  For it to work, first create a conda
-environment named ``ray-tf1`` with Ray Serve and Tensorflow 1 installed,
-and another named ``ray-tf2`` with Ray Serve and Tensorflow 2.  The Ray and
-Python versions must be the same in both environments.
+Example:
 
 .. literalinclude:: ../../../python/ray/serve/examples/doc/conda_env.py
+
+.. note::
+  When using a Ray library (for example, Ray Serve) in a runtime environment, it must
+  explicitly be included in the dependencies, as in the above example.  This is not
+  required when just using Ray Core.
+
+.. tip::
+  Avoid dynamically installing packages that install from source: these can be slow and
+  use up all resources while installing, leading to problems with the Ray cluster.  Consider
+  precompiling such packages in a private repository or Docker image.
 
 The dependencies required in the deployment may be different than
 the dependencies installed in the driver program (the one running Serve API
 calls). In this case, you should use a delayed import within the class to avoid
-importing unavailable packages in the driver.
+importing unavailable packages in the driver.  This applies even when not
+using runtime environments.
+
 Example:
 
 .. literalinclude:: ../../../python/ray/serve/examples/doc/imported_backend.py

--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -338,3 +338,11 @@ py_test(
     tags = ["exclusive", "team:serve"],
     deps = [":serve_lib"]
 )
+
+py_test(
+    name = "conda_env",
+    size = "medium",
+    srcs = glob(["examples/doc/*.py"]),
+    tags = ["exclusive", "post_wheel_build", "team:serve"],
+    deps = [":serve_lib"]
+)

--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -1073,8 +1073,9 @@ class BackendState:
                 f"Deployment '{self._name}' has "
                 f"{len(slow_start_replicas)} replicas that have taken "
                 f"more than {SLOW_STARTUP_WARNING_S}s to start up. This "
-                "may be caused by waiting for the cluster to auto-scale "
-                "or because the constructor is slow. Resources required "
+                "may be caused by waiting for the cluster to auto-scale, "
+                "waiting for a runtime environment to install, or a slow "
+                "constructor. Resources required "
                 f"for each replica: {required}, resources available: "
                 f"{available}. component=serve deployment={self._name}")
 

--- a/python/ray/serve/examples/doc/conda_env.py
+++ b/python/ray/serve/examples/doc/conda_env.py
@@ -1,27 +1,28 @@
 import requests
 from ray import serve
-import tensorflow as tf
 
 serve.start()
 
 
 @serve.deployment
-def tf_version(request):
-    return ("Tensorflow " + tf.__version__)
+def requests_version(request):
+    return requests.__version__
 
 
-tf_version.options(
-    name="tf1", ray_actor_options={
+requests_version.options(
+    name="25",
+    ray_actor_options={
         "runtime_env": {
-            "conda": "ray-tf1"
+            "pip": ["ray[serve]", "requests==2.25.1"]
         }
     }).deploy()
-tf_version.options(
-    name="tf2", ray_actor_options={
+requests_version.options(
+    name="26",
+    ray_actor_options={
         "runtime_env": {
-            "conda": "ray-tf2"
+            "pip": ["ray[serve]", "requests==2.26.0"]
         }
     }).deploy()
 
-print(requests.get("http://127.0.0.1:8000/tf1").text)  # Tensorflow 1.15.0
-print(requests.get("http://127.0.0.1:8000/tf2").text)  # Tensorflow 2.3.0
+assert requests.get("http://127.0.0.1:8000/25").text == "2.25.1"
+assert requests.get("http://127.0.0.1:8000/26").text == "2.26.0"


### PR DESCRIPTION
Reverts ray-project/ray#18935

There was an existing doc snippet and I added it to CI in the reverted PR so it could be tested.  But it's for runtime env, which isn't supported on Windows, so it broke the build.  This PR skips the test for Windows and re-reverts the original PR.