### PR TITLE
[Don't merge yet] increase 1k replica tests

### DIFF
--- a/release/serve_tests/serve_tests.yaml
+++ b/release/serve_tests/serve_tests.yaml
@@ -4,7 +4,8 @@
     compute_template: compute_tpl_8_cpu.yaml
 
   run:
-    timeout: 7200
+    # Takes time to provision 1k replicas on product
+    timeout: 14400
     long_running: False
     script: python workloads/single_deployment_1k_noop_replica.py
 
@@ -17,7 +18,8 @@
     compute_template: compute_tpl_8_cpu.yaml
 
   run:
-    timeout: 7200
+    # Takes time to provision 1k replicas on product
+    timeout: 14400
     long_running: False
     script: python workloads/multi_deployment_1k_noop_replica.py
 


### PR DESCRIPTION
we have some instability on provisioning 1k replicas for serve benchmarks. Increasing selected ones to give a bit more buffer room.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
