### PR TITLE
[SGD] add share_cuda_visible_devices config flag

### DIFF
--- a/python/ray/util/sgd/v2/backends/backend.py
+++ b/python/ray/util/sgd/v2/backends/backend.py
@@ -8,7 +8,7 @@ from typing import Callable, TypeVar, List, Optional, Dict, Union, Type, Tuple
 import ray
 from ray import cloudpickle
 from ray.exceptions import RayActorError
-from ray.ray_constants import env_integer, env_bool
+from ray.ray_constants import env_integer
 from ray.util.sgd.v2.checkpoint import CheckpointStrategy
 from ray.util.sgd.v2.constants import ENABLE_DETAILED_AUTOFILLED_METRICS_ENV, \
     TUNE_INSTALLED, TUNE_CHECKPOINT_FILE_NAME, \
@@ -276,9 +276,9 @@ class BackendExecutor:
                 self._initialization_hook = initialization_hook
                 self.worker_group.execute(initialization_hook)
 
-            share_cuda_visible_devices_enabled = env_bool(
+            share_cuda_visible_devices_enabled = bool(env_integer(
                 ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV,
-                self._backend.share_cuda_visible_devices)
+                self._backend.share_cuda_visible_devices))
 
             if (self._num_gpus_per_worker > 0
                     and share_cuda_visible_devices_enabled):

--- a/python/ray/util/sgd/v2/backends/backend.py
+++ b/python/ray/util/sgd/v2/backends/backend.py
@@ -276,9 +276,9 @@ class BackendExecutor:
                 self._initialization_hook = initialization_hook
                 self.worker_group.execute(initialization_hook)
 
-            share_cuda_visible_devices_enabled = bool(env_integer(
-                ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV,
-                self._backend.share_cuda_visible_devices))
+            share_cuda_visible_devices_enabled = bool(
+                env_integer(ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV,
+                            self._backend.share_cuda_visible_devices))
 
             if (self._num_gpus_per_worker > 0
                     and share_cuda_visible_devices_enabled):

--- a/python/ray/util/sgd/v2/backends/horovod.py
+++ b/python/ray/util/sgd/v2/backends/horovod.py
@@ -33,6 +33,9 @@ class HorovodConfig(BackendConfig):
     nics: Optional[Set[str]] = None
     verbose: int = 1
 
+    # Parent configs
+    share_cuda_visible_devices: bool = True
+
     def __post_init__(self):
         if Coordinator is None:
             raise ValueError(

--- a/python/ray/util/sgd/v2/backends/horovod.py
+++ b/python/ray/util/sgd/v2/backends/horovod.py
@@ -33,9 +33,6 @@ class HorovodConfig(BackendConfig):
     nics: Optional[Set[str]] = None
     verbose: int = 1
 
-    # Parent configs
-    share_cuda_visible_devices: bool = True
-
     def __post_init__(self):
         if Coordinator is None:
             raise ValueError(
@@ -55,6 +52,8 @@ def init_env_vars(world_rank: int, world_size: int, node_id: str):
 
 
 class HorovodBackend(Backend):
+    share_cuda_visible_devices: bool = True
+
     def on_start(self, worker_group: WorkerGroup,
                  backend_config: HorovodConfig):
 

--- a/python/ray/util/sgd/v2/backends/torch.py
+++ b/python/ray/util/sgd/v2/backends/torch.py
@@ -41,6 +41,9 @@ class TorchConfig(BackendConfig):
     init_method: str = "env"
     timeout_s: int = 1800
 
+    # Parent configs
+    share_cuda_visible_devices: bool = True
+
     def __post_init__(self):
         if torch is None:
             raise ValueError("`torch` is not installed. "

--- a/python/ray/util/sgd/v2/backends/torch.py
+++ b/python/ray/util/sgd/v2/backends/torch.py
@@ -41,9 +41,6 @@ class TorchConfig(BackendConfig):
     init_method: str = "env"
     timeout_s: int = 1800
 
-    # Parent configs
-    share_cuda_visible_devices: bool = True
-
     def __post_init__(self):
         if torch is None:
             raise ValueError("`torch` is not installed. "
@@ -95,6 +92,8 @@ def shutdown_torch(destroy_process_group=False):
 
 
 class TorchBackend(Backend):
+    share_cuda_visible_devices: bool = True
+
     def on_start(self, worker_group: WorkerGroup, backend_config: TorchConfig):
         if len(worker_group) > 1 and dist.is_available():
             # Set the appropriate training backend.

--- a/python/ray/util/sgd/v2/constants.py
+++ b/python/ray/util/sgd/v2/constants.py
@@ -44,3 +44,7 @@ TUNE_CHECKPOINT_FILE_NAME = "checkpoint"
 # This needs to be added to the checkpoint dictionary so if the Tune trial
 # is restarted, the checkpoint_id can continue to increment.
 TUNE_CHECKPOINT_ID = "_current_checkpoint_id"
+
+# Boolean value which if set will override the value of
+# Backend.share_cuda_visible_devices.
+ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV = "SGD_ENABLE_SHARE_CUDA_VISIBLE_DEVICES"

--- a/python/ray/util/sgd/v2/constants.py
+++ b/python/ray/util/sgd/v2/constants.py
@@ -45,6 +45,6 @@ TUNE_CHECKPOINT_FILE_NAME = "checkpoint"
 # is restarted, the checkpoint_id can continue to increment.
 TUNE_CHECKPOINT_ID = "_current_checkpoint_id"
 
-# Boolean value which if set will override the value of
-# Backend.share_cuda_visible_devices.
+# Integer value which if set will override the value of
+# Backend.share_cuda_visible_devices. 1 for True, 0 for False.
 ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV = "SGD_ENABLE_SHARE_CUDA_VISIBLE_DEVICES"

--- a/python/ray/util/sgd/v2/examples/tensorflow_mnist_example.py
+++ b/python/ray/util/sgd/v2/examples/tensorflow_mnist_example.py
@@ -72,7 +72,7 @@ def train_func(config):
     return results
 
 
-def train_tensorflow_mnist(num_workers=1, use_gpu=False):
+def train_tensorflow_mnist(num_workers=2, use_gpu=False):
     trainer = Trainer(
         backend="tensorflow", num_workers=num_workers, use_gpu=use_gpu)
     trainer.start()
@@ -98,7 +98,7 @@ if __name__ == "__main__":
         "--num-workers",
         "-n",
         type=int,
-        default=1,
+        default=2,
         help="Sets number of workers for training.")
     parser.add_argument(
         "--use-gpu",

--- a/python/ray/util/sgd/v2/tests/test_backend.py
+++ b/python/ray/util/sgd/v2/tests/test_backend.py
@@ -8,6 +8,7 @@ from ray.cluster_utils import Cluster
 from ray.util.sgd import v2 as sgd
 from ray.util.sgd.v2.backends.backend import BackendConfig, BackendExecutor
 from ray.util.sgd.v2.backends.tensorflow import TensorflowConfig
+from ray.util.sgd.v2.constants import ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV
 from ray.util.sgd.v2.worker_group import WorkerGroup
 from ray.util.sgd.v2.backends.torch import TorchConfig
 
@@ -321,6 +322,7 @@ def test_cuda_visible_devices(ray_2_node_2_gpu, worker_results, tmp_path):
 
     num_workers, expected_results = worker_results
 
+    os.environ[ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV] = "1"
     e = BackendExecutor(
         config,
         num_workers=num_workers,
@@ -349,6 +351,7 @@ def test_cuda_visible_devices_fractional(ray_2_node_2_gpu, worker_results,
 
     num_workers, expected_results = worker_results
 
+    os.environ[ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV] = "1"
     e = BackendExecutor(
         config,
         num_workers=num_workers,
@@ -374,6 +377,7 @@ def test_cuda_visible_devices_multiple(ray_2_node_4_gpu, worker_results,
 
     num_workers, expected_results = worker_results
 
+    os.environ[ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV] = "1"
     e = BackendExecutor(
         config,
         num_workers=num_workers,

--- a/python/ray/util/sgd/v2/tests/test_trainer.py
+++ b/python/ray/util/sgd/v2/tests/test_trainer.py
@@ -15,6 +15,7 @@ from ray.util.sgd.v2 import Trainer, TorchConfig, TensorflowConfig, \
 from ray.util.sgd.v2.backends.backend import BackendConfig, Backend, \
     BackendExecutor
 from ray.util.sgd.v2.callbacks.callback import SGDCallback
+from ray.util.sgd.v2.constants import ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV
 from ray.util.sgd.v2.examples.tensorflow_mnist_example import train_func as \
     tensorflow_mnist_train_func
 from ray.util.sgd.v2.examples.train_fashion_mnist_example import train_func \
@@ -1005,6 +1006,8 @@ def test_gpu_requests(ray_start_4_cpus_4_gpus_4_extra):
 
     def get_resources():
         return os.environ["CUDA_VISIBLE_DEVICES"]
+
+    os.environ[ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV] = "1"
 
     # 0 GPUs will be requested and should not raise an error.
     trainer = Trainer(TestConfig(), num_workers=2, use_gpu=False)


### PR DESCRIPTION
Set a configurable `share_cuda_visible_devices`  flag  in `Backend` to determine how `CUDA_VISIBLE_DEVICES` should be set on worker processes.

This value can be overridden by setting the `SGD_ENABLE_SHARE_CUDA_VISIBLE_DEVICES` environment variable to `1` for `True` or  `0` for `False`.

## Why are these changes needed?

A `_setup_gpus` step was added in https://github.com/ray-project/ray/pull/18047 to support Torch and Horovod backends. While adding GPU tests for SGD, it was noticed that this behavior leads to the following error messages when running a TensorFlow job with multiple GPUs on a single node:

```
(pid=661) 2021-09-28 15:53:29.767329: I tensorflow/stream_executor/cuda/cuda_driver.cc:789] failed to allocate 734.56M (770241792 bytes) from device: CUDA_ERROR_OUT_OF_MEMORY: out of memory
(pid=661) 2021-09-28 15:53:29.774124: I tensorflow/stream_executor/cuda/cuda_driver.cc:789] failed to allocate 661.10M (693217792 bytes) from device: CUDA_ERROR_OUT_OF_MEMORY: out of memory
(pid=661) 2021-09-28 15:53:29.780995: I tensorflow/stream_executor/cuda/cuda_driver.cc:789] failed to allocate 594.99M (623896064 bytes) from device: CUDA_ERROR_OUT_OF_MEMORY: out of memory
(pid=661) 2021-09-28 15:53:29.787624: I tensorflow/stream_executor/cuda/cuda_driver.cc:789] failed to allocate 535.49M (561506560 bytes) from device: CUDA_ERROR_OUT_OF_MEMORY: out of memory
```

```
tensorflow.python.framework.errors_impl.UnknownError: 3 root error(s) found.
  (0) Unknown:  Failed to get convolution algorithm. This is probably because cuDNN failed to initialize, so try looking to see if a warning log message was printed above.
	 [[node sequential/conv2d/Conv2D (defined at /threading.py:926) ]]
  (1) Unknown:  Failed to get convolution algorithm. This is probably because cuDNN failed to initialize, so try looking to see if a warning log message was printed above.
	 [[node sequential/conv2d/Conv2D (defined at /threading.py:926) ]]
	 [[GroupCrossDeviceControlEdges_0/Identity_5/_99]]
  (2) Unknown:  Failed to get convolution algorithm. This is probably because cuDNN failed to initialize, so try looking to see if a warning log message was printed above.
	 [[node sequential/conv2d/Conv2D (defined at /threading.py:926) ]]
	 [[div_no_nan_1/_63]]
```

## Changes

To fix this, we add a `share_cuda_visible_devices` flag to `Backend` to control this behavior with a default value of `False`. This is overridden to `True` by both `TorchBackend` and `HorovodBackend`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

Tested on the following cluster config:
```yaml
cluster_name: tf-gpu

max_workers: 1

provider:
    type: aws
    region: us-west-1

auth:
    ssh_user: ubuntu

docker:
    image: "rayproject/ray-ml:nightly-gpu"
    container_name: "ray_container"

available_node_types:
    2_gpu_node:
        min_workers: 0
        max_workers: 1
        node_config:
            InstanceType: g3.8xlarge
        resources: {}

head_node_type: 2_gpu_node
```
1. 1 machine * 2 GPU:
```
ray submit tf-gpu.yaml ~/workspace/ray/python/ray/util/sgd/v2/examples/tensorflow_mnist_example.py --address="auto" --use-gpu --num-workers 2
```
2. 2 machines * 2 GPU:
```
ray submit tf-gpu.yaml ~/workspace/ray/python/ray/util/sgd/v2/examples/tensorflow_mnist_example.py --address="auto" --use-gpu --num-workers 4
```
3. Verify env var override works by running the following on the cluster head node and watching the original error occur: 
```
SGD_ENABLE_SHARE_CUDA_VISIBLE_DEVICES=1 python tensorflow_mnist_example.py --address="auto" --use-gpu --num-workers 4
```

CI test for this will be enabled in https://github.com/ray-project/ray/pull/18469.

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
