### PR TITLE
[RLlib] Raise error for kl penalty ddpo

### DIFF
--- a/rllib/agents/ppo/ddppo.py
+++ b/rllib/agents/ppo/ddppo.py
@@ -136,14 +136,12 @@ def validate_config(config):
         raise ValueError(
             "Distributed data parallel requires truncate_episodes "
             "batch mode.")
+    # DDPPO doesn't support KL penalties like PPO-1.
+    # In order to support KL penalties, DDPPO would need to become
+    # undecentralized, which defeats the purpose of the algorithm.
+    # Users can still tune the entropy coefficient to control the
+    # policy entropy (similar to controlling the KL penalty).
     if config["kl_coeff"] != 0.0 or config["kl_target"] != 0.0:
-        # DDPPO doesn't support KL penalties like PPO-1.
-        # In order to support KL penalties, DDPPO would need to
-        # become undecentralized, which defeats the purpose of the
-        # algorithm. Users can still tune the entropy coefficient to
-        # control the policy entropy (similar to controlling the KL
-        # penalty.)
-
         raise ValueError("DDPPO doesn't support KL penalties like PPO-1")
 
 

--- a/rllib/agents/ppo/tests/test_ddppo.py
+++ b/rllib/agents/ppo/tests/test_ddppo.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 
 import ray
 import ray.rllib.agents.ppo as ppo
@@ -53,8 +54,20 @@ class TestDDPPO(unittest.TestCase):
             trainer.stop()
             assert lr == 0.0, "lr should anneal to 0.0"
 
+    def test_validate_config(self):
+        """Test if DDPPO will raise errors after invalid configs are passed."""
+        config = ppo.ddppo.DEFAULT_CONFIG.copy()
+        config["kl_coeff"] = 1.
+        msg = "DDPPO doesn't support KL penalties like PPO-1"
+        # import ipdb; ipdb.set_trace()
+        with pytest.raises(ValueError, match=msg):
+            ppo.ddppo.DDPPOTrainer(config=config, env="CartPole-v0")
+        config["kl_coeff"] = 0.
+        config["kl_target"] = 1.
+        with pytest.raises(ValueError, match=msg):
+            ppo.ddppo.DDPPOTrainer(config=config, env="CartPole-v0")
+
 
 if __name__ == "__main__":
-    import pytest
     import sys
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
DDPPO doesn't support KL penalties like PPO-1.
In order to support KL penalties, DDPPO would need to
become undecentralized, which defeats the purpose of the
algorithm. Users can still tune the entropy coefficient to
control the policy entropy (similar to controlling the KL
penalty.)

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
