### PR TITLE
Add a script to analyze python module dependencies using static analysis

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -554,7 +554,7 @@ _check_job_triggers() {
 
   local variable_definitions
   # shellcheck disable=SC2031
-  variable_definitions=($(python "${ROOT_DIR}"/determine_tests_to_run.py))
+  variable_definitions=($(python3 "${ROOT_DIR}"/determine_tests_to_run.py))
   if [ 0 -lt "${#variable_definitions[@]}" ]; then
     local expression restore_shell_state=""
     if [ -o xtrace ]; then set +x; restore_shell_state="set -x;"; fi  # Disable set -x (noisy here)

--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
         try:
             graph = pda.build_dep_graph()
             rllib_tests = pda.list_rllib_tests()
-            print("Total # of RLlib tests: ", len(tests), file=sys.stderr)
+            print("Total # of RLlib tests: ", len(rllib_tests), file=sys.stderr)
 
             impacted = {}
             for test in rllib_tests:

--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -99,6 +99,12 @@ if __name__ == "__main__":
 
         # Dry run py_dep_analysis.py to see which tests we would have run.
         try:
+            print("--------")
+            print("cur_dir is: ", os.getcwd())
+            for f in os.listdir('.'):
+                print(f)
+            print("--------")
+
             graph = pda.build_dep_graph()
             rllib_tests = pda.list_rllib_tests()
             impacted = {}

--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -107,8 +107,9 @@ if __name__ == "__main__":
             for test in rllib_tests:
                 for file in files:
                     if pda.test_depends_on_file(graph, test, file):
-                        impacted[test] = True
-            print("RLlib tests impacted:", file=sys.stderr)
+                        impacted[test[0]] = True
+
+            print("RLlib tests impacted: ", len(impacted), file=sys.stderr)
             for test in impacted.keys():
                 print("    ", test, file=sys.stderr)
         except Exception as e:

--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -99,14 +99,10 @@ if __name__ == "__main__":
 
         # Dry run py_dep_analysis.py to see which tests we would have run.
         try:
-            print("--------")
-            print("cur_dir is: ", os.getcwd())
-            for f in os.listdir('.'):
-                print(f)
-            print("--------")
-
             graph = pda.build_dep_graph()
             rllib_tests = pda.list_rllib_tests()
+            print("Total # of RLlib tests: ", len(tests), file=sys.stderr)
+
             impacted = {}
             for test in rllib_tests:
                 for file in files:

--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -67,10 +67,8 @@ def get_commit_range():
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--output",
-                        type=str,
-                        help="json or envvars",
-                        default="envvars")
+    parser.add_argument(
+        "--output", type=str, help="json or envvars", default="envvars")
     args = parser.parse_args()
 
     RAY_CI_TUNE_AFFECTED = 0
@@ -101,7 +99,8 @@ if __name__ == "__main__":
         try:
             graph = pda.build_dep_graph()
             rllib_tests = pda.list_rllib_tests()
-            print("Total # of RLlib tests: ", len(rllib_tests), file=sys.stderr)
+            print(
+                "Total # of RLlib tests: ", len(rllib_tests), file=sys.stderr)
 
             impacted = {}
             for test in rllib_tests:

--- a/ci/travis/py_dep_analysis.py
+++ b/ci/travis/py_dep_analysis.py
@@ -342,9 +342,10 @@ if __name__ == "__main__":
         type=str,
         help="Path of a .py source file relative to --base_dir.")
     parser.add_argument("--test", type=str, help="Specific test to check.")
-    parser.add_argument("--smoke-test",
-                        action="store_true",
-                        help="Load only a few tests for testing.")
+    parser.add_argument(
+        "--smoke-test",
+        action="store_true",
+        help="Load only a few tests for testing.")
 
     args = parser.parse_args()
 

--- a/ci/travis/py_dep_analysis.py
+++ b/ci/travis/py_dep_analysis.py
@@ -26,9 +26,9 @@ from typing import Dict, List, Tuple
 
 class DepGraph(object):
     def __init__(self):
-        self.edges = {}
-        self.ids = {}
-        self.inv_ids = {}
+        self.edges: Dict[str, Dict[str, bool]] = {}
+        self.ids: Dict[str, int] = {}
+        self.inv_ids: Dict[int, str] = {}
 
 
 def _run_shell(args: List[str]) -> str:

--- a/ci/travis/py_dep_analysis.py
+++ b/ci/travis/py_dep_analysis.py
@@ -69,8 +69,6 @@ def list_rllib_tests(n: int = -1, test: str = None) -> Tuple[str, List[str]]:
         if n > 0 and len(all_tests) >= n:
             break
 
-    print("Total # of tests: ", len(all_tests))
-
     return all_tests
 
 
@@ -265,7 +263,7 @@ def test_depends_on_file(graph: DepGraph, test: str, path: str) -> List[int]:
     """
     query = _file_path_to_module_path(path)
     if query not in graph.ids:
-        print("Warning: unknown source file ", path)
+        # Not a file that we care about.
         return []
 
     t, srcs = test
@@ -280,7 +278,7 @@ def test_depends_on_file(graph: DepGraph, test: str, path: str) -> List[int]:
 
         tid = _file_path_to_module_path(src)
         if tid not in graph.ids:
-            print("Warning: unknown test ", t)
+            # Not a test that we care about.
             # TODO(jungong): What tests are these?????
             continue
 
@@ -370,6 +368,7 @@ if __name__ == "__main__":
         # The way Tune tests are defined, they all depend on
         # the entire tune codebase.
         tests = list_rllib_tests(5 if args.smoke_test else -1, args.test)
+        print("Total # of tests: ", len(tests))
 
         for t in tests:
             branch = test_depends_on_file(graph, t, args.file)

--- a/ci/travis/py_dep_analysis.py
+++ b/ci/travis/py_dep_analysis.py
@@ -253,7 +253,8 @@ def _depends(graph: DepGraph, visited: Dict[int, bool], tid: int,
     return []
 
 
-def test_depends_on_file(graph: DepGraph, test: str, path: str) -> List[int]:
+def test_depends_on_file(graph: DepGraph, test: Tuple[str, Tuple[str]],
+                         path: str) -> List[int]:
     """Give dependency graph, check if a test depends on a specific .py file.
 
     Args:

--- a/ci/travis/py_dep_analysis.py
+++ b/ci/travis/py_dep_analysis.py
@@ -26,9 +26,9 @@ from typing import Dict, List, Tuple
 
 class DepGraph(object):
     def __init__(self):
-        self.edges: Dict[str, Dict[str, bool]] = {}
-        self.ids: Dict[str, int] = {}
-        self.inv_ids: Dict[int, str] = {}
+        self.edges = {}
+        self.ids = {}
+        self.inv_ids = {}
 
 
 def _run_shell(args: List[str]) -> str:

--- a/ci/travis/py_dep_analysis.py
+++ b/ci/travis/py_dep_analysis.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python
+#
+# This file contains utilities for understanding dependencies between python
+# source files and tests.
+#
+# Utils are assumed to be used from top level ray/ folder, since that is how
+# our tests are defined today.
+#
+# Example usage:
+#     To find all circular dependencies under ray/python/:
+#         python ci/travis/py_dep_analysis.py --mode=circular-dep
+#     To find all the RLlib tests that depend on a file:
+#         python ci/travis/py_dep_analysis.py --mode=test-dep \
+#             --file=python/ray/tune/tune.py
+#     For testing, add --smoke-test to any commands, so it doesn't spend
+#     tons of time querying for available RLlib tests.
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from typing import Dict, List
+
+
+class DepGraph(object):
+    def __init__(self):
+        self.edges: Dict[str, Dict[str, bool]] = {}
+        self.ids: Dict[str, int] = {}
+        self.inv_ids: Dict[int, str] = {}
+
+
+def _run_shell(args: List[str]):
+    return subprocess.check_output(args).decode(sys.stdout.encoding)
+
+
+def list_rllib_tests(n: int, test: str):
+    """List RLlib tests.
+
+    Args:
+        n: return at most n tests. all tests if n = -1.
+        test: only return information about a specific test.
+    """
+    tests_res = _run_shell(
+        ["bazel", "query", "tests(//python/ray/rllib:*)", "--output", "label"])
+
+    all_tests = []
+
+    # Strip, also skip any empty lines
+    tests = [t.strip() for t in tests_res.splitlines() if t.strip()]
+    for t in tests:
+        if test and t != test:
+            continue
+
+        src_out = _run_shell([
+            "bazel", "query", "kind(\"source file\", deps({}))".format(t),
+            "--output", "label"
+        ])
+
+        srcs = [f.strip() for f in src_out.splitlines()]
+        srcs = [
+            f for f in srcs if f.startswith("//python") and f.endswith(".py")
+        ]
+        if srcs:
+            all_tests.append((t, srcs))
+
+        # Break early if smoke test.
+        if n > 0 and len(all_tests) >= n:
+            break
+
+    print("Total # of tests: ", len(all_tests))
+
+    return all_tests
+
+
+def _new_dep(graph: DepGraph, src_module: str, dep: str):
+    """Create a new dependency between src_module and dep.
+    """
+    if dep not in graph.ids:
+        graph.ids[dep] = len(graph.ids)
+
+    src_id = graph.ids[src_module]
+    dep_id = graph.ids[dep]
+
+    if src_id not in graph.edges:
+        graph.edges[src_id] = {}
+    graph.edges[src_id][dep_id] = True
+
+
+def _new_import(graph: DepGraph, src_module: str, line: str):
+    """Process a new import statement in src_module.
+    """
+    m = re.match(r"import (\S+)", line)
+    if m:
+        module = m.group(1)
+
+        # We don't care about system imports.
+        if not module.startswith("ray"):
+            return
+
+        _new_dep(graph, src_module, module)
+
+
+def _is_path_module(base: str, sub: str, _base_dir: str):
+    """Figure out if base.sub is a python module or not.
+    """
+    # Special handling for _raylet, which is a C++ lib.
+    if base == "ray._raylet":
+        return False
+
+    bps = ["python"] + base.split(".")
+    path = os.path.join(_base_dir, os.path.join(*bps), sub + ".py")
+    if os.path.isfile(path):
+        return True  # file module
+    return False
+
+
+def _count_triple_quotes(fl: str):
+    """Figure out how many triple quotes are in a line of code.
+
+    This is to correctly handle the cases:
+        '''single multi-line string'''
+        and
+        '''multi-line
+        string
+        '''
+    """
+    def _count_type(tq):
+        c = 0
+        start = fl.find(tq)
+        while start >= 0:
+            c += 1
+            start = fl.find(tq, start + 1)
+        return c
+
+    return _count_type('"""') + _count_type("'''")
+
+
+def _new_from_import(graph: DepGraph, src_module: str, line: str,
+                     _base_dir: str):
+    """Process a new "from ... import ..." statement in src_module.
+    """
+    line = re.sub(r" as .*", "", line)
+    m = re.match(r"from (\S+) import (.+)", line)
+    if not m:
+        return
+
+    base = m.group(1)
+    # We don't care about system imports.
+    if not base.startswith("ray"):
+        return
+
+    # This is where things are not handled 100%.
+    # If we have something like:
+    #     from ray.rllib.env.some_module import (ClassName1, ClassName2,
+    #                                            ClassName3)
+    # We are basically gonna say src_module depends on some_module and
+    # call it a day.
+    # This simplification is almost always true. It also allows us not
+    # to worry about complicated () line continuation problem.
+    if m.group(2).startswith("("):
+        # Simply add the dependency on base module and return.
+        _new_dep(graph, src_module, base)
+        return
+
+    # Handle the case: from xx.yy import aa, bb
+    for sub in m.group(2).split(","):
+        sub = sub.strip()
+
+        # In the case of "from xxx import *", we are going to simply
+        # add a dep from full to xxx. The module xxx should import all
+        # the sub modules that are exposed in __all__.
+        if sub == "*":
+            _new_dep(graph, src_module, base)
+        else:
+            if _is_path_module(base, sub, _base_dir):
+                # base.sub points to a file.
+                _new_dep(graph, src_module, _full_module_path(base, sub))
+            else:
+                # sub is an obj on base dir/file.
+                _new_dep(graph, src_module, base)
+
+
+def _process_file(graph: DepGraph,
+                  src_path: str,
+                  src_module: str,
+                  _base_dir=""):
+    """Create dependencies from src_module to all the valid imports in src_path.
+
+    Args:
+        graph: the DepGraph to be added to.
+        src_path: .py file to be processed.
+        src_module: full module path of the source file.
+        _base_dir: use a different base dir than current dir. For unit testing.
+    """
+    with open(os.path.join(_base_dir, src_path), "r") as in_f:
+        in_multiline_comments = False
+        fl = ""
+        for line in in_f.readlines():
+            line = line.strip()
+            # Strip comments from the line.
+            line = re.sub(r"#.*", "", line)
+
+            # Line continuation.
+            # TODO(jungong) : also need to handle line breaks with ().
+            if line.endswith("\\"):
+                # line continuation.
+                fl += line[:-1]
+                continue
+            else:
+                fl += line
+
+            # Need to make sure we don't process multi-line comments.
+            # TODO(jungong) : this is quite ugly. Find a lib to do this maybe.
+            tq_count = _count_triple_quotes(fl)
+            if tq_count > 0 and tq_count % 2 == 0:
+                # Single multiline comment. Probably not import statement.
+                fl = ""
+                continue
+            elif tq_count % 2 == 1:
+                in_multiline_comments = not in_multiline_comments
+
+            if in_multiline_comments:
+                fl = ""
+                continue
+
+            if fl.startswith("import"):
+                _new_import(graph, src_module, fl)
+            elif fl.startswith("from"):
+                _new_from_import(graph, src_module, fl, _base_dir)
+
+            fl = ""
+
+
+def build_dep_graph():
+    """Build index from py files to their immediate dependees.
+    """
+    graph = DepGraph()
+
+    # Assuming we run from root /ray directory.
+    # Follow links since rllib is linked to /rllib.
+    for root, sub_dirs, files in os.walk("python", followlinks=True):
+        if _should_skip(root):
+            continue
+
+        module = _bazel_path_to_module_path(root)
+
+        # Process files first.
+        for f in files:
+            if not f.endswith(".py"):
+                continue
+
+            full = _full_module_path(module, f)
+
+            if full not in graph.ids:
+                graph.ids[full] = len(graph.ids)
+
+            # Process file:
+            _process_file(graph, os.path.join(root, f), full)
+
+    # Build reverse index for convenience.
+    graph.inv_ids = {v: k for k, v in graph.ids.items()}
+
+    return graph
+
+
+def _full_module_path(module, f):
+    if f == "__init__.py":
+        # __init__ file for this module.
+        # Full path is the same as the module name.
+        return module
+
+    fn = re.sub(r"\.py$", "", f)
+
+    if not module:
+        return fn
+    return module + "." + fn
+
+
+def _should_skip(d: str):
+    """Skip directories that should not contain py sources.
+    """
+    if d.startswith("python/.eggs/"):
+        return True
+    if d.startswith("python/."):
+        return True
+    if d.startswith("python/ray/cpp"):
+        return True
+    return False
+
+
+def _bazel_path_to_module_path(d: str):
+    """Convert a Bazel file path to python module path.
+
+    Example: //python/ray/rllib:xxx/yyy/dd -> ray.rllib.xxx.yyy.dd
+    """
+    # Do this in 3 steps, so all of 'python:', 'python/', or '//python', etc
+    # will get stripped.
+    d = re.sub(r"^\/\/", "", d)
+    d = re.sub(r"^python", "", d)
+    d = re.sub(r"^[\/:]", "", d)
+    return d.replace("/", ".").replace(":", ".")
+
+
+def _file_path_to_module_path(f: str):
+    """Return the corresponding module path for a .py file.
+    """
+    dir, fn = os.path.split(f)
+    return _full_module_path(_bazel_path_to_module_path(dir), fn)
+
+
+def _depends(graph: DepGraph, visited: Dict[int, bool], tid: int, qid: int):
+    """Whether there is a dependency path from module tid to module qid.
+
+    Given graph, and without going through visited.
+    """
+    if tid not in graph.edges or qid not in graph.edges:
+        return []
+    if qid in graph.edges[tid]:
+        # tid directly depends on qid.
+        return [tid, qid]
+    for c in graph.edges[tid]:
+        if c in visited:
+            continue
+        visited[c] = True
+        # Reduce to a question of whether there is a path from c to qid.
+        ds = _depends(graph, visited, c, qid)
+        if ds:
+            # From tid -> c -> qid.
+            return [tid] + ds
+    return []
+
+
+def test_depends_on_file(graph: DepGraph, test: str, path: str):
+    """Give dependency graph, check if a test depends on a specific .py file.
+
+    Args:
+        graph: the dependency graph.
+        test: information about a test, in the format of:
+            [test_name, (src files for the test)]
+    """
+    query = _file_path_to_module_path(path)
+    if query not in graph.ids:
+        print("Warning: unknown source file ", path)
+        return []
+
+    t, srcs = test
+
+    # Skip tuned_examples/ and examples/ tests.
+    if t.startswith("//python/ray/rllib:examples/"):
+        return []
+
+    for src in srcs:
+        if src == "ray.rllib.tests.run_regression_tests":
+            return []
+
+        tid = _file_path_to_module_path(src)
+        if tid not in graph.ids:
+            print("Warning: unknown test ", t)
+            # TODO(jungong): What tests are these?????
+            continue
+
+        branch = _depends(graph, {}, graph.ids[tid], graph.ids[query])
+        if branch:
+            return branch
+
+    # Does not depend on file.
+    return []
+
+
+def _find_circular_dep_impl(graph: DepGraph, id: str, branch: str):
+    if id not in graph.edges:
+        return False
+    for c in graph.edges[id]:
+        if c in branch:
+            # Found a circle.
+            branch.append(c)
+            return True
+        branch.append(c)
+        if _find_circular_dep_impl(graph, c, branch):
+            return True
+        branch.pop()
+    return False
+
+
+def find_circular_dep(graph: DepGraph):
+    """Find circular dependencies among a dependency graph.
+    """
+    known = {}
+    circles = {}
+    for m, id in graph.ids.items():
+        branch = []
+        if _find_circular_dep_impl(graph, id, branch):
+            if branch[-1] in known:
+                # Already knew, skip.
+                continue
+            # Since this is a cycle dependency, any step along the circle
+            # will form a different circle.
+            # So we mark every entry on this circle known.
+            for n in branch:
+                known[n] = True
+            # Mark that module m contains a potential circular dep.
+            circles[m] = branch
+    return circles
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--mode",
+        type=str,
+        default="test-dep",
+        help=("test-dep: find dependencies for a specified test. "
+              "circular-dep: find circular dependencies in "
+              "the specific codebase."))
+    parser.add_argument(
+        "--file",
+        type=str,
+        help="Path of a .py source file relative to --base_dir.")
+    parser.add_argument("--test", type=str, help="Specific test to check.")
+    parser.add_argument("--smoke-test",
+                        action="store_true",
+                        help="Load only a few tests for testing.")
+
+    args = parser.parse_args()
+
+    print("building dep graph ...")
+    graph = build_dep_graph()
+    print("done. total {} files, {} of which have dependencies.".format(
+        len(graph.ids), len(graph.edges)))
+
+    if args.mode == "circular-dep":
+        circles = find_circular_dep(graph)
+        print("Found following circular dependencies: \n")
+        for m, b in circles.items():
+            print(m)
+            for n in b:
+                print("    ", graph.inv_ids[n])
+            print()
+
+    if args.mode == "test-dep":
+        assert args.file, "Must specify --file for the query."
+
+        # Only support RLlib tests for now.
+        # The way Tune tests are defined, they all depend on
+        # the entire tune codebase.
+        tests = list_rllib_tests(5 if args.smoke_test else -1, args.test)
+
+        for t in tests:
+            branch = test_depends_on_file(graph, t, args.file)
+            if branch:
+                print("{} depends on {}".format(t[0], args.file))
+                # Print some debugging info.
+                for n in branch:
+                    print("    ", graph.inv_ids[n])
+            else:
+                print("{} does not depend on {}".format(t[0], args.file))

--- a/ci/travis/py_dep_analysis_test.py
+++ b/ci/travis/py_dep_analysis_test.py
@@ -77,68 +77,6 @@ b = 2
         self.assertEqual(graph.ids["ray.rllib.env"], 1)
         self.assertEqual(graph.edges[0], {1: True})
 
-    def test_import_in_comment(self):
-        graph = pda.DepGraph()
-        graph.ids["ray"] = 0
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            src_path = os.path.join(tmpdir, "comment1.py")
-            self.create_tmp_file(
-                src_path, '''
-import ray.rllib.env.mock_env
-a = 1  # this is a comment import ray.rllib.env.multi_agent_env
-b = 2
-''')
-            pda._process_file(graph, src_path, "ray")
-
-        self.assertEqual(len(graph.ids), 2)
-        self.assertEqual(graph.ids["ray.rllib.env.mock_env"], 1)
-        # Only 1 edge from ray to ray.rllib.env.mock_env
-        # ray.tune.tune is ignored.
-        self.assertEqual(graph.edges[0], {1: True})
-
-    def test_import_in_multi_line_comment_1(self):
-        graph = pda.DepGraph()
-        graph.ids["ray"] = 0
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            src_path = os.path.join(tmpdir, "multi_line_comment1.py")
-            self.create_tmp_file(
-                src_path, '''
-a = 1
-b = 2  """usa this like: import ray.tune.tune"""
-import ray.rllib.env.mock_env
-''')
-            pda._process_file(graph, src_path, "ray")
-
-        self.assertEqual(len(graph.ids), 2)
-        self.assertEqual(graph.ids["ray.rllib.env.mock_env"], 1)
-        # Only 1 edge from ray to ray.rllib.env.mock_env
-        # ray.tune.tune is ignored.
-        self.assertEqual(graph.edges[0], {1: True})
-
-    def test_import_in_multi_line_comment_2(self):
-        graph = pda.DepGraph()
-        graph.ids["ray"] = 0
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            src_path = os.path.join(tmpdir, "multi_line_comment2.py")
-            self.create_tmp_file(
-                src_path, '''
-a = 1
-b = 2  """
-usa this like: import ray.tune.tune
-"""
-import ray.rllib.env.mock_env
-''')
-            pda._process_file(graph, src_path, "ray")
-
-        self.assertEqual(len(graph.ids), 2)
-        self.assertEqual(graph.ids["ray.rllib.env.mock_env"], 1)
-        # Only 1 edge from ray to ray.rllib.env.mock_env
-        # ray.tune.tune is ignored.
-        self.assertEqual(graph.edges[0], {1: True})
-
     def test_from_import_file_module(self):
         graph = pda.DepGraph()
         graph.ids["ray"] = 0
@@ -147,11 +85,9 @@ import ray.rllib.env.mock_env
             src_path = "multi_line_comment_3.py"
             self.create_tmp_file(
                 os.path.join(tmpdir, src_path), '''
-a = 1
-b = 2  """
-usa this like: from ray.tune import tune
-"""
 from ray.rllib.env import mock_env
+a = 1
+b = 2
 ''')
             # Touch ray/rllib/env/mock_env.py in tmpdir,
             # so that it looks like a module.
@@ -177,11 +113,9 @@ from ray.rllib.env import mock_env
             src_path = "multi_line_comment_3.py"
             self.create_tmp_file(
                 os.path.join(tmpdir, src_path), '''
-a = 1
-b = 2  """
-usa this like: from ray.tune import tune
-"""
 from ray.rllib.env import MockEnv
+a = 1
+b = 2
 ''')
             # Touch ray/rllib/env.py in tmpdir,
             # MockEnv is a class on env module.

--- a/ci/travis/py_dep_analysis_test.py
+++ b/ci/travis/py_dep_analysis_test.py
@@ -1,0 +1,207 @@
+import os
+import tempfile
+import unittest
+
+import py_dep_analysis as pda
+
+
+class TestPyDepAnalysis(unittest.TestCase):
+    def create_tmp_file(self, path: str, content: str):
+        f = open(path, "w")
+        f.write(content)
+        f.close()
+
+    def test_full_module_path(self):
+        self.assertEqual(pda._full_module_path("aa.bb.cc", "__init__.py"),
+                         "aa.bb.cc")
+        self.assertEqual(pda._full_module_path("aa.bb.cc", "dd.py"),
+                         "aa.bb.cc.dd")
+        self.assertEqual(pda._full_module_path("", "dd.py"), "dd")
+
+    def test_bazel_path_to_module_path(self):
+        self.assertEqual(
+            pda._bazel_path_to_module_path("//python/ray/rllib:xxx/yyy/dd"),
+            "ray.rllib.xxx.yyy.dd")
+        self.assertEqual(
+            pda._bazel_path_to_module_path("python:ray/rllib/xxx/yyy/dd"),
+            "ray.rllib.xxx.yyy.dd")
+        self.assertEqual(
+            pda._bazel_path_to_module_path("python/ray/rllib:xxx/yyy/dd"),
+            "ray.rllib.xxx.yyy.dd")
+
+    def test_file_path_to_module_path(self):
+        self.assertEqual(
+            pda._file_path_to_module_path("python/ray/rllib/env/env.py"),
+            "ray.rllib.env.env")
+        self.assertEqual(
+            pda._file_path_to_module_path("python/ray/rllib/env/__init__.py"),
+            "ray.rllib.env")
+
+    def test_import_line_continuation(self):
+        graph = pda.DepGraph()
+        graph.ids["ray"] = 0
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src_path = os.path.join(tmpdir, "continuation1.py")
+            self.create_tmp_file(
+                src_path, '''
+import ray.rllib.env.\\
+    mock_env
+b = 2
+''')
+            pda._process_file(graph, src_path, "ray")
+
+        self.assertEqual(len(graph.ids), 2)
+        print(graph.ids)
+        # Shoud pick up the full module name.
+        self.assertEqual(graph.ids["ray.rllib.env.mock_env"], 1)
+        self.assertEqual(graph.edges[0], {1: True})
+
+    def test_import_line_continuation_parenthesis(self):
+        graph = pda.DepGraph()
+        graph.ids["ray"] = 0
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src_path = os.path.join(tmpdir, "continuation1.py")
+            self.create_tmp_file(
+                src_path, '''
+from ray.rllib.env import (ClassName,
+    module1, module2)
+b = 2
+''')
+            pda._process_file(graph, src_path, "ray")
+
+        self.assertEqual(len(graph.ids), 2)
+        print(graph.ids)
+        # Shoud pick up the full module name without trailing (.
+        self.assertEqual(graph.ids["ray.rllib.env"], 1)
+        self.assertEqual(graph.edges[0], {1: True})
+
+    def test_import_in_comment(self):
+        graph = pda.DepGraph()
+        graph.ids["ray"] = 0
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src_path = os.path.join(tmpdir, "comment1.py")
+            self.create_tmp_file(
+                src_path, '''
+import ray.rllib.env.mock_env
+a = 1  # this is a comment import ray.rllib.env.multi_agent_env
+b = 2
+''')
+            pda._process_file(graph, src_path, "ray")
+
+        self.assertEqual(len(graph.ids), 2)
+        self.assertEqual(graph.ids["ray.rllib.env.mock_env"], 1)
+        # Only 1 edge from ray to ray.rllib.env.mock_env
+        # ray.tune.tune is ignored.
+        self.assertEqual(graph.edges[0], {1: True})
+
+    def test_import_in_multi_line_comment_1(self):
+        graph = pda.DepGraph()
+        graph.ids["ray"] = 0
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src_path = os.path.join(tmpdir, "multi_line_comment1.py")
+            self.create_tmp_file(
+                src_path, '''
+a = 1
+b = 2  """usa this like: import ray.tune.tune"""
+import ray.rllib.env.mock_env
+''')
+            pda._process_file(graph, src_path, "ray")
+
+        self.assertEqual(len(graph.ids), 2)
+        self.assertEqual(graph.ids["ray.rllib.env.mock_env"], 1)
+        # Only 1 edge from ray to ray.rllib.env.mock_env
+        # ray.tune.tune is ignored.
+        self.assertEqual(graph.edges[0], {1: True})
+
+    def test_import_in_multi_line_comment_2(self):
+        graph = pda.DepGraph()
+        graph.ids["ray"] = 0
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src_path = os.path.join(tmpdir, "multi_line_comment2.py")
+            self.create_tmp_file(
+                src_path, '''
+a = 1
+b = 2  """
+usa this like: import ray.tune.tune
+"""
+import ray.rllib.env.mock_env
+''')
+            pda._process_file(graph, src_path, "ray")
+
+        self.assertEqual(len(graph.ids), 2)
+        self.assertEqual(graph.ids["ray.rllib.env.mock_env"], 1)
+        # Only 1 edge from ray to ray.rllib.env.mock_env
+        # ray.tune.tune is ignored.
+        self.assertEqual(graph.edges[0], {1: True})
+
+    def test_from_import_file_module(self):
+        graph = pda.DepGraph()
+        graph.ids["ray"] = 0
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src_path = "multi_line_comment_3.py"
+            self.create_tmp_file(
+                os.path.join(tmpdir, src_path), '''
+a = 1
+b = 2  """
+usa this like: from ray.tune import tune
+"""
+from ray.rllib.env import mock_env
+''')
+            # Touch ray/rllib/env/mock_env.py in tmpdir,
+            # so that it looks like a module.
+            module_dir = os.path.join(tmpdir, "python", "ray", "rllib", "env")
+            os.makedirs(module_dir, exist_ok=True)
+            f = open(os.path.join(module_dir, "mock_env.py"), "w")
+            f.write("print('hello world!')")
+            f.close
+
+            pda._process_file(graph, src_path, "ray", _base_dir=tmpdir)
+
+        self.assertEqual(len(graph.ids), 2)
+        self.assertEqual(graph.ids["ray.rllib.env.mock_env"], 1)
+        # Only 1 edge from ray to ray.rllib.env.mock_env
+        # ray.tune.tune is ignored.
+        self.assertEqual(graph.edges[0], {1: True})
+
+    def test_from_import_class_object(self):
+        graph = pda.DepGraph()
+        graph.ids["ray"] = 0
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src_path = "multi_line_comment_3.py"
+            self.create_tmp_file(
+                os.path.join(tmpdir, src_path), '''
+a = 1
+b = 2  """
+usa this like: from ray.tune import tune
+"""
+from ray.rllib.env import MockEnv
+''')
+            # Touch ray/rllib/env.py in tmpdir,
+            # MockEnv is a class on env module.
+            module_dir = os.path.join(tmpdir, "python", "ray", "rllib")
+            os.makedirs(module_dir, exist_ok=True)
+            f = open(os.path.join(module_dir, "env.py"), "w")
+            f.write("print('hello world!')")
+            f.close
+
+            pda._process_file(graph, src_path, "ray", _base_dir=tmpdir)
+
+        self.assertEqual(len(graph.ids), 2)
+        # Should depend on env.py instead.
+        self.assertEqual(graph.ids["ray.rllib.env"], 1)
+        # Only 1 edge from ray to ray.rllib.env.mock_env
+        # ray.tune.tune is ignored.
+        self.assertEqual(graph.edges[0], {1: True})
+
+
+if __name__ == "__main__":
+    import pytest
+    import sys
+    sys.exit(pytest.main(["-v", __file__]))

--- a/ci/travis/py_dep_analysis_test.py
+++ b/ci/travis/py_dep_analysis_test.py
@@ -12,10 +12,10 @@ class TestPyDepAnalysis(unittest.TestCase):
         f.close()
 
     def test_full_module_path(self):
-        self.assertEqual(pda._full_module_path("aa.bb.cc", "__init__.py"),
-                         "aa.bb.cc")
-        self.assertEqual(pda._full_module_path("aa.bb.cc", "dd.py"),
-                         "aa.bb.cc.dd")
+        self.assertEqual(
+            pda._full_module_path("aa.bb.cc", "__init__.py"), "aa.bb.cc")
+        self.assertEqual(
+            pda._full_module_path("aa.bb.cc", "dd.py"), "aa.bb.cc.dd")
         self.assertEqual(pda._full_module_path("", "dd.py"), "dd")
 
     def test_bazel_path_to_module_path(self):
@@ -44,11 +44,11 @@ class TestPyDepAnalysis(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             src_path = os.path.join(tmpdir, "continuation1.py")
             self.create_tmp_file(
-                src_path, '''
+                src_path, """
 import ray.rllib.env.\\
     mock_env
 b = 2
-''')
+""")
             pda._process_file(graph, src_path, "ray")
 
         self.assertEqual(len(graph.ids), 2)
@@ -64,11 +64,11 @@ b = 2
         with tempfile.TemporaryDirectory() as tmpdir:
             src_path = os.path.join(tmpdir, "continuation1.py")
             self.create_tmp_file(
-                src_path, '''
+                src_path, """
 from ray.rllib.env import (ClassName,
     module1, module2)
 b = 2
-''')
+""")
             pda._process_file(graph, src_path, "ray")
 
         self.assertEqual(len(graph.ids), 2)
@@ -84,11 +84,11 @@ b = 2
         with tempfile.TemporaryDirectory() as tmpdir:
             src_path = "multi_line_comment_3.py"
             self.create_tmp_file(
-                os.path.join(tmpdir, src_path), '''
+                os.path.join(tmpdir, src_path), """
 from ray.rllib.env import mock_env
 a = 1
 b = 2
-''')
+""")
             # Touch ray/rllib/env/mock_env.py in tmpdir,
             # so that it looks like a module.
             module_dir = os.path.join(tmpdir, "python", "ray", "rllib", "env")
@@ -112,11 +112,11 @@ b = 2
         with tempfile.TemporaryDirectory() as tmpdir:
             src_path = "multi_line_comment_3.py"
             self.create_tmp_file(
-                os.path.join(tmpdir, src_path), '''
+                os.path.join(tmpdir, src_path), """
 from ray.rllib.env import MockEnv
 a = 1
 b = 2
-''')
+""")
             # Touch ray/rllib/env.py in tmpdir,
             # MockEnv is a class on env module.
             module_dir = os.path.join(tmpdir, "python", "ray", "rllib")

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -42,8 +42,6 @@ from ray.tune.utils.placement_groups import PlacementGroupFactory
 
 logger = logging.getLogger(__name__)
 
-# this is just a test
-
 
 def _check_default_resources_override(run_identifier):
     if not isinstance(run_identifier, str):

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -42,6 +42,8 @@ from ray.tune.utils.placement_groups import PlacementGroupFactory
 
 logger = logging.getLogger(__name__)
 
+# this is just a test
+
 
 def _check_default_resources_override(run_identifier):
     if not isinstance(run_identifier, str):


### PR DESCRIPTION
## Why are these changes needed?

This script can potentially be integrated with CI framework to figure out the exact set of units for python PRs.

## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
