### PR TITLE
[nightly] update nightly test for many node test

### DIFF
--- a/release/nightly_tests/many_nodes_tests/app_config.yaml
+++ b/release/nightly_tests/many_nodes_tests/app_config.yaml
@@ -1,5 +1,5 @@
 base_image: "anyscale/ray-ml:pinned-nightly-py37"
-env_vars: {"RAY_event_log_reporter_enabled": "1"}
+env_vars: {"RAY_event_log_reporter_enabled": "1", "RAY_gcs_server_rpc_server_thread_num": "8", "RAY_GCS_ACTOR_SCHEDULING_ENABLED": "true"}
 debian_packages: []
 
 python:

--- a/release/nightly_tests/nightly_tests.yaml
+++ b/release/nightly_tests/nightly_tests.yaml
@@ -325,4 +325,6 @@
   run:
     timeout: 7200
     prepare: python wait_cluster.py 500 5400
-    script: python many_nodes_tests/actor_test.py --cpus-per-actor=0.1 --total-actors=10000 && python many_nodes_tests/actor_test.py --cpus-per-actor=0.1 --total-actors=10000 --fail --no-report && python many_nodes_tests/actor_test.py --cpus-per-actor=0.1 --total-actors=10000 --no-report
+    script: python many_nodes_tests/actor_test.py --cpus-per-actor=0.1 --total-actors=10000
+    # TODO: enable failure test later
+    #&& python many_nodes_tests/actor_test.py --cpus-per-actor=0.1 --total-actors=10000 --fail --no-report && python many_nodes_tests/actor_test.py --cpus-per-actor=0.1 --total-actors=10000 --no-report


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
many node tests are really flaky now. But before we'd like to change the flags by default we need to test it to make sure it's working well. Due to k8s issues, thread number is reverted back.

- test gcs actor scheduler
- test gcs grpc mult-thread 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
