### PR TITLE
Fix false positive error message from autoscaler events

### DIFF
--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -245,8 +245,7 @@ class Monitor:
                     resource_message.node_id.hex())
                 resources = {}
                 for k, v in resource_message.resources_total.items():
-                    if not k.startswith("node:"):
-                        resources[k] = v
+                    resources[k] = v
                 mirror_node_types[node_type] = {
                     "resources": resources,
                     "node_config": {},

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -65,13 +65,15 @@ def test_autoscaler_no_spam():
 import ray
 import time
 
-ray.init(num_cpus=1)
+# Check that there are no false positives with custom resources.
+ray.init(num_cpus=1, resources={"node:x": 1})
 
-@ray.remote(num_cpus=1)
+@ray.remote(num_cpus=1, resources={"node:x": 1})
 def f():
     time.sleep(1)
+    print("task done")
 
-ray.get([f.remote() for _ in range(5)])
+ray.get([f.remote() for _ in range(15)])
     """
 
     proc = run_string_as_driver_nonblocking(script)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The previous PR incorrectly filtered out node: custom resources from the "manual cluster" mode, which leads to occasional false positive warnings. This PR removes this bad check and adds a test.

I verified the test fails before this fix.

Closes https://github.com/ray-project/ray/issues/18979