### PR TITLE
[Datasets] Handle empty datasets properly in most Dataset transformations.

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -347,8 +347,13 @@ class Dataset(Generic[T]):
         Returns:
             The shuffled dataset.
         """
+        curr_num_blocks = self.num_blocks()
+        # Handle empty dataset.
+        if curr_num_blocks == 0:
+            return self
+
         if num_blocks is None:
-            num_blocks = self.num_blocks()
+            num_blocks = curr_num_blocks
         new_blocks = simple_shuffle(
             self._move_blocks() if _move else self._blocks,
             num_blocks,
@@ -648,6 +653,9 @@ class Dataset(Generic[T]):
         Returns:
             A new, sorted dataset.
         """
+        # Handle empty dataset.
+        if self.num_blocks() == 0:
+            return self
         return Dataset(sort_impl(self._blocks, key, descending))
 
     def zip(self, other: "Dataset[U]") -> "Dataset[(T, U)]":
@@ -756,6 +764,9 @@ class Dataset(Generic[T]):
         Returns:
             The number of records in the dataset.
         """
+        # Handle empty dataset.
+        if self.num_blocks() == 0:
+            return 0
 
         # For parquet, we can return the count directly from metadata.
         meta_count = self._meta_count()

--- a/python/ray/data/impl/compute.py
+++ b/python/ray/data/impl/compute.py
@@ -35,6 +35,10 @@ def _map_block(block: Block, meta: BlockMetadata,
 class TaskPool(ComputeStrategy):
     def apply(self, fn: Any, remote_args: dict,
               blocks: BlockList[Any]) -> BlockList[Any]:
+        # Handle empty datasets.
+        if len(blocks) == 0:
+            return blocks
+
         map_bar = ProgressBar("Map Progress", total=len(blocks))
 
         kwargs = remote_args.copy()

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -719,6 +719,16 @@ def test_empty_dataset(ray_start_regular_shared):
     assert str(ds) == \
         "Dataset(num_blocks=1, num_rows=0, schema=Unknown schema)"
 
+    # Test map on empty dataset.
+    ds = ray.data.from_items([])
+    ds = ds.map(lambda x: x)
+    assert ds.count() == 0
+
+    # Test filter on empty dataset.
+    ds = ray.data.from_items([])
+    ds = ds.filter(lambda: True)
+    assert ds.count() == 0
+
 
 def test_schema(ray_start_regular_shared):
     ds = ray.data.range(10)
@@ -2354,6 +2364,12 @@ def test_sort_simple(ray_start_regular_shared):
     assert ds.sort(key=lambda x: -x).take(num_items) == list(
         reversed(range(num_items)))
 
+    # Test empty dataset.
+    ds = ray.data.from_items([])
+    s1 = ds.sort()
+    assert s1.count() == 0
+    assert s1 == ds
+
 
 @pytest.mark.parametrize("pipelined", [False, True])
 def test_random_shuffle(shutdown_only, pipelined):
@@ -2404,6 +2420,12 @@ def test_random_shuffle(shutdown_only, pipelined):
             ds = ds.map(lambda x: x).take(999)
     r2 = range(100).random_shuffle(_move=True).take(999)
     assert r1 != r2, (r1, r2)
+
+    # Test empty dataset.
+    ds = ray.data.from_items([])
+    r1 = ds.random_shuffle()
+    assert r1.count() == 0
+    assert r1 == ds
 
 
 def test_random_shuffle_spread(ray_start_cluster):


### PR DESCRIPTION
Explicitly handles empty datasets for more transformations, treating the operation as a no-op.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #18972

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
