### PR TITLE
[core][dataset][RFC] return self for write_related method

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -877,6 +877,7 @@ class Dataset(Generic[T]):
             dataset_uuid=self._uuid,
             filesystem=filesystem,
             **arrow_parquet_args)
+        return self
 
     def write_json(self,
                    path: str,
@@ -911,6 +912,7 @@ class Dataset(Generic[T]):
             dataset_uuid=self._uuid,
             filesystem=filesystem,
             **pandas_json_args)
+        return self
 
     def write_csv(self,
                   path: str,
@@ -942,6 +944,7 @@ class Dataset(Generic[T]):
             dataset_uuid=self._uuid,
             filesystem=filesystem,
             **arrow_csv_args)
+        return self
 
     def write_numpy(
             self,
@@ -971,6 +974,7 @@ class Dataset(Generic[T]):
             path=path,
             dataset_uuid=self._uuid,
             filesystem=filesystem)
+        return self
 
     def write_datasource(self, datasource: Datasource[T],
                          **write_args) -> None:
@@ -998,6 +1002,7 @@ class Dataset(Generic[T]):
             raise
         finally:
             progress.close()
+        return self
 
     def iter_rows(self, *, prefetch_blocks: int = 0) -> Iterator[T]:
         """Return a local row iterator over the dataset.


### PR DESCRIPTION
Does it make sense that dataset.write_*() return itself? In this way we can chain them in dataset_pipeline. Currently dataset_pipeline.write_* returns None.