### PR TITLE
[runtime env] Parse local pip/conda requirements files locally upon task/actor definition

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -491,7 +491,7 @@ The ``runtime_env`` is a Python dictionary including one or more of the followin
   - Example: ``["my_file.txt", "path/to/dir", "*.log"]``
 
 - ``pip`` (List[str] | str): Either a list of pip packages, or a string containing the path to a pip
-  `“requirements.txt” <https://pip.pypa.io/en/stable/user_guide/#requirements-files>`_ file.  The path may be an absolute path or a relative path.  (Note: A relative path will be interpreted relative to ``working_dir`` if ``working_dir`` is specified.)
+  `“requirements.txt” <https://pip.pypa.io/en/stable/user_guide/#requirements-files>`_ file.  The path may be an absolute path or a relative path.
   This will be dynamically installed in the ``runtime_env``.
   To use a library like Ray Serve or Ray Tune, you will need to include ``"ray[serve]"`` or ``"ray[tune]"`` here.
 
@@ -499,7 +499,7 @@ The ``runtime_env`` is a Python dictionary including one or more of the followin
 
   - Example: ``"./requirements.txt"``
 
-- ``conda`` (dict | str): Either (1) a dict representing the conda environment YAML, (2) a string containing the path to a
+- ``conda`` (dict | str): Either (1) a dict representing the conda environment YAML, (2) a string containing the absolute or relative path to a
   `conda “environment.yml” <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#create-env-file-manually>`_ file,
   or (3) the name of a local conda environment already installed on each node in your cluster (e.g., ``"pytorch_p36"``).
   In the first two cases, the Ray and Python dependencies will be automatically injected into the environment to ensure compatibility, so there is no need to manually include them.
@@ -511,7 +511,6 @@ The ``runtime_env`` is a Python dictionary including one or more of the followin
 
   - Example: ``"pytorch_p36"``
 
-  Note: if specifying the path to an "environment.yml" file, you may provide an absolute path or a relative path.  A relative path will be interpreted relative to ``working_dir`` if ``working_dir`` is specified.
 
 - ``env_vars`` (Dict[str, str]): Environment variables to set.
 

--- a/python/ray/_private/runtime_env/__init__.py
+++ b/python/ray/_private/runtime_env/__init__.py
@@ -1,3 +1,4 @@
 from ray._private.runtime_env.context import RuntimeEnvContext  # noqa: F401
 from ray._private.runtime_env.validation import (  # noqa: F401
-    override_task_or_actor_runtime_env, RuntimeEnvDict)  # noqa: F401
+    override_task_or_actor_runtime_env, RuntimeEnvDict, parse_pip_str,
+    parse_conda_str)  # noqa: F401

--- a/python/ray/_private/runtime_env/__init__.py
+++ b/python/ray/_private/runtime_env/__init__.py
@@ -1,4 +1,4 @@
 from ray._private.runtime_env.context import RuntimeEnvContext  # noqa: F401
 from ray._private.runtime_env.validation import (  # noqa: F401
-    override_task_or_actor_runtime_env, RuntimeEnvDict, parse_pip_str,
-    parse_conda_str)  # noqa: F401
+    override_task_or_actor_runtime_env, RuntimeEnvDict,
+    parse_pip_and_conda)  # noqa: F401

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -233,3 +233,16 @@ def parse_pip_str(pip: str):
     if not pip_file.is_file():
         raise ValueError(f"{pip_file} is not a valid file")
     return pip_file.read_text()
+
+
+def parse_pip_and_conda(runtime_env):
+    if runtime_env is not None:
+        new_runtime_env = runtime_env.copy()
+        if isinstance(new_runtime_env.get("pip"), str):
+            new_runtime_env["pip"] = parse_pip_str(new_runtime_env["pip"])
+        if isinstance(new_runtime_env.get("conda"), str):
+            new_runtime_env["conda"] = parse_conda_str(
+                new_runtime_env["conda"])
+    else:
+        new_runtime_env = None
+    return new_runtime_env

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -232,7 +232,7 @@ def parse_pip_str(pip: str):
     pip_file = Path(pip)
     if not pip_file.is_file():
         raise ValueError(f"{pip_file} is not a valid file")
-    return pip_file.read_text()
+    return pip_file.read_text().splitlines()
 
 
 def parse_pip_and_conda(runtime_env):

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -90,23 +90,7 @@ class RuntimeEnvDict:
                                           "Windows.")
             conda = runtime_env_json["conda"]
             if isinstance(conda, str):
-                yaml_file = Path(conda)
-                if yaml_file.suffix in (".yaml", ".yml"):
-                    if working_dir and not yaml_file.is_absolute():
-                        yaml_file = working_dir / yaml_file
-                    if not yaml_file.is_file():
-                        raise ValueError(
-                            f"Can't find conda YAML file {yaml_file}")
-                    try:
-                        self._dict["conda"] = yaml.safe_load(
-                            yaml_file.read_text())
-                    except Exception as e:
-                        raise ValueError(
-                            f"Invalid conda file {yaml_file} with error {e}")
-                else:
-                    logger.info(
-                        f"Using preinstalled conda environment: {conda}")
-                    self._dict["conda"] = conda
+                self._dict["conda"] = conda
             elif isinstance(conda, dict):
                 self._dict["conda"] = conda
             elif conda is not None:
@@ -134,13 +118,7 @@ class RuntimeEnvDict:
                     "user-guide/tasks/manage-environments.html"
                     "#create-env-file-manually")
             if isinstance(pip, str):
-                # We have been given a path to a requirements.txt file.
-                pip_file = Path(pip)
-                if working_dir and not pip_file.is_absolute():
-                    pip_file = working_dir / pip_file
-                if not pip_file.is_file():
-                    raise ValueError(f"{pip_file} is not a valid file")
-                self._dict["pip"] = pip_file.read_text()
+                self._dict["pip"] = pip
             elif isinstance(pip, list) and all(
                     isinstance(dep, str) for dep in pip):
                 # Construct valid pip requirements.txt from list of packages.
@@ -231,3 +209,27 @@ def override_task_or_actor_runtime_env(
         runtime_env_dict["uris"] = parent_runtime_env.get("uris")
 
     return runtime_env_dict
+
+
+def parse_conda_str(conda: str):
+    yaml_file = Path(conda)
+    conda_dict = dict()
+    if yaml_file.suffix in (".yaml", ".yml"):
+        if not yaml_file.is_file():
+            raise ValueError(f"Can't find conda YAML file {yaml_file}")
+        try:
+            conda_dict = yaml.safe_load(yaml_file.read_text())
+        except Exception as e:
+            raise ValueError(f"Invalid conda file {yaml_file} with error {e}")
+        return conda_dict
+    else:
+        logger.info(f"Using preinstalled conda environment: {conda}")
+        return conda
+
+
+def parse_pip_str(pip: str):
+    # We have been given a path to a requirements.txt file.
+    pip_file = Path(pip)
+    if not pip_file.is_file():
+        raise ValueError(f"{pip_file} is not a valid file")
+    return pip_file.read_text()

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -389,6 +389,9 @@ class ActorClass:
             PythonFunctionDescriptor.from_class(
                 modified_class.__ray_actor_class__)
 
+        # Parse local pip/conda config files here. If we instead did it in
+        # .remote(), it would get run in the Ray Client server, which runs on
+        # a remote node where the files aren't available.
         new_runtime_env = parse_pip_and_conda(runtime_env)
 
         self.__ray_metadata__ = ActorClassMetadata(
@@ -467,6 +470,9 @@ class ActorClass:
 
         actor_cls = self
 
+        # Parse local pip/conda config files here. If we instead did it in
+        # .remote(), it would get run in the Ray Client server, which runs on
+        # a remote node where the files aren't available.
         new_runtime_env = parse_pip_and_conda(runtime_env)
 
         class ActorOptionWrapper:

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -587,10 +587,11 @@ class ActorClass:
 
         # Parse pip/conda requirements files before client_mode_convert is
         # called, because the files aren't available on the remote node.
-        if isinstance(runtime_env.get("pip"), str):
-            runtime_env["pip"] = parse_pip_str(runtime_env["pip"])
-        if isinstance(runtime_env.get("conda"), str):
-            runtime_env["conda"] = parse_conda_str(runtime_env["conda"])
+        if runtime_env is not None:
+            if isinstance(runtime_env.get("pip"), str):
+                runtime_env["pip"] = parse_pip_str(runtime_env["pip"])
+            if isinstance(runtime_env.get("conda"), str):
+                runtime_env["conda"] = parse_conda_str(runtime_env["conda"])
 
         if client_mode_should_convert(auto_init=True):
             return client_mode_convert_actor(

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -8,6 +8,7 @@ import ray._private.signature as signature
 import ray._private.runtime_env as runtime_support
 import ray.worker
 from ray.util.annotations import PublicAPI
+from ray._private.runtime_env import parse_pip_str, parse_conda_str
 from ray.util.placement_group import (
     PlacementGroup, check_placement_group_index, get_current_placement_group)
 
@@ -583,6 +584,13 @@ class ActorClass:
 
         if max_concurrency < 1:
             raise ValueError("max_concurrency must be >= 1")
+
+        # Parse pip/conda requirements files before client_mode_convert is
+        # called, because the files aren't available on the remote node.
+        if isinstance(runtime_env.get("pip"), str):
+            runtime_env["pip"] = parse_pip_str(runtime_env["pip"])
+        if isinstance(runtime_env.get("conda"), str):
+            runtime_env["conda"] = parse_conda_str(runtime_env["conda"])
 
         if client_mode_should_convert(auto_init=True):
             return client_mode_convert_actor(

--- a/python/ray/job_config.py
+++ b/python/ray/job_config.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Optional
 import uuid
 
 import ray._private.gcs_utils as gcs_utils
+from ray._private.runtime_env import parse_pip_and_conda
 
 
 class JobConfig:
@@ -58,8 +59,9 @@ class JobConfig:
         # Lazily import this to avoid circular dependencies.
         import ray._private.runtime_env as runtime_support
         if runtime_env:
+            runtime_env_parsed_conda_pip = parse_pip_and_conda(runtime_env)
             self._parsed_runtime_env = runtime_support.RuntimeEnvDict(
-                runtime_env)
+                runtime_env_parsed_conda_pip)
             self.worker_env.update(
                 self._parsed_runtime_env.get_parsed_dict().get("env_vars")
                 or {})

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -109,6 +109,9 @@ class RemoteFunction:
         self._retry_exceptions = (DEFAULT_REMOTE_FUNCTION_RETRY_EXCEPTIONS
                                   if retry_exceptions is None else
                                   retry_exceptions)
+        # Parse local pip/conda config files here. If we instead did it in
+        # .remote(), it would get run in the Ray Client server, which runs on
+        # a remote node where the files aren't available.
         self._runtime_env = parse_pip_and_conda(runtime_env)
         self._decorator = getattr(function, "__ray_invocation_decorator__",
                                   None)
@@ -165,6 +168,9 @@ class RemoteFunction:
         """
 
         func_cls = self
+        # Parse local pip/conda config files here. If we instead did it in
+        # .remote(), it would get run in the Ray Client server, which runs on
+        # a remote node where the files aren't available.
         new_runtime_env = parse_pip_and_conda(runtime_env)
 
         class FuncWrapper:

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -214,10 +214,11 @@ class RemoteFunction:
 
         # Parse pip/conda requirements files before client_mode_convert is
         # called, because the files aren't available on the remote node.
-        if isinstance(runtime_env.get("pip"), str):
-            runtime_env["pip"] = parse_pip_str(runtime_env["pip"])
-        if isinstance(runtime_env.get("conda"), str):
-            runtime_env["conda"] = parse_conda_str(runtime_env["conda"])
+        if runtime_env is not None:
+            if isinstance(runtime_env.get("pip"), str):
+                runtime_env["pip"] = parse_pip_str(runtime_env["pip"])
+            if isinstance(runtime_env.get("conda"), str):
+                runtime_env["conda"] = parse_conda_str(runtime_env["conda"])
 
         if client_mode_should_convert(auto_init=True):
             return client_mode_convert_function(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When using Ray Client, the `.remote()` function for actors and tasks are run on the local driver and run a second time on the remote Client server.

Previously, runtime env dict validation took place in `.remote()`.  This caused a bug where a local file path was specified inthe `"pip"` or `"conda"` field, because when the validation was run in the Client server, the local file wouldn't be present.

This PR fixes this by separating out the `pip` and `conda` validation and moving it to the `__init__` and `.options()` methods for actors and tasks.  Here when a filename string is given, it is parsed into the internal representation `List[str]` (for `pip`) or `Dict` (for `conda`).  Even though `.options()` is called a second time on the client server, the validation is a no-op there because the `conda` and `pip` fields are already in the internal representation at that point.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #18976 
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
