### PR TITLE
[TaskPool] Cancel all transformation tasks when one task fails or when SIGINT is received

### DIFF
--- a/python/ray/data/impl/compute.py
+++ b/python/ray/data/impl/compute.py
@@ -51,8 +51,23 @@ class TaskPool(ComputeStrategy):
         ]
         new_blocks, new_metadata = zip(*refs)
 
-        map_bar.block_until_complete(list(new_blocks))
-        new_metadata = ray.get(list(new_metadata))
+        new_metadata = list(new_metadata)
+        try:
+            new_metadata = map_bar.fetch_until_complete(new_metadata)
+        except (ray.exceptions.RayTaskError, KeyboardInterrupt) as e:
+            # One or more mapper tasks failed, or we received a SIGINT signal
+            # while waiting; either way, we cancel all map tasks.
+            for ref in new_metadata:
+                ray.cancel(ref)
+            # Wait until all tasks have failed or been cancelled.
+            for ref in new_metadata:
+                try:
+                    ray.get(ref)
+                except (ray.exceptions.RayTaskError,
+                        ray.exceptions.TaskCancelledError):
+                    pass
+            # Reraise the original task failure exception.
+            raise e from None
         return BlockList(list(new_blocks), list(new_metadata))
 
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -144,6 +144,19 @@ def test_callable_classes(shutdown_only):
     assert len(actor_reuse) == 10, actor_reuse
 
 
+def test_transform_failure(shutdown_only):
+    ray.init(num_cpus=2)
+    ds = ray.data.from_items([0, 10], parallelism=2)
+
+    def mapper(x):
+        time.sleep(x)
+        assert False
+        return x
+
+    with pytest.raises(ray.exceptions.RayTaskError):
+        ds.map(mapper)
+
+
 @pytest.mark.parametrize(
     "block_sizes,num_splits",
     [


### PR DESCRIPTION
When a transformation task fails or when `KeyboardInterrupt` is raised (i.e. SIGINT is received), we cancel all other transformation tasks and reraise the exception. Note that this only changes the behavior of the task compute model; the actor compute model is unchanged.

## TODOs

- [ ] (Optional, could wait for future PR) Apply the same change to the actor model.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #18171

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
