### PR TITLE
[Datasets] Delineate between ref and raw APIs for the Pandas/Arrow integrations.

### DIFF
--- a/doc/source/data/dataset-tensor-support.rst
+++ b/doc/source/data/dataset-tensor-support.rst
@@ -55,7 +55,7 @@ If you already have a Parquet dataset with columns containing serialized tensors
 
     # Write the dataset to Parquet. The tensor column will be written as an
     # array of opaque byte blobs.
-    ds = ray.data.from_pandas([ray.put(df)])
+    ds = ray.data.from_pandas([df])
     ds.write_parquet(path)
 
     # Read the Parquet files into a new Dataset, with the serialized tensors
@@ -85,7 +85,7 @@ If your serialized tensors don't fit the above constraints (e.g. they're stored 
 
     # Write the dataset to Parquet. The tensor column will be written as an
     # array of opaque byte blobs.
-    ds = ray.data.from_pandas([ray.put(df)])
+    ds = ray.data.from_pandas([df])
     ds.write_parquet(path)
 
     # Manually deserialize the tensor pickle bytes and cast to our tensor
@@ -212,7 +212,7 @@ If working with in-memory Pandas DataFrames that you want to analyze, manipulate
 
     # In addition to doing Pandas operations on the tensor column,
     # you can now put the DataFrame directly into a Dataset.
-    ds = ray.data.from_pandas([ray.put(df)])
+    ds = ray.data.from_pandas([df])
     # Internally, this column is represented with the corresponding
     # Arrow tensor extension type.
     print(ds.schema())
@@ -227,7 +227,7 @@ If working with in-memory Pandas DataFrames that you want to analyze, manipulate
     # -> one: int64
     #    two: extension<arrow.py_extension_type<ArrowTensorType>>
 
-    read_df = ray.get(read_ds.to_pandas())[0]
+    read_df = read_ds.to_pandas()[0]
     print(read_df.dtypes)
     # -> one          int64
     #    two    TensorDtype

--- a/doc/source/data/dataset-tensor-support.rst
+++ b/doc/source/data/dataset-tensor-support.rst
@@ -227,7 +227,7 @@ If working with in-memory Pandas DataFrames that you want to analyze, manipulate
     # -> one: int64
     #    two: extension<arrow.py_extension_type<ArrowTensorType>>
 
-    read_df = read_ds.to_pandas()[0]
+    read_df = ray.get(read_ds.to_pandas_refs())[0]
     print(read_df.dtypes)
     # -> one          int64
     #    two    TensorDtype

--- a/doc/source/data/dataset-tensor-support.rst
+++ b/doc/source/data/dataset-tensor-support.rst
@@ -227,7 +227,7 @@ If working with in-memory Pandas DataFrames that you want to analyze, manipulate
     # -> one: int64
     #    two: extension<arrow.py_extension_type<ArrowTensorType>>
 
-    read_df = ray.get(read_ds.to_pandas_refs())[0]
+    read_df = read_ds.to_pandas()
     print(read_df.dtypes)
     # -> one          int64
     #    two    TensorDtype

--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -202,7 +202,7 @@ Finally, you can create a ``Dataset`` from existing data in the Ray object store
 
     # Create a Dataset from a list of Pandas DataFrame objects.
     pdf = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
-    ds = ray.data.from_pandas([ray.put(pdf)])
+    ds = ray.data.from_pandas([pdf])
 
     # Create a Dataset from a Dask-on-Ray DataFrame.
     dask_df = dd.from_pandas(pdf, npartitions=10)

--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -123,7 +123,7 @@ Datasource Compatibility Matrices
      - ``ds.iter_batches(batch_format="pyarrow")``
      - ✅
    * - Pandas Dataframe Objects
-     - ``ds.to_pandas_refs()``
+     - ``ds.to_pandas()``
      - ✅
    * - NumPy ndarray Objects
      - ``ds.to_numpy()``

--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -123,7 +123,7 @@ Datasource Compatibility Matrices
      - ``ds.iter_batches(batch_format="pyarrow")``
      - ✅
    * - Pandas Dataframe Objects
-     - ``ds.to_pandas()``
+     - ``ds.to_pandas_refs()``
      - ✅
    * - NumPy ndarray Objects
      - ``ds.to_numpy()``

--- a/doc/source/data/package-ref.rst
+++ b/doc/source/data/package-ref.rst
@@ -15,11 +15,13 @@ Creating a Dataset
 .. autofunction:: ray.data.read_datasource
 .. autofunction:: ray.data.from_items
 .. autofunction:: ray.data.from_arrow
+.. autofunction:: ray.data.from_arrow_refs
 .. autofunction:: ray.data.from_spark
 .. autofunction:: ray.data.from_dask
 .. autofunction:: ray.data.from_modin
 .. autofunction:: ray.data.from_mars
 .. autofunction:: ray.data.from_pandas
+.. autofunction:: ray.data.from_pandas_refs
 .. autofunction:: ray.data.from_numpy
 
 Dataset API

--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -1,7 +1,8 @@
 from ray.data.read_api import from_items, range, range_arrow, \
     range_tensor, read_parquet, read_json, read_csv, read_binary_files, \
-    from_dask, from_modin, from_mars, from_pandas, from_numpy, from_arrow, \
-    from_spark, read_datasource, read_numpy, read_text
+    from_dask, from_modin, from_mars, from_pandas, from_pandas_refs, \
+    from_numpy, from_arrow, from_arrow_refs, from_spark, read_datasource, \
+    read_numpy, read_text
 from ray.data.datasource import Datasource, ReadTask
 from ray.data.dataset import Dataset
 from ray.data.impl.progress_bar import set_progress_bars
@@ -18,10 +19,12 @@ __all__ = [
     "from_dask",
     "from_items",
     "from_arrow",
+    "from_arrow_refs",
     "from_mars",
     "from_modin",
     "from_numpy",
     "from_pandas",
+    "from_pandas_refs",
     "from_spark",
     "range",
     "range_arrow",

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1361,10 +1361,10 @@ class Dataset(Generic[T]):
             spark, self.schema(), self.get_internal_block_refs(), locations)
 
     def to_pandas(self, limit: int = 1000) -> "pandas.DataFrame":
-        """Convert this dataset into a single Pandas DataFrame, limiting the
-        number of records returned.
+        """Convert this dataset into a single Pandas DataFrame.
 
-        This is only supported for datasets convertible to Arrow records.
+        This is only supported for datasets convertible to Arrow records. This
+        limits the number of records returned to the provided limit.
 
         Time complexity: O(limit)
 

--- a/python/ray/data/extensions/tensor_extension.py
+++ b/python/ray/data/extensions/tensor_extension.py
@@ -140,7 +140,7 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
         one: int64
         two: extension<arrow.py_extension_type<ArrowTensorType>>
 
-        >>> read_df = ray.get(read_ds.to_pandas())[0]
+        >>> read_df = ray.get(read_ds.to_pandas_refs())[0]
         >>> read_df.dtypes
         one          int64
         two    TensorDtype
@@ -422,7 +422,7 @@ class TensorArray(pd.api.extensions.ExtensionArray, TensorOpsMixin):
         one: int64
         two: extension<arrow.py_extension_type<ArrowTensorType>>
 
-        >>> read_df = ray.get(read_ds.to_pandas())[0]
+        >>> read_df = ray.get(read_ds.to_pandas_refs())[0]
         >>> read_df.dtypes
         one          int64
         two    TensorDtype

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 import ray
 from ray.types import ObjectRef
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import PublicAPI, DeveloperAPI
 from ray.data.block import Block, BlockAccessor, BlockMetadata
 from ray.data.dataset import Dataset
 from ray.data.datasource import Datasource, RangeDatasource, \
@@ -513,8 +513,23 @@ def from_modin(df: "modin.DataFrame") -> Dataset[ArrowRow]:
 
 
 @PublicAPI(stability="beta")
-def from_pandas(dfs: List[ObjectRef["pandas.DataFrame"]]) -> Dataset[ArrowRow]:
-    """Create a dataset from a set of Pandas dataframes.
+def from_pandas(dfs: List["pandas.DataFrame"]) -> Dataset[ArrowRow]:
+    """Create a dataset from a list of Pandas dataframes.
+
+    Args:
+        dfs: A list of Pandas dataframes.
+
+    Returns:
+        Dataset holding Arrow records read from the dataframes.
+    """
+    return from_pandas_refs([ray.put(df) for df in dfs])
+
+
+@DeveloperAPI
+def from_pandas_refs(
+        dfs: List[ObjectRef["pandas.DataFrame"]]) -> Dataset[ArrowRow]:
+    """Create a dataset from a list of Ray object references to Pandas
+    dataframes.
 
     Args:
         dfs: A list of Ray object references to pandas dataframes.
@@ -546,8 +561,23 @@ def from_numpy(ndarrays: List[ObjectRef[np.ndarray]]) -> Dataset[ArrowRow]:
 
 
 @PublicAPI(stability="beta")
-def from_arrow(tables: List[ObjectRef[Union["pyarrow.Table", bytes]]]
-               ) -> Dataset[ArrowRow]:
+def from_arrow(
+        tables: List[Union["pyarrow.Table", bytes]]) -> Dataset[ArrowRow]:
+    """Create a dataset from a list of Arrow tables.
+
+    Args:
+        tables: A list of Ray object references to Arrow tables,
+                or its streaming format in bytes.
+
+    Returns:
+        Dataset holding Arrow records from the tables.
+    """
+    return from_arrow_refs([ray.put(t) for t in tables])
+
+
+@DeveloperAPI
+def from_arrow_refs(tables: List[ObjectRef[Union["pyarrow.Table", bytes]]]
+                    ) -> Dataset[ArrowRow]:
     """Create a dataset from a set of Arrow tables.
 
     Args:

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -509,7 +509,7 @@ def from_modin(df: "modin.DataFrame") -> Dataset[ArrowRow]:
     from modin.distributed.dataframe.pandas.partitions import unwrap_partitions
 
     parts = unwrap_partitions(df, axis=0)
-    return from_pandas(parts)
+    return from_pandas_refs(parts)
 
 
 @PublicAPI(stability="beta")

--- a/python/ray/data/tests/test_dataset_pipeline.py
+++ b/python/ray/data/tests/test_dataset_pipeline.py
@@ -178,7 +178,7 @@ def test_parquet_write(ray_start_regular_shared, tmp_path):
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
     df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
     df = pd.concat([df1, df2])
-    ds = ray.data.from_pandas([ray.put(df1), ray.put(df2)])
+    ds = ray.data.from_pandas([df1, df2])
     ds = ds.pipeline(parallelism=1)
     path = os.path.join(tmp_path, "test_parquet_dir")
     os.mkdir(path)

--- a/python/ray/data/tests/test_raydp_dataset.py
+++ b/python/ray/data/tests/test_raydp_dataset.py
@@ -16,6 +16,10 @@ def spark_on_ray_small(request):
     return spark
 
 
+@pytest.mark.skip(
+    reason=(
+        "raydp.spark.spark_dataframe_to_ray_dataset needs to be updated to "
+        "use ray.data.from_arrow_refs."))
 def test_raydp_roundtrip(spark_on_ray_small):
     spark = spark_on_ray_small
     spark_df = spark.createDataFrame([(1, "a"), (2, "b"), (3, "c")],


### PR DESCRIPTION
Users have been confused by `ray.data.from_pandas()` and `ray.data.from_arrow()` taking list of object references to tables instead of just a list of tables, and have been likewise confused by `Dataset.to_pandas()` and `Dataset.to_arrow()` returning object references instead of tables. This PR renames these ref-centric APIs to have a `_refs` suffix to make this signature clearer, and have added new APIs that take/return the raw tables under the current ref-centric API names. This PR also marks the former as developer APIs to make it clear that the ref-centric APIs aren't end-user APIs.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #18978 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
