### PR TITLE
Upgrade bazel version to 4.2.1

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -23,7 +23,7 @@ import urllib.request
 logger = logging.getLogger(__name__)
 
 SUPPORTED_PYTHONS = [(3, 6), (3, 7), (3, 8), (3, 9)]
-SUPPORTED_BAZEL = (3, 4, 1)
+SUPPORTED_BAZEL = (4, 2, 1)
 
 ROOT_DIR = os.path.dirname(__file__)
 BUILD_JAVA = os.getenv("RAY_INSTALL_JAVA") == "1"


### PR DESCRIPTION
Also while debugging this, I realized that we can directly ask "bazel aquery ..." to
output in --jsonproto format, so we don't have to do the complicated textproto to
json conversion in bazel.py.

## Why are these changes needed?

Bazel 4.2.1 is required for supporting M1 build.

## Related issue number

#16621

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
