### PR TITLE
[Scheduling] Report resource demand for infeasible 1-CPU tasks

### DIFF
--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -2,6 +2,7 @@
 import collections
 import logging
 import platform
+import subprocess
 import sys
 import time
 import unittest
@@ -576,6 +577,45 @@ def test_gpu(monkeypatch):
     finally:
         ray.shutdown()
         cluster.shutdown()
+
+
+@pytest.mark.parametrize(
+    "ray_start_cluster", [{
+        "num_cpus": 0,
+        "num_nodes": 1,
+    }], indirect=True)
+def test_head_node_without_cpu(ray_start_cluster):
+    @ray.remote(num_cpus=1)
+    def f():
+        return 1
+
+    f.remote()
+
+    check_count = 0
+    demand_1cpu = "Demands:\n {'CPU': 1.0}:"
+    while True:
+        status = subprocess.check_output(["ray", "status"]).decode()
+        if demand_1cpu in status:
+            break
+        check_count += 1
+        assert check_count < 5, f"Incorrect demand. Last status {status}"
+        time.sleep(1)
+
+    @ray.remote(num_cpus=2)
+    def g():
+        return 2
+
+    g.remote()
+
+    check_count = 0
+    demand_2cpu = "\n {'CPU': 2.0}:"
+    while True:
+        status = subprocess.check_output(["ray", "status"]).decode()
+        if demand_1cpu in status and demand_2cpu in status:
+            break
+        check_count += 1
+        assert check_count < 5, f"Incorrect demand. Last status {status}"
+        time.sleep(1)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -592,7 +592,7 @@ def test_head_node_without_cpu(ray_start_cluster):
     f.remote()
 
     check_count = 0
-    demand_1cpu = "Demands:\n {'CPU': 1.0}:"
+    demand_1cpu = " {'CPU': 1.0}:"
     while True:
         status = subprocess.check_output(["ray", "status"]).decode()
         if demand_1cpu in status:
@@ -608,7 +608,7 @@ def test_head_node_without_cpu(ray_start_cluster):
     g.remote()
 
     check_count = 0
-    demand_2cpu = "\n {'CPU': 2.0}:"
+    demand_2cpu = " {'CPU': 2.0}:"
     while True:
         status = subprocess.check_output(["ray", "status"]).decode()
         if demand_1cpu in status and demand_2cpu in status:

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -725,6 +725,10 @@ void ClusterTaskManager::FillResourceUsage(
     if (it != tasks_to_dispatch_.end()) {
       count += it->second.size();
     }
+    it = infeasible_tasks_.find(one_cpu_scheduling_cls);
+    if (it != infeasible_tasks_.end()) {
+      count += it->second.size();
+    }
 
     if (count > 0) {
       auto by_shape_entry = resource_load_by_shape->Add();

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -716,35 +716,34 @@ void ClusterTaskManager::FillResourceUsage(
       TaskSpecification::GetSchedulingClass(one_cpu_resource_set));
   {
     num_reported++;
-    int count = 0;
+    int ready_count = 0;
     auto it = tasks_to_schedule_.find(one_cpu_scheduling_cls);
     if (it != tasks_to_schedule_.end()) {
-      count += it->second.size();
+      ready_count += it->second.size();
     }
     it = tasks_to_dispatch_.find(one_cpu_scheduling_cls);
     if (it != tasks_to_dispatch_.end()) {
-      count += it->second.size();
+      ready_count += it->second.size();
     }
+    int infeasible_count = 0;
     it = infeasible_tasks_.find(one_cpu_scheduling_cls);
     if (it != infeasible_tasks_.end()) {
-      count += it->second.size();
+      infeasible_count += it->second.size();
     }
-
-    if (count > 0) {
+    const int total_count = ready_count + infeasible_count;
+    if (total_count > 0) {
       auto by_shape_entry = resource_load_by_shape->Add();
 
-      for (const auto &resource : one_cpu_resource_set.GetResourceMap()) {
+      for (const auto &[label, quantity] : one_cpu_resource_set.GetResourceMap()) {
         // Add to `resource_loads`.
-        const auto &label = resource.first;
-        const auto &quantity = resource.second;
-        (*resource_loads)[label] += quantity * count;
+        (*resource_loads)[label] += quantity * total_count;
 
         // Add to `resource_load_by_shape`.
         (*by_shape_entry->mutable_shape())[label] = quantity;
       }
 
-      int num_ready = by_shape_entry->num_ready_requests_queued();
-      by_shape_entry->set_num_ready_requests_queued(num_ready + count);
+      by_shape_entry->set_num_ready_requests_queued(ready_count);
+      by_shape_entry->set_num_infeasible_requests_queued(infeasible_count);
 
       auto backlog_it = backlog_tracker_.find(one_cpu_scheduling_cls);
       if (backlog_it != backlog_tracker_.end()) {

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -1545,8 +1545,8 @@ TEST_F(ClusterTaskManagerTestWithoutCPUsAtHead, OneCpuInfeasibleTask) {
   rpc::RequestWorkerLeaseReply reply;
   bool callback_occurred = false;
   bool *callback_occurred_ptr = &callback_occurred;
-  auto callback = [callback_occurred_ptr](Status, std::function<void()>,
-                                          std::function<void()>) {
+  auto callback = [callback_occurred_ptr](const Status &, const std::function<void()> &,
+                                          const std::function<void()> &) {
     *callback_occurred_ptr = true;
   };
 

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -101,10 +101,11 @@ class MockWorkerPool : public WorkerPoolInterface {
   int num_pops;
 };
 
-std::shared_ptr<ClusterResourceScheduler> CreateSingleNodeScheduler(
-    const std::string &id, double num_gpus = 0.0) {
+std::shared_ptr<ClusterResourceScheduler> CreateSingleNodeScheduler(const std::string &id,
+                                                                    double num_cpus,
+                                                                    double num_gpus) {
   std::unordered_map<std::string, double> local_node_resources;
-  local_node_resources[ray::kCPU_ResourceLabel] = 8;
+  local_node_resources[ray::kCPU_ResourceLabel] = num_cpus;
   local_node_resources[ray::kGPU_ResourceLabel] = num_gpus;
   local_node_resources[ray::kMemory_ResourceLabel] = 128;
 
@@ -179,9 +180,10 @@ class MockTaskDependencyManager : public TaskDependencyManagerInterface {
 
 class ClusterTaskManagerTest : public ::testing::Test {
  public:
-  ClusterTaskManagerTest(double num_gpus_at_head = 0.0)
+  ClusterTaskManagerTest(double num_cpus_at_head = 8.0, double num_gpus_at_head = 0.0)
       : id_(NodeID::FromRandom()),
-        scheduler_(CreateSingleNodeScheduler(id_.Binary(), num_gpus_at_head)),
+        scheduler_(
+            CreateSingleNodeScheduler(id_.Binary(), num_cpus_at_head, num_gpus_at_head)),
         is_owner_alive_(true),
         node_info_calls_(0),
         announce_infeasible_task_calls_(0),
@@ -290,7 +292,15 @@ class ClusterTaskManagerTest : public ::testing::Test {
 // Same as ClusterTaskManagerTest, but the head node starts with 4.0 num gpus.
 class ClusterTaskManagerTestWithGPUsAtHead : public ClusterTaskManagerTest {
  public:
-  ClusterTaskManagerTestWithGPUsAtHead() : ClusterTaskManagerTest(4.0) {}
+  ClusterTaskManagerTestWithGPUsAtHead()
+      : ClusterTaskManagerTest(/*num_cpus_at_head=*/8.0, /*num_gpus_at_head=*/4.0) {}
+};
+
+// Same as ClusterTaskManagerTest, but the head node starts with 0.0 num cpus.
+class ClusterTaskManagerTestWithoutCPUsAtHead : public ClusterTaskManagerTest {
+ public:
+  ClusterTaskManagerTestWithoutCPUsAtHead()
+      : ClusterTaskManagerTest(/*num_cpus_at_head=*/0.0) {}
 };
 
 TEST_F(ClusterTaskManagerTest, BasicTest) {
@@ -1526,6 +1536,40 @@ TEST_F(ClusterTaskManagerTest, PopWorkerExactlyOnce) {
   ASSERT_EQ(finished_task.GetTaskSpecification().TaskId(),
             task.GetTaskSpecification().TaskId());
   AssertNoLeaks();
+}
+
+// Regression test for https://github.com/ray-project/ray/issues/16935:
+// When a task requires 1 CPU and is infeasible because head node has 0 CPU,
+// make sure the task's resource demand is reported.
+TEST_F(ClusterTaskManagerTestWithoutCPUsAtHead, OneCpuInfeasibleTask) {
+  rpc::RequestWorkerLeaseReply reply;
+  bool callback_occurred = false;
+  bool *callback_occurred_ptr = &callback_occurred;
+  auto callback = [callback_occurred_ptr](Status, std::function<void()>,
+                                          std::function<void()>) {
+    *callback_occurred_ptr = true;
+  };
+
+  RayTask task = CreateTask({{ray::kCPU_ResourceLabel, 1}});
+  task_manager_.QueueAndScheduleTask(task, &reply, callback);
+  pool_.TriggerCallbacks();
+
+  // The task cannot run because there is only 1 node (head) with 0 CPU.
+  ASSERT_FALSE(callback_occurred);
+  ASSERT_EQ(leased_workers_.size(), 0);
+  ASSERT_EQ(pool_.workers.size(), 0);
+  ASSERT_EQ(node_info_calls_, 0);
+
+  {
+    rpc::ResourcesData data;
+    task_manager_.FillResourceUsage(data);
+    const auto &resource_load_by_shape = data.resource_load_by_shape();
+    ASSERT_EQ(resource_load_by_shape.resource_demands().size(), 1);
+    const auto &shape = resource_load_by_shape.resource_demands()[0];
+
+    ASSERT_EQ(shape.shape().size(), 1);
+    ASSERT_EQ(shape.shape().at("CPU"), 1);
+  }
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
See https://github.com/ray-project/ray/issues/16935#issuecomment-909612684 for the reported issue. Basically, when a task requires 1 CPU and is infeasible because there is 0 CPU available in the cluster, the resource demand is not reported.

The problem is that scheduler has an optimization to treat 1-CPU tasks differently. However the logic did not include infeasible tasks, which can only happen when the cluster has 0 CPU. The fix here is to include infeasible tasks in resource demand.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #16935

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
