### PR TITLE
[Workflow] Move arguments into workflow step context

### DIFF
--- a/python/ray/workflow/execution.py
+++ b/python/ray/workflow/execution.py
@@ -51,7 +51,7 @@ def run(entry_workflow: Workflow,
         #  - it's a new workflow
         # TODO (yic): follow up with force rerun
         if entry_workflow.data.step_type != StepType.FUNCTION or not wf_exists:
-            commit_step(ws, "", entry_workflow, None)
+            commit_step(ws, "", entry_workflow, exception=None)
         workflow_manager = get_or_create_management_actor()
         ignore_existing = (entry_workflow.data.step_type != StepType.FUNCTION)
         # NOTE: It is important to 'ray.get' the returned output. This

--- a/python/ray/workflow/recovery.py
+++ b/python/ray/workflow/recovery.py
@@ -124,10 +124,10 @@ def _resume_workflow_step_executor(workflow_id: str, step_id: "StepID",
         raise WorkflowNotResumableError(workflow_id) from e
 
     if isinstance(r, Workflow):
-        with workflow_context.workflow_step_context(workflow_id,
-                                                    store.storage_url):
-            from ray.workflow.step_executor import (execute_workflow)
-            result = execute_workflow(r, last_step_of_workflow=True)
+        with workflow_context.workflow_step_context(
+                workflow_id, store.storage_url, last_step_of_workflow=True):
+            from ray.workflow.step_executor import execute_workflow
+            result = execute_workflow(r)
             return result.persisted_output, result.volatile_output
     assert isinstance(r, StepID)
     return wf_store.load_step_output(r), None

--- a/python/ray/workflow/step_executor.py
+++ b/python/ray/workflow/step_executor.py
@@ -347,7 +347,7 @@ def _workflow_step_executor(step_type: StepType, func: Callable,
                     # there is no outer step for the current step. So the
                     # current step is the outer most step for the inner nested
                     # workflow steps.
-                    outer_most_step_id = workflow_context.get_current_step_id()                
+                    outer_most_step_id = workflow_context.get_current_step_id()
             assert volatile_output is None
             # Execute sub-workflow. Pass down "outer_most_step_id".
             with workflow_context.fork_workflow_step_context(

--- a/python/ray/workflow/step_executor.py
+++ b/python/ray/workflow/step_executor.py
@@ -134,33 +134,9 @@ def _resolve_step_inputs(
     return signature.recover_args(flattened_args)
 
 
-def execute_workflow(
-        workflow: "Workflow",
-        outer_most_step_id: Optional[str] = None,
-        last_step_of_workflow: bool = False) -> "WorkflowExecutionResult":
+def execute_workflow(workflow: "Workflow") -> "WorkflowExecutionResult":
     """Execute workflow.
 
-    To fully explain what we are doing, we need to introduce some syntax first.
-    The syntax for dependencies between workflow steps
-    "B.step(A.step())" is "A - B"; the syntax for nested workflow steps
-    "def A(): return B.step()" is "A / B".
-
-    In a chain/DAG of step dependencies, the "output step" is the step of last
-    (topological) order. For example, in "A - B - C", C is the output step.
-
-    In a chain of nested workflow steps, the initial "output step" is
-    called the "outer most step" for other "output steps". For example, in
-    "A / B / C / D", "A" is the outer most step for "B", "C", "D";
-    in the hybrid workflow "((A - B) / C / D) - (E / (F - G) / H)",
-    "B" is the outer most step for "C", "D"; "E" is the outer most step
-    for "G", "H".
-
-    Args:
-        workflow: The workflow to be executed.
-        outer_most_step_id: The ID of the outer most workflow. None if it
-            does not exists.
-        last_step_of_workflow: The step that generates the output of the
-            workflow (including nested steps).
     Returns:
         An object ref that represent the result.
     """
@@ -173,8 +149,8 @@ def execute_workflow(
         **workflow_data.ray_options).remote(
             workflow_data.step_type, workflow_data.func_body,
             workflow_context.get_workflow_step_context(), workflow.step_id,
-            baked_inputs, outer_most_step_id, workflow_data.catch_exceptions,
-            workflow_data.max_retries, last_step_of_workflow)
+            baked_inputs, workflow_data.catch_exceptions,
+            workflow_data.max_retries)
 
     if not isinstance(persisted_output, WorkflowOutputType):
         raise TypeError("Unexpected return type of the workflow.")
@@ -213,19 +189,13 @@ async def _write_step_inputs(wf_storage: workflow_storage.WorkflowStorage,
     await asyncio.gather(*save_tasks)
 
 
-def commit_step(store: workflow_storage.WorkflowStorage,
-                step_id: "StepID",
-                ret: Union["Workflow", Any],
-                exception: Optional[Exception],
-                outer_most_step_id: Optional[str] = None):
+def commit_step(store: workflow_storage.WorkflowStorage, step_id: "StepID",
+                ret: Union["Workflow", Any], exception: Optional[Exception]):
     """Checkpoint the step output.
     Args:
         store: The storage the current workflow is using.
         step_id: The ID of the step.
         ret: The returned object of the workflow step.
-        outer_most_step_id: The ID of the outer most workflow. None if it
-            does not exists. See "step_executor.execute_workflow" for detailed
-            explanation.
     """
     from ray.workflow.common import Workflow
     if isinstance(ret, Workflow):
@@ -236,7 +206,7 @@ def commit_step(store: workflow_storage.WorkflowStorage,
         ]
         asyncio.get_event_loop().run_until_complete(asyncio.gather(*tasks))
 
-    store.save_step_output(step_id, ret, exception, outer_most_step_id)
+    store.save_step_output(step_id, ret, exception)
 
 
 def _wrap_run(func: Callable, step_type: StepType, step_id: "StepID",
@@ -328,12 +298,11 @@ def _wrap_run(func: Callable, step_type: StepType, step_id: "StepID",
 
 
 @ray.remote(num_returns=2)
-def _workflow_step_executor(
-        step_type: StepType, func: Callable,
-        context: workflow_context.WorkflowStepContext, step_id: "StepID",
-        baked_inputs: "_BakedWorkflowInputs", outer_most_step_id: "StepID",
-        catch_exceptions: bool, max_retries: int,
-        last_step_of_workflow: bool) -> Any:
+def _workflow_step_executor(step_type: StepType, func: Callable,
+                            context: workflow_context.WorkflowStepContext,
+                            step_id: "StepID",
+                            baked_inputs: "_BakedWorkflowInputs",
+                            catch_exceptions: bool, max_retries: int) -> Any:
     """Executor function for workflow step.
 
     Args:
@@ -342,13 +311,9 @@ def _workflow_step_executor(
         context: Workflow step context. Used to access correct storage etc.
         step_id: The ID of the step.
         baked_inputs: The processed inputs for the step.
-        outer_most_step_id: See "step_executor.execute_workflow" for
-            explanation.
         catch_exceptions: If set to be true, return
             (Optional[Result], Optional[Error]) instead of Result.
         max_retries: Max number of retries encounter of a failure.
-        last_step_of_workflow: The step that generates the output of the
-            workflow (including nested steps).
 
     Returns:
         Workflow step output.
@@ -361,7 +326,7 @@ def _workflow_step_executor(
             func, step_type, step_id, catch_exceptions, max_retries, *args,
             **kwargs)
     except Exception as e:
-        commit_step(store, step_id, None, e, outer_most_step_id)
+        commit_step(store, step_id, None, e)
         raise e
     if step_type == StepType.READONLY_ACTOR_METHOD:
         if isinstance(volatile_output, Workflow):
@@ -371,26 +336,29 @@ def _workflow_step_executor(
         assert not isinstance(persisted_output, Workflow)
     else:
         store = workflow_storage.get_workflow_storage()
-        commit_step(store, step_id, persisted_output, None, outer_most_step_id)
+        commit_step(store, step_id, persisted_output, None)
         if isinstance(persisted_output, Workflow):
             if step_type == StepType.FUNCTION:
                 # Passing down outer most step so inner nested steps would
                 # access the same outer most step.
-                if not outer_most_step_id:
+                if not context.outer_most_step_id:
                     # The current workflow step returns a nested workflow, and
                     # there is no outer step for the current step. So the
                     # current step is the outer most step for the inner nested
                     # workflow steps.
                     outer_most_step_id = workflow_context.get_current_step_id()
+                else:
+                    outer_most_step_id = context.outer_most_step_id
             assert volatile_output is None
-            # execute sub-workflow
-            result = execute_workflow(persisted_output, outer_most_step_id,
-                                      last_step_of_workflow)
+            # Execute sub-workflow. Pass down "outer_most_step_id".
+            with workflow_context.fork_workflow_step_context(
+                    outer_most_step_id=outer_most_step_id):
+                result = execute_workflow(persisted_output)
             # When virtual actor returns a workflow in the method,
             # the volatile_output and persisted_output will be put together
             persisted_output = result.persisted_output
             volatile_output = result.volatile_output
-        elif last_step_of_workflow:
+        elif context.last_step_of_workflow:
             # advance the progress of the workflow
             store.advance_progress(step_id)
         _record_step_status(step_id, WorkflowStatus.SUCCESSFUL)
@@ -415,9 +383,11 @@ class _BakedWorkflowInputs:
 
     @classmethod
     def from_workflow_inputs(cls, inputs: "WorkflowInputs"):
-        workflow_outputs = [
-            execute_workflow(w).persisted_output for w in inputs.workflows
-        ]
+        with workflow_context.fork_workflow_step_context(
+                outer_most_step_id=None, last_step_of_workflow=False):
+            workflow_outputs = [
+                execute_workflow(w).persisted_output for w in inputs.workflows
+            ]
         return cls(inputs.args, workflow_outputs, inputs.workflow_refs)
 
     def __reduce__(self):

--- a/python/ray/workflow/step_executor.py
+++ b/python/ray/workflow/step_executor.py
@@ -206,7 +206,12 @@ def commit_step(store: workflow_storage.WorkflowStorage, step_id: "StepID",
         ]
         asyncio.get_event_loop().run_until_complete(asyncio.gather(*tasks))
 
-    store.save_step_output(step_id, ret, exception)
+    context = workflow_context.get_workflow_step_context()
+    store.save_step_output(
+        step_id,
+        ret,
+        exception=exception,
+        outer_most_step_id=context.outer_most_step_id)
 
 
 def _wrap_run(func: Callable, step_type: StepType, step_id: "StepID",

--- a/python/ray/workflow/step_executor.py
+++ b/python/ray/workflow/step_executor.py
@@ -337,6 +337,7 @@ def _workflow_step_executor(step_type: StepType, func: Callable,
     else:
         store = workflow_storage.get_workflow_storage()
         commit_step(store, step_id, persisted_output, None)
+        outer_most_step_id = context.outer_most_step_id
         if isinstance(persisted_output, Workflow):
             if step_type == StepType.FUNCTION:
                 # Passing down outer most step so inner nested steps would
@@ -346,9 +347,7 @@ def _workflow_step_executor(step_type: StepType, func: Callable,
                     # there is no outer step for the current step. So the
                     # current step is the outer most step for the inner nested
                     # workflow steps.
-                    outer_most_step_id = workflow_context.get_current_step_id()
-                else:
-                    outer_most_step_id = context.outer_most_step_id
+                    outer_most_step_id = workflow_context.get_current_step_id()                
             assert volatile_output is None
             # Execute sub-workflow. Pass down "outer_most_step_id".
             with workflow_context.fork_workflow_step_context(

--- a/python/ray/workflow/workflow_access.py
+++ b/python/ray/workflow/workflow_access.py
@@ -327,9 +327,8 @@ class WorkflowManagementActor:
                 actor = get_management_actor()
                 return actor.get_output.remote(workflow_id,
                                                result.output_step_id)
-            raise ValueError(
-                f"Cannot load output from step id {step_id} "
-                f"in workflow {workflow_id}")
+            raise ValueError(f"Cannot load output from step id {step_id} "
+                             f"in workflow {workflow_id}")
 
         return ray.put(
             _SelfDereferenceObject(None,

--- a/python/ray/workflow/workflow_access.py
+++ b/python/ray/workflow/workflow_access.py
@@ -328,7 +328,8 @@ class WorkflowManagementActor:
                 return actor.get_output.remote(workflow_id,
                                                result.output_step_id)
             raise ValueError(
-                f"No such step id {step_id} in workflow {workflow_id}")
+                f"Cannot load output from step id {step_id} "
+                f"in workflow {workflow_id}")
 
         return ray.put(
             _SelfDereferenceObject(None,

--- a/python/ray/workflow/workflow_context.py
+++ b/python/ray/workflow/workflow_context.py
@@ -93,7 +93,7 @@ def fork_workflow_step_context(
         outer_most_step_id: Optional[str] = _sentinel,
         last_step_of_workflow: Optional[bool] = _sentinel):
     """Fork the workflow step context.
-    Inherits the original value if provided value is 'None'.
+    Inherits the original value if no value is provided.
 
     Args:
         workflow_id: The ID of the workflow.

--- a/python/ray/workflow/workflow_context.py
+++ b/python/ray/workflow/workflow_context.py
@@ -31,21 +31,18 @@ class WorkflowStepContext:
     in the hybrid workflow "((A - B) / C / D) - (E / (F - G) / H)",
     "B" is the outer most step for "C", "D"; "E" is the outer most step
     for "G", "H".
-
-    Args:
-        workflow_id: The workflow job ID.
-        storage_url: The storage of the workflow, used for checkpointing.
-        workflow_scope: The "calling stack" of the current workflow step.
-            It describe the parent workflow steps.
-        outer_most_step_id: The ID of the outer most workflow. None if it
-            does not exists.
-        last_step_of_workflow: The step that generates the output of the
-            workflow (including nested steps).
     """
+    # ID of the workflow.
     workflow_id: Optional[str] = None
+    # The storage of the workflow, used for checkpointing.
     storage_url: Optional[str] = None
+    # The "calling stack" of the current workflow step. It describe
+    # the parent workflow steps.
     workflow_scope: List[str] = field(default_factory=list)
+    # The ID of the outer most workflow. "None" if it does not exists.
     outer_most_step_id: "Optional[StepID]" = None
+    # The step that generates the output of the workflow (including all
+    # nested steps).
     last_step_of_workflow: bool = False
 
 

--- a/python/ray/workflow/workflow_storage.py
+++ b/python/ray/workflow/workflow_storage.py
@@ -118,8 +118,7 @@ class WorkflowStorage:
         raise output_err
 
     def save_step_output(self, step_id: StepID, ret: Union[Workflow, Any],
-                         exception: Optional[Exception],
-                         outer_most_step_id: Optional[StepID]) -> None:
+                         exception: Optional[Exception]) -> None:
         """When a workflow step returns,
         1. If the returned object is a workflow, this means we are a nested
            workflow. We save the output metadata that points to the workflow.
@@ -130,8 +129,6 @@ class WorkflowStorage:
                 it means we are in the workflow job driver process.
             ret: The returned object from a workflow step.
             exception: This step should throw exception.
-            outer_most_step_id: See
-                "step_executor.execute_workflow" for explanation.
         """
         tasks = []
         if isinstance(ret, Workflow):
@@ -154,14 +151,7 @@ class WorkflowStorage:
                 # tasks.append(self._put(self._key_step_output(step_id), ret))
                 dynamic_output_id = step_id
                 # TODO (yic): Delete exception file
-
-                # outer_most_step_id == "" indicates the root step of a
-                # workflow. This would directly update "outputs.json" in
-                # the workflow dir, and we want to avoid it.
-                if outer_most_step_id is not None and outer_most_step_id != "":
-                    tasks.append(
-                        self._update_dynamic_output(outer_most_step_id,
-                                                    dynamic_output_id))
+                tasks.append(self._update_dynamic_output(dynamic_output_id))
             else:
                 assert ret is None
                 promise = serialization.dump_to_storage(
@@ -252,7 +242,7 @@ class WorkflowStorage:
 
         return asyncio_run(_load_obj_ref())
 
-    async def _update_dynamic_output(self, outer_most_step_id: StepID,
+    async def _update_dynamic_output(self,
                                      dynamic_output_step_id: StepID) -> None:
         """Update dynamic output.
 
@@ -271,10 +261,16 @@ class WorkflowStorage:
         critical for scalability of virtual actors.
 
         Args:
-            outer_most_step_id: ID of outer_most_step. See
-                "step_executor.execute_workflow" for explanation.
             dynamic_output_step_id: ID of dynamic_step.
         """
+        context = workflow_context.get_workflow_step_context()
+        outer_most_step_id = context.outer_most_step_id
+        # outer_most_step_id == "" indicates the root step of a
+        # workflow. This would directly update "outputs.json" in
+        # the workflow dir, and we want to avoid it.
+        if outer_most_step_id is None or outer_most_step_id == "":
+            return
+
         metadata = await self._get(
             self._key_step_output_metadata(outer_most_step_id), True)
         if (dynamic_output_step_id != metadata["output_step_id"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We are passing too many arguments. Some of them should be considered as context, since their value depends on the execution status instead of options provided by users.

`outer_most_step_id ` and `last_step_of_workflow` are moved into workflow context.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
