### PR TITLE
[Doc] [runtime env] Remove delta caching remark and state Client+@remote limitation

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -468,6 +468,7 @@ Or specify per-actor or per-task in the ``@ray.remote()`` decorator or by using 
    :start-after: __per_task_per_actor_start__
    :end-before: __per_task_per_actor_end__
 
+Note: specifying within the ``@ray.remote()`` decorator is currently unsupported while using Ray Client; please use ``.options()`` instead in this case.
 
 The ``runtime_env`` is a Python dictionary including one or more of the following arguments:
 

--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -446,7 +446,7 @@ On Mac OS and Linux, Ray 1.4+ supports dynamically setting the runtime environme
 The ``runtime_env`` is a (JSON-serializable) dictionary that can be passed as an option to tasks and actors, and can also be passed to ``ray.init()``.
 The runtime environment defines the dependencies required for your workload.
 
-You can specify a runtime environment for your whole job using ``ray.init()`` or Ray Client...
+You can specify a runtime environment for your whole job using ``ray.init()`` or Ray Client:
 
 .. literalinclude:: ../examples/doc_code/runtime_env_example.py
    :language: python
@@ -461,19 +461,19 @@ You can specify a runtime environment for your whole job using ``ray.init()`` or
     # Using Ray Client
     ray.init("ray://localhost:10001", runtime_env=runtime_env)
 
-...or specify per-actor or per-task in the ``@ray.remote()`` decorator or by using ``.options()``:
+Or specify per-actor or per-task in the ``@ray.remote()`` decorator or by using ``.options()``:
 
 .. literalinclude:: ../examples/doc_code/runtime_env_example.py
    :language: python
    :start-after: __per_task_per_actor_start__
    :end-before: __per_task_per_actor_end__
 
+
 The ``runtime_env`` is a Python dictionary including one or more of the following arguments:
 
 - ``working_dir`` (Path): Specifies the working directory for your job. This must be an existing local directory.
   It will be cached on the cluster, so the next time you connect with Ray Client you will be able to skip uploading the directory contents.
-  Furthermore, if you locally make a small change to your directory, the next time you connect only the updated part will be uploaded.
-  All Ray workers for your job will be started in their node's copy of this working directory.
+  All Ray workers for your job will be started in their node's local copy of this working directory.
 
   - Examples
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- Remove an incorrect remark about only uploading deltas to `working_dir`
- Add a remark describing the limitation that `@ray.remote(runtime_env=...)` does not work with Ray Client (https://github.com/ray-project/ray/issues/19002)
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
