### PR TITLE
Fix port collision between metrics agent port and metrics export port

### DIFF
--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -572,7 +572,7 @@ class Node:
             log_stderr = os.path.join(self._logs_dir, f"{name}.err")
         return log_stdout, log_stderr
 
-    def _get_unused_port(self, close_on_exit=True):
+    def _get_unused_port(self, allocated_ports=set()):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.bind(("", 0))
         port = s.getsockname()[1]
@@ -582,6 +582,10 @@ class Node:
         # from this method has been used by a different process.
         for _ in range(NUM_PORT_RETRIES):
             new_port = random.randint(port, 65535)
+            if new_port in allocated_ports:
+                # This port is allocated for other usage already,
+                # so we shouldn't use it even if it's not in use right now.
+                continue
             new_s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             try:
                 new_s.bind(("", new_port))
@@ -589,13 +593,11 @@ class Node:
                 new_s.close()
                 continue
             s.close()
-            if close_on_exit:
-                new_s.close()
-            return new_port, new_s
+            new_s.close()
+            return new_port
         logger.error("Unable to succeed in selecting a random port.")
-        if close_on_exit:
-            s.close()
-        return port, s
+        s.close()
+        return port
 
     def _prepare_socket_file(self, socket_path, default_prefix):
         """Prepare the socket file for raylet and plasma.
@@ -613,7 +615,7 @@ class Node:
         if sys.platform == "win32":
             if socket_path is None:
                 result = (f"tcp://{self._localhost}"
-                          f":{self._get_unused_port()[0]}")
+                          f":{self._get_unused_port()}")
         else:
             if socket_path is None:
                 result = self._make_inc_temp(
@@ -665,7 +667,8 @@ class Node:
             port = int(ports_by_node[self.unique_id][port_name])
         else:
             # Pick a new port to use and cache it at this node.
-            port = (default_port or self._get_unused_port()[0])
+            port = (default_port or self._get_unused_port(
+                set(ports_by_node[self.unique_id].values())))
             ports_by_node[self.unique_id][port_name] = port
             with open(file_path, "w") as f:
                 json.dump(ports_by_node, f)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We get random ports for metrics agent port and metrics export port. If we are unlucky, we may get the same port number which causes the ValueError. This PR fixes the issue by making sure we don't reuse the same random port if it's allocated for other usage already.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #19009
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
