### PR TITLE
[Docker] Fix Rsync Down 

### DIFF
--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -673,9 +673,9 @@ class DockerCommandRunner(CommandRunnerInterface):
             # Without it, docker copies the source *into* the target
         if not options.get("docker_mount_if_possible", False):
             self.ssh_command_runner.run(
-                "{} cp {}:{} {}".format(self.docker_cmd, self.container_name,
-                                        self._docker_expand_user(source),
-                                        host_source),
+                "rsync -e '{} exec -i' -avz --delete {}:{} {}".format(
+                    self.docker_cmd, self.container_name,
+                    self._docker_expand_user(source), host_source),
                 silent=is_rsync_silent())
         self.ssh_command_runner.run_rsync_down(
             host_source, target, options=options)

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -672,6 +672,8 @@ class DockerCommandRunner(CommandRunnerInterface):
             # Adding a "." means that docker copies the *contents*
             # Without it, docker copies the source *into* the target
         if not options.get("docker_mount_if_possible", False):
+            # NOTE: `--delete` is okay here because the container is the source
+            # of truth.
             self.ssh_command_runner.run(
                 "rsync -e '{} exec -i' -avz --delete {}:{} {}".format(
                     self.docker_cmd, self.container_name,

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -652,9 +652,9 @@ class DockerCommandRunner(CommandRunnerInterface):
                 # Without it, docker copies the source *into* the target
                 host_destination += "/."
             self.ssh_command_runner.run(
-                "{} cp {} {}:{}".format(self.docker_cmd, host_destination,
-                                        self.container_name,
-                                        self._docker_expand_user(target)),
+                "rsync -e '{} exec -i' -avz {} {}:{}".format(
+                    self.docker_cmd, host_destination, self.container_name,
+                    self._docker_expand_user(target)),
                 silent=is_rsync_silent())
 
     def run_rsync_down(self, source, target, options=None):

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -860,7 +860,8 @@ class DockerCommandRunner(CommandRunnerInterface):
                     # is called before the first `file_sync` happens
                     self.run_rsync_up(file_mounts[mount], mount)
                 self.ssh_command_runner.run(
-                    "{cmd} cp {src} {container}:{dst}".format(
+                    "rsync -e '{cmd} exec -i' -avz {src} {container}:{dst}".
+                    format(
                         cmd=self.docker_cmd,
                         src=os.path.join(
                             self._get_docker_host_mount_location(

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -605,12 +605,13 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_not_has_call(
             "1.2.3.4",
             pattern=f"-v {docker_mount_prefix}/~/ray_bootstrap_config")
+        common_container_copy = \
+            f"rsync -e.*docker exec -i.*{docker_mount_prefix}/~/"
+        runner.assert_has_call(
+            "1.2.3.4", pattern=common_container_copy + "ray_bootstrap_key.pem")
         runner.assert_has_call(
             "1.2.3.4",
-            pattern=f"{docker_mount_prefix}/~/ray_bootstrap_key.pem mock:")
-        pattern_to_assert = \
-            f"{docker_mount_prefix}/~/ray_bootstrap_config.yaml mock:"
-        runner.assert_has_call("1.2.3.4", pattern=pattern_to_assert)
+            pattern=common_container_copy + "ray_bootstrap_config.yaml")
         return config
 
     def testNodeTypeNameChange(self):
@@ -779,12 +780,13 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_not_has_call(
             "1.2.3.4",
             pattern=f"-v {docker_mount_prefix}/~/ray_bootstrap_config")
+        common_container_copy = \
+            f"rsync -e.*podman exec -i.*{docker_mount_prefix}/~/"
+        runner.assert_has_call(
+            "1.2.3.4", pattern=common_container_copy + "ray_bootstrap_key.pem")
         runner.assert_has_call(
             "1.2.3.4",
-            pattern=f"{docker_mount_prefix}/~/ray_bootstrap_key.pem mock:")
-        pattern_to_assert = \
-            f"{docker_mount_prefix}/~/ray_bootstrap_config.yaml mock:"
-        runner.assert_has_call("1.2.3.4", pattern=pattern_to_assert)
+            pattern=common_container_copy + "ray_bootstrap_config.yaml")
 
         for cmd in runner.command_history():
             assert "docker" not in cmd, ("Docker (not podman) found in call: "
@@ -828,12 +830,13 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_not_has_call(
             "1.2.3.4",
             pattern=f"-v {docker_mount_prefix}/~/ray_bootstrap_config")
+        common_container_copy = \
+            f"rsync -e.*docker exec -i.*{docker_mount_prefix}/~/"
+        runner.assert_has_call(
+            "1.2.3.4", pattern=common_container_copy + "ray_bootstrap_key.pem")
         runner.assert_has_call(
             "1.2.3.4",
-            pattern=f"{docker_mount_prefix}/~/ray_bootstrap_key.pem mock:")
-        pattern_to_assert = \
-            f"{docker_mount_prefix}/~/ray_bootstrap_config.yaml mock:"
-        runner.assert_has_call("1.2.3.4", pattern=pattern_to_assert)
+            pattern=common_container_copy + "ray_bootstrap_config.yaml")
 
         # This next section of code ensures that the following order of
         # commands are executed:
@@ -940,12 +943,13 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_not_has_call(
             "1.2.3.4",
             pattern=f"-v {docker_mount_prefix}/~/ray_bootstrap_config")
+        common_container_copy = \
+            f"rsync -e.*docker exec -i.*{docker_mount_prefix}/~/"
+        runner.assert_has_call(
+            "1.2.3.4", pattern=common_container_copy + "ray_bootstrap_key.pem")
         runner.assert_has_call(
             "1.2.3.4",
-            pattern=f"{docker_mount_prefix}/~/ray_bootstrap_key.pem mock:")
-        pattern_to_assert = \
-            f"{docker_mount_prefix}/~/ray_bootstrap_config.yaml mock:"
-        runner.assert_has_call("1.2.3.4", pattern=pattern_to_assert)
+            pattern=common_container_copy + "ray_bootstrap_config.yaml")
 
     def testDockerFileMountsRemoved(self):
         config = copy.deepcopy(SMALL_CLUSTER)
@@ -989,12 +993,13 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_not_has_call(
             "1.2.3.4",
             pattern=f"-v {docker_mount_prefix}/~/ray_bootstrap_config")
+        common_container_copy = \
+            f"rsync -e.*docker exec -i.*{docker_mount_prefix}/~/"
+        runner.assert_has_call(
+            "1.2.3.4", pattern=common_container_copy + "ray_bootstrap_key.pem")
         runner.assert_has_call(
             "1.2.3.4",
-            pattern=f"{docker_mount_prefix}/~/ray_bootstrap_key.pem mock:")
-        pattern_to_assert = \
-            f"{docker_mount_prefix}/~/ray_bootstrap_config.yaml mock:"
-        runner.assert_has_call("1.2.3.4", pattern=pattern_to_assert)
+            pattern=common_container_copy + "ray_bootstrap_config.yaml")
 
     def testRsyncCommandWithDocker(self):
         assert SMALL_CLUSTER["docker"]["container_name"]

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -848,7 +848,8 @@ class AutoscalingTest(unittest.TestCase):
             x for x in commands_with_mount if "rsync --rsh" in x[1]
         ]
         copy_into_container = [
-            x for x in commands_with_mount if "rsync -e" in x[1]
+            x for x in commands_with_mount
+            if re.search("rsync -e.*docker exec -i", x[1])
         ]
         first_mkdir = min(x[0] for x in commands_with_mount if "mkdir" in x[1])
         docker_run_cmd_indx = [
@@ -1020,7 +1021,7 @@ class AutoscalingTest(unittest.TestCase):
             override_cluster_name=None,
             down=True,
             _runner=runner)
-        runner.assert_has_call("1.2.3.0", pattern="rsync -e")
+        runner.assert_has_call("1.2.3.0", pattern="rsync -e.*docker exec -i")
         runner.assert_has_call("1.2.3.0", pattern="rsync --rsh")
         runner.clear_history()
 
@@ -1032,7 +1033,7 @@ class AutoscalingTest(unittest.TestCase):
             down=True,
             ip_address="1.2.3.5",
             _runner=runner)
-        runner.assert_has_call("1.2.3.5", pattern="rsync -e")
+        runner.assert_has_call("1.2.3.5", pattern="rsync -e.*docker exec -i")
         runner.assert_has_call("1.2.3.5", pattern="rsync --rsh")
         runner.clear_history()
 
@@ -1045,7 +1046,7 @@ class AutoscalingTest(unittest.TestCase):
             down=True,
             use_internal_ip=True,
             _runner=runner)
-        runner.assert_has_call("172.0.0.4", pattern="rsync -e")
+        runner.assert_has_call("172.0.0.4", pattern="rsync -e.*docker exec -i")
         runner.assert_has_call("172.0.0.4", pattern="rsync --rsh")
 
     def testRsyncCommandWithoutDocker(self):

--- a/python/ray/tests/test_command_runner.py
+++ b/python/ray/tests/test_command_runner.py
@@ -254,8 +254,9 @@ def test_docker_rsync():
         "1.2.3.4", pattern=f"-avz {local_mount} ray@1.2.3.4:{remote_mount}")
     process_runner.assert_not_has_call(
         "1.2.3.4", pattern=f"mkdir -p {remote_mount}")
-    # No rsync -e for file_mounts
-    process_runner.assert_not_has_call("1.2.3.4", pattern="rsync -e")
+    # No rsync -e.*docker exec -i for file_mounts
+    process_runner.assert_not_has_call(
+        "1.2.3.4", pattern="rsync -e.*docker exec -i")
     process_runner.assert_has_call(
         "1.2.3.4",
         pattern=f"-avz {local_mount} ray@1.2.3.4:{remote_host_mount}")
@@ -272,7 +273,8 @@ def test_docker_rsync():
     process_runner.assert_not_has_call(
         "1.2.3.4", pattern=f"mkdir -p {remote_file}")
 
-    process_runner.assert_has_call("1.2.3.4", pattern="rsync -e")
+    process_runner.assert_has_call(
+        "1.2.3.4", pattern="rsync -e.*docker exec -i")
     process_runner.assert_has_call(
         "1.2.3.4", pattern=f"-avz {local_file} ray@1.2.3.4:{remote_host_file}")
     process_runner.clear_history()
@@ -281,7 +283,8 @@ def test_docker_rsync():
     cmd_runner.run_rsync_down(
         remote_mount, local_mount, options={"docker_mount_if_possible": True})
 
-    process_runner.assert_not_has_call("1.2.3.4", pattern="rsync -e")
+    process_runner.assert_not_has_call(
+        "1.2.3.4", pattern="rsync -e.*docker exec -i")
     process_runner.assert_not_has_call(
         "1.2.3.4", pattern=f"-avz ray@1.2.3.4:{remote_mount} {local_mount}")
     process_runner.assert_has_call(
@@ -294,7 +297,8 @@ def test_docker_rsync():
     cmd_runner.run_rsync_down(
         remote_file, local_file, options={"docker_mount_if_possible": False})
 
-    process_runner.assert_has_call("1.2.3.4", pattern="rsync -e")
+    process_runner.assert_has_call(
+        "1.2.3.4", pattern="rsync -e.*docker exec -i")
     process_runner.assert_not_has_call(
         "1.2.3.4", pattern=f"-avz ray@1.2.3.4:{remote_file} {local_file}")
     process_runner.assert_has_call(

--- a/python/ray/tests/test_command_runner.py
+++ b/python/ray/tests/test_command_runner.py
@@ -254,8 +254,8 @@ def test_docker_rsync():
         "1.2.3.4", pattern=f"-avz {local_mount} ray@1.2.3.4:{remote_mount}")
     process_runner.assert_not_has_call(
         "1.2.3.4", pattern=f"mkdir -p {remote_mount}")
-    # No docker cp for file_mounts
-    process_runner.assert_not_has_call("1.2.3.4", pattern="docker cp")
+    # No rsync -e for file_mounts
+    process_runner.assert_not_has_call("1.2.3.4", pattern="rsync -e")
     process_runner.assert_has_call(
         "1.2.3.4",
         pattern=f"-avz {local_mount} ray@1.2.3.4:{remote_host_mount}")
@@ -272,7 +272,7 @@ def test_docker_rsync():
     process_runner.assert_not_has_call(
         "1.2.3.4", pattern=f"mkdir -p {remote_file}")
 
-    process_runner.assert_has_call("1.2.3.4", pattern="docker cp")
+    process_runner.assert_has_call("1.2.3.4", pattern="rsync -e")
     process_runner.assert_has_call(
         "1.2.3.4", pattern=f"-avz {local_file} ray@1.2.3.4:{remote_host_file}")
     process_runner.clear_history()
@@ -281,7 +281,7 @@ def test_docker_rsync():
     cmd_runner.run_rsync_down(
         remote_mount, local_mount, options={"docker_mount_if_possible": True})
 
-    process_runner.assert_not_has_call("1.2.3.4", pattern="docker cp")
+    process_runner.assert_not_has_call("1.2.3.4", pattern="rsync -e")
     process_runner.assert_not_has_call(
         "1.2.3.4", pattern=f"-avz ray@1.2.3.4:{remote_mount} {local_mount}")
     process_runner.assert_has_call(
@@ -294,7 +294,7 @@ def test_docker_rsync():
     cmd_runner.run_rsync_down(
         remote_file, local_file, options={"docker_mount_if_possible": False})
 
-    process_runner.assert_has_call("1.2.3.4", pattern="docker cp")
+    process_runner.assert_has_call("1.2.3.4", pattern="rsync -e")
     process_runner.assert_not_has_call(
         "1.2.3.4", pattern=f"-avz ray@1.2.3.4:{remote_file} {local_file}")
     process_runner.assert_has_call(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* `rsync --delete` from the Container to the host. This is safe because the **container is the source of truth**, while the host is just an 'implementation detail'.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

* Closes #18150
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
Manually tested:
* Rsyncing Up into a folder that does not exist yet
* Rsyncing Down from a deeply nested folder