### PR TITLE
[Lint] Update clang-tidy rules

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,27 +1,43 @@
-# Disable the following checks due to frequent false positives, noisiness,
-# inconsistent style with existing codebase and other reasons:
+# Disable the following checks with reasons in parenthesis:
+#
+# -bugprone-macro-parentheses (inconsistent style)
+# -google-readability-todo (potentially too restrictive)
 # -misc-non-private-member-variables-in-classes (potentially too restrictive)
 # -misc-unused-parameters (can be cleaned up in batch and enabled)
 # -modernize-avoid-c-arrays (too restrictive)
+# -modernize-concat-nested-namespaces (inconsistent style)
 # -modernize-pass-by-value (too restrictive)
 # -modernize-return-braced-init-list (inconsistent style)
 # -modernize-use-emplace (more subtle behavior)
 # -modernize-use-trailing-return-type (inconsistent style)
+# -modernize-use-trailing-return-type (inconsistent style)
+# -readability-convert-member-functions-to-static (potentially too restrictive)
+# Other rules not mentioned here or below (not yet evaluated)
 #
 # TODO: enable google-* and readability-* families of checks.
 Checks: >
   abseil-*,
   bugprone-*,
+  -bugprone-macro-parentheses,
+  google-*,
+  -google-readability-todo,
   misc-*,
   -misc-non-private-member-variables-in-classes,
   -misc-unused-parameters,
   modernize-*,
   -modernize-avoid-c-arrays,
+  -modernize-concat-nested-namespaces,
   -modernize-pass-by-value,
   -modernize-return-braced-init-list,
   -modernize-use-emplace,
   -modernize-use-trailing-return-type,
   performance-*,
+  readability-avoid-const-params-in-decls,
+  readability-braces-around-statements,
+  readability-const-return-type,
+  readability-container-size-empty,
+  readability-delete-null-pointer,
+  readability-else-after-return,
 
 CheckOptions:
   # Reduce noisiness of the bugprone-narrowing-conversions check.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
It has been reported that rules `modernize-concat-nested-namespaces` and `bugprone-macro-parentheses` are a bit inconsistent with existing style. Disabling them for now. Also add a few more rules that seem useful.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
