### PR TITLE
[core] Remove "plasma promotion" for serialized ObjectRefs

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1726,7 +1726,6 @@ cdef class CoreWorker:
             CObjectID c_object_id = object_ref.native()
             CAddress c_owner_address = CAddress()
             c_string serialized_object_status
-        CCoreWorkerProcess.GetCoreWorker().PromoteObjectToPlasma(c_object_id)
         CCoreWorkerProcess.GetCoreWorker().GetOwnershipInfo(
                 c_object_id, &c_owner_address, &serialized_object_status)
         return (object_ref,

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1025,6 +1025,7 @@ void CoreWorker::PutObjectIntoPlasma(const RayObject &object, const ObjectID &ob
 }
 
 void CoreWorker::PromoteObjectToPlasma(const ObjectID &object_id) {
+  // TODO(swang): Remove.
   auto value = memory_store_->GetOrPromoteToPlasma(object_id);
   if (value) {
     PutObjectIntoPlasma(*value, object_id);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously if an ObjectRef was serialized, we would "promote" the object to plasma. This allowed any ref holders to get the object by requesting it through the plasma store. However, this is no longer necessary because the owner can send objects directly to any ref holders (#13618).

It looks like plasma promotion + the new pubsub layer (#14762) is causing #19024. The root cause is that every time a worker serialized the ObjectRef, we would send another IPC to its local raylet asking it to pin the object (to make sure it's available for ref holders). The raylet would then subscribe to messages about the object from the object's owner. This could cause a duplicate subscription to the same key, which is not allowed in the new pubsub layer. I think this race condition has likely been an issue in the codebase for a while.

## Related issue number

Closes #19024.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
