### PR TITLE
Update build rules and patches for darwin_arm64 platform.

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -161,10 +161,9 @@ def ray_deps_setup():
     auto_http_archive(
         name = "com_github_nelhage_rules_boost",
         # If you update the Boost version, remember to update the 'boost' rule.
-        url = "https://github.com/nelhage/rules_boost/archive/2613d04ab3d22dfc4543ea0a083d9adeaa0daf09.tar.gz",
-        sha256 = "512f913240e026099d4ca4a98b1ce8048c99de77fdc8e8584e9e2539ee119ca2",
+        url = "https://github.com/nelhage/rules_boost/archive/652b21e35e4eeed5579e696da0facbe8dba52b1f.tar.gz",
+        sha256 = "c1b8b2adc3b4201683cf94dda7eef3fc0f4f4c0ea5caa3ed3feffe07e1fb5b15",
         patches = [
-            "//thirdparty/patches:rules_boost-undefine-boost_fallthrough.patch",
             "//thirdparty/patches:rules_boost-windows-linkopts.patch",
         ],
     )

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -151,8 +151,8 @@ def ray_deps_setup():
         # declaring it here allows us to avoid patching the latter.
         name = "boost",
         build_file = "@com_github_nelhage_rules_boost//:BUILD.boost",
-        sha256 = "d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee",
-        url = "https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2",
+        sha256 = "83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1",
+        url = "https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2",
         patches = [
             "//thirdparty/patches:boost-exception-no_warn_typeid_evaluated.patch",
         ],

--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -90,6 +90,7 @@ genrule(
         mkdir -p "$$PY_CPP_DIR/lib/" &&
         cp -f -r $$WORK_DIR/external/msgpack/include/* "$$PY_CPP_DIR/include" &&
         cp -f -r "$$WORK_DIR/external/boost/boost/archive" "$$BOOST_DIR" &&
+        cp -f -r "$$WORK_DIR/external/boost/boost/assert" "$$BOOST_DIR" &&
         cp -f -r "$$WORK_DIR/external/boost/boost/bind" "$$BOOST_DIR" &&
         cp -f -r "$$WORK_DIR/external/boost/boost/callable_traits" "$$BOOST_DIR" &&
         cp -f -r "$$WORK_DIR/external/boost/boost/concept" "$$BOOST_DIR" &&

--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -19,7 +19,7 @@
 #include <boost/asio/placeholders.hpp>
 #include <boost/asio/read.hpp>
 #include <boost/asio/write.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <chrono>
 #include <sstream>
 #include <thread>

--- a/src/ray/common/network_util.h
+++ b/src/ray/common/network_util.h
@@ -16,7 +16,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/asio/deadline_timer.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/system/error_code.hpp>
 #include <string>

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <boost/bind/bind.hpp>
-
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"

--- a/src/ray/core_worker/reference_count_test.cc
+++ b/src/ray/core_worker/reference_count_test.cc
@@ -16,6 +16,7 @@
 
 #include <vector>
 
+#include "absl/functional/bind_front.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "ray/common/asio/instrumented_io_context.h"
@@ -25,8 +26,6 @@
 #include "ray/pubsub/mock_pubsub.h"
 #include "ray/pubsub/publisher.h"
 #include "ray/pubsub/subscriber.h"
-
-namespace ph = boost::placeholders;
 
 namespace ray {
 namespace core {
@@ -271,7 +270,7 @@ class MockWorkerClient : public MockCoreWorkerClientInterface {
 
     auto borrower_callback = [=]() {
       auto ref_removed_callback =
-          boost::bind(&ReferenceCounter::HandleRefRemoved, &rc_, ph::_1);
+          absl::bind_front(&ReferenceCounter::HandleRefRemoved, &rc_);
       rc_.SetRefRemovedCallback(object_id, contained_in_id, owner_address,
                                 ref_removed_callback);
     };

--- a/src/ray/core_worker/reference_count_test.cc
+++ b/src/ray/core_worker/reference_count_test.cc
@@ -26,6 +26,8 @@
 #include "ray/pubsub/publisher.h"
 #include "ray/pubsub/subscriber.h"
 
+namespace ph = boost::placeholders;
+
 namespace ray {
 namespace core {
 
@@ -269,7 +271,7 @@ class MockWorkerClient : public MockCoreWorkerClientInterface {
 
     auto borrower_callback = [=]() {
       auto ref_removed_callback =
-          boost::bind(&ReferenceCounter::HandleRefRemoved, &rc_, _1);
+          boost::bind(&ReferenceCounter::HandleRefRemoved, &rc_, ph::_1);
       rc_.SetRefRemovedCallback(object_id, contained_in_id, owner_address,
                                 ref_removed_callback);
     };

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -16,7 +16,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/asio/error.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <thread>
 
 #include "absl/container/flat_hash_map.h"

--- a/src/ray/gcs/asio.h
+++ b/src/ray/gcs/asio.h
@@ -38,7 +38,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/asio/error.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <iostream>
 #include <string>
 

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <functional>
 #include <memory>
 #include <mutex>

--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -16,7 +16,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/asio/error.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <list>
 #include <memory>
 #include <vector>

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -17,7 +17,7 @@
 #include <algorithm>
 #include <boost/asio.hpp>
 #include <boost/asio/error.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <cstdint>
 #include <deque>
 #include <map>

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -298,7 +298,8 @@ void PlasmaStore::ConnectClient(const boost::system::error_code &error) {
   if (!error) {
     // Accept a new local client and dispatch it to the node manager.
     auto new_connection = Client::Create(
-        boost::bind(&PlasmaStore::ProcessMessage, this, ph::_1, ph::_2, ph::_3),
+        boost::bind(&PlasmaStore::ProcessMessage,
+		    this, ph::_1, ph::_2, ph::_3),  // NOLINT
         std::move(socket_));
   }
   // We're ready to accept another client.

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -297,10 +297,12 @@ int PlasmaStore::AbortObject(const ObjectID &object_id,
 void PlasmaStore::ConnectClient(const boost::system::error_code &error) {
   if (!error) {
     // Accept a new local client and dispatch it to the node manager.
-    auto new_connection = Client::Create(
-        boost::bind(&PlasmaStore::ProcessMessage, this,  // NOLINT
-                    ph::_1, ph::_2, ph::_3),
+    // NOLINTBEGIN : handler must be boost::AcceptHandler type.
+    auto new_connection =
+        Client::Create(boost::bind(&PlasmaStore::ProcessMessage, this,
+                                   ph::_1, ph::_2, ph::_3),
         std::move(socket_));
+    // NOLINTEND
   }
   // We're ready to accept another client.
   DoAccept();

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -298,7 +298,7 @@ void PlasmaStore::ConnectClient(const boost::system::error_code &error) {
   if (!error) {
     // Accept a new local client and dispatch it to the node manager.
     auto new_connection = Client::Create(
-	// NOLINTNEXTLINE : handler must be of boost::AcceptHandler type.
+        // NOLINTNEXTLINE : handler must be of boost::AcceptHandler type.
         boost::bind(&PlasmaStore::ProcessMessage, this, ph::_1, ph::_2, ph::_3),
         std::move(socket_));
   }

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -297,11 +297,10 @@ int PlasmaStore::AbortObject(const ObjectID &object_id,
 void PlasmaStore::ConnectClient(const boost::system::error_code &error) {
   if (!error) {
     // Accept a new local client and dispatch it to the node manager.
-    // NOLINTBEGIN : handler must be boost::AcceptHandler type.
     auto new_connection = Client::Create(
+	// NOLINTNEXTLINE : handler must be of boost::AcceptHandler type.
         boost::bind(&PlasmaStore::ProcessMessage, this, ph::_1, ph::_2, ph::_3),
         std::move(socket_));
-    // NOLINTEND
   }
   // We're ready to accept another client.
   DoAccept();

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <chrono>
 #include <ctime>
 #include <deque>
@@ -53,6 +53,7 @@
 #include "ray/object_manager/plasma/protocol.h"
 #include "ray/util/util.h"
 
+namespace ph = boost::placeholders;
 namespace fb = plasma::flatbuf;
 
 namespace plasma {
@@ -297,7 +298,8 @@ void PlasmaStore::ConnectClient(const boost::system::error_code &error) {
   if (!error) {
     // Accept a new local client and dispatch it to the node manager.
     auto new_connection = Client::Create(
-        boost::bind(&PlasmaStore::ProcessMessage, this, _1, _2, _3), std::move(socket_));
+        boost::bind(&PlasmaStore::ProcessMessage, this, ph::_1, ph::_2, ph::_3),
+	std::move(socket_));
   }
   // We're ready to accept another client.
   DoAccept();

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -298,9 +298,8 @@ void PlasmaStore::ConnectClient(const boost::system::error_code &error) {
   if (!error) {
     // Accept a new local client and dispatch it to the node manager.
     // NOLINTBEGIN : handler must be boost::AcceptHandler type.
-    auto new_connection =
-        Client::Create(boost::bind(&PlasmaStore::ProcessMessage, this,
-                                   ph::_1, ph::_2, ph::_3),
+    auto new_connection = Client::Create(
+        boost::bind(&PlasmaStore::ProcessMessage, this, ph::_1, ph::_2, ph::_3),
         std::move(socket_));
     // NOLINTEND
   }

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -297,10 +297,9 @@ int PlasmaStore::AbortObject(const ObjectID &object_id,
 void PlasmaStore::ConnectClient(const boost::system::error_code &error) {
   if (!error) {
     // Accept a new local client and dispatch it to the node manager.
-    auto new_connection = Client::Create(
-        boost::bind(&PlasmaStore::ProcessMessage,
-		    this, ph::_1, ph::_2, ph::_3),  // NOLINT
-        std::move(socket_));
+    auto new_connection = Client::Create(boost::bind(&PlasmaStore::ProcessMessage, this,
+                                                     ph::_1, ph::_2, ph::_3),  // NOLINT
+                                         std::move(socket_));
   }
   // We're ready to accept another client.
   DoAccept();

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -299,7 +299,7 @@ void PlasmaStore::ConnectClient(const boost::system::error_code &error) {
     // Accept a new local client and dispatch it to the node manager.
     auto new_connection = Client::Create(
         boost::bind(&PlasmaStore::ProcessMessage, this, ph::_1, ph::_2, ph::_3),
-	std::move(socket_));
+        std::move(socket_));
   }
   // We're ready to accept another client.
   DoAccept();

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -297,9 +297,10 @@ int PlasmaStore::AbortObject(const ObjectID &object_id,
 void PlasmaStore::ConnectClient(const boost::system::error_code &error) {
   if (!error) {
     // Accept a new local client and dispatch it to the node manager.
-    auto new_connection = Client::Create(boost::bind(&PlasmaStore::ProcessMessage, this,
-                                                     ph::_1, ph::_2, ph::_3),  // NOLINT
-                                         std::move(socket_));
+    auto new_connection = Client::Create(
+        boost::bind(&PlasmaStore::ProcessMessage, this,  // NOLINT
+                    ph::_1, ph::_2, ph::_3),
+        std::move(socket_));
   }
   // We're ready to accept another client.
   DoAccept();

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -16,7 +16,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/asio/error.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <map>
 
 #include "absl/container/flat_hash_map.h"

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -15,7 +15,7 @@
 #include "ray/raylet/raylet.h"
 
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <iostream>
 

--- a/src/ray/raylet/worker.cc
+++ b/src/ray/raylet/worker.cc
@@ -14,7 +14,7 @@
 
 #include "ray/raylet/worker.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "ray/raylet/format/node_manager_generated.h"
 #include "ray/raylet/raylet.h"

--- a/streaming/src/queue/queue_handler.h
+++ b/streaming/src/queue/queue_handler.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread.hpp>
 #include <thread>
 

--- a/thirdparty/patches/prometheus-windows-pollfd.patch
+++ b/thirdparty/patches/prometheus-windows-pollfd.patch
@@ -6,17 +6,46 @@ Windows Vista and later SDKs define struct pollfd for WSAPoll(), but it has a pe
 civetweb provides its own implementation of poll, but it has a conflicting definition for pollfd.
 Hence we block Windows from defining pollfd (which this project doesn't use).
 ---
- bazel/civetweb.BUILD | 1 +
- 1 file changed, 1 insertion(+)
+ bazel/civetweb.BUILD | 7 +++++++
+ 1 file changed, 7 insertions(+)
 
 diff --git bazel/civetweb.BUILD bazel/civetweb.BUILD
 --- bazel/civetweb.BUILD
 +++ bazel/civetweb.BUILD
-@@ -34,5 +34,6 @@ cc_library(
+@@ -9,6 +9,11 @@ config_setting(
+     values = {"cpu": "darwin_x86_64"},
+ )
+
++config_setting(
++    name = "darwin_arm64",
++    values = {"cpu": "darwin_arm64"},
++)
++
+ config_setting(
+     name = "windows",
+     values = { "cpu": "x64_windows" },
+@@ -34,6 +39,7 @@ cc_library(
          "-DNO_CACHING",
          "-DNO_SSL",
          "-DNO_FILES",
 +        "-D_WIN32_WINNT=0x0502",
          "-UDEBUG",
      ],
--- 
+     includes = [
+@@ -46,6 +52,7 @@ cc_library(
+     }) + select({
+         ":darwin": [],
+         ":darwin_x86_64": [],
++        ":darwin_arm64": [],
+         ":windows": [],
+         ":windows_msvc": [],
+         "//conditions:default": ["-lrt"],
+@@ -86,6 +93,7 @@ cc_library(
+     }) + select({
+         ":darwin": [],
+         ":darwin_x86_64": [],
++        ":darwin_arm64": [],
+         ":windows": [],
+         ":windows_msvc": [],
+         "//conditions:default": ["-lrt"],
+--

--- a/thirdparty/patches/rules_boost-undefine-boost_fallthrough.patch
+++ b/thirdparty/patches/rules_boost-undefine-boost_fallthrough.patch
@@ -1,8 +1,0 @@
-diff --git BUILD.boost BUILD.boost
---- BUILD.boost
-+++ BUILD.boost
-@@ -1356,3 +1356,2 @@ boost_library(
-     defines = [
--        "BOOST_FALLTHROUGH",
-     ],
--- 

--- a/thirdparty/patches/rules_boost-windows-linkopts.patch
+++ b/thirdparty/patches/rules_boost-windows-linkopts.patch
@@ -1,15 +1,12 @@
 diff --git BUILD.boost BUILD.boost
 --- BUILD.boost
 +++ BUILD.boost
-@@ -313,1 +313,9 @@ boost_library(name = "asio",
--    linkopts = ["-lpthread"],
-+    linkopts = select({
-+        ":linux": [
-+            "-lpthread",
-+        ],
-+        ":osx_x86_64": [
-+            "-lpthread",
-+        ],
-+        "//conditions:default": [],
-+    }),
--- 
+@@ -428,6 +428,7 @@ boost_library(
+     }),
+     linkopts = select({
+         ":android": [],
++        ":windows": [],
+         "//conditions:default": ["-lpthread"],
+     }),
+     deps = [
+--


### PR DESCRIPTION
Changes include:

Update nelhage/rules_boost package from current version (08/5/2020) to 5/27/2021 version.
Remove rules_boost-undefine-boost_fallthrough.patch, since BOOST_FALLTHROUGH seems to be defined now.
Minor changes to rules_boost-windows-linkopts.patch to use default condition to add -lpthread flag for all platforms.
Add darwin_arm64 config to BUILD files for lib civetweb pulled in via prometheu dependency.

## Why are these changes needed?

Build fixes for Apple M1 laptop.

## Related issue number

#16621

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [*] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
