### PR TITLE
Implement basic runtime env plugin mechanism

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -182,6 +182,7 @@ test_python() {
       -python/ray/tests:test_ray_init  # test_redis_port() seems to fail here, but pass in isolation
       -python/ray/tests:test_resource_demand_scheduler
       -python/ray/tests:test_reference_counting  # too flaky 9/25/21
+      -python/ray/tests:test_runtime_env_plugin # runtime_env not supported on Windows
       -python/ray/tests:test_runtime_env_env_vars # runtime_env not supported on Windows
       -python/ray/tests:test_runtime_env_complicated # conda install slow leading to timeout
       -python/ray/tests:test_stress  # timeout

--- a/dashboard/modules/runtime_env/runtime_env_agent.py
+++ b/dashboard/modules/runtime_env/runtime_env_agent.py
@@ -6,6 +6,7 @@ import logging
 import os
 import time
 from typing import Dict, Set
+from ray._private.runtime_env.plugin import load_plugins
 
 from ray.core.generated import runtime_env_agent_pb2
 from ray.core.generated import runtime_env_agent_pb2_grpc
@@ -97,6 +98,14 @@ class RuntimeEnvAgent(dashboard_utils.DashboardAgentModule,
                 for uri in runtime_env.get("uris") or []:
                     self._working_dir_uri_to_envs[uri].add(
                         serialized_runtime_env)
+
+                # Run setup function from all the plugins
+                for plugin_class in load_plugins(runtime_env).values():
+                    # TODO(simon): implement uri support
+                    plugin_class.create("uri not implemented", runtime_env,
+                                        context)
+                    plugin_class.modify_context("uri not implemented",
+                                                runtime_env, context)
 
                 return context
 

--- a/dashboard/modules/runtime_env/runtime_env_agent.py
+++ b/dashboard/modules/runtime_env/runtime_env_agent.py
@@ -6,7 +6,7 @@ import logging
 import os
 import time
 from typing import Dict, Set
-from ray._private.runtime_env.plugin import load_plugins
+from ray._private.utils import import_attr
 
 from ray.core.generated import runtime_env_agent_pb2
 from ray.core.generated import runtime_env_agent_pb2_grpc
@@ -100,7 +100,8 @@ class RuntimeEnvAgent(dashboard_utils.DashboardAgentModule,
                         serialized_runtime_env)
 
                 # Run setup function from all the plugins
-                for plugin_class in load_plugins(runtime_env).values():
+                for plugin_class_path in runtime_env.get("plugins", {}).keys():
+                    plugin_class = import_attr(plugin_class_path)
                     # TODO(simon): implement uri support
                     plugin_class.create("uri not implemented", runtime_env,
                                         context)

--- a/python/ray/_private/runtime_env/context.py
+++ b/python/ray/_private/runtime_env/context.py
@@ -4,9 +4,12 @@ import os
 import sys
 from typing import Dict, List, Optional
 
+from ray.util.annotations import DeveloperAPI
+
 logger = logging.getLogger(__name__)
 
 
+@DeveloperAPI
 class RuntimeEnvContext:
     """A context used to describe the created runtime env."""
 

--- a/python/ray/_private/runtime_env/plugin.py
+++ b/python/ray/_private/runtime_env/plugin.py
@@ -1,0 +1,105 @@
+from abc import ABC, abstractstaticmethod
+import os
+from typing import Dict, Iterable, Type
+
+from ray._private.runtime_env.context import RuntimeEnvContext
+from ray._private.utils import import_attr
+from ray.util.annotations import DeveloperAPI
+
+RAY_PLUGIN_ENV_KEY_PREFIX = "RAY_RUNTIME_ENV_PLUGIN_"
+
+
+@DeveloperAPI
+class RuntimeEnvPlugin(ABC):
+    @abstractstaticmethod
+    def validate(runtime_env_dict: dict) -> str:
+        """Validate user entry and returns a URI uniquely describing resource.
+
+        This method will be called at ``f.options(runtime_env=...)`` or
+        ``ray.init(runtime_env=...)`` time and it should check the runtime env
+        dictionary for any errors. For example, it can raise "TypeError:
+        expected string for "conda" field".
+
+        Args:
+            runtime_env_dict(dict): the entire dictionary passed in by user.
+
+        Returns:
+            uri(str): a URI uniquely describing this resource (e.g., a hash of
+              the conda spec).
+        """
+        raise NotImplementedError()
+
+    def create(uri: str, runtime_env_dict: dict,
+               ctx: RuntimeEnvContext) -> float:
+        """Create and install the runtime environment.
+
+        Gets called in the runtime env agent at install time. The URI can be
+        used as a caching mechanism.
+
+        Args:
+            uri(str): a URI uniquely describing this resource.
+            runtime_env_dict(dict): the entire dictionary passed in by user.
+            ctx(RuntimeEnvContext): auxiliary information supplied by Ray.
+
+        Returns:
+            the disk space taken up by this plugin installation for this
+            environment. e.g. for working_dir, this downloads the files to the
+            local node.
+        """
+        return 0
+
+    def modify_context(uri: str, runtime_env_dict: dict,
+                       ctx: RuntimeEnvContext) -> None:
+        """Modify context to change worker startup behavior.
+
+        For example, you can use this to preprend "cd <dir>" command to worker
+        startup, or add new environment variables.
+
+        Args:
+            uri(str): a URI uniquely describing this resource.
+            runtime_env_dict(dict): the entire dictionary passed in by user.
+            ctx(RuntimeEnvContext): auxiliary information supplied by Ray.
+        """
+        return
+
+    def delete(uri: str, ctx: RuntimeEnvContext) -> float:
+        """Delete the the runtime environment given uri.
+
+        Args:
+            uri(str): a URI uniquely describing this resource.
+            ctx(RuntimeEnvContext): auxiliary information supplied by Ray.
+
+        Returns:
+            the amount of space reclaimed by the deletion.
+        """
+        return 0
+
+
+def load_plugins(
+        runtime_env_keys: Iterable[str]) -> Dict[str, Type[RuntimeEnvPlugin]]:
+    """Load plugins by parsing environment variables.
+
+    Args:
+        runtime_env_keys (Iterable[str]): the runtime_env keys supplied by the
+          users. Only plugins that have a key matched will be loaded.
+    Returns:
+        A dictionary mapping key to plugin class.
+    """
+
+    loaded = dict()
+    for key, value in os.environ.items():
+        # This plugin is specified via environment variable.
+        if key.startswith(RAY_PLUGIN_ENV_KEY_PREFIX):
+            entry_key = key.replace(RAY_PLUGIN_ENV_KEY_PREFIX, "")
+
+            # User has supplied a field matching this plugin.
+            if entry_key in runtime_env_keys:
+                plugin_class_path = value
+                plugin_class: RuntimeEnvPlugin = import_attr(plugin_class_path)
+                if not issubclass(plugin_class, RuntimeEnvPlugin):
+                    # TODO(simon): move the class to public once ready.
+                    raise TypeError(
+                        f"{plugin_class_path} must be inherit from "
+                        "ray._private.runtime_env.plugin.RuntimeEnvPlugin.")
+                loaded[entry_key] = plugin_class
+    return loaded

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -4,8 +4,8 @@ import os
 from pathlib import Path
 import sys
 from typing import Any, Dict, Optional, Set
-from ray._private.runtime_env.plugin import (RAY_PLUGIN_ENV_KEY_PREFIX,
-                                             load_plugins)
+from ray._private.runtime_env.plugin import RuntimeEnvPlugin
+from ray._private.utils import import_attr
 import yaml
 
 import ray
@@ -75,7 +75,7 @@ class RuntimeEnvDict:
         self._dict = dict()
         self.known_fields: Set[str] = {
             "working_dir", "conda", "pip", "uris", "containers", "env_vars",
-            "_ray_release", "_ray_commit", "_inject_current_ray"
+            "_ray_release", "_ray_commit", "_inject_current_ray", "plugins"
         }
 
         if "working_dir" in runtime_env_json:
@@ -171,31 +171,33 @@ class RuntimeEnvDict:
         # TODO(ekl) support py_modules
         # TODO(architkulkarni) support docker
 
-        self._load_and_validate_plugins(runtime_env_json)
+        if "plugins" in runtime_env_json:
+            self._dict["plugins"] = dict()
+            for class_path, plugin_field in runtime_env_json[
+                    "plugins"].items():
+                plugin_class: RuntimeEnvPlugin = import_attr(class_path)
+                if not issubclass(plugin_class, RuntimeEnvPlugin):
+                    # TODO(simon): move the inferface to public once ready.
+                    raise TypeError(
+                        f"{class_path} must be inherit from "
+                        "ray._private.runtime_env.plugin.RuntimeEnvPlugin.")
+                # TODO(simon): implement uri support.
+                _ = plugin_class.validate(runtime_env_json)
+                # Validation passed, add the entry to parsed runtime env.
+                self._dict["plugins"][class_path] = plugin_field
+
         unknown_fields = set(runtime_env_json.keys()) - self.known_fields
         if len(unknown_fields):
             logger.warning(
                 "The following unknown entries in the runtime_env dictionary "
                 f"will be ignored: {unknown_fields}. If you are intended to "
-                "use plugin, make sure to supply environment variable "
-                f"{RAY_PLUGIN_ENV_KEY_PREFIX}*=your.plugin.Class")
+                "use plugin, make sure to nest them in the ``plugins`` field.")
 
         # TODO(architkulkarni) This is to make it easy for the worker caching
         # code in C++ to check if the env is empty without deserializing and
         # parsing it.  We should use a less confusing approach here.
         if all(val is None for val in self._dict.values()):
             self._dict = {}
-
-    def _load_and_validate_plugins(self, runtime_env_dict: dict):
-        for entry_key, plugin_class in load_plugins(
-                runtime_env_dict.keys()).items():
-
-            # TODO(simon): implement uri support.
-            _ = plugin_class.validate(runtime_env_dict)
-
-            # Validation passed, add the entry to parsed runtime env.
-            self._dict[entry_key] = runtime_env_dict[entry_key]
-            self.known_fields.add(entry_key)
 
     def get_parsed_dict(self) -> dict:
         return self._dict

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -66,6 +66,11 @@ class RuntimeEnvDict:
                 {"OMP_NUM_THREADS": "32", "TF_WARNINGS": "none"}
     """
 
+    known_fields: Set[str] = {
+        "working_dir", "conda", "pip", "uris", "containers", "env_vars",
+        "_ray_release", "_ray_commit", "_inject_current_ray", "plugins"
+    }
+
     def __init__(self,
                  runtime_env_json: dict,
                  working_dir: Optional[str] = None):
@@ -73,10 +78,6 @@ class RuntimeEnvDict:
         # contain all supported keys; values will be set to None if
         # unspecified. However, if all values are None this is set to {}.
         self._dict = dict()
-        self.known_fields: Set[str] = {
-            "working_dir", "conda", "pip", "uris", "containers", "env_vars",
-            "_ray_release", "_ray_commit", "_inject_current_ray", "plugins"
-        }
 
         if "working_dir" in runtime_env_json:
             self._dict["working_dir"] = runtime_env_json["working_dir"]
@@ -186,7 +187,8 @@ class RuntimeEnvDict:
                 # Validation passed, add the entry to parsed runtime env.
                 self._dict["plugins"][class_path] = plugin_field
 
-        unknown_fields = set(runtime_env_json.keys()) - self.known_fields
+        unknown_fields = (
+            set(runtime_env_json.keys()) - RuntimeEnvDict.known_fields)
         if len(unknown_fields):
             logger.warning(
                 "The following unknown entries in the runtime_env dictionary "

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -82,6 +82,7 @@ py_test_module_list(
     "test_reference_counting.py",
     "test_resource_demand_scheduler.py",
     "test_runtime_env_env_vars.py",
+    "test_runtime_env_plugin.py",
     "test_runtime_env_fork_process.py",
     "test_serialization.py",
     "test_shuffle.py",

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -61,6 +61,7 @@ def test_simple_env_modification_plugin(ray_start_regular):
                         "env_value": 42,
                         "tmp_file": tmp_file_path,
                         "tmp_content": "hello",
+                        # See https://en.wikipedia.org/wiki/Nice_(Unix)
                         "prefix_command": "nice -n 19",
                     }
                 }

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -29,7 +29,7 @@ class MyPlugin(RuntimeEnvPlugin):
             f"echo {plugin_config_dict['tmp_content']} > "
             f"{plugin_config_dict['tmp_file']}")
         ctx.py_executable = (
-            plugin_config_dict['prefix_command'] + " " + ctx.py_executable)
+            plugin_config_dict["prefix_command"] + " " + ctx.py_executable)
 
 
 @pytest.fixture

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -1,0 +1,76 @@
+import os
+import tempfile
+
+import pytest
+from ray._private.runtime_env.context import RuntimeEnvContext
+from ray._private.runtime_env.plugin import (RAY_PLUGIN_ENV_KEY_PREFIX,
+                                             RuntimeEnvPlugin)
+
+import ray
+
+
+class MyPlugin(RuntimeEnvPlugin):
+    entry_key = "my_test_plugin_key"
+    env_key = "MY_PLUGIN_ENV_KEY"
+
+    @staticmethod
+    def validate(runtime_env_dict: dict) -> str:
+        value = runtime_env_dict[MyPlugin.entry_key]
+        if value == "fail":
+            raise ValueError("not allowed")
+        return value
+
+    @staticmethod
+    def modify_context(uri: str, runtime_env_dict: dict,
+                       ctx: RuntimeEnvContext) -> None:
+        plugin_config_dict = runtime_env_dict[MyPlugin.entry_key]
+        ctx.env_vars[MyPlugin.env_key] = str(plugin_config_dict["env_value"])
+        ctx.command_prefix.append(
+            f"echo {plugin_config_dict['tmp_content']} > "
+            f"{plugin_config_dict['tmp_file']}")
+        ctx.py_executable = (
+            plugin_config_dict['prefix_command'] + " " + ctx.py_executable)
+
+
+@pytest.fixture
+def _inject_plugin_env():
+    key = RAY_PLUGIN_ENV_KEY_PREFIX + MyPlugin.entry_key
+    os.environ[key] = "ray.tests.test_runtime_env_plugin.MyPlugin"
+    yield
+    del os.environ[key]
+
+
+def test_simple_env_modification_plugin(_inject_plugin_env, ray_start_regular):
+    _, tmp_file_path = tempfile.mkstemp()
+
+    @ray.remote
+    def f():
+        import psutil
+        with open(tmp_file_path, "r") as f:
+            content = f.read().strip()
+        return {
+            "env_value": os.environ[MyPlugin.env_key],
+            "tmp_content": content,
+            "nice": psutil.Process().nice(),
+        }
+
+    with pytest.raises(ValueError, match="not allowed"):
+        f.options(runtime_env={MyPlugin.entry_key: "fail"}).remote()
+
+    output = ray.get(
+        f.options(
+            runtime_env={
+                MyPlugin.entry_key: {
+                    "env_value": 42,
+                    "tmp_file": tmp_file_path,
+                    "tmp_content": "hello",
+                    "prefix_command": "nice -n 19",
+                }
+            }).remote())
+
+    assert output == {"env_value": "42", "tmp_content": "hello", "nice": 19}
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-sv", __file__]))


### PR DESCRIPTION
This PR implements a very basic and experimental version of [pluggable runtime environment](https://docs.google.com/document/d/1x1JAHg7c0ewcOYwhhclbuW0B0UC7l92WFkF4Su0T-dk/edit). 

In particular, it supports loading an out-of-tree runtime env plugin that can:
- modify command prefix (i.e. run arbitrary commands before worker commend)
- modify python executable prefix (i.e. prepend to, or modify the python executable for worker)
- modify environment variables (i.e. inject arbitrary environment variables)

There are a lot of limitation at the moment:
- no support for caching environment with uris mechanism.
- no support for garbage collection environment files. 

See [here](https://github.com/ray-project/ray/blob/2915260b2f623ee44f53c9cdb3d2fa1633a5b50b/python/ray/_private/runtime_env/plugin.py#L8) for the interface for the plugin you need to write.

Here is a simple example to configure process niceness score using the `nice` command, falling into the "modify python executable prefix" category.

We will define a plugin inside `my_module.py`. I would recommend to put this in an actual python package when running in production.
`my_module.py`: 
```python
from ray._private.runtime_env.context import RuntimeEnvContext
from ray._private.runtime_env.plugin import RuntimeEnvPlugin

class MyPlugin(RuntimeEnvPlugin):
    @staticmethod
    def validate(runtime_env_dict: dict): pass

    @staticmethod
    def modify_context(uri: str, runtime_env_dict: dict, ctx: RuntimeEnvContext) -> None:
        plugin_config_dict = runtime_env_dict["plugins"]["my_module.MyPlugin"]
        ctx.py_executable = (
            plugin_config_dict["prefix_command"] + " " + ctx.py_executable)
```

`app.py`:
```python
import ray
ray.init(runtime_env=dict(working_dir=".")) # needed if my_module.py is not part of package

@ray.remote
def f():
    import psutil
    return {"nice": psutil.Process().nice()}

   
output = ray.get(
    f.options(
        runtime_env={
            "plugins": {
                "my_module.MyPlugin": { # my Plugin will be dynamically imported!
                    # See https://en.wikipedia.org/wiki/Nice_(Unix)
                    "prefix_command": "nice -n 19",
                }
            }
        }).remote())

print(output)
```

```
> python app.py
2021-10-01 16:49:56,637	INFO services.py:1265 -- View the Ray dashboard at http://127.0.0.1:8265
2021-10-01 16:49:56,881	INFO working_dir.py:414 -- gcs://_ray_pkg_d674a1dc7fa916b6689f85a6f5ac9e1a.zip doesn't exist. Create new package with . and None
2021-10-01 16:49:56,883	INFO working_dir.py:425 -- gcs://_ray_pkg_d674a1dc7fa916b6689f85a6f5ac9e1a.zip has been pushed with 2303 bytes
{'nice': 19}
```

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
