### PR TITLE
[CI] Add a retry helper to e2e.py

### DIFF
--- a/release/e2e.py
+++ b/release/e2e.py
@@ -279,7 +279,8 @@ def exponential_backoff_retry(f, retry_exceptions, initial_retry_delay_s,
             if retry_cnt > max_retries:
                 raise
             logger.info(
-                f"Retry function call failed due to {e} in {retry_delay_s} seconds..."
+                f"Retry function call failed due to {e} "
+                f"in {retry_delay_s} seconds..."
             )
             time.sleep(retry_delay_s)
             retry_delay_s *= RETRY_MULTIPLIER

--- a/release/e2e.py
+++ b/release/e2e.py
@@ -278,10 +278,8 @@ def exponential_backoff_retry(f, retry_exceptions, initial_retry_delay_s,
             retry_cnt += 1
             if retry_cnt > max_retries:
                 raise
-            logger.info(
-                f"Retry function call failed due to {e} "
-                f"in {retry_delay_s} seconds..."
-            )
+            logger.info(f"Retry function call failed due to {e} "
+                        f"in {retry_delay_s} seconds...")
             time.sleep(retry_delay_s)
             retry_delay_s *= RETRY_MULTIPLIER
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Add a retry helper so that we can easily retry various transient errors.

I tested it by running e2e.py locally with manually injected transient errors.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
