### PR TITLE
Revert "[runtime_env] Remove deprecated override_environment_variables and worker_env fields"

### DIFF
--- a/dashboard/modules/job/job_agent.py
+++ b/dashboard/modules/job/job_agent.py
@@ -202,9 +202,7 @@ ray.shutdown()
 
         # Per job config
         job_config_items = {
-            "runtime_env": {
-                "env_vars": self._job_info.env
-            },
+            "worker_env": self._job_info.env,
             "code_search_path": [job_package_dir],
         }
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1354,7 +1354,8 @@ cdef class CoreWorker:
                     c_bool placement_group_capture_child_tasks,
                     c_string debugger_breakpoint,
                     runtime_env_dict,
-                    runtime_env_uris
+                    runtime_env_uris,
+                    override_environment_variables
                     ):
         cdef:
             unordered_map[c_string, double] c_resources
@@ -1364,6 +1365,9 @@ cdef class CoreWorker:
                 placement_group_id.native()
             c_string c_serialized_runtime_env
             c_vector[c_string] c_runtime_env_uris = runtime_env_uris
+            unordered_map[c_string, c_string] \
+                c_override_environment_variables = \
+                override_environment_variables
             c_vector[CObjectReference] return_refs
 
         with self.profile_event(b"submit_task"):
@@ -1382,7 +1386,8 @@ cdef class CoreWorker:
                     name, num_returns, c_resources,
                     b"",
                     c_serialized_runtime_env,
-                    c_runtime_env_uris),
+                    c_runtime_env_uris,
+                    c_override_environment_variables),
                 max_retries, retry_exceptions,
                 c_pair[CPlacementGroupID, int64_t](
                     c_placement_group_id, placement_group_bundle_index),
@@ -1410,6 +1415,7 @@ cdef class CoreWorker:
                      c_string extension_data,
                      runtime_env_dict,
                      runtime_env_uris,
+                     override_environment_variables
                      ):
         cdef:
             CRayFunction ray_function
@@ -1422,6 +1428,9 @@ cdef class CoreWorker:
                 placement_group_id.native()
             c_string c_serialized_runtime_env
             c_vector[c_string] c_runtime_env_uris = runtime_env_uris
+            unordered_map[c_string, c_string] \
+                c_override_environment_variables = \
+                override_environment_variables
 
         with self.profile_event(b"submit_task"):
             c_serialized_runtime_env = \
@@ -1446,7 +1455,8 @@ cdef class CoreWorker:
                             placement_group_bundle_index),
                         placement_group_capture_child_tasks,
                         c_serialized_runtime_env,
-                        c_runtime_env_uris),
+                        c_runtime_env_uris,
+                        c_override_environment_variables),
                     extension_data,
                     &c_actor_id))
 

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -448,7 +448,8 @@ class ActorClass:
                 placement_group="default",
                 placement_group_bundle_index=-1,
                 placement_group_capture_child_tasks=None,
-                runtime_env=None):
+                runtime_env=None,
+                override_environment_variables=None):
         """Configures and overrides the actor instantiation parameters.
 
         The arguments are the same as those that can be passed
@@ -495,7 +496,9 @@ class ActorClass:
                     placement_group_bundle_index=placement_group_bundle_index,
                     placement_group_capture_child_tasks=(
                         placement_group_capture_child_tasks),
-                    runtime_env=new_runtime_env)
+                    runtime_env=new_runtime_env,
+                    override_environment_variables=(
+                        override_environment_variables))
 
         return ActorOptionWrapper()
 
@@ -518,7 +521,8 @@ class ActorClass:
                 placement_group="default",
                 placement_group_bundle_index=-1,
                 placement_group_capture_child_tasks=None,
-                runtime_env=None):
+                runtime_env=None,
+                override_environment_variables=None):
         """Create an actor.
 
         This method allows more flexibility than the remote method because
@@ -564,6 +568,9 @@ class ActorClass:
                 this actor or task and its children (see
                 :ref:`runtime-environments` for details).  This API is in beta
                 and may change before becoming stable.
+            override_environment_variables: Environment variables to override
+                and/or introduce for this actor.  This is a dictionary mapping
+                variable names to their values.
 
         Returns:
             A handle to the newly created actor.
@@ -609,7 +616,9 @@ class ActorClass:
                 placement_group_bundle_index=placement_group_bundle_index,
                 placement_group_capture_child_tasks=(
                     placement_group_capture_child_tasks),
-                runtime_env=runtime_env)
+                runtime_env=runtime_env,
+                override_environment_variables=(
+                    override_environment_variables))
 
         worker = ray.worker.global_worker
         worker.check_connected()
@@ -732,6 +741,12 @@ class ActorClass:
         runtime_env_dict = runtime_support.override_task_or_actor_runtime_env(
             runtime_env, job_runtime_env)
 
+        if override_environment_variables:
+            logger.warning("override_environment_variables is deprecated and "
+                           "will be removed in Ray 1.6.  Please use "
+                           ".options(runtime_env={'env_vars': {...}}).remote()"
+                           "instead.")
+
         actor_id = worker.core_worker.create_actor(
             meta.language,
             meta.actor_creation_function_descriptor,
@@ -751,7 +766,9 @@ class ActorClass:
             # Store actor_method_cpu in actor handle's extension data.
             extension_data=str(actor_method_cpu),
             runtime_env_dict=runtime_env_dict,
-            runtime_env_uris=runtime_env_dict.get("uris") or [])
+            runtime_env_uris=runtime_env_dict.get("uris") or [],
+            override_environment_variables=override_environment_variables
+            or dict())
 
         actor_handle = ActorHandle(
             meta.language,

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -260,7 +260,9 @@ cdef extern from "ray/core_worker/common.h" nogil:
                      unordered_map[c_string, double] &resources,
                      c_string concurrency_group_name,
                      c_string serialized_runtime_env,
-                     c_vector[c_string] runtime_env_uris)
+                     c_vector[c_string] runtime_env_uris,
+                     const unordered_map[c_string, c_string]
+                     &override_environment_variables)
 
     cdef cppclass CActorCreationOptions "ray::core::ActorCreationOptions":
         CActorCreationOptions()
@@ -276,7 +278,9 @@ cdef extern from "ray/core_worker/common.h" nogil:
             c_pair[CPlacementGroupID, int64_t] placement_options,
             c_bool placement_group_capture_child_tasks,
             c_string serialized_runtime_env,
-            c_vector[c_string] runtime_env_uris)
+            c_vector[c_string] runtime_env_uris,
+            const unordered_map[c_string, c_string]
+            &override_environment_variables)
 
     cdef cppclass CPlacementGroupCreationOptions \
             "ray::core::PlacementGroupCreationOptions":

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -149,6 +149,7 @@ class RemoteFunction:
                 placement_group_bundle_index=-1,
                 placement_group_capture_child_tasks=None,
                 runtime_env=None,
+                override_environment_variables=None,
                 name=""):
         """Configures and overrides the task invocation parameters.
 
@@ -191,6 +192,8 @@ class RemoteFunction:
                     placement_group_capture_child_tasks=(
                         placement_group_capture_child_tasks),
                     runtime_env=new_runtime_env,
+                    override_environment_variables=(
+                        override_environment_variables),
                     name=name)
 
         return FuncWrapper()
@@ -212,6 +215,7 @@ class RemoteFunction:
                 placement_group_bundle_index=-1,
                 placement_group_capture_child_tasks=None,
                 runtime_env=None,
+                override_environment_variables=None,
                 name=""):
         """Submit the remote function for execution."""
 
@@ -234,6 +238,7 @@ class RemoteFunction:
                 placement_group_capture_child_tasks=(
                     placement_group_capture_child_tasks),
                 runtime_env=runtime_env,
+                override_environment_variables=override_environment_variables,
                 name=name)
 
         worker = ray.worker.global_worker
@@ -299,6 +304,12 @@ class RemoteFunction:
         runtime_env_dict = runtime_support.override_task_or_actor_runtime_env(
             runtime_env, job_runtime_env)
 
+        if override_environment_variables:
+            logger.warning("override_environment_variables is deprecated and "
+                           "will be removed in Ray 1.6.  Please use "
+                           ".options(runtime_env={'env_vars': {...}}).remote()"
+                           "instead.")
+
         def invocation(args, kwargs):
             if self._is_cross_language:
                 list_args = cross_language.format_args(worker, args, kwargs)
@@ -313,12 +324,22 @@ class RemoteFunction:
                     "Cross language remote function " \
                     "cannot be executed locally."
             object_refs = worker.core_worker.submit_task(
-                self._language, self._function_descriptor, list_args, name,
-                num_returns, resources, max_retries, retry_exceptions,
-                placement_group.id, placement_group_bundle_index,
+                self._language,
+                self._function_descriptor,
+                list_args,
+                name,
+                num_returns,
+                resources,
+                max_retries,
+                retry_exceptions,
+                placement_group.id,
+                placement_group_bundle_index,
                 placement_group_capture_child_tasks,
-                worker.debugger_breakpoint, runtime_env_dict,
-                runtime_env_dict.get("uris") or [])
+                worker.debugger_breakpoint,
+                runtime_env_dict,
+                runtime_env_dict.get("uris") or [],
+                override_environment_variables=override_environment_variables
+                or dict())
             # Reset worker's debug context from the last "remote" command
             # (which applies only to this .remote call).
             worker.debugger_breakpoint = b""

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -253,10 +253,7 @@ def test_prepare_runtime_init_req_no_modification():
     """
     Check that `prepare_runtime_init_req` properly extracts the JobConfig.
     """
-    job_config = JobConfig(
-        runtime_env={"env_vars": {
-            "KEY": "VALUE"
-        }}, ray_namespace="abc")
+    job_config = JobConfig(worker_env={"KEY": "VALUE"}, ray_namespace="abc")
     init_req = ray_client_pb2.DataRequest(
         init=ray_client_pb2.InitRequest(
             job_config=pickle.dumps(job_config),
@@ -276,10 +273,7 @@ def test_prepare_runtime_init_req_modified_job():
     Check that `prepare_runtime_init_req` properly extracts the JobConfig and
     modifies it according to `ray_client_server_env_prep`.
     """
-    job_config = JobConfig(
-        runtime_env={"env_vars": {
-            "KEY": "VALUE"
-        }}, ray_namespace="abc")
+    job_config = JobConfig(worker_env={"KEY": "VALUE"}, ray_namespace="abc")
     init_req = ray_client_pb2.DataRequest(
         init=ray_client_pb2.InitRequest(
             job_config=pickle.dumps(job_config),

--- a/python/ray/tests/test_multi_tenancy.py
+++ b/python/ray/tests/test_multi_tenancy.py
@@ -111,13 +111,12 @@ ray.shutdown()
                     all_worker_pids.add(worker_pid)
 
 
-def test_runtime_env(shutdown_only):
+def test_worker_env(shutdown_only):
     ray.init(
-        job_config=ray.job_config.JobConfig(
-            runtime_env={"env_vars": {
-                "foo1": "bar1",
-                "foo2": "bar2"
-            }}))
+        job_config=ray.job_config.JobConfig(worker_env={
+            "foo1": "bar1",
+            "foo2": "bar2"
+        }))
 
     @ray.remote
     def get_env(key):

--- a/python/ray/tests/test_runtime_env_env_vars.py
+++ b/python/ray/tests/test_runtime_env_env_vars.py
@@ -7,37 +7,54 @@ import pytest
 import ray
 
 
-def test_environment_variables_task(ray_start_regular):
+@pytest.mark.parametrize("use_runtime_env", [True, False])
+def test_override_environment_variables_task(ray_start_regular,
+                                             use_runtime_env):
     @ray.remote
     def get_env(key):
         return os.environ.get(key)
 
-    assert (ray.get(
-        get_env.options(runtime_env={
-            "env_vars": {
+    if use_runtime_env:
+        assert (ray.get(
+            get_env.options(runtime_env={
+                "env_vars": {
+                    "a": "b",
+                }
+            }).remote("a")) == "b")
+    else:
+        assert (ray.get(
+            get_env.options(override_environment_variables={
                 "a": "b",
-            }
-        }).remote("a")) == "b")
+            }).remote("a")) == "b")
 
 
-def test_environment_variables_actor(ray_start_regular):
+@pytest.mark.parametrize("use_runtime_env", [True, False])
+def test_override_environment_variables_actor(ray_start_regular,
+                                              use_runtime_env):
     @ray.remote
     class EnvGetter:
         def get(self, key):
             return os.environ.get(key)
 
-    a = EnvGetter.options(runtime_env={
-        "env_vars": {
+    if use_runtime_env:
+        a = EnvGetter.options(runtime_env={
+            "env_vars": {
+                "a": "b",
+                "c": "d",
+            }
+        }).remote()
+    else:
+        a = EnvGetter.options(override_environment_variables={
             "a": "b",
             "c": "d",
-        }
-    }).remote()
-
+        }).remote()
     assert (ray.get(a.get.remote("a")) == "b")
     assert (ray.get(a.get.remote("c")) == "d")
 
 
-def test_environment_variables_nested_task(ray_start_regular):
+@pytest.mark.parametrize("use_runtime_env", [True, False])
+def test_override_environment_variables_nested_task(ray_start_regular,
+                                                    use_runtime_env):
     @ray.remote
     def get_env(key):
         return os.environ.get(key)
@@ -46,19 +63,36 @@ def test_environment_variables_nested_task(ray_start_regular):
     def get_env_wrapper(key):
         return ray.get(get_env.remote(key))
 
-    assert (ray.get(
-        get_env_wrapper.options(runtime_env={
-            "env_vars": {
+    if use_runtime_env:
+        assert (ray.get(
+            get_env_wrapper.options(runtime_env={
+                "env_vars": {
+                    "a": "b",
+                }
+            }).remote("a")) == "b")
+    else:
+        assert (ray.get(
+            get_env_wrapper.options(override_environment_variables={
                 "a": "b",
-            }
-        }).remote("a")) == "b")
+            }).remote("a")) == "b")
 
 
-def test_environment_variables_multitenancy(shutdown_only):
-    ray.init(runtime_env={"env_vars": {
-        "foo1": "bar1",
-        "foo2": "bar2",
-    }})
+@pytest.mark.parametrize("use_runtime_env", [True, False])
+def test_override_environment_variables_multitenancy(shutdown_only,
+                                                     use_runtime_env):
+    if use_runtime_env:
+        ray.init(
+            job_config=ray.job_config.JobConfig(
+                runtime_env={"env_vars": {
+                    "foo1": "bar1",
+                    "foo2": "bar2",
+                }}))
+    else:
+        ray.init(
+            job_config=ray.job_config.JobConfig(worker_env={
+                "foo1": "bar1",
+                "foo2": "bar2",
+            }))
 
     @ray.remote
     def get_env(key):
@@ -66,27 +100,48 @@ def test_environment_variables_multitenancy(shutdown_only):
 
     assert ray.get(get_env.remote("foo1")) == "bar1"
     assert ray.get(get_env.remote("foo2")) == "bar2"
-    assert ray.get(
-        get_env.options(runtime_env={
-            "env_vars": {
+    if use_runtime_env:
+        assert ray.get(
+            get_env.options(runtime_env={
+                "env_vars": {
+                    "foo1": "baz1",
+                }
+            }).remote("foo1")) == "baz1"
+        assert ray.get(
+            get_env.options(runtime_env={
+                "env_vars": {
+                    "foo1": "baz1",
+                }
+            }).remote("foo2")) == "bar2"
+    else:
+        assert ray.get(
+            get_env.options(override_environment_variables={
                 "foo1": "baz1",
-            }
-        }).remote("foo1")) == "baz1"
-    assert ray.get(
-        get_env.options(runtime_env={
-            "env_vars": {
+            }).remote("foo1")) == "baz1"
+        assert ray.get(
+            get_env.options(override_environment_variables={
                 "foo1": "baz1",
-            }
-        }).remote("foo2")) == "bar2"
+            }).remote("foo2")) == "bar2"
 
 
-def test_environment_variables_complex(shutdown_only):
-    ray.init(
-        runtime_env={"env_vars": {
-            "a": "job_a",
-            "b": "job_b",
-            "z": "job_z",
-        }})
+@pytest.mark.parametrize("use_runtime_env", [True, False])
+def test_override_environment_variables_complex(shutdown_only,
+                                                use_runtime_env):
+    if use_runtime_env:
+        ray.init(runtime_env={
+            "env_vars": {
+                "a": "job_a",
+                "b": "job_b",
+                "z": "job_z",
+            }
+        })
+    else:
+        ray.init(
+            job_config=ray.job_config.JobConfig(worker_env={
+                "a": "job_a",
+                "b": "job_b",
+                "z": "job_z",
+            }))
 
     @ray.remote
     def get_env(key):
@@ -109,45 +164,69 @@ def test_environment_variables_complex(shutdown_only):
             return ray.get(get_env.remote(key))
 
         def nested_get(self, key):
-            aa = NestedEnvGetter.options(runtime_env={
-                "env_vars": {
+            if use_runtime_env:
+                aa = NestedEnvGetter.options(runtime_env={
+                    "env_vars": {
+                        "c": "e",
+                        "d": "dd",
+                    }
+                }).remote()
+            else:
+                aa = NestedEnvGetter.options(override_environment_variables={
                     "c": "e",
                     "d": "dd",
-                }
-            }).remote()
+                }).remote()
             return ray.get(aa.get.remote(key))
 
-    a = EnvGetter.options(runtime_env={
-        "env_vars": {
+    if use_runtime_env:
+        a = EnvGetter.options(runtime_env={
+            "env_vars": {
+                "a": "b",
+                "c": "d",
+            }
+        }).remote()
+    else:
+        a = EnvGetter.options(override_environment_variables={
             "a": "b",
             "c": "d",
-        }
-    }).remote()
-
+        }).remote()
     assert (ray.get(a.get.remote("a")) == "b")
     assert (ray.get(a.get_task.remote("a")) == "b")
     assert (ray.get(a.nested_get.remote("a")) == "b")
     assert (ray.get(a.nested_get.remote("c")) == "e")
     assert (ray.get(a.nested_get.remote("d")) == "dd")
-    assert (ray.get(
-        get_env.options(runtime_env={
-            "env_vars": {
+    if use_runtime_env:
+        assert (ray.get(
+            get_env.options(runtime_env={
+                "env_vars": {
+                    "a": "b",
+                }
+            }).remote("a")) == "b")
+    else:
+        assert (ray.get(
+            get_env.options(override_environment_variables={
                 "a": "b",
-            }
-        }).remote("a")) == "b")
+            }).remote("a")) == "b")
 
     assert (ray.get(a.get.remote("z")) == "job_z")
     assert (ray.get(a.get_task.remote("z")) == "job_z")
     assert (ray.get(a.nested_get.remote("z")) == "job_z")
-    assert (ray.get(
-        get_env.options(runtime_env={
-            "env_vars": {
+    if use_runtime_env:
+        assert (ray.get(
+            get_env.options(runtime_env={
+                "env_vars": {
+                    "a": "b",
+                }
+            }).remote("z")) == "job_z")
+    else:
+        assert (ray.get(
+            get_env.options(override_environment_variables={
                 "a": "b",
-            }
-        }).remote("z")) == "job_z")
+            }).remote("z")) == "job_z")
 
 
-def test_environment_variables_reuse(shutdown_only):
+@pytest.mark.parametrize("use_runtime_env", [True, False])
+def test_override_environment_variables_reuse(shutdown_only, use_runtime_env):
     """Test that new tasks don't incorrectly reuse previous environments."""
     ray.init()
 
@@ -165,20 +244,32 @@ def test_environment_variables_reuse(shutdown_only):
         return os.environ.get(env_var_name)
 
     assert ray.get(f.remote()) is None
-    assert ray.get(
-        f.options(runtime_env={
-            "env_vars": {
+    if use_runtime_env:
+        assert ray.get(
+            f.options(runtime_env={
+                "env_vars": {
+                    env_var_name: val1
+                }
+            }).remote()) == val1
+    else:
+        assert ray.get(
+            f.options(override_environment_variables={
                 env_var_name: val1
-            }
-        }).remote()) == val1
+            }).remote()) == val1
     assert ray.get(f.remote()) is None
     assert ray.get(g.remote()) is None
-    assert ray.get(
-        f.options(runtime_env={
-            "env_vars": {
+    if use_runtime_env:
+        assert ray.get(
+            f.options(runtime_env={
+                "env_vars": {
+                    env_var_name: val2
+                }
+            }).remote()) == val2
+    else:
+        assert ray.get(
+            f.options(override_environment_variables={
                 env_var_name: val2
-            }
-        }).remote()) == val2
+            }).remote()) == val2
     assert ray.get(g.remote()) is None
     assert ray.get(f.remote()) is None
 
@@ -187,7 +278,9 @@ def test_environment_variables_reuse(shutdown_only):
 # there aren't enough CPUs (2-4 on Travis CI vs. likely 8 on Buildkite) and
 # worker processes are being killed to adhere to the soft limit.
 @pytest.mark.skipif(sys.platform == "darwin", reason="Flaky on Travis CI.")
-def test_environment_variables_env_caching(shutdown_only):
+@pytest.mark.parametrize("use_runtime_env", [True, False])
+def test_override_environment_variables_env_caching(shutdown_only,
+                                                    use_runtime_env):
     """Test that workers with specified envs are cached and reused.
 
     When a new task or actor is created with a new runtime env, a
@@ -214,7 +307,10 @@ def test_environment_variables_env_caching(shutdown_only):
         return task()
 
     def get_options(val):
-        return {"runtime_env": {"env_vars": {env_var_name: val}}}
+        if use_runtime_env:
+            return {"override_environment_variables": {env_var_name: val}}
+        else:
+            return {"runtime_env": {"env_vars": {env_var_name: val}}}
 
     # Empty runtime env does not set our env var.
     assert ray.get(f.remote())[0] is None

--- a/python/ray/util/client/options.py
+++ b/python/ray/util/client/options.py
@@ -36,6 +36,7 @@ options = {
     "placement_group_bundle_index": (),
     "placement_group_capture_child_tasks": (),
     "runtime_env": (),
+    "override_environment_variables": (),
 }
 
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2098,6 +2098,15 @@ def remote(*args, **kwargs):
         retry_exceptions (bool): Only for *remote functions*. This specifies
             whether application-level errors should be retried
             up to max_retries times.
+        override_environment_variables (Dict[str, str]): (Deprecated in Ray
+            1.4.0, will be removed in Ray 1.6--please use the ``env_vars``
+            field of :ref:`runtime-environments` instead.) This specifies
+            environment variables to override for the actor or task.  The
+            overrides are propagated to all child actors and tasks.  This
+            is a dictionary mapping variable names to their values.  Existing
+            variables can be overridden, new ones can be created, and an
+            existing variable can be unset by setting it to an empty string.
+            Note: can only be set via `.options()`.
     """
     worker = global_worker
 

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -172,6 +172,8 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
 
   std::string GetDebuggerBreakpoint() const;
 
+  std::unordered_map<std::string, std::string> OverrideEnvironmentVariables() const;
+
   bool IsDriverTask() const;
 
   Language GetLanguage() const;
@@ -275,10 +277,13 @@ class WorkerCacheKey {
   /// Create a cache key with the given environment variable overrides and serialized
   /// runtime_env.
   ///
+  /// \param override_environment_variables The environment variable overrides set in this
   /// worker. \param serialized_runtime_env The JSON-serialized runtime env for this
   /// worker. \param required_resources The required resouce.
-  WorkerCacheKey(const std::string serialized_runtime_env,
-                 const std::unordered_map<std::string, double> required_resources);
+  WorkerCacheKey(
+      const std::unordered_map<std::string, std::string> override_environment_variables,
+      const std::string serialized_runtime_env,
+      const std::unordered_map<std::string, double> required_resources);
 
   bool operator==(const WorkerCacheKey &k) const;
 
@@ -290,7 +295,8 @@ class WorkerCacheKey {
 
   /// Get the hash for this worker's environment.
   ///
-  /// \return The hash of the serialized runtime_env.
+  /// \return The hash of the override_environment_variables and the serialized
+  /// runtime_env.
   std::size_t Hash() const;
 
   /// Get the int-valued hash for this worker's environment, useful for portability in
@@ -300,6 +306,8 @@ class WorkerCacheKey {
   int IntHash() const;
 
  private:
+  /// The environment variable overrides for this worker.
+  const std::unordered_map<std::string, std::string> override_environment_variables;
   /// The JSON-serialized runtime env for this worker.
   const std::string serialized_runtime_env;
   /// The required resources for this worker.

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -107,6 +107,8 @@ class TaskSpecBuilder {
       const std::string &debugger_breakpoint,
       const std::string &serialized_runtime_env = "{}",
       const std::vector<std::string> &runtime_env_uris = {},
+      const std::unordered_map<std::string, std::string> &override_environment_variables =
+          {},
       const std::string &concurrency_group_name = "") {
     message_->set_type(TaskType::NORMAL_TASK);
     message_->set_name(name);
@@ -133,6 +135,9 @@ class TaskSpecBuilder {
       message_->mutable_runtime_env()->add_uris(uri);
     }
     message_->set_concurrency_group_name(concurrency_group_name);
+    for (const auto &env : override_environment_variables) {
+      (*message_->mutable_override_environment_variables())[env.first] = env.second;
+    }
     return *this;
   }
 

--- a/src/ray/core_worker/common.h
+++ b/src/ray/core_worker/common.h
@@ -60,13 +60,16 @@ struct TaskOptions {
               std::unordered_map<std::string, double> &resources,
               const std::string &concurrency_group_name = "",
               const std::string &serialized_runtime_env = "{}",
-              const std::vector<std::string> &runtime_env_uris = {})
+              const std::vector<std::string> &runtime_env_uris = {},
+              const std::unordered_map<std::string, std::string>
+                  &override_environment_variables = {})
       : name(name),
         num_returns(num_returns),
         resources(resources),
         concurrency_group_name(concurrency_group_name),
         serialized_runtime_env(serialized_runtime_env),
-        runtime_env_uris(runtime_env_uris) {}
+        runtime_env_uris(runtime_env_uris),
+        override_environment_variables(override_environment_variables) {}
 
   /// The name of this task.
   std::string name;
@@ -80,6 +83,10 @@ struct TaskOptions {
   std::string serialized_runtime_env;
   // URIs contained in the runtime_env.
   std::vector<std::string> runtime_env_uris;
+  /// Environment variables to update for this task.  Maps a variable name to its
+  /// value.  Can override existing environment variables and introduce new ones.
+  /// Propagated to child actors and/or tasks.
+  const std::unordered_map<std::string, std::string> override_environment_variables;
 };
 
 /// Options for actor creation tasks.
@@ -95,6 +102,8 @@ struct ActorCreationOptions {
       bool placement_group_capture_child_tasks = true,
       const std::string &serialized_runtime_env = "{}",
       const std::vector<std::string> &runtime_env_uris = {},
+      const std::unordered_map<std::string, std::string> &override_environment_variables =
+          {},
       const std::vector<ConcurrencyGroup> &concurrency_groups = {})
       : max_restarts(max_restarts),
         max_task_retries(max_task_retries),
@@ -110,6 +119,7 @@ struct ActorCreationOptions {
         placement_group_capture_child_tasks(placement_group_capture_child_tasks),
         serialized_runtime_env(serialized_runtime_env),
         runtime_env_uris(runtime_env_uris),
+        override_environment_variables(override_environment_variables),
         concurrency_groups(concurrency_groups.begin(), concurrency_groups.end()){};
 
   /// Maximum number of times that the actor should be restarted if it dies
@@ -153,6 +163,10 @@ struct ActorCreationOptions {
   std::string serialized_runtime_env;
   // URIs contained in the runtime_env.
   std::vector<std::string> runtime_env_uris;
+  /// Environment variables to update for this actor.  Maps a variable name to its
+  /// value.  Can override existing environment variables and introduce new ones.
+  /// Propagated to child actors and/or tasks.
+  const std::unordered_map<std::string, std::string> override_environment_variables;
   /// The actor concurrency groups to indicate how this actor perform its
   /// methods concurrently.
   const std::vector<ConcurrencyGroup> concurrency_groups;

--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -171,6 +171,11 @@ const std::string &WorkerContext::GetCurrentSerializedRuntimeEnv() const {
   return runtime_env_.serialized_runtime_env();
 }
 
+const std::unordered_map<std::string, std::string>
+    &WorkerContext::GetCurrentOverrideEnvironmentVariables() const {
+  return override_environment_variables_;
+}
+
 void WorkerContext::SetCurrentTaskId(const TaskID &task_id) {
   GetThreadContext().SetCurrentTaskId(task_id);
 }
@@ -184,6 +189,7 @@ void WorkerContext::SetCurrentTask(const TaskSpecification &task_spec) {
     // only set runtime_env_ once and then RAY_CHECK that we
     // never see a new one.
     runtime_env_ = task_spec.RuntimeEnv();
+    override_environment_variables_ = task_spec.OverrideEnvironmentVariables();
   } else if (task_spec.IsActorCreationTask()) {
     RAY_CHECK(current_actor_id_.IsNil());
     current_actor_id_ = task_spec.ActorCreationId();
@@ -194,6 +200,7 @@ void WorkerContext::SetCurrentTask(const TaskSpecification &task_spec) {
     current_actor_placement_group_id_ = task_spec.PlacementGroupBundleId().first;
     placement_group_capture_child_tasks_ = task_spec.PlacementGroupCaptureChildTasks();
     runtime_env_ = task_spec.RuntimeEnv();
+    override_environment_variables_ = task_spec.OverrideEnvironmentVariables();
   } else if (task_spec.IsActorTask()) {
     RAY_CHECK(current_actor_id_ == task_spec.ActorId());
   } else {

--- a/src/ray/core_worker/context.h
+++ b/src/ray/core_worker/context.h
@@ -42,6 +42,9 @@ class WorkerContext {
 
   const std::string &GetCurrentSerializedRuntimeEnv() const;
 
+  const std::unordered_map<std::string, std::string>
+      &GetCurrentOverrideEnvironmentVariables() const;
+
   // TODO(edoakes): remove this once Python core worker uses the task interfaces.
   void SetCurrentTaskId(const TaskID &task_id);
 
@@ -97,6 +100,8 @@ class WorkerContext {
   bool placement_group_capture_child_tasks_;
   // The runtime env for the current actor or task.
   rpc::RuntimeEnv runtime_env_;
+  // The environment variable overrides for the current actor or task.
+  std::unordered_map<std::string, std::string> override_environment_variables_;
   /// The id of the (main) thread that constructed this worker context.
   boost::thread::id main_thread_id_;
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -41,6 +41,7 @@ void BuildCommonTaskSpec(
     const BundleID &bundle_id, bool placement_group_capture_child_tasks,
     const std::string debugger_breakpoint, const std::string &serialized_runtime_env,
     const std::vector<std::string> &runtime_env_uris,
+    const std::unordered_map<std::string, std::string> &override_environment_variables,
     const std::string &concurrency_group_name = "") {
   // Build common task spec.
   builder.SetCommonTaskSpec(
@@ -48,7 +49,7 @@ void BuildCommonTaskSpec(
       current_task_id, task_index, caller_id, address, num_returns, required_resources,
       required_placement_resources, bundle_id, placement_group_capture_child_tasks,
       debugger_breakpoint, serialized_runtime_env, runtime_env_uris,
-      concurrency_group_name);
+      override_environment_variables, concurrency_group_name);
   // Set task arguments.
   for (const auto &arg : args) {
     builder.AddArg(*arg);
@@ -1662,13 +1663,22 @@ std::vector<rpc::ObjectReference> CoreWorker::SubmitTask(
   auto task_name = task_options.name.empty()
                        ? function.GetFunctionDescriptor()->DefaultTaskName()
                        : task_options.name;
+  // Propagate existing environment variable overrides, but override them with any new
+  // ones
+  std::unordered_map<std::string, std::string> current_override_environment_variables =
+      worker_context_.GetCurrentOverrideEnvironmentVariables();
+  std::unordered_map<std::string, std::string> override_environment_variables =
+      task_options.override_environment_variables;
+  override_environment_variables.insert(current_override_environment_variables.begin(),
+                                        current_override_environment_variables.end());
   // TODO(ekl) offload task building onto a thread pool for performance
   BuildCommonTaskSpec(builder, worker_context_.GetCurrentJobID(), task_id, task_name,
                       worker_context_.GetCurrentTaskID(), next_task_index, GetCallerId(),
                       rpc_address_, function, args, task_options.num_returns,
                       constrained_resources, required_resources, placement_options,
                       placement_group_capture_child_tasks, debugger_breakpoint,
-                      task_options.serialized_runtime_env, task_options.runtime_env_uris);
+                      task_options.serialized_runtime_env, task_options.runtime_env_uris,
+                      override_environment_variables);
   builder.SetNormalTaskSpec(max_retries, retry_exceptions);
   TaskSpecification task_spec = builder.Build();
   RAY_LOG(DEBUG) << "Submit task " << task_spec.DebugString();
@@ -1704,7 +1714,12 @@ Status CoreWorker::CreateActor(const RayFunction &function,
   const JobID job_id = worker_context_.GetCurrentJobID();
   // Propagate existing environment variable overrides, but override them with any new
   // ones
-  std::vector<ObjectID> return_ids;
+  std::unordered_map<std::string, std::string> current_override_environment_variables =
+      worker_context_.GetCurrentOverrideEnvironmentVariables();
+  std::unordered_map<std::string, std::string> override_environment_variables =
+      actor_creation_options.override_environment_variables;
+  override_environment_variables.insert(current_override_environment_variables.begin(),
+                                        current_override_environment_variables.end());
   TaskSpecBuilder builder;
   auto new_placement_resources =
       AddPlacementGroupConstraint(actor_creation_options.placement_resources,
@@ -1725,7 +1740,8 @@ Status CoreWorker::CreateActor(const RayFunction &function,
                       actor_creation_options.placement_group_capture_child_tasks,
                       "", /* debugger_breakpoint */
                       actor_creation_options.serialized_runtime_env,
-                      actor_creation_options.runtime_env_uris);
+                      actor_creation_options.runtime_env_uris,
+                      override_environment_variables);
 
   auto actor_handle = std::make_unique<ActorHandle>(
       actor_id, GetCallerId(), rpc_address_, job_id,
@@ -1902,6 +1918,7 @@ std::vector<rpc::ObjectReference> CoreWorker::SubmitActorTask(
   const auto task_name = task_options.name.empty()
                              ? function.GetFunctionDescriptor()->DefaultTaskName()
                              : task_options.name;
+  const std::unordered_map<std::string, std::string> override_environment_variables = {};
   BuildCommonTaskSpec(builder, actor_handle->CreationJobID(), actor_task_id, task_name,
                       worker_context_.GetCurrentTaskID(), next_task_index, GetCallerId(),
                       rpc_address_, function, args, num_returns, task_options.resources,
@@ -1910,6 +1927,7 @@ std::vector<rpc::ObjectReference> CoreWorker::SubmitActorTask(
                       "",   /* debugger_breakpoint */
                       "{}", /* serialized_runtime_env */
                       {},   /* runtime_env_uris */
+                      override_environment_variables,
                       task_options.concurrency_group_name);
   // NOTE: placement_group_capture_child_tasks and runtime_env will
   // be ignored in the actor because we should always follow the actor's option.

--- a/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskSubmitter.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskSubmitter.cc
@@ -238,6 +238,7 @@ inline ActorCreationOptions ToActorCreationOptions(JNIEnv *env,
       /*placement_group_capture_child_tasks=*/true,
       /*serialized_runtime_env=*/"{}",
       /*runtime_env_uris=*/{},
+      /*override_environment_variables=*/{},
       concurrency_groups};
   return actor_creation_options;
 }

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -210,19 +210,21 @@ message TaskSpec {
   int64 placement_group_bundle_index = 19;
   // Whether or not this task should capture parent's placement group automatically.
   bool placement_group_capture_child_tasks = 20;
+  // Environment variables to override for this task
+  map<string, string> override_environment_variables = 21;
   // Whether or not to skip the execution of this task. When it's true,
   // the receiver will not execute the task. This field is used by async actors
   // to guarantee task submission order after restart.
-  bool skip_execution = 21;
+  bool skip_execution = 22;
   // Breakpoint if this task should drop into the debugger when it starts executing
   // and "" if the task should not drop into the debugger.
-  bytes debugger_breakpoint = 22;
+  bytes debugger_breakpoint = 23;
   // Runtime environment for this task.
-  RuntimeEnv runtime_env = 23;
+  RuntimeEnv runtime_env = 24;
   // The concurrency group name in which this task will be performed.
-  string concurrency_group_name = 24;
+  string concurrency_group_name = 25;
   // Whether application-level errors (exceptions) should be retried.
-  bool retry_exceptions = 25;
+  bool retry_exceptions = 26;
 }
 
 message Bundle {

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -278,8 +278,6 @@ message TaskLeaseData {
 
 message JobConfig {
   // Environment variables to be set on worker processes.
-  // TODO(edoakes): this is only used by Java. Once Java moves to runtime_env we
-  // should remove worker_env.
   map<string, string> worker_env = 1;
   // The number of java workers per worker process.
   uint32 num_java_workers_per_process = 2;

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -48,7 +48,8 @@ class MockWorkerPool : public WorkerPoolInterface {
   void PopWorker(const TaskSpecification &task_spec, const PopWorkerCallback &callback,
                  const std::string &allocated_instances_serialized_json) {
     num_pops++;
-    const WorkerCacheKey env = {task_spec.SerializedRuntimeEnv(), {}};
+    const WorkerCacheKey env = {
+        task_spec.OverrideEnvironmentVariables(), task_spec.SerializedRuntimeEnv(), {}};
     const int runtime_env_hash = env.IntHash();
     callbacks[runtime_env_hash].push_back(callback);
   }
@@ -379,7 +380,8 @@ TEST_F(ClusterTaskManagerTest, DispatchQueueNonBlockingTest) {
   pool_.TriggerCallbacks();
 
   // Push a worker that can only run task A.
-  const WorkerCacheKey env_A = {serialized_runtime_env_A, {}};
+  const WorkerCacheKey env_A = {
+      /*override_environment_variables=*/{}, serialized_runtime_env_A, {}};
   const int runtime_env_hash_A = env_A.IntHash();
   std::shared_ptr<MockWorker> worker_A =
       std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234, runtime_env_hash_A);

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -176,6 +176,7 @@ Process WorkerPool::StartWorkerProcess(
     const Language &language, const rpc::WorkerType worker_type, const JobID &job_id,
     PopWorkerStatus *status, const std::vector<std::string> &dynamic_options,
     const int runtime_env_hash, const std::string &serialized_runtime_env,
+    std::unordered_map<std::string, std::string> override_environment_variables,
     const std::string &serialized_runtime_env_context,
     const std::string &allocated_instances_serialized_json) {
   rpc::JobConfig *job_config = nullptr;
@@ -312,11 +313,12 @@ Process WorkerPool::StartWorkerProcess(
     // need to add a new CLI parameter for both Python and Java workers.
     env.emplace(kEnvVarKeyJobId, job_id.Hex());
   }
-
-  // TODO(edoakes): this is only used by Java. Once Java moves to runtime_env we
-  // should remove worker_env.
   if (job_config) {
     env.insert(job_config->worker_env().begin(), job_config->worker_env().end());
+  }
+
+  for (const auto &pair : override_environment_variables) {
+    env[pair.first] = pair.second;
   }
 
   if (language == Language::PYTHON) {
@@ -934,7 +936,8 @@ void WorkerPool::PopWorker(const TaskSpecification &task_spec,
     Process proc = StartWorkerProcess(
         task_spec.GetLanguage(), rpc::WorkerType::WORKER, task_spec.JobId(), &status,
         dynamic_options, task_spec.GetRuntimeEnvHash(), serialized_runtime_env,
-        serialized_runtime_env_context, allocated_instances_serialized_json);
+        task_spec.OverrideEnvironmentVariables(), serialized_runtime_env_context,
+        allocated_instances_serialized_json);
     if (status == PopWorkerStatus::OK) {
       RAY_CHECK(proc.IsValid());
       WarnAboutSize();
@@ -1064,7 +1067,7 @@ void WorkerPool::PrestartWorkers(const TaskSpecification &task_spec, int64_t bac
                                  int64_t num_available_cpus) {
   // Code path of task that needs a dedicated worker.
   if ((task_spec.IsActorCreationTask() && !task_spec.DynamicWorkerOptions().empty()) ||
-      task_spec.HasRuntimeEnv()) {
+      task_spec.OverrideEnvironmentVariables().size() > 0 || task_spec.HasRuntimeEnv()) {
     return;  // Not handled.
     // TODO(architkulkarni): We'd eventually like to prestart workers with the same
     // runtime env to improve initial startup performance.

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -397,6 +397,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
       PopWorkerStatus *status /*output*/,
       const std::vector<std::string> &dynamic_options = {},
       const int runtime_env_hash = 0, const std::string &serialized_runtime_env = "{}",
+      std::unordered_map<std::string, std::string> override_environment_variables = {},
       const std::string &serialized_runtime_env_context = "{}",
       const std::string &allocated_instances_serialized_json = "{}");
 

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -1258,7 +1258,8 @@ TEST_F(WorkerPoolTest, CacheWorkersByRuntimeEnvHash) {
       ActorID::Nil(), Language::PYTHON, JOB_ID, ActorID::Nil(),
       /*dynamic_options=*/{}, TaskID::ForFakeTask(), "mock_runtime_env_2");
 
-  const WorkerCacheKey env1 = {"mock_runtime_env_1", {}};
+  const WorkerCacheKey env1 = {
+      /*override_environment_variables=*/{}, "mock_runtime_env_1", {}};
   const int runtime_env_hash_1 = env1.IntHash();
 
   // Push worker with runtime env 1.


### PR DESCRIPTION
Reverts ray-project/ray#18213

windows://python/ray/tests:test_multi_tenancy keeps failing after this PR 