### PR TITLE
[Test] increase time limit for object transfer

### DIFF
--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -647,7 +647,8 @@ def test_maximize_concurrent_pull_race_condition(ray_start_cluster_head):
     start = time.time()
     ray.get(remote_tasks)
     end = time.time()
-    assert end - start < 10, "Too much time spent in pulling objects, " \
+    # end - start would be greater than 20 if there is a retry.
+    assert end - start < 19, "Too much time spent in pulling objects, " \
                              "check the amount of time in retries"
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We saw test failures due to transferring 20 * 8MB objects taking 11s instead of 10s. Increasing the time limit to avoid flakiness. The new time limit (19s) is still less than the minimum time (20s) if a pull retry during object transfer happens, which is the test's goal.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
