### PR TITLE
Rename Dataset.pipeline to Dataset.window

### DIFF
--- a/doc/source/data/dataset-pipeline.rst
+++ b/doc/source/data/dataset-pipeline.rst
@@ -13,6 +13,10 @@ Creating a DatasetPipeline
 
 A DatasetPipeline can be constructed in two ways: either by pipelining the execution of an existing Dataset (via ``Dataset.window``), or generating repeats of an existing Dataset (via ``Dataset.repeat``). Similar to Datasets, you can freely pass DatasetPipelines between Ray tasks, actors, and libraries. Get started with this synthetic data example:
 
+.. tip::
+
+  The "window size" of a pipeline is defined as the number of blocks per Dataset in the pipeline.
+
 .. code-block:: python
 
     import ray
@@ -52,7 +56,6 @@ A DatasetPipeline can be constructed in two ways: either by pipelining the execu
     # Stage 3:  35%|████████████████                         | 8/20 [00:02<00:02,  5.33it/s]
     print("Total num rows", num_rows)
     # -> Total num rows 1000000
-
 
 You can also create a DatasetPipeline from a custom iterator over dataset creators using ``DatasetPipeline.from_iterable``. For example, this is how you would implement ``Dataset.repeat`` and ``Dataset.window`` using ``from_iterable``:
 

--- a/doc/source/data/dataset-pipeline.rst
+++ b/doc/source/data/dataset-pipeline.rst
@@ -67,7 +67,7 @@ You can also create a DatasetPipeline from a custom iterator over dataset creato
         [lambda: source, lambda: source, lambda: source, lambda: source])
 
     # Equivalent to ray.data.range(1000).window(blocks_per_window=10)
-    splits = ray.data.range(1000, blocks_per_window=200).split(20)
+    splits = ray.data.range(1000, parallelism=200).split(20)
     pipe = DatasetPipeline.from_iterable([lambda s=s: s for s in splits])
 
 

--- a/doc/source/raysgd/v2/user_guide.rst
+++ b/doc/source/raysgd/v2/user_guide.rst
@@ -638,7 +638,7 @@ Underneath the hood, RaySGD will automatically shard the given dataset.
         return model
 
     trainer = Trainer(num_workers=8, backend="torch")
-    dataset = ray.data.read_csv("...").filter().pipeline(length=50)
+    dataset = ray.data.read_csv("...").filter().window(blocks_per_window=50)
 
     result = trainer.run(
         train_func,
@@ -741,7 +741,7 @@ A couple caveats:
 
     # Declare the specification for training.
     trainer = Trainer(backend="torch", num_workers=12, use_gpu=True)
-    dataset = ray.dataset.pipeline()
+    dataset = ray.dataset.window()
 
     # Convert this to a trainable.
     trainable = trainer.to_tune_trainable(training_func, dataset=dataset)

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -241,10 +241,10 @@ class DatasetPipeline(Generic[T]):
         ]
 
     def window(self, *, blocks_per_window: int) -> "DatasetPipeline[T]":
-        """Change the windowing of this pipeline.
+        """Change the windowing (blocks per dataset) of this pipeline.
 
         Changes the windowing of this pipeline to the specified size. For
-        example, if the current pipeline has two blocks per datasets, and
+        example, if the current pipeline has two blocks per dataset, and
         `.window(4)` is requested, adjacent datasets will be merged until each
         dataset is 4 blocks. If `.window(1)` was requested the datasets will
         be split into smaller windows.

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -240,6 +240,32 @@ class DatasetPipeline(Generic[T]):
             for idx in range(n)
         ]
 
+    def window(self, *, blocks_per_window: int) -> "DatasetPipeline[T]":
+        """Change the windowing of this pipeline.
+
+        Changes the windowing of this pipeline to the specified size. For
+        example, if the current pipeline has two blocks per datasets, and
+        `.window(4)` is requested, adjacent datasets will be merged until each
+        dataset is 4 blocks. If `.window(1)` was requested the datasets will
+        be split into smaller windows.
+
+        Args:
+            blocks_per_window: The new target blocks per window.
+        """
+        raise NotImplementedError
+
+    def repeat(self, times: int = None) -> "DatasetPipeline[T]":
+        """Repeat this pipeline a given number or times, or indefinitely.
+
+        This operation is only allowed for pipelines of a finite length. An
+        error will be raised for pipelines of unknown length.
+
+        Args:
+            times: The number of times to loop over this pipeline, or None
+                to repeat indefinitely.
+        """
+        raise NotImplementedError
+
     def schema(self) -> Union[type, "pyarrow.lib.Schema"]:
         """Return the schema of the dataset pipeline.
 

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -40,7 +40,7 @@ class DatasetPipeline(Generic[T]):
 
     A DatasetPipeline can be created by either repeating a Dataset
     (``ds.repeat(times=None)``), by turning a single Dataset into a pipeline
-    (``ds.pipeline(parallelism=10)``), or defined explicitly using
+    (``ds.window(blocks_per_window=10)``), or defined explicitly using
     ``DatasetPipeline.from_iterable()``.
 
     DatasetPipeline supports the all the per-record transforms of Datasets
@@ -57,7 +57,7 @@ class DatasetPipeline(Generic[T]):
         """Construct a DatasetPipeline (internal API).
 
         The constructor is not part of the DatasetPipeline API. Use the
-        ``Dataset.repeat()``, ``Dataset.pipeline()``, or
+        ``Dataset.repeat()``, ``Dataset.window()``, or
         ``DatasetPipeline.from_iterable()`` methods to construct a pipeline.
         """
         self._base_iterable = base_iterable

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -258,7 +258,7 @@ class DatasetPipeline(Generic[T]):
         """Repeat this pipeline a given number or times, or indefinitely.
 
         This operation is only allowed for pipelines of a finite length. An
-        error will be raised for pipelines of unknown length.
+        error will be raised for pipelines of infinite or unknown length.
 
         Args:
             times: The number of times to loop over this pipeline, or None

--- a/python/ray/data/examples/demo_infer.py
+++ b/python/ray/data/examples/demo_infer.py
@@ -18,7 +18,7 @@ class Model:
         return x
 
 
-ds = ds.pipeline(parallelism=10) \
+ds = ds.window(blocks_per_window=10) \
     .map(preprocess) \
     .map(Model, compute="actors", num_gpus=1)
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -31,7 +31,7 @@ from ray.data.tests.conftest import *  # noqa
 
 def maybe_pipeline(ds, enabled):
     if enabled:
-        return ds.pipeline(parallelism=1)
+        return ds.window(blocks_per_window=1)
     else:
         return ds
 

--- a/python/ray/data/tests/test_dataset_pipeline.py
+++ b/python/ray/data/tests/test_dataset_pipeline.py
@@ -30,14 +30,14 @@ def test_incremental_take(shutdown_only):
             time.sleep(999999)
         return x
 
-    pipe = ray.data.range(2).pipeline(parallelism=1)
+    pipe = ray.data.range(2).window(blocks_per_window=1)
     pipe = pipe.map(block_on_ones)
     assert pipe.take(1) == [0]
 
 
 def test_cannot_read_twice(ray_start_regular_shared):
     ds = ray.data.range(10)
-    pipe = ds.pipeline(parallelism=1)
+    pipe = ds.window(blocks_per_window=1)
     assert pipe.count() == 10
     with pytest.raises(RuntimeError):
         pipe.count()
@@ -52,15 +52,15 @@ def test_cannot_read_twice(ray_start_regular_shared):
 def test_basic_pipeline(ray_start_regular_shared):
     ds = ray.data.range(10)
 
-    pipe = ds.pipeline(parallelism=1)
+    pipe = ds.window(blocks_per_window=1)
     assert str(pipe) == "DatasetPipeline(length=10, num_stages=1)"
     assert pipe.count() == 10
 
-    pipe = ds.pipeline(parallelism=1).map(lambda x: x).map(lambda x: x)
+    pipe = ds.window(blocks_per_window=1).map(lambda x: x).map(lambda x: x)
     assert str(pipe) == "DatasetPipeline(length=10, num_stages=3)"
     assert pipe.take() == list(range(10))
 
-    pipe = ds.pipeline(parallelism=999)
+    pipe = ds.window(blocks_per_window=999)
     assert str(pipe) == "DatasetPipeline(length=1, num_stages=1)"
     assert pipe.count() == 10
 
@@ -97,30 +97,30 @@ def test_repartition(ray_start_regular_shared):
 
 
 def test_iter_batches(ray_start_regular_shared):
-    pipe = ray.data.range(10).pipeline(parallelism=2)
+    pipe = ray.data.range(10).window(blocks_per_window=2)
     batches = list(pipe.iter_batches())
     assert len(batches) == 10
     assert all(len(e) == 1 for e in batches)
 
 
 def test_iter_datasets(ray_start_regular_shared):
-    pipe = ray.data.range(10).pipeline(parallelism=2)
+    pipe = ray.data.range(10).window(blocks_per_window=2)
     ds = list(pipe.iter_datasets())
     assert len(ds) == 5
 
-    pipe = ray.data.range(10).pipeline(parallelism=5)
+    pipe = ray.data.range(10).window(blocks_per_window=5)
     ds = list(pipe.iter_datasets())
     assert len(ds) == 2
 
 
 def test_foreach_dataset(ray_start_regular_shared):
-    pipe = ray.data.range(5).pipeline(parallelism=2)
+    pipe = ray.data.range(5).window(blocks_per_window=2)
     pipe = pipe.foreach_dataset(lambda ds: ds.map(lambda x: x * 2))
     assert pipe.take() == [0, 2, 4, 6, 8]
 
 
 def test_schema(ray_start_regular_shared):
-    pipe = ray.data.range(5).pipeline(parallelism=2)
+    pipe = ray.data.range(5).window(blocks_per_window=2)
     assert pipe.schema() == int
 
 
@@ -179,7 +179,7 @@ def test_parquet_write(ray_start_regular_shared, tmp_path):
     df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
     df = pd.concat([df1, df2])
     ds = ray.data.from_pandas([df1, df2])
-    ds = ds.pipeline(parallelism=1)
+    ds = ds.window(blocks_per_window=1)
     path = os.path.join(tmp_path, "test_parquet_dir")
     os.mkdir(path)
     ds._set_uuid("data")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The semantics of .pipeline() are really the same as windowing semantics on streams. Renaming .pipeline to .window therefore aligns the method more with standard terminology, and also allows us to more easily support other types of windowing (e.g., bytes per window) rather than just blocks per window.