### PR TITLE
[AWS] Stop Round Robining AZs

### DIFF
--- a/doc/source/cluster/config.rst
+++ b/doc/source/cluster/config.rst
@@ -815,6 +815,8 @@ The user that Ray will authenticate with when launching new nodes.
     .. group-tab:: AWS
 
         A string specifying a comma-separated list of availability zone(s) that nodes may be launched in.
+        Nodes will be launched in the first listed availability zone and will be tried in the following availability
+        zones if launching fails.
 
         * **Required:** No
         * **Importance:** Low

--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -440,7 +440,10 @@ def _configure_subnet(config):
 
     if "availability_zone" in config["provider"]:
         azs = config["provider"]["availability_zone"].split(",")
-        subnets = [s for s in subnets if s.availability_zone in azs]
+        subnets = [
+            s for az in azs  # Iterate over AZs first to maintain the ordering
+            for s in subnets if s.availability_zone == az
+        ]
         if not subnets:
             cli_logger.abort(
                 "No usable subnets matching availability zone {} found.\n"

--- a/python/ray/autoscaler/aws/example-full.yaml
+++ b/python/ray/autoscaler/aws/example-full.yaml
@@ -99,6 +99,8 @@ available_node_types:
             InstanceType: m5.large
             ImageId: ami-0a2363a9cff180a64 # Deep Learning AMI (Ubuntu) Version 30
             # Run workers on spot by default. Comment this out to use on-demand.
+            # NOTE: If relying on spot instances, it is best to specify multiple different instance
+            # types to avoid interruption when one instance type is experiencing heightened demand
             InstanceMarketOptions:
                 MarketType: spot
                 # Additional options can be found in the boto docs, e.g.

--- a/python/ray/autoscaler/aws/example-full.yaml
+++ b/python/ray/autoscaler/aws/example-full.yaml
@@ -100,7 +100,8 @@ available_node_types:
             ImageId: ami-0a2363a9cff180a64 # Deep Learning AMI (Ubuntu) Version 30
             # Run workers on spot by default. Comment this out to use on-demand.
             # NOTE: If relying on spot instances, it is best to specify multiple different instance
-            # types to avoid interruption when one instance type is experiencing heightened demand
+            # types to avoid interruption when one instance type is experiencing heightened demand.
+            # Demand information can be found at https://aws.amazon.com/ec2/spot/instance-advisor/
             InstanceMarketOptions:
                 MarketType: spot
                 # Additional options can be found in the boto docs, e.g.

--- a/python/ray/tests/aws/utils/constants.py
+++ b/python/ray/tests/aws/utils/constants.py
@@ -66,6 +66,17 @@ A_THOUSAND_SUBNETS_IN_DIFFERENT_VPCS = [
     subnet_in_vpc(vpc_num) for vpc_num in range(1, 1000)
 ] + [DEFAULT_SUBNET]
 
+
+def subnet_in_az(idx):
+    azs = ["a", "b", "c", "d"]
+    subnet = copy.copy(DEFAULT_SUBNET)
+    subnet["AvailabilityZone"] = "us-west-2" + azs[idx % 4]
+    subnet["SubnetId"] = f"subnet-{idx:07d}"
+    return subnet
+
+
+TWENTY_SUBNETS_IN_DIFFENT_AZS = [subnet_in_az(i) for i in range(20)]
+
 # Secondary EC2 subnet to expose to tests as required.
 AUX_SUBNET = {
     "AvailabilityZone": "us-west-2a",

--- a/python/ray/tests/aws/utils/constants.py
+++ b/python/ray/tests/aws/utils/constants.py
@@ -75,7 +75,7 @@ def subnet_in_az(idx):
     return subnet
 
 
-TWENTY_SUBNETS_IN_DIFFENT_AZS = [subnet_in_az(i) for i in range(20)]
+TWENTY_SUBNETS_IN_DIFFERENT_AZS = [subnet_in_az(i) for i in range(20)]
 
 # Secondary EC2 subnet to expose to tests as required.
 AUX_SUBNET = {

--- a/python/ray/tests/aws/utils/stubs.py
+++ b/python/ray/tests/aws/utils/stubs.py
@@ -5,7 +5,7 @@ from ray.tests.aws.utils import helpers
 from ray.tests.aws.utils.mocks import mock_path_exists_key_pair
 from ray.tests.aws.utils.constants import DEFAULT_INSTANCE_PROFILE, \
     DEFAULT_KEY_PAIR, DEFAULT_SUBNET, A_THOUSAND_SUBNETS_IN_DIFFERENT_VPCS, \
-    DEFAULT_LT
+    DEFAULT_LT, TWENTY_SUBNETS_IN_DIFFENT_AZS
 
 from unittest import mock
 
@@ -50,6 +50,13 @@ def describe_a_thousand_subnets_in_different_vpcs(ec2_client_stub):
         "describe_subnets",
         expected_params={},
         service_response={"Subnets": A_THOUSAND_SUBNETS_IN_DIFFERENT_VPCS})
+
+
+def describe_twenty_subnets_in_different_azs(ec2_client_stub):
+    ec2_client_stub.add_response(
+        "describe_subnets",
+        expected_params={},
+        service_response={"Subnets": TWENTY_SUBNETS_IN_DIFFENT_AZS})
 
 
 def skip_to_configure_sg(ec2_client_stub, iam_client_stub):

--- a/python/ray/tests/aws/utils/stubs.py
+++ b/python/ray/tests/aws/utils/stubs.py
@@ -5,7 +5,7 @@ from ray.tests.aws.utils import helpers
 from ray.tests.aws.utils.mocks import mock_path_exists_key_pair
 from ray.tests.aws.utils.constants import DEFAULT_INSTANCE_PROFILE, \
     DEFAULT_KEY_PAIR, DEFAULT_SUBNET, A_THOUSAND_SUBNETS_IN_DIFFERENT_VPCS, \
-    DEFAULT_LT, TWENTY_SUBNETS_IN_DIFFENT_AZS
+    DEFAULT_LT, TWENTY_SUBNETS_IN_DIFFERENT_AZS
 
 from unittest import mock
 
@@ -56,7 +56,7 @@ def describe_twenty_subnets_in_different_azs(ec2_client_stub):
     ec2_client_stub.add_response(
         "describe_subnets",
         expected_params={},
-        service_response={"Subnets": TWENTY_SUBNETS_IN_DIFFENT_AZS})
+        service_response={"Subnets": TWENTY_SUBNETS_IN_DIFFERENT_AZS})
 
 
 def skip_to_configure_sg(ec2_client_stub, iam_client_stub):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* Having Ray clusters span across AZs leads to costs (from cross AZ traffic) and increased latency.
* This PR tries to prioritize launching machines into the first AZ if multiple are selected. When a node fails to launch, it will be retried in **a different** AZ!
* Spot instances are not round-robin'ed, changing the behavior from https://github.com/ray-project/ray/pull/2254 This is fine because:
*  1) It is unlikely that only one AZ in a a region has substantially different chance of spot instances being evicted
* 2) AWS tends not to evict a bunch of machines from a single user.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
