### PR TITLE
[core] don't broadcast node failures to drivers and instead log the error

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -149,24 +149,13 @@ std::shared_ptr<rpc::GcsNodeInfo> GcsNodeManager::RemoveNode(
     // Remove from alive nodes.
     alive_nodes_.erase(iter);
     if (!is_intended) {
-      // Broadcast a warning to all of the drivers indicating that the node
+      // Broadcast an error in the logs indicating that the node
       // has been marked as dead.
-      // TODO(rkn): Define this constant somewhere else.
-      std::string type = "node_removed";
-      std::ostringstream error_message;
-      error_message << "The node with node id: " << node_id
-                    << " and ip: " << removed_node->node_manager_address()
-                    << " has been marked dead because the detector"
-                    << " has missed too many heartbeats from it. This can happen when a "
-                       "raylet crashes unexpectedly or has lagging heartbeats.";
-      auto error_data_ptr =
-          gcs::CreateErrorTableData(type, error_message.str(), current_time_ms());
-      RAY_EVENT(ERROR, EL_RAY_NODE_REMOVED)
-              .WithField("node_id", node_id.Hex())
-              .WithField("ip", removed_node->node_manager_address())
-          << error_message.str();
-      RAY_CHECK_OK(gcs_pub_sub_->Publish(ERROR_INFO_CHANNEL, node_id.Hex(),
-                                         error_data_ptr->SerializeAsString(), nullptr));
+      RAY_LOG(ERROR) << "The node with node id: " << node_id
+                     << " and ip: " << removed_node->node_manager_address()
+                     << " has been marked dead because the detector"
+                     << " has missed too many heartbeats from it. This can happen when a "
+                        "raylet crashes unexpectedly or has lagging heartbeats.";
     }
 
     // Notify all listeners.

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -151,7 +151,7 @@ std::shared_ptr<rpc::GcsNodeInfo> GcsNodeManager::RemoveNode(
     if (!is_intended) {
       // Broadcast an error in the logs indicating that the node
       // has been marked as dead.
-      RAY_LOG(ERROR) << "The node with node id: " << node_id
+      RAY_LOG(WARNING) << "The node with node id: " << node_id
                      << " and ip: " << removed_node->node_manager_address()
                      << " has been marked dead because the detector"
                      << " has missed too many heartbeats from it. This can happen when a "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
