### PR TITLE
[Lint] run `clang-tidy` in `scripts/format.h`, update clang-tidy rules

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,9 +9,9 @@
 # -modernize-pass-by-value (too restrictive)
 # -modernize-return-braced-init-list (inconsistent style)
 # -modernize-use-emplace (more subtle behavior)
+# -modernize-use-nodiscard (too much noise)
 # -modernize-use-trailing-return-type (inconsistent style)
-# -modernize-use-trailing-return-type (inconsistent style)
-# -readability-convert-member-functions-to-static (potentially too restrictive)
+# Other readability-* rules (potentially too noisy, inconsistent style)
 # Other rules not mentioned here or below (not yet evaluated)
 #
 # TODO: enable google-* and readability-* families of checks.
@@ -30,6 +30,7 @@ Checks: >
   -modernize-pass-by-value,
   -modernize-return-braced-init-list,
   -modernize-use-emplace,
+  -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   performance-*,
   readability-avoid-const-params-in-decls,
@@ -38,6 +39,16 @@ Checks: >
   readability-container-size-empty,
   readability-delete-null-pointer,
   readability-else-after-return,
+  readability-implicit-bool-conversion,
+  readability-make-member-function-const,
+  readability-misleading-indentation,
+  readability-misplaced-array-index,
+  readability-named-parameter,
+  readability-non-const-parameter,
+  readability-redundant-*,
+  readability-static-definition-in-anonymous-namespace,
+  readability-string-compare,
+  readability-suspicious-call-argument,
 
 CheckOptions:
   # Reduce noisiness of the bugprone-narrowing-conversions check.

--- a/.gitignore
+++ b/.gitignore
@@ -196,6 +196,9 @@ tags.temp
 # tools
 tools/prometheus*
 
+# Generated for clang-tidy
+compile_commands.json
+
 # ray project files
 project-id
 .mypy_cache/

--- a/ci/travis/check-git-clang-format-output.sh
+++ b/ci/travis/check-git-clang-format-output.sh
@@ -15,7 +15,7 @@ if [ "$base_commit" = "$(git rev-parse HEAD)" ] && [ "$(git status --porcelain |
   base_commit="$(git rev-parse HEAD^)"
   printInfo "Running clang-format against parent commit $base_commit"
 else
-  printInfo "Running clang-format against parent commit $base_commit from master branch"
+  printInfo "Running clang-format against commit $base_commit from master branch"
 fi
 
 exclude_regex="(.*thirdparty/|.*redismodule.h|.*.java|.*.jsx?|.*.tsx?)"

--- a/ci/travis/check-git-clang-format-output.sh
+++ b/ci/travis/check-git-clang-format-output.sh
@@ -1,22 +1,30 @@
 #!/bin/bash
 
+printWarning() {
+    printf '\033[31mLINT WARNING (clang-format):\033[0m %s\n' "$@"
+}
+
+printInfo() {
+    printf '\033[34mLINT (clang-format):\033[0m %s\n' "$@"
+}
+
 # Compare against the master branch, because most development is done against it.
 base_commit="$(git merge-base HEAD master)"
 if [ "$base_commit" = "$(git rev-parse HEAD)" ] && [ "$(git status --porcelain | wc -l)" -eq 0 ]; then
   # Prefix of master branch, so compare against parent commit
   base_commit="$(git rev-parse HEAD^)"
-  echo "Running clang-format against parent commit $base_commit"
+  printInfo "Running clang-format against parent commit $base_commit"
 else
-  echo "Running clang-format against parent commit $base_commit from master branch"
+  printInfo "Running clang-format against parent commit $base_commit from master branch"
 fi
 
 exclude_regex="(.*thirdparty/|.*redismodule.h|.*.java|.*.jsx?|.*.tsx?)"
 output="$(ci/travis/git-clang-format --commit "$base_commit" --diff --exclude "$exclude_regex")"
 if [ "$output" = "no modified files to format" ] || [ "$output" = "clang-format did not modify any files" ] ; then
-  echo "clang-format passed."
+  printInfo "clang-format passed."
   exit 0
 else
-  echo "clang-format failed:"
-  echo "$output"
+  printWarning "clang-format failed:"
+  printWarning "$output"
   exit 1
 fi

--- a/ci/travis/check-git-clang-format-output.sh
+++ b/ci/travis/check-git-clang-format-output.sh
@@ -2,7 +2,7 @@
 
 # Compare against the master branch, because most development is done against it.
 base_commit="$(git merge-base HEAD master)"
-if [ "$base_commit" = "$(git rev-parse HEAD)" ]; then
+if [ "$base_commit" = "$(git rev-parse HEAD)" ] && [ "$(git status --porcelain | wc -l)" -eq 0 ]; then
   # Prefix of master branch, so compare against parent commit
   base_commit="$(git rev-parse HEAD^)"
   echo "Running clang-format against parent commit $base_commit"

--- a/ci/travis/check-git-clang-tidy-output.sh
+++ b/ci/travis/check-git-clang-tidy-output.sh
@@ -23,25 +23,23 @@ if [ "$base_commit" = "$(git rev-parse HEAD)" ] && [ "$(git status --porcelain |
   base_commit="$(git rev-parse HEAD^)"
   printInfo "Running clang-tidy against parent commit $base_commit"
 else
-  printInfo "Running clang-tidy against parent commit $base_commit from master branch"
+  printInfo "Running clang-tidy against commit $base_commit from master branch"
 fi
 
-WORKSPACE=$(bazel info workspace)
-BAZEL_ROOT=$(bazel info execution_root)
-
-printInfo "Generating compilation database ..."
+WORKSPACE=$(bazel info workspace 2>/dev/null)
+BAZEL_ROOT=$(bazel info execution_root 2>/dev/null)
 
 case "${OSTYPE}" in
   linux*)
-    printInfo "Running on Linux, using clang to build C++ targets ..."
+    printInfo "Generating compile commands with clang (on Linux) ..."
     bazel build //ci/generate_compile_commands:extract_compile_command //:ray_pkg --config=llvm \
         --experimental_action_listener=//ci/generate_compile_commands:compile_command_listener;;
   darwin*)
-    printInfo "Running on MacOS, using default compiler to build C++ targets ..."
+    printInfo "Generating compile commands with clang (on MacOS) ..."
     bazel build //ci/generate_compile_commands:extract_compile_command //:ray_pkg \
         --experimental_action_listener=//ci/generate_compile_commands:compile_command_listener;;
   msys*)
-    printInfo "Running on Windows, using clang-cl to build C++ targets ..."
+    printInfo "Generating compile commands with clang (on Windows) ..."
     CC=clang-cl bazel build //ci/generate_compile_commands:extract_compile_command //:ray_pkg \
         --experimental_action_listener=//ci/generate_compile_commands:compile_command_listener;;
 esac

--- a/ci/travis/check-git-clang-tidy-output.sh
+++ b/ci/travis/check-git-clang-tidy-output.sh
@@ -1,17 +1,15 @@
 #!/bin/bash
 
-# TODO: integrate this script into pull request workflow.
-
-printError() {
-    printf '\033[31mERROR:\033[0m %s\n' "$@"
+printWarning() {
+    printf '\033[31mLINT WARNING (clang-tidy):\033[0m %s\n' "$@"
 }
 
 printInfo() {
-    printf '\033[32mINFO:\033[0m %s\n' "$@"
+    printf '\033[34mLINT (clang-tidy):\033[0m %s\n' "$@"
 }
 
 log_err() {
-    printError "Setting up clang-tidy encountered an error"
+    printWarning "Setting up clang-tidy encountered an error"
 }
 
 set -eo pipefail
@@ -28,8 +26,6 @@ else
   printInfo "Running clang-tidy against parent commit $base_commit from master branch"
 fi
 
-printInfo "Fetching workspace info ..."
-
 WORKSPACE=$(bazel info workspace)
 BAZEL_ROOT=$(bazel info execution_root)
 
@@ -37,20 +33,18 @@ printInfo "Generating compilation database ..."
 
 case "${OSTYPE}" in
   linux*)
-    printInfo "Running on Linux, using clang to build C++ targets. Please make sure it is installed with install-llvm-binaries.sh"
+    printInfo "Running on Linux, using clang to build C++ targets ..."
     bazel build //ci/generate_compile_commands:extract_compile_command //:ray_pkg --config=llvm \
         --experimental_action_listener=//ci/generate_compile_commands:compile_command_listener;;
   darwin*)
-    printInfo "Running on MacOS, assuming default C++ compiler is clang."
+    printInfo "Running on MacOS, using default compiler to build C++ targets ..."
     bazel build //ci/generate_compile_commands:extract_compile_command //:ray_pkg \
         --experimental_action_listener=//ci/generate_compile_commands:compile_command_listener;;
   msys*)
-    printInfo "Running on Windows, using clang-cl to build C++ targets. Please make sure it is installed."
+    printInfo "Running on Windows, using clang-cl to build C++ targets ..."
     CC=clang-cl bazel build //ci/generate_compile_commands:extract_compile_command //:ray_pkg \
         --experimental_action_listener=//ci/generate_compile_commands:compile_command_listener;;
 esac
-
-printInfo "Assembling compilation database ..."
 
 TMPFILE=$(mktemp)
 printf '[\n' >"$TMPFILE"
@@ -68,22 +62,21 @@ fi
 OUTFILE=$WORKSPACE/compile_commands.json
 
 if hash jq 2>/dev/null; then
-    printInfo "Formatting compilation database ..."
     jq . "$TMPFILE" >"$OUTFILE"
 else
-    printInfo "Can not find jq. Skip formatting compilation database."
     cp --no-preserve=mode "$TMPFILE" "$OUTFILE"
 fi
 
 trap - EXIT
 
+printInfo "Running clang-tidy ..."
 output="$(git diff -U0 "$base_commit" | ci/travis/clang-tidy-diff.py -p1 -fix)"
 if [[ ! "$output" =~ "error: " ]]; then
   printInfo "clang-tidy passed."
 else
-  printError "clang-tidy issued warnings. See below for details. Suggested fixes have also been applied."
-  printError "$output"
-  printError "If a warning is too pedantic, a proposed fix is incorrect or you are unsure about how to fix a warning,"
-  printError "feel free to raise the issue on the pull request."
-  printError "clang-tidy warnings can also be suppressed with NOLINT"
+  printWarning "clang-tidy issued warnings. See below for details. Suggested fixes have also been applied."
+  printWarning "$output"
+  printWarning "If a warning is too pedantic, a proposed fix is incorrect or you are unsure about how to fix a warning,"
+  printWarning "feel free to raise the issue on the pull request."
+  printWarning "clang-tidy warnings can also be suppressed with NOLINT"
 fi

--- a/ci/travis/clang-tidy-diff.py
+++ b/ci/travis/clang-tidy-diff.py
@@ -251,7 +251,7 @@ def main():
     start_workers(max_task_count, run_tidy, task_queue, lock, args.timeout)
 
     # Form the common args list.
-    common_clang_tidy_args = []
+    common_clang_tidy_args = ["--use-color"]
     if args.fix:
         common_clang_tidy_args.append("-fix")
     if args.checks != "":

--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -5,6 +5,18 @@
 # Cause the script to exit if a single command fails
 set -euo pipefail
 
+printWarning() {
+    printf '\033[31mLINT WARNING:\033[0m %s\n' "$@"
+}
+
+printInfo() {
+    printf '\033[34mLINT:\033[0m %s\n' "$@"
+}
+
+if ! git diff --quiet &>/dev/null; then
+    printWarning 'Found unstaged changes before lint. They will be mixed with reformatting, if there is any.'
+fi
+
 FLAKE8_VERSION_REQUIRED="3.9.1"
 YAPF_VERSION_REQUIRED="0.23.0"
 SHELLCHECK_VERSION_REQUIRED="0.7.1"
@@ -26,11 +38,11 @@ check_command_exist() {
             VERSION=$MYPY_VERSION_REQUIRED
             ;;
         *)
-            echo "$1 is not a required dependency"
+            printWarning "$1 is not a required dependency"
             exit 1
     esac
     if ! [ -x "$(command -v "$1")" ]; then
-        echo "$1 not installed. pip install $1==$VERSION"
+        printWarning "$1 not installed. pip install $1==$VERSION"
         exit 1
     fi
 }
@@ -54,7 +66,7 @@ GOOGLE_JAVA_FORMAT_JAR=/tmp/google-java-format-1.7-all-deps.jar
 # params: tool name, tool version, required version
 tool_version_check() {
     if [ "$2" != "$3" ]; then
-        echo "WARNING: Ray uses $1 $3, You currently are using $2. This might generate different results."
+        printWarning "Ray uses $1 $3, You currently are using $2. This might generate different results."
     fi
 }
 
@@ -63,7 +75,7 @@ tool_version_cmd_check() {
     local tool_version
     tool_version="$($2)"
     if [[ ! "$tool_version" =~ $3 ]]; then
-        echo "WARNING: Ray uses $1 $3, but running $2 indicates otherwise. This might generate different results."
+        printWarning "Ray uses $1 $3, but running $2 indicates otherwise. This might generate different results."
     fi
 }
 
@@ -75,37 +87,37 @@ tool_version_check "mypy" "$MYPY_VERSION" "$MYPY_VERSION_REQUIRED"
 if command -v clang-format >/dev/null; then
   tool_version_cmd_check "clang-format" "clang-format --version" "12.0"
 else
-    echo "WARNING: clang-format 12 is not installed!"
-    echo "To install on MacOS: brew install clang-format"
-    echo "To install on Ubuntu: use package manager e.g. sudo apt install clang-format-12 -y && sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-12 100"
-    echo "Or run scripts/install-llvm-binaries.sh"
+    printWarning "clang-format 12 is not installed!"
+    printWarning "To install on MacOS: brew install clang-format"
+    printWarning "To install on Ubuntu: use package manager e.g. sudo apt install clang-format-12 -y && sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-12 100"
+    printWarning "Or run scripts/install-llvm-binaries.sh"
 fi
 
 if command -v clang-tidy >/dev/null; then
   tool_version_cmd_check "clang-tidy" "clang-tidy --version" "12.0"
 else
-    echo "WARNING: clang-tidy 12 is not installed!"
-    echo "To install on MacOS: brew install clang-tidy"
-    echo "To install on Ubuntu: use package manager e.g. sudo apt install clang-tidy-12 -y && sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-12 100"
-    echo "Or run scripts/install-llvm-binaries.sh"
+    printWarning "clang-tidy 12 is not installed!"
+    printWarning "To install on MacOS: brew install clang-tidy"
+    printWarning "To install on Ubuntu: use package manager e.g. sudo apt install clang-tidy-12 -y && sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-12 100"
+    printWarning "Or run scripts/install-llvm-binaries.sh"
 fi
 
 if ! command -v clang >/dev/null; then
-    echo "WARNING: clang is not installed! clang-tidy will be disabled."
-    echo "To install, use package manager, run scripts/install-llvm-binaries.sh (Ubuntu only), or compile from source."
+    printWarning "clang is not installed! clang-tidy will be disabled."
+    printWarning "To install, use package manager, run scripts/install-llvm-binaries.sh (Ubuntu only), or compile from source."
 fi
 
 if command -v java >/dev/null; then
   if [ ! -f "$GOOGLE_JAVA_FORMAT_JAR" ]; then
-    echo "Java code format tool google-java-format.jar is not installed, start to install it."
+    printWarning "Java code format tool google-java-format.jar is not installed, start to install it."
     wget https://github.com/google/google-java-format/releases/download/google-java-format-1.7/google-java-format-1.7-all-deps.jar -O "$GOOGLE_JAVA_FORMAT_JAR"
   fi
 else
-    echo "WARNING: Java is not installed, skip formatting Java files!"
+    printWarning "Java is not installed, skip formatting Java files!"
 fi
 
 if [[ $(flake8 --version) != *"flake8_quotes"* ]]; then
-    echo "WARNING: Ray uses flake8 with flake8_quotes. Might error without it. Install with: pip install flake8-quotes"
+    printWarning "Ray uses flake8 with flake8_quotes. Might error without it. Install with: pip install flake8-quotes"
 fi
 
 SHELLCHECK_FLAGS=(
@@ -176,7 +188,7 @@ shellcheck_scripts() {
 mypy_on_each() {
     pushd python/ray
     for file in "$@"; do
-       echo "Running mypy on $file"
+       printInfo "Running mypy on $file"
        mypy ${MYPY_FLAGS[@]+"${MYPY_FLAGS[@]}"} "$file"
     done
     popd
@@ -208,7 +220,7 @@ format_files() {
       elif [ -z "${suffix}" ] && [ "${shebang}" != "${shebang%sh}" ] || [ "${suffix}" != "${suffix#.sh}" ]; then
         shell_files+=("${name}")
       else
-        echo "error: failed to determine file type: ${name}" 1>&2
+        printWarning "failed to determine file type: ${name}" 1>&2
         return 1
       fi
     done
@@ -225,7 +237,7 @@ format_files() {
         printf "%s" "${difference}" | patch -p1
       fi
     else
-      echo "error: this version of shellcheck does not support diffs"
+      printWarning "this version of shellcheck does not support diffs"
     fi
 }
 
@@ -233,13 +245,13 @@ format_all_scripts() {
     command -v flake8 &> /dev/null;
     HAS_FLAKE8=$?
 
-    echo "$(date)" "YAPF...."
+    printInfo "$(date)" "YAPF...."
     git ls-files -- '*.py' "${GIT_LS_EXCLUDES[@]}" | xargs -P 10 \
       yapf --in-place "${YAPF_EXCLUDES[@]}" "${YAPF_FLAGS[@]}"
-    echo "$(date)" "MYPY...."
+    printInfo "$(date)" "MYPY...."
     mypy_on_each "${MYPY_FILES[@]}"
     if [ $HAS_FLAKE8 ]; then
-      echo "$(date)" "Flake8...."
+      printInfo "$(date)" "Flake8...."
       git ls-files -- '*.py' "${GIT_LS_EXCLUDES[@]}" | xargs -P 5 \
         flake8 --config=.flake8
 
@@ -255,7 +267,7 @@ format_all_scripts() {
         shell_files+=($(git --no-pager grep -l -- '^#!\(/usr\)\?/bin/\(env \+\)\?\(ba\)\?sh' "${non_shell_files[@]}" || true))
       fi
       if [ 0 -lt "${#shell_files[@]}" ]; then
-        echo "$(date)" "shellcheck scripts...."
+        printInfo "$(date)" "shellcheck scripts...."
         shellcheck_scripts "${shell_files[@]}"
       fi
     fi
@@ -266,17 +278,17 @@ format_all_scripts() {
 format_all() {
     format_all_scripts "${@}"
 
-    echo "$(date)" "clang-format...."
+    printInfo "$(date)" "clang-format...."
     if command -v clang-format >/dev/null; then
       git ls-files -- '*.cc' '*.h' '*.proto' "${GIT_LS_EXCLUDES[@]}" | xargs -P 5 clang-format -i
     fi
 
-    echo "$(date)" "format java...."
+    printInfo "$(date)" "format java...."
     if command -v java >/dev/null & [ -f "$GOOGLE_JAVA_FORMAT_JAR" ]; then
       git ls-files -- '*.java' "${GIT_LS_EXCLUDES[@]}" | sed -E "\:$JAVA_EXCLUDES_REGEX:d" | xargs -P 5 java -jar "$GOOGLE_JAVA_FORMAT_JAR" -i
     fi
 
-    echo "$(date)" "done!"
+    printInfo "$(date)" "done!"
 }
 
 # Format files that differ from main branch. Ignores dirs that are not slated
@@ -290,6 +302,7 @@ format_changed() {
     # exist on both branches.
     MERGEBASE="$(git merge-base upstream/master HEAD)"
 
+    printInfo "Running fake8 on *.py ..."
     if ! git diff --diff-filter=ACRM --quiet --exit-code "$MERGEBASE" -- '*.py' &>/dev/null; then
         git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- '*.py' | xargs -P 5 \
              yapf --in-place "${YAPF_EXCLUDES[@]}" "${YAPF_FLAGS[@]}"
@@ -299,6 +312,7 @@ format_changed() {
         fi
     fi
 
+    printInfo "Running fake8 on cython files ..."
     if ! git diff --diff-filter=ACRM --quiet --exit-code "$MERGEBASE" -- '*.pyx' '*.pxd' '*.pxi' &>/dev/null; then
         if command -v flake8 >/dev/null; then
             git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- '*.pyx' '*.pxd' '*.pxi' | xargs -P 5 \
@@ -306,20 +320,24 @@ format_changed() {
         fi
     fi
 
+    printInfo "Running clang-format ..."
     if command -v clang-format >/dev/null; then
         ci/travis/check-git-clang-format-output.sh
     fi
 
+    printInfo "Running clang-tidy ..."
     if command -v clang-tidy >/dev/null && command -v clang >/dev/null; then
         ci/travis/check-git-clang-tidy-output.sh
     fi
 
+    printInfo "Running Java format ..."
     if command -v java >/dev/null & [ -f "$GOOGLE_JAVA_FORMAT_JAR" ]; then
        if ! git diff --diff-filter=ACRM --quiet --exit-code "$MERGEBASE" -- '*.java' &>/dev/null; then
             git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- '*.java' | sed -E "\:$JAVA_EXCLUDES_REGEX:d" | xargs -P 5 java -jar "$GOOGLE_JAVA_FORMAT_JAR" -i
         fi
     fi
 
+    printInfo "Running shellcheck ..."
     if command -v shellcheck >/dev/null; then
         local shell_files non_shell_files
         non_shell_files=($(git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- ':(exclude)*.sh'))
@@ -369,9 +387,7 @@ PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE:-python}
 $PYTHON_EXECUTABLE ci/travis/check_import_order.py . -s ci -s python/ray/thirdparty_files -s python/build -s lib
 
 if ! git diff --quiet &>/dev/null; then
-    echo 'Reformatted changed files. Please review and stage the changes.'
-    echo 'Files updated:'
-    echo
+    printWarning 'Found unstaged changes after lint, possibly from reformatting:'
 
     git --no-pager diff --name-only
 

--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -372,7 +372,7 @@ else
     fi
 
     # Only fetch master since that's the branch we're diffing against.
-    git fetch upstream master || true
+    git fetch --quiet upstream master || true
 
     # Format only the files that changed in last commit.
     format_changed


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- Make it more convenient to run `clang-tidy` by including it in `scripts/format.h`.
- Use the same script to run `clang-format` in `scripts/format.h` as in CI. Currently they use different logic to run `clang-format` on changes, which can lead to different results.
- Include additional `clang-tidy` rules to catch more readability issues.
- Improve messages emitted during lint, to clarify installation instructions for missing tools, and make lint errors stand out more. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
