### PR TITLE
add msvcp140.dll to the wheel on windows

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -564,9 +564,8 @@ def pip_run(build_ext):
     for filename in setup_spec.files_to_include:
         copied_files += copy_file(build_ext.build_lib, filename, ROOT_DIR)
     if sys.platform == 'win32':
-        print('copy_file uses', build_ext.build_lib, ROOT_DIR)
-        shutil.copy(r'c:\Windows\system32\msvcp140.dll',
-                        os.path.join(build_ext.build_lib, 'ray'))
+        shutil.copy(r"c:\Windows\system32\msvcp140.dll",
+                        os.path.join(build_ext.build_lib, "ray"))
         copied_files += 1
     print("# of files copied to {}: {}".format(build_ext.build_lib,
                                                copied_files))

--- a/python/setup.py
+++ b/python/setup.py
@@ -539,6 +539,19 @@ def copy_file(target_dir, filename, rootdir):
     return 0
 
 
+def add_system_dlls(dlls, target_dir):
+    """
+    Copy any required dlls required by the c-extension module and not already
+    provided by python. They will end up in the wheel next to the c-extension
+    module which will guarentee they are available at runtime.
+    """
+    for dll in dlls:
+        # Installing Visual Studio will copy the runtime dlls to system32
+        src = os.path.join(r"c:\Windows\system32", dll)
+        assert os.path.exists(src)
+        shutil.copy(src, target_dir)
+
+
 def pip_run(build_ext):
     build(True, BUILD_JAVA, True)
 
@@ -564,9 +577,12 @@ def pip_run(build_ext):
     for filename in setup_spec.files_to_include:
         copied_files += copy_file(build_ext.build_lib, filename, ROOT_DIR)
     if sys.platform == 'win32':
-        shutil.copy(r"c:\Windows\system32\msvcp140.dll",
-                        os.path.join(build_ext.build_lib, "ray"))
-        copied_files += 1
+        # _raylet.pyd links to some MSVC runtime DLLS, this one may not be
+        # present on a user's machine. While vcruntime140.dll and
+        # vcruntime140_1.dll are also required, they are provided by CPython.
+        runtime_dlls = ["msvcp140.dll"]
+        add_system_dlls(runtime_dlls, os.path.join(build_ext.build_lib, "ray"))
+        copied_files += len(runtime_dlls)
     print("# of files copied to {}: {}".format(build_ext.build_lib,
                                                copied_files))
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -576,7 +576,7 @@ def pip_run(build_ext):
     copied_files = 0
     for filename in setup_spec.files_to_include:
         copied_files += copy_file(build_ext.build_lib, filename, ROOT_DIR)
-    if sys.platform == 'win32':
+    if sys.platform == "win32":
         # _raylet.pyd links to some MSVC runtime DLLS, this one may not be
         # present on a user's machine. While vcruntime140.dll and
         # vcruntime140_1.dll are also required, they are provided by CPython.

--- a/python/setup.py
+++ b/python/setup.py
@@ -563,6 +563,11 @@ def pip_run(build_ext):
     copied_files = 0
     for filename in setup_spec.files_to_include:
         copied_files += copy_file(build_ext.build_lib, filename, ROOT_DIR)
+    if sys.platform == 'win32':
+        print('copy_file uses', build_ext.build_lib, ROOT_DIR)
+        shutil.copy(r'c:\Windows\system32\msvcp140.dll',
+                        os.path.join(build_ext.build_lib, 'ray'))
+        copied_files += 1
     print("# of files copied to {}: {}".format(build_ext.build_lib,
                                                copied_files))
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Closes #13293. As described in the issue, on a minimal windows image the support dll `msvcp140.dll` is needed to load `_raylet.pyd`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
