### PR TITLE
[wip] Enforce the address to be local in driver mode

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -7,6 +7,7 @@ import io
 import json
 import logging
 import os
+import socket
 import redis
 import sys
 import threading
@@ -809,6 +810,12 @@ def init(
     # Convert hostnames to numerical IP address.
     if _node_ip_address is not None:
         node_ip_address = services.address_to_ip(_node_ip_address)
+        local_ip_address = socket.gethostbyname(socket.gethostname())
+        if node_ip_address != local_ip_address:
+            raise ValueError("Connect to a remote node is only allowed in ray"
+                             " client. Please add `ray://` to the beginning of"
+                             " the address")
+
     raylet_ip_address = node_ip_address
 
     if address:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The driver has to be started in the cluster connecting to the local host. Otherwise, it needs ray client. 

This PR failed the init and give the error message to the users asking them to use ray client.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #19052

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
