### PR TITLE
[flaky] Fix gcs_placement_group_manager_mock_test.cc flaky in windows

### DIFF
--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_mock_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_mock_test.cc
@@ -121,7 +121,8 @@ TEST_F(GcsPlacementGroupManagerMockTest, PendingQueuePriorityFailed) {
   ASSERT_EQ(1, pending_queue.size());
   ASSERT_EQ(rank, pending_queue.begin()->first);
 
-  absl::SleepFor(absl::Nanoseconds(rank - absl::GetCurrentTimeNanos()));
+  absl::SleepFor(absl::Milliseconds(1) +
+                 absl::Nanoseconds(rank - absl::GetCurrentTimeNanos()));
   gcs_placement_group_manager_->SchedulePendingPlacementGroups();
   ASSERT_EQ(0, pending_queue.size());
   pg->UpdateState(rpc::PlacementGroupTableData::PENDING);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The test is flaky due to the resolution of clock in windows (https://github.com/abseil/abseil-cpp/blob/master/absl/time/clock.cc#L559-L568)
This PR adds 1ms to the duration to fix this.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
