### PR TITLE
[ci] Clean wheels directory before build, validate wheel commit strings

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -349,6 +349,13 @@ validate_wheels_commit_str() {
 
   for whl in .whl/*.whl; do
     basename=${whl##*/}
+
+    if [[ "$basename" =~ "_cpp" ]]; then
+      # cpp wheels cannot be checked this way
+      echo "Skipping CPP wheel ${basename} for wheel commit validation."
+      continue
+    fi
+
     folder=${basename%%-cp*}
     WHL_COMMIT=$(unzip -p "$whl" "${folder}.data/purelib/ray/__init__.py" | grep "__commit__" | awk -F'"' '{print $2}')
 

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -408,11 +408,12 @@ build_wheels() {
       else
         rm -rf /ray-mount/*
         rm -rf /ray-mount/.whl || true
+        rm -rf /ray/.whl || true
         cp -rT /ray /ray-mount
         ls -a /ray-mount
-        docker run --rm -v /ray-mount:/ray-mounted ubuntu:focal ls /
-        docker run --rm -v /ray-mount:/ray-mounted ubuntu:focal ls /ray-mounted
-        docker run --rm -w /ray-mount -v /ray:/ray "${MOUNT_BAZEL_CACHE[@]}" \
+        docker run --rm -v /ray:/ray-mounted ubuntu:focal ls /
+        docker run --rm -v /ray:/ray-mounted ubuntu:focal ls /ray-mounted
+        docker run --rm -w /ray -v /ray:/ray "${MOUNT_BAZEL_CACHE[@]}" \
           quay.io/pypa/manylinux2014_x86_64 /ray/python/build-wheel-manylinux2014.sh
         cp -rT /ray-mount /ray # copy new files back here
         find . | grep whl # testing

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -374,7 +374,7 @@ build_wheels() {
   # Create wheel output directory and empty contents
   # If buildkite runners are re-used, wheels from previous builds might be here, so we delete them.
   mkdir -p .whl
-  rm -rf .whl/*
+  rm -rf .whl/* || true
 
   case "${OSTYPE}" in
     linux*)

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -408,10 +408,10 @@ build_wheels() {
       else
         rm -rf /ray-mount/*
         cp -rT /ray /ray-mount
-        ls /ray-mount
-        docker run --rm -v /ray:/ray-mounted ubuntu:focal ls /
-        docker run --rm -v /ray:/ray-mounted ubuntu:focal ls /ray-mounted
-        docker run --rm -w /ray -v /ray:/ray "${MOUNT_BAZEL_CACHE[@]}" \
+        ls -a /ray-mount
+        docker run --rm -v /ray-mount:/ray-mounted ubuntu:focal ls /
+        docker run --rm -v /ray-mount:/ray-mounted ubuntu:focal ls /ray-mounted
+        docker run --rm -w /ray-mount -v /ray:/ray "${MOUNT_BAZEL_CACHE[@]}" \
           quay.io/pypa/manylinux2014_x86_64 /ray/python/build-wheel-manylinux2014.sh
         cp -rT /ray-mount /ray # copy new files back here
         find . | grep whl # testing

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -340,7 +340,11 @@ validate_wheels_commit_str() {
     return 0
   fi
 
-  EXPECTED_COMMIT=$TRAVIS_COMMIT
+  if [ -n "${BUILDKITE_COMMIT}" ]; then
+    EXPECTED_COMMIT=${BUILDKITE_COMMIT:-}
+  else
+    EXPECTED_COMMIT=${TRAVIS_COMMIT:-}
+  fi
 
   if [ -z "$EXPECTED_COMMIT" ]; then
     echo "Could not validate expected wheel commits: TRAVIS_COMMIT is empty."

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -407,6 +407,7 @@ build_wheels() {
         quay.io/pypa/manylinux2014_x86_64 /ray/python/build-wheel-manylinux2014.sh
       else
         rm -rf /ray-mount/*
+        rm -rf /ray-mount/.whl || true
         cp -rT /ray /ray-mount
         ls -a /ray-mount
         docker run --rm -v /ray-mount:/ray-mounted ubuntu:focal ls /


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Buildkite runners are re-used and sometimes have leftover state.

This is illustrated in these two builds:

https://buildkite.com/ray-project/ray-builders-branch/builds/3798#98bd4bff-8b77-484d-94a9-5e09ea5f13e2

and

https://buildkite.com/ray-project/ray-builders-branch/builds/3799#283c057c-6334-466b-805d-75535a16e169

(click on "Timeline").

In this case, wheels from the first build (2.0.0.dev0) still exist on the runner and are uploaded again in the next build (1.7.0). In this case this is obvious, but sometimes this happens for the same version string and can lead to confusion.

This PR clears the `.whl` directory in `ci.sh build` so that previous build wheels are deleted. We also introduce a sanity check that extracts the wheel commit string from each wheel and compares it to the expected commit.



## Related issue number

Closes #18702

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
