### PR TITLE
[ci/release] Check test result alerts after test finished

### DIFF
--- a/release/alerts/xgboost_tests.py
+++ b/release/alerts/xgboost_tests.py
@@ -43,7 +43,9 @@ def handle_result(created_on: datetime.datetime, category: str,
     else:
         # train scripts
         if test_name == "train_small":
-            target_time = 30
+            # Leave a couple of seconds for ray connect setup
+            # (without connect it should finish in < 30)
+            target_time = 45
         elif test_name == "train_moderate":
             target_time = 60
         elif test_name == "train_gpu":

--- a/release/e2e.py
+++ b/release/e2e.py
@@ -286,7 +286,8 @@ def exponential_backoff_retry(f, retry_exceptions, initial_retry_delay_s,
 
 def maybe_fetch_api_token():
     if GLOBAL_CONFIG["ANYSCALE_CLI_TOKEN"] is None:
-        print("Missing ANYSCALE_CLI_TOKEN, retrieving from AWS secrets store")
+        logger.info(
+            "Missing ANYSCALE_CLI_TOKEN, retrieving from AWS secrets store")
         # NOTE(simon) This should automatically retrieve
         # release-automation@anyscale.com's anyscale token
         GLOBAL_CONFIG["ANYSCALE_CLI_TOKEN"] = boto3.client(
@@ -2000,7 +2001,7 @@ if __name__ == "__main__":
         # If we get a result dict, check if any alerts should be raised
         from alert import SUITE_TO_FN, default_handle_result
 
-        print("Checking if results are valid...")
+        logger.info("Checking if results are valid...")
 
         handle_result_kwargs = result_dict.copy()
         handle_result_kwargs["created_on"] = None
@@ -2011,7 +2012,7 @@ if __name__ == "__main__":
 
         handle_fn = SUITE_TO_FN.get(test_suite, None)
         if not handle_fn:
-            print(f"No handle for suite {test_suite}")
+            logger.warning(f"No handle for suite {test_suite}")
             alert = default_handle_result(**handle_result_kwargs)
         else:
             alert = handle_fn(**handle_result_kwargs)
@@ -2020,5 +2021,5 @@ if __name__ == "__main__":
             # If we get an alert, the test failed.
             raise RuntimeError(alert)
         else:
-            print(f"No alert raised for test {test_suite}/{test_name} "
-                  f"({category}) - the test successfully passed!")
+            logger.info(f"No alert raised for test {test_suite}/{test_name} "
+                        f"({category}) - the test successfully passed!")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

After running release tests, we should check right away if relevant metrics have been reached. E.g. if execution time is too slow for benchmarking tests, the test should fail.

Previously the test would have succeeded (turn up as green) and alerts would have only been raised during post processing on Slack. However, because of this we could miss actual regressions (e.g. when a long running test stalled and hasn't been updated in a long time).

cc @jjyao 

## Related issue number

Closes #19085

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
