### PR TITLE
add missing <limits> header for prometheus_cpp

### DIFF
--- a/thirdparty/patches/prometheus-windows-headers.patch
+++ b/thirdparty/patches/prometheus-windows-headers.patch
@@ -1,7 +1,8 @@
 diff --git core/src/histogram.cc core/src/histogram.cc
 --- core/src/histogram.cc
 +++ core/src/histogram.cc
-@@ -6,1 +6,2 @@
+@@ -6,1 +6,3 @@
  #include <numeric>
 +#include <stdexcept>
++#include <limits>
 -- 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Fixes build issue

prometheus_cpp has updated their repo with their fix, but the commit we base our dependency on does not have the required fix. This commit adds the fix to the corresponding patch we have for the prometheus headers.
See: https://github.com/jupp0r/prometheus-cpp/commit/e0cc7b5e3ecde5afc9f3f0f00f38ef7bdd321491 for upstream commit

I tried to update the prometheus dep, but the corresponding opencensus dep we have would require changes and thought this was the best approach.

## Related issue number

<!-- For example: "Closes #1234" -->

closes #19107

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
