### PR TITLE
[Core] QuickExit CoreWorker when GetCoreWorker is called after shutdown

### DIFF
--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -294,6 +294,9 @@ class CoreWorkerProcess {
 
   void InitializeSystemConfig();
 
+  /// Check that if the global worker should be created on construction.
+  bool ShouldCreateGlobalWorkerOnConstruction() const;
+
   /// Get the `CoreWorker` instance by worker ID.
   ///
   /// \param[in] workerId The worker ID.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->


<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?


There is a race condition between core worker shutdown versus language front end calling APIs on coreworkers. In this case we will crash as we failed the RAY_CHECK, which causes confusion to the users. 

We fix it by calling quick_exit if we know the core_worker is already shutdown.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #18995 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests: TBD, rerun the script in the
   - [ ] This PR is not tested :(
