### PR TITLE
[Serve] [Doc] Add note about serving multiple deployments defined by the same class

### DIFF
--- a/doc/source/serve/core-apis.rst
+++ b/doc/source/serve/core-apis.rst
@@ -35,7 +35,14 @@ Deployments can be exposed in two ways: over HTTP or in Python via the :ref:`ser
 By default, HTTP requests will be forwarded to the ``__call__`` method of the class (or the function) and a ``Starlette Request`` object will be the sole argument.
 You can also define a deployment that wraps a FastAPI app for more flexible handling of HTTP requests. See :ref:`serve-fastapi-http` for details.
 
-We can also list all available deployments and dynamically get a reference to them:
+To serve multiple deployments defined by the same class, use the ``name`` option:
+
+.. code-block:: python
+
+  MyFirstDeployment.options(name="hello_service").deploy("Hello!")
+  MyFirstDeployment.options(name="hi_service").deploy("Hi!)
+
+You can also list all available deployments and dynamically get references to them:
 
 .. code-block:: python
 

--- a/doc/source/serve/ml-models.rst
+++ b/doc/source/serve/ml-models.rst
@@ -70,10 +70,10 @@ Integration with Model Registries
 Ray Serve is flexible.  If you can load your model as a Python
 function or class, then you can scale it up and serve it with Ray Serve.
 
-For example, if you are using the 
+For example, if you are using the
 `MLflow Model Registry <https://www.mlflow.org/docs/latest/model-registry.html>`_
 to manage your models, the following wrapper
-class will allow you to load a model using its MLflow `Model URI`: 
+class will allow you to load a model using its MLflow `Model URI`:
 
 .. code-block:: python
 
@@ -93,12 +93,19 @@ class will allow you to load a model using its MLflow `Model URI`:
   model_uri = "model:/my_registered_model/Production"
   MLflowDeployment.deploy(model_uri)
 
-.. tip:: 
+To serve multiple different MLflow models in the same program, use the `name` option:
+
+.. code-block:: python
+
+  MLflowDeployment.options(name="my_mlflow_model_1").deploy(model_uri)
+
+
+.. tip::
 
   The above approach will work for any model registry, not just MLflow.
   Namely, load the model from the registry in ``__init__``, and forward the request to the model in ``__call__``.
 
-For an even more hands-off and seamless integration with MLflow, check out the 
+For an even more hands-off and seamless integration with MLflow, check out the
 `Ray Serve MLflow deployment plugin <https://github.com/ray-project/mlflow-ray-serve>`__.  A full
 tutorial is available `here <https://github.com/mlflow/mlflow/tree/master/examples/ray_serve>`__.
 

--- a/doc/source/serve/ml-models.rst
+++ b/doc/source/serve/ml-models.rst
@@ -93,7 +93,7 @@ class will allow you to load a model using its MLflow `Model URI`:
   model_uri = "model:/my_registered_model/Production"
   MLflowDeployment.deploy(model_uri)
 
-To serve multiple different MLflow models in the same program, use the `name` option:
+To serve multiple different MLflow models in the same program, use the ``name`` option:
 
 .. code-block:: python
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR adds a note about using `name=` to serve multiple models defined by the same class in the "Creating Deployments" section.  This PR also adds a note about this in the section about MLflow deployment wrapper class, which is a setting where this note would be relevant.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
