### PR TITLE
[Hotfix] Revert "[Lint] run `clang-tidy` in `scripts/format.h`, update clang-t…

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,9 +9,9 @@
 # -modernize-pass-by-value (too restrictive)
 # -modernize-return-braced-init-list (inconsistent style)
 # -modernize-use-emplace (more subtle behavior)
-# -modernize-use-nodiscard (too much noise)
 # -modernize-use-trailing-return-type (inconsistent style)
-# Other readability-* rules (potentially too noisy, inconsistent style)
+# -modernize-use-trailing-return-type (inconsistent style)
+# -readability-convert-member-functions-to-static (potentially too restrictive)
 # Other rules not mentioned here or below (not yet evaluated)
 #
 # TODO: enable google-* and readability-* families of checks.
@@ -30,7 +30,6 @@ Checks: >
   -modernize-pass-by-value,
   -modernize-return-braced-init-list,
   -modernize-use-emplace,
-  -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   performance-*,
   readability-avoid-const-params-in-decls,
@@ -39,16 +38,6 @@ Checks: >
   readability-container-size-empty,
   readability-delete-null-pointer,
   readability-else-after-return,
-  readability-implicit-bool-conversion,
-  readability-make-member-function-const,
-  readability-misleading-indentation,
-  readability-misplaced-array-index,
-  readability-named-parameter,
-  readability-non-const-parameter,
-  readability-redundant-*,
-  readability-static-definition-in-anonymous-namespace,
-  readability-string-compare,
-  readability-suspicious-call-argument,
 
 CheckOptions:
   # Reduce noisiness of the bugprone-narrowing-conversions check.

--- a/.gitignore
+++ b/.gitignore
@@ -196,9 +196,6 @@ tags.temp
 # tools
 tools/prometheus*
 
-# Generated for clang-tidy
-compile_commands.json
-
 # ray project files
 project-id
 .mypy_cache/

--- a/ci/travis/check-git-clang-format-output.sh
+++ b/ci/travis/check-git-clang-format-output.sh
@@ -1,30 +1,22 @@
 #!/bin/bash
 
-printWarning() {
-    printf '\033[31mLINT WARNING (clang-format):\033[0m %s\n' "$@"
-}
-
-printInfo() {
-    printf '\033[34mLINT (clang-format):\033[0m %s\n' "$@"
-}
-
 # Compare against the master branch, because most development is done against it.
 base_commit="$(git merge-base HEAD master)"
-if [ "$base_commit" = "$(git rev-parse HEAD)" ] && [ "$(git status --porcelain | wc -l)" -eq 0 ]; then
+if [ "$base_commit" = "$(git rev-parse HEAD)" ]; then
   # Prefix of master branch, so compare against parent commit
   base_commit="$(git rev-parse HEAD^)"
-  printInfo "Running clang-format against parent commit $base_commit"
+  echo "Running clang-format against parent commit $base_commit"
 else
-  printInfo "Running clang-format against commit $base_commit from master branch"
+  echo "Running clang-format against parent commit $base_commit from master branch"
 fi
 
 exclude_regex="(.*thirdparty/|.*redismodule.h|.*.java|.*.jsx?|.*.tsx?)"
 output="$(ci/travis/git-clang-format --commit "$base_commit" --diff --exclude "$exclude_regex")"
 if [ "$output" = "no modified files to format" ] || [ "$output" = "clang-format did not modify any files" ] ; then
-  printInfo "clang-format passed."
+  echo "clang-format passed."
   exit 0
 else
-  printWarning "clang-format failed:"
-  printWarning "$output"
+  echo "clang-format failed:"
+  echo "$output"
   exit 1
 fi

--- a/ci/travis/check-git-clang-tidy-output.sh
+++ b/ci/travis/check-git-clang-tidy-output.sh
@@ -1,48 +1,46 @@
 #!/bin/bash
 
-printWarning() {
-    printf '\033[31mLINT WARNING (clang-tidy):\033[0m %s\n' "$@"
+# TODO: integrate this script into pull request workflow.
+
+printError() {
+    printf '\033[31mERROR:\033[0m %s\n' "$@"
 }
 
 printInfo() {
-    printf '\033[34mLINT (clang-tidy):\033[0m %s\n' "$@"
+    printf '\033[32mINFO:\033[0m %s\n' "$@"
 }
 
 log_err() {
-    printWarning "Setting up clang-tidy encountered an error"
+    printError "Setting up clang-tidy encountered an error"
 }
 
 set -eo pipefail
 
 trap '[ $? -eq 0 ] || log_err' EXIT
 
-# Compare against the master branch, because most development is done against it.
-base_commit="$(git merge-base HEAD master)"
-if [ "$base_commit" = "$(git rev-parse HEAD)" ] && [ "$(git status --porcelain | wc -l)" -eq 0 ]; then
-  # Prefix of master branch, so compare against parent commit
-  base_commit="$(git rev-parse HEAD^)"
-  printInfo "Running clang-tidy against parent commit $base_commit"
-else
-  printInfo "Running clang-tidy against commit $base_commit from master branch"
-fi
+printInfo "Fetching workspace info ..."
 
-WORKSPACE=$(bazel info workspace 2>/dev/null)
-BAZEL_ROOT=$(bazel info execution_root 2>/dev/null)
+WORKSPACE=$(bazel info workspace)
+BAZEL_ROOT=$(bazel info execution_root)
+
+printInfo "Generating compilation database ..."
 
 case "${OSTYPE}" in
   linux*)
-    printInfo "Generating compile commands with clang (on Linux) ..."
+    printInfo "Running on Linux, using clang to build C++ targets. Please make sure it is installed with install-llvm-binaries.sh"
     bazel build //ci/generate_compile_commands:extract_compile_command //:ray_pkg --config=llvm \
         --experimental_action_listener=//ci/generate_compile_commands:compile_command_listener;;
   darwin*)
-    printInfo "Generating compile commands with clang (on MacOS) ..."
+    printInfo "Running on MacOS, assuming default C++ compiler is clang."
     bazel build //ci/generate_compile_commands:extract_compile_command //:ray_pkg \
         --experimental_action_listener=//ci/generate_compile_commands:compile_command_listener;;
   msys*)
-    printInfo "Generating compile commands with clang (on Windows) ..."
+    printInfo "Running on Windows, using clang-cl to build C++ targets. Please make sure it is installed."
     CC=clang-cl bazel build //ci/generate_compile_commands:extract_compile_command //:ray_pkg \
         --experimental_action_listener=//ci/generate_compile_commands:compile_command_listener;;
 esac
+
+printInfo "Assembling compilation database ..."
 
 TMPFILE=$(mktemp)
 printf '[\n' >"$TMPFILE"
@@ -60,21 +58,35 @@ fi
 OUTFILE=$WORKSPACE/compile_commands.json
 
 if hash jq 2>/dev/null; then
+    printInfo "Formatting compilation database ..."
     jq . "$TMPFILE" >"$OUTFILE"
 else
+    printInfo "Can not find jq. Skip formatting compilation database."
     cp --no-preserve=mode "$TMPFILE" "$OUTFILE"
+fi
+
+# Compare against the master branch, because most development is done against it.
+base_commit="$(git merge-base HEAD master)"
+if [ "$base_commit" = "$(git rev-parse HEAD)" ]; then
+  # Prefix of master branch, so compare against parent commit
+  base_commit="$(git rev-parse HEAD^)"
+  printInfo "Running clang-tidy against parent commit $base_commit"
+else
+  printInfo "Running clang-tidy against parent commit $base_commit from master branch"
 fi
 
 trap - EXIT
 
-printInfo "Running clang-tidy ..."
-output="$(git diff -U0 "$base_commit" | ci/travis/clang-tidy-diff.py -p1 -fix)"
-if [[ ! "$output" =~ "error: " ]]; then
+if git diff -U0 "$base_commit" | ci/travis/clang-tidy-diff.py -p1 -fix; then
   printInfo "clang-tidy passed."
 else
-  printWarning "clang-tidy issued warnings. See below for details. Suggested fixes have also been applied."
-  printWarning "$output"
-  printWarning "If a warning is too pedantic, a proposed fix is incorrect or you are unsure about how to fix a warning,"
-  printWarning "feel free to raise the issue on the pull request."
-  printWarning "clang-tidy warnings can also be suppressed with NOLINT"
+  printError "clang-tidy failed. See above for details including suggested fixes."
+  printError
+  printError "If you think the warning is too aggressive, the proposed fix is incorrect or are unsure about how to"
+  printError "fix, feel free to raise the issue on the PR or Anyscale #learning-cplusplus Slack channel."
+  printError
+  printError "To run clang-tidy locally with fix suggestions, make sure clang and clang-tidy are installed and"
+  printError "available in PATH (version 12 is preferred). Then run"
+  printError "scripts/check-git-clang-tidy-output.sh"
+  printError "from repo root."
 fi

--- a/ci/travis/clang-tidy-diff.py
+++ b/ci/travis/clang-tidy-diff.py
@@ -251,7 +251,7 @@ def main():
     start_workers(max_task_count, run_tidy, task_queue, lock, args.timeout)
 
     # Form the common args list.
-    common_clang_tidy_args = ["--use-color"]
+    common_clang_tidy_args = []
     if args.fix:
         common_clang_tidy_args.append("-fix")
     if args.checks != "":

--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -5,18 +5,6 @@
 # Cause the script to exit if a single command fails
 set -euo pipefail
 
-printWarning() {
-    printf '\033[31mLINT WARNING:\033[0m %s\n' "$@"
-}
-
-printInfo() {
-    printf '\033[34mLINT:\033[0m %s\n' "$@"
-}
-
-if ! git diff --quiet &>/dev/null; then
-    printWarning 'Found unstaged changes before lint. They will be mixed with reformatting, if there is any.'
-fi
-
 FLAKE8_VERSION_REQUIRED="3.9.1"
 YAPF_VERSION_REQUIRED="0.23.0"
 SHELLCHECK_VERSION_REQUIRED="0.7.1"
@@ -38,11 +26,11 @@ check_command_exist() {
             VERSION=$MYPY_VERSION_REQUIRED
             ;;
         *)
-            printWarning "$1 is not a required dependency"
+            echo "$1 is not a required dependency"
             exit 1
     esac
     if ! [ -x "$(command -v "$1")" ]; then
-        printWarning "$1 not installed. pip install $1==$VERSION"
+        echo "$1 not installed. pip install $1==$VERSION"
         exit 1
     fi
 }
@@ -66,16 +54,7 @@ GOOGLE_JAVA_FORMAT_JAR=/tmp/google-java-format-1.7-all-deps.jar
 # params: tool name, tool version, required version
 tool_version_check() {
     if [ "$2" != "$3" ]; then
-        printWarning "Ray uses $1 $3, You currently are using $2. This might generate different results."
-    fi
-}
-
-# params: tool name, version command, desired version
-tool_version_cmd_check() {
-    local tool_version
-    tool_version="$($2)"
-    if [[ ! "$tool_version" =~ $3 ]]; then
-        printWarning "Ray uses $1 $3, but running $2 indicates otherwise. This might generate different results."
+        echo "WARNING: Ray uses $1 $3, You currently are using $2. This might generate different results."
     fi
 }
 
@@ -84,40 +63,24 @@ tool_version_check "yapf" "$YAPF_VERSION" "$YAPF_VERSION_REQUIRED"
 tool_version_check "shellcheck" "$SHELLCHECK_VERSION" "$SHELLCHECK_VERSION_REQUIRED"
 tool_version_check "mypy" "$MYPY_VERSION" "$MYPY_VERSION_REQUIRED"
 
-if command -v clang-format >/dev/null; then
-  tool_version_cmd_check "clang-format" "clang-format --version" "12.0"
+if which clang-format >/dev/null; then
+  CLANG_FORMAT_VERSION=$(clang-format --version | awk '{print $3}')
+  tool_version_check "clang-format" "$CLANG_FORMAT_VERSION" "12.0.0"
 else
-    printWarning "clang-format 12 is not installed!"
-    printWarning "To install on MacOS: brew install clang-format"
-    printWarning "To install on Ubuntu: use package manager e.g. sudo apt install clang-format-12 -y && sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-12 100"
-    printWarning "Or run scripts/install-llvm-binaries.sh"
-fi
-
-if command -v clang-tidy >/dev/null; then
-  tool_version_cmd_check "clang-tidy" "clang-tidy --version" "12.0"
-else
-    printWarning "clang-tidy 12 is not installed!"
-    printWarning "To install on MacOS: brew install clang-tidy"
-    printWarning "To install on Ubuntu: use package manager e.g. sudo apt install clang-tidy-12 -y && sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-12 100"
-    printWarning "Or run scripts/install-llvm-binaries.sh"
-fi
-
-if ! command -v clang >/dev/null; then
-    printWarning "clang is not installed! clang-tidy will be disabled."
-    printWarning "To install, use package manager, run scripts/install-llvm-binaries.sh (Ubuntu only), or compile from source."
+    echo "WARNING: clang-format is not installed!"
 fi
 
 if command -v java >/dev/null; then
   if [ ! -f "$GOOGLE_JAVA_FORMAT_JAR" ]; then
-    printWarning "Java code format tool google-java-format.jar is not installed, start to install it."
+    echo "Java code format tool google-java-format.jar is not installed, start to install it."
     wget https://github.com/google/google-java-format/releases/download/google-java-format-1.7/google-java-format-1.7-all-deps.jar -O "$GOOGLE_JAVA_FORMAT_JAR"
   fi
 else
-    printWarning "Java is not installed, skip formatting Java files!"
+    echo "WARNING:java is not installed, skip format java files!"
 fi
 
 if [[ $(flake8 --version) != *"flake8_quotes"* ]]; then
-    printWarning "Ray uses flake8 with flake8_quotes. Might error without it. Install with: pip install flake8-quotes"
+    echo "WARNING: Ray uses flake8 with flake8_quotes. Might error without it. Install with: pip install flake8-quotes"
 fi
 
 if [[ $(flake8 --version) != *"flake8-bugbear"* ]]; then
@@ -125,9 +88,9 @@ if [[ $(flake8 --version) != *"flake8-bugbear"* ]]; then
 fi
 
 SHELLCHECK_FLAGS=(
-  "--exclude=1090"  # "Can't follow non-constant source. Use a directive to specify location."
-  "--exclude=1091"  # "Not following {file} due to some error"
-  "--exclude=2207"  # "Prefer mapfile or read -a to split command output (or quote to avoid splitting)." -- these aren't compatible with macOS's old Bash
+  --exclude=1090  # "Can't follow non-constant source. Use a directive to specify location."
+  --exclude=1091  # "Not following {file} due to some error"
+  --exclude=2207  # "Prefer mapfile or read -a to split command output (or quote to avoid splitting)." -- these aren't compatible with macOS's old Bash
 )
 
 YAPF_FLAGS=(
@@ -192,7 +155,7 @@ shellcheck_scripts() {
 mypy_on_each() {
     pushd python/ray
     for file in "$@"; do
-       printInfo "Running mypy on $file"
+       echo "Running mypy on $file"
        mypy ${MYPY_FLAGS[@]+"${MYPY_FLAGS[@]}"} "$file"
     done
     popd
@@ -224,7 +187,7 @@ format_files() {
       elif [ -z "${suffix}" ] && [ "${shebang}" != "${shebang%sh}" ] || [ "${suffix}" != "${suffix#.sh}" ]; then
         shell_files+=("${name}")
       else
-        printWarning "failed to determine file type: ${name}" 1>&2
+        echo "error: failed to determine file type: ${name}" 1>&2
         return 1
       fi
     done
@@ -241,7 +204,7 @@ format_files() {
         printf "%s" "${difference}" | patch -p1
       fi
     else
-      printWarning "this version of shellcheck does not support diffs"
+      echo "error: this version of shellcheck does not support diffs"
     fi
 }
 
@@ -249,13 +212,13 @@ format_all_scripts() {
     command -v flake8 &> /dev/null;
     HAS_FLAKE8=$?
 
-    printInfo "$(date)" "YAPF...."
+    echo "$(date)" "YAPF...."
     git ls-files -- '*.py' "${GIT_LS_EXCLUDES[@]}" | xargs -P 10 \
       yapf --in-place "${YAPF_EXCLUDES[@]}" "${YAPF_FLAGS[@]}"
-    printInfo "$(date)" "MYPY...."
+    echo "$(date)" "MYPY...."
     mypy_on_each "${MYPY_FILES[@]}"
     if [ $HAS_FLAKE8 ]; then
-      printInfo "$(date)" "Flake8...."
+      echo "$(date)" "Flake8...."
       git ls-files -- '*.py' "${GIT_LS_EXCLUDES[@]}" | xargs -P 5 \
         flake8 --config=.flake8
 
@@ -271,7 +234,7 @@ format_all_scripts() {
         shell_files+=($(git --no-pager grep -l -- '^#!\(/usr\)\?/bin/\(env \+\)\?\(ba\)\?sh' "${non_shell_files[@]}" || true))
       fi
       if [ 0 -lt "${#shell_files[@]}" ]; then
-        printInfo "$(date)" "shellcheck scripts...."
+        echo "$(date)" "shellcheck scripts...."
         shellcheck_scripts "${shell_files[@]}"
       fi
     fi
@@ -282,17 +245,17 @@ format_all_scripts() {
 format_all() {
     format_all_scripts "${@}"
 
-    printInfo "$(date)" "clang-format...."
+    echo "$(date)" "clang-format...."
     if command -v clang-format >/dev/null; then
       git ls-files -- '*.cc' '*.h' '*.proto' "${GIT_LS_EXCLUDES[@]}" | xargs -P 5 clang-format -i
     fi
 
-    printInfo "$(date)" "format java...."
+    echo "$(date)" "format java...."
     if command -v java >/dev/null & [ -f "$GOOGLE_JAVA_FORMAT_JAR" ]; then
       git ls-files -- '*.java' "${GIT_LS_EXCLUDES[@]}" | sed -E "\:$JAVA_EXCLUDES_REGEX:d" | xargs -P 5 java -jar "$GOOGLE_JAVA_FORMAT_JAR" -i
     fi
 
-    printInfo "$(date)" "done!"
+    echo "$(date)" "done!"
 }
 
 # Format files that differ from main branch. Ignores dirs that are not slated
@@ -306,42 +269,35 @@ format_changed() {
     # exist on both branches.
     MERGEBASE="$(git merge-base upstream/master HEAD)"
 
-    printInfo "Running fake8 on *.py ..."
     if ! git diff --diff-filter=ACRM --quiet --exit-code "$MERGEBASE" -- '*.py' &>/dev/null; then
         git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- '*.py' | xargs -P 5 \
              yapf --in-place "${YAPF_EXCLUDES[@]}" "${YAPF_FLAGS[@]}"
-        if command -v flake8 >/dev/null; then
+        if which flake8 >/dev/null; then
             git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- '*.py' | xargs -P 5 \
                  flake8 --config=.flake8
         fi
     fi
 
-    printInfo "Running fake8 on cython files ..."
     if ! git diff --diff-filter=ACRM --quiet --exit-code "$MERGEBASE" -- '*.pyx' '*.pxd' '*.pxi' &>/dev/null; then
-        if command -v flake8 >/dev/null; then
+        if which flake8 >/dev/null; then
             git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- '*.pyx' '*.pxd' '*.pxi' | xargs -P 5 \
                  flake8 --config=.flake8 "$FLAKE8_PYX_IGNORES"
         fi
     fi
 
-    printInfo "Running clang-format ..."
-    if command -v clang-format >/dev/null; then
-        ci/travis/check-git-clang-format-output.sh
+    if which clang-format >/dev/null; then
+        if ! git diff --diff-filter=ACRM --quiet --exit-code "$MERGEBASE" -- '*.cc' '*.h' &>/dev/null; then
+            git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- '*.cc' '*.h' | xargs -P 5 \
+                 clang-format -i
+        fi
     fi
 
-    printInfo "Running clang-tidy ..."
-    if command -v clang-tidy >/dev/null && command -v clang >/dev/null; then
-        ci/travis/check-git-clang-tidy-output.sh
-    fi
-
-    printInfo "Running Java format ..."
     if command -v java >/dev/null & [ -f "$GOOGLE_JAVA_FORMAT_JAR" ]; then
        if ! git diff --diff-filter=ACRM --quiet --exit-code "$MERGEBASE" -- '*.java' &>/dev/null; then
             git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- '*.java' | sed -E "\:$JAVA_EXCLUDES_REGEX:d" | xargs -P 5 java -jar "$GOOGLE_JAVA_FORMAT_JAR" -i
         fi
     fi
 
-    printInfo "Running shellcheck ..."
     if command -v shellcheck >/dev/null; then
         local shell_files non_shell_files
         non_shell_files=($(git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- ':(exclude)*.sh'))
@@ -376,7 +332,7 @@ else
     fi
 
     # Only fetch master since that's the branch we're diffing against.
-    git fetch --quiet upstream master || true
+    git fetch upstream master || true
 
     # Format only the files that changed in last commit.
     format_changed
@@ -391,7 +347,9 @@ PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE:-python}
 $PYTHON_EXECUTABLE ci/travis/check_import_order.py . -s ci -s python/ray/thirdparty_files -s python/build -s lib
 
 if ! git diff --quiet &>/dev/null; then
-    printWarning 'Found unstaged changes after lint, possibly from reformatting:'
+    echo 'Reformatted changed files. Please review and stage the changes.'
+    echo 'Files updated:'
+    echo
 
     git --no-pager diff --name-only
 


### PR DESCRIPTION
…idy rules (#19055)"

This reverts commit 5d9e3a01218d951294cc94a4122e2bf737e4d824.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

After this PR, running scripts/format.sh is very slow. I think this is breaking the incremental format logic which only lints changed files.