### PR TITLE
Add serve ft nightly

### DIFF
--- a/python/ray/serve/storage/checkpoint_path.py
+++ b/python/ray/serve/storage/checkpoint_path.py
@@ -32,7 +32,7 @@ def make_kv_store(checkpoint_path, namespace):
 
         if parsed_url.scheme == "s3":
             bucket = parsed_url.netloc
-            prefix = parsed_url.path
+            prefix = parsed_url.path.lstrip('/')
             logger.info(
                 "Using Ray S3 KVStore for controller checkpoint and recovery: "
                 f"bucket={bucket} checkpoint_path={checkpoint_path}")

--- a/python/ray/serve/storage/checkpoint_path.py
+++ b/python/ray/serve/storage/checkpoint_path.py
@@ -32,7 +32,7 @@ def make_kv_store(checkpoint_path, namespace):
 
         if parsed_url.scheme == "s3":
             bucket = parsed_url.netloc
-            prefix = parsed_url.path.lstrip('/')
+            prefix = parsed_url.path.lstrip("/")
             logger.info(
                 "Using Ray S3 KVStore for controller checkpoint and recovery: "
                 f"bucket={bucket} checkpoint_path={checkpoint_path}")

--- a/python/ray/serve/storage/checkpoint_path.py
+++ b/python/ray/serve/storage/checkpoint_path.py
@@ -32,6 +32,8 @@ def make_kv_store(checkpoint_path, namespace):
 
         if parsed_url.scheme == "s3":
             bucket = parsed_url.netloc
+            # We need to strip leading "/" in path as right key to use in
+            # boto3. Ex: s3://bucket/folder/file.zip -> key = "folder/file.zip"
             prefix = parsed_url.path.lstrip("/")
             logger.info(
                 "Using Ray S3 KVStore for controller checkpoint and recovery: "

--- a/python/ray/serve/storage/kv_store.py
+++ b/python/ray/serve/storage/kv_store.py
@@ -179,14 +179,11 @@ class RayS3KVStore(KVStoreBase):
             namepsace: str,
             bucket="",
             prefix="",
-            region_name="us-west-2",
-            aws_access_key_id=None,
-            aws_secret_access_key=None,
-            aws_session_token=None,
+            region_name="us-west-2"
     ):
         self._namespace = namepsace
         self._bucket = bucket
-        self._prefix = prefix + "/" if prefix else ""
+        self._prefix = prefix
         if not boto3:
             raise ImportError(
                 "You tried to use S3KVstore client without boto3 installed."
@@ -194,12 +191,12 @@ class RayS3KVStore(KVStoreBase):
         self._s3 = boto3.client(
             "s3",
             region_name=region_name,
-            aws_access_key_id=aws_access_key_id,
-            aws_secret_access_key=aws_secret_access_key,
-            aws_session_token=aws_session_token)
+            aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", None),
+            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY", None),
+            aws_session_token=os.environ.get("AWS_SESSION_TOKEN", None))
 
     def get_storage_key(self, key: str) -> str:
-        return f"{self._prefix}{self._namespace}-{key}"
+        return f"{self._prefix}/{self._namespace}-{key}"
 
     def put(self, key: str, val: bytes) -> bool:
         """Put the key-value pair into the store.

--- a/python/ray/serve/storage/kv_store.py
+++ b/python/ray/serve/storage/kv_store.py
@@ -174,13 +174,11 @@ class RayS3KVStore(KVStoreBase):
     caller must handle serialization.
     """
 
-    def __init__(
-            self,
-            namepsace: str,
-            bucket="",
-            prefix="",
-            region_name="us-west-2"
-    ):
+    def __init__(self,
+                 namepsace: str,
+                 bucket="",
+                 prefix="",
+                 region_name="us-west-2"):
         self._namespace = namepsace
         self._bucket = bucket
         self._prefix = prefix
@@ -192,7 +190,8 @@ class RayS3KVStore(KVStoreBase):
             "s3",
             region_name=region_name,
             aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", None),
-            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY", None),
+            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY",
+                                                 None),
             aws_session_token=os.environ.get("AWS_SESSION_TOKEN", None))
 
     def get_storage_key(self, key: str) -> str:

--- a/python/ray/serve/storage/kv_store.py
+++ b/python/ray/serve/storage/kv_store.py
@@ -174,7 +174,8 @@ class RayS3KVStore(KVStoreBase):
     caller must handle serialization.
     """
 
-    def __init__(self,
+    def __init__(
+            self,
             namepsace: str,
             bucket="",
             prefix="",
@@ -182,7 +183,7 @@ class RayS3KVStore(KVStoreBase):
             aws_access_key_id=None,
             aws_secret_access_key=None,
             aws_session_token=None,
-        ):
+    ):
         self._namespace = namepsace
         self._bucket = bucket
         self._prefix = prefix

--- a/python/ray/serve/storage/kv_store.py
+++ b/python/ray/serve/storage/kv_store.py
@@ -175,10 +175,14 @@ class RayS3KVStore(KVStoreBase):
     """
 
     def __init__(self,
-                 namepsace: str,
-                 bucket="",
-                 prefix="",
-                 region_name="us-west-2"):
+            namepsace: str,
+            bucket="",
+            prefix="",
+            region_name="us-west-2",
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+            aws_session_token=None,
+        ):
         self._namespace = namepsace
         self._bucket = bucket
         self._prefix = prefix
@@ -189,10 +193,9 @@ class RayS3KVStore(KVStoreBase):
         self._s3 = boto3.client(
             "s3",
             region_name=region_name,
-            aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", None),
-            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY",
-                                                 None),
-            aws_session_token=os.environ.get("AWS_SESSION_TOKEN", None))
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token)
 
     def get_storage_key(self, key: str) -> str:
         return f"{self._prefix}/{self._namespace}-{key}"

--- a/release/serve_tests/serve_tests.yaml
+++ b/release/serve_tests/serve_tests.yaml
@@ -27,12 +27,27 @@
 - name: serve_micro_benchmark
   cluster:
     app_config: app_config.yaml
+    # 16 CPUS
     compute_template: compute_tpl_single_node.yaml
 
   run:
     timeout: 7200
     long_running: False
     script: python workloads/serve_micro_benchmark.py
+
+  smoke_test:
+    timeout: 600
+
+- name: serve_cluster_fault_tolerance
+  cluster:
+    app_config: app_config.yaml
+    # 16 CPUS
+    compute_template: compute_tpl_single_node.yaml
+
+  run:
+    timeout: 7200
+    long_running: False
+    script: python workloads/serve_cluster_fault_tolerance.py
 
   smoke_test:
     timeout: 600

--- a/release/serve_tests/workloads/serve_cluster_fault_tolerance.py
+++ b/release/serve_tests/workloads/serve_cluster_fault_tolerance.py
@@ -1,0 +1,100 @@
+"""
+Test that a serve deployment can recover from cluster failures by resuming
+from checkpoints of external source, such as s3.
+
+For product testing, we skip the part of actually starting new cluster as
+it's Job Manager's responsibility, and only re-deploy to the same cluster
+with remote checkpoint.
+"""
+
+import click
+import os
+import time
+import requests
+
+from serve_test_cluster_utils import (
+    setup_local_single_node_cluster,
+    setup_anyscale_cluster
+)
+from serve_test_utils import (
+    save_test_results,
+)
+from ray.serve.backend_state import CHECKPOINT_KEY as backend_checkpoint_key
+from ray.serve.endpoint_state import CHECKPOINT_KEY as endpoint_state_key
+
+import ray
+from ray import serve
+from ray.serve.utils import logger
+
+# Deployment configs
+DEFAULT_NUM_REPLICAS = 4
+DEFAULT_MAX_BATCH_SIZE = 16
+
+# Checkpoint configs
+DEFAULT_CHECKPOINT_PATH = "s3://serve-nightly-tests/fault-tolerant-test-checkpoint"
+
+def request_with_retries(endpoint, timeout=30):
+    start = time.time()
+    while True:
+        try:
+            return requests.get(
+                "http://127.0.0.1:8000" + endpoint, timeout=timeout)
+        except requests.RequestException:
+            if time.time() - start > timeout:
+                raise TimeoutError
+            time.sleep(0.1)
+
+@click.command()
+def main():
+    # (1) Setup cluster
+    # IS_SMOKE_TEST is set by args of releaser's e2e.py
+    smoke_test = os.environ.get("IS_SMOKE_TEST", "1")
+    if smoke_test == "1":
+        setup_local_single_node_cluster(1, checkpoint_path=DEFAULT_CHECKPOINT_PATH)
+    else:
+        setup_anyscale_cluster(checkpoint_path=DEFAULT_CHECKPOINT_PATH)
+
+    # Deploy for the first time
+    @serve.deployment(name="echo", num_replicas=DEFAULT_NUM_REPLICAS)
+    class Echo:
+        def __init__(self):
+            return True
+
+        def __call__(self, request):
+            return "hii"
+
+    Echo.deploy()
+
+    # Ensure endpoint is working
+    for _ in range(10):
+        response = request_with_retries("/echo/", timeout=30)
+        assert response.text == "hii"
+
+    logger.info("Initial deployment successful with working endpoint.")
+
+    # Kill controller and wait for endpoint to be available again
+    # Recover from remote checkpoint
+    # Ensure endpoint is still available with expected results
+    ray.kill(serve.api._global_client._controller, no_restart=False)
+    for _ in range(10):
+        response = request_with_retries("/echo/", timeout=30)
+        assert response.text == "hii"
+
+    logger.info(
+        "Deployment recovery from s3 checkpoint is successful "
+        "with working endpoint.")
+
+    # Checkpoints in S3 bucket are moved after 7 days with explicit lifecycle
+    # rules. Each checkpoint is ~260 Bytes in size from this test.
+
+    # Save results
+    save_test_results(
+        {"result": "success"},
+        default_output_file="/tmp/serve_cluster_fault_tolerance.json")
+
+
+if __name__ == "__main__":
+    main()
+    import pytest
+    import sys
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/release/serve_tests/workloads/serve_cluster_fault_tolerance.py
+++ b/release/serve_tests/workloads/serve_cluster_fault_tolerance.py
@@ -15,9 +15,7 @@ import os
 
 from serve_test_cluster_utils import setup_local_single_node_cluster
 
-from serve_test_utils import (
-    save_test_results
-)
+from serve_test_utils import (save_test_results)
 
 import ray
 from ray import serve
@@ -26,6 +24,7 @@ from ray.serve.utils import logger
 # Deployment configs
 DEFAULT_NUM_REPLICAS = 4
 DEFAULT_MAX_BATCH_SIZE = 16
+
 
 def request_with_retries(endpoint, timeout=3):
     start = time.time()
@@ -52,7 +51,7 @@ def main():
     if smoke_test == "1":
         checkpoint_path = "file://checkpoint.db"
     else:
-        checkpoint_path = "s3://serve-nightly-tests/fault-tolerant-test-checkpoint" # noqa: E501
+        checkpoint_path = "s3://serve-nightly-tests/fault-tolerant-test-checkpoint"  # noqa: E501
 
     _, cluster = setup_local_single_node_cluster(
         1, checkpoint_path=checkpoint_path, namespace=namespace)
@@ -85,7 +84,8 @@ def main():
 
     # Start another ray cluster with same namespace to resume from previous
     # checkpoints with no new deploy() call.
-    setup_local_single_node_cluster(1, checkpoint_path=checkpoint_path, namespace=namespace)
+    setup_local_single_node_cluster(
+        1, checkpoint_path=checkpoint_path, namespace=namespace)
 
     for _ in range(5):
         response = request_with_retries("/echo/", timeout=3)

--- a/release/serve_tests/workloads/serve_cluster_fault_tolerance.py
+++ b/release/serve_tests/workloads/serve_cluster_fault_tolerance.py
@@ -12,15 +12,10 @@ import os
 import time
 import requests
 
-from serve_test_cluster_utils import (
-    setup_local_single_node_cluster,
-    setup_anyscale_cluster
-)
+from serve_test_cluster_utils import (setup_local_single_node_cluster,
+                                      setup_anyscale_cluster)
 from serve_test_utils import (
-    save_test_results,
-)
-from ray.serve.backend_state import CHECKPOINT_KEY as backend_checkpoint_key
-from ray.serve.endpoint_state import CHECKPOINT_KEY as endpoint_state_key
+    save_test_results, )
 
 import ray
 from ray import serve
@@ -31,7 +26,8 @@ DEFAULT_NUM_REPLICAS = 4
 DEFAULT_MAX_BATCH_SIZE = 16
 
 # Checkpoint configs
-DEFAULT_CHECKPOINT_PATH = "s3://serve-nightly-tests/fault-tolerant-test-checkpoint"
+DEFAULT_CHECKPOINT_PATH = "s3://serve-nightly-tests/fault-tolerant-test-checkpoint"  # noqa: E501
+
 
 def request_with_retries(endpoint, timeout=30):
     start = time.time()
@@ -44,13 +40,15 @@ def request_with_retries(endpoint, timeout=30):
                 raise TimeoutError
             time.sleep(0.1)
 
+
 @click.command()
 def main():
     # (1) Setup cluster
     # IS_SMOKE_TEST is set by args of releaser's e2e.py
     smoke_test = os.environ.get("IS_SMOKE_TEST", "1")
     if smoke_test == "1":
-        setup_local_single_node_cluster(1, checkpoint_path=DEFAULT_CHECKPOINT_PATH)
+        setup_local_single_node_cluster(
+            1, checkpoint_path=DEFAULT_CHECKPOINT_PATH)
     else:
         setup_anyscale_cluster(checkpoint_path=DEFAULT_CHECKPOINT_PATH)
 
@@ -80,16 +78,17 @@ def main():
         response = request_with_retries("/echo/", timeout=30)
         assert response.text == "hii"
 
-    logger.info(
-        "Deployment recovery from s3 checkpoint is successful "
-        "with working endpoint.")
+    logger.info("Deployment recovery from s3 checkpoint is successful "
+                "with working endpoint.")
 
     # Checkpoints in S3 bucket are moved after 7 days with explicit lifecycle
     # rules. Each checkpoint is ~260 Bytes in size from this test.
 
     # Save results
     save_test_results(
-        {"result": "success"},
+        {
+            "result": "success"
+        },
         default_output_file="/tmp/serve_cluster_fault_tolerance.json")
 
 

--- a/release/serve_tests/workloads/serve_test_cluster_utils.py
+++ b/release/serve_tests/workloads/serve_test_cluster_utils.py
@@ -13,7 +13,7 @@ NUM_CONNECTIONS = 10
 
 
 def setup_local_single_node_cluster(
-        num_nodes: int, checkpoint_path: str = DEFAULT_CHECKPOINT_PATH):
+        num_nodes: int, checkpoint_path: str = DEFAULT_CHECKPOINT_PATH, namespace="serve"):
     """Setup ray cluster locally via ray.init() and Cluster()
 
     Each actor is simulated in local process on single node,
@@ -27,13 +27,14 @@ def setup_local_single_node_cluster(
             num_gpus=0,
             resources={str(i): 2},
         )
-    ray.init(address=cluster.address, dashboard_host="0.0.0.0")
+    ray.init(address=cluster.address, dashboard_host="0.0.0.0", namespace=namespace)
     serve_client = serve.start(
+        detached=True,
         http_options={"location": DeploymentMode.EveryNode},
         _checkpoint_path=checkpoint_path,
     )
 
-    return serve_client
+    return serve_client, cluster
 
 
 def setup_anyscale_cluster(checkpoint_path: str = DEFAULT_CHECKPOINT_PATH):

--- a/release/serve_tests/workloads/serve_test_cluster_utils.py
+++ b/release/serve_tests/workloads/serve_test_cluster_utils.py
@@ -13,7 +13,9 @@ NUM_CONNECTIONS = 10
 
 
 def setup_local_single_node_cluster(
-        num_nodes: int, checkpoint_path: str = DEFAULT_CHECKPOINT_PATH, namespace="serve"):
+        num_nodes: int,
+        checkpoint_path: str = DEFAULT_CHECKPOINT_PATH,
+        namespace="serve"):
     """Setup ray cluster locally via ray.init() and Cluster()
 
     Each actor is simulated in local process on single node,
@@ -27,7 +29,8 @@ def setup_local_single_node_cluster(
             num_gpus=0,
             resources={str(i): 2},
         )
-    ray.init(address=cluster.address, dashboard_host="0.0.0.0", namespace=namespace)
+    ray.init(
+        address=cluster.address, dashboard_host="0.0.0.0", namespace=namespace)
     serve_client = serve.start(
         detached=True,
         http_options={"location": DeploymentMode.EveryNode},

--- a/release/serve_tests/workloads/serve_test_cluster_utils.py
+++ b/release/serve_tests/workloads/serve_test_cluster_utils.py
@@ -6,13 +6,16 @@ from ray import serve
 from ray.cluster_utils import Cluster
 from ray.serve.utils import logger
 from ray.serve.config import DeploymentMode
-
+from ray.serve.constants import DEFAULT_CHECKPOINT_PATH
 # Cluster setup configs
 NUM_CPU_PER_NODE = 10
 NUM_CONNECTIONS = 10
 
 
-def setup_local_single_node_cluster(num_nodes):
+def setup_local_single_node_cluster(
+    num_nodes: int,
+    checkpoint_path: str = DEFAULT_CHECKPOINT_PATH
+):
     """Setup ray cluster locally via ray.init() and Cluster()
 
     Each actor is simulated in local process on single node,
@@ -28,12 +31,14 @@ def setup_local_single_node_cluster(num_nodes):
         )
     ray.init(address=cluster.address, dashboard_host="0.0.0.0")
     serve_client = serve.start(
-        http_options={"location": DeploymentMode.EveryNode})
+        http_options={"location": DeploymentMode.EveryNode},
+        _checkpoint_path=checkpoint_path,
+    )
 
     return serve_client
 
 
-def setup_anyscale_cluster():
+def setup_anyscale_cluster(checkpoint_path: str = DEFAULT_CHECKPOINT_PATH):
     """Setup ray cluster at anyscale via ray.client()
 
     Note this is by default large scale and should be kicked off
@@ -44,7 +49,9 @@ def setup_anyscale_cluster():
     # ray.client().env({}).connect()
     ray.init(address="auto")
     serve_client = serve.start(
-        http_options={"location": DeploymentMode.EveryNode})
+        http_options={"location": DeploymentMode.EveryNode},
+        _checkpoint_path=checkpoint_path,
+    )
 
     return serve_client
 

--- a/release/serve_tests/workloads/serve_test_cluster_utils.py
+++ b/release/serve_tests/workloads/serve_test_cluster_utils.py
@@ -13,9 +13,7 @@ NUM_CONNECTIONS = 10
 
 
 def setup_local_single_node_cluster(
-    num_nodes: int,
-    checkpoint_path: str = DEFAULT_CHECKPOINT_PATH
-):
+        num_nodes: int, checkpoint_path: str = DEFAULT_CHECKPOINT_PATH):
     """Setup ray cluster locally via ray.init() and Cluster()
 
     Each actor is simulated in local process on single node,

--- a/release/serve_tests/workloads/serve_test_cluster_utils.py
+++ b/release/serve_tests/workloads/serve_test_cluster_utils.py
@@ -24,7 +24,7 @@ def setup_local_single_node_cluster(
     cluster = Cluster()
     for i in range(num_nodes):
         cluster.add_node(
-            redis_port=6379 if i == 0 else None,
+            redis_port=6380 if i == 0 else None,
             num_cpus=NUM_CPU_PER_NODE,
             num_gpus=0,
             resources={str(i): 2},


### PR DESCRIPTION
Create a serve FT test for both local testing as well as product nightly.

It uses s3://serve-nightly-tests/fault-tolerant-test-checkpoint as checkpoint path with 7 days TTL, each checkpoint is 260 Bytes in size. 

In each test run, it will try to run test in uuid4 namespace with unique storage key, go through deploy() -> kill controller & ray & cluster -> resume in same namespace -> check endpoints availability process, then attempt to clean up checkpoint file and exit.

Works for both local disk and s3 path, since we don't have sufficient infra for multi cluster yet, both local and product tests will be using the same cluster_utils to run local cluster, except using different storage paths.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
