### PR TITLE
[Client] disable auto init for get_runtime_context()

### DIFF
--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -189,7 +189,7 @@ _runtime_context = None
 
 
 @PublicAPI(stability="beta")
-@client_mode_hook(auto_init=True)
+@client_mode_hook(auto_init=False)
 def get_runtime_context():
     """Get the runtime context of the current driver/worker.
 

--- a/python/ray/tests/test_runtime_context.py
+++ b/python/ray/tests/test_runtime_context.py
@@ -220,6 +220,14 @@ def test_actor_stats_async_actor(ray_start_regular):
     assert max(result["AysncActor.func"]["pending"] for result in results) == 3
 
 
+# get_runtime_context() can be called outside of Ray so it should not start
+# Ray automatically.
+def test_no_auto_init(shutdown_only):
+    assert not ray.is_initialized()
+    ray.get_runtime_context()
+    assert not ray.is_initialized()
+
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`ray.get_runtime_context()` is sometimes called without Ray initialized, to test if the logic is indeed running with Ray. It seems we should not auto initialize Ray from calling this API.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
