### PR TITLE
add dependencies to BUILD.bazel and update windows bazel to 4.2.1

### DIFF
--- a/.buildkite/windows/install/bazel.ps1
+++ b/.buildkite/windows/install/bazel.ps1
@@ -1,4 +1,4 @@
-$Env:BAZEL_URL="https://github.com/bazelbuild/bazel/releases/download/3.2.0/bazel-3.2.0-windows-x86_64.zip"
+$Env:BAZEL_URL="https://github.com/bazelbuild/bazel/releases/download/4.2.1/bazel-4.2.1-windows-x86_64.zip"
 Write-Host ('Downloading {0} ...' -f $env:BAZEL_URL);
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
 Invoke-WebRequest -Uri $env:BAZEL_URL -OutFile 'bazel.zip';

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -623,10 +623,12 @@ cc_library(
         "src/ray/stats/metric_exporter_client.cc",
     ],
     hdrs = [
+        "src/ray/stats/metric.h",
         "src/ray/stats/metric_defs.h",
         "src/ray/stats/metric_exporter.h",
         "src/ray/stats/metric_exporter_client.h",
         "src/ray/stats/stats.h",
+        "src/ray/stats/tag_defs.h",
     ],
     copts = COPTS,
     linkopts = select({

--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -100,7 +100,8 @@ Ray can be built from the repository as follows.
   git clone https://github.com/ray-project/ray.git
 
   # Install Bazel.
-  # (Windows users: please manually place Bazel in your PATH, and point BAZEL_SH to MSYS2's Bash.)
+  # (Windows users: please manually place Bazel in your PATH, and point
+    BAZEL_SH to MSYS2's Bash: ``set BAZEL_SH=C:\Program Files\Git\bin\bash.exe``)
   ray/ci/travis/install-bazel.sh
 
   # Build the dashboard
@@ -126,7 +127,7 @@ Building Ray on Windows (full)
 
 The following links were correct during the writing of this section. In case the URLs changed, search at the organizations' sites.
 
-- bazel 3.4 (https://github.com/bazelbuild/bazel/releases/tag/3.4.0)
+- bazel 4.2 (https://github.com/bazelbuild/bazel/releases/tag/4.2.1)
 - Microsoft Visual Studio 2019 (or Microsoft Build Tools 2019 - https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019)
 - JDK 15 (https://www.oracle.com/java/technologies/javase-jdk15-downloads.html)
 - Miniconda 3 (https://docs.conda.io/en/latest/miniconda.html)
@@ -149,7 +150,11 @@ The following links were correct during the writing of this section. In case the
 
 3. Define an environment variable BAZEL_SH to point to bash.exe. If git for Windows was installed for all users, bash's path should be ``C:\Program Files\Git\bin\bash.exe``. If git was installed for a single user, adjust the path accordingly.
 
-4. Bazel 3.4 installation. Go to bazel 3.4 release web page and download bazel-3.4.0-windows-x86_64.exe. Copy the exe into the directory of your choice. Define an environment variable BAZEL_PATH to full exe path (example: ``C:\bazel\bazel-3.4.0-windows-x86_64.exe``) 
+4. Bazel 4.2 installation. Go to bazel 4.2 release web page and download
+bazel-4.2.1-windows-x86_64.exe. Copy the exe into the directory of your choice.
+Define an environment variable BAZEL_PATH to full exe path (example:
+``set BAZEL_PATH=C:\bazel\bazel.exe``). Also add the bazel directory to the
+``PATH`` (example: ``set PATH=%PATH%;C:\bazel``)
 
 5. Install cython and pytest:
 

--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -100,9 +100,9 @@ Ray can be built from the repository as follows.
   git clone https://github.com/ray-project/ray.git
 
   # Install Bazel.
-  # (Windows users: please manually place Bazel in your PATH, and point
-    BAZEL_SH to MSYS2's Bash: ``set BAZEL_SH=C:\Program Files\Git\bin\bash.exe``)
   ray/ci/travis/install-bazel.sh
+  # (Windows users: please manually place Bazel in your PATH, and point
+  # BAZEL_SH to MSYS2's Bash: ``set BAZEL_SH=C:\Program Files\Git\bin\bash.exe``)
 
   # Build the dashboard
   # (requires Node.js, see https://nodejs.org/ for more information).


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes failure when building locally on windows. Also update bazel to 4.2.1 on windows (in buildkite and docs)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #19099 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

I am a bit confused by the need for this PR. As far as I can tell, the dependency chain for the headers should be solved by the dependency of `stats_lib` on `stats_metric`, since `stats_metric` depends on the missing headers. Also CI is passing, but two developers reported failures when building with windows locally. Updating the local bazel version to 4.2.1 did not solve the problem, but it unifies the bazel versions across the system, including documentation (the version in `python/setup.py` is 4.2.1.