### PR TITLE
[tune] Use queue to display JupyterNotebookReporter updates in Ray client

### DIFF
--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -8,6 +8,9 @@ import sys
 import numpy as np
 import time
 
+from ray.util.annotations import PublicAPI, DeveloperAPI
+from ray.util.queue import Queue
+
 from ray.tune.callback import Callback
 from ray.tune.logger import pretty_print, logger
 from ray.tune.result import (DEFAULT_METRIC, EPISODE_REWARD_MEAN,
@@ -16,7 +19,6 @@ from ray.tune.result import (DEFAULT_METRIC, EPISODE_REWARD_MEAN,
 from ray.tune.trial import DEBUG_PRINT_INTERVAL, Trial
 from ray.tune.utils import unflattened_lookup
 from ray.tune.utils.log import Verbosity, has_verbosity
-from ray.util.annotations import PublicAPI, DeveloperAPI
 
 try:
     from collections.abc import Mapping, MutableMapping
@@ -416,15 +418,32 @@ class JupyterNotebookReporter(TuneReporterBase):
                 "to `tune.run()` instead.")
 
         self._overwrite = overwrite
+        self._output_queue = None
+
+    def set_output_queue(self, queue: Queue):
+        self._output_queue = queue
 
     def report(self, trials: List[Trial], done: bool, *sys_info: Dict):
-        from IPython.display import clear_output
-        from IPython.core.display import display, HTML
-        if self._overwrite:
-            clear_output(wait=True)
+        overwrite = self._overwrite
         progress_str = self._progress_str(
             trials, done, *sys_info, fmt="html", delim="<br>")
-        display(HTML(progress_str))
+
+        def update_output():
+            from IPython.display import clear_output
+            from IPython.core.display import display, HTML
+
+            if overwrite:
+                clear_output(wait=True)
+
+            display(HTML(progress_str))
+
+        if self._output_queue is not None:
+            # If an output queue is set, send callable (e.g. when using
+            # Ray client)
+            self._output_queue.put(update_output)
+        else:
+            # Else, output directly
+            update_output()
 
 
 @PublicAPI

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -11,13 +11,15 @@ import warnings
 
 import ray
 from ray.util.annotations import PublicAPI
+from ray.util.queue import Queue, Empty
 
 from ray.tune.analysis import ExperimentAnalysis
 from ray.tune.callback import Callback
 from ray.tune.error import TuneError
 from ray.tune.experiment import Experiment, convert_to_experiment_list
 from ray.tune.logger import Logger
-from ray.tune.progress_reporter import detect_reporter, ProgressReporter
+from ray.tune.progress_reporter import (detect_reporter, ProgressReporter,
+                                        JupyterNotebookReporter)
 from ray.tune.ray_trial_executor import RayTrialExecutor
 from ray.tune.registry import get_trainable_cls
 from ray.tune.stopper import Stopper
@@ -314,7 +316,39 @@ def run(
         # Make sure tune.run is called on the sever node.
         remote_run = force_on_current_node(remote_run)
 
-        return ray.get(remote_run.remote(_remote=False, **remote_run_kwargs))
+        # JupyterNotebooks don't work with remote tune runs out of the box
+        # (e.g. via Ray client) as they don't have access to the main
+        # process stdout. So we introduce a queue here that accepts
+        # callables, which will then be executed on the driver side.
+        if isinstance(progress_reporter, JupyterNotebookReporter):
+            execute_queue = Queue(actor_options=force_on_current_node(None))
+            progress_reporter.set_output_queue(execute_queue)
+
+            def get_next_queue_item():
+                try:
+                    return execute_queue.get(block=False)
+                except Empty:
+                    return None
+
+        else:
+            # If we don't need a queue, use this dummy get fn instead of
+            # scheduling an unneeded actor
+            def get_next_queue_item():
+                return None
+
+        remote_future = remote_run.remote(_remote=False, **remote_run_kwargs)
+
+        # ray.wait(...)[1] returns futures that are not ready, yet
+        while ray.wait([remote_future], timeout=1)[1]:
+            # Check if we have items to execute
+            execute_item = get_next_queue_item()
+            while execute_item:
+                if isinstance(execute_item, Callable):
+                    execute_item()
+
+                execute_item = get_next_queue_item()
+
+        return ray.get(remote_future)
 
     del remote_run_kwargs
 

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -645,7 +645,7 @@ def get_current_node_resource_key() -> str:
         raise ValueError("Cannot found the node dictionary for current node.")
 
 
-def force_on_current_node(task_or_actor):
+def force_on_current_node(task_or_actor=None):
     """Given a task or actor, place it on the current node.
 
     If using Ray Client, the current node is the client server node.

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -652,7 +652,8 @@ def force_on_current_node(task_or_actor):
 
     Args:
         task_or_actor: A Ray remote function or class to place on the
-            current node.
+            current node. If None, returns the options dict to pass to
+            another actor.
 
     Returns:
         The provided task or actor, but with options modified to force
@@ -660,6 +661,10 @@ def force_on_current_node(task_or_actor):
     """
     node_resource_key = get_current_node_resource_key()
     options = {"resources": {node_resource_key: 0.01}}
+
+    if task_or_actor is None:
+        return options
+
     return task_or_actor.options(**options)
 
 


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Jupyter notebook HTML updates need access to the main process stdout - however, this is not available in remote tune.run calls (e.g. via Ray client). This PR introduces an execution queue that can be utilized to display Jupyter notebook updates.

## Related issue number

Closes #16016

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
