### PR TITLE
[client] deflake test_object_ref_cleanup

### DIFF
--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -705,7 +705,9 @@ def test_object_ref_cleanup():
     # See https://github.com/ray-project/ray/issues/17968 for details
     with ray_start_client_server():
         result = run_string_as_driver(object_ref_cleanup_script)
-        assert result == ""
+        assert "Error in sys.excepthook:" not in result
+        assert "AttributeError: 'NoneType' object has no " not in result
+        assert "Exception ignored in" not in result
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current check for `test_object_ref_cleanup` looks for completely empty output in the example script, but sometimes random core stuff pops up which causes the test to flake. This loosens the check by only checking that the output the test was written for aren't present (original issue: #17968). Example random output from flaky run:

```
E           AssertionError: assert '3 retries le...troyed.\r\r\n' == ''
E             + 3 retries left for task ffffffffffffffffb693ceca96c0e452795ee22201000000, attempting to resubmit.

E             + (pid=None) [2021-10-04 07:16:14,793 E 4056 2912] gcs_actor_manager.cc:187: Failed to create actor, job id = 01000000, actor id = b693ceca96c0e452795ee22201000000, status: Invalid: Actor may be already destroyed.

E             +
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
