### PR TITLE
[tune] Add resume="AUTO" and enhance resume error messages

### DIFF
--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -195,7 +195,9 @@ class TrialRunner:
     """
 
     CKPT_FILE_TMPL = "experiment_state-{}.json"
-    VALID_RESUME_TYPES = [True, "LOCAL", "REMOTE", "PROMPT", "ERRORED_ONLY"]
+    VALID_RESUME_TYPES = [
+        True, "LOCAL", "REMOTE", "PROMPT", "ERRORED_ONLY", "AUTO"
+    ]
     RAISE = "RAISE"
 
     def __init__(self,
@@ -415,7 +417,7 @@ class TrialRunner:
 
         Args:
             resume_type: One of True, "REMOTE", "LOCAL",
-                "PROMPT", "ERRORED_ONLY".
+                "PROMPT", "ERRORED_ONLY", "AUTO".
         """
         # TODO: Consider supporting ERRORED_ONLY+REMOTE?
         if not resume_type:
@@ -426,11 +428,54 @@ class TrialRunner:
         # Not clear if we need this assertion, since we should always have a
         # local checkpoint dir.
         assert self._local_checkpoint_dir or self._remote_checkpoint_dir
+
+        if resume_type == "AUTO":
+            if self._remote_checkpoint_dir:
+                logger.info(
+                    f"Trying to find and download experiment checkpoint at "
+                    f"{self._remote_checkpoint_dir}")
+                # Todo: This syncs the entire experiment including trial
+                # checkpoints. We should exclude these in the future.
+                try:
+                    self._syncer.sync_down_if_needed()
+                    self._syncer.wait()
+                except TuneError as e:
+                    logger.warning(
+                        f"Got error when trying to sync down: {e}. "
+                        f"\nPlease check this error message for potential "
+                        f"access problems - if a directory was not found, "
+                        f"that is expected at this stage when you're starting "
+                        f"a new experiment.")
+                    logger.info(
+                        "No remote checkpoint was found or an error occurred "
+                        "when trying to download the experiment checkpoint. "
+                        "Please check the previous warning message for more "
+                        "details. "
+                        "Ray Tune will now start a new experiment.")
+                    return False
+                logger.info(
+                    "A remote experiment checkpoint was found and will be "
+                    "used to restore the previous experiment state.")
+                return True
+            elif not self.checkpoint_exists(self._local_checkpoint_dir):
+                logger.info("No local checkpoint was found. "
+                            "Ray Tune will now start a new experiment.")
+                return False
+            logger.info(
+                "A local experiment checkpoint was found and will be used "
+                "to restore the previous experiment state.")
+            return True
+
         if resume_type in [True, "LOCAL", "PROMPT", "ERRORED_ONLY"]:
             if not self.checkpoint_exists(self._local_checkpoint_dir):
                 raise ValueError(
-                    f"Called resume ({resume_type}) when no checkpoint exists "
-                    f"in local directory ({self._local_checkpoint_dir}).")
+                    f"You called resume ({resume_type}) when no checkpoint "
+                    f"exists in local directory "
+                    f"({self._local_checkpoint_dir}). If you want to start "
+                    f"a new experiment, use `resume=\"AUTO\"` or "
+                    f"`resume=None`. If you expected an experiment to "
+                    f"already exist, check if you supplied the correct "
+                    f"`local_dir` to `tune.run()`.")
             elif resume_type == "PROMPT":
                 if click.confirm(f"Resume from local directory? "
                                  f"({self._local_checkpoint_dir})"):
@@ -448,12 +493,22 @@ class TrialRunner:
                     "`upload_dir` set to `tune.run(sync_config=...)`.")
 
             # Try syncing down the upload directory.
-            logger.info("Downloading from %s", self._remote_checkpoint_dir)
-            # TODO(ujvl): Note that this syncs down the entire directory,
-            #  which may also contain trial checkpoints. We should selectively
-            #  sync the necessary files instead.
-            self._syncer.sync_down_if_needed()
-            self._syncer.wait()
+            logger.info(f"Downloading experiment checkpoint from "
+                        f"{self._remote_checkpoint_dir}")
+            # Todo: This syncs the entire experiment including trial
+            # checkpoints. We should exclude these in the future.
+            try:
+                self._syncer.sync_down_if_needed()
+                self._syncer.wait()
+            except TuneError as e:
+                raise RuntimeError(
+                    "Syncing the remote experiment checkpoint to the driver "
+                    "failed. Please check the error message. If you want to "
+                    "start a new experiment, use `resume=\"AUTO\"` or "
+                    "`resume=None`. If you expected an experiment to "
+                    "already exist, check if you supplied the correct "
+                    "`upload_dir` to the `tune.SyncConfig` passed to "
+                    "`tune.run()`.") from e
 
             if not self.checkpoint_exists(self._local_checkpoint_dir):
                 raise ValueError("Called resume when no checkpoint exists "

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -441,7 +441,7 @@ class TrialRunner:
                     self._syncer.wait()
                 except TuneError as e:
                     logger.warning(
-                        f"Got error when trying to sync down: {e}. "
+                        f"Got error when trying to sync down: {e} "
                         f"\nPlease check this error message for potential "
                         f"access problems - if a directory was not found, "
                         f"that is expected at this stage when you're starting "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add `resume="AUTO"` which restores experiment state if a checkpoint is found and otherwise starts a new experiment.

## Related issue number

cc @gjoliver @richardliaw 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
