### PR TITLE
[workflow/doc] Update doc to include `actor.ready()`

### DIFF
--- a/doc/source/workflows/actors.rst
+++ b/doc/source/workflows/actors.rst
@@ -29,6 +29,9 @@ Workflows also provides a *virtual actors* abstraction, which can be thought of 
     # Initialize a Counter actor with id="my_counter".
     counter = Counter.get_or_create("my_counter", 0)
 
+    # Wait to ensure virtual actor is initialized
+    ray.get(counter.ready())
+
     # Similar to workflow steps, actor methods support:
     # - `run()`, which will return the value
     # - `run_async()`, which will return a ObjectRef
@@ -51,7 +54,7 @@ We can retrieve the actor via its ``workflow_id`` in another process, to get the
     counter = workflow.get_actor(workflow_id="counter")
     assert 30 == counter.value.run()
 
-Readonly methods are not only lower overhead since they skip action logging, but can be executed concurrently with respect to mutating methods on the actor.
+Readonly methods are not only lower overhead since they skip action logging, but can be executed concurrently with respect to mutating methods on the actor. Readonly method has to be called after the virtual actor is initialized. ``ray.get(counter.ready())`` can be used to make sure initialization step is finished.
 
 Launching sub-workflows from actor methods
 ------------------------------------------


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
readonly method has to be called after the virtual actor initialization is finished. This is not documented in the doc. This PR updated it.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
