### PR TITLE
[data] Add support for Arrow open input/output stream kwargs.

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -972,6 +972,7 @@ class Dataset(Generic[T]):
                       *,
                       filesystem: Optional["pyarrow.fs.FileSystem"] = None,
                       try_create_dir: bool = True,
+                      arrow_open_stream_args: Optional[Dict[str, Any]] = None,
                       **arrow_parquet_args) -> None:
         """Write the dataset to parquet.
 
@@ -992,6 +993,8 @@ class Dataset(Generic[T]):
             filesystem: The filesystem implementation to write to.
             try_create_dir: Try to create all directories in destination path
                 if True. Does nothing if all directories already exist.
+            arrow_open_stream_args: kwargs passed to
+                pyarrow.fs.FileSystem.open_output_stream
             arrow_parquet_args: Options to pass to
                 pyarrow.parquet.write_table(), which is used to write out each
                 block to a file.
@@ -1002,6 +1005,7 @@ class Dataset(Generic[T]):
             dataset_uuid=self._uuid,
             filesystem=filesystem,
             try_create_dir=try_create_dir,
+            open_stream_args=arrow_open_stream_args,
             **arrow_parquet_args)
 
     def write_json(self,
@@ -1009,6 +1013,7 @@ class Dataset(Generic[T]):
                    *,
                    filesystem: Optional["pyarrow.fs.FileSystem"] = None,
                    try_create_dir: bool = True,
+                   arrow_open_stream_args: Optional[Dict[str, Any]] = None,
                    **pandas_json_args) -> None:
         """Write the dataset to json.
 
@@ -1029,6 +1034,8 @@ class Dataset(Generic[T]):
             filesystem: The filesystem implementation to write to.
             try_create_dir: Try to create all directories in destination path
                 if True. Does nothing if all directories already exist.
+            arrow_open_stream_args: kwargs passed to
+                pyarrow.fs.FileSystem.open_output_stream
             pandas_json_args: These args will be passed to
                 pandas.DataFrame.to_json(), which we use under the hood to
                 write out each Datasets block. These
@@ -1040,6 +1047,7 @@ class Dataset(Generic[T]):
             dataset_uuid=self._uuid,
             filesystem=filesystem,
             try_create_dir=try_create_dir,
+            open_stream_args=arrow_open_stream_args,
             **pandas_json_args)
 
     def write_csv(self,
@@ -1047,6 +1055,7 @@ class Dataset(Generic[T]):
                   *,
                   filesystem: Optional["pyarrow.fs.FileSystem"] = None,
                   try_create_dir: bool = True,
+                  arrow_open_stream_args: Optional[Dict[str, Any]] = None,
                   **arrow_csv_args) -> None:
         """Write the dataset to csv.
 
@@ -1067,6 +1076,8 @@ class Dataset(Generic[T]):
             filesystem: The filesystem implementation to write to.
             try_create_dir: Try to create all directories in destination path
                 if True. Does nothing if all directories already exist.
+            arrow_open_stream_args: kwargs passed to
+                pyarrow.fs.FileSystem.open_output_stream
             arrow_csv_args: Other CSV write options to pass to pyarrow.
         """
         self.write_datasource(
@@ -1075,14 +1086,17 @@ class Dataset(Generic[T]):
             dataset_uuid=self._uuid,
             filesystem=filesystem,
             try_create_dir=try_create_dir,
+            open_stream_args=arrow_open_stream_args,
             **arrow_csv_args)
 
-    def write_numpy(self,
-                    path: str,
-                    *,
-                    column: str = "value",
-                    filesystem: Optional["pyarrow.fs.FileSystem"] = None,
-                    try_create_dir: bool = True) -> None:
+    def write_numpy(
+            self,
+            path: str,
+            *,
+            column: str = "value",
+            filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+            try_create_dir: bool = True,
+            arrow_open_stream_args: Optional[Dict[str, Any]] = None) -> None:
         """Write a tensor column of the dataset to npy files.
 
         This is only supported for datasets convertible to Arrow records that
@@ -1105,6 +1119,8 @@ class Dataset(Generic[T]):
             filesystem: The filesystem implementation to write to.
             try_create_dir: Try to create all directories in destination path
                 if True. Does nothing if all directories already exist.
+            arrow_open_stream_args: kwargs passed to
+                pyarrow.fs.FileSystem.open_output_stream
         """
         self.write_datasource(
             NumpyDatasource(),
@@ -1112,7 +1128,8 @@ class Dataset(Generic[T]):
             dataset_uuid=self._uuid,
             column=column,
             filesystem=filesystem,
-            try_create_dir=try_create_dir)
+            try_create_dir=try_create_dir,
+            open_stream_args=arrow_open_stream_args)
 
     def write_datasource(self, datasource: Datasource[T],
                          **write_args) -> None:

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -283,6 +283,7 @@ def read_json(paths: Union[str, List[str]],
               filesystem: Optional["pyarrow.fs.FileSystem"] = None,
               parallelism: int = 200,
               ray_remote_args: Dict[str, Any] = None,
+              arrow_open_stream_args: Optional[Dict[str, Any]] = None,
               **arrow_json_args) -> Dataset[ArrowRow]:
     """Create an Arrow dataset from json files.
 
@@ -302,6 +303,8 @@ def read_json(paths: Union[str, List[str]],
         filesystem: The filesystem implementation to read from.
         parallelism: The amount of parallelism to use for the dataset.
         ray_remote_args: kwargs passed to ray.remote in the read tasks.
+        arrow_open_stream_args: kwargs passed to
+            pyarrow.fs.FileSystem.open_input_stream
         arrow_json_args: Other json read options to pass to pyarrow.
 
     Returns:
@@ -313,6 +316,7 @@ def read_json(paths: Union[str, List[str]],
         paths=paths,
         filesystem=filesystem,
         ray_remote_args=ray_remote_args,
+        open_stream_args=arrow_open_stream_args,
         **arrow_json_args)
 
 
@@ -322,6 +326,7 @@ def read_csv(paths: Union[str, List[str]],
              filesystem: Optional["pyarrow.fs.FileSystem"] = None,
              parallelism: int = 200,
              ray_remote_args: Dict[str, Any] = None,
+             arrow_open_stream_args: Optional[Dict[str, Any]] = None,
              **arrow_csv_args) -> Dataset[ArrowRow]:
     """Create an Arrow dataset from csv files.
 
@@ -341,6 +346,8 @@ def read_csv(paths: Union[str, List[str]],
         filesystem: The filesystem implementation to read from.
         parallelism: The amount of parallelism to use for the dataset.
         ray_remote_args: kwargs passed to ray.remote in the read tasks.
+        arrow_open_stream_args: kwargs passed to
+            pyarrow.fs.FileSystem.open_input_stream
         arrow_csv_args: Other csv read options to pass to pyarrow.
 
     Returns:
@@ -352,6 +359,7 @@ def read_csv(paths: Union[str, List[str]],
         paths=paths,
         filesystem=filesystem,
         ray_remote_args=ray_remote_args,
+        open_stream_args=arrow_open_stream_args,
         **arrow_csv_args)
 
 
@@ -362,6 +370,7 @@ def read_text(
         encoding: str = "utf-8",
         filesystem: Optional["pyarrow.fs.FileSystem"] = None,
         parallelism: int = 200,
+        arrow_open_stream_args: Optional[Dict[str, Any]] = None,
 ) -> Dataset[str]:
     """Create a dataset from lines stored in text files.
 
@@ -377,13 +386,18 @@ def read_text(
         encoding: The encoding of the files (e.g., "utf-8" or "ascii").
         filesystem: The filesystem implementation to read from.
         parallelism: The amount of parallelism to use for the dataset.
+        arrow_open_stream_args: kwargs passed to
+            pyarrow.fs.FileSystem.open_input_stream
 
     Returns:
         Dataset holding lines of text read from the specified paths.
     """
 
     return read_binary_files(
-        paths, filesystem=filesystem, parallelism=parallelism).flat_map(
+        paths,
+        filesystem=filesystem,
+        parallelism=parallelism,
+        arrow_open_stream_args=arrow_open_stream_args).flat_map(
             lambda x: x.decode(encoding).split("\n"))
 
 
@@ -392,6 +406,7 @@ def read_numpy(paths: Union[str, List[str]],
                *,
                filesystem: Optional["pyarrow.fs.FileSystem"] = None,
                parallelism: int = 200,
+               arrow_open_stream_args: Optional[Dict[str, Any]] = None,
                **numpy_load_args) -> Dataset[ArrowRow]:
     """Create an Arrow dataset from csv files.
 
@@ -410,6 +425,8 @@ def read_numpy(paths: Union[str, List[str]],
             A list of paths can contain both files and directories.
         filesystem: The filesystem implementation to read from.
         parallelism: The amount of parallelism to use for the dataset.
+        arrow_open_stream_args: kwargs passed to
+            pyarrow.fs.FileSystem.open_input_stream
         numpy_load_args: Other options to pass to np.load.
 
     Returns:
@@ -420,6 +437,7 @@ def read_numpy(paths: Union[str, List[str]],
         parallelism=parallelism,
         paths=paths,
         filesystem=filesystem,
+        open_stream_args=arrow_open_stream_args,
         **numpy_load_args)
 
 
@@ -431,6 +449,7 @@ def read_binary_files(
         filesystem: Optional["pyarrow.fs.FileSystem"] = None,
         parallelism: int = 200,
         ray_remote_args: Dict[str, Any] = None,
+        arrow_open_stream_args: Optional[Dict[str, Any]] = None,
 ) -> Dataset[Union[Tuple[str, bytes], bytes]]:
     """Create a dataset from binary files of arbitrary contents.
 
@@ -449,6 +468,8 @@ def read_binary_files(
         filesystem: The filesystem implementation to read from.
         ray_remote_args: kwargs passed to ray.remote in the read tasks.
         parallelism: The amount of parallelism to use for the dataset.
+        arrow_open_stream_args: kwargs passed to
+            pyarrow.fs.FileSystem.open_input_stream
 
     Returns:
         Dataset holding Arrow records read from the specified paths.
@@ -460,6 +481,7 @@ def read_binary_files(
         include_paths=include_paths,
         filesystem=filesystem,
         ray_remote_args=ray_remote_args,
+        open_stream_args=arrow_open_stream_args,
         schema=bytes)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
These changes support specifying custom compression types that can't be automatically inferred from the file path, specifying the size of a read/write buffer to improve read/write throughput, and other Filesystem-specific parameters that cannot be generalized for all cases (e.g. custom S3 object metadata). 

Closes https://github.com/ray-project/ray/issues/19078

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
