### PR TITLE
[data] Make directory creation in dataset output path optional.

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -990,6 +990,7 @@ class Dataset(Generic[T]):
                       path: str,
                       *,
                       filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+                      try_create_dir: bool = True,
                       **arrow_parquet_args) -> None:
         """Write the dataset to parquet.
 
@@ -1008,6 +1009,8 @@ class Dataset(Generic[T]):
             path: The path to the destination root directory, where Parquet
                 files will be written to.
             filesystem: The filesystem implementation to write to.
+            try_create_dir: Try to create all directories in destination path
+                if True. Does nothing if all directories already exist.
             arrow_parquet_args: Options to pass to
                 pyarrow.parquet.write_table(), which is used to write out each
                 block to a file.
@@ -1017,12 +1020,14 @@ class Dataset(Generic[T]):
             path=path,
             dataset_uuid=self._uuid,
             filesystem=filesystem,
+            try_create_dir=try_create_dir,
             **arrow_parquet_args)
 
     def write_json(self,
                    path: str,
                    *,
                    filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+                   try_create_dir: bool = True,
                    **pandas_json_args) -> None:
         """Write the dataset to json.
 
@@ -1041,6 +1046,8 @@ class Dataset(Generic[T]):
             path: The path to the destination root directory, where json
                 files will be written to.
             filesystem: The filesystem implementation to write to.
+            try_create_dir: Try to create all directories in destination path
+                if True. Does nothing if all directories already exist.
             pandas_json_args: These args will be passed to
                 pandas.DataFrame.to_json(), which we use under the hood to
                 write out each Datasets block. These
@@ -1051,12 +1058,14 @@ class Dataset(Generic[T]):
             path=path,
             dataset_uuid=self._uuid,
             filesystem=filesystem,
+            try_create_dir=try_create_dir,
             **pandas_json_args)
 
     def write_csv(self,
                   path: str,
                   *,
                   filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+                  try_create_dir: bool = True,
                   **arrow_csv_args) -> None:
         """Write the dataset to csv.
 
@@ -1075,6 +1084,8 @@ class Dataset(Generic[T]):
             path: The path to the destination root directory, where csv
                 files will be written to.
             filesystem: The filesystem implementation to write to.
+            try_create_dir: Try to create all directories in destination path
+                if True. Does nothing if all directories already exist.
             arrow_csv_args: Other CSV write options to pass to pyarrow.
         """
         self.write_datasource(
@@ -1082,14 +1093,15 @@ class Dataset(Generic[T]):
             path=path,
             dataset_uuid=self._uuid,
             filesystem=filesystem,
+            try_create_dir=try_create_dir,
             **arrow_csv_args)
 
-    def write_numpy(
-            self,
-            path: str,
-            *,
-            column: str = "value",
-            filesystem: Optional["pyarrow.fs.FileSystem"] = None) -> None:
+    def write_numpy(self,
+                    path: str,
+                    *,
+                    column: str = "value",
+                    filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+                    try_create_dir: bool = True) -> None:
         """Write a tensor column of the dataset to npy files.
 
         This is only supported for datasets convertible to Arrow records that
@@ -1110,13 +1122,16 @@ class Dataset(Generic[T]):
             column: The name of the table column that contains the tensor to
                 be written. This defaults to "value".
             filesystem: The filesystem implementation to write to.
+            try_create_dir: Try to create all directories in destination path
+                if True. Does nothing if all directories already exist.
         """
         self.write_datasource(
             NumpyDatasource(),
             path=path,
             dataset_uuid=self._uuid,
             column=column,
-            filesystem=filesystem)
+            filesystem=filesystem,
+            try_create_dir=try_create_dir)
 
     def write_datasource(self, datasource: Datasource[T],
                          **write_args) -> None:

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -115,12 +115,14 @@ class FileBasedDatasource(Datasource[Union[ArrowRow, Any]]):
                  path: str,
                  dataset_uuid: str,
                  filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+                 try_create_dir: bool = True,
                  _block_udf: Optional[Callable[[Block], Block]] = None,
                  **write_args) -> List[ObjectRef[WriteResult]]:
         """Creates and returns write tasks for a file-based datasource."""
         path, filesystem = _resolve_paths_and_filesystem(path, filesystem)
         path = path[0]
-        filesystem.create_dir(path, recursive=True)
+        if try_create_dir:
+            filesystem.create_dir(path, recursive=True)
         filesystem = _wrap_s3_serialization_workaround(filesystem)
 
         _write_block_to_file = self._write_block


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current do_write implementation for FileBasedDatasource always invokes filesystem.create_dir(path, recursive=True) to try to create all directories in the given output path, but directory creation should be optional and based on user-preference.

While prerequisite output directory creation is generally helpful and should remain on by default, it becomes a blocker in cases where the writer has insufficient privileges to perform this operation (e.g. has permissions to create keys but not buckets in an S3 destination path) or it is otherwise impossible to fulfill in the underlying FileSystem implementation. 

For example, Ray users at Amazon are currently unable to use datasets to write back to a centralized, S3-based data catalog due to lacking permissions to create buckets in this data catalog (which is a desirable feature to retain from both security and scalability perspectives).

## Related issue number

Closes https://github.com/ray-project/ray/issues/19199

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
