### PR TITLE
[Datasets] Fix API breakage in Datasets nightly test.

### DIFF
--- a/release/nightly_tests/dataset/dataset_shuffle_data_loader.py
+++ b/release/nightly_tests/dataset/dataset_shuffle_data_loader.py
@@ -85,7 +85,7 @@ def create_torch_iterator(split, batch_size, rank=None):
 
 def create_dataset(filenames, repeat_times):
     pipeline = ray.data.read_parquet(list(filenames))\
-        .repeat(times=repeat_times).random_shuffle()
+        .repeat(times=repeat_times).random_shuffle_each_window()
     return pipeline
 
 


### PR DESCRIPTION
`DatasetPipeline.random_shuffle()` --> `DatasetPipeline.random_shuffle_each_window()`

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
