### PR TITLE
[Serve] Make long poll wait for non-existent keys

### DIFF
--- a/python/ray/serve/long_poll.py
+++ b/python/ray/serve/long_poll.py
@@ -104,12 +104,9 @@ class LongPollClient:
             return
 
         if isinstance(updates, (ray.exceptions.RayTaskError)):
-            # This can happen during shutdown where the controller doesn't
-            # contain this key, we will just repull.
-            # NOTE(simon): should we repull or just wait in the long poll
-            # host?
-            if not isinstance(updates.as_instanceof_cause(), ValueError):
-                logger.error("LongPollHost errored\n" + updates.traceback_str)
+            # Some error happened in the controller. It could be a bug or some
+            # undesired state.
+            logger.error("LongPollHost errored\n" + updates.traceback_str)
             self._poll_next()
             return
 
@@ -167,22 +164,21 @@ class LongPollHost:
         until there's one updates.
         """
         watched_keys = keys_to_snapshot_ids.keys()
-        nonexistent_keys = set(watched_keys) - set(self.snapshot_ids.keys())
-        if len(nonexistent_keys) > 0:
-            raise ValueError(f"Keys not found: {nonexistent_keys}.")
+        existent_keys = set(watched_keys).intersection(
+            set(self.snapshot_ids.keys()))
 
-        # 2. If there are any outdated keys (by comparing snapshot ids)
-        #    return immediately.
+        # If there are any outdated keys (by comparing snapshot ids)
+        # return immediately.
         client_outdated_keys = {
             key: UpdatedObject(self.object_snapshots[key],
                                self.snapshot_ids[key])
-            for key in watched_keys
+            for key in existent_keys
             if self.snapshot_ids[key] != keys_to_snapshot_ids[key]
         }
         if len(client_outdated_keys) > 0:
             return client_outdated_keys
 
-        # 3. Otherwise, register asyncio events to be waited.
+        # Otherwise, register asyncio events to be waited.
         async_task_to_watched_keys = {}
         for key in watched_keys:
             # Create a new asyncio event for this key


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This makes long poll host wait for non-existent keys instead of immediately erroring and trigger client to immediately retries. The original issue happened because a deployment takes a long time to startup, but http proxy already created the handles for those deployments and tries to pull the `REPLICA_HANDLES` for the deployments. The handles key doesn't exist as deployment pending, so long poll client keep retries and cause a lot of exceptions (key not found) in controller and it being retried every 50ms or so.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #19201
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
