### PR TITLE
Force disable placement_group for all dataset tasks

### DIFF
--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -485,7 +485,8 @@ class StandardAutoscaler:
         pending = []
         infeasible = []
         for bundle in unfulfilled:
-            placement_group = any("_group_" in k for k in bundle)
+            placement_group = any(
+                "_group_" in k or k == "bundle" for k in bundle)
             if placement_group:
                 continue
             if self.resource_demand_scheduler.is_feasible(bundle):

--- a/python/ray/cross_language.py
+++ b/python/ray/cross_language.py
@@ -79,7 +79,8 @@ def java_function(class_name, function_name):
         None,  # max_calls,
         None,  # max_retries,
         None,  # retry_exceptions,
-        None)  # runtime_env
+        None,  # runtime_env
+        None)  # placement_group
 
 
 @PublicAPI(stability="beta")

--- a/python/ray/data/impl/pipeline_executor.py
+++ b/python/ray/data/impl/pipeline_executor.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from ray.data.dataset_pipeline import DatasetPipeline
 
 
-@ray.remote
+@ray.remote(num_cpus=0, placement_group=None)
 def pipeline_stage(fn: Callable[[], Dataset[T]]) -> Dataset[T]:
     try:
         prev = set_progress_bars(False)
@@ -87,7 +87,7 @@ class PipelineExecutor:
         return output
 
 
-@ray.remote
+@ray.remote(num_cpus=0, placement_group=None)
 class PipelineSplitExecutorCoordinator:
     def __init__(self, pipeline: "DatasetPipeline[T]", n: int,
                  splitter: Callable[[Dataset], "DatasetPipeline[T]"]):

--- a/python/ray/data/impl/remote_fn.py
+++ b/python/ray/data/impl/remote_fn.py
@@ -13,7 +13,10 @@ def cached_remote_fn(fn: Any, **ray_remote_args) -> Any:
     which means ray.remote cannot be used top-level in ray.data).
     """
     if fn not in CACHED_FUNCTIONS:
-        default_ray_remote_args = {"retry_exceptions": True}
+        default_ray_remote_args = {
+            "retry_exceptions": True,
+            "placement_group": None,
+        }
         CACHED_FUNCTIONS[fn] = ray.remote(**{
             **default_ray_remote_args,
             **ray_remote_args

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -60,7 +60,10 @@ def test_avoid_placement_group_capture(shutdown_only, pipelined):
         assert sorted(ds.iter_rows()) == [0, 1, 2, 3, 4]
 
     pg = ray.util.placement_group([{"CPU": 1}])
-    ray.get(run.options(placement_group=pg).remote())
+    ray.get(
+        run.options(
+            placement_group=pg,
+            placement_group_capture_child_tasks=True).remote())
 
 
 @pytest.mark.parametrize("pipelined", [False, True])

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -79,7 +79,7 @@ class RemoteFunction:
     def __init__(self, language, function, function_descriptor, num_cpus,
                  num_gpus, memory, object_store_memory, resources,
                  accelerator_type, num_returns, max_calls, max_retries,
-                 retry_exceptions, runtime_env):
+                 retry_exceptions, runtime_env, placement_group):
         if inspect.iscoroutinefunction(function):
             raise ValueError("'async def' should not be used for remote "
                              "tasks. You can wrap the async function with "
@@ -112,8 +112,13 @@ class RemoteFunction:
         # Parse local pip/conda config files here. If we instead did it in
         # .remote(), it would get run in the Ray Client server, which runs on
         # a remote node where the files aren't available.
+<<<<<<< Updated upstream
         self._runtime_env = ParsedRuntimeEnv(
             runtime_env or {}, is_task_or_actor=True)
+=======
+        self._runtime_env = parse_pip_and_conda(runtime_env)
+        self._placement_group = placement_group
+>>>>>>> Stashed changes
         self._decorator = getattr(function, "__ray_invocation_decorator__",
                                   None)
         self._function_signature = ray._private.signature.extract_signature(
@@ -276,7 +281,12 @@ class RemoteFunction:
             placement_group_capture_child_tasks = (
                 worker.should_capture_child_tasks_in_placement_group)
 
-        if placement_group == "default":
+        if self._placement_group != "default":
+            if self._placement_group:
+                placement_group = self._placement_group
+            else:
+                placement_group = PlacementGroup.empty()
+        elif placement_group == "default":
             if placement_group_capture_child_tasks:
                 placement_group = get_current_placement_group()
             else:

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -112,13 +112,9 @@ class RemoteFunction:
         # Parse local pip/conda config files here. If we instead did it in
         # .remote(), it would get run in the Ray Client server, which runs on
         # a remote node where the files aren't available.
-<<<<<<< Updated upstream
         self._runtime_env = ParsedRuntimeEnv(
             runtime_env or {}, is_task_or_actor=True)
-=======
-        self._runtime_env = parse_pip_and_conda(runtime_env)
         self._placement_group = placement_group
->>>>>>> Stashed changes
         self._decorator = getattr(function, "__ray_invocation_decorator__",
                                   None)
         self._function_signature = ray._private.signature.extract_signature(

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2144,7 +2144,7 @@ def remote(*args, **kwargs):
     object_store_memory = kwargs.get("object_store_memory")
     max_retries = kwargs.get("max_retries")
     runtime_env = kwargs.get("runtime_env")
-    placement_group = kwargs.get("placement_group")
+    placement_group = kwargs.get("placement_group", "default")
     retry_exceptions = kwargs.get("retry_exceptions")
 
     return make_decorator(

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1929,6 +1929,7 @@ def make_decorator(num_returns=None,
                    max_restarts=None,
                    max_task_retries=None,
                    runtime_env=None,
+                   placement_group="default",
                    worker=None,
                    retry_exceptions=None):
     def decorator(function_or_class):
@@ -1960,7 +1961,7 @@ def make_decorator(num_returns=None,
                 Language.PYTHON, function_or_class, None, num_cpus, num_gpus,
                 memory, object_store_memory, resources, accelerator_type,
                 num_returns, max_calls, max_retries, retry_exceptions,
-                runtime_env)
+                runtime_env, placement_group)
 
         if inspect.isclass(function_or_class):
             if num_returns is not None:
@@ -2109,7 +2110,8 @@ def remote(*args, **kwargs):
     valid_kwargs = [
         "num_returns", "num_cpus", "num_gpus", "memory", "object_store_memory",
         "resources", "accelerator_type", "max_calls", "max_restarts",
-        "max_task_retries", "max_retries", "runtime_env", "retry_exceptions"
+        "max_task_retries", "max_retries", "runtime_env", "retry_exceptions",
+        "placement_group"
     ]
     error_string = ("The @ray.remote decorator must be applied either "
                     "with no arguments and no parentheses, for example "
@@ -2142,6 +2144,7 @@ def remote(*args, **kwargs):
     object_store_memory = kwargs.get("object_store_memory")
     max_retries = kwargs.get("max_retries")
     runtime_env = kwargs.get("runtime_env")
+    placement_group = kwargs.get("placement_group")
     retry_exceptions = kwargs.get("retry_exceptions")
 
     return make_decorator(
@@ -2157,5 +2160,6 @@ def remote(*args, **kwargs):
         max_task_retries=max_task_retries,
         max_retries=max_retries,
         runtime_env=runtime_env,
+        placement_group=placement_group,
         worker=worker,
         retry_exceptions=retry_exceptions)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray tune currently sets placement_group_capture_child_tasks, which prevents the use of Datasets in Tune trials. Hard-code placement_groups=None to allow dataset tasks to break out of placement groups.