### PR TITLE
[Lint] tweak clang-tidy rules

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,9 +9,9 @@
 # -modernize-pass-by-value (too restrictive)
 # -modernize-return-braced-init-list (inconsistent style)
 # -modernize-use-emplace (more subtle behavior)
+# -modernize-use-nodiscard (too much noise)
 # -modernize-use-trailing-return-type (inconsistent style)
-# -modernize-use-trailing-return-type (inconsistent style)
-# -readability-convert-member-functions-to-static (potentially too restrictive)
+# Other readability-* rules (potentially too noisy, inconsistent style)
 # Other rules not mentioned here or below (not yet evaluated)
 #
 # TODO: enable google-* and readability-* families of checks.
@@ -30,6 +30,7 @@ Checks: >
   -modernize-pass-by-value,
   -modernize-return-braced-init-list,
   -modernize-use-emplace,
+  -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   performance-*,
   readability-avoid-const-params-in-decls,
@@ -38,6 +39,16 @@ Checks: >
   readability-container-size-empty,
   readability-delete-null-pointer,
   readability-else-after-return,
+  readability-implicit-bool-conversion,
+  readability-make-member-function-const,
+  readability-misleading-indentation,
+  readability-misplaced-array-index,
+  readability-named-parameter,
+  readability-non-const-parameter,
+  readability-redundant-*,
+  readability-static-definition-in-anonymous-namespace,
+  readability-string-compare,
+  readability-suspicious-call-argument,
 
 CheckOptions:
   # Reduce noisiness of the bugprone-narrowing-conversions check.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- Disable `modernize-use-nodiscard` which is too pedantic.
- Add more readability checks to clang-tidy

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
