### PR TITLE
[Datasets] Parallelize Parquet metadata fetches.

### DIFF
--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -139,8 +139,8 @@ class ParquetDatasource(FileBasedDatasource):
             if len(piece_data) == 0:
                 continue
             pieces, serialized_pieces, metadata = zip(*piece_data)
-            block_metadata = _build_block_metadata(
-                pieces, metadata, inferred_schema)
+            block_metadata = _build_block_metadata(pieces, metadata,
+                                                   inferred_schema)
             read_tasks.append(
                 ReadTask(
                     lambda pieces_=serialized_pieces: read_pieces(pieces_),
@@ -158,8 +158,9 @@ class ParquetDatasource(FileBasedDatasource):
         return "parquet"
 
 
-def _fetch_metadata_remotely(pieces: List[bytes]) -> List[
-        ObjectRef["pyarrow.parquet.FileMetaData"]]:
+def _fetch_metadata_remotely(
+        pieces: List[bytes]
+) -> List[ObjectRef["pyarrow.parquet.FileMetaData"]]:
     remote_fetch_metadata = cached_remote_fn(
         _fetch_metadata_serialization_wrapper)
     metas = []
@@ -173,8 +174,8 @@ def _fetch_metadata_remotely(pieces: List[bytes]) -> List[
     return list(itertools.chain.from_iterable(metas))
 
 
-def _fetch_metadata_serialization_wrapper(pieces: List[bytes]) -> List[
-        "pyarrow.parquet.FileMetaData"]:
+def _fetch_metadata_serialization_wrapper(
+        pieces: List[bytes]) -> List["pyarrow.parquet.FileMetaData"]:
     # Implicitly trigger S3 subsystem initialization by importing
     # pyarrow.fs.
     import pyarrow.fs  # noqa: F401
@@ -188,9 +189,8 @@ def _fetch_metadata_serialization_wrapper(pieces: List[bytes]) -> List[
     return _fetch_metadata(pieces)
 
 
-def _fetch_metadata(
-        pieces: List["pyarrow.dataset.ParquetFileFragment"]) -> List[
-            "pyarrow.parquet.FileMetaData"]:
+def _fetch_metadata(pieces: List["pyarrow.dataset.ParquetFileFragment"]
+                    ) -> List["pyarrow.parquet.FileMetaData"]:
     piece_metadata = []
     for p in pieces:
         try:

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -128,8 +128,7 @@ class ParquetDatasource(FileBasedDatasource):
             inferred_schema = schema
         read_tasks = []
         serialized_pieces = [cloudpickle.dumps(p) for p in pq_ds.pieces]
-        if (_is_remote_fs(filesystem)
-                and len(pq_ds.pieces) > PARALLELIZE_META_FETCH_THRESHOLD):
+        if len(pq_ds.pieces) > PARALLELIZE_META_FETCH_THRESHOLD:
             metadata = _fetch_metadata_remotely(serialized_pieces)
         else:
             metadata = _fetch_metadata(pq_ds.pieces)
@@ -155,12 +154,6 @@ class ParquetDatasource(FileBasedDatasource):
 
     def _file_format(self):
         return "parquet"
-
-
-def _is_remote_fs(filesystem: "pyarrow.fs.FileSystem"):
-    import pyarrow as pa
-
-    return isinstance(filesystem, (pa.fs.S3FileSystem, pa.fs.HadoopFileSystem))
 
 
 def _fetch_metadata_remotely(pieces: List[bytes]):

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -138,7 +138,8 @@ class ParquetDatasource(FileBasedDatasource):
             if len(piece_data) == 0:
                 continue
             pieces, serialized_pieces, metadata = zip(*piece_data)
-            block_metadata = _get_block_metadata(pieces, metadata, schema)
+            block_metadata = _get_block_metadata(
+                pieces, metadata, inferred_schema)
             read_tasks.append(
                 ReadTask(
                     lambda pieces_=serialized_pieces: read_pieces(pieces_),

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -1,17 +1,25 @@
 import logging
+import itertools
 from typing import Callable, Optional, List, Union, TYPE_CHECKING
+
+import numpy as np
 
 if TYPE_CHECKING:
     import pyarrow
 
+import ray
 from ray.data.block import Block, BlockAccessor
 from ray.data.datasource.datasource import ReadTask
 from ray.data.datasource.file_based_datasource import (
     FileBasedDatasource, _resolve_paths_and_filesystem)
 from ray.data.impl.block_list import BlockMetadata
+from ray.data.impl.remote_fn import cached_remote_fn
 from ray.data.impl.util import _check_pyarrow_version
 
 logger = logging.getLogger(__name__)
+
+PIECES_PER_META_FETCH = 4
+PARALLELIZE_META_FETCH_THRESHOLD = 4 * PIECES_PER_META_FETCH
 
 
 class ParquetDatasource(FileBasedDatasource):
@@ -119,14 +127,22 @@ class ParquetDatasource(FileBasedDatasource):
         else:
             inferred_schema = schema
         read_tasks = []
-        for pieces in np.array_split(pq_ds.pieces, parallelism):
-            if len(pieces) == 0:
+        serialized_pieces = [cloudpickle.dumps(p) for p in pq_ds.pieces]
+        if len(pq_ds.pieces) > PARALLELIZE_META_FETCH_THRESHOLD:
+            metadata = _fetch_metadata_remotely(serialized_pieces)
+        else:
+            metadata = _fetch_metadata(pq_ds.pieces)
+        for piece_data in np.array_split(
+                list(zip(pq_ds.pieces, serialized_pieces, metadata)),
+                parallelism):
+            if len(piece_data) == 0:
                 continue
-            metadata = _get_metadata(pieces, inferred_schema)
-            pieces = [cloudpickle.dumps(p) for p in pieces]
+            pieces, serialized_pieces, metadata = zip(*piece_data)
+            block_metadata = _get_block_metadata(pieces, metadata, schema)
             read_tasks.append(
                 ReadTask(
-                    lambda pieces_=pieces: read_pieces(pieces_), metadata))
+                    lambda pieces_=serialized_pieces: read_pieces(pieces_),
+                    block_metadata))
 
         return read_tasks
 
@@ -140,24 +156,54 @@ class ParquetDatasource(FileBasedDatasource):
         return "parquet"
 
 
-def _get_metadata(pieces: List["pyarrow._dataset.ParquetFileFragment"],
-                  schema: Optional[Union[type, "pyarrow.lib.Schema"]] = None):
+def _fetch_metadata_remotely(pieces: List[bytes]):
+    remote_fetch_metadata = cached_remote_fn(_fetch_metadata_wrapper)
+    metas = []
+    parallelism = min(len(pieces) // PIECES_PER_META_FETCH, 100)
+    for pieces_ in np.array_split(pieces, parallelism):
+        if len(pieces_) == 0:
+            continue
+        metas.append(remote_fetch_metadata.remote(pieces_))
+    return list(itertools.chain.from_iterable(ray.get(metas)))
+
+
+def _fetch_metadata_wrapper(pieces: List[bytes]):
+    # Implicitly trigger S3 subsystem initialization by importing
+    # pyarrow.fs.
+    import pyarrow.fs  # noqa: F401
+    from ray import cloudpickle
+
+    # Deserialize after loading the filesystem class.
+    pieces: List["pyarrow._dataset.ParquetFileFragment"] = [
+        cloudpickle.loads(p) for p in pieces
+    ]
+
+    return _fetch_metadata(pieces)
+
+
+def _fetch_metadata(pieces: List["pyarrow.dataset.ParquetFileFragment"]):
     piece_metadata = []
     for p in pieces:
         try:
             piece_metadata.append(p.metadata)
         except AttributeError:
             break
+    return piece_metadata
+
+
+def _get_block_metadata(pieces: List["pyarrow.dataset.ParquetFileFragment"],
+                        metadata: List["pyarrow.parquet.FileMetaData"],
+                        schema: Optional[Union[type, "pyarrow.lib.Schema"]]):
     input_files = [p.path for p in pieces]
-    if len(piece_metadata) == len(pieces):
+    if len(metadata) == len(pieces):
         # Piece metadata was available, construct a normal
         # BlockMetadata.
         block_metadata = BlockMetadata(
-            num_rows=sum(m.num_rows for m in piece_metadata),
+            num_rows=sum(m.num_rows for m in metadata),
             size_bytes=sum(
                 sum(
                     m.row_group(i).total_byte_size
-                    for i in range(m.num_row_groups)) for m in piece_metadata),
+                    for i in range(m.num_row_groups)) for m in metadata),
             schema=schema,
             input_files=input_files)
     else:

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1304,7 +1304,7 @@ def test_parquet_read_with_udf(ray_start_regular_shared, tmp_path):
 def test_parquet_read_parallel_meta_fetch(ray_start_regular_shared, fs,
                                           data_path):
     setup_data_path = _unwrap_protocol(data_path)
-    num_dfs = 2 * PARALLELIZE_META_FETCH_THRESHOLD
+    num_dfs = PARALLELIZE_META_FETCH_THRESHOLD + 1
     for idx in range(num_dfs):
         df = pd.DataFrame({"one": list(range(3 * idx, 3 * (idx + 1)))})
         table = pa.Table.from_pandas(df)

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1298,8 +1298,7 @@ def test_parquet_read_with_udf(ray_start_regular_shared, tmp_path):
         (None, lazy_fixture("local_path")),
         (lazy_fixture("local_fs"), lazy_fixture("local_path")),
         (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
-        (lazy_fixture("s3_fs_with_space"), lazy_fixture("s3_path_with_space")
-         )  # Path contains space.
+        (lazy_fixture("s3_fs_with_space"), lazy_fixture("s3_path_with_space"))
     ])
 def test_parquet_read_parallel_meta_fetch(ray_start_regular_shared, fs,
                                           data_path):

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -24,7 +24,7 @@ from ray.data.block import BlockAccessor
 from ray.data.impl.block_list import BlockList
 from ray.data.datasource.file_based_datasource import _unwrap_protocol
 from ray.data.datasource.parquet_datasource import (
-    PARALLELIZE_METADATA_FETCH_THRESHOLD)
+    PARALLELIZE_META_FETCH_THRESHOLD)
 from ray.data.extensions.tensor_extension import (
     TensorArray, TensorDtype, ArrowTensorType, ArrowTensorArray)
 import ray.data.tests.util as util
@@ -1304,7 +1304,7 @@ def test_parquet_read_with_udf(ray_start_regular_shared, tmp_path):
 def test_parquet_read_parallel_meta_fetch(ray_start_regular_shared, fs,
                                           data_path):
     setup_data_path = _unwrap_protocol(data_path)
-    num_dfs = 2 * PARALLELIZE_METADATA_FETCH_THRESHOLD
+    num_dfs = 2 * PARALLELIZE_META_FETCH_THRESHOLD
     for idx in range(num_dfs):
         df = pd.DataFrame({"one": list(range(3 * idx, 3 * (idx + 1)))})
         table = pa.Table.from_pandas(df)

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1294,12 +1294,10 @@ def test_parquet_read_with_udf(ray_start_regular_shared, tmp_path):
 
 @pytest.mark.parametrize(
     "fs,data_path",
-    [
-        (None, lazy_fixture("local_path")),
-        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
-        (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
-        (lazy_fixture("s3_fs_with_space"), lazy_fixture("s3_path_with_space"))
-    ])
+    [(None, lazy_fixture("local_path")),
+     (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+     (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
+     (lazy_fixture("s3_fs_with_space"), lazy_fixture("s3_path_with_space"))])
 def test_parquet_read_parallel_meta_fetch(ray_start_regular_shared, fs,
                                           data_path):
     setup_data_path = _unwrap_protocol(data_path)

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -23,6 +23,8 @@ from ray.data.datasource.csv_datasource import CSVDatasource
 from ray.data.block import BlockAccessor
 from ray.data.impl.block_list import BlockList
 from ray.data.datasource.file_based_datasource import _unwrap_protocol
+from ray.data.datasource.parquet_datasource import (
+    PARALLELIZE_METADATA_FETCH_THRESHOLD)
 from ray.data.extensions.tensor_extension import (
     TensorArray, TensorDtype, ArrowTensorType, ArrowTensorArray)
 import ray.data.tests.util as util
@@ -1288,6 +1290,44 @@ def test_parquet_read_with_udf(ray_start_regular_shared, tmp_path):
     ones, twos = zip(*[[s["one"], s["two"]] for s in ds.take()])
     assert len(ds._blocks._blocks) == 2
     np.testing.assert_array_equal(sorted(ones), np.array(one_data[:2]) + 1)
+
+
+@pytest.mark.parametrize(
+    "fs,data_path",
+    [
+        (None, lazy_fixture("local_path")),
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
+        (lazy_fixture("s3_fs_with_space"), lazy_fixture("s3_path_with_space")
+         )  # Path contains space.
+    ])
+def test_parquet_read_parallel_meta_fetch(ray_start_regular_shared, fs,
+                                          data_path):
+    setup_data_path = _unwrap_protocol(data_path)
+    num_dfs = 2 * PARALLELIZE_METADATA_FETCH_THRESHOLD
+    for idx in range(num_dfs):
+        df = pd.DataFrame({"one": list(range(3 * idx, 3 * (idx + 1)))})
+        table = pa.Table.from_pandas(df)
+        path = os.path.join(setup_data_path, f"test_{idx}.parquet")
+        pq.write_table(table, path, filesystem=fs)
+
+    parallelism = 8
+    ds = ray.data.read_parquet(
+        data_path, filesystem=fs, parallelism=parallelism)
+
+    # Test metadata-only parquet ops.
+    assert len(ds._blocks._blocks) == 1
+    assert ds.count() == num_dfs * 3
+    assert ds.size_bytes() > 0
+    assert ds.schema() is not None
+    input_files = ds.input_files()
+    assert len(input_files) == num_dfs, input_files
+    assert len(ds._blocks._blocks) == 1
+
+    # Forces a data read.
+    values = [s["one"] for s in ds.take(limit=3 * num_dfs)]
+    assert len(ds._blocks._blocks) == parallelism
+    assert sorted(values) == list(range(3 * num_dfs))
 
 
 @pytest.mark.parametrize("fs,data_path,endpoint_url", [


### PR DESCRIPTION
Parallelize Parquet metadata fetches if the number of files exceeds some threshold.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #19089 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
