### PR TITLE
Refactor LazyBlockList to simplify union of lists

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -704,8 +704,7 @@ class Dataset(Generic[T]):
 
         return splits
 
-    def union(self, *other: List["Dataset[T]"],
-              preserve_order: bool = False) -> "Dataset[T]":
+    def union(self, *other: List["Dataset[T]"]) -> "Dataset[T]":
         """Combine this dataset with others of the same type.
 
         The order of the blocks in the datasets is preserved, as is the

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -708,51 +708,33 @@ class Dataset(Generic[T]):
               preserve_order: bool = False) -> "Dataset[T]":
         """Combine this dataset with others of the same type.
 
+        The order of the blocks in the datasets is preserved, as is the
+        relative ordering between the datasets passed in the argument list.
+
         Args:
             other: List of datasets to combine with this one. The datasets
                 must have the same schema as this dataset, otherwise the
                 behavior is undefined.
-            preserve_order: Whether to preserve the order of the data blocks.
-                This may trigger eager loading of data from disk.
 
         Returns:
             A new dataset holding the union of their data.
         """
 
-        blocks: List[ObjectRef[Block]] = []
+        calls: List[Callable[[], ObjectRef[Block]]] = []
         metadata: List[BlockMetadata] = []
-        pending_blocks: List[Callable[[], ObjectRef[Block]]] = []
-        pending_metadata: List[BlockMetadata] = []
+        blocks: List[ObjectRef[Block]] = []
 
         datasets = [self] + list(other)
         for ds in datasets:
             bl = ds._blocks
             if isinstance(bl, LazyBlockList):
-                if preserve_order:
-                    # Force evaluation of blocks, which preserves order since
-                    # then we don't need to move evaluated blocks to the front
-                    # of LazyBlockList.
-                    list(bl)
-                for block, meta in zip(bl._blocks, bl._metadata):
-                    blocks.append(block)
-                    metadata.append(meta)
-                lim = len(bl._blocks)
-                for call, meta in zip(bl._calls[lim:], bl._metadata[lim:]):
-                    pending_blocks.append(call)
-                    pending_metadata.append(meta)
+                calls.extend(bl._calls)
             else:
-                assert isinstance(bl, BlockList), bl
-                blocks.extend(list(bl._blocks))
-                metadata.extend(bl.get_metadata())
+                calls.extend([None] * len(bl))
+            metadata.extend(bl._metadata)
+            blocks.extend(bl._blocks)
 
-        result = LazyBlockList([], [])
-        result._calls = ([None] * len(blocks)) + pending_blocks
-        result._blocks = blocks
-        result._metadata = metadata + pending_metadata
-
-        assert len(result._calls) == len(result._metadata), result
-        assert len(result._blocks) <= len(result._calls), result
-        return Dataset(result)
+        return Dataset(LazyBlockList(calls, metadata, blocks))
 
     def sort(self,
              key: Union[None, str, List[str], Callable[[T], Any]] = None,

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -268,7 +268,7 @@ class DatasetPipeline(Generic[T]):
                         self._buffer = next(self._original_iter)
                     while self._buffer.num_blocks() < blocks_per_window:
                         self._buffer = self._buffer.union(
-                            next(self._original_iter), preserve_order=True)
+                            next(self._original_iter))
                     # Slice off the left-most chunk and return it.
                     res, self._buffer = self._buffer._divide(blocks_per_window)
                     assert res.num_blocks() <= blocks_per_window, res

--- a/python/ray/data/impl/lazy_block_list.py
+++ b/python/ray/data/impl/lazy_block_list.py
@@ -9,45 +9,49 @@ from ray.data.impl.block_list import BlockList
 
 
 class LazyBlockList(BlockList[T]):
-    def __init__(self, calls: Callable[[], ObjectRef[Block]],
-                 metadata: List[BlockMetadata]):
-        assert len(calls) == len(metadata), (calls, metadata)
+    def __init__(self,
+                 calls: Callable[[], ObjectRef[Block]],
+                 metadata: List[BlockMetadata],
+                 blocks: List[ObjectRef[Block]] = None):
         self._calls = calls
-        self._blocks = [calls[0]()] if calls else []
         self._metadata = metadata
+        if blocks:
+            self._blocks = blocks
+        else:
+            self._blocks = [None] * len(calls)
+            # Immediately compute the first block at least.
+            if calls:
+                self._blocks[0] = calls[0]()
+        assert len(calls) == len(metadata), (calls, metadata)
+        assert len(calls) == len(self._blocks), (calls, self._blocks)
 
     def copy(self) -> "LazyBlockList":
-        new_list = LazyBlockList.__new__(LazyBlockList)
-        new_list._calls = self._calls
-        new_list._blocks = self._blocks
-        new_list._metadata = self._metadata
-        return new_list
+        return LazyBlockList(self._calls.copy(), self._metadata.copy(),
+                             self._blocks.copy())
 
     def clear(self):
         super().clear()
         self._calls = None
 
     def split(self, split_size: int) -> List["LazyBlockList"]:
-        # TODO(ekl) isn't this not copying already computed blocks?
         self._check_if_cleared()
         num_splits = math.ceil(len(self._calls) / split_size)
         calls = np.array_split(self._calls, num_splits)
         meta = np.array_split(self._metadata, num_splits)
+        blocks = np.array_split(self._blocks, num_splits)
         output = []
-        for c, m in zip(calls, meta):
-            output.append(LazyBlockList(c.tolist(), m.tolist()))
+        for c, m, b in zip(calls, meta, blocks):
+            output.append(LazyBlockList(c.tolist(), m.tolist(), b.tolist()))
         return output
 
     def divide(self, block_idx: int) -> ("BlockList", "BlockList"):
         self._check_if_cleared()
-        left = self.copy()
-        right = self.copy()
-        left._calls = left._calls[:block_idx]
-        left._blocks = left._blocks[:block_idx]
-        left._metadata = left._metadata[:block_idx]
-        right._calls = right._calls[block_idx:]
-        right._blocks = right._blocks[block_idx:]
-        right._metadata = right._metadata[block_idx:]
+        left = LazyBlockList(self._calls[:block_idx],
+                             self._metadata[:block_idx],
+                             self._blocks[:block_idx])
+        right = LazyBlockList(self._calls[block_idx:],
+                              self._metadata[block_idx:],
+                              self._blocks[block_idx:])
         return left, right
 
     def __len__(self):
@@ -77,9 +81,19 @@ class LazyBlockList(BlockList[T]):
         self._check_if_cleared()
         assert i < len(self._calls), i
         # Check if we need to compute more blocks.
-        if i >= len(self._blocks):
-            start = len(self._blocks)
+        if not self._blocks[i]:
             # Exponentially increase the number of blocks computed per batch.
-            for c in self._calls[start:max(i + 1, start * 2)]:
-                self._blocks.append(c())
+            for j in range(max(i + 1, i * 2)):
+                if j >= len(self._blocks):
+                    break
+                if not self._blocks[j]:
+                    self._blocks[j] = self._calls[j]()
+            assert self._blocks[i], self._blocks
         return self._blocks[i]
+
+    def _num_computed(self):
+        i = 0
+        for b in self._blocks:
+            if b is not None:
+                i += 1
+        return i

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -845,17 +845,17 @@ def test_schema(ray_start_regular_shared):
 
 def test_lazy_loading_exponential_rampup(ray_start_regular_shared):
     ds = ray.data.range(100, parallelism=20)
-    assert len(ds._blocks._blocks) == 1
+    assert ds._blocks._num_computed() == 1
     assert ds.take(10) == list(range(10))
-    assert len(ds._blocks._blocks) == 2
+    assert ds._blocks._num_computed() == 2
     assert ds.take(20) == list(range(20))
-    assert len(ds._blocks._blocks) == 4
+    assert ds._blocks._num_computed() == 4
     assert ds.take(30) == list(range(30))
-    assert len(ds._blocks._blocks) == 8
+    assert ds._blocks._num_computed() == 8
     assert ds.take(50) == list(range(50))
-    assert len(ds._blocks._blocks) == 16
+    assert ds._blocks._num_computed() == 16
     assert ds.take(100) == list(range(100))
-    assert len(ds._blocks._blocks) == 20
+    assert ds._blocks._num_computed() == 20
 
 
 def test_limit(ray_start_regular_shared):
@@ -1093,7 +1093,7 @@ def test_fsspec_filesystem(ray_start_regular_shared, tmp_path):
     ds = ray.data.read_parquet([path1, path2], filesystem=fs)
 
     # Test metadata-only parquet ops.
-    assert len(ds._blocks._blocks) == 1
+    assert ds._blocks._num_computed() == 1
     assert ds.count() == 6
 
     out_path = os.path.join(tmp_path, "out")
@@ -1132,7 +1132,7 @@ def test_parquet_read(ray_start_regular_shared, fs, data_path):
     ds = ray.data.read_parquet(data_path, filesystem=fs)
 
     # Test metadata-only parquet ops.
-    assert len(ds._blocks._blocks) == 1
+    assert ds._blocks._num_computed() == 1
     assert ds.count() == 6
     assert ds.size_bytes() > 0
     assert ds.schema() is not None
@@ -1146,11 +1146,11 @@ def test_parquet_read(ray_start_regular_shared, fs, data_path):
     assert repr(ds) == \
         "Dataset(num_blocks=2, num_rows=6, " \
         "schema={one: int64, two: string})", ds
-    assert len(ds._blocks._blocks) == 1
+    assert ds._blocks._num_computed() == 1
 
     # Forces a data read.
     values = [[s["one"], s["two"]] for s in ds.take()]
-    assert len(ds._blocks._blocks) == 2
+    assert ds._blocks._num_computed() == 2
     assert sorted(values) == [[1, "a"], [2, "b"], [3, "c"], [4, "e"], [5, "f"],
                               [6, "g"]]
 
@@ -1181,7 +1181,7 @@ def test_parquet_read_partitioned(ray_start_regular_shared, fs, data_path):
     ds = ray.data.read_parquet(data_path, filesystem=fs)
 
     # Test metadata-only parquet ops.
-    assert len(ds._blocks._blocks) == 1
+    assert ds._blocks._num_computed() == 1
     assert ds.count() == 6
     assert ds.size_bytes() > 0
     assert ds.schema() is not None
@@ -1195,11 +1195,11 @@ def test_parquet_read_partitioned(ray_start_regular_shared, fs, data_path):
         "Dataset(num_blocks=2, num_rows=6, " \
         "schema={two: string, " \
         "one: dictionary<values=int32, indices=int32, ordered=0>})", ds
-    assert len(ds._blocks._blocks) == 1
+    assert ds._blocks._num_computed() == 1
 
     # Forces a data read.
     values = [[s["one"], s["two"]] for s in ds.take()]
-    assert len(ds._blocks._blocks) == 2
+    assert ds._blocks._num_computed() == 2
     assert sorted(values) == [[1, "a"], [1, "b"], [1, "c"], [3, "e"], [3, "f"],
                               [3, "g"]]
 
@@ -1228,7 +1228,7 @@ def test_parquet_read_partitioned_with_filter(ray_start_regular_shared,
         str(tmp_path), parallelism=1, filter=(pa.dataset.field("two") == "a"))
 
     values = [[s["one"], s["two"]] for s in ds.take()]
-    assert len(ds._blocks._blocks) == 1
+    assert ds._blocks._num_computed() == 1
     assert sorted(values) == [[1, "a"], [1, "a"]]
 
     # 2 partitions, 1 empty partition, 2 block/read tasks, 1 empty block
@@ -1237,7 +1237,7 @@ def test_parquet_read_partitioned_with_filter(ray_start_regular_shared,
         str(tmp_path), parallelism=2, filter=(pa.dataset.field("two") == "a"))
 
     values = [[s["one"], s["two"]] for s in ds.take()]
-    assert len(ds._blocks._blocks) == 2
+    assert ds._blocks._num_computed() == 2
     assert sorted(values) == [[1, "a"], [1, "a"]]
 
 
@@ -1265,7 +1265,7 @@ def test_parquet_read_with_udf(ray_start_regular_shared, tmp_path):
         str(tmp_path), parallelism=1, _block_udf=_block_udf)
 
     ones, twos = zip(*[[s["one"], s["two"]] for s in ds.take()])
-    assert len(ds._blocks._blocks) == 1
+    assert ds._blocks._num_computed() == 1
     np.testing.assert_array_equal(sorted(ones), np.array(one_data) + 1)
 
     # 2 blocks/read tasks
@@ -1274,7 +1274,7 @@ def test_parquet_read_with_udf(ray_start_regular_shared, tmp_path):
         str(tmp_path), parallelism=2, _block_udf=_block_udf)
 
     ones, twos = zip(*[[s["one"], s["two"]] for s in ds.take()])
-    assert len(ds._blocks._blocks) == 2
+    assert ds._blocks._num_computed() == 2
     np.testing.assert_array_equal(sorted(ones), np.array(one_data) + 1)
 
     # 2 blocks/read tasks, 1 empty block
@@ -1286,7 +1286,7 @@ def test_parquet_read_with_udf(ray_start_regular_shared, tmp_path):
         _block_udf=_block_udf)
 
     ones, twos = zip(*[[s["one"], s["two"]] for s in ds.take()])
-    assert len(ds._blocks._blocks) == 2
+    assert ds._blocks._num_computed() == 2
     np.testing.assert_array_equal(sorted(ones), np.array(one_data[:2]) + 1)
 
 
@@ -1660,7 +1660,7 @@ def test_lazy_loading_iter_batches_exponential_rampup(
     ds = ray.data.range(32, parallelism=8)
     expected_num_blocks = [1, 2, 4, 4, 8, 8, 8, 8]
     for _, expected in zip(ds.iter_batches(), expected_num_blocks):
-        assert len(ds._blocks._blocks) == expected
+        assert ds._blocks._num_computed() == expected
 
 
 def test_map_batch(ray_start_regular_shared, tmp_path):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously, LazyBlockList assumed a prefix of blocks was always computed. This made operations like union quite complicated. This PR changes it to use an array with Nones representing un-computed blocks.