### PR TITLE
[serve] Catch ConnectionError during shutdown in LongPollClient

### DIFF
--- a/python/ray/serve/long_poll.py
+++ b/python/ray/serve/long_poll.py
@@ -103,6 +103,10 @@ class LongPollClient:
                          "Shutting down.")
             return
 
+        if isinstance(updates, ConnectionError):
+            logger.warning("LongPollClient connection failed, shutting down.")
+            return
+
         if isinstance(updates, (ray.exceptions.RayTaskError)):
             # Some error happened in the controller. It could be a bug or some
             # undesired state.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

These are seen when Ray client is shutting down:
```
ray/serve/tests/test_ray_client.py::test_quickstart_task
  /Users/eoakes/anaconda3/lib/python3.8/site-packages/_pytest/threadexception.py:75: PytestUnhandledThreadExceptionWarning: Exception in thread
 ray_client_streaming_rpc

  Traceback (most recent call last):
    File "/Users/eoakes/anaconda3/lib/python3.8/threading.py", line 932, in _bootstrap_inner
      self.run()
    File "/Users/eoakes/anaconda3/lib/python3.8/threading.py", line 870, in run
      self._target(*self._args, **self._kwargs)
    File "/Users/eoakes/code/ray/python/ray/util/client/dataclient.py", line 111, in _data_main
      self._shutdown()
    File "/Users/eoakes/code/ray/python/ray/util/client/dataclient.py", line 179, in _shutdown
      callback(err)
    File "python/ray/includes/object_ref.pxi", line 250, in ray._raylet.ClientObjectRef._on_completed.deserialize_obj
    File "/Users/eoakes/code/ray/python/ray/serve/long_poll.py", line 95, in <lambda>
      lambda update: self._process_update(update))
    File "/Users/eoakes/code/ray/python/ray/serve/long_poll.py", line 116, in _process_update
      logger.debug(f"LongPollClient {self} received updates for keys: "
  AttributeError: 'ConnectionError' object has no attribute 'keys'
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
