### PR TITLE
[Core] loosen some clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,11 @@
 # -modernize-use-emplace (more subtle behavior)
 # -modernize-use-nodiscard (too much noise)
 # -modernize-use-trailing-return-type (inconsistent style)
+# -modernize-avoid-bind (incorrect conversion)
+# -modernize-loop-convert (more subtle behavior)
+# -modernize-replace-disallow-copy-and-assign-macro (inconsistent style)
+# -modernize-make-unique (doesn't work with private constructor)
+# -modernize-make-shared (doesn't work with private constructor)
 # Other readability-* rules (potentially too noisy, inconsistent style)
 # Other rules not mentioned here or below (not yet evaluated)
 #
@@ -32,6 +37,11 @@ Checks: >
   -modernize-use-emplace,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
+  -modernize-avoid-bind,
+  -modernize-loop-convert,
+  -modernize-replace-disallow-copy-and-assign-macro,
+  -modernize-make-unique,
+  -modernize-make-shared,
   performance-*,
   readability-avoid-const-params-in-decls,
   readability-braces-around-statements,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Some of the clang-tidy rules are too strict, loosen them.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
