### PR TITLE
[RLlib] Report timesteps_this_iter to Tune, so it can track/checkpoint/restore total timesteps trained.

### DIFF
--- a/rllib/agents/dqn/apex.py
+++ b/rllib/agents/dqn/apex.py
@@ -22,8 +22,9 @@ from ray.rllib.agents.dqn.dqn import calculate_rr_weights, \
     DEFAULT_CONFIG as DQN_CONFIG, DQNTrainer, validate_config
 from ray.rllib.agents.dqn.learner_thread import LearnerThread
 from ray.rllib.evaluation.worker_set import WorkerSet
-from ray.rllib.execution.common import (STEPS_TRAINED_COUNTER,
-                                        _get_global_vars, _get_shared_metrics)
+from ray.rllib.execution.common import (
+    STEPS_TRAINED_COUNTER, STEPS_TRAINED_THIS_ITER_COUNTER,
+    _get_global_vars, _get_shared_metrics)
 from ray.rllib.execution.concurrency_ops import Concurrently, Dequeue, Enqueue
 from ray.rllib.execution.metric_ops import StandardMetricsReporting
 from ray.rllib.execution.replay_buffer import ReplayActor
@@ -168,6 +169,7 @@ def apex_execution_plan(workers: WorkerSet,
         metrics = _get_shared_metrics()
         # Manually update the steps trained counter since the learner thread
         # is executing outside the pipeline.
+        metrics.counters[STEPS_TRAINED_THIS_ITER_COUNTER] = count
         metrics.counters[STEPS_TRAINED_COUNTER] += count
         metrics.timers["learner_dequeue"] = learner_thread.queue_timer
         metrics.timers["learner_grad"] = learner_thread.grad_timer

--- a/rllib/agents/dqn/apex.py
+++ b/rllib/agents/dqn/apex.py
@@ -22,9 +22,9 @@ from ray.rllib.agents.dqn.dqn import calculate_rr_weights, \
     DEFAULT_CONFIG as DQN_CONFIG, DQNTrainer, validate_config
 from ray.rllib.agents.dqn.learner_thread import LearnerThread
 from ray.rllib.evaluation.worker_set import WorkerSet
-from ray.rllib.execution.common import (
-    STEPS_TRAINED_COUNTER, STEPS_TRAINED_THIS_ITER_COUNTER,
-    _get_global_vars, _get_shared_metrics)
+from ray.rllib.execution.common import (STEPS_TRAINED_COUNTER,
+                                        STEPS_TRAINED_THIS_ITER_COUNTER,
+                                        _get_global_vars, _get_shared_metrics)
 from ray.rllib.execution.concurrency_ops import Concurrently, Dequeue, Enqueue
 from ray.rllib.execution.metric_ops import StandardMetricsReporting
 from ray.rllib.execution.replay_buffer import ReplayActor

--- a/rllib/agents/impala/impala.py
+++ b/rllib/agents/impala/impala.py
@@ -7,8 +7,9 @@ from ray.rllib.agents.trainer_template import build_trainer
 from ray.rllib.execution.learner_thread import LearnerThread
 from ray.rllib.execution.multi_gpu_learner_thread import MultiGPULearnerThread
 from ray.rllib.execution.tree_agg import gather_experiences_tree_aggregation
-from ray.rllib.execution.common import STEPS_TRAINED_COUNTER, \
-    _get_global_vars, _get_shared_metrics
+from ray.rllib.execution.common import (
+    STEPS_TRAINED_COUNTER, STEPS_TRAINED_THIS_ITER_COUNTER,
+    _get_global_vars, _get_shared_metrics)
 from ray.rllib.execution.replay_ops import MixInReplay
 from ray.rllib.execution.rollout_ops import ParallelRollouts, ConcatBatches
 from ray.rllib.execution.concurrency_ops import Concurrently, Enqueue, Dequeue
@@ -284,6 +285,7 @@ def record_steps_trained(item):
     metrics = _get_shared_metrics()
     # Manually update the steps trained counter since the learner thread
     # is executing outside the pipeline.
+    metrics.counters[STEPS_TRAINED_THIS_ITER_COUNTER] = count
     metrics.counters[STEPS_TRAINED_COUNTER] += count
     return item
 

--- a/rllib/agents/impala/impala.py
+++ b/rllib/agents/impala/impala.py
@@ -7,9 +7,9 @@ from ray.rllib.agents.trainer_template import build_trainer
 from ray.rllib.execution.learner_thread import LearnerThread
 from ray.rllib.execution.multi_gpu_learner_thread import MultiGPULearnerThread
 from ray.rllib.execution.tree_agg import gather_experiences_tree_aggregation
-from ray.rllib.execution.common import (
-    STEPS_TRAINED_COUNTER, STEPS_TRAINED_THIS_ITER_COUNTER,
-    _get_global_vars, _get_shared_metrics)
+from ray.rllib.execution.common import (STEPS_TRAINED_COUNTER,
+                                        STEPS_TRAINED_THIS_ITER_COUNTER,
+                                        _get_global_vars, _get_shared_metrics)
 from ray.rllib.execution.replay_ops import MixInReplay
 from ray.rllib.execution.rollout_ops import ParallelRollouts, ConcatBatches
 from ray.rllib.execution.concurrency_ops import Concurrently, Enqueue, Dequeue

--- a/rllib/agents/maml/maml.py
+++ b/rllib/agents/maml/maml.py
@@ -8,7 +8,8 @@ from ray.rllib.agents.maml.maml_torch_policy import MAMLTorchPolicy
 from ray.rllib.agents.trainer_template import build_trainer
 from ray.rllib.evaluation.metrics import get_learner_stats
 from ray.rllib.execution.common import STEPS_SAMPLED_COUNTER, \
-    STEPS_TRAINED_COUNTER, _get_shared_metrics
+    STEPS_TRAINED_COUNTER, STEPS_TRAINED_THIS_ITER_COUNTER, \
+    _get_shared_metrics
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.execution.metric_ops import CollectMetrics
 from ray.rllib.evaluation.metrics import collect_metrics
@@ -126,6 +127,7 @@ class MetaUpdate:
         # Modify Reporting Metrics
         metrics = _get_shared_metrics()
         metrics.info[LEARNER_INFO] = fetches
+        metrics.counters[STEPS_TRAINED_THIS_ITER_COUNTER] = samples.count
         metrics.counters[STEPS_TRAINED_COUNTER] += samples.count
 
         res = self.metric_gen.__call__(None)

--- a/rllib/agents/mbmpo/mbmpo.py
+++ b/rllib/agents/mbmpo/mbmpo.py
@@ -26,7 +26,8 @@ from ray.rllib.evaluation.metrics import collect_episodes, collect_metrics, \
     get_learner_stats
 from ray.rllib.evaluation.worker_set import WorkerSet
 from ray.rllib.execution.common import STEPS_SAMPLED_COUNTER, \
-    STEPS_TRAINED_COUNTER, _get_shared_metrics
+    STEPS_TRAINED_COUNTER, STEPS_TRAINED_THIS_ITER_COUNTER, \
+    _get_shared_metrics
 from ray.rllib.execution.metric_ops import CollectMetrics
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID, SampleBatch
 from ray.rllib.utils.deprecation import DEPRECATED_VALUE
@@ -182,6 +183,7 @@ class MetaUpdate:
         # Modify Reporting Metrics.
         metrics = _get_shared_metrics()
         metrics.info[LEARNER_INFO] = fetches
+        metrics.counters[STEPS_TRAINED_THIS_ITER_COUNTER] = samples.count
         metrics.counters[STEPS_TRAINED_COUNTER] += samples.count
 
         if self.step_counter == self.num_steps - 1:

--- a/rllib/agents/ppo/ddppo.py
+++ b/rllib/agents/ppo/ddppo.py
@@ -26,8 +26,8 @@ from ray.rllib.evaluation.worker_set import WorkerSet
 from ray.rllib.execution.rollout_ops import ParallelRollouts
 from ray.rllib.execution.metric_ops import StandardMetricsReporting
 from ray.rllib.execution.common import STEPS_SAMPLED_COUNTER, \
-    STEPS_TRAINED_COUNTER, LEARN_ON_BATCH_TIMER, \
-    _get_shared_metrics, _get_global_vars
+    STEPS_TRAINED_COUNTER, STEPS_TRAINED_THIS_ITER_COUNTER,\
+    LEARN_ON_BATCH_TIMER, _get_shared_metrics, _get_global_vars
 from ray.rllib.evaluation.rollout_worker import get_global_worker
 from ray.rllib.utils.metrics.learner_info import LEARNER_INFO
 from ray.rllib.utils.sgd import do_minibatch_sgd
@@ -212,6 +212,7 @@ def execution_plan(workers: WorkerSet,
             for item in items:
                 info, count = item
                 metrics = _get_shared_metrics()
+                metrics.counters[STEPS_TRAINED_THIS_ITER_COUNTER] = count
                 metrics.counters[STEPS_SAMPLED_COUNTER] += count
                 metrics.counters[STEPS_TRAINED_COUNTER] += count
                 metrics.info[LEARNER_INFO] = info

--- a/rllib/execution/common.py
+++ b/rllib/execution/common.py
@@ -7,6 +7,7 @@ from ray.util.iter_metrics import MetricsContext
 STEPS_SAMPLED_COUNTER = "num_steps_sampled"
 AGENT_STEPS_SAMPLED_COUNTER = "num_agent_steps_sampled"
 STEPS_TRAINED_COUNTER = "num_steps_trained"
+STEPS_TRAINED_THIS_ITER_COUNTER = "num_steps_trained_this_iter"
 AGENT_STEPS_TRAINED_COUNTER = "num_agent_steps_trained"
 
 # Counters to track target network updates.

--- a/rllib/execution/metric_ops.py
+++ b/rllib/execution/metric_ops.py
@@ -5,7 +5,8 @@ from ray.actor import ActorHandle
 from ray.util.iter import LocalIterator
 from ray.rllib.evaluation.metrics import collect_episodes, summarize_episodes
 from ray.rllib.execution.common import AGENT_STEPS_SAMPLED_COUNTER, \
-    STEPS_SAMPLED_COUNTER, STEPS_TRAINED_COUNTER, _get_shared_metrics
+    STEPS_SAMPLED_COUNTER, STEPS_TRAINED_COUNTER, \
+    STEPS_TRAINED_THIS_ITER_COUNTER, _get_shared_metrics
 from ray.rllib.evaluation.worker_set import WorkerSet
 
 
@@ -110,6 +111,10 @@ class CollectMetrics:
         res.update({
             "num_healthy_workers": len(self.workers.remote_workers()),
             "timesteps_total": metrics.counters[STEPS_SAMPLED_COUNTER],
+            # tune.Trainable uses timesteps_this_iter for tracking
+            # total timesteps.
+            "timesteps_this_iter": metrics.counters[
+                STEPS_TRAINED_THIS_ITER_COUNTER],
             "agent_timesteps_total": metrics.counters.get(
                 AGENT_STEPS_SAMPLED_COUNTER, 0),
         })


### PR DESCRIPTION
## Why are these changes needed?

Tune doesn't know which timestep an RL trainer is current at.
So we see log messages like this:

(pid=5236, ip=10.20.1.3) 2021-10-08 14:57:19,848        INFO trainable.py:401 -- Current state after restoring: {'_iteration': 10, '_timesteps_total': None, '_time_total': 535.9482250213623, '_episodes_total': 28695}

This PR report timesteps_this_iter to Tune, so it can calculate _timesteps_total.

## Related issue number

## Checks

- [*] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Local test runs
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
