### PR TITLE
[Build] Add an Option to Skip Bazel Build

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -27,7 +27,7 @@ SUPPORTED_BAZEL = (4, 2, 1)
 
 ROOT_DIR = os.path.dirname(__file__)
 BUILD_JAVA = os.getenv("RAY_INSTALL_JAVA") == "1"
-SKIP_BAZEL_BUILD = os.getenv("SKIP_BAZEL_BUILD") is not None
+SKIP_BAZEL_BUILD = os.getenv("SKIP_BAZEL_BUILD") == "1"
 
 PICKLE5_SUBDIR = os.path.join("ray", "pickle5_files")
 THIRDPARTY_SUBDIR = os.path.join("ray", "thirdparty_files")

--- a/python/setup.py
+++ b/python/setup.py
@@ -27,6 +27,7 @@ SUPPORTED_BAZEL = (4, 2, 1)
 
 ROOT_DIR = os.path.dirname(__file__)
 BUILD_JAVA = os.getenv("RAY_INSTALL_JAVA") == "1"
+SKIP_BAZEL_BUILD = os.getenv("SKIP_BAZEL_BUILD") is not None
 
 PICKLE5_SUBDIR = os.path.join("ray", "pickle5_files")
 THIRDPARTY_SUBDIR = os.path.join("ray", "thirdparty_files")
@@ -553,7 +554,10 @@ def add_system_dlls(dlls, target_dir):
 
 
 def pip_run(build_ext):
-    build(True, BUILD_JAVA, True)
+    if SKIP_BAZEL_BUILD:
+        build(False, False, False)
+    else:
+        build(True, BUILD_JAVA, True)
 
     if setup_spec.type == SetupType.RAY:
         setup_spec.files_to_include += ray_files


### PR DESCRIPTION
## Why are these changes needed?

Sometimes I've already built ray binaries by `bazel build ray_pkg`, and want to install them to site-packages only.

But when I run `pip install -e ./ -v`, pip will run `bazel build` again. And because environment variables are different when running pip, bazel can't use the cache and has to build all things again(pip will export some internal env variables).

In this PR I add an option to skip Bazel build when running `pip install`.

Usage: `export SKIP_BAZEL_BUILD=1` before `pip install`

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
