### PR TITLE
[RLlib] Support >1 loss terms and optimizers for framework=tf2 (already supported for framework=[tf|torch])

### DIFF
--- a/rllib/agents/ppo/tests/test_appo.py
+++ b/rllib/agents/ppo/tests/test_appo.py
@@ -59,7 +59,7 @@ class TestAPPO(unittest.TestCase):
         num_iterations = 2
 
         # Only supported for tf so far.
-        for _ in framework_iterator(config, frameworks="tf"):
+        for _ in framework_iterator(config, frameworks=("tf2", "tf")):
             trainer = ppo.APPOTrainer(config=config, env="CartPole-v0")
             for i in range(num_iterations):
                 results = trainer.train()

--- a/rllib/policy/eager_tf_policy.py
+++ b/rllib/policy/eager_tf_policy.py
@@ -335,9 +335,10 @@ def build_eager_tf_policy(
                 optimizers = self.exploration.get_exploration_optimizer(
                     optimizers)
 
+            # The list of local (tf) optimizers (one per loss term).
             self._optimizers: List[LocalOptimizer] = optimizers
-            # Backward compatibility and for some code shared with tf-eager
-            # Policy.
+            # Backward compatibility: A user's policy may only support a single
+            # loss term and optimizer (no lists).
             self._optimizer: LocalOptimizer = \
                 optimizers[0] if optimizers else None
 
@@ -749,7 +750,7 @@ def build_eager_tf_policy(
             else:
                 variables = self.model.trainable_variables()
 
-            # Calculate the gradients using a tf GradientTape.
+            # Calculate the loss(es) inside a tf GradientTape.
             with tf.GradientTape(persistent=compute_gradients_fn is not None) \
                     as tape:
                 losses = loss_fn(self, self.model, self.dist_class, samples)

--- a/rllib/policy/eager_tf_policy.py
+++ b/rllib/policy/eager_tf_policy.py
@@ -754,6 +754,7 @@ def build_eager_tf_policy(
             with tf.GradientTape(persistent=compute_gradients_fn is not None) \
                     as tape:
                 losses = loss_fn(self, self.model, self.dist_class, samples)
+            losses = force_list(losses)
 
             # User provided a compute_gradients_fn.
             if compute_gradients_fn:
@@ -764,13 +765,12 @@ def build_eager_tf_policy(
                 optimizer = OptimizerWrapper(tape)
                 # More than one loss terms/optimizers.
                 if self.config["_tf_policy_handles_more_than_one_loss"]:
-                    losses = force_list(losses)
                     grads_and_vars = compute_gradients_fn(
                         self, [optimizer] * len(losses), losses)
                 # Only one loss and one optimizer.
                 else:
                     grads_and_vars = [
-                        compute_gradients_fn(self, optimizer, losses)
+                        compute_gradients_fn(self, optimizer, losses[0])
                     ]
             # Default: Compute gradients using the above tape.
             else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Support >1 loss terms and optimizers for framework=tf2 (already supported for framework=[tf|torch]).
- The experimental flag `_tf_policy_handles_more_than_one_loss` must be set to True (False by default) if more than one loss term and optimizer are used with tf-eager.
- The `test_appo_two_tf_optimizers` test case has been expanded to cover tf2 as well.

In a follow up PR, tf2 will be added to our learning tests for CartPole and Pendulum, which will then also include a setup for two losses/optimizers in IMPALA and APPO.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
