### PR TITLE
[Placement group] Warm up the cluster before running the unit test 

### DIFF
--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -345,6 +345,13 @@ def test_remove_placement_group(ray_start_cluster, connect_to_client):
     cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
 
+    @ray.remote
+    def warmup():
+        pass
+
+    # warm up the cluster.
+    ray.get([warmup.remote() for _ in range(4)])
+
     with connect_to_client_or_not(connect_to_client):
         # First try to remove a placement group that doesn't
         # exist. This should not do anything.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It seems like the placement group removal unit test is flaky. https://buildkite.com/ray-project/ray-builders-branch/builds/3925#fdd019eb-6b57-41f4-9915-4afac73dc96c

```python3
# Since the placement group is removed,
--
  | # the actor should've been killed.
  | # That means this request should fail.
  | with pytest.raises(ray.exceptions.RayActorError, match="actor died"):
  | ray.get(a.f.remote(), timeout=3.0)
  | with pytest.raises(ray.exceptions.WorkerCrashedError):
  | >               ray.get(task_ref)
  | E               Failed: DID NOT RAISE <class 'ray.exceptions.WorkerCrashedError'>

```

I am not sure about the root cause, but one of my guess is that the task is started before the placement group is removed because the process is started late. To avoid the issue, I try warming up the cluster (which pre-starts tasks).

I am not saying this is the right solution, but I am trying to merge this PR to see if my hypothesis is correct. If this indeed fixes the flaky test issue, we should find a way to resolve it as a follow up. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
