### PR TITLE
[runtime env] Fix handling of runtime env with None fields

### DIFF
--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -303,11 +303,10 @@ class ParsedRuntimeEnv(dict):
                 f"will be ignored: {unknown_fields}. If you intended to use "
                 "them as plugins, they must be nested in the `plugins` field.")
 
-        # TODO(architkulkarni) This is to make it easy for the worker caching
-        # code in C++ to check if the env is empty without deserializing and
-        # parsing it.  We should use a less confusing approach here.
+        # NOTE(architkulkarni): This allows worker caching code in C++ to check
+        # if a runtime env is empty without deserializing it.
         if all(val is None for val in self.values()):
-            self._dict = {}
+            self.clear()
 
     @classmethod
     def deserialize(cls, serialized: str) -> "ParsedRuntimeEnv":

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -304,7 +304,8 @@ class ParsedRuntimeEnv(dict):
                 "them as plugins, they must be nested in the `plugins` field.")
 
         # NOTE(architkulkarni): This allows worker caching code in C++ to check
-        # if a runtime env is empty without deserializing it.
+        # if a runtime env is empty without deserializing it.  This is a catch-
+        # all; for validated inputs we won't set the key if the value is None.
         if all(val is None for val in self.values()):
             self.clear()
 

--- a/python/ray/tests/test_runtime_env_validation.py
+++ b/python/ray/tests/test_runtime_env_validation.py
@@ -38,6 +38,7 @@ def test_directory():
         yield subdir, requirements_file, good_conda_file, bad_conda_file
         os.chdir(old_dir)
 
+
 def test_key_with_value_none():
     runtime_env_dict = {"pip": None}
     parsed_runtime_env = ParsedRuntimeEnv(runtime_env_dict)

--- a/python/ray/tests/test_runtime_env_validation.py
+++ b/python/ray/tests/test_runtime_env_validation.py
@@ -38,6 +38,11 @@ def test_directory():
         yield subdir, requirements_file, good_conda_file, bad_conda_file
         os.chdir(old_dir)
 
+def test_key_with_value_none():
+    runtime_env_dict = {"pip": None}
+    parsed_runtime_env = ParsedRuntimeEnv(runtime_env_dict)
+    assert parsed_runtime_env == {}
+
 
 class TestValidateWorkingDir:
     @pytest.mark.parametrize("absolute_path", [True, False])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
With the recent runtime env refactor, we can now remove the `._dict` field from the runtime env dictionary and use the `ParsedRuntimeEnv` object itself, which inherits from `dict`.

The logic ensures that all fields of a parsed runtime env are not None.  One interesting side effect of this approach is that if a task/actor/job has a non-None `"pip"` field, then it is impossible to undo this for any child task/actor (say, if you want the child to use the ambient cluster environment).  If you try to set `'pip': None` in the child, the key will be removed upon parsing.  This seems like a niche feature which we can try to support later.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
