### PR TITLE
[Core] [Hotfix] Handle logging redirected to stdout when configuring log file

### DIFF
--- a/python/ray/_private/ray_logging.py
+++ b/python/ray/_private/ray_logging.py
@@ -191,6 +191,10 @@ def get_worker_log_file_name(worker_type):
 
 
 def configure_log_file(out_file, err_file):
+    # If either of the file handles are None, there are no log files to
+    # configure since we're redirecting all output to stdout and stderr.
+    if out_file is None or err_file is None:
+        return
     stdout_fileno = sys.stdout.fileno()
     stderr_fileno = sys.stderr.fileno()
     # C++ logging requires redirecting the stdout file descriptor. Note that

--- a/python/ray/workers/default_worker.py
+++ b/python/ray/workers/default_worker.py
@@ -206,8 +206,7 @@ if __name__ == "__main__":
     # Setup log file.
     out_file, err_file = node.get_log_file_handles(
         get_worker_log_file_name(args.worker_type))
-    if out_file is not None and err_file is not None:
-        configure_log_file(out_file, err_file)
+    configure_log_file(out_file, err_file)
 
     if mode == ray.WORKER_MODE:
         ray.worker.global_worker.main_loop()

--- a/python/ray/workers/default_worker.py
+++ b/python/ray/workers/default_worker.py
@@ -206,7 +206,8 @@ if __name__ == "__main__":
     # Setup log file.
     out_file, err_file = node.get_log_file_handles(
         get_worker_log_file_name(args.worker_type))
-    configure_log_file(out_file, err_file)
+    if out_file is not None and err_file is not None:
+        configure_log_file(out_file, err_file)
 
     if mode == ray.WORKER_MODE:
         ray.worker.global_worker.main_loop()


### PR DESCRIPTION
When redirecting logging to stdout/stderr, don't pass `None` file handles to `configure_log_file`.

```
Traceback (most recent call last):
  File "/home/ray/workers/default_worker.py", line 209, in <module>
    configure_log_file(out_file, err_file)
  File "/home/ray/_private/ray_logging.py", line 199, in configure_log_file
    os.dup2(out_file.fileno(), stdout_fileno)
AttributeError: 'NoneType' object has no attribute 'fileno'
```

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
