### PR TITLE
Enable dashboard on Windows

### DIFF
--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -340,7 +340,7 @@ if __name__ == "__main__":
 
         # The dashboard is currently broken on Windows.
         # https://github.com/ray-project/ray/issues/14026.
-        if sys.platform == "win32":
+        if 0 and sys.platform == "win32":
             logger.warning(
                 "The dashboard is currently disabled on windows. "
                 "See https://github.com/ray-project/ray/issues/14026 "

--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -7,7 +7,6 @@ import platform
 import sys
 import socket
 import json
-import time
 import traceback
 
 from grpc.experimental import aio as aiogrpc
@@ -338,13 +337,10 @@ if __name__ == "__main__":
             backup_count=args.logging_rotate_backup_count)
         setup_component_logger(**logging_params)
 
-        # The dashboard is currently broken on Windows.
-        # https://github.com/ray-project/ray/issues/14026.
         if sys.platform == "win32":
             logger.warning(
-                "The dashboard is currently broken on windows. "
-                "See https://github.com/ray-project/ray/issues/14026 "
-                "for more details. Experimental support only.")
+                "The dashboard is currently experimental on windows. "
+                "See https://github.com/ray-project/ray/issues/14026 ")
 
         agent = DashboardAgent(
             args.node_ip_address,

--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -340,13 +340,11 @@ if __name__ == "__main__":
 
         # The dashboard is currently broken on Windows.
         # https://github.com/ray-project/ray/issues/14026.
-        if 0 and sys.platform == "win32":
+        if sys.platform == "win32":
             logger.warning(
-                "The dashboard is currently disabled on windows. "
+                "The dashboard is currently broken on windows. "
                 "See https://github.com/ray-project/ray/issues/14026 "
-                "for more details")
-            while True:
-                time.sleep(999)
+                "for more details. Experimental support only.")
 
         agent = DashboardAgent(
             args.node_ip_address,

--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -337,11 +337,6 @@ if __name__ == "__main__":
             backup_count=args.logging_rotate_backup_count)
         setup_component_logger(**logging_params)
 
-        if sys.platform == "win32":
-            logger.warning(
-                "The dashboard is currently experimental on windows. "
-                "See https://github.com/ray-project/ray/issues/14026 ")
-
         agent = DashboardAgent(
             args.node_ip_address,
             args.redis_address,

--- a/dashboard/head.py
+++ b/dashboard/head.py
@@ -6,7 +6,7 @@ import logging
 import ipaddress
 import threading
 
-from grpc import aio as aiogrpc
+from grpc.experimental import aio as aiogrpc
 from distutils.version import LooseVersion
 
 import ray._private.services

--- a/dashboard/head.py
+++ b/dashboard/head.py
@@ -54,7 +54,7 @@ async def make_gcs_grpc_channel(redis_client):
 
 
 class GCSHealthCheckThread(threading.Thread):
-    def __init__(self, redis_address, reddis_password):
+    def __init__(self, redis_address, redis_password):
         self.thread_local_loop = asyncio.new_event_loop()
         self.aiogrpc_gcs_channel = None
         self.gcs_heartbeat_info_stub = None
@@ -192,7 +192,7 @@ class DashboardHead:
             self.aioredis_client)
 
         self.health_check_thread = GCSHealthCheckThread(
-            redis_address, redis_password)
+            self.redis_address, self.redis_password)
         self.health_check_thread.start()
 
         # Start a grpc asyncio server.

--- a/dashboard/head.py
+++ b/dashboard/head.py
@@ -6,7 +6,7 @@ import logging
 import ipaddress
 import threading
 
-from grpc.experimental import aio as aiogrpc
+from grpc import aio as aiogrpc
 from distutils.version import LooseVersion
 
 import ray._private.services
@@ -54,18 +54,26 @@ async def make_gcs_grpc_channel(redis_client):
 
 
 class GCSHealthCheckThread(threading.Thread):
-    def __init__(self, redis_client):
+    def __init__(self, redis_address, reddis_password):
         self.thread_local_loop = asyncio.new_event_loop()
         self.aiogrpc_gcs_channel = None
         self.gcs_heartbeat_info_stub = None
 
         async def on_startup():
-            aiogrpc.init_grpc_aio()
-            self.aiogrpc_gcs_channel = await (
-                make_gcs_grpc_channel(redis_client))
-            self.gcs_heartbeat_info_stub = (
-                gcs_service_pb2_grpc.HeartbeatInfoGcsServiceStub(
-                    self.aiogrpc_gcs_channel))
+            try:
+                aiogrpc.init_grpc_aio()
+                redis_client = await dashboard_utils.get_aioredis_client(
+                redis_address, redis_password,
+                dashboard_consts.CONNECT_REDIS_INTERNAL_SECONDS,
+                dashboard_consts.RETRY_REDIS_CONNECTION_TIMES)
+                self.aiogrpc_gcs_channel = await (
+                    make_gcs_grpc_channel(redis_client))
+                self.gcs_heartbeat_info_stub = (
+                    gcs_service_pb2_grpc.HeartbeatInfoGcsServiceStub(
+                        self.aiogrpc_gcs_channel))
+            except Exception as e:
+                logger.error('exception in on_startup: "%s"' % str(e))
+                raise
 
         self.startup_task = self.thread_local_loop.create_task(on_startup())
 
@@ -184,7 +192,7 @@ class DashboardHead:
             self.aioredis_client)
 
         self.health_check_thread = GCSHealthCheckThread(
-            redis_client=self.aioredis_client)
+            redis_address, redis_password)
         self.health_check_thread.start()
 
         # Start a grpc asyncio server.

--- a/dashboard/head.py
+++ b/dashboard/head.py
@@ -63,9 +63,9 @@ class GCSHealthCheckThread(threading.Thread):
             try:
                 aiogrpc.init_grpc_aio()
                 redis_client = await dashboard_utils.get_aioredis_client(
-                redis_address, redis_password,
-                dashboard_consts.CONNECT_REDIS_INTERNAL_SECONDS,
-                dashboard_consts.RETRY_REDIS_CONNECTION_TIMES)
+                    redis_address, redis_password,
+                    dashboard_consts.CONNECT_REDIS_INTERNAL_SECONDS,
+                    dashboard_consts.RETRY_REDIS_CONNECTION_TIMES)
                 self.aiogrpc_gcs_channel = await (
                     make_gcs_grpc_channel(redis_client))
                 self.gcs_heartbeat_info_stub = (

--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -243,13 +243,13 @@ class ReporterAgent(dashboard_utils.DashboardAgentModule,
         if IN_KUBERNETES_POD:
             # If in a K8s pod, disable disk display by passing in dummy values.
             return {
-                '/': psutil._common.sdiskusage(
+                "/": psutil._common.sdiskusage(
                     total=1, used=0, free=1, percent=0.0)
             }
         root = os.environ["USERPROFILE"] if sys.platform == "win32" else os.sep
         tmp = ray._private.utils.get_user_temp_dir()
         return {
-            '/': psutil.disk_usage(root),
+            "/": psutil.disk_usage(root),
             tmp: psutil.disk_usage(tmp),
         }
 

--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -240,19 +240,18 @@ class ReporterAgent(dashboard_utils.DashboardAgentModule,
 
     @staticmethod
     def _get_disk_usage():
-        dirs = [
-            os.environ["USERPROFILE"] if sys.platform == "win32" else os.sep,
-            ray._private.utils.get_user_temp_dir(),
-        ]
         if IN_KUBERNETES_POD:
             # If in a K8s pod, disable disk display by passing in dummy values.
             return {
-                x: psutil._common.sdiskusage(
+                '/': psutil._common.sdiskusage(
                     total=1, used=0, free=1, percent=0.0)
-                for x in dirs
             }
-        else:
-            return {x: psutil.disk_usage(x) for x in dirs}
+        root = os.environ["USERPROFILE"] if sys.platform == "win32" else os.sep
+        tmp = ray._private.utils.get_user_temp_dir()
+        return {
+            '/': psutil.disk_usage(root),
+            tmp: psutil.disk_usage(tmp),
+        }
 
     def _get_workers(self):
         raylet_proc = self._get_raylet_proc()

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -92,7 +92,7 @@ def test_basic(ray_start_with_dashboard):
         for p in processes:
             try:
                 for c in p.cmdline():
-                    if "dashboard/agent.py" in c:
+                    if os.path.join("dashboard", "agent.py") in c:
                         return p
             except Exception:
                 pass

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1521,7 +1521,7 @@ def start_raylet(redis_address,
         agent_command = [
             sys.executable,
             "-u",
-            os.path.join(RAY_PATH, "dashboard/agent.py"),
+            os.path.join(RAY_PATH, "dashboard", "agent.py"),
             f"--node-ip-address={node_ip_address}",
             f"--redis-address={redis_address}",
             f"--metrics-export-port={metrics_export_port}",

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1181,7 +1181,10 @@ def start_dashboard(require_dashboard,
                 port_test_socket.bind((host, port))
                 port_test_socket.close()
             except socket.error as e:
-                if e.errno in {48, 98}:  # address already in use.
+                # 10013 on windows is a bit more broad than just
+                # "address in use": it can also indicate "permission denied".
+                # TODO: improve the error message?
+                if e.errno in {48, 98, 10013}:  # address already in use.
                     raise ValueError(
                         f"Failed to bind to {host}:{port} because it's "
                         "already occupied. You can use `ray start "

--- a/python/ray/autoscaler/_private/constants.py
+++ b/python/ray/autoscaler/_private/constants.py
@@ -94,7 +94,7 @@ RAY_PROCESSES = [
     ["io.ray.runtime.runner.worker.DefaultWorker", False],  # Java worker.
     ["log_monitor.py", False],
     ["reporter.py", False],
-    ["dashboard/dashboard.py", False],
+    [os.path.join("dashboard", "dashboard.py"), False],
     ["dashboard/agent.py", False],
     ["ray_process_reaper.py", False],
 ]

--- a/python/ray/autoscaler/_private/constants.py
+++ b/python/ray/autoscaler/_private/constants.py
@@ -95,7 +95,7 @@ RAY_PROCESSES = [
     ["log_monitor.py", False],
     ["reporter.py", False],
     [os.path.join("dashboard", "dashboard.py"), False],
-    ["dashboard/agent.py", False],
+    [os.path.join("dashboard", "agent.py"), False],
     ["ray_process_reaper.py", False],
 ]
 

--- a/python/ray/tests/test_dashboard.py
+++ b/python/ray/tests/test_dashboard.py
@@ -1,3 +1,4 @@
+import os
 import re
 import socket
 import subprocess
@@ -23,7 +24,7 @@ def search_agents(cluster):
         for p in processes:
             try:
                 for c in p.cmdline():
-                    if "dashboard/agent.py" in c:
+                    if os.path.join("dashboard", "agent.py") in c:
                         return p
             except Exception:
                 pass

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -10,7 +10,7 @@ aioredis < 2
 click >= 7.0
 cloudpickle
 filelock
-gpustat
+gpustat >= 1.0.0b1
 grpcio >= 1.28.1
 jsonschema
 msgpack >= 1.0.0, < 2.0.0

--- a/python/setup.py
+++ b/python/setup.py
@@ -197,7 +197,7 @@ if setup_spec.type == SetupType.RAY:
             "py-spy >= 0.2.0",
             "jsonschema",
             "requests",
-            "gpustat >= 1.0.0b1", # for windows
+            "gpustat >= 1.0.0b1",  # for windows
             "opencensus",
             "prometheus_client >= 0.7.1",
         ],

--- a/python/setup.py
+++ b/python/setup.py
@@ -197,7 +197,7 @@ if setup_spec.type == SetupType.RAY:
             "py-spy >= 0.2.0",
             "jsonschema",
             "requests",
-            "gpustat",
+            "gpustat >= 1.0.0b1", # for windows
             "opencensus",
             "prometheus_client >= 0.7.1",
         ],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This builds on #19014 (which in general fixes windows process creation) to enable the dashboard on windows.
- use `pip install gpustat==1.0.0b1` (closes #15650)
- remove the code in `agent.py` that disabled the dashboard
- change the way a new redis connection is made in the dashboard so that the connection is created inside the thread that uses it.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #18413, #9620. 
<!-- For example: "Closes #1234" -->

I still cannot see http://127.0.0.1:8265/#/, I must go to any of the other links like http://127.0.0.1:8265/#/job or http://127.0.0.1:8265/#/node. The top-level link has a javascript exception 
```
TypeError: e.disk['/'] is undefined
    D NodeInfo.tsx:218
    Vn NodeInfo.tsx:218
```

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
