### PR TITLE
[CI BLOCKER] [Core] [Hotfix] Fix for LazyBlockList refactor.

### DIFF
--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1316,17 +1316,17 @@ def test_parquet_read_parallel_meta_fetch(ray_start_regular_shared, fs,
         data_path, filesystem=fs, parallelism=parallelism)
 
     # Test metadata-only parquet ops.
-    assert len(ds._blocks._blocks) == 1
+    assert ds._blocks._num_computed() == 1
     assert ds.count() == num_dfs * 3
     assert ds.size_bytes() > 0
     assert ds.schema() is not None
     input_files = ds.input_files()
     assert len(input_files) == num_dfs, input_files
-    assert len(ds._blocks._blocks) == 1
+    assert ds._blocks._num_computed() == 1
 
     # Forces a data read.
     values = [s["one"] for s in ds.take(limit=3 * num_dfs)]
-    assert len(ds._blocks._blocks) == parallelism
+    assert ds._blocks._num_computed() == parallelism
     assert sorted(values) == list(range(3 * num_dfs))
 
 


### PR DESCRIPTION
`LazyBlockList` refactor changed the data model so `len(block_list._blocks) == len(block_list._calls)` is always true, even if most blocks haven't yet been computed. This PR ports to the new `block_list._num_computed()` private API.

I've tested this locally, the test failed before this change and passed after this change.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
