### PR TITLE
[release] fix `torch_tune_serve` test by pinning `filelock`

### DIFF
--- a/release/golden_notebook_tests/torch_tune_serve_app_config.yaml
+++ b/release/golden_notebook_tests/torch_tune_serve_app_config.yaml
@@ -11,6 +11,7 @@ python:
     - fastapi
     - uvicorn
     - tblib
+    - filelock>=3.3.0
   conda_packages: [ ]
 
 post_build_cmds:


### PR DESCRIPTION
Bumping `filelock` so the Ray Client `torch_tune_serve` test does not run into compatibility issues.

## Why are these changes needed?

[This](https://github.com/tox-dev/py-filelock/commit/da241c617edbe6f20e57e6f00adc3a539a6dcd4d) commit in `filelock` changes the package structure and was released in version `3.2.0`. 

The Anyscale Docker image uses `filelock` `3.0.12`, while the Buildkite host running the release test was on `filelock` `3.3.0`.

Bumping the version in the app config adds compatibility between cluster and client.

## Related issue number

Closes #19310.

## Checks

Verified [here](https://beta.anyscale.com/o/anyscale-internal/jobs/job_Qmjh1HNjssdHYJ1j9bVtZBAy).

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
