### PR TITLE
[tune] Fix `DistributedTrainable` restore

### DIFF
--- a/python/ray/tune/integration/torch.py
+++ b/python/ray/tune/integration/torch.py
@@ -99,11 +99,10 @@ class _TorchTrainable(DistributedTrainable):
 
         pgroup_params = self.default_process_group_parameters()
         from functools import partial
-        setup_on_worker = partial(
-            setup_process_group,
-            url=address,
-            world_size=num_workers,
-            **pgroup_params)
+        setup_on_worker = partial(setup_process_group,
+                                  url=address,
+                                  world_size=num_workers,
+                                  **pgroup_params)
         ray.get([
             w.execute.remote(lambda _: setup_on_worker(world_rank=rank))
             for rank, w in enumerate(self.workers)
@@ -131,8 +130,9 @@ class _TorchTrainable(DistributedTrainable):
 
     def load_checkpoint(self, checkpoint_dir: str):
         checkpoint_obj = TrainableUtil.checkpoint_to_object(checkpoint_dir)
-        return ray.get(
-            w.restore_from_object.remote(checkpoint_obj) for w in self.workers)
+        return ray.get([
+            w.restore_from_object.remote(checkpoint_obj) for w in self.workers
+        ])
 
     def stop(self):
         ray.get([worker.stop.remote() for worker in self.workers])
@@ -211,18 +211,18 @@ def DistributedTrainableCreator(func: Callable,
         @classmethod
         def default_resource_request(cls, config: Dict) -> Resources:
 
-            return Resources(
-                cpu=0,
-                gpu=0,
-                extra_cpu=num_cpus_per_worker * num_workers,
-                extra_gpu=num_gpus_per_worker * num_workers)
+            return Resources(cpu=0,
+                             gpu=0,
+                             extra_cpu=num_cpus_per_worker * num_workers,
+                             extra_gpu=num_gpus_per_worker * num_workers)
 
     return WrappedDistributedTorchTrainable
 
 
 @contextmanager
-def distributed_checkpoint_dir(
-        step: int, disable: bool = False) -> Generator[str, None, None]:
+def distributed_checkpoint_dir(step: int,
+                               disable: bool = False
+                               ) -> Generator[str, None, None]:
     """ContextManager for creating a distributed checkpoint.
 
     Only checkpoints a file on the "main" training actor, avoiding

--- a/python/ray/tune/integration/torch.py
+++ b/python/ray/tune/integration/torch.py
@@ -99,10 +99,11 @@ class _TorchTrainable(DistributedTrainable):
 
         pgroup_params = self.default_process_group_parameters()
         from functools import partial
-        setup_on_worker = partial(setup_process_group,
-                                  url=address,
-                                  world_size=num_workers,
-                                  **pgroup_params)
+        setup_on_worker = partial(
+            setup_process_group,
+            url=address,
+            world_size=num_workers,
+            **pgroup_params)
         ray.get([
             w.execute.remote(lambda _: setup_on_worker(world_rank=rank))
             for rank, w in enumerate(self.workers)
@@ -211,18 +212,18 @@ def DistributedTrainableCreator(func: Callable,
         @classmethod
         def default_resource_request(cls, config: Dict) -> Resources:
 
-            return Resources(cpu=0,
-                             gpu=0,
-                             extra_cpu=num_cpus_per_worker * num_workers,
-                             extra_gpu=num_gpus_per_worker * num_workers)
+            return Resources(
+                cpu=0,
+                gpu=0,
+                extra_cpu=num_cpus_per_worker * num_workers,
+                extra_gpu=num_gpus_per_worker * num_workers)
 
     return WrappedDistributedTorchTrainable
 
 
 @contextmanager
-def distributed_checkpoint_dir(step: int,
-                               disable: bool = False
-                               ) -> Generator[str, None, None]:
+def distributed_checkpoint_dir(
+        step: int, disable: bool = False) -> Generator[str, None, None]:
     """ContextManager for creating a distributed checkpoint.
 
     Only checkpoints a file on the "main" training actor, avoiding

--- a/python/ray/tune/tests/test_torch_trainable.py
+++ b/python/ray/tune/tests/test_torch_trainable.py
@@ -7,10 +7,9 @@ import torch.distributed as dist
 import ray
 from ray import tune
 from ray.cluster_utils import Cluster
-from ray.tune.integration.torch import (DistributedTrainableCreator,
-                                        distributed_checkpoint_dir,
-                                        _train_simple, _train_check_global,
-                                        _train_validate_session)
+from ray.tune.integration.torch import (
+    DistributedTrainableCreator, distributed_checkpoint_dir, _train_simple,
+    _train_check_global, _train_validate_session)
 
 
 @pytest.fixture
@@ -59,8 +58,8 @@ def test_validation(ray_start_2_cpus):  # noqa: F811
 
 
 def test_set_global(ray_start_2_cpus):  # noqa: F811
-    trainable_cls = DistributedTrainableCreator(_train_check_global,
-                                                num_workers=2)
+    trainable_cls = DistributedTrainableCreator(
+        _train_check_global, num_workers=2)
     trainable = trainable_cls()
     result = trainable.train()
     assert result["is_distributed"]
@@ -88,10 +87,11 @@ def test_restore_checkpoint(ray_start_2_cpus):  # noqa: F811
 @pytest.mark.parametrize("enabled_checkpoint", [True, False])
 def test_simple_tune(ray_start_4_cpus, enabled_checkpoint):
     trainable_cls = DistributedTrainableCreator(_train_simple, num_workers=2)
-    analysis = tune.run(trainable_cls,
-                        config={"enable_checkpoint": enabled_checkpoint},
-                        num_samples=2,
-                        stop={"training_iteration": 2})
+    analysis = tune.run(
+        trainable_cls,
+        config={"enable_checkpoint": enabled_checkpoint},
+        num_samples=2,
+        stop={"training_iteration": 2})
     assert analysis.trials[0].last_result["training_iteration"] == 2
     assert analysis.trials[0].has_checkpoint() == enabled_checkpoint
 
@@ -143,9 +143,8 @@ def ray_4_node_gpu():
 
 def test_colocated(ray_4_node):  # noqa: F811
     assert ray.available_resources()["CPU"] == 4
-    trainable_cls = DistributedTrainableCreator(_train_check_global,
-                                                num_workers=4,
-                                                num_workers_per_host=1)
+    trainable_cls = DistributedTrainableCreator(
+        _train_check_global, num_workers=4, num_workers_per_host=1)
     trainable = trainable_cls()
     assert ray.available_resources().get("CPU", 0) == 0
     trainable.train()
@@ -154,10 +153,11 @@ def test_colocated(ray_4_node):  # noqa: F811
 
 def test_colocated_gpu(ray_4_node_gpu):  # noqa: F811
     assert ray.available_resources()["GPU"] == 8
-    trainable_cls = DistributedTrainableCreator(_train_check_global,
-                                                num_workers=4,
-                                                num_gpus_per_worker=2,
-                                                num_workers_per_host=1)
+    trainable_cls = DistributedTrainableCreator(
+        _train_check_global,
+        num_workers=4,
+        num_gpus_per_worker=2,
+        num_workers_per_host=1)
     trainable = trainable_cls()
     assert ray.available_resources().get("GPU", 0) == 0
     trainable.train()
@@ -166,11 +166,12 @@ def test_colocated_gpu(ray_4_node_gpu):  # noqa: F811
 
 def test_colocated_gpu_double(ray_4_node_gpu):  # noqa: F811
     assert ray.available_resources()["GPU"] == 8
-    trainable_cls = DistributedTrainableCreator(_train_check_global,
-                                                num_workers=8,
-                                                num_gpus_per_worker=1,
-                                                num_workers_per_host=2,
-                                                timeout_s=30)
+    trainable_cls = DistributedTrainableCreator(
+        _train_check_global,
+        num_workers=8,
+        num_gpus_per_worker=1,
+        num_workers_per_host=2,
+        timeout_s=30)
     trainable = trainable_cls()
     print("?????")
     print(ray.available_resources().get("GPU"))

--- a/python/ray/tune/tests/test_torch_trainable.py
+++ b/python/ray/tune/tests/test_torch_trainable.py
@@ -7,9 +7,10 @@ import torch.distributed as dist
 import ray
 from ray import tune
 from ray.cluster_utils import Cluster
-from ray.tune.integration.torch import (
-    DistributedTrainableCreator, distributed_checkpoint_dir, _train_simple,
-    _train_check_global, _train_validate_session)
+from ray.tune.integration.torch import (DistributedTrainableCreator,
+                                        distributed_checkpoint_dir,
+                                        _train_simple, _train_check_global,
+                                        _train_validate_session)
 
 
 @pytest.fixture
@@ -58,8 +59,8 @@ def test_validation(ray_start_2_cpus):  # noqa: F811
 
 
 def test_set_global(ray_start_2_cpus):  # noqa: F811
-    trainable_cls = DistributedTrainableCreator(
-        _train_check_global, num_workers=2)
+    trainable_cls = DistributedTrainableCreator(_train_check_global,
+                                                num_workers=2)
     trainable = trainable_cls()
     result = trainable.train()
     assert result["is_distributed"]
@@ -75,14 +76,22 @@ def test_save_checkpoint(ray_start_2_cpus):  # noqa: F811
     trainer.stop()
 
 
+def test_restore_checkpoint(ray_start_2_cpus):  # noqa: F811
+    trainable_cls = DistributedTrainableCreator(_train_simple, num_workers=2)
+    trainer = trainable_cls(config={"epochs": 1})
+    trainer.train()
+    checkpoint_dir = trainer.save()
+    trainer.restore(checkpoint_dir)
+    trainer.stop()
+
+
 @pytest.mark.parametrize("enabled_checkpoint", [True, False])
 def test_simple_tune(ray_start_4_cpus, enabled_checkpoint):
     trainable_cls = DistributedTrainableCreator(_train_simple, num_workers=2)
-    analysis = tune.run(
-        trainable_cls,
-        config={"enable_checkpoint": enabled_checkpoint},
-        num_samples=2,
-        stop={"training_iteration": 2})
+    analysis = tune.run(trainable_cls,
+                        config={"enable_checkpoint": enabled_checkpoint},
+                        num_samples=2,
+                        stop={"training_iteration": 2})
     assert analysis.trials[0].last_result["training_iteration"] == 2
     assert analysis.trials[0].has_checkpoint() == enabled_checkpoint
 
@@ -134,8 +143,9 @@ def ray_4_node_gpu():
 
 def test_colocated(ray_4_node):  # noqa: F811
     assert ray.available_resources()["CPU"] == 4
-    trainable_cls = DistributedTrainableCreator(
-        _train_check_global, num_workers=4, num_workers_per_host=1)
+    trainable_cls = DistributedTrainableCreator(_train_check_global,
+                                                num_workers=4,
+                                                num_workers_per_host=1)
     trainable = trainable_cls()
     assert ray.available_resources().get("CPU", 0) == 0
     trainable.train()
@@ -144,11 +154,10 @@ def test_colocated(ray_4_node):  # noqa: F811
 
 def test_colocated_gpu(ray_4_node_gpu):  # noqa: F811
     assert ray.available_resources()["GPU"] == 8
-    trainable_cls = DistributedTrainableCreator(
-        _train_check_global,
-        num_workers=4,
-        num_gpus_per_worker=2,
-        num_workers_per_host=1)
+    trainable_cls = DistributedTrainableCreator(_train_check_global,
+                                                num_workers=4,
+                                                num_gpus_per_worker=2,
+                                                num_workers_per_host=1)
     trainable = trainable_cls()
     assert ray.available_resources().get("GPU", 0) == 0
     trainable.train()
@@ -157,12 +166,11 @@ def test_colocated_gpu(ray_4_node_gpu):  # noqa: F811
 
 def test_colocated_gpu_double(ray_4_node_gpu):  # noqa: F811
     assert ray.available_resources()["GPU"] == 8
-    trainable_cls = DistributedTrainableCreator(
-        _train_check_global,
-        num_workers=8,
-        num_gpus_per_worker=1,
-        num_workers_per_host=2,
-        timeout_s=30)
+    trainable_cls = DistributedTrainableCreator(_train_check_global,
+                                                num_workers=8,
+                                                num_gpus_per_worker=1,
+                                                num_workers_per_host=2,
+                                                timeout_s=30)
     trainable = trainable_cls()
     print("?????")
     print(ray.available_resources().get("GPU"))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Restore of a `ray.tune.integration.torch.DistributedTrainableCreator` gets a
`ValueError: 'object_refs' must either be an object ref or a list of object refs`


<!-- Please give a short summary of the change and the problem this solves. -->
`ray.get` expects a list of `object_refs`. Passing the arguments as a list fixes this. Also added unit test. 

## Related issue number
https://github.com/ray-project/ray/issues/17054 depends on this.

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
