### PR TITLE
[workflow] fix workflow user metadata return when None is given

### DIFF
--- a/python/ray/workflow/execution.py
+++ b/python/ray/workflow/execution.py
@@ -37,6 +37,7 @@ def run(entry_workflow: Workflow,
                 raise ValueError("metadata values must be JSON serializable, "
                                  "however '{}' has a value whose {}.".format(
                                      k, e))
+    metadata = metadata or {}
 
     store = get_global_storage()
     assert ray.is_initialized()

--- a/python/ray/workflow/tests/test_metadata_put.py
+++ b/python/ray/workflow/tests/test_metadata_put.py
@@ -86,6 +86,25 @@ def test_workflow_runtime_metadata(workflow_start_regular):
     assert "end_time" in postrun_meta
 
 
+def test_no_user_metadata(workflow_start_regular):
+
+    workflow_id = "simple"
+    step_name = "simple_step"
+
+    @workflow.step(name=step_name)
+    def simple():
+        return 0
+
+    simple.step().run(workflow_id)
+
+    checkpointed_user_step_metadata = get_metadata(
+        [workflow_id, "steps", step_name, workflow_storage.STEP_USER_METADATA])
+    checkpointed_user_run_metadata = get_metadata(
+        [workflow_id, workflow_storage.WORKFLOW_USER_METADATA])
+    assert {} == checkpointed_user_step_metadata
+    assert {} == checkpointed_user_run_metadata
+
+
 def test_all_metadata(workflow_start_regular):
 
     user_step_metadata = {"k1": "v1"}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Quick fix for metadata put.   Currently when workflow-level metadata is not given, it will output `null` to `user_run_metadata.json`, this fix will make it output `{}`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
original issue: https://github.com/ray-project/ray/issues/17090
original PR: https://github.com/ray-project/ray/pull/19195

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
