### PR TITLE
[ci] Fix double `gym` in requirements

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -51,7 +51,6 @@ cython >= 0.29.15
 dataclasses; python_version < '3.7'
 feather-format
 google-api-python-client
-gym
 gym-minigrid
 kubernetes
 lxml


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

gym is defined twice in requirements.txt, which can cause issues

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
