### PR TITLE
[data] Preserve epoch by default when using rewindow()

### DIFF
--- a/doc/source/data/dataset-pipeline.rst
+++ b/doc/source/data/dataset-pipeline.rst
@@ -336,7 +336,7 @@ See :ref:`the SGD User Guide <sgd-dataset-pipeline>` for more details.
 Changing Pipeline Structure
 ---------------------------
 
-Sometimes, you may want to change the structure of an existing pipeline. For example, after generating a pipeline with ``ds.window(k)``, you may want to repeat that windowed pipeline ``n`` times. This can be done with ``ds.window(k).repeat(n)``. As another example, suppose you have a repeating pipeline generated with ``ds.repeat(n)``. The windowing of that pipeline can be changed with ``ds.repeat(n).rewindow(k)``. Note the subtle difference in the two examples: the former is repeating a windowed pipeline that has a base window size of ``k``, while the latter is re-windowing a pipeline of initial window size of ``ds.num_blocks()``. The latter may produce windows that span multiple copies of the same original data:
+Sometimes, you may want to change the structure of an existing pipeline. For example, after generating a pipeline with ``ds.window(k)``, you may want to repeat that windowed pipeline ``n`` times. This can be done with ``ds.window(k).repeat(n)``. As another example, suppose you have a repeating pipeline generated with ``ds.repeat(n)``. The windowing of that pipeline can be changed with ``ds.repeat(n).rewindow(k)``. Note the subtle difference in the two examples: the former is repeating a windowed pipeline that has a base window size of ``k``, while the latter is re-windowing a pipeline of initial window size of ``ds.num_blocks()``. The latter may produce windows that span multiple copies of the same original data if ``preserve_epochs=False`` is set:
 
 .. code-block:: python
 
@@ -365,12 +365,12 @@ Sometimes, you may want to change the structure of an existing pipeline. For exa
     # === Window 5 ===
     # 4
 
-    # Repeat followed by window. Note that epoch 1 contains some leftover
-    # data from the tail end of epoch 0, since re-windowing can merge windows
-    # across epochs.
+    # Repeat followed by window. Since preserve_epoch=True, at epoch boundaries
+    # windows may be smaller than the target size. If it was set to False, all
+    # windows except the last would be the target size.
     ray.data.range(5) \
         .repeat(2) \
-        .rewindow(blocks_per_window=2) \
+        .rewindow(blocks_per_window=2, preserve_epochs=True) \
         .show_windows()
     # ->
     # ------ Epoch 0 ------
@@ -380,13 +380,14 @@ Sometimes, you may want to change the structure of an existing pipeline. For exa
     # === Window 1 ===
     # 2
     # 3
-    # ------ Epoch 1 ------
     # === Window 2 ===
     # 4
-    # 0
+    # ------ Epoch 1 ------
     # === Window 3 ===
+    # 0
     # 1
-    # 2
     # === Window 4 ===
+    # 2
     # 3
+    # === Window 5 ===
     # 4

--- a/doc/source/data/dataset-pipeline.rst
+++ b/doc/source/data/dataset-pipeline.rst
@@ -336,7 +336,7 @@ See :ref:`the SGD User Guide <sgd-dataset-pipeline>` for more details.
 Changing Pipeline Structure
 ---------------------------
 
-Sometimes, you may want to change the structure of an existing pipeline. For example, after generating a pipeline with ``ds.window(k)``, you may want to repeat that windowed pipeline ``n`` times. This can be done with ``ds.window(k).repeat(n)``. As another example, suppose you have a repeating pipeline generated with ``ds.repeat(n)``. The windowing of that pipeline can be changed with ``ds.repeat(n).rewindow(k)``. Note the subtle difference in the two examples: the former is repeating a windowed pipeline that has a base window size of ``k``, while the latter is re-windowing a pipeline of initial window size of ``ds.num_blocks()``. The latter may produce windows that span multiple copies of the same original data if ``preserve_epochs=False`` is set:
+Sometimes, you may want to change the structure of an existing pipeline. For example, after generating a pipeline with ``ds.window(k)``, you may want to repeat that windowed pipeline ``n`` times. This can be done with ``ds.window(k).repeat(n)``. As another example, suppose you have a repeating pipeline generated with ``ds.repeat(n)``. The windowing of that pipeline can be changed with ``ds.repeat(n).rewindow(k)``. Note the subtle difference in the two examples: the former is repeating a windowed pipeline that has a base window size of ``k``, while the latter is re-windowing a pipeline of initial window size of ``ds.num_blocks()``. The latter may produce windows that span multiple copies of the same original data if ``reserve_epoch=False`` is set:
 
 .. code-block:: python
 
@@ -365,12 +365,12 @@ Sometimes, you may want to change the structure of an existing pipeline. For exa
     # === Window 5 ===
     # 4
 
-    # Repeat followed by window. Since preserve_epochs=True, at epoch boundaries
+    # Repeat followed by window. Since preserve_epoch=True, at epoch boundaries
     # windows may be smaller than the target size. If it was set to False, all
     # windows except the last would be the target size.
     ray.data.range(5) \
         .repeat(2) \
-        .rewindow(blocks_per_window=2, preserve_epochs=True) \
+        .rewindow(blocks_per_window=2, preserve_epoch=True) \
         .show_windows()
     # ->
     # ------ Epoch 0 ------

--- a/doc/source/data/dataset-pipeline.rst
+++ b/doc/source/data/dataset-pipeline.rst
@@ -365,7 +365,7 @@ Sometimes, you may want to change the structure of an existing pipeline. For exa
     # === Window 5 ===
     # 4
 
-    # Repeat followed by window. Since preserve_epoch=True, at epoch boundaries
+    # Repeat followed by window. Since preserve_epochs=True, at epoch boundaries
     # windows may be smaller than the target size. If it was set to False, all
     # windows except the last would be the target size.
     ray.data.range(5) \

--- a/doc/source/data/dataset-pipeline.rst
+++ b/doc/source/data/dataset-pipeline.rst
@@ -78,7 +78,8 @@ It's common in ML training to want to divide data ingest into epochs, or repetit
 
 .. code-block:: python
 
-    pipe = ray.data.range(5).repeat(3).random_shuffle_each_window()
+    pipe = ray.data.from_items([0, 1, 2, 3, 4]) \
+        .repeat(3).random_shuffle_each_window()
     for i, epoch in enumerate(pipe.iter_epochs()):
         print("Epoch {}", i)
         for row in epoch.iter_rows():
@@ -113,7 +114,8 @@ While most Dataset operations are per-row (e.g., map, filter), some operations a
 .. code-block:: python
 
     # Example of randomly shuffling each window of a pipeline.
-    ray.data.range(5).repeat(2).random_shuffle_each_window().show_windows()
+    ray.data.from_items([0, 1, 2, 3, 4]) \
+        .repeat(2).random_shuffle_each_window().show_windows()
     # -> 
     # ----- Epoch 0 ------
     # === Window 0 ===
@@ -135,7 +137,8 @@ You can also apply arbitrary transformations to each window using ``DatasetPipel
 .. code-block:: python
 
     # Equivalent transformation using .foreach_window() 
-    ray.data.range(5).repeat(2).foreach_window(lambda w: w.random_shuffle()).show_windows()
+    ray.data.from_items([0, 1, 2, 3, 4]) \
+        .repeat(2).foreach_window(lambda w: w.random_shuffle()).show_windows()
     # -> 
     # ----- Epoch 0 ------
     # === Window 0 ===
@@ -341,7 +344,7 @@ Sometimes, you may want to change the structure of an existing pipeline. For exa
 .. code-block:: python
 
     # Window followed by repeat.
-    ray.data.range(5) \
+    ray.data.from_items([0, 1, 2, 3, 4]) \
         .window(blocks_per_window=2) \
         .repeat(2) \
         .show_windows()
@@ -368,7 +371,7 @@ Sometimes, you may want to change the structure of an existing pipeline. For exa
     # Repeat followed by window. Since preserve_epoch=True, at epoch boundaries
     # windows may be smaller than the target size. If it was set to False, all
     # windows except the last would be the target size.
-    ray.data.range(5) \
+    ray.data.from_items([0, 1, 2, 3, 4]) \
         .repeat(2) \
         .rewindow(blocks_per_window=2, preserve_epoch=True) \
         .show_windows()

--- a/doc/source/data/dataset-pipeline.rst
+++ b/doc/source/data/dataset-pipeline.rst
@@ -79,7 +79,8 @@ It's common in ML training to want to divide data ingest into epochs, or repetit
 .. code-block:: python
 
     pipe = ray.data.from_items([0, 1, 2, 3, 4]) \
-        .repeat(3).random_shuffle_each_window()
+        .repeat(3) \
+        .random_shuffle_each_window()
     for i, epoch in enumerate(pipe.iter_epochs()):
         print("Epoch {}", i)
         for row in epoch.iter_rows():
@@ -115,7 +116,9 @@ While most Dataset operations are per-row (e.g., map, filter), some operations a
 
     # Example of randomly shuffling each window of a pipeline.
     ray.data.from_items([0, 1, 2, 3, 4]) \
-        .repeat(2).random_shuffle_each_window().show_windows()
+        .repeat(2) \
+        .random_shuffle_each_window() \
+        .show_windows()
     # -> 
     # ----- Epoch 0 ------
     # === Window 0 ===
@@ -138,7 +141,9 @@ You can also apply arbitrary transformations to each window using ``DatasetPipel
 
     # Equivalent transformation using .foreach_window() 
     ray.data.from_items([0, 1, 2, 3, 4]) \
-        .repeat(2).foreach_window(lambda w: w.random_shuffle()).show_windows()
+        .repeat(2) \
+        .foreach_window(lambda w: w.random_shuffle()) \
+        .show_windows()
     # -> 
     # ----- Epoch 0 ------
     # === Window 0 ===
@@ -339,7 +344,7 @@ See :ref:`the SGD User Guide <sgd-dataset-pipeline>` for more details.
 Changing Pipeline Structure
 ---------------------------
 
-Sometimes, you may want to change the structure of an existing pipeline. For example, after generating a pipeline with ``ds.window(k)``, you may want to repeat that windowed pipeline ``n`` times. This can be done with ``ds.window(k).repeat(n)``. As another example, suppose you have a repeating pipeline generated with ``ds.repeat(n)``. The windowing of that pipeline can be changed with ``ds.repeat(n).rewindow(k)``. Note the subtle difference in the two examples: the former is repeating a windowed pipeline that has a base window size of ``k``, while the latter is re-windowing a pipeline of initial window size of ``ds.num_blocks()``. The latter may produce windows that span multiple copies of the same original data if ``reserve_epoch=False`` is set:
+Sometimes, you may want to change the structure of an existing pipeline. For example, after generating a pipeline with ``ds.window(k)``, you may want to repeat that windowed pipeline ``n`` times. This can be done with ``ds.window(k).repeat(n)``. As another example, suppose you have a repeating pipeline generated with ``ds.repeat(n)``. The windowing of that pipeline can be changed with ``ds.repeat(n).rewindow(k)``. Note the subtle difference in the two examples: the former is repeating a windowed pipeline that has a base window size of ``k``, while the latter is re-windowing a pipeline of initial window size of ``ds.num_blocks()``. The latter may produce windows that span multiple copies of the same original data if ``preserve_epoch=False`` is set:
 
 .. code-block:: python
 

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -243,7 +243,7 @@ class DatasetPipeline(Generic[T]):
         ]
 
     def rewindow(self, *, blocks_per_window: int,
-                 preserve_epochs: bool = True) -> "DatasetPipeline[T]":
+                 preserve_epoch: bool = True) -> "DatasetPipeline[T]":
         """Change the windowing (blocks per dataset) of this pipeline.
 
         Changes the windowing of this pipeline to the specified size. For
@@ -255,7 +255,7 @@ class DatasetPipeline(Generic[T]):
 
         Args:
             blocks_per_window: The new target blocks per window.
-            preserve_epochs: Whether to preserve epoch boundaries. If set to
+            preserve_epoch: Whether to preserve epoch boundaries. If set to
                 False, then windows can contain data from two adjacent epochs.
         """
 
@@ -271,7 +271,7 @@ class DatasetPipeline(Generic[T]):
                         self._buffer = next(self._original_iter)
                     while self._buffer.num_blocks() < blocks_per_window:
                         next_ds = next(self._original_iter)
-                        if (preserve_epochs and self._buffer._get_epoch() !=
+                        if (preserve_epoch and self._buffer._get_epoch() !=
                                 next_ds._get_epoch()):
                             partial_window = self._buffer
                             self._buffer = next_ds

--- a/python/ray/data/tests/test_dataset_pipeline.py
+++ b/python/ray/data/tests/test_dataset_pipeline.py
@@ -53,14 +53,14 @@ def test_epoch(ray_start_regular_shared):
     assert results == [[0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
                        [0, 1, 2, 3, 4, 0, 1, 2, 3, 4]]
 
-    # Test preserve_epochs=True.
+    # Test preserve_epoch=True.
     pipe = ray.data.range(5).repeat(2).rewindow(blocks_per_window=2)
     results = [p.take() for p in pipe.iter_epochs()]
     assert results == [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]]
 
-    # Test preserve_epochs=False.
+    # Test preserve_epoch=False.
     pipe = ray.data.range(5).repeat(2).rewindow(
-        blocks_per_window=2, preserve_epochs=False)
+        blocks_per_window=2, preserve_epoch=False)
     results = [p.take() for p in pipe.iter_epochs()]
     assert results == [[0, 1, 2, 3], [4, 0, 1, 2, 3, 4]]
 

--- a/python/ray/data/tests/test_dataset_pipeline.py
+++ b/python/ray/data/tests/test_dataset_pipeline.py
@@ -53,6 +53,17 @@ def test_epoch(ray_start_regular_shared):
     assert results == [[0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
                        [0, 1, 2, 3, 4, 0, 1, 2, 3, 4]]
 
+    # Test preserve_epochs=True.
+    pipe = ray.data.range(5).repeat(2).rewindow(blocks_per_window=2)
+    results = [p.take() for p in pipe.iter_epochs()]
+    assert results == [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]]
+
+    # Test preserve_epochs=False.
+    pipe = ray.data.range(5).repeat(2).rewindow(
+        blocks_per_window=2, preserve_epochs=False)
+    results = [p.take() for p in pipe.iter_epochs()]
+    assert results == [[0, 1, 2, 3], [4, 0, 1, 2, 3, 4]]
+
 
 def test_cannot_read_twice(ray_start_regular_shared):
     ds = ray.data.range(10)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

DatasetPipeline.rewindow() can cause windows to contain data across multiple epochs. Disable this behavior by default and add an option to opt-in to avoid confusion.