### PR TITLE
Use 127.0.0.1 for node IP address in ``win32``

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -399,8 +399,8 @@ def node_ip_address_from_perspective(address):
 def get_node_ip_address(address="8.8.8.8:53"):
     if ray.worker._global_node is not None:
         return ray.worker._global_node.node_ip_address
-    if sys.platform == "darwin":
-        # Due to the mac osx firewall,
+    if sys.platform == "darwin" or sys.platform == "win32":
+        # Due to the mac osx/windows firewall,
         # we use loopback ip as the ip address
         # to prevent security popups.
         return "127.0.0.1"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR extends https://github.com/ray-project/ray/pull/18904 for Windows systems by returning `127.0.0.1` when the sys.platform is either darwin or win32. 

Note that, there will still be one pop from Python to allow it communicate on networks. I can investigate that further if required. For executables generated by ray (redis-server.exe, gcs_server.exe, raylet.exe) there will be no pop ups on Windows after this PR.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/19109

How to test? -> First open the Windows defender firewall -> Allow app or feature through windows defender firewall -> remove, redis-server.exe, raylet.exe, gcs_server.exe (duplicates too) and then execute, ray.init() under python.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(

cc: @dharhas @pcmoritz @wuisawesome 