### PR TITLE
Switch from yaml.load to yaml.safe_load

### DIFF
--- a/release/e2e.py
+++ b/release/e2e.py
@@ -1806,7 +1806,7 @@ def run_test(test_config_file: str,
              session_name: Optional[str] = None,
              app_config_id_override=None) -> Dict[str, Any]:
     with open(test_config_file, "rt") as f:
-        test_configs = yaml.load(f, Loader=yaml.FullLoader)
+        test_configs = yaml.safe_load(f)
 
     test_config_dict = {}
     for test_config in test_configs:

--- a/rllib/tests/git_bisect/debug_learning_failure_git_bisect.py
+++ b/rllib/tests/git_bisect/debug_learning_failure_git_bisect.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     # Explicit yaml config file.
     if args.f:
         with open(args.f, "r") as fp:
-            experiment_config = yaml.load(fp)
+            experiment_config = yaml.safe_load(fp)
             experiment_config = experiment_config[next(
                 iter(experiment_config))]
             config = experiment_config.get("config", {})

--- a/rllib/tests/run_regression_tests.py
+++ b/rllib/tests/run_regression_tests.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
 
     # Loop through all collected files.
     for yaml_file in yaml_files:
-        experiments = yaml.load(open(yaml_file).read())
+        experiments = yaml.safe_load(open(yaml_file).read())
         assert len(experiments) == 1,\
             "Error, can only run a single experiment per yaml file!"
 

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -576,7 +576,7 @@ def run_learning_tests_from_yaml(
     # Loop through all collected files and gather experiments.
     # Augment all by `torch` framework.
     for yaml_file in yaml_files:
-        tf_experiments = yaml.load(open(yaml_file).read())
+        tf_experiments = yaml.safe_load(open(yaml_file).read())
 
         # Add torch version of all experiments to the list.
         for k, e in tf_experiments.items():


### PR DESCRIPTION
Due to `yaml.load()` partial [deprecation](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation), all instances where load was called without the loader parameter, are now failing.
`yaml.safe_load()` should now be the standard way of safely loading a yaml file, without risking exploits.

This fixes some automated tests failing recently