### PR TITLE
[Lint] Disable `modernize-use-override`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,7 @@
 # -modernize-use-emplace (more subtle behavior)
 # -modernize-use-nodiscard (too much noise)
 # -modernize-use-trailing-return-type (inconsistent style)
+# -modernize-use-override (TODO(mwtian): re-enable after fixing existing derived classes)
 # -modernize-avoid-bind (incorrect conversion)
 # -modernize-loop-convert (more subtle behavior)
 # -modernize-replace-disallow-copy-and-assign-macro (inconsistent style)
@@ -42,6 +43,7 @@ Checks: >
   -modernize-replace-disallow-copy-and-assign-macro,
   -modernize-make-unique,
   -modernize-make-shared,
+  -modernize-use-override,
   performance-*,
   readability-avoid-const-params-in-decls,
   readability-braces-around-statements,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This lint rule cannot apply only to changed lines because currently Ray has `-Winconsistent-missing-override` as a build flag. Either all or none of member functions from a derived class can have the `override` / `final` annocation.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
