### PR TITLE
Fix bad indentation in RaySGDv2 Trainer docstring

### DIFF
--- a/python/ray/util/sgd/v2/trainer.py
+++ b/python/ray/util/sgd/v2/trainer.py
@@ -78,7 +78,7 @@ class Trainer:
         logdir (Optional[str]): Path to the file directory where logs
             should be persisted. If this is not specified, one will be
             generated.
-         max_retries (int): Number of retries when Ray actors fail.
+        max_retries (int): Number of retries when Ray actors fail.
             Defaults to 3. Set to -1 for unlimited retries.
     """
 


### PR DESCRIPTION
## Why are these changes needed?

A line indentation issue is causing the RaySGDv2 Trainer docs to render the `max_retries` field like a blockquote.

Here is an image of the RaySGDv2 Trainer docs with the **incorrect** indentation.

<img width="812" alt="Screen Shot 2021-10-13 at 8 48 00 PM" src="https://user-images.githubusercontent.com/3060429/137237124-157cbe7b-c58b-4357-84bd-2b3425c68b94.png">
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
