### PR TITLE
[Test] Add complicated threaded actor tests

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -91,6 +91,7 @@ py_test_module_list(
     "test_stress_sharded.py",
     "test_tempfile.py",
     "test_tensorflow.py",
+    "test_threaded_actor.py",
     "test_ray_debugger.py",
   ],
   size = "medium",

--- a/python/ray/tests/test_threaded_actor.py
+++ b/python/ray/tests/test_threaded_actor.py
@@ -38,7 +38,7 @@ def test_threaded_actor_basic(shutdown_only):
     seqnos = ray.get(a.get_all.remote())
     # Currently, the caller submission order is not guaranteed
     # when the threaded actor is used.
-    assert sorted(seqnos) == [i for i in range(max_seq)]
+    assert sorted(seqnos) == list(range(max_seq))
     ray.kill(a)
     ensure_cpu_returned(1)
 
@@ -89,7 +89,7 @@ def test_threaded_actor_api_thread_safe(shutdown_only):
     # Test in-memory return obj
     seqnos = ray.get(
         [a.in_memory_return_test.remote(seqno) for seqno in range(max_seq)])
-    assert sorted(seqnos) == [i for i in range(max_seq)]
+    assert sorted(seqnos) == list(range(max_seq))
 
     # Test plasma return obj
     real = ray.get(

--- a/python/ray/tests/test_threaded_actor.py
+++ b/python/ray/tests/test_threaded_actor.py
@@ -1,0 +1,168 @@
+import sys
+import threading
+import time
+
+import numpy as np
+import ray
+
+from ray.state import available_resources
+import ray._private.test_utils as test_utils
+
+
+def ensure_cpu_returned(expected_cpus):
+    test_utils.wait_for_condition(
+        lambda: (available_resources().get("CPU", 0) == expected_cpus))
+
+
+def test_threaded_actor_basic(shutdown_only):
+    """Test the basic threaded actor."""
+    ray.init(num_cpus=1)
+
+    @ray.remote(num_cpus=1)
+    class ThreadedActor:
+        def __init__(self):
+            self.received = []
+            self.lock = threading.Lock()
+
+        def add(self, seqno):
+            with self.lock:
+                self.received.append(seqno)
+
+        def get_all(self):
+            with self.lock:
+                return self.received
+
+    a = ThreadedActor.options(max_concurrency=10).remote()
+    max_seq = 50
+    ray.get([a.add.remote(seqno) for seqno in range(max_seq)])
+    seqnos = ray.get(a.get_all.remote())
+    # Currently, the caller submission order is not guaranteed
+    # when the threaded actor is used.
+    assert sorted(seqnos) == [i for i in range(max_seq)]
+    ray.kill(a)
+    ensure_cpu_returned(1)
+
+
+def test_threaded_actor_api_thread_safe(shutdown_only):
+    """Test if Ray APIs are thread safe
+        when they are used within threaded actor
+    """
+    ray.init(
+        num_cpus=8,
+        # from 1024 bytes, the return obj will go to the plasma store.
+        _system_config={"max_direct_call_object_size": 1024})
+
+    @ray.remote
+    def in_memory_return(i):
+        return i
+
+    @ray.remote
+    def plasma_return(i):
+        arr = np.zeros(8 * 1024 * i, dtype=np.uint8)  # 8 * i KB
+        return arr
+
+    @ray.remote(num_cpus=1)
+    class ThreadedActor:
+        def __init__(self):
+            self.received = []
+            self.lock = threading.Lock()
+
+        def in_memory_return_test(self, i):
+            self._add(i)
+            return ray.get(in_memory_return.remote(i))
+
+        def plasma_return_test(self, i):
+            self._add(i)
+            return ray.get(plasma_return.remote(i))
+
+        def _add(self, seqno):
+            with self.lock:
+                self.received.append(seqno)
+
+        def get_all(self):
+            with self.lock:
+                return self.received
+
+    a = ThreadedActor.options(max_concurrency=10).remote()
+    max_seq = 50
+
+    # Test in-memory return obj
+    seqnos = ray.get(
+        [a.in_memory_return_test.remote(seqno) for seqno in range(max_seq)])
+    assert sorted(seqnos) == [i for i in range(max_seq)]
+
+    # Test plasma return obj
+    real = ray.get(
+        [a.plasma_return_test.remote(seqno) for seqno in range(max_seq)])
+    expected = [np.zeros(8 * 1024 * i, dtype=np.uint8) for i in range(max_seq)]
+    for r, e in zip(real, expected):
+        assert np.array_equal(r, e)
+
+    ray.kill(a)
+    ensure_cpu_returned(8)
+
+
+def test_threaded_actor_creation_and_kill(ray_start_cluster):
+    cluster = ray_start_cluster
+    NUM_CPUS_PER_NODE = 3
+    NUM_NODES = 2
+    for _ in range(NUM_NODES):
+        cluster.add_node(num_cpus=NUM_CPUS_PER_NODE)
+    ray.init(address=cluster.address)
+
+    @ray.remote(num_cpus=0)
+    class ThreadedActor:
+        def __init__(self):
+            self.received = []
+            self.lock = threading.Lock()
+
+        def add(self, seqno):
+            time.sleep(1)
+            with self.lock:
+                self.received.append(seqno)
+
+        def get_all(self):
+            with self.lock:
+                return self.received
+
+        def ready(self):
+            pass
+
+        def terminate(self):
+            ray.actor.exit_actor()
+
+    for _ in range(10):
+        actors = [
+            ThreadedActor.options(max_concurrency=10).remote()
+            for _ in range(NUM_NODES * NUM_CPUS_PER_NODE)
+        ]
+        ray.get([actor.ready.remote() for actor in actors])
+
+        for _ in range(10):
+            for actor in actors:
+                actor.add.remote(1)
+        time.sleep(0.5)
+        for actor in actors:
+            ray.kill(actor)
+    ensure_cpu_returned(NUM_NODES * NUM_CPUS_PER_NODE)
+
+    for _ in range(10):
+        actors = [
+            ThreadedActor.options(max_concurrency=10).remote()
+            for _ in range(NUM_NODES * NUM_CPUS_PER_NODE)
+        ]
+        ray.get([actor.ready.remote() for actor in actors])
+        for _ in range(10):
+            for actor in actors:
+                actor.add.remote(1)
+
+        time.sleep(0.5)
+        for actor in actors:
+            actor.terminate.remote()
+    ensure_cpu_returned(NUM_NODES * NUM_CPUS_PER_NODE)
+
+
+if __name__ == "__main__":
+    import pytest
+    # Test suite is timing out. Disable on windows for now.
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_threaded_actor.py
+++ b/python/ray/tests/test_threaded_actor.py
@@ -45,7 +45,7 @@ def test_threaded_actor_basic(shutdown_only):
 
 def test_threaded_actor_api_thread_safe(shutdown_only):
     """Test if Ray APIs are thread safe
-        when they are used within threaded actor
+        when they are used within threaded actor.
     """
     ray.init(
         num_cpus=8,
@@ -103,6 +103,8 @@ def test_threaded_actor_api_thread_safe(shutdown_only):
 
 
 def test_threaded_actor_creation_and_kill(ray_start_cluster):
+    """Test the scenario where the threaded actors are created and killed.
+    """
     cluster = ray_start_cluster
     NUM_CPUS_PER_NODE = 3
     NUM_NODES = 2
@@ -131,6 +133,9 @@ def test_threaded_actor_creation_and_kill(ray_start_cluster):
         def terminate(self):
             ray.actor.exit_actor()
 
+    # - Create threaded actors
+    # - Submit many tasks.
+    # - Ungracefully kill them in the middle.
     for _ in range(10):
         actors = [
             ThreadedActor.options(max_concurrency=10).remote()
@@ -146,6 +151,9 @@ def test_threaded_actor_creation_and_kill(ray_start_cluster):
             ray.kill(actor)
     ensure_cpu_returned(NUM_NODES * NUM_CPUS_PER_NODE)
 
+    # - Create threaded actors
+    # - Submit many tasks.
+    # - Gracefully kill them in the middle.
     for _ in range(10):
         actors = [
             ThreadedActor.options(max_concurrency=10).remote()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There are only 2 simple threaded actor tests in Ray repo. This PR adds more complicated threaded actor tests to make sure it is well tested.

The third tests print a lot of 
```
(pid=42032) [2021-10-13 19:02:36,102 E 42032 10779969] core_worker.cc:270: The global worker has already been shutdown. This happens when the language frontend accesses the Ray's worker after it is shutdown. The process will exit
```
which was the bug @scv119 fixed. Maybe we can start debugging this to make sure when this happens and fix the real shutdown bugs.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
