### PR TITLE
[runtime env] Fix bug when all working_dir contents are excluded with Ray Client

### DIFF
--- a/python/ray/_private/runtime_env/working_dir.py
+++ b/python/ray/_private/runtime_env/working_dir.py
@@ -135,7 +135,6 @@ def _get_excludes(path: Path, excludes: List[str]) -> Callable:
 
     def match(p: Path):
         path_str = str(p.absolute().relative_to(path))
-        path_str += "/"
         return pathspec.match_file(path_str)
 
     return match
@@ -150,8 +149,6 @@ def _get_gitignore(path: Path) -> Optional[Callable]:
 
         def match(p: Path):
             path_str = str(p.absolute().relative_to(path))
-            if p.is_dir():
-                path_str += "/"
             return pathspec.match_file(path_str)
 
         return match
@@ -202,7 +199,7 @@ def get_project_package_name(
         Package name as a string.
     """
     RAY_PKG_PREFIX = "_ray_pkg_"
-    hash_val = None
+    hash_val = b"0"
     if working_dir:
         if not isinstance(working_dir, str):
             raise TypeError("`working_dir` must be a string.")
@@ -227,7 +224,7 @@ def get_project_package_name(
         hash_val = _xor_bytes(
             hash_val,
             _hash_modules(module_dir, module_dir.parent, None, logger=logger))
-    return RAY_PKG_PREFIX + hash_val.hex() + ".zip" if hash_val else None
+    return RAY_PKG_PREFIX + hash_val.hex() + ".zip"
 
 
 def rewrite_runtime_env_uris(job_config: JobConfig) -> None:

--- a/python/ray/_private/runtime_env/working_dir.py
+++ b/python/ray/_private/runtime_env/working_dir.py
@@ -344,16 +344,16 @@ class WorkingDirManager:
                       pkg_uri: str,
                       logger: Optional[logging.Logger] = default_logger
                       ) -> int:
-        """Fetch a package from a given uri if not exists locally.
+        """Fetch a package from a given URI if it doesn't exist locally.
 
-        This function is used to fetch a pacakge from the given uri and unpack
+        This function is used to fetch a package from the given URI and unpack
         it.
 
         Args:
-            pkg_uri (str): The uri of the package to download.
+            pkg_uri (str): The URI of the package to download.
 
         Returns:
-            The directory containing this package
+            The directory containing this package.
         """
         if logger is None:
             logger = default_logger
@@ -377,6 +377,7 @@ class WorkingDirManager:
         else:
             raise NotImplementedError(f"Protocol {protocol} is not supported")
 
+        os.mkdir(local_dir)
         logger.debug(f"Unpacking {pkg_file} to {local_dir}")
         with ZipFile(str(pkg_file), "r") as zip_ref:
             zip_ref.extractall(local_dir)
@@ -493,6 +494,8 @@ class WorkingDirManager:
 
         working_dir = self.ensure_runtime_env_setup(
             runtime_env["uris"], logger=logger)
+        if working_dir is None:
+            return
         context.command_prefix += [f"cd {working_dir}"]
 
         # Insert the working_dir as the first entry in PYTHONPATH. This is

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -388,7 +388,7 @@ def test_exclusion(ray_start_cluster_head, working_dir, client_mode):
     # Test excluding all files using gitignore pattern matching syntax
     runtime_env = f"""{{
         "working_dir": r"{working_dir}",
-        "excludes": ["**"]
+        "excludes": ["*"]
     }}"""
     script = driver_script.format(**locals())
     out = run_string_as_driver(script, env)

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -385,6 +385,15 @@ def test_exclusion(ray_start_cluster_head, working_dir, client_mode):
     out = run_string_as_driver(script, env)
     assert out.strip().split("\n")[-1] == \
         "Test,FAILED,Test,FAILED,FAILED,Test,FAILED,FAILED"
+    # Test excluding all files using gitignore pattern matching syntax
+    runtime_env = f"""{{
+        "working_dir": r"{working_dir}",
+        "excludes": ["**"]
+    }}"""
+    script = driver_script.format(**locals())
+    out = run_string_as_driver(script, env)
+    assert out.strip().split("\n")[-1] == \
+        "FAILED,FAILED,FAILED,FAILED,FAILED,FAILED,FAILED,FAILED"
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- Even in the case where all files are excluded from the working directory, we still need to create an empty directory and `cd` into it.  This wasn't being done before, which caused https://github.com/ray-project/ray/issues/19241 linked below.  The root cause is that we were calling `zip_ref.extractall`, which appears to not create the target directory in the case where the zipped package doesn't contain any files.  The solution in this PR is to create the target directory always, and to create it before calling `extractall`.  
- We were previously using custom logic to append `/` to the end of any user-provided directory in `excludes`, before matching it using gitignore syntax.  I don't think we need to insert custom logic here; instead we should exactly follow gitignore syntax https://git-scm.com/docs/gitignore.  This is more predictable for the user, reduces complexity and I think it's equally convenient: 

> The slash / is used as the directory separator. Separators may occur at the beginning, middle or end of the .gitignore search pattern. If there is a separator at the end of the pattern then the pattern will only match directories, otherwise the pattern can match both files **and directories**.  

Removing the custom logic fixes https://github.com/ray-project/ray/issues/19236.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/19241.
Closes #19236.
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
