### PR TITLE
[data] Add pickle support for PyArrow CSV WriteOptions

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -778,7 +778,7 @@ class Dataset(Generic[T]):
             >>> ds.sort(lambda record: record["field1"] % 100)
 
             >>> # Sort by multiple columns (not yet supported).
-            >>> ds.sort([("field1", "ascending"), ("field2", "descending)])
+            >>> ds.sort([("field1", "ascending"), ("field2", "descending")])
 
         Time complexity: O(dataset size * log(dataset size / parallelism))
 
@@ -991,13 +991,15 @@ class Dataset(Generic[T]):
                 files.add(f)
         return list(files)
 
-    def write_parquet(self,
-                      path: str,
-                      *,
-                      filesystem: Optional["pyarrow.fs.FileSystem"] = None,
-                      try_create_dir: bool = True,
-                      arrow_open_stream_args: Optional[Dict[str, Any]] = None,
-                      **arrow_parquet_args) -> None:
+    def write_parquet(
+            self,
+            path: str,
+            *,
+            filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+            try_create_dir: bool = True,
+            arrow_open_stream_args: Optional[Dict[str, Any]] = None,
+            arrow_parquet_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
+            **arrow_parquet_args) -> None:
         """Write the dataset to parquet.
 
         This is only supported for datasets convertible to Arrow records.
@@ -1019,6 +1021,12 @@ class Dataset(Generic[T]):
                 if True. Does nothing if all directories already exist.
             arrow_open_stream_args: kwargs passed to
                 pyarrow.fs.FileSystem.open_output_stream
+            arrow_parquet_args_fn: Callable that returns a dictionary of write
+                arguments to use when writing each block to a file. Overrides
+                any duplicate keys from arrow_parquet_args. This should be used
+                instead of arrow_parquet_args if any of your write arguments
+                cannot be pickled, or if you'd like to lazily resolve the write
+                arguments for each dataset block.
             arrow_parquet_args: Options to pass to
                 pyarrow.parquet.write_table(), which is used to write out each
                 block to a file.
@@ -1030,15 +1038,18 @@ class Dataset(Generic[T]):
             filesystem=filesystem,
             try_create_dir=try_create_dir,
             open_stream_args=arrow_open_stream_args,
+            write_args_fn=arrow_parquet_args_fn,
             **arrow_parquet_args)
 
-    def write_json(self,
-                   path: str,
-                   *,
-                   filesystem: Optional["pyarrow.fs.FileSystem"] = None,
-                   try_create_dir: bool = True,
-                   arrow_open_stream_args: Optional[Dict[str, Any]] = None,
-                   **pandas_json_args) -> None:
+    def write_json(
+            self,
+            path: str,
+            *,
+            filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+            try_create_dir: bool = True,
+            arrow_open_stream_args: Optional[Dict[str, Any]] = None,
+            pandas_json_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
+            **pandas_json_args) -> None:
         """Write the dataset to json.
 
         This is only supported for datasets convertible to Arrow records.
@@ -1060,6 +1071,12 @@ class Dataset(Generic[T]):
                 if True. Does nothing if all directories already exist.
             arrow_open_stream_args: kwargs passed to
                 pyarrow.fs.FileSystem.open_output_stream
+            pandas_json_args_fn: Callable that returns a dictionary of write
+                arguments to use when writing each block to a file. Overrides
+                any duplicate keys from pandas_json_args. This should be used
+                instead of pandas_json_args if any of your write arguments
+                cannot be pickled, or if you'd like to lazily resolve the write
+                arguments for each dataset block.
             pandas_json_args: These args will be passed to
                 pandas.DataFrame.to_json(), which we use under the hood to
                 write out each Datasets block. These
@@ -1072,6 +1089,7 @@ class Dataset(Generic[T]):
             filesystem=filesystem,
             try_create_dir=try_create_dir,
             open_stream_args=arrow_open_stream_args,
+            write_args_fn=pandas_json_args_fn,
             **pandas_json_args)
 
     def write_csv(self,
@@ -1080,6 +1098,7 @@ class Dataset(Generic[T]):
                   filesystem: Optional["pyarrow.fs.FileSystem"] = None,
                   try_create_dir: bool = True,
                   arrow_open_stream_args: Optional[Dict[str, Any]] = None,
+                  arrow_csv_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
                   **arrow_csv_args) -> None:
         """Write the dataset to csv.
 
@@ -1102,6 +1121,12 @@ class Dataset(Generic[T]):
                 if True. Does nothing if all directories already exist.
             arrow_open_stream_args: kwargs passed to
                 pyarrow.fs.FileSystem.open_output_stream
+            arrow_csv_args_fn: Callable that returns a dictionary of write
+                arguments to use when writing each block to a file. Overrides
+                any duplicate keys from arrow_csv_args. This should be used
+                instead of arrow_csv_args if any of your write arguments
+                cannot be pickled, or if you'd like to lazily resolve the write
+                arguments for each dataset block.
             arrow_csv_args: Other CSV write options to pass to pyarrow.
         """
         self.write_datasource(
@@ -1111,6 +1136,7 @@ class Dataset(Generic[T]):
             filesystem=filesystem,
             try_create_dir=try_create_dir,
             open_stream_args=arrow_open_stream_args,
+            write_args_fn=arrow_csv_args_fn,
             **arrow_csv_args)
 
     def write_numpy(

--- a/python/ray/data/datasource/csv_datasource.py
+++ b/python/ray/data/datasource/csv_datasource.py
@@ -4,7 +4,8 @@ if TYPE_CHECKING:
     import pyarrow
 
 from ray.data.block import BlockAccessor
-from ray.data.datasource.file_based_datasource import (FileBasedDatasource)
+from ray.data.datasource.file_based_datasource import (FileBasedDatasource,
+                                                       _WriteOptionsWrapper)
 
 
 class CSVDatasource(FileBasedDatasource):
@@ -28,6 +29,8 @@ class CSVDatasource(FileBasedDatasource):
         from pyarrow import csv
 
         write_options = writer_args.pop("write_options", None)
+        if isinstance(write_options, _WriteOptionsWrapper):
+            write_options = write_options.unwrap()
         csv.write_csv(block.to_arrow(), f, write_options, **writer_args)
 
     def _file_format(self):

--- a/python/ray/data/datasource/json_datasource.py
+++ b/python/ray/data/datasource/json_datasource.py
@@ -1,10 +1,11 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Callable
 
 if TYPE_CHECKING:
     import pyarrow
 
 from ray.data.block import BlockAccessor
-from ray.data.datasource.file_based_datasource import (FileBasedDatasource)
+from ray.data.datasource.file_based_datasource import (FileBasedDatasource,
+                                                       _resolve_kwargs)
 
 
 class JSONDatasource(FileBasedDatasource):
@@ -23,8 +24,12 @@ class JSONDatasource(FileBasedDatasource):
             "read_options", json.ReadOptions(use_threads=False))
         return json.read_json(f, read_options=read_options, **reader_args)
 
-    def _write_block(self, f: "pyarrow.NativeFile", block: BlockAccessor,
+    def _write_block(self,
+                     f: "pyarrow.NativeFile",
+                     block: BlockAccessor,
+                     writer_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
                      **writer_args):
+        writer_args = _resolve_kwargs(writer_args_fn, **writer_args)
         orient = writer_args.pop("orient", "records")
         lines = writer_args.pop("lines", True)
         block.to_pandas().to_json(f, orient=orient, lines=lines, **writer_args)

--- a/python/ray/data/datasource/numpy_datasource.py
+++ b/python/ray/data/datasource/numpy_datasource.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Callable
 
 import numpy as np
 
@@ -33,8 +33,12 @@ class NumpyDatasource(FileBasedDatasource):
             "value": TensorArray(np.load(buf, allow_pickle=True))
         })
 
-    def _write_block(self, f: "pyarrow.NativeFile", block: BlockAccessor,
-                     column: str, **writer_args):
+    def _write_block(self,
+                     f: "pyarrow.NativeFile",
+                     block: BlockAccessor,
+                     column: str,
+                     writer_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
+                     **writer_args):
         value = block.to_numpy(column)
         np.save(f, value)
 

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -1,6 +1,6 @@
 import logging
 import itertools
-from typing import Callable, Optional, List, Union, TYPE_CHECKING
+from typing import Any, Callable, Dict, Optional, List, Union, TYPE_CHECKING
 
 import numpy as np
 
@@ -11,7 +11,7 @@ from ray.types import ObjectRef
 from ray.data.block import Block, BlockAccessor
 from ray.data.datasource.datasource import ReadTask
 from ray.data.datasource.file_based_datasource import (
-    FileBasedDatasource, _resolve_paths_and_filesystem)
+    FileBasedDatasource, _resolve_paths_and_filesystem, _resolve_kwargs)
 from ray.data.impl.block_list import BlockMetadata
 from ray.data.impl.progress_bar import ProgressBar
 from ray.data.impl.remote_fn import cached_remote_fn
@@ -148,10 +148,14 @@ class ParquetDatasource(FileBasedDatasource):
 
         return read_tasks
 
-    def _write_block(self, f: "pyarrow.NativeFile", block: BlockAccessor,
+    def _write_block(self,
+                     f: "pyarrow.NativeFile",
+                     block: BlockAccessor,
+                     writer_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
                      **writer_args):
         import pyarrow.parquet as pq
 
+        writer_args = _resolve_kwargs(writer_args_fn, **writer_args)
         pq.write_table(block.to_arrow(), f, **writer_args)
 
     def _file_format(self) -> str:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Users cannot specify custom Dataset write options when writing output to CSV via `dataset.write_csv()`, because the `pyarrow.csv.WriteOptions` class retrieved from `writer_args["write_options"]` in `CSVDatasource._write_block()` cannot be pickled by Ray. 

This PR presents a solution to this problem via a `_WriteOptionsWrapper` class that wraps `WriteOptions` while implementing the required `__getstate__` and `__setstate__` methods.

## Related issue number
Closes https://github.com/ray-project/ray/issues/19366

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
