### PR TITLE
Remove invalid `max_calls` from RemoteFunction options documentation

### DIFF
--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -151,6 +151,7 @@ class RemoteFunction:
 
         The arguments are the same as those that can be passed to
         :obj:`ray.remote`.
+        Overriding `max_calls` is not supported.
 
         Examples:
 
@@ -160,7 +161,7 @@ class RemoteFunction:
             def f():
                return 1, 2
             # Task f will require 2 gpus instead of 1.
-            g = f.options(num_gpus=2, max_calls=None)
+            g = f.options(num_gpus=2)
         """
 
         func_cls = self

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2127,7 +2127,7 @@ def remote(*args, **kwargs):
         @ray.remote(num_gpus=1, max_calls=1, num_returns=2)
         def f():
             return 1, 2
-        g = f.options(num_gpus=2, max_calls=None)
+        g = f.options(num_gpus=2)
 
         @ray.remote(num_cpus=2, resources={"CustomResource": 1})
         class Foo:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The `max_calls` keyword argument was not implemented for `RemoteFunction.options`, which was inconsistent with the `remote` decorator API and the documentation. 

## Related issue number

Closes #18430

## Checks

I checked this fix locally with the code example provided in the related issue. As this is such a trivial change (and I couldn't find tests for similar cases) I didn't add a test, but I'd be happy to add one if desired!

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
