### PR TITLE
[release] Allow commit hashes instead of URLs, add bisection utility

### DIFF
--- a/release/.buildkite/build_pipeline.py
+++ b/release/.buildkite/build_pipeline.py
@@ -296,7 +296,12 @@ def ask_configuration():
                 "hint": ("ATTENTION: If you provide this, RAY_REPO, "
                          "RAY_BRANCH and RAY_VERSION will be ignored! "
                          "Please also make sure to provide the wheels URL "
-                         "for Python 3.7 on Linux."),
+                         "for Python 3.7 on Linux.\n"
+                         "You can also insert a commit hash here instead "
+                         "of a full URL.\n"
+                         "NOTE: You can specify multiple commits or URLs "
+                         "for easy bisection (one per line) - this will "
+                         "run each test on each of the specified wheels."),
                 "required": False,
                 "default": RAY_WHEELS,
                 "key": "ray_wheels"

--- a/release/e2e.py
+++ b/release/e2e.py
@@ -372,6 +372,16 @@ def wheel_exists(ray_version, git_branch, git_commit):
     return requests.head(url).status_code == 200
 
 
+def commit_or_url(commit_or_url: str) -> str:
+    if commit_or_url.startswith("http"):
+        # Assume URL
+        return commit_or_url
+
+    # Else, assume commit
+    return wheel_url(GLOBAL_CONFIG["RAY_VERSION"], GLOBAL_CONFIG["RAY_BRANCH"],
+                     commit_or_url)
+
+
 def get_latest_commits(repo: str, branch: str = "master") -> List[str]:
     cur = os.getcwd()
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -1965,7 +1975,7 @@ if __name__ == "__main__":
     maybe_fetch_api_token()
     if args.ray_wheels:
         os.environ["RAY_WHEELS"] = str(args.ray_wheels)
-        url = str(args.ray_wheels)
+        url = commit_or_url(str(args.ray_wheels))
     elif not args.check and not os.environ.get("RAY_WHEELS"):
         url = find_ray_wheels(
             GLOBAL_CONFIG["RAY_REPO"],
@@ -1979,9 +1989,9 @@ if __name__ == "__main__":
 
         # RAY_COMMIT is set by find_ray_wheels
     elif os.environ.get("RAY_WHEELS"):
-        logger.info(f"Using Ray wheels provided from URL: "
+        logger.info(f"Using Ray wheels provided from URL/commit: "
                     f"{os.environ.get('RAY_WHEELS')}")
-        url = os.environ.get("RAY_WHEELS")
+        url = commit_or_url(os.environ.get("RAY_WHEELS"))
 
     populate_wheels_sanity_check(os.environ.get("RAY_COMMIT", ""))
 

--- a/release/e2e.py
+++ b/release/e2e.py
@@ -1974,8 +1974,9 @@ if __name__ == "__main__":
 
     maybe_fetch_api_token()
     if args.ray_wheels:
-        os.environ["RAY_WHEELS"] = str(args.ray_wheels)
         url = commit_or_url(str(args.ray_wheels))
+        # Overwrite with actual URL
+        os.environ["RAY_WHEELS"] = url
     elif not args.check and not os.environ.get("RAY_WHEELS"):
         url = find_ray_wheels(
             GLOBAL_CONFIG["RAY_REPO"],
@@ -1992,6 +1993,8 @@ if __name__ == "__main__":
         logger.info(f"Using Ray wheels provided from URL/commit: "
                     f"{os.environ.get('RAY_WHEELS')}")
         url = commit_or_url(os.environ.get("RAY_WHEELS"))
+        # Overwrite with actual URL
+        os.environ["RAY_WHEELS"] = url
 
     populate_wheels_sanity_check(os.environ.get("RAY_COMMIT", ""))
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We can now also just specify commit hashes instead of full wheel URLs.

Multiple commit hashes can be specified for an easy bisection tool.

Example: https://buildkite.com/ray-project/periodic-ci/builds/1239

Example with commit sanity check: https://buildkite.com/ray-project/periodic-ci/builds/1240

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
