### PR TITLE
[tune] Fix result buffering case check (fixes bug introduced in #19140)

### DIFF
--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -393,8 +393,8 @@ def run(
         scheduler = create_scheduler(scheduler)
     scheduler = scheduler or FIFOScheduler()
 
-    if scheduler.supports_buffered_results:
-        # Result buffering with a Hyperband scheduler is a bad idea, as
+    if not scheduler.supports_buffered_results:
+        # Result buffering with e.g. a Hyperband scheduler is a bad idea, as
         # hyperband tries to stop trials when processing brackets. With result
         # buffering, we might trigger this multiple times when evaluating
         # a single trial, which leads to unexpected behavior.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#19140 introduced a check to force no result buffering for certain schedulers. However, the check was faulty, as discovered in nightly release testing. This PR fixes the issue.

Bisection output identifying the issue: https://buildkite.com/ray-project/periodic-ci/builds/1239#_

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
