### PR TITLE
[Collective] Remove an unnecessary cuda.stream.synchornize

### DIFF
--- a/python/ray/util/collective/collective.py
+++ b/python/ray/util/collective/collective.py
@@ -619,6 +619,21 @@ def recv_multigpu(tensor,
     g.recv([tensor], opts)
 
 
+def synchronize(gpu_id: int):
+    """Synchronize the current process to a give device.
+
+    Args:
+        gpu_id (int): the GPU device id to synchronize.
+
+    Returns:
+        None
+    """
+    if not types.cupy_available():
+        raise RuntimeError("synchronize call requires CUDA and NCCL.")
+    import cupy as cp
+    cp.cuda.Device(gpu_id).synchronize()
+
+
 def _check_and_get_group(group_name):
     """Check the existence and return the group handle."""
     _check_inside_actor()

--- a/python/ray/util/collective/collective_group/nccl_collective_group.py
+++ b/python/ray/util/collective/collective_group/nccl_collective_group.py
@@ -439,8 +439,6 @@ class NCCLGroup(BaseGroup):
                 with nccl_util.Device(device):
                     events[i].record(cupy.cuda.get_current_stream())
                     streams[i].wait_event(events[i])
-        else:
-            cupy.cuda.Stream.null.synchronize()
 
     def _get_nccl_p2p_communicator(self, comm_key, my_gpu_idx, peer_rank,
                                    peer_gpu_idx):


### PR DESCRIPTION


## Why are these changes needed?
This `cuda.stream.synchronize()` call is unnecessary because when a collective function uses the default stream, default stream will always sync with other streams on GPU. See [CUDA default stream doc](https://docs.nvidia.com/cuda/cuda-runtime-api/stream-sync-behavior.html).

## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
