### PR TITLE
`get_runtime_context` gets address info of Ray Cluster.

### DIFF
--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -2,7 +2,6 @@ import ray.worker
 import logging
 from ray._private.client_mode_hook import client_mode_hook
 from ray.util.annotations import PublicAPI
-from ray.worker import _global_node
 
 logger = logging.getLogger(__name__)
 
@@ -13,6 +12,7 @@ class RuntimeContext(object):
 
     def __init__(self, worker):
         assert worker is not None
+        self.address_info = ray.worker.get_global_address_info()
         self.worker = worker
 
     def get(self):
@@ -28,7 +28,7 @@ class RuntimeContext(object):
             "node_ip_address": self.node_ip_address,
             "raylet_ip_address": self.raylet_ip_address,
             "redis_address": self.redis_address,
-            "object_store_memory": self.object_store_memory,
+            "object_store_address": self.object_store_address,
             "raylet_socket_name": self.raylet_socket_name,
             "webui_url": self.webui_url,
             "session_dir": self.session_dir,
@@ -128,35 +128,35 @@ class RuntimeContext(object):
 
     @property
     def node_ip_address(self):
-        return _global_node.node_ip_address
+        return self.address_info["node_ip_address"]
 
     @property
     def raylet_ip_address(self):
-        return _global_node.raylet_ip_address
+        return self.address_info["raylet_ip_address"]
 
     @property
     def redis_address(self):
-        return _global_node.redis_address
+        return self.address_info["redis_address"]
 
     @property
-    def object_store_memory(self):
-        return _global_node.object_store_memory
+    def object_store_address(self):
+        return self.address_info["object_store_address"]
 
     @property
     def raylet_socket_name(self):
-        return _global_node.raylet_socket_name
+        return self.address_info["raylet_socket_name"]
 
     @property
     def webui_url(self):
-        return _global_node.webui_url
+        return self.address_info["webui_url"]
 
     @property
     def session_dir(self):
-        return _global_node.session_dir
+        return self.address_info["session_dir"]
 
     @property
     def metrics_export_port(self):
-        return _global_node.metrics_export_port
+        return self.address_info["metrics_export_port"]
 
     @property
     def was_current_actor_reconstructed(self):

--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -26,13 +26,8 @@ class RuntimeContext(object):
             "node_id": self.node_id,
             "namespace": self.namespace,
             "node_ip_address": self.node_ip_address,
-            "raylet_ip_address": self.raylet_ip_address,
-            "redis_address": self.redis_address,
-            "object_store_address": self.object_store_address,
-            "raylet_socket_name": self.raylet_socket_name,
             "webui_url": self.webui_url,
             "session_dir": self.session_dir,
-            "metrics_export_port": self.metrics_export_port,
         }
         if self.worker.mode == ray.worker.WORKER_MODE:
             if self.task_id is not None:
@@ -131,32 +126,12 @@ class RuntimeContext(object):
         return self.address_info["node_ip_address"]
 
     @property
-    def raylet_ip_address(self):
-        return self.address_info["raylet_ip_address"]
-
-    @property
-    def redis_address(self):
-        return self.address_info["redis_address"]
-
-    @property
-    def object_store_address(self):
-        return self.address_info["object_store_address"]
-
-    @property
-    def raylet_socket_name(self):
-        return self.address_info["raylet_socket_name"]
-
-    @property
     def webui_url(self):
         return self.address_info["webui_url"]
 
     @property
     def session_dir(self):
         return self.address_info["session_dir"]
-
-    @property
-    def metrics_export_port(self):
-        return self.address_info["metrics_export_port"]
 
     @property
     def was_current_actor_reconstructed(self):

--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -2,6 +2,7 @@ import ray.worker
 import logging
 from ray._private.client_mode_hook import client_mode_hook
 from ray.util.annotations import PublicAPI
+from ray.worker import _global_node
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,14 @@ class RuntimeContext(object):
             "job_id": self.job_id,
             "node_id": self.node_id,
             "namespace": self.namespace,
+            "node_ip_address": self.node_ip_address,
+            "raylet_ip_address": self.raylet_ip_address,
+            "redis_address": self.redis_address,
+            "object_store_memory": self.object_store_memory,
+            "raylet_socket_name": self.raylet_socket_name,
+            "webui_url": self.webui_url,
+            "session_dir": self.session_dir,
+            "metrics_export_port": self.metrics_export_port,
         }
         if self.worker.mode == ray.worker.WORKER_MODE:
             if self.task_id is not None:
@@ -116,6 +125,38 @@ class RuntimeContext(object):
     @property
     def namespace(self):
         return self.worker.namespace
+
+    @property
+    def node_ip_address(self):
+        return _global_node.node_ip_address
+
+    @property
+    def raylet_ip_address(self):
+        return _global_node.raylet_ip_address
+
+    @property
+    def redis_address(self):
+        return _global_node.redis_address
+
+    @property
+    def object_store_memory(self):
+        return _global_node.object_store_memory
+
+    @property
+    def raylet_socket_name(self):
+        return _global_node.raylet_socket_name
+
+    @property
+    def webui_url(self):
+        return _global_node.webui_url
+
+    @property
+    def session_dir(self):
+        return _global_node.session_dir
+
+    @property
+    def metrics_export_port(self):
+        return _global_node.metrics_export_port
 
     @property
     def was_current_actor_reconstructed(self):

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -1,9 +1,11 @@
 import os
 import sys
+import tempfile
 
 import logging
 import pytest
 import redis
+import json
 import unittest.mock
 import ray
 import ray._private.services
@@ -298,6 +300,24 @@ def test_auto_init_client(call_ray_start, function):
         res = function()
         # Ensure this is a client connection.
         assert isinstance(res, ClientObjectRef)
+
+
+def test_init_with_ray_job_config_json():
+    config = {
+        "num_java_workers_per_process": 2,
+        "jvm_options": ["test"],
+        "code_search_path": sys.path,
+        "runtime_env": {
+            "test": "test"
+        },
+        "client_job": True
+    }
+    with tempfile.TemporaryDirectory() as tmpdir:
+        job_config_json_path = os.path.join(tmpdir, "config.json")
+        with open(job_config_json_path, "w") as file:
+            json.dump(config, file)
+        os.environ["RAY_JOB_CONFIG_JSON"] = job_config_json_path
+        ray.init()
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_runtime_context.py
+++ b/python/ray/tests/test_runtime_context.py
@@ -14,8 +14,7 @@ def test_was_current_actor_reconstructed(shutdown_only):
     class A(object):
         def __init__(self):
             self._was_reconstructed = ray.get_runtime_context(
-            ).was_current_actor_reconstructed
-
+            ).was_current_actor_reconstructe
         def get_was_reconstructed(self):
             return self._was_reconstructed
 

--- a/python/ray/tests/test_runtime_context.py
+++ b/python/ray/tests/test_runtime_context.py
@@ -219,6 +219,34 @@ def test_actor_stats_async_actor(ray_start_regular):
     assert max(result["AysncActor.func"]["pending"] for result in results) == 3
 
 
+def test_compare_with_init_context(ray_start_regular):
+    runtime_ctx = ray.get_runtime_context().get()
+    targets = [
+        "node_ip_address",
+        "raylet_ip_address",
+        "redis_address",
+        "object_store_address",
+        "raylet_socket_name",
+        "webui_url",
+        "session_dir",
+        "metrics_export_port"
+    ]
+    for target in targets:
+        assert ray_start_regular[target] == runtime_ctx[target]
+
+
+def test_compare_with_init_context_using_property(ray_start_regular):
+    runtime_ctx = ray.get_runtime_context()
+    assert runtime_ctx.node_ip_address == ray_start_regular["node_ip_address"]
+    assert runtime_ctx.raylet_ip_address == ray_start_regular["raylet_ip_address"]
+    assert runtime_ctx.redis_address == ray_start_regular["redis_address"]
+    assert runtime_ctx.object_store_address == ray_start_regular["object_store_address"]
+    assert runtime_ctx.raylet_socket_name == ray_start_regular["raylet_socket_name"]
+    assert runtime_ctx.webui_url == ray_start_regular["webui_url"]
+    assert runtime_ctx.session_dir == ray_start_regular["session_dir"]
+    assert runtime_ctx.metrics_export_port == ray_start_regular["metrics_export_port"]
+
+
 # get_runtime_context() can be called outside of Ray so it should not start
 # Ray automatically.
 def test_no_auto_init(shutdown_only):

--- a/python/ray/tests/test_runtime_context.py
+++ b/python/ray/tests/test_runtime_context.py
@@ -14,7 +14,7 @@ def test_was_current_actor_reconstructed(shutdown_only):
     class A(object):
         def __init__(self):
             self._was_reconstructed = ray.get_runtime_context(
-            ).was_current_actor_reconstructe
+            ).was_current_actor_reconstructed
 
         def get_was_reconstructed(self):
             return self._was_reconstructed
@@ -222,11 +222,7 @@ def test_actor_stats_async_actor(ray_start_regular):
 
 def test_compare_with_init_context(ray_start_regular):
     runtime_ctx = ray.get_runtime_context().get()
-    targets = [
-        "node_ip_address", "raylet_ip_address", "redis_address",
-        "object_store_address", "raylet_socket_name", "webui_url",
-        "session_dir", "metrics_export_port"
-    ]
+    targets = ["node_ip_address", "webui_url", "session_dir"]
     for target in targets:
         assert ray_start_regular[target] == runtime_ctx[target]
 
@@ -234,17 +230,8 @@ def test_compare_with_init_context(ray_start_regular):
 def test_compare_with_init_context_using_property(ray_start_regular):
     runtime_ctx = ray.get_runtime_context()
     assert runtime_ctx.node_ip_address == ray_start_regular["node_ip_address"]
-    assert runtime_ctx.raylet_ip_address == ray_start_regular[
-        "raylet_ip_address"]
-    assert runtime_ctx.redis_address == ray_start_regular["redis_address"]
-    assert runtime_ctx.object_store_address == ray_start_regular[
-        "object_store_address"]
-    assert runtime_ctx.raylet_socket_name == ray_start_regular[
-        "raylet_socket_name"]
     assert runtime_ctx.webui_url == ray_start_regular["webui_url"]
     assert runtime_ctx.session_dir == ray_start_regular["session_dir"]
-    assert runtime_ctx.metrics_export_port == ray_start_regular[
-        "metrics_export_port"]
 
 
 # get_runtime_context() can be called outside of Ray so it should not start

--- a/python/ray/tests/test_runtime_context.py
+++ b/python/ray/tests/test_runtime_context.py
@@ -15,6 +15,7 @@ def test_was_current_actor_reconstructed(shutdown_only):
         def __init__(self):
             self._was_reconstructed = ray.get_runtime_context(
             ).was_current_actor_reconstructe
+
         def get_was_reconstructed(self):
             return self._was_reconstructed
 
@@ -222,14 +223,9 @@ def test_actor_stats_async_actor(ray_start_regular):
 def test_compare_with_init_context(ray_start_regular):
     runtime_ctx = ray.get_runtime_context().get()
     targets = [
-        "node_ip_address",
-        "raylet_ip_address",
-        "redis_address",
-        "object_store_address",
-        "raylet_socket_name",
-        "webui_url",
-        "session_dir",
-        "metrics_export_port"
+        "node_ip_address", "raylet_ip_address", "redis_address",
+        "object_store_address", "raylet_socket_name", "webui_url",
+        "session_dir", "metrics_export_port"
     ]
     for target in targets:
         assert ray_start_regular[target] == runtime_ctx[target]
@@ -238,13 +234,17 @@ def test_compare_with_init_context(ray_start_regular):
 def test_compare_with_init_context_using_property(ray_start_regular):
     runtime_ctx = ray.get_runtime_context()
     assert runtime_ctx.node_ip_address == ray_start_regular["node_ip_address"]
-    assert runtime_ctx.raylet_ip_address == ray_start_regular["raylet_ip_address"]
+    assert runtime_ctx.raylet_ip_address == ray_start_regular[
+        "raylet_ip_address"]
     assert runtime_ctx.redis_address == ray_start_regular["redis_address"]
-    assert runtime_ctx.object_store_address == ray_start_regular["object_store_address"]
-    assert runtime_ctx.raylet_socket_name == ray_start_regular["raylet_socket_name"]
+    assert runtime_ctx.object_store_address == ray_start_regular[
+        "object_store_address"]
+    assert runtime_ctx.raylet_socket_name == ray_start_regular[
+        "raylet_socket_name"]
     assert runtime_ctx.webui_url == ray_start_regular["webui_url"]
     assert runtime_ctx.session_dir == ray_start_regular["session_dir"]
-    assert runtime_ctx.metrics_export_port == ray_start_regular["metrics_export_port"]
+    assert runtime_ctx.metrics_export_port == ray_start_regular[
+        "metrics_export_port"]
 
 
 # get_runtime_context() can be called outside of Ray so it should not start

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2162,6 +2162,5 @@ def remote(*args, **kwargs):
         retry_exceptions=retry_exceptions)
 
 
-
 def get_global_address_info():
     return dict(_global_node.address_info)

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2160,3 +2160,8 @@ def remote(*args, **kwargs):
         placement_group=placement_group,
         worker=worker,
         retry_exceptions=retry_exceptions)
+
+
+
+def get_global_address_info():
+    return dict(_global_node.address_info)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The output of `ray.init`, address_info, could not be obtained again. Now we can get this output back via `ray.get_runtime_context`.

get_runtime_context gets Address Info of Ray Cluster.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #14998

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
