### PR TITLE
[Collective] Enhance the collective group GC a bit

### DIFF
--- a/python/ray/util/collective/collective.py
+++ b/python/ray/util/collective/collective.py
@@ -99,6 +99,14 @@ class GroupManager(object):
         # Release the communicator resources
         g.destroy_group()
 
+        # Release the detached actors spawned by `create_collective_group()`
+        name = "info_" + group_name
+        try:
+            store = ray.get_actor(name)
+            ray.kill(store)
+        except ValueError:
+            pass
+
 
 _group_mgr = GroupManager()
 


### PR DESCRIPTION

## Why are these changes needed?
When a user uses the `create_collective_group` API, a detached actor with its name starting with `info_` will be createds and put in Ray. We should GC this detached actor when the group is destoryed.

## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
