### PR TITLE
[dashboard] Disable dashboard and agent when include_dashboard is False

### DIFF
--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -157,6 +157,17 @@ def test_basic(ray_start_with_dashboard):
     assert agent_ports is not None
 
 
+def test_no_dashbaord(ray_start_without_dashboard):
+    @ray.remote
+    def foo():
+        time.sleep(10)
+        return 1
+
+    ray.get(foo.remote())
+    all_processes = ray.worker._global_node.all_processes
+    assert ray_constants.PROCESS_TYPE_DASHBOARD not in all_processes
+
+
 @pytest.mark.parametrize(
     "ray_start_with_dashboard", [{
         "dashboard_host": "127.0.0.1"

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1365,7 +1365,8 @@ def start_raylet(redis_address,
                  max_bytes=0,
                  backup_count=0,
                  ray_debugger_external=False,
-                 env_updates=None):
+                 env_updates=None,
+                 disable_dashboard=False):
     """Start a raylet, which is a combined local scheduler and object manager.
 
     Args:
@@ -1412,6 +1413,7 @@ def start_raylet(redis_address,
         ray_debugger_external (bool): True if the Ray debugger should be made
             available externally to this node.
         env_updates (dict): Environment variable overrides.
+        disable_dashboard (bool): True if dashboard is disabled
 
     Returns:
         ProcessInfo for the process that was started.
@@ -1510,7 +1512,7 @@ def start_raylet(redis_address,
         try:
             import ray.dashboard.optional_deps  # noqa: F401
 
-            return True
+            return True and not disable_dashboard
         except ImportError:
             return False
 

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -847,6 +847,7 @@ class Node:
             start_initial_python_workers_for_first_job,
             ray_debugger_external=self._ray_params.ray_debugger_external,
             env_updates=self._ray_params.env_vars,
+            disable_dashboard=(self._ray_params.include_dashboard == False),
         )
         assert ray_constants.PROCESS_TYPE_RAYLET not in self.all_processes
         self.all_processes[ray_constants.PROCESS_TYPE_RAYLET] = [process_info]

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -847,7 +847,8 @@ class Node:
             start_initial_python_workers_for_first_job,
             ray_debugger_external=self._ray_params.ray_debugger_external,
             env_updates=self._ray_params.env_vars,
-            disable_dashboard=(self._ray_params.include_dashboard == False),
+            disable_dashboard=(
+                self._ray_params.include_dashboard == False),  # noqa: E712
         )
         assert ray_constants.PROCESS_TYPE_RAYLET not in self.all_processes
         self.all_processes[ray_constants.PROCESS_TYPE_RAYLET] = [process_info]

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -63,6 +63,15 @@ def ray_start_with_dashboard(request):
         yield address_info
 
 
+@pytest.fixture
+def ray_start_without_dashboard(request):
+    param = getattr(request, "param", {})
+    if param.get("num_cpus") is None:
+        param["num_cpus"] = 1
+    with _ray_start(include_dashboard=False, **param) as res:
+        yield res
+
+
 # The following fixture will start ray with 0 cpu.
 @pytest.fixture
 def ray_start_no_cpu(request):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When include_dashboard is set to false, though we don't start dashboard but we still runs agent to keep it alive. This PR ensure the agent also doesn't run when include_dashboard is False.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
