### PR TITLE
[Debugging] Print Python stack trace in addition to C++ stack trace, when Python worker crashes

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -115,7 +115,11 @@ CoreWorkerProcess::CoreWorkerProcess(const CoreWorkerOptions &options)
     }
     RayLog::StartRayLog(app_name.str(), RayLogLevel::INFO, options_.log_dir);
     if (options_.install_failure_signal_handler) {
-      RayLog::InstallFailureSignalHandler();
+      // Core worker is loaded as a dynamic library from Python or other languages.
+      // We are not sure if the default argv[0] would be suitable for loading symbols
+      // so leaving it unspecified. This would make symbolization of crash traces fail in
+      // some circumstances.
+      RayLog::InstallFailureSignalHandler(nullptr);
     }
   } else {
     RAY_CHECK(options_.log_dir.empty())

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -117,9 +117,12 @@ CoreWorkerProcess::CoreWorkerProcess(const CoreWorkerOptions &options)
     if (options_.install_failure_signal_handler) {
       // Core worker is loaded as a dynamic library from Python or other languages.
       // We are not sure if the default argv[0] would be suitable for loading symbols
-      // so leaving it unspecified. This would make symbolization of crash traces fail in
-      // some circumstances.
-      RayLog::InstallFailureSignalHandler(nullptr);
+      // so leaving it unspecified as nullptr. This could make symbolization of crash
+      // traces fail in some circumstances.
+      //
+      // Also, chain the crash handler installed by the language worker, e.g. Python
+      // worker.
+      RayLog::InstallFailureSignalHandler(nullptr, /*chain=*/true);
     }
   } else {
     RAY_CHECK(options_.log_dir.empty())

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -120,9 +120,9 @@ CoreWorkerProcess::CoreWorkerProcess(const CoreWorkerOptions &options)
       // so leaving it unspecified as nullptr. This could make symbolization of crash
       // traces fail in some circumstances.
       //
-      // Also, chain the crash handler installed by the language worker, e.g. Python
+      // Also, call the previous crash handler, e.g. the one installed by the Python
       // worker.
-      RayLog::InstallFailureSignalHandler(nullptr, /*chain=*/true);
+      RayLog::InstallFailureSignalHandler(nullptr, /*call_previous_handler=*/true);
     }
   } else {
     RAY_CHECK(options_.log_dir.empty())

--- a/src/ray/core_worker/test/actor_creator_test.cc
+++ b/src/ray/core_worker/test/actor_creator_test.cc
@@ -89,6 +89,6 @@ int main(int argc, char **argv) {
                                          ray::RayLog::ShutDownRayLog, argv[0],
                                          ray::RayLogLevel::INFO,
                                          /*log_dir=*/"");
-  ray::RayLog::InstallFailureSignalHandler();
+  ray::RayLog::InstallFailureSignalHandler(argv[0]);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/core_worker/test/direct_actor_transport_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_test.cc
@@ -645,6 +645,6 @@ int main(int argc, char **argv) {
                                          ray::RayLog::ShutDownRayLog, argv[0],
                                          ray::RayLogLevel::INFO,
                                          /*log_dir=*/"");
-  ray::RayLog::InstallFailureSignalHandler();
+  ray::RayLog::InstallFailureSignalHandler(argv[0]);
   return RUN_ALL_TESTS();
 }

--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -281,7 +281,7 @@ TEST_F(GlobalStateAccessorTest, TestPlacementGroupTable) {
 }  // namespace ray
 
 int main(int argc, char **argv) {
-  ray::RayLog::InstallFailureSignalHandler();
+  ray::RayLog::InstallFailureSignalHandler(argv[0]);
   InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
                                          ray::RayLog::ShutDownRayLog, argv[0],
                                          ray::RayLogLevel::INFO,

--- a/src/ray/gcs/gcs_server/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server/gcs_server_main.cc
@@ -37,7 +37,7 @@ int main(int argc, char *argv[]) {
   InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
                                          ray::RayLog::ShutDownRayLog, argv[0],
                                          ray::RayLogLevel::INFO, /*log_dir=*/"");
-  ray::RayLog::InstallFailureSignalHandler();
+  ray::RayLog::InstallFailureSignalHandler(argv[0]);
 
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   const std::string redis_address = FLAGS_redis_address;

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -71,7 +71,7 @@ int main(int argc, char *argv[]) {
                                          ray::RayLog::ShutDownRayLog, argv[0],
                                          ray::RayLogLevel::INFO,
                                          /*log_dir=*/"");
-  ray::RayLog::InstallFailureSignalHandler();
+  ray::RayLog::InstallFailureSignalHandler(argv[0]);
 
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   const std::string raylet_socket_name = FLAGS_raylet_socket_name;

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -325,7 +325,7 @@ bool RayLog::IsFailureSignalHandlerEnabled() {
   return is_failure_signal_handler_installed_;
 }
 
-void RayLog::InstallFailureSignalHandler(const char *argv0, bool chain) {
+void RayLog::InstallFailureSignalHandler(const char *argv0, bool call_previous_handler) {
 #ifdef _WIN32
   // If process fails to initialize, don't display an error window.
   SetErrorMode(GetErrorMode() | SEM_FAILCRITICALERRORS);
@@ -337,7 +337,7 @@ void RayLog::InstallFailureSignalHandler(const char *argv0, bool chain) {
   }
   absl::InitializeSymbolizer(argv0);
   absl::FailureSignalHandlerOptions options;
-  options.call_previous_handler = chain;
+  options.call_previous_handler = call_previous_handler;
   options.writerfn = WriteFailureMessage;
   absl::InstallFailureSignalHandler(options);
   is_failure_signal_handler_installed_ = true;

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -31,16 +31,15 @@
 #include <iostream>
 #include <sstream>
 
-#include "spdlog/sinks/basic_file_sink.h"
-#include "spdlog/sinks/rotating_file_sink.h"
-#include "spdlog/sinks/stdout_color_sinks.h"
-#include "spdlog/spdlog.h"
-
 #include "absl/debugging/failure_signal_handler.h"
 #include "absl/debugging/stacktrace.h"
 #include "absl/debugging/symbolize.h"
 #include "ray/util/event_label.h"
 #include "ray/util/filesystem.h"
+#include "spdlog/sinks/basic_file_sink.h"
+#include "spdlog/sinks/rotating_file_sink.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
+#include "spdlog/spdlog.h"
 
 namespace ray {
 
@@ -326,7 +325,7 @@ bool RayLog::IsFailureSignalHandlerEnabled() {
   return is_failure_signal_handler_installed_;
 }
 
-void RayLog::InstallFailureSignalHandler() {
+void RayLog::InstallFailureSignalHandler(const char *argv0) {
 #ifdef _WIN32
   // If process fails to initialize, don't display an error window.
   SetErrorMode(GetErrorMode() | SEM_FAILCRITICALERRORS);
@@ -336,7 +335,8 @@ void RayLog::InstallFailureSignalHandler() {
   if (is_failure_signal_handler_installed_) {
     return;
   }
-  absl::FailureSignalHandlerOptions options{};
+  absl::InitializeSymbolizer(argv0);
+  absl::FailureSignalHandlerOptions options;
   options.writerfn = WriteFailureMessage;
   absl::InstallFailureSignalHandler(options);
   is_failure_signal_handler_installed_ = true;

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -325,7 +325,7 @@ bool RayLog::IsFailureSignalHandlerEnabled() {
   return is_failure_signal_handler_installed_;
 }
 
-void RayLog::InstallFailureSignalHandler(const char *argv0) {
+void RayLog::InstallFailureSignalHandler(const char *argv0, bool chain) {
 #ifdef _WIN32
   // If process fails to initialize, don't display an error window.
   SetErrorMode(GetErrorMode() | SEM_FAILCRITICALERRORS);
@@ -337,6 +337,7 @@ void RayLog::InstallFailureSignalHandler(const char *argv0) {
   }
   absl::InitializeSymbolizer(argv0);
   absl::FailureSignalHandlerOptions options;
+  options.call_previous_handler = chain;
   options.writerfn = WriteFailureMessage;
   absl::InstallFailureSignalHandler(options);
   is_failure_signal_handler_installed_ = true;

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -49,6 +49,7 @@
 #pragma once
 
 #include <gtest/gtest_prod.h>
+
 #include <atomic>
 #include <chrono>
 #include <functional>
@@ -245,7 +246,12 @@ class RayLog : public RayLogBase {
   static bool IsLevelEnabled(RayLogLevel log_level);
 
   /// Install the failure signal handler to output call stack when crash.
-  static void InstallFailureSignalHandler();
+  ///
+  /// \param argv0 This is the argv[0] supplied to main(). It enables an alternative way
+  /// to locate the object file containing debug symbols for ELF format executables. If
+  /// this is left as nullptr, symbolization can fail in some cases. More details in:
+  /// https://github.com/abseil/abseil-cpp/blob/master/absl/debugging/symbolize_elf.inc
+  static void InstallFailureSignalHandler(const char *argv0);
 
   /// To check failure signal handler enabled or not.
   static bool IsFailureSignalHandlerEnabled();

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -251,7 +251,11 @@ class RayLog : public RayLogBase {
   /// to locate the object file containing debug symbols for ELF format executables. If
   /// this is left as nullptr, symbolization can fail in some cases. More details in:
   /// https://github.com/abseil/abseil-cpp/blob/master/absl/debugging/symbolize_elf.inc
-  static void InstallFailureSignalHandler(const char *argv0);
+  /// \parem chain Whether to call the previous signal handler. See important caveats:
+  /// https://github.com/abseil/abseil-cpp/blob/7e446075d4aff4601c1e7627c7c0be2c4833a53a/absl/debugging/failure_signal_handler.h#L76-L88
+  /// This is currently used to enable signal handler from both Python worker and core
+  /// worker.
+  static void InstallFailureSignalHandler(const char *argv0, bool chain = false);
 
   /// To check failure signal handler enabled or not.
   static bool IsFailureSignalHandlerEnabled();

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -251,11 +251,13 @@ class RayLog : public RayLogBase {
   /// to locate the object file containing debug symbols for ELF format executables. If
   /// this is left as nullptr, symbolization can fail in some cases. More details in:
   /// https://github.com/abseil/abseil-cpp/blob/master/absl/debugging/symbolize_elf.inc
-  /// \parem chain Whether to call the previous signal handler. See important caveats:
+  /// \parem call_previous_handler Whether to call the previous signal handler. See
+  /// important caveats:
   /// https://github.com/abseil/abseil-cpp/blob/7e446075d4aff4601c1e7627c7c0be2c4833a53a/absl/debugging/failure_signal_handler.h#L76-L88
-  /// This is currently used to enable signal handler from both Python worker and core
+  /// This is currently used to enable signal handler from both Python and C++ in Python
   /// worker.
-  static void InstallFailureSignalHandler(const char *argv0, bool chain = false);
+  static void InstallFailureSignalHandler(const char *argv0,
+                                          bool call_previous_handler = false);
 
   /// To check failure signal handler enabled or not.
   static bool IsFailureSignalHandlerEnabled();

--- a/src/ray/util/signal_test.cc
+++ b/src/ray/util/signal_test.cc
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
                                          ray::RayLog::ShutDownRayLog, argv[0],
                                          ray::RayLogLevel::INFO,
                                          /*log_dir=*/"");
-  ray::RayLog::InstallFailureSignalHandler();
+  ray::RayLog::InstallFailureSignalHandler(argv[0]);
   ::testing::InitGoogleTest(&argc, argv);
   int failed = RUN_ALL_TESTS();
   return failed;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Right now the failure signal handler [registered](https://github.com/ray-project/ray/blob/545db13800386da0e3465a824a70b2c5df4d37a9/python/ray/worker.py#L1285) in Python worker is skipped on crashes like segfault, because C++ core worker overrides the failure signal handler [here](https://github.com/ray-project/ray/blob/c96c2e9b5fcc22313a36519c94ad15c115b1ce5d/src/ray/util/logging.cc#L339-L341) and does not call the previously registered handler. This prevents Python stack trace from being printed on crashes. The fix is to make the C++ fault signal handler to call the previous signal handler registered in Python. For example with the script below which segfaults,
```
import ray
ray.init()

@ray.remote
def f():
    import ctypes;
    ctypes.string_at(0)

ray.get(f.remote())
```
Ray currently only prints the following stack trace:
```
(pid=26693) *** SIGSEGV received at time=1634418743 ***
(pid=26693) PC: @     0x7fff203d9552  (unknown)  _platform_strlen
(pid=26693) [2021-10-16 14:12:23,331 E 26693 12194577] logging.cc:313: *** SIGSEGV received at time=1634418743 ***
(pid=26693) [2021-10-16 14:12:23,331 E 26693 12194577] logging.cc:313: PC: @     0x7fff203d9552  (unknown)  _platform_strlen
```
With this change, Python stack trace will be printed in addition to the stack trace above:
```
(pid=26693) Fatal Python error: Segmentation fault
(pid=26693)
(pid=26693) Stack (most recent call first):
(pid=26693)   File "/Users/mwtian/opt/anaconda3/envs/ray/lib/python3.7/ctypes/__init__.py", line 505 in string_at
(pid=26693)   File "stack.py", line 7 in f
(pid=26693)   File "/Users/mwtian/work/ray-project/ray/python/ray/worker.py", line 425 in main_loop
(pid=26693)   File "/Users/mwtian/work/ray-project/ray/python/ray/workers/default_worker.py", line 212 in <module>
```
This should make debugging crashes in Python worker easier, for users and Ray devs.

Also, try to initialize symbolizer in GCS, Raylet and core worker. This is a no-op on MacOS and some Linux environments (e.g. Ray on Ubuntu 20.04 already produces symbolized stack traces), but should make Ray more likely to have symbolized stack traces on other platforms.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
