### PR TITLE
MAINT: cleanups for windows

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1,5 +1,4 @@
 import asyncio
-import errno
 import io
 import fnmatch
 import os
@@ -32,9 +31,6 @@ except (ImportError, ModuleNotFoundError):
 
 import psutil  # We must import psutil after ray because we bundle it with ray.
 
-if sys.platform == "win32":
-    import _winapi
-
 
 class RayTestTimeoutException(Exception):
     """Exception used to identify timeouts from test utilities."""
@@ -50,22 +46,10 @@ def _pid_alive(pid):
     Returns:
         This returns false if the process is dead. Otherwise, it returns true.
     """
-    no_such_process = errno.EINVAL if sys.platform == "win32" else errno.ESRCH
     alive = True
     try:
-        if sys.platform == "win32":
-            SYNCHRONIZE = 0x00100000  # access mask defined in <winnt.h>
-            handle = _winapi.OpenProcess(SYNCHRONIZE, False, pid)
-            try:
-                alive = (_winapi.WaitForSingleObject(handle, 0) !=
-                         _winapi.WAIT_OBJECT_0)
-            finally:
-                _winapi.CloseHandle(handle)
-        else:
-            os.kill(pid, 0)
-    except OSError as ex:
-        if ex.errno != no_such_process:
-            raise
+        psutil.Process(pid)
+    except psutil.NoSuchProcess:
         alive = False
     return alive
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -851,7 +851,7 @@ def stop(force, verbose, log_style, log_color):
                 cli_logger.verbose(
                     "Attempted to stop `{}`, but process was already dead.",
                     cf.bold(proc_string))
-                pass
+                total_stopped += 1
             except (psutil.Error, OSError) as ex:
                 cli_logger.error("Could not terminate `{}` due to {}",
                                  cf.bold(proc_string), str(ex))

--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -26,13 +26,6 @@ else:
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize(
-    "shutdown_only", [{
-        "local_mode": True
-    }, {
-        "local_mode": False
-    }],
-    indirect=True)
 def test_variable_number_of_args(shutdown_only):
     ray.init(num_cpus=1)
 
@@ -78,13 +71,6 @@ def test_variable_number_of_args(shutdown_only):
         ray.get(no_op.remote())
 
 
-@pytest.mark.parametrize(
-    "shutdown_only", [{
-        "local_mode": True
-    }, {
-        "local_mode": False
-    }],
-    indirect=True)
 def test_defining_remote_functions(shutdown_only):
     ray.init(num_cpus=3)
 
@@ -133,13 +119,6 @@ def test_defining_remote_functions(shutdown_only):
     assert ray.get(m.remote(1)) == 2
 
 
-@pytest.mark.parametrize(
-    "shutdown_only", [{
-        "local_mode": True
-    }, {
-        "local_mode": False
-    }],
-    indirect=True)
 def test_redefining_remote_functions(shutdown_only):
     ray.init(num_cpus=1)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
### Dead processes should increment total_stopped
On windows, `ray start --head && ray stop` will stop all the processes, but some are killed by parent processes and are reported as "Attempted to stop `{}`, but process was already dead.". These processes should be counted in the `total_stopped` counter so that `ray stop` will exit without emitting a warning.
### Replace code to detect PID with psutils.Process(PID)
A code cleanup to use psutils where possible
### Add a sleep between windows tests
Windows task management is laggy. Allow time for things to settle before running the next test

### Remove parametrization of tests that was a no-op
The "shutdown_only" tests do not use the startup fixture, so the use of local_mode has no effect and runs the same test twice.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
