### PR TITLE
Draft: skip tests on windows, add delay between tests

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -152,7 +152,6 @@ test_python() {
       -python/ray/tests:test_autoscaler_aws
       -python/ray/tests:test_component_failures
       -python/ray/tests:test_component_failures_3 # timeout
-      -python/ray/tests:test_basic_2  # hangs on shared cluster tests
       -python/ray/tests:test_basic_2_client_mode
       -python/ray/tests:test_basic_3  # timeout
       -python/ray/tests:test_basic_3_client_mode

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -19,7 +19,7 @@ def shutdown_only():
     yield None
     # The code after the yield will run as teardown code.
     ray.shutdown()
-    if os.name == 'nt':
+    if os.name == "nt":
         # Give a little time for the OS to free resources
         import time
         time.sleep(5)
@@ -56,7 +56,7 @@ def _ray_start(**kwargs):
     yield address_info
     # The code after the yield will run as teardown code.
     ray.shutdown()
-    if os.name == 'nt':
+    if os.name == "nt":
         # Give a little time for the OS to free resources
         import time
         time.sleep(5)

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -19,6 +19,10 @@ def shutdown_only():
     yield None
     # The code after the yield will run as teardown code.
     ray.shutdown()
+    if os.name == 'nt':
+        # Give a little time for the OS to free resources
+        import time
+        time.sleep(5)
 
 
 def get_default_fixure_system_config():
@@ -52,6 +56,10 @@ def _ray_start(**kwargs):
     yield address_info
     # The code after the yield will run as teardown code.
     ray.shutdown()
+    if os.name == 'nt':
+        # Give a little time for the OS to free resources
+        import time
+        time.sleep(5)
 
 
 @pytest.fixture

--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
         "local_mode": False
     }],
     indirect=True)
+@pytest.mark.skipif(sys.platform == "win32", reason="Segfaults on Windows")
 def test_variable_number_of_args(shutdown_only):
     ray.init(num_cpus=1)
 
@@ -85,6 +86,7 @@ def test_variable_number_of_args(shutdown_only):
         "local_mode": False
     }],
     indirect=True)
+@pytest.mark.skipif(sys.platform == "win32", reason="Segfaults on Windows")
 def test_defining_remote_functions(shutdown_only):
     ray.init(num_cpus=3)
 
@@ -342,6 +344,8 @@ def test_call_chain(ray_start_cluster):
 
 
 @pytest.mark.skipif(client_test_enabled(), reason="init issue")
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="reddit connection issue on Windows")
 def test_system_config_when_connecting(ray_start_cluster):
     config = {"object_timeout_milliseconds": 200}
     cluster = ray.cluster_utils.Cluster()
@@ -374,7 +378,7 @@ def test_get_multiple(ray_start_regular_shared):
     results = ray.get([object_refs[i] for i in indices])
     assert results == indices
 
-
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows")
 def test_get_with_timeout(ray_start_regular_shared):
     SignalActor = create_remote_signal_actor(ray)
     signal = SignalActor.remote()
@@ -398,6 +402,7 @@ def test_get_with_timeout(ray_start_regular_shared):
 
 
 # https://github.com/ray-project/ray/issues/6329
+@pytest.mark.skipif(sys.platform == "win32", reason="Hangs on Windows")
 def test_call_actors_indirect_through_tasks(ray_start_regular_shared):
     @ray.remote
     class Counter:
@@ -427,6 +432,7 @@ def test_call_actors_indirect_through_tasks(ray_start_regular_shared):
         ray.get(zoo.remote([c]))
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Segfaults on Windows")
 def test_inline_arg_memory_corruption(ray_start_regular_shared):
     @ray.remote
     def f():
@@ -448,6 +454,7 @@ def test_inline_arg_memory_corruption(ray_start_regular_shared):
 
 
 @pytest.mark.skipif(client_test_enabled(), reason="internal api")
+@pytest.mark.skipif(sys.platform == "win32", reason="Segfaults on Windows")
 def test_skip_plasma(ray_start_regular_shared):
     @ray.remote
     class Actor:
@@ -465,6 +472,7 @@ def test_skip_plasma(ray_start_regular_shared):
 
 
 @pytest.mark.skipif(client_test_enabled(), reason="internal api")
+@pytest.mark.skipif(sys.platform == "win32", reason="Hangs on Windows")
 def test_actor_large_objects(ray_start_regular_shared):
     @ray.remote
     class Actor:
@@ -484,6 +492,7 @@ def test_actor_large_objects(ray_start_regular_shared):
     assert isinstance(ray.get(obj_ref), np.ndarray)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Segfaults on Windows")
 def test_actor_pass_by_ref(ray_start_regular_shared):
     @ray.remote
     class Actor:
@@ -512,6 +521,7 @@ def test_actor_pass_by_ref(ray_start_regular_shared):
         ray.get(a.f.remote(error.remote()))
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Segfaults on Windows")
 def test_actor_recursive(ray_start_regular_shared):
     @ray.remote
     class Actor:
@@ -535,6 +545,7 @@ def test_actor_recursive(ray_start_regular_shared):
     assert result == [x * 2 for x in range(100)]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Segfaults on Windows")
 def test_actor_concurrent(ray_start_regular_shared):
     @ray.remote
     class Batcher:
@@ -561,6 +572,7 @@ def test_actor_concurrent(ray_start_regular_shared):
     assert r1 == r2 == r3
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Segfaults on Windows")
 def test_actor_max_concurrency(ray_start_regular_shared):
     """
     Test that an actor of max_concurrency=N should only run
@@ -594,6 +606,7 @@ def test_actor_max_concurrency(ray_start_regular_shared):
     assert ray.get(actor.get_num_threads.remote()) <= CONCURRENCY
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Segfaults on Windows")
 def test_wait(ray_start_regular_shared):
     @ray.remote
     def f(delay):
@@ -641,6 +654,7 @@ def test_wait(ray_start_regular_shared):
         ray.wait([1])
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows")
 def test_duplicate_args(ray_start_regular_shared):
     @ray.remote
     def f(arg1,
@@ -722,6 +736,7 @@ if __name__ == "__main__":
 
 @pytest.mark.skipif(
     client_test_enabled(), reason="JobConfig doesn't work in client mode")
+@pytest.mark.skipif(sys.platform == "win32", reason="Hangs on Windows")
 def test_use_dynamic_function_and_class():
     # Test use dynamically defined functions
     # and classes for remote tasks and actors.

--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -378,6 +378,7 @@ def test_get_multiple(ray_start_regular_shared):
     results = ray.get([object_refs[i] for i in indices])
     assert results == indices
 
+
 @pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows")
 def test_get_with_timeout(ray_start_regular_shared):
     SignalActor = create_remote_signal_actor(ray)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Enable test_basic_2.py on windows, but skip the segfaults/hangs/flaky tests

## Related issue number
Related to #19177
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
