### PR TITLE
[dataset][nightly-test] fix pipeline ingest test

### DIFF
--- a/release/nightly_tests/dataset/pipelined_training.py
+++ b/release/nightly_tests/dataset/pipelined_training.py
@@ -119,18 +119,17 @@ def train_main(args, splits):
         for batch_idx, (data, target) in enumerate(train_dataset):
             batch_wait_times.append(timeit.default_timer() - last_batch_time)
             if torch.cuda.is_available():
-                data = [t.cuda() for t in data]
+                data = data.cuda()
                 target = target.cuda()
             for opt in optimizers:
                 opt.zero_grad()
             batch = OrderedDict()
             batch["embeddings"] = OrderedDict()
             batch["one_hot"] = OrderedDict()
-            for name, tensor in zip(annotation["embeddings"], data):
-                batch["embeddings"][name] = tensor
-            hot0, hot1 = data[-2:]
-            batch["one_hot"]["hot0"] = hot0
-            batch["one_hot"]["hot1"] = hot1
+            for i, name in enumerate(annotation["embeddings"]):
+                batch["embeddings"][name] = data[:, i:i + 1]
+            batch["one_hot"]["hot0"] = data[:, -2:-1]
+            batch["one_hot"]["hot1"] = data[:, -1:]
 
             batch_pred = model(batch)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

dataset.to_torch return type is changed by [this pr](https://github.com/ray-project/ray/commit/f6f2435b91ed0bf5b4a2ac2f114a01b35b0e2f15#) and broke this nightly test.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] [Release tests](https://beta.anyscale.com/o/anyscale-internal/projects/prj_SVFGM5yBqK6DHCfLtRMryXHM/clusters/ses_5jzk2zVSs5T4mCCtqa5ar3iT?command-history-section=command_history) 
   - [ ] This PR is not tested :(
