### PR TITLE
[release] pin modin>=0.11.0 due to ray.services being removed

### DIFF
--- a/release/golden_notebook_tests/modin_xgboost_app_config.yaml
+++ b/release/golden_notebook_tests/modin_xgboost_app_config.yaml
@@ -7,7 +7,7 @@ python:
   pip_packages:
     - pandas>=1.3.0  # otherwise, a version mismatch between local and remote will cause an exception
     - git+https://github.com/ray-project/xgboost_ray.git#egg=xgboost_ray
-    - modin
+    - modin>=0.11.0 # ray.services has been removed
     - s3fs
     - fastapi
     - uvicorn


### PR DESCRIPTION
## Why are these changes needed?

`ray.services` was removed in #18475.

Currently the `modin_xgboost` release test is failing with the error:
```  
  | File "/home/ray/anaconda3/lib/python3.7/site-packages/modin/engines/ray/pandas_on_ray/frame/partition.py", line 23, in <module>
  | from ray.util import get_node_ip_address
  | ModuleNotFoundError: No module named 'ray.services'
```

This message seems a bit misleading... `modin` was updated to read from `ray.util` instead of `ray.services` in `0.11.0`, while the Anyscale cluster running the job is still on `modin` `0.10.2`. Is this trace a mix between the client side and server side?

## Related issue number

Closes #19445

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
