### PR TITLE
[runtime env] runtime env eager install by default

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -517,9 +517,9 @@ The ``runtime_env`` is a Python dictionary including one or more of the followin
 
   - Example: ``{"OMP_NUM_THREADS": "32", "TF_WARNINGS": "none"}``
 
-- ``eager_install`` (bool): A boolean indicates whether to install runtime env eagerly before the workers are leased. This flag is set to false by default.
+- ``eager_install`` (bool): A boolean indicates whether to install runtime env eagerly before the workers are leased. This flag is set to True by default and only job level is supported now.
 
-  - Example: ``{"eager_install": True}``
+  - Example: ``{"eager_install": False}``
 
 The runtime environment is inheritable, so it will apply to all tasks/actors within a job and all child tasks/actors of a task or actor, once set.
 

--- a/python/ray/job_config.py
+++ b/python/ray/job_config.py
@@ -54,7 +54,7 @@ class JobConfig:
         from ray._private.runtime_env.validation import ParsedRuntimeEnv
         self._parsed_runtime_env = ParsedRuntimeEnv(runtime_env or {})
         self.runtime_env = runtime_env or dict()
-        eager_install = False
+        eager_install = True
         if runtime_env and "eager_install" in runtime_env:
             eager_install = runtime_env["eager_install"]
         self.runtime_env_eager_install = eager_install

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -198,8 +198,8 @@ def test_job_config_conda_env(conda_envs, shutdown_only):
     os.environ.get("CI") and sys.platform != "linux",
     reason="This test is only run on linux CI machines.")
 def test_job_eager_install(shutdown_only):
-    # Test enable eager install
-    runtime_env = {"conda": {"dependencies": ["toolz"]}, "eager_install": True}
+    # Test enable eager install. This flag is set to True by default.
+    runtime_env = {"conda": {"dependencies": ["toolz"]}}
     env_count = len(get_conda_env_list())
     ray.init(runtime_env=runtime_env)
     wait_for_condition(


### PR DESCRIPTION
## Why are these changes needed?

- turn on eager install by default
- only job level is supported now.

## Related issue number

https://github.com/ray-project/ray/issues/19424

