### PR TITLE
[Fix] Typo in kv_store.py

### DIFF
--- a/python/ray/serve/storage/kv_store.py
+++ b/python/ray/serve/storage/kv_store.py
@@ -176,7 +176,7 @@ class RayS3KVStore(KVStoreBase):
 
     def __init__(
             self,
-            namepsace: str,
+            namespace: str,
             bucket="",
             prefix="",
             region_name="us-west-2",
@@ -184,7 +184,7 @@ class RayS3KVStore(KVStoreBase):
             aws_secret_access_key=None,
             aws_session_token=None,
     ):
-        self._namespace = namepsace
+        self._namespace = namespace
         self._bucket = bucket
         self._prefix = prefix
         if not boto3:


### PR DESCRIPTION
## Why are these changes needed?

Fixing typo in init of RayS3KVStore class

## Related issue number

None

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests