### PR TITLE
[ci/release] Bump long running release test timeouts to 6 minutes

### DIFF
--- a/release/alerts/long_running_tests.py
+++ b/release/alerts/long_running_tests.py
@@ -12,15 +12,23 @@ def handle_result(created_on: datetime.datetime, category: str,
     last_update_diff = results.get("last_update_diff", float("inf"))
 
     if test_name in [
-            "actor_deaths", "many_actor_tasks", "many_drivers", "many_tasks",
-            "many_tasks_serialized_ids", "node_failures",
-            "object_spilling_shuffle", "serve", "serve_failure"
+            "actor_deaths",
+            "many_actor_tasks",
+            "many_drivers",
+            "many_tasks",
+            "many_tasks_serialized_ids",
+            "node_failures",
+            "object_spilling_shuffle",
     ]:
         # Core tests
         target_update_diff = 120
 
     elif test_name in ["apex", "impala", "many_ppo", "pbt"]:
         # Tune/RLLib style tests
+        target_update_diff = 360
+    elif test_name in ["serve", "serve_failure"]:
+        # Serve tests have workload logs every five minutes.
+        # Leave up to 60 seconds overhead.
         target_update_diff = 360
     else:
         return None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
