### PR TITLE
[hotfix] Pin pyspark dep to 3.1.2

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -67,7 +67,7 @@ opentelemetry-exporter-otlp==1.1.0
 pexpect
 Pillow; platform_system != "Windows"
 pygments
-pyspark
+pyspark==3.1.2
 pytest==5.4.3
 pytest-asyncio
 pytest-rerunfailures


### PR DESCRIPTION
The recent pyspark upgrade is breaking raydp tests.