### PR TITLE
Reduce success criteria for a few learning tests.

### DIFF
--- a/release/rllib_tests/learning_tests/hard_learning_tests.yaml
+++ b/release/rllib_tests/learning_tests/hard_learning_tests.yaml
@@ -302,7 +302,7 @@ dqn-breakoutnoframeskip-v4:
     run: DQN
     # Minimum reward and total ts (in given time_total_s) to pass this test.
     pass_criteria:
-        episode_reward_mean: 30.0
+        episode_reward_mean: 20.0
         timesteps_total: 400000
     stop:
         time_total_s: 7200
@@ -347,7 +347,7 @@ impala-breakoutnoframeskip-v4:
     run: IMPALA
     # Minimum reward and total ts (in given time_total_s) to pass this test.
     pass_criteria:
-        episode_reward_mean: 300.0
+        episode_reward_mean: 200.0
         timesteps_total: 6000000
     stop:
         time_total_s: 3600
@@ -423,7 +423,7 @@ sac-halfcheetahbulletenv-v0:
     run: SAC
     # Minimum reward and total ts (in given time_total_s) to pass this test.
     pass_criteria:
-        episode_reward_mean: 600.0
+        episode_reward_mean: 500.0
         timesteps_total: 100000
     stop:
         time_total_s: 7200


### PR DESCRIPTION
## Why are these changes needed?

Learning tests often fail due to variations between runs. This will hopefully make it less flaky.
None of the threshold changes are "material". We should still be learning things if they can achieve the new bar.

## Related issue number

Closes #19465

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
