### PR TITLE
[runtime env] Raise error when creating runtime env when ray[default] is not installed

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -199,7 +199,9 @@
       python/ray/tests/test_basic_2
     - bazel test --test_output=streamed --config=ci $(./scripts/bazel_export_options)
       python/ray/tests/test_basic_3
-
+    - bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 $(./scripts/bazel_export_options)
+      python/ray/tests/test_runtime_env_ray_minimal
+    # TODO(archit)
 - label: ":python: (Flaky tests)"
   conditions: ["RAY_CI_PYTHON_AFFECTED", "RAY_CI_SERVE_AFFECTED", "RAY_CI_RLLIB_AFFECTED", "RAY_CI_TUNE_AFFECTED"]
   commands:

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1502,19 +1502,7 @@ def start_raylet(redis_address,
     if max_worker_port is None:
         max_worker_port = 0
 
-    # Check to see if we should start the dashboard agent or not based on the
-    # Ray installation version the user has installed (ray vs. ray[default]).
-    # Unfortunately there doesn't seem to be a cleaner way to detect this other
-    # than just blindly importing the relevant packages.
-    def check_should_start_agent():
-        try:
-            import ray.dashboard.optional_deps  # noqa: F401
-
-            return True
-        except ImportError:
-            return False
-
-    if not check_should_start_agent():
+    if not ray._private.utils.check_dashboard_dependencies_installed():
         # An empty agent command will cause the raylet not to start it.
         agent_command = []
     else:

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1107,3 +1107,20 @@ def validate_namespace(namespace: str):
     elif namespace == "":
         raise ValueError("\"\" is not a valid namespace. "
                          "Pass None to not specify a namespace.")
+
+
+def check_dashboard_dependencies_installed() -> bool:
+    """Returns True if Ray Dashboard dependencies are installed.
+
+    Checks to see if we should start the dashboard agent or not based on the
+    Ray installation version the user has installed (ray vs. ray[default]).
+    Unfortunately there doesn't seem to be a cleaner way to detect this other
+    than just blindly importing the relevant packages.
+
+    """
+    try:
+        import ray.dashboard.optional_deps  # noqa: F401
+
+        return True
+    except ImportError:
+        return False

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -311,6 +311,14 @@ py_test(
     deps = ["//:ray_lib"],
 )
 
+py_test(
+    name = "test_runtime_env_ray_minimal",
+    size = "small",
+    srcs = SRCS + ["test_runtime_env_ray_minimal.py"],
+    tags = ["exclusive", "team:serve"],
+    deps = ["//:ray_lib"],
+)
+
 # TODO(ekl) we can't currently support tagging these as flaky since there's
 # no way to filter by both flaky and client mode tests in bazel.
 py_test_module_list(

--- a/python/ray/tests/test_runtime_env_ray_minimal.py
+++ b/python/ray/tests/test_runtime_env_ray_minimal.py
@@ -1,0 +1,107 @@
+"""Test that runtime_env raises good errors if ray[default] is not installed.
+
+
+In CI, this file is run with a minimal ray installation (`pip install ray`.)
+
+To run this test file locally, remove some dependency that appears in
+ray[default] but not in ray (e.g., `pip uninstall aiohttp`) and set
+`export RAY_MINIMAL=1`.
+
+"""
+
+import os
+import sys
+import pytest
+
+import ray
+from ray.exceptions import RuntimeEnvSetupError
+from ray._private.test_utils import wait_for_condition
+
+
+def _test_task_and_actor(capsys):
+    @ray.remote
+    def f():
+        pass
+
+    with pytest.raises(RuntimeEnvSetupError):
+        ray.get(f.options(runtime_env={"pip": ["requests"]}).remote())
+
+    def stderr_checker():
+        captured = capsys.readouterr()
+        return "ray[default]" in captured.err
+
+    wait_for_condition(stderr_checker)
+
+    @ray.remote
+    class A:
+        def task(self):
+            pass
+
+    A.options(runtime_env={"pip": ["requests"]}).remote()
+
+    wait_for_condition(stderr_checker)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="runtime_env unsupported on Windows.")
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") != "1",
+    reason="This test is only run in CI with a minimal Ray installation.")
+@pytest.mark.parametrize(
+    "call_ray_start",
+    ["ray start --head --ray-client-server-port 25553 --port 0"],
+    indirect=True)
+def test_ray_client_task_actor(call_ray_start, capsys):
+    ray.init("ray://localhost:25553")
+    _test_task_and_actor(capsys)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="runtime_env unsupported on Windows.")
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") != "1",
+    reason="This test is only run in CI with a minimal Ray installation.")
+def test_task_actor(shutdown_only, capsys):
+    ray.init()
+    _test_task_and_actor(capsys)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="runtime_env unsupported on Windows.")
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") != "1",
+    reason="This test is only run in CI with a minimal Ray installation.")
+def test_ray_init(shutdown_only, capsys):
+    with pytest.raises(RuntimeEnvSetupError):
+        ray.init(runtime_env={"pip": ["requests"]})
+
+        @ray.remote
+        def f():
+            pass
+
+        ray.get(f.remote())
+
+    def stderr_checker():
+        captured = capsys.readouterr()
+        return "ray[default]" in captured.err
+
+    wait_for_condition(stderr_checker)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="runtime_env unsupported on Windows.")
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") != "1",
+    reason="This test is only run in CI with a minimal Ray installation.")
+@pytest.mark.parametrize(
+    "call_ray_start",
+    ["ray start --head --ray-client-server-port 25552 --port 0"],
+    indirect=True)
+def test_ray_client_init(call_ray_start):
+    with pytest.raises(ConnectionAbortedError) as excinfo:
+        ray.init("ray://localhost:25552", runtime_env={"pip": ["requests"]})
+    assert "ray[default]" in str(excinfo.value)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -29,7 +29,8 @@ from ray._private.client_mode_hook import disable_client_hook
 from ray._private.parameter import RayParams
 from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.services import ProcessInfo, start_ray_client_server
-from ray._private.utils import detect_fate_sharing_support
+from ray._private.utils import (detect_fate_sharing_support,
+                                check_dashboard_dependencies_installed)
 
 # Import psutil after ray so the packaged version is used.
 import psutil
@@ -206,7 +207,13 @@ class ProxyManager():
 
             Includes retry logic to handle the case when the agent is
             temporarily unreachable (e.g., hasn't been started up yet).
-            """
+        """
+        if not check_dashboard_dependencies_installed():
+            raise RuntimeError("Not all required Ray dependencies for the "
+                               "runtime_env feature were found on the "
+                               "cluster. To install the required "
+                               "dependencies, please run `pip install "
+                               "'ray[default]'` on all cluster nodes.")
         create_env_request = runtime_env_agent_pb2.CreateRuntimeEnvRequest(
             serialized_runtime_env=serialized_runtime_env,
             job_id=f"ray_client_server_{specific_server.port}".encode("utf-8"))

--- a/src/ray/raylet/agent_manager.cc
+++ b/src/ray/raylet/agent_manager.cc
@@ -131,7 +131,7 @@ void AgentManager::CreateRuntimeEnv(
     const std::string &serialized_allocated_resource_instances,
     CreateRuntimeEnvCallback callback) {
   if (!should_start_agent_) {
-    RAY_LOG(ERROR) << "Not all required Ray dependencies for the Runtime Environments "
+    RAY_LOG(ERROR) << "Not all required Ray dependencies for the runtime_env "
                       "feature were found. To install the required dependencies, "
                    << "please run `pip install 'ray[default]'`.";
     // Execute the callback after the currently executing callback finishes.  Otherwise

--- a/src/ray/raylet/agent_manager.cc
+++ b/src/ray/raylet/agent_manager.cc
@@ -135,8 +135,9 @@ void AgentManager::CreateRuntimeEnv(
                       "feature were found. To install the required dependencies, "
                    << "please run `pip install 'ray[default]'`.";
     // Execute the callback after the currently executing callback finishes.  Otherwise
-    // the task may be erased from the dispatch queue during the queue iteration in 
-    // DispatchScheduledTasksToWorkers(), invalidating the iterator and causing a segfault.
+    // the task may be erased from the dispatch queue during the queue iteration in
+    // ClusterTaskManager::DispatchScheduledTasksToWorkers(), invalidating the iterator
+    // and causing a segfault.
     delay_executor_([callback] { callback(false, ""); }, 0);
     RAY_LOG(ERROR) << "Made it past the print...";
     return;

--- a/src/ray/raylet/agent_manager.cc
+++ b/src/ray/raylet/agent_manager.cc
@@ -138,7 +138,11 @@ void AgentManager::CreateRuntimeEnv(
     // the task may be erased from the dispatch queue during the queue iteration in
     // ClusterTaskManager::DispatchScheduledTasksToWorkers(), invalidating the iterator
     // and causing a segfault.
-    delay_executor_([callback] { callback(false, ""); }, 0);
+    delay_executor_(
+        [callback] {
+          callback(/*successful=*/false, /*serialized_runtime_env_context=*/"");
+        },
+        0);
     return;
   }
   if (runtime_env_agent_client_ == nullptr) {

--- a/src/ray/raylet/agent_manager.cc
+++ b/src/ray/raylet/agent_manager.cc
@@ -139,7 +139,6 @@ void AgentManager::CreateRuntimeEnv(
     // ClusterTaskManager::DispatchScheduledTasksToWorkers(), invalidating the iterator
     // and causing a segfault.
     delay_executor_([callback] { callback(false, ""); }, 0);
-    RAY_LOG(ERROR) << "Made it past the print...";
     return;
   }
   if (runtime_env_agent_client_ == nullptr) {

--- a/src/ray/raylet/agent_manager.cc
+++ b/src/ray/raylet/agent_manager.cc
@@ -43,6 +43,7 @@ void AgentManager::HandleRegisterAgent(const rpc::RegisterAgentRequest &request,
 
 void AgentManager::StartAgent() {
   if (options_.agent_commands.empty()) {
+    should_start_agent_ = false;
     RAY_LOG(INFO) << "Not starting agent, the agent command is empty.";
     return;
   }
@@ -129,6 +130,17 @@ void AgentManager::CreateRuntimeEnv(
     const JobID &job_id, const std::string &serialized_runtime_env,
     const std::string &serialized_allocated_resource_instances,
     CreateRuntimeEnvCallback callback) {
+  if (!should_start_agent_) {
+    RAY_LOG(ERROR) << "Not all required Ray dependencies for the Runtime Environments "
+                      "feature were found. To install the required dependencies, "
+                   << "please run `pip install 'ray[default]'`.";
+    // Execute the callback after the currently executing callback finishes.  Otherwise
+    // the task may be erased from the dispatch queue during the queue iteration in 
+    // DispatchScheduledTasksToWorkers(), invalidating the iterator and causing a segfault.
+    delay_executor_([callback] { callback(false, ""); }, 0);
+    RAY_LOG(ERROR) << "Made it past the print...";
+    return;
+  }
   if (runtime_env_agent_client_ == nullptr) {
     RAY_LOG(INFO)
         << "Runtime env agent is not registered yet. Will retry CreateRuntimeEnv later: "

--- a/src/ray/raylet/agent_manager.h
+++ b/src/ray/raylet/agent_manager.h
@@ -83,6 +83,9 @@ class AgentManager : public rpc::AgentManagerServiceHandler {
   int agent_port_ = 0;
   /// The number of times the agent is restarted.
   std::atomic<uint32_t> agent_restart_count_ = 0;
+  /// Whether or not we intend to start the agent.  This is false if we
+  /// are missing Ray Dashboard dependencies, for example.
+  bool should_start_agent_ = true;
   std::string agent_ip_address_;
   DelayExecutorFn delay_executor_;
   RuntimeEnvAgentClientFactoryFn runtime_env_agent_client_factory_;

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -343,7 +343,7 @@ void ClusterTaskManager::DispatchScheduledTasksToWorkers(
         bool did_spill = TrySpillback(work, is_infeasible);
         if (!did_spill) {
           // There must not be any other available nodes in the cluster, so the task
-          // should stay on this node. We can skip the reest of the shape because the
+          // should stay on this node. We can skip the rest of the shape because the
           // scheduler will make the same decision.
           break;
         }

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -626,8 +626,6 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   std::shared_ptr<gcs::GcsClient> gcs_client_;
   /// The callback that will be triggered once it times out to start a worker.
   std::function<void()> starting_worker_timeout_callback_;
-  /// The callback that will be triggered when a runtime_env setup for a task fails.
-  std::function<void(const TaskID &)> runtime_env_setup_failed_callback_;
   /// If 1, expose Ray debuggers started by the workers externally (to this node).
   int ray_debugger_external;
   FRIEND_TEST(WorkerPoolTest, InitialWorkerProcessCount);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Prior to this, Ray would hang when creating a runtime environment without the requisite `ray[default]` installed.  This PR adds an error message in this case.

There's two ways this can happen: the CreateRuntimeEnv RPC call on the RuntimeEnvAgent can either be made 
- from the Raylet (in the case of a per-task/actor runtime env), or 
- from the Ray Client server (in the case where we're specifying a runtime env in the Ray Client connection step.). 

In the Raylet, we check if the runtime env agent has been started, and fail the CreateRuntimeEnv call if it hasn't been started (and fail the corresponding task).

In the Ray Client server, we check if `ray[default]` is installed on the cluster and fail the request if it isn't. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #17845 
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
