### PR TITLE
Adds custom exploration algorithm registration mechanism. 

### DIFF
--- a/python/ray/tune/__init__.py
+++ b/python/ray/tune/__init__.py
@@ -4,7 +4,8 @@ from ray.tune.syncer import SyncConfig
 from ray.tune.experiment import Experiment
 from ray.tune.analysis import ExperimentAnalysis, Analysis
 from ray.tune.stopper import Stopper
-from ray.tune.registry import register_env, register_trainable
+from ray.tune.registry import (register_env, register_trainable,
+                               register_exploration)
 from ray.tune.trainable import Trainable
 from ray.tune.durable_trainable import DurableTrainable, durable
 from ray.tune.callback import Callback
@@ -33,5 +34,5 @@ __all__ = [
     "get_trial_name", "get_trial_id", "get_trial_resources",
     "make_checkpoint_dir", "save_checkpoint", "is_session_enabled",
     "checkpoint_dir", "SyncConfig", "create_searcher", "create_scheduler",
-    "PlacementGroupFactory"
+    "PlacementGroupFactory", "register_exploration"
 ]

--- a/python/ray/tune/tests/test_api.py
+++ b/python/ray/tune/tests/test_api.py
@@ -16,7 +16,8 @@ from ray.rllib import _register_all
 
 from ray import tune
 from ray.tune import (DurableTrainable, Trainable, TuneError, Stopper, run)
-from ray.tune import register_env, register_trainable, run_experiments
+from ray.tune import (register_env, register_trainable, register_exploration,
+                      run_experiments)
 from ray.tune.callback import Callback
 from ray.tune.durable_trainable import durable
 from ray.tune.schedulers import (TrialScheduler, FIFOScheduler,
@@ -233,6 +234,16 @@ class TrainableFunctionApiTest(unittest.TestCase):
         register_trainable("foo", train)
         register_trainable("foo", tune.durable("foo"))
         register_trainable("foo", tune.durable("foo"))
+
+    def testRegisterExploration(self):
+        class A:
+            pass
+
+        class B(ray.rllib.utils.exploration.Exploration):
+            pass
+
+        register_exploration("B", B)
+        self.assertRaises(TypeError, lambda: register_exploration("A", A))
 
     def testTrainableCallable(self):
         def dummy_fn(config, reporter, steps):

--- a/rllib/utils/exploration/tests/test_explorations.py
+++ b/rllib/utils/exploration/tests/test_explorations.py
@@ -181,10 +181,7 @@ class TestExplorations(unittest.TestCase):
 
 
 class TestCustomExplorations(unittest.TestCase):
-    """
-    Tests all Exploration components and the deterministic flag for
-    compute_action calls.
-    """
+    """Tests custom exploration algorithm registration."""
 
     @classmethod
     def setUpClass(cls):

--- a/rllib/utils/exploration/tests/test_explorations.py
+++ b/rllib/utils/exploration/tests/test_explorations.py
@@ -180,6 +180,34 @@ class TestExplorations(unittest.TestCase):
             expected_mean_action=0.0)
 
 
+class TestCustomExplorations(unittest.TestCase):
+    """
+    Tests all Exploration components and the deterministic flag for
+    compute_action calls.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        ray.init(num_cpus=4)
+
+    @classmethod
+    def tearDownClass(cls):
+        ray.shutdown()
+
+    def test_custom_exploration(self):
+        from ray.rllib.utils.exploration import Exploration, Random
+        Exploration.register_custom_exploration("RandomNew", Random)
+        config = ppo.DEFAULT_CONFIG.copy()
+        config["exploration_config"]["type"] = "RandomNew"
+        do_test_explorations(
+            ppo.PPOTrainer,
+            "Pendulum-v0",
+            config,
+            np.array([0.0, 0.1, 0.0]),
+            prev_a=np.array([0.0]),
+            expected_mean_action=0.0)
+
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/utils/from_config.py
+++ b/rllib/utils/from_config.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import yaml
+import pickle
 
 from ray.rllib.utils import force_list, merge_dicts
 
@@ -186,6 +187,12 @@ def from_config(cls, config=None, **kwargs):
     if not constructor:
         raise TypeError(
             "Invalid type '{}'. Cannot create `from_config`.".format(type_))
+
+    # check if the constructor is binary
+    if isinstance(constructor, bytes):
+        # Convert the returned value from type_registry to the proper object
+        # format.
+        constructor = pickle.loads(constructor)
 
     # Create object with inferred constructor.
     try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds a mechanism to register a custom exploration algorithm. Users can define a custom exploration algorithm inheriting the Exploration API and register the same without changing RLLib internal code.  

This will help end-users experiment with different custom exploration algorithms effortlessly. 
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
