### PR TITLE
[train] add callbacks package compatibility

### DIFF
--- a/python/ray/util/sgd/v2/callbacks/__init__.py
+++ b/python/ray/util/sgd/v2/callbacks/__init__.py
@@ -1,0 +1,1 @@
+from ray.train.callbacks import *  # noqa: F401, F403


### PR DESCRIPTION

## Why are these changes needed?

Follow-up to #19436 to ensure the `callbacks` subpackage is properly importable.

## Related issue number

n/a

## Checks


```
>>> from ray.util.sgd.v2.callbacks import JsonLoggerCallback
/Users/matt/workspace/ray/python/ray/util/sgd/v2/__init__.py:4: UserWarning: ray.util.sgd.v2 has been moved to ray.train.
  warnings.warn("ray.util.sgd.v2 has been moved to ray.train.")
>>> JsonLoggerCallback
<class 'ray.train.callbacks.logging.JsonLoggerCallback'>
```

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
