### PR TITLE
Correctly set num_replicas when deploying autoscaling deployment

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1016,6 +1016,11 @@ def deployment(
         Deployment
     """
 
+    if num_replicas is not None \
+            and _autoscaling_config is not None:
+        raise ValueError("Manually setting num_replicas is not allowed when "
+                         "_autoscaling_config is provided.")
+
     config = BackendConfig()
     if num_replicas is not None:
         config.num_replicas = num_replicas

--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -726,9 +726,7 @@ class BackendState:
 
         if backend_info is not None:
             self._target_info = backend_info
-            target_replicas = backend_info.backend_config.num_replicas
-
-            self._target_replicas = target_replicas
+            self._target_replicas = backend_info.backend_config.num_replicas
 
             self._target_version = BackendVersion(
                 backend_info.version,

--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -726,7 +726,18 @@ class BackendState:
 
         if backend_info is not None:
             self._target_info = backend_info
-            self._target_replicas = backend_info.backend_config.num_replicas
+            target_replicas = backend_info.backend_config.num_replicas
+
+            # make sure that autoscaling config bounds are respected
+            autoscaling_config = backend_info.backend_config.autoscaling_config
+            if autoscaling_config is not None:
+                target_replicas = max(target_replicas,
+                                      autoscaling_config.min_replicas)
+                target_replicas = min(target_replicas,
+                                      autoscaling_config.max_replicas)
+
+            self._target_replicas = target_replicas
+
             self._target_version = BackendVersion(
                 backend_info.version,
                 user_config=backend_info.backend_config.user_config)

--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -728,14 +728,6 @@ class BackendState:
             self._target_info = backend_info
             target_replicas = backend_info.backend_config.num_replicas
 
-            # make sure that autoscaling config bounds are respected
-            autoscaling_config = backend_info.backend_config.autoscaling_config
-            if autoscaling_config is not None:
-                target_replicas = max(target_replicas,
-                                      autoscaling_config.min_replicas)
-                target_replicas = min(target_replicas,
-                                      autoscaling_config.max_replicas)
-
             self._target_replicas = target_replicas
 
             self._target_version = BackendVersion(

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -1,17 +1,21 @@
 import sys
 import time
 
+
 import pytest
+from unittest import mock
+
 from ray._private.test_utils import SignalActor, wait_for_condition
 from ray.serve.autoscaling_policy import (BasicAutoscalingPolicy,
                                           calculate_desired_num_replicas)
 from ray.serve.backend_state import ReplicaState
 from ray.serve.config import AutoscalingConfig
 from ray.serve.constants import CONTROL_LOOP_PERIOD_S
+from ray.serve.controller import ServeController
+
 
 import ray
 from ray import serve
-
 
 class TestCalculateDesiredNumReplicas:
     def test_bounds_checking(self):
@@ -84,6 +88,15 @@ class TestCalculateDesiredNumReplicas:
         assert 5 <= desired_num_replicas <= 8  # 10 + 0.5 * (2.5 - 10) = 6.25
 
 
+def get_num_running_replicas(controller: ServeController,
+                             deployment_name: str) -> int:
+    """ Get the amount of replicas currently running for given deployment name """
+    replicas = ray.get(
+        controller._dump_replica_states_for_testing.remote(deployment_name))
+    running_replicas = replicas.get([ReplicaState.RUNNING])
+    return len(running_replicas)
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_e2e_basic_scale_up_down(serve_instance):
     """Send 100 requests and check that we autoscale up, and then back down."""
@@ -114,17 +127,36 @@ def test_e2e_basic_scale_up_down(serve_instance):
 
     controller = serve_instance._controller
 
-    def get_num_running_replicas():
-        replicas = ray.get(
-            controller._dump_replica_states_for_testing.remote("A"))
-        running_replicas = replicas.get([ReplicaState.RUNNING])
-        return len(running_replicas)
-
-    wait_for_condition(lambda: get_num_running_replicas() >= 2)
+    wait_for_condition(lambda: get_num_running_replicas(controller, "A") >= 2)
     signal.send.remote()
 
     # As the queue is drained, we should scale back down.
-    wait_for_condition(lambda: get_num_running_replicas() <= 1)
+    wait_for_condition(lambda: get_num_running_replicas(controller, "A") <= 1)
+
+
+@mock.patch.object(ServeController, 'autoscale')
+def test_initial_num_replicas(mock, serve_instance):
+    """ assert that the inital amount of replicas a deployment is launched with
+    respects the bounds set by autoscaling_config.
+    
+    For this test we mock out the autoscaling loop, make sure the number of replicas
+    is set correctly before we hit the autoscaling procedure.
+    """
+
+    @serve.deployment(
+        _autoscaling_config={
+            "min_replicas": 2,
+            "max_replicas": 4,
+        },
+        version="v1")
+    class A:
+        def __call__(self):
+            return "ok!"
+
+    A.deploy()
+
+    controller = serve_instance._controller
+    assert get_num_running_replicas(controller, "A") == 2
 
 
 class MockTimer:

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -11,11 +11,10 @@ from ray.serve.backend_state import ReplicaState
 from ray.serve.config import AutoscalingConfig
 from ray.serve.constants import CONTROL_LOOP_PERIOD_S
 from ray.serve.controller import ServeController
+from ray.serve.api import Deployment
 
 import ray
 from ray import serve
-
-from api import Deployment
 
 
 class TestCalculateDesiredNumReplicas:

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -1,7 +1,6 @@
 import sys
 import time
 
-
 import pytest
 from unittest import mock
 
@@ -13,9 +12,9 @@ from ray.serve.config import AutoscalingConfig
 from ray.serve.constants import CONTROL_LOOP_PERIOD_S
 from ray.serve.controller import ServeController
 
-
 import ray
 from ray import serve
+
 
 class TestCalculateDesiredNumReplicas:
     def test_bounds_checking(self):
@@ -90,7 +89,7 @@ class TestCalculateDesiredNumReplicas:
 
 def get_num_running_replicas(controller: ServeController,
                              deployment_name: str) -> int:
-    """ Get the amount of replicas currently running for given deployment name """
+    """ Get the amount of replicas currently running for given deployment """
     replicas = ray.get(
         controller._dump_replica_states_for_testing.remote(deployment_name))
     running_replicas = replicas.get([ReplicaState.RUNNING])
@@ -134,13 +133,13 @@ def test_e2e_basic_scale_up_down(serve_instance):
     wait_for_condition(lambda: get_num_running_replicas(controller, "A") <= 1)
 
 
-@mock.patch.object(ServeController, 'autoscale')
+@mock.patch.object(ServeController, "autoscale")
 def test_initial_num_replicas(mock, serve_instance):
     """ assert that the inital amount of replicas a deployment is launched with
     respects the bounds set by autoscaling_config.
-    
-    For this test we mock out the autoscaling loop, make sure the number of replicas
-    is set correctly before we hit the autoscaling procedure.
+
+    For this test we mock out the autoscaling loop, make sure the number of
+    replicas is set correctly before we hit the autoscaling procedure.
     """
 
     @serve.deployment(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Deployments can currently have an amount of replicas that is outside the bounds set in the autoscaling config. This can be easily verified by creating a deployment with `num_replicas` set to a number outside the autoscaling bounds (this naturally happens when using the default `num_replicas` = 1, as in the linked issue).

## Related issue number

Closes #19169
Closes #18928

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
