### PR TITLE
[ci/release] wrap all release test pip github installs in quotation marks

### DIFF
--- a/release/e2e.py
+++ b/release/e2e.py
@@ -491,6 +491,15 @@ def _load_config(local_dir: str, config_file: Optional[str]) -> Optional[Dict]:
     return yaml.safe_load(content)
 
 
+def _wrap_app_config_pip_installs(app_config: Dict[Any, Any]):
+    """Wrap pip package install in quotation marks"""
+    if app_config.get("python", {}).get("pip_packages"):
+        new_pip_packages = []
+        for pip_package in app_config["python"]["pip_packages"]:
+            new_pip_packages.append(f"\"{pip_package}\"")
+        app_config["python"]["pip_packages"] = new_pip_packages
+
+
 def has_errored(result: Dict[Any, Any]) -> bool:
     return result.get("status", "invalid") != "finished"
 
@@ -1154,6 +1163,7 @@ def run_test_config(
 
     app_config_rel_path = test_config["cluster"].get("app_config", None)
     app_config = _load_config(local_dir, app_config_rel_path)
+    _wrap_app_config_pip_installs(app_config)
 
     compute_tpl_rel_path = test_config["cluster"].get("compute_template", None)
     compute_tpl = _load_config(local_dir, compute_tpl_rel_path)


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#19464 did not solve the problem as the yaml is parsed and the quotation marks are lost when converting to json. So we should explicitly wrap pip installs in quotation marks instead.

Example build: https://beta.anyscale.com/o/anyscale-internal/configurations/app-config-details/bld_xUauvTB2pjXSi6ymwMAgbtmA

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
