### PR TITLE
[Test] Fix flaky test_gpu test

### DIFF
--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -550,7 +550,7 @@ def test_gpu(monkeypatch):
             def get_location(self):
                 return ray.worker.global_worker.node.unique_id
 
-        @ray.remote(num_cpus=0.5)
+        @ray.remote(num_cpus=1)
         def task_cpu():
             time.sleep(10)
             return ray.worker.global_worker.node.unique_id
@@ -558,7 +558,8 @@ def test_gpu(monkeypatch):
         @ray.remote(num_returns=2, num_gpus=0.5)
         def launcher():
             a = Actor1.remote()
-            task_results = [task_cpu.remote() for _ in range(n)]
+            # Leave one cpu for the actor.
+            task_results = [task_cpu.remote() for _ in range(n - 1)]
             actor_results = [a.get_location.remote() for _ in range(n)]
             return ray.get(task_results + actor_results
                            ), ray.worker.global_worker.node.unique_id

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -307,7 +307,7 @@ RAY_CONFIG(int64_t, task_rpc_inlined_bytes_limit, 10 * 1024 * 1024)
 RAY_CONFIG(uint32_t, max_tasks_in_flight_per_worker, 1)
 
 /// Maximum number of pending lease requests per scheduling category
-RAY_CONFIG(uint64_t, max_pending_lease_requests_per_scheduling_category, 1)
+RAY_CONFIG(uint64_t, max_pending_lease_requests_per_scheduling_category, 10)
 
 /// Interval to restart dashboard agent after the process exit.
 RAY_CONFIG(uint32_t, agent_restart_interval_ms, 1000)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Basically we have a race condition and fragmentation issue.
The setup is that we have 5 cpus (1 per node) in total and we want to start a 1 cpu actor and 5 0.5 cpu tasks. We have more cpus than needed so we shouldn't run any of those on the gpu nodes. However, one possible way raylet schedules them is scheduling 5 0.5 cpu tasks first and then the 1 cpu actor creation task (this goes to gcs first so raylet may receive the lease request after the 5 normal task leases). When raylet schedules the 5 normal tasks with default spread_threshold=0.5, it's basically an even spread. After scheduling these 5 normal tasks, each node has 0.5 cpu left but the actor needs 1 cpu so it's scheduled to the gpu node and the test check failed.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
