### PR TITLE
[Datasets] Unrevert Arrow table copy method change.

### DIFF
--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -285,7 +285,7 @@ class ArrowBlockAccessor(BlockAccessor):
         return ret, ArrowBlockAccessor(ret).get_metadata(None)
 
 
-def _copy_table(table: "pyarrow.Table"):
+def _copy_table(table: "pyarrow.Table") -> "pyarrow.Table":
     """Copy the provided Arrow table.
     """
     import pyarrow as pa

--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -169,9 +169,15 @@ class ArrowBlockAccessor(BlockAccessor):
     def slice(self, start: int, end: int, copy: bool) -> "pyarrow.Table":
         view = self._table.slice(start, end - start)
         if copy:
-            # TODO(ekl) there must be a cleaner way to force a copy of a table.
-            copy = [c.to_pandas() for c in view.itercolumns()]
-            return pyarrow.Table.from_arrays(copy, schema=self._table.schema)
+            # TODO(Clark): Find a better method to ensure a copy. This Pandas
+            # roundtrip isn't ideal because:
+            #  1. It may break for nested schemas.
+            #  2. Future optimizations of zero-copy roundtrip with Pandas could
+            #     break this copy guarantee.
+            #  3. It creates two full memory copies,
+            #     Arrow --> Pandas --> Arrow, instead of just one.
+            return pyarrow.Table.from_pandas(
+                view.to_pandas(), schema=view.schema)
         else:
             return view
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -295,6 +295,40 @@ def test_batch_tensors(ray_start_regular_shared):
     assert df.to_dict().keys() == {0, 1}
 
 
+def test_arrow_block_slice_copy():
+    # Test that ArrowBlock slicing properly copies the underlying Arrow
+    # table.
+    n = 20
+    df = pd.DataFrame({"one": list(range(n))})
+    table = pa.Table.from_pandas(df)
+    og_chunk = table.column(0).chunk(0)
+    og_bufs = og_chunk.buffers()
+    a, b = 5, 10
+    expected_slice = table.slice(a, b - a)
+    block_accessor = BlockAccessor.for_block(table)
+
+    # Test with copy.
+    table2 = block_accessor.slice(a, b, True)
+    assert table2.equals(expected_slice)
+    assert table2.schema == table.schema
+    chunk = table2.column(0).chunk(0)
+    assert chunk.offset == 0
+    assert len(chunk) == b - a
+    bufs = chunk.buffers()
+    print(len(bufs))
+    assert bufs[1].address != og_bufs[1].address
+
+    # Test without copy.
+    table2 = block_accessor.slice(a, b, False)
+    assert table2.equals(expected_slice)
+    assert table2.schema == table.schema
+    chunk = table2.column(0).chunk(0)
+    assert chunk.offset == a
+    assert len(chunk) == b - a
+    bufs = chunk.buffers()
+    assert bufs[1].address == og_bufs[1].address
+
+
 def test_tensors(ray_start_regular_shared):
     # Create directly.
     ds = ray.data.range_tensor(5, shape=(3, 5))
@@ -357,6 +391,37 @@ def test_tensor_array_reductions(ray_start_regular_shared):
             np_kwargs["ddof"] = 1
         np.testing.assert_equal(df["two"].agg(name),
                                 reducer(arr, axis=0, **np_kwargs))
+
+
+def test_tensor_array_block_slice():
+    # Test that ArrowBlock slicing workers with tensor column extension type.
+    n = 20
+    df = pd.DataFrame({"one": TensorArray(np.array(list(range(n))))})
+    table = pa.Table.from_pandas(df)
+    og_chunk = table.column(0).chunk(0)
+    og_bufs = og_chunk.buffers()
+    a, b = 5, 10
+    expected_slice = table.slice(a, b - a)
+    block_accessor = BlockAccessor.for_block(table)
+
+    # Test with copy.
+    table2 = block_accessor.slice(a, b, True)
+    assert table2.equals(expected_slice)
+    chunk = table2.column(0).chunk(0)
+    assert chunk.offset == 0
+    assert len(chunk) == b - a
+    bufs = chunk.buffers()
+    print(len(bufs))
+    assert bufs[1].address != og_bufs[1].address
+
+    # Test without copy.
+    table2 = block_accessor.slice(a, b, False)
+    assert table2.equals(expected_slice)
+    chunk = table2.column(0).chunk(0)
+    assert chunk.offset == a
+    assert len(chunk) == b - a
+    bufs = chunk.buffers()
+    assert bufs[1].address == og_bufs[1].address
 
 
 def test_arrow_tensor_array_getitem(ray_start_regular_shared):

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -298,12 +298,49 @@ def test_batch_tensors(ray_start_regular_shared):
 def test_arrow_block_slice_copy():
     # Test that ArrowBlock slicing properly copies the underlying Arrow
     # table.
+    def check_for_copy(table1, table2, a, b, is_copy):
+        expected_slice = table1.slice(a, b - a)
+        assert table2.equals(expected_slice)
+        assert table2.schema == table1.schema
+        assert table1.num_columns == table2.num_columns
+        for col1, col2 in zip(table1.columns, table2.columns):
+            assert col1.num_chunks == col2.num_chunks
+            for chunk1, chunk2 in zip(col1.chunks, col2.chunks):
+                bufs1 = chunk1.buffers()
+                bufs2 = chunk2.buffers()
+                expected_offset = 0 if is_copy else a
+                assert chunk2.offset == expected_offset
+                assert len(chunk2) == b - a
+                if is_copy:
+                    assert bufs2[1].address != bufs1[1].address
+                else:
+                    assert bufs2[1].address == bufs1[1].address
+
     n = 20
-    df = pd.DataFrame({"one": list(range(n))})
+    df = pd.DataFrame({
+        "one": list(range(n)),
+        "two": ["a"] * n,
+        "three": [np.nan] + [1.5] * (n - 1)
+    })
     table = pa.Table.from_pandas(df)
-    og_chunk = table.column(0).chunk(0)
-    og_bufs = og_chunk.buffers()
     a, b = 5, 10
+    block_accessor = BlockAccessor.for_block(table)
+
+    # Test with copy.
+    table2 = block_accessor.slice(a, b, True)
+    check_for_copy(table, table2, a, b, is_copy=True)
+
+    # Test without copy.
+    table2 = block_accessor.slice(a, b, False)
+    check_for_copy(table, table2, a, b, is_copy=False)
+
+
+def test_arrow_block_slice_copy_empty():
+    # Test that ArrowBlock slicing properly copies the underlying Arrow
+    # table when the table is empty.
+    df = pd.DataFrame({"one": []})
+    table = pa.Table.from_pandas(df)
+    a, b = 0, 0
     expected_slice = table.slice(a, b - a)
     block_accessor = BlockAccessor.for_block(table)
 
@@ -311,22 +348,13 @@ def test_arrow_block_slice_copy():
     table2 = block_accessor.slice(a, b, True)
     assert table2.equals(expected_slice)
     assert table2.schema == table.schema
-    chunk = table2.column(0).chunk(0)
-    assert chunk.offset == 0
-    assert len(chunk) == b - a
-    bufs = chunk.buffers()
-    print(len(bufs))
-    assert bufs[1].address != og_bufs[1].address
+    assert table2.num_rows == 0
 
     # Test without copy.
     table2 = block_accessor.slice(a, b, False)
     assert table2.equals(expected_slice)
     assert table2.schema == table.schema
-    chunk = table2.column(0).chunk(0)
-    assert chunk.offset == a
-    assert len(chunk) == b - a
-    bufs = chunk.buffers()
-    assert bufs[1].address == og_bufs[1].address
+    assert table2.num_rows == 0
 
 
 def test_tensors(ray_start_regular_shared):
@@ -395,33 +423,40 @@ def test_tensor_array_reductions(ray_start_regular_shared):
 
 def test_tensor_array_block_slice():
     # Test that ArrowBlock slicing workers with tensor column extension type.
+    def check_for_copy(table1, table2, a, b, is_copy):
+        expected_slice = table1.slice(a, b - a)
+        assert table2.equals(expected_slice)
+        assert table2.schema == table1.schema
+        assert table1.num_columns == table2.num_columns
+        for col1, col2 in zip(table1.columns, table2.columns):
+            assert col1.num_chunks == col2.num_chunks
+            for chunk1, chunk2 in zip(col1.chunks, col2.chunks):
+                bufs1 = chunk1.buffers()
+                bufs2 = chunk2.buffers()
+                expected_offset = 0 if is_copy else a
+                assert chunk2.offset == expected_offset
+                assert len(chunk2) == b - a
+                if is_copy:
+                    assert bufs2[1].address != bufs1[1].address
+                else:
+                    assert bufs2[1].address == bufs1[1].address
+
     n = 20
-    df = pd.DataFrame({"one": TensorArray(np.array(list(range(n))))})
+    df = pd.DataFrame({
+        "one": TensorArray(np.array(list(range(n)))),
+        "two": ["a"] * n
+    })
     table = pa.Table.from_pandas(df)
-    og_chunk = table.column(0).chunk(0)
-    og_bufs = og_chunk.buffers()
     a, b = 5, 10
-    expected_slice = table.slice(a, b - a)
     block_accessor = BlockAccessor.for_block(table)
 
     # Test with copy.
     table2 = block_accessor.slice(a, b, True)
-    assert table2.equals(expected_slice)
-    chunk = table2.column(0).chunk(0)
-    assert chunk.offset == 0
-    assert len(chunk) == b - a
-    bufs = chunk.buffers()
-    print(len(bufs))
-    assert bufs[1].address != og_bufs[1].address
+    check_for_copy(table, table2, a, b, is_copy=True)
 
     # Test without copy.
     table2 = block_accessor.slice(a, b, False)
-    assert table2.equals(expected_slice)
-    chunk = table2.column(0).chunk(0)
-    assert chunk.offset == a
-    assert len(chunk) == b - a
-    bufs = chunk.buffers()
-    assert bufs[1].address == og_bufs[1].address
+    check_for_copy(table, table2, a, b, is_copy=False)
 
 
 def test_arrow_tensor_array_getitem(ray_start_regular_shared):


### PR DESCRIPTION
Unreverts the reversion of #19494. This PR also changes the Arrow table copy method to a per-column copy via chunk concatenation, which
1. Is guaranteed to be single-copy.
2. Is guaranteed to preserve the original data (no roundtrip with other representation that might perform casting).

Opening the PR to let the failing example run in CI since I wasn't able to reproduce the failure locally.

## Related issue number

Closes #19476 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
