### PR TITLE
Change configure_subnet function to use client instead of resource so that it gets values back

### DIFF
--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -399,6 +399,7 @@ def _key_assert_msg(node_type: str) -> str:
         return ("`KeyName` missing from the `node_config` of"
                 f" node type `{node_type}`.")
 
+
 def _configure_subnet(config):
     ec2 = _client('ec2', config)
 
@@ -414,6 +415,7 @@ def _configure_subnet(config):
         vpc_id_of_sg = _get_vpc_id_of_sg(sg_ids, config)
     else:
         vpc_id_of_sg = None
+ 
     try:
         candidate_subnets = ec2.describe_subnets()['Subnets']
         candidate_subnets = [SimpleNamespace(**{k.lower(): v for k, v in x.items()}) for x in candidate_subnets]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The boto3 resource does not find subnets.  Must use a client to get these.

<!-- Please give a short summary of the change and the problem this solves. -->
Changed the configure subnet function so that it uses a client and actually gets returned values.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
