### PR TITLE
[Core][CoreWorker] increase the default port range

### DIFF
--- a/doc/kubernetes/ray-cluster.yaml
+++ b/doc/kubernetes/ray-cluster.yaml
@@ -57,7 +57,7 @@ spec:
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "-c", "--" ]
           args:
-            - "ray start --head --port=6379 --redis-shard-ports=6380,6381 --num-cpus=$MY_CPU_REQUEST --object-manager-port=12345 --node-manager-port=12346 --dashboard-host=0.0.0.0 --block"
+            - "ray start --head --port=6379 --redis-shard-ports=6380,6381 --num-cpus=$MY_CPU_REQUEST --object-manager-port=22345 --node-manager-port=22346 --dashboard-host=0.0.0.0 --block"
           ports:
             - containerPort: 6379 # Redis port
             - containerPort: 10001 # Used by Ray Client
@@ -111,7 +111,7 @@ spec:
         imagePullPolicy: IfNotPresent
         command: ["/bin/bash", "-c", "--"]
         args:
-          - "ray start --num-cpus=$MY_CPU_REQUEST --address=$EXAMPLE_CLUSTER_RAY_HEAD_SERVICE_HOST:$EXAMPLE_CLUSTER_RAY_HEAD_SERVICE_PORT_REDIS --object-manager-port=12345 --node-manager-port=12346 --block"
+          - "ray start --num-cpus=$MY_CPU_REQUEST --address=$EXAMPLE_CLUSTER_RAY_HEAD_SERVICE_HOST:$EXAMPLE_CLUSTER_RAY_HEAD_SERVICE_PORT_REDIS --object-manager-port=22345 --node-manager-port=22346 --block"
         # This volume allocates shared memory for Ray to use for its plasma
         # object store. If you do not provide this, Ray will fall back to
         # /tmp which cause slowdowns if is not a shared memory volume.

--- a/doc/source/configure.rst
+++ b/doc/source/configure.rst
@@ -134,7 +134,7 @@ The following options specify the range of ports used by worker processes across
 - ``--min-worker-port``: Minimum port number worker can be bound to. Default: 10002.
 - ``--max-worker-port``: Maximum port number worker can be bound to. Default: 19999.
 
-Port numbers are how Ray disambiguates input and output to and from multiple workers on a single node. Each worker will take input and give output on a single port number. Thus, for example, by default, there is a maximum of 1,000 workers on each node, irrespective of number of CPUs.
+Port numbers are how Ray disambiguates input and output to and from multiple workers on a single node. Each worker will take input and give output on a single port number. Thus, for example, by default, there is a maximum of 10,000 workers on each node, irrespective of number of CPUs.
 
 In general, it is recommended to give Ray a wide range of possible worker ports, in case any of those ports happen to be in use by some other program on your machine. However, when debugging it is useful to explicitly specify a short list of worker ports such as ``--worker-port-list=10000,10001,10002,10003,10004`` (note that this will limit the number of workers, just like specifying a narrow range).
 

--- a/doc/source/configure.rst
+++ b/doc/source/configure.rst
@@ -132,7 +132,7 @@ The node manager and object manager run as separate processes with their own por
 The following options specify the range of ports used by worker processes across machines. All ports in the range should be open.
 
 - ``--min-worker-port``: Minimum port number worker can be bound to. Default: 10002.
-- ``--max-worker-port``: Maximum port number worker can be bound to. Default: 10999.
+- ``--max-worker-port``: Maximum port number worker can be bound to. Default: 19999.
 
 Port numbers are how Ray disambiguates input and output to and from multiple workers on a single node. Each worker will take input and give output on a single port number. Thus, for example, by default, there is a maximum of 1,000 workers on each node, irrespective of number of CPUs.
 

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -190,7 +190,7 @@ def find_redis_address(address=None):
     # /usr/local/lib/python3.8/dist-packages/ray/core/src/ray/raylet/raylet
     # --redis_address=123.456.78.910 --node_ip_address=123.456.78.910
     # --raylet_socket_name=... --store_socket_name=... --object_manager_port=0
-    # --min_worker_port=10000 --max_worker_port=10999
+    # --min_worker_port=10000 --max_worker_port=19999
     # --node_manager_port=58578 --redis_port=6379
     # --maximum_startup_concurrency=8
     # --static_resource_list=node:123.456.78.910,1.0,object_store_memory,66

--- a/python/ray/autoscaler/kubernetes/example-ingress.yaml
+++ b/python/ray/autoscaler/kubernetes/example-ingress.yaml
@@ -155,8 +155,8 @@ head_node:
                   - containerPort: 6379 # Redis port.
                   - containerPort: 6380 # Redis port.
                   - containerPort: 6381 # Redis port.
-                  - containerPort: 12345 # Ray internal communication.
-                  - containerPort: 12346 # Ray internal communication.
+                  - containerPort: 22345 # Ray internal communication.
+                  - containerPort: 22346 # Ray internal communication.
 
               # This volume allocates shared memory for Ray to use for its plasma
               # object store. If you do not provide this, Ray will fall back to
@@ -227,8 +227,8 @@ worker_nodes:
               command: ["/bin/bash", "-c", "--"]
               args: ["trap : TERM INT; sleep infinity & wait;"]
               ports:
-                  - containerPort: 12345 # Ray internal communication.
-                  - containerPort: 12346 # Ray internal communication.
+                  - containerPort: 22345 # Ray internal communication.
+                  - containerPort: 22346 # Ray internal communication.
 
               # This volume allocates shared memory for Ray to use for its plasma
               # object store. If you do not provide this, Ray will fall back to

--- a/python/ray/autoscaler/staroid/defaults.yaml
+++ b/python/ray/autoscaler/staroid/defaults.yaml
@@ -145,8 +145,8 @@ available_node_types:
                       - containerPort: 6379 # Redis port.
                       - containerPort: 6380 # Redis port.
                       - containerPort: 6381 # Redis port.
-                      - containerPort: 12345 # Ray internal communication.
-                      - containerPort: 12346 # Ray internal communication.
+                      - containerPort: 22345 # Ray internal communication.
+                      - containerPort: 22346 # Ray internal communication.
 
                   # This volume allocates shared memory for Ray to use for its plasma
                   # object store. If you do not provide this, Ray will fall back to
@@ -232,8 +232,8 @@ available_node_types:
                   command: ["/bin/bash", "-c", "--"]
                   args: ["touch ~/.bashrc; trap : TERM INT; sleep infinity & wait;"]
                   ports:
-                      - containerPort: 12345 # Ray internal communication.
-                      - containerPort: 12346 # Ray internal communication.
+                      - containerPort: 22345 # Ray internal communication.
+                      - containerPort: 22346 # Ray internal communication.
 
                   # This volume allocates shared memory for Ray to use for its plasma
                   # object store. If you do not provide this, Ray will fall back to

--- a/python/ray/autoscaler/staroid/example-full.yaml
+++ b/python/ray/autoscaler/staroid/example-full.yaml
@@ -148,8 +148,8 @@ head_node:
               - containerPort: 6379 # Redis port.
               - containerPort: 6380 # Redis port.
               - containerPort: 6381 # Redis port.
-              - containerPort: 12345 # Ray internal communication.
-              - containerPort: 12346 # Ray internal communication.
+              - containerPort: 22345 # Ray internal communication.
+              - containerPort: 22346 # Ray internal communication.
 
           # This volume allocates shared memory for Ray to use for its plasma
           # object store. If you do not provide this, Ray will fall back to
@@ -241,8 +241,8 @@ worker_nodes:
           command: ["/bin/bash", "-c", "--"]
           args: ["touch ~/.bashrc; trap : TERM INT; sleep infinity & wait;"]
           ports:
-              - containerPort: 12345 # Ray internal communication.
-              - containerPort: 12346 # Ray internal communication.
+              - containerPort: 22345 # Ray internal communication.
+              - containerPort: 22346 # Ray internal communication.
 
           # This volume allocates shared memory for Ray to use for its plasma
           # object store. If you do not provide this, Ray will fall back to

--- a/python/ray/autoscaler/staroid/example-gpu.yaml
+++ b/python/ray/autoscaler/staroid/example-gpu.yaml
@@ -148,8 +148,8 @@ head_node:
               - containerPort: 6379 # Redis port.
               - containerPort: 6380 # Redis port.
               - containerPort: 6381 # Redis port.
-              - containerPort: 12345 # Ray internal communication.
-              - containerPort: 12346 # Ray internal communication.
+              - containerPort: 22345 # Ray internal communication.
+              - containerPort: 22346 # Ray internal communication.
 
           # This volume allocates shared memory for Ray to use for its plasma
           # object store. If you do not provide this, Ray will fall back to
@@ -245,8 +245,8 @@ worker_nodes:
           command: ["/bin/bash", "-c", "--"]
           args: ["touch ~/.bashrc; trap : TERM INT; sleep infinity & wait;"]
           ports:
-              - containerPort: 12345 # Ray internal communication.
-              - containerPort: 12346 # Ray internal communication.
+              - containerPort: 22345 # Ray internal communication.
+              - containerPort: 22346 # Ray internal communication.
 
           # This volume allocates shared memory for Ray to use for its plasma
           # object store. If you do not provide this, Ray will fall back to

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -306,7 +306,7 @@ def debug(address):
     "--max-worker-port",
     required=False,
     type=int,
-    default=10999,
+    default=19999,
     help="the highest port number that workers will bind on. If set, "
     "'--min-worker-port' must also be set.")
 @click.option(

--- a/python/ray/tests/test_cli_patterns/test_k8s_cluster_launcher.yaml
+++ b/python/ray/tests/test_cli_patterns/test_k8s_cluster_launcher.yaml
@@ -151,8 +151,8 @@ head_node:
               - containerPort: 6379 # Redis port.
               - containerPort: 6380 # Redis port.
               - containerPort: 6381 # Redis port.
-              - containerPort: 12345 # Ray internal communication.
-              - containerPort: 12346 # Ray internal communication.
+              - containerPort: 22345 # Ray internal communication.
+              - containerPort: 22346 # Ray internal communication.
 
           # This volume allocates shared memory for Ray to use for its plasma
           # object store. If you do not provide this, Ray will fall back to
@@ -221,8 +221,8 @@ worker_nodes:
           command: ["/bin/bash", "-c", "--"]
           args: ["trap : TERM INT; sleep infinity & wait;"]
           ports:
-              - containerPort: 12345 # Ray internal communication.
-              - containerPort: 12346 # Ray internal communication.
+              - containerPort: 22345 # Ray internal communication.
+              - containerPort: 22346 # Ray internal communication.
 
           # This volume allocates shared memory for Ray to use for its plasma
           # object store. If you do not provide this, Ray will fall back to

--- a/python/ray/tests/test_multi_node_3.py
+++ b/python/ray/tests/test_multi_node_3.py
@@ -35,7 +35,7 @@ def test_calling_start_ray_head(call_ray_stop_only):
     # Test starting Ray with the object manager and node manager ports
     # specified.
     check_call_ray([
-        "start", "--head", "--object-manager-port", "12345",
+        "start", "--head", "--object-manager-port", "22345",
         "--node-manager-port", "54321", "--port", "0"
     ])
     check_call_ray(["stop"])
@@ -79,7 +79,7 @@ def test_calling_start_ray_head(call_ray_stop_only):
     # Test starting Ray with all arguments specified.
     check_call_ray([
         "start", "--head", "--redis-shard-ports", "6380,6381,6382",
-        "--object-manager-port", "12345", "--num-cpus", "2", "--num-gpus", "0",
+        "--object-manager-port", "22345", "--num-cpus", "2", "--num-gpus", "0",
         "--resources", "{\"Custom\": 1}", "--port", "0"
     ])
     check_call_ray(["stop"])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In the current logic of popping workers, we first select a free port and use that port to start Worker. There will be a race condition that the port was previously free being occupied when worker process starts.

In this PR, we increase the initial port selection range by 10x (from 1000 -> 10000) to reduce the likelihood of this race condition.

## Related issue number

Closes #19336

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
