### PR TITLE
[Log] Print actor & task name upon stderr messages.

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -456,8 +456,11 @@ cdef execute_task(
             # We need to handle this separately because `__repr__` may not be
             # runnable until after `__init__` (e.g., if it accesses fields
             # defined in the constructor).
-            print("{}{}".format(
-                ray_constants.LOG_PREFIX_ACTOR_NAME, actor_class.__name__))
+            actor_magic_token = "{}{}".format(
+                ray_constants.LOG_PREFIX_ACTOR_NAME, actor_class.__name__)
+            # Flush to both .out and .err
+            print(actor_magic_token)
+            print(actor_magic_token, file=sys.stderr)
 
     execution_info = execution_infos.get(function_descriptor)
     if not execution_info:
@@ -477,8 +480,11 @@ cdef execute_task(
         function_executor = execution_info.function
         # Record the task name via :task_name: magic token in the log file.
         # This is used for the prefix in driver logs `(task_name pid=123) ...`
-        print("{}{}".format(
-            ray_constants.LOG_PREFIX_TASK_NAME, task_name.replace("()", "")))
+        task_name_magic_token = "{}{}".format(
+            ray_constants.LOG_PREFIX_TASK_NAME, task_name.replace("()", ""))
+        # Print on both .out and .err
+        print(task_name_magic_token)
+        print(task_name_magic_token, file=sys.stderr)
     else:
         actor = worker.actors[core_worker.get_actor_id()]
         class_name = actor.__class__.__name__
@@ -605,8 +611,11 @@ cdef execute_task(
                 if (hasattr(actor_class, "__ray_actor_class__") and
                         "__repr__" in
                         actor_class.__ray_actor_class__.__dict__):
-                    print("{}{}".format(
-                        ray_constants.LOG_PREFIX_ACTOR_NAME, repr(actor)))
+                    actor_magic_token = "{}{}".format(
+                        ray_constants.LOG_PREFIX_ACTOR_NAME, repr(actor))
+                    # Flush on both stdout and stderr.
+                    print(actor_magic_token)
+                    print(actor_magic_token, file=sys.stderr)
             # Check for a cancellation that was called when the function
             # was exiting and was raised after the except block.
             if not check_signals().ok():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, names of actors/tasks are not printed to the driver when messages are flushed to stderr (i.e. it only works on stdout messages). This PR fixes the issue. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
