### PR TITLE
[data] Fix O(n^2) issues in simple_block sort

### DIFF
--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -303,17 +303,21 @@ class ArrowBlockAccessor(BlockAccessor):
 
 
 def _copy_table(table: "pyarrow.Table") -> "pyarrow.Table":
+    """Copy the provided Arrow table."""
     import pyarrow as pa
 
+    # Copy the table by copying each column and constructing a new table with
+    # the same schema.
     cols = table.columns
     new_cols = []
     for col in cols:
-        chunks = []
-        for chunk in col.chunks:
-            if isinstance(chunk, pa.ExtensionArray):
-                new_chunk = type(chunk).from_numpy(chunk.to_numpy())
-            else:
-                new_chunk = pa.array(chunk.to_numpy(), chunk.type)
-            chunks.append(new_chunk)
-        new_cols.append(pa.chunked_array(chunks, col.type))
+        if col.num_chunks > 0 and isinstance(col.chunk(0), pa.ExtensionArray):
+            # If an extension array, we copy the underlying storage arrays.
+            chunk = col.chunk(0)
+            arr = type(chunk).from_storage(
+                chunk.type, pa.concat_arrays([c.storage for c in col.chunks]))
+        else:
+            # Otherwise, we copy the top-level chunk arrays.
+            arr = col.combine_chunks()
+        new_cols.append(arr)
     return pa.Table.from_arrays(new_cols, schema=table.schema)

--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -287,6 +287,8 @@ class ArrowBlockAccessor(BlockAccessor):
         ret = []
         prev_i = 0
         for i in boundary_indices:
+            # Slices need to be copied to avoid including the base table
+            # during serialization.
             ret.append(_copy_table(table.slice(prev_i, i - prev_i)))
             prev_i = i
         ret.append(_copy_table(table.slice(prev_i)))

--- a/python/ray/data/impl/simple_block.py
+++ b/python/ray/data/impl/simple_block.py
@@ -118,9 +118,19 @@ class SimpleBlockAccessor(BlockAccessor):
         key_fn = key if key else lambda x: x
         comp_fn = lambda x, b: key_fn(x) > b \
             if descending else lambda x, b: key_fn(x) < b  # noqa E731
-        boundary_indices = [
+        boundary_indices = []
+        remaining = boundaries.copy()
+        for i, x in enumerate(items):
+            while remaining and not comp_fn(x, remaining[0]):
+                remaining.pop(0)
+                boundary_indices.append(i)
+        for _ in remaining:
+            boundary_indices.append(len(items))
+        assert len(boundary_indices) == len(boundaries)
+        bx = [
             len([1 for x in items if comp_fn(x, b)]) for b in boundaries
         ]
+        assert bx == boundary_indices
         ret = []
         prev_i = 0
         for i in boundary_indices:

--- a/python/ray/data/impl/simple_block.py
+++ b/python/ray/data/impl/simple_block.py
@@ -118,6 +118,8 @@ class SimpleBlockAccessor(BlockAccessor):
         key_fn = key if key else lambda x: x
         comp_fn = lambda x, b: key_fn(x) > b \
             if descending else lambda x, b: key_fn(x) < b  # noqa E731
+
+        # Compute the boundary indices in O(n) time via scan.
         boundary_indices = []
         remaining = boundaries.copy()
         for i, x in enumerate(items):
@@ -127,10 +129,7 @@ class SimpleBlockAccessor(BlockAccessor):
         for _ in remaining:
             boundary_indices.append(len(items))
         assert len(boundary_indices) == len(boundaries)
-        bx = [
-            len([1 for x in items if comp_fn(x, b)]) for b in boundaries
-        ]
-        assert bx == boundary_indices
+
         ret = []
         prev_i = 0
         for i in boundary_indices:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`ray.data.range(int(100e6)).sort()` is much faster after this change. This is a quick fix; we should profile these methods more carefully prior to moving out of experimental.