### PR TITLE
Add entropy_coeff_schedule support for APPO.

### DIFF
--- a/rllib/agents/ppo/appo_tf_policy.py
+++ b/rllib/agents/ppo/appo_tf_policy.py
@@ -20,7 +20,8 @@ from ray.rllib.models.tf.tf_action_dist import Categorical
 from ray.rllib.policy.policy import Policy
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.policy.tf_policy_template import build_tf_policy
-from ray.rllib.policy.tf_policy import LearningRateSchedule, TFPolicy
+from ray.rllib.policy.tf_policy import EntropyCoeffSchedule, \
+    LearningRateSchedule, TFPolicy
 from ray.rllib.agents.ppo.ppo_tf_policy import KLCoeffMixin, ValueNetworkMixin
 from ray.rllib.models.catalog import ModelCatalog
 from ray.rllib.models.modelv2 import ModelV2
@@ -252,7 +253,7 @@ def appo_surrogate_loss(
 
     # The summed weighted loss.
     total_loss = mean_policy_loss - \
-        mean_entropy * policy.config["entropy_coeff"]
+        mean_entropy * policy.entropy_coeff
     # Optional KL loss.
     if policy.config["use_kl_loss"]:
         total_loss += policy.kl_coeff * mean_kl_loss
@@ -304,7 +305,8 @@ def stats(policy: Policy, train_batch: SampleBatch) -> Dict[str, TensorType]:
         "vf_loss": policy._mean_vf_loss,
         "vf_explained_var": explained_variance(
             tf.reshape(policy._value_targets, [-1]),
-            tf.reshape(values_batched, [-1]))
+            tf.reshape(values_batched, [-1])),
+        "entropy_coeff": policy.entropy_coeff,
     }
 
     if policy.config["vtrace"]:
@@ -400,6 +402,8 @@ def setup_mixins(policy: Policy, obs_space: gym.spaces.Space,
     LearningRateSchedule.__init__(policy, config["lr"], config["lr_schedule"])
     KLCoeffMixin.__init__(policy, config)
     ValueNetworkMixin.__init__(policy, obs_space, action_space, config)
+    EntropyCoeffSchedule.__init__(policy, config["entropy_coeff"],
+                                  config["entropy_coeff_schedule"])
 
 
 def setup_late_mixins(policy: Policy, obs_space: gym.spaces.Space,
@@ -431,6 +435,6 @@ AsyncPPOTFPolicy = build_tf_policy(
     after_init=setup_late_mixins,
     mixins=[
         LearningRateSchedule, KLCoeffMixin, TargetNetworkMixin,
-        ValueNetworkMixin
+        ValueNetworkMixin, EntropyCoeffSchedule,
     ],
     get_batch_divisibility_req=lambda p: p.config["rollout_fragment_length"])

--- a/rllib/agents/ppo/appo_tf_policy.py
+++ b/rllib/agents/ppo/appo_tf_policy.py
@@ -434,7 +434,10 @@ AsyncPPOTFPolicy = build_tf_policy(
     before_loss_init=setup_mixins,
     after_init=setup_late_mixins,
     mixins=[
-        LearningRateSchedule, KLCoeffMixin, TargetNetworkMixin,
-        ValueNetworkMixin, EntropyCoeffSchedule,
+        LearningRateSchedule,
+        KLCoeffMixin,
+        TargetNetworkMixin,
+        ValueNetworkMixin,
+        EntropyCoeffSchedule,
     ],
     get_batch_divisibility_req=lambda p: p.config["rollout_fragment_length"])

--- a/rllib/agents/ppo/appo_torch_policy.py
+++ b/rllib/agents/ppo/appo_torch_policy.py
@@ -25,7 +25,8 @@ from ray.rllib.models.torch.torch_action_dist import \
 from ray.rllib.policy.policy import Policy
 from ray.rllib.policy.policy_template import build_policy_class
 from ray.rllib.policy.sample_batch import SampleBatch
-from ray.rllib.policy.torch_policy import LearningRateSchedule
+from ray.rllib.policy.torch_policy import EntropyCoeffSchedule, \
+    LearningRateSchedule
 from ray.rllib.utils.framework import try_import_torch
 from ray.rllib.utils.torch_ops import apply_grad_clipping, explained_variance,\
     global_norm, sequence_mask
@@ -204,7 +205,7 @@ def appo_surrogate_loss(policy: Policy, model: ModelV2,
     # The summed weighted loss
     total_loss = mean_policy_loss + \
         mean_vf_loss * policy.config["vf_loss_coeff"] - \
-        mean_entropy * policy.config["entropy_coeff"]
+        mean_entropy * policy.entropy_coeff
 
     # Optional additional KL Loss
     if policy.config["use_kl_loss"]:
@@ -246,6 +247,7 @@ def stats(policy: Policy, train_batch: SampleBatch):
             torch.stack(policy.get_tower_stats("mean_policy_loss"))),
         "entropy": torch.mean(
             torch.stack(policy.get_tower_stats("mean_entropy"))),
+        "entropy_coeff": policy.entropy_coeff,
         "var_gnorm": global_norm(policy.model.trainable_variables()),
         "vf_loss": torch.mean(
             torch.stack(policy.get_tower_stats("mean_vf_loss"))),
@@ -285,6 +287,8 @@ def setup_early_mixins(policy: Policy, obs_space: gym.spaces.Space,
         config (TrainerConfigDict): The Policy's config.
     """
     LearningRateSchedule.__init__(policy, config["lr"], config["lr_schedule"])
+    EntropyCoeffSchedule.__init__(policy, config["entropy_coeff"],
+                                  config["entropy_coeff_schedule"])
 
 
 def setup_late_mixins(policy: Policy, obs_space: gym.spaces.Space,
@@ -319,6 +323,6 @@ AsyncPPOTorchPolicy = build_policy_class(
     make_model=make_appo_model,
     mixins=[
         LearningRateSchedule, KLCoeffMixin, TargetNetworkMixin,
-        ValueNetworkMixin
+        ValueNetworkMixin, EntropyCoeffSchedule
     ],
     get_batch_divisibility_req=lambda p: p.config["rollout_fragment_length"])

--- a/rllib/agents/ppo/tests/test_appo.py
+++ b/rllib/agents/ppo/tests/test_appo.py
@@ -2,6 +2,9 @@ import unittest
 
 import ray
 import ray.rllib.agents.ppo as ppo
+from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
+from ray.rllib.utils.metrics.learner_info import LEARNER_INFO, \
+    LEARNER_STATS_KEY
 from ray.rllib.utils.test_utils import check_compute_single_action, \
     check_train_results, framework_iterator
 
@@ -66,6 +69,54 @@ class TestAPPO(unittest.TestCase):
                 check_train_results(results)
                 print(results)
             check_compute_single_action(trainer)
+            trainer.stop()
+
+    def test_appo_entropy_coeff_schedule(self):
+        config = ppo.appo.DEFAULT_CONFIG.copy()
+        config["num_workers"] = 1
+        config["num_gpus"] = 0
+        config["train_batch_size"] = 20
+        config["batch_mode"] = "truncate_episodes"
+        config["rollout_fragment_length"] = 10
+        config["timesteps_per_iteration"] = 10
+        # 0 metrics reporting delay, this makes sure timestep,
+        # which entropy coeff depends on, is updated after each worker rollout.
+        config["min_iter_time_s"] = 0
+        # Initial lr, doesn't really matter because of the schedule below.
+        config["entropy_coeff"] = 0.01
+        schedule = [
+            [0, 0.01],
+            [60, 0.001],
+            [120, 0.0001],
+        ]
+        config["entropy_coeff_schedule"] = schedule
+
+        def _step_n_times(trainer, n: int):
+            """Step trainer n times.
+
+            Returns:
+                learning rate at the end of the execution.
+            """
+            for _ in range(n):
+                results = trainer.train()
+            print(results["info"][LEARNER_INFO][DEFAULT_POLICY_ID][
+                LEARNER_STATS_KEY])
+            return results["info"][LEARNER_INFO][DEFAULT_POLICY_ID][
+                LEARNER_STATS_KEY]["entropy_coeff"]
+
+        for _ in framework_iterator(config):
+            trainer = ppo.APPOTrainer(config=config, env="CartPole-v0")
+
+            coeff = _step_n_times(trainer, 3)  # 60 timesteps
+            # PiecewiseSchedule does interpolation. So roughly 0.001 here.
+            self.assertLessEqual(coeff, 0.005)
+            self.assertGreaterEqual(coeff, 0.0005)
+
+            coeff = _step_n_times(trainer, 6)  # 120 timesteps
+            # PiecewiseSchedule does interpolation. So roughly 0.0001 here.
+            self.assertLessEqual(coeff, 0.0005)
+            self.assertGreaterEqual(coeff, 0.00005)
+
             trainer.stop()
 
 


### PR DESCRIPTION
## Why are these changes needed?

Add missing entropy_coeff_schedule support for APPO agent.

## Related issue number


## Checks

- [*] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
