### PR TITLE
[tune] sync_client: Fix delete template formatting

### DIFF
--- a/python/ray/tune/sync_client.py
+++ b/python/ray/tune/sync_client.py
@@ -267,7 +267,8 @@ class CommandBasedClient(SyncClient):
         if self.is_running:
             logger.warning("Last sync client cmd still in progress, skipping.")
             return False
-        final_cmd = self.delete_template.format(target=quote(target))
+        final_cmd = self.delete_template.format(
+            target=quote(target), options="")
         logger.debug("Running delete: {}".format(final_cmd))
         self.cmd_process = subprocess.Popen(
             final_cmd,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Running into:

```
(pid=451) 2021-10-20 08:58:13,409	ERROR worker.py:80 -- Unhandled error (suppress with RAY_IGNORE_UNHANDLED_ERRORS=1): ray::ImplicitFunc.delete_checkpoint() (pid=522, ip=172.31.30.220, repr=<ray.tune.function_runner.ImplicitFunc object at 0x7fc292f45e50>)
(pid=451)   File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/tune/durable_trainable.py", line 105, in delete_checkpoint
(pid=451)     self.storage_client.delete(self._storage_path(local_dirpath))
(pid=451)   File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/tune/sync_client.py", line 270, in delete
(pid=451)     final_cmd = self.delete_template.format(target=quote(target))
(pid=451) KeyError: 'options'
(run pid=451) == Status ==
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
