### PR TITLE
[Train] Backwards Compatibility for `TrainingCallback`

### DIFF
--- a/python/ray/util/sgd/v2/__init__.py
+++ b/python/ray/util/sgd/v2/__init__.py
@@ -1,4 +1,8 @@
-from ray.train import *  # noqa: F401, F403
 import warnings
+
+from ray.train import *  # noqa: F401, F403
+from ray.train import TrainingCallback
+
+SGDCallback = TrainingCallback
 
 warnings.warn("ray.util.sgd.v2 has been moved to ray.train.")

--- a/python/ray/util/sgd/v2/callbacks/__init__.py
+++ b/python/ray/util/sgd/v2/callbacks/__init__.py
@@ -1,1 +1,4 @@
 from ray.train.callbacks import *  # noqa: F401, F403
+from ray.train.callbacks import TrainingCallback
+
+SGDCallback = TrainingCallback


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
`SGDCallback` was renamed to `TrainingCallback` in the move from `ray.util.sgd.v2` to `ray.train`. However we should maintain backwards compatibility for `SGDCallback` until `ray.util.sgd.v2` is fully deprecated.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
