### PR TITLE
[Tune] Do not report metrics on magic kw from RLlib Trainable

### DIFF
--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -662,6 +662,9 @@ class Trial:
         self.last_update_time = time.time()
 
         for metric, value in flatten_dict(result).items():
+            # Skip the magic words from metric recording.
+            if metric.startswith("config/"):
+                continue
             if isinstance(value, Number):
                 if metric not in self.metric_analysis:
                     self.metric_analysis[metric] = {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Some of the metrics from RLlib trainables are static configs and should not be recorded into per trial metrics.

Manually tested:
```
ipdb> trial.metric_analysis
{'episode_reward_max': {'max': 82.0, 'min': 82.0, 'avg': 82.0, 'last': 82.0, 'last-5-avg': 82.0, 'last-10-avg': 82.0}, 'episode_reward_min': {'max': 8.0, 'min': 8.0, 'avg': 8.0, 'last': 8.0, 'last-5-avg': 8.0, 'last-10-avg': 8.0}, 'episode_reward_mean': {'max': 23.476331360946745, 'min': 23.476331360946745, 'avg': 23.476331360946745, 'last': 23.476331360946745, 'last-5-avg': 23.476331360946745, 'last-10-avg': 23.476331360946745}, 'episode_len_mean': {'max': 23.476331360946745, 'min': 23.476331360946745, 'avg': 23.476331360946745, 'last': 23.476331360946745, 'last-5-avg': 23.476331360946745, 'last-10-avg': 23.476331360946745}, 'episodes_this_iter': {'max': 338, 'min': 338, 'avg': 338, 'last': 338, 'last-5-avg': 338, 'last-10-avg': 338}, 'num_healthy_workers': {'max': 7, 'min': 7, 'avg': 7, 'last': 7, 'last-5-avg': 7, 'last-10-avg': 7}, 'timesteps_total': {'max': 7994, 'min': 7994, 'avg': 7994, 'last': 7994, 'last-5-avg': 7994, 'last-10-avg': 7994}, 'timesteps_this_iter': {'max': 0, 'min': 0, 'avg': 0, 'last': 0, 'last-5-avg': 0, 'last-10-avg': 0}, 'agent_timesteps_total': {'max': 7994, 'min': 7994, 'avg': 7994, 'last': 7994, 'last-5-avg': 7994, 'last-10-avg': 7994}, 'done': {'max': True, 'min': True, 'avg': True, 'last': True, 'last-5-avg': True, 'last-10-avg': True}, 'episodes_total': {'max': 338, 'min': 338, 'avg': 338, 'last': 338, 'last-5-avg': 338, 'last-10-avg': 338}, 'training_iteration': {'max': 1, 'min': 1, 'avg': 1, 'last': 1, 'last-5-avg': 1, 'last-10-avg': 1}, 'timestamp': {'max': 1634774821, 'min': 1634774821, 'avg': 1634774821, 'last': 1634774821, 'last-5-avg': 1634774821, 'last-10-avg': 1634774821}, 'time_this_iter_s': {'max': 2.777583599090576, 'min': 2.777583599090576, 'avg': 2.777583599090576, 'last': 2.777583599090576, 'last-5-avg': 2.777583599090576, 'last-10-avg': 2.777583599090576}, 'time_total_s': {'max': 2.777583599090576, 'min': 2.777583599090576, 'avg': 2.777583599090576, 'last': 2.777583599090576, 'last-5-avg': 2.777583599090576, 'last-10-avg': 2.777583599090576}, 'pid': {'max': 5252, 'min': 5252, 'avg': 5252, 'last': 5252, 'last-5-avg': 5252, 'last-10-avg': 5252}, 'time_since_restore': {'max': 2.777583599090576, 'min': 2.777583599090576, 'avg': 2.777583599090576, 'last': 2.777583599090576, 'last-5-avg': 2.777583599090576, 'last-10-avg': 2.777583599090576}, 'timesteps_since_restore': {'max': 0, 'min': 0, 'avg': 0, 'last': 0, 'last-5-avg': 0, 'last-10-avg': 0}, 'iterations_since_restore': {'max': 1, 'min': 1, 'avg': 1, 'last': 1, 'last-5-avg': 1, 'last-10-avg': 1}, 'sampler_perf/mean_raw_obs_processing_ms': {'max': 0.14262098821890926, 'min': 0.14262098821890926, 'avg': 0.14262098821890926, 'last': 0.14262098821890926, 'last-5-avg': 0.14262098821890926, 'last-10-avg': 0.14262098821890926}, 'sampler_perf/mean_inference_ms': {'max': 1.521778875510903, 'min': 1.521778875510903, 'avg': 1.521778875510903, 'last': 1.521778875510903, 'last-5-avg': 1.521778875510903, 'last-10-avg': 1.521778875510903}, 'sampler_perf/mean_action_processing_ms': {'max': 0.06828449021097073, 'min': 0.06828449021097073, 'avg': 0.06828449021097073, 'last': 0.06828449021097073, 'last-5-avg': 0.06828449021097073, 'last-10-avg': 0.06828449021097073}, 'sampler_perf/mean_env_wait_ms': {'max': 0.07986415513553516, 'min': 0.07986415513553516, 'avg': 0.07986415513553516, 'last': 0.07986415513553516, 'last-5-avg': 0.07986415513553516, 'last-10-avg': 0.07986415513553516}, 'sampler_perf/mean_env_render_ms': {'max': 0.0, 'min': 0.0, 'avg': 0.0, 'last': 0.0, 'last-5-avg': 0.0, 'last-10-avg': 0.0}, 'timers/sample_time_ms': {'max': 2416.215, 'min': 2416.215, 'avg': 2416.215, 'last': 2416.215, 'last-5-avg': 2416.215, 'last-10-avg': 2416.215}, 'timers/sample_throughput': {'max': 3308.481, 'min': 3308.481, 'avg': 3308.481, 'last': 3308.481, 'last-5-avg': 3308.481, 'last-10-avg': 3308.481}, 'timers/load_time_ms': {'max': 0.458, 'min': 0.458, 'avg': 0.458, 'last': 0.458, 'last-5-avg': 0.458, 'last-10-avg': 0.458}, 'timers/load_throughput': {'max': 17454068.806, 'min': 17454068.806, 'avg': 17454068.806, 'last': 17454068.806, 'last-5-avg': 17454068.806, 'last-10-avg': 17454068.806}, 'timers/learn_time_ms': {'max': 363.176, 'min': 363.176, 'avg': 363.176, 'last': 363.176, 'last-5-avg': 363.176, 'last-10-avg': 363.176}, 'timers/learn_throughput': {'max': 22011.389, 'min': 22011.389, 'avg': 22011.389, 'last': 22011.389, 'last-5-avg': 22011.389, 'last-10-avg': 22011.389}, 'timers/update_time_ms': {'max': 1.806, 'min': 1.806, 'avg': 1.806, 'last': 1.806, 'last-5-avg': 1.806, 'last-10-avg': 1.806}, 'info/num_steps_sampled': {'max': 7994, 'min': 7994, 'avg': 7994, 'last': 7994, 'last-5-avg': 7994, 'last-10-avg': 7994}, 'info/num_agent_steps_sampled': {'max': 7994, 'min': 7994, 'avg': 7994, 'last': 7994, 'last-5-avg': 7994, 'last-10-avg': 7994}, 'info/num_steps_trained': {'max': 7994, 'min': 7994, 'avg': 7994, 'last': 7994, 'last-5-avg': 7994, 'last-10-avg': 7994}, 'info/num_agent_steps_trained': {'max': 7994, 'min': 7994, 'avg': 7994, 'last': 7994, 'last-5-avg': 7994, 'last-10-avg': 7994}, 'perf/cpu_util_percent': {'max': 76.175, 'min': 76.175, 'avg': 76.175, 'last': 76.175, 'last-5-avg': 76.175, 'last-10-avg': 76.175}, 'perf/ram_util_percent': {'max': 17.275, 'min': 17.275, 'avg': 17.275, 'last': 17.275, 'last-5-avg': 17.275, 'last-10-avg': 17.275}, 'info/learner/default_policy/learner_stats/allreduce_latency': {'max': 0.0, 'min': 0.0, 'avg': 0.0, 'last': 0.0, 'last-5-avg': 0.0, 'last-10-avg': 0.0}, 'info/learner/default_policy/learner_stats/cur_kl_coeff': {'max': 0.19999999999999993, 'min': 0.19999999999999993, 'avg': 0.19999999999999993, 'last': 0.19999999999999993, 'last-5-avg': 0.19999999999999993, 'last-10-avg': 0.19999999999999993}, 'info/learner/default_policy/learner_stats/cur_lr': {'max': 5.0000000000000016e-05, 'min': 5.0000000000000016e-05, 'avg': 5.0000000000000016e-05, 'last': 5.0000000000000016e-05, 'last-5-avg': 5.0000000000000016e-05, 'last-10-avg': 5.0000000000000016e-05}, 'info/learner/default_policy/learner_stats/total_loss': {'max': 297.63268809164725, 'min': 297.63268809164725, 'avg': 297.63268809164725, 'last': 297.63268809164725, 'last-5-avg': 297.63268809164725, 'last-10-avg': 297.63268809164725}, 'info/learner/default_policy/learner_stats/policy_loss': {'max': -0.015470280041617731, 'min': -0.015470280041617731, 'avg': -0.015470280041617731, 'last': -0.015470280041617731, 'last-5-avg': -0.015470280041617731, 'last-10-avg': -0.015470280041617731}, 'info/learner/default_policy/learner_stats/vf_loss': {'max': 297.6467662934334, 'min': 297.6467662934334, 'avg': 297.6467662934334, 'last': 297.6467662934334, 'last-5-avg': 297.6467662934334, 'last-10-avg': 297.6467662934334}, 'info/learner/default_policy/learner_stats/vf_explained_var': {'max': 0.00015216008309395083, 'min': 0.00015216008309395083, 'avg': 0.00015216008309395083, 'last': 0.00015216008309395083, 'last-5-avg': 0.00015216008309395083, 'last-10-avg': 0.00015216008309395083}, 'info/learner/default_policy/learner_stats/kl': {'max': 0.0069541639009123414, 'min': 0.0069541639009123414, 'avg': 0.0069541639009123414, 'last': 0.0069541639009123414, 'last-5-avg': 0.0069541639009123414, 'last-10-avg': 0.0069541639009123414}, 'info/learner/default_policy/learner_stats/entropy': {'max': 0.6862201344582343, 'min': 0.6862201344582343, 'avg': 0.6862201344582343, 'last': 0.6862201344582343, 'last-5-avg': 0.6862201344582343, 'last-10-avg': 0.6862201344582343}, 'info/learner/default_policy/learner_stats/entropy_coeff': {'max': 0.0, 'min': 0.0, 'avg': 0.0, 'last': 0.0, 'last-5-avg': 0.0, 'last-10-avg': 0.0}}
ipdb> trial.metric_n_steps
{'episode_reward_max': {'5': deque([82.0], maxlen=5), '10': deque([82.0], maxlen=10)}, 'episode_reward_min': {'5': deque([8.0], maxlen=5), '10': deque([8.0], maxlen=10)}, 'episode_reward_mean': {'5': deque([23.476331360946745], maxlen=5), '10': deque([23.476331360946745], maxlen=10)}, 'episode_len_mean': {'5': deque([23.476331360946745], maxlen=5), '10': deque([23.476331360946745], maxlen=10)}, 'episodes_this_iter': {'5': deque([338], maxlen=5), '10': deque([338], maxlen=10)}, 'num_healthy_workers': {'5': deque([7], maxlen=5), '10': deque([7], maxlen=10)}, 'timesteps_total': {'5': deque([7994], maxlen=5), '10': deque([7994], maxlen=10)}, 'timesteps_this_iter': {'5': deque([0], maxlen=5), '10': deque([0], maxlen=10)}, 'agent_timesteps_total': {'5': deque([7994], maxlen=5), '10': deque([7994], maxlen=10)}, 'done': {'5': deque([True], maxlen=5), '10': deque([True], maxlen=10)}, 'episodes_total': {'5': deque([338], maxlen=5), '10': deque([338], maxlen=10)}, 'training_iteration': {'5': deque([1], maxlen=5), '10': deque([1], maxlen=10)}, 'timestamp': {'5': deque([1634774821], maxlen=5), '10': deque([1634774821], maxlen=10)}, 'time_this_iter_s': {'5': deque([2.777583599090576], maxlen=5), '10': deque([2.777583599090576], maxlen=10)}, 'time_total_s': {'5': deque([2.777583599090576], maxlen=5), '10': deque([2.777583599090576], maxlen=10)}, 'pid': {'5': deque([5252], maxlen=5), '10': deque([5252], maxlen=10)}, 'time_since_restore': {'5': deque([2.777583599090576], maxlen=5), '10': deque([2.777583599090576], maxlen=10)}, 'timesteps_since_restore': {'5': deque([0], maxlen=5), '10': deque([0], maxlen=10)}, 'iterations_since_restore': {'5': deque([1], maxlen=5), '10': deque([1], maxlen=10)}, 'sampler_perf/mean_raw_obs_processing_ms': {'5': deque([0.14262098821890926], maxlen=5), '10': deque([0.14262098821890926], maxlen=10)}, 'sampler_perf/mean_inference_ms': {'5': deque([1.521778875510903], maxlen=5), '10': deque([1.521778875510903], maxlen=10)}, 'sampler_perf/mean_action_processing_ms': {'5': deque([0.06828449021097073], maxlen=5), '10': deque([0.06828449021097073], maxlen=10)}, 'sampler_perf/mean_env_wait_ms': {'5': deque([0.07986415513553516], maxlen=5), '10': deque([0.07986415513553516], maxlen=10)}, 'sampler_perf/mean_env_render_ms': {'5': deque([0.0], maxlen=5), '10': deque([0.0], maxlen=10)}, 'timers/sample_time_ms': {'5': deque([2416.215], maxlen=5), '10': deque([2416.215], maxlen=10)}, 'timers/sample_throughput': {'5': deque([3308.481], maxlen=5), '10': deque([3308.481], maxlen=10)}, 'timers/load_time_ms': {'5': deque([0.458], maxlen=5), '10': deque([0.458], maxlen=10)}, 'timers/load_throughput': {'5': deque([17454068.806], maxlen=5), '10': deque([17454068.806], maxlen=10)}, 'timers/learn_time_ms': {'5': deque([363.176], maxlen=5), '10': deque([363.176], maxlen=10)}, 'timers/learn_throughput': {'5': deque([22011.389], maxlen=5), '10': deque([22011.389], maxlen=10)}, 'timers/update_time_ms': {'5': deque([1.806], maxlen=5), '10': deque([1.806], maxlen=10)}, 'info/num_steps_sampled': {'5': deque([7994], maxlen=5), '10': deque([7994], maxlen=10)}, 'info/num_agent_steps_sampled': {'5': deque([7994], maxlen=5), '10': deque([7994], maxlen=10)}, 'info/num_steps_trained': {'5': deque([7994], maxlen=5), '10': deque([7994], maxlen=10)}, 'info/num_agent_steps_trained': {'5': deque([7994], maxlen=5), '10': deque([7994], maxlen=10)}, 'perf/cpu_util_percent': {'5': deque([76.175], maxlen=5), '10': deque([76.175], maxlen=10)}, 'perf/ram_util_percent': {'5': deque([17.275], maxlen=5), '10': deque([17.275], maxlen=10)}, 'info/learner/default_policy/learner_stats/allreduce_latency': {'5': deque([0.0], maxlen=5), '10': deque([0.0], maxlen=10)}, 'info/learner/default_policy/learner_stats/cur_kl_coeff': {'5': deque([0.19999999999999993], maxlen=5), '10': deque([0.19999999999999993], maxlen=10)}, 'info/learner/default_policy/learner_stats/cur_lr': {'5': deque([5.0000000000000016e-05], maxlen=5), '10': deque([5.0000000000000016e-05], maxlen=10)}, 'info/learner/default_policy/learner_stats/total_loss': {'5': deque([297.63268809164725], maxlen=5), '10': deque([297.63268809164725], maxlen=10)}, 'info/learner/default_policy/learner_stats/policy_loss': {'5': deque([-0.015470280041617731], maxlen=5), '10': deque([-0.015470280041617731], maxlen=10)}, 'info/learner/default_policy/learner_stats/vf_loss': {'5': deque([297.6467662934334], maxlen=5), '10': deque([297.6467662934334], maxlen=10)}, 'info/learner/default_policy/learner_stats/vf_explained_var': {'5': deque([0.00015216008309395083], maxlen=5), '10': deque([0.00015216008309395083], maxlen=10)}, 'info/learner/default_policy/learner_stats/kl': {'5': deque([0.0069541639009123414], maxlen=5), '10': deque([0.0069541639009123414], maxlen=10)}, 'info/learner/default_policy/learner_stats/entropy': {'5': deque([0.6862201344582343], maxlen=5), '10': deque([0.6862201344582343], maxlen=10)}, 'info/learner/default_policy/learner_stats/entropy_coeff': {'5': deque([0.0], maxlen=5), '10': deque([0.0], maxlen=10)}}
ipdb> 
```

Alternatively, I guess we can also modify `step()` in `trainer_template.py`. But I am not sure how each dict is populated. Open to suggestions.

## Related issue number
#19309

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
